### PR TITLE
Add production Pi agent integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       desktop: ${{ steps.filter.outputs.desktop }}
       desktop-rust: ${{ steps.filter.outputs.desktop-rust }}
+      pi-agent: ${{ steps.filter.outputs.pi-agent }}
       web: ${{ steps.filter.outputs.web }}
       mobile: ${{ steps.filter.outputs.mobile }}
     steps:
@@ -55,6 +56,16 @@ jobs:
               - 'pnpm-lock.yaml'
             desktop-rust:
               - 'desktop/src-tauri/**'
+            pi-agent:
+              - 'packages/buzz-pi-agent/**'
+              - 'crates/buzz-acp/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'pnpm-workspace.yaml'
+              - 'pnpm-lock.yaml'
+              - 'Justfile'
+              - '.github/workflows/ci.yml'
             web:
               - 'scripts/check-file-sizes-core.mjs'
               - 'scripts/check-file-sizes-core.test.mjs'
@@ -129,6 +140,42 @@ jobs:
           tool: cargo-nextest@0.9.136
       - name: Unit tests
         run: just test-unit
+
+  pi-agent:
+    name: Pi Agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [changes]
+    if: github.event_name == 'push' || needs.changes.outputs.pi-agent == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' }}
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm store cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Pi adapter lint and typecheck
+        run: just pi-agent-check
+      - name: Pi adapter, Buzz ACP, and cross-process contract tests
+        run: just pi-agent-verify
+      - name: Save pnpm store cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
   desktop-core:
     name: Desktop Core

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -648,30 +648,39 @@ Standalone binary that bridges Buzz relay events to AI agents via the [Agent Com
 **Architecture:**
 
 ```
-Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent (goose/codex/claude)
+Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent (goose/codex/claude/pi)
 ```
 
-`buzz-acp` spawns AI agent subprocesses (1–32, default 1), connects to the relay via WebSocket with NIP-42 auth, discovers channels via REST API, and queues `@mention` events per channel. At most one prompt is in-flight per channel. Queued events are batched into a single prompt sent via `session/prompt` over ACP.
+`buzz-acp` spawns AI agent subprocesses (1–32, default 1), connects to the relay via WebSocket with NIP-42 auth, discovers channels via REST API, and routes accepted events by exact conversation. A channel thread is keyed by its validated NIP-10 root; a definite DM conversation uses its participant scope. At most one prompt is in flight per conversation, while sibling threads can run concurrently. Queued events for the same conversation are batched into one `session/prompt` call.
+
+Adapters can advertise Buzz's thread-session ACP extension. The harness then supplies a stable, opaque conversation ID, caches sessions with an idle TTL and LRU bound, and asks the adapter to dispose or forget them explicitly. Durable adapters can additionally advertise synchronous reset commits. `/new` is owner-authenticated and transactionally ordered: Buzz preflights bounded reset metadata, commits an idempotent adapter tombstone, fences and cancels the old generation, then publishes a pre-signed acknowledgement. Replacement work is released only after the old turn drains and the relay explicitly accepts that acknowledgement. A short-lived helper performs the same commit when the owning adapter is busy or the pool is still lazy.
+
+The `buzz-pi-agent` adapter persists each conversation as a Pi JSONL session, so cold eviction or process restart does not lose context. It enforces a 150,000-token logical ceiling, proactively compacts, performs a final provider-payload guard, and emits typed lifecycle events that the harness renders as safe, thread-scoped Buzz notices. Project-local Pi resources are fail-closed behind Pi's project trust store; normal global Pi extensions and resources are reused.
 
 **Key modules:**
 
 | Module | LOC | Responsibility |
 |--------|-----|---------------|
-| `relay.rs` | 3,143 | WebSocket + REST relay connection, NIP-42 auth |
-| `queue.rs` | 2,565 | Per-channel event queue, batching, dedup |
-| `main.rs` | 2,457 | Event loop, pool orchestration, heartbeat |
-| `pool.rs` | 2,253 | N-agent pool, claim/return lifecycle |
-| `config.rs` | 1,903 | CLI/env/TOML configuration |
-| `acp.rs` | 1,785 | ACP client, stdio JSON-RPC, timeouts |
-| `filter.rs` | 814 | Subscription rules, evalexpr filtering |
+| `lib.rs` | 10,675 | Event loop, reset coordination, pool orchestration, heartbeat |
+| `pool.rs` | 8,361 | N-agent pool, sticky conversation sessions, claim/return lifecycle |
+| `relay.rs` | 7,104 | WebSocket + REST relay connection, NIP-42 auth |
+| `queue.rs` | 6,017 | Per-conversation event queue, batching, reset generations, dedup |
+| `acp.rs` | 5,884 | ACP client, stdio JSON-RPC, extension negotiation, timeouts |
+| `config.rs` | 3,109 | CLI/env/TOML configuration |
+| `durable_outbox.rs` | 929 | Crash-safe lifecycle notices and committed reset barriers |
+| `filter.rs` | 787 | Subscription rules, evalexpr filtering |
 
 **Key behaviors:**
 - Pool of 1–32 agent subprocesses with claim/return lifecycle.
-- Per-channel queuing: at most one prompt in-flight per channel; subsequent @mentions queue until the agent responds.
+- Per-conversation queuing: at most one prompt in flight per thread or DM scope; sibling threads remain independent.
+- Sticky agent affinity keeps a hot conversation on one subprocess when possible, with fair bypass when that subprocess is busy.
+- Bounded hot-session lifecycle (8 sessions per process, 30-minute idle TTL by default) with explicit adapter disposal and durable cold resume where supported.
+- Owner-authenticated, thread-local `/new` with generation fencing and an accepted signed acknowledgement before replacement work is released.
+- Typed session lifecycle notices for context status, compaction, reset, and resource reload.
 - Crash recovery: agent subprocess crashes are detected and the agent is respawned.
 - Depends on `buzz-core` (kind constants) and `buzz-sdk` (relay/REST utilities).
 
-**Does NOT:** persist state.
+**Persistence boundary:** the harness keeps only an in-memory reconnect/startup watermark; it does not persist a durable relay cursor across process restarts. Conversation persistence and acknowledged reset tombstones belong to capable adapters. Legacy ACP adapters remain hot-session-only; `buzz-pi-agent` provides durable thread sessions, and reset safety never relies on relay replay behavior.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,9 @@ dependencies = [
  "buzz-sdk",
  "chrono",
  "clap",
+ "dirs",
  "evalexpr",
+ "fs2",
  "futures-util",
  "hex",
  "httparse",
@@ -818,6 +820,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -2984,6 +2987,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ uuid    = { version = "1", features = ["v4", "serde"] }
 chrono  = { version = "0.4", features = ["serde"] }
 
 # HTTP client (webhook delivery)
-reqwest = { version = "0.13", features = ["json", "rustls"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "rustls", "stream"], default-features = false }
 
 # Cryptography
 sha2      = "0.11"

--- a/Justfile
+++ b/Justfile
@@ -92,7 +92,7 @@ build-release:
     cargo build --workspace --release
 
 # Run repo lint and formatting checks
-check: fmt-check clippy desktop-check desktop-tauri-fmt-check desktop-tauri-clippy web-check mobile-check
+check: fmt-check clippy desktop-check desktop-tauri-fmt-check desktop-tauri-clippy web-check mobile-check pi-agent-check
 
 # Format all Rust code
 fmt:
@@ -129,6 +129,35 @@ desktop-test:
 # Run desktop TypeScript checks
 desktop-typecheck:
     cd {{desktop_dir}} && pnpm typecheck
+
+# Build the Pi SDK ACP adapter used by the Desktop Pi harness preset
+pi-agent-build:
+    pnpm --dir packages/buzz-pi-agent build
+
+# Install the built Pi adapter on PATH for the Desktop Pi preset
+pi-agent-install: pi-agent-build
+    npm install --global ./packages/buzz-pi-agent
+
+# Type-check and lint the Pi SDK ACP adapter
+pi-agent-check:
+    pnpm --dir packages/buzz-pi-agent check
+
+# Run the Pi SDK ACP adapter unit and protocol tests
+pi-agent-test:
+    pnpm --dir packages/buzz-pi-agent test
+
+# Run the Pi adapter and full ACP unit suites, then reuse the adapter build for
+# the real cross-process contract. This is the production verification path
+# used by CI/pre-push and avoids rebuilding dist between the Node and contract
+# suites.
+pi-agent-verify:
+    pnpm --dir packages/buzz-pi-agent test
+    cargo test -p buzz-acp --lib
+    BUZZ_PI_AGENT_BIN="{{justfile_directory()}}/packages/buzz-pi-agent/dist/cli.js" cargo test -p buzz-acp --test pi_adapter_contract -- --nocapture
+
+# Exercise the real Rust harness ↔ built Pi adapter persistence/reset contract
+pi-agent-contract-test: pi-agent-build
+    BUZZ_PI_AGENT_BIN="{{justfile_directory()}}/packages/buzz-pi-agent/dist/cli.js" cargo test -p buzz-acp --test pi_adapter_contract -- --nocapture
 
 # Build desktop frontend assets
 desktop-build:
@@ -270,7 +299,7 @@ desktop-e2e-pre-push: _ensure-migrations
     cd {{desktop_dir}} && pnpm build:e2e && pnpm exec playwright test --only-changed=origin/main
 
 # Run all checks suitable for CI / pre-push (no infra needed)
-ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri-test web-build mobile-test
+ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri-test web-build mobile-test pi-agent-verify
 
 # ─── Test ─────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Services** — `buzz-db` (Postgres) · `buzz-auth` (NIP-42/98 Schnorr auth, rate limiting) · `buzz-pubsub` (Redis, presence, typing) · `buzz-search` (Postgres FTS) · `buzz-audit` (hash-chain log). Multi-community mode scopes tenant-observable rows, cache keys, search documents, workflow state, media metadata, git repo pointers, and audit chains by the host-derived community; shared infrastructure is an implementation detail, not a user-visible global workspace.
 
-**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
+**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (thread-aware ACP harness for Goose/Codex/Claude Code/Pi) · `buzz-pi-agent` (durable Pi SDK adapter with compaction and extension support) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -53,6 +53,8 @@ url = { workspace = true }
 sha2 = { workspace = true }
 base64 = "0.22"
 hex = { workspace = true }
+dirs = "6"
+fs2 = "0.4"
 
 # Logging
 tracing = { workspace = true }
@@ -79,3 +81,4 @@ nix = { version = "0.31", default-features = false, features = ["signal"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 httparse = "1"
+tempfile = "3"

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -9,7 +9,7 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **Pi** through the repository's production [`buzz-pi-agent`](../../packages/buzz-pi-agent/README.md) adapter.
 
 ## Prerequisites
 
@@ -98,6 +98,32 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with Pi
+
+The Pi adapter uses the real Pi coding-agent SDK, keeps one durable Pi context
+per Buzz thread, and reuses your normal global Pi authentication, settings,
+extensions, skills, prompts, providers, and context files.
+
+```bash
+. ./bin/activate-hermit
+pnpm install
+just pi-agent-install
+
+export BUZZ_ACP_AGENT_COMMAND="buzz-pi-agent"
+export BUZZ_ACP_AGENT_ARGS=""
+buzz-acp
+```
+
+The production `buzz-pi-agent` command automatically enables the fail-closed
+durable-thread contract before lazy startup. If you launch it through a wrapper
+whose executable has a different name, also set
+`BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS=true` explicitly.
+
+Buzz Desktop also includes a **Pi** runtime preset once `buzz-pi-agent` is on
+`PATH`. See the [Pi adapter guide](../../packages/buzz-pi-agent/README.md) for
+the 150k context policy, durable state, extension compatibility, project trust,
+and tuning variables.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).
@@ -111,13 +137,63 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
-| `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `BUZZ_ACP_IDLE_TIMEOUT` | no | `900` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `BUZZ_ACP_MAX_CACHED_CONVERSATION_SESSIONS` | no | `8` | Maximum hot thread sessions per ACP subprocess; least-recently-used idle sessions are disposed first. |
+| `BUZZ_ACP_CONVERSATION_SESSION_IDLE_TTL_SECS` | no | `1800` | Idle lifetime of a hot session. Durable adapters can reopen its context later. |
+| `BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS` | no | `false` (automatic for `buzz-pi-agent`) | Select thread-local queue identity before lazy startup and fail closed unless the adapter advertises durable sessions plus synchronous reset commits. Set explicitly when a wrapper hides the Pi adapter's executable name. |
+| `BUZZ_ACP_STATE_DIR` | no | platform-local data directory, scoped by canonical relay + agent pubkey | Absolute directory for the harness's signed lifecycle outbox, `/new` commit intents, accepted reset receipts, and notice-deduplication records. Equivalent relay spellings share one identity. CLI: `--state-dir`. |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+### Durable Harness State
+
+`buzz-acp` persists the safety-critical half of Pi lifecycle reporting and
+`/new` under `--state-dir` / `BUZZ_ACP_STATE_DIR`. When unset, the directory is:
+
+```text
+<platform local data>/Buzz/acp/<first 24 hex chars of SHA-256(canonical relay URL)>/<agent pubkey>/
+```
+
+Relay scheme/host casing, default ports, and a trailing slash are normalized
+before hashing; a path-scoped relay remains a different identity. An explicit
+state directory must be absolute. Do not point two agents or two relays at one
+explicit directory.
+
+The directory contains two alternating, generation-stamped signed-outbox
+snapshots, a private initialized marker that detects missing/partial restores,
+and an exclusive lock. It records:
+
+- signed user-visible lifecycle notices until Buzz accepts them;
+- prepared and adapter-committed `/new` intents until their signed ACK is
+  accepted;
+- bounded consumed-reset receipts, so relay replay cannot apply one `/new`
+  twice; and
+- bounded lifecycle delivery keys, so adapter replay is idempotent.
+
+On Unix, the harness enforces `0700` on the directory and `0600` on its files.
+Only one harness may hold the directory lock. Each snapshot is capped at 8 MiB;
+pending lifecycle notices and resets are capped at 256 each, delivered keys and
+consumed-reset receipts at 1,024 each, and signed notice content at 16 KiB.
+Capacity, corruption, lock, permission, and write failures fail closed: `/new`
+is not acknowledged, adapter lifecycle events are not ACKed, and a request
+whose recovery notice cannot be persisted is retained behind a retry gate
+without consuming its normal dead-letter budget.
+
+Treat this as service state, not a disposable cache. Losing it can cause
+duplicate lifecycle notices and removes the harness's proof that an old
+`/new` event was already consumed. Back up or migrate both snapshot files **and
+the initialized marker as one set**, only while the harness is stopped. Retain
+them for as long as relay history may be replayed, and restore them only with
+the same agent identity and canonical relay. A marker with no valid snapshot is
+rejected rather than silently reinitialized. The files contain signed events,
+thread identifiers, and reset tokens
+(but not the Nostr private key), so protect backups accordingly. Pi's own
+conversation transcripts and mapping store are separate and documented in the
+[Pi adapter guide](../../packages/buzz-pi-agent/README.md).
 
 ### Parallel Agents & Heartbeat
 
@@ -125,6 +201,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 |------|---------|---------|-------------|
 | `--agents` | `BUZZ_ACP_AGENTS` | `1` | Number of agent subprocesses (1–32). |
 | `--lazy-pool` | `BUZZ_ACP_LAZY_POOL` | `false` | Connect, subscribe, and queue accepted work before starting ACP/LLM subprocesses. The first accepted event wakes one pool initialization task; failures retry with bounded exponential backoff while work remains. |
+| `--require-durable-thread-sessions` | `BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS` | `false` (automatic for `buzz-pi-agent`) | Require the durable thread-session/reset-commit contract. This must be known before a lazy `/new`; set it explicitly for wrapper commands whose name does not identify the Pi adapter. |
 | `--heartbeat-interval` | `BUZZ_ACP_HEARTBEAT_INTERVAL` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be `0` or ≥10 when enabled. |
 | `--heartbeat-prompt` | `BUZZ_ACP_HEARTBEAT_PROMPT` | (built-in) | Custom heartbeat prompt text. Conflicts with `--heartbeat-prompt-file`. |
 | `--heartbeat-prompt-file` | `BUZZ_ACP_HEARTBEAT_PROMPT_FILE` | — | Read heartbeat prompt from a file. Conflicts with `--heartbeat-prompt`. |
@@ -154,10 +231,20 @@ The gate applies to **all** inbound events — @mentions, DMs, thread replies, a
 | `!shutdown` | Gracefully exits the harness. |
 | `!cancel` | Cancels the current in-flight turn for that channel, if any. |
 | `!rotate` | Rotates the ACP session for that channel. If a turn is in-flight, it is cancelled and the channel session is invalidated when the task returns; otherwise the cached idle session is invalidated immediately. The next queued/received event starts a fresh session. |
+| `/new` | For thread-session adapters, securely replaces only the addressed thread's durable context. Work waits behind a reset barrier until old-session disposal and the signed Buzz acknowledgement succeed. |
+| `/compact` | Requests compaction in adapters that implement it. For Pi this is owner-only and posts a lifecycle result in the same thread. |
+| `/reload` | Reloads adapter resources. For Pi this is owner-only and re-evaluates project trust before loading extensions. |
+| `/context` | Reports current context usage and compaction threshold when supported. |
 
 Use `!cancel` to stop only the current turn; it is a no-op when the channel is idle. Use `!rotate` when you want the next turn in the channel to start from a fresh ACP session, even if the channel is currently idle.
 
-Owner control commands must be kind:9 stream messages from the owner, must mention this agent with a `p` tag, and are consumed by the harness instead of being forwarded to the agent.
+Harness control commands must be kind:9 stream messages that mention this agent
+with a `p` tag. Destructive controls are owner-only and consumed by the harness;
+unaddressed or non-owner `/new`, `/compact`, and `/reload` shapes are also
+reserved and dropped before adapter dispatch, including in subscribe-all and
+no-mention modes. `/context` is a read-only adapter command. `/new` is scoped by
+a validated NIP-10 thread root rather than resetting every conversation in the
+channel.
 
 > **Note:** The default mode is `owner-only`. Agents without a registered `agent_owner_pubkey` will not respond to any events until the owner is resolved. Set `--respond-to anyone` to disable the gate entirely.
 
@@ -203,7 +290,7 @@ buzz-acp --agents 2 --heartbeat-interval 300 \
 
 ### Shared Identity
 
-All N agents authenticate as the **same Nostr bot identity** — users see one bot regardless of how many agents are running. The same channel is never processed by two agents simultaneously (the queue enforces this). Cross-channel message ordering is not guaranteed when N>1.
+All N agents authenticate as the **same Nostr bot identity** — users see one bot regardless of how many agents are running. The same logical conversation is never processed by two agents simultaneously (the queue enforces this); sibling threads in one channel may run concurrently. Cross-conversation message ordering is not guaranteed when N>1.
 
 ### Heartbeat Semantics
 
@@ -252,14 +339,22 @@ Forum event kinds:
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
-4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
+3. **Event loop** — Listens for accepted events and resolves a strict conversation key: channel plus validated NIP-10 root, or a definite DM participant scope.
+4. **Prompting** — When events are pending and no prompt is in flight for that conversation, drains its queued events into one batched ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
-Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
+Each conversation has at most one prompt in flight. Sibling threads and separate
+DM conversations can run concurrently when `agents > 1`. Capable adapters
+receive stable conversation metadata and can resume durable context after hot
+LRU/TTL eviction or process restart; legacy adapters retain channel-scoped
+compatibility behavior.
 
-> **Note:** On startup, the harness replays all unprocessed @mentions since the last run. Expect a burst of activity if there are stale events in the channel.
+> **Note:** The harness uses an in-memory startup/reconnect watermark, not a
+> durable cursor persisted across process restarts. It can recover events around
+> an active connection boundary, but does not promise replay of every historical
+> unprocessed mention after a cold restart. Pi's durable `/new` safety uses an
+> adapter tombstone and does not depend on relay replay.
 
 ## Bring Your Own Harness (BYOH)
 
@@ -269,7 +364,7 @@ Buzz Desktop supports registering any ACP-speaking agent tool as a selectable ru
 
 **Tier-1 — compiled-in runtimes** (Goose, Claude Code, Codex, Buzz Agent): have auto-installers, auth probes, and first-class onboarding. Their IDs (`goose`, `claude`, `codex`, `buzz-agent`) are reserved and cannot be overridden.
 
-**Tier-2 — preset catalog** (Cursor, Oh My Pi, Grok Build, OpenCode, Kimi Code, Amp, Hermes Agent, OpenClaw): static `HarnessDefinition` entries in `desktop/src-tauri/src/managed_agents/discovery.rs` (`PRESET_HARNESSES`). They are always present in the runtime catalog, PATH-probed for availability, not editable or deletable by the user. Displayed with bundled logos; if not installed, a docs link appears instead.
+**Tier-2 — preset catalog** (Devin, Cursor, Oh My Pi, Grok Build, OpenCode, Kimi Code, Amp, Pi, Hermes Agent, OpenClaw): static entries in `desktop/src-tauri/src/managed_agents/discovery/presets.rs` (`PRESET_HARNESSES`). They are always present in the runtime catalog, PATH-probed for availability, not editable or deletable by the user. Displayed with bundled logos; if not installed, a docs link appears instead.
 
 > **Note — OpenClaw:** `openclaw acp` is a Gateway-backed bridge; PATH availability shows "Available" even when the OpenClaw Gateway daemon is not running. This is expected tier-2 semantics (same class as a preset with unconfigured auth). The Gateway URL is configured via `OPENCLAW_GATEWAY_URL` (or the equivalent env var from OpenClaw's docs) — set it in the agent's **env vars** in Edit Agent, not in the definition env (the preset definition carries no env entries). Note that `openclaw acp` executes tools inside the Gateway daemon, not the Desktop process, so Desktop-injected `BUZZ_*` env vars do NOT reach the execution locus unless you also set them on the Gateway's own environment.
 
@@ -313,12 +408,11 @@ Invalid files (bad JSON, unknown id, empty command) are skipped with a warning a
 To add a new runtime to the tier-2 gallery:
 
 1. **Verify the ACP entrypoint** from the vendor's own documentation — do not rely on a PR description alone. Test with the actual binary.
-2. **Add a `HarnessDefinition` entry** to the `PRESET_HARNESSES` slice in `desktop/src-tauri/src/managed_agents/discovery.rs`. Fill `id`, `label`, `command`, `args`, `install_instructions_url`, `install_hint`. Leave `env` empty unless the harness requires a specific env var to enable ACP mode.
-3. **Add the preset id to `BUILTIN_IDS`** in `desktop/src-tauri/src/managed_agents/custom_harnesses.rs` so custom JSON files cannot shadow it.
-4. **Add a bundled logo** (64×64 PNG or optimised SVG) to `desktop/public/harness-logos/<id>.png` and add a corresponding entry to `PRESET_LOGOS` in `desktop/src/features/onboarding/ui/RuntimeIcon.tsx`. Record the source and license in `desktop/public/harness-logos/CREDITS.md`. Only bundle a mark whose upstream license permits redistribution; skipping this step is caught by `presetLogos.test.mjs`, which asserts every `PRESET_HARNESSES` id has a mapped logo that exists on disk.
-5. Run `cargo test --lib` and `just desktop-typecheck` to verify everything compiles.
+2. **Add a `PresetHarness` entry** to the `PRESET_HARNESSES` slice in `desktop/src-tauri/src/managed_agents/discovery/presets.rs`. Fill `id`, `label`, `command`, `args`, `install_instructions_url`, `install_hint`, and `underlying_cli`. Preset IDs are automatically reserved against custom definitions from this slice.
+3. **Add a bundled logo** (64×64 PNG or optimised SVG) to `desktop/public/harness-logos/<id>.png` and add a corresponding entry to `PRESET_LOGOS` in `desktop/src/features/onboarding/ui/RuntimeIcon.tsx`. Record the source and license in `desktop/public/harness-logos/CREDITS.md`. Only bundle a mark whose upstream license permits redistribution; skipping this step is caught by `presetLogos.test.mjs`, which asserts every `PRESET_HARNESSES` id has a mapped logo that exists on disk.
+4. Run `cargo test --lib` and `just desktop-typecheck` to verify everything compiles.
 
-The built-in `BUILTIN_IDS` set (`goose`, `claude`, `codex`, `buzz-agent`, and all current preset ids) is the reserved namespace; every other id is available for custom harnesses.
+The compiled-in tier-1 IDs (`goose`, `claude`, `codex`, `buzz-agent`) plus every ID derived from `PRESET_HARNESSES` form the reserved namespace; every other id is available for custom harnesses.
 
 ## Using Any ACP Agent
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -8,6 +8,8 @@
 //! 4. [`AcpClient::session_prompt_with_idle_timeout`] — send prompt with idle/hard deadline, return stop reason
 //! 5. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
 
+use std::collections::{HashMap, HashSet, VecDeque};
+
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
@@ -19,6 +21,377 @@ use crate::usage::{TurnUsage, UsageTracker};
 /// Maximum allowed size of a single NDJSON line from the agent's stdout.
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
+/// Adapter lifecycle events are small status records, never transcripts. Keep
+/// them far below the general ACP line cap so a noisy/malicious extension
+/// cannot retain tens or hundreds of megabytes in the bounded event queue.
+const MAX_BUZZ_SESSION_EVENT_BYTES: usize = 64 * 1024;
+
+/// Maximum number of adapter lifecycle events retained until the pool drains
+/// them at turn completion. This prevents a buggy or hostile adapter from
+/// growing the harness indefinitely while preserving more than enough room for
+/// the handful of compaction/context events a normal turn emits.
+const MAX_PENDING_SESSION_EVENTS: usize = 64;
+const MAX_SEEN_SESSION_EVENT_IDS: usize = 512;
+
+/// Best-effort lifecycle RPCs must not stall a user turn if an adapter accepts
+/// the request but never replies.
+const SESSION_DISPOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Buzz-specific ACP notification emitted by adapters that have meaningful
+/// session lifecycle state to surface back into the originating Buzz thread.
+pub(crate) const BUZZ_SESSION_EVENT_METHOD: &str = "_buzz/session/event";
+pub(crate) const BUZZ_SESSION_EVENT_SCHEMA_VERSION: u32 = 2;
+const BUZZ_SESSION_EVENT_ACK_METHOD: &str = "_buzz/session/event_ack";
+const MAX_PENDING_SESSION_EVENT_ACKS: usize = 256;
+
+/// Explicit result of Buzz's idempotent durable conversation-reset RPC.
+/// `AlreadyCommitted` is intentionally distinct: a freshly received command
+/// may only advance the harness queue on `NewlyCommitted`, while crash recovery
+/// may accept either result for its already-persisted prepared intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConversationResetCommit {
+    NewlyCommitted,
+    AlreadyCommitted,
+}
+
+/// Wire envelope for [`BUZZ_SESSION_EVENT_METHOD`]. The ACP session id lets the
+/// pool reject late notifications from a session invalidated by `/new`.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BuzzSessionEventNotification {
+    #[serde(rename = "schemaVersion")]
+    pub(crate) schema_version: u32,
+    pub(crate) session_id: String,
+    pub(crate) conversation_id: String,
+    pub(crate) event_id: String,
+    pub(crate) event: BuzzSessionEvent,
+}
+
+/// Durable adapter lifecycle record that may be acknowledged only after the
+/// equivalent signed Buzz notice has entered the harness outbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BuzzSessionEventAck {
+    pub(crate) conversation_id: String,
+    pub(crate) event_id: String,
+}
+
+/// User-visible session lifecycle events emitted by the Pi adapter.
+///
+/// The adapter includes a ready-to-display `message` for local diagnostics,
+/// but the Buzz harness renders notices from the typed numeric fields instead
+/// of blindly publishing adapter-provided text.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum BuzzSessionEvent {
+    CompactionCompleted {
+        #[serde(rename = "compactionId")]
+        compaction_id: String,
+        timestamp: String,
+        message: String,
+        #[serde(rename = "piSessionId")]
+        pi_session_id: String,
+        reason: CompactionReason,
+        #[serde(rename = "beforeTokens")]
+        before_tokens: Option<u64>,
+        #[serde(rename = "afterTokens")]
+        after_tokens: Option<u64>,
+        #[serde(rename = "limitTokens")]
+        limit_tokens: u64,
+        #[serde(rename = "effectiveLimitTokens")]
+        effective_limit_tokens: u64,
+        #[serde(rename = "compactionThresholdTokens")]
+        compaction_threshold_tokens: u64,
+        #[serde(rename = "willRetry")]
+        will_retry: bool,
+        #[serde(rename = "fromExtension")]
+        from_extension: bool,
+    },
+    CompactionFailed {
+        #[serde(rename = "compactionId")]
+        compaction_id: String,
+        timestamp: String,
+        message: String,
+        #[serde(rename = "piSessionId")]
+        pi_session_id: String,
+        reason: CompactionReason,
+        #[serde(rename = "beforeTokens")]
+        before_tokens: Option<u64>,
+        #[serde(rename = "limitTokens")]
+        limit_tokens: u64,
+        #[serde(rename = "effectiveLimitTokens")]
+        effective_limit_tokens: u64,
+        #[serde(rename = "compactionThresholdTokens")]
+        compaction_threshold_tokens: u64,
+        error: String,
+        aborted: bool,
+        #[serde(rename = "willRetry")]
+        will_retry: bool,
+        #[serde(rename = "fromExtension")]
+        from_extension: bool,
+    },
+    ContextStatus {
+        timestamp: String,
+        message: String,
+        #[serde(rename = "piSessionId")]
+        pi_session_id: String,
+        #[serde(rename = "usedTokens")]
+        used_tokens: Option<u64>,
+        #[serde(rename = "remainingTokens")]
+        remaining_tokens: Option<u64>,
+        percent: Option<f64>,
+        #[serde(rename = "limitTokens")]
+        limit_tokens: u64,
+        #[serde(rename = "effectiveLimitTokens")]
+        effective_limit_tokens: u64,
+        #[serde(rename = "compactionThresholdTokens")]
+        compaction_threshold_tokens: u64,
+        #[serde(rename = "autoCompaction")]
+        auto_compaction: bool,
+        compacting: bool,
+        model: Option<String>,
+    },
+    SessionReset {
+        timestamp: String,
+        message: String,
+        #[serde(rename = "previousPiSessionId")]
+        previous_pi_session_id: String,
+        #[serde(rename = "piSessionId")]
+        pi_session_id: String,
+        #[serde(rename = "limitTokens")]
+        limit_tokens: u64,
+        #[serde(rename = "effectiveLimitTokens")]
+        effective_limit_tokens: u64,
+        #[serde(rename = "compactionThresholdTokens")]
+        compaction_threshold_tokens: u64,
+    },
+    ExtensionsReloaded {
+        timestamp: String,
+        message: String,
+        #[serde(rename = "piSessionId")]
+        pi_session_id: String,
+        extensions: u64,
+        skills: u64,
+        prompts: u64,
+        #[serde(rename = "contextFiles")]
+        context_files: u64,
+        errors: Vec<String>,
+        #[serde(rename = "projectTrusted")]
+        project_trusted: bool,
+    },
+}
+
+/// Why Pi compacted (or attempted to compact) a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CompactionReason {
+    Manual,
+    Threshold,
+    Overflow,
+    Preflight,
+}
+
+impl BuzzSessionEvent {
+    pub(crate) fn compaction_id(&self) -> Option<&str> {
+        match self {
+            Self::CompactionCompleted { compaction_id, .. }
+            | Self::CompactionFailed { compaction_id, .. } => Some(compaction_id),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::CompactionCompleted { .. } => "compaction_completed",
+            Self::CompactionFailed { .. } => "compaction_failed",
+            Self::ContextStatus { .. } => "context_status",
+            Self::SessionReset { .. } => "session_reset",
+            Self::ExtensionsReloaded { .. } => "extensions_reloaded",
+        }
+    }
+
+    pub(crate) fn pi_session_id(&self) -> &str {
+        match self {
+            Self::CompactionCompleted { pi_session_id, .. }
+            | Self::CompactionFailed { pi_session_id, .. }
+            | Self::ContextStatus { pi_session_id, .. }
+            | Self::SessionReset { pi_session_id, .. }
+            | Self::ExtensionsReloaded { pi_session_id, .. } => pi_session_id,
+        }
+    }
+
+    fn validate(&self) -> std::result::Result<(), &'static str> {
+        const MAX_CONTEXT_TOKENS: u64 = 10_000_000_000;
+        const MAX_RESOURCE_COUNT: u64 = 1_000_000;
+
+        let (timestamp, message, pi_session_id) = match self {
+            Self::CompactionCompleted {
+                timestamp,
+                message,
+                pi_session_id,
+                ..
+            }
+            | Self::CompactionFailed {
+                timestamp,
+                message,
+                pi_session_id,
+                ..
+            }
+            | Self::ContextStatus {
+                timestamp,
+                message,
+                pi_session_id,
+                ..
+            }
+            | Self::SessionReset {
+                timestamp,
+                message,
+                pi_session_id,
+                ..
+            }
+            | Self::ExtensionsReloaded {
+                timestamp,
+                message,
+                pi_session_id,
+                ..
+            } => (timestamp, message, pi_session_id),
+        };
+        if timestamp.len() > 64 || chrono::DateTime::parse_from_rfc3339(timestamp).is_err() {
+            return Err("invalid timestamp");
+        }
+        if message.len() > 4_096 {
+            return Err("message too long");
+        }
+        if pi_session_id.is_empty() || pi_session_id.len() > 256 {
+            return Err("invalid Pi session id");
+        }
+
+        let validate_limits = |limit: u64, effective: u64, threshold: u64| {
+            if limit == 0
+                || limit > MAX_CONTEXT_TOKENS
+                || effective == 0
+                || effective > limit
+                || threshold == 0
+                || threshold > effective
+            {
+                Err("invalid context limits")
+            } else {
+                Ok(())
+            }
+        };
+        let validate_optional_tokens = |tokens: Option<u64>| {
+            if tokens.is_some_and(|value| value > MAX_CONTEXT_TOKENS) {
+                Err("invalid token count")
+            } else {
+                Ok(())
+            }
+        };
+
+        match self {
+            Self::CompactionCompleted {
+                compaction_id,
+                before_tokens,
+                after_tokens,
+                limit_tokens,
+                effective_limit_tokens,
+                compaction_threshold_tokens,
+                ..
+            } => {
+                uuid::Uuid::parse_str(compaction_id).map_err(|_| "invalid compaction id")?;
+                validate_limits(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )?;
+                validate_optional_tokens(*before_tokens)?;
+                validate_optional_tokens(*after_tokens)
+            }
+            Self::CompactionFailed {
+                compaction_id,
+                before_tokens,
+                limit_tokens,
+                effective_limit_tokens,
+                compaction_threshold_tokens,
+                error,
+                ..
+            } => {
+                uuid::Uuid::parse_str(compaction_id).map_err(|_| "invalid compaction id")?;
+                validate_limits(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )?;
+                validate_optional_tokens(*before_tokens)?;
+                if error.len() > 4_096 {
+                    return Err("error too long");
+                }
+                Ok(())
+            }
+            Self::ContextStatus {
+                used_tokens,
+                remaining_tokens,
+                percent,
+                limit_tokens,
+                effective_limit_tokens,
+                compaction_threshold_tokens,
+                model,
+                ..
+            } => {
+                validate_limits(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )?;
+                validate_optional_tokens(*used_tokens)?;
+                validate_optional_tokens(*remaining_tokens)?;
+                if percent
+                    .is_some_and(|value| !value.is_finite() || !(0.0..=10_000.0).contains(&value))
+                {
+                    return Err("invalid percentage");
+                }
+                if model.as_ref().is_some_and(|value| value.len() > 256) {
+                    return Err("model id too long");
+                }
+                Ok(())
+            }
+            Self::SessionReset {
+                previous_pi_session_id,
+                limit_tokens,
+                effective_limit_tokens,
+                compaction_threshold_tokens,
+                ..
+            } => {
+                validate_limits(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )?;
+                if previous_pi_session_id.is_empty() || previous_pi_session_id.len() > 256 {
+                    return Err("invalid previous Pi session id");
+                }
+                Ok(())
+            }
+            Self::ExtensionsReloaded {
+                extensions,
+                skills,
+                prompts,
+                context_files,
+                errors,
+                ..
+            } => {
+                if [*extensions, *skills, *prompts, *context_files]
+                    .into_iter()
+                    .any(|count| count > MAX_RESOURCE_COUNT)
+                {
+                    return Err("invalid resource count");
+                }
+                if errors.len() > 64 || errors.iter().any(|error| error.len() > 2_000) {
+                    return Err("invalid resource diagnostics");
+                }
+                Ok(())
+            }
+        }
+    }
+}
 
 /// An MCP server configuration passed to `session/new`.
 ///
@@ -187,6 +560,10 @@ pub struct AcpClient {
     /// Other agents may leave this unset — readers must treat `None` as
     /// "no active run to steer into" and fall back to cancel+merge.
     active_run_id: Option<String>,
+    /// Capability cache for Buzz's optional session-dispose extension.
+    /// `Some(false)` suppresses future probes after a standards-compliant
+    /// method-not-found response; timeouts remain retryable.
+    buzz_session_dispose_supported: Option<bool>,
     /// Whether the agent advertised `_meta.steering.supported: true` in its
     /// `initialize` response, meaning it implements the cross-adapter
     /// [`ACP_STEER_METHOD`] extension.
@@ -198,6 +575,15 @@ pub struct AcpClient {
     /// a JSON-RPC *success*, not `-32601` — which the main loop would read as
     /// a delivered steer and drop the user's message from the queue.
     steering_supported: bool,
+    /// Whether the adapter explicitly opts into Buzz's thread-scoped session
+    /// lifecycle contract (persistent conversation identity + bounded
+    /// disposal). Legacy adapters stay channel-scoped to avoid leaking an
+    /// unbounded number of inner sessions they cannot release.
+    thread_sessions_supported: bool,
+    conversation_reset_supported: bool,
+    /// The adapter persists lifecycle records before notification, replays
+    /// them after process death, and removes them only after an explicit ACK.
+    durable_session_events_supported: bool,
     /// Per-turn channel for receiving goose-native non-cancelling steer
     /// requests from the main loop. Installed by
     /// [`install_steer_rx`](Self::install_steer_rx) at dispatch and
@@ -211,6 +597,23 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Bounded FIFO of adapter lifecycle events waiting for the pool to attach
+    /// them to the exact Buzz conversation that owns this ACP session.
+    buzz_session_events: VecDeque<BuzzSessionEventNotification>,
+    /// Bounded compaction-event deduplication. IDs are supplied by the adapter
+    /// and shared by retransmissions of the same lifecycle transition.
+    seen_session_event_ids: HashSet<String>,
+    seen_session_event_id_order: VecDeque<String>,
+    /// ACKs are queued synchronously when the Buzz outbox commit succeeds and
+    /// flushed before the next prompt (or during orderly shutdown). Keeping
+    /// them here avoids blocking the relay loop on an adapter round trip.
+    pending_session_event_acks: VecDeque<BuzzSessionEventAck>,
+    pending_session_event_ack_ids: HashSet<String>,
+    /// Current durable Pi generation attached to each ACP session. Lifecycle
+    /// replay is accepted only when both the outer ACP envelope and this inner
+    /// Pi identity match, so a late pre-`/new` writer cannot leak into the
+    /// replacement conversation.
+    pi_session_ids: HashMap<String, String>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -417,6 +820,9 @@ impl AcpClient {
     /// Call this when you need guaranteed cleanup — e.g., in `run_models`
     /// before process exit.
     pub async fn shutdown(&mut self) {
+        if !self.pending_session_event_acks.is_empty() {
+            self.flush_buzz_session_event_acks().await;
+        }
         // Kill the entire process group when possible. The child was spawned
         // with process_group(0), so its PID == its PGID. Killing the group
         // ensures subprocesses (MCP servers, tool processes) are cleaned up
@@ -547,9 +953,19 @@ impl AcpClient {
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
             active_run_id: None,
+            buzz_session_dispose_supported: None,
             steering_supported: false,
+            thread_sessions_supported: false,
+            conversation_reset_supported: false,
+            durable_session_events_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            buzz_session_events: VecDeque::new(),
+            seen_session_event_ids: HashSet::new(),
+            seen_session_event_id_order: VecDeque::new(),
+            pending_session_event_acks: VecDeque::new(),
+            pending_session_event_ack_ids: HashSet::new(),
+            pi_session_ids: HashMap::new(),
         })
     }
 
@@ -562,6 +978,19 @@ impl AcpClient {
     /// Update metadata that will be attached to subsequent raw wire events.
     pub fn set_observer_context(&mut self, context: ObserverContext) {
         self.observer_context = context;
+    }
+
+    /// ACP session currently attached to this process's in-flight turn.
+    ///
+    /// Lifecycle notifications are accepted only when their envelope matches
+    /// this value, preventing a late event from an invalidated `/new` session
+    /// from being surfaced in the replacement conversation.
+    pub(crate) fn current_turn_session_id(&self) -> Option<&str> {
+        self.observer_context.session_id.as_deref()
+    }
+
+    pub(crate) fn pi_session_id_for(&self, session_id: &str) -> Option<&str> {
+        self.pi_session_ids.get(session_id).map(String::as_str)
     }
 
     /// Return a clone of the observer handle, if attached.
@@ -604,6 +1033,31 @@ impl AcpClient {
             .pointer("/_meta/steering/supported")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        self.thread_sessions_supported = result
+            .pointer("/_meta/buzz/threadSessions/supported")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        self.conversation_reset_supported = result
+            .pointer("/_meta/buzz/threadSessions/resetCommit")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        self.durable_session_events_supported = result
+            .pointer("/_meta/buzz/sessionEvents")
+            .is_some_and(|capability| {
+                capability
+                    .get("supported")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true)
+                    && capability
+                        .get("schemaVersion")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(u64::from(BUZZ_SESSION_EVENT_SCHEMA_VERSION))
+                    && capability
+                        .get("durableReplay")
+                        .and_then(serde_json::Value::as_bool)
+                        == Some(true)
+                    && capability.get("ack").and_then(serde_json::Value::as_bool) == Some(true)
+            });
         tracing::debug!(target: "acp::init", "initialize response: {result}");
         Ok(result)
     }
@@ -642,6 +1096,34 @@ impl AcpClient {
         system_prompt: Option<SystemPromptTransport<'_>>,
         session_title: Option<&str>,
     ) -> Result<SessionNewResponse, AcpError> {
+        self.session_new_full_for_conversation(
+            cwd,
+            mcp_servers,
+            system_prompt,
+            session_title,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// Send `session/new` with Buzz's stable logical conversation identity.
+    ///
+    /// Adapters that understand `_meta.buzz.conversationId` can resume their
+    /// persisted SDK session after harness restarts or outer-cache eviction.
+    /// A unique `_meta.buzz.resetToken` marks `/new`; adapters atomically
+    /// replace the logical mapping when that token changes. Other ACP agents
+    /// ignore the metadata. The identifier is opaque to the adapter and
+    /// deliberately excludes the in-process race-prevention epoch.
+    pub async fn session_new_full_for_conversation(
+        &mut self,
+        cwd: &str,
+        mcp_servers: Vec<McpServer>,
+        system_prompt: Option<SystemPromptTransport<'_>>,
+        session_title: Option<&str>,
+        conversation_id: Option<&str>,
+        reset_token: Option<&str>,
+    ) -> Result<SessionNewResponse, AcpError> {
         let mut params = serde_json::json!({
             "cwd": cwd,
             "mcpServers": mcp_servers,
@@ -660,16 +1142,156 @@ impl AcpClient {
             // Merge — _meta may already carry systemPrompt from ClaudeMeta above.
             params["_meta"]["sessionTitle"] = serde_json::Value::String(title.to_owned());
         }
+        if conversation_id.is_some() || reset_token.is_some() {
+            let mut buzz = serde_json::Map::new();
+            if let Some(conversation_id) = conversation_id {
+                buzz.insert(
+                    "conversationId".to_string(),
+                    serde_json::Value::String(conversation_id.to_owned()),
+                );
+            }
+            if let Some(reset_token) = reset_token {
+                buzz.insert(
+                    "resetToken".to_string(),
+                    serde_json::Value::String(reset_token.to_owned()),
+                );
+            }
+            // Merge — _meta may already carry a Claude system prompt and a title.
+            params["_meta"]["buzz"] = serde_json::Value::Object(buzz);
+        }
         let result = self.send_request("session/new", params).await?;
         let session_id = result["sessionId"]
             .as_str()
             .ok_or_else(|| AcpError::Protocol("session/new response missing sessionId".into()))?
             .to_owned();
+        if let Some(pi_session_id) = result
+            .pointer("/_meta/buzz/piSessionId")
+            .and_then(serde_json::Value::as_str)
+        {
+            if pi_session_id.is_empty() || pi_session_id.len() > 256 {
+                return Err(AcpError::Protocol(
+                    "session/new response has invalid _meta.buzz.piSessionId".into(),
+                ));
+            }
+            self.pi_session_ids
+                .insert(session_id.clone(), pi_session_id.to_owned());
+        }
         tracing::info!(target: "acp::session", "session created: {session_id}");
         Ok(SessionNewResponse {
             session_id,
             raw: result,
         })
+    }
+
+    /// Best-effort Buzz extension for releasing an adapter-owned SDK session.
+    ///
+    /// `forget=false` closes in-memory resources while preserving the adapter's
+    /// persisted conversation mapping, so a later `session/new` can resume it.
+    /// `forget=true` is `/new`: the mapping must be removed before disposal so
+    /// the next session is guaranteed to start with an empty context.
+    /// Returns `Ok(false)` when the adapter explicitly does not implement the
+    /// extension; callers may safely continue in either case.
+    pub async fn session_dispose(
+        &mut self,
+        session_id: &str,
+        forget: bool,
+    ) -> Result<bool, AcpError> {
+        if self.buzz_session_dispose_supported == Some(false) {
+            return Ok(false);
+        }
+
+        let result = tokio::time::timeout(
+            SESSION_DISPOSE_TIMEOUT,
+            self.send_request(
+                "_buzz/session/dispose",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "forget": forget,
+                }),
+            ),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(response))
+                if response
+                    .get("disposed")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true)
+                    && (!forget
+                        || response
+                            .get("forgotten")
+                            .and_then(serde_json::Value::as_bool)
+                            == Some(true)) =>
+            {
+                self.buzz_session_dispose_supported = Some(true);
+                self.pi_session_ids.remove(session_id);
+                Ok(true)
+            }
+            Ok(Ok(_)) => Err(AcpError::Protocol(
+                "_buzz/session/dispose did not confirm the requested disposal".into(),
+            )),
+            Ok(Err(AcpError::AgentError { code: -32601, .. })) => {
+                self.buzz_session_dispose_supported = Some(false);
+                Ok(false)
+            }
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(AcpError::Timeout(SESSION_DISPOSE_TIMEOUT)),
+        }
+    }
+
+    /// Durably commit an authenticated Buzz conversation reset before the
+    /// harness acknowledges `/new`. Unlike session disposal, this operation is
+    /// keyed by the stable logical conversation and works after its hot ACP
+    /// handle was already evicted. The signed command event ID is an
+    /// idempotency token.
+    pub async fn conversation_reset(
+        &mut self,
+        conversation_id: &str,
+        reset_token: &str,
+    ) -> Result<Option<ConversationResetCommit>, AcpError> {
+        if !self.conversation_reset_supported {
+            return Ok(None);
+        }
+        let result = tokio::time::timeout(
+            SESSION_DISPOSE_TIMEOUT,
+            self.send_request(
+                "_buzz/conversation/reset",
+                serde_json::json!({
+                    "conversationId": conversation_id,
+                    "resetToken": reset_token,
+                }),
+            ),
+        )
+        .await;
+        match result {
+            Ok(Ok(response))
+                if response
+                    .get("committed")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true) =>
+            {
+                match response
+                    .get("alreadyCommitted")
+                    .and_then(serde_json::Value::as_bool)
+                {
+                    Some(true) => Ok(Some(ConversationResetCommit::AlreadyCommitted)),
+                    Some(false) => Ok(Some(ConversationResetCommit::NewlyCommitted)),
+                    None => Err(AcpError::Protocol(
+                        "_buzz/conversation/reset omitted alreadyCommitted".into(),
+                    )),
+                }
+            }
+            Ok(Ok(_)) => Err(AcpError::Protocol(
+                "_buzz/conversation/reset did not confirm a durable commit".into(),
+            )),
+            Ok(Err(AcpError::AgentError { code: -32601, .. })) => {
+                self.conversation_reset_supported = false;
+                Ok(None)
+            }
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err(AcpError::Timeout(SESSION_DISPOSE_TIMEOUT)),
+        }
     }
 
     /// Send `session/new` and return only the `sessionId` string.
@@ -768,6 +1390,9 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        if !self.pending_session_event_acks.is_empty() {
+            self.flush_buzz_session_event_acks().await;
+        }
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -867,6 +1492,87 @@ impl AcpClient {
         self.steering_supported
     }
 
+    /// Whether this adapter opted into Buzz's thread-session lifecycle
+    /// extension during `initialize`.
+    pub fn thread_sessions_supported(&self) -> bool {
+        self.thread_sessions_supported
+    }
+
+    pub fn conversation_reset_supported(&self) -> bool {
+        self.conversation_reset_supported
+    }
+
+    pub fn durable_session_events_supported(&self) -> bool {
+        self.durable_session_events_supported
+    }
+
+    /// Queue a durable lifecycle ACK after the corresponding signed Buzz event
+    /// has been persisted. Duplicate adapter replay is harmless and bounded.
+    pub(crate) fn queue_buzz_session_event_ack(&mut self, ack: BuzzSessionEventAck) {
+        if !self.durable_session_events_supported
+            || self.pending_session_event_ack_ids.contains(&ack.event_id)
+        {
+            return;
+        }
+        if self.pending_session_event_acks.len() >= MAX_PENDING_SESSION_EVENT_ACKS {
+            tracing::error!(
+                max_pending = MAX_PENDING_SESSION_EVENT_ACKS,
+                "durable lifecycle ACK queue is full; leaving adapter record unacknowledged for replay"
+            );
+            return;
+        }
+        self.pending_session_event_ack_ids
+            .insert(ack.event_id.clone());
+        self.pending_session_event_acks.push_back(ack);
+    }
+
+    /// Flush queued ACKs outside an active prompt. The adapter confirms only
+    /// after atomically deleting its durable record. Any failure leaves the
+    /// record queued and therefore replayable after this process dies.
+    pub(crate) async fn flush_buzz_session_event_acks(&mut self) {
+        if !self.durable_session_events_supported {
+            return;
+        }
+        while let Some(ack) = self.pending_session_event_acks.front().cloned() {
+            let request = self.send_request(
+                BUZZ_SESSION_EVENT_ACK_METHOD,
+                serde_json::json!({
+                    "conversationId": ack.conversation_id,
+                    "eventId": ack.event_id,
+                }),
+            );
+            let acknowledged = match tokio::time::timeout(SESSION_DISPOSE_TIMEOUT, request).await {
+                Ok(Ok(response)) => {
+                    response
+                        .get("acknowledged")
+                        .and_then(serde_json::Value::as_bool)
+                        == Some(true)
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        event_id = %ack.event_id,
+                        %error,
+                        "durable lifecycle ACK failed; adapter will replay it"
+                    );
+                    false
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        event_id = %ack.event_id,
+                        "durable lifecycle ACK timed out; adapter will replay it"
+                    );
+                    false
+                }
+            };
+            if !acknowledged {
+                break;
+            }
+            let removed = self.pending_session_event_acks.pop_front();
+            debug_assert_eq!(removed.as_ref(), Some(&ack));
+            self.pending_session_event_ack_ids.remove(&ack.event_id);
+        }
+    }
+
     /// Consume and return the per-turn usage record computed from the most
     /// recent `_goose/unstable/session/update` notification.
     ///
@@ -879,6 +1585,16 @@ impl AcpClient {
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
         self.goose_usage.take()
+    }
+
+    /// Drain adapter session lifecycle events observed since the previous call.
+    ///
+    /// The pool must still verify `session_id` against its current session and
+    /// generation before publishing a notice. Draining here ensures events are
+    /// associated with exactly one completed turn and cannot leak into a later
+    /// conversation when this subprocess is reused.
+    pub(crate) fn take_buzz_session_events(&mut self) -> Vec<BuzzSessionEventNotification> {
+        self.buzz_session_events.drain(..).collect()
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1236,6 +1952,9 @@ impl AcpClient {
                     }
                     "_goose/unstable/session/update" => {
                         self.handle_goose_usage_update(&msg);
+                    }
+                    BUZZ_SESSION_EVENT_METHOD => {
+                        self.handle_buzz_session_event(&msg)?;
                     }
                     "session/request_permission" => {
                         self.handle_permission_request(&msg).await?;
@@ -1681,6 +2400,9 @@ impl AcpClient {
                             "_goose/unstable/session/update" => {
                                 self.handle_goose_usage_update(&msg);
                             }
+                            BUZZ_SESSION_EVENT_METHOD => {
+                                self.handle_buzz_session_event(&msg)?;
+                            }
                             "session/request_permission" => {
                                 self.handle_permission_request(&msg).await?;
                             }
@@ -1867,6 +2589,155 @@ impl AcpClient {
                     "_goose/unstable/session/update: deserialization error: {e}"
                 );
             }
+        }
+    }
+
+    /// Parse and retain a Buzz adapter lifecycle notification.
+    ///
+    /// Older adapters treated these notifications as optional observability,
+    /// so malformed records and bounded-queue overflow remain best-effort for
+    /// adapters that did not negotiate durable session events. Once an adapter
+    /// advertises the durable v2 contract, however, every record remains in its
+    /// own outbox until Buzz ACKs it. Silently dropping or ignoring one would
+    /// strand that record for the lifetime of this ACP process. Durable-mode
+    /// validation and backpressure therefore fail the transport closed, forcing
+    /// a fresh adapter process to replay the exact event ID.
+    fn handle_buzz_session_event(&mut self, msg: &serde_json::Value) -> Result<(), AcpError> {
+        let Some(params) = msg.get("params") else {
+            tracing::debug!(
+                target: "acp::session_event",
+                "{BUZZ_SESSION_EVENT_METHOD}: missing params"
+            );
+            return self.reject_invalid_buzz_session_event("missing params");
+        };
+
+        let serialized_size = serde_json::to_vec(params)
+            .map(|bytes| bytes.len())
+            .unwrap_or(usize::MAX);
+        if serialized_size > MAX_BUZZ_SESSION_EVENT_BYTES {
+            tracing::warn!(
+                target: "acp::session_event",
+                serialized_size,
+                max_bytes = MAX_BUZZ_SESSION_EVENT_BYTES,
+                "ignoring oversized adapter session event"
+            );
+            return self.reject_invalid_buzz_session_event(format!(
+                "payload exceeded {MAX_BUZZ_SESSION_EVENT_BYTES} bytes"
+            ));
+        }
+
+        match serde_json::from_value::<BuzzSessionEventNotification>(params.clone()) {
+            Ok(notification) => {
+                if notification.schema_version != BUZZ_SESSION_EVENT_SCHEMA_VERSION {
+                    tracing::debug!(
+                        target: "acp::session_event",
+                        schema_version = notification.schema_version,
+                        "ignoring unsupported adapter session-event schema"
+                    );
+                    return self.reject_invalid_buzz_session_event(format!(
+                        "unsupported schema version {}",
+                        notification.schema_version
+                    ));
+                }
+                if notification.session_id.is_empty() || notification.session_id.len() > 256 {
+                    tracing::debug!(
+                        target: "acp::session_event",
+                        "ignoring adapter session event with invalid ACP session id"
+                    );
+                    return self.reject_invalid_buzz_session_event("invalid ACP session id");
+                }
+                if notification.conversation_id.is_empty()
+                    || notification.conversation_id.len() > 1_024
+                    || uuid::Uuid::parse_str(&notification.event_id).is_err()
+                {
+                    tracing::debug!(
+                        target: "acp::session_event",
+                        "ignoring adapter session event with invalid durable identity"
+                    );
+                    return self.reject_invalid_buzz_session_event(
+                        "invalid durable conversation or event identity",
+                    );
+                }
+                if let Err(reason) = notification.event.validate() {
+                    tracing::debug!(
+                        target: "acp::session_event",
+                        event_kind = notification.event.kind(),
+                        reason,
+                        "ignoring invalid adapter session event"
+                    );
+                    return self.reject_invalid_buzz_session_event(format!(
+                        "invalid typed lifecycle event: {reason}"
+                    ));
+                }
+                if !self
+                    .seen_session_event_ids
+                    .insert(notification.event_id.clone())
+                {
+                    tracing::debug!(
+                        target: "acp::session_event",
+                        event_id = %notification.event_id,
+                        "ignoring duplicate durable adapter session event"
+                    );
+                    return Ok(());
+                }
+                if let Some(compaction_id) = notification.event.compaction_id() {
+                    if uuid::Uuid::parse_str(compaction_id).is_err() {
+                        // Event validation already checked this. Keep a
+                        // defensive branch so future event variants cannot
+                        // accidentally weaken durable dedupe identity.
+                        self.seen_session_event_ids.remove(&notification.event_id);
+                        return self
+                            .reject_invalid_buzz_session_event("invalid compaction identity");
+                    }
+                }
+                if self.buzz_session_events.len() == MAX_PENDING_SESSION_EVENTS {
+                    if self.durable_session_events_supported {
+                        self.seen_session_event_ids.remove(&notification.event_id);
+                        return Err(AcpError::Protocol(format!(
+                            "durable adapter session-event queue reached its {MAX_PENDING_SESSION_EVENTS}-record limit"
+                        )));
+                    }
+                    let _ = self.buzz_session_events.pop_front();
+                    tracing::warn!(
+                        target: "acp::session_event",
+                        max_pending = MAX_PENDING_SESSION_EVENTS,
+                        "adapter session-event queue full; dropped oldest event"
+                    );
+                }
+                self.seen_session_event_id_order
+                    .push_back(notification.event_id.clone());
+                if self.seen_session_event_id_order.len() > MAX_SEEN_SESSION_EVENT_IDS {
+                    if let Some(expired) = self.seen_session_event_id_order.pop_front() {
+                        self.seen_session_event_ids.remove(&expired);
+                    }
+                }
+                tracing::debug!(
+                    target: "acp::session_event",
+                    session_id = %notification.session_id,
+                    event_kind = notification.event.kind(),
+                    "adapter session event"
+                );
+                self.buzz_session_events.push_back(notification);
+                Ok(())
+            }
+            Err(error) => {
+                tracing::debug!(
+                    target: "acp::session_event",
+                    "{BUZZ_SESSION_EVENT_METHOD}: deserialization error: {error}"
+                );
+                self.reject_invalid_buzz_session_event(format!("deserialization failed: {error}"))
+            }
+        }
+    }
+
+    fn reject_invalid_buzz_session_event(&self, reason: impl Into<String>) -> Result<(), AcpError> {
+        let reason = reason.into();
+        if self.durable_session_events_supported {
+            Err(AcpError::Protocol(format!(
+                "durable adapter session event rejected: {reason}"
+            )))
+        } else {
+            Ok(())
         }
     }
 
@@ -2167,6 +3038,7 @@ pub fn resolve_model_switch_method(
 /// already-extracted `configOptions` (model category) and `models` state that
 /// [`AgentModelCapabilities`](crate::pool::AgentModelCapabilities) caches — the
 /// idle-path pre-cancel guard has those halves, not the full `session/new` JSON.
+#[cfg(test)]
 pub fn model_in_catalog(
     config_options: &[serde_json::Value],
     available_models: Option<&serde_json::Value>,
@@ -3435,6 +4307,145 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_new_sends_persistent_buzz_conversation_identity() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{}}}'
+            read -t 2 REQ
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"ses_test","_receivedRequest":'"$REQ"'}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let response = client
+            .session_new_full_for_conversation(
+                "/tmp",
+                vec![],
+                Some(SystemPromptTransport::ClaudeMeta("Be concise")),
+                Some("Fizz · #buzz-dev"),
+                Some("channel:abc:thread:def"),
+                Some("reset-event-123"),
+            )
+            .await
+            .expect("session_new should succeed");
+
+        let params = &response.raw["_receivedRequest"]["params"];
+        assert_eq!(params["_meta"]["systemPrompt"]["append"], "Be concise");
+        assert_eq!(params["_meta"]["sessionTitle"], "Fizz · #buzz-dev");
+        assert_eq!(
+            params["_meta"]["buzz"]["conversationId"],
+            "channel:abc:thread:def"
+        );
+        assert_eq!(params["_meta"]["buzz"]["resetToken"], "reset-event-123");
+    }
+
+    #[tokio::test]
+    async fn buzz_session_dispose_sends_forget_flag() {
+        let script = r#"
+            read -t 2 REQ
+            if [[ "$REQ" == *'"method":"_buzz/session/dispose"'* && "$REQ" == *'"sessionId":"session-to-forget"'* && "$REQ" == *'"forget":true'* ]]; then
+                echo '{"jsonrpc":"2.0","id":0,"result":{"disposed":true,"forgotten":true}}'
+            else
+                echo '{"jsonrpc":"2.0","id":0,"error":{"code":-32602,"message":"wrong dispose payload"}}'
+            fi
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        assert!(client
+            .session_dispose("session-to-forget", true)
+            .await
+            .expect("dispose should succeed"));
+        assert_eq!(client.buzz_session_dispose_supported, Some(true));
+    }
+
+    #[tokio::test]
+    async fn destructive_session_dispose_fails_closed_without_forgotten_confirmation() {
+        let script = r#"
+            read -t 2 _REQ
+            echo '{"jsonrpc":"2.0","id":0,"result":{"disposed":true,"forgotten":false}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        let result = client.session_dispose("session-not-forgotten", true).await;
+        assert!(matches!(result, Err(AcpError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn conversation_reset_sends_stable_identity_and_requires_explicit_commit() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"_meta":{"buzz":{"threadSessions":{"supported":true,"resetCommit":true}}}}}'
+            read -t 2 REQ
+            if [[ "$REQ" == *'"method":"_buzz/conversation/reset"'* && "$REQ" == *'"conversationId":"buzz:channel:thread"'* && "$REQ" == *'"resetToken":"signed-event-id"'* ]]; then
+                echo '{"jsonrpc":"2.0","id":1,"result":{"committed":true,"alreadyCommitted":false}}'
+            else
+                echo '{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"wrong reset payload"}}'
+            fi
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        assert_eq!(
+            client
+                .conversation_reset("buzz:channel:thread", "signed-event-id")
+                .await
+                .expect("explicitly committed reset should succeed"),
+            Some(ConversationResetCommit::NewlyCommitted)
+        );
+    }
+
+    #[tokio::test]
+    async fn conversation_reset_fails_closed_on_unconfirmed_success_payload() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"_meta":{"buzz":{"threadSessions":{"supported":true,"resetCommit":true}}}}}'
+            read -t 2 _REQ
+            echo '{"jsonrpc":"2.0","id":1,"result":{"committed":false}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        let result = client
+            .conversation_reset("buzz:channel:thread", "signed-event-id")
+            .await;
+        assert!(matches!(result, Err(AcpError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn unsupported_buzz_session_dispose_is_cached() {
+        let script = r#"
+            read -t 2 _REQ
+            echo '{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"Method not found"}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        assert!(!client
+            .session_dispose("session-1", false)
+            .await
+            .expect("method-not-found should be a soft result"));
+        assert_eq!(client.buzz_session_dispose_supported, Some(false));
+
+        let cached = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            client.session_dispose("session-2", false),
+        )
+        .await
+        .expect("cached unsupported result must not wait on the subprocess")
+        .expect("cached unsupported result is not an error");
+        assert!(!cached);
+    }
+
+    #[tokio::test]
     async fn session_new_full_omits_meta_when_session_title_none() {
         let script = r#"
             read -t 2 _init
@@ -3995,6 +5006,61 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn initialize_records_buzz_thread_session_capability() {
+        let script = r#"
+            read -r _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"_meta":{"buzz":{"threadSessions":{"supported":true,"persistence":true,"dispose":true,"resetToken":true,"resetCommit":true}}}}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        assert!(client.thread_sessions_supported());
+        assert!(client.conversation_reset_supported());
+    }
+
+    #[tokio::test]
+    async fn durable_session_events_require_the_exact_supported_schema() {
+        for (schema_version, expected) in [(1, false), (2, true), (3, false)] {
+            let script = format!(
+                r#"
+                    read -r _init
+                    echo '{{"jsonrpc":"2.0","id":0,"result":{{"protocolVersion":2,"_meta":{{"buzz":{{"sessionEvents":{{"supported":true,"schemaVersion":{schema_version},"durableReplay":true,"ack":true}}}}}}}}}}'
+                    sleep 1
+                "#,
+            );
+            let mut client = spawn_script(&script).await;
+            client
+                .initialize()
+                .await
+                .expect("initialize should succeed");
+            assert_eq!(
+                client.durable_session_events_supported(),
+                expected,
+                "schema {schema_version} negotiation did not fail closed",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn thread_sessions_default_off_for_legacy_adapters() {
+        let script = r#"
+            read -r _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{}}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        assert!(!client.thread_sessions_supported());
+        assert!(!client.conversation_reset_supported());
+    }
+
     /// Test 2: no `active_run_id` + capability advertised → the bytes on the
     /// wire are an `_session/steering` request carrying `sessionId` and
     /// `prompt`, and carrying **no** `expectedRunId` (the adapters reject
@@ -4288,6 +5354,211 @@ mod tests {
                 "update": update
             }
         })
+    }
+
+    fn buzz_compaction_event_msg(session_id: &str, before: u64) -> serde_json::Value {
+        let event_id = uuid::Uuid::from_u128(before as u128).to_string();
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": BUZZ_SESSION_EVENT_METHOD,
+            "params": {
+                "schemaVersion": 2,
+                "sessionId": session_id,
+                "conversationId": "buzz:fixture:conversation",
+                "eventId": event_id,
+                "event": {
+                    "type": "compaction_completed",
+                    "compactionId": event_id,
+                    "timestamp": "2026-08-02T12:00:00.000Z",
+                    "message": "Context compacted",
+                    "piSessionId": "pi-session-1",
+                    "reason": "threshold",
+                    "beforeTokens": before,
+                    "afterTokens": 31_400,
+                    "limitTokens": 150_000,
+                    "effectiveLimitTokens": 150_000,
+                    "compactionThresholdTokens": 133_616,
+                    "willRetry": false,
+                    "fromExtension": false
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn shared_pi_lifecycle_fixture_matches_rust_wire_schema() {
+        let fixture = include_str!(
+            "../../../packages/buzz-pi-agent/test/fixtures/buzz-session-event-v2.json"
+        );
+        let notification: BuzzSessionEventNotification =
+            serde_json::from_str(fixture).expect("shared Pi lifecycle fixture must deserialize");
+
+        assert_eq!(
+            notification.schema_version,
+            BUZZ_SESSION_EVENT_SCHEMA_VERSION
+        );
+        assert_eq!(notification.session_id, "ses_fixture");
+        assert_eq!(notification.conversation_id, "buzz:fixture:conversation");
+        assert!(uuid::Uuid::parse_str(&notification.event_id).is_ok());
+        assert!(matches!(
+            notification.event,
+            BuzzSessionEvent::CompactionCompleted {
+                limit_tokens: 150_000,
+                effective_limit_tokens: 150_000,
+                compaction_threshold_tokens: 133_616,
+                will_retry: false,
+                from_extension: false,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn buzz_session_event_is_typed_and_drained_once() {
+        let mut client = spawn_inert_client().await;
+        client
+            .handle_buzz_session_event(&buzz_compaction_event_msg("acp-session-1", 147_820))
+            .expect("valid lifecycle event");
+
+        let events = client.take_buzz_session_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "acp-session-1");
+        match &events[0].event {
+            BuzzSessionEvent::CompactionCompleted {
+                reason,
+                before_tokens,
+                after_tokens,
+                limit_tokens,
+                effective_limit_tokens,
+                compaction_threshold_tokens,
+                ..
+            } => {
+                assert_eq!(*reason, CompactionReason::Threshold);
+                assert_eq!(*before_tokens, Some(147_820));
+                assert_eq!(*after_tokens, Some(31_400));
+                assert_eq!(*limit_tokens, 150_000);
+                assert_eq!(*effective_limit_tokens, 150_000);
+                assert_eq!(*compaction_threshold_tokens, 133_616);
+            }
+            other => panic!("expected compaction event, got {other:?}"),
+        }
+        assert!(
+            client.take_buzz_session_events().is_empty(),
+            "events must be consumed exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn buzz_session_event_queue_is_bounded_and_keeps_newest() {
+        let mut client = spawn_inert_client().await;
+        for before in 0..=(MAX_PENDING_SESSION_EVENTS as u64) {
+            client
+                .handle_buzz_session_event(&buzz_compaction_event_msg("acp-session-1", before))
+                .expect("legacy lifecycle event remains best-effort");
+        }
+
+        let events = client.take_buzz_session_events();
+        assert_eq!(events.len(), MAX_PENDING_SESSION_EVENTS);
+        match &events[0].event {
+            BuzzSessionEvent::CompactionCompleted { before_tokens, .. } => {
+                assert_eq!(*before_tokens, Some(1), "oldest event should be dropped");
+            }
+            other => panic!("expected compaction event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_buzz_compaction_event_is_queued_once() {
+        let mut client = spawn_inert_client().await;
+        let event = buzz_compaction_event_msg("acp-session-1", 100_000);
+        client
+            .handle_buzz_session_event(&event)
+            .expect("first lifecycle event");
+        client
+            .handle_buzz_session_event(&event)
+            .expect("duplicate lifecycle event");
+
+        assert_eq!(client.take_buzz_session_events().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_buzz_session_events_are_ignored() {
+        let mut client = spawn_inert_client().await;
+        client
+            .handle_buzz_session_event(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": BUZZ_SESSION_EVENT_METHOD,
+                "params": {"sessionId": "s", "event": {"type": "unknown"}}
+            }))
+            .expect("legacy malformed event is optional");
+        client
+            .handle_buzz_session_event(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": BUZZ_SESSION_EVENT_METHOD
+            }))
+            .expect("legacy missing event is optional");
+
+        assert!(client.take_buzz_session_events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn untrusted_buzz_session_events_are_bounded_and_validated() {
+        let mut client = spawn_inert_client().await;
+
+        let mut unsupported_schema = buzz_compaction_event_msg("session", 10);
+        unsupported_schema["params"]["schemaVersion"] = serde_json::json!(3);
+        client
+            .handle_buzz_session_event(&unsupported_schema)
+            .expect("legacy unsupported schema is optional");
+
+        let mut invalid_id = buzz_compaction_event_msg("session", 11);
+        invalid_id["params"]["event"]["compactionId"] = serde_json::json!("not-a-uuid");
+        client
+            .handle_buzz_session_event(&invalid_id)
+            .expect("legacy invalid id is optional");
+
+        let mut invalid_limits = buzz_compaction_event_msg("session", 12);
+        invalid_limits["params"]["event"]["compactionThresholdTokens"] = serde_json::json!(200_000);
+        client
+            .handle_buzz_session_event(&invalid_limits)
+            .expect("legacy invalid limits are optional");
+
+        let mut oversized = buzz_compaction_event_msg("session", 13);
+        oversized["params"]["event"]["message"] =
+            serde_json::json!("x".repeat(MAX_BUZZ_SESSION_EVENT_BYTES));
+        client
+            .handle_buzz_session_event(&oversized)
+            .expect("legacy oversized event is optional");
+
+        assert!(client.take_buzz_session_events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn durable_buzz_session_event_overflow_fails_closed_for_replay() {
+        let mut client = spawn_inert_client().await;
+        client.durable_session_events_supported = true;
+        for before in 0..(MAX_PENDING_SESSION_EVENTS as u64) {
+            client
+                .handle_buzz_session_event(&buzz_compaction_event_msg("acp-session-1", before))
+                .expect("queue below durable capacity");
+        }
+
+        let overflow = client
+            .handle_buzz_session_event(&buzz_compaction_event_msg(
+                "acp-session-1",
+                MAX_PENDING_SESSION_EVENTS as u64,
+            ))
+            .expect_err("durable lifecycle events must never be dropped");
+        assert!(matches!(overflow, AcpError::Protocol(_)));
+
+        let events = client.take_buzz_session_events();
+        assert_eq!(events.len(), MAX_PENDING_SESSION_EVENTS);
+        match &events[0].event {
+            BuzzSessionEvent::CompactionCompleted { before_tokens, .. } => {
+                assert_eq!(*before_tokens, Some(0), "oldest durable event was retained");
+            }
+            other => panic!("expected compaction event, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::ValueEnum;
 use nostr::Keys;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
@@ -341,6 +342,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_CONFIG", default_value = "./buzz-acp.toml")]
     pub config: PathBuf,
 
+    /// Durable harness state directory for signed lifecycle notices and
+    /// committed `/new` acknowledgement barriers. Must be absolute when set.
+    #[arg(long, env = "BUZZ_ACP_STATE_DIR")]
+    pub state_dir: Option<PathBuf>,
+
     #[arg(long, env = "BUZZ_ACP_DEDUP", default_value = "queue", value_enum)]
     pub dedup: DedupMode,
 
@@ -372,6 +378,27 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MAX_TURNS_PER_SESSION", default_value_t = 0,
           value_parser = clap::value_parser!(u32))]
     pub max_turns_per_session: u32,
+
+    /// Maximum hot thread sessions cached by each ACP agent process. Least-
+    /// recently-used idle sessions are closed before a new one is created;
+    /// persistent adapters can reopen their durable context on demand.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_MAX_CACHED_CONVERSATION_SESSIONS",
+        default_value_t = 8,
+        value_parser = clap::value_parser!(u32).range(1..=4096)
+    )]
+    pub max_cached_conversation_sessions: u32,
+
+    /// Idle lifetime of a hot thread session, in seconds. Persistent adapters
+    /// retain the durable conversation even after the runtime is closed.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_CONVERSATION_SESSION_IDLE_TTL_SECS",
+        default_value_t = 1800,
+        value_parser = clap::value_parser!(u64).range(60..)
+    )]
+    pub conversation_session_idle_ttl_secs: u64,
 
     /// Disable automatic presence (online/offline) status.
     #[arg(long, env = "BUZZ_ACP_NO_PRESENCE")]
@@ -482,6 +509,17 @@ pub struct CliArgs {
     /// Connect and subscribe before starting the ACP/LLM subprocess pool.
     #[arg(long, env = "BUZZ_ACP_LAZY_POOL", default_value_t = false)]
     pub lazy_pool: bool,
+
+    /// Require the configured adapter to provide Buzz's durable thread-session
+    /// and reset-commit capability contract. This also selects thread-local
+    /// queue identity before a lazy adapter starts, so the first event cannot
+    /// be grouped into legacy channel-wide context.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS",
+        default_value_t = false
+    )]
+    pub require_durable_thread_sessions: bool,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -521,9 +559,12 @@ pub struct Config {
     pub channels_override: Option<Vec<String>>,
     pub no_mention_filter: bool,
     pub config_path: PathBuf,
+    pub state_dir: PathBuf,
     pub context_message_limit: u32,
     /// Maximum turns per session before proactive rotation. 0 = disabled.
     pub max_turns_per_session: u32,
+    pub max_cached_conversation_sessions: u32,
+    pub conversation_session_idle_ttl_secs: u64,
     pub presence_enabled: bool,
     pub typing_enabled: bool,
     /// Whether NIP-AE agent core memory injection is enabled. When false,
@@ -559,6 +600,9 @@ pub struct Config {
     pub exit_after_inactivity_secs: u64,
     /// Whether ACP/LLM subprocess initialization is deferred until accepted work arrives.
     pub lazy_pool: bool,
+    /// Whether startup must fail closed unless every adapter process supports
+    /// durable per-thread sessions and synchronous conversation reset commits.
+    pub require_durable_thread_sessions: bool,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -701,9 +745,13 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent" | "buzz-pi-agent" => Some(Vec::new()),
         _ => None,
     }
+}
+
+fn agent_requires_durable_thread_sessions(command: &str) -> bool {
+    normalize_agent_command_identity(command) == "buzz-pi-agent"
 }
 
 /// Per-runtime environment defaults applied when Buzz owns the agent process.
@@ -848,6 +896,22 @@ impl Config {
             .replace_range(.., &"0".repeat(args.private_key.len()));
         args.private_key.clear();
 
+        args.relay_url =
+            buzz_core::relay::normalize_relay_url(&args.relay_url).map_err(|error| {
+                ConfigError::ConfigFile(format!("invalid --relay-url / BUZZ_RELAY_URL: {error}"))
+            })?;
+
+        let state_dir = match args.state_dir {
+            Some(path) if path.is_absolute() => path,
+            Some(path) => {
+                return Err(ConfigError::ConfigFile(format!(
+                    "--state-dir / BUZZ_ACP_STATE_DIR must be absolute: {}",
+                    path.display()
+                )));
+            }
+            None => default_state_dir(&keys, &args.relay_url)?,
+        };
+
         let system_prompt = if let Some(text) = args.system_prompt {
             Some(text)
         } else if let Some(ref path) = args.system_prompt_file {
@@ -913,6 +977,12 @@ impl Config {
         }
 
         let agent_args = normalize_agent_args(&agent_command, args.agent_args);
+        // Pi's durable identity must be selected before a lazy adapter starts;
+        // waiting for initialize would let the first root event or `/new`
+        // enter the legacy channel-wide queue. Recognize the production binary
+        // directly while retaining the explicit flag for wrapper commands.
+        let require_durable_thread_sessions = args.require_durable_thread_sessions
+            || agent_requires_durable_thread_sessions(&agent_command);
 
         if let Some(ref channels) = args.channels {
             for ch in channels {
@@ -1088,8 +1158,11 @@ impl Config {
             channels_override: args.channels,
             no_mention_filter: args.no_mention_filter,
             config_path: args.config,
+            state_dir,
             context_message_limit: args.context_message_limit,
             max_turns_per_session: args.max_turns_per_session,
+            max_cached_conversation_sessions: args.max_cached_conversation_sessions,
+            conversation_session_idle_ttl_secs: args.conversation_session_idle_ttl_secs,
             presence_enabled: !args.no_presence,
             typing_enabled: !args.no_typing,
             memory_enabled: args.memory && !args.no_memory,
@@ -1107,6 +1180,7 @@ impl Config {
             relay_observer: args.relay_observer,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
+            require_durable_thread_sessions,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1131,7 +1205,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} durable_thread_sessions_required={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1152,10 +1226,30 @@ impl Config {
             self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
+            self.require_durable_thread_sessions,
             respond_to_detail,
             allowed_respond_to_detail,
         )
     }
+}
+
+fn default_state_dir(keys: &Keys, relay_url: &str) -> Result<PathBuf, ConfigError> {
+    let base = dirs::data_local_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".local").join("share")))
+        .ok_or_else(|| {
+            ConfigError::ConfigFile(
+                "could not resolve a durable data directory; set BUZZ_ACP_STATE_DIR".into(),
+            )
+        })?;
+    let relay_identity = buzz_core::relay::normalize_relay_url(relay_url).map_err(|error| {
+        ConfigError::ConfigFile(format!("invalid relay URL for durable state: {error}"))
+    })?;
+    let relay_hash = hex::encode(Sha256::digest(relay_identity.as_bytes()));
+    Ok(base
+        .join("Buzz")
+        .join("acp")
+        .join(&relay_hash[..24])
+        .join(keys.public_key().to_hex()))
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -1437,6 +1531,26 @@ mod tests {
     use crate::filter::{ChannelScope, SubscriptionRule};
     use clap::{Parser, ValueEnum};
 
+    #[test]
+    fn durable_state_identity_canonicalizes_equivalent_relay_spellings() {
+        let keys = nostr::Keys::generate();
+        let canonical = default_state_dir(&keys, "wss://relay.example").expect("canonical path");
+        let equivalent =
+            default_state_dir(&keys, " WSS://Relay.Example:443/ ").expect("equivalent path");
+        assert_eq!(canonical, equivalent);
+
+        let distinct_path =
+            default_state_dir(&keys, "wss://relay.example/community").expect("path-scoped relay");
+        assert_ne!(canonical, distinct_path);
+    }
+
+    #[test]
+    fn durable_state_identity_rejects_invalid_relay_origins() {
+        let keys = nostr::Keys::generate();
+        assert!(default_state_dir(&keys, "https://relay.example").is_err());
+        assert!(default_state_dir(&keys, "wss://user@relay.example").is_err());
+    }
+
     /// Build a minimal Config for testing without CLI parsing.
     fn test_config(mode: SubscribeMode) -> Config {
         Config {
@@ -1462,8 +1576,11 @@ mod tests {
             channels_override: None,
             no_mention_filter: false,
             config_path: PathBuf::from("./buzz-acp.toml"),
+            state_dir: std::env::temp_dir().join("buzz-acp-config-test"),
             context_message_limit: 12,
             max_turns_per_session: 0,
+            max_cached_conversation_sessions: 8,
+            conversation_session_idle_ttl_secs: 1_800,
             presence_enabled: true,
             typing_enabled: true,
             memory_enabled: true,
@@ -1478,6 +1595,7 @@ mod tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            require_durable_thread_sessions: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -1599,6 +1717,23 @@ mod tests {
             normalize_agent_args("buzz-agent", vec!["acp".into()]),
             Vec::<String>::new()
         );
+        assert_eq!(
+            normalize_agent_args("/usr/local/bin/buzz-pi-agent", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn production_pi_binary_requires_durable_thread_identity_before_startup() {
+        for command in [
+            "buzz-pi-agent",
+            "/usr/local/bin/buzz-pi-agent",
+            r"C:\Users\test\AppData\Roaming\npm\buzz-pi-agent.cmd",
+        ] {
+            assert!(agent_requires_durable_thread_sessions(command));
+        }
+        assert!(!agent_requires_durable_thread_sessions("pi"));
+        assert!(!agent_requires_durable_thread_sessions("wrapper-script"));
     }
 
     #[test]
@@ -2204,6 +2339,24 @@ channels = "ALL"
         let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool=true"]);
         assert!(args.is_err(), "bool flags do not take an explicit value");
         assert!(CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool"]).lazy_pool);
+    }
+
+    #[test]
+    fn durable_thread_session_requirement_defaults_off_and_can_be_enabled() {
+        let key = "0".repeat(64);
+        assert!(
+            !CliArgs::parse_from(["buzz-acp", "--private-key", &key])
+                .require_durable_thread_sessions
+        );
+        assert!(
+            CliArgs::parse_from([
+                "buzz-acp",
+                "--private-key",
+                &key,
+                "--require-durable-thread-sessions",
+            ])
+            .require_durable_thread_sessions
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/durable_outbox.rs
+++ b/crates/buzz-acp/src/durable_outbox.rs
@@ -1,0 +1,929 @@
+//! Crash-durable signed notice and `/new` intent storage.
+//!
+//! Two alternating, generation-stamped snapshots avoid in-place replacement:
+//! a crash while writing the next slot always leaves the prior generation
+//! intact, including on Windows where replacing an open destination is not
+//! uniformly atomic. An OS file lock prevents two harnesses for one agent and
+//! relay from racing the snapshots.
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use nostr::Event;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+const SCHEMA_VERSION: u32 = 2;
+const MAX_SNAPSHOT_BYTES: u64 = 8 * 1024 * 1024;
+pub(crate) const MAX_PENDING_LIFECYCLE: usize = 256;
+pub(crate) const MAX_PENDING_RESETS: usize = 256;
+const MAX_DELIVERED_KEYS: usize = 1_024;
+const MAX_CONSUMED_RESET_RECEIPTS: usize = 1_024;
+const MAX_EVENT_CONTENT_BYTES: usize = 16 * 1024;
+const SLOT_A: &str = "signed-outbox-a.json";
+const SLOT_B: &str = "signed-outbox-b.json";
+const LOCK_FILE: &str = "signed-outbox.lock";
+const INITIALIZED_MARKER: &str = ".signed-outbox-initialized-v1";
+const INITIALIZED_MARKER_TEMP: &str = ".signed-outbox-initialized-v1.tmp";
+const INITIALIZED_MARKER_CONTENT: &[u8] = b"buzz-acp-signed-outbox-v1\n";
+
+#[derive(Debug, Error)]
+pub(crate) enum DurableOutboxError {
+    #[error("durable outbox I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("durable outbox JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("durable outbox is already locked by another harness: {0}")]
+    Locked(PathBuf),
+    #[error("durable outbox is invalid: {0}")]
+    Invalid(String),
+    #[error("durable outbox capacity reached: {0}")]
+    Capacity(&'static str),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DurableLifecycleEnvelope {
+    pub(crate) dedupe_key: Option<String>,
+    pub(crate) event: Event,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DurableResetPhase {
+    Prepared,
+    Committed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DurableResetRecord {
+    pub(crate) channel_id: Uuid,
+    pub(crate) root_event_id: String,
+    pub(crate) conversation_id: String,
+    pub(crate) reset_token: String,
+    pub(crate) event: Event,
+    pub(crate) phase: DurableResetPhase,
+}
+
+impl DurableResetRecord {
+    pub(crate) fn identity(&self) -> (Uuid, String) {
+        (self.channel_id, self.root_event_id.clone())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DurableResetReceipt {
+    pub(crate) channel_id: Uuid,
+    pub(crate) root_event_id: String,
+    pub(crate) reset_token: String,
+    pub(crate) event: Event,
+}
+
+impl From<DurableResetRecord> for DurableResetReceipt {
+    fn from(record: DurableResetRecord) -> Self {
+        Self {
+            channel_id: record.channel_id,
+            root_event_id: record.root_event_id,
+            reset_token: record.reset_token,
+            event: record.event,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DurableState {
+    schema_version: u32,
+    generation: u64,
+    pending_lifecycle: Vec<DurableLifecycleEnvelope>,
+    delivered_keys: Vec<String>,
+    pending_resets: Vec<DurableResetRecord>,
+    #[serde(default)]
+    consumed_reset_receipts: Vec<DurableResetReceipt>,
+}
+
+impl Default for DurableState {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            generation: 0,
+            pending_lifecycle: Vec::new(),
+            delivered_keys: Vec::new(),
+            pending_resets: Vec::new(),
+            consumed_reset_receipts: Vec::new(),
+        }
+    }
+}
+
+struct Inner {
+    state_dir: PathBuf,
+    expected_pubkey: String,
+    state: Mutex<DurableState>,
+    _lock: File,
+}
+
+#[derive(Clone)]
+pub(crate) struct DurableOutbox {
+    inner: Arc<Inner>,
+}
+
+impl DurableOutbox {
+    pub(crate) fn open(
+        state_dir: &Path,
+        expected_pubkey: &str,
+    ) -> Result<Self, DurableOutboxError> {
+        if !state_dir.is_absolute() {
+            return Err(DurableOutboxError::Invalid(format!(
+                "state directory is not absolute: {}",
+                state_dir.display()
+            )));
+        }
+        std::fs::create_dir_all(state_dir)?;
+        set_private_dir_permissions(state_dir)?;
+
+        let lock_path = state_dir.join(LOCK_FILE);
+        let lock = private_open(&lock_path, false)?;
+        fs2::FileExt::try_lock_exclusive(&lock)
+            .map_err(|_| DurableOutboxError::Locked(lock_path))?;
+
+        let initialized = read_initialized_marker(&state_dir.join(INITIALIZED_MARKER))?;
+        let slot_a = read_slot(&state_dir.join(SLOT_A), expected_pubkey);
+        let slot_b = read_slot(&state_dir.join(SLOT_B), expected_pubkey);
+        let mut valid = Vec::new();
+        let mut errors = Vec::new();
+        for result in [slot_a, slot_b] {
+            match result {
+                Ok(Some(state)) => valid.push(state),
+                Ok(None) => {}
+                Err(error) => errors.push(error),
+            }
+        }
+        let had_valid_snapshot = !valid.is_empty();
+        let state = valid
+            .into_iter()
+            .max_by_key(|state| state.generation)
+            .unwrap_or_default();
+        if !had_valid_snapshot {
+            if !errors.is_empty() {
+                return Err(errors.remove(0));
+            }
+            if initialized {
+                return Err(DurableOutboxError::Invalid(
+                    "initialized durable outbox has no valid snapshot".into(),
+                ));
+            }
+        }
+        for error in errors {
+            tracing::warn!(%error, "ignored invalid older durable outbox slot");
+        }
+        // Establish a synced generation-0 predecessor before accepting the
+        // first mutation. Without this bootstrap slot, a crash during the very
+        // first generation write would leave no valid snapshot to fall back to.
+        if !had_valid_snapshot {
+            write_slot(state_dir, &state)?;
+        }
+        if !initialized {
+            write_initialized_marker(state_dir)?;
+        }
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                state_dir: state_dir.to_path_buf(),
+                expected_pubkey: expected_pubkey.to_owned(),
+                state: Mutex::new(state),
+                _lock: lock,
+            }),
+        })
+    }
+
+    pub(crate) fn pending_lifecycle(
+        &self,
+    ) -> Result<Vec<DurableLifecycleEnvelope>, DurableOutboxError> {
+        Ok(self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| DurableOutboxError::Invalid("state mutex was poisoned".into()))?
+            .pending_lifecycle
+            .clone())
+    }
+
+    pub(crate) fn pending_resets(&self) -> Result<Vec<DurableResetRecord>, DurableOutboxError> {
+        Ok(self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| DurableOutboxError::Invalid("state mutex was poisoned".into()))?
+            .pending_resets
+            .clone())
+    }
+
+    pub(crate) fn delivered_keys(&self) -> Result<Vec<String>, DurableOutboxError> {
+        Ok(self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| DurableOutboxError::Invalid("state mutex was poisoned".into()))?
+            .delivered_keys
+            .clone())
+    }
+
+    pub(crate) fn consumed_reset(
+        &self,
+        identity: &(Uuid, String),
+        reset_token: &str,
+    ) -> Result<Option<DurableResetReceipt>, DurableOutboxError> {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| DurableOutboxError::Invalid("state mutex was poisoned".into()))?;
+        Ok(state
+            .consumed_reset_receipts
+            .iter()
+            .find(|receipt| {
+                receipt.channel_id == identity.0
+                    && receipt.root_event_id == identity.1
+                    && receipt.reset_token == reset_token
+            })
+            .cloned())
+    }
+
+    /// Persist a signed lifecycle event before it can be acknowledged to the
+    /// adapter or handed to the asynchronous relay worker. Returns `false` for
+    /// an already-pending or already-delivered stable dedupe key.
+    pub(crate) fn enqueue_lifecycle(
+        &self,
+        envelope: DurableLifecycleEnvelope,
+    ) -> Result<bool, DurableOutboxError> {
+        self.update(|state| {
+            if let Some(key) = envelope.dedupe_key.as_deref() {
+                if state.delivered_keys.iter().any(|item| item == key)
+                    || state
+                        .pending_lifecycle
+                        .iter()
+                        .any(|item| item.dedupe_key.as_deref() == Some(key))
+                {
+                    return Ok((false, false));
+                }
+            }
+            if state
+                .pending_lifecycle
+                .iter()
+                .any(|item| item.event.id == envelope.event.id)
+            {
+                return Ok((false, false));
+            }
+            if state.pending_lifecycle.len() >= MAX_PENDING_LIFECYCLE {
+                return Err(DurableOutboxError::Capacity("lifecycle notices"));
+            }
+            state.pending_lifecycle.push(envelope);
+            Ok((true, true))
+        })
+    }
+
+    pub(crate) fn mark_lifecycle_delivered(
+        &self,
+        event_id: &str,
+    ) -> Result<bool, DurableOutboxError> {
+        self.update(|state| {
+            let Some(index) = state
+                .pending_lifecycle
+                .iter()
+                .position(|item| item.event.id.to_hex() == event_id)
+            else {
+                return Ok((false, false));
+            };
+            let envelope = state.pending_lifecycle.remove(index);
+            if let Some(key) = envelope.dedupe_key {
+                state.delivered_keys.retain(|item| item != &key);
+                state.delivered_keys.push(key);
+                if state.delivered_keys.len() > MAX_DELIVERED_KEYS {
+                    let excess = state.delivered_keys.len() - MAX_DELIVERED_KEYS;
+                    state.delivered_keys.drain(..excess);
+                }
+            }
+            Ok((true, true))
+        })
+    }
+
+    pub(crate) fn prepare_reset(
+        &self,
+        record: DurableResetRecord,
+    ) -> Result<(), DurableOutboxError> {
+        self.update(|state| {
+            if let Some(existing) = state.pending_resets.iter_mut().find(|item| {
+                item.channel_id == record.channel_id && item.root_event_id == record.root_event_id
+            }) {
+                if existing.reset_token == record.reset_token
+                    && existing.event.id == record.event.id
+                {
+                    return Ok(((), false));
+                }
+                *existing = record;
+                return Ok(((), true));
+            }
+            if state.pending_resets.len() >= MAX_PENDING_RESETS {
+                return Err(DurableOutboxError::Capacity("reset acknowledgements"));
+            }
+            state.pending_resets.push(record);
+            Ok(((), true))
+        })
+    }
+
+    pub(crate) fn mark_reset_committed(
+        &self,
+        identity: &(Uuid, String),
+        event_id: &str,
+    ) -> Result<bool, DurableOutboxError> {
+        self.update(|state| {
+            let Some(record) = state.pending_resets.iter_mut().find(|item| {
+                item.channel_id == identity.0
+                    && item.root_event_id == identity.1
+                    && item.event.id.to_hex() == event_id
+            }) else {
+                return Ok((false, false));
+            };
+            if record.phase == DurableResetPhase::Committed {
+                return Ok((true, false));
+            }
+            record.phase = DurableResetPhase::Committed;
+            Ok((true, true))
+        })
+    }
+
+    pub(crate) fn discard_reset(
+        &self,
+        identity: &(Uuid, String),
+        event_id: &str,
+    ) -> Result<bool, DurableOutboxError> {
+        self.update(|state| {
+            let before = state.pending_resets.len();
+            state.pending_resets.retain(|item| {
+                !(item.channel_id == identity.0
+                    && item.root_event_id == identity.1
+                    && item.event.id.to_hex() == event_id)
+            });
+            let removed = state.pending_resets.len() != before;
+            Ok((removed, removed))
+        })
+    }
+
+    /// Atomically retire an accepted reset ACK and retain the signed command
+    /// token as a bounded durable replay receipt. A replay can then resend the
+    /// same acknowledgement without advancing the conversation generation.
+    pub(crate) fn complete_reset(
+        &self,
+        identity: &(Uuid, String),
+        event_id: &str,
+    ) -> Result<bool, DurableOutboxError> {
+        self.update(|state| {
+            let Some(index) = state.pending_resets.iter().position(|item| {
+                item.channel_id == identity.0
+                    && item.root_event_id == identity.1
+                    && item.event.id.to_hex() == event_id
+                    && item.phase == DurableResetPhase::Committed
+            }) else {
+                return Ok((false, false));
+            };
+            let record = state.pending_resets.remove(index);
+            state.consumed_reset_receipts.retain(|receipt| {
+                !(receipt.channel_id == record.channel_id
+                    && receipt.root_event_id == record.root_event_id
+                    && receipt.reset_token == record.reset_token)
+            });
+            state.consumed_reset_receipts.push(record.into());
+            if state.consumed_reset_receipts.len() > MAX_CONSUMED_RESET_RECEIPTS {
+                let excess = state.consumed_reset_receipts.len() - MAX_CONSUMED_RESET_RECEIPTS;
+                state.consumed_reset_receipts.drain(..excess);
+            }
+            Ok((true, true))
+        })
+    }
+
+    fn update<T>(
+        &self,
+        mutate: impl FnOnce(&mut DurableState) -> Result<(T, bool), DurableOutboxError>,
+    ) -> Result<T, DurableOutboxError> {
+        let mut guard = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| DurableOutboxError::Invalid("state mutex was poisoned".into()))?;
+        let mut candidate = guard.clone();
+        let (result, changed) = mutate(&mut candidate)?;
+        if !changed {
+            return Ok(result);
+        }
+        candidate.generation = candidate
+            .generation
+            .checked_add(1)
+            .ok_or_else(|| DurableOutboxError::Invalid("generation exhausted".into()))?;
+        validate_state(&candidate, &self.inner.expected_pubkey)?;
+        write_slot(&self.inner.state_dir, &candidate)?;
+        *guard = candidate;
+        Ok(result)
+    }
+}
+
+fn validate_state(state: &DurableState, expected_pubkey: &str) -> Result<(), DurableOutboxError> {
+    if state.schema_version != SCHEMA_VERSION {
+        return Err(DurableOutboxError::Invalid(format!(
+            "unsupported schema version {}",
+            state.schema_version
+        )));
+    }
+    if state.pending_lifecycle.len() > MAX_PENDING_LIFECYCLE
+        || state.pending_resets.len() > MAX_PENDING_RESETS
+        || state.delivered_keys.len() > MAX_DELIVERED_KEYS
+        || state.consumed_reset_receipts.len() > MAX_CONSUMED_RESET_RECEIPTS
+    {
+        return Err(DurableOutboxError::Invalid(
+            "entry count exceeds cap".into(),
+        ));
+    }
+    let mut event_ids = HashSet::new();
+    for envelope in &state.pending_lifecycle {
+        validate_event(&envelope.event, expected_pubkey)?;
+        if envelope
+            .dedupe_key
+            .as_ref()
+            .is_some_and(|key| key.is_empty() || key.len() > 1_024)
+        {
+            return Err(DurableOutboxError::Invalid(
+                "invalid lifecycle dedupe key".into(),
+            ));
+        }
+        if !event_ids.insert(envelope.event.id.to_hex()) {
+            return Err(DurableOutboxError::Invalid(
+                "duplicate pending event".into(),
+            ));
+        }
+    }
+    if state
+        .delivered_keys
+        .iter()
+        .any(|key| key.is_empty() || key.len() > 1_024)
+    {
+        return Err(DurableOutboxError::Invalid(
+            "invalid delivered dedupe key".into(),
+        ));
+    }
+    for reset in &state.pending_resets {
+        validate_event(&reset.event, expected_pubkey)?;
+        if reset.root_event_id.is_empty()
+            || reset.root_event_id.len() > 512
+            || reset.conversation_id.is_empty()
+            || reset.conversation_id.len() > 1_024
+            || reset.reset_token.is_empty()
+            || reset.reset_token.len() > 256
+        {
+            return Err(DurableOutboxError::Invalid(
+                "invalid reset record fields".into(),
+            ));
+        }
+        if !event_ids.insert(reset.event.id.to_hex()) {
+            return Err(DurableOutboxError::Invalid(
+                "duplicate pending event".into(),
+            ));
+        }
+    }
+    for receipt in &state.consumed_reset_receipts {
+        validate_event(&receipt.event, expected_pubkey)?;
+        if receipt.root_event_id.is_empty()
+            || receipt.root_event_id.len() > 512
+            || receipt.reset_token.is_empty()
+            || receipt.reset_token.len() > 256
+        {
+            return Err(DurableOutboxError::Invalid(
+                "invalid consumed reset receipt".into(),
+            ));
+        }
+        if !event_ids.insert(receipt.event.id.to_hex()) {
+            return Err(DurableOutboxError::Invalid(
+                "duplicate pending/receipt event".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_event(event: &Event, expected_pubkey: &str) -> Result<(), DurableOutboxError> {
+    buzz_core::verify_event(event)
+        .map_err(|error| DurableOutboxError::Invalid(format!("invalid signed event: {error}")))?;
+    if event.pubkey.to_hex() != expected_pubkey {
+        return Err(DurableOutboxError::Invalid(
+            "signed event belongs to another agent".into(),
+        ));
+    }
+    if event.kind.as_u16() as u32 != buzz_core::kind::KIND_STREAM_MESSAGE
+        || event.content.len() > MAX_EVENT_CONTENT_BYTES
+    {
+        return Err(DurableOutboxError::Invalid(
+            "signed event has invalid kind or content size".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_initialized_marker(path: &Path) -> Result<bool, DurableOutboxError> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    let metadata = file.metadata()?;
+    if metadata.len() != INITIALIZED_MARKER_CONTENT.len() as u64 {
+        return Err(DurableOutboxError::Invalid(
+            "durable outbox initialized marker has invalid size".into(),
+        ));
+    }
+    let mut content = Vec::with_capacity(INITIALIZED_MARKER_CONTENT.len());
+    file.read_to_end(&mut content)?;
+    if content != INITIALIZED_MARKER_CONTENT {
+        return Err(DurableOutboxError::Invalid(
+            "durable outbox initialized marker has invalid content".into(),
+        ));
+    }
+    Ok(true)
+}
+
+fn write_initialized_marker(state_dir: &Path) -> Result<(), DurableOutboxError> {
+    let path = state_dir.join(INITIALIZED_MARKER);
+    let temp_path = state_dir.join(INITIALIZED_MARKER_TEMP);
+    match std::fs::remove_file(&temp_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut file = private_open(&temp_path, true)?;
+    file.write_all(INITIALIZED_MARKER_CONTENT)?;
+    file.sync_all()?;
+    std::fs::rename(&temp_path, &path)?;
+    sync_directory(state_dir)?;
+    Ok(())
+}
+
+fn read_slot(
+    path: &Path,
+    expected_pubkey: &str,
+) -> Result<Option<DurableState>, DurableOutboxError> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let metadata = file.metadata()?;
+    if metadata.len() == 0 || metadata.len() > MAX_SNAPSHOT_BYTES {
+        return Err(DurableOutboxError::Invalid(format!(
+            "snapshot {} has invalid size {}",
+            path.display(),
+            metadata.len()
+        )));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_SNAPSHOT_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_SNAPSHOT_BYTES {
+        return Err(DurableOutboxError::Invalid(
+            "snapshot exceeds byte cap".into(),
+        ));
+    }
+    let mut state: DurableState = serde_json::from_slice(&bytes)?;
+    // Schema v2 only adds the bounded consumed-reset receipt collection, which
+    // is serde-defaulted above. Upgrade v1 snapshots in memory and let the next
+    // mutation rewrite them; rejecting the previous production format here
+    // would strand otherwise valid pending lifecycle/reset records.
+    if state.schema_version == 1 {
+        state.schema_version = SCHEMA_VERSION;
+    }
+    validate_state(&state, expected_pubkey)?;
+    Ok(Some(state))
+}
+
+fn write_slot(state_dir: &Path, state: &DurableState) -> Result<(), DurableOutboxError> {
+    let bytes = serde_json::to_vec(state)?;
+    if bytes.len() as u64 > MAX_SNAPSHOT_BYTES {
+        return Err(DurableOutboxError::Capacity("snapshot bytes"));
+    }
+    let slot_name = if state.generation.is_multiple_of(2) {
+        SLOT_A
+    } else {
+        SLOT_B
+    };
+    let path = state_dir.join(slot_name);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut file = private_open(&path, true)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    sync_directory(state_dir)?;
+    Ok(())
+}
+
+fn private_open(path: &Path, create_new: bool) -> Result<File, std::io::Error> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    if create_new {
+        options.create_new(true);
+    } else {
+        options.create(true);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &Path) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+}
+
+#[cfg(not(unix))]
+fn set_private_dir_permissions(_path: &Path) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<(), std::io::Error> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<(), std::io::Error> {
+    // Windows does not provide a portable directory fsync through std. Each
+    // complete slot file is still flushed before it becomes the newest valid
+    // generation, and the previous slot remains intact.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind};
+
+    fn signed_notice(keys: &Keys, content: &str) -> Event {
+        EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            content,
+        )
+        .sign_with_keys(keys)
+        .expect("sign notice")
+    }
+
+    fn reset(keys: &Keys, channel_id: Uuid) -> DurableResetRecord {
+        DurableResetRecord {
+            channel_id,
+            root_event_id: "aa".repeat(32),
+            conversation_id: format!("{channel_id}:thread:{}", "aa".repeat(32)),
+            reset_token: "bb".repeat(32),
+            event: signed_notice(keys, "reset ready"),
+            phase: DurableResetPhase::Prepared,
+        }
+    }
+
+    #[test]
+    fn lifecycle_and_reset_survive_restart_and_delivered_key_dedupes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let channel_id = Uuid::new_v4();
+        let lifecycle = DurableLifecycleEnvelope {
+            dedupe_key: Some("compaction:one".into()),
+            event: signed_notice(&keys, "compacted"),
+        };
+        let lifecycle_id = lifecycle.event.id.to_hex();
+        let reset = reset(&keys, channel_id);
+        let reset_id = reset.event.id.to_hex();
+        let identity = reset.identity();
+
+        {
+            let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("open");
+            assert!(outbox
+                .enqueue_lifecycle(lifecycle.clone())
+                .expect("enqueue"));
+            outbox.prepare_reset(reset).expect("prepare reset");
+            assert!(outbox
+                .mark_reset_committed(&identity, &reset_id)
+                .expect("commit reset"));
+        }
+
+        let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("reopen");
+        assert_eq!(outbox.pending_lifecycle().expect("read lifecycle").len(), 1);
+        let pending_resets = outbox.pending_resets().expect("read resets");
+        assert_eq!(pending_resets.len(), 1);
+        assert_eq!(pending_resets[0].phase, DurableResetPhase::Committed);
+        assert!(outbox
+            .mark_lifecycle_delivered(&lifecycle_id)
+            .expect("mark delivered"));
+        assert!(!outbox
+            .enqueue_lifecycle(lifecycle)
+            .expect("dedupe delivered"));
+        let reset_token = pending_resets[0].reset_token.clone();
+        assert!(outbox
+            .complete_reset(&identity, &reset_id)
+            .expect("complete reset"));
+        let receipt = outbox
+            .consumed_reset(&identity, &reset_token)
+            .expect("read receipt")
+            .expect("consumed reset receipt");
+        assert_eq!(receipt.event.id.to_hex(), reset_id);
+        assert!(outbox
+            .pending_lifecycle()
+            .expect("read lifecycle")
+            .is_empty());
+        assert!(outbox.pending_resets().expect("read resets").is_empty());
+
+        drop(outbox);
+        let reopened = DurableOutbox::open(dir.path(), &pubkey).expect("reopen receipt");
+        assert_eq!(
+            reopened
+                .consumed_reset(&identity, &reset_token)
+                .expect("read receipt")
+                .expect("receipt survives restart")
+                .event
+                .id
+                .to_hex(),
+            reset_id
+        );
+    }
+
+    #[test]
+    fn schema_one_snapshot_migrates_without_losing_pending_records() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let envelope = DurableLifecycleEnvelope {
+            dedupe_key: Some("legacy-one".into()),
+            event: signed_notice(&keys, "legacy"),
+        };
+        {
+            let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("open");
+            outbox.enqueue_lifecycle(envelope).expect("enqueue");
+        }
+
+        let slot = dir.path().join(SLOT_B);
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&slot).expect("read slot")).expect("decode slot");
+        value["schemaVersion"] = serde_json::json!(1);
+        value
+            .as_object_mut()
+            .expect("state object")
+            .remove("consumedResetReceipts");
+        std::fs::write(&slot, serde_json::to_vec(&value).expect("encode legacy"))
+            .expect("write legacy");
+
+        let reopened = DurableOutbox::open(dir.path(), &pubkey).expect("migrate v1");
+        assert_eq!(
+            reopened.pending_lifecycle().expect("read lifecycle").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn corrupt_newest_slot_falls_back_to_previous_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        {
+            let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("open");
+            outbox
+                .enqueue_lifecycle(DurableLifecycleEnvelope {
+                    dedupe_key: Some("one".into()),
+                    event: signed_notice(&keys, "one"),
+                })
+                .expect("first generation");
+            outbox
+                .enqueue_lifecycle(DurableLifecycleEnvelope {
+                    dedupe_key: Some("two".into()),
+                    event: signed_notice(&keys, "two"),
+                })
+                .expect("second generation");
+        }
+        std::fs::write(dir.path().join(SLOT_A), b"truncated").expect("corrupt newest even slot");
+
+        let recovered = DurableOutbox::open(dir.path(), &pubkey).expect("recover older slot");
+        let pending = recovered.pending_lifecycle().expect("read lifecycle");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].dedupe_key.as_deref(), Some("one"));
+    }
+
+    #[test]
+    fn first_generation_has_a_synced_empty_predecessor() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        {
+            let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("open");
+            outbox
+                .enqueue_lifecycle(DurableLifecycleEnvelope {
+                    dedupe_key: Some("first".into()),
+                    event: signed_notice(&keys, "first"),
+                })
+                .expect("first generation");
+        }
+        std::fs::write(dir.path().join(SLOT_B), b"torn-first-generation")
+            .expect("corrupt first mutation");
+
+        let recovered = DurableOutbox::open(dir.path(), &pubkey)
+            .expect("generation zero must remain recoverable");
+        assert!(recovered
+            .pending_lifecycle()
+            .expect("read lifecycle")
+            .is_empty());
+    }
+
+    #[test]
+    fn second_harness_for_same_state_directory_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let _first = DurableOutbox::open(dir.path(), &pubkey).expect("first lock");
+        assert!(matches!(
+            DurableOutbox::open(dir.path(), &pubkey),
+            Err(DurableOutboxError::Locked(_))
+        ));
+    }
+
+    #[test]
+    fn initialized_marker_makes_missing_both_snapshots_fail_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        {
+            let outbox = DurableOutbox::open(dir.path(), &pubkey).expect("initialize");
+            outbox
+                .enqueue_lifecycle(DurableLifecycleEnvelope {
+                    dedupe_key: Some("material-state".into()),
+                    event: signed_notice(&keys, "material state"),
+                })
+                .expect("write second slot");
+        }
+        assert!(dir.path().join(INITIALIZED_MARKER).exists());
+        std::fs::remove_file(dir.path().join(SLOT_A)).expect("delete bootstrap slot");
+        std::fs::remove_file(dir.path().join(SLOT_B)).expect("delete current slot");
+
+        assert!(matches!(
+            DurableOutbox::open(dir.path(), &pubkey),
+            Err(DurableOutboxError::Invalid(message))
+                if message.contains("no valid snapshot")
+        ));
+    }
+
+    #[test]
+    fn initialized_marker_recovers_a_torn_temp_file_without_touching_valid_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = DurableState::default();
+        write_slot(dir.path(), &state).expect("write valid bootstrap snapshot");
+        std::fs::write(dir.path().join(INITIALIZED_MARKER_TEMP), b"torn")
+            .expect("write torn marker temp");
+
+        write_initialized_marker(dir.path()).expect("replace torn marker temp atomically");
+        assert!(
+            read_initialized_marker(&dir.path().join(INITIALIZED_MARKER)).expect("read marker")
+        );
+        assert!(!dir.path().join(INITIALIZED_MARKER_TEMP).exists());
+    }
+
+    #[test]
+    fn poisoned_state_cannot_masquerade_as_an_unconsumed_reset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keys = Keys::generate();
+        let outbox = DurableOutbox::open(dir.path(), &keys.public_key().to_hex()).expect("open");
+        let inner = Arc::clone(&outbox.inner);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = inner.state.lock().expect("lock before poison");
+            panic!("intentional durable state poison");
+        }));
+
+        let identity = (Uuid::new_v4(), "root".to_owned());
+        assert!(matches!(
+            outbox.consumed_reset(&identity, "token"),
+            Err(DurableOutboxError::Invalid(message)) if message.contains("poisoned")
+        ));
+        assert!(matches!(
+            outbox.pending_lifecycle(),
+            Err(DurableOutboxError::Invalid(message)) if message.contains("poisoned")
+        ));
+        assert!(matches!(
+            outbox.pending_resets(),
+            Err(DurableOutboxError::Invalid(message)) if message.contains("poisoned")
+        ));
+        assert!(matches!(
+            outbox.delivered_keys(),
+            Err(DurableOutboxError::Invalid(message)) if message.contains("poisoned")
+        ));
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod acp;
 mod config;
+mod durable_outbox;
 mod engram_fetch;
 mod filter;
 mod observer;
@@ -15,10 +16,10 @@ mod usage;
 pub use usage::TurnUsage;
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
-use acp::{AcpClient, EnvVar, McpServer};
+use acp::{AcpClient, BuzzSessionEvent, ConversationResetCommit, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
@@ -33,17 +34,20 @@ use config::{
     AuthAgentArgs, AuthMethodsArgs, AuthenticateArgs, Config, DedupMode, ModelsArgs,
     MultipleEventHandling, RespondTo, SubscribeMode,
 };
+use durable_outbox::{
+    DurableLifecycleEnvelope, DurableOutbox, DurableResetPhase, DurableResetRecord,
+};
 use filter::SubscriptionRule;
 use futures_util::FutureExt;
 use nostr::{PublicKey, ToBech32};
 use pool::{
-    AgentPool, ControlSignal, IdleSwitchResult, OwnedAgent, PromptContext, PromptOutcome,
-    PromptResult, PromptSource, SessionState, TimeoutKind,
+    AgentPool, ControlSignal, OwnedAgent, PromptContext, PromptOutcome, PromptResult, PromptSource,
+    SessionState, TimeoutKind,
 };
 use pool_lifecycle::PoolLifecycle;
-use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
+use queue::{CancelReason, ConversationKey, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
 use relay::{HarnessRelay, RelayEventPublisher};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, watch, Semaphore};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
@@ -274,14 +278,29 @@ pub(crate) async fn is_dm_channel(
     channel_id: Uuid,
     channel_info: &pool::ChannelInfoResolver,
 ) -> bool {
+    resolve_dm_channel_scope(channel_id, channel_info).await.0
+}
+
+/// Return `(author_gate_is_dm, conversation_scope_is_dm)`.
+///
+/// Unknown metadata must be restrictive for authorization but isolated for
+/// context: treating an unknown public channel as a stable DM conversation
+/// would collapse unrelated top-level messages into one agent session.
+async fn resolve_dm_channel_scope(
+    channel_id: Uuid,
+    channel_info: &pool::ChannelInfoResolver,
+) -> (bool, bool) {
     match channel_info.resolve(channel_id).await {
-        Some(info) => info.channel_type == "dm",
+        Some(info) => {
+            let is_dm = info.channel_type == "dm";
+            (is_dm, is_dm)
+        }
         None => {
             tracing::warn!(
                 channel_id = %channel_id,
-                "channel type unresolved — treating as DM for author gate (fail closed)"
+                "channel type unresolved — treating as DM for author gate while isolating conversation scope"
             );
-            true
+            (true, false)
         }
     }
 }
@@ -833,6 +852,48 @@ async fn publish_relay_observer_event(
 
 /// Maximum age (seconds) for an observer control frame to be considered fresh.
 const OBSERVER_CONTROL_FRESHNESS_SECS: i64 = 300;
+/// Retain every authenticated control ID for the full freshness window. If an
+/// owner legitimately produces more than this many controls before entries
+/// expire, fail closed instead of evicting replay protection early.
+const OBSERVER_CONTROL_REPLAY_CAPACITY: usize = 8_192;
+
+#[derive(Debug, Default)]
+struct ObserverControlReplayCache {
+    seen: HashSet<String>,
+    expiry_order: VecDeque<(String, i64)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObserverControlAdmission {
+    Accepted,
+    Replay,
+    Saturated,
+}
+
+impl ObserverControlReplayCache {
+    fn admit(&mut self, event_id: String, event_ts: i64, now: i64) -> ObserverControlAdmission {
+        while self
+            .expiry_order
+            .front()
+            .is_some_and(|(_, expires_at)| *expires_at < now)
+        {
+            if let Some((expired_id, _)) = self.expiry_order.pop_front() {
+                self.seen.remove(&expired_id);
+            }
+        }
+        if self.seen.contains(&event_id) {
+            return ObserverControlAdmission::Replay;
+        }
+        if self.seen.len() >= OBSERVER_CONTROL_REPLAY_CAPACITY {
+            return ObserverControlAdmission::Saturated;
+        }
+
+        let expires_at = event_ts.saturating_add(OBSERVER_CONTROL_FRESHNESS_SECS);
+        self.seen.insert(event_id.clone());
+        self.expiry_order.push_back((event_id, expires_at));
+        ObserverControlAdmission::Accepted
+    }
+}
 
 fn handle_relay_observer_control_event(
     keys: &nostr::Keys,
@@ -840,6 +901,7 @@ fn handle_relay_observer_control_event(
     pool: &mut AgentPool,
     observer: Option<&observer::ObserverHandle>,
     owner_pubkey_hex: &str,
+    replay_cache: &mut ObserverControlReplayCache,
 ) {
     // Defense-in-depth: verify signature even though the relay already checked.
     if let Err(e) = buzz_core::verify_event(&event) {
@@ -877,17 +939,55 @@ fn handle_relay_observer_control_event(
         }
     };
 
+    route_authenticated_observer_control(
+        event.id.to_hex(),
+        event_ts,
+        now,
+        &payload,
+        pool,
+        observer,
+        replay_cache,
+    );
+}
+
+fn route_authenticated_observer_control(
+    event_id: String,
+    event_ts: i64,
+    now: i64,
+    payload: &serde_json::Value,
+    pool: &mut AgentPool,
+    observer: Option<&observer::ObserverHandle>,
+    replay_cache: &mut ObserverControlReplayCache,
+) {
     let command_type = payload.get("type").and_then(|value| value.as_str());
+    if !matches!(command_type, Some("cancel_turn" | "switch_model")) {
+        tracing::debug!(payload = %payload, "ignoring unknown observer control frame");
+        return;
+    }
+    match replay_cache.admit(event_id.clone(), event_ts, now) {
+        ObserverControlAdmission::Accepted => {}
+        ObserverControlAdmission::Replay => {
+            tracing::warn!(%event_id, "dropping replayed observer control frame");
+            return;
+        }
+        ObserverControlAdmission::Saturated => {
+            tracing::error!(
+                %event_id,
+                capacity = OBSERVER_CONTROL_REPLAY_CAPACITY,
+                "observer control replay cache saturated — failing closed"
+            );
+            return;
+        }
+    }
+
     match command_type {
         Some("cancel_turn") => {
-            handle_cancel_turn_control(&payload, pool, observer);
+            handle_cancel_turn_control(payload, pool, observer);
         }
         Some("switch_model") => {
-            handle_switch_model_control(&payload, pool, observer);
+            handle_switch_model_control(payload, pool, observer);
         }
-        _ => {
-            tracing::debug!(payload = %payload, "ignoring unknown observer control frame");
-        }
+        _ => unreachable!("recognized observer control type checked above"),
     }
 }
 
@@ -906,22 +1006,35 @@ fn handle_cancel_turn_control(
         return;
     };
 
-    let fired = signal_in_flight_task(pool, channel_id, ControlSignal::Cancel);
-    let status = if fired { "sent" } else { "no_active_turn" };
+    let Some(turn_id) = payload
+        .get("turnId")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+    else {
+        tracing::warn!(
+            channel = %channel_id,
+            "observer cancel_turn control frame missing turnId — dropping fail closed"
+        );
+        return;
+    };
+    let status =
+        signal_observer_control(pool, channel_id, turn_id, ControlSignal::Cancel).as_status();
     if let Some(observer) = observer {
+        let mut result = serde_json::json!({
+            "type": "cancel_turn",
+            "status": status,
+        });
+        result["turnId"] = serde_json::Value::String(turn_id.to_string());
         observer.emit(
             "control_result",
             None,
             &observer::ObserverContext {
                 channel_id: Some(channel_id.to_string()),
                 session_id: None,
-                turn_id: None,
+                turn_id: Some(turn_id.to_owned()),
                 started_at: None,
             },
-            serde_json::json!({
-                "type": "cancel_turn",
-                "status": status,
-            }),
+            result,
         );
     }
 }
@@ -934,9 +1047,6 @@ fn handle_cancel_turn_control(
 /// post-cancel via `create_session_and_apply_model` (the turn restarts on the
 /// unchanged model + an `unsupported_model` result).
 ///
-/// Idle path: validate against the cached catalog *before* invalidating
-/// (pre-cancel guard), then set `desired_model` + invalidate. The override
-/// takes visible effect on the agent's next turn.
 fn handle_switch_model_control(
     payload: &serde_json::Value,
     pool: &mut AgentPool,
@@ -954,52 +1064,46 @@ fn handle_switch_model_control(
         tracing::warn!("observer switch_model control frame missing modelId");
         return;
     };
-
-    // A turn is in flight for this channel iff a task_map entry exists. The
-    // agent is moved out of the pool during a turn, so the control oneshot is
-    // the only reachable lever; an idle channel has no such entry.
-    let turn_in_flight = pool
-        .task_map()
-        .values()
-        .any(|m| m.channel_id == Some(channel_id));
-
-    let status = if turn_in_flight {
-        // Busy path: deliver over the oneshot. `false` means the oneshot was
-        // already consumed this turn (a prior cancel/interrupt) — the turn is
-        // already ending, so the switch cannot land on it.
-        if signal_in_flight_task(
-            pool,
-            channel_id,
-            ControlSignal::SwitchModel(model_id.to_string()),
-        ) {
-            "sent"
-        } else {
-            "turn_ending"
-        }
-    } else {
-        // Idle path: validate against the cached catalog before invalidating.
-        match pool.switch_idle_agent_model(channel_id, model_id) {
-            IdleSwitchResult::Switched => "switched",
-            IdleSwitchResult::UnsupportedModel => "unsupported_model",
-            IdleSwitchResult::NoIdleAgent => "no_active_turn",
-        }
+    let Some(turn_id) = payload
+        .get("turnId")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+    else {
+        tracing::warn!(
+            channel = %channel_id,
+            "observer switch_model control frame missing turnId — dropping fail closed"
+        );
+        return;
     };
 
+    // Controls are deliberately turn-bound: if that turn completed between
+    // the desktop snapshot and this frame arriving, never fall back to a
+    // potentially unrelated current or idle thread in the same channel.
+    let status = signal_observer_control(
+        pool,
+        channel_id,
+        turn_id,
+        ControlSignal::SwitchModel(model_id.to_string()),
+    )
+    .as_status();
+
     if let Some(observer) = observer {
+        let mut result = serde_json::json!({
+            "type": "switch_model",
+            "status": status,
+            "modelId": model_id,
+        });
+        result["turnId"] = serde_json::Value::String(turn_id.to_string());
         observer.emit(
             "control_result",
             None,
             &observer::ObserverContext {
                 channel_id: Some(channel_id.to_string()),
                 session_id: None,
-                turn_id: None,
+                turn_id: Some(turn_id.to_owned()),
                 started_at: None,
             },
-            serde_json::json!({
-                "type": "switch_model",
-                "status": status,
-                "modelId": model_id,
-            }),
+            result,
         );
     }
 }
@@ -1155,6 +1259,7 @@ struct RespawnResult {
 /// `event_id` is the hex id of the single event the steer carried.
 struct SteerAckEvent {
     channel_id: Uuid,
+    conversation_key: ConversationKey,
     event_id: String,
     /// `Ok` if the read loop sent any of the locked `SteerAck` variants.
     /// `Err` if the oneshot was dropped without a send — should not happen
@@ -1162,6 +1267,737 @@ struct SteerAckEvent {
     /// loop treats it as `PromptCompletedNeutral` (release withheld, no
     /// fallback signal) to avoid leaking the withheld event.
     ack: std::result::Result<pool::SteerAck, tokio::sync::oneshot::error::RecvError>,
+}
+
+struct PendingResetConfirmation {
+    event: nostr::Event,
+    next_attempt_at: Instant,
+    durable: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResetAckAttemptKey {
+    identity: (Uuid, String),
+    event_id: String,
+}
+
+#[derive(Debug)]
+struct ResetAckAttemptResult {
+    key: ResetAckAttemptKey,
+    accepted: bool,
+}
+
+const RESET_ACK_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const RESET_HELPER_INIT_TIMEOUT: Duration = Duration::from_secs(15);
+const RESET_HELPER_ATTEMPTS: usize = 2;
+
+fn reset_confirmation(thread_sessions_enabled: bool) -> &'static str {
+    if thread_sessions_enabled {
+        "✨ Fresh context ready. I’ll keep this Buzz thread separate and start the next request without its prior conversation history."
+    } else {
+        "✨ Fresh context ready. This agent adapter does not support thread-local sessions, so the reset applies to this entire Buzz channel."
+    }
+}
+
+/// Commit `/new` in the adapter's durable store before relying on any
+/// in-memory queue/barrier state. An idle pool process is preferred. When the
+/// only process is busy with the turn being reset, a short-lived ACP helper is
+/// initialized against the same adapter state and performs the idempotent
+/// logical reset by stable conversation id.
+async fn commit_durable_conversation_reset(
+    pool: &mut AgentPool,
+    config: &Config,
+    conversation_id: &str,
+    reset_token: &str,
+) -> Option<ConversationResetCommit> {
+    commit_durable_conversation_reset_with_adapter(
+        pool,
+        &config.agent_command,
+        &config.agent_args,
+        &config.persona_env_vars,
+        config.has_generated_codex_config,
+        conversation_id,
+        reset_token,
+    )
+    .await
+}
+
+async fn commit_durable_conversation_reset_with_adapter(
+    pool: &mut AgentPool,
+    agent_command: &str,
+    agent_args: &[String],
+    persona_env_vars: &[(String, String)],
+    has_generated_codex_config: bool,
+    conversation_id: &str,
+    reset_token: &str,
+) -> Option<ConversationResetCommit> {
+    if let Some(commit) = pool
+        .commit_conversation_reset(conversation_id, reset_token)
+        .await
+    {
+        return Some(commit);
+    }
+
+    // A timeout/EOF after the request is ambiguous: the adapter may have
+    // committed just before its response was lost. Retry the same idempotency
+    // token through a fresh process so a durable commit can be confirmed.
+    for attempt in 1..=RESET_HELPER_ATTEMPTS {
+        let mut helper = match AcpClient::spawn(
+            agent_command,
+            agent_args,
+            persona_env_vars,
+            has_generated_codex_config,
+        )
+        .await
+        {
+            Ok(helper) => helper,
+            Err(error) => {
+                tracing::error!(
+                    conversation_id,
+                    attempt,
+                    %error,
+                    "could not spawn the durable reset helper"
+                );
+                continue;
+            }
+        };
+
+        let initialized =
+            tokio::time::timeout(RESET_HELPER_INIT_TIMEOUT, helper.initialize()).await;
+        let supported = match initialized {
+            Ok(Ok(_)) => {
+                helper.thread_sessions_supported()
+                    && helper.conversation_reset_supported()
+                    && helper.durable_session_events_supported()
+            }
+            Ok(Err(error)) => {
+                tracing::error!(
+                    conversation_id,
+                    attempt,
+                    %error,
+                    "durable reset helper initialization failed"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::error!(
+                    conversation_id,
+                    attempt,
+                    timeout_secs = RESET_HELPER_INIT_TIMEOUT.as_secs(),
+                    "durable reset helper initialization timed out"
+                );
+                false
+            }
+        };
+
+        let committed = if supported {
+            match helper
+                .conversation_reset(conversation_id, reset_token)
+                .await
+            {
+                Ok(Some(commit)) => Some(commit),
+                Ok(None) => {
+                    tracing::error!(
+                        conversation_id,
+                        attempt,
+                        "durable reset helper withdrew its advertised reset capability"
+                    );
+                    None
+                }
+                Err(error) => {
+                    tracing::error!(
+                        conversation_id,
+                        attempt,
+                        %error,
+                        "durable reset helper reset result was not confirmed"
+                    );
+                    None
+                }
+            }
+        } else {
+            tracing::error!(
+                conversation_id,
+                attempt,
+                "durable reset helper does not advertise the required thread reset contract"
+            );
+            None
+        };
+        helper.shutdown().await;
+        if committed.is_some() {
+            return committed;
+        }
+    }
+    None
+}
+
+/// Resolve crash-interrupted `/new` intents before relay intake. A prepared
+/// record means the signed acknowledgement was durably stored before the Pi
+/// tombstone RPC began, but the process died before recording its response.
+/// Repeating the same reset token is idempotent and converts that ambiguity
+/// into a confirmed committed record.
+async fn recover_durable_reset_intents(
+    outbox: &DurableOutbox,
+    pool: &mut AgentPool,
+    config: &Config,
+    thread_sessions_enabled: bool,
+) -> Result<Vec<DurableResetRecord>> {
+    for record in outbox
+        .pending_resets()
+        .map_err(|error| anyhow::anyhow!("could not read durable /new intents: {error}"))?
+    {
+        if record.phase == DurableResetPhase::Committed {
+            continue;
+        }
+        if !thread_sessions_enabled {
+            return Err(anyhow::anyhow!(
+                "a prepared durable /new intent exists, but the configured adapter no longer supports durable thread sessions"
+            ));
+        }
+        if commit_durable_conversation_reset(
+            pool,
+            config,
+            &record.conversation_id,
+            &record.reset_token,
+        )
+        .await
+        .is_none()
+        {
+            return Err(anyhow::anyhow!(
+                "could not recover durable /new intent for {}:{}; refusing relay intake",
+                record.channel_id,
+                record.root_event_id
+            ));
+        }
+        let identity = record.identity();
+        if !outbox
+            .mark_reset_committed(&identity, &record.event.id.to_hex())
+            .map_err(|error| anyhow::anyhow!("could not checkpoint recovered /new: {error}"))?
+        {
+            return Err(anyhow::anyhow!(
+                "recovered /new record disappeared before it could be committed"
+            ));
+        }
+    }
+    outbox
+        .pending_resets()
+        .map_err(|error| anyhow::anyhow!("could not read recovered /new intents: {error}"))
+}
+
+/// Select queue identity before any event is accepted. A required durable
+/// adapter declares thread scope up front even when its pool starts lazily;
+/// once a process is initialized, failure to advertise the full contract is a
+/// startup error rather than a silent downgrade to channel-wide context.
+fn select_thread_session_scope(
+    durable_sessions_required: bool,
+    pool_ready: bool,
+    durable_sessions_supported: bool,
+) -> Result<bool, &'static str> {
+    if pool_ready && durable_sessions_required && !durable_sessions_supported {
+        return Err(
+            "configured adapter does not advertise required durable thread-session and reset-commit capabilities",
+        );
+    }
+    Ok(durable_sessions_required || (pool_ready && durable_sessions_supported))
+}
+
+/// Start at most one reset acknowledgement delivery attempt without awaiting
+/// the relay. The reset barrier remains closed until the signed event is
+/// explicitly accepted, while a slow or black-holed HTTP bridge cannot stall
+/// WebSocket ingress, prompt completion, or shutdown handling.
+fn schedule_completed_reset_ack(
+    queue: &EventQueue,
+    pending: &HashMap<(Uuid, String), PendingResetConfirmation>,
+    rest: &relay::RestClient,
+    tasks: &mut tokio::task::JoinSet<ResetAckAttemptResult>,
+    in_flight: &mut Option<ResetAckAttemptKey>,
+) {
+    if in_flight.is_some() {
+        return;
+    }
+
+    for identity in queue.completed_resets() {
+        let Some(confirmation) = pending.get(&identity) else {
+            tracing::warn!(
+                channel_id = %identity.0,
+                root_event_id = %identity.1,
+                "completed reset barrier has no signed acknowledgement; keeping it closed"
+            );
+            continue;
+        };
+        let next_attempt_at = confirmation.next_attempt_at;
+        let event = confirmation.event.clone();
+        if Instant::now() < next_attempt_at {
+            continue;
+        }
+
+        let key = ResetAckAttemptKey {
+            identity,
+            event_id: event.id.to_string(),
+        };
+        let task_key = key.clone();
+        let task_rest = rest.clone();
+        *in_flight = Some(key);
+        tasks.spawn(async move {
+            let accepted = pool::submit_notice_event(&task_rest, &event).await;
+            ResetAckAttemptResult {
+                key: task_key,
+                accepted,
+            }
+        });
+        return;
+    }
+}
+
+/// Apply one tracked delivery result. Event identity is checked before the
+/// barrier is released so a stale completion can never acknowledge a newer
+/// reset for the same Buzz thread.
+fn finish_reset_ack_attempt(
+    queue: &mut EventQueue,
+    pending: &mut HashMap<(Uuid, String), PendingResetConfirmation>,
+    in_flight: &mut Option<ResetAckAttemptKey>,
+    durable_outbox: Option<&DurableOutbox>,
+    result: std::result::Result<ResetAckAttemptResult, tokio::task::JoinError>,
+) {
+    let Some(expected) = in_flight.take() else {
+        tracing::warn!("reset acknowledgement task completed without in-flight identity");
+        return;
+    };
+
+    let (key, accepted) = match result {
+        Ok(result) if result.key == expected => (result.key, result.accepted),
+        Ok(result) => {
+            tracing::error!(
+                expected_channel_id = %expected.identity.0,
+                expected_root_event_id = %expected.identity.1,
+                actual_channel_id = %result.key.identity.0,
+                actual_root_event_id = %result.key.identity.1,
+                "reset acknowledgement task returned the wrong identity"
+            );
+            if let Some(confirmation) = pending.get_mut(&expected.identity) {
+                confirmation.next_attempt_at = Instant::now() + RESET_ACK_RETRY_INTERVAL;
+            }
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(
+                channel_id = %expected.identity.0,
+                root_event_id = %expected.identity.1,
+                %error,
+                "reset acknowledgement task failed"
+            );
+            if let Some(confirmation) = pending.get_mut(&expected.identity) {
+                confirmation.next_attempt_at = Instant::now() + RESET_ACK_RETRY_INTERVAL;
+            }
+            return;
+        }
+    };
+
+    let is_current_event = pending
+        .get(&key.identity)
+        .is_some_and(|confirmation| confirmation.event.id.to_string() == key.event_id);
+    if !is_current_event {
+        tracing::warn!(
+            channel_id = %key.identity.0,
+            root_event_id = %key.identity.1,
+            event_id = %key.event_id,
+            "ignoring stale reset acknowledgement completion"
+        );
+        return;
+    }
+
+    if accepted {
+        let requires_durable_completion = pending
+            .get(&key.identity)
+            .is_some_and(|confirmation| confirmation.durable);
+        if requires_durable_completion {
+            let durable_result = durable_outbox
+                .ok_or_else(|| "durable outbox unavailable".to_string())
+                .and_then(|outbox| {
+                    outbox
+                        .complete_reset(&key.identity, &key.event_id)
+                        .map_err(|error| error.to_string())
+                });
+            match durable_result {
+                Ok(true) => {}
+                Ok(false) => {
+                    tracing::error!(
+                        channel_id = %key.identity.0,
+                        root_event_id = %key.identity.1,
+                        event_id = %key.event_id,
+                        "accepted reset acknowledgement was absent from durable state; keeping barrier closed"
+                    );
+                    if let Some(confirmation) = pending.get_mut(&key.identity) {
+                        confirmation.next_attempt_at = Instant::now() + RESET_ACK_RETRY_INTERVAL;
+                    }
+                    return;
+                }
+                Err(error) => {
+                    tracing::error!(
+                        channel_id = %key.identity.0,
+                        root_event_id = %key.identity.1,
+                        event_id = %key.event_id,
+                        %error,
+                        "relay accepted reset acknowledgement but durable completion failed; keeping barrier closed"
+                    );
+                    if let Some(confirmation) = pending.get_mut(&key.identity) {
+                        confirmation.next_attempt_at = Instant::now() + RESET_ACK_RETRY_INTERVAL;
+                    }
+                    return;
+                }
+            }
+        }
+        pending.remove(&key.identity);
+        queue.release_completed_reset(&key.identity);
+    } else if let Some(confirmation) = pending.get_mut(&key.identity) {
+        confirmation.next_attempt_at = Instant::now() + RESET_ACK_RETRY_INTERVAL;
+        tracing::warn!(
+            channel_id = %key.identity.0,
+            root_event_id = %key.identity.1,
+            event_id = %key.event_id,
+            "reset acknowledgement is still pending relay delivery"
+        );
+    }
+}
+
+/// Earliest signed reset acknowledgement that is both ready to publish and
+/// guarding a completed reset barrier. Keeping this deadline in the main
+/// `select!` prevents a quiet relay from leaving `/new` blocked forever after
+/// one transient HTTP failure. Confirmations whose old turn is still draining
+/// are deliberately excluded to avoid a past-deadline busy loop.
+fn next_completed_reset_ack_attempt(
+    queue: &EventQueue,
+    pending: &HashMap<(Uuid, String), PendingResetConfirmation>,
+) -> Option<Instant> {
+    queue
+        .completed_resets()
+        .into_iter()
+        .filter_map(|identity| pending.get(&identity).map(|item| item.next_attempt_at))
+        .min()
+}
+
+#[cfg(test)]
+mod reset_ack_retry_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind};
+
+    fn signed_notice() -> nostr::Event {
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "reset ready")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign reset notice")
+    }
+
+    fn completed_reset() -> (EventQueue, ConversationKey) {
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        let conversation = ConversationKey {
+            channel_id: Uuid::new_v4(),
+            root_event_id: "44".repeat(32),
+            generation: 0,
+            reset_token: None,
+        };
+        queue
+            .reset_conversation(&conversation, "cc".repeat(32))
+            .expect("idle reset completes immediately");
+        (queue, conversation)
+    }
+
+    fn unreachable_rest_client() -> relay::RestClient {
+        relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:9".to_string(),
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        }
+    }
+
+    #[test]
+    fn retry_deadline_tracks_only_completed_reset_barriers() {
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        let first = ConversationKey {
+            channel_id: Uuid::new_v4(),
+            root_event_id: "11".repeat(32),
+            generation: 0,
+            reset_token: None,
+        };
+        let second = ConversationKey {
+            channel_id: Uuid::new_v4(),
+            root_event_id: "22".repeat(32),
+            generation: 0,
+            reset_token: None,
+        };
+        queue
+            .reset_conversation(&first, "aa".repeat(32))
+            .expect("first idle reset");
+        queue
+            .reset_conversation(&second, "bb".repeat(32))
+            .expect("second idle reset");
+
+        let now = Instant::now();
+        let first_deadline = now + Duration::from_secs(7);
+        let second_deadline = now + Duration::from_secs(3);
+        let unrelated_identity = (Uuid::new_v4(), "33".repeat(32));
+        let pending = HashMap::from([
+            (
+                (first.channel_id, first.root_event_id.clone()),
+                PendingResetConfirmation {
+                    event: signed_notice(),
+                    next_attempt_at: first_deadline,
+                    durable: false,
+                },
+            ),
+            (
+                (second.channel_id, second.root_event_id.clone()),
+                PendingResetConfirmation {
+                    event: signed_notice(),
+                    next_attempt_at: second_deadline,
+                    durable: false,
+                },
+            ),
+            (
+                unrelated_identity,
+                PendingResetConfirmation {
+                    event: signed_notice(),
+                    next_attempt_at: now,
+                    durable: false,
+                },
+            ),
+        ]);
+
+        assert_eq!(
+            next_completed_reset_ack_attempt(&queue, &pending),
+            Some(second_deadline),
+            "unrelated past-due confirmations must not busy-spin the loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_ack_scheduler_is_non_blocking_and_globally_bounded() {
+        let (queue, conversation) = completed_reset();
+        let identity = (conversation.channel_id, conversation.root_event_id.clone());
+        let pending = HashMap::from([(
+            identity,
+            PendingResetConfirmation {
+                event: signed_notice(),
+                next_attempt_at: Instant::now(),
+                durable: false,
+            },
+        )]);
+        let mut tasks = tokio::task::JoinSet::new();
+        let mut in_flight = None;
+
+        schedule_completed_reset_ack(
+            &queue,
+            &pending,
+            &unreachable_rest_client(),
+            &mut tasks,
+            &mut in_flight,
+        );
+        assert!(in_flight.is_some());
+        assert_eq!(tasks.len(), 1);
+
+        // Re-entering the scheduler while HTTP is pending cannot spawn a
+        // second task, even if more barriers become ready.
+        schedule_completed_reset_ack(
+            &queue,
+            &pending,
+            &unreachable_rest_client(),
+            &mut tasks,
+            &mut in_flight,
+        );
+        assert_eq!(tasks.len(), 1);
+        tasks.shutdown().await;
+    }
+
+    #[test]
+    fn accepted_reset_ack_releases_only_the_matching_barrier() {
+        let (mut queue, conversation) = completed_reset();
+        let identity = (conversation.channel_id, conversation.root_event_id.clone());
+        let event = signed_notice();
+        let key = ResetAckAttemptKey {
+            identity: identity.clone(),
+            event_id: event.id.to_string(),
+        };
+        let mut pending = HashMap::from([(
+            identity.clone(),
+            PendingResetConfirmation {
+                event,
+                next_attempt_at: Instant::now(),
+                durable: false,
+            },
+        )]);
+        let mut in_flight = Some(key.clone());
+
+        finish_reset_ack_attempt(
+            &mut queue,
+            &mut pending,
+            &mut in_flight,
+            None,
+            Ok(ResetAckAttemptResult {
+                key,
+                accepted: true,
+            }),
+        );
+
+        assert!(in_flight.is_none());
+        assert!(!pending.contains_key(&identity));
+        assert!(queue.completed_resets().is_empty());
+    }
+
+    #[test]
+    fn accepted_durable_reset_ack_atomically_becomes_a_replay_receipt() {
+        let (mut queue, conversation) = completed_reset();
+        let identity = (conversation.channel_id, conversation.root_event_id.clone());
+        let keys = Keys::generate();
+        let event = EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            reset_confirmation(true),
+        )
+        .sign_with_keys(&keys)
+        .expect("sign reset acknowledgement");
+        let event_id = event.id.to_hex();
+        let reset_token = "dd".repeat(32);
+        let dir = tempfile::tempdir().expect("durable state dir");
+        let durable = DurableOutbox::open(dir.path(), &keys.public_key().to_hex()).expect("open");
+        durable
+            .prepare_reset(DurableResetRecord {
+                channel_id: identity.0,
+                root_event_id: identity.1.clone(),
+                conversation_id: conversation.stable_id(),
+                reset_token: reset_token.clone(),
+                event: event.clone(),
+                phase: DurableResetPhase::Prepared,
+            })
+            .expect("prepare durable reset");
+        assert!(durable
+            .mark_reset_committed(&identity, &event_id)
+            .expect("commit durable reset"));
+        let key = ResetAckAttemptKey {
+            identity: identity.clone(),
+            event_id,
+        };
+        let mut pending = HashMap::from([(
+            identity.clone(),
+            PendingResetConfirmation {
+                event,
+                next_attempt_at: Instant::now(),
+                durable: true,
+            },
+        )]);
+        let mut in_flight = Some(key.clone());
+
+        finish_reset_ack_attempt(
+            &mut queue,
+            &mut pending,
+            &mut in_flight,
+            Some(&durable),
+            Ok(ResetAckAttemptResult {
+                key,
+                accepted: true,
+            }),
+        );
+
+        assert!(pending.is_empty());
+        assert!(queue.completed_resets().is_empty());
+        assert!(durable
+            .pending_resets()
+            .expect("read pending resets")
+            .is_empty());
+        assert!(durable
+            .consumed_reset(&identity, &reset_token)
+            .expect("read receipt")
+            .is_some());
+    }
+
+    #[test]
+    fn stale_reset_ack_cannot_release_a_newer_notice() {
+        let (mut queue, conversation) = completed_reset();
+        let identity = (conversation.channel_id, conversation.root_event_id.clone());
+        let stale_event = signed_notice();
+        let current_event = signed_notice();
+        let stale_key = ResetAckAttemptKey {
+            identity: identity.clone(),
+            event_id: stale_event.id.to_string(),
+        };
+        let mut pending = HashMap::from([(
+            identity.clone(),
+            PendingResetConfirmation {
+                event: current_event,
+                next_attempt_at: Instant::now(),
+                durable: false,
+            },
+        )]);
+        let mut in_flight = Some(stale_key.clone());
+
+        finish_reset_ack_attempt(
+            &mut queue,
+            &mut pending,
+            &mut in_flight,
+            None,
+            Ok(ResetAckAttemptResult {
+                key: stale_key,
+                accepted: true,
+            }),
+        );
+
+        assert!(pending.contains_key(&identity));
+        assert_eq!(queue.completed_resets().len(), 1);
+    }
+
+    #[test]
+    fn required_durable_scope_is_selected_before_a_lazy_pool_wakes() {
+        assert_eq!(select_thread_session_scope(true, false, false), Ok(true));
+    }
+
+    #[test]
+    fn required_durable_scope_fails_closed_after_an_unsupported_wake() {
+        assert!(select_thread_session_scope(true, true, false).is_err());
+    }
+
+    #[test]
+    fn optional_scope_uses_the_initialized_adapter_capability() {
+        assert_eq!(select_thread_session_scope(false, false, false), Ok(false));
+        assert_eq!(select_thread_session_scope(false, true, false), Ok(false));
+        assert_eq!(select_thread_session_scope(false, true, true), Ok(true));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn durable_reset_retries_same_token_when_first_commit_response_is_dropped() {
+        let marker =
+            std::env::temp_dir().join(format!("buzz-acp-reset-commit-{}", uuid::Uuid::new_v4()));
+        let script = format!(
+            r#"
+                read -r _init
+                echo '{{"jsonrpc":"2.0","id":0,"result":{{"protocolVersion":2,"_meta":{{"buzz":{{"threadSessions":{{"supported":true,"persistence":true,"dispose":true,"resetToken":true,"resetCommit":true}},"sessionEvents":{{"supported":true,"schemaVersion":2,"durableReplay":true,"ack":true}}}}}}}}}}'
+                read -r _reset
+                if [ -f '{marker}' ]; then
+                    echo '{{"jsonrpc":"2.0","id":1,"result":{{"committed":true,"alreadyCommitted":true}}}}'
+                    sleep 1
+                else
+                    printf committed > '{marker}'
+                    exit 0
+                fi
+            "#,
+            marker = marker.display(),
+        );
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let committed = commit_durable_conversation_reset_with_adapter(
+            &mut pool,
+            "bash",
+            &["-c".to_string(), script],
+            &[],
+            false,
+            "buzz:channel:root",
+            "signed-reset-event-id",
+        )
+        .await;
+        assert_eq!(
+            committed,
+            Some(ConversationResetCommit::AlreadyCommitted),
+            "fresh helper must distinguish the idempotent retry"
+        );
+        assert!(marker.exists(), "first helper performed the durable commit");
+        std::fs::remove_file(marker).expect("remove reset test marker");
+    }
 }
 
 /// RAII guard that ensures a `RespawnResult` is sent even if the task panics.
@@ -1286,6 +2122,392 @@ pub fn run() -> Result<()> {
     tokio_main()
 }
 
+/// Exercise the production Buzz↔Pi ACP contract against a built adapter.
+///
+/// This is intentionally a narrow public probe rather than exposing the
+/// harness's internal ACP client module. It starts the real Node adapter in an
+/// isolated state directory, proves a logical conversation survives an adapter
+/// restart, commits an idempotent reset, and verifies the replacement reports
+/// that relay history must be skipped. It never sends a model prompt or reads
+/// the caller's normal Pi settings.
+///
+/// `adapter_entrypoint`, `state_dir`, `pi_agent_dir`, and `cwd` must be absolute
+/// paths. The adapter entrypoint is run with the `node` executable on `PATH`.
+#[doc(hidden)]
+pub async fn verify_pi_adapter_contract(
+    adapter_entrypoint: &std::path::Path,
+    state_dir: &std::path::Path,
+    pi_agent_dir: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Result<()> {
+    for (name, path) in [
+        ("adapter entrypoint", adapter_entrypoint),
+        ("state directory", state_dir),
+        ("Pi agent directory", pi_agent_dir),
+        ("working directory", cwd),
+    ] {
+        anyhow::ensure!(
+            path.is_absolute(),
+            "{name} must be absolute: {}",
+            path.display()
+        );
+    }
+    anyhow::ensure!(
+        adapter_entrypoint.is_file(),
+        "Pi adapter entrypoint does not exist: {}",
+        adapter_entrypoint.display()
+    );
+    std::fs::create_dir_all(state_dir)?;
+    std::fs::create_dir_all(pi_agent_dir)?;
+
+    async fn spawn_adapter(
+        adapter_entrypoint: &std::path::Path,
+        state_dir: &std::path::Path,
+        pi_agent_dir: &std::path::Path,
+        namespace: &str,
+    ) -> Result<AcpClient> {
+        let isolated_env = [
+            (
+                "BUZZ_PI_STATE_DIR".to_owned(),
+                state_dir.to_string_lossy().into_owned(),
+            ),
+            ("BUZZ_PI_NAMESPACE".to_owned(), namespace.to_owned()),
+            ("BUZZ_PI_CONTEXT_LIMIT".to_owned(), "150000".to_owned()),
+            (
+                "PI_CODING_AGENT_DIR".to_owned(),
+                pi_agent_dir.to_string_lossy().into_owned(),
+            ),
+            ("BUZZ_PI_TRUST_PROJECT".to_owned(), "false".to_owned()),
+            ("BUZZ_PI_LOG_LEVEL".to_owned(), "error".to_owned()),
+        ];
+
+        #[cfg(unix)]
+        {
+            // `AcpClient::spawn` normally gives parent environment variables
+            // operator precedence. The contract probe must never reuse a
+            // developer's real state, so launch through `env KEY=value ...`
+            // and make the isolation overrides unambiguous.
+            let mut args: Vec<String> = isolated_env
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect();
+            args.push("node".to_owned());
+            args.push(adapter_entrypoint.to_string_lossy().into_owned());
+            return AcpClient::spawn("env", &args, &[], false)
+                .await
+                .map_err(Into::into);
+        }
+
+        #[cfg(not(unix))]
+        {
+            AcpClient::spawn(
+                "node",
+                &[adapter_entrypoint.to_string_lossy().into_owned()],
+                &isolated_env,
+                false,
+            )
+            .await
+            .map_err(Into::into)
+        }
+    }
+
+    fn assert_initialize_contract(client: &AcpClient, response: &serde_json::Value) -> Result<()> {
+        anyhow::ensure!(
+            response
+                .get("protocolVersion")
+                .and_then(|value| value.as_u64())
+                == Some(2),
+            "Pi adapter did not negotiate ACP protocol version 2"
+        );
+        anyhow::ensure!(
+            response
+                .pointer("/agentInfo/name")
+                .and_then(|value| value.as_str())
+                == Some("buzz-pi-agent"),
+            "Pi adapter initialize response has an unexpected agent identity"
+        );
+        anyhow::ensure!(
+            response
+                .pointer("/_meta/buzz/contextLimitTokens")
+                .and_then(|value| value.as_u64())
+                == Some(150_000),
+            "Pi adapter initialize response did not advertise the 150k context ceiling"
+        );
+        anyhow::ensure!(
+            response
+                .pointer("/_meta/buzz/sessionEvents/supported")
+                .and_then(|value| value.as_bool())
+                == Some(true)
+                && client.durable_session_events_supported(),
+            "Pi adapter did not advertise durable replay plus ACKs for typed lifecycle events"
+        );
+        anyhow::ensure!(
+            client.thread_sessions_supported() && client.conversation_reset_supported(),
+            "Pi adapter did not advertise durable thread sessions plus reset commits"
+        );
+        Ok(())
+    }
+
+    fn pi_session_id(response: &acp::SessionNewResponse) -> Result<&str> {
+        response
+            .raw
+            .pointer("/_meta/buzz/piSessionId")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow::anyhow!("session/new response omitted _meta.buzz.piSessionId"))
+    }
+
+    fn assert_session_shape(response: &acp::SessionNewResponse) -> Result<()> {
+        anyhow::ensure!(
+            response
+                .raw
+                .get("configOptions")
+                .is_some_and(|value| value.is_array()),
+            "session/new response omitted stable configOptions"
+        );
+        anyhow::ensure!(
+            response
+                .raw
+                .pointer("/models/availableModels")
+                .is_some_and(|value| value.is_array()),
+            "session/new response omitted available model metadata"
+        );
+        anyhow::ensure!(
+            response
+                .raw
+                .pointer("/_meta/buzz/persistent")
+                .and_then(|value| value.as_bool())
+                == Some(true),
+            "Pi session was not persisted"
+        );
+        anyhow::ensure!(
+            response
+                .raw
+                .pointer("/_meta/buzz/contextLimitTokens")
+                .and_then(|value| value.as_u64())
+                == Some(150_000),
+            "session/new response lost the configured context ceiling"
+        );
+        Ok(())
+    }
+
+    let namespace = format!("contract-{}", Uuid::new_v4());
+    let conversation_id = format!("contract:{}:thread", Uuid::new_v4());
+    let reset_token = format!("contract-reset:{}", Uuid::new_v4());
+    let cwd = cwd.to_string_lossy();
+
+    let mut first = spawn_adapter(adapter_entrypoint, state_dir, pi_agent_dir, &namespace).await?;
+    let first_result: Result<(String, String)> = async {
+        let initialize = first.initialize().await?;
+        assert_initialize_contract(&first, &initialize)?;
+
+        // Heartbeat and compatibility/admin callers do not carry a Buzz
+        // conversation identity. A server that negotiated durable schema v2
+        // must never emit its legacy schema-v1 lifecycle envelope on those
+        // sessions: doing so is a protocol-fatal downgrade in AcpClient. The
+        // adapter therefore completes local commands but suppresses their
+        // undeliverable lifecycle notice.
+        let unmapped = first
+            .session_new_full(
+                &cwd,
+                Vec::new(),
+                None,
+                Some("Buzz Pi unmapped lifecycle smoke"),
+            )
+            .await?;
+        let unmapped_stop = first
+            .session_prompt_with_idle_timeout(
+                &unmapped.session_id,
+                "/context",
+                Duration::from_secs(15),
+                Duration::from_secs(30),
+            )
+            .await?;
+        anyhow::ensure!(
+            unmapped_stop == acp::StopReason::EndTurn,
+            "Pi's local /context command failed on an unmapped heartbeat-like session"
+        );
+        anyhow::ensure!(
+            first.take_buzz_session_events().is_empty(),
+            "Pi emitted a lifecycle envelope without a durable Buzz conversation identity"
+        );
+        anyhow::ensure!(
+            first.session_dispose(&unmapped.session_id, false).await?,
+            "Pi did not dispose the unmapped contract session"
+        );
+
+        let session = first
+            .session_new_full_for_conversation(
+                &cwd,
+                Vec::new(),
+                None,
+                Some("Buzz Pi contract smoke"),
+                Some(&conversation_id),
+                None,
+            )
+            .await?;
+        assert_session_shape(&session)?;
+        anyhow::ensure!(
+            session
+                .raw
+                .pointer("/_meta/buzz/resumedConversation")
+                .and_then(|value| value.as_bool())
+                == Some(false),
+            "the first logical conversation unexpectedly resumed"
+        );
+        anyhow::ensure!(
+            session
+                .raw
+                .pointer("/_meta/buzz/skipRelayHistory")
+                .and_then(|value| value.as_bool())
+                == Some(false),
+            "the first logical conversation unexpectedly suppressed relay context"
+        );
+        let stop_reason = first
+            .session_prompt_with_idle_timeout(
+                &session.session_id,
+                "/context",
+                Duration::from_secs(15),
+                Duration::from_secs(30),
+            )
+            .await?;
+        anyhow::ensure!(
+            stop_reason == acp::StopReason::EndTurn,
+            "Pi's local /context command did not complete normally"
+        );
+        let lifecycle_events = first.take_buzz_session_events();
+        anyhow::ensure!(
+            lifecycle_events.len() == 1,
+            "Pi /context emitted {} typed lifecycle events instead of one",
+            lifecycle_events.len()
+        );
+        let context_event = &lifecycle_events[0];
+        anyhow::ensure!(
+            context_event.schema_version == acp::BUZZ_SESSION_EVENT_SCHEMA_VERSION
+                && context_event.session_id == session.session_id
+                && context_event.conversation_id == conversation_id
+                && Uuid::parse_str(&context_event.event_id).is_ok(),
+            "Pi /context lifecycle envelope did not match the active ACP session"
+        );
+        anyhow::ensure!(
+            matches!(
+                &context_event.event,
+                BuzzSessionEvent::ContextStatus {
+                    limit_tokens: 150_000,
+                    auto_compaction: true,
+                    ..
+                }
+            ),
+            "Pi /context lifecycle payload did not report the 150k automatic-compaction policy"
+        );
+        let context_event_ack = acp::BuzzSessionEventAck {
+            conversation_id: context_event.conversation_id.clone(),
+            event_id: context_event.event_id.clone(),
+        };
+        first.queue_buzz_session_event_ack(context_event_ack);
+        first.flush_buzz_session_event_acks().await;
+        let pi_session_id = pi_session_id(&session)?.to_owned();
+        Ok((session.session_id, pi_session_id))
+    }
+    .await;
+    first.shutdown().await;
+    let (first_acp_session_id, first_pi_session_id) = first_result?;
+
+    let mut second = spawn_adapter(adapter_entrypoint, state_dir, pi_agent_dir, &namespace).await?;
+    let second_result: Result<()> = async {
+        let initialize = second.initialize().await?;
+        assert_initialize_contract(&second, &initialize)?;
+        let resumed = second
+            .session_new_full_for_conversation(
+                &cwd,
+                Vec::new(),
+                None,
+                Some("Buzz Pi contract smoke"),
+                Some(&conversation_id),
+                None,
+            )
+            .await?;
+        assert_session_shape(&resumed)?;
+        anyhow::ensure!(
+            resumed.session_id != first_acp_session_id,
+            "a restarted adapter reused an outer ACP session ID"
+        );
+        anyhow::ensure!(
+            pi_session_id(&resumed)? == first_pi_session_id,
+            "a restarted adapter failed to resume the same durable Pi session"
+        );
+        anyhow::ensure!(
+            resumed
+                .raw
+                .pointer("/_meta/buzz/resumedConversation")
+                .and_then(|value| value.as_bool())
+                == Some(true),
+            "the restarted adapter did not report a resumed conversation"
+        );
+        anyhow::ensure!(
+            resumed
+                .raw
+                .pointer("/_meta/buzz/skipRelayHistory")
+                .and_then(|value| value.as_bool())
+                == Some(false),
+            "a normal resume incorrectly suppressed Buzz relay context"
+        );
+
+        anyhow::ensure!(
+            second
+                .conversation_reset(&conversation_id, &reset_token)
+                .await?
+                == Some(ConversationResetCommit::NewlyCommitted),
+            "Pi adapter did not explicitly confirm the durable reset"
+        );
+        anyhow::ensure!(
+            second
+                .conversation_reset(&conversation_id, &reset_token)
+                .await?
+                == Some(ConversationResetCommit::AlreadyCommitted),
+            "Pi adapter did not idempotently confirm the same reset token"
+        );
+        let fresh = second
+            .session_new_full_for_conversation(
+                &cwd,
+                Vec::new(),
+                None,
+                Some("Buzz Pi contract smoke"),
+                Some(&conversation_id),
+                Some(&reset_token),
+            )
+            .await?;
+        assert_session_shape(&fresh)?;
+        anyhow::ensure!(
+            pi_session_id(&fresh)? != first_pi_session_id,
+            "the committed reset reopened the previous Pi session"
+        );
+        anyhow::ensure!(
+            fresh
+                .raw
+                .pointer("/_meta/buzz/resumedConversation")
+                .and_then(|value| value.as_bool())
+                == Some(false),
+            "the committed reset was reported as a resume"
+        );
+        anyhow::ensure!(
+            fresh
+                .raw
+                .pointer("/_meta/buzz/skipRelayHistory")
+                .and_then(|value| value.as_bool())
+                == Some(true),
+            "the committed reset did not request relay-history suppression"
+        );
+        anyhow::ensure!(
+            second.session_dispose(&fresh.session_id, true).await?,
+            "Pi adapter did not confirm destructive session disposal"
+        );
+        Ok(())
+    }
+    .await;
+    second.shutdown().await;
+    second_result
+}
+
 #[tokio::main]
 async fn tokio_main() -> Result<()> {
     // Install the ring crypto provider for rustls (required for wss:// connections).
@@ -1371,6 +2593,17 @@ async fn tokio_main() -> Result<()> {
         initialize_agent_pool(&PoolStartup::from_config(&config, observer.clone()), None).await?
     };
     let mut pool_ready = !config.lazy_pool;
+    let mut thread_sessions_enabled = match select_thread_session_scope(
+        config.require_durable_thread_sessions,
+        pool_ready,
+        pool.thread_sessions_supported(),
+    ) {
+        Ok(enabled) => enabled,
+        Err(message) => {
+            shutdown_agent_pool(&mut pool).await;
+            return Err(anyhow::anyhow!(message));
+        }
+    };
     let mut pool_lifecycle: PoolLifecycle<AgentPool> = PoolLifecycle::listening();
 
     // Capture a startup watermark BEFORE connecting to the relay. This timestamp
@@ -1384,6 +2617,11 @@ async fn tokio_main() -> Result<()> {
         .as_secs();
 
     let pubkey_hex = config.keys.public_key().to_hex();
+    let durable_outbox = DurableOutbox::open(&config.state_dir, &pubkey_hex)
+        .map_err(|error| anyhow::anyhow!("could not open durable harness state: {error}"))?;
+    let recovered_reset_records =
+        recover_durable_reset_intents(&durable_outbox, &mut pool, &config, thread_sessions_enabled)
+            .await?;
 
     // Parse BUZZ_AUTH_TAG into a nostr::Tag for NIP-OA relay membership delegation.
     let relay_auth_tag: Option<nostr::Tag> = std::env::var("BUZZ_AUTH_TAG")
@@ -1553,8 +2791,27 @@ async fn tokio_main() -> Result<()> {
 
     let runtime_start_nonce = std::env::var("BUZZ_MANAGED_AGENT_START_NONCE").unwrap_or_default();
     let dedup_mode = config.dedup_mode;
-    let mut queue =
-        EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
+    let mut queue = EventQueue::new(dedup_mode)
+        .with_thread_sessions_enabled(thread_sessions_enabled)
+        .with_in_flight_deadline(config.max_turn_duration_secs);
+    let mut pending_reset_confirmations: HashMap<(Uuid, String), PendingResetConfirmation> =
+        HashMap::new();
+    for record in recovered_reset_records {
+        let identity = record.identity();
+        queue.restore_completed_reset_barrier(identity.clone());
+        pending_reset_confirmations.insert(
+            identity,
+            PendingResetConfirmation {
+                event: record.event,
+                next_attempt_at: Instant::now(),
+                durable: true,
+            },
+        );
+    }
+    tracing::info!(
+        thread_sessions_enabled,
+        "configured ACP conversation scoping"
+    );
 
     // Online means the harness can receive work, not merely that its socket is
     // connected. Publishing after channel subscriptions gives desktop callers
@@ -1604,6 +2861,10 @@ async fn tokio_main() -> Result<()> {
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,
         max_turns_per_session: config.max_turns_per_session,
+        max_cached_conversation_sessions: config.max_cached_conversation_sessions as usize,
+        conversation_session_idle_ttl: Duration::from_secs(
+            config.conversation_session_idle_ttl_secs,
+        ),
         permission_mode: config.permission_mode,
         agent_keys: config.keys.clone(),
         agent_owner_pubkey: startup_owner
@@ -1613,6 +2874,8 @@ async fn tokio_main() -> Result<()> {
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
     });
+    let mut lifecycle_notice_outbox =
+        LifecycleNoticeOutbox::spawn(ctx.rest_client.clone(), durable_outbox.clone())?;
 
     if !config.memory_enabled {
         tracing::info!(
@@ -1651,7 +2914,16 @@ async fn tokio_main() -> Result<()> {
     } else {
         None
     };
-    let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
+    let mut typing_channels: HashMap<ConversationKey, ThreadTags> = HashMap::new();
+    let mut observer_control_replay_cache = ObserverControlReplayCache::default();
+    // Reset success notices have stronger ordering than ordinary lifecycle
+    // notices: their completed barrier is released only after relay
+    // acceptance. Keep one tracked HTTP attempt globally so delivery never
+    // blocks relay ingress and a relay outage cannot create an unbounded task
+    // fan-out.
+    let mut reset_ack_tasks: tokio::task::JoinSet<ResetAckAttemptResult> =
+        tokio::task::JoinSet::new();
+    let mut reset_ack_in_flight: Option<ResetAckAttemptKey> = None;
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
 
     // Independent of pool readiness: a never-mentioned lazy agent must still
@@ -1767,11 +3039,21 @@ async fn tokio_main() -> Result<()> {
     enum PoolEvent {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
+        ResetAck(std::result::Result<ResetAckAttemptResult, tokio::task::JoinError>),
         SteerAck(SteerAckEvent),
         Wake(u32, Result<AgentPool, String>),
     }
 
+    let mut terminal_error = None;
     loop {
+        schedule_completed_reset_ack(
+            &queue,
+            &pending_reset_confirmations,
+            &ctx.rest_client,
+            &mut reset_ack_tasks,
+            &mut reset_ack_in_flight,
+        );
+
         // Whether buffered work is waiting on a lazy pool. Also gates the
         // retry-deadline sleep arm below: a `Failed` lifecycle keeps its
         // (possibly past) `retry_at` until the next wake, so sleeping on it
@@ -1854,7 +3136,25 @@ async fn tokio_main() -> Result<()> {
         while let Ok(rr) = respawn_rx.try_recv() {
             crash_history[rr.index].respawn_in_flight = false;
             match rr.result {
-                Ok((acp, protocol_version, agent_name)) => {
+                Ok((mut acp, protocol_version, agent_name)) => {
+                    let durable_thread_sessions_supported = acp.thread_sessions_supported()
+                        && acp.conversation_reset_supported()
+                        && acp.durable_session_events_supported();
+                    if thread_sessions_enabled && !durable_thread_sessions_supported {
+                        tracing::error!(
+                            agent = rr.index,
+                            "rejecting respawn whose adapter no longer advertises durable thread-session reset support"
+                        );
+                        acp.shutdown().await;
+                        crash_history[rr.index].mark_spawn_failed();
+                        continue;
+                    }
+                    if !thread_sessions_enabled && durable_thread_sessions_supported {
+                        tracing::info!(
+                            agent = rr.index,
+                            "respawn supports thread sessions; retaining startup legacy channel scope"
+                        );
+                    }
                     let agent = OwnedAgent {
                         index: rr.index,
                         acp,
@@ -1862,6 +3162,7 @@ async fn tokio_main() -> Result<()> {
                         model_capabilities: None,
                         desired_model: config.model.clone(),
                         model_overridden: false,
+                        pending_model_switch: None,
                         agent_name,
                         goose_system_prompt_supported: None,
                         protocol_version,
@@ -1887,6 +3188,11 @@ async fn tokio_main() -> Result<()> {
             }
         }
 
+        let reset_ack_retry_at = reset_ack_in_flight
+            .is_none()
+            .then(|| next_completed_reset_ack_attempt(&queue, &pending_reset_confirmations))
+            .flatten();
+
         // Borrow result_rx and join_set simultaneously via split-borrow helper.
         let pool_event: Option<PoolEvent> = {
             let (result_rx, join_set) = pool.rx_and_join_set();
@@ -1906,6 +3212,9 @@ async fn tokio_main() -> Result<()> {
                 // are in-flight tasks.
                 Some(Err(e)) = join_set.join_next(), if !join_set.is_empty() => {
                     Some(PoolEvent::Panic(e))
+                }
+                Some(result) = reset_ack_tasks.join_next(), if !reset_ack_tasks.is_empty() => {
+                    Some(PoolEvent::ResetAck(result))
                 }
                 // Goose-native steer ack from a watcher task. Outcomes drive
                 // queue side-effects (drop / release withheld event) and
@@ -1928,6 +3237,14 @@ async fn tokio_main() -> Result<()> {
                             tokio::time::sleep_until(retry_at).await
                         }
                         _ => std::future::pending().await,
+                    }
+                } => None,
+                _ = async {
+                    match reset_ack_retry_at {
+                        Some(deadline) => {
+                            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await
+                        }
+                        None => std::future::pending().await,
                     }
                 } => None,
                 Some(Err(error)) = wake_tasks.join_next(), if !wake_tasks.is_empty() => {
@@ -1960,7 +3277,14 @@ async fn tokio_main() -> Result<()> {
                     match control_event {
                         Some(event) => {
                             if let Some(ref owner_hex) = owner_cache.pubkey {
-                                handle_relay_observer_control_event(&config.keys, event, &mut pool, observer.as_ref(), owner_hex);
+                                handle_relay_observer_control_event(
+                                    &config.keys,
+                                    event,
+                                    &mut pool,
+                                    observer.as_ref(),
+                                    owner_hex,
+                                    &mut observer_control_replay_cache,
+                                );
                             } else {
                                 tracing::warn!("observer control frame received but no owner resolved — dropping");
                             }
@@ -1983,7 +3307,7 @@ async fn tokio_main() -> Result<()> {
                                 || kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION
                             {
                                 let ch = buzz_event.channel_id;
-                                let ts = buzz_event.event.created_at.as_secs();
+                                let ts = relay::bounded_event_replay_timestamp(&buzz_event.event);
                                 let eid = buzz_event.event.id.to_hex();
 
                                 // Two-layer membership dedup:
@@ -2060,14 +3384,14 @@ async fn tokio_main() -> Result<()> {
                                     // the agent lost access).
                                     let drained_ids = queue.drain_channel(ch);
                                     let invalidated = if pool_ready {
-                                        pool.invalidate_channel_sessions(ch)
+                                        pool.dispose_channel_sessions(ch, true).await
                                     } else {
                                         0
                                     };
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
-                                    typing_channels.remove(&ch);
+                                    typing_channels.retain(|key, _| key.channel_id != ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
                                     // emitting the notification, so this DELETE may
@@ -2100,12 +3424,46 @@ async fn tokio_main() -> Result<()> {
                                 continue;
                             }
 
+                            // Conversation identity is security-sensitive: it
+                            // selects the queue, session, control target, and
+                            // relay context query. Reject malformed or
+                            // conflicting NIP-10 markers before interpreting
+                            // any lifecycle command.
+                            if !queue::has_valid_thread_identity(&buzz_event.event) {
+                                tracing::warn!(
+                                    channel_id = %buzz_event.channel_id,
+                                    event_id = %buzz_event.event.id,
+                                    "dropping event with invalid NIP-10 thread identity"
+                                );
+                                continue;
+                            }
+
+                            // Compute thread identity once, before any control
+                            // command can consume the event. Top-level events
+                            // are their own prospective roots; replies inherit
+                            // their NIP-10 root.
+                            let (event_is_dm, conversation_is_dm) =
+                                resolve_dm_channel_scope(
+                                    buzz_event.channel_id,
+                                    &ctx.channel_info,
+                                )
+                                .await;
+                            queue.set_channel_is_dm(
+                                buzz_event.channel_id,
+                                conversation_is_dm,
+                            );
+                            let event_conversation = queue.conversation_key_for_event(
+                                buzz_event.channel_id,
+                                &buzz_event.event,
+                            );
+
                             // Check: kind:9, content "!shutdown", from owner, mentions THIS agent.
                             let is_shutdown = is_owner_control_command(
                                 &buzz_event.event,
                                 kind_u32,
                                 "!shutdown",
                                 &pubkey_hex,
+                                config.session_title.as_deref(),
                             );
                             if is_shutdown {
                                 let owner = owner_cache.get();
@@ -2137,13 +3495,14 @@ async fn tokio_main() -> Result<()> {
                                 kind_u32,
                                 "!cancel",
                                 &pubkey_hex,
+                                config.session_title.as_deref(),
                             );
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
+                                        let fired = signal_in_flight_conversation(
                                             &mut pool,
-                                            buzz_event.channel_id,
+                                            &event_conversation,
                                             ControlSignal::Cancel,
                                         );
                                         if !fired {
@@ -2175,22 +3534,29 @@ async fn tokio_main() -> Result<()> {
                                 kind_u32,
                                 "!rotate",
                                 &pubkey_hex,
+                                config.session_title.as_deref(),
                             );
                             if is_rotate {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
+                                        let rotated = rotate_all_in_flight_channel(
                                             &mut pool,
                                             buzz_event.channel_id,
-                                            ControlSignal::Rotate,
                                         );
-                                        if fired {
+                                        let invalidated = pool
+                                            .dispose_channel_sessions(
+                                                buzz_event.channel_id,
+                                                true,
+                                            )
+                                            .await;
+                                        if rotated > 0 {
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
+                                                rotated,
+                                                invalidated,
                                                 "!rotate received — cancelling in-flight turn and rotating session"
                                             );
                                         } else {
-                                            let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
                                                 invalidated,
@@ -2201,6 +3567,327 @@ async fn tokio_main() -> Result<()> {
                                     }
                                 }
                                 // Not from owner — fall through to normal prompt handling.
+                            }
+
+                            // Thread-local context reset. Unlike channel-wide
+                            // `!rotate`, `/new` affects only the NIP-10 thread
+                            // containing the command. It is owner-authorized,
+                            // consumed by the harness, and visibly acknowledged
+                            // in the same thread.
+                            let is_new = is_owner_control_command(
+                                &buzz_event.event,
+                                kind_u32,
+                                "/new",
+                                &pubkey_hex,
+                                config.session_title.as_deref(),
+                            );
+                            if is_new {
+                                if let Some(owner) = owner_cache.get() {
+                                    if buzz_event.event.pubkey.to_hex() == *owner {
+                                        let command_id = buzz_event.event.id.to_hex();
+                                        let mut thread_tags =
+                                            queue::parse_thread_tags(&buzz_event.event);
+                                        if thread_tags.root_event_id.is_none() {
+                                            thread_tags.root_event_id = Some(command_id.clone());
+                                            thread_tags.parent_event_id = Some(command_id.clone());
+                                        }
+                                        let conversation_id = event_conversation.stable_id();
+                                        let reset_identity = (
+                                            event_conversation.channel_id,
+                                            event_conversation.root_event_id.clone(),
+                                        );
+                                        if thread_sessions_enabled {
+                                            match durable_outbox
+                                                .consumed_reset(&reset_identity, &command_id)
+                                            {
+                                              Ok(Some(receipt)) => {
+                                                // Relay overlap or a long-delayed duplicate must
+                                                // not advance the queue generation or cancel a
+                                                // newer turn. The original signed ACK was already
+                                                // accepted before this receipt was checkpointed;
+                                                // re-submit it idempotently for convergence.
+                                                tracing::info!(
+                                                    conversation = %event_conversation,
+                                                    command_id,
+                                                    acknowledgement_event_id = %receipt.event.id,
+                                                    "replaying previously consumed /new without mutating context"
+                                                );
+                                                let rest = ctx.rest_client.clone();
+                                                tokio::spawn(async move {
+                                                    if !pool::submit_notice_event(&rest, &receipt.event).await {
+                                                        tracing::warn!(
+                                                            event_id = %receipt.event.id,
+                                                            "relay did not accept replayed /new acknowledgement"
+                                                        );
+                                                    }
+                                                });
+                                                continue;
+                                              }
+                                              Ok(None) => {}
+                                              Err(error) => {
+                                                  // Treat loss of durable replay knowledge as
+                                                  // a process-fatal safety fault. Continuing
+                                                  // would make a consumed `/new` look fresh.
+                                                  return Err(anyhow::anyhow!(
+                                                      "could not read durable /new replay receipts: {error}"
+                                                  ));
+                                              }
+                                            }
+                                        }
+                                        let reset_notice_event = match pool::build_notice_event(
+                                            &ctx.rest_client,
+                                            buzz_event.channel_id,
+                                            &thread_tags,
+                                            reset_confirmation(thread_sessions_enabled),
+                                        ) {
+                                            Ok(event) => event,
+                                            Err(error) => {
+                                                tracing::error!(
+                                                    conversation = %event_conversation,
+                                                    %error,
+                                                    "/new rejected because its acknowledgement could not be signed"
+                                                );
+                                                continue;
+                                            }
+                                        };
+                                        let prepared_reset = match queue
+                                            .prepare_reset_conversation(&event_conversation)
+                                        {
+                                            Ok(prepared) => prepared,
+                                            Err(error) => {
+                                                tracing::error!(
+                                                    conversation = %event_conversation,
+                                                    %error,
+                                                    "/new rejected before mutating the active session"
+                                                );
+                                                let failure = match error {
+                                                    queue::ResetConversationError::ResetInProgress => {
+                                                        "⚠️ A previous `/new` for this thread is still waiting for Buzz to acknowledge its signed reset notice. I left that reset intact; wait a moment, then try again."
+                                                    }
+                                                    queue::ResetConversationError::MetadataCapacity => {
+                                                        "⚠️ I couldn't reset this thread because the agent's reset metadata is at capacity. No success was recorded; restart the agent and try `/new` again."
+                                                    }
+                                                };
+                                                pool::post_failure_notice(
+                                                    &ctx.rest_client,
+                                                    buzz_event.channel_id,
+                                                    &thread_tags,
+                                                    failure,
+                                                )
+                                                .await;
+                                                continue;
+                                            }
+                                        };
+                                        if thread_sessions_enabled {
+                                            let record = DurableResetRecord {
+                                                channel_id: reset_identity.0,
+                                                root_event_id: reset_identity.1.clone(),
+                                                conversation_id: conversation_id.clone(),
+                                                reset_token: command_id.clone(),
+                                                event: reset_notice_event.clone(),
+                                                phase: DurableResetPhase::Prepared,
+                                            };
+                                            if let Err(error) = durable_outbox.prepare_reset(record) {
+                                                tracing::error!(
+                                                    conversation = %event_conversation,
+                                                    %error,
+                                                    "/new rejected because its signed acknowledgement intent could not be persisted"
+                                                );
+                                                pool::post_failure_notice(
+                                                    &ctx.rest_client,
+                                                    buzz_event.channel_id,
+                                                    &thread_tags,
+                                                    "⚠️ I couldn't persist the reset safely, so the active context was left unchanged. Free local disk space and try `/new` again.",
+                                                )
+                                                .await;
+                                                continue;
+                                            }
+                                        }
+                                        let reset_commit = if thread_sessions_enabled {
+                                            commit_durable_conversation_reset(
+                                                &mut pool,
+                                                &config,
+                                                &conversation_id,
+                                                &command_id,
+                                            )
+                                            .await
+                                        } else {
+                                            Some(ConversationResetCommit::NewlyCommitted)
+                                        };
+                                        if reset_commit != Some(ConversationResetCommit::NewlyCommitted) {
+                                            // The result may be ambiguous (the
+                                            // tombstone can outlive a dropped
+                                            // response), or an evicted replay
+                                            // receipt may have produced an
+                                            // already-committed token. Never
+                                            // advance a second queue generation
+                                            // or continue using an old hot
+                                            // handle in either state.
+                                            let cancelled = signal_in_flight_conversation(
+                                                &mut pool,
+                                                &event_conversation,
+                                                ControlSignal::Cancel,
+                                            );
+                                            let invalidated = pool
+                                                .dispose_conversation_sessions(
+                                                    &event_conversation,
+                                                    false,
+                                                )
+                                                .await;
+                                            tracing::error!(
+                                                conversation = %event_conversation,
+                                                cancelled,
+                                                invalidated,
+                                                "durable reset remained unconfirmed; old hot context was invalidated without acknowledging success"
+                                            );
+                                            if let Err(error) = durable_outbox.discard_reset(
+                                                &reset_identity,
+                                                &reset_notice_event.id.to_hex(),
+                                            ) {
+                                                tracing::error!(
+                                                    %error,
+                                                    "could not remove an unconfirmed durable reset intent; restart recovery will retry it"
+                                                );
+                                            }
+                                            pool::post_failure_notice(
+                                                &ctx.rest_client,
+                                                buzz_event.channel_id,
+                                                &thread_tags,
+                                                "⚠️ I couldn't uniquely confirm this durable reset. I stopped the old live context and did not record success; send a new `/new` command to finish safely.",
+                                            )
+                                            .await;
+                                            continue;
+                                        }
+
+                                        if thread_sessions_enabled {
+                                            match durable_outbox.mark_reset_committed(
+                                                &reset_identity,
+                                                &reset_notice_event.id.to_hex(),
+                                            ) {
+                                                Ok(true) => {}
+                                                Ok(false) => {
+                                                    tracing::error!(
+                                                        conversation = %event_conversation,
+                                                        "durable reset intent disappeared after adapter commit; stopping before in-memory release"
+                                                    );
+                                                    return Err(anyhow::anyhow!(
+                                                        "durable /new intent disappeared after commit"
+                                                    ));
+                                                }
+                                                Err(error) => {
+                                                    tracing::error!(
+                                                        conversation = %event_conversation,
+                                                        %error,
+                                                        "could not checkpoint committed reset; prepared recovery record remains"
+                                                    );
+                                                    return Err(anyhow::anyhow!(
+                                                        "could not checkpoint committed durable /new: {error}"
+                                                    ));
+                                                }
+                                            }
+                                        }
+
+                                        // No fallible queue mutation remains after
+                                        // the durable adapter commit. If the harness
+                                        // dies before this in-memory step, Pi's reset
+                                        // tombstone still forces fresh context and
+                                        // suppresses relay-history seeding on restart.
+                                        let fresh_conversation = queue
+                                            .commit_prepared_reset(prepared_reset, command_id);
+                                        let reset_signal = if thread_sessions_enabled {
+                                            // The durable mapping is already gone;
+                                            // cancellation only releases the old hot
+                                            // handle and must not issue a second forget.
+                                            ControlSignal::Cancel
+                                        } else {
+                                            ControlSignal::Rotate
+                                        };
+                                        let fired = signal_in_flight_conversation(
+                                            &mut pool,
+                                            &event_conversation,
+                                            reset_signal,
+                                        );
+                                        let invalidated = pool
+                                            .dispose_conversation_sessions(
+                                                &event_conversation,
+                                                !thread_sessions_enabled,
+                                            )
+                                            .await;
+                                        tracing::info!(
+                                            conversation = %event_conversation,
+                                            fresh_conversation = %fresh_conversation,
+                                            fired,
+                                            invalidated,
+                                            "/new consumed — resetting thread context"
+                                        );
+                                        let identity = (
+                                            fresh_conversation.channel_id,
+                                            fresh_conversation.root_event_id.clone(),
+                                        );
+                                        debug_assert_eq!(identity, reset_identity);
+                                        pending_reset_confirmations.insert(
+                                            identity,
+                                            PendingResetConfirmation {
+                                                event: reset_notice_event,
+                                                next_attempt_at: Instant::now(),
+                                                durable: thread_sessions_enabled,
+                                            },
+                                        );
+                                        tracing::info!(
+                                            conversation = %fresh_conversation,
+                                            waiting_for_old_turn = fired,
+                                            "deferring /new dispatch until its signed acknowledgement is accepted"
+                                        );
+                                        continue;
+                                    }
+                                }
+                                tracing::warn!(
+                                    conversation = %event_conversation,
+                                    sender = %buzz_event.event.pubkey,
+                                    "denying non-owner /new command"
+                                );
+                                // Reserved lifecycle commands are always
+                                // consumed. Forwarding this to Pi could let an
+                                // adapter or extension reset context despite
+                                // the harness authorization failure.
+                                continue;
+                            }
+
+                            // Pi lifecycle commands that mutate a thread's
+                            // durable runtime are owner-only. They still pass
+                            // through to the adapter for an authorized owner;
+                            // an untrusted participant cannot force compaction
+                            // or reload executable extension resources.
+                            if let Some(command) = reserved_pi_lifecycle_command(
+                                &buzz_event.event,
+                                kind_u32,
+                                config.session_title.as_deref(),
+                            ) {
+                                // An addressed /new was consumed above whether
+                                // authorized or denied. Reaching this arm with
+                                // /new means it lacked this agent's p tag; never
+                                // forward it to an adapter whose first-line
+                                // command parser could interpret it anyway.
+                                let authorized = command != "/new"
+                                    && is_owner_control_command(
+                                        &buzz_event.event,
+                                        kind_u32,
+                                        command,
+                                        &pubkey_hex,
+                                        config.session_title.as_deref(),
+                                    )
+                                    && owner_cache.get().is_some_and(|owner| {
+                                        buzz_event.event.pubkey.to_hex() == *owner
+                                    });
+                                if !authorized {
+                                    tracing::warn!(
+                                        conversation = %event_conversation,
+                                        sender = %buzz_event.event.pubkey,
+                                        command,
+                                        "denying unaddressed or non-owner Pi lifecycle command"
+                                    );
+                                    continue;
+                                }
                             }
 
                             // Coarse security policy: drop events from disallowed
@@ -2219,13 +3906,11 @@ async fn tokio_main() -> Result<()> {
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
                                     &author,
-                                    is_dm,
+                                    event_is_dm,
                                     &owner_cache,
                                     &ctx.rest_client,
                                 )
@@ -2235,7 +3920,7 @@ async fn tokio_main() -> Result<()> {
                                         channel_id = %buzz_event.channel_id,
                                         author = %buzz_event.event.pubkey.to_hex(),
                                         mode = %config.respond_to,
-                                        is_dm,
+                                        is_dm = event_is_dm,
                                         "inbound author gate — dropping event"
                                     );
                                     continue;
@@ -2287,7 +3972,9 @@ async fn tokio_main() -> Result<()> {
                             // Event is already queued. If mode requires it AND
                             // the channel has an in-flight task, fire cancel —
                             // OR take the non-cancelling (ACP steer) fork for Steer signals.
-                            if accepted && queue.is_channel_in_flight(buzz_event.channel_id) {
+                            if accepted
+                                && queue.is_conversation_in_flight(&event_conversation)
+                            {
                                 // Author eligibility (owner ∪ allowlist ∪ siblings)
                                 // is already enforced by the inbound author gate
                                 // above, so the mid-turn signal fires for every
@@ -2314,15 +4001,15 @@ async fn tokio_main() -> Result<()> {
                                         && try_native_steer(
                                             &mut pool,
                                             &mut queue,
-                                            buzz_event.channel_id,
+                                            event_conversation.clone(),
                                             event_for_steer,
                                             prompt_tag_for_steer,
                                             &steer_ack_tx,
                                         );
                                     if !native_attempted {
-                                        signal_in_flight_task(
+                                        signal_in_flight_conversation(
                                             &mut pool,
-                                            buzz_event.channel_id,
+                                            &event_conversation,
                                             signal,
                                         );
                                     }
@@ -2421,7 +4108,8 @@ async fn tokio_main() -> Result<()> {
                     // Use try_publish (non-blocking) for typing indicators —
                     // they're ephemeral and must not block the main loop during
                     // relay reconnection (#35).
-                    for (&ch, thread_tags) in &typing_channels {
+                    for (conversation_key, thread_tags) in &typing_channels {
+                        let ch = conversation_key.channel_id;
                         if let Ok(event) = relay.build_typing_event(
                             ch,
                             thread_tags.root_event_id.as_deref(),
@@ -2443,24 +4131,35 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
-                // Stop typing indicator for the completed channel.
-                if let PromptSource::Channel(ch) = &result.source {
-                    typing_channels.remove(ch);
+                let mut result = *result;
+                // Membership removal can race a checked-out agent that still
+                // owns sibling thread sessions in the removed channel. Forget
+                // those adapter runtimes before this agent becomes claimable
+                // again; on failure the adapter is terminated fail-closed.
+                for channel_id in &removed_channels {
+                    result.agent.forget_channel_sessions(*channel_id).await;
                 }
-                if handle_prompt_result(
+                // Stop typing indicator for the completed channel.
+                if let PromptSource::Conversation(key) = &result.source {
+                    typing_channels.remove(key);
+                } else if let PromptSource::Channel(ch) = &result.source {
+                    typing_channels.retain(|key, _| key.channel_id != *ch);
+                }
+                let action = handle_prompt_result(
                     &mut pool,
                     &mut queue,
                     &config,
-                    *result,
+                    result,
                     &mut heartbeat_in_flight,
                     &removed_channels,
                     &mut crash_history,
                     &respawn_tx,
                     &mut respawn_tasks,
                     observer.clone(),
+                    Some(&lifecycle_notice_outbox),
                     Some(&ctx.rest_client),
-                ) == LoopAction::Exit
-                {
+                );
+                if action == LoopAction::Exit {
                     break;
                 }
                 if drain_ready_join_results(
@@ -2509,8 +4208,18 @@ async fn tokio_main() -> Result<()> {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
+            Some(PoolEvent::ResetAck(result)) => {
+                finish_reset_ack_attempt(
+                    &mut queue,
+                    &mut pending_reset_confirmations,
+                    &mut reset_ack_in_flight,
+                    Some(&durable_outbox),
+                    result,
+                );
+            }
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
+                conversation_key,
                 event_id,
                 ack,
             })) => {
@@ -2624,13 +4333,16 @@ async fn tokio_main() -> Result<()> {
                     "non-cancelling steer ack received"
                 );
                 if matches!(ack, Ok(pool::SteerAck::Success)) {
-                    queue.extend_in_flight_deadline(channel_id, config.max_turn_duration_secs);
+                    queue.extend_conversation_deadline(
+                        &conversation_key,
+                        config.max_turn_duration_secs,
+                    );
                 }
                 if drop_withheld {
-                    queue.remove_event(channel_id, &event_id);
+                    queue.remove_conversation_event(&conversation_key, &event_id);
                 }
                 if release_withheld {
-                    queue.release_native_steer(channel_id, &event_id);
+                    queue.release_conversation_native_steer(&conversation_key, &event_id);
                 }
                 if signal_fallback {
                     // Universal cancel+merge fallback. Note: the
@@ -2638,7 +4350,11 @@ async fn tokio_main() -> Result<()> {
                     // front of `queues[channel_id]`, so the cancel
                     // will pick it up as part of the merged batch and
                     // re-prompt the agent.
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    signal_in_flight_conversation(
+                        &mut pool,
+                        &conversation_key,
+                        ControlSignal::Steer,
+                    );
                 }
                 // After releasing a withheld event, give dispatch a chance
                 // to re-flush. If the prompt is still in flight, the
@@ -2666,6 +4382,50 @@ async fn tokio_main() -> Result<()> {
                         pool = pool_lifecycle
                             .take_ready()
                             .expect("successful wake stores a ready pool");
+                        thread_sessions_enabled = match select_thread_session_scope(
+                            config.require_durable_thread_sessions,
+                            true,
+                            pool.thread_sessions_supported(),
+                        ) {
+                            Ok(enabled) => enabled,
+                            Err(message) => {
+                                tracing::error!(
+                                    message,
+                                    "lazy adapter capability check failed closed"
+                                );
+                                emit_runtime_lifecycle(
+                                    observer.as_ref(),
+                                    &runtime_start_nonce,
+                                    &pubkey_hex,
+                                    &config.relay_url,
+                                    "failed",
+                                    Some(message),
+                                );
+                                terminal_error = Some(anyhow::anyhow!(message));
+                                break;
+                            }
+                        };
+                        if !queue.set_thread_sessions_enabled(thread_sessions_enabled) {
+                            if config.require_durable_thread_sessions {
+                                let message = "required durable thread-session scope could not be applied to the lazy event queue";
+                                tracing::error!(message, "lazy adapter queue scope failed closed");
+                                emit_runtime_lifecycle(
+                                    observer.as_ref(),
+                                    &runtime_start_nonce,
+                                    &pubkey_hex,
+                                    &config.relay_url,
+                                    "failed",
+                                    Some(message),
+                                );
+                                terminal_error = Some(anyhow::anyhow!(message));
+                                break;
+                            }
+                            tracing::error!(
+                                thread_sessions_enabled,
+                                "lazy pool initialized after queue lifecycle state; retaining prior conversation scope"
+                            );
+                            thread_sessions_enabled = queue.thread_sessions_enabled();
+                        }
                         pool_ready = true;
                         emit_runtime_lifecycle(
                             observer.as_ref(),
@@ -2696,6 +4456,35 @@ async fn tokio_main() -> Result<()> {
             }
             None => {} // relay/heartbeat/shutdown branches handled inline above
         }
+    }
+
+    // A reset acknowledgement may be inside its bounded HTTP attempt when a
+    // signal arrives. Give that tracked delivery one attempt window to finish
+    // so a normal shutdown does not discard an already-signed `/new` success
+    // message. We deliberately do not begin a fresh retry schedule while
+    // shutting down.
+    schedule_completed_reset_ack(
+        &queue,
+        &pending_reset_confirmations,
+        &ctx.rest_client,
+        &mut reset_ack_tasks,
+        &mut reset_ack_in_flight,
+    );
+    let reset_ack_drain = tokio::time::timeout(Duration::from_secs(6), async {
+        while let Some(result) = reset_ack_tasks.join_next().await {
+            finish_reset_ack_attempt(
+                &mut queue,
+                &mut pending_reset_confirmations,
+                &mut reset_ack_in_flight,
+                Some(&durable_outbox),
+                result,
+            );
+        }
+    })
+    .await;
+    if reset_ack_drain.is_err() {
+        tracing::warn!("reset acknowledgement task did not drain — aborting it");
+        reset_ack_tasks.shutdown().await;
     }
 
     // Drain wake tasks gracefully rather than aborting: an in-flight
@@ -2744,6 +4533,20 @@ async fn tokio_main() -> Result<()> {
                 }
                 maybe_result = rx_ref.recv() => {
                     if let Some(mut pr) = maybe_result {
+                        let lifecycle_scope = lifecycle_notice_scope(&pr);
+                        let lifecycle_notices =
+                            take_current_buzz_session_notices(&mut pr, &queue);
+                        let lifecycle_outcome = enqueue_session_lifecycle_notices(
+                            Some(&lifecycle_notice_outbox),
+                            Some(&ctx.rest_client),
+                            lifecycle_scope,
+                            lifecycle_notices,
+                        );
+                        for acknowledgement in lifecycle_outcome.acknowledgements {
+                            pr.agent
+                                .acp
+                                .queue_buzz_session_event_ack(acknowledgement);
+                        }
                         let idx = pr.agent.index;
                         pr.agent.acp.shutdown().await;
                         tracing::debug!(agent = idx, "reaped checked-out agent on shutdown");
@@ -2761,6 +4564,17 @@ async fn tokio_main() -> Result<()> {
     // Drain any remaining results that arrived after join_set drained but
     // before tasks were aborted.
     while let Ok(mut pr) = pool.result_rx_try_recv() {
+        let lifecycle_scope = lifecycle_notice_scope(&pr);
+        let lifecycle_notices = take_current_buzz_session_notices(&mut pr, &queue);
+        let lifecycle_outcome = enqueue_session_lifecycle_notices(
+            Some(&lifecycle_notice_outbox),
+            Some(&ctx.rest_client),
+            lifecycle_scope,
+            lifecycle_notices,
+        );
+        for acknowledgement in lifecycle_outcome.acknowledgements {
+            pr.agent.acp.queue_buzz_session_event_ack(acknowledgement);
+        }
         let idx = pr.agent.index;
         pr.agent.acp.shutdown().await;
         tracing::debug!(agent = idx, "reaped late-arriving agent on shutdown");
@@ -2814,18 +4628,37 @@ async fn tokio_main() -> Result<()> {
         handle.abort();
     }
 
+    // Compaction/session lifecycle notices are product-visible state, not
+    // cosmetic telemetry. Drain their signed, retrying outbox before tearing
+    // down relay resources so a normal shutdown cannot lose an awareness
+    // message that was already emitted by Pi.
+    lifecycle_notice_outbox.shutdown().await;
+
     // Graceful relay shutdown — sends WebSocket close frame and waits up to 5s
     // for the background task to finish, rather than aborting immediately (#40).
     relay.shutdown().await;
 
     tracing::info!("buzz-acp stopped");
-    Ok(())
+    match terminal_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 #[derive(PartialEq)]
 enum LoopAction {
     Continue,
     Exit,
+}
+
+#[cfg(test)]
+fn test_conversation_key(channel_id: Uuid) -> ConversationKey {
+    ConversationKey {
+        channel_id,
+        root_event_id: format!("channel:{channel_id}"),
+        generation: 0,
+        reset_token: None,
+    }
 }
 
 fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
@@ -2840,10 +4673,50 @@ fn is_owner_control_command(
     kind_u32: u32,
     command: &str,
     agent_pubkey_hex: &str,
+    agent_display_name: Option<&str>,
 ) -> bool {
+    let content_matches = if command.starts_with('/') {
+        let known_names = agent_display_name.map_or_else(Vec::new, |name| vec![name]);
+        adapter_leading_slash_command(&event.content, &known_names).as_deref() == Some(command)
+    } else {
+        event.content.trim() == command
+    };
     kind_u32 == KIND_STREAM_MESSAGE
-        && event.content.trim() == command
+        && content_matches
         && event_mentions_agent(event, agent_pubkey_hex)
+}
+
+/// Mirror the adapter's first-line command semantics after Buzz mention
+/// normalization. This closes a policy gap where `/reload\n...` was not an
+/// exact harness match but Pi still executed its first line as `/reload`.
+fn adapter_leading_slash_command(content: &str, known_names: &[&str]) -> Option<String> {
+    queue::extract_slash_command(content, known_names).and_then(|command| {
+        command
+            .split(['\r', '\n'])
+            .next()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// Detect every Pi command that can mutate or replace durable session state,
+/// independently of Nostr mention tags. Detection happens before the general
+/// author/filter gates so subscribe-all and no-mention modes cannot smuggle a
+/// bare command into Pi's first text block.
+fn reserved_pi_lifecycle_command(
+    event: &nostr::Event,
+    kind_u32: u32,
+    agent_display_name: Option<&str>,
+) -> Option<&'static str> {
+    if kind_u32 != KIND_STREAM_MESSAGE {
+        return None;
+    }
+    let known_names = agent_display_name.map_or_else(Vec::new, |name| vec![name]);
+    let command = adapter_leading_slash_command(&event.content, &known_names)?;
+    ["/new", "/compact", "/reload"]
+        .into_iter()
+        .find(|reserved| command == *reserved)
 }
 
 // ── signal_in_flight_task ─────────────────────────────────────────────────────
@@ -2876,11 +4749,27 @@ fn mode_gate_signal(
 
 /// Send a control signal to the in-flight task for `channel_id`.
 /// Returns `true` if a signal was sent, `false` if no in-flight task was found.
+#[cfg(test)]
 fn signal_in_flight_task(
     pool: &mut AgentPool,
     channel_id: uuid::Uuid,
     mode: ControlSignal,
 ) -> bool {
+    let matches = pool
+        .task_map()
+        .values()
+        .filter(|meta| meta.channel_id == Some(channel_id))
+        .count();
+    if matches != 1 {
+        if matches > 1 {
+            tracing::warn!(
+                channel = %channel_id,
+                active_conversations = matches,
+                "refusing ambiguous channel-only control signal"
+            );
+        }
+        return false;
+    }
     let entry = pool
         .task_map_mut()
         .values_mut()
@@ -2889,6 +4778,129 @@ fn signal_in_flight_task(
     if let Some(meta) = entry {
         if let Some(tx) = meta.control_tx.take() {
             tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
+            let _ = tx.send(mode);
+            return true;
+        }
+    }
+    false
+}
+
+/// Routing outcome for an owner-authenticated desktop control frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ObserverControlResult {
+    Sent,
+    TurnEnding,
+    NoActiveTurn,
+    Ambiguous,
+}
+
+impl ObserverControlResult {
+    fn as_status(self) -> &'static str {
+        match self {
+            Self::Sent => "sent",
+            Self::TurnEnding => "turn_ending",
+            Self::NoActiveTurn => "no_active_turn",
+            Self::Ambiguous => "ambiguous",
+        }
+    }
+}
+
+/// Route a desktop control to one in-flight turn.
+///
+/// `turn_id` must match both the exact turn and its channel. Channel-only relay
+/// controls are rejected before this function so a retained signed frame can
+/// never select a later turn after a process restart.
+fn signal_observer_control(
+    pool: &mut AgentPool,
+    channel_id: Uuid,
+    turn_id: &str,
+    signal: ControlSignal,
+) -> ObserverControlResult {
+    let matching_task_ids: Vec<_> = pool
+        .task_map()
+        .iter()
+        .filter(|(_, meta)| meta.channel_id == Some(channel_id) && meta.turn_id == turn_id)
+        .map(|(task_id, _)| *task_id)
+        .collect();
+
+    let task_id = match matching_task_ids.as_slice() {
+        [] => return ObserverControlResult::NoActiveTurn,
+        [task_id] => *task_id,
+        _ => {
+            tracing::warn!(
+                channel = %channel_id,
+                %turn_id,
+                matches = matching_task_ids.len(),
+                "refusing ambiguous observer control signal"
+            );
+            return ObserverControlResult::Ambiguous;
+        }
+    };
+
+    let Some(meta) = pool.task_map_mut().get_mut(&task_id) else {
+        return ObserverControlResult::NoActiveTurn;
+    };
+    let Some(tx) = meta.control_tx.take() else {
+        return ObserverControlResult::TurnEnding;
+    };
+
+    match tx.send(signal) {
+        Ok(()) => {
+            tracing::info!(
+                channel = %channel_id,
+                turn_id = %meta.turn_id,
+                "observer control signal sent to exact in-flight turn"
+            );
+            ObserverControlResult::Sent
+        }
+        Err(signal) => {
+            tracing::warn!(
+                channel = %channel_id,
+                turn_id = %meta.turn_id,
+                ?signal,
+                "observer control receiver closed before delivery"
+            );
+            ObserverControlResult::TurnEnding
+        }
+    }
+}
+
+/// Broadcast the intentionally channel-wide `!rotate` command to every active
+/// thread. Unlike legacy channel-only desktop controls, this fan-out is
+/// explicit product semantics rather than an ambiguous first-match lookup.
+fn rotate_all_in_flight_channel(pool: &mut AgentPool, channel_id: Uuid) -> usize {
+    let mut sent = 0;
+    for meta in pool
+        .task_map_mut()
+        .values_mut()
+        .filter(|meta| meta.channel_id == Some(channel_id))
+    {
+        if let Some(tx) = meta.control_tx.take() {
+            let _ = tx.send(ControlSignal::Rotate);
+            sent += 1;
+        }
+    }
+    sent
+}
+
+/// Send a control signal to one exact in-flight thread conversation.
+fn signal_in_flight_conversation(
+    pool: &mut AgentPool,
+    conversation_key: &ConversationKey,
+    mode: ControlSignal,
+) -> bool {
+    let entry = pool
+        .task_map_mut()
+        .values_mut()
+        .find(|meta| meta.conversation_key.as_ref() == Some(conversation_key));
+
+    if let Some(meta) = entry {
+        if let Some(tx) = meta.control_tx.take() {
+            tracing::info!(
+                conversation = %conversation_key,
+                ?mode,
+                "control signal sent to in-flight conversation"
+            );
             let _ = tx.send(mode);
             return true;
         }
@@ -2923,11 +4935,12 @@ fn signal_in_flight_task(
 fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
-    channel_id: uuid::Uuid,
+    conversation_key: ConversationKey,
     event: nostr::Event,
     prompt_tag: String,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
+    let channel_id = conversation_key.channel_id;
     // Build the steer body: framing strings come from
     // `queue::native_steer_framing()` (Eva's drift-proof requirement —
     // native and cancel+merge fallback share these so the agent gets the
@@ -2957,14 +4970,15 @@ fn try_native_steer(
         ack_tx,
     };
 
-    match pool.send_steer(channel_id, request) {
+    match pool.send_conversation_steer(&conversation_key, request) {
         Ok(()) => {
             // Withhold the queued event synchronously BEFORE spawning
             // the watcher: this closes the race where `mark_complete`
             // clears `in_flight_channels` and a stray `flush_next` could
             // re-deliver the event via normal dispatch. See
             // `EventQueue::mark_native_steer_pending` docs at queue.rs:606.
-            let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
+            let withheld =
+                queue.mark_conversation_native_steer_pending(&conversation_key, &event_id_hex);
             if !withheld {
                 // Race: the event was already drained out of the queue
                 // before we got here (e.g. a concurrent flush picked it
@@ -2986,6 +5000,7 @@ fn try_native_steer(
                 let ack = ack_rx.await;
                 let _ = ack_tx_clone.send(SteerAckEvent {
                     channel_id,
+                    conversation_key,
                     event_id: event_id_for_watcher,
                     ack,
                 });
@@ -3011,27 +5026,33 @@ fn dispatch_pending(
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
     last_activity: &mut tokio::time::Instant,
-) -> Vec<(Uuid, ThreadTags)> {
+) -> Vec<(ConversationKey, ThreadTags)> {
     let mut dispatched_channels = Vec::new();
+    let mut affinity_blocked = HashSet::new();
     loop {
-        let batch = match queue.flush_next() {
+        let batch = match queue.flush_next_excluding(&affinity_blocked) {
             Some(b) => b,
             None => break,
         };
         let channel_id = batch.channel_id;
+        let conversation_key = batch.conversation_key.clone();
         let typing_scope = batch
             .events
             .last()
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
-        let affinity_hit = pool.has_session_for(channel_id);
-        let mut agent = match pool.try_claim(Some(channel_id)) {
+        let affinity_hit = pool.has_session_for_conversation(&conversation_key);
+        let mut agent = match pool.try_claim_conversation(&conversation_key) {
             Some(a) => a,
             None => {
                 let pending = queue.pending_channels();
                 tracing::debug!(pending_channels = pending, "pool_exhausted");
                 queue.requeue_preserve_timestamps(batch);
-                queue.mark_complete(channel_id);
+                queue.mark_conversation_complete(&conversation_key);
+                if pool.any_idle() {
+                    affinity_blocked.insert(conversation_key);
+                    continue;
+                }
                 break;
             }
         };
@@ -3083,13 +5104,14 @@ fn dispatch_pending(
             pool::TaskMeta {
                 agent_index,
                 channel_id: Some(channel_id),
+                conversation_key: Some(conversation_key.clone()),
                 turn_id,
                 recoverable_batch,
                 control_tx: Some(control_tx),
                 steer_tx,
             },
         );
-        dispatched_channels.push((channel_id, typing_scope));
+        dispatched_channels.push((conversation_key, typing_scope));
         *last_activity = tokio::time::Instant::now();
     }
     tracing::debug!(
@@ -3129,6 +5151,96 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
+/// Stable adapter error used when Pi's final provider-payload guard cannot
+/// compact enough to stay under the configured context ceiling.
+const PI_CONTEXT_LIMIT_ERROR_CODE: i64 = -32042;
+/// Pi session transcript/quota exhaustion. This is distinct from the context
+/// window: retrying appends more rollback/control entries and cannot recover.
+const PI_SESSION_STORAGE_LIMIT_ERROR_CODE: i64 = -32044;
+/// Pi has deliberately invalidated the inner runtime after a safety-boundary
+/// failure (for example, a project-resource reload whose old runner was
+/// disposed). The outer ACP process must be replaced; reusing its session ID
+/// can only repeat against the invalid registry proxy.
+const PI_SESSION_INVALIDATED_ERROR_CODE: i64 = -32045;
+/// Disk/outbox repair is an operator prerequisite, not a prompt failure. Keep
+/// the original request crash-replayable in Buzz and retry locally at a calm
+/// fixed cadence without burning the normal poison-batch budget.
+const DURABLE_NOTICE_BLOCKED_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+fn is_pi_context_limit_error(error: &acp::AcpError) -> bool {
+    matches!(
+        error,
+        acp::AcpError::AgentError {
+            code: PI_CONTEXT_LIMIT_ERROR_CODE,
+            ..
+        }
+    )
+}
+
+fn is_pi_session_storage_limit_error(error: &acp::AcpError) -> bool {
+    matches!(
+        error,
+        acp::AcpError::AgentError {
+            code: PI_SESSION_STORAGE_LIMIT_ERROR_CODE,
+            ..
+        }
+    )
+}
+
+fn is_pi_session_invalidated_error(error: &acp::AcpError) -> bool {
+    matches!(
+        error,
+        acp::AcpError::AgentError {
+            code: PI_SESSION_INVALIDATED_ERROR_CODE,
+            ..
+        }
+    )
+}
+
+fn pi_session_storage_limit_notice() -> &'static str {
+    "⚠️ This thread's durable Pi session reached its local storage limit, so I stopped without retrying or changing its context. Use `/new` in this thread to start a fresh session, then resend the request."
+}
+
+fn persist_pi_session_storage_limit_notice(
+    outbox: Option<&LifecycleNoticeOutbox>,
+    rest: Option<&relay::RestClient>,
+    batch: &FlushBatch,
+) -> bool {
+    let (Some(outbox), Some(rest)) = (outbox, rest) else {
+        return false;
+    };
+    let mut thread_tags = batch
+        .events
+        .last()
+        .map(|event| queue::parse_thread_tags(&event.event))
+        .unwrap_or_default();
+    if thread_tags.root_event_id.is_none()
+        && !batch.conversation_key.root_event_id.starts_with("dm:")
+        && nostr::EventId::from_hex(&batch.conversation_key.root_event_id).is_ok()
+    {
+        thread_tags.root_event_id = Some(batch.conversation_key.root_event_id.clone());
+        thread_tags.parent_event_id = Some(batch.conversation_key.root_event_id.clone());
+    }
+    let source_event = batch
+        .events
+        .last()
+        .map(|event| event.event.id.to_hex())
+        .unwrap_or_else(|| batch.conversation_key.stable_id());
+    outbox
+        .enqueue(
+            batch.channel_id,
+            &thread_tags,
+            vec![LifecycleNotice {
+                dedupe_key: Some(format!("pi-storage-limit:{source_event}")),
+                content: pi_session_storage_limit_notice().to_owned(),
+                ack: None,
+            }],
+            rest,
+        )
+        .persisted
+        == 1
+}
+
 /// Spawn a task that posts a user-visible failure notice to the relay.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
@@ -3152,6 +5264,683 @@ fn spawn_failure_notice(
     }
 }
 
+fn format_token_count(value: u64) -> String {
+    let digits = value.to_string();
+    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, digit) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            formatted.push(',');
+        }
+        formatted.push(digit);
+    }
+    formatted
+}
+
+fn context_limit_summary(limit: u64, effective: u64, threshold: u64) -> String {
+    if limit == effective {
+        format!(
+            "Configured cap {} tokens; automatic compaction threshold {}.",
+            format_token_count(limit),
+            format_token_count(threshold)
+        )
+    } else {
+        format!(
+            "Configured cap {} tokens; this model's effective limit is {}; automatic compaction threshold {}.",
+            format_token_count(limit),
+            format_token_count(effective),
+            format_token_count(threshold)
+        )
+    }
+}
+
+fn safe_notice_model(model: &str) -> Option<String> {
+    let model = model.trim();
+    (!model.is_empty()
+        && model.len() <= 128
+        && model
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-._/:+".contains(character)))
+    .then(|| model.to_string())
+}
+
+fn should_publish_buzz_session_notice(event: &BuzzSessionEvent) -> bool {
+    match event {
+        // Pi retries this internally. Publishing the transient failure before
+        // the eventual completion would make one successful compaction look
+        // like an error to the user.
+        BuzzSessionEvent::CompactionFailed {
+            will_retry: true, ..
+        } => false,
+        // The harness acknowledges `/new` only after its reset barrier commits.
+        // Repeating Pi's confirmation on the next prompt is noisy and can be
+        // mistaken for a second reset.
+        BuzzSessionEvent::SessionReset { .. } => false,
+        _ => true,
+    }
+}
+
+/// Render a lifecycle notice exclusively from bounded typed fields. Adapter
+/// `message`, `error`, paths, and resource diagnostics are intentionally never
+/// copied into Buzz content.
+fn render_buzz_session_notice(event: &BuzzSessionEvent) -> String {
+    match event {
+        BuzzSessionEvent::CompactionCompleted {
+            reason,
+            before_tokens,
+            after_tokens,
+            limit_tokens,
+            effective_limit_tokens,
+            compaction_threshold_tokens,
+            ..
+        } => {
+            let mode = if matches!(reason, acp::CompactionReason::Manual) {
+                "on request"
+            } else {
+                "automatically"
+            };
+            let change = match (before_tokens, after_tokens) {
+                (Some(before), Some(after)) => format!(
+                    ": {} → ~{} tokens",
+                    format_token_count(*before),
+                    format_token_count(*after)
+                ),
+                (Some(before), None) => {
+                    format!(" from about {} tokens", format_token_count(*before))
+                }
+                _ => String::new(),
+            };
+            format!(
+                "🧠 Pi compacted this thread's context {mode}{change}. It will continue from a summary. {}",
+                context_limit_summary(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )
+            )
+        }
+        BuzzSessionEvent::CompactionFailed {
+            limit_tokens,
+            effective_limit_tokens,
+            compaction_threshold_tokens,
+            aborted,
+            ..
+        } => {
+            let failure = if *aborted {
+                "Context compaction was cancelled"
+            } else {
+                "Context compaction failed"
+            };
+            format!(
+                "⚠️ {failure}, so this request was stopped before Pi could exceed its context limit. Your thread is preserved; try again or use `/new` for a fresh session. {}",
+                context_limit_summary(
+                    *limit_tokens,
+                    *effective_limit_tokens,
+                    *compaction_threshold_tokens,
+                )
+            )
+        }
+        BuzzSessionEvent::ContextStatus {
+            used_tokens,
+            limit_tokens,
+            effective_limit_tokens,
+            compaction_threshold_tokens,
+            auto_compaction,
+            compacting,
+            model,
+            ..
+        } => {
+            let usage = match used_tokens {
+                Some(used) => {
+                    let percent = (*used as f64 / *effective_limit_tokens as f64) * 100.0;
+                    format!(
+                        "{} / {} tokens ({percent:.1}%)",
+                        format_token_count(*used),
+                        format_token_count(*effective_limit_tokens)
+                    )
+                }
+                None => format!(
+                    "recalculating after compaction (effective limit {})",
+                    format_token_count(*effective_limit_tokens)
+                ),
+            };
+            let state = if *compacting {
+                " Compaction is running now."
+            } else if *auto_compaction {
+                " Auto-compaction is enabled."
+            } else {
+                " Auto-compaction is disabled."
+            };
+            let model = model
+                .as_deref()
+                .and_then(safe_notice_model)
+                .map(|model| format!(" Model: `{model}`."))
+                .unwrap_or_default();
+            format!(
+                "🧭 Pi context: {usage}. Automatic compaction threshold {}.{}{model} Configured cap {} tokens.",
+                format_token_count(*compaction_threshold_tokens),
+                state,
+                format_token_count(*limit_tokens),
+            )
+        }
+        BuzzSessionEvent::SessionReset {
+            limit_tokens,
+            effective_limit_tokens,
+            compaction_threshold_tokens,
+            ..
+        } => format!(
+            "✅ Pi confirmed a fresh persistent session for this Buzz thread. Its previous conversation context will not be reused. {}",
+            context_limit_summary(
+                *limit_tokens,
+                *effective_limit_tokens,
+                *compaction_threshold_tokens,
+            )
+        ),
+        BuzzSessionEvent::ExtensionsReloaded {
+            extensions,
+            skills,
+            prompts,
+            context_files,
+            errors,
+            project_trusted,
+            ..
+        } => {
+            let trust = if *project_trusted {
+                "Trusted project-local Pi resources are enabled."
+            } else {
+                "Untrusted project-local Pi resources stayed disabled."
+            };
+            let diagnostics = if errors.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " {} resource diagnostic(s) were reported; see the agent logs for safe details.",
+                    errors.len()
+                )
+            };
+            format!(
+                "🧩 Reloaded Pi resources: {extensions} extension(s), {skills} skill(s), {prompts} prompt template(s), and {context_files} context file(s). {trust}{diagnostics}"
+            )
+        }
+    }
+}
+
+fn lifecycle_notice_scope(result: &PromptResult) -> Option<(Uuid, ThreadTags)> {
+    let PromptSource::Conversation(key) = &result.source else {
+        return None;
+    };
+    let mut tags = result
+        .batch
+        .as_ref()
+        .and_then(|batch| batch.events.last())
+        .map(|event| queue::parse_thread_tags(&event.event))
+        .unwrap_or_default();
+    if tags.root_event_id.is_none()
+        && !key.root_event_id.starts_with("dm:")
+        && nostr::EventId::from_hex(&key.root_event_id).is_ok()
+    {
+        tags.root_event_id = Some(key.root_event_id.clone());
+        tags.parent_event_id = Some(key.root_event_id.clone());
+    }
+    Some((key.channel_id, tags))
+}
+
+/// A rendered lifecycle transition plus its adapter-stable identity. Pi emits
+/// a UUID for every compaction attempt; retaining it here lets the delivery
+/// outbox collapse retransmissions without trusting adapter-provided prose.
+#[derive(Debug)]
+struct LifecycleNotice {
+    dedupe_key: Option<String>,
+    content: String,
+    ack: Option<acp::BuzzSessionEventAck>,
+}
+
+#[derive(Default)]
+struct LifecycleEnqueueOutcome {
+    acknowledgements: Vec<acp::BuzzSessionEventAck>,
+    persisted: usize,
+    failed: usize,
+}
+
+fn lifecycle_persistence_boundary_error(failed: usize) -> Option<acp::AcpError> {
+    (failed > 0).then(|| {
+        acp::AcpError::Protocol(format!(
+            "failed to durably persist {failed} adapter lifecycle notice(s)"
+        ))
+    })
+}
+
+type LifecycleNoticeEnvelope = DurableLifecycleEnvelope;
+
+#[derive(Debug, Default)]
+struct LifecycleNoticeDedupe {
+    pending: HashSet<String>,
+    delivered: HashSet<String>,
+    delivered_order: VecDeque<String>,
+}
+
+impl LifecycleNoticeDedupe {
+    fn reserve(&mut self, key: Option<&str>) -> bool {
+        let Some(key) = key else {
+            return true;
+        };
+        if self.pending.contains(key) || self.delivered.contains(key) {
+            return false;
+        }
+        self.pending.insert(key.to_owned());
+        true
+    }
+
+    fn finish(&mut self, key: Option<&str>, delivered: bool) {
+        let Some(key) = key else {
+            return;
+        };
+        self.pending.remove(key);
+        if !delivered || !self.delivered.insert(key.to_owned()) {
+            return;
+        }
+        self.delivered_order.push_back(key.to_owned());
+        while self.delivered_order.len() > LIFECYCLE_NOTICE_DEDUPE_CAPACITY {
+            if let Some(expired) = self.delivered_order.pop_front() {
+                self.delivered.remove(&expired);
+            }
+        }
+    }
+}
+
+const LIFECYCLE_NOTICE_DEDUPE_CAPACITY: usize = 1_024;
+const LIFECYCLE_NOTICE_SHUTDOWN_GRACE: Duration = Duration::from_secs(60);
+/// Bound relay pressure while allowing unrelated threads to make progress
+/// around a permanently rejected lifecycle notice.
+const LIFECYCLE_NOTICE_MAX_IN_FLIGHT_ATTEMPTS: usize = 8;
+const LIFECYCLE_NOTICE_RETRY_DELAYS: [Duration; 6] = [
+    Duration::ZERO,
+    Duration::from_millis(250),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(10),
+];
+
+/// Bounded, tracked delivery for user-visible Pi lifecycle messages.
+///
+/// Events are signed and persisted before entering the worker queue, so every
+/// retry has the same Nostr event ID. Pending events and delivered compaction
+/// identities survive a hard process death. The worker retries until the relay
+/// accepts the event *and* that completion is durably checkpointed.
+struct LifecycleNoticeOutbox {
+    tx: Option<mpsc::UnboundedSender<LifecycleNoticeEnvelope>>,
+    worker: Option<tokio::task::JoinHandle<()>>,
+    dedupe: Arc<Mutex<LifecycleNoticeDedupe>>,
+    durable: DurableOutbox,
+}
+
+impl LifecycleNoticeOutbox {
+    fn spawn(rest: relay::RestClient, durable: DurableOutbox) -> Result<Self> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<LifecycleNoticeEnvelope>();
+        let restored = durable.pending_lifecycle()?;
+        let mut initial_dedupe = LifecycleNoticeDedupe::default();
+        for envelope in &restored {
+            if let Some(key) = envelope.dedupe_key.as_ref() {
+                initial_dedupe.pending.insert(key.clone());
+            }
+        }
+        for key in durable.delivered_keys()? {
+            initial_dedupe.delivered.insert(key.clone());
+            initial_dedupe.delivered_order.push_back(key);
+        }
+        let dedupe = Arc::new(Mutex::new(initial_dedupe));
+        let worker_dedupe = Arc::clone(&dedupe);
+        let worker_durable = durable.clone();
+        let worker = tokio::spawn(async move {
+            let attempt_slots = Arc::new(Semaphore::new(LIFECYCLE_NOTICE_MAX_IN_FLIGHT_ATTEMPTS));
+            let mut deliveries = tokio::task::JoinSet::new();
+            loop {
+                tokio::select! {
+                    envelope = rx.recv() => {
+                        let Some(envelope) = envelope else {
+                            break;
+                        };
+                        let delivery_rest = rest.clone();
+                        let delivery_durable = worker_durable.clone();
+                        let delivery_dedupe = Arc::clone(&worker_dedupe);
+                        let delivery_slots = Arc::clone(&attempt_slots);
+                        deliveries.spawn(async move {
+                            let delivered = submit_lifecycle_notice_until_persisted(
+                                &delivery_rest,
+                                &delivery_durable,
+                                &envelope,
+                                &delivery_slots,
+                            )
+                            .await;
+                            if let Ok(mut state) = delivery_dedupe.lock() {
+                                state.finish(envelope.dedupe_key.as_deref(), delivered);
+                            } else {
+                                tracing::error!(
+                                    event_id = %envelope.event.id,
+                                    "lifecycle notice dedupe state was poisoned"
+                                );
+                            }
+                        });
+                    }
+                    completed = deliveries.join_next(), if !deliveries.is_empty() => {
+                        if let Some(Err(error)) = completed {
+                            tracing::error!(%error, "lifecycle notice delivery task failed");
+                        }
+                    }
+                }
+            }
+
+            // Normal shutdown keeps its existing bounded grace period: accepted
+            // deliveries drain, while a permanently rejected envelope is
+            // aborted with this worker and remains in the durable snapshot for
+            // exact-event replay on the next start.
+            while let Some(completed) = deliveries.join_next().await {
+                if let Err(error) = completed {
+                    tracing::error!(%error, "lifecycle notice delivery task failed while draining");
+                }
+            }
+        });
+        for envelope in restored {
+            tx.send(envelope).map_err(|error| {
+                anyhow::anyhow!("could not restore durable lifecycle notice: {error}")
+            })?;
+        }
+        Ok(Self {
+            tx: Some(tx),
+            worker: Some(worker),
+            dedupe,
+            durable,
+        })
+    }
+
+    fn enqueue(
+        &self,
+        channel_id: Uuid,
+        thread_tags: &ThreadTags,
+        notices: Vec<LifecycleNotice>,
+        rest: &relay::RestClient,
+    ) -> LifecycleEnqueueOutcome {
+        let mut outcome = LifecycleEnqueueOutcome::default();
+        let Some(tx) = self.tx.as_ref() else {
+            tracing::warn!("lifecycle notice outbox is already closed");
+            outcome.failed = notices.len();
+            return outcome;
+        };
+        for notice in notices {
+            let event = match pool::build_notice_event(
+                rest,
+                channel_id,
+                thread_tags,
+                &notice.content,
+            ) {
+                Ok(event) => event,
+                Err(error) => {
+                    tracing::error!(channel = %channel_id, %error, "could not construct lifecycle notice");
+                    outcome.failed += 1;
+                    continue;
+                }
+            };
+            let dedupe_key = notice.dedupe_key.map(|key| {
+                let thread_scope = thread_tags
+                    .root_event_id
+                    .as_deref()
+                    .unwrap_or("channel-root");
+                format!("{channel_id}:{thread_scope}:{key}")
+            });
+            let reserved = match self.dedupe.lock() {
+                Ok(mut state) => Some(state.reserve(dedupe_key.as_deref())),
+                Err(_) => {
+                    tracing::error!(
+                        event_id = %event.id,
+                        "lifecycle notice dedupe state was poisoned"
+                    );
+                    None
+                }
+            };
+            let Some(reserved) = reserved else {
+                // A poisoned in-memory dedupe index is not evidence of an
+                // already-persisted duplicate. Do not ACK the adapter or claim
+                // the user-visible notice is safe; its durable record remains
+                // available for retransmission after harness restart.
+                outcome.failed += 1;
+                continue;
+            };
+            if !reserved {
+                tracing::debug!(
+                    event_id = %event.id,
+                    lifecycle_key = dedupe_key.as_deref(),
+                    "suppressing duplicate lifecycle notice"
+                );
+                outcome.persisted += 1;
+                outcome.acknowledgements.extend(notice.ack);
+                continue;
+            }
+
+            let envelope = LifecycleNoticeEnvelope {
+                dedupe_key: dedupe_key.clone(),
+                event,
+            };
+            match self.durable.enqueue_lifecycle(envelope.clone()) {
+                Ok(true) => {}
+                Ok(false) => {
+                    if let Ok(mut state) = self.dedupe.lock() {
+                        state.finish(dedupe_key.as_deref(), true);
+                    }
+                    outcome.persisted += 1;
+                    outcome.acknowledgements.extend(notice.ack);
+                    continue;
+                }
+                Err(error) => {
+                    if let Ok(mut state) = self.dedupe.lock() {
+                        state.finish(dedupe_key.as_deref(), false);
+                    }
+                    tracing::error!(
+                        channel = %channel_id,
+                        lifecycle_key = dedupe_key.as_deref(),
+                        %error,
+                        "could not durably enqueue lifecycle notice"
+                    );
+                    outcome.failed += 1;
+                    continue;
+                }
+            }
+            if let Err(error) = tx.send(envelope) {
+                tracing::error!(
+                    channel = %channel_id,
+                    lifecycle_key = dedupe_key.as_deref(),
+                    %error,
+                    "lifecycle notice outbox worker is closed"
+                );
+            }
+            // Durability, not worker queue admission, is the ACK boundary. A
+            // closed worker leaves this exact signed event for startup replay.
+            outcome.persisted += 1;
+            outcome.acknowledgements.extend(notice.ack);
+        }
+        outcome
+    }
+
+    async fn shutdown(&mut self) {
+        self.tx.take();
+        let Some(mut worker) = self.worker.take() else {
+            return;
+        };
+        match tokio::time::timeout(LIFECYCLE_NOTICE_SHUTDOWN_GRACE, &mut worker).await {
+            Ok(Ok(())) => tracing::debug!("lifecycle notice outbox drained"),
+            Ok(Err(error)) => tracing::warn!(%error, "lifecycle notice outbox worker failed"),
+            Err(_) => {
+                tracing::warn!("lifecycle notice outbox did not drain within shutdown grace");
+                worker.abort();
+                let _ = worker.await;
+            }
+        }
+    }
+}
+
+async fn submit_lifecycle_notice_until_persisted(
+    rest: &relay::RestClient,
+    durable: &DurableOutbox,
+    envelope: &LifecycleNoticeEnvelope,
+    attempt_slots: &Semaphore,
+) -> bool {
+    let event = &envelope.event;
+    let mut attempt = 0usize;
+    loop {
+        let delay = LIFECYCLE_NOTICE_RETRY_DELAYS
+            .get(attempt)
+            .copied()
+            .unwrap_or(Duration::from_secs(30));
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        let attempt_permit = match attempt_slots.acquire().await {
+            Ok(permit) => permit,
+            Err(_) => return false,
+        };
+        let accepted = pool::submit_notice_event(rest, event).await;
+        drop(attempt_permit);
+        if accepted {
+            match durable.mark_lifecycle_delivered(&event.id.to_hex()) {
+                Ok(true) => return true,
+                Ok(false) => {
+                    // Absence is success only when the same stable key is
+                    // durably recorded as delivered. Otherwise we cannot
+                    // distinguish a logic/corruption bug from completion and
+                    // must keep retrying the exact accepted event ID.
+                    let durably_delivered = envelope.dedupe_key.as_ref().is_some_and(|key| {
+                        durable
+                            .delivered_keys()
+                            .is_ok_and(|keys| keys.iter().any(|item| item == key))
+                    });
+                    if durably_delivered {
+                        return true;
+                    }
+                    tracing::error!(
+                        event_id = %event.id,
+                        "accepted lifecycle notice was absent without a durable delivered receipt; retrying"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        event_id = %event.id,
+                        %error,
+                        "relay accepted lifecycle notice but durable completion failed; retrying the same event ID"
+                    );
+                }
+            }
+        }
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+/// Drain lifecycle events at the terminal boundary of one exact turn. The ACP
+/// session envelope and conversation generation must both still match.
+fn take_current_buzz_session_notices(
+    result: &mut PromptResult,
+    queue: &EventQueue,
+) -> Vec<LifecycleNotice> {
+    let expected_session_id = result
+        .agent
+        .acp
+        .current_turn_session_id()
+        .map(ToOwned::to_owned);
+    let expected_pi_session_id = expected_session_id
+        .as_deref()
+        .and_then(|session_id| result.agent.acp.pi_session_id_for(session_id))
+        .map(ToOwned::to_owned);
+    let events = result.agent.acp.take_buzz_session_events();
+    if events.is_empty() {
+        return Vec::new();
+    }
+    let (is_current_generation, expected_conversation_id) = match &result.source {
+        PromptSource::Conversation(key) => {
+            (queue.is_current_conversation(key), Some(key.stable_id()))
+        }
+        PromptSource::Channel(_) | PromptSource::Heartbeat => (false, None),
+    };
+    let Some(expected_session_id) = expected_session_id.filter(|_| is_current_generation) else {
+        tracing::debug!(
+            count = events.len(),
+            "discarding lifecycle events without a current conversation session"
+        );
+        return Vec::new();
+    };
+
+    let Some(expected_conversation_id) = expected_conversation_id else {
+        return Vec::new();
+    };
+    let mut notices = Vec::new();
+    for notification in events {
+        if notification.session_id != expected_session_id {
+            tracing::debug!(
+                event_kind = notification.event.kind(),
+                "discarding lifecycle event from a stale ACP session"
+            );
+            continue;
+        }
+        if notification.conversation_id != expected_conversation_id {
+            tracing::warn!(
+                event_id = %notification.event_id,
+                "discarding lifecycle event whose durable conversation identity does not match the active turn"
+            );
+            continue;
+        }
+        let ack = acp::BuzzSessionEventAck {
+            conversation_id: notification.conversation_id,
+            event_id: notification.event_id,
+        };
+        if expected_pi_session_id.as_deref() != Some(notification.event.pi_session_id()) {
+            tracing::warn!(
+                event_id = %ack.event_id,
+                "suppressing stale lifecycle event from a superseded Pi session"
+            );
+            // The outer ACP session and durable conversation are current, so
+            // the mismatched inner Pi identity is definitively stale. ACKing
+            // deletes it instead of replaying it forever into this generation.
+            result.agent.acp.queue_buzz_session_event_ack(ack);
+            continue;
+        }
+        if !should_publish_buzz_session_notice(&notification.event) {
+            tracing::debug!(
+                event_kind = notification.event.kind(),
+                "suppressing non-terminal compaction failure while Pi retries"
+            );
+            result.agent.acp.queue_buzz_session_event_ack(ack);
+            continue;
+        }
+        notices.push(LifecycleNotice {
+            dedupe_key: Some(format!("adapter-event:{}", ack.event_id)),
+            content: render_buzz_session_notice(&notification.event),
+            ack: Some(ack),
+        });
+    }
+    notices
+}
+
+fn enqueue_session_lifecycle_notices(
+    outbox: Option<&LifecycleNoticeOutbox>,
+    rest_client: Option<&relay::RestClient>,
+    scope: Option<(Uuid, ThreadTags)>,
+    notices: Vec<LifecycleNotice>,
+) -> LifecycleEnqueueOutcome {
+    if notices.is_empty() {
+        return LifecycleEnqueueOutcome::default();
+    }
+    let notice_count = notices.len();
+    let (Some(outbox), Some(rest), Some((channel_id, thread_tags))) = (outbox, rest_client, scope)
+    else {
+        tracing::error!(
+            notice_count,
+            "durable lifecycle notices had no delivery scope or outbox"
+        );
+        return LifecycleEnqueueOutcome {
+            failed: notice_count,
+            ..LifecycleEnqueueOutcome::default()
+        };
+    };
+    outbox.enqueue(channel_id, &thread_tags, notices, rest)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_prompt_result(
     pool: &mut AgentPool,
@@ -3164,6 +5953,7 @@ fn handle_prompt_result(
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
+    lifecycle_notice_outbox: Option<&LifecycleNoticeOutbox>,
     rest_client: Option<&relay::RestClient>,
 ) -> LoopAction {
     let before = pool.task_map().len();
@@ -3171,6 +5961,33 @@ fn handle_prompt_result(
     pool.task_map_mut()
         .retain(|_, meta| meta.agent_index != agent_index);
     debug_assert_eq!(before, pool.task_map().len() + 1);
+
+    // Drain before any outcome arm moves or respawns the agent. The scope is
+    // captured while the original batch is still present, including successful
+    // turns whose batch is consumed below.
+    let lifecycle_scope = lifecycle_notice_scope(&result);
+    let lifecycle_notices = take_current_buzz_session_notices(&mut result, queue);
+    let lifecycle_outcome = enqueue_session_lifecycle_notices(
+        lifecycle_notice_outbox,
+        rest_client,
+        lifecycle_scope,
+        lifecycle_notices,
+    );
+    for acknowledgement in lifecycle_outcome.acknowledgements {
+        result
+            .agent
+            .acp
+            .queue_buzz_session_event_ack(acknowledgement);
+    }
+    if let Some(error) = lifecycle_persistence_boundary_error(lifecycle_outcome.failed) {
+        // The Pi adapter retains every durable lifecycle record until it gets
+        // an explicit ACK. Continuing to reuse this ACP process after draining
+        // a record that Buzz could not persist would suppress the adapter's
+        // replay behind this client's in-memory seen-ID set. Treat the boundary
+        // as a transport failure: the child is replaced and replays the exact
+        // event ID from its own durable outbox on startup.
+        result.outcome = PromptOutcome::Error(error);
+    }
 
     // The hard-timeout death_message (below) must describe the batch's
     // *actual* fate, not just the `recently_active` eligibility flag — a
@@ -3187,9 +6004,15 @@ fn handle_prompt_result(
     // every retry starts at attempt 1 — defeating exponential backoff and
     // dead-letter protection.
     if let Some(batch) = result.batch.take() {
+        if !queue.is_current_conversation(&batch.conversation_key) {
+            tracing::info!(
+                conversation = %batch.conversation_key,
+                events = batch.events.len(),
+                "discarding late batch from superseded /new generation"
+            );
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
-        if !removed_channels.contains(&batch.channel_id) {
+        } else if !removed_channels.contains(&batch.channel_id) {
             if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
@@ -3249,6 +6072,36 @@ fn handle_prompt_result(
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
                 }
+            } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_pi_context_limit_error(e))
+            {
+                // Pi already emitted one typed, safely-rendered lifecycle
+                // notice for this failure. Retrying would append duplicate
+                // error turns to its durable context and publish duplicate
+                // notices, while the same oversized provider payload remains
+                // deterministic. Preserve the session and dead-letter once.
+                tracing::warn!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    "dead-lettering batch immediately — Pi context ceiling could not be satisfied"
+                );
+            } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_pi_session_storage_limit_error(e))
+            {
+                tracing::warn!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    "dead-lettering batch immediately — Pi durable session storage is exhausted"
+                );
+                if !persist_pi_session_storage_limit_notice(
+                    lifecycle_notice_outbox,
+                    rest_client,
+                    &batch,
+                ) {
+                    tracing::error!(
+                        channel_id = %batch.channel_id,
+                        "could not persist the storage-limit recovery notice; retaining the user batch"
+                    );
+                    queue.requeue_blocked(batch, DURABLE_NOTICE_BLOCKED_RETRY_DELAY);
+                }
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
                 // Auth errors are non-retryable: the token won't self-repair
                 // between retries, so requeueing only wastes attempt slots and
@@ -3290,6 +6143,7 @@ fn handle_prompt_result(
     }
 
     match &result.source {
+        PromptSource::Conversation(key) => queue.mark_conversation_complete(key),
         PromptSource::Channel(ch) => queue.mark_complete(*ch),
         PromptSource::Heartbeat => *heartbeat_in_flight = false,
     }
@@ -3326,6 +6180,7 @@ fn handle_prompt_result(
     let harness_pid = std::process::id();
 
     let channel_id = match &result.source {
+        PromptSource::Conversation(key) => Some(key.channel_id),
         PromptSource::Channel(ch) => Some(*ch),
         PromptSource::Heartbeat => None,
     };
@@ -3472,7 +6327,7 @@ fn handle_prompt_result(
                     | acp::AcpError::WriteTimeout(_)
                     | acp::AcpError::Timeout(_)
                     | acp::AcpError::Protocol(_)
-            );
+            ) || is_pi_session_invalidated_error(e);
             let error_code = match &e {
                 acp::AcpError::AgentError { code, .. } => Some(*code),
                 _ => None,
@@ -3528,7 +6383,7 @@ fn recover_panicked_agent(
     join_error: tokio::task::JoinError,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<ConversationKey, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -3544,7 +6399,12 @@ fn recover_panicked_agent(
     // Requeue BEFORE mark_complete (same rationale as handle_prompt_result).
     if let Some(batch) = meta.recoverable_batch {
         if let Some(ch) = meta.channel_id {
-            if !removed_channels.contains(&ch) {
+            if !queue.is_current_conversation(&batch.conversation_key) {
+                tracing::info!(
+                    conversation = %batch.conversation_key,
+                    "discarding panicked batch from superseded /new generation"
+                );
+            } else if !removed_channels.contains(&ch) {
                 // Dead-letter on exhaustion is logged inside requeue(); a
                 // panic path has no outcome to report, so no notice here.
                 let _ = queue.requeue(batch);
@@ -3558,10 +6418,14 @@ fn recover_panicked_agent(
         }
     }
 
-    if let Some(ch) = meta.channel_id {
+    if let Some(key) = meta.conversation_key.as_ref() {
+        queue.mark_conversation_complete(key);
+        typing_channels.remove(key);
+        tracing::warn!("cleared wedged in-flight conversation {key} from panicked agent {i}");
+    } else if let Some(ch) = meta.channel_id {
         queue.mark_complete(ch);
-        typing_channels.remove(&ch);
-        tracing::warn!("cleared wedged in-flight channel {ch} from panicked agent {i}");
+        typing_channels.retain(|key, _| key.channel_id != ch);
+        tracing::warn!("cleared wedged legacy in-flight channel {ch} from panicked agent {i}");
     } else {
         *heartbeat_in_flight = false;
         tracing::warn!("cleared wedged heartbeat_in_flight from panicked agent {i}");
@@ -3626,7 +6490,7 @@ fn drain_ready_join_results(
     config: &Config,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<ConversationKey, ThreadTags>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
@@ -3697,6 +6561,7 @@ fn dispatch_heartbeat(
         pool::TaskMeta {
             agent_index,
             channel_id: None,
+            conversation_key: None,
             turn_id,
             recoverable_batch: None,
             control_tx: None,
@@ -3938,6 +6803,7 @@ async fn initialize_agent_pool(
                             model_capabilities: None,
                             desired_model: startup.model.clone(),
                             model_overridden: false,
+                            pending_model_switch: None,
                             agent_name,
                             goose_system_prompt_supported: None,
                             protocol_version,
@@ -4367,6 +7233,446 @@ mod heartbeat_base_prompt_tests {
 }
 
 #[cfg(test)]
+mod buzz_session_notice_tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_persistence_failure_poison_is_transport_fatal() {
+        let error = lifecycle_persistence_boundary_error(1)
+            .expect("one unpersisted durable notice must poison the live ACP process");
+        assert!(matches!(error, acp::AcpError::Protocol(_)));
+        assert!(lifecycle_persistence_boundary_error(0).is_none());
+    }
+
+    #[test]
+    fn lifecycle_notice_dedupe_covers_pending_and_delivered_compactions() {
+        let mut state = LifecycleNoticeDedupe::default();
+        assert!(state.reserve(Some("compaction:one")));
+        assert!(!state.reserve(Some("compaction:one")));
+        state.finish(Some("compaction:one"), true);
+        assert!(!state.reserve(Some("compaction:one")));
+
+        assert!(state.reserve(Some("compaction:retryable")));
+        state.finish(Some("compaction:retryable"), false);
+        assert!(
+            state.reserve(Some("compaction:retryable")),
+            "a notice that exhausted delivery must remain retryable if Pi retransmits it"
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_notice_outbox_dedupes_and_drains_on_shutdown() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = Arc::clone(&requests);
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = vec![0; 16_384];
+                let _ = socket.read(&mut request).await;
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                let body = r#"{"event_id":"accepted","accepted":true,"message":"ok"}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        let keys = nostr::Keys::generate();
+        let rest = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: keys.clone(),
+            auth_tag_json: None,
+        };
+        let state_dir = tempfile::tempdir().expect("outbox tempdir");
+        let durable = DurableOutbox::open(state_dir.path(), &keys.public_key().to_hex())
+            .expect("open durable outbox");
+        let mut outbox =
+            LifecycleNoticeOutbox::spawn(rest.clone(), durable).expect("spawn lifecycle outbox");
+        let channel_id = Uuid::new_v4();
+        let notice = || LifecycleNotice {
+            dedupe_key: Some("compaction:stable-id".to_owned()),
+            content: "🧹 Context compacted safely.".to_owned(),
+            ack: Some(acp::BuzzSessionEventAck {
+                conversation_id: "buzz:test:conversation".to_owned(),
+                event_id: Uuid::new_v4().to_string(),
+            }),
+        };
+
+        outbox.enqueue(channel_id, &ThreadTags::default(), vec![notice()], &rest);
+        outbox.enqueue(channel_id, &ThreadTags::default(), vec![notice()], &rest);
+        outbox.enqueue(
+            Uuid::new_v4(),
+            &ThreadTags::default(),
+            vec![notice()],
+            &rest,
+        );
+        outbox.shutdown().await;
+
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "one thread must dedupe its compaction ID without suppressing another thread"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn rejected_lifecycle_notice_does_not_block_another_thread() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let blocked_event_id = Arc::new(Mutex::new(None::<String>));
+        let server_blocked_event_id = Arc::clone(&blocked_event_id);
+        let accepted_requests = Arc::new(AtomicUsize::new(0));
+        let server_accepted_requests = Arc::clone(&accepted_requests);
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 4_096];
+                while let Ok(read) = socket.read(&mut buffer).await {
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                    let Some(header_end) = request.windows(4).position(|item| item == b"\r\n\r\n")
+                    else {
+                        continue;
+                    };
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    if request.len() >= header_end + 4 + content_length {
+                        break;
+                    }
+                }
+
+                let blocked = loop {
+                    if let Ok(guard) = server_blocked_event_id.lock() {
+                        if let Some(value) = guard.clone() {
+                            break value;
+                        }
+                    }
+                    tokio::task::yield_now().await;
+                };
+                let is_blocked = String::from_utf8_lossy(&request).contains(&blocked);
+                if !is_blocked {
+                    server_accepted_requests.fetch_add(1, Ordering::SeqCst);
+                }
+                let body = format!(
+                    r#"{{"event_id":"fixture","accepted":{},"message":"fixture"}}"#,
+                    !is_blocked
+                );
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let keys = nostr::Keys::generate();
+        let rest = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: keys.clone(),
+            auth_tag_json: None,
+        };
+        let state_dir = tempfile::tempdir().expect("outbox tempdir");
+        let durable = DurableOutbox::open(state_dir.path(), &keys.public_key().to_hex())
+            .expect("open durable outbox");
+        let mut outbox = LifecycleNoticeOutbox::spawn(rest.clone(), durable.clone())
+            .expect("spawn lifecycle outbox");
+        let blocked_channel = Uuid::new_v4();
+        let healthy_channel = Uuid::new_v4();
+        let notice = |key: &str, content: &str| LifecycleNotice {
+            dedupe_key: Some(key.to_owned()),
+            content: content.to_owned(),
+            ack: None,
+        };
+
+        let blocked_outcome = outbox.enqueue(
+            blocked_channel,
+            &ThreadTags::default(),
+            vec![notice("blocked", "blocked lifecycle notice")],
+            &rest,
+        );
+        assert_eq!(blocked_outcome.persisted, 1);
+        let pending = durable
+            .pending_lifecycle()
+            .expect("read blocked durable lifecycle event");
+        assert_eq!(pending.len(), 1);
+        let rejected_event_id = pending[0].event.id.to_hex();
+        *blocked_event_id.lock().expect("set blocked event id") = Some(rejected_event_id.clone());
+
+        let healthy_outcome = outbox.enqueue(
+            healthy_channel,
+            &ThreadTags::default(),
+            vec![notice("healthy", "healthy lifecycle notice")],
+            &rest,
+        );
+        assert_eq!(healthy_outcome.persisted, 1);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let pending = durable
+                    .pending_lifecycle()
+                    .expect("read lifecycle delivery progress");
+                if accepted_requests.load(Ordering::SeqCst) >= 1
+                    && pending.len() == 1
+                    && pending[0].event.id.to_hex() == rejected_event_id
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("healthy lifecycle notice was head-of-line blocked");
+
+        let healthy_key = format!("{healthy_channel}:channel-root:healthy");
+        assert!(
+            durable
+                .delivered_keys()
+                .expect("read durable delivery receipts")
+                .contains(&healthy_key),
+            "healthy notice must be durably retired while the rejected notice remains pending"
+        );
+
+        outbox.tx.take();
+        if let Some(worker) = outbox.worker.take() {
+            worker.abort();
+            let _ = worker.await;
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn poisoned_lifecycle_dedupe_never_acks_without_durable_persistence() {
+        let keys = nostr::Keys::generate();
+        let rest = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:9".to_owned(),
+            keys: keys.clone(),
+            auth_tag_json: None,
+        };
+        let state_dir = tempfile::tempdir().expect("outbox tempdir");
+        let durable = DurableOutbox::open(state_dir.path(), &keys.public_key().to_hex())
+            .expect("open durable outbox");
+        let mut outbox =
+            LifecycleNoticeOutbox::spawn(rest.clone(), durable.clone()).expect("spawn outbox");
+        let poisoned = Arc::clone(&outbox.dedupe);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = poisoned.lock().expect("lock before poison");
+            panic!("intentional lifecycle dedupe poison");
+        }));
+
+        let ack = acp::BuzzSessionEventAck {
+            conversation_id: "buzz:test:poison".to_owned(),
+            event_id: Uuid::new_v4().to_string(),
+        };
+        let adapter_event_id = ack.event_id.clone();
+        let outcome = outbox.enqueue(
+            Uuid::new_v4(),
+            &ThreadTags::default(),
+            vec![LifecycleNotice {
+                dedupe_key: Some("poisoned-dedupe-event".to_owned()),
+                content: "must not be acknowledged".to_owned(),
+                ack: Some(ack.clone()),
+            }],
+            &rest,
+        );
+        assert_eq!(outcome.persisted, 0);
+        assert_eq!(outcome.failed, 1);
+        assert!(outcome.acknowledgements.is_empty());
+        assert!(durable
+            .pending_lifecycle()
+            .expect("read pending lifecycle")
+            .is_empty());
+        outbox.shutdown().await;
+
+        // A poisoned live boundary is fatal to that ACP process. After a
+        // replacement process replays the same adapter record, the exact
+        // durable event identity can be persisted and acknowledged.
+        let mut recovered = LifecycleNoticeOutbox::spawn(rest.clone(), durable.clone())
+            .expect("restart lifecycle outbox");
+        let recovery_channel_id = Uuid::new_v4();
+        let recovered_outcome = recovered.enqueue(
+            recovery_channel_id,
+            &ThreadTags::default(),
+            vec![LifecycleNotice {
+                dedupe_key: Some(format!("adapter-event:{adapter_event_id}")),
+                content: "replayed safely".to_owned(),
+                ack: Some(ack.clone()),
+            }],
+            &rest,
+        );
+        assert_eq!(recovered_outcome.failed, 0);
+        assert_eq!(recovered_outcome.persisted, 1);
+        assert_eq!(recovered_outcome.acknowledgements, vec![ack]);
+        let pending = durable
+            .pending_lifecycle()
+            .expect("read recovered durable lifecycle");
+        assert_eq!(pending.len(), 1);
+        let expected_key =
+            format!("{recovery_channel_id}:channel-root:adapter-event:{adapter_event_id}");
+        assert_eq!(
+            pending[0].dedupe_key.as_deref(),
+            Some(expected_key.as_str())
+        );
+        recovered.tx.take();
+        if let Some(worker) = recovered.worker.take() {
+            worker.abort();
+        }
+    }
+
+    #[test]
+    fn compaction_notice_reports_configured_cap_and_effective_threshold() {
+        let notice = render_buzz_session_notice(&BuzzSessionEvent::CompactionCompleted {
+            compaction_id: Uuid::new_v4().to_string(),
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "do not publish adapter prose SECRET".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            reason: acp::CompactionReason::Threshold,
+            before_tokens: Some(147_820),
+            after_tokens: Some(31_400),
+            limit_tokens: 150_000,
+            effective_limit_tokens: 150_000,
+            compaction_threshold_tokens: 133_616,
+            will_retry: false,
+            from_extension: false,
+        });
+
+        assert!(notice.contains("147,820 → ~31,400"));
+        assert!(notice.contains("Configured cap 150,000 tokens"));
+        assert!(notice.contains("automatic compaction threshold 133,616"));
+        assert!(!notice.contains("SECRET"));
+    }
+
+    #[test]
+    fn compaction_failure_never_exposes_adapter_error_details() {
+        let notice = render_buzz_session_notice(&BuzzSessionEvent::CompactionFailed {
+            compaction_id: Uuid::new_v4().to_string(),
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "secret message".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            reason: acp::CompactionReason::Preflight,
+            before_tokens: Some(140_000),
+            limit_tokens: 150_000,
+            effective_limit_tokens: 150_000,
+            compaction_threshold_tokens: 133_616,
+            error: "/Users/example/.pi/extensions/private.ts: API_KEY=secret".to_string(),
+            aborted: false,
+            will_retry: false,
+            from_extension: true,
+        });
+
+        assert!(notice.contains("request was stopped"));
+        assert!(notice.contains("`/new`"));
+        assert!(!notice.contains("API_KEY"));
+        assert!(!notice.contains("/Users"));
+        assert!(!notice.contains("secret message"));
+    }
+
+    #[test]
+    fn context_and_reload_notices_sanitize_untrusted_strings() {
+        let context = render_buzz_session_notice(&BuzzSessionEvent::ContextStatus {
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "ignored".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            used_tokens: Some(75_000),
+            remaining_tokens: Some(75_000),
+            percent: Some(1.0),
+            limit_tokens: 150_000,
+            effective_limit_tokens: 150_000,
+            compaction_threshold_tokens: 133_616,
+            auto_compaction: true,
+            compacting: false,
+            model: Some("provider/model`\n@everyone SECRET".to_string()),
+        });
+        assert!(
+            context.contains("50.0%"),
+            "percentage is recomputed from counts"
+        );
+        assert!(!context.contains("@everyone"));
+        assert!(!context.contains("SECRET"));
+
+        let reload = render_buzz_session_notice(&BuzzSessionEvent::ExtensionsReloaded {
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "ignored".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            extensions: 2,
+            skills: 3,
+            prompts: 4,
+            context_files: 1,
+            errors: vec!["/private/path: token=SECRET".to_string()],
+            project_trusted: false,
+        });
+        assert!(reload.contains("1 resource diagnostic(s)"));
+        assert!(reload.contains("stayed disabled"));
+        assert!(!reload.contains("SECRET"));
+        assert!(!reload.contains("/private/path"));
+    }
+
+    #[test]
+    fn transient_compaction_failures_and_pi_reset_echoes_are_not_published() {
+        let retrying_failure = BuzzSessionEvent::CompactionFailed {
+            compaction_id: Uuid::new_v4().to_string(),
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "ignored".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            reason: acp::CompactionReason::Preflight,
+            before_tokens: Some(140_000),
+            limit_tokens: 150_000,
+            effective_limit_tokens: 150_000,
+            compaction_threshold_tokens: 133_616,
+            error: "ignored".to_string(),
+            aborted: false,
+            will_retry: true,
+            from_extension: false,
+        };
+        let reset_echo = BuzzSessionEvent::SessionReset {
+            timestamp: "2026-08-02T12:00:00Z".to_string(),
+            message: "ignored".to_string(),
+            previous_pi_session_id: "old-pi-session".to_string(),
+            pi_session_id: "pi-session".to_string(),
+            limit_tokens: 150_000,
+            effective_limit_tokens: 150_000,
+            compaction_threshold_tokens: 133_616,
+        };
+
+        assert!(!should_publish_buzz_session_notice(&retrying_failure));
+        assert!(!should_publish_buzz_session_notice(&reset_echo));
+    }
+}
+
+#[cfg(test)]
 mod owner_control_command_tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag};
@@ -4392,18 +7698,26 @@ mod owner_control_command_tests {
             &event,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            None,
         ));
 
         let wrong_kind = make_event(1, "!rotate", Some(&agent));
-        assert!(!is_owner_control_command(&wrong_kind, 1, "!rotate", &agent));
+        assert!(!is_owner_control_command(
+            &wrong_kind,
+            1,
+            "!rotate",
+            &agent,
+            None,
+        ));
 
         let wrong_content = make_event(KIND_STREAM_MESSAGE, "!cancel", Some(&agent));
         assert!(!is_owner_control_command(
             &wrong_content,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            None,
         ));
 
         let no_mention = make_event(KIND_STREAM_MESSAGE, "!rotate", None);
@@ -4411,7 +7725,141 @@ mod owner_control_command_tests {
             &no_mention,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            None,
+        ));
+    }
+
+    #[test]
+    fn reserved_new_uses_the_same_leading_mention_normalization_as_slash_commands() {
+        let agent = "ab".repeat(32);
+        let npub = "nostr:npub1xhqc4cnnln86lqxk983qulu8yxusfxfhntwl75es2jkvy5zvz26qzr0685";
+
+        for content in ["/new", "@Agent /new", &format!("{npub} /new")] {
+            let event = make_event(KIND_STREAM_MESSAGE, content, Some(&agent));
+            assert!(
+                is_owner_control_command(&event, KIND_STREAM_MESSAGE, "/new", &agent, None),
+                "reserved /new should be recognized after mention stripping: {content}"
+            );
+        }
+
+        for content in [
+            "@Agent see /new",
+            "@Agent /new please",
+            "@Agent /newer",
+            "@Agent /tmp/new",
+            "look at /new",
+        ] {
+            let event = make_event(KIND_STREAM_MESSAGE, content, Some(&agent));
+            assert!(
+                !is_owner_control_command(&event, KIND_STREAM_MESSAGE, "/new", &agent, None),
+                "non-exact or non-leading content must not be consumed: {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_new_recognizes_the_configured_multi_word_agent_name() {
+        let agent = "ab".repeat(32);
+        let event = make_event(KIND_STREAM_MESSAGE, "@Buzz Agent /new", Some(&agent));
+
+        assert!(is_owner_control_command(
+            &event,
+            KIND_STREAM_MESSAGE,
+            "/new",
+            &agent,
+            Some("Buzz Agent"),
+        ));
+        assert!(!is_owner_control_command(
+            &event,
+            KIND_STREAM_MESSAGE,
+            "/new",
+            &agent,
+            None,
+        ));
+    }
+
+    #[test]
+    fn reserved_new_detection_is_sender_independent_so_non_owners_are_consumed() {
+        let agent = "ab".repeat(32);
+        let owner_event = make_event(KIND_STREAM_MESSAGE, "@Agent /new", Some(&agent));
+        let non_owner_event = make_event(KIND_STREAM_MESSAGE, "@Agent /new", Some(&agent));
+
+        assert_ne!(owner_event.pubkey, non_owner_event.pubkey);
+        assert!(is_owner_control_command(
+            &owner_event,
+            KIND_STREAM_MESSAGE,
+            "/new",
+            &agent,
+            None,
+        ));
+        assert!(is_owner_control_command(
+            &non_owner_event,
+            KIND_STREAM_MESSAGE,
+            "/new",
+            &agent,
+            None,
+        ));
+        // The main intake authorizes the first only when its pubkey equals the
+        // configured owner, but consumes both once this reserved shape matches.
+    }
+
+    #[test]
+    fn bare_pi_mutations_are_reserved_even_without_a_nostr_mention() {
+        let agent = "ab".repeat(32);
+        for (content, expected) in [
+            ("/new", "/new"),
+            ("/compact", "/compact"),
+            ("/reload\nignore this trailing prompt", "/reload"),
+            ("@Buzz Agent /compact", "/compact"),
+        ] {
+            let event = make_event(KIND_STREAM_MESSAGE, content, None);
+            assert_eq!(
+                reserved_pi_lifecycle_command(&event, KIND_STREAM_MESSAGE, Some("Buzz Agent")),
+                Some(expected),
+                "subscribe-all/no-mention intake must reserve {content:?}"
+            );
+            assert!(
+                !is_owner_control_command(
+                    &event,
+                    KIND_STREAM_MESSAGE,
+                    expected,
+                    &agent,
+                    Some("Buzz Agent"),
+                ),
+                "an unaddressed command may be consumed but never authorized"
+            );
+        }
+    }
+
+    #[test]
+    fn pi_mutation_reservation_matches_only_the_adapter_command_line() {
+        for content in ["/compact now", "/reloader", "please /reload", "/context"] {
+            let event = make_event(KIND_STREAM_MESSAGE, content, None);
+            assert_eq!(
+                reserved_pi_lifecycle_command(&event, KIND_STREAM_MESSAGE, None),
+                None,
+                "non-mutating or non-exact command must not be reserved: {content:?}"
+            );
+        }
+        let wrong_kind = make_event(1, "/reload", None);
+        assert_eq!(reserved_pi_lifecycle_command(&wrong_kind, 1, None), None);
+    }
+
+    #[test]
+    fn addressed_owner_command_uses_the_same_first_line_semantics_as_pi() {
+        let agent = "ab".repeat(32);
+        let event = make_event(
+            KIND_STREAM_MESSAGE,
+            "@Buzz Agent /reload\ntrailing context",
+            Some(&agent),
+        );
+        assert!(is_owner_control_command(
+            &event,
+            KIND_STREAM_MESSAGE,
+            "/reload",
+            &agent,
+            Some("Buzz Agent"),
         ));
     }
 
@@ -4468,6 +7916,7 @@ mod owner_control_command_tests {
             pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: Some(control_tx),
@@ -4491,6 +7940,194 @@ mod owner_control_command_tests {
             channel_id,
             ControlSignal::Rotate
         ));
+    }
+
+    #[tokio::test]
+    async fn observer_control_routes_exact_turn_and_rejects_ambiguous_legacy_frames() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let wrong_channel_id = Uuid::new_v4();
+        let (first_tx, mut first_rx) = tokio::sync::oneshot::channel();
+        let (second_tx, second_rx) = tokio::sync::oneshot::channel();
+
+        let first_task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            first_task.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "turn-one".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(first_tx),
+                steer_tx: None,
+            },
+        );
+        let second_task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            second_task.id(),
+            pool::TaskMeta {
+                agent_index: 1,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "turn-two".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(second_tx),
+                steer_tx: None,
+            },
+        );
+
+        assert_eq!(
+            signal_observer_control(&mut pool, channel_id, "turn-two", ControlSignal::Cancel,),
+            ObserverControlResult::Sent
+        );
+        assert_eq!(second_rx.await.unwrap(), ControlSignal::Cancel);
+        assert!(
+            first_rx.try_recv().is_err(),
+            "sibling turn must be untouched"
+        );
+
+        assert_eq!(
+            signal_observer_control(
+                &mut pool,
+                wrong_channel_id,
+                "turn-one",
+                ControlSignal::Cancel,
+            ),
+            ObserverControlResult::NoActiveTurn,
+            "an exact turn id cannot be replayed against another channel"
+        );
+        assert_eq!(
+            signal_observer_control(&mut pool, channel_id, "turn-two", ControlSignal::Cancel,),
+            ObserverControlResult::TurnEnding,
+            "a second signal for the same turn reports that it is already ending"
+        );
+
+        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
+        drop(closed_rx);
+        let closed_task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            closed_task.id(),
+            pool::TaskMeta {
+                agent_index: 2,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "turn-closed".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(closed_tx),
+                steer_tx: None,
+            },
+        );
+        assert_eq!(
+            signal_observer_control(
+                &mut pool,
+                channel_id,
+                "turn-closed",
+                ControlSignal::SwitchModel("provider/model".to_string()),
+            ),
+            ObserverControlResult::TurnEnding,
+            "a closed receiver must never be reported to Desktop as sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_observer_control_cannot_mutate_turns_across_fresh_replay_caches() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let mut replay_cache = ObserverControlReplayCache::default();
+        let channel_id = Uuid::new_v4();
+        let payload = serde_json::json!({
+            "type": "cancel_turn",
+            "channelId": channel_id,
+        });
+        let now = chrono::Utc::now().timestamp();
+
+        let (first_tx, mut first_rx) = tokio::sync::oneshot::channel();
+        let first_task = pool.join_set.spawn(std::future::pending::<()>());
+        let first_task_id = first_task.id();
+        pool.task_map_mut().insert(
+            first_task_id,
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "turn-one".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(first_tx),
+                steer_tx: None,
+            },
+        );
+
+        route_authenticated_observer_control(
+            "aa".repeat(32),
+            now,
+            now,
+            &payload,
+            &mut pool,
+            None,
+            &mut replay_cache,
+        );
+        assert!(
+            first_rx.try_recv().is_err(),
+            "a channel-only control must not mutate even the first matching turn"
+        );
+        pool.task_map_mut().remove(&first_task_id);
+        first_task.abort();
+
+        let (second_tx, mut second_rx) = tokio::sync::oneshot::channel();
+        let second_task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            second_task.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "turn-two".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(second_tx),
+                steer_tx: None,
+            },
+        );
+
+        // A restart has an empty in-memory replay cache. The missing turnId is
+        // still enough to reject the retained signed frame fail closed.
+        let mut restarted_replay_cache = ObserverControlReplayCache::default();
+        route_authenticated_observer_control(
+            "aa".repeat(32),
+            now,
+            now,
+            &payload,
+            &mut pool,
+            None,
+            &mut restarted_replay_cache,
+        );
+        assert!(
+            second_rx.try_recv().is_err(),
+            "the same signed legacy control must not target a later turn"
+        );
+    }
+
+    #[test]
+    fn observer_control_replay_cache_fails_closed_at_capacity_until_expiry() {
+        let mut cache = ObserverControlReplayCache::default();
+        let now = 10_000;
+        for index in 0..OBSERVER_CONTROL_REPLAY_CAPACITY {
+            assert_eq!(
+                cache.admit(format!("event-{index}"), now, now),
+                ObserverControlAdmission::Accepted
+            );
+        }
+        assert_eq!(
+            cache.admit("overflow".into(), now, now),
+            ObserverControlAdmission::Saturated
+        );
+        assert_eq!(
+            cache.admit(
+                "after-expiry".into(),
+                now + OBSERVER_CONTROL_FRESHNESS_SECS + 1,
+                now + OBSERVER_CONTROL_FRESHNESS_SECS + 1,
+            ),
+            ObserverControlAdmission::Accepted
+        );
     }
 }
 
@@ -4788,6 +8425,13 @@ mod author_gate_tests {
             is_dm_channel(id, &resolver(startup)).await,
             "missing startup metadata must not be trusted as a stream"
         );
+    }
+
+    #[tokio::test]
+    async fn unknown_channel_is_dm_for_auth_but_not_for_conversation_scope() {
+        let id = Uuid::new_v4();
+        let classification = resolve_dm_channel_scope(id, &resolver(HashMap::new())).await;
+        assert_eq!(classification, (true, false));
     }
 
     async fn lazy_resolver_with_response(
@@ -5118,8 +8762,11 @@ mod build_mcp_servers_tests {
             channels_override: None,
             no_mention_filter: false,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
+            state_dir: std::env::temp_dir().join("buzz-acp-lib-test"),
             context_message_limit: 12,
             max_turns_per_session: 0,
+            max_cached_conversation_sessions: 8,
+            conversation_session_idle_ttl_secs: 1_800,
             presence_enabled: true,
             typing_enabled: true,
             memory_enabled: false,
@@ -5134,6 +8781,7 @@ mod build_mcp_servers_tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            require_durable_thread_sessions: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -5340,8 +8988,11 @@ mod error_outcome_emission_tests {
             channels_override: None,
             no_mention_filter: false,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
+            state_dir: std::env::temp_dir().join("buzz-acp-observer-test"),
             context_message_limit: 12,
             max_turns_per_session: 0,
+            max_cached_conversation_sessions: 8,
+            conversation_session_idle_ttl_secs: 1_800,
             presence_enabled: true,
             typing_enabled: true,
             memory_enabled: false,
@@ -5356,6 +9007,7 @@ mod error_outcome_emission_tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            require_durable_thread_sessions: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -5391,6 +9043,7 @@ mod error_outcome_emission_tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
+            pending_model_switch: None,
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             // Error branches under test never read this; 1 is the legacy
@@ -5415,6 +9068,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -5455,6 +9109,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
+            None,
         );
 
         let turn_errors: Vec<_> = observer
@@ -5491,6 +9146,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                conversation_key: None,
                 turn_id: "panic-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -5583,6 +9239,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    conversation_key: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -5620,6 +9277,7 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 Some(observer.clone()),
                 None,
+                None,
             );
             let events = observer.snapshot();
             let turn_error = events.iter().find(|e| e.kind == "turn_error").unwrap();
@@ -5651,8 +9309,10 @@ mod error_outcome_emission_tests {
             let event = EventBuilder::new(Kind::Custom(9), "test")
                 .sign_with_keys(&keys)
                 .unwrap();
+            let channel_id = Uuid::new_v4();
             FlushBatch {
-                channel_id: Uuid::new_v4(),
+                channel_id,
+                conversation_key: test_conversation_key(channel_id),
                 events: vec![BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -5674,6 +9334,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    conversation_key: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -5708,6 +9369,7 @@ mod error_outcome_emission_tests {
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
+                None,
                 None,
                 None,
             );
@@ -5759,6 +9421,7 @@ mod error_outcome_emission_tests {
                 .unwrap();
             FlushBatch {
                 channel_id,
+                conversation_key: test_conversation_key(channel_id),
                 events: vec![BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -5779,6 +9442,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    conversation_key: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -5813,6 +9477,7 @@ mod error_outcome_emission_tests {
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
+                None,
                 None,
                 None,
             );
@@ -5855,6 +9520,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -5875,6 +9541,7 @@ mod error_outcome_emission_tests {
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "test")
                     .sign_with_keys(&Keys::generate())
@@ -5905,6 +9572,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -5949,6 +9617,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -5968,6 +9637,7 @@ mod error_outcome_emission_tests {
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "final-attempt")
                     .sign_with_keys(&Keys::generate())
@@ -5998,6 +9668,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6048,6 +9719,7 @@ mod error_outcome_emission_tests {
         let channel_id = Uuid::new_v4();
         let batch = FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![BatchEvent {
                 event: original_event.clone(),
                 prompt_tag: "test".into(),
@@ -6065,6 +9737,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6113,6 +9786,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6204,6 +9878,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6245,6 +9920,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6355,6 +10031,130 @@ mod error_outcome_emission_tests {
         );
     }
 
+    #[test]
+    fn pi_context_limit_code_is_stable_and_non_retryable() {
+        let limit = acp::AcpError::AgentError {
+            code: PI_CONTEXT_LIMIT_ERROR_CODE,
+            message: "untrusted adapter prose is not part of classification".to_string(),
+        };
+        let other = acp::AcpError::AgentError {
+            code: -32000,
+            message: "context words alone must not trigger dead-lettering".to_string(),
+        };
+
+        assert!(is_pi_context_limit_error(&limit));
+        assert!(!is_pi_context_limit_error(&other));
+    }
+
+    #[test]
+    fn pi_storage_limit_code_and_recovery_notice_are_stable() {
+        let limit = acp::AcpError::AgentError {
+            code: PI_SESSION_STORAGE_LIMIT_ERROR_CODE,
+            message: "adapter detail must not drive classification".to_string(),
+        };
+        let other = acp::AcpError::AgentError {
+            code: -32602,
+            message: "BUZZ_SESSION_STORAGE_LIMIT text alone is untrusted".to_string(),
+        };
+        assert!(is_pi_session_storage_limit_error(&limit));
+        assert!(!is_pi_session_storage_limit_error(&other));
+        assert!(pi_session_storage_limit_notice().contains("`/new`"));
+        assert!(pi_session_storage_limit_notice().contains("without retrying"));
+    }
+
+    #[test]
+    fn pi_session_invalidation_code_is_stable_and_exact() {
+        let invalidated = acp::AcpError::AgentError {
+            code: PI_SESSION_INVALIDATED_ERROR_CODE,
+            message: "safe adapter detail does not drive classification".to_string(),
+        };
+        let text_only = acp::AcpError::AgentError {
+            code: -32603,
+            message: "BUZZ_PI_SESSION_INVALIDATED".to_string(),
+        };
+        assert!(is_pi_session_invalidated_error(&invalidated));
+        assert!(!is_pi_session_invalidated_error(&text_only));
+    }
+
+    #[tokio::test]
+    async fn pi_session_invalidation_requeues_exact_batch_and_replaces_agent() {
+        let channel_id = Uuid::new_v4();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "reload safely")
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign invalidation fixture");
+        let event_id = event.id.to_hex();
+        let batch = FlushBatch {
+            channel_id,
+            conversation_key: test_conversation_key(channel_id),
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "reload-invalidated-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            PromptResult {
+                agent,
+                source: PromptSource::Channel(channel_id),
+                turn_id: "reload-invalidated-turn".to_string(),
+                outcome: PromptOutcome::Error(acp::AcpError::AgentError {
+                    code: PI_SESSION_INVALIDATED_ERROR_CODE,
+                    message: "Pi session was invalidated after reload failure".to_string(),
+                }),
+                batch: Some(batch),
+            },
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(pool.live_count(), 0, "invalid proxy must never be reused");
+        assert_eq!(respawn_tasks.len(), 1, "ACP process must be replaced");
+        assert_eq!(queue.queued_event_count(&channel_id), 1);
+        assert_eq!(
+            queue.drain_channel(channel_id),
+            vec![event_id],
+            "the exact triggering event must survive for the fresh process"
+        );
+    }
+
     // ── auth error dead-letter behavior ────────────────────────────────────
 
     /// An auth-class `PromptOutcome::Error` must dead-letter immediately
@@ -6369,6 +10169,7 @@ mod error_outcome_emission_tests {
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -6392,6 +10193,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6428,6 +10230,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             None,
             None,
+            None,
         );
 
         // The batch must not be requeued: pending_channels returns 0.
@@ -6443,6 +10246,96 @@ mod error_outcome_emission_tests {
         );
     }
 
+    #[tokio::test]
+    async fn pi_storage_exhaustion_dead_letters_immediately_without_requeueing() {
+        let channel_id = uuid::Uuid::new_v4();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "test")
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign test event");
+        let batch = FlushBatch {
+            channel_id,
+            conversation_key: test_conversation_key(channel_id),
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: None,
+                turn_id: "storage-limit-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+        let notice_keys = nostr::Keys::generate();
+        let rest = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:9".to_owned(),
+            keys: notice_keys.clone(),
+            auth_tag_json: None,
+        };
+        let state_dir = tempfile::tempdir().expect("durable state tempdir");
+        let durable = DurableOutbox::open(state_dir.path(), &notice_keys.public_key().to_hex())
+            .expect("open durable outbox");
+        let outbox = LifecycleNoticeOutbox::spawn(rest.clone(), durable.clone())
+            .expect("spawn durable notice worker");
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            PromptResult {
+                agent,
+                source: PromptSource::Channel(channel_id),
+                turn_id: "storage-limit-turn".to_string(),
+                outcome: PromptOutcome::Error(acp::AcpError::AgentError {
+                    code: PI_SESSION_STORAGE_LIMIT_ERROR_CODE,
+                    message: "quota exhausted".to_string(),
+                }),
+                batch: Some(batch),
+            },
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            Some(&outbox),
+            Some(&rest),
+        );
+        assert_eq!(queue.pending_channels(), 0);
+        assert_eq!(queue.queued_event_count(&channel_id), 0);
+        assert_eq!(
+            durable
+                .pending_lifecycle()
+                .expect("read pending lifecycle")
+                .len(),
+            1,
+            "dead-lettering is allowed only after the recovery notice is crash-durable"
+        );
+    }
+
     /// A non-auth application error (e.g. usage credits) must still follow the
     /// standard requeue path so today's behavior is unchanged.
     #[tokio::test]
@@ -6454,6 +10347,7 @@ mod error_outcome_emission_tests {
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -6477,6 +10371,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                conversation_key: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6511,6 +10406,7 @@ mod error_outcome_emission_tests {
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
+            None,
             None,
             None,
         );

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -30,21 +30,27 @@ use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::acp::{
-    extract_model_config_options, extract_model_state, model_in_catalog,
-    resolve_model_switch_method, AcpClient, AcpError, McpServer, ModelSwitchMethod, StopReason,
+    extract_model_config_options, extract_model_state, resolve_model_switch_method, AcpClient,
+    AcpError, ConversationResetCommit, McpServer, ModelSwitchMethod, StopReason,
     SystemPromptTransport,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
 use crate::queue::{
-    CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
-    PromptProfile, PromptProfileLookup, ThreadTags,
+    CancelReason, ContextMessage, ConversationContext, ConversationKey, FlushBatch,
+    PromptChannelInfo, PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
 
 /// Window within which agent activity before a hard-cap death qualifies
 /// the turn as "recently active" (eligible for requeue instead of dead-letter).
 const RECENT_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
+
+/// Affinity is a routing cache, not authoritative session storage. Keep it
+/// bounded even for legacy adapters whose channel-session map predates the
+/// thread-session LRU. Exact busy-task checks below preserve the no-fork rule
+/// when a cache entry is evicted.
+const MAX_AFFINITY_ENTRIES: usize = 16_384;
 
 // FlushBatch and BatchEvent derive Clone (added in queue.rs) so we can store
 // a recoverable copy in TaskMeta for panic recovery in Queue mode.
@@ -53,6 +59,8 @@ const RECENT_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
 pub struct TaskMeta {
     pub agent_index: usize,
     pub channel_id: Option<Uuid>,
+    /// Exact thread conversation for channel prompts. `None` for heartbeats.
+    pub conversation_key: Option<ConversationKey>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
@@ -80,18 +88,20 @@ pub struct AgentModelCapabilities {
     pub available_models_raw: Option<serde_json::Value>,
 }
 
-/// Per-channel session IDs and turn counters.
+/// Per-conversation session IDs and turn counters.
 ///
 /// Separated from `OwnedAgent` so the state machine is testable without
 /// spawning a real agent subprocess.
 #[derive(Default)]
 pub struct SessionState {
-    /// channel_id → session_id
-    pub sessions: HashMap<Uuid, String>,
+    /// thread conversation → session_id
+    pub sessions: HashMap<ConversationKey, String>,
     pub heartbeat_session: Option<String>,
     /// Per-channel turn counters for proactive session rotation.
     /// Incremented on each successful prompt; reset when the session is rotated.
-    pub turn_counts: HashMap<Uuid, u32>,
+    pub turn_counts: HashMap<ConversationKey, u32>,
+    /// Last successful use (or creation) for idle TTL/LRU eviction.
+    pub last_used: HashMap<ConversationKey, std::time::Instant>,
     /// Turn counter for the heartbeat session.
     pub heartbeat_turn_count: u32,
     /// channel_id → rendered NIP-AE core prompt section, populated once at
@@ -110,6 +120,9 @@ impl SessionState {
     /// Invalidate the session (and turn counter) for a specific prompt source.
     pub fn invalidate(&mut self, source: &PromptSource) {
         match source {
+            PromptSource::Conversation(key) => {
+                self.invalidate_conversation(key);
+            }
             PromptSource::Channel(cid) => {
                 self.invalidate_channel(cid);
             }
@@ -123,16 +136,91 @@ impl SessionState {
     /// Invalidate a single channel's session and turn counter.
     /// Returns `true` if the channel had an active session.
     pub fn invalidate_channel(&mut self, channel_id: &Uuid) -> bool {
-        self.turn_counts.remove(channel_id);
+        let keys: Vec<_> = self
+            .sessions
+            .keys()
+            .chain(self.turn_counts.keys())
+            .chain(self.last_used.keys())
+            .filter(|key| key.channel_id == *channel_id)
+            .cloned()
+            .collect();
+        let mut removed = false;
+        for key in keys {
+            removed |= self.invalidate_conversation(&key);
+        }
         self.core_sections.remove(channel_id);
         self.canvas_sections.remove(channel_id);
-        self.sessions.remove(channel_id).is_some()
+        removed
+    }
+
+    /// Invalidate one thread without disturbing sibling threads in its channel.
+    pub fn invalidate_conversation(&mut self, key: &ConversationKey) -> bool {
+        self.turn_counts.remove(key);
+        self.last_used.remove(key);
+        self.sessions.remove(key).is_some()
+    }
+
+    fn take_conversation(&mut self, key: &ConversationKey) -> Option<String> {
+        self.turn_counts.remove(key);
+        self.last_used.remove(key);
+        self.sessions.remove(key)
+    }
+
+    /// Evict idle sessions by TTL, then oldest-first until the configured cap.
+    /// `active` is never evicted, even when the configured cap is zero.
+    pub fn prune_idle(
+        &mut self,
+        active: &ConversationKey,
+        max_sessions: usize,
+        idle_ttl: Duration,
+    ) -> Vec<(ConversationKey, String)> {
+        let now = std::time::Instant::now();
+        let mut evicted = Vec::new();
+        let expired: Vec<_> = self
+            .sessions
+            .keys()
+            .filter(|key| *key != active)
+            .filter(|key| {
+                self.last_used
+                    .get(*key)
+                    .is_none_or(|used| now.duration_since(*used) >= idle_ttl)
+            })
+            .cloned()
+            .collect();
+        for key in expired {
+            if let Some(session_id) = self.take_conversation(&key) {
+                evicted.push((key, session_id));
+            }
+        }
+
+        let max_sessions = max_sessions.max(1);
+        let target_before_use = if self.sessions.contains_key(active) {
+            max_sessions
+        } else {
+            max_sessions.saturating_sub(1)
+        };
+        while self.sessions.len() > target_before_use {
+            let Some(oldest) = self
+                .sessions
+                .keys()
+                .filter(|key| *key != active)
+                .min_by_key(|key| self.last_used.get(*key).copied())
+                .cloned()
+            else {
+                break;
+            };
+            if let Some(session_id) = self.take_conversation(&oldest) {
+                evicted.push((oldest, session_id));
+            }
+        }
+        evicted
     }
 
     /// Invalidate all sessions and turn counters (e.g. after agent exit).
     pub fn invalidate_all(&mut self) {
         self.sessions.clear();
         self.turn_counts.clear();
+        self.last_used.clear();
         self.heartbeat_session = None;
         self.heartbeat_turn_count = 0;
         self.core_sections.clear();
@@ -141,14 +229,62 @@ impl SessionState {
 
     #[cfg(test)]
     fn has_channel_state(&self, channel_id: &Uuid) -> bool {
-        self.sessions.contains_key(channel_id)
-            || self.turn_counts.contains_key(channel_id)
+        self.sessions
+            .keys()
+            .any(|key| key.channel_id == *channel_id)
+            || self
+                .turn_counts
+                .keys()
+                .any(|key| key.channel_id == *channel_id)
             || self.core_sections.contains_key(channel_id)
             || self.canvas_sections.contains_key(channel_id)
     }
 }
 
 /// An agent with its session state, owned by the pool or a running task.
+pub(crate) struct PendingModelSwitch {
+    turn_id: String,
+    previous_model: Option<String>,
+    previous_model_overridden: bool,
+}
+
+/// A control cancellation can fail after Desktop already received the
+/// immediate `sent` acknowledgement. Close that known outcome explicitly:
+/// restore this process's prior model intent and emit the exact correlated
+/// terminal result. A process crash before this branch remains honestly
+/// `pending` because no actor observed a definitive application result.
+fn report_control_cancel_failure(
+    agent: &mut OwnedAgent,
+    signal: &ControlSignal,
+    fallback_turn_id: &str,
+) {
+    let ControlSignal::SwitchModel(requested_model) = signal else {
+        return;
+    };
+    let pending = agent.pending_model_switch.take();
+    let result_turn_id = if let Some(pending) = pending {
+        agent.desired_model = pending.previous_model;
+        agent.model_overridden = pending.previous_model_overridden;
+        pending.turn_id
+    } else {
+        tracing::error!(
+            turn_id = fallback_turn_id,
+            model_id = requested_model,
+            "failed model-switch cancellation lost its pending correlation"
+        );
+        fallback_turn_id.to_owned()
+    };
+    agent.acp.observe(
+        "control_result",
+        serde_json::json!({
+            "type": "switch_model",
+            "status": "switch_failed",
+            "modelId": requested_model,
+            "turnId": result_turn_id,
+        }),
+    );
+}
+
 pub struct OwnedAgent {
     pub index: usize,
     pub acp: AcpClient,
@@ -162,6 +298,11 @@ pub struct OwnedAgent {
     /// desktop reader to distinguish a genuine runtime override from a stale
     /// session whose persona model was edited. Reset on spawn/restart.
     pub model_overridden: bool,
+    /// Exact desktop turn awaiting the final result of a busy live-model
+    /// switch. The immediate control acknowledgement means only "delivered";
+    /// this correlation survives cancel/requeue so the desktop resolves on
+    /// the later applied/unsupported result instead of showing false success.
+    pub pending_model_switch: Option<PendingModelSwitch>,
     /// Normalized agent name from initialize (`agentInfo.name`/`serverInfo.name`).
     pub agent_name: String,
     /// Whether Goose accepted its custom system-prompt method. `None` probes on
@@ -216,6 +357,32 @@ impl OwnedAgent {
             self.goose_system_prompt_supported,
         )
     }
+
+    /// Forget every cached conversation for a channel before membership
+    /// removal returns this checked-out agent to the pool. Idle agents are
+    /// handled by [`AgentPool::dispose_channel_sessions`]; this closes the
+    /// checked-out gap without leaving adapter-owned Pi runtimes behind.
+    pub(crate) async fn forget_channel_sessions(&mut self, channel_id: Uuid) -> usize {
+        let sessions: Vec<String> = self
+            .state
+            .sessions
+            .iter()
+            .filter(|(key, _)| key.channel_id == channel_id)
+            .map(|(_, session_id)| session_id.clone())
+            .collect();
+        self.state.invalidate_channel(&channel_id);
+
+        let mut forgotten = 0;
+        for session_id in sessions {
+            forgotten += 1;
+            if !dispose_session_or_poison(self, &session_id, true, "channel membership removal")
+                .await
+            {
+                break;
+            }
+        }
+        forgotten
+    }
 }
 
 /// Pool of agents with take-and-return ownership semantics.
@@ -225,6 +392,10 @@ impl OwnedAgent {
 /// tasks for panic recovery.
 pub struct AgentPool {
     agents: Vec<Option<OwnedAgent>>,
+    /// Sticky ownership of a conversation by one ACP subprocess. A busy owner
+    /// makes dispatch wait; routing the same key to a different idle process
+    /// would silently fork its model context.
+    affinities: HashMap<ConversationKey, usize>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
     result_rx: mpsc::UnboundedReceiver<PromptResult>,
     pub join_set: JoinSet<()>,
@@ -245,6 +416,10 @@ pub struct PromptResult {
 /// Whether the prompt came from a channel event or a heartbeat.
 #[derive(Debug)]
 pub enum PromptSource {
+    Conversation(ConversationKey),
+    /// Channel-wide compatibility/admin source. Normal message turns use
+    /// [`Conversation`](Self::Conversation).
+    #[allow(dead_code)] // Retained for adapters without thread-session capability.
     Channel(Uuid),
     Heartbeat,
 }
@@ -295,6 +470,34 @@ pub enum ControlSignal {
     /// turn re-creates the session and re-applies `desired_model`. Runtime-only
     /// — never persisted, gone on restart/respawn.
     SwitchModel(String),
+}
+
+/// Only explicit context-clear controls may delete a durable adapter mapping.
+/// Cancel, steer/interrupt, and live model switches all preserve the thread's
+/// Pi transcript while replacing only the hot ACP handle.
+fn control_forgets_durable_context(signal: &ControlSignal) -> bool {
+    matches!(signal, ControlSignal::Rotate)
+}
+
+#[cfg(test)]
+mod durable_control_policy_tests {
+    use super::{control_forgets_durable_context, ControlSignal};
+
+    #[test]
+    fn only_explicit_rotation_forgets_durable_context() {
+        assert!(control_forgets_durable_context(&ControlSignal::Rotate));
+        for signal in [
+            ControlSignal::Cancel,
+            ControlSignal::Interrupt,
+            ControlSignal::Steer,
+            ControlSignal::SwitchModel("model".to_string()),
+        ] {
+            assert!(
+                !control_forgets_durable_context(&signal),
+                "ordinary lifecycle signal must preserve durable context: {signal:?}"
+            );
+        }
+    }
 }
 
 /// Goose-native non-cancelling steer request, sent from the main loop to an
@@ -543,6 +746,10 @@ pub struct PromptContext {
     pub context_message_limit: u32,
     /// Max turns per session before proactive rotation. 0 = disabled.
     pub max_turns_per_session: u32,
+    /// Per-agent cap for cached thread sessions.
+    pub max_cached_conversation_sessions: usize,
+    /// Idle TTL for cached thread sessions.
+    pub conversation_session_idle_ttl: Duration,
     /// Permission mode to apply after session creation. `Default` = skip.
     pub permission_mode: PermissionMode,
     /// Agent identity — used to derive the NIP-AE conversation key at
@@ -575,12 +782,91 @@ impl AgentPool {
     /// the index invariant.
     pub fn from_slots(slots: Vec<Option<OwnedAgent>>) -> Self {
         let (result_tx, result_rx) = mpsc::unbounded_channel();
+        let affinities = slots
+            .iter()
+            .enumerate()
+            .flat_map(|(index, slot)| {
+                slot.iter().flat_map(move |agent| {
+                    agent
+                        .state
+                        .sessions
+                        .keys()
+                        .cloned()
+                        .map(move |key| (key, index))
+                })
+            })
+            .collect();
         Self {
             agents: slots,
+            affinities,
             result_tx,
             result_rx,
             join_set: JoinSet::new(),
             task_map: HashMap::new(),
+        }
+    }
+
+    /// Whether every live adapter explicitly implements Buzz's production
+    /// per-thread lifecycle contract: durable identity/reset plus replayable,
+    /// acknowledged user-awareness events. A partial pool is safe because
+    /// every live slot is checked; an empty pool is deliberately unsupported.
+    pub fn thread_sessions_supported(&self) -> bool {
+        let mut live = self.agents.iter().filter_map(Option::as_ref).peekable();
+        live.peek().is_some()
+            && live.all(|agent| {
+                agent.acp.thread_sessions_supported()
+                    && agent.acp.conversation_reset_supported()
+                    && agent.acp.durable_session_events_supported()
+            })
+    }
+
+    /// Atomically forget a stable logical conversation in an idle adapter.
+    ///
+    /// This is the durable half of `/new`: it remains effective when the hot
+    /// ACP session was already evicted, so the relay acknowledgement must not
+    /// be published until this method succeeds. A failed or capability-drifted
+    /// adapter is terminated rather than returned to the pool; maintenance
+    /// will replace the empty slot while the reset barrier stays closed.
+    pub async fn commit_conversation_reset(
+        &mut self,
+        conversation_id: &str,
+        reset_token: &str,
+    ) -> Option<ConversationResetCommit> {
+        let index = self.agents.iter().position(Option::is_some)?;
+        let mut agent = self.agents[index].take()?;
+
+        match agent
+            .acp
+            .conversation_reset(conversation_id, reset_token)
+            .await
+        {
+            Ok(Some(commit)) => {
+                self.return_agent(agent);
+                Some(commit)
+            }
+            Ok(None) => {
+                tracing::error!(
+                    agent = index,
+                    conversation_id,
+                    "adapter lost durable conversation-reset support; terminating it before /new acknowledgement"
+                );
+                agent.acp.shutdown().await;
+                agent.state.invalidate_all();
+                self.affinities.retain(|_, owner| *owner != index);
+                None
+            }
+            Err(error) => {
+                tracing::error!(
+                    agent = index,
+                    conversation_id,
+                    %error,
+                    "durable conversation reset failed; terminating adapter and keeping /new barrier closed"
+                );
+                agent.acp.shutdown().await;
+                agent.state.invalidate_all();
+                self.affinities.retain(|_, owner| *owner != index);
+                None
+            }
         }
     }
 
@@ -595,7 +881,7 @@ impl AgentPool {
         if let Some(cid) = channel_id {
             let idx = self.agents.iter().position(|slot| {
                 slot.as_ref()
-                    .map(|a| a.state.sessions.contains_key(&cid))
+                    .map(|a| a.state.sessions.keys().any(|key| key.channel_id == cid))
                     .unwrap_or(false)
             });
             if let Some(i) = idx {
@@ -608,9 +894,62 @@ impl AgentPool {
         idx.map(|i| self.agents[i].take().unwrap())
     }
 
+    /// Claim an idle agent, preferring the one that owns this exact thread.
+    pub fn try_claim_conversation(
+        &mut self,
+        conversation_key: &ConversationKey,
+    ) -> Option<OwnedAgent> {
+        if self
+            .task_map
+            .values()
+            .any(|meta| meta.conversation_key.as_ref() == Some(conversation_key))
+        {
+            return None;
+        }
+        if let Some(&index) = self.affinities.get(conversation_key) {
+            if self.agents.get(index).is_some_and(Option::is_none) {
+                // The owning subprocess is checked out. Never fork context to
+                // a different slot; leave the batch queued until it returns.
+                if self.task_map.values().any(|meta| meta.agent_index == index) {
+                    return None;
+                }
+                // Empty slot with no task means the owner died. Let a healthy
+                // process adopt the conversation with a fresh ACP session.
+                self.affinities.remove(conversation_key);
+            } else if self
+                .agents
+                .get(index)
+                .and_then(Option::as_ref)
+                .is_some_and(|agent| agent.state.sessions.contains_key(conversation_key))
+            {
+                return self.agents[index].take();
+            } else {
+                // Respawned/replaced slot no longer owns the session.
+                self.affinities.remove(conversation_key);
+            }
+        }
+        if let Some(index) = self.agents.iter().position(|slot| {
+            slot.as_ref()
+                .is_some_and(|agent| agent.state.sessions.contains_key(conversation_key))
+        }) {
+            return self.agents[index].take();
+        }
+        let index = self.agents.iter().position(Option::is_some)?;
+        self.agents[index].take()
+    }
+
     /// Return an agent to its slot after a task completes.
     pub fn return_agent(&mut self, agent: OwnedAgent) {
         let idx = agent.index;
+        self.affinities.retain(|_, owner| *owner != idx);
+        self.affinities
+            .extend(agent.state.sessions.keys().cloned().map(|key| (key, idx)));
+        while self.affinities.len() > MAX_AFFINITY_ENTRIES {
+            let Some(victim) = self.affinities.keys().next().cloned() else {
+                break;
+            };
+            self.affinities.remove(&victim);
+        }
         if self.agents[idx].is_some() {
             // This is a bug: two tasks returned the same agent index. Log it
             // loudly so it shows up in production logs, then overwrite — the
@@ -629,13 +968,11 @@ impl AgentPool {
         self.agents.iter().any(|slot| slot.is_some())
     }
 
-    /// Whether any idle agent already has a session for `channel_id`.
-    /// Used to compute `affinity_hit` before calling `try_claim`.
-    pub fn has_session_for(&self, channel_id: Uuid) -> bool {
+    /// Whether an idle agent owns the exact thread session.
+    pub fn has_session_for_conversation(&self, conversation_key: &ConversationKey) -> bool {
         self.agents.iter().any(|slot| {
             slot.as_ref()
-                .map(|a| a.state.sessions.contains_key(&channel_id))
-                .unwrap_or(false)
+                .is_some_and(|agent| agent.state.sessions.contains_key(conversation_key))
         })
     }
 
@@ -656,44 +993,23 @@ impl AgentPool {
         &mut self.task_map
     }
 
-    /// Try to send a goose-native steer request to the in-flight task for
-    /// `channel_id`.
-    ///
-    /// Returns `Ok(())` if the request was accepted by the read loop's
-    /// receiver (capacity-1 mpsc; one slot is the single in-flight steer
-    /// write). Returns `Err(SteerError::Transport(_))` on `Full`/`Closed`
-    /// (already-in-flight write, or read loop torn down). Callers must
-    /// fall back to the universal `ControlSignal::Steer` cancel+merge path
-    /// on `Err`.
-    ///
-    /// This does **not** spawn the ack watcher — the caller owns the
-    /// oneshot `ack_tx` inside `SteerRequest` and is responsible for
-    /// awaiting it and applying the locked Success / Err / PromptCompletedNeutral
-    /// semantics. Caller is also responsible for the synchronous
-    /// `queue.mark_native_steer_pending(...)` *before* spawning the
-    /// watcher, to close the result-vs-ack race.
-    ///
-    /// Returns `Err(SteerError::PromptCompleted)` if no task is in flight
-    /// for `channel_id` (the prompt completed between the mode-gate check
-    /// and this call, or the channel was never in flight). This is
-    /// semantically a soft no-op — the caller should release any withheld
-    /// event and let normal dispatch handle delivery.
-    pub fn send_steer(
+    /// Send a steer request only to the task for `conversation_key`.
+    pub fn send_conversation_steer(
         &mut self,
-        channel_id: Uuid,
+        conversation_key: &ConversationKey,
         request: SteerRequest,
     ) -> Result<(), SteerError> {
         let meta = self
             .task_map
             .values_mut()
-            .find(|m| m.channel_id == Some(channel_id))
+            .find(|meta| meta.conversation_key.as_ref() == Some(conversation_key))
             .ok_or(SteerError::PromptCompleted)?;
         let tx = meta
             .steer_tx
             .as_ref()
             .ok_or_else(|| SteerError::Transport("steer_tx not installed".into()))?;
         tx.try_send(request)
-            .map_err(|e| SteerError::Transport(e.to_string()))
+            .map_err(|error| SteerError::Transport(error.to_string()))
     }
 
     pub fn result_tx(&self) -> mpsc::UnboundedSender<PromptResult> {
@@ -731,82 +1047,70 @@ impl AgentPool {
         &mut self.agents
     }
 
-    /// Remove the session for `channel_id` from all idle agents.
-    ///
-    /// Called when the agent is removed from a channel — stale sessions
-    /// should not be reused. Checked-out agents (in-flight) are not
-    /// modified; their sessions will fail naturally on the next prompt
-    /// if the relay rejects the request.
-    ///
-    /// Returns the number of sessions invalidated.
-    pub fn invalidate_channel_sessions(&mut self, channel_id: Uuid) -> usize {
-        let mut count = 0;
-        for slot in &mut self.agents {
-            if let Some(agent) = slot.as_mut() {
-                if agent.state.invalidate_channel(&channel_id) {
-                    count += 1;
-                }
-            }
-        }
-        count
-    }
-
-    /// Idle-path model switch: set `desired_model` on the idle agent for
-    /// `channel_id` and invalidate its session so the next turn re-creates the
-    /// session under the new model.
-    ///
-    /// Pre-cancel guard: the desired model is validated against the agent's
-    /// cached catalog *before* the session is invalidated, so an unsupported
-    /// pick is rejected without disturbing the existing session.
-    ///
-    /// Returns [`IdleSwitchResult`] describing what happened. The model does not
-    /// take effect — and the panel does not reflect it — until the agent next
-    /// runs a turn (no live session exists to re-emit `session_config_captured`
-    /// from an idle agent). This lag is intentional: faking the emit would
-    /// surface an override the session has not actually applied.
-    pub fn switch_idle_agent_model(
+    /// Dispose one idle conversation in each owning adapter and remove local
+    /// affinity. `forget=true` is used by `/new`; `false` is reserved for
+    /// eviction where a persisted adapter mapping may later be resumed.
+    pub async fn dispose_conversation_sessions(
         &mut self,
-        channel_id: Uuid,
-        model_id: &str,
-    ) -> IdleSwitchResult {
-        let Some(agent) = self
-            .agents
-            .iter_mut()
-            .flatten()
-            .find(|a| a.state.sessions.contains_key(&channel_id))
-        else {
-            return IdleSwitchResult::NoIdleAgent;
-        };
-
-        // Pre-cancel guard against the cached catalog. None = catalog not yet
-        // populated (no session ever created); defer validation to apply time.
-        if let Some(caps) = agent.model_capabilities.as_ref() {
-            if !model_in_catalog(
-                &caps.config_options_raw,
-                caps.available_models_raw.as_ref(),
-                model_id,
-            ) {
-                return IdleSwitchResult::UnsupportedModel;
+        key: &ConversationKey,
+        forget: bool,
+    ) -> usize {
+        let mut disposed = 0;
+        for agent in self.agents.iter_mut().flatten() {
+            if let Some(session_id) = agent.state.take_conversation(key) {
+                match agent.acp.session_dispose(&session_id, forget).await {
+                    Ok(true) => {}
+                    Ok(false) if forget => {
+                        tracing::error!(
+                            conversation = %key,
+                            %session_id,
+                            "adapter cannot durably forget sessions; terminating it to enforce reset isolation"
+                        );
+                        agent.acp.shutdown().await;
+                        agent.state.invalidate_all();
+                    }
+                    Ok(false) => {}
+                    Err(error) if forget => {
+                        tracing::error!(
+                            conversation = %key,
+                            %session_id,
+                            %error,
+                            "adapter session disposal failed; terminating it before acknowledging reset"
+                        );
+                        agent.acp.shutdown().await;
+                        agent.state.invalidate_all();
+                    }
+                    Err(error) => tracing::warn!(
+                        conversation = %key,
+                        %session_id,
+                        %error,
+                        "adapter session disposal failed; local context was still invalidated"
+                    ),
+                }
+                disposed += 1;
             }
         }
-
-        agent.desired_model = Some(model_id.to_string());
-        agent.model_overridden = true;
-        agent.state.invalidate_channel(&channel_id);
-        IdleSwitchResult::Switched
+        self.affinities.remove(key);
+        disposed
     }
-}
 
-/// Outcome of [`AgentPool::switch_idle_agent_model`].
-#[derive(Debug, PartialEq, Eq)]
-pub enum IdleSwitchResult {
-    /// `desired_model` set and the channel session invalidated.
-    Switched,
-    /// Desired model is not in the agent's cached catalog — pick rejected,
-    /// session untouched.
-    UnsupportedModel,
-    /// No idle agent available (all checked out / none spawned).
-    NoIdleAgent,
+    /// Dispose every idle conversation in a channel. Used by intentionally
+    /// channel-wide `!rotate` and membership removal.
+    pub async fn dispose_channel_sessions(&mut self, channel_id: Uuid, forget: bool) -> usize {
+        let keys: Vec<_> = self
+            .agents
+            .iter()
+            .flatten()
+            .flat_map(|agent| agent.state.sessions.keys())
+            .filter(|key| key.channel_id == channel_id)
+            .cloned()
+            .collect();
+        let mut disposed = 0;
+        for key in keys {
+            disposed += self.dispose_conversation_sessions(&key, forget).await;
+        }
+        disposed
+    }
 }
 
 /// Timeout for a single pre-prompt context fetch attempt (thread/DM history).
@@ -882,13 +1186,55 @@ async fn resolve_new_session_channel_context(
 /// On error from `session_new_full()`, returns the `AcpError` — caller handles
 /// error reporting. Model-switch failures are logged and gracefully ignored
 /// (the agent proceeds with its default model).
+struct CreatedSession {
+    session_id: String,
+    /// The adapter reopened an existing durable logical conversation. Buzz
+    /// must not seed relay history again in that case.
+    resumed_conversation: bool,
+    /// A durable adapter tombstone says this is intentionally fresh after a
+    /// prior forget, even if the outer harness restarted and lost its in-memory
+    /// reset token. Relay history must not resurrect the cleared conversation.
+    skip_relay_history: bool,
+}
+
+fn should_seed_relay_history(
+    resumed_conversation: bool,
+    skip_relay_history: bool,
+    reset_token: Option<&str>,
+) -> bool {
+    !resumed_conversation && !skip_relay_history && reset_token.is_none()
+}
+
+#[cfg(test)]
+mod conversation_history_seed_tests {
+    use super::should_seed_relay_history;
+
+    #[test]
+    fn seeds_only_a_truly_new_non_reset_conversation() {
+        assert!(should_seed_relay_history(false, false, None));
+        assert!(!should_seed_relay_history(true, false, None));
+        assert!(!should_seed_relay_history(false, true, None));
+        assert!(!should_seed_relay_history(
+            false,
+            false,
+            Some("signed-reset-event")
+        ));
+        assert!(!should_seed_relay_history(
+            true,
+            false,
+            Some("signed-reset-event")
+        ));
+    }
+}
+
 async fn create_session_and_apply_model(
     agent: &mut OwnedAgent,
     ctx: &PromptContext,
     agent_core: Option<&str>,
     agent_canvas: Option<&str>,
     channel_name: Option<&str>,
-) -> Result<String, AcpError> {
+    conversation_key: Option<&ConversationKey>,
+) -> Result<CreatedSession, AcpError> {
     // Build base_prompt + system_prompt + agent core + canvas metadata into a
     // single prompt. Standard protocol-v2 agents receive it in `session/new`;
     // Goose receives it through the custom request below. Legacy agents receive
@@ -914,7 +1260,7 @@ async fn create_session_and_apply_model(
 
     let resp = agent
         .acp
-        .session_new_full(
+        .session_new_full_for_conversation(
             &ctx.cwd,
             ctx.mcp_servers.clone(),
             session_new_system_prompt(
@@ -924,6 +1270,8 @@ async fn create_session_and_apply_model(
                 combined_system_prompt.as_deref(),
             ),
             session_title.as_deref(),
+            conversation_key.map(ConversationKey::stable_id).as_deref(),
+            conversation_key.and_then(|key| key.reset_token.as_deref()),
         )
         .await?;
 
@@ -955,51 +1303,145 @@ async fn create_session_and_apply_model(
         });
     }
 
-    // Apply desired_model if set, matching against the fresh session/new response.
-    // Track whether the switch succeeded so session_config_captured reflects
-    // the post-switch state (not the pre-switch desired state).
-    let switch_succeeded = if let Some(ref desired) = agent.desired_model {
-        match resolve_model_switch_method(&resp.raw, desired) {
+    // Apply desired_model if set, matching against the fresh session/new
+    // response. Live switches are transactional: if A -> B is rejected after
+    // the old A session was cancelled, explicitly restore A on this fresh
+    // session before the requeued prompt is allowed to run.
+    let mut reported_config_options = resp
+        .raw
+        .get("configOptions")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let mut reported_models = resp
+        .raw
+        .get("models")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let desired_model = agent.desired_model.clone();
+    if let Some(desired) = desired_model {
+        match resolve_model_switch_method(&resp.raw, &desired) {
             Some(method) => {
-                apply_model_switch(&mut agent.acp, &resp.session_id, desired, &method).await?;
-                true
+                match apply_model_switch(&mut agent.acp, &resp.session_id, &desired, &method).await
+                {
+                    Ok(ModelSwitchApplyOutcome::Applied { response }) => {
+                        merge_applied_model_state(
+                            &mut reported_config_options,
+                            &mut reported_models,
+                            &response,
+                            &method,
+                        );
+                        if let Some(pending) = agent.pending_model_switch.take() {
+                            agent.acp.observe(
+                                "control_result",
+                                serde_json::json!({
+                                    "type": "switch_model",
+                                    "status": "switched",
+                                    "modelId": desired,
+                                    "turnId": pending.turn_id,
+                                }),
+                            );
+                        }
+                    }
+                    Ok(ModelSwitchApplyOutcome::Rejected) => {
+                        if let Some(pending) = agent.pending_model_switch.take() {
+                            agent.desired_model = pending.previous_model.clone();
+                            agent.model_overridden = pending.previous_model_overridden;
+                            let rollback = restore_previous_model(
+                                &mut agent.acp,
+                                &resp.session_id,
+                                &resp.raw,
+                                pending.previous_model.as_deref(),
+                            )
+                            .await;
+                            agent.acp.observe(
+                                "control_result",
+                                serde_json::json!({
+                                    "type": "switch_model",
+                                    "status": "switch_failed",
+                                    "modelId": desired,
+                                    "turnId": pending.turn_id,
+                                }),
+                            );
+                            match rollback {
+                                Ok(Some((response, method))) => merge_applied_model_state(
+                                    &mut reported_config_options,
+                                    &mut reported_models,
+                                    &response,
+                                    &method,
+                                ),
+                                Ok(None) => {}
+                                Err(error) => return Err(error),
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        if let Some(pending) = agent.pending_model_switch.take() {
+                            agent.desired_model = pending.previous_model;
+                            agent.model_overridden = pending.previous_model_overridden;
+                            agent.acp.observe(
+                                "control_result",
+                                serde_json::json!({
+                                    "type": "switch_model",
+                                    "status": "switch_failed",
+                                    "modelId": desired,
+                                    "turnId": pending.turn_id,
+                                }),
+                            );
+                        }
+                        return Err(error);
+                    }
+                }
             }
             None => {
                 tracing::warn!(
                     target: "pool::model",
                     "desired model {desired} not found in agent's available models — proceeding with agent default"
                 );
-                // Surface the miss so the desktop ModelPicker can reject a live
-                // pick rather than silently no-op. On the busy path the turn has
-                // already been cancelled+requeued by the time we get here, so the
-                // turn restarts on the unchanged model and the user is told no.
-                agent.acp.observe(
-                    "control_result",
-                    serde_json::json!({
-                        "type": "switch_model",
-                        "status": "unsupported_model",
-                        "modelId": desired,
-                    }),
-                );
-                false
+                if let Some(pending) = agent.pending_model_switch.take() {
+                    agent.desired_model = pending.previous_model.clone();
+                    agent.model_overridden = pending.previous_model_overridden;
+                    let rollback = restore_previous_model(
+                        &mut agent.acp,
+                        &resp.session_id,
+                        &resp.raw,
+                        pending.previous_model.as_deref(),
+                    )
+                    .await;
+                    agent.acp.observe(
+                        "control_result",
+                        serde_json::json!({
+                            "type": "switch_model",
+                            "status": "unsupported_model",
+                            "modelId": desired,
+                            "turnId": pending.turn_id,
+                        }),
+                    );
+                    match rollback {
+                        Ok(Some((response, method))) => merge_applied_model_state(
+                            &mut reported_config_options,
+                            &mut reported_models,
+                            &response,
+                            &method,
+                        ),
+                        Ok(None) => {}
+                        Err(error) => return Err(error),
+                    }
+                }
             }
         }
-    } else {
-        false
-    };
+    }
 
     // Emit session config for desktop consumption (config bridge tier 1b).
     // Emitted AFTER desired_model resolution so the desktop caches the
-    // post-switch state. modelOverridden reflects whether the switch actually
-    // applied — false on the unsupported arm so the panel doesn't show a
-    // stale override badge.
+    // post-switch state. A failed live switch may restore an earlier live
+    // override, so modelOverridden reflects the confirmed final session.
     agent.acp.observe(
         "session_config_captured",
         serde_json::json!({
-            "configOptions": resp.raw.get("configOptions").cloned().unwrap_or(serde_json::Value::Null),
+            "configOptions": reported_config_options,
             "modes": resp.raw.get("modes").cloned().unwrap_or(serde_json::Value::Null),
-            "models": resp.raw.get("models").cloned().unwrap_or(serde_json::Value::Null),
-            "modelOverridden": agent.model_overridden && switch_succeeded,
+            "models": reported_models,
+            "modelOverridden": agent.model_overridden,
             // Pair identity for the desktop session-config cache, which is
             // keyed by (agent, relay) like the lifecycle frames.
             "relayUrl": ctx.relay_url,
@@ -1016,21 +1458,164 @@ async fn create_session_and_apply_model(
         apply_permission_mode(&mut agent.acp, &resp.session_id, &ctx.permission_mode).await?;
     }
 
-    Ok(resp.session_id)
+    let resumed_conversation = resp
+        .raw
+        .pointer("/_meta/buzz/resumedConversation")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let skip_relay_history = resp
+        .raw
+        .pointer("/_meta/buzz/skipRelayHistory")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    Ok(CreatedSession {
+        session_id: resp.session_id,
+        resumed_conversation,
+        skip_relay_history,
+    })
 }
 
-/// Send the appropriate ACP model-switch request with a timeout.
-///
-/// On timeout or error, logs a warning and returns — the caller proceeds
-/// with the agent's default model. This is intentionally non-fatal: a stale
-/// response from a timed-out request is safely ignored by `read_until_response`
-/// (non-matching JSON-RPC IDs are skipped).
+/// Result of one model application attempt. A successful response is retained
+/// so the observer cache can publish authoritative post-switch configuration.
+#[derive(Debug, PartialEq)]
+enum ModelSwitchApplyOutcome {
+    Applied { response: serde_json::Value },
+    Rejected,
+}
+
+fn model_switch_response_confirms(
+    response: &serde_json::Value,
+    method: &ModelSwitchMethod,
+) -> bool {
+    match method {
+        ModelSwitchMethod::ConfigOption {
+            config_id,
+            option_value,
+        } => {
+            let standard_confirmation = response
+                .get("configOptions")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|options| {
+                    options.iter().any(|option| {
+                        option
+                            .get("id")
+                            .or_else(|| option.get("configId"))
+                            .and_then(serde_json::Value::as_str)
+                            == Some(config_id.as_str())
+                            && option
+                                .get("currentValue")
+                                .or_else(|| option.get("value"))
+                                .and_then(serde_json::Value::as_str)
+                                == Some(option_value.as_str())
+                    })
+                });
+            if standard_confirmation {
+                return true;
+            }
+            let returned_id = response.get("configId").and_then(serde_json::Value::as_str);
+            let returned_value = response.get("value").and_then(serde_json::Value::as_str);
+            returned_id == Some(config_id.as_str()) && returned_value == Some(option_value.as_str())
+        }
+        ModelSwitchMethod::SetModel { model_id } => {
+            match response.get("modelId").and_then(serde_json::Value::as_str) {
+                Some(returned) => returned == model_id,
+                None => response
+                    .as_object()
+                    .is_some_and(|object| object.keys().all(|key| key == "_meta")),
+            }
+        }
+    }
+}
+
+/// Merge a confirmed response into the configuration snapshot sent to the
+/// desktop. Stable ACP returns the full updated `configOptions` list; legacy
+/// echo and unstable set-model responses are normalized locally.
+fn merge_applied_model_state(
+    config_options: &mut serde_json::Value,
+    models: &mut serde_json::Value,
+    response: &serde_json::Value,
+    method: &ModelSwitchMethod,
+) {
+    if response
+        .get("configOptions")
+        .is_some_and(serde_json::Value::is_array)
+    {
+        *config_options = response["configOptions"].clone();
+    }
+    if response
+        .get("models")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        *models = response["models"].clone();
+    }
+
+    let (config_id, model_id) = match method {
+        ModelSwitchMethod::ConfigOption {
+            config_id,
+            option_value,
+        } => (Some(config_id.as_str()), option_value.as_str()),
+        ModelSwitchMethod::SetModel { model_id } => (None, model_id.as_str()),
+    };
+    if let (Some(config_id), Some(options)) = (config_id, config_options.as_array_mut()) {
+        if let Some(option) = options.iter_mut().find(|option| {
+            option
+                .get("id")
+                .or_else(|| option.get("configId"))
+                .and_then(serde_json::Value::as_str)
+                == Some(config_id)
+        }) {
+            if let Some(object) = option.as_object_mut() {
+                let key = if object.contains_key("currentValue") {
+                    "currentValue"
+                } else {
+                    "value"
+                };
+                object.insert(
+                    key.to_string(),
+                    serde_json::Value::String(model_id.to_string()),
+                );
+            }
+        }
+    }
+    if let Some(models) = models.as_object_mut() {
+        models.insert(
+            "currentModelId".to_string(),
+            serde_json::Value::String(model_id.to_string()),
+        );
+    }
+}
+
+/// Reapply the model that was active before a rejected live switch. Returning
+/// without a confirmed rollback would run the requeued turn on an unreported
+/// adapter default, so any miss poisons the fresh session.
+async fn restore_previous_model(
+    acp: &mut AcpClient,
+    session_id: &str,
+    session_new_result: &serde_json::Value,
+    previous_model: Option<&str>,
+) -> Result<Option<(serde_json::Value, ModelSwitchMethod)>, AcpError> {
+    let Some(previous_model) = previous_model else {
+        return Ok(None);
+    };
+    let method = resolve_model_switch_method(session_new_result, previous_model).ok_or_else(|| {
+        AcpError::Protocol(format!(
+            "cannot restore previous model {previous_model}: it is absent from the fresh session catalog"
+        ))
+    })?;
+    match apply_model_switch(acp, session_id, previous_model, &method).await? {
+        ModelSwitchApplyOutcome::Applied { response } => Ok(Some((response, method))),
+        ModelSwitchApplyOutcome::Rejected => Err(AcpError::Protocol(format!(
+            "adapter rejected rollback to previous model {previous_model}"
+        ))),
+    }
+}
+
 async fn apply_model_switch(
     acp: &mut AcpClient,
     session_id: &str,
     desired: &str,
     method: &ModelSwitchMethod,
-) -> Result<(), AcpError> {
+) -> Result<ModelSwitchApplyOutcome, AcpError> {
     let method_label = match method {
         ModelSwitchMethod::ConfigOption { config_id, .. } => {
             format!("configOption (configId={config_id})")
@@ -1055,31 +1640,40 @@ async fn apply_model_switch(
     .await;
 
     match result {
-        Ok(Ok(_)) => {
+        Ok(Ok(response)) if model_switch_response_confirms(&response, method) => {
             tracing::info!(
                 target: "pool::model",
                 "applied model {desired} via {method_label} on session {session_id}"
             );
+            Ok(ModelSwitchApplyOutcome::Applied { response })
         }
-        // Transport-class errors may have corrupted the stdio stream — propagate
-        // so the caller can respawn the agent instead of reusing a poisoned one.
-        Ok(Err(e @ AcpError::Io(_)))
-        | Ok(Err(e @ AcpError::WriteTimeout(_)))
-        | Ok(Err(e @ AcpError::Timeout(_)))
-        | Ok(Err(e @ AcpError::Protocol(_)))
-        | Ok(Err(e @ AcpError::AgentExited)) => {
+        Ok(Ok(response)) => {
+            tracing::warn!(
+                target: "pool::model",
+                response = %response,
+                "agent returned a contradictory model-switch success via {method_label}"
+            );
+            Ok(ModelSwitchApplyOutcome::Rejected)
+        }
+        // JSON-RPC application rejection leaves the agent usable but does not
+        // mean the requested model was applied.
+        Ok(Err(AcpError::AgentError { code, message })) => {
+            tracing::warn!(
+                target: "pool::model",
+                code,
+                message,
+                "agent rejected model {desired} via {method_label}"
+            );
+            Ok(ModelSwitchApplyOutcome::Rejected)
+        }
+        // Every other ACP error may indicate a damaged or desynchronized
+        // transport. Propagate so the caller replaces the agent.
+        Ok(Err(e)) => {
             tracing::error!(
                 target: "pool::model",
                 "fatal error setting model {desired} via {method_label}: {e}"
             );
-            return Err(e);
-        }
-        // Application-level errors (Json, etc.) — agent is fine, just uses default model.
-        Ok(Err(e)) => {
-            tracing::warn!(
-                target: "pool::model",
-                "failed to set model {desired} via {method_label}: {e} — proceeding with agent default"
-            );
+            Err(e)
         }
         Err(_) => {
             // Outer timeout fired — the inner send_request may have left the
@@ -1088,10 +1682,9 @@ async fn apply_model_switch(
                 target: "pool::model",
                 "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
             );
-            return Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT));
+            Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT))
         }
     }
-    Ok(())
 }
 
 /// Set the session permission mode via `session/set_config_option`.
@@ -1351,6 +1944,46 @@ fn send_prompt_result(
 ///
 /// The agent is ALWAYS returned — even on panic the `JoinSet` detects the
 /// abort and the caller uses `task_map` to recover the agent index.
+/// Dispose an adapter session or poison the whole adapter process if disposal
+/// fails. `forget=true` is reserved for authenticated destructive lifecycle
+/// actions (`/new`, `!rotate`, membership removal). Ordinary cancellation,
+/// model switching, interruption, and automatic hot-session rotation pass
+/// `false`, releasing the live handle while preserving durable Pi context.
+async fn dispose_session_or_poison(
+    agent: &mut OwnedAgent,
+    session_id: &str,
+    forget: bool,
+    operation: &'static str,
+) -> bool {
+    match agent.acp.session_dispose(session_id, forget).await {
+        Ok(true) => true,
+        Ok(false) if !forget => true,
+        Ok(false) => {
+            tracing::error!(
+                target: "pool::session",
+                %session_id,
+                operation,
+                "adapter cannot forget sessions; terminating it to preserve context isolation"
+            );
+            agent.acp.shutdown().await;
+            agent.state.invalidate_all();
+            false
+        }
+        Err(error) => {
+            tracing::error!(
+                target: "pool::session",
+                %session_id,
+                %error,
+                operation,
+                "adapter session disposal failed; terminating it to preserve context isolation"
+            );
+            agent.acp.shutdown().await;
+            agent.state.invalidate_all();
+            false
+        }
+    }
+}
+
 pub async fn run_prompt_task(
     mut agent: OwnedAgent,
     batch: Option<FlushBatch>,
@@ -1362,10 +1995,11 @@ pub async fn run_prompt_task(
 ) {
     // Is this a channel prompt or a heartbeat?
     let source = match &batch {
-        Some(b) => PromptSource::Channel(b.channel_id),
+        Some(b) => PromptSource::Conversation(b.conversation_key.clone()),
         None => PromptSource::Heartbeat,
     };
     let observer_channel_id = match &source {
+        PromptSource::Conversation(key) => Some(key.channel_id),
         PromptSource::Channel(channel_id) => Some(*channel_id),
         PromptSource::Heartbeat => None,
     };
@@ -1384,6 +2018,7 @@ pub async fn run_prompt_task(
         "turn_started",
         serde_json::json!({
             "source": match &source {
+                PromptSource::Conversation(_) => "thread",
                 PromptSource::Channel(_) => "channel",
                 PromptSource::Heartbeat => "heartbeat",
             },
@@ -1465,11 +2100,12 @@ pub async fn run_prompt_task(
     //
     // Operator opt-out: `--no-memory` / `BUZZ_ACP_NO_MEMORY` skips the fetch.
     if ctx.memory_enabled {
-        if let (PromptSource::Channel(cid), Some(owner_pk)) =
+        if let (PromptSource::Conversation(key), Some(owner_pk)) =
             (&source, ctx.agent_owner_pubkey.as_ref())
         {
-            let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-            if is_new_channel_session && !agent.state.core_sections.contains_key(cid) {
+            let cid = key.channel_id;
+            let is_new_conversation_session = !agent.state.sessions.contains_key(key);
+            if is_new_conversation_session && !agent.state.core_sections.contains_key(&cid) {
                 // Bounded — we'd rather start the session with no core hint
                 // than block session creation on a stalled relay.
                 const CORE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
@@ -1497,7 +2133,7 @@ pub async fn run_prompt_task(
                         section_len = rendered.len(),
                         "injected NIP-AE core section into system prompt"
                     );
-                    agent.state.core_sections.insert(*cid, rendered);
+                    agent.state.core_sections.insert(cid, rendered);
                 }
             }
         }
@@ -1519,19 +2155,21 @@ pub async fn run_prompt_task(
     // Channel name for the session title, from the same single resolve the
     // canvas DM check uses — see `resolve_new_session_channel_context`.
     let mut title_channel: Option<String> = None;
-    if let PromptSource::Channel(cid) = &source {
-        let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-        let needs_canvas = is_new_channel_session && !agent.state.canvas_sections.contains_key(cid);
-        let needs_title = is_new_channel_session && ctx.session_title.is_some();
+    if let PromptSource::Conversation(key) = &source {
+        let cid = key.channel_id;
+        let is_new_conversation_session = !agent.state.sessions.contains_key(key);
+        let needs_canvas =
+            is_new_conversation_session && !agent.state.canvas_sections.contains_key(&cid);
+        let needs_title = is_new_conversation_session && ctx.session_title.is_some();
         if needs_canvas || needs_title {
             let (is_dm, resolved_channel) =
-                resolve_new_session_channel_context(&ctx.channel_info, *cid).await;
+                resolve_new_session_channel_context(&ctx.channel_info, cid).await;
             title_channel = resolved_channel;
             // A confirmed DM never receives a canvas section; an undeterminable
             // channel type fails closed as a DM for the same reason.
             if needs_canvas && !is_dm {
-                if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
-                    pending_canvas = Some((*cid, section));
+                if let Some(section) = fetch_canvas_section(cid, &ctx.rest_client).await {
+                    pending_canvas = Some((cid, section));
                 }
             }
         }
@@ -1540,6 +2178,7 @@ pub async fn run_prompt_task(
     // The core section to fold into the system prompt for this turn's session.
     // Channel-scoped; heartbeats carry no owner core.
     let agent_core: Option<String> = match &source {
+        PromptSource::Conversation(key) => agent.state.core_sections.get(&key.channel_id).cloned(),
         PromptSource::Channel(cid) => agent.state.core_sections.get(cid).cloned(),
         PromptSource::Heartbeat => None,
     };
@@ -1547,6 +2186,12 @@ pub async fn run_prompt_task(
     // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
     // Prefer the committed cache; fall back to pending (for new sessions being created now).
     let agent_canvas: Option<String> = match &source {
+        PromptSource::Conversation(key) => agent
+            .state
+            .canvas_sections
+            .get(&key.channel_id)
+            .cloned()
+            .or_else(|| pending_canvas.as_ref().map(|(_, s)| s.clone())),
         PromptSource::Channel(cid) => agent
             .state
             .canvas_sections
@@ -1556,11 +2201,115 @@ pub async fn run_prompt_task(
         PromptSource::Heartbeat => None,
     };
 
-    let (session_id, is_new_session) = match &source {
-        PromptSource::Channel(cid) => {
-            if let Some(sid) = agent.state.sessions.get(cid) {
-                (sid.clone(), false)
+    let (session_id, is_new_session, seed_conversation_history) = match &source {
+        PromptSource::Conversation(key) => {
+            let evicted_sessions = if agent.acp.thread_sessions_supported() {
+                agent.state.prune_idle(
+                    key,
+                    ctx.max_cached_conversation_sessions,
+                    ctx.conversation_session_idle_ttl,
+                )
             } else {
+                // Legacy adapters own opaque channel sessions and do not
+                // implement disposal/resume. Auto-evicting the outer ACP ID
+                // would leak their inner session and lose context on revisit.
+                Vec::new()
+            };
+            for (evicted, evicted_session_id) in evicted_sessions {
+                match agent.acp.session_dispose(&evicted_session_id, false).await {
+                    Ok(true) => tracing::debug!(
+                        target: "pool::session",
+                        conversation = %evicted,
+                        session_id = %evicted_session_id,
+                        "adapter released idle session while preserving persistent mapping"
+                    ),
+                    Ok(false) => {}
+                    Err(error) => tracing::warn!(
+                        target: "pool::session",
+                        conversation = %evicted,
+                        session_id = %evicted_session_id,
+                        %error,
+                        "adapter could not release evicted session; local LRU still applied"
+                    ),
+                }
+                tracing::info!(
+                    target: "pool::session",
+                    conversation = %evicted,
+                    "evicted idle conversation session"
+                );
+            }
+            if let Some(sid) = agent.state.sessions.get(key) {
+                agent
+                    .state
+                    .last_used
+                    .insert(key.clone(), std::time::Instant::now());
+                (sid.clone(), false, false)
+            } else {
+                match create_session_and_apply_model(
+                    &mut agent,
+                    &ctx,
+                    agent_core.as_deref(),
+                    agent_canvas.as_deref(),
+                    title_channel.as_deref(),
+                    Some(key),
+                )
+                .await
+                {
+                    Ok(created) => {
+                        let sid = created.session_id;
+                        let seed_history = should_seed_relay_history(
+                            created.resumed_conversation,
+                            created.skip_relay_history,
+                            key.reset_token.as_deref(),
+                        );
+                        tracing::info!(
+                            target: "pool::session",
+                            conversation = %key,
+                            resumed = created.resumed_conversation,
+                            skip_relay_history = created.skip_relay_history,
+                            seed_history,
+                            "created session {sid} for Buzz thread"
+                        );
+                        agent.state.sessions.insert(key.clone(), sid.clone());
+                        agent
+                            .state
+                            .last_used
+                            .insert(key.clone(), std::time::Instant::now());
+                        if let Some((pending_cid, section)) = pending_canvas.take() {
+                            agent.state.canvas_sections.insert(pending_cid, section);
+                        }
+                        (sid, !created.resumed_conversation, seed_history)
+                    }
+                    Err(AcpError::AgentExited) => {
+                        agent.state.invalidate_all();
+                        send_prompt_result(
+                            &result_tx,
+                            &turn_id,
+                            agent,
+                            source,
+                            PromptOutcome::AgentExited,
+                            batch,
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        send_prompt_result(
+                            &result_tx,
+                            &turn_id,
+                            agent,
+                            source,
+                            PromptOutcome::Error(e),
+                            batch,
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+        PromptSource::Channel(cid) => {
+            // Compatibility/admin source: it never owns a regular per-thread
+            // session. Create an untracked session if exercised by old callers.
+            {
                 // The title is channel-qualified (`Agent · #channel`) so one
                 // agent in several channels doesn't produce identical session
                 // rows; `title_channel` comes from the single resolve above and
@@ -1571,20 +2320,25 @@ pub async fn run_prompt_task(
                     agent_core.as_deref(),
                     agent_canvas.as_deref(),
                     title_channel.as_deref(),
+                    None,
                 )
                 .await
                 {
-                    Ok(sid) => {
+                    Ok(created) => {
+                        let sid = created.session_id;
                         tracing::info!(
                             target: "pool::session",
                             "created session {sid} for channel {cid}"
                         );
-                        agent.state.sessions.insert(*cid, sid.clone());
                         // Commit canvas only after session creation succeeds (I3).
                         if let Some((pending_cid, section)) = pending_canvas.take() {
                             agent.state.canvas_sections.insert(pending_cid, section);
                         }
-                        (sid, true)
+                        (
+                            sid,
+                            !created.resumed_conversation,
+                            !created.resumed_conversation,
+                        )
                     }
                     Err(AcpError::AgentExited) => {
                         agent.state.invalidate_all();
@@ -1616,17 +2370,19 @@ pub async fn run_prompt_task(
         }
         PromptSource::Heartbeat => {
             if let Some(sid) = &agent.state.heartbeat_session {
-                (sid.clone(), false)
+                (sid.clone(), false, false)
             } else {
-                match create_session_and_apply_model(&mut agent, &ctx, None, None, None).await {
-                    Ok(sid) => {
+                match create_session_and_apply_model(&mut agent, &ctx, None, None, None, None).await
+                {
+                    Ok(created) => {
+                        let sid = created.session_id;
                         tracing::info!(
                             target: "pool::session",
                             "created heartbeat session {sid} for agent {}",
                             agent.index
                         );
                         agent.state.heartbeat_session = Some(sid.clone());
-                        (sid, true)
+                        (sid, !created.resumed_conversation, false)
                     }
                     Err(AcpError::AgentExited) => {
                         agent.state.invalidate_all();
@@ -1673,11 +2429,13 @@ pub async fn run_prompt_task(
     );
 
     if is_new_session {
-        if let (PromptSource::Channel(cid), Some(ref initial_msg)) = (&source, &ctx.initial_message)
+        if let (PromptSource::Conversation(key), Some(ref initial_msg)) =
+            (&source, &ctx.initial_message)
         {
             tracing::info!(
                 target: "pool::session",
-                "sending initial_message to session {session_id} for channel {cid}"
+                conversation = %key,
+                "sending initial_message to new thread session {session_id}"
             );
             // For agents with systemPrompt support (protocol_version >= 2),
             // base_prompt is delivered via the system role in session/new.
@@ -1717,7 +2475,8 @@ pub async fn run_prompt_task(
                 Ok(stop_reason) => {
                     tracing::info!(
                         target: "pool::session",
-                        "initial_message complete for channel {cid}: {stop_reason:?}"
+                        conversation = %key,
+                        "initial_message complete: {stop_reason:?}"
                     );
                 }
                 Err(AcpError::AgentExited) => {
@@ -1735,7 +2494,8 @@ pub async fn run_prompt_task(
                 Err(AcpError::IdleTimeout(_)) => {
                     tracing::warn!(
                         target: "pool::session",
-                        "initial_message idle timeout ({}s) for channel {cid} — cancelling",
+                        conversation = %key,
+                        "initial_message idle timeout ({}s) — cancelling",
                         ctx.idle_timeout.as_secs()
                     );
                     match agent
@@ -1780,7 +2540,8 @@ pub async fn run_prompt_task(
                     let recently_active = silence < RECENT_ACTIVITY_WINDOW;
                     tracing::error!(
                         target: "pool::session",
-                        "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) during initial_message for channel {cid} — agent process is unrecoverable",
+                        conversation = %key,
+                        "hard timeout ({}s cap, silence {silence:?}, recently_active={recently_active}) during initial_message — agent process is unrecoverable",
                         ctx.max_turn_duration.as_secs()
                     );
                     agent.state.invalidate_all();
@@ -1797,7 +2558,8 @@ pub async fn run_prompt_task(
                 Err(e) => {
                     tracing::error!(
                         target: "pool::session",
-                        "initial_message failed for channel {cid}: {e} — invalidating session"
+                        conversation = %key,
+                        "initial_message failed: {e} — invalidating session"
                     );
                     agent.state.invalidate(&source);
                     send_prompt_result(
@@ -1838,7 +2600,13 @@ pub async fn run_prompt_task(
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
         let channel_info = ctx.channel_info.resolve(b.channel_id).await;
 
-        let conversation_context = if ctx.context_message_limit > 0 {
+        // Seed relay history exactly once for a genuinely fresh logical
+        // conversation. Reused local sessions and adapter-resumed persistent
+        // sessions already contain prior prompts; embedding the full thread on
+        // every turn would grow context quadratically. A `/new` generation is
+        // also deliberately not seeded, because relay history before the reset
+        // command is precisely the context the owner asked to clear.
+        let conversation_context = if seed_conversation_history && ctx.context_message_limit > 0 {
             fetch_conversation_context(b, &channel_info, &ctx).await
         } else {
             None
@@ -1960,8 +2728,14 @@ pub async fn run_prompt_task(
                     // requeued turn (busy) or the next turn (already-completed)
                     // applies the new model. Runtime-only — never persisted.
                     if let ControlSignal::SwitchModel(ref model_id) = control_signal {
+                        let pending = PendingModelSwitch {
+                            turn_id: turn_id.clone(),
+                            previous_model: agent.desired_model.clone(),
+                            previous_model_overridden: agent.model_overridden,
+                        };
                         agent.desired_model = Some(model_id.clone());
                         agent.model_overridden = true;
+                        agent.pending_model_switch = Some(pending);
                     }
                     // Control signal received. Guard against Race 1: the turn may
                     // have completed naturally just as cancel fired.
@@ -1974,6 +2748,15 @@ pub async fn run_prompt_task(
                         {
                             Ok(stop_reason) => {
                                 log_stop_reason(&source, &stop_reason);
+                                let forget_context =
+                                    control_forgets_durable_context(&control_signal);
+                                dispose_session_or_poison(
+                                    &mut agent,
+                                    &session_id,
+                                    forget_context,
+                                    "control cancellation",
+                                )
+                                .await;
                                 agent.state.invalidate(&source);
                                 let retry_batch =
                                     requeue_cancelled_batch(&ctx, control_signal, batch);
@@ -2002,6 +2785,13 @@ pub async fn run_prompt_task(
                                 // Single production arm: classify the error→outcome
                                 // and outcome→batch-fate boundary once via the seam
                                 // shared with tests, then invalidate/publish/send once.
+                                let forget_context =
+                                    control_forgets_durable_context(&control_signal);
+                                report_control_cancel_failure(
+                                    &mut agent,
+                                    &control_signal,
+                                    &turn_id,
+                                );
                                 let failure = classify_control_cancel_failure(
                                     &ctx,
                                     error,
@@ -2011,6 +2801,13 @@ pub async fn run_prompt_task(
                                 if failure.invalidate_all {
                                     agent.state.invalidate_all();
                                 } else {
+                                    dispose_session_or_poison(
+                                        &mut agent,
+                                        &session_id,
+                                        forget_context,
+                                        "failed control cancellation",
+                                    )
+                                    .await;
                                     agent.state.invalidate(&source);
                                 }
 
@@ -2069,6 +2866,18 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        if matches!(
+                            control_signal,
+                            ControlSignal::Rotate | ControlSignal::SwitchModel(_)
+                        ) {
+                            dispose_session_or_poison(
+                                &mut agent,
+                                &session_id,
+                                control_forgets_durable_context(&control_signal),
+                                "completed-turn rotation",
+                            )
+                            .await;
+                        }
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2107,11 +2916,12 @@ pub async fn run_prompt_task(
                 let limit = ctx.max_turns_per_session;
                 if limit > 0 {
                     match &source {
-                        PromptSource::Channel(cid) => {
-                            let count = agent.state.turn_counts.entry(*cid).or_insert(0);
+                        PromptSource::Conversation(key) => {
+                            let count = agent.state.turn_counts.entry(key.clone()).or_insert(0);
                             *count += 1;
                             *count >= limit
                         }
+                        PromptSource::Channel(_) => false,
                         PromptSource::Heartbeat => {
                             agent.state.heartbeat_turn_count += 1;
                             agent.state.heartbeat_turn_count >= limit
@@ -2127,6 +2937,8 @@ pub async fn run_prompt_task(
                     target: "pool::session",
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
+                dispose_session_or_poison(&mut agent, &session_id, false, "automatic rotation")
+                    .await;
                 agent.state.invalidate(&source);
             }
 
@@ -2616,6 +3428,11 @@ async fn fetch_conversation_context(
     // channels and DMs. A DM reply needs thread context (not channel history)
     // because /api/channels/{id}/messages excludes thread replies.
     let last_event = batch.events.last()?;
+    let batch_event_ids: HashSet<String> = batch
+        .events
+        .iter()
+        .map(|event| event.event.id.to_hex())
+        .collect();
     let tags = crate::queue::parse_thread_tags(&last_event.event);
     if let Some(root_id) = tags.root_event_id {
         return fetch_thread_context(
@@ -2623,6 +3440,7 @@ async fn fetch_conversation_context(
             &root_id,
             limit,
             ctx.agent_keys.public_key(),
+            &batch_event_ids,
             &ctx.rest_client,
         )
         .await;
@@ -2630,7 +3448,7 @@ async fn fetch_conversation_context(
 
     // DM non-reply: fetch recent conversation history.
     if is_dm {
-        return fetch_dm_context(batch.channel_id, limit, &ctx.rest_client).await;
+        return fetch_dm_context(batch.channel_id, limit, &batch_event_ids, &ctx.rest_client).await;
     }
 
     None
@@ -2802,6 +3620,7 @@ async fn fetch_thread_context(
     root_event_id: &str,
     limit: u32,
     agent_pubkey: nostr::PublicKey,
+    excluded_event_ids: &HashSet<String>,
     rest: &RestClient,
 ) -> Option<ConversationContext> {
     fetch_thread_context_with(
@@ -2809,6 +3628,7 @@ async fn fetch_thread_context(
         root_event_id,
         limit,
         agent_pubkey,
+        excluded_event_ids,
         |filters| async move { rest.query(&filters).await },
         |filters| async move { rest.count(&filters).await },
     )
@@ -2820,6 +3640,7 @@ async fn fetch_thread_context_with<Query, QueryFut, Count, CountFut>(
     root_event_id: &str,
     limit: u32,
     agent_pubkey: nostr::PublicKey,
+    excluded_event_ids: &HashSet<String>,
     query: Query,
     count: Count,
 ) -> Option<ConversationContext>
@@ -2849,7 +3670,16 @@ where
 
     // Three filters: (1) root event by ID, (2) recent replies with #e=root +
     // #h=channel plus a sentinel, and (3) the agent's newest reply for pinning.
-    let root_filter = nostr::Filter::new().id(nostr::EventId::from_hex(root_event_id).ok()?);
+    let root_filter = nostr::Filter::new()
+        .id(nostr::EventId::from_hex(root_event_id).ok()?)
+        .kinds([
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
+        ])
+        .custom_tags(h_tag, [ch_str.as_str()]);
+    let reply_limit = (limit as usize)
+        .saturating_add(excluded_event_ids.len())
+        .saturating_add(1);
     let replies_filter = nostr::Filter::new()
         .kinds([
             nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
@@ -2857,7 +3687,7 @@ where
         ])
         .custom_tags(e_tag, [root_event_id])
         .custom_tags(h_tag, [ch_str.as_str()])
-        .limit(limit.saturating_add(1) as usize);
+        .limit(reply_limit);
     let agent_reply_filter = replies_filter.clone().author(agent_pubkey).limit(1);
 
     let context = fetch_with_retry(|| async {
@@ -2871,9 +3701,13 @@ where
         )
         .await
         {
-            Ok(Ok(json)) => {
-                parse_nostr_thread_response_with_meta(json, root_event_id, limit, &agent_pubkey)
-            }
+            Ok(Ok(json)) => parse_nostr_thread_response_with_meta(
+                json,
+                root_event_id,
+                limit,
+                &agent_pubkey,
+                excluded_event_ids,
+            ),
             Ok(Err(e)) => {
                 tracing::warn!(
                     channel_id = %channel_id,
@@ -2967,6 +3801,7 @@ where
 async fn fetch_dm_context(
     channel_id: Uuid,
     limit: u32,
+    excluded_event_ids: &HashSet<String>,
     rest: &RestClient,
 ) -> Option<ConversationContext> {
     use nostr::{Alphabet, SingleLetterTag};
@@ -2979,7 +3814,7 @@ async fn fetch_dm_context(
             nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
         ])
         .custom_tags(h_tag, [ch_str.as_str()])
-        .limit(limit as usize);
+        .limit((limit as usize).saturating_add(excluded_event_ids.len()));
 
     fetch_with_retry(|| async {
         match timeout(
@@ -2988,7 +3823,7 @@ async fn fetch_dm_context(
         )
         .await
         {
-            Ok(Ok(json)) => parse_nostr_dm_response(json, limit),
+            Ok(Ok(json)) => parse_nostr_dm_response(json, limit, excluded_event_ids),
             Ok(Err(e)) => {
                 tracing::warn!(
                     channel_id = %channel_id,
@@ -3124,9 +3959,16 @@ fn parse_nostr_thread_response(
     root_event_id: &str,
     limit: u32,
     agent_pubkey: &nostr::PublicKey,
+    excluded_event_ids: &HashSet<String>,
 ) -> Option<ConversationContext> {
-    parse_nostr_thread_response_with_meta(json, root_event_id, limit, agent_pubkey)
-        .map(|parsed| parsed.context)
+    parse_nostr_thread_response_with_meta(
+        json,
+        root_event_id,
+        limit,
+        agent_pubkey,
+        excluded_event_ids,
+    )
+    .map(|parsed| parsed.context)
 }
 
 struct ParsedThreadContext {
@@ -3139,19 +3981,26 @@ fn parse_nostr_thread_response_with_meta(
     root_event_id: &str,
     limit: u32,
     agent_pubkey: &nostr::PublicKey,
+    excluded_event_ids: &HashSet<String>,
 ) -> Option<ParsedThreadContext> {
     let events = json.as_array()?;
     let agent_pubkey_hex = agent_pubkey.to_hex();
     let mut root_msg = None;
     let mut reply_msgs = Vec::new();
-    let mut seen_reply_ids = HashSet::new();
+    let mut seen_ids = HashSet::new();
 
     for ev in events {
         let ev_id = ev.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        if ev_id.is_empty()
+            || !seen_ids.insert(ev_id.to_ascii_lowercase())
+            || excluded_event_ids.contains(&ev_id.to_ascii_lowercase())
+        {
+            continue;
+        }
         if let Some(msg) = json_to_context_message(ev) {
-            if ev_id == root_event_id {
+            if ev_id.eq_ignore_ascii_case(root_event_id) {
                 root_msg = Some(msg);
-            } else if seen_reply_ids.insert(ev_id.to_string()) {
+            } else {
                 let is_agent = msg.pubkey.eq_ignore_ascii_case(&agent_pubkey_hex);
                 reply_msgs.push((
                     ev_id.to_string(),
@@ -3223,12 +4072,21 @@ fn parse_nostr_thread_response_with_meta(
 /// Parse a Nostr query response (array of events) into DM context.
 ///
 /// Events arrive in relay order (newest first); reversed to chronological.
-fn parse_nostr_dm_response(json: serde_json::Value, limit: u32) -> Option<ConversationContext> {
+fn parse_nostr_dm_response(
+    json: serde_json::Value,
+    limit: u32,
+    excluded_event_ids: &HashSet<String>,
+) -> Option<ConversationContext> {
     let events = json.as_array()?;
+    let mut seen_ids = HashSet::new();
 
     let mut messages: Vec<(u64, ContextMessage)> = events
         .iter()
         .filter_map(|ev| {
+            let event_id = ev.get("id")?.as_str()?.to_ascii_lowercase();
+            if !seen_ids.insert(event_id.clone()) || excluded_event_ids.contains(&event_id) {
+                return None;
+            }
             let ts = ev.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0);
             json_to_context_message(ev).map(|msg| (ts, msg))
         })
@@ -3347,6 +4205,7 @@ fn classify_control_cancel_failure(
 /// Shared by the turn-start and turn-stop lines so a log can be read as pairs.
 fn prompt_label(source: &PromptSource) -> String {
     match source {
+        PromptSource::Conversation(key) => format!("conversation {key}"),
         PromptSource::Channel(cid) => format!("channel {cid}"),
         PromptSource::Heartbeat => "heartbeat".to_string(),
     }
@@ -3824,16 +4683,15 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
-pub(crate) async fn post_failure_notice(
+/// Build and sign one visible harness notice. Keeping this separate from
+/// submission lets reset acknowledgements retry the exact same Nostr event ID
+/// after an ambiguous timeout.
+pub(crate) fn build_notice_event(
     rest: &crate::relay::RestClient,
     channel_id: Uuid,
     thread_tags: &ThreadTags,
     content: &str,
-) {
+) -> Result<nostr::Event, String> {
     let thread_ref = thread_tags.root_event_id.as_deref().and_then(|root| {
         let root_id = nostr::EventId::from_hex(root).ok()?;
         let parent_id = thread_tags
@@ -3847,24 +4705,100 @@ pub(crate) async fn post_failure_notice(
         })
     });
     let builder =
-        match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
-                return;
-            }
-        };
-    let event = match builder.sign_with_keys(&rest.keys) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
-            return;
+        buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[])
+            .map_err(|error| format!("notice build failed: {error}"))?;
+    builder
+        .sign_with_keys(&rest.keys)
+        .map_err(|error| format!("notice signing failed: {error}"))
+}
+
+fn notice_response_is_accepted(response: &serde_json::Value) -> bool {
+    response.get("accepted").and_then(|value| value.as_bool()) == Some(true)
+}
+
+/// Submit an already-signed notice once. `true` means the relay accepted the
+/// event (including its idempotent duplicate path); false is safe to retry with
+/// the same event ID.
+pub(crate) async fn submit_notice_event(
+    rest: &crate::relay::RestClient,
+    event: &nostr::Event,
+) -> bool {
+    match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(event)).await {
+        Ok(Ok(response)) if notice_response_is_accepted(&response) => true,
+        Ok(Ok(response)) => {
+            tracing::warn!(
+                event_id = %event.id,
+                accepted = response.get("accepted").and_then(|value| value.as_bool()),
+                "notice rejected by relay"
+            );
+            false
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(event_id = %event.id, %error, "notice submission failed");
+            false
+        }
+        Err(_) => {
+            tracing::warn!(event_id = %event.id, "notice submission timed out");
+            false
+        }
+    }
+}
+
+/// Submit one signed notice with a short bounded retry schedule.
+pub(crate) async fn submit_notice_event_with_retry(
+    rest: &crate::relay::RestClient,
+    event: &nostr::Event,
+) -> bool {
+    for delay in [
+        Duration::ZERO,
+        Duration::from_millis(250),
+        Duration::from_secs(1),
+    ] {
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        if submit_notice_event(rest, event).await {
+            return true;
+        }
+    }
+    false
+}
+
+/// Post a visible kind-9 harness notice with bounded idempotent retry. The
+/// event is signed once; every retry therefore has the same event ID and
+/// cannot create duplicate Buzz messages if an earlier response was lost.
+pub(crate) async fn post_failure_notice(
+    rest: &crate::relay::RestClient,
+    channel_id: Uuid,
+    thread_tags: &ThreadTags,
+    content: &str,
+) -> bool {
+    let event = match build_notice_event(rest, channel_id, thread_tags, content) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::error!(channel = %channel_id, %error, "could not construct user-visible notice");
+            return false;
         }
     };
-    match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
-        Ok(Ok(_)) => {}
-        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
-        Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
+    submit_notice_event_with_retry(rest, &event).await
+}
+
+#[cfg(test)]
+mod notice_delivery_tests {
+    use super::notice_response_is_accepted;
+
+    #[test]
+    fn relay_notice_acceptance_requires_an_explicit_accepted_response() {
+        assert!(notice_response_is_accepted(&serde_json::json!({
+            "event_id": "abc",
+            "accepted": true,
+            "message": "duplicate:"
+        })));
+        assert!(!notice_response_is_accepted(&serde_json::json!({
+            "event_id": "abc",
+            "accepted": false
+        })));
+        assert!(!notice_response_is_accepted(&serde_json::Value::Null));
     }
 }
 
@@ -3988,6 +4922,16 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+    use std::time::Instant;
+
+    fn test_conversation_key(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            root_event_id: format!("test-root-{channel_id}"),
+            generation: 0,
+            reset_token: None,
+        }
+    }
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
     // a legacy agent WITH a base_prompt must get [Base] prepended to the user
@@ -4475,8 +5419,9 @@ mod tests {
             }
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
-            .expect("should parse");
+        let ctx =
+            parse_nostr_thread_response(json, root_id, 2, &agent.public_key(), &HashSet::new())
+                .expect("should parse");
         match ctx {
             ConversationContext::Thread {
                 messages,
@@ -4516,8 +5461,9 @@ mod tests {
             }
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
-            .expect("should parse");
+        let ctx =
+            parse_nostr_thread_response(json, root_id, 2, &agent.public_key(), &HashSet::new())
+                .expect("should parse");
         match ctx {
             ConversationContext::Thread {
                 messages,
@@ -4570,8 +5516,9 @@ mod tests {
             }
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
-            .expect("should parse");
+        let ctx =
+            parse_nostr_thread_response(json, root_id, 2, &agent.public_key(), &HashSet::new())
+                .expect("should parse");
         match ctx {
             ConversationContext::Thread { messages, .. } => {
                 assert_eq!(messages.len(), 3); // root + 2 displayed replies
@@ -4626,6 +5573,7 @@ mod tests {
             root_id,
             2,
             agent_pubkey,
+            &HashSet::new(),
             move |filters| {
                 assert_thread_query_filters(&filters, channel_id, root_id, agent_pubkey, 3);
                 std::future::ready(Ok(json.clone()))
@@ -4650,6 +5598,74 @@ mod tests {
             }
             _ => panic!("expected Thread context"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_thread_context_excludes_live_batch_without_shrinking_prior_window() {
+        let agent = Keys::generate();
+        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let current_id = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let channel_id = Uuid::new_v4();
+        let agent_pubkey = agent.public_key();
+        let excluded = HashSet::from([current_id.to_string()]);
+        let json = json!([
+            thread_event(root_id, "rootpub", "root", 1000),
+            thread_event(current_id, "humanpub", "current request", 6000),
+            thread_event(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "humanpub",
+                "newest prior reply",
+                5000
+            ),
+            thread_event(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "humanpub",
+                "middle prior reply",
+                4000
+            ),
+            thread_event(
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "humanpub",
+                "sentinel prior reply",
+                3000
+            )
+        ]);
+
+        let ctx = fetch_thread_context_with(
+            channel_id,
+            root_id,
+            2,
+            agent_pubkey,
+            &excluded,
+            move |filters| {
+                assert_thread_query_filters(&filters, channel_id, root_id, agent_pubkey, 4);
+                std::future::ready(Ok(json.clone()))
+            },
+            |_filters| std::future::ready(Err(crate::relay::RelayError::Http("boom".into()))),
+        )
+        .await
+        .expect("thread context");
+
+        let ConversationContext::Thread {
+            messages,
+            total,
+            truncated,
+        } = ctx
+        else {
+            panic!("expected Thread context");
+        };
+        assert!(truncated);
+        assert_eq!(total, 4, "root plus three distinct prior replies");
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["root", "middle prior reply", "newest prior reply"]
+        );
+        assert!(messages
+            .iter()
+            .all(|message| message.content != "current request"));
     }
 
     #[tokio::test]
@@ -4683,6 +5699,7 @@ mod tests {
             root_id,
             2,
             agent.public_key(),
+            &HashSet::new(),
             move |_filters| std::future::ready(Ok(json.clone())),
             |_filters| std::future::ready(Ok(json!({ "count": 6 }))),
         )
@@ -4735,6 +5752,7 @@ mod tests {
             root_id,
             2,
             agent.public_key(),
+            &HashSet::new(),
             move |_filters| std::future::ready(Ok(json.clone())),
             |_filters| std::future::ready(Ok(json!({ "count": 1 }))),
         )
@@ -4787,6 +5805,7 @@ mod tests {
             root_id,
             2,
             agent.public_key(),
+            &HashSet::new(),
             move |_filters| std::future::ready(Ok(json.clone())),
             |_filters| std::future::ready(Err(crate::relay::RelayError::Http("boom".into()))),
         )
@@ -4848,6 +5867,7 @@ mod tests {
             root_id,
             2,
             agent.public_key(),
+            &HashSet::new(),
             move |_filters| std::future::ready(Ok(json.clone())),
             |_filters| std::future::ready(Ok(json!({ "count": 3 }))),
         )
@@ -4921,6 +5941,7 @@ mod tests {
             root_id,
             2,
             agent.public_key(),
+            &HashSet::new(),
             move |_filters| std::future::ready(Ok(json.clone())),
             |_filters| std::future::ready(Err(crate::relay::RelayError::Http("boom".into()))),
         )
@@ -4971,6 +5992,8 @@ mod tests {
 
         let root = serde_json::to_value(&filters[0]).expect("serialize root filter");
         assert_eq!(root.get("ids"), Some(&json!([root_id])));
+        assert_eq!(root.get("kinds"), Some(&json!([9, 40002])));
+        assert_eq!(root.get("#h"), Some(&json!([channel_id.to_string()])));
         assert!(root.get("limit").is_none());
 
         let replies = serde_json::to_value(&filters[1]).expect("serialize replies filter");
@@ -5007,6 +6030,61 @@ mod tests {
             "content": content,
             "created_at": created_at
         })
+    }
+
+    #[test]
+    fn nostr_thread_context_excludes_live_batch_and_deduplicates_relay_rows() {
+        let root = "aa".repeat(32);
+        let prior = "bb".repeat(32);
+        let current = "cc".repeat(32);
+        let json = json!([
+            { "id": root, "content": "root", "pubkey": "01", "created_at": 1 },
+            { "id": prior, "content": "prior", "pubkey": "02", "created_at": 2 },
+            { "id": prior, "content": "duplicate prior", "pubkey": "02", "created_at": 2 },
+            { "id": current, "content": "current request", "pubkey": "03", "created_at": 3 }
+        ]);
+        let excluded = HashSet::from([current]);
+        let agent = Keys::generate();
+
+        let context = parse_nostr_thread_response(json, &root, 12, &agent.public_key(), &excluded)
+            .expect("root and prior reply remain");
+        let ConversationContext::Thread { messages, .. } = context else {
+            panic!("expected thread context");
+        };
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["root", "prior"]
+        );
+    }
+
+    #[test]
+    fn nostr_dm_context_excludes_live_batch_and_deduplicates_relay_rows() {
+        let older = "aa".repeat(32);
+        let prior = "bb".repeat(32);
+        let current = "cc".repeat(32);
+        let json = json!([
+            { "id": current, "content": "current request", "pubkey": "03", "created_at": 3 },
+            { "id": prior, "content": "prior", "pubkey": "02", "created_at": 2 },
+            { "id": prior, "content": "duplicate prior", "pubkey": "02", "created_at": 2 },
+            { "id": older, "content": "older", "pubkey": "01", "created_at": 1 }
+        ]);
+        let excluded = HashSet::from([current]);
+
+        let context =
+            parse_nostr_dm_response(json, 12, &excluded).expect("older DM history remains");
+        let ConversationContext::Dm { messages, .. } = context else {
+            panic!("expected DM context");
+        };
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["older", "prior"]
+        );
     }
 
     #[test]
@@ -5054,6 +6132,7 @@ mod tests {
         let author_hex = event.pubkey.to_hex();
         let batch = FlushBatch {
             channel_id: Uuid::new_v4(),
+            conversation_key: test_conversation_key(Uuid::new_v4()),
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -5183,10 +6262,12 @@ mod tests {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
-        s.turn_counts.insert(ch_a, 5);
-        s.turn_counts.insert(ch_b, 3);
+        s.sessions
+            .insert(test_conversation_key(ch_a), "sess-a".into());
+        s.sessions
+            .insert(test_conversation_key(ch_b), "sess-b".into());
+        s.turn_counts.insert(test_conversation_key(ch_a), 5);
+        s.turn_counts.insert(test_conversation_key(ch_b), 3);
         s.core_sections.insert(ch_a, "core-a".into());
         s.core_sections.insert(ch_b, "core-b".into());
         s.heartbeat_session = Some("sess-hb".into());
@@ -5204,12 +6285,15 @@ mod tests {
             &ControlSignal::Rotate,
         );
 
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&test_conversation_key(ch_a)));
+        assert!(!s.turn_counts.contains_key(&test_conversation_key(ch_a)));
         assert!(!s.core_sections.contains_key(&ch_a));
         assert!(!s.has_channel_state(&ch_a));
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
         assert_eq!(s.heartbeat_turn_count, 7);
@@ -5225,10 +6309,16 @@ mod tests {
             &ControlSignal::Cancel,
         );
 
-        assert_eq!(s.sessions.get(&ch_a).unwrap(), "sess-a");
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_a)).unwrap(),
+            "sess-a"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_a)).unwrap(), 5);
         assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
     }
 
     #[test]
@@ -5236,13 +6326,16 @@ mod tests {
         let (mut s, ch_a, ch_b) = make_state();
         s.invalidate(&PromptSource::Channel(ch_a));
 
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&test_conversation_key(ch_a)));
+        assert!(!s.turn_counts.contains_key(&test_conversation_key(ch_a)));
         assert!(!s.core_sections.contains_key(&ch_a));
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
@@ -5258,8 +6351,8 @@ mod tests {
         assert_eq!(s.heartbeat_turn_count, 0);
         // channels untouched
         assert_eq!(s.sessions.len(), 2);
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_a)).unwrap(), 5);
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
     }
@@ -5285,8 +6378,8 @@ mod tests {
         // Everything still intact.
         assert_eq!(s.sessions.len(), 2);
         assert_eq!(s.turn_counts.len(), 2);
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_a)).unwrap(), 5);
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
     }
@@ -5304,13 +6397,16 @@ mod tests {
     fn test_invalidate_channel_returns_true_when_session_existed() {
         let (mut s, ch_a, ch_b) = make_state();
         assert!(s.invalidate_channel(&ch_a));
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&test_conversation_key(ch_a)));
+        assert!(!s.turn_counts.contains_key(&test_conversation_key(ch_a)));
         assert!(!s.core_sections.contains_key(&ch_a));
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
         // heartbeat untouched
         assert_eq!(s.heartbeat_session.as_deref(), Some("sess-hb"));
@@ -5328,6 +6424,140 @@ mod tests {
     }
 
     #[test]
+    fn invalidate_conversation_preserves_sibling_thread_and_channel_metadata() {
+        let channel_id = Uuid::new_v4();
+        let first = ConversationKey {
+            channel_id,
+            root_event_id: "a".repeat(64),
+            generation: 0,
+            reset_token: None,
+        };
+        let second = ConversationKey {
+            channel_id,
+            root_event_id: "b".repeat(64),
+            generation: 0,
+            reset_token: None,
+        };
+        let mut state = SessionState::default();
+        state.sessions.insert(first.clone(), "first-session".into());
+        state
+            .sessions
+            .insert(second.clone(), "second-session".into());
+        state.turn_counts.insert(first.clone(), 3);
+        state.turn_counts.insert(second.clone(), 7);
+        state.last_used.insert(first.clone(), Instant::now());
+        state.last_used.insert(second.clone(), Instant::now());
+        state.core_sections.insert(channel_id, "shared core".into());
+        state
+            .canvas_sections
+            .insert(channel_id, "shared canvas".into());
+
+        assert!(state.invalidate_conversation(&first));
+        assert!(!state.sessions.contains_key(&first));
+        assert!(!state.turn_counts.contains_key(&first));
+        assert!(!state.last_used.contains_key(&first));
+        assert_eq!(
+            state.sessions.get(&second).map(String::as_str),
+            Some("second-session")
+        );
+        assert_eq!(state.turn_counts.get(&second), Some(&7));
+        assert!(state.core_sections.contains_key(&channel_id));
+        assert!(state.canvas_sections.contains_key(&channel_id));
+    }
+
+    #[test]
+    fn prune_idle_removes_expired_sessions_before_applying_lru_cap() {
+        let channel_id = Uuid::new_v4();
+        let active = ConversationKey {
+            channel_id,
+            root_event_id: "active".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let expired = ConversationKey {
+            channel_id,
+            root_event_id: "expired".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let recent = ConversationKey {
+            channel_id,
+            root_event_id: "recent".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let now = Instant::now();
+        let mut state = SessionState::default();
+        for (key, session) in [
+            (active.clone(), "active-session"),
+            (expired.clone(), "expired-session"),
+            (recent.clone(), "recent-session"),
+        ] {
+            state.sessions.insert(key, session.into());
+        }
+        state.last_used.insert(active.clone(), now);
+        state
+            .last_used
+            .insert(expired.clone(), now - Duration::from_secs(120));
+        state.last_used.insert(recent.clone(), now);
+
+        let evicted = state.prune_idle(&active, 2, Duration::from_secs(60));
+        assert_eq!(evicted, vec![(expired.clone(), "expired-session".into())]);
+        assert!(state.sessions.contains_key(&active));
+        assert!(state.sessions.contains_key(&recent));
+        assert!(!state.sessions.contains_key(&expired));
+    }
+
+    #[test]
+    fn prune_idle_reserves_capacity_for_a_new_active_session_without_off_by_one() {
+        let channel_id = Uuid::new_v4();
+        let oldest = ConversationKey {
+            channel_id,
+            root_event_id: "oldest".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let newest = ConversationKey {
+            channel_id,
+            root_event_id: "newest".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let new_active = ConversationKey {
+            channel_id,
+            root_event_id: "new-active".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let now = Instant::now();
+        let mut state = SessionState::default();
+        state
+            .sessions
+            .insert(oldest.clone(), "oldest-session".into());
+        state
+            .sessions
+            .insert(newest.clone(), "newest-session".into());
+        state
+            .last_used
+            .insert(oldest.clone(), now - Duration::from_secs(10));
+        state.last_used.insert(newest.clone(), now);
+
+        let evicted = state.prune_idle(&new_active, 2, Duration::from_secs(60));
+        assert_eq!(evicted, vec![(oldest, "oldest-session".into())]);
+        assert_eq!(state.sessions.len(), 1);
+        assert!(state.sessions.contains_key(&newest));
+
+        state
+            .sessions
+            .insert(new_active.clone(), "active-session".into());
+        state.last_used.insert(new_active.clone(), Instant::now());
+        assert!(state
+            .prune_idle(&new_active, 2, Duration::from_secs(60))
+            .is_empty());
+        assert_eq!(state.sessions.len(), 2);
+    }
+
+    #[test]
     fn test_removed_channels_cleaned_via_invalidate_channel() {
         // Simulates handle_prompt_result: channels removed while agent
         // was checked out should have both sessions and turn_counts stripped.
@@ -5336,12 +6566,15 @@ mod tests {
         for ch in &removed {
             s.invalidate_channel(ch);
         }
-        assert!(!s.sessions.contains_key(&ch_a));
-        assert!(!s.turn_counts.contains_key(&ch_a));
+        assert!(!s.sessions.contains_key(&test_conversation_key(ch_a)));
+        assert!(!s.turn_counts.contains_key(&test_conversation_key(ch_a)));
         assert!(!s.core_sections.contains_key(&ch_a));
         assert!(!s.has_channel_state(&ch_a));
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
         assert_eq!(s.core_sections.get(&ch_b).unwrap(), "core-b");
     }
 
@@ -5361,8 +6594,180 @@ mod tests {
 
         assert!(!s.has_channel_state(&ch_a));
         // ch_b untouched — the switch is channel-scoped.
-        assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
-        assert_eq!(*s.turn_counts.get(&ch_b).unwrap(), 3);
+        assert_eq!(
+            s.sessions.get(&test_conversation_key(ch_b)).unwrap(),
+            "sess-b"
+        );
+        assert_eq!(*s.turn_counts.get(&test_conversation_key(ch_b)).unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn failed_switch_cancellation_restores_model_and_emits_terminal_result() {
+        let mut acp = AcpClient::spawn(
+            "bash",
+            &["-c".to_string(), "sleep 10".to_string()],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn model cancellation fixture");
+        let observer = observer::ObserverHandle::in_process();
+        acp.set_observer(Some(observer.clone()), 0);
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: Some("model-b".to_string()),
+            model_overridden: true,
+            pending_model_switch: Some(PendingModelSwitch {
+                turn_id: "target-turn".to_string(),
+                previous_model: Some("model-a".to_string()),
+                previous_model_overridden: false,
+            }),
+            agent_name: "fixture".to_string(),
+            goose_system_prompt_supported: None,
+            protocol_version: 2,
+        };
+
+        report_control_cancel_failure(
+            &mut agent,
+            &ControlSignal::SwitchModel("model-b".to_string()),
+            "fallback-turn",
+        );
+
+        assert_eq!(agent.desired_model.as_deref(), Some("model-a"));
+        assert!(!agent.model_overridden);
+        assert!(agent.pending_model_switch.is_none());
+        let result = observer
+            .snapshot()
+            .into_iter()
+            .find(|event| event.kind == "control_result")
+            .expect("known cancellation failure must emit a terminal result");
+        assert_eq!(result.payload["type"], "switch_model");
+        assert_eq!(result.payload["status"], "switch_failed");
+        assert_eq!(result.payload["modelId"], "model-b");
+        assert_eq!(result.payload["turnId"], "target-turn");
+        agent.acp.shutdown().await;
+    }
+
+    #[test]
+    fn stable_model_switch_requires_an_explicit_matching_confirmation() {
+        let method = ModelSwitchMethod::ConfigOption {
+            config_id: "model".into(),
+            option_value: "model-b".into(),
+        };
+        assert!(model_switch_response_confirms(
+            &json!({
+                "configOptions": [{
+                    "id": "model",
+                    "currentValue": "model-b",
+                    "options": []
+                }]
+            }),
+            &method,
+        ));
+        assert!(model_switch_response_confirms(
+            &json!({"configId": "model", "value": "model-b"}),
+            &method,
+        ));
+        assert!(!model_switch_response_confirms(&json!({}), &method));
+        assert!(!model_switch_response_confirms(
+            &json!({
+                "configOptions": [{"configId": "model", "value": "model-a"}]
+            }),
+            &method,
+        ));
+    }
+
+    #[test]
+    fn unstable_model_switch_accepts_only_empty_success_or_a_matching_echo() {
+        let method = ModelSwitchMethod::SetModel {
+            model_id: "model-b".into(),
+        };
+        assert!(model_switch_response_confirms(&json!({}), &method));
+        assert!(model_switch_response_confirms(
+            &json!({"_meta": {"adapter": "ok"}}),
+            &method,
+        ));
+        assert!(model_switch_response_confirms(
+            &json!({"modelId": "model-b"}),
+            &method,
+        ));
+        assert!(!model_switch_response_confirms(
+            &json!({"modelId": "model-a"}),
+            &method,
+        ));
+        assert!(!model_switch_response_confirms(
+            &json!({"unexpected": true}),
+            &method,
+        ));
+    }
+
+    #[test]
+    fn confirmed_model_switch_updates_both_desktop_catalog_shapes() {
+        let mut config_options = json!([{
+            "configId": "model",
+            "category": "model",
+            "value": "model-a",
+            "options": [{"value": "model-a"}, {"value": "model-b"}]
+        }]);
+        let mut models = json!({
+            "currentModelId": "model-a",
+            "availableModels": [{"modelId": "model-a"}, {"modelId": "model-b"}]
+        });
+        let method = ModelSwitchMethod::ConfigOption {
+            config_id: "model".into(),
+            option_value: "model-b".into(),
+        };
+        merge_applied_model_state(
+            &mut config_options,
+            &mut models,
+            &json!({"configId": "model", "value": "model-b"}),
+            &method,
+        );
+        assert_eq!(config_options[0]["value"], "model-b");
+        assert_eq!(models["currentModelId"], "model-b");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejected_live_model_switch_reapplies_the_previous_model() {
+        let script = r#"
+            read -r _attempt_b
+            echo '{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"model b unavailable"}}'
+            read -r _rollback_a
+            echo '{"jsonrpc":"2.0","id":1,"result":{"configOptions":[{"configId":"model","category":"model","value":"model-a","options":[{"value":"model-a"},{"value":"model-b"}]}]}}'
+            sleep 1
+        "#;
+        let mut acp = AcpClient::spawn("bash", &["-c".to_string(), script.to_string()], &[], false)
+            .await
+            .expect("spawn model-switch test adapter");
+        let fresh_catalog = json!({
+            "configOptions": [{
+                "configId": "model",
+                "category": "model",
+                "value": "adapter-default",
+                "options": [{"value": "model-a"}, {"value": "model-b"}]
+            }]
+        });
+        let method_b = resolve_model_switch_method(&fresh_catalog, "model-b")
+            .expect("model b appears in fresh catalog");
+        assert_eq!(
+            apply_model_switch(&mut acp, "session-1", "model-b", &method_b)
+                .await
+                .expect("application rejection keeps transport usable"),
+            ModelSwitchApplyOutcome::Rejected,
+        );
+
+        let (response, rollback_method) =
+            restore_previous_model(&mut acp, "session-1", &fresh_catalog, Some("model-a"))
+                .await
+                .expect("rollback request is transport-safe")
+                .expect("previous explicit model requires rollback");
+        assert!(model_switch_response_confirms(&response, &rollback_method));
+        assert_eq!(response["configOptions"][0]["value"], "model-a");
+        acp.shutdown().await;
     }
 
     // ── requeue_cancelled_batch ────────────────────────────────────────────
@@ -5380,6 +6785,7 @@ mod tests {
             .unwrap();
         FlushBatch {
             channel_id,
+            conversation_key: test_conversation_key(channel_id),
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -5930,6 +7336,7 @@ mod tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
+            pending_model_switch: None,
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
@@ -5988,6 +7395,7 @@ mod tests {
             model_capabilities: None,
             desired_model: None,
             model_overridden: false,
+            pending_model_switch: None,
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
@@ -6023,6 +7431,93 @@ mod tests {
         let (_steer_tx, steer_rx) = tokio::sync::mpsc::channel::<SteerRequest>(1);
         result.agent.acp.install_steer_rx(steer_rx);
         // Reaching here without a panic is the test.
+    }
+
+    #[tokio::test]
+    async fn two_agent_affinity_keeps_interleaved_threads_sticky_and_never_forks_busy_owner() {
+        async fn test_agent(index: usize, key: ConversationKey) -> OwnedAgent {
+            let acp = AcpClient::spawn(
+                "bash",
+                &["-c".to_string(), "sleep 10".to_string()],
+                &[],
+                false,
+            )
+            .await
+            .expect("spawn affinity test agent");
+            let mut state = SessionState::default();
+            state.sessions.insert(key, format!("session-{index}"));
+            OwnedAgent {
+                index,
+                acp,
+                state,
+                model_capabilities: None,
+                desired_model: None,
+                model_overridden: false,
+                pending_model_switch: None,
+                agent_name: "test".into(),
+                goose_system_prompt_supported: None,
+                protocol_version: 2,
+            }
+        }
+
+        let channel_id = Uuid::new_v4();
+        let first = ConversationKey {
+            channel_id,
+            root_event_id: "a".repeat(64),
+            generation: 0,
+            reset_token: None,
+        };
+        let second = ConversationKey {
+            channel_id,
+            root_event_id: "b".repeat(64),
+            generation: 0,
+            reset_token: None,
+        };
+        let first_agent = test_agent(0, first.clone()).await;
+        let second_agent = test_agent(1, second.clone()).await;
+        let mut pool = AgentPool::from_slots(vec![Some(first_agent), Some(second_agent)]);
+
+        let claimed_first = pool
+            .try_claim_conversation(&first)
+            .expect("first thread owner");
+        let claimed_second = pool
+            .try_claim_conversation(&second)
+            .expect("sibling thread owner");
+        assert_eq!(claimed_first.index, 0);
+        assert_eq!(claimed_second.index, 1);
+        pool.return_agent(claimed_second);
+        pool.return_agent(claimed_first);
+
+        let claimed_first = pool
+            .try_claim_conversation(&first)
+            .expect("first owner remains sticky");
+        assert_eq!(claimed_first.index, 0);
+        let task_id = pool.join_set.spawn(std::future::pending::<()>()).id();
+        pool.task_map.insert(
+            task_id,
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                conversation_key: Some(first.clone()),
+                turn_id: "affinity-test".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        assert!(
+            pool.try_claim_conversation(&first).is_none(),
+            "a busy owner must not let the same thread fork onto idle slot 1"
+        );
+
+        pool.task_map.remove(&task_id);
+        pool.join_set.abort_all();
+        pool.return_agent(claimed_first);
+        for slot in &mut pool.agents {
+            if let Some(mut agent) = slot.take() {
+                agent.acp.shutdown().await;
+            }
+        }
     }
 
     // ── NIP-AM emit-hook unit tests ────────────────────────────────────────
@@ -6451,6 +7946,8 @@ mod tests {
             ),
             context_message_limit: 0,
             max_turns_per_session: 0,
+            max_cached_conversation_sessions: 8,
+            conversation_session_idle_ttl: Duration::from_secs(1_800),
             permission_mode: PermissionMode::Default,
             agent_keys: agent_keys.clone(),
             agent_owner_pubkey: owner_pubkey,
@@ -6509,14 +8006,14 @@ mod tests {
     fn test_invalidate_channel_clears_canvas_section() {
         let ch = Uuid::new_v4();
         let mut s = SessionState::default();
-        s.sessions.insert(ch, "sess".into());
+        s.sessions.insert(test_conversation_key(ch), "sess".into());
         s.canvas_sections
             .insert(ch, "[Channel Canvas]\nrev abc".into());
 
         s.invalidate_channel(&ch);
 
         assert!(!s.canvas_sections.contains_key(&ch));
-        assert!(!s.sessions.contains_key(&ch));
+        assert!(!s.sessions.contains_key(&test_conversation_key(ch)));
     }
 
     #[test]
@@ -6526,7 +8023,8 @@ mod tests {
         let mut s = SessionState::default();
         s.canvas_sections.insert(ch_a, "canvas-a".into());
         s.canvas_sections.insert(ch_b, "canvas-b".into());
-        s.sessions.insert(ch_a, "sess-a".into());
+        s.sessions
+            .insert(test_conversation_key(ch_a), "sess-a".into());
 
         s.invalidate_all();
 
@@ -6539,8 +8037,10 @@ mod tests {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
         let mut s = SessionState::default();
-        s.sessions.insert(ch_a, "sess-a".into());
-        s.sessions.insert(ch_b, "sess-b".into());
+        s.sessions
+            .insert(test_conversation_key(ch_a), "sess-a".into());
+        s.sessions
+            .insert(test_conversation_key(ch_b), "sess-b".into());
         s.canvas_sections.insert(ch_a, "canvas-a".into());
         s.canvas_sections.insert(ch_b, "canvas-b".into());
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -20,8 +20,99 @@ use uuid::Uuid;
 
 use crate::config::DedupMode;
 
+/// Stable identity for one independent agent conversation inside Buzz.
+///
+/// A channel can contain many NIP-10 threads.  The root event id is therefore
+/// part of the identity: replies use their declared root while a top-level
+/// event is its own (prospective) root.  Keeping this type explicit prevents a
+/// future caller from accidentally collapsing thread state back to the channel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConversationKey {
+    pub channel_id: Uuid,
+    pub root_event_id: String,
+    /// Monotonic thread epoch. `/new` advances it so late results from the
+    /// preceding context cannot mutate or block the replacement context.
+    pub generation: u64,
+    /// Unique signed `/new` event id that created this epoch. Passed to
+    /// adapters as an idempotent durable-reset token; excluded from
+    /// [`stable_id`](Self::stable_id) so the logical thread route stays stable.
+    pub reset_token: Option<String>,
+}
+
+impl ConversationKey {
+    /// Stable adapter persistence identity. Generation is intentionally
+    /// excluded: `/new` forgets the old mapping before creating the next epoch.
+    pub fn stable_id(&self) -> String {
+        format!("buzz:{}:{}", self.channel_id, self.root_event_id)
+    }
+    /// Derive a key while preserving unthreaded DM continuity.
+    pub fn for_event_with_dm_scope(channel_id: Uuid, event: &Event, is_dm: bool) -> Self {
+        let tags = parse_thread_tags(event);
+        let root_event_id = tags.root_event_id.unwrap_or_else(|| {
+            if is_dm {
+                format!("dm:{channel_id}")
+            } else {
+                event.id.to_hex()
+            }
+        });
+        Self {
+            channel_id,
+            root_event_id,
+            generation: 0,
+            reset_token: None,
+        }
+    }
+}
+
+impl std::fmt::Display for ConversationKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}@{}",
+            self.channel_id, self.root_event_id, self.generation
+        )
+    }
+}
+
 /// Maximum events queued per channel before oldest events are dropped.
 const MAX_PENDING_PER_CHANNEL: usize = 500;
+
+/// Defense-in-depth bounds for thread-shaped traffic. Without aggregate caps,
+/// an author could create a fresh top-level root for every event and bypass the
+/// per-conversation depth bound above.
+const MAX_PENDING_CONVERSATIONS_PER_CHANNEL: usize = 256;
+const MAX_PENDING_CONVERSATIONS_GLOBAL: usize = 2_048;
+const MAX_PENDING_EVENTS_PER_CHANNEL: usize = 2_000;
+const MAX_PENDING_EVENTS_GLOBAL: usize = 10_000;
+
+/// Owner-driven `/new` epochs are rare, but the map must still have a hard
+/// ceiling over a long-running process.
+const MAX_GENERATION_ENTRIES: usize = 65_536;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetConversationError {
+    /// Every bounded metadata slot is still attached to live queue state.
+    MetadataCapacity,
+    /// A prior `/new` has committed and its signed acknowledgement is not yet
+    /// accepted. Replacing that durable record would orphan the first barrier.
+    ResetInProgress,
+}
+
+/// Capacity-checked reset intent. Constructing this value may evict only
+/// inactive generation metadata; applying it is infallible while the relay
+/// event loop retains exclusive access to the queue.
+pub(crate) struct PreparedConversationReset {
+    old: ConversationKey,
+}
+
+impl std::fmt::Display for ResetConversationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MetadataCapacity => formatter.write_str("reset metadata capacity reached"),
+            Self::ResetInProgress => formatter.write_str("reset acknowledgement already pending"),
+        }
+    }
+}
 
 /// Maximum events drained into a single batch.
 const MAX_BATCH_EVENTS: usize = 50;
@@ -76,6 +167,8 @@ pub enum CancelReason {
 #[derive(Debug, Clone)]
 pub struct FlushBatch {
     pub channel_id: Uuid,
+    /// Exact thread/session identity shared by every event in this batch.
+    pub conversation_key: ConversationKey,
     pub events: Vec<BatchEvent>,
     /// Events from a cancelled batch that triggered this re-prompt.
     /// Empty for normal (non-cancel) batches. When non-empty, `format_prompt()`
@@ -135,24 +228,24 @@ pub struct FlushBatch {
 ///     else: push_front with original received_at, set exponential backoff retry_after with jitter
 /// ```
 pub struct EventQueue {
-    queues: HashMap<Uuid, VecDeque<QueuedEvent>>,
-    in_flight_channels: HashSet<Uuid>,
+    queues: HashMap<ConversationKey, VecDeque<QueuedEvent>>,
+    in_flight_channels: HashSet<ConversationKey>,
     /// Per-channel deadline for auto-expiring stuck in-flight entries.
-    in_flight_deadlines: HashMap<Uuid, Instant>,
+    in_flight_deadlines: HashMap<ConversationKey, Instant>,
     /// Number of events in each in-flight batch (for expiry logging).
-    in_flight_batch_sizes: HashMap<Uuid, usize>,
-    retry_after: HashMap<Uuid, Instant>,
+    in_flight_batch_sizes: HashMap<ConversationKey, usize>,
+    retry_after: HashMap<ConversationKey, Instant>,
     /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
-    retry_counts: HashMap<Uuid, u32>,
+    retry_counts: HashMap<ConversationKey, u32>,
     dedup_mode: DedupMode,
     /// Events from cancelled batches, keyed by channel. Merged into the next
     /// `FlushBatch` for that channel as `cancelled_events` so `format_prompt()`
     /// can produce annotated "[Previous request — interrupted]" sections.
-    cancelled_batches: HashMap<Uuid, Vec<BatchEvent>>,
+    cancelled_batches: HashMap<ConversationKey, Vec<BatchEvent>>,
     /// Why each channel's cancelled batch was cancelled (steer vs interrupt).
     /// Set by `requeue_as_cancelled`, consumed by `flush_next` to set
     /// `FlushBatch::cancel_reason`. Keyed by channel, cleared on flush.
-    cancel_reasons: HashMap<Uuid, CancelReason>,
+    cancel_reasons: HashMap<ConversationKey, CancelReason>,
     /// Events withheld from `queues` while a goose-native steer is in flight
     /// for that event. Invisible to `flush_next` / `has_flushable_work` /
     /// `drain` (the events have been moved out of `queues`), so the queue's
@@ -163,7 +256,25 @@ pub struct EventQueue {
     /// at line 453). Bulk recovery on in-flight deadline expiry is performed
     /// by `flush_next` / `has_flushable_work` (recover, not log-and-drop —
     /// the events were never delivered to the agent).
-    withheld_native_steer: HashMap<Uuid, Vec<QueuedEvent>>,
+    withheld_native_steer: HashMap<ConversationKey, Vec<QueuedEvent>>,
+    /// Current epoch for each logical (channel, root) conversation.
+    generations: HashMap<(Uuid, String), u64>,
+    /// Latest durable reset token for each logical conversation.
+    reset_tokens: HashMap<(Uuid, String), String>,
+    /// Logical conversations whose old checked-out turn must finish disposal
+    /// before the replacement generation can dispatch.
+    reset_barriers: HashSet<(Uuid, String)>,
+    /// Barriers whose old turn has finished. They remain dispatch-blocking
+    /// until the main loop attempts the visible acknowledgement.
+    completed_reset_barriers: HashSet<(Uuid, String)>,
+    /// Channels confirmed as DMs by the metadata resolver. Unthreaded DM
+    /// messages share a stable channel conversation; explicit NIP-10 replies
+    /// remain root-specific.
+    dm_channels: HashSet<Uuid>,
+    /// Whether the configured ACP adapter explicitly supports Buzz's
+    /// per-thread session lifecycle contract. Adapters that omit the
+    /// capability retain the historical one-conversation-per-channel model.
+    thread_sessions_enabled: bool,
     /// Duration after which an in-flight channel is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
@@ -188,8 +299,64 @@ impl EventQueue {
             cancelled_batches: HashMap::new(),
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
+            generations: HashMap::new(),
+            reset_tokens: HashMap::new(),
+            reset_barriers: HashSet::new(),
+            completed_reset_barriers: HashSet::new(),
+            dm_channels: HashSet::new(),
+            thread_sessions_enabled: false,
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
         }
+    }
+
+    /// Select thread-local or legacy channel-local conversation identity.
+    pub fn with_thread_sessions_enabled(mut self, enabled: bool) -> Self {
+        self.thread_sessions_enabled = enabled;
+        self
+    }
+
+    /// Change conversation scoping before any work has entered flight.
+    ///
+    /// Lazy-pool startup receives events before the adapter initializes. Those
+    /// events are temporarily grouped with legacy channel identity, then
+    /// reindexed here once the adapter advertises thread-session support.
+    /// Refusing a transition with lifecycle state prevents split ownership or
+    /// loss of retry/cancellation bookkeeping.
+    pub fn set_thread_sessions_enabled(&mut self, enabled: bool) -> bool {
+        if self.thread_sessions_enabled == enabled {
+            return true;
+        }
+        if !self.in_flight_channels.is_empty()
+            || !self.in_flight_deadlines.is_empty()
+            || !self.in_flight_batch_sizes.is_empty()
+            || !self.retry_after.is_empty()
+            || !self.retry_counts.is_empty()
+            || !self.cancelled_batches.is_empty()
+            || !self.cancel_reasons.is_empty()
+            || !self.withheld_native_steer.is_empty()
+            || !self.generations.is_empty()
+            || !self.reset_tokens.is_empty()
+            || !self.reset_barriers.is_empty()
+            || !self.completed_reset_barriers.is_empty()
+        {
+            tracing::error!(
+                requested = enabled,
+                "refusing to change thread-session scope after lifecycle state was created"
+            );
+            return false;
+        }
+
+        self.thread_sessions_enabled = enabled;
+        let queued = std::mem::take(&mut self.queues);
+        for event in queued.into_values().flatten() {
+            let _ = self.push(event);
+        }
+        true
+    }
+
+    /// Whether messages are isolated by NIP-10 root rather than channel.
+    pub fn thread_sessions_enabled(&self) -> bool {
+        self.thread_sessions_enabled
     }
 
     /// Set the in-flight backstop deadline from the configured max turn
@@ -207,13 +374,32 @@ impl EventQueue {
     /// moves backward. If the channel is not in-flight (already completed
     /// via `mark_complete`), this is a no-op: a late ack never resurrects
     /// a deadline.
+    #[cfg(test)]
     pub fn extend_in_flight_deadline(&mut self, channel_id: Uuid, max_turn_secs: u64) {
-        if let Some(current) = self.in_flight_deadlines.get_mut(&channel_id) {
+        let keys: Vec<_> = self
+            .in_flight_deadlines
+            .keys()
+            .filter(|key| key.channel_id == channel_id)
+            .cloned()
+            .collect();
+        for key in keys {
+            self.extend_conversation_deadline(&key, max_turn_secs);
+        }
+    }
+
+    /// Monotonically extend the deadline for one exact conversation.
+    pub fn extend_conversation_deadline(
+        &mut self,
+        conversation_key: &ConversationKey,
+        max_turn_secs: u64,
+    ) {
+        if let Some(current) = self.in_flight_deadlines.get_mut(conversation_key) {
             let extended = Instant::now()
                 + Duration::from_secs(max_turn_secs + IN_FLIGHT_DEADLINE_BUFFER_SECS);
             if extended > *current {
                 tracing::info!(
-                    %channel_id,
+                    channel_id = %conversation_key.channel_id,
+                    conversation = %conversation_key,
                     "extending in-flight deadline by {max_turn_secs}s + {IN_FLIGHT_DEADLINE_BUFFER_SECS}s buffer"
                 );
                 *current = extended;
@@ -228,27 +414,337 @@ impl EventQueue {
     ///
     /// Returns `true` if the event was accepted, `false` if dropped.
     pub fn push(&mut self, event: QueuedEvent) -> bool {
-        if matches!(self.dedup_mode, DedupMode::Drop)
-            && self.in_flight_channels.contains(&event.channel_id)
-        {
-            tracing::debug!(
+        if !has_valid_thread_identity(&event.event) {
+            tracing::warn!(
                 channel_id = %event.channel_id,
-                "dropping event for in-flight channel (drop mode)"
+                event_id = %event.event.id,
+                "dropping event with malformed or conflicting NIP-10 thread identity"
             );
             return false;
         }
-        let queue = self.queues.entry(event.channel_id).or_default();
+        let conversation_key = self.conversation_key_for_event(event.channel_id, &event.event);
+        if matches!(self.dedup_mode, DedupMode::Drop)
+            && self.in_flight_channels.contains(&conversation_key)
+        {
+            tracing::debug!(
+                channel_id = %event.channel_id,
+                conversation = %conversation_key,
+                "dropping event for in-flight conversation (drop mode)"
+            );
+            return false;
+        }
+        let conversation_known = self.queues.contains_key(&conversation_key)
+            || self.in_flight_channels.contains(&conversation_key)
+            || self.cancelled_batches.contains_key(&conversation_key)
+            || self.withheld_native_steer.contains_key(&conversation_key)
+            || self.retry_after.contains_key(&conversation_key)
+            || self.retry_counts.contains_key(&conversation_key);
+        if !conversation_known && !self.make_room_for_conversation(event.channel_id) {
+            tracing::warn!(
+                channel_id = %event.channel_id,
+                conversation = %conversation_key,
+                "dropping event because all bounded pending conversation slots are active"
+            );
+            return false;
+        }
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         // Enforce per-channel depth cap: drop oldest to make room.
         if queue.len() >= MAX_PENDING_PER_CHANNEL {
             queue.pop_front();
             tracing::warn!(
                 channel_id = %event.channel_id,
+                conversation = %conversation_key,
                 limit = MAX_PENDING_PER_CHANNEL,
-                "queue depth cap reached — dropped oldest event"
+                "conversation queue depth cap reached — dropped oldest event"
             );
         }
         queue.push_back(event);
+        self.enforce_aggregate_event_caps(conversation_key.channel_id);
         true
+    }
+
+    /// Evict the oldest non-active pending conversation when an aggregate
+    /// conversation cap is reached. Active keys are never touched.
+    fn make_room_for_conversation(&mut self, channel_id: Uuid) -> bool {
+        while self
+            .queues
+            .keys()
+            .filter(|key| key.channel_id == channel_id)
+            .count()
+            >= MAX_PENDING_CONVERSATIONS_PER_CHANNEL
+        {
+            if !self.evict_oldest_pending_conversation(Some(channel_id)) {
+                return false;
+            }
+        }
+        while self.queues.len() >= MAX_PENDING_CONVERSATIONS_GLOBAL {
+            if !self.evict_oldest_pending_conversation(None) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn evict_oldest_pending_conversation(&mut self, channel_id: Option<Uuid>) -> bool {
+        let victim = self
+            .queues
+            .iter()
+            .filter(|(key, queue)| {
+                !queue.is_empty()
+                    && !self.in_flight_channels.contains(*key)
+                    && channel_id.is_none_or(|channel| key.channel_id == channel)
+            })
+            .min_by_key(|(_, queue)| queue.front().map(|event| event.received_at))
+            .map(|(key, _)| key.clone());
+        let Some(victim) = victim else {
+            return false;
+        };
+        let dropped = self.queues.remove(&victim).map_or(0, |queue| queue.len());
+        self.retry_after.remove(&victim);
+        self.retry_counts.remove(&victim);
+        self.cancelled_batches.remove(&victim);
+        self.cancel_reasons.remove(&victim);
+        tracing::warn!(
+            channel_id = %victim.channel_id,
+            conversation = %victim,
+            dropped,
+            "pending conversation cap reached — evicted oldest pending conversation"
+        );
+        true
+    }
+
+    fn enforce_aggregate_event_caps(&mut self, channel_id: Uuid) {
+        while self
+            .queues
+            .iter()
+            .filter(|(key, _)| key.channel_id == channel_id)
+            .map(|(_, queue)| queue.len())
+            .sum::<usize>()
+            > MAX_PENDING_EVENTS_PER_CHANNEL
+        {
+            if !self.drop_oldest_pending_event(Some(channel_id)) {
+                break;
+            }
+        }
+        while self.queues.values().map(VecDeque::len).sum::<usize>() > MAX_PENDING_EVENTS_GLOBAL {
+            if !self.drop_oldest_pending_event(None) {
+                break;
+            }
+        }
+    }
+
+    fn drop_oldest_pending_event(&mut self, channel_id: Option<Uuid>) -> bool {
+        let victim = self
+            .queues
+            .iter()
+            .filter(|(key, queue)| {
+                !queue.is_empty() && channel_id.is_none_or(|channel| key.channel_id == channel)
+            })
+            .min_by_key(|(_, queue)| queue.front().map(|event| event.received_at))
+            .map(|(key, _)| key.clone());
+        let Some(victim) = victim else {
+            return false;
+        };
+        if let Some(queue) = self.queues.get_mut(&victim) {
+            queue.pop_front();
+        }
+        if self.queues.get(&victim).is_some_and(VecDeque::is_empty) {
+            self.queues.remove(&victim);
+        }
+        tracing::warn!(
+            channel_id = %victim.channel_id,
+            conversation = %victim,
+            "aggregate pending-event cap reached — dropped oldest event"
+        );
+        true
+    }
+
+    /// Resolve an event to the current generation of its Buzz thread.
+    pub fn conversation_key_for_event(&self, channel_id: Uuid, event: &Event) -> ConversationKey {
+        let mut key = if self.thread_sessions_enabled {
+            ConversationKey::for_event_with_dm_scope(
+                channel_id,
+                event,
+                self.dm_channels.contains(&channel_id),
+            )
+        } else {
+            ConversationKey {
+                channel_id,
+                root_event_id: format!("channel:{channel_id}"),
+                generation: 0,
+                reset_token: None,
+            }
+        };
+        let identity = (channel_id, key.root_event_id.clone());
+        key.generation = self.generations.get(&identity).copied().unwrap_or(0);
+        key.reset_token = self.reset_tokens.get(&identity).cloned();
+        key
+    }
+
+    /// Record authoritative channel metadata used for conversation scoping.
+    pub fn set_channel_is_dm(&mut self, channel_id: Uuid, is_dm: bool) {
+        if is_dm {
+            self.dm_channels.insert(channel_id);
+        } else {
+            self.dm_channels.remove(&channel_id);
+        }
+    }
+
+    /// Atomically advance a thread to a fresh context generation.
+    ///
+    /// Pending work and retry/steer side state from the old generation are
+    /// dropped. Any old in-flight turn remains tracked under its old key until
+    /// completion, while new events immediately route to the returned key.
+    #[cfg(test)]
+    pub fn reset_conversation(
+        &mut self,
+        old: &ConversationKey,
+        reset_token: String,
+    ) -> Result<ConversationKey, ResetConversationError> {
+        let prepared = self.prepare_reset_conversation(old)?;
+        Ok(self.commit_prepared_reset(prepared, reset_token))
+    }
+
+    /// Reserve bounded generation metadata before an external adapter reset is
+    /// durably committed. This lets the caller guarantee that no fallible local
+    /// capacity check remains after Pi has forgotten the old conversation.
+    pub(crate) fn prepare_reset_conversation(
+        &mut self,
+        old: &ConversationKey,
+    ) -> Result<PreparedConversationReset, ResetConversationError> {
+        let identity = (old.channel_id, old.root_event_id.clone());
+        if self.reset_barriers.contains(&identity)
+            || self.completed_reset_barriers.contains(&identity)
+        {
+            return Err(ResetConversationError::ResetInProgress);
+        }
+        if !self.generations.contains_key(&identity)
+            && self.generations.len() >= MAX_GENERATION_ENTRIES
+        {
+            let victim = self
+                .generations
+                .keys()
+                .find(|candidate| !self.identity_has_queue_lifecycle_state(candidate))
+                .cloned();
+            if let Some(victim) = victim {
+                self.generations.remove(&victim);
+                self.reset_tokens.remove(&victim);
+                self.completed_reset_barriers.remove(&victim);
+                tracing::warn!(
+                    channel_id = %victim.0,
+                    root_event_id = %victim.1,
+                    limit = MAX_GENERATION_ENTRIES,
+                    "generation metadata cap reached — evicted an inactive identity"
+                );
+            } else {
+                tracing::error!(
+                    limit = MAX_GENERATION_ENTRIES,
+                    "generation metadata cap reached with no inactive identity to evict"
+                );
+                return Err(ResetConversationError::MetadataCapacity);
+            }
+        }
+
+        Ok(PreparedConversationReset { old: old.clone() })
+    }
+
+    /// Apply a reset whose metadata capacity was reserved by
+    /// [`prepare_reset_conversation`](Self::prepare_reset_conversation).
+    pub(crate) fn commit_prepared_reset(
+        &mut self,
+        prepared: PreparedConversationReset,
+        reset_token: String,
+    ) -> ConversationKey {
+        let old = prepared.old;
+        let identity = (old.channel_id, old.root_event_id.clone());
+
+        let waits_for_old_turn =
+            self.in_flight_channels.contains(&old) || self.reset_barriers.contains(&identity);
+
+        self.queues.remove(&old);
+        self.retry_after.remove(&old);
+        self.retry_counts.remove(&old);
+        self.cancelled_batches.remove(&old);
+        self.cancel_reasons.remove(&old);
+        self.withheld_native_steer.remove(&old);
+
+        let generation = self.generations.entry(identity).or_insert(old.generation);
+        *generation = generation.saturating_add(1);
+        let new_generation = *generation;
+        let identity = (old.channel_id, old.root_event_id.clone());
+        self.reset_tokens
+            .insert(identity.clone(), reset_token.clone());
+        if waits_for_old_turn {
+            self.completed_reset_barriers.remove(&identity);
+            self.reset_barriers.insert(identity);
+        } else {
+            // Even an idle reset stays gated until its signed Buzz
+            // acknowledgement is accepted. This makes lifecycle awareness a
+            // delivery contract rather than a best-effort side effect.
+            self.reset_barriers.remove(&identity);
+            self.completed_reset_barriers.insert(identity);
+        }
+        ConversationKey {
+            channel_id: old.channel_id,
+            root_event_id: old.root_event_id,
+            generation: new_generation,
+            reset_token: Some(reset_token),
+        }
+    }
+
+    fn identity_has_queue_lifecycle_state(&self, identity: &(Uuid, String)) -> bool {
+        let matches =
+            |key: &ConversationKey| key.channel_id == identity.0 && key.root_event_id == identity.1;
+        self.queues.keys().any(&matches)
+            || self.in_flight_channels.iter().any(&matches)
+            || self.retry_after.keys().any(&matches)
+            || self.retry_counts.keys().any(&matches)
+            || self.cancelled_batches.keys().any(&matches)
+            || self.cancel_reasons.keys().any(&matches)
+            || self.withheld_native_steer.keys().any(matches)
+            || self.reset_barriers.contains(identity)
+            || self.completed_reset_barriers.contains(identity)
+    }
+
+    /// Whether `key` is still the authoritative epoch for its logical thread.
+    pub fn is_current_conversation(&self, key: &ConversationKey) -> bool {
+        self.generations
+            .get(&(key.channel_id, key.root_event_id.clone()))
+            .copied()
+            .unwrap_or(0)
+            == key.generation
+    }
+
+    /// Reset barriers whose old turns have completed and are awaiting a
+    /// visible acknowledgement from the main loop.
+    pub fn completed_resets(&self) -> Vec<(Uuid, String)> {
+        self.completed_reset_barriers.iter().cloned().collect()
+    }
+
+    /// Restore a crash-durable reset acknowledgement barrier before relay
+    /// intake starts. The adapter mapping was already reset transactionally;
+    /// this identity-only gate prevents new work in that Buzz thread until the
+    /// original signed success event is accepted.
+    pub(crate) fn restore_completed_reset_barrier(&mut self, identity: (Uuid, String)) {
+        self.reset_barriers.remove(&identity);
+        self.completed_reset_barriers.insert(identity);
+    }
+
+    /// Release a completed reset after its acknowledgement was attempted.
+    pub fn release_completed_reset(&mut self, identity: &(Uuid, String)) -> bool {
+        self.completed_reset_barriers.remove(identity)
+    }
+
+    fn reset_blocks_key(&self, key: &ConversationKey) -> bool {
+        let identity = (key.channel_id, key.root_event_id.clone());
+        self.reset_barriers.contains(&identity) || self.completed_reset_barriers.contains(&identity)
+    }
+
+    fn finish_reset_barrier(&mut self, key: &ConversationKey) {
+        let identity = (key.channel_id, key.root_event_id.clone());
+        if self.reset_barriers.remove(&identity) {
+            self.completed_reset_barriers.insert(identity);
+        }
     }
 
     /// Try to flush the next batch.
@@ -257,20 +753,33 @@ impl EventQueue {
     /// Otherwise picks the channel with the oldest pending event (FIFO fairness
     /// across channels), drains ALL events for that channel into a single batch,
     /// inserts into `in_flight_channels`, and returns the batch.
+    #[cfg(test)]
     pub fn flush_next(&mut self) -> Option<FlushBatch> {
+        self.flush_next_excluding(&HashSet::new())
+    }
+
+    /// Flush the oldest eligible conversation except keys that dispatch has
+    /// already found temporarily affinity-blocked during this scheduling pass.
+    /// This prevents one busy thread owner from head-of-line blocking sibling
+    /// threads that could run on other idle agents.
+    pub(crate) fn flush_next_excluding(
+        &mut self,
+        excluded: &HashSet<ConversationKey>,
+    ) -> Option<FlushBatch> {
         let now = Instant::now();
 
         // Auto-expire any stuck in-flight entries that missed mark_complete.
-        let expired: Vec<Uuid> = self
+        let expired: Vec<ConversationKey> = self
             .in_flight_deadlines
             .iter()
             .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
+            .map(|(id, _)| id.clone())
             .collect();
         for id in expired {
             let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
             tracing::error!(
-                channel_id = %id,
+                channel_id = %id.channel_id,
+                conversation = %id,
                 lost_events,
                 deadline_secs = self.in_flight_deadline.as_secs(),
                 "BUG: in-flight channel expired without mark_complete — \
@@ -278,50 +787,59 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
+            self.finish_reset_barrier(&id);
             // Recover any withheld goose-native steer events for the expired
             // channel back to the queue front so normal dispatch delivers
             // them. Unlike the in-flight batch above (already delivered to a
             // now-hung prompt — nothing to recover), these events were never
             // delivered to the agent.
-            self.recover_withheld_for_expired_channel(id);
+            self.recover_withheld_for_expired_conversation(&id);
         }
 
         // Find the channel whose head event has the oldest received_at,
         // excluding in-flight channels and throttled channels.
-        let channel_id = self
+        let conversation_key = self
             .queues
             .iter()
             .filter(|(id, q)| {
                 !q.is_empty()
                     && !self.in_flight_channels.contains(id)
+                    && !excluded.contains(id)
+                    && !self.reset_blocks_key(id)
                     && self.retry_after.get(id).is_none_or(|&t| t <= now)
             })
             .min_by_key(|(_, q)| q.front().unwrap().received_at)
-            .map(|(id, _)| *id);
+            .map(|(id, _)| id.clone());
 
         // Fallback: if no queued events are ready but a channel has cancelled
         // events waiting (e.g., explicit !cancel with no new @mention), flush
         // those as a regular batch (re-dispatch unchanged).
-        let channel_id = match channel_id {
+        let conversation_key = match conversation_key {
             Some(id) => id,
             None => {
                 let cancelled_id = self
                     .cancelled_batches
                     .keys()
-                    .find(|id| !self.in_flight_channels.contains(id))
-                    .copied();
+                    .find(|id| {
+                        !self.in_flight_channels.contains(*id)
+                            && !excluded.contains(*id)
+                            && !self.reset_blocks_key(id)
+                    })
+                    .cloned();
                 match cancelled_id {
                     Some(id) => {
                         // Move cancelled events into the regular events slot.
                         // No new events to merge — re-dispatch the original batch.
                         let cancelled = self.cancelled_batches.remove(&id).unwrap_or_default();
                         let cancel_reason = self.cancel_reasons.remove(&id);
-                        self.in_flight_channels.insert(id);
+                        self.in_flight_channels.insert(id.clone());
                         self.in_flight_deadlines
-                            .insert(id, now + self.in_flight_deadline);
-                        self.in_flight_batch_sizes.insert(id, cancelled.len());
+                            .insert(id.clone(), now + self.in_flight_deadline);
+                        self.in_flight_batch_sizes
+                            .insert(id.clone(), cancelled.len());
                         return Some(FlushBatch {
-                            channel_id: id,
+                            channel_id: id.channel_id,
+                            conversation_key: id,
                             events: cancelled,
                             cancelled_events: vec![],
                             cancel_reason,
@@ -333,7 +851,8 @@ impl EventQueue {
         };
 
         // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
-        let queue = self.queues.entry(channel_id).or_default();
+        let channel_id = conversation_key.channel_id;
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         let drain_count = MAX_BATCH_EVENTS.min(queue.len());
         let mut events: Vec<BatchEvent> = queue
             .drain(..drain_count)
@@ -350,29 +869,35 @@ impl EventQueue {
         events.sort_by_key(|be| be.event.created_at);
 
         // Remove the queue entry if now empty.
-        if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {
-            self.queues.remove(&channel_id);
+        if self
+            .queues
+            .get(&conversation_key)
+            .is_some_and(|q| q.is_empty())
+        {
+            self.queues.remove(&conversation_key);
         }
 
-        self.in_flight_channels.insert(channel_id);
+        self.in_flight_channels.insert(conversation_key.clone());
         self.in_flight_deadlines
-            .insert(channel_id, now + self.in_flight_deadline);
-        self.in_flight_batch_sizes.insert(channel_id, events.len());
+            .insert(conversation_key.clone(), now + self.in_flight_deadline);
+        self.in_flight_batch_sizes
+            .insert(conversation_key.clone(), events.len());
 
         // Merge any cancelled events stored by requeue_as_cancelled().
         let cancelled_events = self
             .cancelled_batches
-            .remove(&channel_id)
+            .remove(&conversation_key)
             .unwrap_or_default();
         let cancel_reason = if cancelled_events.is_empty() {
-            self.cancel_reasons.remove(&channel_id);
+            self.cancel_reasons.remove(&conversation_key);
             None
         } else {
-            self.cancel_reasons.remove(&channel_id)
+            self.cancel_reasons.remove(&conversation_key)
         };
 
         Some(FlushBatch {
             channel_id,
+            conversation_key,
             events,
             cancelled_events,
             cancel_reason,
@@ -390,21 +915,35 @@ impl EventQueue {
     ///
     /// Also cleans up any already-expired `retry_after` entry.
     pub fn mark_complete(&mut self, channel_id: Uuid) {
-        self.in_flight_channels.remove(&channel_id);
-        self.in_flight_deadlines.remove(&channel_id);
-        self.in_flight_batch_sizes.remove(&channel_id);
+        let keys: Vec<_> = self
+            .in_flight_channels
+            .iter()
+            .filter(|key| key.channel_id == channel_id)
+            .cloned()
+            .collect();
+        for key in keys {
+            self.mark_conversation_complete(&key);
+        }
+    }
+
+    /// Mark one exact thread conversation complete.
+    pub fn mark_conversation_complete(&mut self, conversation_key: &ConversationKey) {
+        self.in_flight_channels.remove(conversation_key);
+        self.in_flight_deadlines.remove(conversation_key);
+        self.in_flight_batch_sizes.remove(conversation_key);
+        self.finish_reset_barrier(conversation_key);
         let now = Instant::now();
-        match self.retry_after.get(&channel_id) {
+        match self.retry_after.get(conversation_key) {
             // Active throttle → channel was requeued; keep retry_counts intact.
             Some(&deadline) if deadline > now => {}
             // Expired or absent throttle → successful completion; reset counter
             // and clean up the stale retry_after entry.
             Some(_) => {
-                self.retry_after.remove(&channel_id);
-                self.retry_counts.remove(&channel_id);
+                self.retry_after.remove(conversation_key);
+                self.retry_counts.remove(conversation_key);
             }
             None => {
-                self.retry_counts.remove(&channel_id);
+                self.retry_counts.remove(conversation_key);
             }
         }
     }
@@ -428,8 +967,12 @@ impl EventQueue {
     /// `mark_complete` separately.
     pub fn requeue(&mut self, batch: FlushBatch) -> Option<FlushBatch> {
         let channel_id = batch.channel_id;
+        let conversation_key = batch.conversation_key.clone();
         let attempt = {
-            let count = self.retry_counts.entry(channel_id).or_insert(0);
+            let count = self
+                .retry_counts
+                .entry(conversation_key.clone())
+                .or_insert(0);
             *count += 1;
             *count
         };
@@ -437,16 +980,17 @@ impl EventQueue {
         if attempt > MAX_RETRIES {
             tracing::error!(
                 channel_id = %channel_id,
+                conversation = %conversation_key,
                 attempt,
                 events = batch.events.len(),
                 "dead-lettering batch after {} retries — discarding {} events",
                 MAX_RETRIES,
                 batch.events.len(),
             );
-            self.retry_counts.remove(&channel_id);
+            self.retry_counts.remove(&conversation_key);
             // Also clear retry_after so fresh traffic on this channel isn't
             // throttled by stale backoff from the discarded poison batch.
-            self.retry_after.remove(&channel_id);
+            self.retry_after.remove(&conversation_key);
             return Some(batch);
         }
 
@@ -465,6 +1009,7 @@ impl EventQueue {
 
         tracing::warn!(
             channel_id = %channel_id,
+            conversation = %conversation_key,
             attempt,
             max = MAX_RETRIES,
             delay_secs = delay.as_secs_f64(),
@@ -472,7 +1017,7 @@ impl EventQueue {
             "requeueing failed batch with backoff"
         );
 
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
@@ -493,7 +1038,9 @@ impl EventQueue {
                 "requeue overflow — dropped oldest event to enforce cap"
             );
         }
-        self.retry_after.insert(channel_id, Instant::now() + delay);
+        self.retry_after
+            .insert(conversation_key, Instant::now() + delay);
+        self.enforce_aggregate_event_caps(channel_id);
         None
     }
 
@@ -505,9 +1052,12 @@ impl EventQueue {
     ///
     /// Does NOT set `retry_after`. Does NOT remove from `in_flight_channels` —
     /// caller must call `mark_complete` separately.
-    pub fn requeue_preserve_timestamps(&mut self, batch: FlushBatch) {
+    pub fn requeue_preserve_timestamps(&mut self, mut batch: FlushBatch) {
         let channel_id = batch.channel_id;
-        let queue = self.queues.entry(channel_id).or_default();
+        let conversation_key = batch.conversation_key.clone();
+        let cancelled_events = std::mem::take(&mut batch.cancelled_events);
+        let cancel_reason = batch.cancel_reason;
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
@@ -522,10 +1072,43 @@ impl EventQueue {
             queue.pop_back();
             tracing::warn!(
                 channel_id = %channel_id,
+                conversation = %conversation_key,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "requeue_preserve overflow — dropped newest event to enforce cap"
             );
         }
+        if !cancelled_events.is_empty() {
+            self.cancelled_batches
+                .entry(conversation_key.clone())
+                .or_default()
+                .extend(cancelled_events);
+            if let Some(reason) = cancel_reason {
+                self.cancel_reasons.insert(conversation_key, reason);
+            }
+        }
+        self.enforce_aggregate_event_caps(channel_id);
+    }
+
+    /// Preserve a batch behind a fixed retry gate without consuming the normal
+    /// failure/dead-letter budget.
+    ///
+    /// This is reserved for local safety prerequisites such as a temporarily
+    /// unwritable durable notice outbox. The user's request did not fail in the
+    /// agent and must never become a poison batch merely because disk recovery
+    /// took longer than [`MAX_RETRIES`]. The caller still marks the in-flight
+    /// conversation complete after installing this gate.
+    pub fn requeue_blocked(&mut self, batch: FlushBatch, delay: Duration) {
+        let channel_id = batch.channel_id;
+        let conversation_key = batch.conversation_key.clone();
+        self.requeue_preserve_timestamps(batch);
+        self.retry_after
+            .insert(conversation_key.clone(), Instant::now() + delay);
+        tracing::error!(
+            %channel_id,
+            conversation = %conversation_key,
+            delay_secs = delay.as_secs_f64(),
+            "preserving batch behind a local safety-prerequisite retry gate"
+        );
     }
 
     /// Requeue a cancelled batch so its events appear as `cancelled_events`
@@ -540,11 +1123,25 @@ impl EventQueue {
     /// the generic queue — they are stored separately and merged by
     /// `flush_next()`. No retry throttle, no backoff.
     pub fn requeue_as_cancelled(&mut self, batch: FlushBatch, reason: CancelReason) {
-        let entry = self.cancelled_batches.entry(batch.channel_id).or_default();
+        let conversation_key = batch.conversation_key.clone();
+        let entry = self
+            .cancelled_batches
+            .entry(conversation_key.clone())
+            .or_default();
         // Preserve any already-cancelled events from a prior cancel (double-cancel).
         entry.extend(batch.cancelled_events);
         entry.extend(batch.events);
-        self.cancel_reasons.insert(batch.channel_id, reason);
+        if entry.len() > MAX_PENDING_PER_CHANNEL {
+            let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
+            entry.drain(..overflow);
+            tracing::warn!(
+                channel_id = %batch.channel_id,
+                conversation = %conversation_key,
+                dropped = overflow,
+                "cancelled-event cap reached — dropped oldest carried-over events"
+            );
+        }
+        self.cancel_reasons.insert(conversation_key, reason);
     }
 
     /// Returns `true` if any channel has pending events that are not in-flight
@@ -557,16 +1154,17 @@ impl EventQueue {
         let now = Instant::now();
 
         // Auto-expire stuck in-flight entries (same logic as flush_next).
-        let expired: Vec<Uuid> = self
+        let expired: Vec<ConversationKey> = self
             .in_flight_deadlines
             .iter()
             .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
+            .map(|(id, _)| id.clone())
             .collect();
         for id in expired {
             let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
             tracing::error!(
-                channel_id = %id,
+                channel_id = %id.channel_id,
+                conversation = %id,
                 lost_events,
                 deadline_secs = self.in_flight_deadline.as_secs(),
                 "BUG: in-flight channel expired without mark_complete — \
@@ -574,20 +1172,22 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
+            self.finish_reset_barrier(&id);
             // Symmetric with the flush_next expiry block: recover withheld
             // goose-native steer events for the expired channel so they are
             // not permanently orphaned in the side table.
-            self.recover_withheld_for_expired_channel(id);
+            self.recover_withheld_for_expired_conversation(&id);
         }
 
         self.queues.iter().any(|(id, q)| {
             !q.is_empty()
                 && !self.in_flight_channels.contains(id)
+                && !self.reset_blocks_key(id)
                 && self.retry_after.get(id).is_none_or(|&t| t <= now)
         }) || self
             .cancelled_batches
             .keys()
-            .any(|id| !self.in_flight_channels.contains(id))
+            .any(|id| !self.in_flight_channels.contains(id) && !self.reset_blocks_key(id))
     }
 
     /// Number of channels with pending events.
@@ -598,7 +1198,11 @@ impl EventQueue {
     /// Number of queued events for a specific channel. Test-only.
     #[cfg(test)]
     pub fn queued_event_count(&self, channel_id: &Uuid) -> usize {
-        self.queues.get(channel_id).map_or(0, |q| q.len())
+        self.queues
+            .iter()
+            .filter(|(key, _)| key.channel_id == *channel_id)
+            .map(|(_, q)| q.len())
+            .sum()
     }
 
     /// Force a channel's retry-attempt counter to `count`, simulating `count`
@@ -608,7 +1212,18 @@ impl EventQueue {
     /// `requeue()`'s dead-letter threshold directly.
     #[cfg(test)]
     pub fn set_retry_count_for_test(&mut self, channel_id: Uuid, count: u32) {
-        self.retry_counts.insert(channel_id, count);
+        let key = self
+            .queues
+            .keys()
+            .find(|key| key.channel_id == channel_id)
+            .cloned()
+            .unwrap_or_else(|| ConversationKey {
+                channel_id,
+                root_event_id: format!("channel:{channel_id}"),
+                generation: 0,
+                reset_token: None,
+            });
+        self.retry_counts.insert(key, count);
     }
 
     /// Drop all queued (non-in-flight) events for a channel.
@@ -623,27 +1238,52 @@ impl EventQueue {
     /// Returns the event IDs of dropped events so the caller can clean up
     /// any reactions (👀) that were added at queue-push time.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
-        let ids = self
+        let keys: Vec<_> = self
             .queues
-            .remove(&channel_id)
-            .map(|q| q.into_iter().map(|e| e.event.id.to_hex()).collect())
-            .unwrap_or_default();
-        self.retry_after.remove(&channel_id);
-        self.retry_counts.remove(&channel_id);
-        self.cancelled_batches.remove(&channel_id);
-        self.cancel_reasons.remove(&channel_id);
-        self.withheld_native_steer.remove(&channel_id);
+            .keys()
+            .chain(self.cancelled_batches.keys())
+            .chain(self.withheld_native_steer.keys())
+            .chain(self.retry_after.keys())
+            .chain(self.retry_counts.keys())
+            .chain(self.cancel_reasons.keys())
+            .filter(|key| key.channel_id == channel_id)
+            .cloned()
+            .collect();
+        let mut ids = HashSet::new();
+        for key in keys {
+            if let Some(q) = self.queues.remove(&key) {
+                ids.extend(q.into_iter().map(|e| e.event.id.to_hex()));
+            }
+            if let Some(events) = self.cancelled_batches.remove(&key) {
+                ids.extend(events.into_iter().map(|event| event.event.id.to_hex()));
+            }
+            if let Some(events) = self.withheld_native_steer.remove(&key) {
+                ids.extend(events.into_iter().map(|event| event.event.id.to_hex()));
+            }
+            self.retry_after.remove(&key);
+            self.retry_counts.remove(&key);
+            self.cancel_reasons.remove(&key);
+        }
+        self.generations
+            .retain(|(candidate_channel, _), _| *candidate_channel != channel_id);
+        self.reset_tokens
+            .retain(|(candidate_channel, _), _| *candidate_channel != channel_id);
+        self.reset_barriers
+            .retain(|(candidate_channel, _)| *candidate_channel != channel_id);
+        self.completed_reset_barriers
+            .retain(|(candidate_channel, _)| *candidate_channel != channel_id);
+        self.dm_channels.remove(&channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
         // removing in_flight_channels would disable auto-expiry and leave a
         // wedged task permanently blocking the channel.
-        ids
+        ids.into_iter().collect()
     }
 
-    /// Whether a prompt is currently in-flight for the given channel.
-    pub fn is_channel_in_flight(&self, channel_id: Uuid) -> bool {
-        self.in_flight_channels.contains(&channel_id)
+    /// Whether one exact conversation currently has a prompt in flight.
+    pub fn is_conversation_in_flight(&self, conversation_key: &ConversationKey) -> bool {
+        self.in_flight_channels.contains(conversation_key)
     }
 
     /// Whether any channel currently has a turn in flight.
@@ -675,8 +1315,28 @@ impl EventQueue {
     /// after `pool.send_steer` returns `Ok(())` and before any watcher task
     /// is spawned, so the withhold is established before `mark_complete` /
     /// any subsequent `flush_next` tick can run.
+    #[cfg(test)]
     pub fn mark_native_steer_pending(&mut self, channel_id: Uuid, event_id: &str) -> bool {
-        let Some(q) = self.queues.get_mut(&channel_id) else {
+        let Some(key) = self
+            .queues
+            .iter()
+            .find(|(key, q)| {
+                key.channel_id == channel_id && q.iter().any(|qe| qe.event.id.to_hex() == event_id)
+            })
+            .map(|(key, _)| key.clone())
+        else {
+            return false;
+        };
+        self.mark_conversation_native_steer_pending(&key, event_id)
+    }
+
+    /// Withhold a queued event from one exact conversation during a native steer.
+    pub fn mark_conversation_native_steer_pending(
+        &mut self,
+        conversation_key: &ConversationKey,
+        event_id: &str,
+    ) -> bool {
+        let Some(q) = self.queues.get_mut(conversation_key) else {
             return false;
         };
         let Some(pos) = q.iter().position(|qe| qe.event.id.to_hex() == event_id) else {
@@ -686,10 +1346,10 @@ impl EventQueue {
             .remove(pos)
             .expect("position came from iter so remove must succeed");
         if q.is_empty() {
-            self.queues.remove(&channel_id);
+            self.queues.remove(conversation_key);
         }
         self.withheld_native_steer
-            .entry(channel_id)
+            .entry(conversation_key.clone())
             .or_default()
             .push(qe);
         true
@@ -705,8 +1365,29 @@ impl EventQueue {
     ///
     /// Push-to-front matches the discipline of `requeue_preserve_timestamps`
     /// at line 453, preserving fairness across channels.
+    #[cfg(test)]
     pub fn release_native_steer(&mut self, channel_id: Uuid, event_id: &str) {
-        let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) else {
+        let Some(key) = self
+            .withheld_native_steer
+            .iter()
+            .find(|(key, entries)| {
+                key.channel_id == channel_id
+                    && entries.iter().any(|qe| qe.event.id.to_hex() == event_id)
+            })
+            .map(|(key, _)| key.clone())
+        else {
+            return;
+        };
+        self.release_conversation_native_steer(&key, event_id);
+    }
+
+    /// Release a withheld event into its exact conversation queue.
+    pub fn release_conversation_native_steer(
+        &mut self,
+        conversation_key: &ConversationKey,
+        event_id: &str,
+    ) {
+        let Some(entries) = self.withheld_native_steer.get_mut(conversation_key) else {
             return;
         };
         let Some(pos) = entries
@@ -717,40 +1398,40 @@ impl EventQueue {
         };
         let qe = entries.remove(pos);
         if entries.is_empty() {
-            self.withheld_native_steer.remove(&channel_id);
+            self.withheld_native_steer.remove(conversation_key);
         }
         // Push to FRONT so original `received_at` keeps the event at the head
         // of the channel's queue. Per-channel cap is enforced below in case
         // a flood of events arrived during the ack window.
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         queue.push_front(qe);
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                channel_id = %conversation_key.channel_id,
+                conversation = %conversation_key,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "release_native_steer overflow — dropped newest event to enforce cap"
             );
         }
     }
 
-    /// Drop a specific event by id from both the side table and the main
-    /// queue.
-    ///
-    /// Called on `SteerAck::Success` — the agent received the steer, so the
-    /// event has been "delivered" via the non-cancelling path and must not
-    /// be redelivered via normal dispatch. Idempotent across both stores.
-    pub fn remove_event(&mut self, channel_id: Uuid, event_id: &str) {
-        if let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) {
+    /// Drop an event only from its exact conversation.
+    pub fn remove_conversation_event(
+        &mut self,
+        conversation_key: &ConversationKey,
+        event_id: &str,
+    ) {
+        if let Some(entries) = self.withheld_native_steer.get_mut(conversation_key) {
             entries.retain(|qe| qe.event.id.to_hex() != event_id);
             if entries.is_empty() {
-                self.withheld_native_steer.remove(&channel_id);
+                self.withheld_native_steer.remove(conversation_key);
             }
         }
-        if let Some(q) = self.queues.get_mut(&channel_id) {
+        if let Some(q) = self.queues.get_mut(conversation_key) {
             q.retain(|qe| qe.event.id.to_hex() != event_id);
             if q.is_empty() {
-                self.queues.remove(&channel_id);
+                self.queues.remove(conversation_key);
             }
         }
     }
@@ -768,25 +1449,27 @@ impl EventQueue {
     /// Iterates the stored entries in reverse so per-entry `push_front`
     /// composes to original-FIFO order at the queue front (same discipline
     /// as `requeue_preserve_timestamps` at line 453).
-    fn recover_withheld_for_expired_channel(&mut self, channel_id: Uuid) {
-        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+    fn recover_withheld_for_expired_conversation(&mut self, conversation_key: &ConversationKey) {
+        let Some(entries) = self.withheld_native_steer.remove(conversation_key) else {
             return;
         };
         let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(conversation_key.clone()).or_default();
         for qe in entries.into_iter().rev() {
             queue.push_front(qe);
         }
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                channel_id = %conversation_key.channel_id,
+                conversation = %conversation_key,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "withheld-steer recovery overflow — dropped newest event to enforce cap"
             );
         }
         tracing::warn!(
-            channel_id = %channel_id,
+            channel_id = %conversation_key.channel_id,
+            conversation = %conversation_key,
             recovered = n,
             "in-flight expiry recovered withheld steer event(s) — \
              steer ack never arrived; normal dispatch will deliver"
@@ -860,11 +1543,17 @@ pub fn parse_thread_tags(event: &Event) -> ThreadTags {
         let parts = tag.as_slice();
         match parts.first().map(|s| s.as_str()) {
             Some("e") if parts.len() >= 4 => {
-                let id = &parts[1];
+                // Canonicalize valid IDs so equivalent upper/lowercase hex
+                // cannot split queue or session identity. Invalid values are
+                // retained for diagnostics; intake rejects them through
+                // `has_valid_thread_identity` before this result is trusted.
+                let id = nostr::EventId::from_hex(&parts[1])
+                    .map(|event_id| event_id.to_hex())
+                    .unwrap_or_else(|_| parts[1].clone());
                 let marker = &parts[3];
                 match marker.as_str() {
                     "root" => root = Some(id.clone()),
-                    "reply" => reply = Some(id.clone()),
+                    "reply" => reply = Some(id),
                     _ => {}
                 }
             }
@@ -889,6 +1578,55 @@ pub fn parse_thread_tags(event: &Event) -> ThreadTags {
         parent_event_id,
         mentioned_pubkeys: mentions,
     }
+}
+
+/// Validate the marker-bearing NIP-10 tags that define conversation identity.
+///
+/// Buzz uses those values as queue/session keys and as relay query parameters,
+/// so accepting malformed or conflicting roots would let one event be routed
+/// differently at different layers. Duplicate markers are permitted only when
+/// they repeat the same canonical event id.
+pub fn has_valid_thread_identity(event: &Event) -> bool {
+    let mut root: Option<String> = None;
+    let mut reply: Option<String> = None;
+
+    for tag in event.tags.iter() {
+        let parts = tag.as_slice();
+        if parts.first().map(String::as_str) != Some("e") || parts.len() < 4 {
+            continue;
+        }
+
+        let marker = parts[3].as_str();
+        if marker != "root" && marker != "reply" {
+            continue;
+        }
+
+        let event_id = parts[1].as_str();
+        if event_id.len() != 64
+            || !event_id
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        {
+            return false;
+        }
+        let Ok(event_id) = nostr::EventId::from_hex(event_id) else {
+            return false;
+        };
+        let canonical = event_id.to_hex();
+
+        let identity = if marker == "root" {
+            &mut root
+        } else {
+            &mut reply
+        };
+        match identity {
+            Some(existing) if *existing != canonical => return false,
+            Some(_) => {}
+            None => *identity = Some(canonical),
+        }
+    }
+
+    true
 }
 
 /// Extract a leading slash command from message content.
@@ -1636,6 +2374,15 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Timestamp};
     use std::time::Duration;
 
+    fn test_conversation_key(channel_id: Uuid) -> ConversationKey {
+        ConversationKey {
+            channel_id,
+            root_event_id: format!("channel:{channel_id}"),
+            generation: 0,
+            reset_token: None,
+        }
+    }
+
     /// Build a test event with the given content and kind.
     fn make_event(content: &str) -> Event {
         let keys = Keys::generate();
@@ -1873,6 +2620,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -1903,6 +2651,7 @@ mod tests {
         let ch = Uuid::new_v4();
         FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event: make_event("the new message"),
                 prompt_tag: "@mention".into(),
@@ -2034,6 +2783,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![
                 BatchEvent {
                     event: make_event("new one"),
@@ -2091,6 +2841,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event: steering,
                 prompt_tag: "@mention".into(),
@@ -2142,7 +2893,7 @@ mod tests {
         queue.mark_complete(ch);
 
         // retry_after is set, so manually clear it for this test.
-        queue.retry_after.remove(&ch);
+        queue.retry_after.remove(&test_conversation_key(ch));
 
         // Should be able to flush again and get the same events in order.
         let batch2 = queue.flush_next().unwrap();
@@ -2183,6 +2934,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![
                 BatchEvent {
                     event: e1,
@@ -2223,6 +2975,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2246,6 +2999,7 @@ mod tests {
         let event = make_event("hi");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2278,6 +3032,7 @@ mod tests {
         let event = make_event("hi");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2308,6 +3063,7 @@ mod tests {
         let event = make_event("hi");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2335,6 +3091,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2359,6 +3116,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2415,6 +3173,7 @@ mod tests {
 
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2453,6 +3212,7 @@ mod tests {
         let event = make_event("hello");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -2665,8 +3425,8 @@ mod tests {
         // Complete only A.
         q.mark_complete(ch_a);
         assert_eq!(q.in_flight_channels.len(), 1);
-        assert!(q.in_flight_channels.contains(&ch_b));
-        assert!(!q.in_flight_channels.contains(&ch_a));
+        assert!(q.in_flight_channels.contains(&test_conversation_key(ch_b)));
+        assert!(!q.in_flight_channels.contains(&test_conversation_key(ch_a)));
 
         // B still in-flight.
         assert!(any_in_flight(&q));
@@ -2712,8 +3472,40 @@ mod tests {
         q.mark_complete(ch);
 
         // No retry_after — channel should be immediately flushable.
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_after.contains_key(&test_conversation_key(ch)));
         assert!(q.flush_next().is_some());
+    }
+
+    #[test]
+    fn blocked_requeue_never_consumes_or_dead_letters_retry_budget() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let key = test_conversation_key(ch);
+        q.push(make_queued(ch, "must-survive-local-disk-failure"));
+        let batch = q.flush_next().expect("flush");
+
+        // Simulate more local prerequisite failures than the normal agent
+        // poison-batch budget. Each cycle reuses the exact batch only to prove
+        // the operation itself never increments or dead-letters that budget.
+        q.retry_counts.insert(key.clone(), MAX_RETRIES);
+        q.requeue_blocked(batch, Duration::from_secs(30));
+        q.mark_complete(ch);
+
+        assert_eq!(q.retry_counts.get(&key), Some(&MAX_RETRIES));
+        assert_eq!(pending_count(&q), 1);
+        assert!(q.retry_after.contains_key(&key));
+        for _ in 0..(MAX_RETRIES + 5) {
+            let batch = FlushBatch {
+                channel_id: ch,
+                conversation_key: key.clone(),
+                events: Vec::new(),
+                cancelled_events: Vec::new(),
+                cancel_reason: None,
+            };
+            q.requeue_blocked(batch, Duration::from_secs(30));
+            assert_eq!(q.retry_counts.get(&key), Some(&MAX_RETRIES));
+        }
+        assert_eq!(pending_count(&q), 1);
     }
 
     #[test]
@@ -2817,8 +3609,10 @@ mod tests {
         );
 
         // Manually expire the retry_after to simulate time passing.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         assert!(
             q.has_flushable_work(),
             "expired throttle should be flushable"
@@ -2832,8 +3626,10 @@ mod tests {
 
         q.push(make_queued(ch, "poison"));
         for attempt in 1..=MAX_RETRIES {
-            q.retry_after
-                .insert(ch, Instant::now() - Duration::from_secs(1));
+            q.retry_after.insert(
+                test_conversation_key(ch),
+                Instant::now() - Duration::from_secs(1),
+            );
             let batch = q.flush_next().expect("flush");
             assert!(
                 q.requeue(batch).is_none(),
@@ -2843,16 +3639,18 @@ mod tests {
         }
 
         // The MAX_RETRIES+1'th failure dead-letters: batch is returned.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let batch = q.flush_next().expect("flush");
         let dead = q.requeue(batch).expect("should dead-letter");
         assert_eq!(dead.channel_id, ch);
         assert_eq!(dead.events.len(), 1);
         q.mark_complete(ch);
         // Retry state is cleared so fresh traffic isn't throttled.
-        assert!(!q.retry_counts.contains_key(&ch));
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_counts.contains_key(&test_conversation_key(ch)));
+        assert!(!q.retry_after.contains_key(&test_conversation_key(ch)));
     }
 
     #[test]
@@ -2877,8 +3675,10 @@ mod tests {
         assert_eq!(batch2.channel_id, ch2);
 
         // After retry_after expires, ch should be flushable again.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         q.mark_complete(ch2);
         let batch3 = q
             .flush_next()
@@ -2902,6 +3702,307 @@ mod tests {
             .unwrap()
     }
 
+    fn make_thread_reply(
+        channel_id: Uuid,
+        content: &str,
+        root_event_id: &str,
+        received_at: Instant,
+    ) -> QueuedEvent {
+        let event = make_event_with_tags(
+            content,
+            vec![
+                vec!["e".into(), root_event_id.into(), "".into(), "root".into()],
+                vec!["e".into(), root_event_id.into(), "".into(), "reply".into()],
+            ],
+        );
+        QueuedEvent {
+            channel_id,
+            event,
+            received_at,
+            prompt_tag: "test".into(),
+        }
+    }
+
+    #[test]
+    fn legacy_adapter_scope_keeps_one_conversation_per_channel() {
+        let channel_id = Uuid::new_v4();
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        queue.push(make_queued(channel_id, "first top-level"));
+        queue.push(make_queued(channel_id, "second top-level"));
+
+        let batch = queue.flush_next().expect("legacy channel batch");
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(
+            batch.conversation_key.root_event_id,
+            format!("channel:{channel_id}")
+        );
+    }
+
+    #[test]
+    fn lazy_capability_enable_reindexes_buffered_events_by_thread() {
+        let channel_id = Uuid::new_v4();
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        queue.push(make_queued(channel_id, "first top-level"));
+        queue.push(make_queued(channel_id, "second top-level"));
+        assert_eq!(queue.queues.len(), 1);
+
+        assert!(queue.set_thread_sessions_enabled(true));
+        assert_eq!(queue.queues.len(), 2);
+        assert!(queue.thread_sessions_enabled());
+    }
+
+    #[test]
+    fn sibling_threads_flush_separately_and_can_run_concurrently() {
+        let channel_id = Uuid::new_v4();
+        let now = Instant::now();
+        let root_one = make_queued_at(channel_id, "root one", Duration::from_millis(40));
+        let root_one_id = root_one.event.id.to_hex();
+        let reply_one = make_thread_reply(
+            channel_id,
+            "reply one",
+            &root_one_id,
+            now - Duration::from_millis(30),
+        );
+        let root_two = make_queued_at(channel_id, "root two", Duration::from_millis(20));
+        let root_two_id = root_two.event.id.to_hex();
+        let reply_two = make_thread_reply(
+            channel_id,
+            "reply two",
+            &root_two_id,
+            now - Duration::from_millis(10),
+        );
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+
+        for event in [root_one, reply_one, root_two, reply_two] {
+            assert!(queue.push(event));
+        }
+
+        let first = queue.flush_next().expect("first thread");
+        assert_eq!(first.conversation_key.root_event_id, root_one_id);
+        assert_eq!(first.events.len(), 2);
+
+        let second = queue
+            .flush_next()
+            .expect("sibling thread should flush while first is active");
+        assert_eq!(second.conversation_key.root_event_id, root_two_id);
+        assert_eq!(second.events.len(), 2);
+        assert_eq!(queue.in_flight_channels.len(), 2);
+    }
+
+    #[test]
+    fn excluded_affinity_blocked_thread_does_not_block_younger_sibling() {
+        let channel_id = Uuid::new_v4();
+        let mut oldest = make_queued(channel_id, "busy owner");
+        oldest.received_at = Instant::now() - Duration::from_millis(20);
+        let oldest_id = oldest.event.id.to_hex();
+        let mut sibling = make_queued(channel_id, "idle sibling");
+        sibling.received_at = Instant::now() - Duration::from_millis(10);
+        let sibling_id = sibling.event.id.to_hex();
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        assert!(queue.push(oldest));
+        assert!(queue.push(sibling));
+
+        let blocked = queue.flush_next().expect("oldest thread");
+        assert_eq!(blocked.conversation_key.root_event_id, oldest_id);
+        let blocked_key = blocked.conversation_key.clone();
+        queue.requeue_preserve_timestamps(blocked);
+        queue.mark_conversation_complete(&blocked_key);
+
+        let sibling = queue
+            .flush_next_excluding(&HashSet::from([blocked_key]))
+            .expect("eligible sibling must bypass affinity-blocked oldest thread");
+        assert_eq!(sibling.conversation_key.root_event_id, sibling_id);
+    }
+
+    #[test]
+    fn pending_conversation_caps_evict_oldest_non_active_key() {
+        let channel_id = Uuid::new_v4();
+        let template = make_queued(channel_id, "template");
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        let oldest_key = ConversationKey {
+            channel_id,
+            root_event_id: "oldest".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        for index in 0..MAX_PENDING_CONVERSATIONS_PER_CHANNEL {
+            let key = if index == 0 {
+                oldest_key.clone()
+            } else {
+                ConversationKey {
+                    channel_id,
+                    root_event_id: format!("root-{index}"),
+                    generation: 0,
+                    reset_token: None,
+                }
+            };
+            let mut event = template.clone();
+            event.received_at = Instant::now() + Duration::from_millis(index as u64);
+            queue.queues.insert(key, VecDeque::from([event]));
+        }
+
+        assert!(queue.make_room_for_conversation(channel_id));
+        assert_eq!(
+            queue
+                .queues
+                .keys()
+                .filter(|key| key.channel_id == channel_id)
+                .count(),
+            MAX_PENDING_CONVERSATIONS_PER_CHANNEL - 1
+        );
+        assert!(!queue.queues.contains_key(&oldest_key));
+    }
+
+    #[test]
+    fn aggregate_event_caps_bound_thread_shaped_pending_traffic() {
+        let channel_id = Uuid::new_v4();
+        let template = make_queued(channel_id, "template");
+        let key = ConversationKey {
+            channel_id,
+            root_event_id: "aggregate".into(),
+            generation: 0,
+            reset_token: None,
+        };
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        queue.queues.insert(
+            key,
+            std::iter::repeat_n(template, MAX_PENDING_EVENTS_PER_CHANNEL + 1).collect(),
+        );
+
+        queue.enforce_aggregate_event_caps(channel_id);
+        assert_eq!(
+            queue
+                .queues
+                .iter()
+                .filter(|(candidate, _)| candidate.channel_id == channel_id)
+                .map(|(_, events)| events.len())
+                .sum::<usize>(),
+            MAX_PENDING_EVENTS_PER_CHANNEL
+        );
+    }
+
+    #[test]
+    fn reset_generation_isolates_fresh_work_from_late_old_completion() {
+        let channel_id = Uuid::new_v4();
+        let root = make_queued(channel_id, "root");
+        let root_id = root.event.id.to_hex();
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        assert!(queue.push(root));
+        let old = queue.flush_next().expect("old generation");
+
+        let reset_token = "ab".repeat(32);
+        let fresh_key = queue
+            .reset_conversation(&old.conversation_key, reset_token.clone())
+            .expect("reset should reserve metadata");
+        assert_eq!(fresh_key.generation, old.conversation_key.generation + 1);
+        assert_eq!(fresh_key.reset_token.as_deref(), Some(reset_token.as_str()));
+        assert!(!queue.is_current_conversation(&old.conversation_key));
+        assert!(queue.is_current_conversation(&fresh_key));
+
+        assert!(queue.push(make_thread_reply(
+            channel_id,
+            "fresh request",
+            &root_id,
+            Instant::now(),
+        )));
+        assert!(
+            queue.flush_next().is_none(),
+            "fresh generation must wait for old session disposal"
+        );
+
+        queue.mark_conversation_complete(&old.conversation_key);
+        assert!(
+            queue.flush_next().is_none(),
+            "fresh generation stays blocked until the reset acknowledgement"
+        );
+        let identity = (channel_id, root_id.clone());
+        assert!(queue.completed_resets().contains(&identity));
+        assert!(queue.release_completed_reset(&identity));
+
+        let fresh = queue
+            .flush_next()
+            .expect("fresh generation dispatches after disposal and acknowledgement");
+        assert_eq!(fresh.conversation_key, fresh_key);
+
+        assert!(queue.is_conversation_in_flight(&fresh_key));
+        queue.mark_conversation_complete(&fresh_key);
+        assert!(!queue.is_conversation_in_flight(&fresh_key));
+    }
+
+    #[test]
+    fn repeated_reset_is_rejected_until_the_first_acknowledgement_releases() {
+        let channel_id = Uuid::new_v4();
+        let root = make_queued(channel_id, "root");
+        let root_id = root.event.id.to_hex();
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        assert!(queue.push(root));
+        let original = ConversationKey {
+            channel_id,
+            root_event_id: root_id.clone(),
+            generation: 0,
+            reset_token: None,
+        };
+
+        let first = queue
+            .reset_conversation(&original, "11".repeat(32))
+            .expect("idle reset");
+        assert_eq!(
+            queue.reset_conversation(&first, "22".repeat(32)),
+            Err(ResetConversationError::ResetInProgress),
+            "a second reset must not replace the durable record guarding the first barrier"
+        );
+        assert!(queue.push(make_thread_reply(
+            channel_id,
+            "after reset",
+            &root_id,
+            Instant::now(),
+        )));
+        assert!(
+            queue.flush_next().is_none(),
+            "an idle reset is still gated on visible acknowledgement"
+        );
+
+        let identity = (channel_id, root_id);
+        assert_eq!(queue.completed_resets(), vec![identity.clone()]);
+        assert!(queue.release_completed_reset(&identity));
+        let batch = queue
+            .flush_next()
+            .expect("first reset generation dispatches after its acknowledgement");
+        assert_eq!(batch.conversation_key, first);
+    }
+
+    #[test]
+    fn unthreaded_dm_messages_share_context_but_explicit_threads_do_not() {
+        let channel_id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut first = make_queued(channel_id, "dm one");
+        first.received_at = now - Duration::from_millis(30);
+        let mut second = make_queued(channel_id, "dm two");
+        second.received_at = now - Duration::from_millis(20);
+        let explicit_root = "ab".repeat(32);
+        let explicit = make_thread_reply(
+            channel_id,
+            "explicit dm thread",
+            &explicit_root,
+            now - Duration::from_millis(10),
+        );
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+        queue.set_channel_is_dm(channel_id, true);
+
+        assert!(queue.push(first));
+        assert!(queue.push(second));
+        assert!(queue.push(explicit));
+
+        let unthreaded = queue.flush_next().expect("unthreaded DM batch");
+        assert_eq!(
+            unthreaded.conversation_key.root_event_id,
+            format!("dm:{channel_id}")
+        );
+        assert_eq!(unthreaded.events.len(), 2);
+        let explicit = queue.flush_next().expect("explicit DM thread batch");
+        assert_eq!(explicit.conversation_key.root_event_id, explicit_root);
+    }
+
     #[test]
     fn test_parse_thread_tags_no_tags() {
         let event = make_event("plain message");
@@ -2909,6 +4010,82 @@ mod tests {
         assert!(tags.root_event_id.is_none());
         assert!(tags.parent_event_id.is_none());
         assert!(tags.mentioned_pubkeys.is_empty());
+    }
+
+    #[test]
+    fn valid_thread_identity_accepts_matching_duplicate_markers() {
+        let root = "ab".repeat(32);
+        let event = make_event_with_tags(
+            "duplicate root",
+            vec![
+                vec!["e".into(), root.clone(), "".into(), "root".into()],
+                vec!["e".into(), root, "".into(), "root".into()],
+            ],
+        );
+
+        assert!(has_valid_thread_identity(&event));
+    }
+
+    #[test]
+    fn thread_identity_canonicalizes_uppercase_hex_without_splitting_duplicates() {
+        let lowercase = "ab".repeat(32);
+        let uppercase = lowercase.to_ascii_uppercase();
+        let event = make_event_with_tags(
+            "case variants",
+            vec![
+                vec!["e".into(), uppercase, "".into(), "root".into()],
+                vec!["e".into(), lowercase.clone(), "".into(), "root".into()],
+            ],
+        );
+
+        assert!(has_valid_thread_identity(&event));
+        assert_eq!(
+            parse_thread_tags(&event).root_event_id.as_deref(),
+            Some(lowercase.as_str())
+        );
+    }
+
+    #[test]
+    fn valid_thread_identity_rejects_malformed_or_conflicting_markers() {
+        let first = "ab".repeat(32);
+        let second = "cd".repeat(32);
+        let malformed = make_event_with_tags(
+            "malformed root",
+            vec![vec![
+                "e".into(),
+                "not-an-event-id".into(),
+                "".into(),
+                "root".into(),
+            ]],
+        );
+        let conflicting = make_event_with_tags(
+            "conflicting roots",
+            vec![
+                vec!["e".into(), first, "".into(), "root".into()],
+                vec!["e".into(), second, "".into(), "root".into()],
+            ],
+        );
+
+        assert!(!has_valid_thread_identity(&malformed));
+        assert!(!has_valid_thread_identity(&conflicting));
+    }
+
+    #[test]
+    fn push_defensively_rejects_invalid_thread_identity() {
+        let channel_id = Uuid::new_v4();
+        let event = make_event_with_tags(
+            "bad root",
+            vec![vec!["e".into(), "bad".into(), "".into(), "root".into()]],
+        );
+        let mut queue = EventQueue::new(DedupMode::Queue).with_thread_sessions_enabled(true);
+
+        assert!(!queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        assert_eq!(pending_count(&queue), 0);
     }
 
     #[test]
@@ -2970,6 +4147,7 @@ mod tests {
         let event = make_event("hello");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3001,6 +4179,7 @@ mod tests {
         let event = make_event("hey");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3039,6 +4218,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3067,6 +4247,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3111,6 +4292,7 @@ mod tests {
         let event = make_event("ok do that");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3160,6 +4342,7 @@ mod tests {
         let author_hex = event.pubkey.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3367,6 +4550,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3424,6 +4608,7 @@ mod tests {
         let event = make_event("hey there");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "dm".into(),
@@ -3464,6 +4649,7 @@ mod tests {
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3488,6 +4674,7 @@ mod tests {
         let npub = event.pubkey.to_bech32().unwrap();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3511,6 +4698,7 @@ mod tests {
         let event = make_event_with_tags("hello", vec![vec!["h".into(), ch.to_string()]]);
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3608,25 +4796,27 @@ mod tests {
         let batch = q.flush_next().unwrap();
         q.requeue(batch);
         q.mark_complete(ch);
-        assert!(q.retry_after.contains_key(&ch));
-        assert!(q.retry_counts.contains_key(&ch));
+        assert!(q.retry_after.contains_key(&test_conversation_key(ch)));
+        assert!(q.retry_counts.contains_key(&test_conversation_key(ch)));
 
         // The requeued event is back in the queue. Flush it again so the
         // queue is empty (simulating a successful retry dispatch).
         // We need to wait for retry_after to expire first.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let _batch2 = q.flush_next().unwrap();
         // Now mark_complete with no active throttle — clears retry_counts.
         q.mark_complete(ch);
-        assert!(!q.retry_counts.contains_key(&ch));
+        assert!(!q.retry_counts.contains_key(&test_conversation_key(ch)));
 
         // Re-create the orphan scenario: manually insert stale retry_counts
         // with no queue, no throttle, and no in-flight.
-        q.retry_counts.insert(ch, 3);
+        q.retry_counts.insert(test_conversation_key(ch), 3);
         q.compact_expired_state();
         assert!(
-            !q.retry_counts.contains_key(&ch),
+            !q.retry_counts.contains_key(&test_conversation_key(ch)),
             "orphaned retry_counts should be removed"
         );
     }
@@ -3643,18 +4833,23 @@ mod tests {
         q.mark_complete(ch);
 
         // Expire the throttle so the requeued event can be flushed.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let _batch2 = q.flush_next().unwrap();
         // Channel is now in-flight with empty queue and expired throttle.
-        assert!(q.in_flight_channels.contains(&ch));
-        assert!(q.queues.get(&ch).is_none_or(|q| q.is_empty()));
+        assert!(q.in_flight_channels.contains(&test_conversation_key(ch)));
+        assert!(q
+            .queues
+            .get(&test_conversation_key(ch))
+            .is_none_or(|q| q.is_empty()));
 
         // compact must NOT remove retry_counts — the in-flight attempt
         // may fail and requeue, which needs the existing count.
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&test_conversation_key(ch)),
             "retry_counts must survive while channel is in-flight"
         );
     }
@@ -3666,11 +4861,11 @@ mod tests {
 
         // Manually set up: retry_counts exists, queue is non-empty, no throttle.
         q.push(make_queued(ch, "msg1"));
-        q.retry_counts.insert(ch, 2);
+        q.retry_counts.insert(test_conversation_key(ch), 2);
 
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&test_conversation_key(ch)),
             "retry_counts should survive when queue is non-empty"
         );
     }
@@ -3877,6 +5072,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3919,6 +5115,7 @@ mod tests {
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -3953,6 +5150,7 @@ mod tests {
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -3982,6 +5180,7 @@ mod tests {
         let event = make_event("hey there");
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "test".into(),
@@ -4024,6 +5223,7 @@ mod tests {
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4060,6 +5260,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -4095,6 +5296,7 @@ mod tests {
         );
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![
                 BatchEvent {
                     event: plain,
@@ -4132,6 +5334,7 @@ mod tests {
         let plain_id = plain.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![
                 BatchEvent {
                     event: threaded,
@@ -4165,6 +5368,7 @@ mod tests {
     fn make_single_batch(content: &str) -> FlushBatch {
         FlushBatch {
             channel_id: Uuid::new_v4(),
+            conversation_key: test_conversation_key(Uuid::new_v4()),
             events: vec![BatchEvent {
                 event: make_event(content),
                 prompt_tag: "test".into(),
@@ -4299,7 +5503,12 @@ mod tests {
             "withheld-only channel must not register as flushable work"
         );
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(1));
+        assert_eq!(
+            q.withheld_native_steer
+                .get(&test_conversation_key(ch))
+                .map(|v| v.len()),
+            Some(1)
+        );
     }
 
     /// Earlier events on the same channel must flush normally during the
@@ -4367,17 +5576,20 @@ mod tests {
 
         // Simulate a prompt in flight for `ch`, then withhold the queued
         // event for an in-flight goose-native steer.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines
+            .insert(test_conversation_key(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 1);
         assert!(q.mark_native_steer_pending(ch, &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
         // steer ack never arriving and the read loop hanging long enough
         // for `in_flight_deadline` to elapse. Same expiry-simulation
         // trick used by `test_retry_throttle_blocks_requeue_channel`.
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
 
         // `has_flushable_work` runs the expiry block first; it must recover
         // the withheld event so the channel registers as flushable.
@@ -4429,20 +5641,27 @@ mod tests {
         assert!(q.mark_native_steer_pending(ch, &e2_id));
         assert!(q.mark_native_steer_pending(ch, &e3_id));
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(3));
+        assert_eq!(
+            q.withheld_native_steer
+                .get(&test_conversation_key(ch))
+                .map(|v| v.len()),
+            Some(3)
+        );
 
         // Trigger expiry → bulk-release path.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
-        q.in_flight_batch_sizes.insert(ch, 3);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 3);
         assert!(q.has_flushable_work());
 
         // After recovery, the queue front-to-back order must match the
         // original FIFO: e1, e2, e3.
         let recovered: Vec<String> = q
             .queues
-            .get(&ch)
+            .get(&test_conversation_key(ch))
             .expect("queue restored")
             .iter()
             .map(|qe| qe.event.id.to_hex())
@@ -4459,6 +5678,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4488,6 +5708,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4516,6 +5737,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
             channel_id: ch,
+            conversation_key: test_conversation_key(ch),
             events: vec![BatchEvent {
                 event: make_event("hi"),
                 prompt_tag: "test".into(),
@@ -4564,11 +5786,15 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let old_deadline = Instant::now() + Duration::from_secs(100);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, old_deadline);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines
+            .insert(test_conversation_key(ch), old_deadline);
 
         q.extend_in_flight_deadline(ch, 7200);
-        let new = *q.in_flight_deadlines.get(&ch).unwrap();
+        let new = *q
+            .in_flight_deadlines
+            .get(&test_conversation_key(ch))
+            .unwrap();
         assert!(
             new > old_deadline,
             "extended deadline must be past the original"
@@ -4580,11 +5806,15 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let far_future = Instant::now() + Duration::from_secs(999_999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, far_future);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines
+            .insert(test_conversation_key(ch), far_future);
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after = *q
+            .in_flight_deadlines
+            .get(&test_conversation_key(ch))
+            .unwrap();
         assert_eq!(after, far_future, "deadline must never move backward");
     }
 
@@ -4592,17 +5822,22 @@ mod tests {
     fn extend_in_flight_deadline_noop_after_mark_complete() {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() + Duration::from_secs(100),
+        );
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 1);
 
         q.mark_complete(ch);
-        assert!(!q.in_flight_deadlines.contains_key(&ch));
+        assert!(!q
+            .in_flight_deadlines
+            .contains_key(&test_conversation_key(ch)));
 
         q.extend_in_flight_deadline(ch, 7200);
         assert!(
-            !q.in_flight_deadlines.contains_key(&ch),
+            !q.in_flight_deadlines
+                .contains_key(&test_conversation_key(ch)),
             "extend after mark_complete must not resurrect a deadline"
         );
     }
@@ -4612,17 +5847,21 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let extended = Instant::now() + Duration::from_secs(9999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, extended);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines
+            .insert(test_conversation_key(ch), extended);
 
         q.compact_expired_state();
 
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines
+                .contains_key(&test_conversation_key(ch)),
             "compaction must not touch in-flight deadlines"
         );
         assert_eq!(
-            *q.in_flight_deadlines.get(&ch).unwrap(),
+            *q.in_flight_deadlines
+                .get(&test_conversation_key(ch))
+                .unwrap(),
             extended,
             "compaction must leave extended deadline intact"
         );
@@ -4641,9 +5880,10 @@ mod tests {
 
         // Insert the channel as in-flight with a deadline already in the past
         // (Instant::now() — by the time flush_next runs, now >= deadline).
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines
+            .insert(test_conversation_key(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 1);
 
         // Also push an event so flush_next has something to do after expiry.
         q.push(make_queued(ch, "after-expiry"));
@@ -4669,10 +5909,12 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // Put the channel in-flight with an extended deadline far in the future.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() + Duration::from_secs(9999),
+        );
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 1);
 
         // Push an event for another channel so flush_next has work to do.
         let ch2 = Uuid::new_v4();
@@ -4686,11 +5928,12 @@ mod tests {
 
         // ch must still be in-flight — the extended deadline did not expire.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&test_conversation_key(ch)),
             "ch must remain in-flight after flush_next with an extended deadline"
         );
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines
+                .contains_key(&test_conversation_key(ch)),
             "in-flight deadline for ch must not be removed by flush_next"
         );
     }
@@ -4707,10 +5950,12 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // In-flight channel with extended (far-future) deadline.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() + Duration::from_secs(9999),
+        );
+        q.in_flight_batch_sizes.insert(test_conversation_key(ch), 1);
 
         // No other channels — nothing flushable.
         assert!(
@@ -4718,7 +5963,7 @@ mod tests {
             "has_flushable_work must return false when the only channel is in-flight with extended deadline"
         );
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&test_conversation_key(ch)),
             "ch must remain in-flight after has_flushable_work with extended deadline"
         );
 
@@ -4731,7 +5976,7 @@ mod tests {
         );
         // ch still in-flight and not expired.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&test_conversation_key(ch)),
             "ch must still be in-flight after has_flushable_work finds ch2 work"
         );
     }
@@ -4746,15 +5991,23 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
 
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
+        q.in_flight_channels.insert(test_conversation_key(ch));
+        q.in_flight_deadlines.insert(
+            test_conversation_key(ch),
+            Instant::now() + Duration::from_secs(100),
+        );
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after_first = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after_first = *q
+            .in_flight_deadlines
+            .get(&test_conversation_key(ch))
+            .unwrap();
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after_second = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after_second = *q
+            .in_flight_deadlines
+            .get(&test_conversation_key(ch))
+            .unwrap();
 
         assert!(
             after_second >= after_first,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -251,6 +251,14 @@ const REST_RETRY_BASE_DELAYS: [Duration; 3] = [
     Duration::from_millis(2000),
 ];
 
+/// `/query` can legitimately return channel discovery metadata plus bounded
+/// conversation history, but it must never allocate an untrusted relay-sized
+/// body without a ceiling.
+const MAX_QUERY_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+/// `/events` acknowledgements are tiny JSON objects. A larger response is a
+/// broken or hostile relay and is never needed to decide acceptance.
+const MAX_EVENT_SUBMIT_RESPONSE_BYTES: usize = 64 * 1024;
+
 fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -400,9 +408,10 @@ impl RestClient {
         let body_bytes = serde_json::to_vec(filters)
             .map_err(|e| RelayError::Http(format!("filter serialize error: {e}")))?;
         let resp = self.bridge_post("/query", &body_bytes).await?;
-        resp.json()
-            .await
-            .map_err(|e| RelayError::Http(e.to_string()))
+        let body =
+            read_bounded_http_body(resp, MAX_QUERY_RESPONSE_BYTES, "/query response").await?;
+        serde_json::from_slice(&body)
+            .map_err(|error| RelayError::Http(format!("invalid /query response: {error}")))
     }
 
     /// Count events via the HTTP bridge: `POST /count` with NIP-98 auth.
@@ -425,14 +434,14 @@ impl RestClient {
         let body_bytes = serde_json::to_vec(event)
             .map_err(|e| RelayError::Http(format!("event serialize error: {e}")))?;
         let resp = self.bridge_post("/events", &body_bytes).await?;
-        let text = resp
-            .text()
-            .await
-            .map_err(|e| RelayError::Http(e.to_string()))?;
-        if text.is_empty() {
+        let body =
+            read_bounded_http_body(resp, MAX_EVENT_SUBMIT_RESPONSE_BYTES, "/events response")
+                .await?;
+        if body.is_empty() {
             return Ok(Value::Null);
         }
-        serde_json::from_str(&text).map_err(|e| RelayError::Http(e.to_string()))
+        serde_json::from_slice(&body)
+            .map_err(|error| RelayError::Http(format!("invalid /events response: {error}")))
     }
 }
 
@@ -510,6 +519,14 @@ enum RelayMessage {
 const MEMBERSHIP_NOTIF_SUB_ID: &str = "membership-notif";
 /// Subscription ID for encrypted owner-to-agent observer control frames.
 const OBSERVER_CONTROL_SUB_ID: &str = "agent-observer-control";
+/// Reject signed events implausibly far ahead of the local clock before they
+/// can poison reconnect watermarks. Five minutes tolerates ordinary host skew
+/// while bounding suppression of subsequent traffic.
+const MAX_EVENT_FUTURE_SKEW_SECS: u64 = 5 * 60;
+/// NIP-11 is a small metadata document. Bound both declared and chunked bodies
+/// before JSON parsing so a relay cannot make harness startup allocate an
+/// attacker-controlled response.
+const MAX_NIP11_DOCUMENT_BYTES: usize = 64 * 1024;
 
 /// Commands sent from `HarnessRelay` to the background WebSocket task.
 enum RelayCommand {
@@ -601,6 +618,78 @@ impl RelayEventPublisher {
     }
 }
 
+async fn fetch_relay_signing_pubkey(
+    http: &reqwest::Client,
+    relay_url: &str,
+) -> Result<String, RelayError> {
+    let info_url = relay_ws_to_http(relay_url);
+    let response = http
+        .get(&info_url)
+        .header(reqwest::header::ACCEPT, "application/nostr+json")
+        .send()
+        .await
+        .map_err(|error| RelayError::Http(format!("NIP-11 request failed: {error}")))?
+        .error_for_status()
+        .map_err(|error| RelayError::Http(format!("NIP-11 request failed: {error}")))?;
+    let body = read_bounded_nip11_body(response).await?;
+    let document: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|error| RelayError::Http(format!("invalid NIP-11 document: {error}")))?;
+    let relay_self = document
+        .get("self")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            RelayError::Http(
+                "NIP-11 document omitted relay signing identity (`self`); refusing relay-only membership events"
+                    .into(),
+            )
+        })?;
+    nostr::PublicKey::from_hex(relay_self)
+        .map(|key| key.to_hex())
+        .map_err(|error| RelayError::Http(format!("invalid NIP-11 `self` pubkey: {error}")))
+}
+
+async fn read_bounded_nip11_body(response: reqwest::Response) -> Result<Vec<u8>, RelayError> {
+    read_bounded_http_body(response, MAX_NIP11_DOCUMENT_BYTES, "NIP-11 document").await
+}
+
+/// Read an HTTP response without trusting either `Content-Length` or transfer
+/// framing. The declared length is rejected before allocation, and every
+/// streamed chunk is checked before it is appended, covering chunked bodies
+/// and servers that lie about their length.
+async fn read_bounded_http_body(
+    response: reqwest::Response,
+    max_bytes: usize,
+    label: &str,
+) -> Result<Vec<u8>, RelayError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(RelayError::Http(format!(
+            "{label} exceeds {max_bytes} byte limit"
+        )));
+    }
+
+    let mut body =
+        Vec::with_capacity(response.content_length().unwrap_or(0).min(max_bytes as u64) as usize);
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(|error| RelayError::Http(format!("{label} body read failed: {error}")))?;
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| RelayError::Http(format!("{label} size overflow")))?;
+        if next_len > max_bytes {
+            return Err(RelayError::Http(format!(
+                "{label} exceeds {max_bytes} byte limit"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
 impl HarnessRelay {
     /// Connect to relay and authenticate via NIP-42.
     ///
@@ -612,6 +701,12 @@ impl HarnessRelay {
         agent_pubkey_hex: &str,
         auth_tag: Option<nostr::Tag>,
     ) -> Result<Self, RelayError> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?;
+        let relay_signing_pubkey = fetch_relay_signing_pubkey(&http, relay_url).await?;
         // Perform the initial connection and auth handshake, retrying
         // transient failures (dropped handshake, timeout) with bounded
         // jittered backoff. A terminal error (bad URL, bad auth tag,
@@ -641,6 +736,7 @@ impl HarnessRelay {
                 bg_relay_url,
                 bg_agent_pubkey_hex,
                 bg_auth_tag,
+                relay_signing_pubkey,
             )
             .await;
         });
@@ -649,11 +745,7 @@ impl HarnessRelay {
             event_rx,
             observer_control_rx: Some(observer_control_rx),
             cmd_tx,
-            http: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(10))
-                .connect_timeout(std::time::Duration::from_secs(5))
-                .build()
-                .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?,
+            http,
             relay_url: relay_url.to_string(),
             keys: keys.clone(),
             auth_tag,
@@ -987,8 +1079,14 @@ impl TwoGenDedup {
 
 /// State maintained by the background WebSocket task.
 struct BgState {
+    /// Relay signing identity pinned from the TLS-authenticated NIP-11 `self`
+    /// document. Relay-only membership kinds are authorized against this key,
+    /// not merely by having a valid Schnorr signature.
+    relay_signing_pubkey: Option<String>,
     /// Active subscriptions: channel_id → subscription_id string.
     active_subscriptions: HashMap<Uuid, String>,
+    /// Exact `since` floor serialized in the currently active channel REQ.
+    active_subscription_since: HashMap<Uuid, u64>,
     /// Most recent `created_at` timestamp seen per channel (for `since` filter).
     last_seen: HashMap<Uuid, u64>,
     /// Two-generation dedup set of event IDs seen.
@@ -1004,8 +1102,12 @@ struct BgState {
     membership_last_seen: Option<u64>,
     /// Whether the membership notification subscription is active.
     membership_sub_active: bool,
+    /// Exact `since` floor serialized in the active membership REQ.
+    membership_active_since: Option<u64>,
     /// Whether the observer control subscription is active.
     observer_control_sub_active: bool,
+    /// Exact `since` floor serialized in the active observer-control REQ.
+    observer_control_active_since: Option<u64>,
     /// Oldest dropped channel-event timestamp per channel, keyed by channel_id.
     /// Mirrors `membership_dropped_since` but for ordinary channel events.
     /// On reconnect resubscribe, `since` = min(last_seen, channel_dropped_since).
@@ -1075,14 +1177,18 @@ struct BgState {
 impl BgState {
     fn new() -> Self {
         Self {
+            relay_signing_pubkey: None,
             active_subscriptions: HashMap::new(),
+            active_subscription_since: HashMap::new(),
             last_seen: HashMap::new(),
             seen_ids: TwoGenDedup::new(SEEN_ID_LIMIT),
             active_filters: HashMap::new(),
             membership_dropped_since: None,
             membership_last_seen: None,
             membership_sub_active: false,
+            membership_active_since: None,
             observer_control_sub_active: false,
+            observer_control_active_since: None,
             channel_dropped_since: HashMap::new(),
             proactive_resubscribe_needed: false,
             startup_watermark: None,
@@ -1102,6 +1208,9 @@ impl BgState {
     /// Record a received event for dedup and `since` tracking.
     /// Returns `true` if the event is new (not a duplicate).
     fn record_event(&mut self, channel_id: Uuid, event: &Event) -> bool {
+        if !event_timestamp_is_acceptable(event, unix_now_secs()) {
+            return false;
+        }
         let id_hex = event.id.to_hex();
 
         // Two-generation dedup: no amnesia window on rotation.
@@ -1110,7 +1219,10 @@ impl BgState {
         }
 
         // Update last_seen timestamp.
-        let ts = event.created_at.as_secs();
+        // Preserve the signed event timestamp in the event itself, but never
+        // let an accepted future-skewed value advance a reconnect watermark
+        // beyond local time and suppress normal subsequent traffic.
+        let ts = bounded_replay_timestamp(event, unix_now_secs());
         self.last_seen
             .entry(channel_id)
             .and_modify(|t| *t = (*t).max(ts))
@@ -1148,6 +1260,7 @@ impl BgState {
         self.subscribe_since.remove(channel_id);
         self.channel_dropped_since.remove(channel_id);
         self.active_filters.remove(channel_id);
+        self.active_subscription_since.remove(channel_id);
         self.rate_limited_pending.remove(channel_id);
         self.resubscribe_retry.remove(channel_id);
     }
@@ -1264,6 +1377,7 @@ fn apply_command_to_state(state: &mut BgState, cmd: RelayCommand) {
             state
                 .active_subscriptions
                 .insert(channel_id, channel_sub_id(channel_id));
+            state.active_subscription_since.remove(&channel_id);
             state.active_filters.insert(channel_id, filter);
             state.subscribe_since.entry(channel_id).or_insert_with(|| {
                 // Use an explicit replay floor when available (dynamic
@@ -1280,9 +1394,11 @@ fn apply_command_to_state(state: &mut BgState, cmd: RelayCommand) {
         }
         RelayCommand::SubscribeMembership => {
             state.membership_sub_active = true;
+            state.membership_active_since = None;
         }
         RelayCommand::SubscribeObserverControls => {
             state.observer_control_sub_active = true;
+            state.observer_control_active_since = None;
         }
         RelayCommand::SetStartupWatermark { ts } => {
             state.startup_watermark = Some(ts);
@@ -1399,12 +1515,15 @@ async fn execute_connected_command(
                 .get(&channel_id)
                 .copied()
                 .or_else(|| state.subscribe_since.get(&channel_id).copied());
-            let sent =
+            let sent_since =
                 send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
-            if sent {
+            if let Some(sent_since) = sent_since {
                 state
                     .active_subscriptions
                     .insert(channel_id, channel_sub_id(channel_id));
+                state
+                    .active_subscription_since
+                    .insert(channel_id, sent_since);
                 state.active_filters.insert(channel_id, filter);
                 // Evict stale drain entries so the drain loop can't send a
                 // duplicate REQ for this now-live subscription.
@@ -1447,9 +1566,10 @@ async fn execute_connected_command(
                 return true;
             }
             let since = state.membership_last_seen.or(state.startup_watermark);
-            let sent = send_membership_subscribe(ws, agent_pubkey_hex, since).await;
-            if sent {
+            let sent_since = send_membership_subscribe(ws, agent_pubkey_hex, since).await;
+            if let Some(sent_since) = sent_since {
                 state.membership_resub_needed = false;
+                state.membership_active_since = Some(sent_since);
                 if state.membership_last_seen.is_none() {
                     state.membership_last_seen = since;
                 }
@@ -1468,9 +1588,10 @@ async fn execute_connected_command(
                 state.observer_resub_needed = true;
                 return true;
             }
-            let sent = send_observer_control_subscribe(ws, agent_pubkey_hex).await;
-            if sent {
+            let sent_since = send_observer_control_subscribe(ws, agent_pubkey_hex).await;
+            if let Some(sent_since) = sent_since {
                 state.observer_resub_needed = false;
+                state.observer_control_active_since = Some(sent_since);
                 true
             } else {
                 warn!("observer control subscribe REQ failed — recording intent for reconnect");
@@ -1554,8 +1675,10 @@ async fn run_background_task(
     relay_url: String,
     agent_pubkey_hex: String,
     auth_tag: Option<nostr::Tag>,
+    relay_signing_pubkey: String,
 ) {
     let mut state = BgState::new();
+    state.relay_signing_pubkey = Some(relay_signing_pubkey);
 
     let handshake_ok = process_handshake_buffer(
         &mut ws,
@@ -1732,9 +1855,12 @@ async fn run_background_task(
                             (None, Some(l)) => Some(l),
                             (None, None) => state.startup_watermark,
                         };
-                    if send_membership_subscribe(&mut ws, &agent_pubkey_hex, replay_since).await {
+                    if let Some(sent_since) =
+                        send_membership_subscribe(&mut ws, &agent_pubkey_hex, replay_since).await
+                    {
                         state.membership_resub_needed = false;
                         state.membership_dropped_since = None;
+                        state.membership_active_since = Some(sent_since);
                         budget = budget.saturating_sub(1);
                         any_sent = true;
                     } else {
@@ -1744,8 +1870,11 @@ async fn run_background_task(
                     }
                 }
                 if state.observer_resub_needed && budget > 0 {
-                    if send_observer_control_subscribe(&mut ws, &agent_pubkey_hex).await {
+                    if let Some(sent_since) =
+                        send_observer_control_subscribe(&mut ws, &agent_pubkey_hex).await
+                    {
                         state.observer_resub_needed = false;
+                        state.observer_control_active_since = Some(sent_since);
                         budget = budget.saturating_sub(1);
                         any_sent = true;
                     } else {
@@ -2048,6 +2177,31 @@ async fn run_background_task(
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+enum InboundEventVerificationError {
+    #[error(transparent)]
+    InvalidEvent(#[from] buzz_core::VerificationError),
+
+    #[error("event verification worker failed: {0}")]
+    Worker(#[from] tokio::task::JoinError),
+}
+
+/// Authenticate one relay-supplied Nostr event without blocking the async
+/// WebSocket task. The original event is returned only after both its canonical
+/// ID and Schnorr signature have been verified.
+async fn verify_inbound_event(
+    event: Box<Event>,
+) -> Result<Box<Event>, InboundEventVerificationError> {
+    let event = tokio::task::spawn_blocking(
+        move || -> Result<Box<Event>, buzz_core::VerificationError> {
+            buzz_core::verify_event(&event)?;
+            Ok(event)
+        },
+    )
+    .await??;
+    Ok(event)
+}
+
 /// Handle a single WebSocket message in the background task.
 ///
 /// Returns `false` if the connection has been lost (Close frame or unrecoverable
@@ -2079,7 +2233,52 @@ async fn handle_ws_message(
                     subscription_id,
                     event,
                 } => {
+                    // A relay is a transport, not a trust boundary. Authenticate every
+                    // NIP-01 EVENT before inspecting its subscription, touching dedup /
+                    // replay state, or forwarding it to code that can mutate a session.
+                    // Schnorr verification is CPU-bound, so keep it off this async task.
+                    let event_id = event.id.to_hex();
+                    let author = event.pubkey.to_hex();
+                    let event = match verify_inbound_event(event).await {
+                        Ok(event) => event,
+                        Err(error) => {
+                            warn!(
+                                subscription_id = %subscription_id,
+                                event_id = %event_id,
+                                author = %author,
+                                %error,
+                                "dropping relay EVENT that failed authenticity verification"
+                            );
+                            return true;
+                        }
+                    };
+                    if !event_timestamp_is_acceptable(&event, unix_now_secs()) {
+                        warn!(
+                            subscription_id = %subscription_id,
+                            event_id = %event.id,
+                            created_at = event.created_at.as_secs(),
+                            max_future_skew_secs = MAX_EVENT_FUTURE_SKEW_SECS,
+                            "dropping relay EVENT with an implausible future timestamp"
+                        );
+                        return true;
+                    }
+
                     if subscription_id == OBSERVER_CONTROL_SUB_ID {
+                        if !state.observer_control_sub_active
+                            || !event_matches_since_floor(
+                                &event,
+                                state.observer_control_active_since,
+                            )
+                            || event.kind.as_u16() as u32 != KIND_AGENT_OBSERVER_FRAME
+                            || !event_has_tag_value(&event, "p", agent_pubkey_hex)
+                        {
+                            warn!(
+                                subscription_id = %subscription_id,
+                                event_id = %event.id,
+                                "dropping observer control EVENT that does not match the active signed subscription"
+                            );
+                            return true;
+                        }
                         match observer_control_tx.try_send(*event) {
                             Ok(()) => {}
                             Err(mpsc::error::TrySendError::Full(_)) => {
@@ -2088,13 +2287,15 @@ async fn handle_ws_message(
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
                     } else if subscription_id == MEMBERSHIP_NOTIF_SUB_ID {
-                        // Membership notification — extract channel UUID from h tag.
-                        let channel_uuid = match extract_h_tag_uuid(&event) {
-                            Some(uuid) => uuid,
-                            None => {
-                                warn!("membership notification missing h tag — dropping");
-                                return true;
-                            }
+                        let Some(channel_uuid) =
+                            event_matches_membership_subscription(state, &event, agent_pubkey_hex)
+                        else {
+                            warn!(
+                                subscription_id = %subscription_id,
+                                event_id = %event.id,
+                                "dropping membership EVENT that does not match the active signed subscription"
+                            );
+                            return true;
                         };
                         // Dedup membership notifications through TwoGenDedup.
                         // We use seen_ids directly instead of record_event()
@@ -2111,7 +2312,7 @@ async fn handle_ws_message(
                             );
                             return true;
                         }
-                        let ts = event.created_at.as_secs();
+                        let ts = bounded_replay_timestamp(&event, unix_now_secs());
                         let buzz_event = BuzzEvent {
                             channel_id: channel_uuid,
                             event: *event,
@@ -2150,7 +2351,22 @@ async fn handle_ws_message(
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
                     } else if let Some(channel_id) = channel_id_from_sub_id(&subscription_id) {
-                        let ts = event.created_at.as_secs();
+                        if !event_matches_channel_subscription(
+                            state,
+                            &subscription_id,
+                            channel_id,
+                            &event,
+                            agent_pubkey_hex,
+                        ) {
+                            warn!(
+                                subscription_id = %subscription_id,
+                                channel_id = %channel_id,
+                                event_id = %event.id,
+                                "dropping channel EVENT that does not match the active signed subscription"
+                            );
+                            return true;
+                        }
+                        let ts = bounded_replay_timestamp(&event, unix_now_secs());
                         let event_id_hex = event.id.to_hex();
                         if state.record_event(channel_id, &event) {
                             let buzz_event = BuzzEvent {
@@ -2248,13 +2464,16 @@ async fn handle_ws_message(
                         );
                         if let Some(channel_id) = channel_id_from_sub_id(&subscription_id) {
                             state.rate_limited_pending.insert(channel_id, deadline);
+                            state.active_subscription_since.remove(&channel_id);
                         } else if subscription_id == MEMBERSHIP_NOTIF_SUB_ID {
                             // Mark membership sub for drain recovery. The relay rejected
                             // this REQ before registering it, so the sub does not exist
                             // server-side — the drain must re-send it.
                             state.membership_resub_needed = true;
+                            state.membership_active_since = None;
                         } else if subscription_id == OBSERVER_CONTROL_SUB_ID {
                             state.observer_resub_needed = true;
+                            state.observer_control_active_since = None;
                         }
                         return true; // keep the socket
                     }
@@ -2282,9 +2501,11 @@ async fn handle_ws_message(
                     // resubscribe_after_reconnect() needs the subscription to
                     // still be in state so it can restore it.
                     if subscription_id == OBSERVER_CONTROL_SUB_ID {
-                        let sent = send_observer_control_subscribe(ws, agent_pubkey_hex).await;
-                        if sent {
+                        let sent_since =
+                            send_observer_control_subscribe(ws, agent_pubkey_hex).await;
+                        if let Some(sent_since) = sent_since {
                             state.observer_control_sub_active = true;
+                            state.observer_control_active_since = Some(sent_since);
                         } else {
                             warn!("observer control resubscribe failed after CLOSED — triggering reconnect");
                             return false;
@@ -2297,10 +2518,12 @@ async fn handle_ws_message(
                                 (None, Some(l)) => Some(l),
                                 (None, None) => state.startup_watermark,
                             };
-                        let sent = send_membership_subscribe(ws, agent_pubkey_hex, since).await;
-                        if sent {
+                        let sent_since =
+                            send_membership_subscribe(ws, agent_pubkey_hex, since).await;
+                        if let Some(sent_since) = sent_since {
                             // Success — subscription is live again.
                             state.membership_dropped_since = None;
+                            state.membership_active_since = Some(sent_since);
                         } else {
                             // Resubscribe failed — likely half-dead socket.
                             // Keep membership_sub_active = true so reconnect restores it.
@@ -2328,7 +2551,7 @@ async fn handle_ws_message(
                                     return false;
                                 }
                             };
-                            let sent = send_subscribe(
+                            let sent_since = send_subscribe(
                                 ws,
                                 state,
                                 channel_id,
@@ -2337,11 +2560,14 @@ async fn handle_ws_message(
                                 &filter,
                             )
                             .await;
-                            if sent {
+                            if let Some(sent_since) = sent_since {
                                 // Success — update subscription ID (relay may assign new one).
                                 state
                                     .active_subscriptions
                                     .insert(channel_id, channel_sub_id(channel_id));
+                                state
+                                    .active_subscription_since
+                                    .insert(channel_id, sent_since);
                                 state.channel_dropped_since.remove(&channel_id);
                             } else {
                                 // Resubscribe failed — likely half-dead socket.
@@ -2394,6 +2620,103 @@ async fn handle_ws_message(
         // Binary, Pong, Frame — ignore
         _ => true,
     }
+}
+
+fn event_has_tag_value(event: &Event, kind: &str, expected: &str) -> bool {
+    event.tags.iter().any(|tag| {
+        let values = tag.as_slice();
+        values.len() >= 2 && values[0] == kind && values[1] == expected
+    })
+}
+
+fn event_timestamp_is_acceptable(event: &Event, now: u64) -> bool {
+    event.created_at.as_secs() <= now.saturating_add(MAX_EVENT_FUTURE_SKEW_SECS)
+}
+
+fn bounded_replay_timestamp(event: &Event, now: u64) -> u64 {
+    event.created_at.as_secs().min(now)
+}
+
+/// Timestamp safe to reuse as a dynamic subscription watermark outside the
+/// relay background task. Accepted near-future events remain processable but
+/// never suppress subsequent real-time traffic until the local clock catches up.
+pub(crate) fn bounded_event_replay_timestamp(event: &Event) -> u64 {
+    bounded_replay_timestamp(event, unix_now_secs())
+}
+
+fn event_matches_since_floor(event: &Event, floor: Option<u64>) -> bool {
+    floor.is_some_and(|floor| event.created_at.as_secs() >= floor)
+}
+
+fn event_has_exact_channel_tag(event: &Event, expected: Uuid) -> bool {
+    let mut channel_tags = event.tags.iter().filter(|tag| {
+        let values = tag.as_slice();
+        !values.is_empty() && values[0] == "h"
+    });
+    let Some(channel_tag) = channel_tags.next() else {
+        return false;
+    };
+    if channel_tags.next().is_some() {
+        return false;
+    }
+    let values = channel_tag.as_slice();
+    values.len() >= 2 && values[1].parse::<Uuid>() == Ok(expected)
+}
+
+fn event_matches_channel_subscription(
+    state: &BgState,
+    subscription_id: &str,
+    channel_id: Uuid,
+    event: &Event,
+    agent_pubkey_hex: &str,
+) -> bool {
+    if state
+        .active_subscriptions
+        .get(&channel_id)
+        .map(String::as_str)
+        != Some(subscription_id)
+        || !event_has_exact_channel_tag(event, channel_id)
+        || !event_matches_since_floor(
+            event,
+            state.active_subscription_since.get(&channel_id).copied(),
+        )
+    {
+        return false;
+    }
+    let Some(filter) = state.active_filters.get(&channel_id) else {
+        return false;
+    };
+    let kind = event.kind.as_u16() as u32;
+    if filter
+        .kinds
+        .as_ref()
+        .is_some_and(|kinds| !kinds.contains(&kind))
+    {
+        return false;
+    }
+    !filter.require_mention || event_has_tag_value(event, "p", agent_pubkey_hex)
+}
+
+fn event_matches_membership_subscription(
+    state: &BgState,
+    event: &Event,
+    agent_pubkey_hex: &str,
+) -> Option<Uuid> {
+    let kind = event.kind.as_u16() as u32;
+    let expected_relay = state.relay_signing_pubkey.as_deref()?;
+    if !state.membership_sub_active
+        || !event_matches_since_floor(event, state.membership_active_since)
+        || !matches!(
+            kind,
+            KIND_MEMBER_ADDED_NOTIFICATION | KIND_MEMBER_REMOVED_NOTIFICATION
+        )
+        || !event_has_tag_value(event, "p", agent_pubkey_hex)
+        || event.pubkey.to_hex() != expected_relay
+    {
+        return None;
+    }
+    let channel_id = extract_h_tag_uuid(event)?;
+    event_has_exact_channel_tag(event, channel_id).then_some(channel_id)
 }
 
 /// Process messages buffered during the NIP-42 auth handshake.
@@ -2506,6 +2829,12 @@ async fn resubscribe_after_reconnect(
     agent_pubkey_hex: &str,
     is_fresh_connection: bool,
 ) -> ResubscribeResult {
+    // A new socket has no server-side subscriptions. Floors are reinstalled
+    // only after each exact REQ is successfully written; until then inbound
+    // EVENT frames fail closed even if a malicious relay reuses an old sub ID.
+    state.active_subscription_since.clear();
+    state.membership_active_since = None;
+    state.observer_control_active_since = None;
     if is_fresh_connection {
         // These queues are derived from active subscription intent and rebuilt
         // below. The rate-limit gate is deliberately preserved: the relay's
@@ -2543,9 +2872,12 @@ async fn resubscribe_after_reconnect(
                     continue;
                 }
             };
-            let this_sent =
+            let sent_since =
                 send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
-            if this_sent {
+            if let Some(sent_since) = sent_since {
+                state
+                    .active_subscription_since
+                    .insert(channel_id, sent_since);
                 state.channel_dropped_since.remove(&channel_id);
                 // Shutdown-aware pacing sleep before any next replay/deferred REQ.
                 if !pacing_sleep(cmd_rx, &mut deferred_commands, REQ_PACING_INTERVAL).await {
@@ -2581,10 +2913,11 @@ async fn resubscribe_after_reconnect(
                 (None, Some(l)) => Some(l),
                 (None, None) => state.startup_watermark,
             };
-            let sent = send_membership_subscribe(ws, agent_pubkey_hex, replay_since).await;
-            if sent {
+            let sent_since = send_membership_subscribe(ws, agent_pubkey_hex, replay_since).await;
+            if let Some(sent_since) = sent_since {
                 state.membership_dropped_since = None;
                 state.membership_resub_needed = false;
+                state.membership_active_since = Some(sent_since);
             } else {
                 warn!("failed to resubscribe membership after reconnect");
                 retain_deferred_command_intent(state, &mut deferred_commands);
@@ -2601,12 +2934,17 @@ async fn resubscribe_after_reconnect(
             if !pacing_sleep(cmd_rx, &mut deferred_commands, REQ_PACING_INTERVAL).await {
                 return ResubscribeResult::Shutdown;
             }
-            if !send_observer_control_subscribe(ws, agent_pubkey_hex).await {
-                warn!("failed to resubscribe observer controls after reconnect");
-                retain_deferred_command_intent(state, &mut deferred_commands);
-                return ResubscribeResult::RetryConnection;
+            match send_observer_control_subscribe(ws, agent_pubkey_hex).await {
+                Some(sent_since) => {
+                    state.observer_control_active_since = Some(sent_since);
+                    state.observer_resub_needed = false;
+                }
+                None => {
+                    warn!("failed to resubscribe observer controls after reconnect");
+                    retain_deferred_command_intent(state, &mut deferred_commands);
+                    return ResubscribeResult::RetryConnection;
+                }
             }
-            state.observer_resub_needed = false;
         }
     }
 
@@ -2714,8 +3052,12 @@ async fn drain_rate_limited_pending(
                 continue;
             }
         };
-        let sent = send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
-        if sent {
+        let sent_since =
+            send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
+        if let Some(sent_since) = sent_since {
+            state
+                .active_subscription_since
+                .insert(channel_id, sent_since);
             state.rate_limited_pending.remove(&channel_id);
             state.channel_dropped_since.remove(&channel_id);
             sent_count += 1;
@@ -2771,8 +3113,12 @@ async fn drain_resubscribe_retry(
                 continue;
             }
         };
-        let sent = send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
-        if sent {
+        let sent_since =
+            send_subscribe(ws, state, channel_id, agent_pubkey_hex, since, &filter).await;
+        if let Some(sent_since) = sent_since {
+            state
+                .active_subscription_since
+                .insert(channel_id, sent_since);
             state.resubscribe_retry.remove(&channel_id);
             state.channel_dropped_since.remove(&channel_id);
             sent_count += 1;
@@ -3177,7 +3523,7 @@ async fn send_subscribe(
     agent_pubkey_hex: &str,
     since: Option<u64>,
     filter: &ChannelFilter,
-) -> bool {
+) -> Option<u64> {
     let sub_id = channel_sub_id(channel_id);
 
     let mut req_filter = serde_json::Map::new();
@@ -3220,17 +3566,17 @@ async fn send_subscribe(
                             " (since=now)"
                         }
                     );
-                    true
+                    Some(since_ts)
                 }
                 Err(e) => {
                     warn!("failed to send REQ for channel {channel_id}: {e}");
-                    false
+                    None
                 }
             }
         }
         Err(e) => {
             warn!("failed to serialize REQ for channel {channel_id}: {e}");
-            false
+            None
         }
     }
 }
@@ -3241,7 +3587,7 @@ async fn send_membership_subscribe(
     ws: &mut WsStream,
     agent_pubkey_hex: &str,
     since: Option<u64>,
-) -> bool {
+) -> Option<u64> {
     let mut req_filter = serde_json::Map::new();
     req_filter.insert(
         "kinds".into(),
@@ -3267,33 +3613,31 @@ async fn send_membership_subscribe(
             match ws_send_timeout(ws, Message::Text(text.into()), WS_SEND_TIMEOUT_SECS).await {
                 Ok(()) => {
                     debug!("subscribed to membership notifications (since={since_ts})");
-                    true
+                    Some(since_ts)
                 }
                 Err(e) => {
                     warn!("failed to send membership notification REQ: {e}");
-                    false
+                    None
                 }
             }
         }
         Err(e) => {
             warn!("failed to serialize membership notification REQ: {e}");
-            false
+            None
         }
     }
 }
 
 /// Send a NIP-01 REQ for owner-to-agent observer control frames.
-async fn send_observer_control_subscribe(ws: &mut WsStream, agent_pubkey_hex: &str) -> bool {
+async fn send_observer_control_subscribe(ws: &mut WsStream, agent_pubkey_hex: &str) -> Option<u64> {
+    let since_ts = unix_now_secs();
     let req = json!([
         "REQ",
         OBSERVER_CONTROL_SUB_ID,
         {
             "kinds": [KIND_AGENT_OBSERVER_FRAME],
             "#p": [agent_pubkey_hex],
-            "since": std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            "since": since_ts,
         }
     ]);
 
@@ -3302,17 +3646,17 @@ async fn send_observer_control_subscribe(ws: &mut WsStream, agent_pubkey_hex: &s
             match ws_send_timeout(ws, Message::Text(text.into()), WS_SEND_TIMEOUT_SECS).await {
                 Ok(()) => {
                     debug!("subscribed to observer control frames");
-                    true
+                    Some(since_ts)
                 }
                 Err(e) => {
                     warn!("failed to send observer control REQ: {e}");
-                    false
+                    None
                 }
             }
         }
         Err(e) => {
             warn!("failed to serialize observer control REQ: {e}");
-            false
+            None
         }
     }
 }
@@ -4008,6 +4352,136 @@ async fn wait_for_any_ok(
 mod tests {
     use super::*;
 
+    async fn one_shot_http_response(response: Vec<u8>) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind HTTP fixture");
+        let address = listener.local_addr().expect("fixture address");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept fixture request");
+            let mut request = vec![0_u8; 4_096];
+            let _ = socket.read(&mut request).await;
+            socket.write_all(&response).await.expect("write response");
+        });
+        format!("ws://{address}")
+    }
+
+    #[tokio::test]
+    async fn nip11_rejects_oversized_declared_content_length_before_body_read() {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            MAX_NIP11_DOCUMENT_BYTES + 1
+        )
+        .into_bytes();
+        let relay_url = one_shot_http_response(response).await;
+        let error = fetch_relay_signing_pubkey(&reqwest::Client::new(), &relay_url)
+            .await
+            .expect_err("oversized NIP-11 must fail");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn nip11_rejects_oversized_chunked_body_without_content_length() {
+        let body = vec![b'x'; MAX_NIP11_DOCUMENT_BYTES + 1];
+        let mut response =
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+                .to_vec();
+        response.extend_from_slice(format!("{:X}\r\n", body.len()).as_bytes());
+        response.extend_from_slice(&body);
+        response.extend_from_slice(b"\r\n0\r\n\r\n");
+        let relay_url = one_shot_http_response(response).await;
+        let error = fetch_relay_signing_pubkey(&reqwest::Client::new(), &relay_url)
+            .await
+            .expect_err("oversized chunked NIP-11 must fail");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn bounded_http_reader_rejects_declared_body_before_allocation() {
+        const TEST_LIMIT: usize = 1_024;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            TEST_LIMIT + 1
+        )
+        .into_bytes();
+        let relay_url = one_shot_http_response(response).await;
+        let response = reqwest::Client::new()
+            .get(relay_ws_to_http(&relay_url))
+            .send()
+            .await
+            .expect("receive declared-length fixture");
+        let error = read_bounded_http_body(response, TEST_LIMIT, "test response")
+            .await
+            .expect_err("oversized declared response must fail");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn bounded_http_reader_rejects_oversized_chunked_body() {
+        const TEST_LIMIT: usize = 1_024;
+        let body = vec![b'x'; TEST_LIMIT + 1];
+        let mut response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n".to_vec();
+        response.extend_from_slice(format!("{:X}\r\n", body.len()).as_bytes());
+        response.extend_from_slice(&body);
+        response.extend_from_slice(b"\r\n0\r\n\r\n");
+        let relay_url = one_shot_http_response(response).await;
+        let response = reqwest::Client::new()
+            .get(relay_ws_to_http(&relay_url))
+            .send()
+            .await
+            .expect("receive chunked fixture");
+        let error = read_bounded_http_body(response, TEST_LIMIT, "test response")
+            .await
+            .expect_err("oversized chunked response must fail");
+        assert!(error.to_string().contains("exceeds"), "{error}");
+    }
+
+    fn rest_client_for_fixture(relay_url: &str) -> RestClient {
+        RestClient {
+            http: reqwest::Client::new(),
+            base_url: relay_ws_to_http(relay_url),
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn query_rejects_oversized_declared_response() {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            MAX_QUERY_RESPONSE_BYTES + 1
+        )
+        .into_bytes();
+        let relay_url = one_shot_http_response(response).await;
+        let rest = rest_client_for_fixture(&relay_url);
+        let error = rest
+            .query(&[])
+            .await
+            .expect_err("oversized /query response must fail");
+        assert!(error.to_string().contains("/query response exceeds"));
+    }
+
+    #[tokio::test]
+    async fn event_submit_rejects_oversized_chunked_response() {
+        let body = vec![b'x'; MAX_EVENT_SUBMIT_RESPONSE_BYTES + 1];
+        let mut response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n".to_vec();
+        response.extend_from_slice(format!("{:X}\r\n", body.len()).as_bytes());
+        response.extend_from_slice(&body);
+        response.extend_from_slice(b"\r\n0\r\n\r\n");
+        let relay_url = one_shot_http_response(response).await;
+        let rest = rest_client_for_fixture(&relay_url);
+        let event = EventBuilder::new(Kind::TextNote, "bounded response test")
+            .sign_with_keys(&rest.keys)
+            .expect("sign fixture event");
+        let error = rest
+            .submit_event(&event)
+            .await
+            .expect_err("oversized /events response must fail");
+        assert!(error.to_string().contains("/events response exceeds"));
+    }
+
     #[test]
     fn relay_ws_to_http_plain() {
         assert_eq!(
@@ -4367,6 +4841,387 @@ mod tests {
         (client, server.await.expect("join test websocket server"))
     }
 
+    async fn dispatch_test_channel_event(
+        channel_id: Uuid,
+        event: Event,
+    ) -> (
+        bool,
+        BgState,
+        mpsc::Receiver<Option<BuzzEvent>>,
+        mpsc::Receiver<Event>,
+    ) {
+        let (mut client, _server) = test_ws_pair().await;
+        let (event_tx, event_rx) = mpsc::channel(4);
+        let (observer_control_tx, observer_control_rx) = mpsc::channel(4);
+        let mut state = BgState::new();
+        seed_test_subscription(&mut state, channel_id);
+        let keys = Keys::generate();
+        let agent_pubkey_hex = Keys::generate().public_key().to_hex();
+        let text = serde_json::to_string(&json!(["EVENT", channel_sub_id(channel_id), event]))
+            .expect("serialize inbound EVENT");
+
+        let should_continue = handle_ws_message(
+            Message::Text(text.into()),
+            &mut client,
+            &event_tx,
+            &observer_control_tx,
+            &mut state,
+            &keys,
+            "ws://127.0.0.1",
+            &agent_pubkey_hex,
+            None,
+        )
+        .await;
+
+        (should_continue, state, event_rx, observer_control_rx)
+    }
+
+    #[tokio::test]
+    async fn valid_inbound_event_is_forwarded_after_authenticity_verification() {
+        let channel_id = Uuid::new_v4();
+        let channel = channel_id.to_string();
+        let event = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "test",
+        )
+        .tags([Tag::parse(["h", channel.as_str()]).expect("h tag")])
+        .custom_created_at(nostr::Timestamp::from(2_000))
+        .sign_with_keys(&Keys::generate())
+        .expect("sign channel event");
+        let event_id = event.id.to_hex();
+
+        let (should_continue, state, mut event_rx, mut observer_control_rx) =
+            dispatch_test_channel_event(channel_id, event).await;
+
+        assert!(should_continue, "a valid event must keep the relay live");
+        let forwarded = event_rx
+            .try_recv()
+            .expect("valid event should be forwarded")
+            .expect("forwarded item should contain an event");
+        assert_eq!(forwarded.channel_id, channel_id);
+        assert_eq!(forwarded.event.id.to_hex(), event_id);
+        assert!(
+            state.seen_ids.contains(&event_id),
+            "valid event should enter dedup only after verification"
+        );
+        assert!(
+            observer_control_rx.try_recv().is_err(),
+            "a channel event must not enter the observer-control queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_signed_event_from_another_channel_cannot_cross_subscription_scope() {
+        let subscribed_channel = Uuid::new_v4();
+        let signed_channel = Uuid::new_v4();
+        let signed_channel_text = signed_channel.to_string();
+        let event = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "@agent /new",
+        )
+        .tags([Tag::parse(["h", signed_channel_text.as_str()]).expect("h tag")])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign wrong-channel event");
+        let event_id = event.id.to_hex();
+
+        let (should_continue, state, mut event_rx, mut observer_control_rx) =
+            dispatch_test_channel_event(subscribed_channel, event).await;
+
+        assert!(should_continue);
+        assert!(event_rx.try_recv().is_err());
+        assert!(observer_control_rx.try_recv().is_err());
+        assert!(!state.seen_ids.contains(&event_id));
+        assert!(!state.last_seen.contains_key(&subscribed_channel));
+    }
+
+    #[tokio::test]
+    async fn valid_old_owner_control_cannot_cross_the_active_req_since_floor() {
+        let channel_id = Uuid::new_v4();
+        let channel = channel_id.to_string();
+        let event = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "/new",
+        )
+        .tags([Tag::parse(["h", channel.as_str()]).expect("h tag")])
+        .custom_created_at(nostr::Timestamp::from(
+            1_000u64.saturating_sub(SINCE_SKEW_SECS + 1),
+        ))
+        .sign_with_keys(&Keys::generate())
+        .expect("sign old owner control");
+        let event_id = event.id.to_hex();
+
+        let (should_continue, state, mut event_rx, _) =
+            dispatch_test_channel_event(channel_id, event).await;
+
+        assert!(should_continue);
+        assert!(event_rx.try_recv().is_err());
+        assert!(!state.seen_ids.contains(&event_id));
+        assert!(!state.last_seen.contains_key(&channel_id));
+    }
+
+    #[tokio::test]
+    async fn channel_event_must_match_kind_and_mention_constraints() {
+        let channel_id = Uuid::new_v4();
+        let channel = channel_id.to_string();
+        let agent = Keys::generate().public_key().to_hex();
+        let mut state = BgState::new();
+        apply_command_to_state(
+            &mut state,
+            RelayCommand::Subscribe {
+                channel_id,
+                filter: ChannelFilter {
+                    kinds: Some(vec![buzz_core::kind::KIND_STREAM_MESSAGE]),
+                    require_mention: true,
+                },
+                replay_since: Some(1_000),
+            },
+        );
+        state.active_subscription_since.insert(channel_id, 1_000);
+        let wrong_kind = EventBuilder::new(Kind::TextNote, "test")
+            .tags([
+                Tag::parse(["h", channel.as_str()]).expect("h tag"),
+                Tag::parse(["p", agent.as_str()]).expect("p tag"),
+            ])
+            .sign_with_keys(&Keys::generate())
+            .expect("sign wrong-kind event");
+        let missing_mention = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "test",
+        )
+        .tags([Tag::parse(["h", channel.as_str()]).expect("h tag")])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign missing-mention event");
+
+        assert!(!event_matches_channel_subscription(
+            &state,
+            &channel_sub_id(channel_id),
+            channel_id,
+            &wrong_kind,
+            &agent,
+        ));
+        assert!(!event_matches_channel_subscription(
+            &state,
+            &channel_sub_id(channel_id),
+            channel_id,
+            &missing_mention,
+            &agent,
+        ));
+
+        let duplicate_h = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "test",
+        )
+        .tags([
+            Tag::parse(["h", channel.as_str()]).expect("first h tag"),
+            Tag::parse(["h", channel.as_str()]).expect("second h tag"),
+            Tag::parse(["p", agent.as_str()]).expect("p tag"),
+        ])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign duplicate-h event");
+        let malformed_h = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "test",
+        )
+        .tags([
+            Tag::parse(["h", channel.as_str()]).expect("valid h tag"),
+            Tag::parse(["h", "not-a-uuid"]).expect("malformed h tag"),
+            Tag::parse(["p", agent.as_str()]).expect("p tag"),
+        ])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign malformed-h event");
+        assert!(!event_matches_channel_subscription(
+            &state,
+            &channel_sub_id(channel_id),
+            channel_id,
+            &duplicate_h,
+            &agent,
+        ));
+        assert!(!event_matches_channel_subscription(
+            &state,
+            &channel_sub_id(channel_id),
+            channel_id,
+            &malformed_h,
+            &agent,
+        ));
+    }
+
+    #[test]
+    fn subscription_floors_and_future_skew_are_enforced_before_watermarking() {
+        let keys = Keys::generate();
+        let now = unix_now_secs();
+        let old = make_test_event(&keys, now.saturating_sub(10));
+        assert!(!event_matches_since_floor(&old, Some(now)));
+        assert!(event_matches_since_floor(
+            &old,
+            Some(now.saturating_sub(10))
+        ));
+        assert!(!event_matches_since_floor(&old, None));
+
+        let future = make_test_event(&keys, now.saturating_add(MAX_EVENT_FUTURE_SKEW_SECS + 1));
+        assert!(!event_timestamp_is_acceptable(&future, now));
+        let mut state = BgState::new();
+        let channel_id = Uuid::new_v4();
+        assert!(!state.record_event(channel_id, &future));
+        assert!(!state.seen_ids.contains(&future.id.to_hex()));
+        assert!(!state.last_seen.contains_key(&channel_id));
+
+        let accepted_future =
+            make_test_event(&keys, now.saturating_add(MAX_EVENT_FUTURE_SKEW_SECS));
+        assert!(event_timestamp_is_acceptable(&accepted_future, now));
+        assert_eq!(bounded_replay_timestamp(&accepted_future, now), now);
+        assert!(state.record_event(channel_id, &accepted_future));
+        assert!(
+            state.last_seen[&channel_id] <= unix_now_secs(),
+            "accepted future skew must not poison a channel reconnect watermark"
+        );
+        // Membership uses the same bounded helper before advancing either its
+        // successful or dropped replay floor.
+        let mut membership_last_seen = None;
+        let bounded = bounded_replay_timestamp(&accepted_future, now);
+        membership_last_seen = Some(membership_last_seen.unwrap_or(0).max(bounded));
+        assert_eq!(membership_last_seen, Some(now));
+    }
+
+    #[test]
+    fn membership_notifications_require_the_pinned_nip11_relay_signer() {
+        let relay_keys = Keys::generate();
+        let attacker_keys = Keys::generate();
+        let agent = Keys::generate().public_key().to_hex();
+        let channel_id = Uuid::new_v4();
+        let channel = channel_id.to_string();
+        let build = |keys: &Keys| {
+            EventBuilder::new(Kind::Custom(KIND_MEMBER_REMOVED_NOTIFICATION as u16), "")
+                .tags([
+                    Tag::parse(["h", channel.as_str()]).expect("h tag"),
+                    Tag::parse(["p", agent.as_str()]).expect("p tag"),
+                ])
+                .sign_with_keys(keys)
+                .expect("sign membership notification")
+        };
+        let mut state = BgState::new();
+        state.membership_sub_active = true;
+        state.membership_active_since = Some(0);
+        state.relay_signing_pubkey = Some(relay_keys.public_key().to_hex());
+
+        assert_eq!(
+            event_matches_membership_subscription(&state, &build(&relay_keys), &agent),
+            Some(channel_id)
+        );
+        assert_eq!(
+            event_matches_membership_subscription(&state, &build(&attacker_keys), &agent),
+            None,
+            "a valid signature is not authorization for relay-only membership kinds"
+        );
+        state.relay_signing_pubkey = None;
+        assert_eq!(
+            event_matches_membership_subscription(&state, &build(&relay_keys), &agent),
+            None,
+            "missing NIP-11 relay identity must fail closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn forged_owner_new_event_is_rejected_before_routing_or_dedup() {
+        let channel_id = Uuid::new_v4();
+        let channel_id_string = channel_id.to_string();
+        let owner_keys = Keys::generate();
+        let agent_pubkey_hex = Keys::generate().public_key().to_hex();
+        let original = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "@Buzz Agent summarize the thread",
+        )
+        .tags([
+            Tag::parse(["h", channel_id_string.as_str()]).expect("h tag"),
+            Tag::parse(["p", agent_pubkey_hex.as_str()]).expect("p tag"),
+        ])
+        .sign_with_keys(&owner_keys)
+        .expect("sign benign owner event");
+
+        // Model a malicious relay/client that keeps the owner's pubkey and tags,
+        // changes the request to `/new`, and recomputes the canonical event ID.
+        // The attacker can make verify_id() pass but cannot produce the owner's
+        // Schnorr signature for that new ID.
+        let forged_content = "@Buzz Agent /new";
+        let forged_id = nostr::EventId::new(
+            &original.pubkey,
+            &original.created_at,
+            &original.kind,
+            &original.tags,
+            forged_content,
+        );
+        let mut forged_json = serde_json::to_value(&original).expect("serialize signed event");
+        forged_json["content"] = Value::String(forged_content.to_string());
+        forged_json["id"] = Value::String(forged_id.to_hex());
+        let forged: Event = serde_json::from_value(forged_json).expect("parse forged event");
+
+        assert_eq!(forged.pubkey, owner_keys.public_key());
+        assert!(forged.verify_id(), "attacker recomputed a canonical ID");
+        assert!(
+            !forged.verify_signature(),
+            "attacker must not have a signature for the forged /new ID"
+        );
+        assert!(
+            crate::is_owner_control_command(
+                &forged,
+                buzz_core::kind::KIND_STREAM_MESSAGE,
+                "/new",
+                &agent_pubkey_hex,
+                Some("Buzz Agent"),
+            ),
+            "the forged payload would be interpreted as /new if it reached intake"
+        );
+        let verification = verify_inbound_event(Box::new(forged.clone())).await;
+        assert!(matches!(
+            verification,
+            Err(InboundEventVerificationError::InvalidEvent(
+                buzz_core::VerificationError::InvalidSignature
+            ))
+        ));
+        let forged_id_hex = forged.id.to_hex();
+
+        let (should_continue, state, mut event_rx, mut observer_control_rx) =
+            dispatch_test_channel_event(channel_id, forged).await;
+
+        assert!(
+            should_continue,
+            "an unauthentic event is isolated without dropping the connection"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "forged /new must not reach normal harness intake"
+        );
+        assert!(
+            observer_control_rx.try_recv().is_err(),
+            "forged /new must not reach the observer-control intake"
+        );
+        assert!(
+            !state.seen_ids.contains(&forged_id_hex),
+            "invalid events must not poison replay dedup"
+        );
+        assert!(
+            !state.last_seen.contains_key(&channel_id),
+            "invalid events must not advance replay watermarks"
+        );
+    }
+
+    #[tokio::test]
+    async fn inbound_event_with_stale_id_is_rejected() {
+        let signed = make_test_event(&Keys::generate(), 2_000);
+        let mut tampered_json = serde_json::to_value(signed).expect("serialize signed event");
+        tampered_json["content"] = Value::String("tampered after signing".to_string());
+        let tampered: Event =
+            serde_json::from_value(tampered_json).expect("parse structurally valid event");
+
+        assert!(!tampered.verify_id());
+        let result = verify_inbound_event(Box::new(tampered)).await;
+        assert!(matches!(
+            result,
+            Err(InboundEventVerificationError::InvalidEvent(
+                buzz_core::VerificationError::InvalidId { .. }
+            ))
+        ));
+    }
+
     async fn next_test_frame(
         server: &mut WebSocketStream<tokio::net::TcpStream>,
     ) -> serde_json::Value {
@@ -4395,6 +5250,9 @@ mod tests {
                 replay_since: Some(1_000),
             },
         );
+        state
+            .active_subscription_since
+            .insert(channel_id, 1_000u64.saturating_sub(SINCE_SKEW_SECS));
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/tests/pi_adapter_contract.rs
+++ b/crates/buzz-acp/tests/pi_adapter_contract.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+#[tokio::test]
+async fn real_pi_adapter_persists_and_resets_one_logical_thread() {
+    let Some(adapter_entrypoint) = std::env::var_os("BUZZ_PI_AGENT_BIN").map(PathBuf::from) else {
+        eprintln!(
+            "skipping real Pi adapter contract smoke; set BUZZ_PI_AGENT_BIN or run `just pi-agent-contract-test`"
+        );
+        return;
+    };
+    let adapter_entrypoint = adapter_entrypoint
+        .canonicalize()
+        .expect("BUZZ_PI_AGENT_BIN must point to the built dist/cli.js");
+    let cwd = std::env::current_dir()
+        .expect("read test cwd")
+        .canonicalize()
+        .expect("canonicalize test cwd");
+    let root = std::env::temp_dir().join(format!(
+        "buzz-pi-adapter-contract-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let state_dir = root.join("state");
+    let pi_agent_dir = root.join("pi-agent");
+
+    let result =
+        buzz_acp::verify_pi_adapter_contract(&adapter_entrypoint, &state_dir, &pi_agent_dir, &cwd)
+            .await;
+    if let Err(error) = std::fs::remove_dir_all(&root) {
+        eprintln!("warning: could not remove contract-smoke state: {error}");
+    }
+    result.expect("real Buzz ACP ↔ Pi adapter contract must hold");
+}

--- a/desktop/public/harness-logos/CREDITS.md
+++ b/desktop/public/harness-logos/CREDITS.md
@@ -26,6 +26,7 @@ Monochrome marks inlined as `currentColor` paths in
 |---|---|---|---|---|---|
 | Goose | [block/goose](https://github.com/block/goose) | `305849b71709b95b86ed9f11bd3bc939899c0aab` | Apache-2.0 © Block, Inc. | `documentation/static/img/goose.svg` | `fill="#101010"` → `currentColor`; dropped the redundant clipPath wrapper |
 | Cursor | [simple-icons](https://github.com/simple-icons/simple-icons) | `16.27.1` (slug `cursor`) | CC0-1.0 (path data); nominative use of the Cursor mark to identify Cursor's harness | `icons/cursor.svg` | `fill` → `currentColor` |
+| Pi | Locally drawn mathematical symbol | N/A | Original to Buzz | N/A | Neutral `currentColor` outline used to identify the Pi SDK adapter without redistributing a vendor mark |
 
 Codex deliberately has **no** bundled mark: the OpenAI blossom was removed
 from simple-icons in v16 at the vendor's request, so we do not ship it —

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -10,9 +10,12 @@ use crate::managed_agents::{
     HarnessSource,
 };
 
+mod command_identity;
 mod presets;
 mod runtime_metadata;
 
+use command_identity::normalize_command_identity;
+pub(crate) use command_identity::requires_durable_thread_sessions;
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use presets::{preset_harness_definitions, preset_harness_ids};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
@@ -227,35 +230,6 @@ fn executable_basename(command: &str) -> String {
     } else {
         format!("{command}{suffix}")
     }
-}
-
-fn normalize_command_identity(command: &str) -> String {
-    let normalized = command.trim().replace('\\', "/");
-    let basename = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
-    let lower = basename
-        .chars()
-        .map(|character| match character {
-            ' ' | '_' => '-',
-            _ => character.to_ascii_lowercase(),
-        })
-        .collect::<String>();
-    let lower = lower.strip_suffix(".exe").unwrap_or(&lower).to_string();
-
-    if let Some(suffix) = std::env::consts::EXE_SUFFIX.strip_prefix('.') {
-        return lower
-            .strip_suffix(&format!(".{suffix}"))
-            .unwrap_or(&lower)
-            .to_string();
-    }
-
-    if !std::env::consts::EXE_SUFFIX.is_empty() {
-        return lower
-            .strip_suffix(std::env::consts::EXE_SUFFIX)
-            .unwrap_or(&lower)
-            .to_string();
-    }
-
-    lower
 }
 
 pub(crate) fn known_acp_runtime(command: &str) -> Option<&'static KnownAcpRuntime> {

--- a/desktop/src-tauri/src/managed_agents/discovery/command_identity.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/command_identity.rs
@@ -1,0 +1,51 @@
+/// Normalize a configured ACP command to the executable identity used by
+/// runtime presets. Paths, Windows suffixes, case, spaces, and underscores do
+/// not change the identity.
+pub(super) fn normalize_command_identity(command: &str) -> String {
+    let normalized = command.trim().replace('\\', "/");
+    let basename = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
+    let lower = basename
+        .chars()
+        .map(|character| match character {
+            ' ' | '_' => '-',
+            _ => character.to_ascii_lowercase(),
+        })
+        .collect::<String>();
+    let lower = lower.strip_suffix(".exe").unwrap_or(&lower).to_string();
+
+    if let Some(suffix) = std::env::consts::EXE_SUFFIX.strip_prefix('.') {
+        return lower
+            .strip_suffix(&format!(".{suffix}"))
+            .unwrap_or(&lower)
+            .to_string();
+    }
+    if !std::env::consts::EXE_SUFFIX.is_empty() {
+        return lower
+            .strip_suffix(std::env::consts::EXE_SUFFIX)
+            .unwrap_or(&lower)
+            .to_string();
+    }
+    lower
+}
+
+/// Whether this adapter contract requires Buzz to select durable per-thread
+/// queue identity before lazy startup accepts its first event.
+pub(crate) fn requires_durable_thread_sessions(command: &str) -> bool {
+    normalize_command_identity(command) == "buzz-pi-agent"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::requires_durable_thread_sessions;
+
+    #[test]
+    fn pi_requires_durable_thread_sessions_for_bare_and_resolved_commands() {
+        assert!(requires_durable_thread_sessions("buzz-pi-agent"));
+        assert!(requires_durable_thread_sessions(
+            "/Users/example/.local/bin/buzz-pi-agent"
+        ));
+        assert!(requires_durable_thread_sessions("BUZZ_PI_AGENT.EXE"));
+        assert!(!requires_durable_thread_sessions("pi"));
+        assert!(!requires_durable_thread_sessions("goose"));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -147,6 +147,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         underlying_cli: Some("amp"),
     },
     PresetHarness {
+        id: "pi",
+        label: "Pi",
+        command: "buzz-pi-agent",
+        args: &[],
+        install_instructions_url: "https://github.com/block/buzz/tree/main/packages/buzz-pi-agent",
+        install_hint: "Buzz talks to the Pi coding agent through Buzz's buzz-pi-agent ACP adapter. Install the adapter so buzz-pi-agent is on your PATH; your existing Pi authentication, settings, and trusted extensions are reused.",
+        underlying_cli: Some("pi"),
+    },
+    PresetHarness {
         id: "hermes",
         label: "Hermes Agent",
         command: "hermes-acp",
@@ -268,6 +277,39 @@ mod tests {
         assert_eq!(entry.default_args, vec!["acp"]);
         assert_eq!(entry.install_instructions_url, "https://docs.devin.ai/cli");
         assert_eq!(entry.source, HarnessSource::Preset);
+    }
+
+    #[test]
+    fn pi_preset_uses_the_buzz_adapter_and_detects_an_existing_pi_cli() {
+        let preset = PRESET_HARNESSES
+            .iter()
+            .find(|preset| preset.id == "pi")
+            .expect("Pi preset should be present");
+
+        assert_eq!(preset.label, "Pi");
+        assert_eq!(preset.command, "buzz-pi-agent");
+        assert!(preset.args.is_empty());
+        assert_eq!(preset.underlying_cli, Some("pi"));
+
+        let adapter_missing = preset_catalog_entry(preset, |command| {
+            (command == "pi").then(|| PathBuf::from("/usr/local/bin/pi"))
+        });
+        assert_eq!(
+            adapter_missing.availability,
+            AcpAvailabilityStatus::AdapterMissing
+        );
+        assert!(adapter_missing.command.is_none());
+        assert_eq!(
+            adapter_missing.underlying_cli_path.as_deref(),
+            Some("/usr/local/bin/pi")
+        );
+
+        let available = preset_catalog_entry(preset, |command| {
+            (command == "buzz-pi-agent").then(|| PathBuf::from("/usr/local/bin/buzz-pi-agent"))
+        });
+        assert_eq!(available.availability, AcpAvailabilityStatus::Available);
+        assert_eq!(available.command.as_deref(), Some("buzz-pi-agent"));
+        assert!(available.default_args.is_empty());
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -71,6 +71,10 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     "BUZZ_ACP_AGENT_COMMAND",
     "BUZZ_ACP_AGENT_ARGS",
     "BUZZ_ACP_MCP_COMMAND",
+    // Conversation-safety contract: the desktop derives this from the
+    // selected harness. A user override could silently collapse Pi threads
+    // into one channel context or force an incompatible adapter to crash-loop.
+    "BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS",
     // Security gates: respond-to mode + allowlist + legacy owner-only
     // fallback. Overriding would make the running agent's gate diverge
     // from the saved/UI-visible settings.

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -168,6 +168,14 @@ fn reserved_keys_include_remote_lifetime_policy() {
 }
 
 #[test]
+fn reserved_keys_include_durable_thread_session_contract() {
+    let key = "BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS";
+    assert!(is_reserved_env_key(key));
+    let agent = map(&[(key, "false")]);
+    assert!(merged_user_env(&BTreeMap::new(), &agent).is_empty());
+}
+
+#[test]
 fn reserved_keys_include_code_execution_surface() {
     // The agent/MCP command + args are what Buzz actually exec's.
     // Overriding lets the user run arbitrary code as the agent.

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -20,6 +20,9 @@ pub(crate) use path::compose_path_entries;
 pub(crate) use path::should_skip_claude_executable;
 pub(crate) use path::should_use_inherited;
 
+mod spawn_env;
+use spawn_env::{apply_harness_process_env, HarnessProcessEnv};
+
 mod metadata;
 pub(crate) use metadata::{
     resolve_effective_prompt_model_provider, resolve_session_title, runtime_metadata_env_vars,
@@ -576,26 +579,19 @@ pub fn spawn_agent_child(
     if let Some(ref path) = augmented_path {
         command.env("PATH", path);
     }
-    command.env("RUST_LOG", child_rust_log_filter());
-    command.env("BUZZ_PRIVATE_KEY", &record.private_key_nsec);
-    command.env("BUZZ_RELAY_URL", &effective_relay_url);
-    command.env("BUZZ_ACP_LAZY_POOL", if lazy { "true" } else { "false" });
-    command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
-    command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
-    match &resolved_mcp_command {
-        Some(mcp_cmd) => {
-            command.env("BUZZ_ACP_MCP_COMMAND", mcp_cmd);
-        }
-        None => {
-            command.env("BUZZ_ACP_MCP_COMMAND", "");
-        }
-    }
-    // Enable MCP hook tools (_Stop, _PostCompact) for agents that need them.
-    // Uses "*" because build_mcp_servers() hard-codes the server name to "buzz-mcp".
     let runtime_meta = known_acp_runtime(effective_command);
-    if runtime_meta.is_some_and(|r| r.mcp_hooks) {
-        command.env("MCP_HOOK_SERVERS", "*");
-    }
+    apply_harness_process_env(
+        &mut command,
+        HarnessProcessEnv {
+            record,
+            relay_url: &effective_relay_url,
+            lazy,
+            effective_command,
+            resolved_agent_command: &resolved_agent_command,
+            agent_args,
+            resolved_mcp_command: resolved_mcp_command.as_deref(),
+        },
+    );
 
     // ── Readiness check: set setup-payload if agent is not ready ─────────────
     //

--- a/desktop/src-tauri/src/managed_agents/runtime/spawn_env.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/spawn_env.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::managed_agents::{
+    known_acp_runtime, requires_durable_thread_sessions, ManagedAgentRecord,
+};
+
+pub(super) struct HarnessProcessEnv<'a> {
+    pub record: &'a ManagedAgentRecord,
+    pub relay_url: &'a str,
+    pub lazy: bool,
+    pub effective_command: &'a str,
+    pub resolved_agent_command: &'a str,
+    pub agent_args: &'a [String],
+    pub resolved_mcp_command: Option<&'a Path>,
+}
+
+/// Apply the Buzz-owned harness environment as one unit. Keeping these values
+/// together makes the thread-session safety flag inseparable from the adapter
+/// command it describes and keeps the process-spawn boundary reviewable.
+pub(super) fn apply_harness_process_env(command: &mut Command, env: HarnessProcessEnv<'_>) {
+    command.env("RUST_LOG", super::child_rust_log_filter());
+    command.env("BUZZ_PRIVATE_KEY", &env.record.private_key_nsec);
+    command.env("BUZZ_RELAY_URL", env.relay_url);
+    command.env("BUZZ_ACP_LAZY_POOL", env.lazy.to_string());
+    command.env("BUZZ_ACP_AGENT_COMMAND", env.resolved_agent_command);
+    command.env("BUZZ_ACP_AGENT_ARGS", env.agent_args.join(","));
+    command.env(
+        "BUZZ_ACP_REQUIRE_DURABLE_THREAD_SESSIONS",
+        requires_durable_thread_sessions(env.effective_command).to_string(),
+    );
+    command.env(
+        "BUZZ_ACP_MCP_COMMAND",
+        env.resolved_mcp_command
+            .map_or_else(|| "".into(), Path::to_path_buf),
+    );
+    if known_acp_runtime(env.effective_command).is_some_and(|runtime| runtime.mcp_hooks) {
+        // `build_mcp_servers()` fixes the server name to `buzz-mcp`.
+        command.env("MCP_HOOK_SERVERS", "*");
+    }
+}

--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, afterEach, mock } from "node:test";
 import {
   syncAgentTurnsFromEvents,
   syncActiveAgentTurnsFromObserver,
+  getActiveTurnDetailsForAgent,
   getActiveTurnsForAgent,
   getActiveTurnsByChannel,
   resetActiveAgentTurnsStore,
@@ -734,6 +735,27 @@ describe("activeAgentTurnsStore", () => {
         summaries[0].anchorAt,
         firstAnchor,
         "earliest start's anchor must be surfaced",
+      );
+    });
+
+    it("preserves exact turn ids for sibling thread controls", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "thread-b", channelId: "c1" }),
+        makeEvent({ seq: 2, turnId: "thread-a", channelId: "c1" }),
+      ]);
+
+      const details = getActiveTurnDetailsForAgent(AGENT);
+      assert.deepEqual(
+        details.map(({ channelId, turnId }) => ({ channelId, turnId })),
+        [
+          { channelId: "c1", turnId: "thread-a" },
+          { channelId: "c1", turnId: "thread-b" },
+        ],
+      );
+      assert.equal(
+        getActiveTurnDetailsForAgent(AGENT),
+        details,
+        "exact-turn snapshot must keep a stable reference",
       );
     });
 

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -50,6 +50,12 @@ export type ActiveTurnSummary = {
   anchorAt: number;
 };
 
+/** One exact active turn. Used by controls that must never guess between
+ * sibling thread turns running concurrently in the same channel. */
+export type ActiveTurnDetail = ActiveTurnSummary & {
+  turnId: string;
+};
+
 /** One channel with active agent work, aggregated across agents. */
 export type ActiveChannelTurnSummary = {
   channelId: string;
@@ -83,6 +89,7 @@ const clockOffsetByAgent = new Map<string, number>();
 // Cached snapshots for useSyncExternalStore reference stability.
 // Only regenerated when the underlying turn map for an agent actually changes.
 const cachedTurnSummaries = new Map<string, ActiveTurnSummary[]>();
+const cachedTurnDetails = new Map<string, ActiveTurnDetail[]>();
 let cachedChannelTurnSummaries: ActiveChannelTurnSummary[] | null = null;
 
 // Composite watermark per agent: the newest observer event processed, by
@@ -103,6 +110,7 @@ let pruneInterval: ReturnType<typeof setInterval> | null = null;
 
 function invalidateCache(agentKey: string) {
   cachedTurnSummaries.delete(agentKey);
+  cachedTurnDetails.delete(agentKey);
   cachedChannelTurnSummaries = null;
 }
 
@@ -457,7 +465,41 @@ export function getActiveTurnsForAgent(
 }
 
 const EMPTY_TURNS: ActiveTurnSummary[] = [];
+const EMPTY_TURN_DETAILS: ActiveTurnDetail[] = [];
 const EMPTY_CHANNEL_TURNS: ActiveChannelTurnSummary[] = [];
+
+/**
+ * Returns every exact active turn for an agent. Unlike
+ * `getActiveTurnsForAgent`, this deliberately does not collapse sibling turns
+ * in the same channel; callers use `turnId` as the authoritative control key.
+ * The returned reference is stable until the underlying turn map changes.
+ */
+export function getActiveTurnDetailsForAgent(
+  agentPubkey: string | null | undefined,
+): ActiveTurnDetail[] {
+  if (!agentPubkey) return EMPTY_TURN_DETAILS;
+  const key = normalizePubkey(agentPubkey);
+  const agentTurns = activeTurnsByAgent.get(key);
+  if (!agentTurns || agentTurns.size === 0) return EMPTY_TURN_DETAILS;
+
+  const cached = cachedTurnDetails.get(key);
+  if (cached) return cached;
+
+  const offset = clockOffsetByAgent.get(key) ?? 0;
+  const result = [...agentTurns.values()]
+    .map((turn) => ({
+      turnId: turn.turnId,
+      channelId: turn.channelId,
+      anchorAt: turn.startedAt + offset,
+    }))
+    .sort(
+      (a, b) =>
+        a.channelId.localeCompare(b.channelId) ||
+        a.turnId.localeCompare(b.turnId),
+    );
+  cachedTurnDetails.set(key, result);
+  return result;
+}
 
 /**
  * Returns active working channels across all tracked agents, sorted by
@@ -529,6 +571,18 @@ export function useActiveAgentTurns(
 ): ActiveTurnSummary[] {
   const getSnapshot = React.useCallback(
     () => getActiveTurnsForAgent(agentPubkey),
+    [agentPubkey],
+  );
+
+  return React.useSyncExternalStore(subscribeActiveAgentTurns, getSnapshot);
+}
+
+/** React hook for exact active turn identities (including sibling threads). */
+export function useActiveAgentTurnDetails(
+  agentPubkey: string | null | undefined,
+): ActiveTurnDetail[] {
+  const getSnapshot = React.useCallback(
+    () => getActiveTurnDetailsForAgent(agentPubkey),
     [agentPubkey],
   );
 
@@ -618,6 +672,7 @@ export function resetActiveAgentTurnsStore() {
   lastProcessed.clear();
   clockOffsetByAgent.clear();
   cachedTurnSummaries.clear();
+  cachedTurnDetails.clear();
   cachedChannelTurnSummaries = null;
   terminalAtByAgent.clear();
   notifyListeners();
@@ -728,6 +783,7 @@ export function restoreActiveAgentTurnsForCommunity(communityId: string): void {
   }
 
   cachedTurnSummaries.clear();
+  cachedTurnDetails.clear();
   cachedChannelTurnSummaries = null;
   notifyListeners();
 }

--- a/desktop/src/features/agents/lib/controlResultCorrelation.test.mjs
+++ b/desktop/src/features/agents/lib/controlResultCorrelation.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { correlateControlResultFrame } from "./controlResultCorrelation.ts";
+
+test("deferred model result preserves the originally targeted turn", () => {
+  assert.deepEqual(
+    correlateControlResultFrame(
+      {
+        type: "switch_model",
+        status: "switched",
+        modelId: "model-b",
+        turnId: "original-turn-a",
+      },
+      "replacement-turn-b",
+    ),
+    {
+      type: "switch_model",
+      status: "switched",
+      modelId: "model-b",
+      turnId: "original-turn-a",
+    },
+  );
+});
+
+test("envelope turn id is used when a legacy result omits payload correlation", () => {
+  assert.deepEqual(
+    correlateControlResultFrame(
+      { type: "switch_model", status: "unsupported_model", modelId: "x" },
+      "turn-a",
+    ),
+    {
+      type: "switch_model",
+      status: "unsupported_model",
+      modelId: "x",
+      turnId: "turn-a",
+    },
+  );
+});
+
+test("contradictory immediate acknowledgement is rejected", () => {
+  assert.equal(
+    correlateControlResultFrame(
+      { type: "switch_model", status: "sent", turnId: "turn-a" },
+      "turn-b",
+    ),
+    null,
+  );
+});
+
+test("oversized payload turn id cannot displace a valid envelope id", () => {
+  const frame = correlateControlResultFrame(
+    { type: "switch_model", status: "switch_failed", turnId: "x".repeat(129) },
+    "turn-a",
+  );
+  assert.equal(frame?.turnId, "turn-a");
+});

--- a/desktop/src/features/agents/lib/controlResultCorrelation.ts
+++ b/desktop/src/features/agents/lib/controlResultCorrelation.ts
@@ -1,0 +1,39 @@
+import type { ControlResultFrame } from "@/shared/api/types";
+
+const DEFERRED_MODEL_RESULTS = new Set([
+  "switched",
+  "switch_failed",
+  "unsupported_model",
+]);
+
+function validTurnId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 128;
+}
+
+/**
+ * Correlate a control result to the turn originally targeted by Desktop.
+ * Deferred model results are emitted from the replacement turn, so their
+ * payload's original turn id intentionally differs from the observer envelope.
+ * Immediate results must agree with the envelope when both ids are present.
+ */
+export function correlateControlResultFrame(
+  payload: ControlResultFrame,
+  envelopeTurnId: string | null,
+): ControlResultFrame | null {
+  const payloadTurnId = validTurnId(payload.turnId)
+    ? payload.turnId
+    : undefined;
+  const envelopeId = validTurnId(envelopeTurnId) ? envelopeTurnId : undefined;
+
+  if (
+    payloadTurnId &&
+    envelopeId &&
+    payloadTurnId !== envelopeId &&
+    !DEFERRED_MODEL_RESULTS.has(payload.status)
+  ) {
+    return null;
+  }
+
+  const turnId = payloadTurnId ?? envelopeId;
+  return turnId ? { ...payload, turnId } : payload;
+}

--- a/desktop/src/features/agents/lib/liveSwitchOutcome.test.mjs
+++ b/desktop/src/features/agents/lib/liveSwitchOutcome.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { awaitLiveSwitchOutcome } from "./liveSwitchOutcome.ts";
+import {
+  awaitLiveSwitchOutcome,
+  sendAllLiveSwitchRequests,
+} from "./liveSwitchOutcome.ts";
 
 const MODEL = "goose-claude-fable-5";
 
@@ -15,7 +18,7 @@ function frame(status, overrides = {}) {
  * no-ops, matching `observerRelayStore`), a manual timeout, and a deferred
  * `sendSwitches` the test resolves explicitly.
  */
-function harness(channelCount) {
+function harness(channelCount, turnIds) {
   let listener = null;
   let timeoutCb = null;
   let unsubscribeCalls = 0;
@@ -28,6 +31,7 @@ function harness(channelCount) {
   const outcome = awaitLiveSwitchOutcome({
     channelCount,
     modelId: MODEL,
+    turnIds,
     subscribe: (fn) => {
       listener = fn;
       return () => {
@@ -90,13 +94,17 @@ test("awaitLiveSwitchOutcome resolves ok only after the last channel acks", asyn
 
   h.push(frame("sent"));
   await drainMicrotasks();
-  assert.equal(settled, false, "must not resolve on the first ack");
+  assert.equal(settled, false, "delivery acknowledgement is not final success");
 
   h.push(frame("switched"));
   await drainMicrotasks();
-  assert.equal(settled, false, "must not resolve before the last ack");
+  assert.equal(settled, false, "must not resolve after the first final result");
 
-  h.push(frame("turn_ending"));
+  h.push(frame("switched"));
+  await drainMicrotasks();
+  assert.equal(settled, false, "must not resolve before the last final result");
+
+  h.push(frame("switched"));
   assert.equal(await h.outcome, "ok");
 });
 
@@ -128,10 +136,137 @@ test("awaitLiveSwitchOutcome ignores frames for a different model or control typ
   assert.equal(await h.outcome, "ok");
 });
 
-test("awaitLiveSwitchOutcome resolves ok via the timeout fallback when the harness never replies", async () => {
+test("awaitLiveSwitchOutcome correlates sibling acknowledgements by exact turn id", async () => {
+  const h = harness(2, ["turn-a", "turn-b"]);
+  h.push(frame("switched", { turnId: "turn-a" }));
+  h.push(frame("switched", { turnId: "turn-a" }));
+  h.push(frame("switched", { turnId: "stale-turn" }));
+
+  let settled = false;
+  void h.outcome.then(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  assert.equal(settled, false, "duplicate/stale turn acks must not over-count");
+
+  h.push(frame("switched", { turnId: "turn-b" }));
+  assert.equal(await h.outcome, "ok");
+});
+
+test("awaitLiveSwitchOutcome fails closed when a targeted turn disappeared, is ending, application failed, or correlation is ambiguous", async () => {
+  for (const status of [
+    "no_active_turn",
+    "turn_ending",
+    "switch_failed",
+    "ambiguous",
+  ]) {
+    const h = harness(1, ["turn-a"]);
+    h.push(frame(status, { turnId: "turn-a" }));
+    assert.equal(await h.outcome, "failed");
+    assert.equal(h.unsubscribeCalls, 1);
+    assert.equal(h.cancelTimeoutCalls, 1);
+  }
+});
+
+test("awaitLiveSwitchOutcome reports failure after a sibling already switched", async () => {
+  const h = harness(2, ["turn-a", "turn-b"]);
+  h.push(frame("switched", { turnId: "turn-a" }));
+  h.push(frame("switch_failed", { turnId: "turn-b" }));
+  assert.equal(
+    await h.outcome,
+    "failed",
+    "a mixed applied/rejected result must never be presented as atomic success",
+  );
+});
+
+test("awaitLiveSwitchOutcome reports failed and cleans up when sending rejects", async () => {
+  let listener = null;
+  let unsubscribeCalls = 0;
+  let cancelTimeoutCalls = 0;
+  const failure = new Error("observer control send failed");
+
+  const outcome = await awaitLiveSwitchOutcome({
+    channelCount: 1,
+    modelId: MODEL,
+    turnIds: ["turn-a"],
+    subscribe: (next) => {
+      listener = next;
+      return () => {
+        unsubscribeCalls += 1;
+        listener = null;
+      };
+    },
+    sendSwitches: async () => {
+      throw failure;
+    },
+    scheduleTimeout: () => () => {
+      cancelTimeoutCalls += 1;
+    },
+  });
+
+  assert.equal(outcome, "failed");
+  assert.equal(listener, null);
+  assert.equal(unsubscribeCalls, 1);
+  assert.equal(cancelTimeoutCalls, 1);
+});
+
+test("sendAllLiveSwitchRequests attempts every sibling before reporting mixed delivery failure", async () => {
+  const attempts = [];
+
+  await assert.rejects(
+    sendAllLiveSwitchRequests([
+      async () => {
+        attempts.push("turn-a");
+      },
+      async () => {
+        attempts.push("turn-b");
+        throw new Error("relay rejected turn-b");
+      },
+      async () => {
+        attempts.push("turn-c");
+      },
+    ]),
+    /Failed to deliver 1 of 3/,
+  );
+
+  assert.deepEqual(attempts, ["turn-a", "turn-b", "turn-c"]);
+});
+
+test("mixed live-send success and rejection resolves to the partial-application failure path", async () => {
+  let listener = null;
+  const attempted = [];
+  const outcome = awaitLiveSwitchOutcome({
+    channelCount: 2,
+    modelId: MODEL,
+    turnIds: ["turn-a", "turn-b"],
+    subscribe: (next) => {
+      listener = next;
+      return () => {
+        listener = null;
+      };
+    },
+    sendSwitches: () =>
+      sendAllLiveSwitchRequests([
+        async () => {
+          attempted.push("turn-a");
+          listener?.(frame("switched", { turnId: "turn-a" }));
+        },
+        async () => {
+          attempted.push("turn-b");
+          throw new Error("publish failed");
+        },
+      ]),
+    scheduleTimeout: () => () => {},
+  });
+
+  assert.equal(await outcome, "failed");
+  assert.deepEqual(attempted, ["turn-a", "turn-b"]);
+});
+
+test("awaitLiveSwitchOutcome reports pending via the timeout fallback when the harness never replies", async () => {
   const h = harness(2);
   h.fireTimeout();
-  assert.equal(await h.outcome, "ok");
+  assert.equal(await h.outcome, "pending");
   assert.equal(h.unsubscribeCalls, 1, "timeout fallback unsubscribes");
 });
 
@@ -140,15 +275,15 @@ test("awaitLiveSwitchOutcome fires the per-channel sends after subscribing", asy
   // The subscription is registered before the sends fire, so a frame arriving
   // mid-send is never dropped. Awaiting sendStarted proves sends ran.
   await h.sendStarted;
-  h.push(frame("sent"));
+  h.push(frame("switched"));
   assert.equal(await h.outcome, "ok");
 });
 
-test("awaitLiveSwitchOutcome with zero channels resolves ok at the timeout (no acks expected)", async () => {
+test("awaitLiveSwitchOutcome with zero channels reports pending at the timeout (no acks expected)", async () => {
   // No active turns means channelCount 0: remaining starts at 0 but the success
   // resolve only fires inside a frame callback, so with no frames the timeout
   // fallback is what settles it. This documents the degenerate path.
   const h = harness(0);
   h.fireTimeout();
-  assert.equal(await h.outcome, "ok");
+  assert.equal(await h.outcome, "pending");
 });

--- a/desktop/src/features/agents/lib/liveSwitchOutcome.ts
+++ b/desktop/src/features/agents/lib/liveSwitchOutcome.ts
@@ -5,11 +5,12 @@ import type { ControlResultFrame } from "@/shared/api/types";
  *
  * A live switch fires a `switch_model` frame per active channel and learns each
  * channel's result asynchronously over the observer relay. The fail-fast rule:
- * any single `unsupported_model` result rejects the whole pick immediately;
- * every other status must arrive from every channel before resolving success.
- * If the harness never replies, the fallback timeout resolves `"ok"` — the
- * override still rides the requeued/next session, we just can't confirm it
- * synchronously.
+ * any terminal failure rejects the whole pick immediately; a final `switched`
+ * status must arrive from every exact turn before resolving success. The
+ * immediate `sent` status is deliberately non-terminal: it confirms delivery,
+ * not model validation or application. If the harness never reports a final
+ * result, the fallback timeout resolves `"pending"` rather than claiming the
+ * model was switched.
  *
  * The counting lives here, isolated from React and the relay so it can be unit
  * tested with synthetic frames and a fake clock. The caller injects the
@@ -18,6 +19,7 @@ import type { ControlResultFrame } from "@/shared/api/types";
 export async function awaitLiveSwitchOutcome({
   channelCount,
   modelId,
+  turnIds,
   subscribe,
   sendSwitches,
   scheduleTimeout,
@@ -26,41 +28,111 @@ export async function awaitLiveSwitchOutcome({
   channelCount: number;
   /** Model being switched to; frames for any other model are ignored. */
   modelId: string;
+  /** Exact turns targeted by this request. When present, duplicate or stale
+   * acknowledgements cannot satisfy another sibling turn's slot. */
+  turnIds?: readonly string[];
   /** Register a control-result listener; returns an unsubscribe function. */
   subscribe: (listener: (frame: ControlResultFrame) => void) => () => void;
   /** Fire the per-channel `switch_model` sends. Resolves when all are sent. */
   sendSwitches: () => Promise<void>;
   /** Schedule the no-reply fallback; returns a cancel function. */
   scheduleTimeout: (onTimeout: () => void) => () => void;
-}): Promise<"ok" | "unsupported"> {
-  const settled = new Promise<"ok" | "unsupported">((resolve) => {
-    let unsubscribe = () => {};
-    let cancelTimeout = () => {};
-    let remaining = channelCount;
-    const finish = (outcome: "ok" | "unsupported") => {
-      cancelTimeout();
-      unsubscribe();
-      resolve(outcome);
-    };
-    cancelTimeout = scheduleTimeout(() => finish("ok"));
-    unsubscribe = subscribe((frame) => {
-      if (frame.type !== "switch_model" || frame.modelId !== modelId) {
-        return;
-      }
-      if (frame.status === "unsupported_model") {
-        // Any single failure rejects the whole pick immediately.
-        finish("unsupported");
-        return;
-      }
-      // sent / switched / turn_ending — count as success for this channel.
-      remaining -= 1;
-      if (remaining <= 0) {
-        finish("ok");
-      }
-    });
-  });
+}): Promise<"ok" | "pending" | "unsupported" | "failed"> {
+  let unsubscribe = () => {};
+  let cancelTimeout = () => {};
+  let finished = false;
+  let resolveSettled: (
+    outcome: "ok" | "pending" | "unsupported" | "failed",
+  ) => void = () => {};
+  const settled = new Promise<"ok" | "pending" | "unsupported" | "failed">(
+    (resolve) => {
+      resolveSettled = resolve;
+    },
+  );
+  let remaining = channelCount;
+  const pendingTurnIds = turnIds ? new Set(turnIds) : null;
+  const cleanup = () => {
+    cancelTimeout();
+    unsubscribe();
+  };
+  const finish = (outcome: "ok" | "pending" | "unsupported" | "failed") => {
+    if (finished) return;
+    finished = true;
+    cleanup();
+    resolveSettled(outcome);
+  };
 
-  await sendSwitches();
+  unsubscribe = subscribe((frame) => {
+    if (frame.type !== "switch_model" || frame.modelId !== modelId) {
+      return;
+    }
+    const isSuccess = frame.status === "switched";
+    const isDeliveryAck = frame.status === "sent";
+    const isUnsupported = frame.status === "unsupported_model";
+    const isFailed = [
+      "no_active_turn",
+      "ambiguous",
+      "turn_ending",
+      "switch_failed",
+    ].includes(frame.status);
+    if (!isSuccess && !isDeliveryAck && !isUnsupported && !isFailed) {
+      return;
+    }
+    if (isDeliveryAck) {
+      return;
+    }
+    if (pendingTurnIds) {
+      if (!frame.turnId || !pendingTurnIds.delete(frame.turnId)) {
+        return;
+      }
+      remaining = pendingTurnIds.size;
+    }
+    if (isUnsupported) {
+      finish("unsupported");
+      return;
+    }
+    if (isFailed) {
+      finish("failed");
+      return;
+    }
+    if (!pendingTurnIds) {
+      remaining -= 1;
+    }
+    if (remaining <= 0) {
+      finish("ok");
+    }
+  });
+  cancelTimeout = scheduleTimeout(() => finish("pending"));
+
+  try {
+    await sendSwitches();
+  } catch {
+    // Delivery is not atomic: one relay publish can succeed before a sibling
+    // publish fails. Treat that as the same partial-application failure as a
+    // rejected harness result so the caller refreshes every session surface
+    // and never implies the previous model was retained everywhere.
+    finish("failed");
+  }
 
   return settled;
+}
+
+/**
+ * Attempt every live model-switch publish even when an earlier target fails.
+ * Relay sends are independent and cannot be rolled back, so fail only after
+ * every exact turn has had a delivery attempt.
+ */
+export async function sendAllLiveSwitchRequests(
+  requests: readonly (() => Promise<void>)[],
+): Promise<void> {
+  const results = await Promise.allSettled(
+    requests.map((request) => Promise.resolve().then(request)),
+  );
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      `Failed to deliver ${failures.length} of ${requests.length} live model-switch requests`,
+    );
+  }
 }

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -25,6 +25,7 @@ import {
   createEmptyTranscriptState,
   processTranscriptEvent,
 } from "./ui/agentSessionTranscript";
+import { correlateControlResultFrame } from "./lib/controlResultCorrelation";
 
 const MAX_OBSERVER_EVENTS = 3000;
 const MAX_PENDING_UNKNOWN_AGENT_FRAMES = 100;
@@ -402,7 +403,7 @@ async function handleRelayObserverEvent(
       void putAgentSessionConfig(agentPubkey, parsed.payload);
       onSessionConfigCaptured?.(agentPubkey);
     } else if (parsed.kind === "control_result") {
-      dispatchControlResult(agentPubkey, parsed.payload);
+      dispatchControlResult(agentPubkey, parsed.payload, parsed.turnId);
     } else if (parsed.kind === "managed_agent_runtime_lifecycle") {
       void putManagedAgentRuntimeLifecycle(agentPubkey, parsed.payload).catch(
         (error) => {
@@ -495,8 +496,16 @@ function isControlResultFrame(payload: unknown): payload is ControlResultFrame {
   );
 }
 
-function dispatchControlResult(agentPubkey: string, payload: unknown) {
+function dispatchControlResult(
+  agentPubkey: string,
+  payload: unknown,
+  envelopeTurnId: string | null,
+) {
   if (!isControlResultFrame(payload)) {
+    return;
+  }
+  const frame = correlateControlResultFrame(payload, envelopeTurnId);
+  if (!frame) {
     return;
   }
   const subscribers = controlResultListeners.get(normalizePubkey(agentPubkey));
@@ -504,7 +513,7 @@ function dispatchControlResult(agentPubkey: string, payload: unknown) {
     return;
   }
   for (const subscriber of subscribers) {
-    subscriber(payload);
+    subscriber(frame);
   }
 }
 

--- a/desktop/src/features/agents/ui/ModelPicker.tsx
+++ b/desktop/src/features/agents/ui/ModelPicker.tsx
@@ -8,10 +8,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { AgentModelsResponse, ManagedAgent } from "@/shared/api/types";
 import { getAgentModels, updateManagedAgent } from "@/shared/api/tauri";
 import { switchManagedAgentModel } from "@/shared/api/agentControl";
-import { awaitLiveSwitchOutcome } from "@/features/agents/lib/liveSwitchOutcome";
-import { subscribeControlResults } from "@/features/agents/observerRelayStore";
-import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
 import {
+  awaitLiveSwitchOutcome,
+  sendAllLiveSwitchRequests,
+} from "@/features/agents/lib/liveSwitchOutcome";
+import { subscribeControlResults } from "@/features/agents/observerRelayStore";
+import { useActiveAgentTurnDetails } from "@/features/agents/activeAgentTurnsStore";
+import {
+  agentConfigSurfaceQueryKey,
   useAgentConfigSurface,
   managedAgentsQueryKey,
 } from "@/features/agents/hooks";
@@ -43,7 +47,7 @@ export function ModelPicker({
   const queryClient = useQueryClient();
 
   const isRunning = agent.status === "running" || agent.status === "deployed";
-  const activeTurns = useActiveAgentTurns(agent.pubkey);
+  const activeTurns = useActiveAgentTurnDetails(agent.pubkey);
   // A live switch rides the agent's running session(s) instead of persisting a
   // new default. It applies only to a persona-linked running agent with at
   // least one active turn — those are the channels the desktop can name in the
@@ -109,25 +113,37 @@ export function ModelPicker({
 
   // Send a live `switch_model` frame to each channel the agent is working in
   // and wait for the harness to acknowledge. Any single `unsupported_model`
-  // result rejects the whole pick immediately; all other statuses must arrive
-  // from every channel before resolving success.
+  // or `switch_failed` result rejects the whole pick immediately; confirmed
+  // success must arrive from every exact turn.
   const sendLiveSwitch = React.useCallback(
     (modelId: string) => {
-      const channelIds = activeTurns.map((turn) => turn.channelId);
+      const turnTargets = activeTurns.map(({ channelId, turnId }) => ({
+        channelId,
+        turnId,
+      }));
       return awaitLiveSwitchOutcome({
-        channelCount: channelIds.length,
+        channelCount: turnTargets.length,
         modelId,
+        turnIds: turnTargets.map((turn) => turn.turnId),
         subscribe: (listener) =>
           subscribeControlResults(agent.pubkey, listener),
         sendSwitches: async () => {
-          await Promise.all(
-            channelIds.map((channelId) =>
-              switchManagedAgentModel(agent.pubkey, channelId, modelId),
+          await sendAllLiveSwitchRequests(
+            turnTargets.map(
+              ({ channelId, turnId }) =>
+                () =>
+                  switchManagedAgentModel(
+                    agent.pubkey,
+                    channelId,
+                    turnId,
+                    modelId,
+                  ),
             ),
           );
         },
-        // No reply in time: treat as sent. The override still rides the
-        // requeued/next session; we just can't confirm synchronously.
+        // No final reply in time: report the switch as pending. A `sent`
+        // control frame confirms delivery only; validation happens after the
+        // active turn is cancelled and its replacement session is created.
         scheduleTimeout: (onTimeout) => {
           const timeout = window.setTimeout(onTimeout, 8_000);
           return () => window.clearTimeout(timeout);
@@ -143,12 +159,31 @@ export function ModelPicker({
     try {
       if (isLiveSwitch) {
         const outcome = await sendLiveSwitch(modelId);
+        // Every exact turn applies independently. Refresh even on failure or
+        // timeout because another sibling turn may already have switched.
+        void queryClient.invalidateQueries({
+          queryKey: agentConfigSurfaceQueryKey(agent.pubkey),
+        });
+        onModelChanged?.();
         if (outcome === "unsupported") {
-          toast.error("That model isn't available for this agent.");
+          toast.error(
+            "At least one active turn rejected that model. Other turns may already have switched; review the refreshed session state.",
+          );
+          return;
+        }
+        if (outcome === "failed") {
+          toast.error(
+            "At least one active turn could not apply the model. Other turns may already have switched; review the refreshed session state.",
+          );
+          return;
+        }
+        if (outcome === "pending") {
+          toast.info(
+            "Model switch requested. It is still being applied to the restarted turn.",
+          );
           return;
         }
         toast.success("Model switched for this session.");
-        onModelChanged?.();
         return;
       }
 

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
+import { useActiveAgentTurnDetails } from "@/features/agents/activeAgentTurnsStore";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import {
   mergeObserverEventWindows,
@@ -105,7 +106,17 @@ export function AgentSessionThreadPanel({
     agent.pubkey,
     sessionChannelId,
   );
-  const canStopCurrentTurn = isWorking && canInterruptTurn;
+  const activeTurnDetails = useActiveAgentTurnDetails(agent.pubkey);
+  const scopedActiveTurns = React.useMemo(
+    () =>
+      sessionChannelId
+        ? activeTurnDetails.filter(
+            (turn) => turn.channelId === sessionChannelId,
+          )
+        : [],
+    [activeTurnDetails, sessionChannelId],
+  );
+  const canStopCurrentTurn = scopedActiveTurns.length > 0 && canInterruptTurn;
   useEscapeKey(onClose, isOverlay || isSinglePanelView);
 
   const scrollRef = React.useRef<HTMLDivElement>(null);
@@ -251,14 +262,20 @@ export function AgentSessionThreadPanel({
   const animateActivity = useTranscriptAnimationEnabled();
   const showTimestamps = useTranscriptTimestampsEnabled();
   async function handleInterruptTurn() {
-    if (!channel) {
+    if (!sessionChannelId || scopedActiveTurns.length === 0) {
       return;
     }
 
     try {
-      await cancelManagedAgentTurn(agent.pubkey, channel.id);
+      await Promise.all(
+        scopedActiveTurns.map((turn) =>
+          cancelManagedAgentTurn(agent.pubkey, sessionChannelId, turn.turnId),
+        ),
+      );
       toast.success(
-        `Stop signal sent to ${agent.name}. It may take a moment to respond.`,
+        scopedActiveTurns.length === 1
+          ? `Stop signal sent to ${agent.name}. It may take a moment to respond.`
+          : `Stop signals sent for ${scopedActiveTurns.length} active ${agent.name} turns in this channel.`,
       );
     } catch (error) {
       toast.error(
@@ -403,7 +420,9 @@ export function AgentSessionThreadPanel({
               <Octagon className="mt-0.5 h-4 w-4 text-muted-foreground" />
               <span className="min-w-0 flex-1">
                 <span className="block text-sm font-medium">
-                  Stop current turn
+                  {scopedActiveTurns.length > 1
+                    ? `Stop ${scopedActiveTurns.length} current turns`
+                    : "Stop current turn"}
                 </span>
                 {!canStopCurrentTurn ? (
                   <span className="mt-0.5 block text-xs text-muted-foreground">

--- a/desktop/src/features/onboarding/ui/HarnessMarks.tsx
+++ b/desktop/src/features/onboarding/ui/HarnessMarks.tsx
@@ -39,6 +39,30 @@ function CursorMark({ className }: MarkProps) {
   );
 }
 
+/** A neutral mathematical pi mark for Buzz's Pi SDK adapter. This is drawn
+ * locally rather than bundling a vendor logo, and follows the surrounding
+ * runtime icon's current color in both themes. */
+function PiMark({ className }: MarkProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      role="img"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6v12" />
+      <path d="M15 6v8a4 4 0 0 0 4 4h2" />
+    </svg>
+  );
+}
+
 /// Theme-adaptive inline marks, keyed by runtime/preset id. Consulted before
 /// the bitmap logo maps in `RuntimeIcon`. Codex deliberately has no entry:
 /// the OpenAI blossom was removed from simple-icons v16 at the vendor's
@@ -46,4 +70,5 @@ function CursorMark({ className }: MarkProps) {
 export const RUNTIME_MARKS: Record<string, React.FC<MarkProps>> = {
   cursor: CursorMark,
   goose: GooseMark,
+  pi: PiMark,
 };

--- a/desktop/src/shared/api/agentControl.ts
+++ b/desktop/src/shared/api/agentControl.ts
@@ -4,10 +4,12 @@ import type { CancelManagedAgentTurnResult } from "@/shared/api/types";
 export async function cancelManagedAgentTurn(
   pubkey: string,
   channelId: string,
+  turnId: string,
 ): Promise<CancelManagedAgentTurnResult> {
   await sendAgentObserverControl(pubkey, {
     type: "cancel_turn",
     channelId,
+    turnId,
   });
   return { status: "sent" };
 }
@@ -21,11 +23,13 @@ export async function cancelManagedAgentTurn(
 export async function switchManagedAgentModel(
   pubkey: string,
   channelId: string,
+  turnId: string,
   modelId: string,
 ): Promise<void> {
   await sendAgentObserverControl(pubkey, {
     type: "switch_model",
     channelId,
+    turnId,
     modelId,
   });
 }

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -461,22 +461,20 @@ export type CancelManagedAgentTurnResult = {
   status: "sent" | "no_active_turn";
 };
 
-/**
- * Outcome of a live `switch_model` control frame, surfaced asynchronously via
- * the agent's `control_result` observer frame. Busy path: `sent` (cancel +
- * requeue on the new model) or `turn_ending` (oneshot already consumed this
- * turn). Idle path: `switched`, `unsupported_model`, or `no_active_turn`.
- */
+/** Delivery and final outcomes from asynchronous live `switch_model` control. */
 export type SwitchManagedAgentModelStatus =
   | "sent"
   | "turn_ending"
   | "switched"
+  | "switch_failed"
   | "unsupported_model"
-  | "no_active_turn";
+  | "no_active_turn"
+  | "ambiguous";
 
 export type ControlResultFrame = {
   type: "cancel_turn" | "switch_model";
   status: string;
+  turnId?: string;
   modelId?: string;
 };
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,8 @@
 # Glob patterns below mirror the `changes` job's dorny/paths-filter groups in
 # .github/workflows/ci.yml — keep the two in sync. Deliberate deviations:
-# - The `.github/workflows/ci.yml` path CI adds to its `rust`/`mobile` filters
-#   is omitted; a CI-workflow-only edit doesn't need a local test run.
+# - The `.github/workflows/ci.yml` path CI adds to its `rust`/`mobile`/
+#   `pi-agent` filters is omitted; a CI-workflow-only edit doesn't need a local
+#   test run.
 # - `desktop-check`/`desktop-test` don't trigger on `rust` changes, though CI's
 #   Desktop Core job does. Those commands are pure TS (biome + node:test) with
 #   no Rust dependency, so the extra trigger would be spurious locally.
@@ -61,6 +62,11 @@ pre-push:
       glob: ["desktop/**", "pnpm-lock.yaml"]
       exclude: ["desktop/src-tauri/**"]
       run: just desktop-test
+    pi-agent:
+      # Keep the Node and cross-process suites in one hook: both touch the
+      # adapter's dist directory, so parallel hooks would race its clean/build.
+      glob: ["packages/buzz-pi-agent/**", "crates/buzz-acp/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "pnpm-workspace.yaml", "pnpm-lock.yaml", "Justfile"]
+      run: just pi-agent-check && just pi-agent-verify
     desktop-tauri-checks:
       # Keep local lint parity with Desktop Core CI for every path that can
       # affect the Tauri crate or its path dependencies. Run clippy and tests

--- a/packages/buzz-pi-agent/.gitignore
+++ b/packages/buzz-pi-agent/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+package-lock.json
+*.tgz

--- a/packages/buzz-pi-agent/README.md
+++ b/packages/buzz-pi-agent/README.md
@@ -1,0 +1,372 @@
+# Buzz Pi Agent
+
+`buzz-pi-agent` is a production ACP adapter that runs the Pi coding-agent SDK as
+a first-class Buzz agent. Buzz owns identity, thread routing, and authenticated
+session resets; Pi owns the model loop, tools, session transcript, compaction,
+extensions, skills, and prompt templates.
+
+The package is intentionally private to the Buzz monorepo. It pins
+`@earendil-works/pi-coding-agent` to exactly `0.83.0` because the durable-session
+and final-provider safety boundaries are version-sensitive.
+
+## What it provides
+
+- One durable Pi session and context per Buzz thread.
+- An authenticated `/new` flow: Buzz issues a new reset token and the adapter
+  atomically replaces only that thread's Pi context.
+- A 150,000-token logical context ceiling with proactive compaction, final
+  provider-context inspection, and visible lifecycle notices.
+- A hard per-thread JSONL transcript quota. Pi compaction is append-only, so
+  storage exhaustion fails closed with an explicit `/new` recovery path.
+- `/context`, `/compact`, and `/reload` commands, plus ACP command descriptors
+  for loaded Pi extension commands, prompt templates, and skills.
+- Regular Pi global extensions, skills, prompts, context files, providers, and
+  model configuration, with fail-closed project trust.
+- Protocol isolation: Pi and third-party extensions run in a child process, so
+  a stray extension write to stdout cannot corrupt ACP's NDJSON stream.
+- Session-local model and thinking changes. The adapter reads normal Pi settings
+  but discards all writes, leaving `~/.pi/agent/settings.json` byte-for-byte
+  unchanged.
+
+## Build and expose the command
+
+From the Buzz repository root:
+
+```bash
+. ./bin/activate-hermit
+pnpm install
+pnpm --filter buzz-pi-agent build
+cd packages/buzz-pi-agent
+npm link
+buzz-pi-agent --version
+```
+
+`npm link` is only a convenient way to put the locally built binary on `PATH`.
+The desktop harness discovery also recognizes the `buzz-pi-agent` command.
+
+For development:
+
+```bash
+pnpm --filter buzz-pi-agent check
+pnpm --filter buzz-pi-agent test
+```
+
+The test suite includes actual Pi SDK session creation/resume, title persistence,
+global and trusted/untrusted project resources, extension command/tool execution,
+settings immutability, adversarial context guards, image payloads, compaction
+lifecycle events, a real SIGKILL at the post-compaction/pre-notification crash
+boundary, active-branch recovery, manifest/lease races, capacity, worker
+timeout/crash recovery, and ACP wire fixtures.
+
+## Thread and `/new` lifecycle
+
+Buzz supplies a stable `_meta.buzz.conversationId` on `session/new`. The adapter
+maps that identity to Pi's JSONL session file in a private manifest under
+`~/.pi/agent/buzz/<account-namespace>/`. Reopening the thread resumes the same Pi
+session, even after its live worker has been evicted or the adapter restarts.
+ACP sessions without a Buzz `conversationId` are intentionally transient: they
+have no durable route and cannot be resumed. Their JSONL is therefore deleted
+on explicit disposal, LRU/TTL eviction, and graceful adapter shutdown, while
+mapped thread transcripts remain available for later resume.
+Unless `BUZZ_PI_NAMESPACE` is explicit, the account namespace is derived from
+the canonical relay URL and canonical 32-byte Nostr secret. Equivalent `nsec`
+and hexadecimal spellings, host casing, default ports, and root URL spellings
+therefore cannot fork persistence or bypass an acknowledged reset barrier.
+
+`/new` is deliberately not executed as an ordinary Pi slash command. Buzz
+authenticates the user action and supplies an idempotent reset token on the next
+`session/new`. A changed token creates a fresh file and atomically repoints the
+thread. The same token is safe to replay. Late touches, releases, or forgets from
+the old session are conditional and cannot overwrite the replacement.
+
+Each mapping also carries a bounded durable lifecycle generation. Ordinary
+continuity recovery may replace Pi's session ID because the workspace changed,
+the JSONL became stale, or a lease was taken over; it preserves this generation,
+so every unacknowledged notice still replays. Only an authenticated reset rotates
+the generation. Late event writes include the emitting handle's captured
+generation and are rejected after that reset boundary, even if an old worker is
+still draining.
+
+An acknowledged destructive reset also writes an atomic reset tombstone before
+the old route is removed. If Buzz or the adapter restarts before the next
+message, the tombstone forces the next token-less `session/new` to create fresh
+Pi context and returns `_meta.buzz.skipRelayHistory: true`; old relay messages
+therefore cannot silently repopulate the cleared context. The tombstone is
+transitioned to a retained marker in the same manifest write that installs the
+fresh mapping. That mapping carries its own durable `relayHistoryCleared`
+anchor. Retained markers are independently pruned by age and count; if an
+anchored mapping is later pruned, its marker is reactivated before the mapping
+is removed. Pending barriers are never expired while their safety is needed.
+They have a strict capacity bound, and a reset fails before ACK when that bound
+is full; opening any pending cleared thread installs its mapping and frees a
+slot.
+
+On macOS and Linux, manifest writes fsync the temporary file, atomically rename
+it, and fsync the containing directory. Node cannot open Windows directories
+for fsync, so Windows retains the file fsync and atomic rename but has weaker
+directory-entry durability across sudden power loss; corrupt or missing
+initialized state still fails closed on restart.
+
+Buzz commits this barrier through the idempotent
+`_buzz/conversation/reset { conversationId, resetToken }` RPC before ACKing a
+reset. It works even after the hot ACP session was LRU-evicted, and is advertised
+as `_meta.buzz.threadSessions.resetCommit: true` during initialization.
+
+Cross-adapter resets are supported even while the old handle still owns a live
+lease. The old JSONL is retained until that handle is actually disposed, then
+removed only after the manifest is verified to point elsewhere.
+
+The manifest and lock directories are `0700`; manifests and session files are
+`0600`. Writes are atomic and byte-bounded before rename. Corrupt or oversized
+manifests fail closed without being replaced, so acknowledged reset boundaries
+can never silently become empty state. Session paths are confined to approved
+roots with symlink checks, and live-PID leases prevent two runtimes from writing
+one JSONL concurrently. Leases include hashed host and
+boot identities: a hard-killed local adapter is recovered immediately, while a
+foreign-host or legacy lease is conservatively honored until its TTL expires.
+
+Each Pi JSONL also has a byte-accurate 64 MiB ceiling by default. The guard is
+installed at Pi's append/rewrite seam and checked before a persisted file is
+opened. Ordinary transcript bytes and a 64 KiB Buzz control reserve are
+accounted as separate partitions, so rollback, compaction-attempt, lifecycle
+watermark, pending-delivery, and ACK markers cannot steal ordinary headroom.
+Every control type has its own schema and byte bound; both partitions and their
+combined size are checked before every append/rewrite. Reaching the limit
+returns a non-retryable `session_storage_limit` error with `/new` as the
+recovery action; compaction cannot reclaim these bytes because Pi transcripts
+are append-only.
+
+## Context limit and compaction
+
+The default logical ceiling is 150,000 tokens. With the default 16,384-token
+reserve, proactive compaction begins around 133,616 tokens. For a model with a
+smaller window, the effective ceiling and compaction settings are automatically
+clamped to that model; retained recent context is capped at 75% of the effective
+threshold so the summary itself always has meaningful room.
+
+Before a turn, the adapter estimates the full provider-facing context, including
+the system prompt, transcript, tool schemas, incoming text, and a conservative
+4,096-token budget per image. It compacts when the next request approaches the
+threshold. It also guards Pi's final transformed context and serialized provider
+payload immediately before dispatch, so extension-added context and tools cannot
+bypass the policy. Raw `before_provider_request` hooks may observe a payload but
+may not mutate it.
+
+There is no provider-independent exact tokenizer for every Pi provider and
+custom provider extension. Accordingly, 150k is an enforced logical safety
+ceiling based on Pi/provider usage for completed turns plus conservative
+full-request estimation; it is not a claim of mathematically exact tokenization
+for every possible provider. The reserve and final guard are intentional safety
+margin. Billing and accumulated usage remain provider-native.
+
+An intrinsically oversized request is rejected before attempting a meaningless
+empty-session compaction. Context refusals use JSON-RPC error `-32042` with:
+
+```json
+{ "kind": "context_limit", "retryable": false }
+```
+
+Blocked user/error entries are branched out of active Pi context, preventing
+retry accumulation. Image binary is size/count checked but is not miscounted as
+base64 text.
+
+Buzz receives typed `_buzz/session/event` schema-v2 notifications for:
+
+- compaction completed or failed, including a UUID, reason, before/after usage,
+  retry status, and whether an extension supplied the result;
+- `/context` status;
+- session reset;
+- extension/resource reload.
+
+For a mapped Buzz thread, each notice is written to a private durable outbox
+*before* it is published. The notification carries a stable UUID `eventId`, the
+durable `conversationId`, the current outer ACP `sessionId`, and the typed event.
+Initialization advertises
+`_meta.buzz.sessionEvents = { supported: true, durableReplay: true, ack: true,
+schemaVersion: 2 }`. Buzz first commits the notice to its own durable relay
+outbox, then calls the idempotent
+`_buzz/session/event_ack { conversationId, eventId }` RPC. Until that ACK, an
+adapter restart or a newly opened outer ACP session replays the same event ID
+under the new `sessionId`; Buzz can therefore deduplicate without losing the
+user-visible compaction/reset status.
+
+Compaction completion additionally uses a child-side handoff inside Pi's JSONL.
+Before the isolated runtime publishes a completion, it appends a bounded
+pending marker keyed by a deterministic delivery UUID. The parent persists that
+same UUID in its outbox, publishes it, and only then ACKs the child marker. A
+successful prompt waits for this handoff. If the child is killed immediately
+after Pi appends its intrinsic compaction entry but before it can append or send
+the notice, the next runtime reconciles that active-branch entry into the same
+durable flow. A feature watermark prevents legacy compactions from being
+backfilled, and orphaned Pi branches are never synthesized as current notices.
+Losing a child ACK can only cause an idempotent replay; it cannot lose the
+parent-durable event. This child ACK is distinct from Buzz's later relay-outbox
+ACK described above.
+
+The outbox never expires or silently drops an unacknowledged notice. It has a
+hard global capacity (256 by default) and a 64 KiB per-record bound; reaching
+either limit fails the live session closed. A mapping with any unacknowledged
+notice is pinned against TTL and capacity pruning until Buzz ACKs it. An
+authenticated reset supersedes all pending notices from the older lifecycle
+generation. Manifest epoch checks also fence a late write from an older adapter
+process, and replay retires only records from a reset-superseded epoch; a Pi ID
+change inside the current epoch remains replayable. Legacy manifests derive a
+stable epoch, and legacy outbox records without one are conservatively adopted
+by the current mapping instead of being dropped during upgrade. Because schema
+v2 is negotiated globally, an ACP session without a durable Buzz
+`conversationId` suppresses typed lifecycle notifications instead of emitting an
+incompatible schema-v1 frame. Its context accounting and compaction still run
+normally; once Buzz supplies a stable conversation identity, notices use the
+durable v2 path.
+
+The adapter also emits provider-native usage updates. When current context is
+temporarily unknown after compaction, it omits `used` instead of reporting a
+misleading zero.
+
+## Pi extensions and resources
+
+By default the adapter uses the same Pi agent directory as regular Pi:
+`~/.pi/agent`. Global extensions, skills, prompts, `AGENTS.md` context, custom
+providers, `models.json`, credentials, and read-only settings are therefore
+available. `PI_CODING_AGENT_DIR` can point at an isolated directory for testing.
+
+This child-process boundary is **not an OS security sandbox**. Any loaded Pi
+extension is trusted code with the agent process's filesystem/network
+permissions and inherited credentials. This is intentional: Pi's bash/tools
+must be able to run the `buzz` CLI to publish its responses and use other
+agent-facing operations. Extensions share that same process and must therefore
+be treated as fully trusted code. Reuse your regular extensions only when you
+fully trust them. For a more isolated agent profile, set
+`PI_CODING_AGENT_DIR` to a dedicated directory containing only reviewed
+resources (and separately configure the credentials and providers that profile
+needs). Project trust protects only project-local resource discovery; it cannot
+make a malicious global extension safe. Isolating untrusted extensions while
+retaining privileged Pi tools would require a separate parent credential broker.
+
+Project-local `.pi` resources are executable configuration and fail closed in
+headless mode. They load only when the regular Pi `ProjectTrustStore` already
+contains an affirmative decision for that workspace, or when an operator sets
+`BUZZ_PI_TRUST_PROJECT=true`. `/reload` re-evaluates trust immediately before
+discovery, so a project cannot gain trust merely by creating resources after
+startup.
+
+The adapter resolves the requested workspace to one canonical directory before
+it creates persistence, trust, settings, or Pi services. It retains both that
+directory's device/inode identity and the original lexical path. If the path is
+later repointed (including a trusted-to-untrusted symlink swap), `/reload` fails
+closed. A Buzz conversation also cannot join a live or pending session created
+for a different canonical workspace.
+
+Pi's synchronously discovered non-code inputs are preflighted with per-file,
+aggregate-byte, file-count, directory-entry, and recursion-depth budgets. This
+includes settings/model/trust and package manifests, context files, skills,
+prompts, themes, ignore manifests, configured paths, and package resource
+trees. Every bounded file receives a content and filesystem-identity
+fingerprint before the SDK load; the complete discovery snapshot must match
+afterward, catching growth, rewrites, additions/removals, inode replacement,
+and symlink swaps in the load window. Any reload/trust/resource failure poisons
+and disposes that Pi generation. Further prompts are rejected until Buzz
+creates a fresh session, so a partially reloaded extension runner is never
+reused. This boundary is reported as JSON-RPC code `-32045` with
+`{ "kind": "session_invalidated", "retryable": true }`, allowing Buzz to
+discard the dead outer session and requeue work onto a newly created one.
+
+Compatibility details:
+
+- Extension tools, event hooks, provider registration, commands, prompts, and
+  skills work. `/reload` hot-reloads them for subsequent turns. The adapter
+  publishes ACP `available_commands_update` descriptors when the session is
+  created. The current Buzz UI does not turn those descriptors into input
+  autocomplete or refresh them in the middle of a session.
+- Extension requests to create/fork/switch sessions are rejected because Buzz
+  owns thread topology. Tree navigation inside the current Pi session remains
+  available.
+- Pi's interactive `ctx.ui` surface is intentionally absent (`hasUI=false`) in
+  this headless adapter. Extensions that require terminal dialogs or widgets
+  need a headless fallback.
+- Provider-payload mutation hooks are rejected to preserve the context ceiling;
+  observation-only hooks work.
+- Pi caches imported extension modules by cwd/path. State created inside the
+  exported extension factory is per session, but mutable module-top-level state
+  can be shared across Buzz thread sessions, just as in regular Pi. A reload can
+  create a new module instance while existing handlers retain the old one. Do
+  not use module globals for thread-private data.
+
+## Operational defaults
+
+| Environment variable | Default | Purpose |
+| --- | ---: | --- |
+| `BUZZ_PI_CONTEXT_LIMIT` | `150000` | Logical context ceiling (maximum 150,000) |
+| `BUZZ_PI_COMPACTION_RESERVE` | `16384` | Reserved output/safety space (maximum 149,999 and must remain below the ceiling) |
+| `BUZZ_PI_KEEP_RECENT_TOKENS` | `24000` | Recent context retained by Pi compaction (maximum 149,999 and must remain below the threshold) |
+| `BUZZ_PI_MAX_SESSIONS` | `12` | Adapter live-session backstop (maximum 128) |
+| `BUZZ_PI_SESSION_TTL_MS` | `2700000` | Live idle TTL (45 minutes; maximum 24 hours) |
+| `BUZZ_PI_SWEEP_INTERVAL_MS` | `300000` | Lease/TTL/prune sweep cadence (maximum 1 hour) |
+| `BUZZ_PI_STATE_DIR` | `~/.pi/agent/buzz` | Durable mapping state |
+| `BUZZ_PI_MAX_PERSISTED_CONVERSATIONS` | `512` | Persisted mapping capacity (maximum 512) |
+| `BUZZ_PI_PERSISTED_CONVERSATION_TTL_MS` | `7776000000` | Mapping TTL (90 days; maximum 365 days) |
+| `BUZZ_PI_MAX_PENDING_RESET_TOMBSTONES` | `512` | Uninstalled reset-barrier capacity (maximum 512) |
+| `BUZZ_PI_MAX_RETAINED_RESET_TOMBSTONES` | `512` | Retained installed-marker capacity (maximum 512) |
+| `BUZZ_PI_RESET_TOMBSTONE_TTL_MS` | `2592000000` | Retained installed-marker TTL (30 days; maximum 365 days) |
+| `BUZZ_PI_CONVERSATION_LEASE_MS` | `3600000` | Advisory lease heartbeat window (maximum 24 hours) |
+| `BUZZ_PI_MAX_SESSION_FILE_BYTES` | `67108864` | Hard per-thread Pi JSONL ceiling (64 MiB; 1 MiB minimum, 512 MiB maximum) |
+| `BUZZ_PI_MAX_PENDING_SESSION_EVENTS` | `256` | Durable unacknowledged lifecycle-event capacity (maximum 512; records are never TTL-pruned) |
+| `BUZZ_PI_RUNTIME_REQUEST_TIMEOUT_MS` | `6600000` | Prompt timeout (110 minutes; maximum 6 hours) |
+| `BUZZ_PI_RUNTIME_CONTROL_TIMEOUT_MS` | `120000` | Create/model/reload control timeout (maximum 30 minutes) |
+| `BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS` | `1200` | Abort/steer/dispose/shutdown timeout (maximum 60 seconds) |
+| `BUZZ_PI_MAX_LINE_BYTES` | `10000000` | ACP NDJSON frame bound (maximum 64 MiB) |
+| `BUZZ_PI_MAX_ACTIVE_REQUESTS` | `64` | Concurrent non-control ACP request bound (maximum 512) |
+| `BUZZ_PI_MAX_OUTPUT_QUEUE_MESSAGES` | `2048` | Ordered ACP stdout queue bound (maximum 8192) |
+| `BUZZ_PI_MAX_OUTPUT_QUEUE_BYTES` | `16777216` | Ordered ACP stdout byte bound (maximum 64 MiB) |
+| `BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_MESSAGES` | `1024` | Ordered runtime IPC queue bound (maximum 4096) |
+| `BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_BYTES` | `16777216` | Ordered runtime IPC byte bound (maximum 64 MiB) |
+| `BUZZ_PI_MAX_RESOURCE_FILE_BYTES` | `1048576` | Per-file non-code Pi resource bound (1 MiB; maximum 16 MiB) |
+| `BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES` | `16777216` | Aggregate non-code resource bytes per discovery generation (16 MiB; maximum 64 MiB; must be at least the per-file bound) |
+| `BUZZ_PI_MAX_RESOURCE_FILES` | `512` | Unique lexical non-code resource file count per generation (maximum 4096) |
+| `BUZZ_PI_MAX_RESOURCE_ENTRIES` | `4096` | Directory entries inspected during resource/package discovery (maximum 16384; must be at least the file count) |
+| `BUZZ_PI_MAX_RESOURCE_DEPTH` | `16` | Recursive skill/package/glob discovery depth (maximum 64) |
+| `BUZZ_PI_TRUST_PROJECT` | unset | Explicit project trust override |
+| `PI_CODING_AGENT_DIR` | `~/.pi/agent` | Pi resource/credential root; use a dedicated directory to avoid loading regular global extensions |
+| `BUZZ_PI_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, or `error` |
+| `BUZZ_PI_NAMESPACE` | derived | Optional durable-account namespace |
+
+Buzz's outer ACP pool normally keeps at most 8 hot sessions for 30 minutes. The
+adapter's 12-session/45-minute limits are a slightly larger backstop, so normal
+outer disposal happens first while durable mappings preserve every thread.
+
+Invalid relationships (for example, reserve greater than the context ceiling,
+recent tokens greater than the threshold, or interrupt timeout greater than the
+control timeout) fail startup with a specific configuration error.
+
+## Protocol notes
+
+The command serves ACP v2 JSON-RPC as newline-delimited JSON on stdin/stdout.
+Logs are stderr-only. Pi runs in an IPC child process and every non-interrupting
+mutation is serialized per session; separate sessions remain concurrent. Abort
+and steering can interrupt an active prompt. A worker crash or timeout invalidates
+the whole worker generation, releases its conversation leases, and allows a
+subsequent `session/new` to recover from the durable JSONL.
+
+ACP stdout and runtime IPC are both callback/drain-driven, strictly ordered,
+and bounded by message count and bytes. A disconnected transport, write error,
+or saturated queue poisons that adapter/worker generation and terminates it;
+responses and tool lifecycle frames are never reordered or silently dropped to
+make room.
+
+Disposal marks a session unavailable for prompts and reuse immediately, while
+retaining its immutable conversation/generation route until buffered runtime
+events have reached the parent outbox. Even a failed worker drains those pending
+parent handoffs before its route is retired; a failed child ACK can therefore
+cause a later idempotent replay, never loss of the parent copy.
+
+`_buzz/conversation/reset` can be committed by a helper adapter process because
+the manifest lock is cross-process. That commit invalidates the durable route,
+but it cannot interrupt a prompt executing in a different owning process. Buzz
+must cancel/drain that owner or suppress its stale generation before ACKing a
+helper-committed reset; when the owner is in the same process, the registry
+aborts and disposes it before returning success.
+
+Adapter tests pin suppression for unmapped compaction/context events as well as
+the mapped schema-v2 persist-before-publish, replay, generation-fencing, and
+idempotent-ACK contract. Buzz's harness contract tests independently exercise
+that same v2 boundary and ACK only after its own durable outbox commit.

--- a/packages/buzz-pi-agent/package.json
+++ b/packages/buzz-pi-agent/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "buzz-pi-agent",
+  "version": "0.1.0",
+  "description": "Production ACP adapter for running Pi as a Buzz agent",
+  "type": "module",
+  "bin": {
+    "buzz-pi-agent": "dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "scripts": {
+    "build": "npm run clean && tsc -p tsconfig.build.json && node scripts/postbuild.mjs",
+    "check": "tsc -p tsconfig.json --noEmit && biome check .",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\""
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "0.83.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.6",
+    "@types/node": "^24.12.0",
+    "typescript": "^5.9.3"
+  },
+  "license": "Apache-2.0",
+  "private": true
+}

--- a/packages/buzz-pi-agent/scripts/postbuild.mjs
+++ b/packages/buzz-pi-agent/scripts/postbuild.mjs
@@ -1,0 +1,4 @@
+import { chmod } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+await chmod(fileURLToPath(new URL("../dist/cli.js", import.meta.url)), 0o755);

--- a/packages/buzz-pi-agent/src/cli.ts
+++ b/packages/buzz-pi-agent/src/cli.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { AcpServer } from "./server.js";
+import { loadConfig } from "./config.js";
+import { ConversationStore } from "./conversation-store.js";
+import { createLogger, guardProtocolStdout } from "./logger.js";
+import { IsolatedPiWorkerFactory } from "./runtime-worker.js";
+import { runRuntimeHost } from "./runtime-host.js";
+import { SessionRegistry } from "./session-registry.js";
+import { NdjsonWriter } from "./wire.js";
+
+const VERSION = "0.1.0";
+
+async function runAdapter(): Promise<void> {
+  const config = loadConfig();
+  const protocolWrite = guardProtocolStdout();
+  const logger = createLogger(config.logLevel);
+  let server: AcpServer | undefined;
+  let transportFailureTimer: NodeJS.Timeout | undefined;
+  const writer = new NdjsonWriter(protocolWrite, logger, {
+    maxQueuedMessages: config.maxOutputQueueMessages,
+    maxQueuedBytes: config.maxOutputQueueBytes,
+    onFatal(error) {
+      process.exitCode = 1;
+      process.stdin.destroy(error);
+      void server?.shutdown().catch((shutdownError: unknown) => {
+        logger.error("failed to shut down after ACP transport failure", {
+          error:
+            shutdownError instanceof Error
+              ? shutdownError.message
+              : String(shutdownError),
+        });
+      });
+      transportFailureTimer ??= setTimeout(
+        () => process.exit(1),
+        Math.max(5_000, config.runtimeInterruptTimeoutMs * 3),
+      );
+      transportFailureTimer.unref();
+    },
+  });
+  const workerFactory = new IsolatedPiWorkerFactory(config, logger);
+  const conversations = new ConversationStore(config, logger);
+  const serverSink = new DeferredEventSink();
+  const registry = new SessionRegistry(
+    workerFactory,
+    conversations,
+    config,
+    serverSink,
+    logger,
+  );
+  server = new AcpServer(
+    process.stdin,
+    writer,
+    registry,
+    config,
+    logger,
+    workerFactory,
+  );
+  serverSink.bind(server);
+
+  let shuttingDown = false;
+  const shutdown = (signal: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info("received shutdown signal", { signal });
+    void server.shutdown().finally(() => {
+      process.exitCode = signal === "SIGINT" ? 130 : 143;
+      process.stdin.destroy();
+    });
+  };
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  if (process.platform !== "win32")
+    process.on("SIGHUP", () => shutdown("SIGHUP"));
+
+  try {
+    await server.run();
+  } catch (error) {
+    if (shuttingDown) return;
+    logger.error("adapter terminated with an error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exitCode = 1;
+  } finally {
+    if (transportFailureTimer) clearTimeout(transportFailureTimer);
+  }
+}
+
+class DeferredEventSink {
+  private target: AcpServer | undefined;
+
+  bind(target: AcpServer): void {
+    this.target = target;
+  }
+
+  sessionUpdate(sessionId: string, update: Record<string, unknown>): void {
+    this.requireTarget().sessionUpdate(sessionId, update);
+  }
+
+  buzzSessionEvent(
+    sessionId: string,
+    event: Parameters<AcpServer["buzzSessionEvent"]>[1],
+    deliveryId?: Parameters<AcpServer["buzzSessionEvent"]>[2],
+  ): ReturnType<AcpServer["buzzSessionEvent"]> {
+    return this.requireTarget().buzzSessionEvent(sessionId, event, deliveryId);
+  }
+
+  usageUpdate(
+    sessionId: string,
+    usage: Parameters<AcpServer["usageUpdate"]>[1],
+    contextLimit: number,
+  ): void {
+    this.requireTarget().usageUpdate(sessionId, usage, contextLimit);
+  }
+
+  private requireTarget(): AcpServer {
+    if (!this.target)
+      throw new Error("ACP event sink was used before server initialization");
+    return this.target;
+  }
+}
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  process.stdout.write(`buzz-pi-agent ${VERSION}
+
+ACP adapter that runs the Pi coding agent inside Buzz.
+
+Usage:
+  buzz-pi-agent                 Serve ACP over stdin/stdout
+  buzz-pi-agent --help          Show this help
+  buzz-pi-agent --version       Show the adapter version
+
+Buzz injects BUZZ_RELAY_URL, BUZZ_PRIVATE_KEY, and BUZZ_AUTH_TAG. See the
+package README for context, persistence, trust, timeout, and retention options.
+`);
+} else if (process.argv.includes("--version") || process.argv.includes("-V")) {
+  process.stdout.write(`${VERSION}\n`);
+} else if (process.argv.includes("--runtime-host")) {
+  await runRuntimeHost();
+} else {
+  await runAdapter();
+}

--- a/packages/buzz-pi-agent/src/config.ts
+++ b/packages/buzz-pi-agent/src/config.ts
@@ -1,0 +1,381 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export interface AdapterConfig {
+  contextLimitTokens: number;
+  compactionReserveTokens: number;
+  keepRecentTokens: number;
+  maxSessions: number;
+  sessionTtlMs: number;
+  sweepIntervalMs: number;
+  maxLineBytes: number;
+  maxActiveRequests: number;
+  maxOutputQueueMessages: number;
+  maxOutputQueueBytes: number;
+  stateDir: string;
+  maxPersistedConversations: number;
+  persistedConversationTtlMs: number;
+  maxPendingResetTombstones: number;
+  maxRetainedResetTombstones: number;
+  resetTombstoneTtlMs: number;
+  conversationLeaseMs: number;
+  maxSessionFileBytes: number;
+  maxPendingSessionEvents: number;
+  runtimeRequestTimeoutMs: number;
+  runtimeControlTimeoutMs: number;
+  runtimeInterruptTimeoutMs: number;
+  maxRuntimeIpcQueueMessages: number;
+  maxRuntimeIpcQueueBytes: number;
+  maxResourceFileBytes: number;
+  maxResourceTotalBytes: number;
+  maxResourceFiles: number;
+  maxResourceEntries: number;
+  maxResourceDepth: number;
+  trustProjectOverride: boolean | undefined;
+  logLevel: "debug" | "info" | "warn" | "error";
+}
+
+const DEFAULT_CONTEXT_LIMIT = 150_000;
+const DEFAULT_RESERVE = 16_384;
+const MAX_CONTEXT_LIMIT = 150_000;
+const MAX_SESSIONS = 128;
+const MAX_SESSION_TTL_MS = 24 * 60 * 60 * 1_000;
+const MAX_SWEEP_INTERVAL_MS = 60 * 60 * 1_000;
+const MAX_LINE_BYTES = 64 * 1_024 * 1_024;
+const MAX_PERSISTED_TTL_MS = 365 * 24 * 60 * 60 * 1_000;
+const MAX_CONVERSATION_LEASE_MS = 24 * 60 * 60 * 1_000;
+const MIN_SESSION_FILE_BYTES = 1 * 1_024 * 1_024;
+const MAX_SESSION_FILE_BYTES = 512 * 1_024 * 1_024;
+const MAX_RUNTIME_REQUEST_TIMEOUT_MS = 6 * 60 * 60 * 1_000;
+const MAX_RUNTIME_CONTROL_TIMEOUT_MS = 30 * 60 * 1_000;
+const MAX_RUNTIME_INTERRUPT_TIMEOUT_MS = 60 * 1_000;
+const MAX_RESOURCE_FILE_BYTES = 16 * 1_024 * 1_024;
+const MAX_RESOURCE_TOTAL_BYTES = 64 * 1_024 * 1_024;
+const MAX_RESOURCE_FILES = 4_096;
+const MAX_RESOURCE_ENTRIES = 16_384;
+const MAX_RESOURCE_DEPTH = 64;
+
+export function loadConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AdapterConfig {
+  const config: AdapterConfig = {
+    contextLimitTokens: boundedPositiveInt(
+      env.BUZZ_PI_CONTEXT_LIMIT,
+      DEFAULT_CONTEXT_LIMIT,
+      "BUZZ_PI_CONTEXT_LIMIT",
+      MAX_CONTEXT_LIMIT,
+    ),
+    compactionReserveTokens: boundedPositiveInt(
+      env.BUZZ_PI_COMPACTION_RESERVE,
+      DEFAULT_RESERVE,
+      "BUZZ_PI_COMPACTION_RESERVE",
+      MAX_CONTEXT_LIMIT - 1,
+    ),
+    keepRecentTokens: boundedPositiveInt(
+      env.BUZZ_PI_KEEP_RECENT_TOKENS,
+      24_000,
+      "BUZZ_PI_KEEP_RECENT_TOKENS",
+      MAX_CONTEXT_LIMIT - 1,
+    ),
+    // Buzz's ACP pool normally disposes idle sessions first (8 sessions / 30m).
+    // These are a defensive backstop for non-Buzz or interrupted callers.
+    maxSessions: boundedPositiveInt(
+      env.BUZZ_PI_MAX_SESSIONS,
+      12,
+      "BUZZ_PI_MAX_SESSIONS",
+      MAX_SESSIONS,
+    ),
+    sessionTtlMs: boundedPositiveInt(
+      env.BUZZ_PI_SESSION_TTL_MS,
+      45 * 60 * 1_000,
+      "BUZZ_PI_SESSION_TTL_MS",
+      MAX_SESSION_TTL_MS,
+    ),
+    sweepIntervalMs: boundedPositiveInt(
+      env.BUZZ_PI_SWEEP_INTERVAL_MS,
+      5 * 60 * 1_000,
+      "BUZZ_PI_SWEEP_INTERVAL_MS",
+      MAX_SWEEP_INTERVAL_MS,
+    ),
+    maxLineBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_LINE_BYTES,
+      10_000_000,
+      "BUZZ_PI_MAX_LINE_BYTES",
+      MAX_LINE_BYTES,
+    ),
+    maxActiveRequests: boundedPositiveInt(
+      env.BUZZ_PI_MAX_ACTIVE_REQUESTS,
+      64,
+      "BUZZ_PI_MAX_ACTIVE_REQUESTS",
+      512,
+    ),
+    maxOutputQueueMessages: boundedPositiveInt(
+      env.BUZZ_PI_MAX_OUTPUT_QUEUE_MESSAGES,
+      2_048,
+      "BUZZ_PI_MAX_OUTPUT_QUEUE_MESSAGES",
+      8_192,
+    ),
+    maxOutputQueueBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_OUTPUT_QUEUE_BYTES,
+      16 * 1_024 * 1_024,
+      "BUZZ_PI_MAX_OUTPUT_QUEUE_BYTES",
+      64 * 1_024 * 1_024,
+    ),
+    stateDir: resolve(expandHome(env.BUZZ_PI_STATE_DIR ?? "~/.pi/agent/buzz")),
+    maxPersistedConversations: boundedPositiveInt(
+      env.BUZZ_PI_MAX_PERSISTED_CONVERSATIONS,
+      512,
+      "BUZZ_PI_MAX_PERSISTED_CONVERSATIONS",
+      512,
+    ),
+    persistedConversationTtlMs: boundedPositiveInt(
+      env.BUZZ_PI_PERSISTED_CONVERSATION_TTL_MS,
+      90 * 24 * 60 * 60 * 1_000,
+      "BUZZ_PI_PERSISTED_CONVERSATION_TTL_MS",
+      MAX_PERSISTED_TTL_MS,
+    ),
+    maxPendingResetTombstones: boundedPositiveInt(
+      env.BUZZ_PI_MAX_PENDING_RESET_TOMBSTONES,
+      512,
+      "BUZZ_PI_MAX_PENDING_RESET_TOMBSTONES",
+      512,
+    ),
+    maxRetainedResetTombstones: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RETAINED_RESET_TOMBSTONES,
+      512,
+      "BUZZ_PI_MAX_RETAINED_RESET_TOMBSTONES",
+      512,
+    ),
+    resetTombstoneTtlMs: boundedPositiveInt(
+      env.BUZZ_PI_RESET_TOMBSTONE_TTL_MS,
+      30 * 24 * 60 * 60 * 1_000,
+      "BUZZ_PI_RESET_TOMBSTONE_TTL_MS",
+      365 * 24 * 60 * 60 * 1_000,
+    ),
+    conversationLeaseMs: boundedPositiveInt(
+      env.BUZZ_PI_CONVERSATION_LEASE_MS,
+      60 * 60 * 1_000,
+      "BUZZ_PI_CONVERSATION_LEASE_MS",
+      MAX_CONVERSATION_LEASE_MS,
+    ),
+    maxSessionFileBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_SESSION_FILE_BYTES,
+      64 * 1_024 * 1_024,
+      "BUZZ_PI_MAX_SESSION_FILE_BYTES",
+      MAX_SESSION_FILE_BYTES,
+    ),
+    maxPendingSessionEvents: boundedPositiveInt(
+      env.BUZZ_PI_MAX_PENDING_SESSION_EVENTS,
+      256,
+      "BUZZ_PI_MAX_PENDING_SESSION_EVENTS",
+      512,
+    ),
+    runtimeRequestTimeoutMs: boundedPositiveInt(
+      env.BUZZ_PI_RUNTIME_REQUEST_TIMEOUT_MS,
+      110 * 60 * 1_000,
+      "BUZZ_PI_RUNTIME_REQUEST_TIMEOUT_MS",
+      MAX_RUNTIME_REQUEST_TIMEOUT_MS,
+    ),
+    runtimeControlTimeoutMs: boundedPositiveInt(
+      env.BUZZ_PI_RUNTIME_CONTROL_TIMEOUT_MS,
+      2 * 60 * 1_000,
+      "BUZZ_PI_RUNTIME_CONTROL_TIMEOUT_MS",
+      MAX_RUNTIME_CONTROL_TIMEOUT_MS,
+    ),
+    runtimeInterruptTimeoutMs: boundedPositiveInt(
+      env.BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS,
+      1_200,
+      "BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS",
+      MAX_RUNTIME_INTERRUPT_TIMEOUT_MS,
+    ),
+    maxRuntimeIpcQueueMessages: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_MESSAGES,
+      1_024,
+      "BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_MESSAGES",
+      4_096,
+    ),
+    maxRuntimeIpcQueueBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_BYTES,
+      16 * 1_024 * 1_024,
+      "BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_BYTES",
+      64 * 1_024 * 1_024,
+    ),
+    maxResourceFileBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RESOURCE_FILE_BYTES,
+      1 * 1_024 * 1_024,
+      "BUZZ_PI_MAX_RESOURCE_FILE_BYTES",
+      MAX_RESOURCE_FILE_BYTES,
+    ),
+    maxResourceTotalBytes: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES,
+      16 * 1_024 * 1_024,
+      "BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES",
+      MAX_RESOURCE_TOTAL_BYTES,
+    ),
+    maxResourceFiles: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RESOURCE_FILES,
+      512,
+      "BUZZ_PI_MAX_RESOURCE_FILES",
+      MAX_RESOURCE_FILES,
+    ),
+    maxResourceEntries: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RESOURCE_ENTRIES,
+      4_096,
+      "BUZZ_PI_MAX_RESOURCE_ENTRIES",
+      MAX_RESOURCE_ENTRIES,
+    ),
+    maxResourceDepth: boundedPositiveInt(
+      env.BUZZ_PI_MAX_RESOURCE_DEPTH,
+      16,
+      "BUZZ_PI_MAX_RESOURCE_DEPTH",
+      MAX_RESOURCE_DEPTH,
+    ),
+    trustProjectOverride: optionalBoolean(env.BUZZ_PI_TRUST_PROJECT),
+    logLevel: parseLogLevel(env.BUZZ_PI_LOG_LEVEL),
+  };
+  validateConfig(config);
+  return config;
+}
+
+function validateConfig(config: AdapterConfig): void {
+  if (config.compactionReserveTokens >= config.contextLimitTokens) {
+    throw new Error(
+      "BUZZ_PI_COMPACTION_RESERVE must be smaller than BUZZ_PI_CONTEXT_LIMIT",
+    );
+  }
+  const threshold = config.contextLimitTokens - config.compactionReserveTokens;
+  if (config.keepRecentTokens >= threshold) {
+    throw new Error(
+      "BUZZ_PI_KEEP_RECENT_TOKENS must be smaller than the compaction threshold",
+    );
+  }
+  if (config.sweepIntervalMs > config.sessionTtlMs) {
+    throw new Error(
+      "BUZZ_PI_SWEEP_INTERVAL_MS must not exceed BUZZ_PI_SESSION_TTL_MS",
+    );
+  }
+  if (config.conversationLeaseMs < config.sweepIntervalMs * 2) {
+    throw new Error(
+      "BUZZ_PI_CONVERSATION_LEASE_MS must be at least twice BUZZ_PI_SWEEP_INTERVAL_MS",
+    );
+  }
+  if (config.runtimeInterruptTimeoutMs >= config.runtimeControlTimeoutMs) {
+    throw new Error(
+      "BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS must be smaller than BUZZ_PI_RUNTIME_CONTROL_TIMEOUT_MS",
+    );
+  }
+  if (config.maxSessionFileBytes < MIN_SESSION_FILE_BYTES) {
+    throw new Error(
+      `BUZZ_PI_MAX_SESSION_FILE_BYTES must be at least ${MIN_SESSION_FILE_BYTES}`,
+    );
+  }
+  if (config.maxResourceTotalBytes < config.maxResourceFileBytes) {
+    throw new Error(
+      "BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES must be at least BUZZ_PI_MAX_RESOURCE_FILE_BYTES",
+    );
+  }
+  if (config.maxResourceEntries < config.maxResourceFiles) {
+    throw new Error(
+      "BUZZ_PI_MAX_RESOURCE_ENTRIES must be at least BUZZ_PI_MAX_RESOURCE_FILES",
+    );
+  }
+}
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(
+      `Expected a positive integer, received ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
+}
+
+function boundedPositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+  maximum: number,
+): number {
+  const value = positiveInt(raw, fallback);
+  if (value > maximum) {
+    throw new Error(`${name} must not exceed ${maximum}`);
+  }
+  return value;
+}
+
+function optionalBoolean(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  if (["1", "true", "yes", "on"].includes(raw.toLowerCase())) return true;
+  if (["0", "false", "no", "off"].includes(raw.toLowerCase())) return false;
+  throw new Error(`Expected a boolean, received ${JSON.stringify(raw)}`);
+}
+
+function parseLogLevel(raw: string | undefined): AdapterConfig["logLevel"] {
+  if (raw === undefined || raw === "") return "info";
+  if (["debug", "info", "warn", "error"].includes(raw)) {
+    return raw as AdapterConfig["logLevel"];
+  }
+  throw new Error(`Invalid BUZZ_PI_LOG_LEVEL ${JSON.stringify(raw)}`);
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+export function effectiveContextLimit(
+  modelContextWindow: number,
+  configuredLimit: number,
+): number {
+  if (modelContextWindow <= 0) return configuredLimit;
+  return Math.max(1, Math.min(configuredLimit, modelContextWindow));
+}
+
+export function logicalModelContextWindow(
+  modelContextWindow: number,
+  configuredLimit: number,
+): number {
+  if (modelContextWindow <= 0) return configuredLimit;
+  return Math.min(modelContextWindow, configuredLimit);
+}
+
+export function compactionThreshold(
+  effectiveLimitTokens: number,
+  reserveTokens: number,
+): number {
+  return Math.max(1, effectiveLimitTokens - reserveTokens);
+}
+
+export interface EffectiveCompactionSettings {
+  reserveTokens: number;
+  keepRecentTokens: number;
+  thresholdTokens: number;
+}
+
+/**
+ * Clamp configured compaction settings to the active model's logical window.
+ * This keeps small-window custom providers valid without weakening the cap.
+ */
+export function effectiveCompactionSettings(
+  effectiveLimitTokens: number,
+  configuredReserveTokens: number,
+  configuredKeepRecentTokens: number,
+): EffectiveCompactionSettings {
+  if (!Number.isSafeInteger(effectiveLimitTokens) || effectiveLimitTokens < 8) {
+    throw new Error(
+      "The selected Pi model context window is too small to compact safely",
+    );
+  }
+  const maximumReserve = Math.max(1, Math.floor(effectiveLimitTokens / 4));
+  const reserveTokens = Math.min(configuredReserveTokens, maximumReserve);
+  const thresholdTokens = effectiveLimitTokens - reserveTokens;
+  const maximumKeepRecent = Math.max(1, Math.floor(thresholdTokens * 0.75));
+  const keepRecentTokens = Math.min(
+    configuredKeepRecentTokens,
+    maximumKeepRecent,
+  );
+  return { reserveTokens, keepRecentTokens, thresholdTokens };
+}

--- a/packages/buzz-pi-agent/src/conversation-store.ts
+++ b/packages/buzz-pi-agent/src/conversation-store.ts
@@ -1,0 +1,2433 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readlinkSync } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  rmdir,
+  stat,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { hostname } from "node:os";
+import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { AdapterConfig } from "./config.js";
+import type {
+  BuzzSessionEvent,
+  ConversationMapping,
+  Logger,
+  PendingBuzzSessionEvent,
+} from "./types.js";
+
+interface ConversationManifest {
+  version: 1;
+  conversations: Record<string, ConversationMapping>;
+  resetTombstones: Record<string, ResetTombstone>;
+}
+
+interface ResetTombstoneBase {
+  conversationId: string;
+  previousPiSessionId?: string;
+  resetToken?: string;
+  createdAt: string;
+}
+
+type ResetTombstone =
+  | (ResetTombstoneBase & { status: "pending" })
+  | (ResetTombstoneBase & {
+      status: "retained";
+      installedPiSessionId: string;
+      consumedAt: string;
+    });
+
+interface PruneCandidate {
+  mapping: ConversationMapping;
+  reason: "ttl" | "capacity";
+}
+
+export interface ResolveConversationResult {
+  mapping: ConversationMapping;
+  lifecycleGeneration: string;
+  resumed: boolean;
+  previousPiSessionId?: string;
+  retiredSessionFile?: string;
+  skipRelayHistory: boolean;
+  refresh: () => Promise<boolean>;
+  forget: () => Promise<string | undefined>;
+  release: () => Promise<void>;
+}
+
+interface AcquiredStateLock {
+  assertOwned: () => Promise<void>;
+  release: () => Promise<void>;
+}
+
+interface StateLockGeneration {
+  device: number;
+  inode: number;
+  birthtimeMs: number;
+  mtimeMs: number;
+  ownerRaw: string | undefined;
+}
+
+/** Host/process identity used to decide whether a PID liveness probe is safe. */
+export interface LeaseProcessIdentity {
+  hostId: string;
+  bootId?: string;
+  pidProbeSafe: boolean;
+}
+
+export interface CommitConversationResetResult {
+  alreadyCommitted: boolean;
+  disposeLiveSession: boolean;
+  retiredSessionFile?: string;
+}
+
+const MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
+const MAX_MANIFEST_ENTRIES = 100_000;
+const MAX_CWD_CHARACTERS = 2_048;
+const MAX_SESSION_PATH_CHARACTERS = 4_096;
+const LOCK_OWNER_WRITE_GRACE_MS = 2_000;
+const LOCK_FOREIGN_STALE_MS = 2 * 60_000;
+const LOCK_HEARTBEAT_MS = 30_000;
+const INITIALIZED_MARKER = ".buzz-pi-state-v1";
+const MAX_PENDING_SESSION_EVENT_BYTES = 64 * 1_024;
+const EVENT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const EVENT_DIRECTORY_PATTERN = /^[0-9a-f]{64}$/u;
+const LIFECYCLE_GENERATION_PATTERN = /^[0-9a-f]{64}$/u;
+const SESSION_EVENT_TYPES = new Set([
+  "compaction_completed",
+  "compaction_failed",
+  "context_status",
+  "session_reset",
+  "extensions_reloaded",
+]);
+const LOCAL_LEASE_IDENTITY = discoverLocalLeaseIdentity();
+
+export class ConversationStore {
+  readonly namespace: string;
+  private readonly stateRoot: string;
+  private readonly directory: string;
+  private readonly manifestPath: string;
+  private readonly initializedMarkerPath: string;
+  private readonly locksDirectory: string;
+  private readonly pendingEventsDirectory: string;
+  private readonly leaseIdentity: LeaseProcessIdentity;
+  private readonly allowedSessionRoots: readonly string[];
+
+  constructor(
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+    env: NodeJS.ProcessEnv = process.env,
+    leaseIdentity: LeaseProcessIdentity = LOCAL_LEASE_IDENTITY,
+  ) {
+    this.leaseIdentity = leaseIdentity;
+    this.namespace = deriveNamespace(env);
+    this.stateRoot = resolve(config.stateDir);
+    this.directory = resolve(this.stateRoot, this.namespace);
+    if (!pathIsStrictlyWithin(this.directory, this.stateRoot)) {
+      throw new Error("BUZZ_PI_NAMESPACE escapes BUZZ_PI_STATE_DIR");
+    }
+    this.manifestPath = join(this.directory, "conversations.json");
+    this.initializedMarkerPath = join(this.directory, INITIALIZED_MARKER);
+    this.locksDirectory = join(this.directory, "locks");
+    this.pendingEventsDirectory = join(this.directory, "pending-events");
+    // Pi-created sessions live in the first root. The adapter state root is
+    // also allowed for controlled test/migration sessions, but arbitrary
+    // absolute JSONL paths are never opened or deleted from the manifest.
+    this.allowedSessionRoots = [
+      resolve(join(getAgentDir(), "sessions")),
+      this.stateRoot,
+    ];
+  }
+
+  async initialize(): Promise<void> {
+    await mkdir(this.stateRoot, { recursive: true, mode: 0o700 });
+    await chmod(this.stateRoot, 0o700);
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    const namespaceMetadata = await lstat(this.directory);
+    if (
+      namespaceMetadata.isSymbolicLink() ||
+      !namespaceMetadata.isDirectory()
+    ) {
+      throw new Error("Pi state namespace must be a real directory");
+    }
+    const [physicalRoot, physicalDirectory] = await Promise.all([
+      realpath(this.stateRoot),
+      realpath(this.directory),
+    ]);
+    if (!pathIsStrictlyWithin(physicalDirectory, physicalRoot)) {
+      throw new Error("Pi state namespace resolves outside BUZZ_PI_STATE_DIR");
+    }
+    await mkdir(this.locksDirectory, { recursive: true, mode: 0o700 });
+    await mkdir(this.pendingEventsDirectory, {
+      recursive: true,
+      mode: 0o700,
+    });
+    await chmod(this.directory, 0o700);
+    await chmod(this.locksDirectory, 0o700);
+    await chmod(this.pendingEventsDirectory, 0o700);
+    const pendingEventsMetadata = await lstat(this.pendingEventsDirectory);
+    if (
+      pendingEventsMetadata.isSymbolicLink() ||
+      !pendingEventsMetadata.isDirectory()
+    ) {
+      throw new Error("Pi pending-event state must be a real directory");
+    }
+    const physicalEventsDirectory = await realpath(this.pendingEventsDirectory);
+    if (!pathIsStrictlyWithin(physicalEventsDirectory, physicalDirectory)) {
+      throw new Error("Pi pending-event state resolves outside its namespace");
+    }
+    // Validate fail-closed and atomically repair permissions even when the
+    // state was created by an older adapter or a permissive umask.
+    await this.withManifestLock(async () => {});
+    await this.prune(new Set());
+    await this.assertConversationCapacity();
+  }
+
+  async resolve(
+    conversationId: string,
+    resetToken: string | undefined,
+    expectedCwd: string,
+    create: (
+      persistedSessionFile: string | undefined,
+      lifecycleGeneration: string,
+    ) => Promise<{
+      sessionFile: string;
+      piSessionId: string;
+      cwd: string;
+    }>,
+  ): Promise<ResolveConversationResult> {
+    validateConversationId(conversationId);
+    validateResetToken(resetToken);
+    const canonicalCwd = resolve(expectedCwd);
+    validatePathString(canonicalCwd, "conversation cwd", MAX_CWD_CHARACTERS);
+    await this.ensureConversationCapacity(conversationId);
+    const conversationLock = await this.acquireConversationLock(conversationId);
+    let result: ResolveConversationResult;
+    try {
+      const { mapping: existing, resetTombstone } =
+        await this.getConversationState(conversationId);
+      const pendingResetTombstone =
+        resetTombstone?.status === "pending" ? resetTombstone : undefined;
+      if (
+        pendingResetTombstone?.resetToken !== undefined &&
+        resetToken !== undefined &&
+        pendingResetTombstone.resetToken !== resetToken
+      ) {
+        throw new Error(
+          "resetToken must match the latest committed Buzz reset token",
+        );
+      }
+      const resetChanged =
+        resetToken !== undefined && existing?.lastResetToken !== resetToken;
+      const supersededPendingEvents =
+        resetChanged || pendingResetTombstone !== undefined;
+      const existingLeaseDisposition =
+        existing === undefined ? "none" : this.leaseDisposition(existing);
+      const existingLeaseActive = existingLeaseDisposition === "active";
+      const existingLeaseMayStillWrite =
+        existingLeaseActive || existingLeaseDisposition === "uncertain";
+      if (existingLeaseActive && !resetChanged) {
+        throw new Error("Conversation is active in another Pi runtime");
+      }
+
+      const cwdChanged =
+        existing !== undefined && resolve(existing.cwd) !== canonicalCwd;
+      let forceFresh =
+        cwdChanged ||
+        resetChanged ||
+        pendingResetTombstone !== undefined ||
+        existingLeaseDisposition === "uncertain";
+      const lifecycleGeneration = supersededPendingEvents
+        ? newLifecycleGeneration()
+        : (existing?.lifecycleGeneration ?? newLifecycleGeneration());
+      let replacedStale = false;
+      let created: { sessionFile: string; piSessionId: string; cwd: string };
+      try {
+        created = await create(
+          forceFresh ? undefined : existing?.sessionFile,
+          lifecycleGeneration,
+        );
+      } catch (error) {
+        if (!existing || forceFresh || !isRecoverableStaleSessionError(error)) {
+          throw error;
+        }
+        this.logger.warn(
+          "persisted Pi conversation was stale; recreating safely",
+          {
+            conversationId,
+            error: errorMessage(error),
+          },
+        );
+        forceFresh = true;
+        replacedStale = true;
+        created = await create(undefined, lifecycleGeneration);
+      }
+
+      if (resolve(created.cwd) !== canonicalCwd) {
+        throw new Error("Pi session cwd did not match the requested workspace");
+      }
+      const sessionFile = await this.validateSessionFileOnDisk(
+        created.sessionFile,
+      );
+      validatePiSessionId(created.piSessionId);
+      await chmod(sessionFile, 0o600).catch((error: unknown) => {
+        if (!isCode(error, "ENOENT")) throw error;
+      });
+
+      const now = new Date().toISOString();
+      const lastResetToken =
+        resetToken ??
+        pendingResetTombstone?.resetToken ??
+        existing?.lastResetToken;
+      const relayHistoryCleared =
+        existing?.relayHistoryCleared === true ||
+        resetChanged ||
+        pendingResetTombstone !== undefined;
+      const lease = this.newLease();
+      const mapping: ConversationMapping = {
+        conversationId,
+        cwd: canonicalCwd,
+        sessionFile,
+        piSessionId: created.piSessionId,
+        lifecycleGeneration,
+        createdAt: existing?.createdAt ?? now,
+        lastUsedAt: now,
+        ...(lastResetToken === undefined ? {} : { lastResetToken }),
+        ...(relayHistoryCleared ? { relayHistoryCleared: true } : {}),
+        lease,
+      };
+      await this.withManifestLock(async (manifest) => {
+        await conversationLock.assertOwned();
+        if (
+          manifest.conversations[conversationId] === undefined &&
+          Object.keys(manifest.conversations).length >=
+            this.config.maxPersistedConversations
+        ) {
+          throw new Error(
+            `Persisted Pi conversation capacity ${this.config.maxPersistedConversations} is full; no inactive mapping is safe to prune`,
+          );
+        }
+        manifest.conversations[conversationId] = mapping;
+        if (pendingResetTombstone !== undefined) {
+          manifest.resetTombstones[conversationId] = {
+            ...pendingResetTombstone,
+            status: "retained",
+            installedPiSessionId: mapping.piSessionId,
+            consumedAt: now,
+          };
+        } else if (resetChanged) {
+          manifest.resetTombstones[conversationId] = {
+            conversationId,
+            ...(existing?.piSessionId === undefined
+              ? {}
+              : { previousPiSessionId: existing.piSessionId }),
+            ...(lastResetToken === undefined
+              ? {}
+              : { resetToken: lastResetToken }),
+            createdAt: now,
+            status: "retained",
+            installedPiSessionId: mapping.piSessionId,
+            consumedAt: now,
+          };
+        } else if (resetTombstone?.status === "retained") {
+          manifest.resetTombstones[conversationId] = {
+            ...resetTombstone,
+            installedPiSessionId: mapping.piSessionId,
+          };
+        }
+      });
+      const replaced =
+        (existing !== undefined && (forceFresh || replacedStale)) ||
+        pendingResetTombstone !== undefined;
+      const previousPiSessionId =
+        existing?.piSessionId ?? pendingResetTombstone?.previousPiSessionId;
+      const resumed = existing !== undefined && !forceFresh && !replacedStale;
+      result = {
+        mapping: structuredClone(mapping),
+        lifecycleGeneration,
+        resumed,
+        ...(replaced && previousPiSessionId !== undefined
+          ? { previousPiSessionId }
+          : {}),
+        // A changed, authenticated reset token may supersede another process's
+        // active lease. Keep that old JSONL until normal retention pruning;
+        // the other process can still be finishing an in-flight write.
+        ...(replaced &&
+        !existingLeaseMayStillWrite &&
+        existing !== undefined &&
+        existing.sessionFile !== sessionFile
+          ? { retiredSessionFile: existing.sessionFile }
+          : {}),
+        skipRelayHistory: !resumed && relayHistoryCleared,
+        refresh: () =>
+          this.touch(
+            conversationId,
+            mapping.piSessionId,
+            mapping.lastResetToken,
+            lease.ownerId,
+            mapping.lifecycleGeneration,
+            mapping.sessionFile,
+          ),
+        forget: () =>
+          this.forget(
+            conversationId,
+            mapping.piSessionId,
+            mapping.lastResetToken,
+            lease.ownerId,
+            mapping.lifecycleGeneration,
+            mapping.sessionFile,
+          ),
+        release: async () => {
+          const stillReferenced = await this.release(
+            conversationId,
+            mapping.piSessionId,
+            mapping.lastResetToken,
+            lease.ownerId,
+            mapping.lifecycleGeneration,
+            mapping.sessionFile,
+          );
+          // A cross-adapter /new can supersede an active mapping. Its old file
+          // becomes safe to remove only when the old handle is actually being
+          // disposed and invokes this release closure.
+          if (!stillReferenced)
+            await this.safeDeleteSessionFile(mapping.sessionFile);
+        },
+      };
+      if (supersededPendingEvents) {
+        await this.clearPendingSessionEvents(
+          conversationId,
+          lifecycleGeneration,
+        ).catch((error: unknown) => {
+          // The epoch fence is already durable. Keep the fresh session usable;
+          // any record that could not be cleaned is still classified by epoch
+          // during replay rather than being mistaken for a non-reset recovery.
+          this.logger.warn("deferred stale lifecycle-event cleanup failed", {
+            conversationId,
+            error: errorMessage(error),
+          });
+        });
+      }
+    } finally {
+      await conversationLock.release();
+    }
+
+    // Capacity pruning is deliberately outside the conversation lock. Every
+    // victim gets its own lock, avoiding manifest/conversation lock inversion.
+    await this.prune(new Set([conversationId])).catch((error: unknown) => {
+      this.logger.warn("deferred Pi conversation pruning failed", {
+        error: errorMessage(error),
+      });
+    });
+    return result;
+  }
+
+  async touch(
+    conversationId: string,
+    expectedPiSessionId: string,
+    expectedResetToken: string | undefined,
+    expectedLeaseOwnerId?: string,
+    expectedLifecycleGeneration?: string,
+    expectedSessionFile?: string,
+  ): Promise<boolean> {
+    validateConversationId(conversationId);
+    return this.withManifestLock(async (manifest) => {
+      const mapping = manifest.conversations[conversationId];
+      if (
+        !mapping ||
+        mapping.piSessionId !== expectedPiSessionId ||
+        mapping.lastResetToken !== expectedResetToken ||
+        mapping.lease?.ownerId !== expectedLeaseOwnerId ||
+        (expectedLifecycleGeneration !== undefined &&
+          mapping.lifecycleGeneration !== expectedLifecycleGeneration) ||
+        (expectedSessionFile !== undefined &&
+          mapping.sessionFile !== expectedSessionFile)
+      )
+        return false;
+      mapping.lastUsedAt = new Date().toISOString();
+      mapping.lease = this.newLease(expectedLeaseOwnerId);
+      return true;
+    });
+  }
+
+  private async forget(
+    conversationId: string,
+    expectedPiSessionId: string,
+    expectedResetToken: string | undefined,
+    expectedLeaseOwnerId: string,
+    expectedLifecycleGeneration: string,
+    expectedSessionFile: string,
+  ): Promise<string | undefined> {
+    validateConversationId(conversationId);
+    const conversationLock = await this.acquireConversationLock(conversationId);
+    let sessionFile: string | undefined;
+    try {
+      await this.withManifestLock(async (manifest) => {
+        await conversationLock.assertOwned();
+        const mapping = manifest.conversations[conversationId];
+        if (
+          !mapping ||
+          mapping.piSessionId !== expectedPiSessionId ||
+          mapping.lastResetToken !== expectedResetToken ||
+          mapping.lease?.ownerId !== expectedLeaseOwnerId ||
+          mapping.lifecycleGeneration !== expectedLifecycleGeneration ||
+          mapping.sessionFile !== expectedSessionFile
+        )
+          return;
+        sessionFile = mapping.sessionFile;
+        this.assertPendingResetCapacity(manifest, conversationId);
+        manifest.resetTombstones[conversationId] = {
+          conversationId,
+          previousPiSessionId: mapping.piSessionId,
+          createdAt: new Date().toISOString(),
+          status: "pending",
+        };
+        delete manifest.conversations[conversationId];
+      });
+      if (sessionFile !== undefined) {
+        await this.clearPendingSessionEvents(conversationId);
+      }
+      return sessionFile;
+    } finally {
+      await conversationLock.release();
+    }
+  }
+
+  async deleteSessionFile(path: string): Promise<void> {
+    await this.safeDeleteSessionFile(path);
+  }
+
+  async commitReset(
+    conversationId: string,
+    resetToken: string,
+  ): Promise<CommitConversationResetResult> {
+    validateConversationId(conversationId);
+    validateResetToken(resetToken);
+    const conversationLock = await this.acquireConversationLock(conversationId);
+    try {
+      const { result, shouldClearPendingEvents } = await this.withManifestLock(
+        async (manifest) => {
+          await conversationLock.assertOwned();
+          const mapping = manifest.conversations[conversationId];
+          const tombstone = manifest.resetTombstones[conversationId];
+          if (
+            mapping !== undefined &&
+            mapping.lastResetToken === resetToken &&
+            tombstone?.status !== "pending"
+          ) {
+            return {
+              result: { alreadyCommitted: true, disposeLiveSession: false },
+              shouldClearPendingEvents: false,
+            };
+          }
+          if (
+            tombstone?.status === "pending" &&
+            tombstone.resetToken === resetToken
+          ) {
+            return {
+              result: { alreadyCommitted: true, disposeLiveSession: true },
+              shouldClearPendingEvents: true,
+            };
+          }
+
+          const mappingLeaseMayStillWrite =
+            mapping !== undefined && this.leaseMayStillWrite(mapping);
+          const previousPiSessionId =
+            mapping?.piSessionId ?? tombstone?.previousPiSessionId;
+          this.assertPendingResetCapacity(manifest, conversationId);
+          manifest.resetTombstones[conversationId] = {
+            conversationId,
+            ...(previousPiSessionId === undefined
+              ? {}
+              : { previousPiSessionId }),
+            resetToken,
+            createdAt: new Date().toISOString(),
+            status: "pending",
+          };
+          delete manifest.conversations[conversationId];
+          return {
+            result: {
+              alreadyCommitted: false,
+              disposeLiveSession: true,
+              ...(mapping !== undefined && !mappingLeaseMayStillWrite
+                ? { retiredSessionFile: mapping.sessionFile }
+                : {}),
+            },
+            shouldClearPendingEvents: true,
+          };
+        },
+      );
+      // The reset tombstone is committed first. If cleanup fails or the process
+      // crashes here, replay generation checks still suppress old notices and
+      // an idempotent reset retry completes the deletion before ACK.
+      if (shouldClearPendingEvents) {
+        await this.clearPendingSessionEvents(conversationId);
+      }
+      return result;
+    } finally {
+      await conversationLock.release();
+    }
+  }
+
+  async release(
+    conversationId: string,
+    expectedPiSessionId: string,
+    expectedResetToken: string | undefined,
+    expectedLeaseOwnerId: string,
+    expectedLifecycleGeneration: string,
+    expectedSessionFile?: string,
+  ): Promise<boolean> {
+    validateConversationId(conversationId);
+    return this.withManifestLock(async (manifest) => {
+      const mapping = manifest.conversations[conversationId];
+      if (
+        mapping?.piSessionId === expectedPiSessionId &&
+        mapping.lastResetToken === expectedResetToken &&
+        mapping.lease?.ownerId === expectedLeaseOwnerId &&
+        mapping.lifecycleGeneration === expectedLifecycleGeneration &&
+        (expectedSessionFile === undefined ||
+          mapping.sessionFile === expectedSessionFile)
+      ) {
+        delete mapping.lease;
+      }
+      return (
+        expectedSessionFile === undefined ||
+        mapping?.sessionFile === expectedSessionFile
+      );
+    });
+  }
+
+  async prune(
+    activeConversationIds: Set<string>,
+    reserveSlots = 0,
+  ): Promise<number> {
+    const snapshot = await this.withManifestLock(
+      async (manifest) => structuredClone(manifest),
+      false,
+    );
+    const candidates = this.selectPruneCandidates(
+      snapshot,
+      activeConversationIds,
+    );
+    const requiredRemovalCount = Math.max(
+      0,
+      Object.keys(snapshot.conversations).length -
+        Math.max(0, this.config.maxPersistedConversations - reserveSlots),
+    );
+    let pruned = 0;
+    for (const candidate of candidates) {
+      if (candidate.reason === "capacity" && pruned >= requiredRemovalCount) {
+        break;
+      }
+      const conversationLock = await this.acquireConversationLock(
+        candidate.mapping.conversationId,
+      );
+      let removedFile: string | undefined;
+      try {
+        // Pending events pin their mapping. Hold this lock across the final
+        // manifest revalidation/removal: enqueue uses the same pending-events
+        // -> manifest order, so either its durable write wins and pruning
+        // skips, or pruning removes the mapping and enqueue rejects the epoch.
+        const pendingEventsLock = await this.acquireLock("pending-events");
+        try {
+          if (
+            await this.hasPendingSessionEventsLocked(
+              candidate.mapping.conversationId,
+            )
+          ) {
+            continue;
+          }
+          await this.withManifestLock(async (manifest) => {
+            await conversationLock.assertOwned();
+            await pendingEventsLock.assertOwned();
+            const current =
+              manifest.conversations[candidate.mapping.conversationId];
+            if (
+              !current ||
+              activeConversationIds.has(current.conversationId) ||
+              this.leaseMayStillWrite(current) ||
+              !sameMappingVersion(current, candidate.mapping)
+            )
+              return;
+            if (
+              candidate.reason === "ttl" &&
+              Date.now() - Date.parse(current.lastUsedAt) <
+                this.config.persistedConversationTtlMs
+            )
+              return;
+            if (current.relayHistoryCleared === true) {
+              try {
+                this.assertPendingResetCapacity(
+                  manifest,
+                  current.conversationId,
+                );
+              } catch (error) {
+                this.logger.warn(
+                  "retained reset barrier prevented Pi mapping pruning",
+                  {
+                    conversationId: current.conversationId,
+                    error: errorMessage(error),
+                  },
+                );
+                return;
+              }
+              const retained = manifest.resetTombstones[current.conversationId];
+              manifest.resetTombstones[current.conversationId] = {
+                conversationId: current.conversationId,
+                previousPiSessionId: current.piSessionId,
+                ...(current.lastResetToken === undefined
+                  ? {}
+                  : { resetToken: current.lastResetToken }),
+                createdAt: retained?.createdAt ?? new Date().toISOString(),
+                status: "pending",
+              };
+            }
+            removedFile = current.sessionFile;
+            delete manifest.conversations[current.conversationId];
+            pruned++;
+          });
+        } finally {
+          await pendingEventsLock.release();
+        }
+      } finally {
+        await conversationLock.release();
+      }
+      if (removedFile) await this.safeDeleteSessionFile(removedFile);
+    }
+    if (pruned > 0) {
+      this.logger.info("pruned persisted Pi conversations", {
+        count: pruned,
+        namespace: this.namespace,
+      });
+    }
+    return pruned;
+  }
+
+  async get(conversationId: string): Promise<ConversationMapping | undefined> {
+    validateConversationId(conversationId);
+    return this.withManifestLock(async (manifest) => {
+      const mapping = manifest.conversations[conversationId];
+      return mapping ? structuredClone(mapping) : undefined;
+    }, false);
+  }
+
+  async enqueueSessionEvent(
+    conversationId: string,
+    eventId: string,
+    event: BuzzSessionEvent,
+    expectedLifecycleGeneration: string,
+  ): Promise<boolean> {
+    validateConversationId(conversationId);
+    validateEventId(eventId);
+    validateStoredSessionEvent(event);
+    validateLifecycleGeneration(expectedLifecycleGeneration);
+    const record: PendingBuzzSessionEvent = {
+      conversationId,
+      eventId,
+      lifecycleGeneration: expectedLifecycleGeneration,
+      event: structuredClone(event),
+      createdAt: new Date().toISOString(),
+    };
+    const serialized = `${JSON.stringify({ version: 1, ...record })}\n`;
+    if (
+      Buffer.byteLength(serialized, "utf8") > MAX_PENDING_SESSION_EVENT_BYTES
+    ) {
+      throw new Error(
+        `Buzz session lifecycle event exceeds ${MAX_PENDING_SESSION_EVENT_BYTES} bytes`,
+      );
+    }
+    const lock = await this.acquireLock("pending-events");
+    try {
+      const currentMapping = await this.get(conversationId);
+      if (currentMapping?.lifecycleGeneration !== expectedLifecycleGeneration) {
+        // A reset may commit after the runtime emitted an event but before its
+        // asynchronous durable write. Epoch fencing rejects that stale notice,
+        // while a non-reset Pi replacement retains the same epoch and may still
+        // finish a valid in-flight write.
+        return false;
+      }
+      const directory = this.conversationEventDirectory(conversationId);
+      const target = join(directory, `${eventId}.json`);
+      const existing = await this.readPendingSessionEventFile(
+        target,
+        currentMapping.lifecycleGeneration,
+      ).catch((error: unknown) => {
+        if (isCode(error, "ENOENT")) return undefined;
+        throw error;
+      });
+      if (existing) {
+        if (
+          existing.conversationId === conversationId &&
+          existing.eventId === eventId &&
+          existing.lifecycleGeneration === expectedLifecycleGeneration &&
+          JSON.stringify(existing.event) === JSON.stringify(event)
+        ) {
+          return true;
+        }
+        throw new Error("Buzz session lifecycle event id collision");
+      }
+      const count = await this.countPendingSessionEvents();
+      if (count >= this.config.maxPendingSessionEvents) {
+        throw new Error(
+          `Pending Buzz session lifecycle event capacity ${this.config.maxPendingSessionEvents} is full; refusing to drop an unacknowledged notice`,
+        );
+      }
+      await this.ensureConversationEventDirectory(conversationId);
+      const temporary = join(
+        directory,
+        `.event.${process.pid}.${randomUUID()}.tmp`,
+      );
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        handle = await open(temporary, "wx", 0o600);
+        await handle.writeFile(serialized, { encoding: "utf8" });
+        await handle.chmod(0o600);
+        await handle.sync();
+        await handle.close();
+        handle = undefined;
+        await lock.assertOwned();
+        await rename(temporary, target);
+        await syncDirectoryEntry(directory);
+        return true;
+      } finally {
+        await handle?.close().catch(() => {});
+        await rm(temporary, { force: true }).catch(() => {});
+      }
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async listPendingSessionEvents(
+    conversationId: string,
+  ): Promise<PendingBuzzSessionEvent[]> {
+    validateConversationId(conversationId);
+    const lock = await this.acquireLock("pending-events");
+    try {
+      // Lock order is pending-events -> manifest everywhere these overlap.
+      // Legacy records had no explicit epoch; conservatively attach them to
+      // the current mapping so an upgrade cannot silently lose an ACK-pending
+      // notice whose Pi ID changed during a non-reset recovery.
+      const currentLifecycleGeneration = (await this.get(conversationId))
+        ?.lifecycleGeneration;
+      const directory = this.conversationEventDirectory(conversationId);
+      let entries: Awaited<ReturnType<typeof opendir>>;
+      try {
+        entries = await opendir(directory);
+      } catch (error) {
+        if (isCode(error, "ENOENT")) return [];
+        throw error;
+      }
+      const records: PendingBuzzSessionEvent[] = [];
+      for await (const entry of entries) {
+        if (isEventTemporaryFile(entry.name) && entry.isFile()) {
+          await unlink(join(directory, entry.name)).catch(() => {});
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".json")) {
+          throw new Error("invalid pending Buzz session lifecycle entry");
+        }
+        const eventId = entry.name.slice(0, -".json".length);
+        validateEventId(eventId);
+        const record = await this.readPendingSessionEventFile(
+          join(directory, entry.name),
+          currentLifecycleGeneration,
+        );
+        if (
+          record.conversationId !== conversationId ||
+          record.eventId !== eventId
+        ) {
+          throw new Error("pending Buzz session lifecycle identity mismatch");
+        }
+        records.push(record);
+        if (records.length > this.config.maxPendingSessionEvents) {
+          throw new Error(
+            "pending Buzz session lifecycle state exceeds capacity",
+          );
+        }
+      }
+      return records.sort(
+        (left, right) =>
+          Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+          left.eventId.localeCompare(right.eventId),
+      );
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async acknowledgeSessionEvent(
+    conversationId: string,
+    eventId: string,
+  ): Promise<void> {
+    validateConversationId(conversationId);
+    validateEventId(eventId);
+    const lock = await this.acquireLock("pending-events");
+    try {
+      const directory = this.conversationEventDirectory(conversationId);
+      const target = join(directory, `${eventId}.json`);
+      let record: PendingBuzzSessionEvent;
+      try {
+        record = await this.readPendingSessionEventFile(target);
+      } catch (error) {
+        if (isCode(error, "ENOENT")) return;
+        throw error;
+      }
+      if (
+        record.conversationId !== conversationId ||
+        record.eventId !== eventId
+      ) {
+        throw new Error("pending Buzz session lifecycle identity mismatch");
+      }
+      await lock.assertOwned();
+      await unlink(target);
+      await syncDirectoryEntry(directory);
+      await rmdir(directory).catch((error: unknown) => {
+        if (!isCode(error, "ENOTEMPTY") && !isCode(error, "ENOENT")) {
+          throw error;
+        }
+      });
+      await syncDirectoryEntry(this.pendingEventsDirectory);
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async clearPendingSessionEvents(
+    conversationId: string,
+    preserveLifecycleGeneration?: string,
+  ): Promise<void> {
+    validateConversationId(conversationId);
+    if (preserveLifecycleGeneration !== undefined) {
+      validateLifecycleGeneration(preserveLifecycleGeneration);
+    }
+    const lock = await this.acquireLock("pending-events");
+    try {
+      const directory = this.conversationEventDirectory(conversationId);
+      let metadata: Awaited<ReturnType<typeof lstat>>;
+      try {
+        metadata = await lstat(directory);
+      } catch (error) {
+        if (isCode(error, "ENOENT")) return;
+        throw error;
+      }
+      if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+        throw new Error("invalid pending Buzz session lifecycle directory");
+      }
+      const entries = await opendir(directory);
+      let removedAny = false;
+      for await (const entry of entries) {
+        if (
+          !entry.isFile() ||
+          (!isEventTemporaryFile(entry.name) && !entry.name.endsWith(".json"))
+        ) {
+          throw new Error("invalid pending Buzz session lifecycle entry");
+        }
+        if (entry.name.endsWith(".json")) {
+          validateEventId(entry.name.slice(0, -".json".length));
+          if (preserveLifecycleGeneration !== undefined) {
+            const record = await this.readPendingSessionEventFile(
+              join(directory, entry.name),
+            );
+            if (record.lifecycleGeneration === preserveLifecycleGeneration) {
+              continue;
+            }
+          }
+        }
+        await unlink(join(directory, entry.name));
+        removedAny = true;
+      }
+      if (removedAny) await syncDirectoryEntry(directory);
+      let removedDirectory = false;
+      try {
+        await rmdir(directory);
+        removedDirectory = true;
+      } catch (error) {
+        if (!isCode(error, "ENOTEMPTY") && !isCode(error, "ENOENT")) {
+          throw error;
+        }
+      }
+      if (removedAny || removedDirectory) {
+        await syncDirectoryEntry(this.pendingEventsDirectory);
+      }
+    } finally {
+      await lock.release();
+    }
+  }
+
+  private conversationEventDirectory(conversationId: string): string {
+    return join(this.pendingEventsDirectory, hash(conversationId));
+  }
+
+  private async ensureConversationEventDirectory(
+    conversationId: string,
+  ): Promise<string> {
+    const directory = this.conversationEventDirectory(conversationId);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+    const metadata = await lstat(directory);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new Error("invalid pending Buzz session lifecycle directory");
+    }
+    const physical = await realpath(directory);
+    const physicalRoot = await realpath(this.pendingEventsDirectory);
+    if (!pathIsStrictlyWithin(physical, physicalRoot)) {
+      throw new Error("pending Buzz session lifecycle directory escaped state");
+    }
+    await syncDirectoryEntry(this.pendingEventsDirectory);
+    return directory;
+  }
+
+  private async countPendingSessionEvents(): Promise<number> {
+    const root = await opendir(this.pendingEventsDirectory);
+    let count = 0;
+    let scanned = 0;
+    for await (const directoryEntry of root) {
+      scanned++;
+      if (scanned > this.config.maxPendingSessionEvents * 2 + 32) {
+        throw new Error("pending Buzz session lifecycle state is unbounded");
+      }
+      if (
+        !directoryEntry.isDirectory() ||
+        !EVENT_DIRECTORY_PATTERN.test(directoryEntry.name)
+      ) {
+        throw new Error("invalid pending Buzz session lifecycle directory");
+      }
+      const directory = await opendir(
+        join(this.pendingEventsDirectory, directoryEntry.name),
+      );
+      for await (const entry of directory) {
+        scanned++;
+        if (scanned > this.config.maxPendingSessionEvents * 3 + 64) {
+          throw new Error("pending Buzz session lifecycle state is unbounded");
+        }
+        if (isEventTemporaryFile(entry.name) && entry.isFile()) {
+          await unlink(
+            join(this.pendingEventsDirectory, directoryEntry.name, entry.name),
+          ).catch(() => {});
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".json")) {
+          throw new Error("invalid pending Buzz session lifecycle entry");
+        }
+        validateEventId(entry.name.slice(0, -".json".length));
+        count++;
+        if (count >= this.config.maxPendingSessionEvents) return count;
+      }
+    }
+    return count;
+  }
+
+  /** Requires the caller to own the global pending-events lock. */
+  private async hasPendingSessionEventsLocked(
+    conversationId: string,
+  ): Promise<boolean> {
+    const directory = this.conversationEventDirectory(conversationId);
+    let entries: Awaited<ReturnType<typeof opendir>>;
+    try {
+      entries = await opendir(directory);
+    } catch (error) {
+      if (isCode(error, "ENOENT")) return false;
+      throw error;
+    }
+    let hasPending = false;
+    let removedTemporary = false;
+    let scanned = 0;
+    for await (const entry of entries) {
+      scanned++;
+      if (scanned > this.config.maxPendingSessionEvents + 32) {
+        throw new Error("pending Buzz session lifecycle state is unbounded");
+      }
+      if (isEventTemporaryFile(entry.name) && entry.isFile()) {
+        await unlink(join(directory, entry.name));
+        removedTemporary = true;
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        throw new Error("invalid pending Buzz session lifecycle entry");
+      }
+      const eventId = entry.name.slice(0, -".json".length);
+      validateEventId(eventId);
+      const record = await this.readPendingSessionEventFile(
+        join(directory, entry.name),
+      );
+      if (
+        record.conversationId !== conversationId ||
+        record.eventId !== eventId
+      ) {
+        throw new Error("pending Buzz session lifecycle identity mismatch");
+      }
+      hasPending = true;
+    }
+    if (removedTemporary) await syncDirectoryEntry(directory);
+    return hasPending;
+  }
+
+  private async readPendingSessionEventFile(
+    path: string,
+    legacyLifecycleGeneration?: string,
+  ): Promise<PendingBuzzSessionEvent> {
+    const metadata = await lstat(path);
+    if (
+      metadata.isSymbolicLink() ||
+      !metadata.isFile() ||
+      metadata.size > MAX_PENDING_SESSION_EVENT_BYTES
+    ) {
+      throw new Error("invalid pending Buzz session lifecycle file");
+    }
+    await chmod(path, 0o600);
+    const raw: unknown = JSON.parse(await readFile(path, "utf8"));
+    if (!isRecord(raw) || raw.version !== 1) {
+      throw new Error("invalid pending Buzz session lifecycle record");
+    }
+    const conversationId = requiredBoundedString(
+      raw.conversationId,
+      "pendingEvent.conversationId",
+      512,
+    );
+    validateConversationId(conversationId);
+    const eventId = requiredBoundedString(
+      raw.eventId,
+      "pendingEvent.eventId",
+      64,
+    );
+    validateEventId(eventId);
+    validateStoredSessionEvent(raw.event);
+    const lifecycleGeneration =
+      raw.lifecycleGeneration === undefined
+        ? (legacyLifecycleGeneration ??
+          deriveLegacyLifecycleGeneration(raw.event.piSessionId))
+        : requiredBoundedString(
+            raw.lifecycleGeneration,
+            "pendingEvent.lifecycleGeneration",
+            64,
+          );
+    validateLifecycleGeneration(lifecycleGeneration);
+    return {
+      conversationId,
+      eventId,
+      lifecycleGeneration,
+      event: raw.event,
+      createdAt: validIsoDate(raw.createdAt, "pendingEvent.createdAt"),
+    };
+  }
+
+  private async getConversationState(conversationId: string): Promise<{
+    mapping: ConversationMapping | undefined;
+    resetTombstone: ResetTombstone | undefined;
+  }> {
+    return this.withManifestLock(async (manifest) => {
+      const mapping = manifest.conversations[conversationId];
+      const resetTombstone = manifest.resetTombstones[conversationId];
+      return {
+        mapping: mapping ? structuredClone(mapping) : undefined,
+        resetTombstone: resetTombstone
+          ? structuredClone(resetTombstone)
+          : undefined,
+      };
+    }, false);
+  }
+
+  private selectPruneCandidates(
+    manifest: ConversationManifest,
+    activeConversationIds: Set<string>,
+  ): PruneCandidate[] {
+    const now = Date.now();
+    const entries = Object.values(manifest.conversations).sort(
+      (left, right) =>
+        Date.parse(left.lastUsedAt) - Date.parse(right.lastUsedAt),
+    );
+    const expired = entries.filter(
+      (mapping) =>
+        !activeConversationIds.has(mapping.conversationId) &&
+        !this.leaseMayStillWrite(mapping) &&
+        now - Date.parse(mapping.lastUsedAt) >=
+          this.config.persistedConversationTtlMs,
+    );
+    const expiredIds = new Set(
+      expired.map((mapping) => mapping.conversationId),
+    );
+    const excess = entries.filter(
+      (mapping) =>
+        !expiredIds.has(mapping.conversationId) &&
+        !activeConversationIds.has(mapping.conversationId) &&
+        !this.leaseMayStillWrite(mapping),
+    );
+    return [
+      ...expired.map((mapping) => ({ mapping, reason: "ttl" as const })),
+      ...excess.map((mapping) => ({ mapping, reason: "capacity" as const })),
+    ];
+  }
+
+  private async ensureConversationCapacity(
+    conversationId: string,
+  ): Promise<void> {
+    const existing = await this.get(conversationId);
+    if (existing) return;
+    await this.prune(new Set([conversationId]), 1);
+    await this.assertConversationCapacity(conversationId);
+  }
+
+  private async assertConversationCapacity(
+    insertingConversationId?: string,
+  ): Promise<void> {
+    await this.withManifestLock(async (manifest) => {
+      if (
+        insertingConversationId !== undefined &&
+        manifest.conversations[insertingConversationId] !== undefined
+      ) {
+        return;
+      }
+      const count = Object.keys(manifest.conversations).length;
+      const overCapacity =
+        insertingConversationId === undefined
+          ? count > this.config.maxPersistedConversations
+          : count >= this.config.maxPersistedConversations;
+      if (overCapacity) {
+        throw new Error(
+          `Persisted Pi conversation capacity ${this.config.maxPersistedConversations} is full; no inactive mapping is safe to prune`,
+        );
+      }
+    }, false);
+  }
+
+  private assertPendingResetCapacity(
+    manifest: ConversationManifest,
+    conversationId: string,
+  ): void {
+    if (manifest.resetTombstones[conversationId]?.status === "pending") return;
+    const pendingCount = Object.values(manifest.resetTombstones).filter(
+      (tombstone) => tombstone.status === "pending",
+    ).length;
+    if (pendingCount >= this.config.maxPendingResetTombstones) {
+      throw new Error(
+        `Pending reset tombstone capacity ${this.config.maxPendingResetTombstones} is full; a cleared thread must be opened to install its fresh Pi mapping before committing another reset`,
+      );
+    }
+  }
+
+  private pruneRetainedResetTombstones(manifest: ConversationManifest): number {
+    const now = Date.now();
+    const safelyRetained: Array<
+      [string, Extract<ResetTombstone, { status: "retained" }>]
+    > = [];
+    for (const [conversationId, tombstone] of Object.entries(
+      manifest.resetTombstones,
+    )) {
+      if (tombstone.status !== "retained") continue;
+      const mapping = manifest.conversations[conversationId];
+      if (
+        mapping?.relayHistoryCleared !== true ||
+        mapping.piSessionId !== tombstone.installedPiSessionId ||
+        (tombstone.resetToken !== undefined &&
+          mapping.lastResetToken !== tombstone.resetToken)
+      ) {
+        // Never discard an unanchored barrier. Re-activate it so token-less
+        // session/new is forced fresh and skips relay history.
+        manifest.resetTombstones[conversationId] = {
+          conversationId,
+          ...(tombstone.previousPiSessionId === undefined
+            ? {}
+            : { previousPiSessionId: tombstone.previousPiSessionId }),
+          ...(tombstone.resetToken === undefined
+            ? {}
+            : { resetToken: tombstone.resetToken }),
+          createdAt: tombstone.createdAt,
+          status: "pending",
+        };
+        continue;
+      }
+      safelyRetained.push([conversationId, tombstone]);
+    }
+
+    const expired = safelyRetained.filter(
+      ([, tombstone]) =>
+        now - Date.parse(tombstone.consumedAt) >=
+        this.config.resetTombstoneTtlMs,
+    );
+    const expiredIds = new Set(
+      expired.map(([conversationId]) => conversationId),
+    );
+    const remaining = safelyRetained
+      .filter(([conversationId]) => !expiredIds.has(conversationId))
+      .sort(
+        (left, right) =>
+          Date.parse(left[1].consumedAt) - Date.parse(right[1].consumedAt),
+      );
+    const excess = remaining.slice(
+      0,
+      Math.max(0, remaining.length - this.config.maxRetainedResetTombstones),
+    );
+    for (const [conversationId] of [...expired, ...excess]) {
+      delete manifest.resetTombstones[conversationId];
+    }
+    return expired.length + excess.length;
+  }
+
+  private leaseMayStillWrite(mapping: ConversationMapping): boolean {
+    const disposition = this.leaseDisposition(mapping);
+    return disposition === "active" || disposition === "uncertain";
+  }
+
+  private leaseDisposition(
+    mapping: ConversationMapping,
+  ): "none" | "active" | "proven-dead" | "uncertain" {
+    const lease = mapping.lease;
+    if (!lease) return "none";
+    const unexpired = Date.parse(lease.expiresAt) > Date.now();
+
+    // PID liveness is meaningful only on the host that wrote the lease. For a
+    // foreign or legacy lease, an expired TTL permits takeover but cannot
+    // prove the predecessor is dead. That takeover must use a fresh JSONL.
+    if (
+      lease.hostId !== this.leaseIdentity.hostId ||
+      !this.leaseIdentity.pidProbeSafe
+    ) {
+      return unexpired ? "active" : "uncertain";
+    }
+
+    // A reboot makes every process from the prior boot definitively stale,
+    // even if its PID has since been reused by an unrelated process.
+    if (
+      lease.bootId !== undefined &&
+      this.leaseIdentity.bootId !== undefined &&
+      lease.bootId !== this.leaseIdentity.bootId
+    ) {
+      return "proven-dead";
+    }
+
+    // A confirmed-dead process on this host can safely resume its JSONL. A
+    // live PID with an expired lease may merely be suspended, so it is an
+    // uncertain takeover and must be isolated onto a fresh file.
+    if (!isProcessAlive(lease.pid)) return "proven-dead";
+    if (!unexpired) return "uncertain";
+
+    return "active";
+  }
+
+  private newLease(
+    ownerId: string = randomUUID(),
+  ): NonNullable<ConversationMapping["lease"]> {
+    return {
+      ownerId,
+      pid: process.pid,
+      hostId: this.leaseIdentity.hostId,
+      ...(this.leaseIdentity.bootId === undefined
+        ? {}
+        : { bootId: this.leaseIdentity.bootId }),
+      expiresAt: new Date(
+        Date.now() + this.config.conversationLeaseMs,
+      ).toISOString(),
+    };
+  }
+
+  private async withManifestLock<T>(
+    operation: (manifest: ConversationManifest) => Promise<T>,
+    write = true,
+  ): Promise<T> {
+    const lock = await this.acquireLock("manifest");
+    try {
+      const manifest = await this.readManifest();
+      const result = await operation(manifest);
+      if (write) {
+        this.pruneRetainedResetTombstones(manifest);
+        await lock.assertOwned();
+        await this.writeManifest(manifest, lock.assertOwned);
+      }
+      return result;
+    } finally {
+      await lock.release();
+    }
+  }
+
+  private async readManifest(): Promise<ConversationManifest> {
+    try {
+      const metadata = await stat(this.manifestPath);
+      if (!metadata.isFile() || metadata.size > MAX_MANIFEST_BYTES) {
+        throw new Error("invalid conversation manifest file");
+      }
+      await chmod(this.manifestPath, 0o600);
+      const raw = await readFile(this.manifestPath, "utf8");
+      return await this.validateManifest(JSON.parse(raw));
+    } catch (error) {
+      if (isCode(error, "ENOENT")) {
+        try {
+          const marker = await lstat(this.initializedMarkerPath);
+          if (!marker.isFile() || marker.isSymbolicLink()) {
+            throw new Error("invalid Pi state initialization marker");
+          }
+        } catch (markerError) {
+          if (isCode(markerError, "ENOENT")) return emptyManifest();
+          throw markerError;
+        }
+        throw new Error(
+          "Pi conversation manifest is missing after durable initialization",
+        );
+      }
+      this.logger.error("refused corrupt conversation manifest", {
+        error: errorMessage(error),
+      });
+      throw new Error(
+        `Pi conversation manifest is unreadable; refusing to lose durable reset boundaries: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private async validateManifest(
+    value: unknown,
+  ): Promise<ConversationManifest> {
+    if (
+      !isRecord(value) ||
+      value.version !== 1 ||
+      !isRecord(value.conversations)
+    ) {
+      throw new Error("invalid conversation manifest schema");
+    }
+    const resetTombstonesValue = value.resetTombstones ?? {};
+    if (!isRecord(resetTombstonesValue)) {
+      throw new Error("invalid reset tombstone manifest schema");
+    }
+    const entries = Object.entries(value.conversations);
+    const resetEntries = Object.entries(resetTombstonesValue);
+    if (entries.length + resetEntries.length > MAX_MANIFEST_ENTRIES) {
+      throw new Error("conversation manifest contains too many entries");
+    }
+    const conversations: Record<string, ConversationMapping> = {};
+    for (const [key, raw] of entries) {
+      validateConversationId(key);
+      if (!isRecord(raw) || raw.conversationId !== key) {
+        throw new Error("invalid conversation mapping identity");
+      }
+      const cwd = requiredBoundedString(raw.cwd, "cwd", MAX_CWD_CHARACTERS);
+      if (!isAbsolute(cwd)) throw new Error("invalid conversation cwd");
+      const sessionFile = await this.validateSessionFileOnDisk(
+        requiredBoundedString(
+          raw.sessionFile,
+          "sessionFile",
+          MAX_SESSION_PATH_CHARACTERS,
+        ),
+      );
+      const piSessionId = requiredBoundedString(
+        raw.piSessionId,
+        "piSessionId",
+        256,
+      );
+      validatePiSessionId(piSessionId);
+      const lifecycleGeneration =
+        raw.lifecycleGeneration === undefined
+          ? deriveLegacyLifecycleGeneration(piSessionId)
+          : requiredBoundedString(
+              raw.lifecycleGeneration,
+              "lifecycleGeneration",
+              64,
+            );
+      validateLifecycleGeneration(lifecycleGeneration);
+      const createdAt = validIsoDate(raw.createdAt, "createdAt");
+      const lastUsedAt = validIsoDate(raw.lastUsedAt, "lastUsedAt");
+      const lastResetToken = optionalBoundedString(
+        raw.lastResetToken,
+        "lastResetToken",
+        512,
+      );
+      const relayHistoryCleared =
+        raw.relayHistoryCleared === undefined
+          ? lastResetToken !== undefined
+          : requiredBoolean(raw.relayHistoryCleared, "relayHistoryCleared");
+      const lease =
+        raw.lease === undefined ? undefined : validateLease(raw.lease);
+      conversations[key] = {
+        conversationId: key,
+        cwd: resolve(cwd),
+        sessionFile,
+        piSessionId,
+        lifecycleGeneration,
+        createdAt,
+        lastUsedAt,
+        ...(lastResetToken === undefined ? {} : { lastResetToken }),
+        ...(relayHistoryCleared ? { relayHistoryCleared: true } : {}),
+        ...(lease === undefined ? {} : { lease }),
+      };
+    }
+    const resetTombstones: Record<string, ResetTombstone> = {};
+    for (const [key, raw] of resetEntries) {
+      validateConversationId(key);
+      if (!isRecord(raw) || raw.conversationId !== key) {
+        throw new Error("invalid reset tombstone identity");
+      }
+      const previousPiSessionId = optionalBoundedString(
+        raw.previousPiSessionId,
+        "resetTombstone.previousPiSessionId",
+        256,
+      );
+      if (previousPiSessionId !== undefined)
+        validatePiSessionId(previousPiSessionId);
+      const resetToken = optionalBoundedString(
+        raw.resetToken,
+        "resetTombstone.resetToken",
+        512,
+      );
+      const base: ResetTombstoneBase = {
+        conversationId: key,
+        ...(previousPiSessionId === undefined ? {} : { previousPiSessionId }),
+        ...(resetToken === undefined ? {} : { resetToken }),
+        createdAt: validIsoDate(raw.createdAt, "resetTombstone.createdAt"),
+      };
+      const status = raw.status ?? "pending";
+      if (status === "pending") {
+        if (conversations[key] !== undefined) {
+          throw new Error("pending reset tombstone overlaps a mapping");
+        }
+        resetTombstones[key] = { ...base, status };
+        continue;
+      }
+      if (status !== "retained") {
+        throw new Error("invalid reset tombstone status");
+      }
+      const installedPiSessionId = requiredBoundedString(
+        raw.installedPiSessionId,
+        "resetTombstone.installedPiSessionId",
+        256,
+      );
+      validatePiSessionId(installedPiSessionId);
+      const consumedAt = validIsoDate(
+        raw.consumedAt,
+        "resetTombstone.consumedAt",
+      );
+      const mapping = conversations[key];
+      if (
+        mapping?.relayHistoryCleared !== true ||
+        mapping.piSessionId !== installedPiSessionId ||
+        (resetToken !== undefined && mapping.lastResetToken !== resetToken)
+      ) {
+        throw new Error("retained reset tombstone is not safely anchored");
+      }
+      resetTombstones[key] = {
+        ...base,
+        status,
+        installedPiSessionId,
+        consumedAt,
+      };
+    }
+    return { version: 1, conversations, resetTombstones };
+  }
+
+  private async writeManifest(
+    manifest: ConversationManifest,
+    assertLockOwned: () => Promise<void>,
+  ): Promise<void> {
+    const serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+    const serializedBytes = Buffer.byteLength(serialized, "utf8");
+    if (serializedBytes > MAX_MANIFEST_BYTES) {
+      throw new Error(
+        `conversation manifest serialization exceeds ${MAX_MANIFEST_BYTES} bytes`,
+      );
+    }
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    await chmod(this.directory, 0o700);
+    const temporary = join(
+      this.directory,
+      `.${basename(this.manifestPath)}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    let temporaryHandle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      temporaryHandle = await open(temporary, "wx", 0o600);
+      await temporaryHandle.writeFile(serialized, { encoding: "utf8" });
+      await temporaryHandle.chmod(0o600);
+      await temporaryHandle.sync();
+      await temporaryHandle.close();
+      temporaryHandle = undefined;
+      // A long suspension can let another process retire this lock. Recheck
+      // the acquisition token at the last possible point before publishing.
+      await assertLockOwned();
+      await rename(temporary, this.manifestPath);
+      await syncDirectoryEntry(this.directory);
+      await this.ensureInitializedMarker();
+    } finally {
+      await temporaryHandle?.close().catch(() => {});
+      await rm(temporary, { force: true }).catch(() => {});
+    }
+  }
+
+  private async ensureInitializedMarker(): Promise<void> {
+    try {
+      const marker = await lstat(this.initializedMarkerPath);
+      if (marker.isFile() && !marker.isSymbolicLink()) {
+        await chmod(this.initializedMarkerPath, 0o600);
+        return;
+      }
+      throw new Error("invalid Pi state initialization marker");
+    } catch (error) {
+      if (!isCode(error, "ENOENT")) throw error;
+    }
+
+    const temporary = join(
+      this.directory,
+      `.${INITIALIZED_MARKER}.${process.pid}.${randomUUID()}.tmp`,
+    );
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await open(temporary, "wx", 0o600);
+      await handle.writeFile("buzz-pi-state-v1\n", { encoding: "utf8" });
+      await handle.chmod(0o600);
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      try {
+        await rename(temporary, this.initializedMarkerPath);
+      } catch (error) {
+        if (!isCode(error, "EEXIST")) throw error;
+      }
+      await syncDirectoryEntry(this.directory);
+    } finally {
+      await handle?.close().catch(() => {});
+      await rm(temporary, { force: true }).catch(() => {});
+    }
+  }
+
+  private validateSessionFile(path: string): string {
+    validatePathString(path, "Pi session path", MAX_SESSION_PATH_CHARACTERS);
+    const canonical = resolve(path);
+    if (!isAbsolute(path) || !canonical.endsWith(".jsonl")) {
+      throw new Error("invalid Pi session path");
+    }
+    if (
+      !this.allowedSessionRoots.some((root) => pathIsWithin(canonical, root))
+    ) {
+      throw new Error(
+        "Pi session path is outside an allowed session directory",
+      );
+    }
+    return canonical;
+  }
+
+  private async validateSessionFileOnDisk(path: string): Promise<string> {
+    const canonical = this.validateSessionFile(path);
+    try {
+      const physical = await realpath(canonical);
+      const physicalRoots = await Promise.all(
+        this.allowedSessionRoots.map(async (root) =>
+          realpath(root).catch(() => root),
+        ),
+      );
+      if (!physicalRoots.some((root) => pathIsWithin(physical, root))) {
+        throw new Error(
+          "Pi session symlink resolves outside an allowed session directory",
+        );
+      }
+    } catch (error) {
+      // A missing mapping is allowed through so SessionManager.open can fail
+      // and the stale-session recovery path can atomically replace it.
+      if (!isCode(error, "ENOENT")) throw error;
+    }
+    return canonical;
+  }
+
+  private async safeDeleteSessionFile(path: string): Promise<void> {
+    let canonical: string;
+    try {
+      canonical = await this.validateSessionFileOnDisk(path);
+    } catch (error) {
+      this.logger.warn("refused to delete an invalid Pi session path", {
+        error: errorMessage(error),
+      });
+      return;
+    }
+    try {
+      await unlink(canonical);
+    } catch (error) {
+      if (!isCode(error, "ENOENT")) {
+        this.logger.warn("failed to prune Pi session file", {
+          error: errorMessage(error),
+        });
+      }
+    }
+  }
+
+  private acquireConversationLock(
+    conversationId: string,
+  ): Promise<AcquiredStateLock> {
+    return this.acquireLock(`conversation-${hash(conversationId)}`);
+  }
+
+  private async acquireLock(name: string): Promise<AcquiredStateLock> {
+    await mkdir(this.locksDirectory, { recursive: true, mode: 0o700 });
+    await chmod(this.locksDirectory, 0o700);
+    const lockPath = join(this.locksDirectory, `${name}.lock`);
+    const deadline = Date.now() + 30_000;
+    while (true) {
+      try {
+        const acquisitionToken = randomUUID();
+        await mkdir(lockPath, { mode: 0o700 });
+        const ownerFile = join(lockPath, "owner");
+        const owner: LockOwnerRecord = {
+          version: 1,
+          pid: process.pid,
+          token: acquisitionToken,
+          hostId: this.leaseIdentity.hostId,
+          ...(this.leaseIdentity.bootId === undefined
+            ? {}
+            : { bootId: this.leaseIdentity.bootId }),
+          createdAt: new Date().toISOString(),
+        };
+        await writeFile(ownerFile, `${JSON.stringify(owner)}\n`, {
+          mode: 0o600,
+        });
+        await chmod(ownerFile, 0o600);
+        const heartbeatFile = join(lockPath, `heartbeat-${acquisitionToken}`);
+        await writeFile(heartbeatFile, "\n", { mode: 0o600 });
+        const ownedGeneration = await captureStateLockGeneration(lockPath);
+        if (
+          !ownedGeneration ||
+          parseLockOwner(ownedGeneration.ownerRaw ?? "")?.token !==
+            acquisitionToken
+        ) {
+          throw new Error(`Pi state lock ownership was lost (${name})`);
+        }
+        const assertOwned = async (): Promise<void> => {
+          if (!(await stateLockGenerationMatches(lockPath, ownedGeneration))) {
+            throw new Error(`Pi state lock ownership was lost (${name})`);
+          }
+        };
+        const heartbeat = setInterval(() => {
+          const now = new Date();
+          // The token-specific path prevents an old suspended timer from
+          // touching a successor's lock after its directory was renamed.
+          void utimes(heartbeatFile, now, now).catch((error: unknown) => {
+            if (!isCode(error, "ENOENT")) {
+              this.logger.warn("failed to heartbeat Pi state lock", {
+                name,
+                error: errorMessage(error),
+              });
+            }
+          });
+        }, LOCK_HEARTBEAT_MS);
+        heartbeat.unref();
+        return {
+          assertOwned,
+          release: async () => {
+            clearInterval(heartbeat);
+            // Atomically move exactly the generation we acquired, then delete
+            // the private tombstone. A successor reusing lockPath is fenced by
+            // the post-rename generation check.
+            await removeObservedLockGeneration(
+              lockPath,
+              ownedGeneration,
+              "released",
+            );
+          },
+        };
+      } catch (error) {
+        if (!isCode(error, "EEXIST")) throw error;
+        const observed = await inspectStaleLockGeneration(
+          lockPath,
+          this.leaseIdentity,
+        );
+        if (observed) {
+          // Inspect twice and require the exact directory inode + owner bytes
+          // to remain stale. If the old owner released and a successor won
+          // mkdir in between, the successor is never renamed or removed.
+          const revalidated = await inspectStaleLockGeneration(
+            lockPath,
+            this.leaseIdentity,
+          );
+          if (
+            revalidated &&
+            sameStateLockGeneration(observed, revalidated) &&
+            (await removeObservedStaleLock(lockPath, revalidated))
+          ) {
+            continue;
+          }
+        }
+        if (Date.now() >= deadline)
+          throw new Error("Timed out waiting for Pi state lock");
+        await new Promise((resolvePromise) =>
+          setTimeout(resolvePromise, 20 + Math.random() * 30),
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Persist a completed rename in the containing directory where Node supports
+ * directory handles. Windows rejects opening directories through fs.open, so
+ * it retains temp-file fsync plus atomic rename but cannot request this final
+ * namespace flush through Node's portable filesystem API.
+ */
+export async function syncDirectoryEntry(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (platform === "win32") return;
+  const directoryHandle = await open(directory, "r");
+  try {
+    await directoryHandle.sync();
+  } finally {
+    await directoryHandle.close();
+  }
+}
+
+export function deriveNamespace(env: NodeJS.ProcessEnv): string {
+  if (env.BUZZ_PI_NAMESPACE !== undefined && env.BUZZ_PI_NAMESPACE !== "")
+    return safeNamespace(env.BUZZ_PI_NAMESPACE);
+  const identity = [
+    canonicalRelayIdentity(env.BUZZ_RELAY_URL),
+    canonicalPrivateKeyIdentity(env.BUZZ_PRIVATE_KEY),
+  ].join("\0");
+  return `agent-${hash(identity).slice(0, 24)}`;
+}
+
+function canonicalRelayIdentity(value: string | undefined): string {
+  if (value === undefined) return "local";
+  try {
+    const parsed = new URL(value);
+    // Fragments never reach a WebSocket server and therefore cannot identify
+    // a distinct Buzz account boundary. URL also normalizes host casing,
+    // default ports, root paths, and dot segments for us.
+    parsed.hash = "";
+    return `url:${parsed.href}`;
+  } catch {
+    // The ACP harness will reject unusable relay URLs. Keeping invalid values
+    // distinct here makes namespace derivation deterministic without trying
+    // to guess at syntax the harness might accept in a future release.
+    return `raw:${value}`;
+  }
+}
+
+function canonicalPrivateKeyIdentity(value: string | undefined): string {
+  if (value === undefined) return "anonymous";
+  const secretKey = /^[0-9a-fA-F]{64}$/u.test(value)
+    ? Uint8Array.from(Buffer.from(value, "hex"))
+    : decodeNsec(value);
+  if (secretKey?.byteLength !== 32) return `raw:${value}`;
+  // Equivalent nsec/hex spellings now hash the same canonical key material.
+  // Only the outer SHA-256 namespace is persisted; this intermediate value is
+  // never written to disk or logs.
+  return `secret:${Buffer.from(secretKey).toString("hex")}`;
+}
+
+const BECH32_ALPHABET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32_GENERATORS = [
+  0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+] as const;
+
+function decodeNsec(value: string): Uint8Array | undefined {
+  if (value.length < 12 || value.length > 90) return undefined;
+  if (value !== value.toLowerCase() && value !== value.toUpperCase()) {
+    return undefined;
+  }
+  const canonical = value.toLowerCase();
+  const separator = canonical.lastIndexOf("1");
+  if (separator !== 4 || canonical.slice(0, separator) !== "nsec") {
+    return undefined;
+  }
+  const encoded = canonical.slice(separator + 1);
+  if (encoded.length < 7) return undefined;
+  const values: number[] = [];
+  for (const character of encoded) {
+    const index = BECH32_ALPHABET.indexOf(character);
+    if (index < 0) return undefined;
+    values.push(index);
+  }
+  const hrpValues = [
+    ...Array.from("nsec", (character) => character.charCodeAt(0) >> 5),
+    0,
+    ...Array.from("nsec", (character) => character.charCodeAt(0) & 31),
+  ];
+  if (bech32Polymod([...hrpValues, ...values]) !== 1) return undefined;
+  return convertFiveBitWords(values.slice(0, -6));
+}
+
+function bech32Polymod(values: readonly number[]): number {
+  let checksum = 1;
+  for (const value of values) {
+    const top = checksum >>> 25;
+    checksum = (((checksum & 0x1ffffff) << 5) ^ value) >>> 0;
+    for (const [index, generator] of BECH32_GENERATORS.entries()) {
+      if (((top >>> index) & 1) !== 0) {
+        checksum = (checksum ^ generator) >>> 0;
+      }
+    }
+  }
+  return checksum;
+}
+
+function convertFiveBitWords(
+  values: readonly number[],
+): Uint8Array | undefined {
+  const bytes: number[] = [];
+  let accumulator = 0;
+  let bits = 0;
+  for (const value of values) {
+    accumulator = ((accumulator << 5) | value) & 0xfff;
+    bits += 5;
+    while (bits >= 8) {
+      bits -= 8;
+      bytes.push((accumulator >>> bits) & 0xff);
+    }
+  }
+  if (bits >= 5 || ((accumulator << (8 - bits)) & 0xff) !== 0) {
+    return undefined;
+  }
+  return Uint8Array.from(bytes);
+}
+
+function safeNamespace(value: string): string {
+  if (
+    value !== value.trim() ||
+    value.length < 1 ||
+    value.length > 80 ||
+    value === "." ||
+    value === ".." ||
+    !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(value)
+  ) {
+    throw new Error(
+      "BUZZ_PI_NAMESPACE must be 1-80 characters, begin with an alphanumeric character, and contain only letters, numbers, dot, underscore, or hyphen",
+    );
+  }
+  return value;
+}
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function newLifecycleGeneration(): string {
+  return hash(`buzz-pi-lifecycle-generation-v1\0${randomUUID()}`);
+}
+
+function deriveLegacyLifecycleGeneration(piSessionId: string): string {
+  validatePiSessionId(piSessionId);
+  return hash(`buzz-pi-legacy-lifecycle-generation-v1\0${piSessionId}`);
+}
+
+function validateLifecycleGeneration(value: string): void {
+  if (!LIFECYCLE_GENERATION_PATTERN.test(value)) {
+    throw new Error("invalid lifecycle generation");
+  }
+}
+
+function validateConversationId(value: string): void {
+  if (value.length < 1 || value.length > 512 || hasControlCharacters(value)) {
+    throw new Error("conversationId must be 1-512 characters");
+  }
+}
+
+function validateResetToken(value: string | undefined): void {
+  if (
+    value !== undefined &&
+    (value.length < 1 || value.length > 512 || hasControlCharacters(value))
+  ) {
+    throw new Error("resetToken must be 1-512 characters");
+  }
+}
+
+function validateEventId(value: string): void {
+  if (!EVENT_ID_PATTERN.test(value)) {
+    throw new Error("eventId must be a lowercase UUID");
+  }
+}
+
+function validateStoredSessionEvent(
+  value: unknown,
+): asserts value is BuzzSessionEvent {
+  if (
+    !isRecord(value) ||
+    typeof value.type !== "string" ||
+    !SESSION_EVENT_TYPES.has(value.type)
+  ) {
+    throw new Error("invalid pending Buzz session lifecycle event type");
+  }
+  requiredBoundedString(value.timestamp, "pendingEvent.timestamp", 64);
+  validIsoDate(value.timestamp, "pendingEvent.timestamp");
+  requiredBoundedString(value.message, "pendingEvent.message", 1_024);
+  requiredBoundedString(value.piSessionId, "pendingEvent.piSessionId", 256);
+  const serialized = JSON.stringify(value);
+  if (Buffer.byteLength(serialized, "utf8") > 56 * 1_024) {
+    throw new Error("pending Buzz session lifecycle payload is oversized");
+  }
+}
+
+function isEventTemporaryFile(value: string): boolean {
+  return /^\.event\.\d+\.[0-9a-f-]+\.tmp$/u.test(value);
+}
+
+function validatePiSessionId(value: string): void {
+  if (value.length < 1 || value.length > 256 || hasControlCharacters(value)) {
+    throw new Error("invalid Pi session id");
+  }
+}
+
+function validatePathString(value: string, name: string, max: number): void {
+  if (value.length < 1 || value.length > max || hasControlCharacters(value)) {
+    throw new Error(`invalid ${name}`);
+  }
+}
+
+function hasControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function validateLease(
+  value: unknown,
+): NonNullable<ConversationMapping["lease"]> {
+  if (!isRecord(value)) throw new Error("invalid conversation lease");
+  const ownerId = requiredBoundedString(value.ownerId, "lease.ownerId", 256);
+  const pid = value.pid;
+  if (!Number.isSafeInteger(pid) || (pid as number) <= 0) {
+    throw new Error("invalid conversation lease pid");
+  }
+  const hostId = optionalBoundedString(value.hostId, "lease.hostId", 128);
+  const bootId = optionalBoundedString(value.bootId, "lease.bootId", 128);
+  if (bootId !== undefined && hostId === undefined) {
+    throw new Error("invalid conversation lease boot identity");
+  }
+  return {
+    ownerId,
+    pid: pid as number,
+    ...(hostId === undefined ? {} : { hostId }),
+    ...(bootId === undefined ? {} : { bootId }),
+    expiresAt: validIsoDate(value.expiresAt, "lease.expiresAt"),
+  };
+}
+
+function requiredBoundedString(
+  value: unknown,
+  name: string,
+  max: number,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > max ||
+    hasControlCharacters(value)
+  ) {
+    throw new Error(`invalid ${name}`);
+  }
+  return value;
+}
+
+function optionalBoundedString(
+  value: unknown,
+  name: string,
+  max: number,
+): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredBoundedString(value, name, max);
+}
+
+function requiredBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`invalid ${name}`);
+  return value;
+}
+
+function validIsoDate(value: unknown, name: string): string {
+  const raw = requiredBoundedString(value, name, 64);
+  const timestamp = Date.parse(raw);
+  if (!Number.isFinite(timestamp)) throw new Error(`invalid ${name}`);
+  return new Date(timestamp).toISOString();
+}
+
+function sameMappingVersion(
+  left: ConversationMapping,
+  right: ConversationMapping,
+): boolean {
+  return (
+    left.piSessionId === right.piSessionId &&
+    left.lifecycleGeneration === right.lifecycleGeneration &&
+    left.sessionFile === right.sessionFile &&
+    left.lastUsedAt === right.lastUsedAt &&
+    left.lastResetToken === right.lastResetToken &&
+    left.relayHistoryCleared === right.relayHistoryCleared
+  );
+}
+
+function emptyManifest(): ConversationManifest {
+  return { version: 1, conversations: {}, resetTombstones: {} };
+}
+
+function pathIsWithin(path: string, root: string): boolean {
+  const difference = relative(root, path);
+  return (
+    difference === "" ||
+    (!difference.startsWith(`..${sep}`) &&
+      difference !== ".." &&
+      !isAbsolute(difference))
+  );
+}
+
+function pathIsStrictlyWithin(path: string, root: string): boolean {
+  return path !== root && pathIsWithin(path, root);
+}
+
+interface LockOwnerRecord {
+  version: 1;
+  pid: number;
+  token: string;
+  hostId: string;
+  bootId?: string;
+  createdAt: string;
+}
+
+function parseLockOwner(value: string): LockOwnerRecord | undefined {
+  try {
+    const owner: unknown = JSON.parse(value);
+    if (
+      !isRecord(owner) ||
+      owner.version !== 1 ||
+      !Number.isSafeInteger(owner.pid) ||
+      (owner.pid as number) <= 0 ||
+      typeof owner.token !== "string" ||
+      owner.token.length < 1 ||
+      owner.token.length > 128 ||
+      typeof owner.hostId !== "string" ||
+      owner.hostId.length < 1 ||
+      owner.hostId.length > 128 ||
+      (owner.bootId !== undefined &&
+        (typeof owner.bootId !== "string" ||
+          owner.bootId.length < 1 ||
+          owner.bootId.length > 128)) ||
+      typeof owner.createdAt !== "string" ||
+      !Number.isFinite(Date.parse(owner.createdAt))
+    ) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      pid: owner.pid as number,
+      token: owner.token,
+      hostId: owner.hostId,
+      ...(owner.bootId === undefined ? {} : { bootId: owner.bootId }),
+      createdAt: new Date(Date.parse(owner.createdAt)).toISOString(),
+    };
+  } catch {
+    // Legacy PID/token owners and malformed records receive conservative TTL
+    // handling instead of a local PID probe.
+    return undefined;
+  }
+}
+
+async function inspectStaleLockGeneration(
+  path: string,
+  localIdentity: LeaseProcessIdentity,
+): Promise<StateLockGeneration | undefined> {
+  const generation = await captureStateLockGeneration(path);
+  if (!generation) return undefined;
+  const ownerRaw = generation.ownerRaw;
+  if (ownerRaw === undefined) {
+    // mkdir() wins the lock before its owner file is written. A vanished
+    // directory means release won the race; it authorizes a retry, never
+    // removal of whatever generation may appear at the same path next.
+    return Date.now() - generation.mtimeMs > LOCK_OWNER_WRITE_GRACE_MS
+      ? generation
+      : undefined;
+  }
+  try {
+    const owner = parseLockOwner(ownerRaw);
+    const metadata = owner
+      ? await stat(join(path, `heartbeat-${owner.token}`)).catch(
+          async (error: unknown) => {
+            if (!isCode(error, "ENOENT")) throw error;
+            // Owner-to-heartbeat creation has a bounded setup window; the
+            // pre-observed directory mtime excludes any successor generation.
+            return { mtimeMs: generation.mtimeMs };
+          },
+        )
+      : { mtimeMs: generation.mtimeMs };
+    const heartbeatExpired =
+      Date.now() - metadata.mtimeMs > LOCK_FOREIGN_STALE_MS;
+    if (!owner) return heartbeatExpired ? generation : undefined;
+    if (owner.hostId !== localIdentity.hostId)
+      return heartbeatExpired ? generation : undefined;
+    if (!localIdentity.pidProbeSafe)
+      return heartbeatExpired ? generation : undefined;
+    if (
+      owner.bootId !== undefined &&
+      localIdentity.bootId !== undefined &&
+      owner.bootId !== localIdentity.bootId
+    ) {
+      return generation;
+    }
+    // Never steal from a confirmed-live process in the same PID domain. Pi's
+    // session initialization can append to an existing JSONL while resolve()
+    // holds this lock; a machine suspension longer than the heartbeat TTL is
+    // not proof that those writes stopped. Dead PIDs and prior boots are safe
+    // to recover immediately. Foreign/unprovable owners use the conservative
+    // heartbeat path above and always get fresh JSONL takeover semantics.
+    return isProcessAlive(owner.pid) ? undefined : generation;
+  } catch {
+    return undefined;
+  }
+}
+
+/** @internal Exposed only for deterministic lock-generation regression tests. */
+export async function captureStateLockGeneration(
+  path: string,
+): Promise<StateLockGeneration | undefined> {
+  let before: Awaited<ReturnType<typeof stat>>;
+  try {
+    before = await stat(path);
+  } catch (error) {
+    if (isCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+  let ownerRaw: string | undefined;
+  try {
+    ownerRaw = await readFile(join(path, "owner"), "utf8");
+  } catch (error) {
+    if (!isCode(error, "ENOENT")) throw error;
+  }
+  let after: Awaited<ReturnType<typeof stat>>;
+  try {
+    after = await stat(path);
+  } catch (error) {
+    if (isCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+  if (!sameStateLockIdentity(before, after)) return undefined;
+  return {
+    device: after.dev,
+    inode: after.ino,
+    birthtimeMs: after.birthtimeMs,
+    mtimeMs: after.mtimeMs,
+    ownerRaw,
+  };
+}
+
+async function stateLockGenerationMatches(
+  path: string,
+  expected: StateLockGeneration,
+): Promise<boolean> {
+  const current = await captureStateLockGeneration(path);
+  return current !== undefined && sameStateLockGeneration(current, expected);
+}
+
+function sameStateLockGeneration(
+  left: StateLockGeneration,
+  right: StateLockGeneration,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.birthtimeMs === right.birthtimeMs &&
+    left.ownerRaw === right.ownerRaw
+  );
+}
+
+function sameStateLockIdentity(
+  left: Awaited<ReturnType<typeof stat>>,
+  right: Awaited<ReturnType<typeof stat>>,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.birthtimeMs === right.birthtimeMs
+  );
+}
+
+/** @internal Exposed only for deterministic lock-generation regression tests. */
+export async function removeObservedStaleLock(
+  path: string,
+  expected: StateLockGeneration,
+): Promise<boolean> {
+  return removeObservedLockGeneration(path, expected, "stale");
+}
+
+async function removeObservedLockGeneration(
+  path: string,
+  expected: StateLockGeneration,
+  disposition: "released" | "stale",
+): Promise<boolean> {
+  if (!(await stateLockGenerationMatches(path, expected))) return false;
+  const retiredPath = `${path}.${disposition}-${randomUUID()}`;
+  try {
+    await rename(path, retiredPath);
+  } catch (error) {
+    if (isCode(error, "ENOENT")) return false;
+    throw error;
+  }
+  if (!(await stateLockGenerationMatches(retiredPath, expected))) {
+    // Never delete a successor that won the pathname after inspection. Try to
+    // restore it; if another owner already filled the path, preserve both and
+    // fail closed rather than deleting an unrecognized generation.
+    await rename(retiredPath, path).catch(() => {});
+    throw new Error("Pi state lock generation changed during removal");
+  }
+  await rm(retiredPath, { recursive: true, force: true });
+  return true;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return isCode(error, "EPERM");
+  }
+}
+
+function discoverLocalLeaseIdentity(): LeaseProcessIdentity {
+  const machineIdentity = readMachineIdentity();
+  const processDomainIdentity = readProcessDomainIdentity();
+  const pidProbeSafe =
+    machineIdentity !== undefined && processDomainIdentity !== undefined;
+  const hostIdentity = pidProbeSafe
+    ? `machine\0${machineIdentity}\0process-domain\0${processDomainIdentity}`
+    : `hostname-fallback\0${hostname()}`;
+  const bootIdentity = readBootIdentity();
+  return {
+    hostId: hashIdentity(hostIdentity),
+    ...(bootIdentity === undefined
+      ? {}
+      : { bootId: hashIdentity(`boot\0${bootIdentity}`) }),
+    pidProbeSafe,
+  };
+}
+
+function readMachineIdentity(): string | undefined {
+  if (process.platform === "linux") {
+    for (const path of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+      try {
+        const value = readFileSync(path, "utf8").trim();
+        if (value.length > 0) return `linux:${value}`;
+      } catch {
+        // Try the next standard location.
+      }
+    }
+    return undefined;
+  }
+  if (process.platform === "darwin") {
+    try {
+      const value = execFileSync(
+        "/usr/sbin/ioreg",
+        ["-rd1", "-c", "IOPlatformExpertDevice"],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 1_000,
+          maxBuffer: 64 * 1_024,
+        },
+      );
+      const uuid = /"IOPlatformUUID"\s*=\s*"([^"]+)"/u.exec(value)?.[1];
+      if (uuid) return `darwin:${uuid}`;
+    } catch {
+      // Conservative hostname-only fallback below cannot authorize PID probes.
+    }
+    return undefined;
+  }
+  if (process.platform === "win32") {
+    try {
+      const value = execFileSync(
+        "reg.exe",
+        [
+          "query",
+          "HKLM\\SOFTWARE\\Microsoft\\Cryptography",
+          "/v",
+          "MachineGuid",
+        ],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 1_000,
+          maxBuffer: 64 * 1_024,
+        },
+      );
+      const guid = /MachineGuid\s+REG_SZ\s+(\S+)/u.exec(value)?.[1];
+      if (guid) return `windows:${guid}`;
+    } catch {
+      // Conservative hostname-only fallback below cannot authorize PID probes.
+    }
+  }
+  return undefined;
+}
+
+function readProcessDomainIdentity(): string | undefined {
+  if (process.platform === "linux") {
+    try {
+      return `linux-pidns:${readlinkSync("/proc/self/ns/pid")}`;
+    } catch {
+      return undefined;
+    }
+  }
+  // macOS and Windows expose host-global process identifiers.
+  if (process.platform === "darwin" || process.platform === "win32") {
+    return `${process.platform}:global-pid-domain`;
+  }
+  return undefined;
+}
+
+function readBootIdentity(): string | undefined {
+  if (process.platform === "linux") {
+    try {
+      const value = readFileSync(
+        "/proc/sys/kernel/random/boot_id",
+        "utf8",
+      ).trim();
+      if (value.length > 0) return `linux:${value}`;
+    } catch {
+      // Fall through to an unknown boot. Same-host dead PIDs remain safely
+      // recoverable; live PIDs are then bounded by the advisory lease TTL.
+    }
+  }
+  if (process.platform === "darwin") {
+    try {
+      const value = execFileSync("/usr/sbin/sysctl", ["-n", "kern.boottime"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1_000,
+        maxBuffer: 4_096,
+      });
+      const seconds = /sec\s*=\s*(\d+)/u.exec(value)?.[1];
+      if (seconds !== undefined) return `darwin:${seconds}`;
+    } catch {
+      // See the Linux fallback comment above.
+    }
+  }
+  return undefined;
+}
+
+function hashIdentity(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  );
+}
+
+function isRecoverableStaleSessionError(error: unknown): boolean {
+  if (isCode(error, "ENOENT")) return true;
+  const message = errorMessage(error);
+  // Keep this intentionally narrow. Provider/auth/extension/quota failures are
+  // environmental, not proof that the persisted transcript is stale; replacing
+  // its durable route on those errors would silently discard thread context.
+  return message.startsWith("Session file is not a valid pi session:");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/buzz-pi-agent/src/index.ts
+++ b/packages/buzz-pi-agent/src/index.ts
@@ -1,0 +1,63 @@
+export { AcpServer } from "./server.js";
+export {
+  ConversationStore,
+  deriveNamespace,
+  syncDirectoryEntry,
+} from "./conversation-store.js";
+export type { LeaseProcessIdentity } from "./conversation-store.js";
+export {
+  loadConfig,
+  compactionThreshold,
+  effectiveCompactionSettings,
+  effectiveContextLimit,
+  logicalModelContextWindow,
+} from "./config.js";
+export { SessionRegistry } from "./session-registry.js";
+export {
+  IsolatedPiWorkerFactory,
+  RuntimeSessionProxy,
+  RuntimeWorkerClient,
+  requestTimeoutMs,
+} from "./runtime-worker.js";
+export {
+  PiAgentSessionFactory,
+  applyFreshSessionTitle,
+  applyStrictPayloadGuard,
+  assertWithinContextLimit,
+  estimateProviderContextTokens,
+  estimateProviderPayloadTokens,
+  estimateSerializedPayloadTokens,
+  dedupeCommands,
+  guardProviderDispatch,
+  installSessionFileQuota,
+  assertSessionFileSizeWithinQuota,
+  ReadOnlySettingsStorage,
+} from "./pi-runtime.js";
+export {
+  AGENT_CONTEXT_LIMIT,
+  AGENT_OVERLOADED,
+  AGENT_SESSION_STORAGE_LIMIT,
+  AGENT_SESSION_INVALIDATED,
+  NdjsonWriter,
+  JsonRpcError,
+  readNdjson,
+} from "./wire.js";
+export { PerKeyRequestQueue } from "./runtime-host.js";
+export { BoundedIpcSendQueue } from "./ipc-send-queue.js";
+export {
+  assertPiResourceBudget,
+  assertPiResourceSnapshotsEqual,
+} from "./resource-budget.js";
+export type {
+  ResourceBudgetSnapshot,
+  ResourceFileFingerprint,
+} from "./resource-budget.js";
+export type {
+  AdapterEventSink,
+  AgentSessionFactory,
+  AgentSessionHandle,
+  BuzzSessionEvent,
+  ContextSnapshot,
+  ResourceSnapshot,
+  SessionUsageSnapshot,
+} from "./types.js";

--- a/packages/buzz-pi-agent/src/ipc-send-queue.ts
+++ b/packages/buzz-pi-agent/src/ipc-send-queue.ts
@@ -1,0 +1,303 @@
+/**
+ * Strictly ordered, bounded queue for Node IPC frames. `process.send()`'s
+ * callback is the flow-control boundary; a false return simply confirms that
+ * waiting for that callback is mandatory before submitting the next frame.
+ */
+export class BoundedIpcSendQueue<T> {
+  private readonly queue: Array<{ message: T; bytes: number }> = [];
+  private queuedBytes = 0;
+  private sending = false;
+  private fatalError: Error | undefined;
+
+  constructor(
+    private readonly rawSend: (
+      message: T,
+      callback: (error?: Error | null) => void,
+    ) => boolean,
+    private readonly maxQueuedMessages: number,
+    private readonly maxQueuedBytes: number,
+    private readonly onFatal: (error: Error) => void,
+  ) {}
+
+  enqueue(message: T): boolean {
+    if (this.fatalError) return false;
+    let normalized: { message: T; bytes: number };
+    try {
+      normalized = normalizeAndMeasureIpcFrame(message, this.maxQueuedBytes);
+    } catch (error) {
+      this.poison(
+        new Error(
+          `failed to size IPC frame: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+      return false;
+    }
+    if (
+      this.queue.length + 1 > this.maxQueuedMessages ||
+      this.queuedBytes + normalized.bytes > this.maxQueuedBytes
+    ) {
+      this.poison(
+        new Error(
+          `IPC queue saturated (${this.queue.length + 1} messages, ${this.queuedBytes + normalized.bytes} bytes)`,
+        ),
+      );
+      return false;
+    }
+    this.queue.push(normalized);
+    this.queuedBytes += normalized.bytes;
+    this.flush();
+    return true;
+  }
+
+  private flush(): void {
+    if (this.sending || this.fatalError) return;
+    const next = this.queue[0];
+    if (!next) return;
+    this.sending = true;
+    try {
+      // Waiting for the exact frame's callback handles both true and false
+      // return values without reordering the subsequent frame.
+      void this.rawSend(next.message, (error) => {
+        if (error) {
+          this.poison(error);
+          return;
+        }
+        if (this.fatalError) return;
+        this.queue.shift();
+        this.queuedBytes -= next.bytes;
+        this.sending = false;
+        queueMicrotask(() => this.flush());
+      });
+    } catch (error) {
+      this.poison(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private poison(error: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = error;
+    this.sending = false;
+    this.queue.length = 0;
+    this.queuedBytes = 0;
+    this.onFatal(error);
+  }
+}
+
+const MAX_IPC_FRAME_NODES = 50_000;
+const MAX_IPC_FRAME_DEPTH = 128;
+const MAX_IPC_ENUMERATED_KEYS = 8_192;
+
+function normalizeAndMeasureIpcFrame<T>(
+  value: T,
+  maxBytes: number,
+): { message: T; bytes: number } {
+  // Runtime IPC is intentionally a JSON-shaped protocol even though Node's
+  // channel uses the advanced serializer. Clone accepted values before they
+  // enter the queue so later mutation cannot invalidate the size calculation,
+  // and reject advanced/non-plain values instead of sizing them as `{}`.
+  const ancestors = new WeakSet<object>();
+  let nodes = 0;
+  let bytes = 0;
+  const addBytes = (amount: number): void => {
+    bytes += amount;
+    if (bytes > maxBytes) {
+      throw new Error(`IPC frame exceeds ${maxBytes} bytes`);
+    }
+  };
+  const visit = (item: unknown, depth: number): unknown => {
+    nodes += 1;
+    if (nodes > MAX_IPC_FRAME_NODES) {
+      throw new Error(`IPC frame exceeds ${MAX_IPC_FRAME_NODES} nodes`);
+    }
+    if (depth > MAX_IPC_FRAME_DEPTH) {
+      throw new Error(`IPC frame exceeds ${MAX_IPC_FRAME_DEPTH} levels`);
+    }
+    if (typeof item === "string") {
+      addBytes(jsonStringByteLength(item));
+      return item;
+    }
+    if (typeof item === "number") {
+      if (!Number.isFinite(item)) {
+        throw new Error("IPC frame contains a non-finite number");
+      }
+      const normalized = Object.is(item, -0) ? 0 : item;
+      addBytes(Buffer.byteLength(String(normalized)));
+      return normalized;
+    }
+    if (typeof item === "boolean") {
+      addBytes(item ? 4 : 5);
+      return item;
+    }
+    if (item === null) {
+      addBytes(4);
+      return null;
+    }
+    if (typeof item !== "object") {
+      throw new Error(`IPC frame contains unsupported ${typeof item} data`);
+    }
+    const unsupportedKind = unsupportedIpcObjectKind(item);
+    if (unsupportedKind) {
+      throw new Error(`IPC frame contains unsupported ${unsupportedKind} data`);
+    }
+    if (ancestors.has(item)) throw new Error("IPC frame contains a cycle");
+    ancestors.add(item);
+    try {
+      if (Array.isArray(item)) {
+        addBytes(2);
+        const result: unknown[] = [];
+        for (let index = 0; index < item.length; index += 1) {
+          let descriptor: PropertyDescriptor | undefined;
+          try {
+            descriptor = Object.getOwnPropertyDescriptor(item, index);
+          } catch (error) {
+            throw new Error(
+              `IPC frame array item could not be inspected: ${errorMessage(error)}`,
+            );
+          }
+          if (!descriptor) throw new Error("IPC frame contains a sparse array");
+          if (!("value" in descriptor)) {
+            throw new Error("IPC frame contains an accessor property");
+          }
+          if (index > 0) addBytes(1);
+          result.push(visit(descriptor.value, depth + 1));
+        }
+        assertArrayHasNoEnumerableDecorations(item);
+        return result;
+      }
+
+      let prototype: object | null;
+      try {
+        prototype = Object.getPrototypeOf(item);
+      } catch (error) {
+        throw new Error(
+          `IPC frame object could not be inspected: ${errorMessage(error)}`,
+        );
+      }
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error("IPC frame contains a non-plain object");
+      }
+
+      addBytes(2);
+      const result: Record<string, unknown> = {};
+      let entries = 0;
+      let enumeratedKeys = 0;
+      try {
+        for (const key in item) {
+          enumeratedKeys += 1;
+          if (enumeratedKeys > MAX_IPC_ENUMERATED_KEYS) {
+            throw new Error(
+              `IPC frame exceeds ${MAX_IPC_ENUMERATED_KEYS} enumerated keys`,
+            );
+          }
+          if (!Object.hasOwn(item, key)) continue;
+          if (entries >= MAX_IPC_FRAME_NODES) {
+            throw new Error(`IPC frame exceeds ${MAX_IPC_FRAME_NODES} entries`);
+          }
+          if (entries > 0) addBytes(1);
+          addBytes(jsonStringByteLength(key) + 1);
+          let descriptor: PropertyDescriptor | undefined;
+          try {
+            descriptor = Object.getOwnPropertyDescriptor(item, key);
+          } catch (error) {
+            throw new Error(
+              `IPC frame property could not be inspected: ${errorMessage(error)}`,
+            );
+          }
+          if (!descriptor || !("value" in descriptor)) {
+            throw new Error("IPC frame contains an accessor property");
+          }
+          result[key] = visit(descriptor.value, depth + 1);
+          entries += 1;
+        }
+      } catch (error) {
+        if (error instanceof Error) throw error;
+        throw new Error(
+          `IPC frame object could not be inspected: ${errorMessage(error)}`,
+        );
+      }
+      return result;
+    } finally {
+      ancestors.delete(item);
+    }
+  };
+  const message = visit(value, 0) as T;
+  return { message, bytes };
+}
+
+function unsupportedIpcObjectKind(value: object): string | undefined {
+  if (value instanceof ArrayBuffer) return "ArrayBuffer";
+  if (
+    typeof SharedArrayBuffer !== "undefined" &&
+    value instanceof SharedArrayBuffer
+  ) {
+    return "SharedArrayBuffer";
+  }
+  if (ArrayBuffer.isView(value)) return "typed-array/view";
+  if (value instanceof Map) return "Map";
+  if (value instanceof Set) return "Set";
+  if (value instanceof Date) return "Date";
+  return undefined;
+}
+
+function assertArrayHasNoEnumerableDecorations(value: unknown[]): void {
+  let entries = 0;
+  let enumeratedKeys = 0;
+  try {
+    for (const key in value) {
+      enumeratedKeys += 1;
+      if (enumeratedKeys > MAX_IPC_ENUMERATED_KEYS) {
+        throw new Error(
+          `IPC frame exceeds ${MAX_IPC_ENUMERATED_KEYS} enumerated keys`,
+        );
+      }
+      if (!Object.hasOwn(value, key)) continue;
+      if (key !== String(entries) || entries >= value.length) {
+        throw new Error("IPC frame contains a decorated array");
+      }
+      entries += 1;
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("decorated array")) {
+      throw error;
+    }
+    throw new Error(
+      `IPC frame array could not be inspected: ${errorMessage(error)}`,
+    );
+  }
+  if (entries !== value.length) {
+    throw new Error("IPC frame contains a sparse array");
+  }
+}
+
+function jsonStringByteLength(value: string): number {
+  let bytes = 2;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x22 || code === 0x5c) {
+      bytes += 2;
+    } else if (code <= 0x1f) {
+      bytes += [0x08, 0x09, 0x0a, 0x0c, 0x0d].includes(code) ? 2 : 6;
+    } else if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x7ff) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else {
+        bytes += 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes += 6;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/buzz-pi-agent/src/logger.ts
+++ b/packages/buzz-pi-agent/src/logger.ts
@@ -1,0 +1,115 @@
+import type { AdapterConfig } from "./config.js";
+import type { Logger } from "./types.js";
+
+const levels = { debug: 10, info: 20, warn: 30, error: 40 } as const;
+
+export function createLogger(level: AdapterConfig["logLevel"]): Logger {
+  const threshold = levels[level];
+  const log = (
+    name: keyof typeof levels,
+    message: string,
+    fields?: Record<string, unknown>,
+  ): void => {
+    if (levels[name] < threshold) return;
+    const record = {
+      timestamp: new Date().toISOString(),
+      level: name,
+      component: "buzz-pi-agent",
+      message,
+      ...fields,
+    };
+    process.stderr.write(`${JSON.stringify(record)}\n`);
+  };
+
+  return {
+    debug: (message, fields) => log("debug", message, fields),
+    info: (message, fields) => log("info", message, fields),
+    warn: (message, fields) => log("warn", message, fields),
+    error: (message, fields) => log("error", message, fields),
+  };
+}
+
+/**
+ * ACP reserves stdout for NDJSON. Save the only permitted writer, then route
+ * console and ordinary stdout writes to stderr. Pi extensions execute in an
+ * isolated child as an additional boundary, but this guard protects the ACP
+ * parent and accidental writes in adapter code too.
+ */
+export function guardProtocolStdout(): (line: string) => Promise<void> {
+  const stdout = process.stdout;
+  const protocolWrite = stdout.write.bind(stdout) as (
+    line: string,
+    callback: (error?: Error | null) => void,
+  ) => boolean;
+  const stderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = stderrWrite as typeof process.stdout.write;
+  console.log = (...args: unknown[]) => writeConsole(args);
+  console.info = (...args: unknown[]) => writeConsole(args);
+  console.debug = (...args: unknown[]) => writeConsole(args);
+  console.warn = (...args: unknown[]) => writeConsole(args);
+  console.error = (...args: unknown[]) => writeConsole(args);
+
+  return (line: string): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      let callbackDone = false;
+      let drainDone = true;
+      let writeReturned = false;
+      let settled = false;
+
+      const cleanup = (): void => {
+        stdout.off("error", onError);
+        stdout.off("drain", onDrain);
+      };
+      const finish = (): void => {
+        if (settled || !writeReturned || !callbackDone || !drainDone) return;
+        settled = true;
+        cleanup();
+        resolve();
+      };
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const onError = (error: Error): void => fail(error);
+      const onDrain = (): void => {
+        drainDone = true;
+        finish();
+      };
+
+      stdout.once("error", onError);
+      try {
+        const accepted = protocolWrite(line, (error) => {
+          if (error) {
+            fail(error);
+            return;
+          }
+          callbackDone = true;
+          finish();
+        });
+        if (!accepted) {
+          drainDone = false;
+          stdout.once("drain", onDrain);
+        }
+        writeReturned = true;
+        finish();
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+}
+
+function writeConsole(args: unknown[]): void {
+  process.stderr.write(`${args.map(formatValue).join(" ")}\n`);
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/buzz-pi-agent/src/pi-runtime.ts
+++ b/packages/buzz-pi-agent/src/pi-runtime.ts
@@ -1,0 +1,3007 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type AgentSessionRuntime,
+  type CompactionEntry,
+  CONFIG_DIR_NAME,
+  ModelRuntime,
+  ProjectTrustStore,
+  SessionManager,
+  SettingsManager,
+  createAgentSessionFromServices,
+  createAgentSessionRuntime,
+  createAgentSessionServices,
+  estimateTokens,
+  getAgentDir,
+  type AgentSessionEvent,
+  type CreateAgentSessionRuntimeFactory,
+} from "@earendil-works/pi-coding-agent";
+import type { AdapterConfig } from "./config.js";
+import {
+  effectiveContextLimit,
+  effectiveCompactionSettings,
+  logicalModelContextWindow,
+} from "./config.js";
+import {
+  assertPiResourceBudget,
+  assertPiResourceSnapshotsEqual,
+  type ResourceBudgetSnapshot,
+} from "./resource-budget.js";
+import type {
+  AcpImageBlock,
+  AgentSessionFactory,
+  AgentSessionHandle,
+  BuzzSessionEvent,
+  CompactionReason,
+  ContextSnapshot,
+  CreateSessionOptions,
+  Logger,
+  ModelDescriptor,
+  ResourceSnapshot,
+  SessionUsageSnapshot,
+} from "./types.js";
+import {
+  assertWorkspaceIdentity,
+  captureWorkspaceIdentity,
+  type WorkspaceIdentity,
+} from "./workspace.js";
+
+const THINKING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+const MAX_SESSION_TITLE_LENGTH = 256;
+const MAX_PROVIDER_IMAGES = 32;
+const MAX_PROVIDER_IMAGE_BYTES = 8 * 1024 * 1024;
+const MAX_PROVIDER_IMAGE_BYTES_TOTAL = 16 * 1024 * 1024;
+const ESTIMATED_PROVIDER_IMAGE_TOKENS = 4_096;
+const MAX_PROVIDER_PAYLOAD_NODES = 100_000;
+const MAX_PROVIDER_PAYLOAD_ENTRIES = 100_000;
+const MAX_PROVIDER_PAYLOAD_TEXT_BYTES = 4 * 1_024 * 1_024;
+const MAX_PROVIDER_SERIALIZED_BYTES = 8 * 1_024 * 1_024;
+const MAX_ADVERTISED_MODELS = 512;
+const SESSION_FILE_CONTROL_RESERVE_BYTES = 64 * 1_024;
+const quotaInstalled = new WeakSet<SessionManager>();
+const MAX_TOOL_EVENT_PAYLOAD_BYTES = 64_000;
+const MAX_TOOL_EVENT_PAYLOAD_NODES = 2_048;
+const MAX_TOOL_EVENT_CONTAINER_ITEMS = 200;
+const MAX_TOOL_EVENT_DEPTH = 12;
+const MAX_TOOL_EVENT_TEXT_CHARACTERS = 128_000;
+const COMPACTION_ATTEMPT_ENTRY = "buzz.compaction_attempt.v1";
+const LIFECYCLE_WATERMARK_ENTRY = "buzz.lifecycle_watermark.v1";
+const LIFECYCLE_PENDING_ENTRY = "buzz.lifecycle_pending.v1";
+const LIFECYCLE_ACK_ENTRY = "buzz.lifecycle_ack.v1";
+const MAX_CHILD_LIFECYCLE_RECORD_BYTES = 48 * 1_024;
+const MAX_CHILD_LIFECYCLE_ATTEMPT_BYTES = 2 * 1_024;
+const MAX_CHILD_LIFECYCLE_ACK_BYTES = 1 * 1_024;
+const MAX_CHILD_LIFECYCLE_WATERMARK_BYTES = 1 * 1_024;
+const MAX_CHILD_ROLLBACK_MARKER_BYTES = 2 * 1_024;
+const MAX_CHILD_LIFECYCLE_MARKERS = 65_536;
+const LOWERCASE_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+type PiSettingsStorage = Parameters<typeof SettingsManager.fromStorage>[0];
+
+const extensionProviderTrackers = new WeakMap<
+  ModelRuntime,
+  ExtensionProviderTracker
+>();
+
+/**
+ * Pi's ModelRuntime intentionally merges extension provider registrations.
+ * A resource reload therefore needs an adapter-owned generation boundary: an
+ * extension that disappeared (including after project trust is revoked) must
+ * not leave executable provider code behind in the session registry.
+ */
+class ExtensionProviderTracker {
+  private readonly providerIds = new Set<string>();
+  private replacingGeneration = false;
+  private readonly originalRegisterProvider: ModelRuntime["registerProvider"];
+  private readonly originalRegisterNativeProvider: ModelRuntime["registerNativeProvider"];
+  private readonly originalUnregisterProvider: ModelRuntime["unregisterProvider"];
+
+  constructor(private readonly modelRuntime: ModelRuntime) {
+    this.originalRegisterProvider = modelRuntime.registerProvider;
+    this.originalRegisterNativeProvider = modelRuntime.registerNativeProvider;
+    this.originalUnregisterProvider = modelRuntime.unregisterProvider;
+
+    modelRuntime.registerProvider = ((providerId, config) => {
+      this.originalRegisterProvider.call(modelRuntime, providerId, config);
+      this.providerIds.add(providerId);
+    }) as ModelRuntime["registerProvider"];
+    modelRuntime.registerNativeProvider = ((provider) => {
+      this.originalRegisterNativeProvider.call(modelRuntime, provider);
+      this.providerIds.add(provider.id);
+    }) as ModelRuntime["registerNativeProvider"];
+    modelRuntime.unregisterProvider = ((providerId) => {
+      this.originalUnregisterProvider.call(modelRuntime, providerId);
+      this.providerIds.delete(providerId);
+    }) as ModelRuntime["unregisterProvider"];
+  }
+
+  async replaceGeneration<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.replacingGeneration) {
+      throw new Error("Pi extension provider reload is already active");
+    }
+
+    const previousProviderIds = [...this.providerIds];
+    this.replacingGeneration = true;
+    try {
+      // Clear the complete old extension layer before extensions register the
+      // new one. This prevents merge semantics from retaining project-only
+      // fields when a global provider with the same id remains after revocation.
+      for (const providerId of previousProviderIds) {
+        this.modelRuntime.unregisterProvider(providerId);
+      }
+      return await operation();
+    } finally {
+      this.replacingGeneration = false;
+    }
+  }
+}
+
+class PiResourceGenerationGuard {
+  private globalSnapshot: ResourceBudgetSnapshot | undefined;
+  private loadedSnapshot: ResourceBudgetSnapshot | undefined;
+
+  constructor(
+    private readonly workspaceIdentity: WorkspaceIdentity,
+    private readonly agentDir: string,
+    private readonly options: CreateSessionOptions,
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  armGlobalBootstrap(): void {
+    this.globalSnapshot = this.scan(false);
+    this.loadedSnapshot = undefined;
+  }
+
+  verifyGlobalBootstrap(): void {
+    if (!this.globalSnapshot) {
+      throw new Error("Pi resource generation was not armed before discovery");
+    }
+    assertPiResourceSnapshotsEqual(this.globalSnapshot, this.scan(false));
+  }
+
+  verifyModelInitialization(): void {
+    if (!this.globalSnapshot) {
+      throw new Error(
+        "Pi resource generation was not armed before model setup",
+      );
+    }
+    const after = this.scan(false);
+    const authPath = join(this.agentDir, "auth.json");
+    const authWasPresent = this.globalSnapshot.fingerprints.some(
+      (fingerprint) => fingerprint.path === authPath,
+    );
+    const createdAuth = after.fingerprints.find(
+      (fingerprint) => fingerprint.path === authPath,
+    );
+    if (!authWasPresent && createdAuth) {
+      assertPiResourceSnapshotsEqual(this.globalSnapshot, {
+        ...after,
+        files: after.files - 1,
+        bytes: after.bytes - createdAuth.size,
+        fingerprints: after.fingerprints.filter(
+          (fingerprint) => fingerprint !== createdAuth,
+        ),
+      });
+    } else {
+      assertPiResourceSnapshotsEqual(this.globalSnapshot, after);
+    }
+    // ModelRuntime initializes a missing empty auth store. It is bounded and
+    // now becomes part of the immutable loader-generation baseline.
+    this.globalSnapshot = after;
+  }
+
+  resolveProjectTrust(cwd: string): boolean {
+    // Pi invokes this only after its untrusted bootstrap extension pass. Fence
+    // that pass before allowing a trust transition to expose project files.
+    this.verifyGlobalBootstrap();
+    const trust = resolveProjectTrust(
+      cwd,
+      this.agentDir,
+      this.config,
+      this.logger,
+    );
+    this.loadedSnapshot = this.scan(trust);
+    return trust;
+  }
+
+  prepareReloadTrust(cwd: string): boolean {
+    // AgentSession.reload() does not reuse the SDK's initial
+    // resourceLoaderReloadOptions callback. Resolve and install the trust state
+    // explicitly, while retaining one immutable full-generation baseline.
+    const globalBefore = this.scan(false);
+    const trust = resolveProjectTrust(
+      cwd,
+      this.agentDir,
+      this.config,
+      this.logger,
+    );
+    assertPiResourceSnapshotsEqual(globalBefore, this.scan(false));
+    this.globalSnapshot = undefined;
+    this.loadedSnapshot = this.scan(trust);
+    return trust;
+  }
+
+  verifyLoadedGeneration(projectTrusted: boolean): void {
+    if (!this.loadedSnapshot) {
+      throw new Error("Pi resource generation omitted its trust boundary");
+    }
+    const after = this.scan(projectTrusted);
+    assertPiResourceSnapshotsEqual(this.loadedSnapshot, after);
+    this.loadedSnapshot = after;
+    this.globalSnapshot = undefined;
+  }
+
+  private scan(projectTrusted: boolean): ResourceBudgetSnapshot {
+    assertWorkspaceIdentity(this.workspaceIdentity);
+    const snapshot = assertPiResourceBudget({
+      cwd: this.workspaceIdentity.canonicalPath,
+      agentDir: this.agentDir,
+      projectTrusted,
+      config: this.config,
+      ...(this.options.systemPrompt === undefined
+        ? {}
+        : { systemPromptSource: this.options.systemPrompt }),
+    });
+    assertWorkspaceIdentity(this.workspaceIdentity);
+    return snapshot;
+  }
+}
+
+/**
+ * Read the user's normal Pi settings while discarding every attempted write.
+ * Buzz model/thinking changes and extension writes therefore stay local to
+ * this runtime and can never mutate ~/.pi/agent/settings.json.
+ */
+export class ReadOnlySettingsStorage implements PiSettingsStorage {
+  constructor(
+    private readonly cwd: string,
+    private readonly agentDir: string,
+  ) {}
+
+  withLock(
+    scope: "global" | "project",
+    fn: (current: string | undefined) => string | undefined,
+  ): void {
+    const path =
+      scope === "global"
+        ? join(this.agentDir, "settings.json")
+        : join(this.cwd, CONFIG_DIR_NAME, "settings.json");
+    let current: string | undefined;
+    try {
+      current = readFileSync(path, "utf8");
+    } catch (error) {
+      if (!isFileNotFound(error)) throw error;
+    }
+    // The callback reads current state and may return a replacement. Ignoring
+    // that return value is the write-discard boundary.
+    void fn(current);
+  }
+}
+
+type PiModelLike = ReturnType<ModelRuntime["getModels"]>[number];
+
+interface UsageOffsets {
+  input: number;
+  output: number;
+  cached: number;
+  cost: number;
+}
+
+export class PiAgentSessionFactory implements AgentSessionFactory {
+  constructor(
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  async create(options: CreateSessionOptions): Promise<AgentSessionHandle> {
+    return PiAgentSessionHandle.create(options, this.config, this.logger);
+  }
+}
+
+class PiAgentSessionHandle implements AgentSessionHandle {
+  private unsubscribe: (() => void) | undefined;
+  private busy = false;
+  private disposed = false;
+  private failure: Error | undefined;
+  private fatalDisposal: Promise<void> | undefined;
+  private abortRequested = false;
+  private projectTrusted = false;
+  private resourceErrors: string[] = [];
+  private providerGuardedAgent: object | undefined;
+  private contextLimitFailureEmitted = false;
+  private pendingCompactionReason: CompactionReason | undefined;
+  private pendingCompactionBefore: number | null = null;
+  private pendingCompactionId: string | undefined;
+  private pendingCompactionAttemptEntryId: string | undefined;
+  private lifecycleIndexLoaded = false;
+  private lifecycleIndexedLeafId: string | null | undefined;
+  private lifecycleWatermarkEntryId: string | undefined;
+  private readonly pendingLifecycleEvents = new Map<
+    string,
+    { sourceEntryId: string; event: BuzzSessionEvent }
+  >();
+  private readonly acknowledgedLifecycleEvents = new Set<string>();
+  private offsets: UsageOffsets = { input: 0, output: 0, cached: 0, cost: 0 };
+  private lastUsage: SessionUsageSnapshot = {
+    contextTokens: null,
+    accumulatedInputTokens: 0,
+    accumulatedOutputTokens: 0,
+    accumulatedCachedInputTokens: 0,
+    accumulatedCost: null,
+    model: null,
+  };
+
+  private constructor(
+    private readonly runtime: AgentSessionRuntime,
+    private readonly options: CreateSessionOptions,
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+    private readonly resourceGuard: PiResourceGenerationGuard,
+  ) {}
+
+  static async create(
+    options: CreateSessionOptions,
+    config: AdapterConfig,
+    logger: Logger,
+  ): Promise<PiAgentSessionHandle> {
+    const workspaceIdentity = captureWorkspaceIdentity(
+      options.requestedCwd ?? options.cwd,
+      options.requestedCwd === undefined ? undefined : options.cwd,
+    );
+    const normalizedOptions: CreateSessionOptions = {
+      ...options,
+      cwd: workspaceIdentity.canonicalPath,
+      requestedCwd: workspaceIdentity.requestedPath,
+    };
+    const agentDir = getAgentDir();
+    const resourceGuard = new PiResourceGenerationGuard(
+      workspaceIdentity,
+      agentDir,
+      normalizedOptions,
+      config,
+      logger,
+    );
+    resourceGuard.armGlobalBootstrap();
+    const runtimeFactory: CreateAgentSessionRuntimeFactory = async ({
+      cwd,
+      sessionManager,
+      sessionStartEvent,
+    }) => {
+      assertWorkspaceIdentity(workspaceIdentity);
+      installSessionFileQuota(sessionManager, config.maxSessionFileBytes);
+      const modelRuntime = await ModelRuntime.create({
+        authPath: join(agentDir, "auth.json"),
+        modelsPath: join(agentDir, "models.json"),
+      });
+      const providerTracker = new ExtensionProviderTracker(modelRuntime);
+      extensionProviderTrackers.set(modelRuntime, providerTracker);
+      const settingsManager = SettingsManager.fromStorage(
+        new ReadOnlySettingsStorage(cwd, agentDir),
+        {
+          projectTrusted: false,
+        },
+      );
+      await settingsManager.reload();
+      resourceGuard.verifyModelInitialization();
+      settingsManager.applyOverrides({
+        compaction: {
+          enabled: true,
+          reserveTokens: config.compactionReserveTokens,
+          keepRecentTokens: config.keepRecentTokens,
+        },
+      });
+      const services = await providerTracker.replaceGeneration(() =>
+        createAgentSessionServices({
+          cwd,
+          agentDir,
+          modelRuntime,
+          settingsManager,
+          ...(normalizedOptions.systemPrompt === undefined
+            ? {}
+            : {
+                resourceLoaderOptions: {
+                  systemPrompt: normalizedOptions.systemPrompt,
+                },
+              }),
+          resourceLoaderReloadOptions: {
+            resolveProjectTrust: async () =>
+              resourceGuard.resolveProjectTrust(cwd),
+          },
+        }),
+      );
+      resourceGuard.verifyLoadedGeneration(settingsManager.isProjectTrusted());
+      const result = await createAgentSessionFromServices({
+        services,
+        sessionManager,
+        ...(sessionStartEvent === undefined ? {} : { sessionStartEvent }),
+      });
+      resourceGuard.verifyLoadedGeneration(settingsManager.isProjectTrusted());
+      return {
+        ...result,
+        services,
+        diagnostics: services.diagnostics,
+      };
+    };
+
+    if (normalizedOptions.persistedSessionFile) {
+      assertSessionFileSizeWithinQuota(
+        normalizedOptions.persistedSessionFile,
+        config.maxSessionFileBytes,
+      );
+    }
+    const sessionManager = normalizedOptions.persistedSessionFile
+      ? SessionManager.open(
+          normalizedOptions.persistedSessionFile,
+          undefined,
+          normalizedOptions.cwd,
+        )
+      : SessionManager.create(normalizedOptions.cwd);
+    // SessionManager.open may migrate an older transcript by rewriting it.
+    // Recheck immediately, before extensions or a provider can observe it.
+    if (normalizedOptions.persistedSessionFile) {
+      assertSessionFileSizeWithinQuota(
+        normalizedOptions.persistedSessionFile,
+        config.maxSessionFileBytes,
+      );
+    }
+    const runtime = await createAgentSessionRuntime(runtimeFactory, {
+      cwd: normalizedOptions.cwd,
+      agentDir,
+      sessionManager,
+    });
+    if (!normalizedOptions.persistedSessionFile) {
+      applyFreshSessionTitle(runtime.session, normalizedOptions.title);
+      persistFreshSession(runtime.session.sessionManager);
+      const freshFile = runtime.session.sessionFile;
+      if (freshFile)
+        assertSessionFileSizeWithinQuota(freshFile, config.maxSessionFileBytes);
+    }
+    const handle = new PiAgentSessionHandle(
+      runtime,
+      normalizedOptions,
+      config,
+      logger,
+      resourceGuard,
+    );
+    try {
+      await handle.bindCurrentSession();
+      return handle;
+    } catch (error) {
+      await runtime.dispose().catch(() => {});
+      throw error;
+    }
+  }
+
+  get piSessionId(): string {
+    return this.runtime.session.sessionId;
+  }
+
+  get sessionFile(): string | undefined {
+    return this.runtime.session.sessionFile;
+  }
+
+  get cwd(): string {
+    return this.runtime.session.sessionManager.getCwd();
+  }
+
+  get isBusy(): boolean {
+    return (
+      this.busy ||
+      this.runtime.session.isStreaming ||
+      this.runtime.session.isCompacting
+    );
+  }
+
+  get isValid(): boolean {
+    return !this.disposed && this.failure === undefined;
+  }
+
+  async prompt(
+    text: string,
+    images: AcpImageBlock[] = [],
+  ): Promise<"end_turn" | "cancelled" | "max_tokens"> {
+    this.assertUsable();
+    if (this.isBusy) throw new Error("prompt already in flight");
+
+    const command = firstLine(text);
+    if (command === "/context") {
+      this.emitContextStatus();
+      return "end_turn";
+    }
+    if (command === "/reload") {
+      const resources = await this.reload();
+      this.emitResourcesReloaded(resources);
+      return "end_turn";
+    }
+    if (command === "/new") {
+      throw new Error(
+        "/new must be authorized and handled by Buzz, not by the Pi adapter",
+      );
+    }
+    if (command === "/compact") {
+      if (this.runtime.session.agent.state.messages.length === 0) {
+        this.emitContextStatus(
+          "Nothing to compact yet; this Pi session has no conversation history.",
+        );
+        return "end_turn";
+      }
+      try {
+        await this.runManualCompaction("manual");
+      } catch (error) {
+        // The typed lifecycle failure is the user-facing result for an
+        // explicit command. Returning a completed command prevents Buzz from
+        // retrying a deterministic extension cancellation/provider failure.
+        this.logger.warn("manual Pi compaction did not complete", {
+          sessionId: this.options.acpSessionId,
+          error: publicError(errorMessage(error)),
+        });
+      }
+      return "end_turn";
+    }
+
+    this.contextLimitFailureEmitted = false;
+    await this.compactBeforePromptIfNeeded(text, images.length);
+    this.busy = true;
+    this.abortRequested = false;
+    try {
+      const previousLastMessage = this.runtime.session.state.messages.at(-1);
+      const previousLeafId = this.runtime.session.sessionManager.getLeafId();
+      let rollbackAttempted = false;
+      const rollbackTurn = (): void => {
+        if (rollbackAttempted) return;
+        rollbackAttempted = true;
+        const currentLeafId = this.runtime.session.sessionManager.getLeafId();
+        if (currentLeafId === previousLeafId) {
+          // Preflight/quota guards can reject before Pi persists any part of
+          // the turn. Rebuild runtime state, but do not consume the protected
+          // rollback reserve with a redundant marker on every caller retry.
+          this.runtime.session.agent.state.messages =
+            this.runtime.session.sessionManager.buildSessionContext().messages;
+          return;
+        }
+        // Pi's log remains append-only for diagnostics, but the active branch
+        // must exclude cancelled or failed work before dispose(false)/resume.
+        // branch() alone is an in-memory pointer, so append a context-free
+        // marker on the restored branch to make that leaf durable in JSONL.
+        if (previousLeafId === null)
+          this.runtime.session.sessionManager.resetLeaf();
+        else this.runtime.session.sessionManager.branch(previousLeafId);
+        this.runtime.session.sessionManager.appendCustomEntry(
+          "buzz.turn_rollback",
+          { version: 1 },
+        );
+        this.runtime.session.agent.state.messages =
+          this.runtime.session.sessionManager.buildSessionContext().messages;
+      };
+      try {
+        await this.runtime.session.prompt(text, {
+          source: "rpc",
+          ...(images.length === 0
+            ? {}
+            : {
+                images: images.map((image) => ({
+                  type: "image" as const,
+                  data: image.data,
+                  mimeType: image.mimeType,
+                })),
+              }),
+        });
+        const last = this.runtime.session.state.messages.at(-1);
+        const assistant =
+          last !== previousLastMessage && last?.role === "assistant"
+            ? last
+            : undefined;
+        if (this.abortRequested || assistant?.stopReason === "aborted") {
+          rollbackTurn();
+          return "cancelled";
+        }
+        if (assistant?.stopReason === "length") return "max_tokens";
+        if (assistant?.stopReason === "error") {
+          throw new Error(assistant.errorMessage || "Pi model request failed");
+        }
+        return "end_turn";
+      } catch (error) {
+        rollbackTurn();
+        throw error;
+      }
+    } finally {
+      this.busy = false;
+      this.abortRequested = false;
+    }
+  }
+
+  async steer(text: string): Promise<void> {
+    this.assertUsable();
+    if (!this.isBusy) {
+      void this.prompt(text).catch((error: unknown) => {
+        this.logger.error("detached steer turn failed", {
+          sessionId: this.options.acpSessionId,
+          error: errorMessage(error),
+        });
+      });
+      return;
+    }
+    await this.runtime.session.steer(text);
+  }
+
+  async abort(): Promise<void> {
+    if (this.disposed) return;
+    this.abortRequested = true;
+    await this.runtime.session.abort();
+  }
+
+  async setModel(modelId: string): Promise<void> {
+    this.assertUsable();
+    if (this.isBusy)
+      throw new Error("cannot switch model while a turn is active");
+    const model = resolveModel(this.runtime.services.modelRuntime, modelId);
+    if (!model) throw new Error(`Unknown or unavailable Pi model ${modelId}`);
+    await this.runtime.session.setModel(limitModelContext(model, this.config));
+    this.applyCompactionSettings();
+  }
+
+  async setThinkingLevel(level: string): Promise<void> {
+    this.assertUsable();
+    if (!THINKING_LEVELS.includes(level))
+      throw new Error(`Unsupported thinking level ${level}`);
+    this.runtime.session.setThinkingLevel(level as never);
+  }
+
+  async reload(): Promise<ResourceSnapshot> {
+    this.assertUsable();
+    if (this.isBusy)
+      throw new Error("cannot reload resources while a turn is active");
+    return this.reloadResources();
+  }
+
+  private async reloadResources(): Promise<ResourceSnapshot> {
+    this.assertUsable();
+    try {
+      const trust = this.resourceGuard.prepareReloadTrust(this.cwd);
+      this.runtime.services.settingsManager.setProjectTrusted(trust);
+      const providerTracker = extensionProviderTrackers.get(
+        this.runtime.services.modelRuntime,
+      );
+      if (!providerTracker) {
+        throw new Error(
+          "Installed Pi SDK is incompatible with Buzz extension provider reload",
+        );
+      }
+      await providerTracker.replaceGeneration(() =>
+        this.runtime.session.reload(),
+      );
+      this.resourceGuard.verifyLoadedGeneration(
+        this.runtime.services.settingsManager.isProjectTrusted(),
+      );
+      this.projectTrusted =
+        this.runtime.services.settingsManager.isProjectTrusted();
+      this.reconcileCurrentModelWithRegistry();
+      await this.limitCurrentModel();
+      this.applyCompactionSettings();
+      this.installFinalProviderGuard();
+      return this.getResourceSnapshot();
+    } catch (error) {
+      throw this.poisonAfterReloadFailure(error);
+    }
+  }
+
+  async reset(): Promise<{
+    previousPiSessionId: string;
+    resources: ResourceSnapshot;
+  }> {
+    this.assertUsable();
+    if (this.isBusy) await this.abort();
+    this.updateUsageSnapshot();
+    this.offsets = {
+      input: this.lastUsage.accumulatedInputTokens,
+      output: this.lastUsage.accumulatedOutputTokens,
+      cached: this.lastUsage.accumulatedCachedInputTokens,
+      cost: this.lastUsage.accumulatedCost ?? this.offsets.cost,
+    };
+    const previousPiSessionId = this.piSessionId;
+    this.unsubscribe?.();
+    await this.runtime.newSession();
+    this.resetLifecycleIndex();
+    applyFreshSessionTitle(this.runtime.session, this.options.title);
+    persistFreshSession(this.runtime.session.sessionManager);
+    await this.bindCurrentSession();
+    return { previousPiSessionId, resources: this.getResourceSnapshot() };
+  }
+
+  getModels(): ModelDescriptor[] {
+    return this.runtime.services.modelRuntime
+      .getAvailableSnapshot()
+      .filter((model) => `${model.provider}/${model.id}`.length <= 256)
+      .slice(0, MAX_ADVERTISED_MODELS)
+      .map(describeModel);
+  }
+
+  getThinkingLevels(): string[] {
+    return [...THINKING_LEVELS];
+  }
+
+  getResources(): ResourceSnapshot {
+    return this.getResourceSnapshot();
+  }
+
+  getContextSnapshot(): ContextSnapshot {
+    const effectiveLimitTokens = this.getEffectiveLimit();
+    return {
+      usedTokens: this.currentEstimatedContextTokens(),
+      limitTokens: this.config.contextLimitTokens,
+      effectiveLimitTokens,
+      compactionThresholdTokens: this.getCompactionThreshold(),
+      autoCompaction: this.runtime.session.autoCompactionEnabled,
+      compacting: this.runtime.session.isCompacting,
+      model: this.modelId(),
+      thinkingLevel: this.runtime.session.thinkingLevel,
+      piSessionId: this.piSessionId,
+    };
+  }
+
+  getUsageSnapshot(): SessionUsageSnapshot {
+    this.updateUsageSnapshot();
+    return { ...this.lastUsage };
+  }
+
+  async replayLifecycleEvents(): Promise<void> {
+    this.assertUsable();
+    this.ensureLifecycleIndexLoaded();
+    this.reconcileMissingCompactionEvents();
+    for (const [deliveryId, pending] of this.pendingLifecycleEvents) {
+      if (this.acknowledgedLifecycleEvents.has(deliveryId)) continue;
+      await this.options.eventSink.buzzSessionEvent(
+        this.options.acpSessionId,
+        pending.event,
+        deliveryId,
+      );
+    }
+  }
+
+  async acknowledgeLifecycleEvent(deliveryId: string): Promise<void> {
+    this.assertUsable();
+    if (!LOWERCASE_UUID_PATTERN.test(deliveryId)) {
+      throw new Error("lifecycle deliveryId must be a lowercase UUID");
+    }
+    this.ensureLifecycleIndexLoaded();
+    if (this.acknowledgedLifecycleEvents.has(deliveryId)) return;
+    if (!this.pendingLifecycleEvents.has(deliveryId)) {
+      throw new Error("cannot acknowledge an unknown Pi lifecycle delivery");
+    }
+    this.runtime.session.sessionManager.appendCustomEntry(LIFECYCLE_ACK_ENTRY, {
+      version: 1,
+      deliveryId,
+    });
+    this.lifecycleIndexedLeafId =
+      this.runtime.session.sessionManager.getLeafId();
+    this.acknowledgedLifecycleEvents.add(deliveryId);
+    this.pendingLifecycleEvents.delete(deliveryId);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      await this.fatalDisposal;
+      return;
+    }
+    this.disposed = true;
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    this.fatalDisposal ??= this.disposeRuntime();
+    await this.fatalDisposal;
+  }
+
+  private async bindCurrentSession(): Promise<void> {
+    // Establish a durable feature boundary before this Buzz-managed generation
+    // can compact. Legacy Pi compactions before this marker are intentionally
+    // not backfilled as crash-gap notices.
+    this.ensureLifecycleIndexLoaded();
+    this.projectTrusted =
+      this.runtime.services.settingsManager.isProjectTrusted();
+    await this.limitCurrentModel();
+    this.applyCompactionSettings();
+    await this.runtime.session.bindExtensions({
+      mode: "print",
+      commandContextActions: {
+        waitForIdle: () => this.runtime.session.waitForIdle(),
+        newSession: async () => {
+          return { cancelled: true };
+        },
+        fork: async (_entryId, _options) => {
+          return { cancelled: true };
+        },
+        navigateTree: async (entryId, options) => {
+          const result = await this.runtime.session.navigateTree(
+            entryId,
+            options,
+          );
+          return { cancelled: result.cancelled };
+        },
+        switchSession: async (_path, _options) => {
+          return { cancelled: true };
+        },
+        reload: async () => {
+          const resources = await this.reloadResources();
+          this.emitResourcesReloaded(resources);
+        },
+      },
+      shutdownHandler: () => {
+        this.logger.warn(
+          "Pi extension requested shutdown; ignored in Buzz headless mode",
+          {
+            sessionId: this.options.acpSessionId,
+          },
+        );
+      },
+      onError: (error) => {
+        this.resourceErrors.push(publicError(error.error));
+        this.resourceErrors = this.resourceErrors.slice(-50);
+        this.logger.warn("Pi extension error", {
+          sessionId: this.options.acpSessionId,
+          extension: error.extensionPath,
+          event: error.event,
+          error: error.error,
+        });
+      },
+    });
+    // Extensions can register providers or select a model during session_start.
+    // Re-apply the logical model window, then guard the actual LLM context and
+    // provider payload at their final dispatch boundaries.
+    await this.limitCurrentModel();
+    this.installFinalProviderGuard();
+    this.unsubscribe?.();
+    this.unsubscribe = this.runtime.session.subscribe((event) =>
+      this.handleEvent(event),
+    );
+  }
+
+  private handleEvent(event: AgentSessionEvent): void {
+    if (event.type === "message_update") {
+      const update = event.assistantMessageEvent;
+      if (update.type === "text_delta") {
+        this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: update.delta },
+        });
+      } else if (update.type === "thinking_delta") {
+        this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: update.delta },
+        });
+      }
+      return;
+    }
+    if (event.type === "tool_execution_start") {
+      this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: event.toolCallId,
+        title: event.toolName,
+        kind: toolKind(event.toolName),
+        status: "in_progress",
+        rawInput: truncatePayload(event.args),
+      });
+      return;
+    }
+    if (event.type === "tool_execution_update") {
+      this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.toolCallId,
+        status: "in_progress",
+        rawOutput: truncatePayload(event.partialResult),
+      });
+      return;
+    }
+    if (event.type === "tool_execution_end") {
+      this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.toolCallId,
+        status: event.isError ? "failed" : "completed",
+        rawOutput: truncatePayload(event.result),
+      });
+      return;
+    }
+    if (event.type === "compaction_start") {
+      if (!this.pendingCompactionReason) {
+        this.pendingCompactionReason = event.reason;
+        this.pendingCompactionBefore = this.currentEstimatedContextTokens();
+      }
+      this.pendingCompactionId ??= randomUUID();
+      if (this.pendingCompactionAttemptEntryId === undefined) {
+        this.pendingCompactionAttemptEntryId =
+          this.runtime.session.sessionManager.appendCustomEntry(
+            COMPACTION_ATTEMPT_ENTRY,
+            {
+              version: 1,
+              compactionId: this.pendingCompactionId,
+              reason: this.pendingCompactionReason,
+              beforeTokens: this.pendingCompactionBefore,
+              startedAt: new Date().toISOString(),
+            },
+          );
+      }
+      return;
+    }
+    if (event.type === "compaction_end") {
+      this.emitCompactionResult(event);
+      return;
+    }
+    if (event.type === "agent_settled") {
+      const usage = this.getUsageSnapshot();
+      this.options.eventSink.usageUpdate(
+        this.options.acpSessionId,
+        usage,
+        this.getEffectiveLimit(),
+      );
+    }
+  }
+
+  private async compactBeforePromptIfNeeded(
+    text: string,
+    imageCount: number,
+  ): Promise<void> {
+    const context = this.runtime.session.getContextUsage();
+    const state = this.runtime.session.agent.state;
+    const baseEstimate = estimateProviderContextTokens({
+      systemPrompt: state.systemPrompt,
+      messages: state.messages,
+      tools: state.tools,
+    });
+    const currentTokens = Math.max(context?.tokens ?? 0, baseEstimate);
+    const estimatedIncoming =
+      estimateAdaptiveTextTokens(text) + imageCount * 4_096;
+    const fixedContextTokens = estimateProviderContextTokens({
+      systemPrompt: state.systemPrompt,
+      messages: [],
+      tools: state.tools,
+    });
+    if (fixedContextTokens + estimatedIncoming > this.getEffectiveLimit()) {
+      const error = new Error(
+        `BUZZ_CONTEXT_LIMIT: the system prompt, tools, and incoming prompt exceed the ${this.getEffectiveLimit()}-token effective limit even without conversation history`,
+      );
+      this.emitContextLimitFailure(error);
+      throw error;
+    }
+    if (currentTokens + estimatedIncoming < this.getCompactionThreshold())
+      return;
+    // A fresh session has no transcript that compaction can remove. A large
+    // first request may legitimately sit between the proactive threshold and
+    // the effective ceiling; let the final provider guard decide it.
+    if (state.messages.length === 0) return;
+    await this.runManualCompaction("preflight");
+  }
+
+  private async runManualCompaction(
+    reason: "manual" | "preflight",
+  ): Promise<void> {
+    this.pendingCompactionReason = reason;
+    this.pendingCompactionBefore = this.currentEstimatedContextTokens();
+    this.pendingCompactionId = randomUUID();
+    try {
+      await this.runtime.session.compact(
+        "Preserve decisions, unresolved tasks, constraints, identifiers, paths, commands, and the information needed to continue accurately.",
+      );
+    } catch (error) {
+      if (this.pendingCompactionReason) {
+        this.emitCompactionFailure(reason, errorMessage(error), false);
+        this.clearPendingCompaction();
+      }
+      if (reason === "preflight") {
+        if (isContextLimitError(error)) throw error;
+        throw new Error(
+          `BUZZ_CONTEXT_LIMIT: preflight compaction could not create safe room for this turn: ${publicError(errorMessage(error))}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private emitCompactionResult(
+    event: Extract<AgentSessionEvent, { type: "compaction_end" }>,
+  ): void {
+    const reason = this.pendingCompactionReason ?? event.reason;
+    const compactionId = this.pendingCompactionId ?? randomUUID();
+    const beforeTokens =
+      event.result?.tokensBefore ?? this.pendingCompactionBefore;
+    if (event.result && !event.aborted && !event.errorMessage) {
+      const afterTokens = event.result.estimatedTokensAfter ?? null;
+      const lifecycleEvent: BuzzSessionEvent = {
+        type: "compaction_completed",
+        compactionId,
+        timestamp: new Date().toISOString(),
+        message: contextMessage("compacted", beforeTokens, afterTokens),
+        piSessionId: this.piSessionId,
+        reason,
+        beforeTokens,
+        afterTokens,
+        limitTokens: this.config.contextLimitTokens,
+        effectiveLimitTokens: this.getEffectiveLimit(),
+        compactionThresholdTokens: this.getCompactionThreshold(),
+        willRetry: event.willRetry,
+        fromExtension: this.lastCompactionFromExtension(),
+      };
+      const compactionEntry = this.latestPersistedCompaction();
+      if (compactionEntry) {
+        const deliveryId = this.persistCompactionLifecycleEvent(
+          compactionEntry,
+          lifecycleEvent,
+        );
+        void Promise.resolve(
+          this.options.eventSink.buzzSessionEvent(
+            this.options.acpSessionId,
+            lifecycleEvent,
+            deliveryId,
+          ),
+        ).catch((error: unknown) => {
+          // The child-side pending entry remains authoritative. A poisoned IPC
+          // host will exit and replay it after the outer session is recreated.
+          this.logger.error("failed to deliver durable Pi lifecycle event", {
+            sessionId: this.options.acpSessionId,
+            error: errorMessage(error),
+          });
+        });
+      } else {
+        // Synthetic tests/extensions can emit compaction_end without Pi having
+        // appended a compaction entry. There is no durable side effect to
+        // reconcile in that compatibility path.
+        this.options.eventSink.buzzSessionEvent(
+          this.options.acpSessionId,
+          lifecycleEvent,
+        );
+      }
+    } else {
+      this.emitCompactionFailure(
+        reason,
+        event.errorMessage ??
+          (event.aborted ? "Compaction was cancelled" : "Compaction failed"),
+        event.aborted,
+        event.willRetry,
+        false,
+      );
+    }
+    this.clearPendingCompaction();
+  }
+
+  private emitCompactionFailure(
+    reason: CompactionReason,
+    error: string,
+    aborted: boolean,
+    willRetry = false,
+    fromExtension = false,
+  ): void {
+    const compactionId = this.pendingCompactionId ?? randomUUID();
+    const safeError = publicError(error);
+    this.options.eventSink.buzzSessionEvent(this.options.acpSessionId, {
+      type: "compaction_failed",
+      compactionId,
+      timestamp: new Date().toISOString(),
+      message: boundedString(
+        `Pi could not compact this thread's context: ${safeError}`,
+        1_024,
+      ),
+      piSessionId: this.piSessionId,
+      reason,
+      beforeTokens: this.pendingCompactionBefore,
+      limitTokens: this.config.contextLimitTokens,
+      effectiveLimitTokens: this.getEffectiveLimit(),
+      compactionThresholdTokens: this.getCompactionThreshold(),
+      error: boundedString(safeError, 1_024),
+      aborted,
+      willRetry,
+      fromExtension,
+    });
+  }
+
+  private emitContextStatus(messageOverride?: string): void {
+    const snapshot = this.getContextSnapshot();
+    const remainingTokens =
+      snapshot.usedTokens === null
+        ? null
+        : Math.max(0, snapshot.effectiveLimitTokens - snapshot.usedTokens);
+    const percent =
+      snapshot.usedTokens === null
+        ? null
+        : (snapshot.usedTokens / snapshot.effectiveLimitTokens) * 100;
+    const message =
+      messageOverride ??
+      (snapshot.usedTokens === null
+        ? `Pi context usage is being recalculated after compaction. Auto-compaction starts near ${formatTokens(snapshot.compactionThresholdTokens)} (logical cap ${formatTokens(snapshot.effectiveLimitTokens)}).`
+        : `Estimated Pi provider context: ${formatTokens(snapshot.usedTokens)} / ${formatTokens(snapshot.effectiveLimitTokens)} (${percent?.toFixed(1)}%). Auto-compaction starts near ${formatTokens(snapshot.compactionThresholdTokens)}.`);
+    this.options.eventSink.buzzSessionEvent(this.options.acpSessionId, {
+      type: "context_status",
+      timestamp: new Date().toISOString(),
+      message,
+      piSessionId: snapshot.piSessionId,
+      usedTokens: snapshot.usedTokens,
+      remainingTokens,
+      percent,
+      limitTokens: snapshot.limitTokens,
+      effectiveLimitTokens: snapshot.effectiveLimitTokens,
+      compactionThresholdTokens: snapshot.compactionThresholdTokens,
+      autoCompaction: snapshot.autoCompaction,
+      compacting: snapshot.compacting,
+      model: snapshot.model,
+    });
+  }
+
+  private emitResourcesReloaded(resources: ResourceSnapshot): void {
+    const message = `Reloaded Pi resources: ${resources.extensions} extensions, ${resources.skills} skills, ${resources.prompts} prompts, and ${resources.contextFiles} context files.`;
+    this.options.eventSink.buzzSessionEvent(this.options.acpSessionId, {
+      type: "extensions_reloaded",
+      timestamp: new Date().toISOString(),
+      message,
+      piSessionId: this.piSessionId,
+      extensions: resources.extensions,
+      skills: resources.skills,
+      prompts: resources.prompts,
+      contextFiles: resources.contextFiles,
+      errors: resources.errors,
+      projectTrusted: resources.projectTrusted,
+    });
+    this.emitAvailableCommands(resources.commands);
+  }
+
+  private getResourceSnapshot(): ResourceSnapshot {
+    const loader = this.runtime.session.resourceLoader;
+    const extensions = loader.getExtensions();
+    const skills = loader.getSkills();
+    const prompts = loader.getPrompts();
+    const reserved = new Set(["new", "context", "reload", "compact"]);
+    const commands = [
+      ...this.runtime.session.extensionRunner
+        .getRegisteredCommands()
+        .map((command) => ({
+          name: command.invocationName,
+          description: command.description,
+        })),
+      ...prompts.prompts.map((prompt) => ({
+        name: prompt.name,
+        description: prompt.description,
+      })),
+      ...(this.runtime.services.settingsManager.getEnableSkillCommands()
+        ? skills.skills.map((skill) => ({
+            name: `skill:${skill.name}`,
+            description: skill.description,
+          }))
+        : []),
+    ]
+      .filter(
+        (command) =>
+          !reserved.has(command.name) &&
+          command.name.length > 0 &&
+          command.name.length <= 128 &&
+          /^[a-zA-Z0-9:_-]+$/.test(command.name),
+      )
+      .map((command) => ({
+        name: command.name,
+        description: boundedString(command.description || "Pi command", 256),
+      }));
+    const uniqueCommands = dedupeCommands(commands).slice(0, 100);
+    const runtimeDiagnostics = [
+      ...this.runtime.diagnostics,
+      ...this.runtime.services.diagnostics,
+    ].map(
+      (diagnostic) =>
+        `Pi runtime ${diagnostic.type}: ${publicError(diagnostic.message)}`,
+    );
+    const errors = [
+      ...runtimeDiagnostics,
+      ...this.resourceErrors,
+      ...extensions.errors.map(
+        (error) => `Extension: ${publicError(error.error)}`,
+      ),
+      ...skills.diagnostics.map(
+        (diagnostic) => `Skill: ${publicError(diagnostic.message)}`,
+      ),
+      ...prompts.diagnostics.map(
+        (diagnostic) => `Prompt: ${publicError(diagnostic.message)}`,
+      ),
+    ];
+    return {
+      extensions: extensions.extensions.length,
+      skills: skills.skills.length,
+      prompts: prompts.prompts.length,
+      contextFiles: loader.getAgentsFiles().agentsFiles.length,
+      errors: [...new Set(errors)]
+        .slice(0, 20)
+        .map((error) => boundedString(error, 512)),
+      projectTrusted: this.projectTrusted,
+      commands: uniqueCommands,
+    };
+  }
+
+  private emitAvailableCommands(commands: ResourceSnapshot["commands"]): void {
+    this.options.eventSink.sessionUpdate(this.options.acpSessionId, {
+      sessionUpdate: "available_commands_update",
+      availableCommands: [
+        {
+          name: "context",
+          description: "Show live context usage and compaction limit",
+        },
+        {
+          name: "reload",
+          description: "Hot-reload Pi extensions, skills, prompts, and context",
+        },
+        {
+          name: "compact",
+          description: "Compact this thread's Pi context now",
+        },
+        ...commands,
+      ],
+    });
+  }
+
+  private async limitCurrentModel(): Promise<void> {
+    const model = this.runtime.session.model;
+    if (!model) return;
+    const limited = limitModelContext(model, this.config);
+    if (limited.contextWindow !== model.contextWindow) {
+      // This is an adapter-local logical ceiling, not a user model choice.
+      // Mutate only the active runtime state so Pi's settings.json is untouched.
+      this.runtime.session.agent.state.model = limited;
+    }
+  }
+
+  private reconcileCurrentModelWithRegistry(): void {
+    const current = this.runtime.session.model;
+    if (!current) return;
+    const registered = this.runtime.services.modelRuntime.getModel(
+      current.provider,
+      current.id,
+    );
+    // Pi deliberately retains the old active model when a provider disappears.
+    // Buzz must instead fail closed: a model backed only by a revoked extension
+    // cannot service one more request after /reload.
+    // AgentSession.model is documented as optional, although the lower-level
+    // pi-agent-core state type currently declares it as required.
+    (
+      this.runtime.session.agent.state as unknown as {
+        model: ReturnType<ModelRuntime["getModel"]>;
+      }
+    ).model = registered;
+  }
+
+  private applyCompactionSettings(): void {
+    const settings = effectiveCompactionSettings(
+      this.getEffectiveLimit(),
+      this.config.compactionReserveTokens,
+      this.config.keepRecentTokens,
+    );
+    this.runtime.services.settingsManager.applyOverrides({
+      compaction: {
+        enabled: true,
+        reserveTokens: settings.reserveTokens,
+        keepRecentTokens: settings.keepRecentTokens,
+      },
+    });
+  }
+
+  private getEffectiveLimit(): number {
+    return effectiveContextLimit(
+      this.runtime.session.model?.contextWindow ?? 0,
+      this.config.contextLimitTokens,
+    );
+  }
+
+  private currentEstimatedContextTokens(): number | null {
+    const transcript = this.runtime.session.getContextUsage()?.tokens;
+    const state = this.runtime.session.agent.state;
+    const providerEstimate = estimateProviderContextTokens({
+      systemPrompt: state.systemPrompt,
+      messages: state.messages,
+      tools: state.tools,
+    });
+    return typeof transcript === "number"
+      ? Math.max(transcript, providerEstimate)
+      : providerEstimate;
+  }
+
+  private getCompactionThreshold(): number {
+    return effectiveCompactionSettings(
+      this.getEffectiveLimit(),
+      this.config.compactionReserveTokens,
+      this.config.keepRecentTokens,
+    ).thresholdTokens;
+  }
+
+  private modelId(): string | null {
+    const model = this.runtime.session.model;
+    return model ? `${model.provider}/${model.id}` : null;
+  }
+
+  private updateUsageSnapshot(): void {
+    const stats = this.runtime.session.getSessionStats();
+    const input =
+      this.offsets.input +
+      stats.tokens.input +
+      stats.tokens.cacheRead +
+      stats.tokens.cacheWrite;
+    const output = this.offsets.output + stats.tokens.output;
+    const cached = this.offsets.cached + stats.tokens.cacheRead;
+    const cost = this.offsets.cost + stats.cost;
+    this.lastUsage = {
+      contextTokens: stats.contextUsage?.tokens ?? null,
+      accumulatedInputTokens: Math.max(
+        this.lastUsage.accumulatedInputTokens,
+        input,
+      ),
+      accumulatedOutputTokens: Math.max(
+        this.lastUsage.accumulatedOutputTokens,
+        output,
+      ),
+      accumulatedCachedInputTokens: Math.min(
+        Math.max(this.lastUsage.accumulatedCachedInputTokens, cached),
+        Math.max(this.lastUsage.accumulatedInputTokens, input),
+      ),
+      accumulatedCost: Math.max(this.lastUsage.accumulatedCost ?? 0, cost),
+      model: this.modelId(),
+    };
+  }
+
+  private clearPendingCompaction(): void {
+    this.pendingCompactionReason = undefined;
+    this.pendingCompactionBefore = null;
+    this.pendingCompactionId = undefined;
+    this.pendingCompactionAttemptEntryId = undefined;
+  }
+
+  private installFinalProviderGuard(): void {
+    const agent = this.runtime.session.agent;
+    if (this.providerGuardedAgent === agent) return;
+    this.providerGuardedAgent = agent;
+    const priorStream = agent.streamFunction;
+    agent.streamFunction = async (model, context, options) => {
+      const priorOnPayload = options?.onPayload;
+      const guardedOptions = {
+        ...(options ?? {}),
+        onPayload: async (payload: unknown, payloadModel: typeof model) => {
+          try {
+            return await applyStrictPayloadGuard(
+              payload,
+              payloadModel,
+              priorOnPayload,
+              this.getEffectiveLimit(),
+            );
+          } catch (error) {
+            this.emitContextLimitFailure(error);
+            throw error;
+          }
+        },
+      };
+      try {
+        return await guardProviderDispatch(
+          context,
+          this.getEffectiveLimit(),
+          () => priorStream(model, context, guardedOptions),
+        );
+      } catch (error) {
+        this.emitContextLimitFailure(error);
+        throw error;
+      }
+    };
+  }
+
+  private emitContextLimitFailure(error: unknown): void {
+    if (!isContextLimitError(error) || this.contextLimitFailureEmitted) return;
+    this.contextLimitFailureEmitted = true;
+    this.pendingCompactionReason = "preflight";
+    this.pendingCompactionBefore = this.currentEstimatedContextTokens();
+    this.pendingCompactionId = randomUUID();
+    this.emitCompactionFailure(
+      "preflight",
+      errorMessage(error),
+      false,
+      false,
+      false,
+    );
+    this.clearPendingCompaction();
+  }
+
+  private lastCompactionFromExtension(): boolean {
+    const entry = this.latestPersistedCompaction();
+    return entry?.type === "compaction" && entry.fromHook === true;
+  }
+
+  private latestPersistedCompaction(): CompactionEntry | undefined {
+    const entry = this.runtime.session.sessionManager
+      .getEntries()
+      .findLast((candidate) => candidate.type === "compaction");
+    return entry?.type === "compaction" ? entry : undefined;
+  }
+
+  private persistCompactionLifecycleEvent(
+    compactionEntry: CompactionEntry,
+    event: BuzzSessionEvent,
+  ): string {
+    this.ensureLifecycleIndexLoaded();
+    const deliveryId = stableLifecycleUuid(
+      "delivery",
+      this.piSessionId,
+      compactionEntry.id,
+    );
+    const existing = this.pendingLifecycleEvents.get(deliveryId);
+    if (existing) {
+      if (
+        existing.sourceEntryId !== compactionEntry.id ||
+        JSON.stringify(existing.event) !== JSON.stringify(event)
+      ) {
+        throw new Error("conflicting durable Pi lifecycle delivery marker");
+      }
+      return deliveryId;
+    }
+    if (this.acknowledgedLifecycleEvents.has(deliveryId)) return deliveryId;
+    if (
+      this.pendingLifecycleEvents.size >= this.config.maxPendingSessionEvents
+    ) {
+      throw new Error(
+        `Pi child lifecycle outbox capacity ${this.config.maxPendingSessionEvents} is full`,
+      );
+    }
+    const data = {
+      version: 1,
+      deliveryId,
+      sourceEntryId: compactionEntry.id,
+      event,
+    };
+    if (
+      Buffer.byteLength(JSON.stringify(data), "utf8") >
+      MAX_CHILD_LIFECYCLE_RECORD_BYTES
+    ) {
+      throw new Error(
+        "Pi child lifecycle event exceeds its durable record bound",
+      );
+    }
+    this.runtime.session.sessionManager.appendCustomEntry(
+      LIFECYCLE_PENDING_ENTRY,
+      data,
+    );
+    this.lifecycleIndexedLeafId =
+      this.runtime.session.sessionManager.getLeafId();
+    this.pendingLifecycleEvents.set(deliveryId, {
+      sourceEntryId: compactionEntry.id,
+      event,
+    });
+    return deliveryId;
+  }
+
+  private ensureLifecycleIndexLoaded(): void {
+    const manager = this.runtime.session.sessionManager;
+    const currentLeafId = manager.getLeafId();
+    if (
+      this.lifecycleIndexLoaded &&
+      this.lifecycleIndexedLeafId === currentLeafId
+    ) {
+      return;
+    }
+    this.pendingLifecycleEvents.clear();
+    this.acknowledgedLifecycleEvents.clear();
+    this.lifecycleWatermarkEntryId = undefined;
+    const activeBranch = manager.getBranch();
+    const watermarkIndex = activeBranch.findIndex((entry) => {
+      if (
+        entry.type !== "custom" ||
+        entry.customType !== LIFECYCLE_WATERMARK_ENTRY
+      ) {
+        return false;
+      }
+      parseLifecycleWatermarkData(entry.data);
+      this.lifecycleWatermarkEntryId = entry.id;
+      return true;
+    });
+    if (watermarkIndex < 0) {
+      this.lifecycleWatermarkEntryId = manager.appendCustomEntry(
+        LIFECYCLE_WATERMARK_ENTRY,
+        { version: 1 },
+      );
+      this.lifecycleIndexedLeafId = manager.getLeafId();
+      this.lifecycleIndexLoaded = true;
+      return;
+    }
+    let markerCount = 0;
+    for (const entry of activeBranch.slice(watermarkIndex)) {
+      if (entry.type !== "custom") continue;
+      if (
+        entry.customType !== LIFECYCLE_WATERMARK_ENTRY &&
+        entry.customType !== LIFECYCLE_PENDING_ENTRY &&
+        entry.customType !== LIFECYCLE_ACK_ENTRY &&
+        entry.customType !== COMPACTION_ATTEMPT_ENTRY
+      ) {
+        continue;
+      }
+      markerCount += 1;
+      if (markerCount > MAX_CHILD_LIFECYCLE_MARKERS) {
+        throw new Error("Pi child lifecycle marker count exceeds safe bounds");
+      }
+      if (entry.customType === LIFECYCLE_PENDING_ENTRY) {
+        const pending = parsePendingLifecycleData(entry.data, this.piSessionId);
+        const existing = this.pendingLifecycleEvents.get(pending.deliveryId);
+        if (
+          existing &&
+          (existing.sourceEntryId !== pending.sourceEntryId ||
+            JSON.stringify(existing.event) !== JSON.stringify(pending.event))
+        ) {
+          throw new Error("conflicting Pi child lifecycle pending markers");
+        }
+        this.pendingLifecycleEvents.set(pending.deliveryId, {
+          sourceEntryId: pending.sourceEntryId,
+          event: pending.event,
+        });
+      } else if (entry.customType === LIFECYCLE_ACK_ENTRY) {
+        this.acknowledgedLifecycleEvents.add(parseLifecycleAckData(entry.data));
+      } else if (entry.customType === LIFECYCLE_WATERMARK_ENTRY) {
+        parseLifecycleWatermarkData(entry.data);
+      }
+    }
+    for (const deliveryId of this.acknowledgedLifecycleEvents) {
+      this.pendingLifecycleEvents.delete(deliveryId);
+    }
+    if (
+      this.pendingLifecycleEvents.size > this.config.maxPendingSessionEvents
+    ) {
+      throw new Error("Pi child lifecycle outbox exceeds configured capacity");
+    }
+    this.lifecycleIndexedLeafId = manager.getLeafId();
+    this.lifecycleIndexLoaded = true;
+  }
+
+  private reconcileMissingCompactionEvents(): void {
+    this.ensureLifecycleIndexLoaded();
+    const watermarkIndex = this.runtime.session.sessionManager
+      .getBranch()
+      .findIndex((entry) => entry.id === this.lifecycleWatermarkEntryId);
+    if (watermarkIndex < 0) {
+      throw new Error(
+        "Pi lifecycle watermark is absent from the active branch",
+      );
+    }
+    const compactions = this.runtime.session.sessionManager
+      .getBranch()
+      .slice(watermarkIndex + 1)
+      .filter((entry): entry is CompactionEntry => entry.type === "compaction");
+    for (const entry of compactions) {
+      const deliveryId = stableLifecycleUuid(
+        "delivery",
+        this.piSessionId,
+        entry.id,
+      );
+      if (
+        this.pendingLifecycleEvents.has(deliveryId) ||
+        this.acknowledgedLifecycleEvents.has(deliveryId)
+      ) {
+        continue;
+      }
+      const attempt = this.findCompactionAttempt(entry);
+      const beforeTokens = Number.isFinite(entry.tokensBefore)
+        ? Math.max(0, Math.floor(entry.tokensBefore))
+        : null;
+      const recovered: BuzzSessionEvent = {
+        type: "compaction_completed",
+        compactionId:
+          attempt?.compactionId ??
+          stableLifecycleUuid("compaction", this.piSessionId, entry.id),
+        timestamp: entry.timestamp,
+        message: `${contextMessage(
+          "compacted",
+          beforeTokens,
+          null,
+        )} This notice was recovered from Pi's durable transcript after its runtime restarted.`,
+        piSessionId: this.piSessionId,
+        reason: attempt?.reason ?? "threshold",
+        beforeTokens,
+        afterTokens: null,
+        limitTokens: this.config.contextLimitTokens,
+        effectiveLimitTokens: this.getEffectiveLimit(),
+        compactionThresholdTokens: this.getCompactionThreshold(),
+        willRetry: false,
+        fromExtension: entry.fromHook === true,
+      };
+      this.persistCompactionLifecycleEvent(entry, recovered);
+    }
+  }
+
+  private findCompactionAttempt(
+    compactionEntry: CompactionEntry,
+  ): { compactionId: string; reason: CompactionReason } | undefined {
+    let entryId = compactionEntry.parentId;
+    let traversed = 0;
+    while (entryId !== null && traversed < 10_000) {
+      traversed += 1;
+      const entry = this.runtime.session.sessionManager.getEntry(entryId);
+      if (!entry || entry.type === "compaction") return undefined;
+      if (
+        entry.type === "custom" &&
+        entry.customType === COMPACTION_ATTEMPT_ENTRY
+      ) {
+        return parseCompactionAttemptData(entry.data);
+      }
+      entryId = entry.parentId;
+    }
+    if (traversed >= 10_000) {
+      throw new Error("Pi compaction ancestry exceeds safe lifecycle bounds");
+    }
+    return undefined;
+  }
+
+  private resetLifecycleIndex(): void {
+    this.lifecycleIndexLoaded = false;
+    this.lifecycleIndexedLeafId = undefined;
+    this.lifecycleWatermarkEntryId = undefined;
+    this.pendingLifecycleEvents.clear();
+    this.acknowledgedLifecycleEvents.clear();
+  }
+
+  private poisonAfterReloadFailure(cause: unknown): Error {
+    if (this.failure) return this.failure;
+    const detail = publicError(errorMessage(cause));
+    this.failure = new Error(
+      `BUZZ_PI_SESSION_INVALIDATED: Pi resource reload failed; create a fresh session (${detail})`,
+      { cause },
+    );
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    this.busy = false;
+    // Start teardown before the failed request returns. dispose() joins this
+    // promise, so the runtime host cannot release/recreate the session while
+    // the rejected extension generation can still execute callbacks.
+    this.fatalDisposal = this.disposeRuntime().catch((error: unknown) => {
+      this.logger.error(
+        "failed to dispose invalidated Pi resource generation",
+        {
+          sessionId: this.options.acpSessionId,
+          error: publicError(errorMessage(error)),
+        },
+      );
+      throw error;
+    });
+    // A caller may observe invalidation without immediately disposing the
+    // handle. Attach a handler now so a teardown error cannot become an
+    // unhandled rejection; dispose() still receives the original rejection.
+    void this.fatalDisposal.catch(() => {});
+    return this.failure;
+  }
+
+  private async disposeRuntime(): Promise<void> {
+    if (this.runtime.session.isStreaming || this.runtime.session.isCompacting) {
+      await this.runtime.session.abort();
+    }
+    await this.runtime.dispose();
+  }
+
+  private assertUsable(): void {
+    if (this.failure) throw this.failure;
+    if (this.disposed) throw new Error("Pi session has been disposed");
+  }
+}
+
+function stableLifecycleUuid(
+  kind: "delivery" | "compaction",
+  piSessionId: string,
+  sourceEntryId: string,
+): string {
+  const bytes = createHash("sha256")
+    .update(`buzz-pi-lifecycle-v1\0${kind}\0${piSessionId}\0${sourceEntryId}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x50;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16,
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function parsePendingLifecycleData(
+  value: unknown,
+  expectedPiSessionId: string,
+): { deliveryId: string; sourceEntryId: string; event: BuzzSessionEvent } {
+  if (!isPlainRecord(value) || value.version !== 1) {
+    throw new Error("invalid Pi child lifecycle pending marker");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    MAX_CHILD_LIFECYCLE_RECORD_BYTES
+  ) {
+    throw new Error("Pi child lifecycle pending marker exceeds its byte bound");
+  }
+  const deliveryId = requiredLifecycleString(
+    value.deliveryId,
+    "deliveryId",
+    64,
+  );
+  if (!LOWERCASE_UUID_PATTERN.test(deliveryId)) {
+    throw new Error("invalid Pi child lifecycle deliveryId");
+  }
+  const sourceEntryId = requiredLifecycleString(
+    value.sourceEntryId,
+    "sourceEntryId",
+    256,
+  );
+  assertPersistedCompactionEvent(value.event, expectedPiSessionId);
+  return { deliveryId, sourceEntryId, event: value.event };
+}
+
+function parseLifecycleAckData(value: unknown): string {
+  if (!isPlainRecord(value) || value.version !== 1) {
+    throw new Error("invalid Pi child lifecycle acknowledgement marker");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    MAX_CHILD_LIFECYCLE_ACK_BYTES
+  ) {
+    throw new Error(
+      "Pi child lifecycle acknowledgement exceeds its byte bound",
+    );
+  }
+  const deliveryId = requiredLifecycleString(
+    value.deliveryId,
+    "deliveryId",
+    64,
+  );
+  if (!LOWERCASE_UUID_PATTERN.test(deliveryId)) {
+    throw new Error("invalid Pi child lifecycle acknowledgement id");
+  }
+  return deliveryId;
+}
+
+function parseLifecycleWatermarkData(value: unknown): void {
+  if (
+    !isPlainRecord(value) ||
+    value.version !== 1 ||
+    Object.keys(value).length !== 1 ||
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+      MAX_CHILD_LIFECYCLE_WATERMARK_BYTES
+  ) {
+    throw new Error("invalid Pi child lifecycle watermark");
+  }
+}
+
+function parseCompactionAttemptData(value: unknown): {
+  compactionId: string;
+  reason: CompactionReason;
+} {
+  if (!isPlainRecord(value) || value.version !== 1) {
+    throw new Error("invalid Pi compaction attempt marker");
+  }
+  if (
+    Buffer.byteLength(JSON.stringify(value), "utf8") >
+    MAX_CHILD_LIFECYCLE_ATTEMPT_BYTES
+  ) {
+    throw new Error("Pi compaction attempt marker exceeds its byte bound");
+  }
+  const compactionId = requiredLifecycleString(
+    value.compactionId,
+    "compactionId",
+    64,
+  );
+  if (!LOWERCASE_UUID_PATTERN.test(compactionId)) {
+    throw new Error("invalid Pi compaction attempt id");
+  }
+  if (
+    value.reason !== "manual" &&
+    value.reason !== "threshold" &&
+    value.reason !== "overflow" &&
+    value.reason !== "preflight"
+  ) {
+    throw new Error("invalid Pi compaction attempt reason");
+  }
+  assertNullableLifecycleCount(value.beforeTokens, "attempt beforeTokens");
+  const startedAt = requiredLifecycleString(
+    value.startedAt,
+    "attempt startedAt",
+    64,
+  );
+  if (!Number.isFinite(Date.parse(startedAt))) {
+    throw new Error("invalid Pi compaction attempt timestamp");
+  }
+  return { compactionId, reason: value.reason };
+}
+
+function assertPersistedCompactionEvent(
+  value: unknown,
+  expectedPiSessionId: string,
+): asserts value is Extract<
+  BuzzSessionEvent,
+  { type: "compaction_completed" }
+> {
+  if (!isPlainRecord(value) || value.type !== "compaction_completed") {
+    throw new Error("invalid persisted Pi compaction lifecycle event");
+  }
+  const compactionId = requiredLifecycleString(
+    value.compactionId,
+    "compactionId",
+    64,
+  );
+  if (!LOWERCASE_UUID_PATTERN.test(compactionId)) {
+    throw new Error("invalid persisted Pi compaction id");
+  }
+  const timestamp = requiredLifecycleString(value.timestamp, "timestamp", 64);
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    throw new Error("invalid persisted Pi lifecycle timestamp");
+  }
+  requiredLifecycleString(value.message, "message", 1_024);
+  if (value.piSessionId !== expectedPiSessionId) {
+    throw new Error("persisted Pi lifecycle generation mismatch");
+  }
+  if (
+    value.reason !== "manual" &&
+    value.reason !== "threshold" &&
+    value.reason !== "overflow" &&
+    value.reason !== "preflight"
+  ) {
+    throw new Error("invalid persisted Pi lifecycle reason");
+  }
+  assertNullableLifecycleCount(value.beforeTokens, "beforeTokens");
+  assertNullableLifecycleCount(value.afterTokens, "afterTokens");
+  assertLifecycleCount(value.limitTokens, "limitTokens", true);
+  assertLifecycleCount(
+    value.effectiveLimitTokens,
+    "effectiveLimitTokens",
+    true,
+  );
+  assertLifecycleCount(
+    value.compactionThresholdTokens,
+    "compactionThresholdTokens",
+    true,
+  );
+  if (
+    typeof value.willRetry !== "boolean" ||
+    typeof value.fromExtension !== "boolean"
+  ) {
+    throw new Error("invalid persisted Pi lifecycle flags");
+  }
+}
+
+function assertNullableLifecycleCount(value: unknown, name: string): void {
+  if (value === null) return;
+  assertLifecycleCount(value, name, false);
+}
+
+function assertLifecycleCount(
+  value: unknown,
+  name: string,
+  positive: boolean,
+): void {
+  if (!Number.isSafeInteger(value) || (value as number) < (positive ? 1 : 0)) {
+    throw new Error(`invalid persisted Pi lifecycle ${name}`);
+  }
+}
+
+function requiredLifecycleString(
+  value: unknown,
+  name: string,
+  maxLength: number,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > maxLength ||
+    containsControlCharacter(value)
+  ) {
+    throw new Error(`invalid Pi lifecycle ${name}`);
+  }
+  return value;
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}
+
+function resolveProjectTrust(
+  cwd: string,
+  agentDir: string,
+  config: AdapterConfig,
+  logger: Logger,
+): boolean {
+  if (config.trustProjectOverride !== undefined) {
+    logger.warn("using explicit Buzz Pi project-trust override", {
+      cwd,
+      trusted: config.trustProjectOverride,
+    });
+    return config.trustProjectOverride;
+  }
+  try {
+    // Headless Buzz cannot ask an interactive trust question. Only a saved Pi
+    // trust decision (or the explicit env override above) enables *any*
+    // project-local executable/config resource. This also closes reload TOCTOU
+    // when a .pi/extensions directory appears after startup.
+    return new ProjectTrustStore(agentDir).get(cwd) === true;
+  } catch (error) {
+    logger.warn("Pi project trust resolution failed closed", {
+      cwd,
+      error: errorMessage(error),
+    });
+    return false;
+  }
+}
+
+interface ProviderContextLike {
+  systemPrompt?: unknown;
+  messages?: unknown;
+  tools?: unknown;
+}
+
+/**
+ * Estimate the complete provider-facing context, including the system prompt
+ * and tool schemas that Pi's transcript-only accounting does not include.
+ */
+export function estimateProviderContextTokens(
+  context: ProviderContextLike,
+): number {
+  let tokens = 0;
+  if (typeof context.systemPrompt === "string") {
+    tokens += estimateAdaptiveTextTokens(context.systemPrompt);
+  }
+  if (Array.isArray(context.messages)) {
+    for (const message of context.messages) {
+      // Bound custom-provider structures before Pi's estimator sees them.
+      const serializedEstimate = estimateProviderPayloadTokens(message);
+      const piEstimate = estimateTokens(
+        message as Parameters<typeof estimateTokens>[0],
+      );
+      tokens += Math.max(piEstimate, serializedEstimate);
+      // Provider role/content framing has a small but non-zero cost.
+      tokens += 8;
+    }
+  }
+  if (Array.isArray(context.tools) && context.tools.length > 0) {
+    tokens +=
+      estimateProviderPayloadTokens(context.tools, true) +
+      context.tools.length * 16;
+  }
+  return tokens;
+}
+
+export function estimateSerializedPayloadTokens(serialized: string): number {
+  return estimateAdaptiveTextTokens(serialized);
+}
+
+function estimateAdaptiveTextTokens(text: string): number {
+  const bytes = Buffer.byteLength(text, "utf8");
+  const base = Math.ceil(bytes / 4);
+  const punctuation = text.match(/[^\p{L}\p{N}\s]/gu)?.length ?? 0;
+  const asciiSegments = text.match(/[A-Za-z0-9]+|[^\sA-Za-z0-9]/g)?.length ?? 0;
+  const nonAsciiBytes = Buffer.byteLength(
+    [...text]
+      .filter((character) => (character.codePointAt(0) ?? 0) > 0x7f)
+      .join(""),
+    "utf8",
+  );
+  const longestDenseRun = text
+    .split(/\s+/u)
+    .reduce(
+      (longest, part) => Math.max(longest, Buffer.byteLength(part, "utf8")),
+      0,
+    );
+  // Pi's chars/4 estimate is accurate for ordinary prose. These additional
+  // floors protect token-dense source, punctuation, CJK, emoji, and opaque
+  // identifiers that can tokenize materially above that average.
+  return Math.max(
+    base,
+    asciiSegments,
+    Math.ceil(punctuation / 2),
+    Math.ceil(nonAsciiBytes / 2),
+    Math.ceil(longestDenseRun / 2),
+  );
+}
+
+export function assertWithinContextLimit(
+  estimatedTokens: number,
+  limitTokens: number,
+  source = "provider request",
+): void {
+  if (!Number.isSafeInteger(estimatedTokens) || estimatedTokens < 0) {
+    throw new Error(`BUZZ_CONTEXT_LIMIT: could not safely estimate ${source}`);
+  }
+  if (estimatedTokens > limitTokens) {
+    throw new Error(
+      `BUZZ_CONTEXT_LIMIT: ${source} was estimated at ${estimatedTokens} tokens, above the ${limitTokens}-token effective limit; compact or shorten the prompt`,
+    );
+  }
+}
+
+export function guardProviderDispatch<T>(
+  context: ProviderContextLike,
+  limitTokens: number,
+  dispatch: () => T,
+): T {
+  assertWithinContextLimit(
+    estimateProviderContextTokens(context),
+    limitTokens,
+    "final Pi provider context",
+  );
+  return dispatch();
+}
+
+export async function applyStrictPayloadGuard<TModel>(
+  payload: unknown,
+  model: TModel,
+  priorOnPayload:
+    | ((
+        payload: unknown,
+        model: TModel,
+      ) => unknown | undefined | Promise<unknown | undefined>)
+    | undefined,
+  limitTokens: number,
+): Promise<unknown> {
+  const initialEstimate = estimateProviderPayloadTokens(payload);
+  assertWithinContextLimit(
+    initialEstimate,
+    limitTokens,
+    "serialized Pi provider payload",
+  );
+  const before = serializeProviderPayload(payload);
+  const replacement = priorOnPayload
+    ? await priorOnPayload(payload, model)
+    : undefined;
+  const finalPayload = replacement ?? payload;
+  const finalEstimate = estimateProviderPayloadTokens(finalPayload);
+  const after = serializeProviderPayload(finalPayload);
+  // A raw provider hook runs after Pi has assembled the request. There is no
+  // provider-independent tokenizer at this point, so accepting a mutation
+  // would make the cap unenforceable. Observation-only hooks remain compatible.
+  if (after !== before) {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: Pi before_provider_request payload mutation is disabled by the strict context cap",
+    );
+  }
+  assertWithinContextLimit(
+    finalEstimate,
+    limitTokens,
+    "final serialized Pi provider payload",
+  );
+  return finalPayload;
+}
+
+/** Estimate text/schema tokens while accounting for image binary separately. */
+export function estimateProviderPayloadTokens(
+  payload: unknown,
+  allowToolFunctions = false,
+): number {
+  const analysis = {
+    images: 0,
+    imageBytes: 0,
+    nodes: 0,
+    entries: 0,
+    textualBytes: 0,
+    seen: new WeakSet<object>(),
+  };
+  const inspect = (value: unknown, depth: number): unknown => {
+    analysis.nodes += 1;
+    if (analysis.nodes > MAX_PROVIDER_PAYLOAD_NODES) {
+      throwProviderPayloadBounds("node count");
+    }
+    if (depth > 32) {
+      throw new Error(
+        "BUZZ_CONTEXT_LIMIT: provider payload nesting is too deep to inspect",
+      );
+    }
+    if (typeof value === "string" && value.startsWith("data:image/")) {
+      recordImage(
+        analysis,
+        encodedImageBytes(value.slice(value.indexOf(",") + 1)),
+      );
+      recordProviderText(analysis, "<image-binary>");
+      return "<image-binary>";
+    }
+    if (value === null) {
+      recordProviderText(analysis, "null");
+      return value;
+    }
+    if (typeof value === "string") {
+      recordProviderText(analysis, value);
+      return value;
+    }
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) throwUnsafeProviderPayload();
+      recordProviderText(analysis, String(value));
+      return value;
+    }
+    if (typeof value === "boolean") {
+      recordProviderText(analysis, String(value));
+      return value;
+    }
+    if (value === undefined) {
+      // Pi's own JSON-shaped message/tool types use optional properties with
+      // undefined values. JSON serialization omits those object fields (or
+      // emits null for an array slot), so retaining undefined here mirrors the
+      // real provider payload while the surrounding structure remains bounded.
+      recordProviderText(analysis, "undefined");
+      return value;
+    }
+    if (
+      allowToolFunctions &&
+      (typeof value === "function" || typeof value === "symbol")
+    ) {
+      // Agent tool objects contain local execute/render functions that are
+      // removed when Pi builds the provider-facing JSON schema.
+      return undefined;
+    }
+    if (typeof value !== "object") throwUnsafeProviderPayload();
+    if (!Array.isArray(value) && !isPlainObject(value)) {
+      throw new Error(
+        "BUZZ_CONTEXT_LIMIT: provider payload contains non-plain JSON data",
+      );
+    }
+    if (analysis.seen.has(value)) {
+      throwUnsafeProviderPayload();
+    }
+    analysis.seen.add(value);
+    if (Array.isArray(value)) {
+      assertProviderArrayShape(value);
+      const result: unknown[] = [];
+      for (let index = 0; index < value.length; index += 1) {
+        recordProviderEntry(analysis);
+        let descriptor: PropertyDescriptor | undefined;
+        try {
+          descriptor = Object.getOwnPropertyDescriptor(value, index);
+        } catch {
+          throwUnsafeProviderPayload();
+        }
+        if (!descriptor || !("value" in descriptor)) {
+          throwUnsafeProviderPayload();
+        }
+        result.push(inspect(descriptor.value, depth + 1));
+      }
+      return result;
+    }
+    const record = value as Record<string, unknown>;
+    assertNoProviderSymbolKeys(record);
+    const type = providerOwnDataValue(record, "type");
+    const mimeType = providerOwnDataValue(record, "mimeType");
+    const mimeTypeSnake = providerOwnDataValue(record, "mime_type");
+    const data = providerOwnDataValue(record, "data");
+    const imageContainer =
+      type === "image" ||
+      type === "input_image" ||
+      type === "image_url" ||
+      type === "base64" ||
+      ((typeof mimeType === "string" || typeof mimeTypeSnake === "string") &&
+        typeof data === "string");
+    const result: Record<string, unknown> = {};
+    let enumeratedKeys = 0;
+    try {
+      for (const key in record) {
+        enumeratedKeys += 1;
+        if (enumeratedKeys > MAX_PROVIDER_PAYLOAD_ENTRIES) {
+          throwProviderPayloadBounds("enumerated keys");
+        }
+        if (!Object.hasOwn(record, key)) continue;
+        recordProviderEntry(analysis);
+        recordProviderText(analysis, key);
+        const item = providerOwnDataValue(record, key);
+        if (imageContainer && key === "data" && typeof item === "string") {
+          recordImage(analysis, encodedImageBytes(item));
+          recordProviderText(analysis, "<image-binary>");
+          result[key] = "<image-binary>";
+        } else if (
+          (key === "image_url" || key === "url") &&
+          typeof item === "string" &&
+          item.startsWith("data:image/")
+        ) {
+          recordImage(
+            analysis,
+            encodedImageBytes(item.slice(item.indexOf(",") + 1)),
+          );
+          recordProviderText(analysis, "<image-binary>");
+          result[key] = "<image-binary>";
+        } else {
+          result[key] = inspect(item, depth + 1);
+        }
+      }
+    } catch (error) {
+      if (isProviderPayloadError(error)) throw error;
+      throwUnsafeProviderPayload();
+    }
+    return result;
+  };
+  const textualPayload = serializeProviderPayload(inspect(payload, 0));
+  return (
+    estimateSerializedPayloadTokens(textualPayload) +
+    analysis.images * ESTIMATED_PROVIDER_IMAGE_TOKENS
+  );
+}
+
+function recordProviderEntry(analysis: { entries: number }): void {
+  analysis.entries += 1;
+  if (analysis.entries > MAX_PROVIDER_PAYLOAD_ENTRIES) {
+    throwProviderPayloadBounds("entry count");
+  }
+}
+
+function recordProviderText(
+  analysis: { textualBytes: number },
+  value: string,
+): void {
+  const remaining = MAX_PROVIDER_PAYLOAD_TEXT_BYTES - analysis.textualBytes;
+  if (value.length > remaining) throwProviderPayloadBounds("text bytes");
+  analysis.textualBytes += Buffer.byteLength(value);
+  if (analysis.textualBytes > MAX_PROVIDER_PAYLOAD_TEXT_BYTES) {
+    throwProviderPayloadBounds("text bytes");
+  }
+}
+
+function throwProviderPayloadBounds(kind: string): never {
+  throw new Error(
+    `BUZZ_CONTEXT_LIMIT: provider payload ${kind} exceeds safe structural bounds`,
+  );
+}
+
+function throwUnsafeProviderPayload(): never {
+  throw new Error(
+    "BUZZ_CONTEXT_LIMIT: provider payload could not be safely inspected",
+  );
+}
+
+function isPlainObject(value: object): boolean {
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  } catch {
+    return false;
+  }
+}
+
+function assertProviderArrayShape(value: unknown[]): void {
+  if (value.length > MAX_PROVIDER_PAYLOAD_ENTRIES) {
+    throwProviderPayloadBounds("array length");
+  }
+  assertNoProviderSymbolKeys(value);
+  let enumeratedKeys = 0;
+  let ownEnumerableKeys = 0;
+  try {
+    for (const key in value) {
+      enumeratedKeys += 1;
+      if (enumeratedKeys > MAX_PROVIDER_PAYLOAD_ENTRIES) {
+        throwProviderPayloadBounds("enumerated keys");
+      }
+      if (!Object.hasOwn(value, key)) continue;
+      if (
+        ownEnumerableKeys >= value.length ||
+        key !== String(ownEnumerableKeys)
+      ) {
+        throw new Error(
+          "BUZZ_CONTEXT_LIMIT: provider payload contains a decorated array",
+        );
+      }
+      ownEnumerableKeys += 1;
+    }
+  } catch (error) {
+    if (isProviderPayloadError(error)) throw error;
+    throwUnsafeProviderPayload();
+  }
+  if (ownEnumerableKeys !== value.length) {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: provider payload contains a sparse array",
+    );
+  }
+}
+
+function assertNoProviderSymbolKeys(value: object): void {
+  let symbols: symbol[];
+  try {
+    symbols = Object.getOwnPropertySymbols(value);
+  } catch {
+    throwUnsafeProviderPayload();
+  }
+  if (symbols.length > 0) {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: provider payload contains symbol-keyed data",
+    );
+  }
+}
+
+function providerOwnDataValue(
+  value: Record<string, unknown>,
+  key: string,
+): unknown {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(value, key);
+  } catch {
+    throwUnsafeProviderPayload();
+  }
+  if (!descriptor) return undefined;
+  if (!("value" in descriptor)) throwUnsafeProviderPayload();
+  return descriptor.value;
+}
+
+function isProviderPayloadError(error: unknown): error is Error {
+  return (
+    error instanceof Error && error.message.startsWith("BUZZ_CONTEXT_LIMIT:")
+  );
+}
+
+function recordImage(
+  analysis: { images: number; imageBytes: number },
+  bytes: number,
+): void {
+  analysis.images++;
+  analysis.imageBytes += bytes;
+  if (
+    analysis.images > MAX_PROVIDER_IMAGES ||
+    bytes > MAX_PROVIDER_IMAGE_BYTES ||
+    analysis.imageBytes > MAX_PROVIDER_IMAGE_BYTES_TOTAL
+  ) {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: provider image count or size exceeds safe bounds",
+    );
+  }
+}
+
+function encodedImageBytes(value: string): number {
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((value.length * 3) / 4) - padding);
+}
+
+function serializeProviderPayload(payload: unknown): string {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: provider payload could not be safely inspected",
+    );
+  }
+  if (serialized === undefined) {
+    throw new Error(
+      "BUZZ_CONTEXT_LIMIT: provider payload could not be safely inspected",
+    );
+  }
+  if (Buffer.byteLength(serialized) > MAX_PROVIDER_SERIALIZED_BYTES) {
+    throwProviderPayloadBounds("serialized bytes");
+  }
+  return serialized;
+}
+
+function limitModelContext(
+  model: PiModelLike,
+  config: AdapterConfig,
+): PiModelLike {
+  return {
+    ...model,
+    contextWindow: logicalModelContextWindow(
+      model.contextWindow,
+      config.contextLimitTokens,
+    ),
+  };
+}
+
+function resolveModel(
+  runtime: ModelRuntime,
+  modelId: string,
+): PiModelLike | undefined {
+  const models = runtime.getAvailableSnapshot();
+  const exact = models.filter(
+    (model) =>
+      `${model.provider}/${model.id}` === modelId || model.id === modelId,
+  );
+  return exact.length === 1 ? exact[0] : undefined;
+}
+
+export function applyFreshSessionTitle(
+  session: { setSessionName(name: string): void },
+  title: string | undefined,
+): void {
+  const normalized = title?.trim();
+  if (!normalized) return;
+  session.setSessionName(boundedString(normalized, MAX_SESSION_TITLE_LENGTH));
+}
+
+function persistFreshSession(sessionManager: SessionManager): void {
+  // Pi 0.83 intentionally delays writing a session until its first assistant
+  // message. Buzz needs a durable thread mapping immediately at session/new.
+  // This exact, version-pinned seam writes the existing header/title entries
+  // and marks them flushed so Pi appends normally on the first turn.
+  const pinned = sessionManager as unknown as {
+    _rewriteFile?: () => void;
+    flushed?: boolean;
+  };
+  if (typeof pinned._rewriteFile !== "function") {
+    throw new Error(
+      "Installed Pi SDK is incompatible with durable Buzz sessions",
+    );
+  }
+  pinned._rewriteFile();
+  pinned.flushed = true;
+}
+
+/**
+ * Install a byte-accurate guard at Pi's version-pinned append/rewrite seam.
+ *
+ * Pi transcripts are append-only: context compaction reduces provider context
+ * but does not reclaim JSONL bytes. Ordinary and Buzz control entries are
+ * accounted in separate fixed partitions. Rollback/lifecycle records can use
+ * their reserve without stealing ordinary transcript headroom, while neither
+ * partition nor their combined bytes can cross the configured hard ceiling.
+ */
+export function installSessionFileQuota(
+  sessionManager: SessionManager,
+  maxBytes: number,
+): void {
+  if (quotaInstalled.has(sessionManager)) return;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error("invalid Pi session transcript byte limit");
+  }
+  const pinned = sessionManager as unknown as {
+    _appendEntry?: (entry: unknown) => void;
+    _rewriteFile?: () => void;
+    fileEntries?: unknown[];
+  };
+  if (
+    typeof pinned._appendEntry !== "function" ||
+    typeof pinned._rewriteFile !== "function" ||
+    !Array.isArray(pinned.fileEntries)
+  ) {
+    throw new Error(
+      "Installed Pi SDK is incompatible with the Buzz transcript quota",
+    );
+  }
+  const originalAppend = pinned._appendEntry;
+  const originalRewrite = pinned._rewriteFile;
+  const controlReserveBytes = Math.min(
+    SESSION_FILE_CONTROL_RESERVE_BYTES,
+    maxBytes,
+  );
+  const ordinaryLimitBytes = maxBytes - controlReserveBytes;
+  let trackedEntries = pinned.fileEntries;
+  let accounting = classifySessionEntries(trackedEntries);
+  const refreshAccounting = (): void => {
+    if (!Array.isArray(pinned.fileEntries)) {
+      throw new Error(
+        "Installed Pi SDK changed its transcript storage representation",
+      );
+    }
+    if (pinned.fileEntries !== trackedEntries) {
+      trackedEntries = pinned.fileEntries;
+      accounting = classifySessionEntries(trackedEntries);
+    }
+  };
+  const assertAccountingWithinQuota = (
+    nextOrdinaryBytes: number,
+    nextControlBytes: number,
+  ): void => {
+    const totalBytes = nextOrdinaryBytes + nextControlBytes;
+    if (
+      !Number.isSafeInteger(nextOrdinaryBytes) ||
+      !Number.isSafeInteger(nextControlBytes) ||
+      nextOrdinaryBytes < 0 ||
+      nextControlBytes < 0 ||
+      nextOrdinaryBytes > ordinaryLimitBytes ||
+      nextControlBytes > controlReserveBytes ||
+      !Number.isSafeInteger(totalBytes) ||
+      totalBytes > maxBytes
+    ) {
+      throw sessionStorageLimitError(
+        Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, totalBytes)),
+        maxBytes,
+      );
+    }
+  };
+  assertAccountingWithinQuota(
+    accounting.ordinaryBytes,
+    accounting.controlBytes,
+  );
+  pinned._appendEntry = (entry: unknown): void => {
+    refreshAccounting();
+    const incomingBytes = serializedSessionEntryBytes(entry);
+    const control = isBuzzControlEntry(entry);
+    if (control) assertBuzzControlEntry(entry, incomingBytes);
+    const nextOrdinaryBytes =
+      accounting.ordinaryBytes + (control ? 0 : incomingBytes);
+    const nextControlBytes =
+      accounting.controlBytes + (control ? incomingBytes : 0);
+    assertAccountingWithinQuota(nextOrdinaryBytes, nextControlBytes);
+    const sessionFile = sessionManager.getSessionFile();
+    if (sessionManager.isPersisted() && sessionFile) {
+      assertSessionFileGrowthWithinQuota(
+        sessionFile,
+        incomingBytes,
+        maxBytes,
+        maxBytes,
+      );
+    }
+    originalAppend.call(sessionManager, entry);
+    if (pinned.fileEntries === trackedEntries) {
+      accounting = {
+        ordinaryBytes: nextOrdinaryBytes,
+        controlBytes: nextControlBytes,
+      };
+    } else {
+      refreshAccounting();
+    }
+  };
+  pinned._rewriteFile = (): void => {
+    if (!Array.isArray(pinned.fileEntries)) {
+      throw new Error(
+        "Installed Pi SDK changed its transcript storage representation",
+      );
+    }
+    const rewrittenAccounting = classifySessionEntries(pinned.fileEntries);
+    assertAccountingWithinQuota(
+      rewrittenAccounting.ordinaryBytes,
+      rewrittenAccounting.controlBytes,
+    );
+    originalRewrite.call(sessionManager);
+    trackedEntries = pinned.fileEntries;
+    accounting = rewrittenAccounting;
+  };
+  quotaInstalled.add(sessionManager);
+}
+
+export function assertSessionFileSizeWithinQuota(
+  sessionFile: string,
+  maxBytes: number,
+): void {
+  let currentBytes: number;
+  try {
+    currentBytes = statSync(sessionFile).size;
+  } catch (error) {
+    if (isFileNotFound(error)) return;
+    throw error;
+  }
+  if (currentBytes > maxBytes) {
+    throw sessionStorageLimitError(currentBytes, maxBytes);
+  }
+}
+
+function assertSessionFileGrowthWithinQuota(
+  sessionFile: string,
+  incomingBytes: number,
+  operationLimitBytes: number,
+  configuredMaxBytes: number,
+): void {
+  let currentBytes = 0;
+  try {
+    currentBytes = statSync(sessionFile).size;
+  } catch (error) {
+    if (!isFileNotFound(error)) throw error;
+  }
+  if (
+    !Number.isSafeInteger(currentBytes) ||
+    !Number.isSafeInteger(incomingBytes) ||
+    incomingBytes < 0 ||
+    currentBytes > operationLimitBytes - incomingBytes
+  ) {
+    throw sessionStorageLimitError(
+      Math.min(Number.MAX_SAFE_INTEGER, currentBytes + incomingBytes),
+      configuredMaxBytes,
+    );
+  }
+}
+
+function serializedSessionEntryBytes(entry: unknown): number {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(entry);
+  } catch {
+    throw new Error(
+      "BUZZ_SESSION_STORAGE_LIMIT: Pi attempted to persist an unserializable session entry; use /new to start a clean session",
+    );
+  }
+  if (serialized === undefined) {
+    throw new Error(
+      "BUZZ_SESSION_STORAGE_LIMIT: Pi attempted to persist an invalid session entry; use /new to start a clean session",
+    );
+  }
+  return Buffer.byteLength(`${serialized}\n`, "utf8");
+}
+
+function classifySessionEntries(entries: readonly unknown[]): {
+  ordinaryBytes: number;
+  controlBytes: number;
+} {
+  let ordinaryBytes = 0;
+  let controlBytes = 0;
+  for (const entry of entries) {
+    const bytes = serializedSessionEntryBytes(entry);
+    if (isBuzzControlEntry(entry)) {
+      assertBuzzControlEntry(entry, bytes);
+      controlBytes += bytes;
+    } else {
+      ordinaryBytes += bytes;
+    }
+  }
+  return { ordinaryBytes, controlBytes };
+}
+
+function isBuzzControlEntry(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "custom" &&
+    "customType" in value &&
+    (value.customType === "buzz.turn_rollback" ||
+      value.customType === COMPACTION_ATTEMPT_ENTRY ||
+      value.customType === LIFECYCLE_WATERMARK_ENTRY ||
+      value.customType === LIFECYCLE_PENDING_ENTRY ||
+      value.customType === LIFECYCLE_ACK_ENTRY)
+  );
+}
+
+function assertBuzzControlEntry(value: unknown, serializedBytes: number): void {
+  if (!isPlainRecord(value) || value.type !== "custom") {
+    throw new Error("invalid Buzz transcript control entry");
+  }
+  const data = value.data;
+  if (value.customType === "buzz.turn_rollback") {
+    if (
+      serializedBytes > MAX_CHILD_ROLLBACK_MARKER_BYTES ||
+      !isPlainRecord(data) ||
+      data.version !== 1
+    ) {
+      throw new Error("invalid bounded Buzz rollback marker");
+    }
+    return;
+  }
+  if (value.customType === COMPACTION_ATTEMPT_ENTRY) {
+    if (serializedBytes > MAX_CHILD_LIFECYCLE_ATTEMPT_BYTES) {
+      throw new Error("Pi compaction attempt entry exceeds its byte bound");
+    }
+    parseCompactionAttemptData(data);
+    return;
+  }
+  if (value.customType === LIFECYCLE_WATERMARK_ENTRY) {
+    if (serializedBytes > MAX_CHILD_LIFECYCLE_WATERMARK_BYTES) {
+      throw new Error("Pi lifecycle watermark entry exceeds its byte bound");
+    }
+    parseLifecycleWatermarkData(data);
+    return;
+  }
+  if (value.customType === LIFECYCLE_ACK_ENTRY) {
+    if (serializedBytes > MAX_CHILD_LIFECYCLE_ACK_BYTES) {
+      throw new Error("Pi lifecycle ACK entry exceeds its byte bound");
+    }
+    parseLifecycleAckData(data);
+    return;
+  }
+  if (value.customType === LIFECYCLE_PENDING_ENTRY) {
+    if (
+      serializedBytes > MAX_CHILD_LIFECYCLE_RECORD_BYTES + 1_024 ||
+      !isPlainRecord(data) ||
+      !isPlainRecord(data.event) ||
+      typeof data.event.piSessionId !== "string"
+    ) {
+      throw new Error("invalid bounded Pi lifecycle pending entry");
+    }
+    parsePendingLifecycleData(data, data.event.piSessionId);
+    return;
+  }
+  throw new Error("unknown Buzz transcript control entry");
+}
+
+function sessionStorageLimitError(
+  currentBytes: number,
+  maxBytes: number,
+): Error {
+  return new Error(
+    `BUZZ_SESSION_STORAGE_LIMIT: this Pi thread transcript reached its ${formatBytes(maxBytes)} storage ceiling (${formatBytes(currentBytes)} requested); use /new to start a fresh session`,
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_024 * 1_024)
+    return `${(bytes / (1_024 * 1_024)).toFixed(1)} MiB`;
+  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(1)} KiB`;
+  return `${bytes} bytes`;
+}
+
+export function dedupeCommands<T extends { name: string }>(
+  commands: readonly T[],
+): T[] {
+  const seen = new Set<string>();
+  return commands.filter((command) => {
+    if (seen.has(command.name)) return false;
+    seen.add(command.name);
+    return true;
+  });
+}
+
+function describeModel(model: PiModelLike): ModelDescriptor {
+  return {
+    id: `${model.provider}/${model.id}`,
+    name: boundedString(model.name, 256),
+  };
+}
+
+function firstLine(text: string): string {
+  return text.split(/\r?\n/, 1)[0]?.trim() ?? "";
+}
+
+function toolKind(name: string): string {
+  if (name === "bash") return "execute";
+  if (["read", "grep", "find", "ls"].includes(name)) return "search";
+  if (["write", "edit"].includes(name)) return "edit";
+  return "other";
+}
+
+function truncatePayload(value: unknown): unknown {
+  const normalized = normalizeToolEventPayload(value);
+  const serialized = JSON.stringify(normalized);
+  if (Buffer.byteLength(serialized) <= MAX_TOOL_EVENT_PAYLOAD_BYTES) {
+    return normalized;
+  }
+  const suffix = "\n… output truncated by buzz-pi-agent …";
+  return `${truncateUtf8(
+    serialized,
+    MAX_TOOL_EVENT_PAYLOAD_BYTES - Buffer.byteLength(suffix),
+  )}${suffix}`;
+}
+
+interface ToolPayloadBudget {
+  remainingNodes: number;
+  remainingTextCharacters: number;
+  ancestors: WeakSet<object>;
+}
+
+function normalizeToolEventPayload(value: unknown): unknown {
+  return normalizeToolEventNode(value, 0, {
+    remainingNodes: MAX_TOOL_EVENT_PAYLOAD_NODES,
+    remainingTextCharacters: MAX_TOOL_EVENT_TEXT_CHARACTERS,
+    ancestors: new WeakSet(),
+  });
+}
+
+function normalizeToolEventNode(
+  value: unknown,
+  depth: number,
+  budget: ToolPayloadBudget,
+): unknown {
+  if (depth > MAX_TOOL_EVENT_DEPTH || budget.remainingNodes <= 0) {
+    return "[truncated]";
+  }
+  budget.remainingNodes -= 1;
+  if (typeof value === "string") return takeToolEventString(value, budget);
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : `[${String(value)}]`;
+  }
+  if (typeof value === "boolean" || value === null) return value;
+  if (value === undefined) return "[undefined]";
+  if (typeof value === "bigint") {
+    return takeToolEventString(`[bigint:${String(value)}]`, budget);
+  }
+  if (typeof value === "symbol" || typeof value === "function") {
+    return `[unsupported:${typeof value}]`;
+  }
+  if (budget.ancestors.has(value)) return "[circular]";
+
+  if (value instanceof ArrayBuffer) {
+    return { $type: "ArrayBuffer", byteLength: value.byteLength };
+  }
+  if (
+    typeof SharedArrayBuffer !== "undefined" &&
+    value instanceof SharedArrayBuffer
+  ) {
+    return { $type: "SharedArrayBuffer", byteLength: value.byteLength };
+  }
+  if (ArrayBuffer.isView(value)) {
+    return {
+      $type: value instanceof DataView ? "DataView" : "TypedArray",
+      byteLength: value.byteLength,
+    };
+  }
+  if (value instanceof Date) {
+    const timestamp = Date.prototype.getTime.call(value);
+    return {
+      $type: "Date",
+      value: Number.isFinite(timestamp)
+        ? Date.prototype.toISOString.call(value)
+        : "Invalid Date",
+    };
+  }
+  if (value instanceof Error) {
+    return {
+      $type: "Error",
+      name: takeToolEventString(value.name, budget),
+      message: takeToolEventString(value.message, budget),
+    };
+  }
+
+  budget.ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const count = Math.min(value.length, MAX_TOOL_EVENT_CONTAINER_ITEMS);
+      const result: unknown[] = [];
+      for (let index = 0; index < count; index += 1) {
+        let descriptor: PropertyDescriptor | undefined;
+        try {
+          descriptor = Object.getOwnPropertyDescriptor(value, index);
+        } catch {
+          result.push("[unavailable]");
+          continue;
+        }
+        result.push(
+          descriptor && "value" in descriptor
+            ? normalizeToolEventNode(descriptor.value, depth + 1, budget)
+            : descriptor
+              ? "[accessor]"
+              : "[empty]",
+        );
+      }
+      if (value.length > count) result.push("[truncated]");
+      return result;
+    }
+    if (value instanceof Map) {
+      const entries: unknown[] = [];
+      let index = 0;
+      try {
+        for (const [key, item] of Map.prototype.entries.call(value)) {
+          if (index >= MAX_TOOL_EVENT_CONTAINER_ITEMS) {
+            entries.push("[truncated]");
+            break;
+          }
+          entries.push([
+            normalizeToolEventNode(key, depth + 1, budget),
+            normalizeToolEventNode(item, depth + 1, budget),
+          ]);
+          index += 1;
+        }
+      } catch {
+        entries.push("[unavailable]");
+      }
+      return { $type: "Map", entries };
+    }
+    if (value instanceof Set) {
+      const values: unknown[] = [];
+      let index = 0;
+      try {
+        for (const item of Set.prototype.values.call(value)) {
+          if (index >= MAX_TOOL_EVENT_CONTAINER_ITEMS) {
+            values.push("[truncated]");
+            break;
+          }
+          values.push(normalizeToolEventNode(item, depth + 1, budget));
+          index += 1;
+        }
+      } catch {
+        values.push("[unavailable]");
+      }
+      return { $type: "Set", values };
+    }
+
+    let prototype: object | null;
+    try {
+      prototype = Object.getPrototypeOf(value);
+    } catch {
+      return { $type: "NonPlainObject", value: "[unavailable]" };
+    }
+    const result: Record<string, unknown> = {};
+    if (prototype !== Object.prototype && prototype !== null) {
+      result.$type = "NonPlainObject";
+    }
+    let entries = 0;
+    let enumeratedKeys = 0;
+    try {
+      for (const key in value) {
+        enumeratedKeys += 1;
+        if (enumeratedKeys > MAX_TOOL_EVENT_CONTAINER_ITEMS * 2) {
+          result["[truncated]"] = true;
+          break;
+        }
+        if (!Object.hasOwn(value, key)) continue;
+        if (entries >= MAX_TOOL_EVENT_CONTAINER_ITEMS) {
+          result["[truncated]"] = true;
+          break;
+        }
+        let descriptor: PropertyDescriptor | undefined;
+        try {
+          descriptor = Object.getOwnPropertyDescriptor(value, key);
+        } catch {
+          result[key] = "[unavailable]";
+          entries += 1;
+          continue;
+        }
+        result[key] =
+          descriptor && "value" in descriptor
+            ? normalizeToolEventNode(descriptor.value, depth + 1, budget)
+            : "[accessor]";
+        entries += 1;
+      }
+    } catch {
+      result["[unavailable]"] = true;
+    }
+    return result;
+  } finally {
+    budget.ancestors.delete(value);
+  }
+}
+
+function takeToolEventString(value: string, budget: ToolPayloadBudget): string {
+  const allowed = Math.max(
+    0,
+    Math.min(value.length, budget.remainingTextCharacters),
+  );
+  const truncated = allowed < value.length;
+  const result = truncated
+    ? `${value.slice(0, Math.max(0, allowed - 1))}…`
+    : value;
+  budget.remainingTextCharacters = Math.max(
+    0,
+    budget.remainingTextCharacters - result.length,
+  );
+  return result;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(value.slice(0, middle)) <= maxBytes) low = middle;
+    else high = middle - 1;
+  }
+  return value.slice(0, low);
+}
+
+function contextMessage(
+  verb: string,
+  beforeTokens: number | null,
+  afterTokens: number | null,
+): string {
+  const before =
+    beforeTokens === null ? "an unknown size" : formatTokens(beforeTokens);
+  const after =
+    afterTokens === null ? "a compact summary" : formatTokens(afterTokens);
+  return `Pi ${verb} this thread's context from ${before} to approximately ${after}.`;
+}
+
+function formatTokens(tokens: number): string {
+  return `${new Intl.NumberFormat("en-US").format(Math.round(tokens))} tokens`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isContextLimitError(error: unknown): boolean {
+  return errorMessage(error).startsWith("BUZZ_CONTEXT_LIMIT:");
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+function boundedString(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength)}…`;
+}
+
+function publicError(value: string): string {
+  const withoutWindowsPaths = value.replace(
+    /[A-Za-z]:\\(?:[^\\\s:]+\\)*[^\\\s:]*/g,
+    "<path>",
+  );
+  const withoutUnixPaths = withoutWindowsPaths.replace(
+    /\/(?:[^/\s:]+\/)*[^/\s:]*/g,
+    "<path>",
+  );
+  return boundedString(withoutUnixPaths, 1_024);
+}

--- a/packages/buzz-pi-agent/src/resource-budget.ts
+++ b/packages/buzz-pi-agent/src/resource-budget.ts
@@ -1,0 +1,1026 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  openSync,
+  opendirSync,
+  readSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import type { Dirent } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AdapterConfig } from "./config.js";
+
+type ResourceMode = "skills" | "prompts" | "themes";
+
+type ClassifiedPackageSource =
+  | { type: "npm"; name: string | undefined }
+  | { type: "git"; host: string; path: string }
+  | { type: "local"; path: string };
+
+export interface ResourceBudgetSnapshot {
+  files: number;
+  entries: number;
+  bytes: number;
+  fingerprints: readonly ResourceFileFingerprint[];
+}
+
+export interface ResourceFileFingerprint {
+  path: string;
+  canonicalPath: string;
+  device: string;
+  inode: string;
+  size: number;
+  mtimeNs: string;
+  ctimeNs: string;
+  sha256: string;
+}
+
+interface ResourceBudgetOptions {
+  cwd: string;
+  agentDir: string;
+  projectTrusted: boolean;
+  config: AdapterConfig;
+  systemPromptSource?: string;
+}
+
+/**
+ * Preflight every normal non-code file tree Pi will synchronously discover.
+ * Extensions remain trusted executable code; their arbitrary imports cannot be
+ * contained by a file scanner and are covered by the documented worker boundary.
+ */
+export function assertPiResourceBudget(
+  options: ResourceBudgetOptions,
+): ResourceBudgetSnapshot {
+  const budget = new ResourceBudget(options.config);
+  const globalSettings = budget.readJson(
+    join(options.agentDir, "settings.json"),
+    "global settings",
+  );
+  budget.readJson(join(options.agentDir, "models.json"), "model manifest");
+  budget.checkFile(join(options.agentDir, "auth.json"), "credential manifest");
+  budget.readJson(
+    join(options.agentDir, "trust.json"),
+    "project trust manifest",
+  );
+  if (options.systemPromptSource && existsSync(options.systemPromptSource)) {
+    budget.checkFile(options.systemPromptSource, "explicit system prompt");
+  }
+
+  let projectSettings: Record<string, unknown> | undefined;
+  if (options.projectTrusted) {
+    projectSettings = budget.readJson(
+      join(options.cwd, ".pi", "settings.json"),
+      "project settings",
+    );
+  }
+
+  scanContextFiles(budget, options.cwd, options.agentDir);
+  scanScopeResources(budget, options.agentDir, globalSettings);
+  budget.scanDirectory(join(homedir(), ".agents", "skills"), "skills");
+  scanExtensionManifests(budget, join(options.agentDir, "extensions"));
+  scanManagedPackages(budget, options.agentDir, globalSettings, true);
+
+  if (options.projectTrusted) {
+    const projectDir = join(options.cwd, ".pi");
+    scanScopeResources(budget, projectDir, projectSettings);
+    scanExtensionManifests(budget, join(projectDir, "extensions"));
+    scanManagedPackages(budget, projectDir, projectSettings, false);
+    for (const skillsDir of ancestorAgentsSkillDirs(options.cwd)) {
+      budget.scanDirectory(skillsDir, "skills");
+    }
+  }
+
+  return budget.snapshot();
+}
+
+/**
+ * Verify that discovery and every bounded file byte stayed identical across a
+ * Pi SDK load. This catches same-path growth, in-place rewrites, replacement,
+ * symlink swaps, additions, and removals in the preflight/load window.
+ */
+export function assertPiResourceSnapshotsEqual(
+  before: ResourceBudgetSnapshot,
+  after: ResourceBudgetSnapshot,
+): void {
+  if (
+    before.files !== after.files ||
+    before.entries !== after.entries ||
+    before.bytes !== after.bytes ||
+    before.fingerprints.length !== after.fingerprints.length
+  ) {
+    throw resourceChanged("non-code resource discovery changed during Pi load");
+  }
+  for (let index = 0; index < before.fingerprints.length; index += 1) {
+    const left = before.fingerprints[index];
+    const right = after.fingerprints[index];
+    if (!left || !right || !sameFingerprint(left, right)) {
+      throw resourceChanged("a non-code resource changed during Pi load");
+    }
+  }
+}
+
+class ResourceBudget {
+  private readonly checkedFiles = new Map<
+    string,
+    { fingerprint: ResourceFileFingerprint; content: Buffer }
+  >();
+  private files = 0;
+  private entries = 0;
+  private bytes = 0;
+
+  constructor(private readonly config: AdapterConfig) {}
+
+  snapshot(): ResourceBudgetSnapshot {
+    return {
+      files: this.files,
+      entries: this.entries,
+      bytes: this.bytes,
+      fingerprints: [...this.checkedFiles.values()]
+        .map(({ fingerprint }) => ({ ...fingerprint }))
+        .sort((left, right) => left.path.localeCompare(right.path)),
+    };
+  }
+
+  checkFile(path: string, label: string): boolean {
+    return this.checkedFile(path, label) !== undefined;
+  }
+
+  readJson(path: string, label: string): Record<string, unknown> | undefined {
+    const checked = this.checkedFile(path, label);
+    if (!checked) return undefined;
+    try {
+      const parsed: unknown = JSON.parse(checked.content.toString("utf8"));
+      return isRecord(parsed) ? parsed : undefined;
+    } catch {
+      // Pi owns schema/parse diagnostics. The budget only guarantees that the
+      // attempted parse is bounded and cannot exhaust the runtime host.
+      return undefined;
+    }
+  }
+
+  scanPath(path: string, mode: ResourceMode, recursive = false): void {
+    if (!existsSync(path)) return;
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(path);
+    } catch {
+      return;
+    }
+    if (stats.isFile()) {
+      this.checkFile(path, resourceLabel(mode));
+    } else if (stats.isDirectory()) {
+      this.scanDirectory(path, mode, recursive);
+    }
+  }
+
+  scanDirectory(path: string, mode: ResourceMode, recursive = false): void {
+    this.scanDirectoryInner(path, mode, 0, new Set(), recursive);
+  }
+
+  scanExtensionDiscovery(path: string, recursive: boolean): void {
+    if (!existsSync(path)) return;
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(path);
+    } catch {
+      return;
+    }
+    if (!stats.isDirectory()) return;
+    this.scanExtensionDirectoryInner(path, 0, new Set(), recursive);
+  }
+
+  listDirectory(path: string, label: string): string[] {
+    return this.readDirectory(path, label).map((entry) => entry.name);
+  }
+
+  private scanDirectoryInner(
+    path: string,
+    mode: ResourceMode,
+    depth: number,
+    ancestors: Set<string>,
+    recursive: boolean,
+  ): void {
+    if (depth > this.config.maxResourceDepth) {
+      throw resourceLimit(
+        `${resourceLabel(mode)} traversal exceeds depth ${this.config.maxResourceDepth}`,
+      );
+    }
+    let canonical: string;
+    let stats: ReturnType<typeof statSync>;
+    try {
+      canonical = realpathSync.native(path);
+      stats = statSync(path);
+    } catch {
+      return;
+    }
+    if (!stats.isDirectory()) {
+      if (stats.isFile()) this.checkFile(path, resourceLabel(mode));
+      return;
+    }
+    if (ancestors.has(canonical)) {
+      throw resourceLimit(
+        `${resourceLabel(mode)} traversal contains a symlink cycle`,
+      );
+    }
+    const nextAncestors = new Set(ancestors).add(canonical);
+    const entries = this.readDirectory(path, resourceLabel(mode));
+    checkIgnoreManifests(this, path, `${resourceLabel(mode)} ignore manifest`);
+
+    if (mode === "skills") {
+      const rootSkill = entries.find((entry) => entry.name === "SKILL.md");
+      if (rootSkill) {
+        this.checkFile(join(path, rootSkill.name), "skill");
+        return;
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      if (entry.name === "node_modules") continue;
+      const child = join(path, entry.name);
+      if (mode === "skills") {
+        if (entry.name === "node_modules") continue;
+        let childStats: ReturnType<typeof statSync>;
+        try {
+          childStats = statSync(child);
+        } catch {
+          continue;
+        }
+        if (childStats.isDirectory()) {
+          this.scanDirectoryInner(
+            child,
+            mode,
+            depth + 1,
+            nextAncestors,
+            recursive,
+          );
+        } else if (childStats.isFile() && entry.name.endsWith(".md")) {
+          this.checkFile(child, "skill");
+        }
+        continue;
+      }
+      let childStats: ReturnType<typeof statSync>;
+      try {
+        childStats = statSync(child);
+      } catch {
+        continue;
+      }
+      if (recursive && childStats.isDirectory()) {
+        this.scanDirectoryInner(child, mode, depth + 1, nextAncestors, true);
+      } else if (
+        childStats.isFile() &&
+        mode === "prompts" &&
+        entry.name.endsWith(".md")
+      ) {
+        this.checkFile(child, "prompt");
+      } else if (
+        childStats.isFile() &&
+        mode === "themes" &&
+        entry.name.endsWith(".json")
+      ) {
+        this.checkFile(child, "theme");
+      }
+    }
+  }
+
+  private checkedFile(
+    path: string,
+    label: string,
+  ): { fingerprint: ResourceFileFingerprint; content: Buffer } | undefined {
+    const lexicalPath = resolve(path);
+    const existing = this.checkedFiles.get(lexicalPath);
+    if (existing) return existing;
+    const checked = captureResourceFile(
+      lexicalPath,
+      label,
+      this.config.maxResourceFileBytes,
+    );
+    if (!checked) return undefined;
+    const size = checked.fingerprint.size;
+    if (size > this.config.maxResourceFileBytes) {
+      throw resourceLimit(
+        `${boundedLabel(label)} exceeds the per-file limit (${size} > ${this.config.maxResourceFileBytes} bytes)`,
+      );
+    }
+    if (this.files + 1 > this.config.maxResourceFiles) {
+      throw resourceLimit(
+        `non-code resource file count exceeds ${this.config.maxResourceFiles}`,
+      );
+    }
+    if (this.bytes + size > this.config.maxResourceTotalBytes) {
+      throw resourceLimit(
+        `non-code resource bytes exceed ${this.config.maxResourceTotalBytes}`,
+      );
+    }
+    this.checkedFiles.set(lexicalPath, checked);
+    this.files += 1;
+    this.bytes += size;
+    return checked;
+  }
+
+  private scanExtensionDirectoryInner(
+    path: string,
+    depth: number,
+    ancestors: Set<string>,
+    recursive: boolean,
+  ): void {
+    if (depth > this.config.maxResourceDepth) {
+      throw resourceLimit(
+        `extension discovery exceeds depth ${this.config.maxResourceDepth}`,
+      );
+    }
+    let canonical: string;
+    try {
+      canonical = realpathSync.native(path);
+    } catch {
+      return;
+    }
+    if (ancestors.has(canonical)) {
+      throw resourceLimit("extension discovery contains a symlink cycle");
+    }
+    const nextAncestors = new Set(ancestors).add(canonical);
+    checkIgnoreManifests(this, path, "extension ignore manifest");
+    this.readJson(join(path, "package.json"), "extension manifest");
+    const entries = this.readDirectory(path, "extension discovery");
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+      const child = join(path, entry.name);
+      let childStats: ReturnType<typeof statSync>;
+      try {
+        childStats = statSync(child);
+      } catch {
+        continue;
+      }
+      if (!childStats.isDirectory()) continue;
+      if (recursive) {
+        this.scanExtensionDirectoryInner(child, depth + 1, nextAncestors, true);
+      } else {
+        this.readJson(join(child, "package.json"), "extension manifest");
+      }
+    }
+  }
+
+  private readDirectory(path: string, label: string): Dirent<string>[] {
+    if (!existsSync(path)) return [];
+    let directory: ReturnType<typeof opendirSync>;
+    try {
+      directory = opendirSync(path, { encoding: "utf8" });
+    } catch {
+      return [];
+    }
+    const entries: Dirent<string>[] = [];
+    try {
+      while (true) {
+        const entry = directory.readSync();
+        if (entry === null) break;
+        this.addEntries(1, label);
+        entries.push(entry);
+      }
+      return entries;
+    } finally {
+      directory.closeSync();
+    }
+  }
+
+  private addEntries(count: number, label: string): void {
+    if (this.entries + count > this.config.maxResourceEntries) {
+      throw resourceLimit(
+        `${boundedLabel(label)} discovery entries exceed ${this.config.maxResourceEntries}`,
+      );
+    }
+    this.entries += count;
+  }
+}
+
+function scanScopeResources(
+  budget: ResourceBudget,
+  baseDir: string,
+  settings: Record<string, unknown> | undefined,
+): void {
+  budget.scanDirectory(join(baseDir, "skills"), "skills");
+  budget.scanDirectory(join(baseDir, "prompts"), "prompts");
+  budget.scanDirectory(join(baseDir, "themes"), "themes");
+  budget.checkFile(join(baseDir, "SYSTEM.md"), "system prompt");
+  budget.checkFile(join(baseDir, "APPEND_SYSTEM.md"), "appended system prompt");
+
+  for (const mode of ["skills", "prompts", "themes"] as const) {
+    for (const configuredPath of stringEntries(settings?.[mode])) {
+      const base = fixedGlobPrefix(configuredPath);
+      if (!base) continue;
+      budget.scanPath(resolveConfiguredPath(base, baseDir), mode, true);
+    }
+  }
+  for (const configuredPath of stringEntries(settings?.extensions)) {
+    const base = fixedGlobPrefix(configuredPath);
+    if (!base) continue;
+    budget.scanExtensionDiscovery(
+      resolveConfiguredPath(base, baseDir),
+      containsGlob(configuredPath),
+    );
+  }
+  for (const pkg of arrayEntries(settings?.packages)) {
+    const source = packageSource(pkg);
+    if (source === undefined) continue;
+    const classified = classifyPackageSource(source);
+    if (classified.type !== "local") continue;
+    scanPackageRoot(budget, resolveConfiguredPath(classified.path, baseDir));
+  }
+}
+
+function scanContextFiles(
+  budget: ResourceBudget,
+  cwd: string,
+  agentDir: string,
+): void {
+  checkFirstContextFile(budget, agentDir);
+  let current = cwd;
+  while (true) {
+    checkFirstContextFile(budget, current);
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+}
+
+function checkFirstContextFile(budget: ResourceBudget, dir: string): void {
+  for (const name of ["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]) {
+    const path = join(dir, name);
+    if (!existsSync(path)) continue;
+    if (budget.checkFile(path, "context file")) return;
+  }
+}
+
+function scanExtensionManifests(budget: ResourceBudget, root: string): void {
+  checkIgnoreManifests(budget, root, "extension ignore manifest");
+  budget.readJson(join(root, "package.json"), "extension manifest");
+  for (const name of budget.listDirectory(root, "extension discovery")) {
+    const child = join(root, name);
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(child);
+    } catch {
+      continue;
+    }
+    if (stats.isDirectory()) {
+      budget.readJson(join(child, "package.json"), "extension manifest");
+    }
+  }
+}
+
+function checkIgnoreManifests(
+  budget: ResourceBudget,
+  dir: string,
+  label: string,
+): void {
+  for (const name of [".gitignore", ".ignore", ".fdignore"]) {
+    budget.checkFile(join(dir, name), label);
+  }
+}
+
+function scanManagedPackages(
+  budget: ResourceBudget,
+  baseDir: string,
+  settings: Record<string, unknown> | undefined,
+  allowLegacyGlobal: boolean,
+): void {
+  const npmRoot = join(baseDir, "npm", "node_modules");
+  for (const name of configuredNpmPackageNames(settings)) {
+    const managedPath = join(npmRoot, name);
+    if (existsSync(managedPath)) {
+      scanPackageRoot(budget, managedPath);
+      continue;
+    }
+    if (!allowLegacyGlobal) continue;
+    const legacyPath = resolveLegacyGlobalNpmPackage(name, settings);
+    if (legacyPath) scanPackageRoot(budget, legacyPath);
+  }
+  for (const root of configuredGitPackageRoots(settings, baseDir)) {
+    scanPackageRoot(budget, root);
+  }
+}
+
+function configuredNpmPackageNames(
+  settings: Record<string, unknown> | undefined,
+): string[] {
+  const names = new Set<string>();
+  for (const pkg of arrayEntries(settings?.packages)) {
+    const source = packageSource(pkg);
+    if (source === undefined) continue;
+    const classified = classifyPackageSource(source);
+    if (classified.type === "npm" && classified.name)
+      names.add(classified.name);
+  }
+  return [...names];
+}
+
+function configuredGitPackageRoots(
+  settings: Record<string, unknown> | undefined,
+  baseDir: string,
+): string[] {
+  const roots = new Set<string>();
+  for (const pkg of arrayEntries(settings?.packages)) {
+    const source = packageSource(pkg);
+    if (source === undefined) continue;
+    const classified = classifyPackageSource(source);
+    if (classified.type === "git") {
+      roots.add(join(baseDir, "git", classified.host, classified.path));
+    }
+  }
+  return [...roots];
+}
+
+/**
+ * Match Pi 0.83's source ordering: npm first, then known-local syntax, then
+ * supported Git syntax, with every unrecognized value falling back to a path
+ * relative to the package's settings scope. The trim is also the one Pi uses
+ * when it resolves local package paths.
+ */
+function classifyPackageSource(source: string): ClassifiedPackageSource {
+  const trimmed = source.trim();
+  // Pi checks npm against the original string before any path normalization.
+  // A leading-space ` npm:foo` therefore falls through to a scope-relative
+  // local path, while `npm:foo ` remains a managed npm package.
+  if (source.startsWith("npm:")) {
+    return { type: "npm", name: parseNpmPackageName(trimmed) };
+  }
+  if (isPiLocalPackagePath(trimmed)) {
+    return { type: "local", path: trimmed };
+  }
+  const git = parseManagedGitLocation(trimmed);
+  return git ? { type: "git", ...git } : { type: "local", path: trimmed };
+}
+
+function parseNpmPackageName(source: string): string | undefined {
+  const spec = source.slice("npm:".length).trim();
+  let name = spec;
+  if (spec.startsWith("@")) {
+    const versionSeparator = spec.indexOf("@", spec.indexOf("/") + 1);
+    if (versionSeparator >= 0) name = spec.slice(0, versionSeparator);
+  } else {
+    const versionSeparator = spec.indexOf("@");
+    if (versionSeparator >= 0) name = spec.slice(0, versionSeparator);
+  }
+  return name &&
+    !name.includes("..") &&
+    !name.includes("\\") &&
+    !isAbsolute(name)
+    ? name
+    : undefined;
+}
+
+function parseManagedGitLocation(
+  source: string,
+): { host: string; path: string } | undefined {
+  const trimmed = source.trim();
+  const explicitGit = trimmed.startsWith("git:");
+  const value = explicitGit ? trimmed.slice(4).trim() : trimmed;
+  if (!explicitGit && !/^(https?|ssh|git):\/\//iu.test(value)) return undefined;
+
+  const hosted = parseHostedGitLocation(value);
+  if (hosted) return validateManagedGitLocation(hosted.host, hosted.path);
+
+  let host: string;
+  let path: string;
+  const scp = value.match(/^git@([^:]+):(.+)$/u);
+  if (scp) {
+    host = scp[1] ?? "";
+    path = scp[2] ?? "";
+  } else if (/^(https?|ssh|git):\/\//iu.test(value)) {
+    try {
+      const url = new URL(value);
+      host = url.hostname;
+      path = url.pathname.replace(/^\/+/, "");
+    } catch {
+      return undefined;
+    }
+  } else {
+    const slash = value.indexOf("/");
+    if (slash < 0) return undefined;
+    host = value.slice(0, slash);
+    path = value.slice(slash + 1);
+    if (!host.includes(".") && host !== "localhost") return undefined;
+  }
+  const refSeparator = path.indexOf("@");
+  if (refSeparator >= 0) path = path.slice(0, refSeparator);
+  return validateManagedGitLocation(host, path);
+}
+
+function parseHostedGitLocation(
+  value: string,
+): { host: string; path: string } | undefined {
+  const shorthand = value.match(/^(github|gitlab|bitbucket|gist):(.+)$/iu);
+  if (shorthand) {
+    const service = shorthand[1]?.toLowerCase();
+    const host =
+      service === "github"
+        ? "github.com"
+        : service === "gitlab"
+          ? "gitlab.com"
+          : service === "bitbucket"
+            ? "bitbucket.org"
+            : "gist.github.com";
+    return { host, path: stripHostedGitReference(shorthand[2] ?? "") };
+  }
+
+  const scp = value.match(/^git@([^:]+):(.+)$/u);
+  if (scp && isHostedGitDomain(scp[1] ?? "")) {
+    return {
+      host: scp[1] ?? "",
+      path: stripHostedGitReference(scp[2] ?? ""),
+    };
+  }
+
+  if (/^[a-z][a-z+.-]*:\/\//iu.test(value)) {
+    try {
+      const url = new URL(value);
+      if (isHostedGitDomain(url.hostname)) {
+        return {
+          host: url.hostname,
+          path: stripHostedGitReference(url.pathname.replace(/^\/+/, "")),
+        };
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  const slash = value.indexOf("/");
+  if (slash >= 0) {
+    const host = value.slice(0, slash);
+    if (isHostedGitDomain(host)) {
+      return {
+        host,
+        path: stripHostedGitReference(value.slice(slash + 1)),
+      };
+    }
+  }
+
+  // hosted-git-info treats the historical `git:user/repo` shortcut as a
+  // GitHub repository. More deeply nested bare values are generic Git paths.
+  const shortcut = stripHostedGitReference(value).split("/");
+  if (shortcut.length === 2 && shortcut.every(Boolean)) {
+    return { host: "github.com", path: shortcut.join("/") };
+  }
+  return undefined;
+}
+
+function stripHostedGitReference(path: string): string {
+  const hashSeparator = path.indexOf("#");
+  const withoutHash = hashSeparator >= 0 ? path.slice(0, hashSeparator) : path;
+  const slash = withoutHash.indexOf("/");
+  const atSeparator = withoutHash.indexOf("@", slash + 1);
+  return atSeparator >= 0 ? withoutHash.slice(0, atSeparator) : withoutHash;
+}
+
+function isHostedGitDomain(host: string): boolean {
+  return (
+    host === "github.com" ||
+    host === "gitlab.com" ||
+    host === "bitbucket.org" ||
+    host === "gist.github.com"
+  );
+}
+
+function validateManagedGitLocation(
+  host: string,
+  rawPath: string,
+): { host: string; path: string } | undefined {
+  const path = rawPath.replace(/\.git$/u, "").replace(/^\/+/, "");
+  if (
+    !host ||
+    path.split("/").length < 2 ||
+    hasUnsafeGitInstallPart(host, false) ||
+    hasUnsafeGitInstallPart(path, true)
+  ) {
+    return undefined;
+  }
+  return { host, path };
+}
+
+function hasUnsafeGitInstallPart(value: string, allowSlash: boolean): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return true;
+  }
+  for (const candidate of [value, decoded]) {
+    if (
+      candidate.includes("\0") ||
+      candidate.includes("\\") ||
+      candidate.startsWith("/") ||
+      (!allowSlash && candidate.includes("/")) ||
+      candidate.split("/").includes("..")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveLegacyGlobalNpmPackage(
+  packageName: string,
+  settings: Record<string, unknown> | undefined,
+): string | undefined {
+  const configured = stringEntries(settings?.npmCommand);
+  const command = configured[0] ?? "npm";
+  const prefixArgs = configured.slice(1);
+  const commandParts = [command, ...prefixArgs];
+  const separator = commandParts.lastIndexOf("--");
+  const packageManagerCommand =
+    separator >= 0 ? commandParts[separator + 1] : command;
+  const packageManager = packageManagerCommand
+    ? basename(packageManagerCommand).replace(/\.(cmd|exe)$/iu, "")
+    : "";
+  try {
+    if (packageManager === "pnpm") {
+      const output = runPackageManager(command, prefixArgs, [
+        "list",
+        "-g",
+        "--depth",
+        "0",
+        "--json",
+      ]);
+      const parsed: unknown = JSON.parse(output);
+      if (!Array.isArray(parsed)) return undefined;
+      for (const entry of parsed) {
+        if (!isRecord(entry) || !isRecord(entry.dependencies)) continue;
+        const dependency = entry.dependencies[packageName];
+        if (isRecord(dependency) && typeof dependency.path === "string") {
+          return resolve(dependency.path);
+        }
+      }
+      return undefined;
+    }
+    if (packageManager === "bun") {
+      const binDir = runPackageManager(command, prefixArgs, [
+        "pm",
+        "bin",
+        "-g",
+      ]).trim();
+      return binDir
+        ? join(
+            dirname(resolve(binDir)),
+            "install",
+            "global",
+            "node_modules",
+            packageName,
+          )
+        : undefined;
+    }
+    const root = runPackageManager(command, prefixArgs, ["root", "-g"]).trim();
+    return root ? join(resolve(root), packageName) : undefined;
+  } catch {
+    // Pi also treats an unavailable legacy root as missing and may install the
+    // configured package into its managed store. The post-load fingerprint
+    // comparison then requires a fresh session for that new generation.
+    return undefined;
+  }
+}
+
+function runPackageManager(
+  command: string,
+  prefixArgs: string[],
+  args: string[],
+): string {
+  return execFileSync(command, [...prefixArgs, ...args], {
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 1 * 1_024 * 1_024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+function scanPackageRoot(budget: ResourceBudget, root: string): void {
+  const manifest = budget.readJson(
+    join(root, "package.json"),
+    "package manifest",
+  );
+  checkIgnoreManifests(budget, root, "package ignore manifest");
+  const pi = isRecord(manifest?.pi) ? manifest.pi : undefined;
+  const configuredExtensions = stringEntries(pi?.extensions);
+  if (configuredExtensions.length === 0) {
+    budget.scanExtensionDiscovery(join(root, "extensions"), false);
+  } else {
+    for (const entry of configuredExtensions) {
+      const prefix = fixedGlobPrefix(entry);
+      if (prefix) {
+        budget.scanExtensionDiscovery(
+          resolve(prefix, root),
+          containsGlob(entry),
+        );
+      }
+    }
+  }
+  for (const mode of ["skills", "prompts", "themes"] as const) {
+    const configured = stringEntries(pi?.[mode]);
+    if (configured.length === 0) {
+      budget.scanDirectory(join(root, mode), mode, true);
+      continue;
+    }
+    for (const entry of configured) {
+      const prefix = fixedGlobPrefix(entry);
+      if (prefix) budget.scanPath(resolve(prefix, root), mode, true);
+    }
+  }
+}
+
+function ancestorAgentsSkillDirs(cwd: string): string[] {
+  const result: string[] = [];
+  let current = cwd;
+  while (true) {
+    const path = join(current, ".agents", "skills");
+    if (existsSync(path)) result.push(path);
+    const parent = dirname(current);
+    if (parent === current) return result;
+    current = parent;
+  }
+}
+
+function fixedGlobPrefix(path: string): string | undefined {
+  if (path.startsWith("!") || path.startsWith("+") || path.startsWith("-")) {
+    return undefined;
+  }
+  const wildcard = path.search(/[?*[{]/);
+  if (wildcard < 0) return path;
+  const prefix = path.slice(0, wildcard);
+  const slash = Math.max(prefix.lastIndexOf("/"), prefix.lastIndexOf("\\"));
+  return slash < 0 ? "." : prefix.slice(0, slash) || ".";
+}
+
+function containsGlob(path: string): boolean {
+  return /[?*[{]/u.test(path);
+}
+
+function resolveConfiguredPath(path: string, baseDir: string): string {
+  const trimmed = path.trim();
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  const normalized = trimmed.startsWith("file://")
+    ? fileURLToPath(trimmed)
+    : trimmed;
+  return isAbsolute(normalized)
+    ? resolve(normalized)
+    : resolve(baseDir, normalized);
+}
+
+function isPiLocalPackagePath(source: string): boolean {
+  return !(
+    source.startsWith("npm:") ||
+    source.startsWith("git:") ||
+    source.startsWith("github:") ||
+    source.startsWith("http:") ||
+    source.startsWith("https:") ||
+    source.startsWith("ssh:")
+  );
+}
+
+function packageSource(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  return isRecord(value) && typeof value.source === "string"
+    ? value.source
+    : undefined;
+}
+
+function arrayEntries(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringEntries(value: unknown): string[] {
+  return arrayEntries(value).filter(
+    (entry): entry is string => typeof entry === "string",
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resourceLabel(mode: ResourceMode): string {
+  if (mode === "skills") return "skill";
+  if (mode === "prompts") return "prompt";
+  return "theme";
+}
+
+function boundedLabel(label: string): string {
+  return label.replaceAll(/[^a-zA-Z0-9 _-]/g, "").slice(0, 64) || "resource";
+}
+
+function captureResourceFile(
+  path: string,
+  label: string,
+  maxBytes: number,
+): { fingerprint: ResourceFileFingerprint; content: Buffer } | undefined {
+  let canonicalPath: string;
+  try {
+    canonicalPath = realpathSync.native(path);
+  } catch {
+    return undefined;
+  }
+
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      canonicalPath,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+    const before = fstatSync(descriptor, { bigint: true });
+    if (!before.isFile()) return undefined;
+    if (before.size > BigInt(maxBytes)) {
+      throw resourceLimit(
+        `${boundedLabel(label)} exceeds the per-file limit (${before.size.toString()} > ${maxBytes} bytes)`,
+      );
+    }
+    const expectedBytes = Number(before.size);
+    const content = Buffer.allocUnsafe(expectedBytes + 1);
+    let bytesRead = 0;
+    while (bytesRead < content.length) {
+      const count = readSync(
+        descriptor,
+        content,
+        bytesRead,
+        content.length - bytesRead,
+        null,
+      );
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    const after = fstatSync(descriptor, { bigint: true });
+    const verifiedCanonicalPath = realpathSync.native(path);
+    const pathStats = statSync(verifiedCanonicalPath, { bigint: true });
+    if (
+      bytesRead !== expectedBytes ||
+      verifiedCanonicalPath !== canonicalPath ||
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.dev !== pathStats.dev ||
+      before.ino !== pathStats.ino ||
+      before.size !== after.size ||
+      before.size !== pathStats.size ||
+      before.mtimeNs !== after.mtimeNs ||
+      before.mtimeNs !== pathStats.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs ||
+      before.ctimeNs !== pathStats.ctimeNs
+    ) {
+      throw resourceChanged("a non-code resource changed while it was read");
+    }
+    const boundedContent = content.subarray(0, bytesRead);
+    return {
+      fingerprint: {
+        path,
+        canonicalPath,
+        device: before.dev.toString(),
+        inode: before.ino.toString(),
+        size: expectedBytes,
+        mtimeNs: before.mtimeNs.toString(),
+        ctimeNs: before.ctimeNs.toString(),
+        sha256: createHash("sha256").update(boundedContent).digest("hex"),
+      },
+      content: boundedContent,
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.message.startsWith("BUZZ_PI_RESOURCE_LIMIT:") ||
+        error.message.startsWith("BUZZ_PI_RESOURCE_CHANGED:"))
+    ) {
+      throw error;
+    }
+    return undefined;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function sameFingerprint(
+  left: ResourceFileFingerprint,
+  right: ResourceFileFingerprint,
+): boolean {
+  return (
+    left.path === right.path &&
+    left.canonicalPath === right.canonicalPath &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.sha256 === right.sha256
+  );
+}
+
+function resourceLimit(message: string): Error {
+  return new Error(`BUZZ_PI_RESOURCE_LIMIT: ${message.slice(0, 448)}`);
+}
+
+function resourceChanged(message: string): Error {
+  return new Error(`BUZZ_PI_RESOURCE_CHANGED: ${message.slice(0, 448)}`);
+}

--- a/packages/buzz-pi-agent/src/runtime-host-protocol.ts
+++ b/packages/buzz-pi-agent/src/runtime-host-protocol.ts
@@ -1,0 +1,80 @@
+import type {
+  BuzzSessionEvent,
+  ContextSnapshot,
+  ModelDescriptor,
+  ResourceSnapshot,
+  SessionUsageSnapshot,
+} from "./types.js";
+
+export interface RuntimeSessionState {
+  piSessionId: string;
+  sessionFile?: string;
+  cwd: string;
+  isBusy: boolean;
+  models: ModelDescriptor[];
+  thinkingLevels: string[];
+  context: ContextSnapshot;
+  usage: SessionUsageSnapshot;
+}
+
+export interface RuntimeHostRequest {
+  type: "request";
+  id: number;
+  method:
+    | "create"
+    | "prompt"
+    | "steer"
+    | "abort"
+    | "setModel"
+    | "setThinkingLevel"
+    | "reload"
+    | "reset"
+    | "replayLifecycle"
+    | "ackLifecycle"
+    | "dispose"
+    | "shutdown";
+  sessionId?: string;
+  params?: Record<string, unknown>;
+}
+
+export interface RuntimeHostResponse {
+  type: "response";
+  id: number;
+  ok: boolean;
+  result?: unknown;
+  state?: RuntimeSessionState;
+  error?: {
+    message: string;
+    stack?: string;
+  };
+}
+
+export type RuntimeHostEvent =
+  | {
+      type: "event";
+      sessionId: string;
+      eventType: "session_update";
+      payload: Record<string, unknown>;
+    }
+  | {
+      type: "event";
+      sessionId: string;
+      eventType: "buzz_session_event";
+      deliveryId?: string;
+      payload: BuzzSessionEvent;
+    }
+  | {
+      type: "event";
+      sessionId: string;
+      eventType: "usage_update";
+      payload: {
+        usage: SessionUsageSnapshot;
+        contextLimit: number;
+      };
+    };
+
+export type RuntimeHostMessage = RuntimeHostResponse | RuntimeHostEvent;
+
+export interface CreateRuntimeResult {
+  resources: ResourceSnapshot;
+}

--- a/packages/buzz-pi-agent/src/runtime-host.ts
+++ b/packages/buzz-pi-agent/src/runtime-host.ts
@@ -1,0 +1,380 @@
+import { loadConfig } from "./config.js";
+import { BoundedIpcSendQueue } from "./ipc-send-queue.js";
+import { createLogger } from "./logger.js";
+import { PiAgentSessionFactory } from "./pi-runtime.js";
+import type {
+  CreateRuntimeResult,
+  RuntimeHostEvent,
+  RuntimeHostRequest,
+  RuntimeHostResponse,
+  RuntimeSessionState,
+} from "./runtime-host-protocol.js";
+import type {
+  AcpImageBlock,
+  AdapterEventSink,
+  AgentSessionHandle,
+  CreateSessionOptions,
+} from "./types.js";
+
+export class PerKeyRequestQueue {
+  private readonly queues = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const prior = this.queues.get(key) ?? Promise.resolve();
+    let resolveCurrent: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      resolveCurrent = resolve;
+    });
+    this.queues.set(key, current);
+    await prior.catch(() => {});
+    try {
+      return await operation();
+    } finally {
+      resolveCurrent();
+      if (this.queues.get(key) === current) this.queues.delete(key);
+    }
+  }
+}
+
+export async function runRuntimeHost(): Promise<void> {
+  if (!process.send)
+    throw new Error("runtime host must be started with an IPC channel");
+  const config = loadConfig();
+  const logger = createLogger(config.logLevel);
+  const factory = new PiAgentSessionFactory(config, logger);
+  const sessions = new Map<string, AgentSessionHandle>();
+  const sessionQueues = new PerKeyRequestQueue();
+  let shuttingDown = false;
+
+  const disposeAll = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await Promise.allSettled(
+      [...sessions.values()].map(async (session) => {
+        if (session.isBusy) await session.abort();
+        await session.dispose();
+      }),
+    );
+    sessions.clear();
+  };
+
+  let transportFailed = false;
+  const failTransport = (error: Error): void => {
+    if (transportFailed) return;
+    transportFailed = true;
+    logger.error("Pi runtime IPC transport poisoned", {
+      error: error.message,
+    });
+    void disposeAll().finally(() => process.exit(1));
+  };
+  const sender = new BoundedIpcSendQueue<
+    RuntimeHostResponse | RuntimeHostEvent
+  >(
+    (message, callback) => {
+      if (!process.connected || !process.send) {
+        callback(new Error("Pi runtime IPC channel is disconnected"));
+        return false;
+      }
+      return process.send(message, callback);
+    },
+    config.maxRuntimeIpcQueueMessages,
+    config.maxRuntimeIpcQueueBytes,
+    failTransport,
+  );
+  const send = (message: RuntimeHostResponse | RuntimeHostEvent): void => {
+    sender.enqueue(message);
+  };
+
+  const retireInvalidSession = async (
+    sessionId: string,
+    session: AgentSessionHandle,
+    cause: unknown,
+  ): Promise<Error> => {
+    sessions.delete(sessionId);
+    await session.dispose().catch((error: unknown) => {
+      logger.error("failed to dispose invalidated Pi runtime session", {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    if (causeMessage.startsWith("BUZZ_PI_SESSION_INVALIDATED:")) {
+      return cause instanceof Error ? cause : new Error(causeMessage);
+    }
+    return new Error(
+      "BUZZ_PI_SESSION_INVALIDATED: Pi resource generation failed; create a fresh session",
+      { cause },
+    );
+  };
+
+  const sink: AdapterEventSink = {
+    sessionUpdate(sessionId, update) {
+      send({
+        type: "event",
+        sessionId,
+        eventType: "session_update",
+        payload: update,
+      });
+    },
+    buzzSessionEvent(sessionId, event, deliveryId) {
+      send({
+        type: "event",
+        sessionId,
+        eventType: "buzz_session_event",
+        ...(deliveryId === undefined ? {} : { deliveryId }),
+        payload: event,
+      });
+    },
+    usageUpdate(sessionId, usage, contextLimit) {
+      send({
+        type: "event",
+        sessionId,
+        eventType: "usage_update",
+        payload: { usage, contextLimit },
+      });
+    },
+  };
+
+  process.on("message", (raw: unknown) => {
+    if (!isRuntimeHostRequest(raw)) return;
+    void dispatch(raw).catch((error: unknown) => {
+      send({
+        type: "response",
+        id: raw.id,
+        ok: false,
+        error: serializeError(error),
+      });
+    });
+  });
+  process.on("disconnect", () => {
+    void disposeAll().finally(() => process.exit(0));
+  });
+  process.on("SIGTERM", () => {
+    void disposeAll().finally(() => process.exit(0));
+  });
+
+  async function handle(request: RuntimeHostRequest): Promise<void> {
+    if (request.method === "shutdown") {
+      await disposeAll();
+      send({
+        type: "response",
+        id: request.id,
+        ok: true,
+        result: { shutdown: true },
+      });
+      return;
+    }
+    if (shuttingDown) throw new Error("Pi runtime host is shutting down");
+    const sessionId = request.sessionId;
+    if (!sessionId) throw new Error(`${request.method} requires sessionId`);
+
+    if (request.method === "create") {
+      const prior = sessions.get(sessionId);
+      if (prior) {
+        // Remove ownership before teardown: even a broken extension dispose
+        // must not pin a dead same-ID session in the host map forever.
+        sessions.delete(sessionId);
+        await prior.dispose();
+      }
+      const params = request.params ?? {};
+      const systemPrompt = optionalString(params.systemPrompt);
+      const title = optionalString(params.title);
+      const requestedCwd = optionalString(params.requestedCwd);
+      const persistedSessionFile = optionalString(params.persistedSessionFile);
+      const options: CreateSessionOptions = {
+        acpSessionId: sessionId,
+        cwd: requiredString(params.cwd, "cwd"),
+        eventSink: sink,
+        ...(requestedCwd === undefined ? {} : { requestedCwd }),
+        ...(systemPrompt === undefined ? {} : { systemPrompt }),
+        ...(title === undefined ? {} : { title }),
+        ...(persistedSessionFile === undefined ? {} : { persistedSessionFile }),
+      };
+      const session = await factory.create(options);
+      sessions.set(sessionId, session);
+      const state = snapshot(session);
+      const result: CreateRuntimeResult = {
+        resources: session.getResources(),
+      };
+      send({
+        type: "response",
+        id: request.id,
+        ok: true,
+        result,
+        state,
+      });
+      return;
+    }
+
+    const session = sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown runtime session ${sessionId}`);
+    let result: unknown;
+    try {
+      switch (request.method) {
+        case "prompt":
+          result = await session.prompt(
+            requiredString(request.params?.text, "text"),
+            asImages(request.params?.images),
+          );
+          break;
+        case "steer":
+          await session.steer(requiredString(request.params?.text, "text"));
+          result = { steered: true };
+          break;
+        case "abort":
+          await session.abort();
+          result = { aborted: true };
+          break;
+        case "setModel":
+          await session.setModel(
+            requiredString(request.params?.modelId, "modelId"),
+          );
+          result = { changed: true };
+          break;
+        case "setThinkingLevel":
+          await session.setThinkingLevel(
+            requiredString(request.params?.level, "level"),
+          );
+          result = { changed: true };
+          break;
+        case "reload":
+          result = await session.reload();
+          break;
+        case "reset":
+          result = await session.reset();
+          break;
+        case "replayLifecycle":
+          await session.replayLifecycleEvents?.();
+          result = { replayed: true };
+          break;
+        case "ackLifecycle": {
+          const deliveryId = requiredString(
+            request.params?.deliveryId,
+            "deliveryId",
+          );
+          if (!session.acknowledgeLifecycleEvent) {
+            throw new Error(
+              "Pi runtime session does not support lifecycle acknowledgements",
+            );
+          }
+          await session.acknowledgeLifecycleEvent(deliveryId);
+          result = { acknowledged: true };
+          break;
+        }
+        case "dispose":
+          if (session.isBusy) await session.abort();
+          await session.dispose();
+          sessions.delete(sessionId);
+          send({
+            type: "response",
+            id: request.id,
+            ok: true,
+            result: { disposed: true },
+          });
+          return;
+        default:
+          throw new Error(
+            `Unsupported runtime host method ${request.method satisfies never}`,
+          );
+      }
+    } catch (error) {
+      if (!session.isValid) {
+        throw await retireInvalidSession(sessionId, session, error);
+      }
+      throw error;
+    }
+    if (!session.isValid) {
+      throw await retireInvalidSession(
+        sessionId,
+        session,
+        new Error("Pi resource generation became invalid"),
+      );
+    }
+    send({
+      type: "response",
+      id: request.id,
+      ok: true,
+      result,
+      state: snapshot(session),
+    });
+  }
+
+  async function dispatch(request: RuntimeHostRequest): Promise<void> {
+    // Steering and abort must be able to interrupt an active prompt. Every
+    // other state mutation is ordered per session; distinct sessions remain
+    // fully concurrent.
+    if (
+      request.method === "shutdown" ||
+      request.method === "abort" ||
+      request.method === "steer" ||
+      request.method === "dispose" ||
+      !request.sessionId
+    ) {
+      await handle(request);
+      return;
+    }
+    const sessionId = request.sessionId;
+    await sessionQueues.run(sessionId, () => handle(request));
+  }
+}
+
+function snapshot(session: AgentSessionHandle): RuntimeSessionState {
+  return {
+    piSessionId: session.piSessionId,
+    ...(session.sessionFile === undefined
+      ? {}
+      : { sessionFile: session.sessionFile }),
+    cwd: session.cwd,
+    isBusy: session.isBusy,
+    models: session.getModels(),
+    thinkingLevels: session.getThinkingLevels(),
+    context: session.getContextSnapshot(),
+    usage: session.getUsageSnapshot(),
+  };
+}
+
+function isRuntimeHostRequest(value: unknown): value is RuntimeHostRequest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "request" &&
+    "id" in value &&
+    typeof value.id === "number" &&
+    "method" in value &&
+    typeof value.method === "string"
+  );
+}
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function asImages(value: unknown): AcpImageBlock[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is AcpImageBlock =>
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      item.type === "image" &&
+      "data" in item &&
+      typeof item.data === "string" &&
+      "mimeType" in item &&
+      typeof item.mimeType === "string",
+  );
+}
+
+function serializeError(error: unknown): { message: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    message: message.length <= 2_000 ? message : `${message.slice(0, 2_000)}…`,
+  };
+}

--- a/packages/buzz-pi-agent/src/runtime-worker.ts
+++ b/packages/buzz-pi-agent/src/runtime-worker.ts
@@ -1,0 +1,685 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import type { AdapterConfig } from "./config.js";
+import { BoundedIpcSendQueue } from "./ipc-send-queue.js";
+import type {
+  CreateRuntimeResult,
+  RuntimeHostEvent,
+  RuntimeHostMessage,
+  RuntimeHostRequest,
+  RuntimeHostResponse,
+  RuntimeSessionState,
+} from "./runtime-host-protocol.js";
+import type {
+  AcpImageBlock,
+  AdapterEventSink,
+  AgentSessionFactory,
+  AgentSessionHandle,
+  ContextSnapshot,
+  CreateSessionOptions,
+  Logger,
+  ModelDescriptor,
+  ResourceSnapshot,
+  SessionUsageSnapshot,
+} from "./types.js";
+
+interface PendingRequest {
+  resolve: (response: RuntimeHostResponse) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  method: RuntimeHostRequest["method"];
+}
+
+interface WorkerRetirement {
+  child: ChildProcess;
+  exit: Promise<void>;
+  completion: Promise<void>;
+  confirmExit: () => void;
+  terminationTimer?: NodeJS.Timeout;
+  killTimer?: NodeJS.Timeout;
+}
+
+export class IsolatedPiWorkerFactory implements AgentSessionFactory {
+  private readonly client: RuntimeWorkerClient;
+
+  constructor(config: AdapterConfig, logger: Logger) {
+    this.client = new RuntimeWorkerClient(config, logger);
+  }
+
+  async create(options: CreateSessionOptions): Promise<AgentSessionHandle> {
+    const proxy = new RuntimeSessionProxy(
+      this.client,
+      options.acpSessionId,
+      options.eventSink,
+    );
+    this.client.register(proxy);
+    try {
+      const response = await this.client.request(
+        "create",
+        options.acpSessionId,
+        {
+          cwd: options.cwd,
+          ...(options.requestedCwd === undefined
+            ? {}
+            : { requestedCwd: options.requestedCwd }),
+          ...(options.systemPrompt === undefined
+            ? {}
+            : { systemPrompt: options.systemPrompt }),
+          ...(options.title === undefined ? {} : { title: options.title }),
+          ...(options.persistedSessionFile === undefined
+            ? {}
+            : { persistedSessionFile: options.persistedSessionFile }),
+        },
+      );
+      const result = response.result as CreateRuntimeResult;
+      if (!response.state) {
+        throw new Error("Pi runtime create response omitted session state");
+      }
+      proxy.applyState(response.state);
+      proxy.applyResources(result.resources);
+      return proxy;
+    } catch (error) {
+      this.client.unregister(options.acpSessionId);
+      throw error;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.client.shutdown();
+  }
+
+  setInvalidationHandler(
+    handler: (
+      sessionIds: readonly string[],
+      error: Error,
+    ) => void | Promise<void>,
+  ): void {
+    this.client.setInvalidationHandler(handler);
+  }
+}
+
+export class RuntimeWorkerClient {
+  private child: ChildProcess | undefined;
+  private childSender:
+    | {
+        child: ChildProcess;
+        queue: BoundedIpcSendQueue<RuntimeHostRequest>;
+      }
+    | undefined;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly sessions = new Map<string, RuntimeSessionProxy>();
+  private shuttingDown = false;
+  private shutdownPromise: Promise<void> | undefined;
+  private retirement: WorkerRetirement | undefined;
+  private invalidationHandler:
+    | ((sessionIds: readonly string[], error: Error) => void | Promise<void>)
+    | undefined;
+
+  constructor(
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+    private readonly spawnChild?: () => ChildProcess,
+  ) {}
+
+  register(proxy: RuntimeSessionProxy): void {
+    this.sessions.set(proxy.acpSessionId, proxy);
+  }
+
+  unregister(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  setInvalidationHandler(
+    handler: (
+      sessionIds: readonly string[],
+      error: Error,
+    ) => void | Promise<void>,
+  ): void {
+    this.invalidationHandler = handler;
+  }
+
+  async request(
+    method: RuntimeHostRequest["method"],
+    sessionId?: string,
+    params?: Record<string, unknown>,
+  ): Promise<RuntimeHostResponse> {
+    if (this.shuttingDown && method !== "shutdown") {
+      throw new Error("Pi runtime host is shutting down");
+    }
+    const child = await this.ensureChild();
+    const id = this.nextId++;
+    const request: RuntimeHostRequest = {
+      type: "request",
+      id,
+      method,
+      ...(sessionId === undefined ? {} : { sessionId }),
+      ...(params === undefined ? {} : { params }),
+    };
+    const timeoutMs = requestTimeoutMs(method, this.config);
+    const promise = new Promise<RuntimeHostResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        const error = new Error(`Pi runtime ${method} request timed out`);
+        this.handleChildFailure(child, error);
+      }, timeoutMs);
+      timer.unref();
+      this.pending.set(id, { resolve, reject, timer, method });
+    });
+    const sender = this.childSender;
+    if (!sender || sender.child !== child) {
+      this.handleChildFailure(
+        child,
+        new Error("Pi runtime IPC sender is unavailable"),
+      );
+    } else {
+      sender.queue.enqueue(request);
+    }
+    return promise;
+  }
+
+  shutdown(): Promise<void> {
+    this.shutdownPromise ??= this.shutdownInner();
+    return this.shutdownPromise;
+  }
+
+  private async shutdownInner(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.retirement) {
+      await this.retirement.completion;
+      return;
+    }
+    const child = this.child;
+    if (!child) return;
+    try {
+      await this.request("shutdown");
+      await this.beginChildRetirement(
+        child,
+        new Error("Pi runtime host shut down"),
+        false,
+        true,
+      );
+    } catch (error) {
+      this.logger.warn("forcing Pi runtime host shutdown", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await this.beginChildRetirement(
+        child,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  }
+
+  private async ensureChild(): Promise<ChildProcess> {
+    if (this.retirement) await this.retirement.completion;
+    if (this.child?.connected) return this.child;
+    if (this.shuttingDown) throw new Error("Pi runtime host is shutting down");
+    if (this.child) {
+      await this.beginChildRetirement(
+        this.child,
+        new Error("Pi runtime IPC channel disconnected before process exit"),
+      );
+      if (this.shuttingDown)
+        throw new Error("Pi runtime host is shutting down");
+    }
+    const child = this.spawnChild ? this.spawnChild() : spawnRuntimeHost();
+    child.stdout?.on("data", (chunk: Buffer) => {
+      process.stderr.write(
+        `[buzz-pi-runtime stdout] ${chunk.toString("utf8")}`,
+      );
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      process.stderr.write(`[buzz-pi-runtime] ${chunk.toString("utf8")}`);
+    });
+    child.on("message", (message: RuntimeHostMessage) =>
+      this.handleMessage(child, message),
+    );
+    child.on("error", (error) => this.handleChildFailure(child, error));
+    child.on("exit", (code, signal) => {
+      this.handleChildExit(child, code, signal);
+    });
+    this.child = child;
+    this.childSender = {
+      child,
+      queue: new BoundedIpcSendQueue<RuntimeHostRequest>(
+        (message, callback) => child.send(message, callback),
+        this.config.maxRuntimeIpcQueueMessages,
+        this.config.maxRuntimeIpcQueueBytes,
+        (error) => this.handleChildFailure(child, error),
+      ),
+    };
+    this.logger.info("started isolated Pi runtime host", {
+      pid: child.pid,
+      maxSessions: this.config.maxSessions,
+    });
+    return child;
+  }
+
+  private handleMessage(
+    child: ChildProcess,
+    message: RuntimeHostMessage,
+  ): void {
+    if (this.child !== child || this.retirement?.child === child) return;
+    if (message.type === "response") {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.ok) pending.resolve(message);
+      else
+        pending.reject(
+          new Error(message.error?.message ?? "Pi runtime host request failed"),
+        );
+      return;
+    }
+    const proxy = this.sessions.get(message.sessionId);
+    if (!proxy) return;
+    void proxy.handleEvent(message).catch((error: unknown) => {
+      this.handleChildFailure(
+        child,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private handleChildFailure(child: ChildProcess, error: Error): void {
+    if (this.child !== child) return;
+    void this.beginChildRetirement(child, error, child.pid === undefined);
+  }
+
+  private handleChildExit(
+    child: ChildProcess,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    if (this.retirement?.child === child) {
+      this.retirement.confirmExit();
+      return;
+    }
+    if (this.child !== child) return;
+    void this.beginChildRetirement(
+      child,
+      new Error(
+        `Pi runtime host exited (code=${code ?? "none"}, signal=${signal ?? "none"})`,
+      ),
+      true,
+    );
+  }
+
+  private beginChildRetirement(
+    child: ChildProcess,
+    error: Error,
+    alreadyExited = false,
+    graceful = false,
+  ): Promise<void> {
+    if (this.retirement?.child === child) return this.retirement.completion;
+    if (this.child !== child) return Promise.resolve();
+
+    this.childSender = undefined;
+    // Freeze request deadlines while the generation is fenced. Requests are
+    // rejected only after confirmed process exit, so callers cannot release a
+    // conversation lease or spawn a replacement while old Pi code can write.
+    for (const pending of this.pending.values()) clearTimeout(pending.timer);
+
+    let exited = false;
+    let resolveExit: () => void = () => {};
+    const exit = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+    const retirement: WorkerRetirement = {
+      child,
+      exit,
+      completion: Promise.resolve(),
+      confirmExit: () => {
+        if (exited) return;
+        exited = true;
+        resolveExit();
+      },
+    };
+    this.retirement = retirement;
+
+    const proxies = [...this.sessions.values()];
+    const sessionIds = proxies.map((proxy) => proxy.acpSessionId);
+    for (const proxy of proxies) proxy.invalidate(error, exit);
+    this.sessions.clear();
+
+    retirement.completion = (async () => {
+      await exit;
+      if (retirement.terminationTimer)
+        clearTimeout(retirement.terminationTimer);
+      if (retirement.killTimer) clearTimeout(retirement.killTimer);
+      if (this.child === child) this.child = undefined;
+      if (child.connected) {
+        try {
+          child.disconnect();
+        } catch {
+          // The process exit is already confirmed; a closed IPC channel is OK.
+        }
+      }
+      this.rejectAllPending(error);
+      if (sessionIds.length > 0) {
+        try {
+          await this.invalidationHandler?.(sessionIds, error);
+        } catch (handlerError) {
+          this.logger.error("Pi runtime invalidation handler failed", {
+            error:
+              handlerError instanceof Error
+                ? handlerError.message
+                : String(handlerError),
+          });
+        }
+      }
+      if (this.retirement === retirement) this.retirement = undefined;
+    })();
+
+    if (alreadyExited) {
+      retirement.confirmExit();
+      return retirement.completion;
+    }
+
+    const graceMs = this.config.runtimeInterruptTimeoutMs;
+    const forceKill = (): void => {
+      if (exited) return;
+      this.logger.warn("Pi runtime host ignored SIGTERM; sending SIGKILL", {
+        pid: child.pid,
+      });
+      this.signalChild(child, "SIGKILL");
+    };
+    const terminate = (): void => {
+      if (exited) return;
+      this.signalChild(child, "SIGTERM");
+      retirement.killTimer = setTimeout(forceKill, graceMs);
+      retirement.killTimer.unref();
+    };
+    if (graceful) {
+      if (child.connected) {
+        try {
+          child.disconnect();
+        } catch {
+          // Escalation below remains authoritative.
+        }
+      }
+      retirement.terminationTimer = setTimeout(terminate, graceMs);
+      retirement.terminationTimer.unref();
+    } else {
+      terminate();
+    }
+    return retirement.completion;
+  }
+
+  private signalChild(child: ChildProcess, signal: NodeJS.Signals): void {
+    try {
+      child.kill(signal);
+    } catch (signalError) {
+      this.logger.warn("failed to signal Pi runtime host", {
+        pid: child.pid,
+        signal,
+        error:
+          signalError instanceof Error
+            ? signalError.message
+            : String(signalError),
+      });
+    }
+  }
+}
+
+function spawnRuntimeHost(): ChildProcess {
+  const cliPath = fileURLToPath(new URL("./cli.js", import.meta.url));
+  return fork(cliPath, ["--runtime-host"], {
+    env: { ...process.env, BUZZ_PI_RUNTIME_HOST: "1" },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    serialization: "advanced",
+  });
+}
+
+export class RuntimeSessionProxy implements AgentSessionHandle {
+  private state: RuntimeSessionState | undefined;
+  private resources: ResourceSnapshot | undefined;
+  private busy = false;
+  private disposed = false;
+  private disposePromise: Promise<void> | undefined;
+  private failure: Error | undefined;
+  private retirementFence: Promise<void> | undefined;
+  private readonly eventTasks = new Set<Promise<void>>();
+
+  constructor(
+    private readonly client: RuntimeWorkerClient,
+    readonly acpSessionId: string,
+    private readonly sink: AdapterEventSink,
+  ) {}
+
+  get piSessionId(): string {
+    return this.requireState().piSessionId;
+  }
+
+  get sessionFile(): string | undefined {
+    return this.requireState().sessionFile;
+  }
+
+  get cwd(): string {
+    return this.requireState().cwd;
+  }
+
+  get isBusy(): boolean {
+    return this.busy || (this.state?.isBusy ?? false);
+  }
+
+  get isValid(): boolean {
+    return !this.disposed && this.failure === undefined;
+  }
+
+  async prompt(
+    text: string,
+    images: AcpImageBlock[] = [],
+  ): Promise<"end_turn" | "cancelled" | "max_tokens"> {
+    this.busy = true;
+    try {
+      const response = await this.invoke("prompt", { text, images });
+      await this.drainEventTasks();
+      return response.result as "end_turn" | "cancelled" | "max_tokens";
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async steer(text: string): Promise<void> {
+    await this.invoke("steer", { text });
+  }
+
+  async abort(): Promise<void> {
+    if (this.disposed) return;
+    await this.invoke("abort");
+    this.busy = false;
+  }
+
+  async setModel(modelId: string): Promise<void> {
+    await this.invoke("setModel", { modelId });
+  }
+
+  async setThinkingLevel(level: string): Promise<void> {
+    await this.invoke("setThinkingLevel", { level });
+  }
+
+  async reload(): Promise<ResourceSnapshot> {
+    const response = await this.invoke("reload");
+    const resources = response.result as ResourceSnapshot;
+    this.applyResources(resources);
+    return resources;
+  }
+
+  async reset(): Promise<{
+    previousPiSessionId: string;
+    resources: ResourceSnapshot;
+  }> {
+    const response = await this.invoke("reset");
+    const result = response.result as {
+      previousPiSessionId: string;
+      resources: ResourceSnapshot;
+    };
+    this.applyResources(result.resources);
+    return result;
+  }
+
+  async replayLifecycleEvents(): Promise<void> {
+    await this.invoke("replayLifecycle");
+    await this.drainEventTasks();
+  }
+
+  getModels(): ModelDescriptor[] {
+    return [...this.requireState().models];
+  }
+
+  getThinkingLevels(): string[] {
+    return [...this.requireState().thinkingLevels];
+  }
+
+  getResources(): ResourceSnapshot {
+    if (!this.resources)
+      throw new Error("Pi runtime resources have not initialized");
+    return structuredClone(this.resources);
+  }
+
+  getContextSnapshot(): ContextSnapshot {
+    return { ...this.requireState().context };
+  }
+
+  getUsageSnapshot(): SessionUsageSnapshot {
+    return { ...this.requireState().usage };
+  }
+
+  dispose(): Promise<void> {
+    this.disposePromise ??= this.disposeInner();
+    return this.disposePromise;
+  }
+
+  private async disposeInner(): Promise<void> {
+    try {
+      // A worker failure prevents new RPCs but does not erase already-buffered
+      // lifecycle handoffs. Drain them into the parent outbox before registry
+      // identity is retired, even when the child can no longer be disposed.
+      await this.drainEventTasks();
+      if (!this.failure) {
+        this.disposed = true;
+        await this.invoke("dispose");
+      }
+    } finally {
+      this.disposed = true;
+      await this.retirementFence;
+      this.client.unregister(this.acpSessionId);
+    }
+  }
+
+  applyState(state: RuntimeSessionState): void {
+    this.state = state;
+  }
+
+  applyResources(resources: ResourceSnapshot): void {
+    this.resources = structuredClone(resources);
+  }
+
+  handleEvent(event: RuntimeHostEvent): Promise<void> {
+    if (!this.isValid) return Promise.resolve();
+    const task = this.handleEventInner(event);
+    this.eventTasks.add(task);
+    void task.then(
+      () => this.eventTasks.delete(task),
+      () => this.eventTasks.delete(task),
+    );
+    return task;
+  }
+
+  private async handleEventInner(event: RuntimeHostEvent): Promise<void> {
+    if (event.eventType === "session_update") {
+      this.sink.sessionUpdate(this.acpSessionId, event.payload);
+    } else if (event.eventType === "buzz_session_event") {
+      await this.sink.buzzSessionEvent(
+        this.acpSessionId,
+        event.payload,
+        event.deliveryId,
+      );
+      if (event.deliveryId !== undefined) {
+        await this.invoke("ackLifecycle", { deliveryId: event.deliveryId });
+      }
+    } else {
+      this.sink.usageUpdate(
+        this.acpSessionId,
+        event.payload.usage,
+        event.payload.contextLimit,
+      );
+    }
+  }
+
+  private async drainEventTasks(): Promise<void> {
+    const failures: unknown[] = [];
+    while (this.eventTasks.size > 0) {
+      const results = await Promise.allSettled([...this.eventTasks]);
+      for (const result of results) {
+        if (result.status === "rejected") failures.push(result.reason);
+      }
+    }
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        "Pi runtime lifecycle handoff encountered multiple failures",
+      );
+    }
+  }
+
+  private async invoke(
+    method: RuntimeHostRequest["method"],
+    params?: Record<string, unknown>,
+  ): Promise<RuntimeHostResponse> {
+    if (this.disposed && method !== "dispose")
+      throw new Error("Pi runtime session is disposed");
+    if (this.failure) throw this.failure;
+    let response: RuntimeHostResponse;
+    try {
+      response = await this.client.request(method, this.acpSessionId, params);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.startsWith("BUZZ_PI_SESSION_INVALIDATED:")
+      ) {
+        this.failure = error;
+        this.busy = false;
+        this.client.unregister(this.acpSessionId);
+      }
+      throw error;
+    }
+    if (response.state) this.applyState(response.state);
+    return response;
+  }
+
+  private requireState(): RuntimeSessionState {
+    if (this.failure) throw this.failure;
+    if (!this.state) throw new Error("Pi runtime session has not initialized");
+    return this.state;
+  }
+
+  invalidate(error: Error, retirementFence: Promise<void>): void {
+    this.failure = error;
+    this.retirementFence = retirementFence;
+    this.busy = false;
+  }
+}
+
+export function requestTimeoutMs(
+  method: RuntimeHostRequest["method"],
+  config: AdapterConfig,
+): number {
+  if (method === "prompt") return config.runtimeRequestTimeoutMs;
+  if (["steer", "abort", "dispose", "shutdown"].includes(method)) {
+    return config.runtimeInterruptTimeoutMs;
+  }
+  return config.runtimeControlTimeoutMs;
+}

--- a/packages/buzz-pi-agent/src/server.ts
+++ b/packages/buzz-pi-agent/src/server.ts
@@ -1,0 +1,1097 @@
+import { randomUUID } from "node:crypto";
+import { isAbsolute } from "node:path";
+import type { Readable } from "node:stream";
+import type { AdapterConfig } from "./config.js";
+import type { IsolatedPiWorkerFactory } from "./runtime-worker.js";
+import type { SessionRegistry } from "./session-registry.js";
+import type {
+  AcpContentBlock,
+  AcpImageBlock,
+  AdapterEventSink,
+  AgentSessionHandle,
+  BuzzSessionEvent,
+  JsonRpcInbound,
+  Logger,
+  OutputWriter,
+  ResourceSnapshot,
+  SessionUsageSnapshot,
+} from "./types.js";
+import {
+  AGENT_CONTEXT_LIMIT,
+  AGENT_OVERLOADED,
+  AGENT_SESSION_STORAGE_LIMIT,
+  AGENT_SESSION_INVALIDATED,
+  INTERNAL_ERROR,
+  INVALID_PARAMS,
+  METHOD_NOT_FOUND,
+  JsonRpcError,
+  asRecord,
+  errorResponse,
+  notification,
+  parseInbound,
+  readNdjson,
+  requiredString,
+  response,
+} from "./wire.js";
+
+const MAX_SYSTEM_PROMPT_BYTES = 512 * 1024;
+const MAX_PROMPT_BLOCKS = 128;
+const MAX_PROMPT_BYTES = 8 * 1024 * 1024;
+const RESERVED_CONTROL_REQUESTS = 16;
+const LOWERCASE_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export class AcpServer implements AdapterEventSink {
+  private readonly activeRequests = new Set<Promise<void>>();
+  private activeOrdinaryRequests = 0;
+  private initialized = false;
+  private closing = false;
+  private shutdownPromise: Promise<void> | undefined;
+  private readonly lifecycleTasks = new Map<string, Promise<void>>();
+  private readonly lifecycleFailures = new Map<string, Error>();
+  private readonly publishedLifecycleEventIds = new Map<string, Set<string>>();
+
+  constructor(
+    private readonly input: Readable,
+    private readonly output: OutputWriter,
+    private readonly registry: SessionRegistry,
+    private readonly config: AdapterConfig,
+    private readonly logger: Logger,
+    private readonly workerFactory?: IsolatedPiWorkerFactory,
+  ) {}
+
+  async run(): Promise<void> {
+    await this.registry.start();
+    try {
+      for await (const line of readNdjson(
+        this.input,
+        this.config.maxLineBytes,
+      )) {
+        if (line.trim() === "") continue;
+        let message: JsonRpcInbound;
+        try {
+          message = parseInbound(line);
+        } catch (error) {
+          this.output.write(errorResponse(null, error));
+          continue;
+        }
+        const control = isControlMethod(message.method);
+        if (
+          (!control &&
+            this.activeOrdinaryRequests >= this.config.maxActiveRequests) ||
+          this.activeRequests.size >=
+            this.config.maxActiveRequests + RESERVED_CONTROL_REQUESTS
+        ) {
+          if ("id" in message) {
+            this.output.write(
+              errorResponse(
+                message.id,
+                new JsonRpcError(
+                  AGENT_OVERLOADED,
+                  "Pi agent request capacity is full",
+                  { kind: "overloaded", retryable: true },
+                ),
+              ),
+            );
+          }
+          continue;
+        }
+        if (!control) this.activeOrdinaryRequests += 1;
+        const task = this.dispatch(message)
+          .catch((error: unknown) => {
+            this.logger.warn("ACP notification failed", {
+              method: message.method,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          })
+          .finally(() => {
+            this.activeRequests.delete(task);
+            if (!control) this.activeOrdinaryRequests -= 1;
+          });
+        this.activeRequests.add(task);
+      }
+    } finally {
+      // Start cancellation before waiting for request handlers. A prompt may
+      // otherwise remain blocked for the full provider timeout after stdin or
+      // the output transport has failed.
+      const shutdown = this.shutdown();
+      await Promise.allSettled([...this.activeRequests]);
+      await shutdown;
+    }
+  }
+
+  shutdown(): Promise<void> {
+    this.shutdownPromise ??= this.performShutdown();
+    return this.shutdownPromise;
+  }
+
+  private async performShutdown(): Promise<void> {
+    this.closing = true;
+    await Promise.allSettled([...this.lifecycleTasks.values()]);
+    await this.registry.shutdown();
+    await Promise.allSettled([...this.lifecycleTasks.values()]);
+    await this.workerFactory?.shutdown();
+    this.lifecycleTasks.clear();
+    this.lifecycleFailures.clear();
+    this.publishedLifecycleEventIds.clear();
+    await this.output.end();
+  }
+
+  sessionUpdate(sessionId: string, update: Record<string, unknown>): void {
+    this.output.write(
+      notification("session/update", {
+        sessionId,
+        update: sanitizeValue(update),
+      }),
+    );
+  }
+
+  buzzSessionEvent(
+    sessionId: string,
+    event: BuzzSessionEvent,
+    deliveryId?: string,
+  ): void | Promise<void> {
+    const safeEvent = sanitizeLifecycleValue(event) as BuzzSessionEvent;
+    if (deliveryId !== undefined && !LOWERCASE_UUID_PATTERN.test(deliveryId)) {
+      throw new Error(
+        "Pi runtime lifecycle deliveryId must be a lowercase UUID",
+      );
+    }
+    const conversationIdentity =
+      this.registry.conversationIdentityForSession(sessionId);
+    if (!conversationIdentity) {
+      // The adapter advertises schema v2 globally during initialize. Emitting
+      // an older shape for one session would violate that negotiated contract
+      // and make a strict Buzz harness terminate the whole transport. Sessions
+      // without a durable Buzz identity still compact normally, but their
+      // typed lifecycle notices cannot be safely published or replayed.
+      this.logger.debug("suppressed lifecycle event for unmapped ACP session", {
+        sessionId: boundedString(sessionId, 256),
+        eventType: safeEvent.type,
+      });
+      return;
+    }
+    const { conversationId, lifecycleGeneration } = conversationIdentity;
+    const eventId = deliveryId ?? randomUUID();
+    return this.queueLifecycleTask(sessionId, async () => {
+      // Pi extensions can emit during SDK creation, before the manifest route
+      // is installed. Keep the child handoff pending until that atomic
+      // promotion completes; a rejected create therefore never ACKs the marker.
+      await conversationIdentity.readiness;
+      const persisted = await this.registry.persistConversationSessionEvent(
+        conversationId,
+        lifecycleGeneration,
+        eventId,
+        safeEvent,
+      );
+      // A concurrent authenticated reset may supersede this Pi generation
+      // before its asynchronous outbox write begins. The store fences that
+      // race; a rejected stale write must never be published as if durable.
+      if (!persisted) return;
+      if (conversationIdentity.deferPublication) {
+        // session/new will discover this durable outbox record below and emit
+        // it via the existing setImmediate replay after the synchronous ACP
+        // response. The child may ACK now because the parent copy is durable.
+        return;
+      }
+      if (!this.publishedLifecycleEventIds.get(sessionId)?.has(eventId)) {
+        this.writeSessionEventNotification({
+          schemaVersion: 2,
+          sessionId: boundedString(sessionId, 256),
+          conversationId,
+          eventId,
+          event: safeEvent,
+        });
+        this.markLifecycleEventPublished(sessionId, eventId);
+      }
+    });
+  }
+
+  private writeSessionEventNotification(params: Record<string, unknown>): void {
+    if (Buffer.byteLength(JSON.stringify(params)) > 64 * 1024) {
+      throw new Error("refused oversized Buzz session lifecycle event");
+    }
+    this.output.write(notification("_buzz/session/event", params));
+  }
+
+  private queueLifecycleTask(
+    sessionId: string,
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    const previous = this.lifecycleTasks.get(sessionId) ?? Promise.resolve();
+    const task = previous.catch(() => {}).then(operation);
+    this.lifecycleTasks.set(sessionId, task);
+    void task
+      .catch((error: unknown) => {
+        const failure =
+          error instanceof Error ? error : new Error(String(error));
+        // A persistence failure deliberately poisons the live ACP session. It
+        // is unsafe to return a successful prompt after dropping a lifecycle
+        // notice. `/new`, reset, or disposal creates the recovery boundary.
+        if (!this.lifecycleFailures.has(sessionId)) {
+          this.lifecycleFailures.set(sessionId, failure);
+        }
+        this.logger.error("failed to persist Buzz session lifecycle event", {
+          sessionId,
+          error: failure.message,
+        });
+      })
+      .finally(() => {
+        if (this.lifecycleTasks.get(sessionId) === task) {
+          this.lifecycleTasks.delete(sessionId);
+        }
+      });
+    return task;
+  }
+
+  private async flushLifecycleTasks(sessionId: string): Promise<void> {
+    await this.settleLifecycleTasks(sessionId);
+    const failure = this.lifecycleFailures.get(sessionId);
+    if (failure) throw failure;
+  }
+
+  private async settleLifecycleTasks(sessionId: string): Promise<void> {
+    for (;;) {
+      const task = this.lifecycleTasks.get(sessionId);
+      if (!task) return;
+      await task.catch(() => {});
+      if (this.lifecycleTasks.get(sessionId) === task) return;
+    }
+  }
+
+  private markLifecycleEventPublished(
+    sessionId: string,
+    eventId: string,
+  ): void {
+    const published =
+      this.publishedLifecycleEventIds.get(sessionId) ?? new Set<string>();
+    published.add(eventId);
+    this.publishedLifecycleEventIds.set(sessionId, published);
+  }
+
+  private clearLifecycleState(sessionId: string): void {
+    this.lifecycleFailures.delete(sessionId);
+    this.publishedLifecycleEventIds.delete(sessionId);
+    if (!this.registry.hasSession(sessionId)) {
+      this.lifecycleTasks.delete(sessionId);
+    }
+  }
+
+  private pruneDisposedLifecycleState(): void {
+    const sessionIds = new Set([
+      ...this.lifecycleFailures.keys(),
+      ...this.publishedLifecycleEventIds.keys(),
+    ]);
+    for (const sessionId of sessionIds) {
+      if (!this.registry.hasSession(sessionId)) {
+        this.clearLifecycleState(sessionId);
+      }
+    }
+  }
+
+  usageUpdate(
+    sessionId: string,
+    usage: SessionUsageSnapshot,
+    contextLimit: number,
+  ): void {
+    this.output.write(
+      notification("_goose/unstable/session/update", {
+        sessionId,
+        update: {
+          sessionUpdate: "usage_update",
+          ...(usage.contextTokens === null
+            ? {}
+            : { used: nonNegativeInteger(usage.contextTokens) }),
+          contextLimit: nonNegativeInteger(contextLimit),
+          accumulatedInputTokens: nonNegativeInteger(
+            usage.accumulatedInputTokens,
+          ),
+          accumulatedOutputTokens: nonNegativeInteger(
+            usage.accumulatedOutputTokens,
+          ),
+          accumulatedCachedInputTokens: Math.min(
+            nonNegativeInteger(usage.accumulatedCachedInputTokens),
+            nonNegativeInteger(usage.accumulatedInputTokens),
+          ),
+          ...(usage.accumulatedCost === null
+            ? {}
+            : { accumulatedCost: nonNegativeNumber(usage.accumulatedCost) }),
+          ...(usage.model === null
+            ? {}
+            : { model: boundedString(usage.model, 256) }),
+        },
+      }),
+    );
+  }
+
+  private async dispatch(message: JsonRpcInbound): Promise<void> {
+    if (!("id" in message)) {
+      await this.handleNotification(message.method, message.params);
+      return;
+    }
+    try {
+      const result = await this.handleRequest(message.method, message.params);
+      this.output.write(response(message.id, result));
+      if (message.method === "shutdown")
+        queueMicrotask(() => void this.shutdown());
+    } catch (error) {
+      this.logger.warn("ACP request failed", {
+        method: message.method,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.output.write(errorResponse(message.id, normalizeError(error)));
+    }
+  }
+
+  private async handleRequest(
+    method: string,
+    rawParams: unknown,
+  ): Promise<unknown> {
+    if (method === "initialize") {
+      if (this.initialized)
+        throw new JsonRpcError(
+          INVALID_PARAMS,
+          "initialize may only be called once",
+        );
+      return this.initialize(rawParams);
+    }
+    if (this.closing)
+      throw new JsonRpcError(INVALID_PARAMS, "agent is shutting down");
+    if (!this.initialized)
+      throw new JsonRpcError(INVALID_PARAMS, "initialize must be called first");
+    this.pruneDisposedLifecycleState();
+
+    switch (method) {
+      case "session/new":
+        return this.sessionNew(rawParams);
+      case "session/prompt":
+        return this.sessionPrompt(rawParams);
+      case "session/set_model":
+        return this.sessionSetModel(rawParams);
+      case "session/set_config_option":
+        return this.sessionSetConfig(rawParams);
+      case "session/cancel":
+        await this.sessionCancel(rawParams);
+        return null;
+      case "_session/steering":
+        return this.sessionSteer(rawParams);
+      case "_buzz/session/dispose":
+        return this.sessionDispose(rawParams);
+      case "_buzz/conversation/reset":
+        return this.conversationReset(rawParams);
+      case "_buzz/session/event_ack":
+        return this.sessionEventAck(rawParams);
+      case "shutdown":
+        return { shutdown: true };
+      default:
+        throw new JsonRpcError(METHOD_NOT_FOUND, `Method not found: ${method}`);
+    }
+  }
+
+  private async handleNotification(
+    method: string,
+    rawParams: unknown,
+  ): Promise<void> {
+    if (method === "session/cancel") {
+      await this.sessionCancel(rawParams);
+      return;
+    }
+    if (method === "exit") {
+      await this.shutdown();
+    }
+  }
+
+  private initialize(rawParams: unknown): Record<string, unknown> {
+    const params = asRecord(rawParams ?? {}, "initialize params");
+    const requested =
+      typeof params.protocolVersion === "number" ? params.protocolVersion : 1;
+    this.initialized = true;
+    return {
+      protocolVersion: Math.min(2, Math.max(1, Math.floor(requested))),
+      agentCapabilities: {
+        loadSession: false,
+        promptCapabilities: {
+          image: true,
+          audio: false,
+          embeddedContext: false,
+        },
+        mcpCapabilities: { http: false, sse: false },
+      },
+      agentInfo: { name: "buzz-pi-agent", version: "0.1.0" },
+      _meta: {
+        steering: { supported: true },
+        buzz: {
+          conversationPersistence: true,
+          sessionEvents: {
+            supported: true,
+            durableReplay: true,
+            ack: true,
+            schemaVersion: 2,
+          },
+          contextLimitTokens: this.config.contextLimitTokens,
+          sessionTranscriptMaxBytes: this.config.maxSessionFileBytes,
+          threadSessions: {
+            supported: true,
+            persistence: true,
+            dispose: true,
+            resetToken: true,
+            resetCommit: true,
+          },
+        },
+      },
+    };
+  }
+
+  private async sessionNew(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "session/new params");
+    const cwd = requiredString(params, "cwd");
+    if (!isAbsolute(cwd))
+      throw new JsonRpcError(INVALID_PARAMS, "cwd must be absolute");
+    const systemPrompt = optionalString(params.systemPrompt, "systemPrompt");
+    if (
+      systemPrompt &&
+      Buffer.byteLength(systemPrompt) > MAX_SYSTEM_PROMPT_BYTES
+    ) {
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        `systemPrompt exceeds ${MAX_SYSTEM_PROMPT_BYTES} bytes`,
+      );
+    }
+    const meta =
+      params._meta === undefined ? undefined : asRecord(params._meta, "_meta");
+    const buzzMeta =
+      meta?.buzz === undefined ? undefined : asRecord(meta.buzz, "_meta.buzz");
+    const conversationId = optionalString(
+      buzzMeta?.conversationId,
+      "conversationId",
+    );
+    const resetToken = optionalString(buzzMeta?.resetToken, "resetToken");
+    const title = optionalString(meta?.sessionTitle, "sessionTitle");
+    if (title && title.length > 256) {
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        "sessionTitle must not exceed 256 characters",
+      );
+    }
+    if (Array.isArray(params.mcpServers) && params.mcpServers.length > 0) {
+      this.logger.warn(
+        "session/new supplied MCP servers; Pi SDK does not consume ACP MCP config",
+        {
+          count: params.mcpServers.length,
+        },
+      );
+    }
+    const {
+      sessionId,
+      handle,
+      resumedConversation = false,
+      skipRelayHistory = false,
+      lifecycleGeneration,
+    } = await this.registry.create({
+      cwd,
+      ...(systemPrompt === undefined ? {} : { systemPrompt }),
+      ...(title === undefined ? {} : { title }),
+      ...(conversationId === undefined ? {} : { conversationId }),
+      ...(resetToken === undefined ? {} : { resetToken }),
+    });
+    await handle.replayLifecycleEvents?.();
+    await this.flushLifecycleTasks(sessionId);
+    this.emitAvailableCommands(sessionId, handle.getResources().commands);
+    const pendingReplay = conversationId
+      ? await this.registry.listPendingSessionEvents(conversationId)
+      : [];
+    if (conversationId && lifecycleGeneration === undefined) {
+      throw new Error("mapped Pi session has no lifecycle generation");
+    }
+    const replayable: typeof pendingReplay = [];
+    for (const pending of pendingReplay) {
+      if (pending.lifecycleGeneration !== lifecycleGeneration) {
+        // Pi IDs can change during a continuity-preserving cwd/stale/lease
+        // recovery. Only an authenticated reset rotates this durable epoch, so
+        // mismatched records are specifically pre-reset and may be retired.
+        await this.registry.acknowledgeSessionEvent(
+          pending.conversationId,
+          pending.eventId,
+        );
+        continue;
+      }
+      if (
+        !this.publishedLifecycleEventIds.get(sessionId)?.has(pending.eventId)
+      ) {
+        replayable.push(pending);
+      }
+    }
+    if (replayable.length > 0 && conversationId) {
+      this.queueLifecycleTask(sessionId, async () => {
+        // Defer until after dispatch writes the session/new response, so Buzz
+        // learns the new outer sessionId before seeing replay notifications.
+        await new Promise<void>((resolvePromise) => {
+          setImmediate(resolvePromise);
+        });
+        if (
+          !this.registry.hasSession(sessionId) ||
+          this.registry.conversationIdForSession(sessionId) !== conversationId
+        ) {
+          return;
+        }
+        const activeHandle = await this.registry.get(sessionId);
+        if (activeHandle.piSessionId !== handle.piSessionId) return;
+        for (const pending of replayable) {
+          this.writeSessionEventNotification({
+            schemaVersion: 2,
+            sessionId: boundedString(sessionId, 256),
+            conversationId,
+            eventId: pending.eventId,
+            event: pending.event,
+          });
+          this.markLifecycleEventPublished(sessionId, pending.eventId);
+        }
+      });
+    }
+    return sessionDescription(
+      sessionId,
+      handle,
+      this.config,
+      resumedConversation,
+      skipRelayHistory,
+    );
+  }
+
+  private async sessionPrompt(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "session/prompt params");
+    const sessionId = requiredString(params, "sessionId");
+    const blocks = parsePromptBlocks(params.prompt);
+    const text = blocks
+      .filter(
+        (block): block is Extract<AcpContentBlock, { type: "text" }> =>
+          block.type === "text",
+      )
+      .map((block) => block.text)
+      .join("\n\n");
+    const images = blocks.filter(
+      (block): block is AcpImageBlock => block.type === "image",
+    );
+    const session = await this.registry.get(sessionId);
+    let stopReason: Awaited<ReturnType<AgentSessionHandle["prompt"]>>;
+    try {
+      stopReason = await session.prompt(text, images);
+    } finally {
+      await this.flushLifecycleTasks(sessionId);
+    }
+    return { stopReason };
+  }
+
+  private async sessionEventAck(
+    rawParams: unknown,
+  ): Promise<{ acknowledged: true }> {
+    const params = asRecord(rawParams, "_buzz/session/event_ack params");
+    const conversationId = requiredString(params, "conversationId");
+    const eventId = requiredString(params, "eventId");
+    if (conversationId.length > 512) {
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        "conversationId must not exceed 512 characters",
+      );
+    }
+    if (!LOWERCASE_UUID_PATTERN.test(eventId)) {
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        "eventId must be a lowercase UUID",
+      );
+    }
+    await this.registry.acknowledgeSessionEvent(conversationId, eventId);
+    for (const [sessionId, published] of this.publishedLifecycleEventIds) {
+      if (
+        this.registry.conversationIdForSession(sessionId) === conversationId
+      ) {
+        published.delete(eventId);
+        if (published.size === 0) {
+          this.publishedLifecycleEventIds.delete(sessionId);
+        }
+      }
+    }
+    return { acknowledged: true };
+  }
+
+  private async sessionSetModel(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "session/set_model params");
+    const session = await this.registry.get(
+      requiredString(params, "sessionId"),
+    );
+    await session.setModel(requiredString(params, "modelId"));
+    return { modelId: session.getContextSnapshot().model };
+  }
+
+  private async sessionSetConfig(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "session/set_config_option params");
+    const session = await this.registry.get(
+      requiredString(params, "sessionId"),
+    );
+    const configId = requiredString(params, "configId");
+    const value = requiredString(params, "value");
+    if (configId === "model") await session.setModel(value);
+    else if (configId === "thinking") await session.setThinkingLevel(value);
+    else
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        `Unknown config option ${configId}`,
+      );
+    return { configOptions: sessionConfigOptions(session) };
+  }
+
+  private async sessionCancel(rawParams: unknown): Promise<void> {
+    const params = asRecord(rawParams, "session/cancel params");
+    const session = await this.registry.get(
+      requiredString(params, "sessionId"),
+    );
+    await session.abort();
+  }
+
+  private async sessionSteer(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "_session/steering params");
+    const session = await this.registry.get(
+      requiredString(params, "sessionId"),
+    );
+    const blocks = parsePromptBlocks(params.prompt);
+    const text = blocks
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n\n");
+    const wasBusy = session.isBusy;
+    await session.steer(text);
+    return { outcome: wasBusy ? "injected" : "startedNewTurn" };
+  }
+
+  private async sessionDispose(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "_buzz/session/dispose params");
+    const sessionId = requiredString(params, "sessionId");
+    const forget = params.forget === true;
+    await this.settleLifecycleTasks(sessionId);
+    try {
+      const disposed = await this.registry.disposeSession(sessionId, forget);
+      return { disposed, forgotten: disposed && forget };
+    } finally {
+      if (!this.registry.hasSession(sessionId)) {
+        this.clearLifecycleState(sessionId);
+      }
+    }
+  }
+
+  private async conversationReset(
+    rawParams: unknown,
+  ): Promise<Record<string, unknown>> {
+    const params = asRecord(rawParams, "_buzz/conversation/reset params");
+    const conversationId = boundedRequiredString(
+      params.conversationId,
+      "conversationId",
+      512,
+    );
+    const resetToken = boundedRequiredString(
+      params.resetToken,
+      "resetToken",
+      512,
+    );
+    const affectedSessionIds = new Set(
+      [
+        ...this.lifecycleTasks.keys(),
+        ...this.lifecycleFailures.keys(),
+        ...this.publishedLifecycleEventIds.keys(),
+      ].filter(
+        (sessionId) =>
+          this.registry.conversationIdForSession(sessionId) === conversationId,
+      ),
+    );
+    await Promise.allSettled(
+      [...affectedSessionIds].map((sessionId) =>
+        this.settleLifecycleTasks(sessionId),
+      ),
+    );
+    try {
+      return await this.registry.commitConversationReset(
+        conversationId,
+        resetToken,
+      );
+    } finally {
+      for (const sessionId of affectedSessionIds) {
+        if (!this.registry.hasSession(sessionId)) {
+          this.clearLifecycleState(sessionId);
+        }
+      }
+    }
+  }
+
+  private emitAvailableCommands(
+    sessionId: string,
+    commands: ResourceSnapshot["commands"],
+  ): void {
+    this.sessionUpdate(sessionId, {
+      sessionUpdate: "available_commands_update",
+      availableCommands: [
+        {
+          name: "context",
+          description: "Show live context usage and compaction limit",
+        },
+        {
+          name: "reload",
+          description: "Hot-reload Pi extensions, skills, prompts, and context",
+        },
+        {
+          name: "compact",
+          description: "Compact this thread's Pi context now",
+        },
+        ...commands,
+      ],
+    });
+  }
+}
+
+function sessionDescription(
+  sessionId: string,
+  handle: AgentSessionHandle,
+  config: AdapterConfig,
+  resumedConversation: boolean,
+  skipRelayHistory: boolean,
+): Record<string, unknown> {
+  const models = handle.getModels();
+  const currentModelId = handle.getContextSnapshot().model;
+  return {
+    sessionId,
+    configOptions: sessionConfigOptions(handle),
+    models: {
+      currentModelId,
+      availableModels: models.map((model) => ({
+        modelId: model.id,
+        name: model.name,
+        ...(model.description === undefined
+          ? {}
+          : { description: model.description }),
+      })),
+    },
+    _meta: {
+      buzz: {
+        piSessionId: handle.piSessionId,
+        persistent: handle.sessionFile !== undefined,
+        resumedConversation,
+        skipRelayHistory,
+        contextLimitTokens: config.contextLimitTokens,
+        effectiveLimitTokens: handle.getContextSnapshot().effectiveLimitTokens,
+        compactionThresholdTokens:
+          handle.getContextSnapshot().compactionThresholdTokens,
+      },
+    },
+  };
+}
+
+function sessionConfigOptions(
+  handle: AgentSessionHandle,
+): Record<string, unknown>[] {
+  const snapshot = handle.getContextSnapshot();
+  return [
+    {
+      configId: "model",
+      category: "model",
+      displayName: "Model",
+      value: snapshot.model,
+      options: handle.getModels().map((model) => ({
+        value: model.id,
+        displayName: model.name,
+      })),
+    },
+    {
+      configId: "thinking",
+      category: "thought",
+      displayName: "Thinking",
+      value: snapshot.thinkingLevel,
+      options: handle
+        .getThinkingLevels()
+        .map((level) => ({ value: level, displayName: level })),
+    },
+  ];
+}
+
+function parsePromptBlocks(value: unknown): AcpContentBlock[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new JsonRpcError(INVALID_PARAMS, "prompt must be a non-empty array");
+  }
+  if (value.length > MAX_PROMPT_BLOCKS) {
+    throw new JsonRpcError(
+      INVALID_PARAMS,
+      `prompt exceeds ${MAX_PROMPT_BLOCKS} blocks`,
+    );
+  }
+  const blocks = value.map((item, index): AcpContentBlock => {
+    const block = asRecord(item, `prompt[${index}]`);
+    if (block.type === "text" && typeof block.text === "string") {
+      return { type: "text", text: block.text };
+    }
+    if (
+      block.type === "image" &&
+      typeof block.data === "string" &&
+      typeof block.mimeType === "string"
+    ) {
+      return { type: "image", data: block.data, mimeType: block.mimeType };
+    }
+    throw new JsonRpcError(
+      INVALID_PARAMS,
+      `Unsupported prompt block at index ${index}`,
+    );
+  });
+  const size = Buffer.byteLength(JSON.stringify(blocks));
+  if (size > MAX_PROMPT_BYTES) {
+    throw new JsonRpcError(
+      INVALID_PARAMS,
+      `prompt exceeds ${MAX_PROMPT_BYTES} bytes`,
+    );
+  }
+  return blocks;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new JsonRpcError(
+      INVALID_PARAMS,
+      `${name} must be a non-empty string`,
+    );
+  }
+  return value;
+}
+
+function boundedRequiredString(
+  value: unknown,
+  name: string,
+  maxLength: number,
+): string {
+  const result = requiredString({ [name]: value }, name);
+  if (result.length > maxLength) {
+    throw new JsonRpcError(
+      INVALID_PARAMS,
+      `${name} must not exceed ${maxLength} characters`,
+    );
+  }
+  return result;
+}
+
+function normalizeError(error: unknown): JsonRpcError {
+  if (error instanceof JsonRpcError) return error;
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.startsWith("BUZZ_CONTEXT_LIMIT:")) {
+    return new JsonRpcError(
+      AGENT_CONTEXT_LIMIT,
+      boundedString(message, 2_000),
+      {
+        kind: "context_limit",
+        retryable: false,
+      },
+    );
+  }
+  if (message.startsWith("BUZZ_SESSION_STORAGE_LIMIT:")) {
+    return new JsonRpcError(
+      AGENT_SESSION_STORAGE_LIMIT,
+      boundedString(message, 2_000),
+      {
+        kind: "session_storage_limit",
+        retryable: false,
+        recovery: "/new",
+      },
+    );
+  }
+  if (message.startsWith("BUZZ_PI_SESSION_INVALIDATED:")) {
+    return new JsonRpcError(
+      AGENT_SESSION_INVALIDATED,
+      boundedString(message, 2_000),
+      {
+        kind: "session_invalidated",
+        retryable: true,
+      },
+    );
+  }
+  if (
+    message.includes("Unknown") ||
+    message.includes("must be") ||
+    message.includes("already")
+  ) {
+    return new JsonRpcError(INVALID_PARAMS, boundedString(message, 2_000));
+  }
+  return new JsonRpcError(INTERNAL_ERROR, boundedString(message, 2_000));
+}
+
+interface SanitizeLimits {
+  maxDepth: number;
+  maxArrayItems: number;
+  maxObjectEntries: number;
+  maxStringCharacters: number;
+  maxKeyCharacters: number;
+  maxNodes: number;
+  maxBytes: number;
+}
+
+interface SanitizeBudget {
+  remainingNodes: number;
+  remainingBytes: number;
+  seen: WeakSet<object>;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  return sanitizeWithBudget(value, {
+    maxDepth: 8,
+    maxArrayItems: 50,
+    maxObjectEntries: 100,
+    maxStringCharacters: 8_192,
+    maxKeyCharacters: 128,
+    maxNodes: 2_048,
+    maxBytes: 256 * 1_024,
+  });
+}
+
+function sanitizeLifecycleValue(value: unknown): unknown {
+  return sanitizeWithBudget(value, {
+    maxDepth: 6,
+    maxArrayItems: 20,
+    maxObjectEntries: 40,
+    maxStringCharacters: 1_024,
+    maxKeyCharacters: 64,
+    maxNodes: 512,
+    maxBytes: 48 * 1_024,
+  });
+}
+
+function sanitizeWithBudget(value: unknown, limits: SanitizeLimits): unknown {
+  return sanitizeNode(value, 0, limits, {
+    remainingNodes: limits.maxNodes,
+    remainingBytes: limits.maxBytes,
+    seen: new WeakSet(),
+  });
+}
+
+function sanitizeNode(
+  value: unknown,
+  depth: number,
+  limits: SanitizeLimits,
+  budget: SanitizeBudget,
+): unknown {
+  if (
+    depth > limits.maxDepth ||
+    budget.remainingNodes <= 0 ||
+    budget.remainingBytes <= 0
+  ) {
+    return "[truncated]";
+  }
+  budget.remainingNodes -= 1;
+
+  if (typeof value === "string") {
+    return takeBudgetedString(value, limits.maxStringCharacters, budget);
+  }
+  if (typeof value === "number") {
+    budget.remainingBytes = Math.max(0, budget.remainingBytes - 16);
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === "boolean" || value === null || value === undefined) {
+    budget.remainingBytes = Math.max(0, budget.remainingBytes - 8);
+    return value;
+  }
+  if (typeof value !== "object") {
+    return takeBudgetedString(
+      String(value),
+      limits.maxStringCharacters,
+      budget,
+    );
+  }
+  if (budget.seen.has(value)) {
+    return takeBudgetedString("[circular]", 16, budget);
+  }
+  budget.seen.add(value);
+  budget.remainingBytes = Math.max(0, budget.remainingBytes - 2);
+
+  if (Array.isArray(value)) {
+    const result: unknown[] = [];
+    const count = Math.min(value.length, limits.maxArrayItems);
+    for (let index = 0; index < count; index += 1) {
+      if (budget.remainingNodes <= 0 || budget.remainingBytes <= 0) {
+        result.push("[truncated]");
+        break;
+      }
+      result.push(sanitizeNode(value[index], depth + 1, limits, budget));
+    }
+    return result;
+  }
+
+  const result: Record<string, unknown> = {};
+  let entries = 0;
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) continue;
+    if (entries >= limits.maxObjectEntries) break;
+    if (budget.remainingNodes <= 0 || budget.remainingBytes <= 0) {
+      result["[truncated]"] = true;
+      break;
+    }
+    const safeKey = takeBudgetedString(key, limits.maxKeyCharacters, budget);
+    let item: unknown;
+    try {
+      item = (value as Record<string, unknown>)[key];
+    } catch {
+      item = "[unavailable]";
+    }
+    result[safeKey] = sanitizeNode(item, depth + 1, limits, budget);
+    entries += 1;
+  }
+  return result;
+}
+
+function takeBudgetedString(
+  value: string,
+  maxCharacters: number,
+  budget: SanitizeBudget,
+): string {
+  const allowedCharacters = Math.max(
+    1,
+    Math.min(maxCharacters, Math.floor(budget.remainingBytes / 4)),
+  );
+  const truncated = value.length > allowedCharacters;
+  const result = truncated
+    ? `${value.slice(0, Math.max(0, allowedCharacters - 1))}…`
+    : value;
+  budget.remainingBytes = Math.max(
+    0,
+    budget.remainingBytes - Buffer.byteLength(result),
+  );
+  return result;
+}
+
+function nonNegativeInteger(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(Number.MAX_SAFE_INTEGER, Math.round(value)));
+}
+
+function nonNegativeNumber(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+function boundedString(value: string, maximum: number): string {
+  return value.length <= maximum ? value : `${value.slice(0, maximum)}…`;
+}
+
+function isControlMethod(method: string): boolean {
+  return [
+    "session/cancel",
+    "_session/steering",
+    "_buzz/session/dispose",
+    "_buzz/conversation/reset",
+    "_buzz/session/event_ack",
+    "shutdown",
+    "exit",
+  ].includes(method);
+}

--- a/packages/buzz-pi-agent/src/session-registry.ts
+++ b/packages/buzz-pi-agent/src/session-registry.ts
@@ -1,0 +1,803 @@
+import { randomUUID } from "node:crypto";
+import type { AdapterConfig } from "./config.js";
+import type {
+  ConversationStore,
+  ResolveConversationResult,
+} from "./conversation-store.js";
+import { INVALID_PARAMS, JsonRpcError } from "./wire.js";
+import type {
+  AdapterEventSink,
+  AgentSessionFactory,
+  AgentSessionHandle,
+  BuzzSessionEvent,
+  Logger,
+  PendingBuzzSessionEvent,
+} from "./types.js";
+import { captureWorkspaceIdentity } from "./workspace.js";
+
+interface LiveSession {
+  handle: AgentSessionHandle;
+  lastUsedMs: number;
+  conversationId?: string;
+  resetToken?: string;
+  lifecycleGeneration?: string;
+  closing?: boolean;
+  disposeForget?: boolean;
+  disposePromise?: Promise<boolean>;
+  refreshConversation?: () => Promise<boolean>;
+  forgetConversation?: () => Promise<string | undefined>;
+  releaseConversation?: () => Promise<void>;
+}
+
+export interface ConversationLifecycleIdentity {
+  conversationId: string;
+  lifecycleGeneration: string;
+  readiness?: Promise<void>;
+  deferPublication?: boolean;
+}
+
+interface PendingLifecycleRoute {
+  identity: ConversationLifecycleIdentity;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class SessionRegistry {
+  private readonly live = new Map<string, LiveSession>();
+  private readonly conversationToSession = new Map<string, string>();
+  private readonly pendingLifecycleRoutes = new Map<
+    string,
+    PendingLifecycleRoute
+  >();
+  private readonly pendingConversations = new Map<
+    string,
+    {
+      resetToken: string | undefined;
+      cwd: string;
+      promise: Promise<{
+        sessionId: string;
+        handle: AgentSessionHandle;
+        resumedConversation: boolean;
+        skipRelayHistory: boolean;
+        lifecycleGeneration?: string;
+      }>;
+    }
+  >();
+  private readonly pendingResets = new Map<
+    string,
+    {
+      resetToken: string;
+      promise: Promise<{ committed: true; alreadyCommitted: boolean }>;
+    }
+  >();
+  private sweepTimer: NodeJS.Timeout | undefined;
+  private closing = false;
+  private capacityMutex: Promise<void> = Promise.resolve();
+  private pendingCapacity = 0;
+
+  constructor(
+    private readonly factory: AgentSessionFactory,
+    private readonly conversations: ConversationStore,
+    private readonly config: AdapterConfig,
+    private readonly eventSink: AdapterEventSink,
+    private readonly logger: Logger,
+    private readonly now: () => number = Date.now,
+  ) {
+    this.factory.setInvalidationHandler?.((sessionIds, error) =>
+      this.invalidateSessions(sessionIds, error),
+    );
+  }
+
+  async start(): Promise<void> {
+    await this.conversations.initialize();
+    this.sweepTimer = setInterval(() => {
+      void this.sweepExpired();
+    }, this.config.sweepIntervalMs);
+    this.sweepTimer.unref();
+  }
+
+  async create(options: {
+    cwd: string;
+    systemPrompt?: string;
+    title?: string;
+    conversationId?: string;
+    resetToken?: string;
+  }): Promise<{
+    sessionId: string;
+    handle: AgentSessionHandle;
+    resumedConversation: boolean;
+    skipRelayHistory: boolean;
+    lifecycleGeneration?: string;
+  }> {
+    this.assertOpen();
+    const workspace = captureWorkspaceIdentity(options.cwd);
+    const normalizedOptions = {
+      ...options,
+      cwd: workspace.canonicalPath,
+      requestedCwd: workspace.requestedPath,
+    };
+    if (normalizedOptions.conversationId) {
+      const pendingReset = this.pendingResets.get(
+        normalizedOptions.conversationId,
+      );
+      if (pendingReset) await pendingReset.promise;
+      this.assertOpen();
+      const existingSessionId = this.conversationToSession.get(
+        normalizedOptions.conversationId,
+      );
+      if (existingSessionId) {
+        const existing = this.live.get(existingSessionId);
+        if (existing?.closing) {
+          if (!existing.disposePromise) {
+            throw new Error("Pi session is closing without a disposal fence");
+          }
+          await existing.disposePromise;
+          this.assertOpen();
+        } else if (existing?.handle.isValid === false) {
+          await this.disposeSession(existingSessionId, false);
+        } else if (existing?.handle.cwd !== normalizedOptions.cwd) {
+          await this.disposeSession(existingSessionId, false);
+        } else if (
+          !normalizedOptions.resetToken ||
+          normalizedOptions.resetToken === existing?.resetToken
+        ) {
+          return {
+            sessionId: existingSessionId,
+            handle: await this.get(existingSessionId),
+            resumedConversation: true,
+            skipRelayHistory: false,
+            ...(existing?.lifecycleGeneration === undefined
+              ? {}
+              : { lifecycleGeneration: existing.lifecycleGeneration }),
+          };
+        } else await this.disposeSession(existingSessionId, false);
+      }
+      const pending = this.pendingConversations.get(
+        normalizedOptions.conversationId,
+      );
+      if (pending) {
+        if (pending.cwd !== normalizedOptions.cwd) {
+          throw new JsonRpcError(
+            INVALID_PARAMS,
+            "A different workspace is already creating this conversation",
+          );
+        }
+        if (pending.resetToken !== normalizedOptions.resetToken) {
+          throw new JsonRpcError(
+            INVALID_PARAMS,
+            "A different reset token is already creating this conversation",
+          );
+        }
+        return pending.promise;
+      }
+      const creation = this.createConversationSession({
+        ...normalizedOptions,
+        conversationId: normalizedOptions.conversationId,
+      }).finally(() => {
+        this.pendingConversations.delete(
+          normalizedOptions.conversationId as string,
+        );
+      });
+      this.pendingConversations.set(normalizedOptions.conversationId, {
+        resetToken: normalizedOptions.resetToken,
+        cwd: normalizedOptions.cwd,
+        promise: creation,
+      });
+      return creation;
+    }
+    return this.createUnmappedSession(normalizedOptions);
+  }
+
+  async commitConversationReset(
+    conversationId: string,
+    resetToken: string,
+  ): Promise<{ committed: true; alreadyCommitted: boolean }> {
+    this.assertOpen();
+    const pendingCreation = this.pendingConversations.get(conversationId);
+    if (pendingCreation) await pendingCreation.promise;
+    this.assertOpen();
+    const pending = this.pendingResets.get(conversationId);
+    if (pending) {
+      if (pending.resetToken !== resetToken) {
+        throw new JsonRpcError(
+          INVALID_PARAMS,
+          "A different reset token is already committing this conversation",
+        );
+      }
+      return pending.promise;
+    }
+    const commit = this.commitConversationResetInner(
+      conversationId,
+      resetToken,
+    ).finally(() => {
+      this.pendingResets.delete(conversationId);
+    });
+    this.pendingResets.set(conversationId, { resetToken, promise: commit });
+    return commit;
+  }
+
+  async get(sessionId: string): Promise<AgentSessionHandle> {
+    this.assertOpen();
+    const session = this.live.get(sessionId);
+    if (!session)
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        `Unknown or disposed session ${sessionId}`,
+      );
+    if (session.closing) {
+      throw new JsonRpcError(INVALID_PARAMS, `Session ${sessionId} is closing`);
+    }
+    if (session.handle.isValid === false) {
+      throw new JsonRpcError(
+        INVALID_PARAMS,
+        `Invalidated runtime session ${sessionId}`,
+      );
+    }
+    if (session.refreshConversation) {
+      let refreshed = false;
+      try {
+        refreshed = await session.refreshConversation();
+      } catch (error) {
+        await this.disposeSession(sessionId, false).catch(() => {});
+        throw error;
+      }
+      if (!refreshed) {
+        await this.disposeSession(sessionId, false).catch(() => {});
+        throw new JsonRpcError(
+          INVALID_PARAMS,
+          `Pi conversation lease was superseded for session ${sessionId}`,
+        );
+      }
+    }
+    session.lastUsedMs = this.now();
+    return session.handle;
+  }
+
+  async disposeSession(sessionId: string, forget = false): Promise<boolean> {
+    const session = this.live.get(sessionId);
+    if (!session) return false;
+    if (session.closing) {
+      if (forget && session.disposeForget !== true) {
+        throw new Error(
+          `Session ${sessionId} is already closing without a forget boundary`,
+        );
+      }
+      if (!session.disposePromise) {
+        throw new Error("Pi session is closing without a disposal fence");
+      }
+      return session.disposePromise;
+    }
+    session.closing = true;
+    session.disposeForget = forget;
+    const disposePromise = this.disposeSessionInner(session).finally(() => {
+      if (this.live.get(sessionId) === session) this.live.delete(sessionId);
+      if (
+        session.conversationId &&
+        this.conversationToSession.get(session.conversationId) === sessionId
+      ) {
+        this.conversationToSession.delete(session.conversationId);
+      }
+    });
+    session.disposePromise = disposePromise;
+    return disposePromise;
+  }
+
+  private async disposeSessionInner(session: LiveSession): Promise<boolean> {
+    const forget = session.disposeForget === true;
+    const failures: unknown[] = [];
+    let forgottenFile: string | undefined;
+    if (forget && session.conversationId) {
+      // Remove the durable route first: a concurrent session/new must never
+      // reopen the context being reset.
+      try {
+        if (!session.forgetConversation) {
+          throw new Error("Pi conversation session has no forget fence");
+        }
+        forgottenFile = await session.forgetConversation();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    try {
+      if (session.handle.isBusy) {
+        try {
+          await session.handle.abort();
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      try {
+        await session.handle.dispose();
+      } catch (error) {
+        failures.push(error);
+      }
+      // A mapped conversation file is only ours to delete when the
+      // conditional manifest removal succeeded. An unmapped session has no
+      // durable route and can never be resumed, so every graceful disposal
+      // must remove its otherwise-inaccessible transcript.
+      const fileToDelete = session.conversationId
+        ? forgottenFile
+        : session.handle.sessionFile;
+      if (fileToDelete) {
+        try {
+          await this.conversations.deleteSessionFile(fileToDelete);
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+    } finally {
+      // Release even after a failed forget. Otherwise the still-present
+      // mapping retains a live-PID lease and /new cannot recover until restart.
+      try {
+        await session.releaseConversation?.();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        "Pi session disposal encountered multiple failures",
+      );
+    }
+    return true;
+  }
+
+  async sweepExpired(): Promise<number> {
+    const cutoff = this.now() - this.config.sessionTtlMs;
+    const expired = [...this.live.entries()]
+      .filter(
+        ([, session]) =>
+          !session.closing &&
+          !session.handle.isBusy &&
+          session.lastUsedMs <= cutoff,
+      )
+      .map(([sessionId]) => sessionId);
+    await Promise.all(expired.map((sessionId) => this.evict(sessionId, "ttl")));
+    for (const [sessionId, session] of [...this.live.entries()]) {
+      if (session.closing || !session.refreshConversation) continue;
+      try {
+        if (!(await session.refreshConversation())) {
+          await this.disposeSession(sessionId, false);
+        }
+      } catch (error) {
+        this.logger.warn("failed to refresh Pi conversation lease", {
+          conversationId: session.conversationId,
+          error: errorMessage(error),
+        });
+        // Treat an indeterminate refresh exactly like a rejected generation.
+        // Continuing to serve the handle would let it append to a JSONL after
+        // another adapter may have taken over the Buzz conversation.
+        await this.disposeSession(sessionId, false).catch(
+          (disposeError: unknown) => {
+            this.logger.warn(
+              "failed to dispose Pi session after lease refresh failure",
+              {
+                conversationId: session.conversationId,
+                error: errorMessage(disposeError),
+              },
+            );
+          },
+        );
+      }
+    }
+    const active = new Set(
+      [...this.live.values()]
+        .map((session) => session.conversationId)
+        .filter((value): value is string => value !== undefined),
+    );
+    await this.conversations.prune(active);
+    return expired.length;
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.closing) return;
+    this.closing = true;
+    if (this.sweepTimer) clearInterval(this.sweepTimer);
+    await Promise.allSettled(
+      [...this.pendingConversations.values()].map((pending) => pending.promise),
+    );
+    await Promise.allSettled(
+      [...this.pendingResets.values()].map((pending) => pending.promise),
+    );
+    const sessions = [...this.live.entries()];
+    await Promise.allSettled(
+      sessions.map(async ([sessionId]) => {
+        try {
+          await this.disposeSession(sessionId, false);
+        } catch (error) {
+          this.logger.warn("failed to dispose session during shutdown", {
+            sessionId,
+            error: errorMessage(error),
+          });
+        }
+      }),
+    );
+    this.live.clear();
+    this.conversationToSession.clear();
+    this.pendingLifecycleRoutes.clear();
+  }
+
+  get size(): number {
+    return this.live.size;
+  }
+
+  hasSession(sessionId: string): boolean {
+    const session = this.live.get(sessionId);
+    return session !== undefined && session.closing !== true;
+  }
+
+  conversationIdForSession(sessionId: string): string | undefined {
+    return this.live.get(sessionId)?.conversationId;
+  }
+
+  conversationIdentityForSession(
+    sessionId: string,
+  ): ConversationLifecycleIdentity | undefined {
+    const pending = this.pendingLifecycleRoutes.get(sessionId);
+    if (pending) return pending.identity;
+    const session = this.live.get(sessionId);
+    if (!session?.conversationId || !session.lifecycleGeneration) {
+      return undefined;
+    }
+    return {
+      conversationId: session.conversationId,
+      lifecycleGeneration: session.lifecycleGeneration,
+    };
+  }
+
+  async persistConversationSessionEvent(
+    conversationId: string,
+    lifecycleGeneration: string,
+    eventId: string,
+    event: BuzzSessionEvent,
+  ): Promise<boolean> {
+    return this.conversations.enqueueSessionEvent(
+      conversationId,
+      eventId,
+      event,
+      lifecycleGeneration,
+    );
+  }
+
+  listPendingSessionEvents(
+    conversationId: string,
+  ): Promise<PendingBuzzSessionEvent[]> {
+    return this.conversations.listPendingSessionEvents(conversationId);
+  }
+
+  acknowledgeSessionEvent(
+    conversationId: string,
+    eventId: string,
+  ): Promise<void> {
+    return this.conversations.acknowledgeSessionEvent(conversationId, eventId);
+  }
+
+  private async createConversationSession(options: {
+    cwd: string;
+    requestedCwd: string;
+    systemPrompt?: string;
+    title?: string;
+    conversationId: string;
+    resetToken?: string;
+  }): Promise<{
+    sessionId: string;
+    handle: AgentSessionHandle;
+    resumedConversation: boolean;
+    skipRelayHistory: boolean;
+    lifecycleGeneration: string;
+  }> {
+    const releaseCapacity = await this.reserveCapacity();
+    try {
+      const cwd = options.cwd;
+      const sessionId = `ses_${randomUUID().replaceAll("-", "")}`;
+      let handle: AgentSessionHandle | undefined;
+      let openedPersisted = false;
+      let pendingLifecycleRoute: PendingLifecycleRoute | undefined;
+      let resolved: ResolveConversationResult;
+      try {
+        resolved = await this.conversations.resolve(
+          options.conversationId,
+          options.resetToken,
+          cwd,
+          async (persistedSessionFile, lifecycleGeneration) => {
+            pendingLifecycleRoute = this.installPendingLifecycleRoute(
+              sessionId,
+              options.conversationId,
+              lifecycleGeneration,
+            );
+            openedPersisted = persistedSessionFile !== undefined;
+            handle = await this.factory.create({
+              cwd,
+              requestedCwd: options.requestedCwd,
+              ...(options.systemPrompt === undefined
+                ? {}
+                : { systemPrompt: options.systemPrompt }),
+              ...(options.title === undefined ? {} : { title: options.title }),
+              ...(persistedSessionFile === undefined
+                ? {}
+                : { persistedSessionFile }),
+              eventSink: this.eventSink,
+              acpSessionId: sessionId,
+            });
+            if (!handle.sessionFile) {
+              await handle.dispose();
+              throw new Error(
+                "Pi returned a non-persistent session for a persisted Buzz conversation",
+              );
+            }
+            return {
+              sessionFile: handle.sessionFile,
+              piSessionId: handle.piSessionId,
+              cwd: handle.cwd,
+            };
+          },
+        );
+      } catch (error) {
+        pendingLifecycleRoute?.reject(asError(error));
+        if (handle) {
+          const file = handle.sessionFile;
+          await handle.dispose().catch(() => {});
+          if (!openedPersisted && file)
+            await this.conversations.deleteSessionFile(file);
+        }
+        this.pendingLifecycleRoutes.delete(sessionId);
+        throw error;
+      }
+      if (!handle)
+        throw new Error(
+          "Pi conversation session creation failed without a handle",
+        );
+      pendingLifecycleRoute?.resolve();
+      // Finish cleanup while this creation is represented only by its reserved
+      // slot. Exposing it in `live` before this await would count one handle as
+      // both live and pending, allowing a concurrent capacity check to evict it
+      // before this session/new returns.
+      if (resolved.retiredSessionFile) {
+        await this.conversations
+          .deleteSessionFile(resolved.retiredSessionFile)
+          .catch((error: unknown) => {
+            // The manifest already points to the replacement generation. An
+            // orphaned inactive JSONL is safer than failing a successfully
+            // committed session transition and losing its live handle.
+            this.logger.warn("failed to delete retired Pi session file", {
+              conversationId: options.conversationId,
+              error: errorMessage(error),
+            });
+          });
+      }
+      // Promotion is synchronous: no other capacity reservation can observe a
+      // gap or double-count between releasing the pending slot and installing
+      // the live handle.
+      releaseCapacity();
+      this.live.set(sessionId, {
+        handle,
+        lastUsedMs: this.now(),
+        conversationId: options.conversationId,
+        ...(options.resetToken === undefined
+          ? {}
+          : { resetToken: options.resetToken }),
+        lifecycleGeneration: resolved.lifecycleGeneration,
+        refreshConversation: resolved.refresh,
+        forgetConversation: resolved.forget,
+        releaseConversation: resolved.release,
+      });
+      this.pendingLifecycleRoutes.delete(sessionId);
+      this.conversationToSession.set(options.conversationId, sessionId);
+      if (resolved.previousPiSessionId) {
+        const context = handle.getContextSnapshot();
+        this.eventSink.buzzSessionEvent(sessionId, {
+          type: "session_reset",
+          timestamp: new Date().toISOString(),
+          message: "Started a fresh Pi session for this Buzz thread.",
+          piSessionId: handle.piSessionId,
+          previousPiSessionId: resolved.previousPiSessionId,
+          limitTokens: context.limitTokens,
+          effectiveLimitTokens: context.effectiveLimitTokens,
+          compactionThresholdTokens: context.compactionThresholdTokens,
+        });
+      }
+      return {
+        sessionId,
+        handle,
+        resumedConversation: resolved.resumed,
+        skipRelayHistory: resolved.skipRelayHistory,
+        lifecycleGeneration: resolved.lifecycleGeneration,
+      };
+    } finally {
+      releaseCapacity();
+    }
+  }
+
+  private async commitConversationResetInner(
+    conversationId: string,
+    resetToken: string,
+  ): Promise<{ committed: true; alreadyCommitted: boolean }> {
+    const result = await this.conversations.commitReset(
+      conversationId,
+      resetToken,
+    );
+    const liveSessionId = this.conversationToSession.get(conversationId);
+    if (result.disposeLiveSession && liveSessionId !== undefined) {
+      await this.disposeSession(liveSessionId, false);
+    }
+    if (result.retiredSessionFile !== undefined) {
+      await this.conversations
+        .deleteSessionFile(result.retiredSessionFile)
+        .catch((error: unknown) => {
+          // The durable route and tombstone are already committed. An orphaned
+          // inactive JSONL cannot be reopened and is safer than turning a
+          // successful reset into a retry/ACK ambiguity.
+          this.logger.warn("failed to delete reset Pi session file", {
+            conversationId,
+            error: errorMessage(error),
+          });
+        });
+    }
+    return { committed: true, alreadyCommitted: result.alreadyCommitted };
+  }
+
+  private async createUnmappedSession(options: {
+    cwd: string;
+    requestedCwd: string;
+    systemPrompt?: string;
+    title?: string;
+  }): Promise<{
+    sessionId: string;
+    handle: AgentSessionHandle;
+    resumedConversation: boolean;
+    skipRelayHistory: boolean;
+    lifecycleGeneration?: string;
+  }> {
+    const releaseCapacity = await this.reserveCapacity();
+    try {
+      const sessionId = `ses_${randomUUID().replaceAll("-", "")}`;
+      const handle = await this.factory.create({
+        cwd: options.cwd,
+        requestedCwd: options.requestedCwd,
+        ...(options.systemPrompt === undefined
+          ? {}
+          : { systemPrompt: options.systemPrompt }),
+        ...(options.title === undefined ? {} : { title: options.title }),
+        eventSink: this.eventSink,
+        acpSessionId: sessionId,
+      });
+      releaseCapacity();
+      this.live.set(sessionId, { handle, lastUsedMs: this.now() });
+      return {
+        sessionId,
+        handle,
+        resumedConversation: false,
+        skipRelayHistory: false,
+      };
+    } finally {
+      releaseCapacity();
+    }
+  }
+
+  private installPendingLifecycleRoute(
+    sessionId: string,
+    conversationId: string,
+    lifecycleGeneration: string,
+  ): PendingLifecycleRoute {
+    const existing = this.pendingLifecycleRoutes.get(sessionId);
+    if (existing) {
+      if (
+        existing.identity.conversationId !== conversationId ||
+        existing.identity.lifecycleGeneration !== lifecycleGeneration
+      ) {
+        throw new Error("Pi creation lifecycle identity changed mid-session");
+      }
+      return existing;
+    }
+    let resolveReadiness: () => void = () => {};
+    let rejectReadiness: (error: Error) => void = () => {};
+    let settled = false;
+    const readiness = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolveReadiness = resolvePromise;
+      rejectReadiness = rejectPromise;
+    });
+    // A failed create can have no early event waiter. Mark the rejection
+    // observed while preserving it for every actual waiter.
+    void readiness.catch(() => {});
+    const route: PendingLifecycleRoute = {
+      identity: Object.freeze({
+        conversationId,
+        lifecycleGeneration,
+        readiness,
+        deferPublication: true,
+      }),
+      resolve: () => {
+        if (settled) return;
+        settled = true;
+        resolveReadiness();
+      },
+      reject: (error) => {
+        if (settled) return;
+        settled = true;
+        rejectReadiness(error);
+      },
+    };
+    this.pendingLifecycleRoutes.set(sessionId, route);
+    return route;
+  }
+
+  private async reserveCapacity(): Promise<() => void> {
+    let unlock = (): void => {};
+    const prior = this.capacityMutex;
+    this.capacityMutex = new Promise<void>((resolveMutex) => {
+      unlock = resolveMutex;
+    });
+    await prior;
+    try {
+      if (this.live.size + this.pendingCapacity >= this.config.maxSessions) {
+        const candidate = [...this.live.entries()]
+          .filter(([, session]) => !session.closing && !session.handle.isBusy)
+          .sort((left, right) => left[1].lastUsedMs - right[1].lastUsedMs)[0];
+        if (!candidate) {
+          throw new JsonRpcError(
+            INVALID_PARAMS,
+            "Session capacity reached; all slots are busy or initializing",
+          );
+        }
+        await this.evict(candidate[0], "lru");
+      }
+      this.pendingCapacity++;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        this.pendingCapacity = Math.max(0, this.pendingCapacity - 1);
+      };
+    } finally {
+      unlock();
+    }
+  }
+
+  private async evict(sessionId: string, reason: "lru" | "ttl"): Promise<void> {
+    const session = this.live.get(sessionId);
+    if (!session || session.handle.isBusy) return;
+    await this.disposeSession(sessionId, false);
+    this.logger.info("evicted inactive Pi session", { sessionId, reason });
+  }
+
+  private assertOpen(): void {
+    if (this.closing)
+      throw new JsonRpcError(INVALID_PARAMS, "Agent is shutting down");
+  }
+
+  private async invalidateSessions(
+    sessionIds: readonly string[],
+    error: Error,
+  ): Promise<void> {
+    for (const sessionId of sessionIds) {
+      // Use the same disposal invariant as explicit/LRU/TTL/shutdown paths:
+      // retain mapped conversation transcripts, but remove an unmapped file
+      // that has no durable route after this failed worker generation exits.
+      await this.disposeSession(sessionId, false).catch(
+        (disposeError: unknown) => {
+          this.logger.warn(
+            "failed to dispose session after runtime host failure",
+            {
+              sessionId,
+              error: errorMessage(disposeError),
+            },
+          );
+        },
+      );
+    }
+    this.logger.error("invalidated Pi sessions after runtime host failure", {
+      count: sessionIds.length,
+      error: errorMessage(error),
+    });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/buzz-pi-agent/src/types.ts
+++ b/packages/buzz-pi-agent/src/types.ts
@@ -1,0 +1,292 @@
+import type { Writable } from "node:stream";
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export type JsonRpcInbound = JsonRpcRequest | JsonRpcNotification;
+
+export interface AcpTextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface AcpImageBlock {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export type AcpContentBlock = AcpTextBlock | AcpImageBlock;
+
+export interface SessionNewParams {
+  cwd: string;
+  mcpServers?: unknown[];
+  systemPrompt?: string;
+  _meta?: {
+    sessionTitle?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface SessionPromptParams {
+  sessionId: string;
+  prompt: AcpContentBlock[];
+}
+
+export interface SessionIdParams {
+  sessionId: string;
+}
+
+export interface SessionSetModelParams extends SessionIdParams {
+  modelId: string;
+}
+
+export interface SessionSetConfigOptionParams extends SessionIdParams {
+  configId: string;
+  value: string;
+}
+
+export interface SessionSteeringParams extends SessionIdParams {
+  prompt: AcpContentBlock[];
+}
+
+export interface ModelDescriptor {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface ContextSnapshot {
+  usedTokens: number | null;
+  limitTokens: number;
+  effectiveLimitTokens: number;
+  compactionThresholdTokens: number;
+  autoCompaction: boolean;
+  compacting: boolean;
+  model: string | null;
+  thinkingLevel: string;
+  piSessionId: string;
+}
+
+export interface ResourceSnapshot {
+  extensions: number;
+  skills: number;
+  prompts: number;
+  contextFiles: number;
+  errors: string[];
+  projectTrusted: boolean;
+  commands: SlashCommandDescriptor[];
+}
+
+export interface SlashCommandDescriptor {
+  name: string;
+  description: string;
+}
+
+export interface SessionUsageSnapshot {
+  contextTokens: number | null;
+  accumulatedInputTokens: number;
+  accumulatedOutputTokens: number;
+  accumulatedCachedInputTokens: number;
+  accumulatedCost: number | null;
+  model: string | null;
+}
+
+export type CompactionReason =
+  | "manual"
+  | "threshold"
+  | "overflow"
+  | "preflight";
+
+export type BuzzSessionEvent =
+  | ({
+      type: "compaction_completed";
+      compactionId: string;
+      reason: CompactionReason;
+      beforeTokens: number | null;
+      afterTokens: number | null;
+      limitTokens: number;
+      effectiveLimitTokens: number;
+      compactionThresholdTokens: number;
+      willRetry: boolean;
+      fromExtension: boolean;
+    } & CommonBuzzSessionEvent)
+  | ({
+      type: "compaction_failed";
+      compactionId: string;
+      reason: CompactionReason;
+      beforeTokens: number | null;
+      limitTokens: number;
+      effectiveLimitTokens: number;
+      compactionThresholdTokens: number;
+      error: string;
+      aborted: boolean;
+      willRetry: boolean;
+      fromExtension: boolean;
+    } & CommonBuzzSessionEvent)
+  | ({
+      type: "context_status";
+      usedTokens: number | null;
+      remainingTokens: number | null;
+      percent: number | null;
+      limitTokens: number;
+      effectiveLimitTokens: number;
+      compactionThresholdTokens: number;
+      autoCompaction: boolean;
+      compacting: boolean;
+      model: string | null;
+    } & CommonBuzzSessionEvent)
+  | ({
+      type: "session_reset";
+      previousPiSessionId: string;
+      limitTokens: number;
+      effectiveLimitTokens: number;
+      compactionThresholdTokens: number;
+    } & CommonBuzzSessionEvent)
+  | ({
+      type: "extensions_reloaded";
+      extensions: number;
+      skills: number;
+      prompts: number;
+      contextFiles: number;
+      errors: string[];
+      projectTrusted: boolean;
+    } & CommonBuzzSessionEvent);
+
+interface CommonBuzzSessionEvent {
+  timestamp: string;
+  message: string;
+  piSessionId: string;
+}
+
+export interface PendingBuzzSessionEvent {
+  conversationId: string;
+  eventId: string;
+  /** Durable context epoch; Pi session IDs may change within one epoch. */
+  lifecycleGeneration: string;
+  event: BuzzSessionEvent;
+  createdAt: string;
+}
+
+export interface AdapterEventSink {
+  sessionUpdate(sessionId: string, update: Record<string, unknown>): void;
+  buzzSessionEvent(
+    sessionId: string,
+    event: BuzzSessionEvent,
+    deliveryId?: string,
+  ): void | Promise<void>;
+  usageUpdate(
+    sessionId: string,
+    usage: SessionUsageSnapshot,
+    contextLimit: number,
+  ): void;
+}
+
+export interface AgentSessionHandle {
+  readonly piSessionId: string;
+  readonly sessionFile: string | undefined;
+  readonly cwd: string;
+  readonly isBusy: boolean;
+  readonly isValid: boolean;
+  prompt(
+    text: string,
+    images?: AcpImageBlock[],
+  ): Promise<"end_turn" | "cancelled" | "max_tokens">;
+  steer(text: string): Promise<void>;
+  abort(): Promise<void>;
+  setModel(modelId: string): Promise<void>;
+  setThinkingLevel(level: string): Promise<void>;
+  reload(): Promise<ResourceSnapshot>;
+  reset(): Promise<{
+    previousPiSessionId: string;
+    resources: ResourceSnapshot;
+  }>;
+  getModels(): ModelDescriptor[];
+  getThinkingLevels(): string[];
+  getResources(): ResourceSnapshot;
+  getContextSnapshot(): ContextSnapshot;
+  getUsageSnapshot(): SessionUsageSnapshot;
+  /** Replay child-side durable lifecycle notices after outer routing is live. */
+  replayLifecycleEvents?(): Promise<void>;
+  /** Mark one child-side lifecycle notice durable in the parent adapter. */
+  acknowledgeLifecycleEvent?(deliveryId: string): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface CreateSessionOptions {
+  cwd: string;
+  /** Original lexical workspace path when cwd has already been canonicalized. */
+  requestedCwd?: string;
+  systemPrompt?: string;
+  title?: string;
+  persistedSessionFile?: string;
+  eventSink: AdapterEventSink;
+  acpSessionId: string;
+}
+
+export interface AgentSessionFactory {
+  create(options: CreateSessionOptions): Promise<AgentSessionHandle>;
+  setInvalidationHandler?(
+    handler: (
+      sessionIds: readonly string[],
+      error: Error,
+    ) => void | Promise<void>,
+  ): void;
+}
+
+export interface SessionMetadata {
+  sessionId: string;
+  cwd: string;
+  systemPrompt?: string;
+  title?: string;
+  piSessionId: string;
+  sessionFile?: string;
+  createdAt: string;
+  lastUsedAt: string;
+}
+
+export interface ConversationMapping {
+  conversationId: string;
+  cwd: string;
+  sessionFile: string;
+  piSessionId: string;
+  /** Rotates only at an authenticated Buzz reset boundary. */
+  lifecycleGeneration: string;
+  createdAt: string;
+  lastUsedAt: string;
+  lastResetToken?: string;
+  relayHistoryCleared?: boolean;
+  lease?: {
+    ownerId: string;
+    pid: number;
+    hostId?: string;
+    bootId?: string;
+    expiresAt: string;
+  };
+}
+
+export interface Logger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+export interface OutputWriter {
+  write(value: unknown): void;
+  end(): Promise<void>;
+}
+
+export type RawStdoutWrite = Writable["write"];

--- a/packages/buzz-pi-agent/src/wire.ts
+++ b/packages/buzz-pi-agent/src/wire.ts
@@ -1,0 +1,285 @@
+import type { Readable } from "node:stream";
+import type {
+  JsonRpcId,
+  JsonRpcInbound,
+  Logger,
+  OutputWriter,
+} from "./types.js";
+
+export const PARSE_ERROR = -32700;
+export const INVALID_REQUEST = -32600;
+export const METHOD_NOT_FOUND = -32601;
+export const INVALID_PARAMS = -32602;
+export const INTERNAL_ERROR = -32603;
+export const AGENT_CONTEXT_LIMIT = -32042;
+export const AGENT_OVERLOADED = -32043;
+export const AGENT_SESSION_STORAGE_LIMIT = -32044;
+export const AGENT_SESSION_INVALIDATED = -32045;
+
+export class JsonRpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "JsonRpcError";
+  }
+}
+
+export class NdjsonWriter implements OutputWriter {
+  private readonly queue: Array<{ line: string; bytes: number }> = [];
+  private queuedBytes = 0;
+  private flushing = false;
+  private closed = false;
+  private fatalError: Error | undefined;
+  private readonly idleWaiters = new Set<{
+    resolve: () => void;
+    reject: (error: Error) => void;
+  }>();
+
+  constructor(
+    private readonly rawWrite: (line: string) => void | Promise<void>,
+    private readonly logger: Logger,
+    private readonly options: {
+      maxQueuedMessages?: number;
+      maxQueuedBytes?: number;
+      onFatal?: (error: Error) => void;
+    } = {},
+  ) {}
+
+  write(value: unknown): void {
+    if (this.fatalError) return;
+    if (this.closed) {
+      this.poison(new Error("ACP stdout write attempted after close"));
+      return;
+    }
+    let line: string;
+    try {
+      line = `${JSON.stringify(value)}\n`;
+    } catch (error) {
+      this.poison(
+        new Error(
+          `failed to serialize protocol message: ${errorMessage(error)}`,
+        ),
+      );
+      return;
+    }
+    const bytes = Buffer.byteLength(line);
+    const maxQueuedMessages = this.options.maxQueuedMessages ?? 2_048;
+    const maxQueuedBytes = this.options.maxQueuedBytes ?? 16 * 1_024 * 1_024;
+    if (
+      this.queue.length + 1 > maxQueuedMessages ||
+      this.queuedBytes + bytes > maxQueuedBytes
+    ) {
+      this.poison(
+        new Error(
+          `ACP stdout queue saturated (${this.queue.length + 1} messages, ${this.queuedBytes + bytes} bytes)`,
+        ),
+      );
+      return;
+    }
+    this.queue.push({ line, bytes });
+    this.queuedBytes += bytes;
+    this.flush();
+  }
+
+  async end(): Promise<void> {
+    this.closed = true;
+    if (this.fatalError) throw this.fatalError;
+    if (this.flushing || this.queue.length > 0) {
+      await new Promise<void>((resolve, reject) => {
+        this.idleWaiters.add({ resolve, reject });
+      });
+    }
+    if (this.fatalError) throw this.fatalError;
+  }
+
+  private flush(): void {
+    if (this.flushing || this.fatalError) return;
+    this.flushing = true;
+    void (async () => {
+      try {
+        while (this.queue.length > 0 && !this.fatalError) {
+          const next = this.queue[0];
+          if (!next) break;
+          await this.rawWrite(next.line);
+          if (this.fatalError) break;
+          this.queue.shift();
+          this.queuedBytes -= next.bytes;
+        }
+      } catch (error) {
+        this.poison(
+          new Error(`failed to write protocol message: ${errorMessage(error)}`),
+        );
+      } finally {
+        this.flushing = false;
+        this.settleIdleWaiters();
+      }
+    })();
+  }
+
+  private poison(error: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = error;
+    this.queue.length = 0;
+    this.queuedBytes = 0;
+    this.logger.error("ACP stdout transport poisoned", {
+      error: error.message,
+    });
+    try {
+      this.options.onFatal?.(error);
+    } catch (callbackError) {
+      this.logger.error("ACP stdout fatal callback failed", {
+        error: errorMessage(callbackError),
+      });
+    }
+    this.settleIdleWaiters();
+  }
+
+  private settleIdleWaiters(): void {
+    if (!this.fatalError && (this.flushing || this.queue.length > 0)) return;
+    for (const waiter of this.idleWaiters) {
+      if (this.fatalError) waiter.reject(this.fatalError);
+      else waiter.resolve();
+    }
+    this.idleWaiters.clear();
+  }
+}
+
+export async function* readNdjson(
+  input: Readable,
+  maxLineBytes: number,
+): AsyncGenerator<string> {
+  let segments: Buffer[] = [];
+  let lineBytes = 0;
+  for await (const rawChunk of input) {
+    const chunk = Buffer.isBuffer(rawChunk)
+      ? rawChunk
+      : Buffer.from(String(rawChunk));
+    let offset = 0;
+    while (offset < chunk.byteLength) {
+      const newline = chunk.indexOf(0x0a, offset);
+      const end = newline === -1 ? chunk.byteLength : newline;
+      const length = end - offset;
+      if (lineBytes + length > maxLineBytes) {
+        throw new JsonRpcError(
+          INVALID_REQUEST,
+          `NDJSON line exceeds ${maxLineBytes} bytes`,
+        );
+      }
+      if (length > 0) {
+        segments.push(chunk.subarray(offset, end));
+        lineBytes += length;
+      }
+      if (newline === -1) break;
+
+      const frame =
+        segments.length === 0
+          ? Buffer.alloc(0)
+          : segments.length === 1
+            ? (segments[0] ?? Buffer.alloc(0))
+            : Buffer.concat(segments, lineBytes);
+      yield frame.toString("utf8").replace(/\r$/, "");
+      segments = [];
+      lineBytes = 0;
+      offset = newline + 1;
+    }
+  }
+  if (lineBytes > 0) {
+    throw new JsonRpcError(PARSE_ERROR, "unterminated NDJSON frame at EOF");
+  }
+}
+
+export function parseInbound(line: string): JsonRpcInbound {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch (error) {
+    throw new JsonRpcError(PARSE_ERROR, `Invalid JSON: ${errorMessage(error)}`);
+  }
+  if (
+    !isRecord(value) ||
+    value.jsonrpc !== "2.0" ||
+    typeof value.method !== "string"
+  ) {
+    throw new JsonRpcError(
+      INVALID_REQUEST,
+      "Expected a JSON-RPC 2.0 request or notification",
+    );
+  }
+  if ("id" in value && !isJsonRpcId(value.id)) {
+    throw new JsonRpcError(
+      INVALID_REQUEST,
+      "JSON-RPC id must be a string, number, or null",
+    );
+  }
+  return value as unknown as JsonRpcInbound;
+}
+
+export function response(
+  id: JsonRpcId,
+  result: unknown,
+): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, result };
+}
+
+export function errorResponse(
+  id: JsonRpcId,
+  error: unknown,
+): Record<string, unknown> {
+  const rpcError =
+    error instanceof JsonRpcError
+      ? error
+      : new JsonRpcError(INTERNAL_ERROR, errorMessage(error));
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: rpcError.code,
+      message: rpcError.message,
+      ...(rpcError.data === undefined ? {} : { data: rpcError.data }),
+    },
+  };
+}
+
+export function notification(
+  method: string,
+  params: unknown,
+): Record<string, unknown> {
+  return { jsonrpc: "2.0", method, params };
+}
+
+export function asRecord(
+  value: unknown,
+  name: string,
+): Record<string, unknown> {
+  if (!isRecord(value))
+    throw new JsonRpcError(INVALID_PARAMS, `${name} must be an object`);
+  return value;
+}
+
+export function requiredString(
+  value: Record<string, unknown>,
+  key: string,
+): string {
+  const item = value[key];
+  if (typeof item !== "string" || item.trim() === "") {
+    throw new JsonRpcError(INVALID_PARAMS, `${key} must be a non-empty string`);
+  }
+  return item;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return (
+    value === null || typeof value === "string" || typeof value === "number"
+  );
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/buzz-pi-agent/src/workspace.ts
+++ b/packages/buzz-pi-agent/src/workspace.ts
@@ -1,0 +1,75 @@
+import { realpathSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface WorkspaceIdentity {
+  requestedPath: string;
+  canonicalPath: string;
+  device: string;
+  inode: string;
+}
+
+/**
+ * Resolve an existing workspace to one stable target before any persistence,
+ * trust decision, session creation, or resource discovery uses it.
+ */
+export function captureWorkspaceIdentity(
+  requestedPath: string,
+  expectedCanonicalPath?: string,
+): WorkspaceIdentity {
+  const resolvedRequestedPath = resolve(requestedPath);
+  let canonicalPath: string;
+  let stats: ReturnType<typeof statSync>;
+  try {
+    canonicalPath = realpathSync.native(resolvedRequestedPath);
+    stats = statSync(canonicalPath, { bigint: true });
+    const verifiedCanonicalPath = realpathSync.native(resolvedRequestedPath);
+    const verifiedStats = statSync(verifiedCanonicalPath, { bigint: true });
+    if (
+      verifiedCanonicalPath !== canonicalPath ||
+      verifiedStats.dev !== stats.dev ||
+      verifiedStats.ino !== stats.ino
+    ) {
+      throw workspaceError("changed targets while its identity was captured");
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("BUZZ_PI_WORKSPACE_CHANGED:")
+    ) {
+      throw error;
+    }
+    throw workspaceError("is unavailable", error);
+  }
+  if (!stats.isDirectory()) {
+    throw workspaceError("is not a directory");
+  }
+  if (
+    expectedCanonicalPath !== undefined &&
+    canonicalPath !== expectedCanonicalPath
+  ) {
+    throw workspaceError("changed targets before Pi session creation");
+  }
+  return {
+    requestedPath: resolvedRequestedPath,
+    canonicalPath,
+    device: stats.dev.toString(),
+    inode: stats.ino.toString(),
+  };
+}
+
+/** Fail closed if a symlink target or the workspace directory inode changed. */
+export function assertWorkspaceIdentity(identity: WorkspaceIdentity): void {
+  const current = captureWorkspaceIdentity(
+    identity.requestedPath,
+    identity.canonicalPath,
+  );
+  if (current.device !== identity.device || current.inode !== identity.inode) {
+    throw workspaceError("was replaced while the Pi session was active");
+  }
+}
+
+function workspaceError(message: string, cause?: unknown): Error {
+  return new Error(`BUZZ_PI_WORKSPACE_CHANGED: workspace ${message}`, {
+    ...(cause === undefined ? {} : { cause }),
+  });
+}

--- a/packages/buzz-pi-agent/test/cli.test.mjs
+++ b/packages/buzz-pi-agent/test/cli.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { execFile, spawn } from "node:child_process";
+import { test } from "node:test";
+
+const execFileAsync = promisify(execFile);
+const cli = new URL("../dist/cli.js", import.meta.url);
+
+test("built CLI is executable and supports clean help/version PATH probes", async () => {
+  await access(cli, constants.X_OK);
+  assert.ok((await stat(cli)).mode & 0o111);
+  const version = await execFileAsync(cli.pathname, ["--version"]);
+  assert.equal(version.stdout, "0.1.0\n");
+  assert.equal(version.stderr, "");
+  const help = await execFileAsync(cli.pathname, ["--help"]);
+  assert.match(help.stdout, /Serve ACP over stdin\/stdout/);
+  assert.equal(help.stderr, "");
+});
+
+test("built CLI completes a real ACP initialize/shutdown stdio exchange", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-cli-smoke-"));
+  const child = spawn(cli.pathname, [], {
+    env: {
+      ...process.env,
+      PI_CODING_AGENT_DIR: join(root, "pi-agent"),
+      BUZZ_PI_STATE_DIR: join(root, "state"),
+      BUZZ_PI_LOG_LEVEL: "error",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  child.stdin.end(
+    `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 2 } })}\n` +
+      `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "shutdown", params: {} })}\n`,
+  );
+  const exit = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  assert.deepEqual(exit, { code: 0, signal: null }, stderr);
+  const messages = stdout
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  assert.equal(messages[0].id, 1);
+  assert.equal(messages[0].result.agentInfo.name, "buzz-pi-agent");
+  assert.deepEqual(messages[1], {
+    jsonrpc: "2.0",
+    id: 2,
+    result: { shutdown: true },
+  });
+});

--- a/packages/buzz-pi-agent/test/config.test.mjs
+++ b/packages/buzz-pi-agent/test/config.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  compactionThreshold,
+  effectiveCompactionSettings,
+  effectiveContextLimit,
+  loadConfig,
+  logicalModelContextWindow,
+} from "../dist/index.js";
+
+test("150k is a logical safety ceiling with a separate model-safe compaction threshold", () => {
+  assert.equal(effectiveContextLimit(200_000, 150_000), 150_000);
+  assert.equal(logicalModelContextWindow(200_000, 150_000), 150_000);
+  assert.equal(compactionThreshold(150_000, 16_384), 133_616);
+});
+
+test("models with smaller windows compact below their own ceiling", () => {
+  assert.equal(effectiveContextLimit(128_000, 150_000), 128_000);
+  assert.equal(logicalModelContextWindow(128_000, 150_000), 128_000);
+  assert.equal(compactionThreshold(128_000, 16_384), 111_616);
+  assert.deepEqual(effectiveCompactionSettings(32_000, 16_384, 24_000), {
+    reserveTokens: 8_000,
+    keepRecentTokens: 18_000,
+    thresholdTokens: 24_000,
+  });
+});
+
+test("configuration defaults to 150k, bounded persistence, and fail-closed trust override", () => {
+  const config = loadConfig({ HOME: "/tmp/pi-home" });
+  assert.equal(config.contextLimitTokens, 150_000);
+  assert.equal(config.maxSessions, 12);
+  assert.equal(config.sessionTtlMs, 45 * 60 * 1_000);
+  assert.equal(config.maxPersistedConversations, 512);
+  assert.equal(config.persistedConversationTtlMs, 90 * 24 * 60 * 60 * 1_000);
+  assert.equal(config.maxPendingResetTombstones, 512);
+  assert.equal(config.maxRetainedResetTombstones, 512);
+  assert.equal(config.resetTombstoneTtlMs, 30 * 24 * 60 * 60 * 1_000);
+  assert.equal(config.maxSessionFileBytes, 64 * 1_024 * 1_024);
+  assert.equal(config.maxPendingSessionEvents, 256);
+  assert.equal(config.trustProjectOverride, undefined);
+  assert.equal(config.runtimeRequestTimeoutMs, 110 * 60 * 1_000);
+  assert.equal(config.runtimeInterruptTimeoutMs, 1_200);
+  assert.equal(config.maxOutputQueueMessages, 2_048);
+  assert.equal(config.maxActiveRequests, 64);
+  assert.equal(config.maxOutputQueueBytes, 16 * 1_024 * 1_024);
+  assert.equal(config.maxRuntimeIpcQueueMessages, 1_024);
+  assert.equal(config.maxRuntimeIpcQueueBytes, 16 * 1_024 * 1_024);
+  assert.equal(config.maxResourceFileBytes, 1 * 1_024 * 1_024);
+  assert.equal(config.maxResourceTotalBytes, 16 * 1_024 * 1_024);
+  assert.equal(config.maxResourceFiles, 512);
+  assert.equal(config.maxResourceEntries, 4_096);
+  assert.equal(config.maxResourceDepth, 16);
+});
+
+test("invalid numeric and trust settings fail startup", () => {
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_CONTEXT_LIMIT: "0" }),
+    /positive integer/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_TRUST_PROJECT: "maybe" }),
+    /boolean/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        BUZZ_PI_CONTEXT_LIMIT: "100",
+        BUZZ_PI_COMPACTION_RESERVE: "100",
+        BUZZ_PI_KEEP_RECENT_TOKENS: "1",
+      }),
+    /COMPACTION_RESERVE/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        BUZZ_PI_CONTEXT_LIMIT: "100",
+        BUZZ_PI_COMPACTION_RESERVE: "10",
+        BUZZ_PI_KEEP_RECENT_TOKENS: "90",
+      }),
+    /KEEP_RECENT/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS: "120000" }),
+    /INTERRUPT_TIMEOUT/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_PENDING_RESET_TOMBSTONES: "513" }),
+    /must not exceed 512/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_RETAINED_RESET_TOMBSTONES: "513" }),
+    /must not exceed 512/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_RESET_TOMBSTONE_TTL_MS: "31536000001" }),
+    /must not exceed 31536000000/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_OUTPUT_QUEUE_MESSAGES: "8193" }),
+    /must not exceed 8192/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_RUNTIME_IPC_QUEUE_MESSAGES: "4097" }),
+    /must not exceed 4096/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_ACTIVE_REQUESTS: "513" }),
+    /must not exceed 512/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_PERSISTED_CONVERSATIONS: "513" }),
+    /must not exceed 512/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_SESSION_FILE_BYTES: "1048575" }),
+    /must be at least 1048576/,
+  );
+  assert.throws(
+    () => loadConfig({ BUZZ_PI_MAX_PENDING_SESSION_EVENTS: "513" }),
+    /must not exceed 512/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        BUZZ_PI_MAX_RESOURCE_FILE_BYTES: "1024",
+        BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES: "512",
+      }),
+    /TOTAL_BYTES must be at least/,
+  );
+  assert.throws(
+    () =>
+      loadConfig({
+        BUZZ_PI_MAX_RESOURCE_FILES: "10",
+        BUZZ_PI_MAX_RESOURCE_ENTRIES: "9",
+      }),
+    /ENTRIES must be at least/,
+  );
+});
+
+test("every resource and timer setting has a production upper bound", () => {
+  for (const [name, maximum] of [
+    ["BUZZ_PI_CONTEXT_LIMIT", 150_000],
+    ["BUZZ_PI_COMPACTION_RESERVE", 149_999],
+    ["BUZZ_PI_KEEP_RECENT_TOKENS", 149_999],
+    ["BUZZ_PI_MAX_SESSIONS", 128],
+    ["BUZZ_PI_SESSION_TTL_MS", 24 * 60 * 60 * 1_000],
+    ["BUZZ_PI_SWEEP_INTERVAL_MS", 60 * 60 * 1_000],
+    ["BUZZ_PI_MAX_LINE_BYTES", 64 * 1_024 * 1_024],
+    ["BUZZ_PI_PERSISTED_CONVERSATION_TTL_MS", 365 * 24 * 60 * 60 * 1_000],
+    ["BUZZ_PI_CONVERSATION_LEASE_MS", 24 * 60 * 60 * 1_000],
+    ["BUZZ_PI_MAX_SESSION_FILE_BYTES", 512 * 1_024 * 1_024],
+    ["BUZZ_PI_MAX_PENDING_SESSION_EVENTS", 512],
+    ["BUZZ_PI_RUNTIME_REQUEST_TIMEOUT_MS", 6 * 60 * 60 * 1_000],
+    ["BUZZ_PI_RUNTIME_CONTROL_TIMEOUT_MS", 30 * 60 * 1_000],
+    ["BUZZ_PI_RUNTIME_INTERRUPT_TIMEOUT_MS", 60 * 1_000],
+    ["BUZZ_PI_MAX_RESOURCE_FILE_BYTES", 16 * 1_024 * 1_024],
+    ["BUZZ_PI_MAX_RESOURCE_TOTAL_BYTES", 64 * 1_024 * 1_024],
+    ["BUZZ_PI_MAX_RESOURCE_FILES", 4_096],
+    ["BUZZ_PI_MAX_RESOURCE_ENTRIES", 16_384],
+    ["BUZZ_PI_MAX_RESOURCE_DEPTH", 64],
+  ]) {
+    assert.throws(
+      () => loadConfig({ [name]: String(maximum + 1) }),
+      new RegExp(`${name} must not exceed ${maximum}`),
+      name,
+    );
+  }
+});
+
+test("absurdly small custom model windows are rejected", () => {
+  assert.throws(() => effectiveCompactionSettings(7, 2, 2), /too small/);
+});
+
+test("maximum retention bounds fit below the durable manifest write ceiling", () => {
+  const conversations = {};
+  const resetTombstones = {};
+  const timestamp = "2026-08-02T00:00:00.000Z";
+  const escaped = '"';
+  for (let index = 0; index < 512; index += 1) {
+    const conversationId = `c${index}`.padEnd(512, escaped);
+    const piSessionId = escaped.repeat(256);
+    const resetToken = escaped.repeat(512);
+    conversations[conversationId] = {
+      conversationId,
+      cwd: `/${escaped.repeat(2_047)}`,
+      sessionFile: `/${escaped.repeat(4_089)}.jsonl`,
+      piSessionId,
+      createdAt: timestamp,
+      lastUsedAt: timestamp,
+      lastResetToken: resetToken,
+      relayHistoryCleared: true,
+      lease: {
+        ownerId: escaped.repeat(256),
+        pid: 999_999,
+        hostId: escaped.repeat(128),
+        bootId: escaped.repeat(128),
+        expiresAt: timestamp,
+      },
+    };
+    resetTombstones[conversationId] = {
+      conversationId,
+      previousPiSessionId: piSessionId,
+      resetToken,
+      createdAt: timestamp,
+      status: "retained",
+      installedPiSessionId: piSessionId,
+      consumedAt: timestamp,
+    };
+  }
+  for (let index = 0; index < 512; index += 1) {
+    const conversationId = `p${index}`.padEnd(512, escaped);
+    resetTombstones[conversationId] = {
+      conversationId,
+      previousPiSessionId: escaped.repeat(256),
+      resetToken: escaped.repeat(512),
+      createdAt: timestamp,
+      status: "pending",
+    };
+  }
+  const bytes = Buffer.byteLength(
+    `${JSON.stringify({ version: 1, conversations, resetTombstones }, null, 2)}\n`,
+  );
+  assert.ok(bytes < 16 * 1_024 * 1_024, `${bytes} must fit below 16 MiB`);
+});

--- a/packages/buzz-pi-agent/test/conversation-store.test.mjs
+++ b/packages/buzz-pi-agent/test/conversation-store.test.mjs
@@ -1,0 +1,2108 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  ConversationStore,
+  deriveNamespace,
+  syncDirectoryEntry,
+} from "../dist/index.js";
+import {
+  captureStateLockGeneration,
+  removeObservedStaleLock,
+} from "../dist/conversation-store.js";
+import { silentLogger, testConfig } from "./helpers.mjs";
+
+async function setup(overrides = {}, leaseIdentity) {
+  const stateDir = await mkdtemp(join(tmpdir(), "buzz-pi-store-"));
+  const config = testConfig({ stateDir, ...overrides });
+  const env = {
+    BUZZ_PI_NAMESPACE: "test-agent",
+    BUZZ_RELAY_URL: "ws://relay.example",
+    BUZZ_PRIVATE_KEY: "secret",
+  };
+  const store = new ConversationStore(config, silentLogger, env, leaseIdentity);
+  await store.initialize();
+  return { store, stateDir, config, env };
+}
+
+async function createSessionFile(directory, name) {
+  const path = join(directory, `${name}.jsonl`);
+  await writeFile(path, '{"type":"session"}\n', { mode: 0o600 });
+  return path;
+}
+
+const TEST_LEASE_IDENTITY = Object.freeze({
+  hostId: "a".repeat(64),
+  bootId: "b".repeat(64),
+  pidProbeSafe: true,
+});
+
+function contextEvent(piSessionId, message = "Context status.") {
+  return {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message,
+    piSessionId,
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+}
+
+test("explicit namespaces reject traversal and lossy normalization collisions", async () => {
+  for (const namespace of [
+    ".",
+    "..",
+    "../outside",
+    "team/name",
+    "team?name",
+    " team",
+    "team ",
+  ]) {
+    assert.throws(
+      () => deriveNamespace({ BUZZ_PI_NAMESPACE: namespace }),
+      /BUZZ_PI_NAMESPACE/,
+      namespace,
+    );
+  }
+  assert.equal(
+    deriveNamespace({ BUZZ_PI_NAMESPACE: "team.alpha_1-prod" }),
+    "team.alpha_1-prod",
+  );
+
+  const parent = await mkdtemp(join(tmpdir(), "buzz-pi-namespace-"));
+  const stateDir = join(parent, "state");
+  assert.throws(
+    () =>
+      new ConversationStore(testConfig({ stateDir }), silentLogger, {
+        BUZZ_PI_NAMESPACE: "..",
+      }),
+    /BUZZ_PI_NAMESPACE/,
+  );
+  await assert.rejects(() => stat(join(parent, "conversations.json")), {
+    code: "ENOENT",
+  });
+});
+
+test("derived namespaces canonicalize equivalent key and relay spellings", () => {
+  const secretHex = `${"0".repeat(63)}1`;
+  const secretNsec =
+    "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl";
+
+  const canonical = deriveNamespace({
+    BUZZ_RELAY_URL: "ws://relay.example/",
+    BUZZ_PRIVATE_KEY: secretHex,
+  });
+  for (const [relayUrl, privateKey] of [
+    ["WS://RELAY.EXAMPLE:80", secretNsec],
+    ["ws://relay.example", secretHex.toUpperCase()],
+    ["ws://relay.example/path/../#ignored", secretNsec],
+    ["ws://relay.example", secretNsec.toUpperCase()],
+  ]) {
+    assert.equal(
+      deriveNamespace({
+        BUZZ_RELAY_URL: relayUrl,
+        BUZZ_PRIVATE_KEY: privateKey,
+      }),
+      canonical,
+    );
+  }
+
+  assert.notEqual(
+    deriveNamespace({
+      BUZZ_RELAY_URL: "wss://relay.example/",
+      BUZZ_PRIVATE_KEY: secretHex,
+    }),
+    canonical,
+  );
+  assert.notEqual(
+    deriveNamespace({
+      BUZZ_RELAY_URL: "ws://relay.example/",
+      BUZZ_PRIVATE_KEY: `${secretNsec.slice(0, -1)}q`,
+    }),
+    canonical,
+  );
+});
+
+test("namespace symlinks cannot redirect durable state outside the configured root", {
+  skip: process.platform === "win32",
+}, async () => {
+  const parent = await mkdtemp(join(tmpdir(), "buzz-pi-namespace-link-"));
+  const stateDir = join(parent, "state");
+  const outside = join(parent, "outside");
+  await mkdir(stateDir, { mode: 0o700 });
+  await mkdir(outside, { mode: 0o700 });
+  await symlink(outside, join(stateDir, "team"));
+  const store = new ConversationStore(testConfig({ stateDir }), silentLogger, {
+    BUZZ_PI_NAMESPACE: "team",
+  });
+  await assert.rejects(() => store.initialize(), /real directory/);
+  await assert.rejects(() => stat(join(outside, "conversations.json")), {
+    code: "ENOENT",
+  });
+});
+
+test("Windows skips unsupported directory fsync after atomic manifest rename", async () => {
+  // A nonexistent path proves the Windows branch returns before fs.open. The
+  // normal-platform branch is exercised by every manifest persistence test.
+  await syncDirectoryEntry("Z:\\definitely-missing\\buzz-state", "win32");
+});
+
+test("conversation mapping is atomically persisted with private permissions", async () => {
+  const { store, stateDir } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "pi-one");
+  const resolved = await store.resolve(
+    "channel:root",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return { sessionFile, piSessionId: "pi-one", cwd: "/tmp/project" };
+    },
+  );
+  await resolved.release();
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(manifest.conversations["channel:root"].piSessionId, "pi-one");
+  assert.equal((await stat(manifestPath)).mode & 0o777, 0o600);
+});
+
+test("legacy manifests and outbox records migrate into one stable replay epoch", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "legacy-epoch");
+  const session = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "legacy-epoch",
+      cwd: "/tmp/project",
+    }),
+  );
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  await store.enqueueSessionEvent(
+    "thread",
+    eventId,
+    contextEvent("legacy-epoch"),
+    session.lifecycleGeneration,
+  );
+  await session.release();
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const legacyManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  delete legacyManifest.conversations.thread.lifecycleGeneration;
+  await writeFile(manifestPath, `${JSON.stringify(legacyManifest)}\n`, {
+    mode: 0o600,
+  });
+  const pendingRoot = join(stateDir, "test-agent", "pending-events");
+  const [conversationDirectory] = await readdir(pendingRoot);
+  const eventPath = join(pendingRoot, conversationDirectory, `${eventId}.json`);
+  const legacyEvent = JSON.parse(await readFile(eventPath, "utf8"));
+  delete legacyEvent.lifecycleGeneration;
+  await writeFile(eventPath, `${JSON.stringify(legacyEvent)}\n`, {
+    mode: 0o600,
+  });
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  const migratedMapping = await restarted.get("thread");
+  assert.match(migratedMapping.lifecycleGeneration, /^[0-9a-f]{64}$/u);
+  const [migratedEvent] = await restarted.listPendingSessionEvents("thread");
+  assert.equal(
+    migratedEvent.lifecycleGeneration,
+    migratedMapping.lifecycleGeneration,
+    "an ambiguous legacy notice is conservatively replayable, never dropped",
+  );
+
+  const resumed = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, sessionFile);
+      return {
+        sessionFile,
+        piSessionId: "legacy-epoch-successor",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(
+    resumed.lifecycleGeneration,
+    migratedMapping.lifecycleGeneration,
+  );
+  const rewritten = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(
+    rewritten.conversations.thread.lifecycleGeneration,
+    migratedMapping.lifecycleGeneration,
+  );
+  await resumed.release();
+});
+
+test("lifecycle events survive restart and are removed only by idempotent ACK", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const event = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Context is at 50%.",
+    piSessionId: "pi-durable-event",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  const sessionFile = await createSessionFile(stateDir, "durable-event");
+  const session = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "pi-durable-event",
+      cwd: "/tmp/project",
+    }),
+  );
+  await store.enqueueSessionEvent(
+    "thread",
+    eventId,
+    event,
+    session.lifecycleGeneration,
+  );
+  await store.enqueueSessionEvent(
+    "thread",
+    eventId,
+    event,
+    session.lifecycleGeneration,
+  );
+  await session.release();
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  const pending = await restarted.listPendingSessionEvents("thread");
+  assert.deepEqual(pending, [
+    {
+      conversationId: "thread",
+      eventId,
+      lifecycleGeneration: session.lifecycleGeneration,
+      event,
+      createdAt: pending[0].createdAt,
+    },
+  ]);
+  const pendingRoot = join(stateDir, "test-agent", "pending-events");
+  const [conversationDirectory] = await readdir(pendingRoot);
+  const [eventFile] = await readdir(join(pendingRoot, conversationDirectory));
+  assert.equal(
+    (await stat(join(pendingRoot, conversationDirectory, eventFile))).mode &
+      0o777,
+    0o600,
+  );
+
+  await restarted.acknowledgeSessionEvent("thread", eventId);
+  await restarted.acknowledgeSessionEvent("thread", eventId);
+  assert.deepEqual(await restarted.listPendingSessionEvents("thread"), []);
+});
+
+test("lifecycle outbox capacity fails closed without dropping older unacknowledged events", async () => {
+  const { store, stateDir } = await setup({ maxPendingSessionEvents: 1 });
+  const lifecycleGenerations = new Map();
+  const event = {
+    type: "session_reset",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Started a fresh session.",
+    piSessionId: "pi-fresh",
+    previousPiSessionId: "pi-old",
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+  };
+  for (const conversationId of ["thread", "other"]) {
+    const sessionFile = await createSessionFile(
+      stateDir,
+      `event-capacity-${conversationId}`,
+    );
+    const session = await store.resolve(
+      conversationId,
+      undefined,
+      "/tmp/project",
+      async () => ({
+        sessionFile,
+        piSessionId: "pi-fresh",
+        cwd: "/tmp/project",
+      }),
+    );
+    lifecycleGenerations.set(conversationId, session.lifecycleGeneration);
+    await session.release();
+  }
+  const firstId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  await store.enqueueSessionEvent(
+    "thread",
+    firstId,
+    event,
+    lifecycleGenerations.get("thread"),
+  );
+  await assert.rejects(
+    () =>
+      store.enqueueSessionEvent(
+        "other",
+        "b8ba08e4-65f5-4aed-9406-6c67fe8375db",
+        event,
+        lifecycleGenerations.get("other"),
+      ),
+    /capacity 1 is full/,
+  );
+  assert.deepEqual(
+    (await store.listPendingSessionEvents("thread")).map(
+      (record) => record.eventId,
+    ),
+    [firstId],
+  );
+  assert.deepEqual(await store.listPendingSessionEvents("other"), []);
+});
+
+test("a committed reset supersedes pending lifecycle events and fences late old-generation writes", async () => {
+  const { store, stateDir } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "event-before-reset");
+  const session = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "pi-before-reset",
+      cwd: "/tmp/project",
+    }),
+  );
+  const event = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Old context status.",
+    piSessionId: "pi-before-reset",
+    usedTokens: 120_000,
+    remainingTokens: 30_000,
+    percent: 80,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  await store.enqueueSessionEvent(
+    "thread",
+    "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+    event,
+    session.lifecycleGeneration,
+  );
+  assert.equal((await store.listPendingSessionEvents("thread")).length, 1);
+
+  await store.commitReset("thread", "signed-reset");
+  assert.deepEqual(await store.listPendingSessionEvents("thread"), []);
+  await store.enqueueSessionEvent(
+    "thread",
+    "b8ba08e4-65f5-4aed-9406-6c67fe8375db",
+    event,
+    session.lifecycleGeneration,
+  );
+  assert.deepEqual(
+    await store.listPendingSessionEvents("thread"),
+    [],
+    "a late event from the old Pi generation must not survive reset cleanup",
+  );
+  await session.release();
+});
+
+test("two adapter stores cannot reinstall or replay an old-generation event after reset", async () => {
+  const {
+    store: oldOwner,
+    stateDir,
+    config,
+    env,
+  } = await setup({}, TEST_LEASE_IDENTITY);
+  const oldSessionFile = await createSessionFile(stateDir, "event-old-owner");
+  const oldSession = await oldOwner.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldSessionFile,
+      piSessionId: "pi-old-owner",
+      cwd: "/tmp/project",
+    }),
+  );
+  const event = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Old owner context status.",
+    piSessionId: "pi-old-owner",
+    usedTokens: 120_000,
+    remainingTokens: 30_000,
+    percent: 80,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  assert.equal(
+    await oldOwner.enqueueSessionEvent(
+      "thread",
+      "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+      event,
+      oldSession.lifecycleGeneration,
+    ),
+    true,
+  );
+
+  const resetOwner = new ConversationStore(
+    config,
+    silentLogger,
+    env,
+    TEST_LEASE_IDENTITY,
+  );
+  await resetOwner.initialize();
+  await resetOwner.commitReset("thread", "signed-reset");
+  assert.deepEqual(await resetOwner.listPendingSessionEvents("thread"), []);
+
+  assert.equal(
+    await oldOwner.enqueueSessionEvent(
+      "thread",
+      "b8ba08e4-65f5-4aed-9406-6c67fe8375db",
+      event,
+      oldSession.lifecycleGeneration,
+    ),
+    false,
+    "the stale adapter must observe the committed manifest generation",
+  );
+
+  const freshSessionFile = await createSessionFile(stateDir, "event-new-owner");
+  const freshSession = await resetOwner.resolve(
+    "thread",
+    "signed-reset",
+    "/tmp/project",
+    async () => ({
+      sessionFile: freshSessionFile,
+      piSessionId: "pi-new-owner",
+      cwd: "/tmp/project",
+    }),
+  );
+  assert.equal(
+    await oldOwner.enqueueSessionEvent(
+      "thread",
+      "a28cf3b0-fdd0-445c-82d1-bbf4de2ab909",
+      event,
+      oldSession.lifecycleGeneration,
+    ),
+    false,
+    "an installed replacement generation must continue fencing the old owner",
+  );
+  assert.deepEqual(await resetOwner.listPendingSessionEvents("thread"), []);
+
+  await freshSession.release();
+  await oldSession.release();
+});
+
+test("replacement cleanup stays inside the conversation fence and cannot delete a successor event", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const initialFile = await createSessionFile(stateDir, "cleanup-race-a");
+  const initial = await store.resolve(
+    "thread",
+    "reset-a",
+    "/tmp/project",
+    async () => ({
+      sessionFile: initialFile,
+      piSessionId: "cleanup-race-a",
+      cwd: "/tmp/project",
+    }),
+  );
+  await initial.release();
+
+  const ownerB = new ConversationStore(config, silentLogger, env);
+  const ownerC = new ConversationStore(config, silentLogger, env);
+  await ownerB.initialize();
+  await ownerC.initialize();
+  let signalCleanupStarted;
+  const cleanupStarted = new Promise((resolve) => {
+    signalCleanupStarted = resolve;
+  });
+  let releaseCleanup;
+  const cleanupGate = new Promise((resolve) => {
+    releaseCleanup = resolve;
+  });
+  const originalCleanup = ownerB.clearPendingSessionEvents.bind(ownerB);
+  ownerB.clearPendingSessionEvents = async (...args) => {
+    signalCleanupStarted();
+    await cleanupGate;
+    return originalCleanup(...args);
+  };
+
+  const fileB = await createSessionFile(stateDir, "cleanup-race-b");
+  const resolveB = ownerB.resolve(
+    "thread",
+    "reset-b",
+    "/tmp/project",
+    async () => ({
+      sessionFile: fileB,
+      piSessionId: "cleanup-race-b",
+      cwd: "/tmp/project",
+    }),
+  );
+  await cleanupStarted;
+
+  let signalCreateC;
+  const createCStarted = new Promise((resolve) => {
+    signalCreateC = resolve;
+  });
+  const fileC = await createSessionFile(stateDir, "cleanup-race-c");
+  const successorEventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const resolveCAndEnqueue = (async () => {
+    const resolved = await ownerC.resolve(
+      "thread",
+      "reset-c",
+      "/tmp/project",
+      async () => {
+        signalCreateC();
+        return {
+          sessionFile: fileC,
+          piSessionId: "cleanup-race-c",
+          cwd: "/tmp/project",
+        };
+      },
+    );
+    await ownerC.enqueueSessionEvent(
+      "thread",
+      successorEventId,
+      {
+        type: "context_status",
+        timestamp: "2026-08-02T00:00:00.000Z",
+        message: "Successor context status.",
+        piSessionId: "cleanup-race-c",
+        usedTokens: 75_000,
+        remainingTokens: 75_000,
+        percent: 50,
+        limitTokens: 150_000,
+        effectiveLimitTokens: 150_000,
+        compactionThresholdTokens: 133_616,
+        autoCompaction: true,
+        compacting: false,
+        model: "provider/model",
+      },
+      resolved.lifecycleGeneration,
+    );
+    return resolved;
+  })();
+  const createEnteredWhileCleanupBlocked = await Promise.race([
+    createCStarted.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 40)),
+  ]);
+  releaseCleanup();
+  const [resolvedB, resolvedC] = await Promise.all([
+    resolveB,
+    resolveCAndEnqueue,
+  ]);
+
+  assert.equal(
+    createEnteredWhileCleanupBlocked,
+    false,
+    "successor creation entered while predecessor cleanup was still fenced",
+  );
+  assert.deepEqual(
+    (await ownerC.listPendingSessionEvents("thread")).map(
+      (pending) => pending.eventId,
+    ),
+    [successorEventId],
+  );
+  await resolvedB.release();
+  await resolvedC.release();
+});
+
+test("cross-host-safe lock owners carry host and boot identity", async () => {
+  const { store, stateDir } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "lock-owner");
+  let owner;
+  const resolved = await store.resolve(
+    "lock-owner-thread",
+    undefined,
+    "/tmp/project",
+    async () => {
+      const locksDirectory = join(stateDir, "test-agent", "locks");
+      const lockName = (await readdir(locksDirectory)).find((name) =>
+        name.startsWith("conversation-"),
+      );
+      assert.ok(lockName);
+      owner = JSON.parse(
+        await readFile(join(locksDirectory, lockName, "owner"), "utf8"),
+      );
+      return {
+        sessionFile,
+        piSessionId: "lock-owner",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(owner.version, 1);
+  assert.equal(owner.pid, process.pid);
+  assert.match(owner.token, /^[0-9a-f-]+$/u);
+  assert.match(owner.hostId, /^[0-9a-f]{64}$/u);
+  if (owner.bootId !== undefined) assert.match(owner.bootId, /^[0-9a-f]{64}$/u);
+  assert.ok(Number.isFinite(Date.parse(owner.createdAt)));
+  await resolved.release();
+});
+
+test("missing persisted JSONL is recreated and mapping is repaired", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const oldFile = await createSessionFile(stateDir, "old");
+  const first = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "old",
+      cwd: "/tmp/project",
+    }),
+  );
+  await first.release();
+  await unlink(oldFile);
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  const newFile = await createSessionFile(stateDir, "new");
+  let calls = 0;
+  const repaired = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      calls++;
+      if (prior)
+        throw Object.assign(new Error("session file missing"), {
+          code: "ENOENT",
+        });
+      return { sessionFile: newFile, piSessionId: "new", cwd: "/tmp/project" };
+    },
+  );
+  assert.equal(calls, 2);
+  assert.equal(repaired.mapping?.piSessionId, "new");
+  await repaired.release();
+});
+
+test("a transcript quota refusal preserves the persisted route and never falls back fresh", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const oldFile = await createSessionFile(stateDir, "quota-route-old");
+  const old = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "quota-route-old",
+      cwd: "/tmp/project",
+    }),
+  );
+  await old.release();
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  let createCalls = 0;
+  await assert.rejects(
+    () =>
+      restarted.resolve("thread", undefined, "/tmp/project", async (prior) => {
+        createCalls += 1;
+        assert.equal(prior, oldFile);
+        throw new Error(
+          "BUZZ_SESSION_STORAGE_LIMIT: transcript is full; use /new",
+        );
+      }),
+    /BUZZ_SESSION_STORAGE_LIMIT/,
+  );
+  assert.equal(createCalls, 1);
+  const mapping = await restarted.get("thread");
+  assert.equal(mapping?.piSessionId, "quota-route-old");
+  assert.equal(mapping?.sessionFile, oldFile);
+  await stat(oldFile);
+});
+
+test("reset token is idempotent and a changed token atomically repoints context", async () => {
+  const { store, stateDir } = await setup();
+  const originalFile = await createSessionFile(stateDir, "original");
+  const original = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: originalFile,
+      piSessionId: "original",
+      cwd: "/tmp/project",
+    }),
+  );
+  await original.release();
+
+  const resetFile = await createSessionFile(stateDir, "reset");
+  const reset = await store.resolve(
+    "thread",
+    "reset-event-1",
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(
+        prior,
+        undefined,
+        "new reset token must never reopen old context",
+      );
+      return {
+        sessionFile: resetFile,
+        piSessionId: "reset",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(reset.previousPiSessionId, "original");
+  assert.equal(reset.skipRelayHistory, true);
+  await reset.release();
+
+  const sameToken = await store.resolve(
+    "thread",
+    "reset-event-1",
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(
+        prior,
+        resetFile,
+        "same reset token must converge on the reset context",
+      );
+      return {
+        sessionFile: resetFile,
+        piSessionId: "reset",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(sameToken.previousPiSessionId, undefined);
+  assert.equal(sameToken.skipRelayHistory, false);
+  await sameToken.release();
+});
+
+test("a reset tombstone survives restart and skips old relay history once fresh context is installed", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const oldFile = await createSessionFile(stateDir, "before-forget");
+  const active = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "before-forget",
+      cwd: "/tmp/project",
+    }),
+  );
+
+  assert.equal(await active.forget(), oldFile);
+  await active.release();
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const afterForget = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(afterForget.conversations.thread, undefined);
+  assert.equal(
+    afterForget.resetTombstones.thread.previousPiSessionId,
+    "before-forget",
+  );
+
+  // Simulate both adapter and outer harness restarting after reset ACK but
+  // before a replacement session/new carried the original reset token.
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  const freshFile = await createSessionFile(stateDir, "after-restart");
+  const fresh = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: freshFile,
+        piSessionId: "after-restart",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(fresh.resumed, false);
+  assert.equal(fresh.skipRelayHistory, true);
+  assert.equal(fresh.previousPiSessionId, "before-forget");
+  await fresh.release();
+
+  const installed = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(installed.resetTombstones.thread.status, "retained");
+  assert.equal(
+    installed.resetTombstones.thread.installedPiSessionId,
+    "after-restart",
+  );
+  assert.equal(installed.conversations.thread.piSessionId, "after-restart");
+  assert.equal(installed.conversations.thread.relayHistoryCleared, true);
+
+  const resumedStore = new ConversationStore(config, silentLogger, env);
+  await resumedStore.initialize();
+  const resumed = await resumedStore.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, freshFile);
+      return {
+        sessionFile: freshFile,
+        piSessionId: "after-restart",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(resumed.resumed, true);
+  assert.equal(resumed.skipRelayHistory, false);
+  await resumed.release();
+});
+
+test("conversation-level reset commit is idempotent for cold mappings and installed fresh generations", async () => {
+  const { store, stateDir } = await setup();
+  const oldFile = await createSessionFile(stateDir, "cold-reset-old");
+  const old = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "cold-reset-old",
+      cwd: "/tmp/project",
+    }),
+  );
+  await old.release();
+
+  assert.deepEqual(await store.commitReset("thread", "signed-reset-1"), {
+    alreadyCommitted: false,
+    disposeLiveSession: true,
+    retiredSessionFile: oldFile,
+  });
+  assert.deepEqual(await store.commitReset("thread", "signed-reset-1"), {
+    alreadyCommitted: true,
+    disposeLiveSession: true,
+  });
+
+  const freshFile = await createSessionFile(stateDir, "cold-reset-fresh");
+  const fresh = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: freshFile,
+        piSessionId: "cold-reset-fresh",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(fresh.skipRelayHistory, true);
+  assert.notEqual(fresh.lifecycleGeneration, old.lifecycleGeneration);
+  const freshEventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const freshEvent = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Fresh reset generation context status.",
+    piSessionId: "cold-reset-fresh",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  await store.enqueueSessionEvent(
+    "thread",
+    freshEventId,
+    freshEvent,
+    fresh.lifecycleGeneration,
+  );
+  await fresh.release();
+
+  assert.deepEqual(await store.commitReset("thread", "signed-reset-1"), {
+    alreadyCommitted: true,
+    disposeLiveSession: false,
+  });
+  assert.equal((await store.get("thread"))?.piSessionId, "cold-reset-fresh");
+  assert.deepEqual(
+    (await store.listPendingSessionEvents("thread")).map(
+      (pending) => pending.eventId,
+    ),
+    [freshEventId],
+    "an idempotent reset retry must not clear the installed epoch's outbox",
+  );
+});
+
+test("pending reset capacity is recoverable and never drops a required barrier", async () => {
+  const { store, stateDir } = await setup({
+    maxPendingResetTombstones: 2,
+    maxRetainedResetTombstones: 1,
+    // This test exercises reset-barrier capacity. Keep enough mapping slots
+    // that the independent persisted-conversation hard cap is not the reason
+    // a pending reset cannot be consumed.
+    maxPersistedConversations: 2,
+  });
+  await store.commitReset("a", "reset-a");
+  await store.commitReset("b", "reset-b");
+  await assert.rejects(
+    () => store.commitReset("c", "reset-c"),
+    /Pending reset tombstone capacity 2 is full/,
+  );
+
+  const aFile = await createSessionFile(stateDir, "bounded-a");
+  const a = await store.resolve(
+    "a",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: aFile,
+        piSessionId: "bounded-a",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(a.skipRelayHistory, true);
+  await a.release();
+  await store.commitReset("c", "reset-c");
+
+  const bFile = await createSessionFile(stateDir, "bounded-b");
+  const b = await store.resolve(
+    "b",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: bFile,
+        piSessionId: "bounded-b",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  await b.release();
+
+  // Filling the second mapping slot proves the reset barrier remains
+  // recoverable when the next insert forces the oldest cleared mapping out.
+  const cFile = await createSessionFile(stateDir, "bounded-c");
+  const c = await store.resolve(
+    "c",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: cFile,
+        piSessionId: "bounded-c",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  await c.release();
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const afterPrune = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(afterPrune.conversations.a, undefined);
+  assert.equal(afterPrune.resetTombstones.a.status, "pending");
+  assert.equal(afterPrune.conversations.b.piSessionId, "bounded-b");
+  assert.equal(afterPrune.conversations.c.piSessionId, "bounded-c");
+  assert.equal(afterPrune.resetTombstones.c.status, "retained");
+
+  const aFreshFile = await createSessionFile(stateDir, "bounded-a-fresh");
+  const aFresh = await store.resolve(
+    "a",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: aFreshFile,
+        piSessionId: "bounded-a-fresh",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(aFresh.skipRelayHistory, true);
+  await aFresh.release();
+});
+
+test("retained tombstone TTL pruning leaves mapping safety that reactivates on cold prune", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const oldFile = await createSessionFile(stateDir, "ttl-reset-old");
+  const active = await store.resolve(
+    "thread",
+    "reset-ttl",
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "ttl-reset-old",
+      cwd: "/tmp/project",
+    }),
+  );
+  await active.release();
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.thread.lastUsedAt = "2000-01-01T00:00:00.000Z";
+  manifest.resetTombstones.thread.consumedAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  const restarted = new ConversationStore(
+    {
+      ...config,
+      persistedConversationTtlMs: 1,
+      resetTombstoneTtlMs: 1,
+    },
+    silentLogger,
+    env,
+  );
+  await restarted.initialize();
+  const pruned = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(pruned.conversations.thread, undefined);
+  assert.equal(pruned.resetTombstones.thread.status, "pending");
+  await assert.rejects(() => stat(oldFile), { code: "ENOENT" });
+
+  const freshFile = await createSessionFile(stateDir, "ttl-reset-fresh");
+  const fresh = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: freshFile,
+        piSessionId: "ttl-reset-fresh",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(fresh.skipRelayHistory, true);
+  await fresh.release();
+});
+
+test("late forget from an old ACP session cannot delete a newer reset mapping", async () => {
+  const { store, stateDir } = await setup();
+  const oldFile = await createSessionFile(stateDir, "old");
+  const old = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "old",
+      cwd: "/tmp/project",
+    }),
+  );
+  await old.release();
+  const newFile = await createSessionFile(stateDir, "new");
+  const current = await store.resolve(
+    "thread",
+    "reset-2",
+    "/tmp/project",
+    async () => ({
+      sessionFile: newFile,
+      piSessionId: "new",
+      cwd: "/tmp/project",
+    }),
+  );
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  await store.enqueueSessionEvent(
+    "thread",
+    eventId,
+    {
+      type: "context_status",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Replacement context status.",
+      piSessionId: "new",
+      usedTokens: 75_000,
+      remainingTokens: 75_000,
+      percent: 50,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      autoCompaction: true,
+      compacting: false,
+      model: "provider/model",
+    },
+    current.lifecycleGeneration,
+  );
+
+  assert.equal(await old.forget(), undefined);
+  assert.equal((await store.get("thread"))?.piSessionId, "new");
+  assert.deepEqual(
+    (await store.listPendingSessionEvents("thread")).map(
+      (pending) => pending.eventId,
+    ),
+    [eventId],
+  );
+  await current.release();
+});
+
+test("late forget from an old lease owner preserves the resumed mapping and its lifecycle outbox", async () => {
+  const { store, stateDir } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "same-pi-generation");
+  const replacementFile = await createSessionFile(
+    stateDir,
+    "same-pi-replacement",
+  );
+  const first = await store.resolve(
+    "thread",
+    "retained-reset-token",
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "same-pi-generation",
+      cwd: "/tmp/project",
+    }),
+  );
+  await first.release();
+  const resumed = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, sessionFile);
+      return {
+        sessionFile: replacementFile,
+        piSessionId: "same-pi-generation",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  await store.enqueueSessionEvent(
+    "thread",
+    eventId,
+    {
+      type: "context_status",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Replacement owner context status.",
+      piSessionId: "same-pi-generation",
+      usedTokens: 75_000,
+      remainingTokens: 75_000,
+      percent: 50,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      autoCompaction: true,
+      compacting: false,
+      model: "provider/model",
+    },
+    resumed.lifecycleGeneration,
+  );
+
+  assert.equal(await first.forget(), undefined);
+  assert.equal(resumed.mapping.lastResetToken, "retained-reset-token");
+  assert.equal(
+    (await store.get("thread"))?.lease?.ownerId,
+    resumed.mapping.lease.ownerId,
+  );
+  await stat(replacementFile);
+  assert.deepEqual(
+    (await store.listPendingSessionEvents("thread")).map(
+      (pending) => pending.eventId,
+    ),
+    [eventId],
+  );
+
+  assert.equal(await resumed.forget(), replacementFile);
+  assert.deepEqual(await store.listPendingSessionEvents("thread"), []);
+  await resumed.release();
+  await assert.rejects(() => stat(replacementFile), { code: "ENOENT" });
+  await unlink(sessionFile);
+});
+
+test("workspace cwd change never resumes a context from another checkout", async () => {
+  const { store, stateDir } = await setup();
+  const firstFile = await createSessionFile(stateDir, "cwd-a");
+  const first = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/a",
+    async () => ({
+      sessionFile: firstFile,
+      piSessionId: "a",
+      cwd: "/tmp/a",
+    }),
+  );
+  await first.release();
+  const secondFile = await createSessionFile(stateDir, "cwd-b");
+  const second = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/b",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return { sessionFile: secondFile, piSessionId: "b", cwd: "/tmp/b" };
+    },
+  );
+  assert.equal(second.previousPiSessionId, "a");
+  assert.equal(
+    second.lifecycleGeneration,
+    first.lifecycleGeneration,
+    "a workspace recovery changes Pi context but not the durable lifecycle epoch",
+  );
+  const recoveryEventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  assert.equal(
+    await store.enqueueSessionEvent(
+      "thread",
+      recoveryEventId,
+      {
+        type: "context_status",
+        timestamp: "2026-08-02T00:00:00.000Z",
+        message: "Late status from the prior Pi process.",
+        piSessionId: "a",
+        usedTokens: 75_000,
+        remainingTokens: 75_000,
+        percent: 50,
+        limitTokens: 150_000,
+        effectiveLimitTokens: 150_000,
+        compactionThresholdTokens: 133_616,
+        autoCompaction: true,
+        compacting: false,
+        model: "provider/model",
+      },
+      first.lifecycleGeneration,
+    ),
+    true,
+  );
+  assert.equal(
+    (await store.listPendingSessionEvents("thread"))[0].lifecycleGeneration,
+    second.lifecycleGeneration,
+  );
+  await second.release();
+});
+
+test("pruning removes oldest inactive mappings and their JSONL files", async () => {
+  const { store, stateDir } = await setup({
+    maxPersistedConversations: 1,
+    persistedConversationTtlMs: 60_000,
+  });
+  const firstFile = await createSessionFile(stateDir, "first");
+  const first = await store.resolve(
+    "first",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: firstFile,
+      piSessionId: "first",
+      cwd: "/tmp/project",
+    }),
+  );
+  await first.release();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  const secondFile = await createSessionFile(stateDir, "second");
+  const second = await store.resolve(
+    "second",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: secondFile,
+      piSessionId: "second",
+      cwd: "/tmp/project",
+    }),
+  );
+  await second.release();
+  await store.prune(new Set());
+
+  assert.equal(await store.get("first"), undefined);
+  assert.equal((await store.get("second"))?.piSessionId, "second");
+  await assert.rejects(() => stat(firstFile), { code: "ENOENT" });
+});
+
+test("unacknowledged lifecycle events pin TTL and capacity pruning until ACK", async () => {
+  const { store, stateDir, config, env } = await setup({
+    maxPersistedConversations: 1,
+    persistedConversationTtlMs: 1,
+  });
+  const sessionFile = await createSessionFile(stateDir, "pinned-outbox");
+  const session = await store.resolve(
+    "pinned",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "pinned-outbox",
+      cwd: "/tmp/project",
+    }),
+  );
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  await store.enqueueSessionEvent(
+    "pinned",
+    eventId,
+    contextEvent("pinned-outbox"),
+    session.lifecycleGeneration,
+  );
+  await session.release();
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.pinned.lastUsedAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  assert.equal(await store.prune(new Set()), 0);
+  await stat(sessionFile);
+  assert.equal((await store.get("pinned"))?.piSessionId, "pinned-outbox");
+  let createCalls = 0;
+  await assert.rejects(
+    () =>
+      store.resolve("blocked", undefined, "/tmp/project", async () => {
+        createCalls++;
+        throw new Error("must not create");
+      }),
+    /capacity 1 is full/,
+  );
+  assert.equal(createCalls, 0);
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  assert.equal((await restarted.get("pinned"))?.piSessionId, "pinned-outbox");
+  assert.deepEqual(
+    (await restarted.listPendingSessionEvents("pinned")).map(
+      (pending) => pending.eventId,
+    ),
+    [eventId],
+  );
+  await restarted.acknowledgeSessionEvent("pinned", eventId);
+  assert.equal(await restarted.prune(new Set()), 1);
+  assert.equal(await restarted.get("pinned"), undefined);
+  await assert.rejects(() => stat(sessionFile), { code: "ENOENT" });
+});
+
+test("capacity pruning skips an older pinned mapping and selects the next safe victim", async () => {
+  const { store, stateDir } = await setup({
+    maxPersistedConversations: 2,
+    persistedConversationTtlMs: 60_000,
+  });
+  const fileA = await createSessionFile(stateDir, "capacity-pinned-a");
+  const a = await store.resolve("a", undefined, "/tmp/project", async () => ({
+    sessionFile: fileA,
+    piSessionId: "capacity-pinned-a",
+    cwd: "/tmp/project",
+  }));
+  await store.enqueueSessionEvent(
+    "a",
+    "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+    contextEvent("capacity-pinned-a"),
+    a.lifecycleGeneration,
+  );
+  await a.release();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  const fileB = await createSessionFile(stateDir, "capacity-victim-b");
+  const b = await store.resolve("b", undefined, "/tmp/project", async () => ({
+    sessionFile: fileB,
+    piSessionId: "capacity-victim-b",
+    cwd: "/tmp/project",
+  }));
+  await b.release();
+
+  const fileC = await createSessionFile(stateDir, "capacity-successor-c");
+  const c = await store.resolve("c", undefined, "/tmp/project", async () => ({
+    sessionFile: fileC,
+    piSessionId: "capacity-successor-c",
+    cwd: "/tmp/project",
+  }));
+  await c.release();
+
+  assert.equal((await store.get("a"))?.piSessionId, "capacity-pinned-a");
+  assert.equal(await store.get("b"), undefined);
+  assert.equal((await store.get("c"))?.piSessionId, "capacity-successor-c");
+  await stat(fileA);
+  await assert.rejects(() => stat(fileB), { code: "ENOENT" });
+  assert.equal((await store.listPendingSessionEvents("a")).length, 1);
+});
+
+test("prune and enqueue serialize so no accepted event can lose its mapping", async () => {
+  const { store, stateDir } = await setup({
+    persistedConversationTtlMs: 1,
+  });
+  const sessionFile = await createSessionFile(stateDir, "prune-enqueue-race");
+  const session = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "prune-enqueue-race",
+      cwd: "/tmp/project",
+    }),
+  );
+  await session.release();
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.thread.lastUsedAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  let signalPruneCheck;
+  const pruneCheckStarted = new Promise((resolve) => {
+    signalPruneCheck = resolve;
+  });
+  let releasePruneCheck;
+  const pruneCheckGate = new Promise((resolve) => {
+    releasePruneCheck = resolve;
+  });
+  const originalHasPending = store.hasPendingSessionEventsLocked.bind(store);
+  store.hasPendingSessionEventsLocked = async (...args) => {
+    signalPruneCheck();
+    await pruneCheckGate;
+    return originalHasPending(...args);
+  };
+
+  const pruning = store.prune(new Set());
+  await pruneCheckStarted;
+  let enqueueSettled = false;
+  const enqueue = store
+    .enqueueSessionEvent(
+      "thread",
+      "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+      contextEvent("prune-enqueue-race"),
+      session.lifecycleGeneration,
+    )
+    .finally(() => {
+      enqueueSettled = true;
+    });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(enqueueSettled, false, "enqueue bypassed the prune outbox lock");
+  releasePruneCheck();
+
+  assert.equal(await pruning, 1);
+  assert.equal(await enqueue, false);
+  assert.equal(await store.get("thread"), undefined);
+  assert.deepEqual(await store.listPendingSessionEvents("thread"), []);
+  await assert.rejects(() => stat(sessionFile), { code: "ENOENT" });
+});
+
+test("corrupt manifest fails closed across restart and never creates fresh context", async () => {
+  const { stateDir, config, env } = await setup();
+  const directory = join(stateDir, "test-agent");
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, "conversations.json"), "not-json", {
+    mode: 0o600,
+  });
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await assert.rejects(
+    () => restarted.initialize(),
+    /refusing to lose durable reset boundaries/,
+  );
+  let createCalls = 0;
+  await assert.rejects(
+    () =>
+      restarted.resolve("anything", undefined, "/tmp/project", async () => {
+        createCalls++;
+        throw new Error("must never create from corrupt state");
+      }),
+    /refusing to lose durable reset boundaries/,
+  );
+  assert.equal(createCalls, 0);
+  assert.equal(
+    await readFile(join(directory, "conversations.json"), "utf8"),
+    "not-json",
+  );
+});
+
+test("a manifest missing after durable initialization fails closed", async () => {
+  const { stateDir, config, env } = await setup();
+  const directory = join(stateDir, "test-agent");
+  const manifestPath = join(directory, "conversations.json");
+  await stat(join(directory, ".buzz-pi-state-v1"));
+  await unlink(manifestPath);
+  await writeFile(join(directory, ".conversations.json.crash.tmp"), "partial", {
+    mode: 0o600,
+  });
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await assert.rejects(
+    () => restarted.initialize(),
+    /manifest is missing after durable initialization/,
+  );
+  await assert.rejects(() => stat(manifestPath), { code: "ENOENT" });
+});
+
+test("an intact manifest safely repairs a missing initialization marker", async () => {
+  const { stateDir, config, env } = await setup();
+  const markerPath = join(stateDir, "test-agent", ".buzz-pi-state-v1");
+  await unlink(markerPath);
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await restarted.initialize();
+  assert.equal(await readFile(markerPath, "utf8"), "buzz-pi-state-v1\n");
+});
+
+test("a newer committed reset token rejects a stale cross-adapter session open", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const helper = new ConversationStore(config, silentLogger, env);
+  await helper.initialize();
+  await helper.commitReset("thread", "reset-newer-b");
+  let createCalls = 0;
+  await assert.rejects(
+    () =>
+      store.resolve("thread", "reset-stale-a", "/tmp/project", async () => {
+        createCalls += 1;
+        return {
+          sessionFile: await createSessionFile(stateDir, "must-not-open"),
+          piSessionId: "must-not-open",
+          cwd: "/tmp/project",
+        };
+      }),
+    /must match the latest committed Buzz reset token/,
+  );
+  assert.equal(createCalls, 0);
+  const manifest = JSON.parse(
+    await readFile(join(stateDir, "test-agent", "conversations.json"), "utf8"),
+  );
+  assert.equal(manifest.conversations.thread, undefined);
+  assert.equal(manifest.resetTombstones.thread.status, "pending");
+  assert.equal(manifest.resetTombstones.thread.resetToken, "reset-newer-b");
+});
+
+test("oversized manifest serialization is rejected before rename and preserves the previous manifest", async () => {
+  const { stateDir, config, env } = await setup();
+  const resetTombstones = {};
+  for (let index = 0; index < 20_800; index++) {
+    const conversationId = `bulk-${String(index).padStart(5, "0")}-${"c".repeat(80)}`;
+    resetTombstones[conversationId] = {
+      conversationId,
+      resetToken: "r".repeat(512),
+      createdAt: "2026-08-02T00:00:00.000Z",
+    };
+  }
+  const manifest = { version: 1, conversations: {}, resetTombstones };
+  const compact = `${JSON.stringify(manifest)}\n`;
+  const prettyBytes = Buffer.byteLength(
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  assert.ok(Buffer.byteLength(compact) < 16 * 1024 * 1024);
+  assert.ok(prettyBytes > 16 * 1024 * 1024);
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  await writeFile(manifestPath, compact, { mode: 0o600 });
+  const restarted = new ConversationStore(config, silentLogger, env);
+  await assert.rejects(
+    () => restarted.touch("new-thread", "missing", undefined),
+    /manifest serialization exceeds 16777216 bytes/,
+  );
+  assert.equal(
+    await readFile(manifestPath, "utf8"),
+    compact,
+    "failed serialization must leave the prior atomic manifest untouched",
+  );
+});
+
+test("a changed signed reset token supersedes an active cross-adapter lease safely", async () => {
+  const { store: firstStore, stateDir, config, env } = await setup();
+  const oldFile = await createSessionFile(stateDir, "active-old");
+  const old = await firstStore.resolve(
+    "thread",
+    "reset-1",
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "old",
+      cwd: "/tmp/project",
+    }),
+  );
+
+  const secondStore = new ConversationStore(config, silentLogger, env);
+  await secondStore.initialize();
+  await assert.rejects(
+    () =>
+      secondStore.resolve("thread", "reset-1", "/tmp/project", async () => {
+        throw new Error("must not create");
+      }),
+    /active in another Pi runtime/,
+  );
+
+  const newFile = await createSessionFile(stateDir, "active-new");
+  const reset = await secondStore.resolve(
+    "thread",
+    "reset-2",
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return { sessionFile: newFile, piSessionId: "new", cwd: "/tmp/project" };
+    },
+  );
+  assert.equal(reset.previousPiSessionId, "old");
+  assert.equal(
+    reset.retiredSessionFile,
+    undefined,
+    "an active writer's JSONL is retained",
+  );
+
+  await old.release();
+  await firstStore.touch("thread", "old", "reset-1");
+  assert.equal(await old.forget(), undefined);
+  const current = await secondStore.get("thread");
+  assert.equal(current?.piSessionId, "new");
+  assert.equal(current?.lastResetToken, "reset-2");
+  assert.ok(
+    current?.lease,
+    "late old release must not clear the replacement lease",
+  );
+  await assert.rejects(() => stat(oldFile), { code: "ENOENT" });
+  await stat(newFile);
+  await reset.release();
+});
+
+test("a future lease from a confirmed-dead local PID is recovered immediately", async () => {
+  const leaseIdentity = {
+    hostId: "a".repeat(64),
+    bootId: "b".repeat(64),
+    pidProbeSafe: true,
+  };
+  const { store, stateDir, config, env } = await setup({}, leaseIdentity);
+  const sessionFile = await createSessionFile(stateDir, "crash-recovery");
+  await store.resolve("thread", undefined, "/tmp/project", async () => ({
+    sessionFile,
+    piSessionId: "before-crash",
+    cwd: "/tmp/project",
+  }));
+
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  assert.ok(child.pid, "spawned process must expose its PID");
+  const deadPid = child.pid;
+  await once(child, "exit");
+  assert.throws(
+    () => process.kill(deadPid, 0),
+    (error) => error?.code === "ESRCH",
+    "fixture PID must be definitively dead on this host",
+  );
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.thread.lease.pid = deadPid;
+  manifest.conversations.thread.lease.expiresAt = new Date(
+    Date.now() + 60 * 60 * 1_000,
+  ).toISOString();
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  const restarted = new ConversationStore(
+    config,
+    silentLogger,
+    env,
+    leaseIdentity,
+  );
+  await restarted.initialize();
+  const recovered = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, sessionFile);
+      return {
+        sessionFile,
+        piSessionId: "before-crash",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(recovered.resumed, true);
+  await recovered.release();
+});
+
+test("an expired same-boot lease cannot be kept alive by PID reuse", async () => {
+  const leaseIdentity = TEST_LEASE_IDENTITY;
+  const { store, stateDir, config, env } = await setup({}, leaseIdentity);
+  const sessionFile = await createSessionFile(stateDir, "pid-reuse");
+  const original = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "pid-reuse",
+      cwd: "/tmp/project",
+    }),
+  );
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.thread.lease.pid = process.pid;
+  manifest.conversations.thread.lease.expiresAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  const restarted = new ConversationStore(
+    config,
+    silentLogger,
+    env,
+    leaseIdentity,
+  );
+  await restarted.initialize();
+  const recovered = await restarted.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(
+        prior,
+        undefined,
+        "an expired live-PID lease must isolate takeover onto fresh JSONL",
+      );
+      return {
+        sessionFile: await createSessionFile(stateDir, "pid-reuse-fresh"),
+        piSessionId: "pid-reuse-fresh",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(recovered.resumed, false);
+  assert.equal(
+    await original.refresh(),
+    false,
+    "a stale runtime generation must not renew its successor's lease",
+  );
+  await original.release();
+  assert.equal((await restarted.get("thread"))?.piSessionId, "pid-reuse-fresh");
+  await recovered.release();
+});
+
+test("an expired foreign-host lease takes over onto a fresh JSONL and fences the old generation", async () => {
+  const {
+    store: first,
+    stateDir,
+    config,
+    env,
+  } = await setup({}, TEST_LEASE_IDENTITY);
+  const oldFile = await createSessionFile(stateDir, "foreign-old");
+  const old = await first.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: oldFile,
+      piSessionId: "foreign-old",
+      cwd: "/tmp/project",
+    }),
+  );
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.thread.lease.expiresAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+
+  const foreignIdentity = {
+    ...TEST_LEASE_IDENTITY,
+    hostId: "f".repeat(64),
+  };
+  const second = new ConversationStore(
+    config,
+    silentLogger,
+    env,
+    foreignIdentity,
+  );
+  await second.initialize();
+  const freshFile = await createSessionFile(stateDir, "foreign-fresh");
+  const fresh = await second.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async (prior) => {
+      assert.equal(prior, undefined);
+      return {
+        sessionFile: freshFile,
+        piSessionId: "foreign-fresh",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  assert.equal(fresh.resumed, false);
+  assert.equal(await old.refresh(), false);
+  await old.release();
+  assert.equal((await second.get("thread"))?.piSessionId, "foreign-fresh");
+  await fresh.release();
+});
+
+test("a delayed resolver cannot publish after its conversation lock generation is stolen", async () => {
+  const {
+    store: first,
+    stateDir,
+    config,
+    env,
+  } = await setup({}, TEST_LEASE_IDENTITY);
+  const second = new ConversationStore(config, silentLogger, env, {
+    ...TEST_LEASE_IDENTITY,
+    hostId: "f".repeat(64),
+  });
+  await second.initialize();
+  const firstFile = await createSessionFile(stateDir, "lock-race-first");
+  const secondFile = await createSessionFile(stateDir, "lock-race-second");
+  let unblockFirst;
+  const firstBlocked = new Promise((resolve) => {
+    unblockFirst = resolve;
+  });
+  let firstEntered;
+  const firstHasLock = new Promise((resolve) => {
+    firstEntered = resolve;
+  });
+  const firstResolve = first.resolve(
+    "lock-race",
+    undefined,
+    "/tmp/project",
+    async () => {
+      firstEntered();
+      await firstBlocked;
+      return {
+        sessionFile: firstFile,
+        piSessionId: "lock-race-first",
+        cwd: "/tmp/project",
+      };
+    },
+  );
+  await firstHasLock;
+
+  const locksDirectory = join(stateDir, "test-agent", "locks");
+  const conversationLock = (await readdir(locksDirectory)).find((name) =>
+    name.startsWith("conversation-"),
+  );
+  assert.ok(conversationLock);
+  const lockDirectory = join(locksDirectory, conversationLock);
+  const heartbeat = (await readdir(lockDirectory)).find((name) =>
+    name.startsWith("heartbeat-"),
+  );
+  assert.ok(heartbeat);
+  const stale = new Date(Date.now() - 5 * 60_000);
+  await utimes(join(lockDirectory, heartbeat), stale, stale);
+
+  const successor = await second.resolve(
+    "lock-race",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: secondFile,
+      piSessionId: "lock-race-second",
+      cwd: "/tmp/project",
+    }),
+  );
+  unblockFirst();
+  await assert.rejects(firstResolve, /lock ownership was lost/);
+  assert.equal(
+    (await second.get("lock-race"))?.piSessionId,
+    "lock-race-second",
+  );
+  await successor.release();
+});
+
+test("persisted conversation capacity fails before create when every victim may still write", async () => {
+  const { store, stateDir } = await setup(
+    { maxPersistedConversations: 1 },
+    TEST_LEASE_IDENTITY,
+  );
+  const firstFile = await createSessionFile(stateDir, "capacity-first");
+  const first = await store.resolve(
+    "first",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile: firstFile,
+      piSessionId: "capacity-first",
+      cwd: "/tmp/project",
+    }),
+  );
+  let createCalls = 0;
+  await assert.rejects(
+    () =>
+      store.resolve("second", undefined, "/tmp/project", async () => {
+        createCalls += 1;
+        return {
+          sessionFile: await createSessionFile(stateDir, "capacity-second"),
+          piSessionId: "capacity-second",
+          cwd: "/tmp/project",
+        };
+      }),
+    /capacity 1 is full/,
+  );
+  assert.equal(createCalls, 0);
+
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  manifest.conversations.first.lease.expiresAt = "2000-01-01T00:00:00.000Z";
+  await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`, {
+    mode: 0o600,
+  });
+  await assert.rejects(
+    () =>
+      store.resolve("second", undefined, "/tmp/project", async () => {
+        createCalls += 1;
+        throw new Error("must not create");
+      }),
+    /capacity 1 is full/,
+  );
+  assert.equal(createCalls, 0);
+  assert.deepEqual(Object.keys(manifest.conversations), ["first"]);
+  assert.deepEqual(
+    Object.keys(JSON.parse(await readFile(manifestPath, "utf8")).conversations),
+    ["first"],
+  );
+  await first.release();
+});
+
+test("an expired same-host lock heartbeat is not stolen from a live PID", async () => {
+  const { store, stateDir, config, env } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "lock-pid-reuse");
+  const active = await store.resolve(
+    "thread",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "lock-pid-reuse",
+      cwd: "/tmp/project",
+    }),
+  );
+  const manifestPath = join(stateDir, "test-agent", "conversations.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const identity = manifest.conversations.thread.lease;
+  await active.release();
+
+  const lockPath = join(stateDir, "test-agent", "locks", "manifest.lock");
+  await mkdir(lockPath, { mode: 0o700 });
+  await writeFile(
+    join(lockPath, "owner"),
+    `${JSON.stringify({
+      version: 1,
+      pid: process.pid,
+      token: "reused-pid-token",
+      hostId: identity.hostId,
+      ...(identity.bootId === undefined ? {} : { bootId: identity.bootId }),
+      createdAt: "2000-01-01T00:00:00.000Z",
+    })}\n`,
+    { mode: 0o600 },
+  );
+  const old = new Date(Date.now() - 5 * 60_000);
+  await utimes(lockPath, old, old);
+
+  const restarted = new ConversationStore(config, silentLogger, env);
+  let settled = false;
+  const initializing = restarted.initialize().finally(() => {
+    settled = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  assert.equal(
+    settled,
+    false,
+    "a suspended but live local owner must retain its lock",
+  );
+  await rm(lockPath, { recursive: true, force: true });
+  await initializing;
+  await assert.rejects(() => stat(lockPath), { code: "ENOENT" });
+});
+
+test("manifest and state directory permissions are repaired on initialization", async () => {
+  const { store, stateDir } = await setup();
+  const sessionFile = await createSessionFile(stateDir, "permissions");
+  const active = await store.resolve(
+    "permissions",
+    undefined,
+    "/tmp/project",
+    async () => ({
+      sessionFile,
+      piSessionId: "permissions",
+      cwd: "/tmp/project",
+    }),
+  );
+  await active.release();
+  const namespaceDir = join(stateDir, "test-agent");
+  const manifestPath = join(namespaceDir, "conversations.json");
+  assert.equal((await stat(namespaceDir)).mode & 0o777, 0o700);
+  assert.equal((await stat(manifestPath)).mode & 0o777, 0o600);
+  assert.equal((await stat(sessionFile)).mode & 0o777, 0o600);
+});
+
+test("two adapter stores safely serialize simultaneous manifest updates", async () => {
+  const { store: left, stateDir, config, env } = await setup();
+  const right = new ConversationStore(config, silentLogger, env);
+  await Promise.all([left.initialize(), right.initialize()]);
+  const leases = await Promise.all(
+    Array.from({ length: 24 }, async (_, index) => {
+      const store = index % 2 === 0 ? left : right;
+      const sessionFile = await createSessionFile(stateDir, `stress-${index}`);
+      return store.resolve(
+        `stress-${index}`,
+        undefined,
+        "/tmp/project",
+        async () => ({
+          sessionFile,
+          piSessionId: `stress-${index}`,
+          cwd: "/tmp/project",
+        }),
+      );
+    }),
+  );
+  for (let index = 0; index < 24; index++) {
+    assert.equal(
+      (await left.get(`stress-${index}`))?.piSessionId,
+      `stress-${index}`,
+    );
+  }
+  await Promise.all(leases.map((lease) => lease.release()));
+});
+
+test("stale lock cleanup never removes a successor generation after pathname reuse", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-lock-generation-"));
+  const lockPath = join(root, "manifest.lock");
+  const oldPath = join(root, "manifest.lock.old");
+  await mkdir(lockPath);
+  await writeFile(join(lockPath, "owner"), "old-generation\n");
+  const observed = await captureStateLockGeneration(lockPath);
+  assert.ok(observed);
+
+  // Deterministically model the ABA window: the observed lock is released,
+  // then a competing owner wins mkdir at the identical pathname before the
+  // stale contender attempts its rename/remove.
+  await rename(lockPath, oldPath);
+  await mkdir(lockPath);
+  await writeFile(join(lockPath, "owner"), "successor-generation\n");
+
+  assert.equal(await removeObservedStaleLock(lockPath, observed), false);
+  assert.equal(
+    await readFile(join(lockPath, "owner"), "utf8"),
+    "successor-generation\n",
+  );
+
+  const successor = await captureStateLockGeneration(lockPath);
+  assert.ok(successor);
+  assert.equal(await removeObservedStaleLock(lockPath, successor), true);
+  await assert.rejects(() => stat(lockPath), { code: "ENOENT" });
+  await rm(root, { recursive: true, force: true });
+});

--- a/packages/buzz-pi-agent/test/fixtures/acp-set-config-option-response.json
+++ b/packages/buzz-pi-agent/test/fixtures/acp-set-config-option-response.json
@@ -1,0 +1,52 @@
+{
+  "model": {
+    "configOptions": [
+      {
+        "configId": "model",
+        "category": "model",
+        "displayName": "Model",
+        "value": "provider/alternate",
+        "options": [
+          { "value": "provider/model", "displayName": "Model" },
+          { "value": "provider/alternate", "displayName": "Alternate" }
+        ]
+      },
+      {
+        "configId": "thinking",
+        "category": "thought",
+        "displayName": "Thinking",
+        "value": "off",
+        "options": [
+          { "value": "off", "displayName": "off" },
+          { "value": "medium", "displayName": "medium" },
+          { "value": "high", "displayName": "high" }
+        ]
+      }
+    ]
+  },
+  "thinking": {
+    "configOptions": [
+      {
+        "configId": "model",
+        "category": "model",
+        "displayName": "Model",
+        "value": "provider/alternate",
+        "options": [
+          { "value": "provider/model", "displayName": "Model" },
+          { "value": "provider/alternate", "displayName": "Alternate" }
+        ]
+      },
+      {
+        "configId": "thinking",
+        "category": "thought",
+        "displayName": "Thinking",
+        "value": "high",
+        "options": [
+          { "value": "off", "displayName": "off" },
+          { "value": "medium", "displayName": "medium" },
+          { "value": "high", "displayName": "high" }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/buzz-pi-agent/test/fixtures/buzz-session-event-v2.json
+++ b/packages/buzz-pi-agent/test/fixtures/buzz-session-event-v2.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 2,
+  "sessionId": "ses_fixture",
+  "conversationId": "buzz:fixture:conversation",
+  "eventId": "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+  "event": {
+    "type": "compaction_completed",
+    "compactionId": "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+    "timestamp": "2026-08-02T00:00:00.000Z",
+    "message": "Pi compacted this thread's context from 140,000 tokens to approximately 30,000 tokens.",
+    "piSessionId": "pi_fixture",
+    "reason": "threshold",
+    "beforeTokens": 140000,
+    "afterTokens": 30000,
+    "limitTokens": 150000,
+    "effectiveLimitTokens": 150000,
+    "compactionThresholdTokens": 133616,
+    "willRetry": false,
+    "fromExtension": false
+  }
+}

--- a/packages/buzz-pi-agent/test/helpers.mjs
+++ b/packages/buzz-pi-agent/test/helpers.mjs
@@ -1,0 +1,155 @@
+export const silentLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+export function testConfig(overrides = {}) {
+  return {
+    contextLimitTokens: 150_000,
+    compactionReserveTokens: 16_384,
+    keepRecentTokens: 24_000,
+    maxSessions: 4,
+    sessionTtlMs: 60_000,
+    sweepIntervalMs: 60_000,
+    maxLineBytes: 10_000_000,
+    maxActiveRequests: 64,
+    maxOutputQueueMessages: 2_048,
+    maxOutputQueueBytes: 16 * 1_024 * 1_024,
+    stateDir: "/tmp/buzz-pi-agent-tests",
+    maxPersistedConversations: 100,
+    persistedConversationTtlMs: 90 * 24 * 60 * 60 * 1_000,
+    maxPendingResetTombstones: 512,
+    maxRetainedResetTombstones: 512,
+    resetTombstoneTtlMs: 30 * 24 * 60 * 60 * 1_000,
+    conversationLeaseMs: 60 * 60 * 1_000,
+    maxSessionFileBytes: 64 * 1_024 * 1_024,
+    maxPendingSessionEvents: 256,
+    runtimeRequestTimeoutMs: 30 * 60 * 1_000,
+    runtimeControlTimeoutMs: 2 * 60 * 1_000,
+    runtimeInterruptTimeoutMs: 1_200,
+    maxRuntimeIpcQueueMessages: 1_024,
+    maxRuntimeIpcQueueBytes: 16 * 1_024 * 1_024,
+    maxResourceFileBytes: 1 * 1_024 * 1_024,
+    maxResourceTotalBytes: 16 * 1_024 * 1_024,
+    maxResourceFiles: 512,
+    maxResourceEntries: 4_096,
+    maxResourceDepth: 16,
+    trustProjectOverride: undefined,
+    logLevel: "error",
+    ...overrides,
+  };
+}
+
+export function fakeHandle(overrides = {}) {
+  let busy = false;
+  let disposed = false;
+  let model = overrides.model ?? "provider/model";
+  let thinkingLevel = overrides.thinkingLevel ?? "off";
+  const handle = {
+    piSessionId: overrides.piSessionId ?? "pi_test",
+    sessionFile: overrides.sessionFile ?? "/tmp/pi_test.jsonl",
+    cwd: overrides.cwd ?? "/tmp",
+    get isBusy() {
+      return busy;
+    },
+    get isValid() {
+      return !disposed;
+    },
+    async prompt(text, images = []) {
+      busy = true;
+      try {
+        if (overrides.prompt) return await overrides.prompt(text, images);
+        return "end_turn";
+      } finally {
+        busy = false;
+      }
+    },
+    async steer(text) {
+      await overrides.steer?.(text);
+    },
+    async abort() {
+      busy = false;
+      await overrides.abort?.();
+    },
+    async setModel(modelId) {
+      await overrides.setModel?.(modelId);
+      model = modelId;
+    },
+    async setThinkingLevel(level) {
+      await overrides.setThinkingLevel?.(level);
+      thinkingLevel = level;
+    },
+    async reload() {
+      return handle.getResources();
+    },
+    async reset() {
+      return {
+        previousPiSessionId: handle.piSessionId,
+        resources: handle.getResources(),
+      };
+    },
+    getModels() {
+      return overrides.models ?? [{ id: "provider/model", name: "Model" }];
+    },
+    getThinkingLevels() {
+      return overrides.thinkingLevels ?? ["off", "medium", "high"];
+    },
+    getResources() {
+      return {
+        extensions: 2,
+        skills: 3,
+        prompts: 4,
+        contextFiles: 1,
+        errors: [],
+        projectTrusted: false,
+        commands: [],
+      };
+    },
+    getContextSnapshot() {
+      return {
+        usedTokens: 12_345,
+        limitTokens: 150_000,
+        effectiveLimitTokens: 150_000,
+        compactionThresholdTokens: 133_616,
+        autoCompaction: true,
+        compacting: false,
+        model,
+        thinkingLevel,
+        piSessionId: handle.piSessionId,
+      };
+    },
+    getUsageSnapshot() {
+      return {
+        contextTokens: 12_345,
+        accumulatedInputTokens: 10_000,
+        accumulatedOutputTokens: 2_000,
+        accumulatedCachedInputTokens: 5_000,
+        accumulatedCost: 0.12,
+        model: "provider/model",
+      };
+    },
+    async dispose() {
+      disposed = true;
+      await overrides.dispose?.();
+    },
+    get disposed() {
+      return disposed;
+    },
+  };
+  return handle;
+}
+
+export class MemoryWriter {
+  messages = [];
+  ended = false;
+
+  write(value) {
+    this.messages.push(structuredClone(value));
+  }
+
+  async end() {
+    this.ended = true;
+  }
+}

--- a/packages/buzz-pi-agent/test/pi-runtime.test.mjs
+++ b/packages/buzz-pi-agent/test/pi-runtime.test.mjs
@@ -1,0 +1,1952 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  stat,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import {
+  BoundedIpcSendQueue,
+  IsolatedPiWorkerFactory,
+  PiAgentSessionFactory,
+  ReadOnlySettingsStorage,
+  applyFreshSessionTitle,
+  applyStrictPayloadGuard,
+  dedupeCommands,
+  estimateProviderContextTokens,
+  estimateProviderPayloadTokens,
+  guardProviderDispatch,
+  installSessionFileQuota,
+  requestTimeoutMs,
+} from "../dist/index.js";
+import { silentLogger, testConfig } from "./helpers.mjs";
+
+const sink = {
+  sessionUpdate() {},
+  buzzSessionEvent() {},
+  usageUpdate() {},
+};
+
+test("read-through settings storage discards model and thinking writes byte-for-byte", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-settings-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(join(cwd, ".pi"), { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const globalPath = join(agentDir, "settings.json");
+  const projectPath = join(cwd, ".pi", "settings.json");
+  const globalBefore =
+    '{\n  "defaultProvider": "anthropic",\n  "defaultModel": "before",\n  "defaultThinkingLevel": "low"\n}\n';
+  const projectBefore = '{\n  "theme": "dark"\n}\n';
+  await writeFile(globalPath, globalBefore);
+  await writeFile(projectPath, projectBefore);
+
+  const manager = SettingsManager.fromStorage(
+    new ReadOnlySettingsStorage(cwd, agentDir),
+    { projectTrusted: true },
+  );
+  assert.equal(manager.getDefaultModel(), "before");
+  manager.setDefaultModelAndProvider("openai", "after");
+  manager.setDefaultThinkingLevel("xhigh");
+  manager.setTheme("light");
+  await manager.flush();
+
+  assert.equal(await readFile(globalPath, "utf8"), globalBefore);
+  assert.equal(await readFile(projectPath, "utf8"), projectBefore);
+});
+
+test("fresh titles are bounded and resumed sessions can intentionally skip title replacement", () => {
+  const calls = [];
+  const session = {
+    setSessionName(name) {
+      calls.push(name);
+    },
+  };
+  applyFreshSessionTitle(session, `  ${"x".repeat(400)}  `);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].length, 257);
+  assert.ok(calls[0].endsWith("…"));
+  applyFreshSessionTitle(session, "   ");
+  assert.equal(calls.length, 1);
+});
+
+test("oversized persisted transcripts fail before Pi opens them", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-cold-quota-"));
+  const cwd = join(root, "workspace");
+  await mkdir(cwd, { recursive: true });
+  const sessionFile = join(root, "oversized.jsonl");
+  await writeFile(sessionFile, "x".repeat(4_097));
+  const factory = new PiAgentSessionFactory(
+    testConfig({ maxSessionFileBytes: 4_096 }),
+    silentLogger,
+  );
+  await assert.rejects(
+    () =>
+      factory.create({
+        cwd,
+        persistedSessionFile: sessionFile,
+        eventSink: sink,
+        acpSessionId: "cold-quota",
+      }),
+    /BUZZ_SESSION_STORAGE_LIMIT:.*use \/new/,
+  );
+  assert.equal((await stat(sessionFile)).size, 4_097);
+});
+
+test("session transcript quota reserves bounded space for rollback and lifecycle ACK records", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-growth-quota-"));
+  const cwd = join(root, "workspace");
+  const sessionDir = join(root, "sessions");
+  await mkdir(cwd, { recursive: true });
+  const manager = SessionManager.create(cwd, sessionDir);
+  const pinned = manager;
+  pinned._rewriteFile();
+  pinned.flushed = true;
+  const sessionFile = manager.getSessionFile();
+  assert.ok(sessionFile);
+  const entry = {
+    type: "custom",
+    customType: "test.boundary",
+    data: { value: "exact" },
+    id: "entry-at-boundary",
+    parentId: null,
+    timestamp: "2026-08-02T00:00:00.000Z",
+  };
+  const entryBytes = Buffer.byteLength(`${JSON.stringify(entry)}\n`);
+  const initialBytes = (await stat(sessionFile)).size;
+  const maxBytes = initialBytes + entryBytes + 64 * 1_024;
+  installSessionFileQuota(manager, maxBytes);
+
+  pinned._appendEntry({
+    type: "custom",
+    customType: "buzz.lifecycle_watermark.v1",
+    data: { version: 1 },
+    id: "lifecycle-watermark-marker",
+    parentId: null,
+    timestamp: "2026-08-02T00:00:01.000Z",
+  });
+  pinned._appendEntry({
+    type: "custom",
+    customType: "buzz.compaction_attempt.v1",
+    data: {
+      version: 1,
+      compactionId: "7f516ff7-e553-4219-b45a-2a432b516cec",
+      reason: "threshold",
+      beforeTokens: 140_000,
+      startedAt: "2026-08-02T00:00:01.500Z",
+    },
+    id: "compaction-attempt-marker",
+    parentId: "lifecycle-watermark-marker",
+    timestamp: "2026-08-02T00:00:01.500Z",
+  });
+  pinned._appendEntry({
+    type: "custom",
+    customType: "buzz.turn_rollback",
+    data: { version: 1 },
+    id: "rollback-marker",
+    parentId: "compaction-attempt-marker",
+    timestamp: "2026-08-02T00:00:02.000Z",
+  });
+
+  const deliveryId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  pinned._appendEntry({
+    type: "custom",
+    customType: "buzz.lifecycle_pending.v1",
+    data: {
+      version: 1,
+      deliveryId,
+      sourceEntryId: "compaction-entry",
+      event: {
+        type: "compaction_completed",
+        compactionId: "7f516ff7-e553-4219-b45a-2a432b516cec",
+        timestamp: "2026-08-02T00:00:02.500Z",
+        message: "Pi compacted this thread's context.",
+        piSessionId: "pi-quota-test",
+        reason: "threshold",
+        beforeTokens: 140_000,
+        afterTokens: 30_000,
+        limitTokens: 150_000,
+        effectiveLimitTokens: 150_000,
+        compactionThresholdTokens: 133_616,
+        willRetry: false,
+        fromExtension: false,
+      },
+    },
+    id: "lifecycle-pending-marker",
+    parentId: "rollback-marker",
+    timestamp: "2026-08-02T00:00:02.500Z",
+  });
+  pinned._appendEntry({
+    type: "custom",
+    customType: "buzz.lifecycle_ack.v1",
+    data: { version: 1, deliveryId },
+    id: "lifecycle-ack-marker",
+    parentId: "lifecycle-pending-marker",
+    timestamp: "2026-08-02T00:00:03.000Z",
+  });
+
+  // Control records were appended first, yet the ordinary partition still
+  // accepts its exact boundary rather than being starved by lifecycle state.
+  pinned._appendEntry(entry);
+  assert.throws(
+    () =>
+      pinned._appendEntry({
+        ...entry,
+        id: "one-byte-too-far",
+        parentId: entry.id,
+      }),
+    /BUZZ_SESSION_STORAGE_LIMIT:.*use \/new/,
+  );
+  assert.ok((await stat(sessionFile)).size < maxBytes);
+
+  const remainingBytes = maxBytes - (await stat(sessionFile)).size;
+  const reserveFiller = (index, paddingLength) => ({
+    type: "custom",
+    customType: "buzz.turn_rollback",
+    data: { version: 1, padding: "x".repeat(paddingLength) },
+    id: `reserve-filler-${index}`,
+    parentId: index === 0 ? entry.id : `reserve-filler-${index - 1}`,
+    timestamp: "2026-08-02T00:00:04.000Z",
+  });
+  const entryBytesForTarget = (index, targetBytes) => {
+    const empty = reserveFiller(index, 0);
+    const baseBytes = Buffer.byteLength(`${JSON.stringify(empty)}\n`);
+    assert.ok(targetBytes >= baseBytes);
+    return reserveFiller(index, targetBytes - baseBytes);
+  };
+  const fullTargetBytes = 1_800;
+  let fullEntries = Math.floor(remainingBytes / fullTargetBytes);
+  const remainder = remainingBytes % fullTargetBytes;
+  const targets = [];
+  if (remainder === 0) {
+    targets.push(...Array.from({ length: fullEntries }, () => fullTargetBytes));
+  } else {
+    const remainderBase = Buffer.byteLength(
+      `${JSON.stringify(reserveFiller(fullEntries, 0))}\n`,
+    );
+    if (remainder >= remainderBase) {
+      targets.push(
+        ...Array.from({ length: fullEntries }, () => fullTargetBytes),
+        remainder,
+      );
+    } else {
+      fullEntries -= 1;
+      assert.ok(fullEntries >= 0);
+      targets.push(
+        ...Array.from({ length: fullEntries }, () => fullTargetBytes),
+        fullTargetBytes + remainder,
+      );
+    }
+  }
+  for (const [index, targetBytes] of targets.entries()) {
+    const filler = entryBytesForTarget(index, targetBytes);
+    assert.equal(Buffer.byteLength(`${JSON.stringify(filler)}\n`), targetBytes);
+    pinned._appendEntry(filler);
+  }
+  assert.equal((await stat(sessionFile)).size, maxBytes);
+  assert.throws(
+    () => pinned._appendEntry(reserveFiller(targets.length, 0)),
+    /BUZZ_SESSION_STORAGE_LIMIT:.*use \/new/,
+  );
+});
+
+test("SIGKILL after Pi compaction append is reconciled and replayed exactly once after ACK", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-compaction-kill-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  const sessionFile = join(root, "killed-after-compaction.jsonl");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+
+  const childScript = `
+    import { writeFileSync } from "node:fs";
+    import { SessionManager } from "@earendil-works/pi-coding-agent";
+    const [sessionFile, cwd] = process.argv.slice(1);
+    writeFileSync(sessionFile, "");
+    const manager = SessionManager.open(sessionFile, undefined, cwd);
+    manager.appendCustomEntry("buzz.lifecycle_watermark.v1", { version: 1 });
+    const firstKeptEntryId = manager.appendCustomEntry("test.seed", { version: 1 });
+    manager.appendCompaction(
+      "Durable summary written immediately before a forced process death",
+      firstKeptEntryId,
+      140000,
+      undefined,
+      false,
+    );
+    process.kill(process.pid, "SIGKILL");
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--input-type=module", "-e", childScript, sessionFile, cwd],
+    { cwd: new URL("..", import.meta.url), stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const [code, signal] = await once(child, "exit");
+  assert.equal(code, null);
+  assert.equal(signal, "SIGKILL");
+  const killedTranscript = await readFile(sessionFile, "utf8");
+  assert.match(killedTranscript, /"type":"compaction"/);
+  assert.doesNotMatch(killedTranscript, /buzz\.lifecycle_pending\.v1/);
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const firstDeliveries = [];
+    const factory = new PiAgentSessionFactory(testConfig(), silentLogger);
+    const recovered = await factory.create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event, deliveryId) {
+          firstDeliveries.push({ event, deliveryId });
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "compaction-kill-recovery-1",
+    });
+    await recovered.replayLifecycleEvents();
+    assert.equal(firstDeliveries.length, 1);
+    assert.match(
+      firstDeliveries[0].deliveryId,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+    assert.equal(firstDeliveries[0].event.type, "compaction_completed");
+    assert.equal(firstDeliveries[0].event.reason, "threshold");
+    assert.equal(firstDeliveries[0].event.beforeTokens, 140_000);
+    assert.equal(firstDeliveries[0].event.afterTokens, null);
+    assert.match(
+      firstDeliveries[0].event.message,
+      /recovered.*runtime restarted/i,
+    );
+    assert.match(
+      await readFile(sessionFile, "utf8"),
+      /buzz\.lifecycle_pending\.v1/,
+    );
+    await recovered.dispose();
+
+    const retriedDeliveries = [];
+    const retried = await factory.create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event, deliveryId) {
+          retriedDeliveries.push({ event, deliveryId });
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "compaction-kill-recovery-2",
+    });
+    await retried.replayLifecycleEvents();
+    assert.deepEqual(retriedDeliveries, firstDeliveries);
+    await retried.acknowledgeLifecycleEvent(retriedDeliveries[0].deliveryId);
+    await retried.dispose();
+    assert.match(
+      await readFile(sessionFile, "utf8"),
+      /buzz\.lifecycle_ack\.v1/,
+    );
+
+    const afterAckDeliveries = [];
+    const afterAck = await factory.create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event, deliveryId) {
+          afterAckDeliveries.push({ event, deliveryId });
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "compaction-kill-recovery-3",
+    });
+    await afterAck.replayLifecycleEvents();
+    assert.deepEqual(afterAckDeliveries, []);
+    await afterAck.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("lifecycle recovery honors its feature watermark and only scans the active Pi branch", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-compaction-branch-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  const sessionDir = join(root, "sessions");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const manager = SessionManager.create(cwd, sessionDir);
+  manager._rewriteFile();
+  manager.flushed = true;
+
+  const legacySeed = manager.appendCustomEntry("test.legacy", { version: 1 });
+  manager.appendCompaction(
+    "Legacy compaction from before Buzz lifecycle delivery existed",
+    legacySeed,
+    110_000,
+    undefined,
+    false,
+  );
+  const watermark = manager.appendCustomEntry("buzz.lifecycle_watermark.v1", {
+    version: 1,
+  });
+  const orphanSeed = manager.appendCustomEntry("test.orphan", { version: 1 });
+  manager.appendCompaction(
+    "Compaction on a branch that is no longer active",
+    orphanSeed,
+    120_000,
+    undefined,
+    false,
+  );
+  manager.branch(watermark);
+  const activeSeed = manager.appendCustomEntry("test.active", { version: 1 });
+  manager.appendCompaction(
+    "Current branch compaction missing its crash-gap marker",
+    activeSeed,
+    130_000,
+    undefined,
+    false,
+  );
+  const sessionFile = manager.getSessionFile();
+  assert.ok(sessionFile);
+
+  const deliveries = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event, deliveryId) {
+          deliveries.push({ event, deliveryId });
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "compaction-active-branch-only",
+    });
+    await handle.replayLifecycleEvents();
+    assert.equal(deliveries.length, 1);
+    assert.equal(deliveries[0].event.beforeTokens, 130_000);
+    assert.match(deliveries[0].event.message, /recovered.*runtime restarted/i);
+    assert.doesNotMatch(
+      deliveries[0].event.message,
+      /legacy|no longer active/i,
+    );
+    await handle.acknowledgeLifecycleEvent(deliveries[0].deliveryId);
+    await handle.dispose();
+
+    const transcript = await readFile(sessionFile, "utf8");
+    assert.equal(transcript.match(/buzz\.lifecycle_pending\.v1/gu)?.length, 1);
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("final provider guard includes system prompt, messages, and tool schemas", () => {
+  let dispatched = false;
+  const context = {
+    systemPrompt: "s".repeat(80_000),
+    messages: [{ role: "user", content: "hello" }],
+    tools: [{ name: "giant", description: "d".repeat(80_000), parameters: {} }],
+  };
+  assert.ok(estimateProviderContextTokens(context) > 50_000);
+  assert.throws(
+    () =>
+      guardProviderDispatch(context, 50_000, () => {
+        dispatched = true;
+      }),
+    /BUZZ_CONTEXT_LIMIT/,
+  );
+  assert.equal(
+    dispatched,
+    false,
+    "an oversized request must never reach the provider",
+  );
+});
+
+test("dense and extension-expanded contexts are rejected before dispatch", () => {
+  for (const content of [
+    "a ".repeat(60_000),
+    "界".repeat(50_000),
+    "!".repeat(120_000),
+  ]) {
+    let dispatched = false;
+    assert.throws(
+      () =>
+        guardProviderDispatch(
+          {
+            systemPrompt: "",
+            messages: [{ role: "user", content }],
+            tools: [],
+          },
+          50_000,
+          () => {
+            dispatched = true;
+          },
+        ),
+      /BUZZ_CONTEXT_LIMIT/,
+    );
+    assert.equal(dispatched, false);
+  }
+});
+
+test("wide custom-provider payloads fail closed before cloning or dispatch", () => {
+  const wide = new Array(100_001).fill(0);
+  assert.throws(
+    () => estimateProviderPayloadTokens({ content: wide }),
+    /safe structural bounds/,
+  );
+  let dispatched = false;
+  assert.throws(
+    () =>
+      guardProviderDispatch(
+        {
+          systemPrompt: "",
+          messages: [{ role: "user", content: wide }],
+          tools: [],
+        },
+        150_000,
+        () => {
+          dispatched = true;
+        },
+      ),
+    /safe structural bounds/,
+  );
+  assert.equal(dispatched, false);
+});
+
+test("provider payload guard rejects advanced and non-plain JSON values", () => {
+  class CustomPayload {
+    value = "custom";
+  }
+  const advancedValues = [
+    new ArrayBuffer(16),
+    new Uint8Array([1, 2, 3]),
+    new DataView(new ArrayBuffer(8)),
+    new Map([["key", "value"]]),
+    new Set(["value"]),
+    new Date("2026-01-01T00:00:00.000Z"),
+    new CustomPayload(),
+  ];
+  if (typeof SharedArrayBuffer !== "undefined") {
+    advancedValues.push(new SharedArrayBuffer(16));
+  }
+  for (const value of advancedValues) {
+    assert.throws(
+      () => estimateProviderPayloadTokens({ value }),
+      /provider payload contains non-plain JSON data/,
+    );
+  }
+  assert.doesNotThrow(() =>
+    estimateProviderPayloadTokens(
+      Object.assign(Object.create(null), { value: ["plain", 1, true] }),
+    ),
+  );
+});
+
+test("provider payload inspection never executes iterators or accessors", () => {
+  let iteratorCalls = 0;
+  const overriddenIterator = [{ safe: true }];
+  Object.defineProperty(overriddenIterator, Symbol.iterator, {
+    value: function* () {
+      iteratorCalls += 1;
+      while (true) yield { unsafe: true };
+    },
+  });
+  assert.throws(
+    () => estimateProviderPayloadTokens(overriddenIterator),
+    /symbol-keyed data/,
+  );
+  assert.equal(iteratorCalls, 0);
+
+  let getterCalls = 0;
+  const accessorObject = {};
+  Object.defineProperty(accessorObject, "secret", {
+    enumerable: true,
+    get() {
+      getterCalls += 1;
+      return "unsafe";
+    },
+  });
+  assert.throws(
+    () => estimateProviderPayloadTokens(accessorObject),
+    /could not be safely inspected/,
+  );
+  assert.equal(getterCalls, 0);
+
+  const accessorArray = ["safe"];
+  Object.defineProperty(accessorArray, 0, {
+    enumerable: true,
+    get() {
+      getterCalls += 1;
+      return "unsafe";
+    },
+  });
+  assert.throws(
+    () => estimateProviderPayloadTokens(accessorArray),
+    /could not be safely inspected/,
+  );
+  assert.equal(getterCalls, 0);
+});
+
+test("provider payload inspection rejects sparse and decorated arrays", () => {
+  const sparse = new Array(2);
+  sparse[0] = "first";
+  assert.throws(() => estimateProviderPayloadTokens(sparse), /sparse array/);
+
+  const decorated = ["first"];
+  decorated.extra = "not provider JSON";
+  assert.throws(
+    () => estimateProviderPayloadTokens(decorated),
+    /decorated array/,
+  );
+
+  const symbolObject = { safe: true };
+  symbolObject[Symbol("hidden")] = "not provider JSON";
+  assert.throws(
+    () => estimateProviderPayloadTokens(symbolObject),
+    /symbol-keyed data/,
+  );
+});
+
+test("raw provider payload hooks may observe but cannot mutate or expand requests", async () => {
+  const payload = { messages: [{ role: "user", content: "hello" }] };
+  assert.equal(
+    await applyStrictPayloadGuard(payload, {}, async () => undefined, 10_000),
+    payload,
+  );
+  await assert.rejects(
+    () =>
+      applyStrictPayloadGuard(
+        payload,
+        {},
+        async (value) => ({ ...value, injected: "x".repeat(100_000) }),
+        10_000,
+      ),
+    /payload mutation is disabled/,
+  );
+});
+
+test("normal vision payloads budget image tokens without counting base64 as text", async () => {
+  const image = Buffer.alloc(1024 * 1024, 0xab).toString("base64");
+  const payload = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: image },
+          },
+        ],
+      },
+    ],
+  };
+  assert.ok(estimateProviderPayloadTokens(payload) < 10_000);
+  assert.equal(
+    await applyStrictPayloadGuard(payload, {}, async () => undefined, 150_000),
+    payload,
+  );
+  let dispatched = false;
+  const piContext = {
+    systemPrompt: "Describe images accurately.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image", data: image, mimeType: "image/png" },
+        ],
+      },
+    ],
+    tools: [],
+  };
+  guardProviderDispatch(piContext, 10_000, () => {
+    dispatched = true;
+  });
+  assert.equal(dispatched, true);
+  assert.ok(
+    estimateProviderPayloadTokens({
+      contents: [
+        { parts: [{ inlineData: { mimeType: "image/png", data: image } }] },
+      ],
+    }) < 10_000,
+  );
+});
+
+test("runtime timeouts keep interrupts below the outer Buzz deadline", () => {
+  const config = testConfig({
+    runtimeRequestTimeoutMs: 10_000,
+    runtimeControlTimeoutMs: 2_000,
+    runtimeInterruptTimeoutMs: 1_000,
+  });
+  assert.equal(requestTimeoutMs("prompt", config), 10_000);
+  assert.equal(requestTimeoutMs("create", config), 2_000);
+  for (const method of ["steer", "abort", "dispose", "shutdown"]) {
+    assert.equal(requestTimeoutMs(method, config), 1_000);
+  }
+});
+
+test("command descriptors deduplicate collisions deterministically", () => {
+  assert.deepEqual(
+    dedupeCommands([
+      { name: "review", description: "extension" },
+      { name: "review", description: "prompt" },
+      { name: "skill:test", description: "skill" },
+    ]),
+    [
+      { name: "review", description: "extension" },
+      { name: "skill:test", description: "skill" },
+    ],
+  );
+});
+
+test("actual Pi SDK creates a titled durable session and resumes its id", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-sdk-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const settingsPath = join(agentDir, "settings.json");
+  const settingsBefore =
+    '{\n  "defaultProvider": "openai",\n  "defaultModel": "gpt-4.1-mini",\n  "defaultThinkingLevel": "low"\n}\n';
+  await writeFile(settingsPath, settingsBefore);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOpenAiKey = process.env.OPENAI_API_KEY;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  process.env.OPENAI_API_KEY = "buzz-test-key-not-used";
+  try {
+    const factory = new PiAgentSessionFactory(testConfig(), silentLogger);
+    const first = await factory.create({
+      cwd,
+      title: "Buzz · durable thread",
+      eventSink: sink,
+      acpSessionId: "sdk-first",
+    });
+    const firstId = first.piSessionId;
+    const sessionFile = first.sessionFile;
+    assert.ok(sessionFile);
+    assert.match(await readFile(sessionFile, "utf8"), /Buzz · durable thread/);
+    const model = first.getModels()[0];
+    assert.ok(
+      model,
+      "a fake environment credential should expose at least one selectable model",
+    );
+    await first.setModel(model.id);
+    await first.setThinkingLevel("high");
+    await first.dispose();
+    assert.equal(
+      await readFile(settingsPath, "utf8"),
+      settingsBefore,
+      "actual AgentSession model/thinking changes must not persist normal Pi settings",
+    );
+
+    const resumed = await factory.create({
+      cwd,
+      title: "This must not replace the persisted title",
+      persistedSessionFile: sessionFile,
+      eventSink: sink,
+      acpSessionId: "sdk-resumed",
+    });
+    assert.equal(resumed.piSessionId, firstId);
+    const persisted = await readFile(sessionFile, "utf8");
+    assert.match(persisted, /Buzz · durable thread/);
+    assert.doesNotMatch(persisted, /This must not replace/);
+    await resumed.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousOpenAiKey;
+  }
+});
+
+test("an oversized first prompt is refused once without attempting empty compaction", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-oversized-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const events = [];
+  const eventSink = {
+    sessionUpdate() {},
+    buzzSessionEvent(_sessionId, event) {
+      events.push(event);
+    },
+    usageUpdate() {},
+  };
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      title: "Oversized prompt test",
+      eventSink,
+      acpSessionId: "oversized",
+    });
+    await assert.rejects(
+      () => handle.prompt("a ".repeat(150_001)),
+      /BUZZ_CONTEXT_LIMIT/,
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "compaction_failed");
+    assert.equal(events[0].reason, "preflight");
+    assert.equal(events[0].willRetry, false);
+    const persisted = await readFile(handle.sessionFile, "utf8");
+    assert.doesNotMatch(persisted, /a a a a a/);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("a fresh threshold-band prompt proceeds without meaningless empty compaction", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-threshold-band-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "threshold-band",
+    });
+    const state = handle.runtime.session.agent.state;
+    const fixedTokens = estimateProviderContextTokens({
+      systemPrompt: state.systemPrompt,
+      messages: [],
+      tools: state.tools,
+    });
+    const context = handle.getContextSnapshot();
+    const incomingTokens =
+      context.compactionThresholdTokens - fixedTokens + 1_000;
+    assert.ok(incomingTokens > 0);
+    assert.ok(fixedTokens + incomingTokens < context.effectiveLimitTokens);
+    let compactCalls = 0;
+    let promptCalls = 0;
+    handle.runtime.session.compact = async () => {
+      compactCalls++;
+    };
+    handle.runtime.session.prompt = async () => {
+      promptCalls++;
+    };
+    assert.equal(await handle.prompt("a ".repeat(incomingTokens)), "end_turn");
+    assert.equal(compactCalls, 0);
+    assert.equal(promptCalls, 1);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("manual compact is a successful status no-op on fresh context and never requests Buzz retry", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-manual-compact-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const events = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event) {
+          events.push(event);
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "manual-compact",
+    });
+    let compactCalls = 0;
+    handle.runtime.session.compact = async () => {
+      compactCalls++;
+      throw new Error("deterministic compaction failure");
+    };
+
+    assert.equal(await handle.prompt("/compact"), "end_turn");
+    assert.equal(compactCalls, 0);
+    assert.equal(events[0].type, "context_status");
+    assert.match(events[0].message, /Nothing to compact yet/);
+
+    handle.runtime.session.agent.state.messages.push({
+      role: "user",
+      content: "existing history",
+    });
+    assert.equal(await handle.prompt("/compact"), "end_turn");
+    assert.equal(compactCalls, 1);
+    assert.equal(events[1].type, "compaction_failed");
+    assert.equal(events[1].reason, "manual");
+    assert.equal(events[1].willRetry, false);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("cancelled preflight compaction is one terminal context-limit failure", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-preflight-cancel-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const events = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event) {
+          events.push(event);
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "preflight-cancel",
+    });
+    handle.runtime.session.agent.state.messages.push({
+      role: "user",
+      content: "old ".repeat(140_000),
+    });
+    let promptCalls = 0;
+    handle.runtime.session.prompt = async () => {
+      promptCalls++;
+    };
+    handle.runtime.session.compact = async () => {
+      handle.handleEvent({ type: "compaction_start", reason: "manual" });
+      handle.handleEvent({
+        type: "compaction_end",
+        reason: "manual",
+        result: undefined,
+        aborted: true,
+        willRetry: false,
+      });
+      throw new Error("Compaction cancelled");
+    };
+
+    await assert.rejects(
+      () => handle.prompt("continue"),
+      /^Error: BUZZ_CONTEXT_LIMIT: preflight compaction could not create safe room/,
+    );
+    assert.equal(promptCalls, 0);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "compaction_failed");
+    assert.equal(events[0].reason, "preflight");
+    assert.equal(events[0].aborted, true);
+    assert.equal(events[0].willRetry, false);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("cancelled turns persist a rollback leaf that excludes partial input after resume", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-cancel-rollback-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const factory = new PiAgentSessionFactory(testConfig(), silentLogger);
+    const handle = await factory.create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "cancel-rollback",
+    });
+    const sessionManager = handle.runtime.session.sessionManager;
+    handle.runtime.session.prompt = async () => {
+      sessionManager.appendCustomMessageEntry(
+        "test.cancelled-turn",
+        "cancelled secret input",
+        false,
+      );
+      handle.runtime.session.agent.state.messages.push({
+        role: "assistant",
+        content: [],
+        stopReason: "aborted",
+      });
+    };
+
+    assert.equal(await handle.prompt("cancelled secret input"), "cancelled");
+    assert.doesNotMatch(
+      JSON.stringify(handle.runtime.session.agent.state.messages),
+      /cancelled secret input/,
+    );
+    const sessionFile = handle.sessionFile;
+    assert.match(await readFile(sessionFile, "utf8"), /buzz.turn_rollback/);
+    await handle.dispose();
+
+    const resumed = await factory.create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: sink,
+      acpSessionId: "cancel-rollback-resumed",
+    });
+    assert.doesNotMatch(
+      JSON.stringify(resumed.runtime.session.agent.state.messages),
+      /cancelled secret input/,
+    );
+    await resumed.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("Pi compaction success/failure events preserve retry classification", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-compaction-events-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const events = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event) {
+          events.push(event);
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "compaction-events",
+    });
+    handle.handleEvent({ type: "compaction_start", reason: "threshold" });
+    handle.handleEvent({
+      type: "compaction_end",
+      reason: "threshold",
+      result: { tokensBefore: 140_000, estimatedTokensAfter: 30_000 },
+      aborted: false,
+      willRetry: false,
+    });
+    handle.handleEvent({ type: "compaction_start", reason: "overflow" });
+    handle.handleEvent({
+      type: "compaction_end",
+      reason: "overflow",
+      aborted: false,
+      errorMessage: "provider failed at /private/path/secret",
+      willRetry: true,
+    });
+    assert.equal(events[0].type, "compaction_completed");
+    assert.equal(events[0].willRetry, false);
+    assert.equal(events[0].fromExtension, false);
+    assert.match(events[0].compactionId, /^[0-9a-f-]{36}$/);
+    assert.equal(events[1].type, "compaction_failed");
+    assert.equal(events[1].willRetry, true);
+    assert.equal(events[1].fromExtension, false);
+    assert.doesNotMatch(events[1].error, /private|secret/);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("tool events normalize advanced values before bounded IPC and truncate by bytes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-tool-ipc-payload-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const updates = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    class CustomToolValue {
+      visible = "kept";
+    }
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate(_sessionId, update) {
+          updates.push(update);
+        },
+        buzzSessionEvent() {},
+        usageUpdate() {},
+      },
+      acpSessionId: "advanced-tool-ipc",
+    });
+    const advanced = {
+      arrayBuffer: new ArrayBuffer(16),
+      view: new Uint16Array([1, 2, 3]),
+      map: new Map([["key", { nested: true }]]),
+      set: new Set(["first", "second"]),
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      custom: new CustomToolValue(),
+      ...(typeof SharedArrayBuffer === "undefined"
+        ? {}
+        : { shared: new SharedArrayBuffer(8) }),
+    };
+    handle.handleEvent({
+      type: "tool_execution_start",
+      toolCallId: "advanced-input",
+      toolName: "extension_tool",
+      args: advanced,
+    });
+    handle.handleEvent({
+      type: "tool_execution_end",
+      toolCallId: "advanced-output",
+      toolName: "extension_tool",
+      result: advanced,
+      isError: false,
+    });
+    const rawInput = updates[0].rawInput;
+    const rawOutput = updates[1].rawOutput;
+    for (const normalized of [rawInput, rawOutput]) {
+      assert.equal(normalized.arrayBuffer.$type, "ArrayBuffer");
+      assert.equal(normalized.arrayBuffer.byteLength, 16);
+      assert.equal(normalized.view.$type, "TypedArray");
+      assert.equal(normalized.map.$type, "Map");
+      assert.deepEqual(normalized.map.entries, [["key", { nested: true }]]);
+      assert.equal(normalized.set.$type, "Set");
+      assert.equal(normalized.date.$type, "Date");
+      assert.equal(normalized.custom.$type, "NonPlainObject");
+      assert.equal(normalized.custom.visible, "kept");
+      if (normalized.shared) {
+        assert.equal(normalized.shared.$type, "SharedArrayBuffer");
+      }
+    }
+
+    const sent = [];
+    const sender = new BoundedIpcSendQueue(
+      (message, callback) => {
+        sent.push(message);
+        queueMicrotask(() => callback(null));
+        return true;
+      },
+      4,
+      256 * 1_024,
+      (error) => assert.fail(error.message),
+    );
+    assert.equal(sender.enqueue(updates[1]), true);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(sent, [updates[1]]);
+
+    const wide = {};
+    for (let index = 0; index < 20_000; index += 1) {
+      wide[`key_${index}`] = index;
+    }
+    handle.handleEvent({
+      type: "tool_execution_update",
+      toolCallId: "wide-output",
+      toolName: "extension_tool",
+      partialResult: wide,
+    });
+    const normalizedWide = updates[2].rawOutput;
+    assert.equal(normalizedWide["[truncated]"], true);
+    assert.ok(Object.keys(normalizedWide).length <= 201);
+
+    const inheritedPrototype = {};
+    for (let index = 0; index < 1_000; index += 1) {
+      inheritedPrototype[`inherited_${index}`] = index;
+    }
+    const inheritedWide = Object.assign(Object.create(inheritedPrototype), {
+      own: "kept",
+    });
+    handle.handleEvent({
+      type: "tool_execution_update",
+      toolCallId: "inherited-wide-output",
+      toolName: "extension_tool",
+      partialResult: inheritedWide,
+    });
+    const normalizedInherited = updates[3].rawOutput;
+    assert.equal(normalizedInherited.$type, "NonPlainObject");
+    assert.equal(normalizedInherited.own, "kept");
+    assert.equal(normalizedInherited["[truncated]"], true);
+
+    handle.handleEvent({
+      type: "tool_execution_end",
+      toolCallId: "oversized-output",
+      toolName: "extension_tool",
+      result: { text: "界".repeat(100_000) },
+      isError: false,
+    });
+    const truncated = updates[4].rawOutput;
+    assert.equal(typeof truncated, "string");
+    assert.match(truncated, /output truncated by buzz-pi-agent/);
+    assert.ok(Buffer.byteLength(truncated) <= 64_000);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("actual Pi resources load globally and project resources fail closed until trusted", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-resources-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await mkdir(join(agentDir, "prompts"), { recursive: true });
+  await mkdir(join(agentDir, "skills", "global-skill"), { recursive: true });
+  await mkdir(join(cwd, ".pi", "extensions"), { recursive: true });
+  const commandMarker = join(root, "global-command-ran.json");
+  await writeFile(
+    join(agentDir, "extensions", "global.js"),
+    `import { writeFileSync } from "node:fs";
+    let moduleCounter = 0;
+    export default function (pi) {
+      pi.registerCommand("global-command", {
+        description: "Global Buzz test command",
+        async handler() {
+          writeFileSync(${JSON.stringify(commandMarker)}, JSON.stringify({
+            moduleCounter: ++moduleCounter,
+            tools: pi.getAllTools().map((tool) => tool.name)
+          }));
+        }
+      });
+      pi.registerTool({
+        name: "global_test_tool",
+        label: "Global test tool",
+        description: "A no-op integration test tool",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        async execute() { return { content: [{ type: "text", text: "ok" }] }; }
+      });
+    }`,
+  );
+  await writeFile(
+    join(cwd, ".pi", "extensions", "project.js"),
+    `export default function (pi) {
+      pi.registerCommand("project-command", {
+        description: "Trusted project test command",
+        async handler() {}
+      });
+    }`,
+  );
+  await writeFile(
+    join(agentDir, "prompts", "global-prompt.md"),
+    "---\ndescription: Global prompt test\n---\nReview $ARGUMENTS",
+  );
+  await writeFile(
+    join(agentDir, "skills", "global-skill", "SKILL.md"),
+    "---\nname: global-skill\ndescription: Global skill test\n---\nDo the skill.",
+  );
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const untrustedFactory = new PiAgentSessionFactory(
+      testConfig({ trustProjectOverride: false }),
+      silentLogger,
+    );
+    const untrusted = await untrustedFactory.create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "resources-untrusted",
+    });
+    const untrustedResources = untrusted.getResources();
+    assert.equal(untrustedResources.projectTrusted, false);
+    assert.equal(untrustedResources.extensions, 1);
+    assert.ok(
+      untrustedResources.commands.some(
+        (command) => command.name === "global-command",
+      ),
+    );
+    assert.ok(
+      untrustedResources.commands.some(
+        (command) => command.name === "global-prompt",
+      ),
+    );
+    assert.ok(
+      untrustedResources.commands.some(
+        (command) => command.name === "skill:global-skill",
+      ),
+    );
+    assert.ok(
+      !untrustedResources.commands.some(
+        (command) => command.name === "project-command",
+      ),
+    );
+    untrusted.runtime.session.agent.state.messages.push({
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage: "stale prior error",
+    });
+    assert.equal(await untrusted.prompt("/global-command"), "end_turn");
+    const firstCommand = JSON.parse(await readFile(commandMarker, "utf8"));
+    assert.equal(firstCommand.moduleCounter, 1);
+    assert.ok(firstCommand.tools.includes("global_test_tool"));
+    await untrusted.dispose();
+
+    const trustedFactory = new PiAgentSessionFactory(
+      testConfig({ trustProjectOverride: true }),
+      silentLogger,
+    );
+    const trusted = await trustedFactory.create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "resources-trusted",
+    });
+    const trustedResources = trusted.getResources();
+    assert.equal(trustedResources.projectTrusted, true);
+    assert.equal(trustedResources.extensions, 2);
+    assert.ok(
+      trustedResources.commands.some(
+        (command) => command.name === "project-command",
+      ),
+    );
+    assert.equal(await trusted.prompt("/global-command"), "end_turn");
+    const secondCommand = JSON.parse(await readFile(commandMarker, "utf8"));
+    assert.equal(
+      secondCommand.moduleCounter,
+      2,
+      "Pi module globals are shared while factory-created handlers remain per session",
+    );
+    await trusted.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("extension-only configured models resolve on cold create and cold restore", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-custom-provider-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({
+      defaultProvider: "buzz-cold-provider",
+      defaultModel: "buzz-cold-model",
+      defaultThinkingLevel: "low",
+    }),
+  );
+  await writeFile(
+    join(agentDir, "extensions", "cold-provider.js"),
+    `export default function (pi) {
+      pi.registerProvider("buzz-cold-provider", {
+        name: "Buzz cold provider",
+        baseUrl: "https://cold.invalid/v1",
+        apiKey: "test-key-not-used",
+        api: "openai-completions",
+        models: [{
+          id: "buzz-cold-model",
+          name: "Buzz cold model",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 4096
+        }]
+      });
+    }`,
+  );
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const initial = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "custom-provider-initial",
+    });
+    assert.equal(
+      initial.getContextSnapshot().model,
+      "buzz-cold-provider/buzz-cold-model",
+      "provider registrations must be flushed before initial model resolution",
+    );
+    await initial.setModel("buzz-cold-provider/buzz-cold-model");
+    initial.runtime.session.sessionManager.appendCustomMessageEntry(
+      "buzz.test.history",
+      "persisted custom provider history",
+      false,
+    );
+    const sessionFile = initial.sessionFile;
+    assert.ok(sessionFile);
+    await initial.dispose();
+
+    const restored = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      persistedSessionFile: sessionFile,
+      eventSink: sink,
+      acpSessionId: "custom-provider-restored",
+    });
+    assert.equal(
+      restored.getContextSnapshot().model,
+      "buzz-cold-provider/buzz-cold-model",
+      "a fresh runtime must resolve the extension model saved in the session",
+    );
+    assert.match(
+      JSON.stringify(restored.runtime.session.agent.state.messages),
+      /persisted custom provider history/,
+    );
+    await restored.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("invalid extension provider registrations surface bounded safe Buzz diagnostics", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-broken-provider-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  const extensionPath = join(
+    agentDir,
+    "extensions",
+    "broken-provider-secret.js",
+  );
+  await mkdir(cwd, { recursive: true });
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await writeFile(
+    extensionPath,
+    `export default function (pi) {
+      pi.registerProvider("buzz-broken-provider", {
+        models: [{
+          id: "broken-model",
+          name: "Broken model",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 4096
+        }]
+      });
+    }`,
+  );
+
+  const lifecycleEvents = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate() {},
+        buzzSessionEvent(_sessionId, event) {
+          lifecycleEvents.push(event);
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "broken-provider-diagnostic",
+    });
+    const diagnostic = handle
+      .getResources()
+      .errors.find((error) => error.startsWith("Pi runtime error:"));
+    assert.ok(diagnostic, "provider setup diagnostics must reach Buzz");
+    assert.match(diagnostic, /buzz-broken-provider|baseUrl|api/i);
+    assert.ok(diagnostic.length <= 512);
+    assert.doesNotMatch(diagnostic, new RegExp(root));
+    assert.doesNotMatch(diagnostic, /broken-provider-secret\.js/);
+
+    assert.equal(await handle.prompt("/reload"), "end_turn");
+    const reload = lifecycleEvents.find(
+      (event) => event.type === "extensions_reloaded",
+    );
+    assert.ok(reload);
+    assert.ok(
+      reload.errors.some((error) => error.startsWith("Pi runtime error:")),
+      "reload lifecycle reporting must retain provider setup diagnostics",
+    );
+    assert.ok(reload.errors.length <= 20);
+    assert.ok(reload.errors.every((error) => error.length <= 512));
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("project providers with the same id stay isolated across cwd sessions", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-provider-isolation-"));
+  const agentDir = join(root, "agent");
+  const cwdA = join(root, "workspace-a");
+  const cwdB = join(root, "workspace-b");
+  await mkdir(agentDir, { recursive: true });
+
+  for (const [cwd, modelName, baseUrl] of [
+    [cwdA, "Workspace A model", "https://workspace-a.invalid/v1"],
+    [cwdB, "Workspace B model", "https://workspace-b.invalid/v1"],
+  ]) {
+    await mkdir(join(cwd, ".pi", "extensions"), { recursive: true });
+    await writeFile(
+      join(cwd, ".pi", "extensions", "provider.js"),
+      `export default function (pi) {
+        pi.registerProvider("shared-project-provider", {
+          name: "Shared project provider",
+          baseUrl: ${JSON.stringify(baseUrl)},
+          apiKey: "test-key-not-used",
+          api: "openai-completions",
+          models: [{
+            id: "same-model-id",
+            name: ${JSON.stringify(modelName)},
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200000,
+            maxTokens: 4096
+          }]
+        });
+      }`,
+    );
+  }
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const factory = new PiAgentSessionFactory(
+      testConfig({ trustProjectOverride: true }),
+      silentLogger,
+    );
+    const sessionA = await factory.create({
+      cwd: cwdA,
+      eventSink: sink,
+      acpSessionId: "provider-isolation-a",
+    });
+    const sessionB = await factory.create({
+      cwd: cwdB,
+      eventSink: sink,
+      acpSessionId: "provider-isolation-b",
+    });
+    const modelId = "shared-project-provider/same-model-id";
+    assert.equal(
+      sessionA.getModels().find((model) => model.id === modelId)?.name,
+      "Workspace A model",
+    );
+    assert.equal(
+      sessionB.getModels().find((model) => model.id === modelId)?.name,
+      "Workspace B model",
+    );
+    assert.notEqual(
+      sessionA.runtime.services.modelRuntime,
+      sessionB.runtime.services.modelRuntime,
+      "each cwd-bound Pi session must own its provider registry",
+    );
+    await sessionA.dispose();
+    await sessionB.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("project trust revocation removes project providers and preserves global providers", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-provider-revocation-"));
+  const agentDir = join(root, "agent");
+  const cwd = join(root, "workspace");
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await mkdir(join(cwd, ".pi", "extensions"), { recursive: true });
+
+  const providerSource = (providerId, modelId, commandName) =>
+    `export default function (pi) {
+      pi.registerProvider(${JSON.stringify(providerId)}, {
+        name: ${JSON.stringify(providerId)},
+        baseUrl: "https://provider.invalid/v1",
+        apiKey: "test-key-not-used",
+        api: "openai-completions",
+        models: [{
+          id: ${JSON.stringify(modelId)},
+          name: ${JSON.stringify(modelId)},
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 4096
+        }]
+      });
+      pi.registerCommand(${JSON.stringify(commandName)}, {
+        description: ${JSON.stringify(commandName)},
+        async handler() {}
+      });
+    }`;
+
+  await writeFile(
+    join(agentDir, "extensions", "global-provider.js"),
+    providerSource(
+      "global-reload-provider",
+      "global-reload-model",
+      "global-reload-command",
+    ),
+  );
+  await writeFile(
+    join(cwd, ".pi", "extensions", "project-provider.js"),
+    providerSource(
+      "project-reload-provider",
+      "project-reload-model",
+      "project-reload-command",
+    ),
+  );
+
+  const canonicalCwd = await realpath(cwd);
+  const trustPath = join(agentDir, "trust.json");
+  await writeFile(trustPath, JSON.stringify({ [canonicalCwd]: true }));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "provider-trust-revocation",
+    });
+    const projectModelId = "project-reload-provider/project-reload-model";
+    const globalModelId = "global-reload-provider/global-reload-model";
+    assert.equal(handle.getResources().projectTrusted, true);
+    assert.ok(handle.getModels().some((model) => model.id === projectModelId));
+    assert.ok(handle.getModels().some((model) => model.id === globalModelId));
+    await handle.setModel(projectModelId);
+    assert.equal(handle.getContextSnapshot().model, projectModelId);
+
+    await writeFile(trustPath, JSON.stringify({ [canonicalCwd]: false }));
+    const resources = await handle.reload();
+
+    assert.equal(resources.projectTrusted, false);
+    assert.ok(
+      !resources.commands.some(
+        (command) => command.name === "project-reload-command",
+      ),
+    );
+    assert.ok(
+      resources.commands.some(
+        (command) => command.name === "global-reload-command",
+      ),
+    );
+    assert.ok(!handle.getModels().some((model) => model.id === projectModelId));
+    assert.ok(handle.getModels().some((model) => model.id === globalModelId));
+    assert.equal(
+      handle.getContextSnapshot().model,
+      null,
+      "the revoked provider must not remain active for one more dispatch",
+    );
+    await assert.rejects(
+      () => handle.setModel(projectModelId),
+      /Unknown or unavailable Pi model/,
+    );
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("a trusted workspace symlink cannot reload onto an untrusted target", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-workspace-symlink-"));
+  const agentDir = join(root, "agent");
+  const workspaceA = join(root, "trusted-a");
+  const workspaceB = join(root, "untrusted-b");
+  const workspaceAlias = join(root, "workspace-current");
+  const untrustedMarker = join(root, "untrusted-command-ran");
+  await mkdir(agentDir, { recursive: true });
+  await mkdir(join(workspaceA, ".pi", "extensions"), { recursive: true });
+  await mkdir(join(workspaceB, ".pi", "extensions"), { recursive: true });
+  await writeFile(
+    join(workspaceA, ".pi", "extensions", "trusted.js"),
+    `export default function (pi) {
+      pi.registerCommand("trusted-only", { description: "trusted", async handler() {} });
+    }`,
+  );
+  await writeFile(
+    join(workspaceB, ".pi", "extensions", "untrusted.js"),
+    `import { writeFileSync } from "node:fs";
+    export default function (pi) {
+      pi.registerCommand("untrusted-only", {
+        description: "untrusted",
+        async handler() { writeFileSync(${JSON.stringify(untrustedMarker)}, "ran"); }
+      });
+    }`,
+  );
+  await symlink(workspaceA, workspaceAlias, "dir");
+  const canonicalA = await realpath(workspaceA);
+  const canonicalB = await realpath(workspaceB);
+  await writeFile(
+    join(agentDir, "trust.json"),
+    JSON.stringify({ [canonicalA]: true, [canonicalB]: false }),
+  );
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousHome = process.env.HOME;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  process.env.HOME = root;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd: workspaceAlias,
+      eventSink: sink,
+      acpSessionId: "workspace-symlink-swap",
+    });
+    assert.equal(handle.cwd, canonicalA);
+    assert.ok(
+      handle
+        .getResources()
+        .commands.some((command) => command.name === "trusted-only"),
+    );
+
+    await unlink(workspaceAlias);
+    await symlink(workspaceB, workspaceAlias, "dir");
+    await assert.rejects(
+      () => handle.reload(),
+      /BUZZ_PI_SESSION_INVALIDATED:.*BUZZ_PI_WORKSPACE_CHANGED/,
+    );
+    assert.equal(handle.isValid, false);
+    await assert.rejects(
+      () => handle.prompt("/untrusted-only"),
+      /BUZZ_PI_SESSION_INVALIDATED/,
+    );
+    await assert.rejects(() => readFile(untrustedMarker), /ENOENT/);
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
+});
+
+test("resource mutation during actual SDK reload retires the old host session and permits a fresh one", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-resource-toctou-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  const promptPath = join(agentDir, "prompts", "stable.md");
+  const triggerPath = join(root, "mutate-on-import");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await mkdir(join(agentDir, "prompts"), { recursive: true });
+  await writeFile(promptPath, "---\ndescription: Stable prompt\n---\nstable");
+  await writeFile(
+    join(agentDir, "extensions", "mutation.js"),
+    `import { appendFileSync, existsSync } from "node:fs";
+    if (existsSync(${JSON.stringify(triggerPath)})) {
+      appendFileSync(${JSON.stringify(promptPath)}, "\\nmutated-during-sdk-load");
+    }
+    export default function (pi) {
+      pi.registerCommand("stable-command", {
+        description: "Stable command",
+        async handler() {}
+      });
+    }`,
+  );
+
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousHome = process.env.HOME;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  process.env.HOME = root;
+  const factory = new IsolatedPiWorkerFactory(testConfig(), silentLogger);
+  try {
+    const options = {
+      cwd,
+      eventSink: sink,
+      acpSessionId: "resource-toctou-generation",
+    };
+    const old = await factory.create(options);
+    assert.ok(
+      old
+        .getResources()
+        .commands.some((command) => command.name === "stable-command"),
+    );
+    await writeFile(triggerPath, "1");
+    await assert.rejects(
+      () => old.reload(),
+      /BUZZ_PI_SESSION_INVALIDATED:.*BUZZ_PI_RESOURCE_CHANGED/,
+    );
+    assert.equal(old.isValid, false);
+    await assert.rejects(
+      () => old.prompt("old generation must not run"),
+      /BUZZ_PI_SESSION_INVALIDATED/,
+    );
+
+    await unlink(triggerPath);
+    await writeFile(promptPath, "---\ndescription: Stable prompt\n---\nstable");
+    const fresh = await factory.create(options);
+    assert.equal(fresh.isValid, true);
+    assert.equal(await fresh.prompt("/stable-command"), "end_turn");
+    await fresh.dispose();
+    await old.dispose();
+  } finally {
+    await factory.shutdown().catch(() => {});
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
+});
+
+test("an actual extension command can reload resources while its prompt is active", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-command-reload-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  const marker = join(root, "reload-command.txt");
+  const reloadedPrompt = join(agentDir, "prompts", "created-on-reload.md");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await mkdir(join(agentDir, "prompts"), { recursive: true });
+  await writeFile(
+    join(agentDir, "extensions", "reload-command.js"),
+    `import { appendFileSync, writeFileSync } from "node:fs";
+    export default function (pi) {
+      pi.registerCommand("reload-self", {
+        description: "Reload from inside an extension command",
+        async handler(_args, ctx) {
+          appendFileSync(${JSON.stringify(marker)}, "before\\n");
+          writeFileSync(${JSON.stringify(reloadedPrompt)}, "---\\ndescription: Created during reload\\n---\\nNew resource");
+          await ctx.reload();
+          appendFileSync(${JSON.stringify(marker)}, "after\\n");
+        }
+      });
+    }`,
+  );
+  const lifecycleEvents = [];
+  const sessionUpdates = [];
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: {
+        sessionUpdate(_sessionId, update) {
+          sessionUpdates.push(update);
+        },
+        buzzSessionEvent(_sessionId, event) {
+          lifecycleEvents.push(event);
+        },
+        usageUpdate() {},
+      },
+      acpSessionId: "extension-command-reload",
+    });
+    assert.ok(
+      handle
+        .getResources()
+        .commands.some((command) => command.name === "reload-self"),
+    );
+    assert.equal(await handle.prompt("/reload-self"), "end_turn");
+    assert.equal(await readFile(marker, "utf8"), "before\nafter\n");
+    assert.equal(handle.getResources().prompts, 1);
+    assert.ok(
+      lifecycleEvents.some(
+        (event) => event.type === "extensions_reloaded" && event.prompts === 1,
+      ),
+      "command-context reload should report refreshed resources to Buzz",
+    );
+    assert.ok(
+      sessionUpdates.some(
+        (update) => update.sessionUpdate === "available_commands_update",
+      ),
+    );
+    assert.ok(
+      handle
+        .getResources()
+        .commands.some((command) => command.name === "reload-self"),
+      "the refreshed extension command registry should remain active",
+    );
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("external resource reload remains blocked during an ordinary active turn", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-external-reload-busy-"));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handle = await new PiAgentSessionFactory(
+      testConfig(),
+      silentLogger,
+    ).create({
+      cwd,
+      eventSink: sink,
+      acpSessionId: "external-reload-busy",
+    });
+    let markStarted;
+    let finishPrompt;
+    const started = new Promise((resolve) => {
+      markStarted = resolve;
+    });
+    const blocked = new Promise((resolve) => {
+      finishPrompt = resolve;
+    });
+    handle.runtime.session.prompt = async () => {
+      markStarted();
+      await blocked;
+    };
+
+    const turn = handle.prompt("ordinary turn");
+    await started;
+    await assert.rejects(
+      () => handle.reload(),
+      /cannot reload resources while a turn is active/,
+    );
+    finishPrompt();
+    assert.equal(await turn, "end_turn");
+    await handle.dispose();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});

--- a/packages/buzz-pi-agent/test/resource-budget.test.mjs
+++ b/packages/buzz-pi-agent/test/resource-budget.test.mjs
@@ -1,0 +1,408 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rename, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+  assertPiResourceBudget,
+  assertPiResourceSnapshotsEqual,
+} from "../dist/index.js";
+import { testConfig } from "./helpers.mjs";
+
+async function fixture(prefix) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  const cwd = join(root, "workspace");
+  const agentDir = join(root, "agent");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(agentDir, { recursive: true });
+  return { root, cwd, agentDir };
+}
+
+async function isolatedHome(root, operation) {
+  const previous = process.env.HOME;
+  process.env.HOME = root;
+  try {
+    return await operation();
+  } finally {
+    if (previous === undefined) delete process.env.HOME;
+    else process.env.HOME = previous;
+  }
+}
+
+function scan(cwd, agentDir, overrides = {}) {
+  return assertPiResourceBudget({
+    cwd,
+    agentDir,
+    projectTrusted: true,
+    config: testConfig(overrides),
+  });
+}
+
+test("context fallback checks the first real file after a directory candidate", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-context-fallback-");
+  await mkdir(join(cwd, "AGENTS.md"));
+  await writeFile(join(cwd, "CLAUDE.md"), "x".repeat(65));
+  await isolatedHome(root, async () => {
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 64 }),
+      /BUZZ_PI_RESOURCE_LIMIT: context file exceeds the per-file limit/,
+    );
+  });
+});
+
+test("global prompt ignore manifests are bounded before Pi discovery", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-prompt-ignore-");
+  await mkdir(join(agentDir, "prompts"));
+  await writeFile(join(agentDir, "prompts", ".ignore"), "x".repeat(513));
+  await isolatedHome(root, async () => {
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 512 }),
+      /BUZZ_PI_RESOURCE_LIMIT: prompt ignore manifest exceeds/,
+    );
+  });
+});
+
+test("package prompt/theme trees include nested resources and nested ignore manifests", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-package-resource-");
+  const pkg = join(agentDir, "fixture-package");
+  const prompt = join(pkg, "prompts", "nested", "review.md");
+  const theme = join(pkg, "themes", "nested", "dark.json");
+  const nestedIgnore = join(pkg, "prompts", "nested", ".fdignore");
+  await mkdir(join(pkg, "prompts", "nested"), { recursive: true });
+  await mkdir(join(pkg, "themes", "nested"), { recursive: true });
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({ packages: ["./fixture-package"] }),
+  );
+  await writeFile(
+    join(pkg, "package.json"),
+    JSON.stringify({ name: "fixture" }),
+  );
+  await writeFile(prompt, "prompt");
+  await writeFile(theme, "{}");
+  await writeFile(nestedIgnore, "small");
+
+  await isolatedHome(root, async () => {
+    const snapshot = scan(cwd, agentDir);
+    const paths = snapshot.fingerprints.map((entry) => entry.path);
+    assert.ok(paths.includes(prompt));
+    assert.ok(paths.includes(theme));
+    assert.ok(paths.includes(nestedIgnore));
+
+    await writeFile(nestedIgnore, "x".repeat(1_025));
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 1_024 }),
+      /BUZZ_PI_RESOURCE_LIMIT: prompt ignore manifest exceeds/,
+    );
+  });
+});
+
+test("package extension glob traversal is bounded without charging code bytes", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-package-extension-");
+  const pkg = join(agentDir, "extension-package");
+  const nested = join(pkg, "extensions", "one", "two");
+  const ignore = join(nested, ".gitignore");
+  await mkdir(nested, { recursive: true });
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({ packages: ["./extension-package"] }),
+  );
+  await writeFile(
+    join(pkg, "package.json"),
+    JSON.stringify({
+      name: "extension-package",
+      pi: { extensions: ["extensions/**/*.js"] },
+    }),
+  );
+  await writeFile(join(nested, "large.js"), "x".repeat(8_192));
+  await writeFile(ignore, "small");
+
+  await isolatedHome(root, async () => {
+    const snapshot = scan(cwd, agentDir, { maxResourceFileBytes: 1_024 });
+    assert.ok(snapshot.fingerprints.some((entry) => entry.path === ignore));
+    assert.ok(
+      !snapshot.fingerprints.some((entry) => entry.path.endsWith("large.js")),
+      "extension source is trusted executable code, not non-code byte budget",
+    );
+    await writeFile(ignore, "x".repeat(1_025));
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 1_024 }),
+      /BUZZ_PI_RESOURCE_LIMIT: extension ignore manifest exceeds/,
+    );
+  });
+});
+
+test("configured legacy global npm packages retain regular Pi resource compatibility", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-legacy-npm-");
+  const globalRoot = join(root, "legacy-global", "node_modules");
+  const pkg = join(globalRoot, "legacy-fixture");
+  const nestedPrompt = join(pkg, "prompts", "nested", "legacy.md");
+  const resolver = join(root, "npm-root.cjs");
+  await mkdir(join(pkg, "prompts", "nested"), { recursive: true });
+  await writeFile(
+    resolver,
+    `process.stdout.write(${JSON.stringify(globalRoot)} + "\\n");`,
+  );
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({
+      npmCommand: [process.execPath, resolver],
+      packages: ["npm:legacy-fixture@1.0.0  "],
+    }),
+  );
+  await writeFile(
+    join(pkg, "package.json"),
+    JSON.stringify({ name: "legacy-fixture", version: "1.0.0" }),
+  );
+  await writeFile(nestedPrompt, "legacy prompt");
+
+  await isolatedHome(root, async () => {
+    const snapshot = scan(cwd, agentDir);
+    assert.ok(
+      snapshot.fingerprints.some((entry) => entry.path === nestedPrompt),
+    );
+  });
+});
+
+test("configured deep Git package roots bypass no resources through intermediate manifests", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-managed-git-");
+  const pkg = join(
+    agentDir,
+    "git",
+    "gitlab.example",
+    "group",
+    "subgroup",
+    "team",
+    "project",
+  );
+  const prompt = join(pkg, "prompts", "deep.md");
+  await mkdir(join(pkg, "prompts"), { recursive: true });
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({
+      packages: ["git:https://gitlab.example/group/subgroup/team/project"],
+    }),
+  );
+  await writeFile(
+    join(agentDir, "git", "gitlab.example", "package.json"),
+    JSON.stringify({ name: "stray-intermediate" }),
+  );
+  await writeFile(join(pkg, "package.json"), JSON.stringify({ name: "deep" }));
+  await writeFile(prompt, "deep prompt");
+  await isolatedHome(root, async () => {
+    const snapshot = scan(cwd, agentDir);
+    assert.ok(snapshot.fingerprints.some((entry) => entry.path === prompt));
+  });
+});
+
+test("hosted Git shorthand refs scan the exact managed package root", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-hosted-git-ref-");
+  const pkg = join(agentDir, "git", "github.com", "user", "repo");
+  const prompt = join(pkg, "prompts", "oversized.md");
+  await mkdir(join(pkg, "prompts"), { recursive: true });
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({ packages: ["  git:github:user/repo#main  "] }),
+  );
+  await writeFile(
+    join(agentDir, "git", "github.com", "package.json"),
+    JSON.stringify({ name: "stray-intermediate" }),
+  );
+  await writeFile(join(pkg, "package.json"), JSON.stringify({ name: "repo" }));
+  await writeFile(prompt, "x".repeat(257));
+
+  await isolatedHome(root, async () => {
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 256 }),
+      /BUZZ_PI_RESOURCE_LIMIT: prompt exceeds the per-file limit/,
+    );
+  });
+});
+
+test("bare, leading-space npm, nested, and malformed package sources fall back to scope-relative paths", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-local-source-parity-");
+  const sources = [
+    ["  my-package  ", join(agentDir, "my-package")],
+    ["subdir/pkg", join(agentDir, "subdir", "pkg")],
+    ["github:user/repo", join(agentDir, "github:user", "repo")],
+    ["https:not-a-url/pkg", join(agentDir, "https:not-a-url", "pkg")],
+    ["  npm:local-package  ", join(agentDir, "npm:local-package")],
+  ];
+  const prompts = [];
+  for (const [source, pkg] of sources) {
+    const prompt = join(pkg, "prompts", "local.md");
+    await mkdir(join(pkg, "prompts"), { recursive: true });
+    await writeFile(
+      join(pkg, "package.json"),
+      JSON.stringify({ name: source.trim() }),
+    );
+    await writeFile(prompt, `prompt:${source.trim()}`);
+    prompts.push(prompt);
+  }
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({ packages: sources.map(([source]) => source) }),
+  );
+
+  await isolatedHome(root, async () => {
+    const before = scan(cwd, agentDir);
+    const paths = new Set(before.fingerprints.map((entry) => entry.path));
+    for (const prompt of prompts) assert.ok(paths.has(prompt));
+
+    await writeFile(prompts[0], "changed bare package prompt");
+    const changed = scan(cwd, agentDir);
+    assert.throws(
+      () => assertPiResourceSnapshotsEqual(before, changed),
+      /BUZZ_PI_RESOURCE_CHANGED/,
+    );
+
+    await writeFile(prompts.at(-1), "x".repeat(257));
+    assert.throws(
+      () => scan(cwd, agentDir, { maxResourceFileBytes: 256 }),
+      /BUZZ_PI_RESOURCE_LIMIT: prompt exceeds the per-file limit/,
+    );
+  });
+});
+
+test("encoded file URLs and whitespace-padded configured resource paths resolve natively", async () => {
+  const { root, cwd, agentDir } = await fixture("buzz-pi-configured-paths-");
+  const pkg = join(root, "package with spaces");
+  const packagePrompt = join(pkg, "prompts", "package.md");
+  const skill = join(agentDir, "custom skills", "review", "SKILL.md");
+  const prompt = join(agentDir, "custom prompts", "review.md");
+  const theme = join(agentDir, "custom themes", "review.json");
+  const extensionIgnore = join(agentDir, "custom extensions", ".ignore");
+  await mkdir(join(pkg, "prompts"), { recursive: true });
+  await mkdir(join(agentDir, "custom skills", "review"), { recursive: true });
+  await mkdir(join(agentDir, "custom prompts"), { recursive: true });
+  await mkdir(join(agentDir, "custom themes"), { recursive: true });
+  await mkdir(join(agentDir, "custom extensions"), { recursive: true });
+  await writeFile(
+    join(pkg, "package.json"),
+    JSON.stringify({ name: "spaces" }),
+  );
+  await writeFile(packagePrompt, "package prompt");
+  await writeFile(skill, "---\ndescription: review\n---\n");
+  await writeFile(prompt, "custom prompt");
+  await writeFile(theme, "{}");
+  await writeFile(extensionIgnore, "small");
+  await writeFile(
+    join(agentDir, "settings.json"),
+    JSON.stringify({
+      packages: [`  ${pathToFileURL(pkg).href}  `],
+      skills: ["  ./custom skills  "],
+      prompts: ["  ./custom prompts  "],
+      themes: ["  ./custom themes  "],
+      extensions: ["  ./custom extensions  "],
+    }),
+  );
+
+  await isolatedHome(root, async () => {
+    const snapshot = scan(cwd, agentDir);
+    const paths = new Set(snapshot.fingerprints.map((entry) => entry.path));
+    for (const expected of [
+      packagePrompt,
+      skill,
+      prompt,
+      theme,
+      extensionIgnore,
+    ]) {
+      assert.ok(paths.has(expected));
+    }
+  });
+});
+
+test("resource aggregate bytes, file count, entry count, and depth fail closed", async () => {
+  const aggregate = await fixture("buzz-pi-resource-aggregate-");
+  await mkdir(join(aggregate.agentDir, "prompts"));
+  await writeFile(
+    join(aggregate.agentDir, "prompts", "one.md"),
+    "x".repeat(40),
+  );
+  await writeFile(
+    join(aggregate.agentDir, "prompts", "two.md"),
+    "x".repeat(40),
+  );
+  await isolatedHome(aggregate.root, async () => {
+    assert.throws(
+      () =>
+        scan(aggregate.cwd, aggregate.agentDir, {
+          maxResourceFileBytes: 64,
+          maxResourceTotalBytes: 70,
+        }),
+      /BUZZ_PI_RESOURCE_LIMIT: non-code resource bytes exceed 70/,
+    );
+    assert.throws(
+      () =>
+        scan(aggregate.cwd, aggregate.agentDir, {
+          maxResourceFiles: 1,
+        }),
+      /BUZZ_PI_RESOURCE_LIMIT: non-code resource file count exceeds 1/,
+    );
+  });
+
+  const entries = await fixture("buzz-pi-resource-entries-");
+  await mkdir(join(entries.agentDir, "prompts"));
+  for (let index = 0; index < 5; index += 1) {
+    await writeFile(
+      join(entries.agentDir, "prompts", `ignored-${index}.txt`),
+      "",
+    );
+  }
+  await isolatedHome(entries.root, async () => {
+    assert.throws(
+      () =>
+        scan(entries.cwd, entries.agentDir, {
+          maxResourceFiles: 1,
+          maxResourceEntries: 4,
+        }),
+      /BUZZ_PI_RESOURCE_LIMIT: prompt discovery entries exceed 4/,
+    );
+  });
+
+  const depth = await fixture("buzz-pi-resource-depth-");
+  await mkdir(join(depth.agentDir, "skills", "one", "two"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(depth.agentDir, "skills", "one", "two", "SKILL.md"),
+    "---\ndescription: nested\n---\n",
+  );
+  await isolatedHome(depth.root, async () => {
+    assert.throws(
+      () =>
+        scan(depth.cwd, depth.agentDir, {
+          maxResourceDepth: 1,
+        }),
+      /BUZZ_PI_RESOURCE_LIMIT: skill traversal exceeds depth 1/,
+    );
+  });
+});
+
+test("resource fingerprints detect same-path growth and inode replacement", async () => {
+  const { root, cwd, agentDir } = await fixture(
+    "buzz-pi-resource-fingerprint-",
+  );
+  const prompt = join(agentDir, "prompts", "stable.md");
+  await mkdir(join(agentDir, "prompts"));
+  await writeFile(prompt, "before");
+  await isolatedHome(root, async () => {
+    const before = scan(cwd, agentDir);
+    await writeFile(prompt, "before plus growth");
+    const grown = scan(cwd, agentDir);
+    assert.throws(
+      () => assertPiResourceSnapshotsEqual(before, grown),
+      /BUZZ_PI_RESOURCE_CHANGED/,
+    );
+
+    const replacementPath = join(agentDir, "prompts", "replacement.tmp");
+    await writeFile(replacementPath, "before");
+    await rename(replacementPath, prompt);
+    const replacement = scan(cwd, agentDir);
+    assert.throws(
+      () => assertPiResourceSnapshotsEqual(before, replacement),
+      /BUZZ_PI_RESOURCE_CHANGED/,
+    );
+  });
+});

--- a/packages/buzz-pi-agent/test/runtime-worker.test.mjs
+++ b/packages/buzz-pi-agent/test/runtime-worker.test.mjs
@@ -1,0 +1,561 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { test } from "node:test";
+import {
+  BoundedIpcSendQueue,
+  PerKeyRequestQueue,
+  RuntimeSessionProxy,
+  RuntimeWorkerClient,
+} from "../dist/index.js";
+import { silentLogger, testConfig } from "./helpers.mjs";
+
+class FakeChild extends EventEmitter {
+  connected = true;
+  killed = false;
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  sent = [];
+  signals = [];
+  disconnectCalls = 0;
+  pid = 42;
+
+  send(message, callback) {
+    this.sent.push(message);
+    callback?.(null);
+    return true;
+  }
+
+  disconnect() {
+    this.disconnectCalls += 1;
+    this.connected = false;
+  }
+
+  kill(signal = "SIGTERM") {
+    this.killed = true;
+    this.signals.push(signal);
+    return true;
+  }
+
+  exit(code = 0, signal = null) {
+    this.connected = false;
+    this.emit("exit", code, signal);
+  }
+}
+
+test("a prompt waits for durable parent persistence before ACKing a child lifecycle record", async () => {
+  const child = new FakeChild();
+  const client = new RuntimeWorkerClient(
+    testConfig({ runtimeControlTimeoutMs: 1_000 }),
+    silentLogger,
+    () => child,
+  );
+  let releasePersistence;
+  const persisted = new Promise((resolve) => {
+    releasePersistence = resolve;
+  });
+  const proxy = new RuntimeSessionProxy(client, "session-lifecycle-ack", {
+    sessionUpdate() {},
+    async buzzSessionEvent() {
+      await persisted;
+    },
+    usageUpdate() {},
+  });
+  client.register(proxy);
+
+  let promptSettled = false;
+  const prompt = proxy.prompt("continue").finally(() => {
+    promptSettled = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  const promptRequest = child.sent.at(-1);
+  assert.equal(promptRequest.method, "prompt");
+
+  const deliveryId = "9ba32f72-e8ce-5195-96a2-7b472198bb7e";
+  child.emit("message", {
+    type: "event",
+    sessionId: "session-lifecycle-ack",
+    eventType: "buzz_session_event",
+    deliveryId,
+    payload: {
+      type: "compaction_completed",
+      compactionId: "a5f4cb48-cdd9-4b7d-9542-3452087f4b45",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Context compacted",
+      piSessionId: "pi_test",
+      reason: "threshold",
+      beforeTokens: 140_000,
+      afterTokens: 30_000,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      willRetry: false,
+      fromExtension: false,
+    },
+  });
+  child.emit("message", {
+    type: "response",
+    id: promptRequest.id,
+    ok: true,
+    result: "end_turn",
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(promptSettled, false);
+  assert.equal(
+    child.sent.some((request) => request.method === "ackLifecycle"),
+    false,
+  );
+
+  releasePersistence();
+  await new Promise((resolve) => setImmediate(resolve));
+  const ackRequest = child.sent.at(-1);
+  assert.equal(ackRequest.method, "ackLifecycle");
+  assert.deepEqual(ackRequest.params, { deliveryId });
+  child.emit("message", {
+    type: "response",
+    id: ackRequest.id,
+    ok: true,
+    result: { acknowledged: true },
+  });
+  assert.equal(await prompt, "end_turn");
+
+  const shutdown = client.shutdown();
+  await new Promise((resolve) => setImmediate(resolve));
+  const shutdownRequest = child.sent.at(-1);
+  child.emit("message", {
+    type: "response",
+    id: shutdownRequest.id,
+    ok: true,
+    result: { shutdown: true },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  child.exit(0, null);
+  await shutdown;
+});
+
+test("failed runtime disposal still drains a buffered parent lifecycle handoff", async () => {
+  const child = new FakeChild();
+  const client = new RuntimeWorkerClient(
+    testConfig({ runtimeControlTimeoutMs: 1_000 }),
+    silentLogger,
+    () => child,
+  );
+  let releasePersistence;
+  const persistenceGate = new Promise((resolve) => {
+    releasePersistence = resolve;
+  });
+  const timeline = [];
+  const proxy = new RuntimeSessionProxy(client, "session-failed-drain", {
+    sessionUpdate() {},
+    async buzzSessionEvent() {
+      await persistenceGate;
+      timeline.push("parent-outbox");
+    },
+    usageUpdate() {},
+  });
+  client.register(proxy);
+  const deliveryId = "9ba32f72-e8ce-5195-96a2-7b472198bb7e";
+  const eventTask = proxy.handleEvent({
+    type: "event",
+    sessionId: "session-failed-drain",
+    eventType: "buzz_session_event",
+    deliveryId,
+    payload: {
+      type: "context_status",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Buffered before worker failure.",
+      piSessionId: "pi_test",
+      usedTokens: 75_000,
+      remainingTokens: 75_000,
+      percent: 50,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      autoCompaction: true,
+      compacting: false,
+      model: "provider/model",
+    },
+  });
+  proxy.invalidate(
+    new Error("BUZZ_PI_SESSION_INVALIDATED: worker exited"),
+    Promise.resolve(),
+  );
+  let disposalSettled = false;
+  const disposal = proxy.dispose().finally(() => {
+    disposalSettled = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(disposalSettled, false);
+
+  releasePersistence();
+  await assert.rejects(eventTask, /BUZZ_PI_SESSION_INVALIDATED/);
+  await assert.rejects(disposal, /BUZZ_PI_SESSION_INVALIDATED/);
+  assert.deepEqual(timeline, ["parent-outbox"]);
+  assert.equal(
+    child.sent.some((request) => request.method === "ackLifecycle"),
+    false,
+    "a failed child ACK cannot undo the parent-durable copy",
+  );
+});
+
+test("a timed-out worker fences replacement and lease invalidation until confirmed exit", async () => {
+  const children = [];
+  const invalidations = [];
+  const client = new RuntimeWorkerClient(
+    testConfig({ runtimeControlTimeoutMs: 20, runtimeInterruptTimeoutMs: 5 }),
+    silentLogger,
+    () => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    },
+  );
+  client.register({
+    acpSessionId: "old",
+    invalidate() {},
+    handleEvent() {},
+  });
+  client.setInvalidationHandler(async (sessionIds) => {
+    invalidations.push([...sessionIds]);
+  });
+
+  const oldRequest = client.request("create", "old", { cwd: "/tmp" });
+  const oldOutcome = oldRequest.then(
+    () => ({ settled: true, error: undefined }),
+    (error) => ({ settled: true, error }),
+  );
+  let oldSettled = false;
+  void oldOutcome.then(() => {
+    oldSettled = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  const oldChild = children[0];
+  assert.deepEqual(oldChild.signals, ["SIGTERM", "SIGKILL"]);
+  assert.equal(oldSettled, false);
+  assert.deepEqual(invalidations, []);
+
+  const replacementRequest = client.request("create", "replacement", {
+    cwd: "/tmp",
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(
+    children.length,
+    1,
+    "replacement spawned before predecessor exit",
+  );
+
+  oldChild.exit(1, "SIGKILL");
+  const outcome = await oldOutcome;
+  assert.match(outcome.error.message, /timed out/);
+  assert.deepEqual(invalidations, [["old"]]);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(children.length, 2);
+  const replacement = children[1];
+  const request = replacement.sent.at(-1);
+  replacement.emit("message", {
+    type: "response",
+    id: request.id,
+    ok: true,
+    result: { generation: "replacement" },
+  });
+  assert.deepEqual((await replacementRequest).result, {
+    generation: "replacement",
+  });
+
+  const shutdown = client.shutdown();
+  await new Promise((resolve) => setImmediate(resolve));
+  const shutdownRequest = replacement.sent.at(-1);
+  replacement.emit("message", {
+    type: "response",
+    id: shutdownRequest.id,
+    ok: true,
+    result: { shutdown: true },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(replacement.disconnectCalls, 1);
+  replacement.exit(0, null);
+  await shutdown;
+});
+
+test("retirement escalates an ignored SIGTERM to SIGKILL without spawning", async () => {
+  const children = [];
+  const client = new RuntimeWorkerClient(
+    testConfig({ runtimeControlTimeoutMs: 10, runtimeInterruptTimeoutMs: 5 }),
+    silentLogger,
+    () => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    },
+  );
+
+  const failed = client.request("create", "stuck", { cwd: "/tmp" });
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  const waitingReplacement = client.request("create", "next", {
+    cwd: "/tmp",
+  });
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  assert.deepEqual(children[0].signals, ["SIGTERM", "SIGKILL"]);
+  assert.equal(children.length, 1);
+
+  children[0].exit(1, "SIGKILL");
+  await assert.rejects(() => failed, /timed out/);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(children.length, 2);
+  const nextRequest = children[1].sent.at(-1);
+  children[1].emit("message", {
+    type: "response",
+    id: nextRequest.id,
+    ok: true,
+    result: { generation: "next" },
+  });
+  assert.equal((await waitingReplacement).result.generation, "next");
+
+  const shutdown = client.shutdown();
+  await new Promise((resolve) => setImmediate(resolve));
+  const shutdownRequest = children[1].sent.at(-1);
+  children[1].emit("message", {
+    type: "response",
+    id: shutdownRequest.id,
+    ok: true,
+    result: { shutdown: true },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  children[1].exit(0, null);
+  await shutdown;
+});
+
+test("worker crash rejects all outstanding requests as one failed generation", async () => {
+  const child = new FakeChild();
+  const client = new RuntimeWorkerClient(
+    testConfig({ runtimeControlTimeoutMs: 1_000 }),
+    silentLogger,
+    () => child,
+  );
+  const first = client.request("create", "one", { cwd: "/tmp" });
+  const second = client.request("create", "two", { cwd: "/tmp" });
+  child.exit(9, null);
+  await assert.rejects(() => first, /exited/);
+  await assert.rejects(() => second, /exited/);
+});
+
+test("runtime host queue serializes one session while allowing distinct sessions in parallel", async () => {
+  const queue = new PerKeyRequestQueue();
+  const order = [];
+  let releaseFirst;
+  const gate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const first = queue.run("same", async () => {
+    order.push("same-1-start");
+    await gate;
+    order.push("same-1-end");
+  });
+  const second = queue.run("same", async () => {
+    order.push("same-2");
+  });
+  const other = queue.run("other", async () => {
+    order.push("other");
+  });
+  await other;
+  assert.deepEqual(order, ["same-1-start", "other"]);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.deepEqual(order, ["same-1-start", "other", "same-1-end", "same-2"]);
+});
+
+test("bounded IPC sender honors callbacks after false returns and never reorders frames", async () => {
+  const sent = [];
+  const callbacks = [];
+  const failures = [];
+  const sender = new BoundedIpcSendQueue(
+    (message, callback) => {
+      sent.push(message);
+      callbacks.push(callback);
+      return false;
+    },
+    4,
+    1_024,
+    (error) => failures.push(error),
+  );
+
+  assert.equal(sender.enqueue({ sequence: 1 }), true);
+  assert.equal(sender.enqueue({ sequence: 2 }), true);
+  assert.deepEqual(sent, [{ sequence: 1 }]);
+  callbacks.shift()(null);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(sent, [{ sequence: 1 }, { sequence: 2 }]);
+  callbacks.shift()(null);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(failures, []);
+});
+
+test("bounded IPC sender poisons the generation on saturation", () => {
+  const failures = [];
+  const sender = new BoundedIpcSendQueue(
+    () => false,
+    2,
+    1_024,
+    (error) => failures.push(error),
+  );
+  assert.equal(sender.enqueue({ sequence: 1 }), true);
+  assert.equal(sender.enqueue({ sequence: 2 }), true);
+  assert.equal(sender.enqueue({ sequence: 3 }), false);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].message, /queue saturated/);
+  assert.equal(sender.enqueue({ sequence: 4 }), false);
+  assert.equal(failures.length, 1);
+});
+
+test("bounded IPC sender drains a burst in exact insertion order", async () => {
+  const sent = [];
+  const sender = new BoundedIpcSendQueue(
+    (message, callback) => {
+      sent.push(message.sequence);
+      queueMicrotask(() => callback(null));
+      return sent.length % 2 === 0;
+    },
+    256,
+    64 * 1_024,
+    (error) => assert.fail(error.message),
+  );
+  for (let sequence = 0; sequence < 128; sequence += 1) {
+    assert.equal(sender.enqueue({ sequence }), true);
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(
+    sent,
+    Array.from({ length: 128 }, (_, index) => index),
+  );
+});
+
+test("bounded IPC sender permits shared aliases that Node IPC serializes", async () => {
+  const shared = { id: "shared-model-capability" };
+  const sent = [];
+  const failures = [];
+  const sender = new BoundedIpcSendQueue(
+    (message, callback) => {
+      // Model Node's JSON IPC serializer: sibling aliases are duplicated and
+      // accepted, even though a permanent WeakSet would reject them.
+      sent.push(JSON.parse(JSON.stringify(message)));
+      queueMicrotask(() => callback(null));
+      return true;
+    },
+    4,
+    1_024,
+    (error) => failures.push(error),
+  );
+
+  assert.equal(
+    sender.enqueue({
+      models: [{ capability: shared }, { capability: shared }],
+    }),
+    true,
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(sent[0].models[0].capability, shared);
+  assert.deepEqual(sent[0].models[1].capability, shared);
+  assert.deepEqual(failures, []);
+});
+
+test("bounded IPC sender still rejects a true recursive cycle", () => {
+  const failures = [];
+  const cyclic = { id: "cycle" };
+  cyclic.self = cyclic;
+  const sender = new BoundedIpcSendQueue(
+    () => true,
+    4,
+    1_024,
+    (error) => failures.push(error),
+  );
+
+  assert.equal(sender.enqueue(cyclic), false);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].message, /contains a cycle/);
+});
+
+test("bounded IPC sender rejects advanced serializer values instead of undercounting them", () => {
+  class CustomFrame {
+    value = "custom";
+  }
+  const advanced = [
+    ["ArrayBuffer", new ArrayBuffer(1_024)],
+    ["typed-array/view", new Uint8Array(1_024)],
+    ["typed-array/view", new DataView(new ArrayBuffer(32))],
+    ["Map", new Map([["key", "value"]])],
+    ["Set", new Set(["value"])],
+    ["Date", new Date()],
+    ["non-plain object", new CustomFrame()],
+  ];
+  if (typeof SharedArrayBuffer !== "undefined") {
+    advanced.push(["SharedArrayBuffer", new SharedArrayBuffer(1_024)]);
+  }
+
+  for (const [kind, value] of advanced) {
+    const failures = [];
+    const sender = new BoundedIpcSendQueue(
+      () => true,
+      4,
+      128,
+      (error) => failures.push(error),
+    );
+    assert.equal(sender.enqueue({ value }), false, kind);
+    assert.equal(failures.length, 1, kind);
+    assert.match(failures[0].message, new RegExp(kind));
+  }
+});
+
+test("bounded IPC sender measures JSON escaping and snapshots queued frames", async () => {
+  const escapingFailures = [];
+  const escaping = new BoundedIpcSendQueue(
+    () => true,
+    4,
+    32,
+    (error) => escapingFailures.push(error),
+  );
+  assert.equal(escaping.enqueue({ text: "\u0000".repeat(10) }), false);
+  assert.match(escapingFailures[0].message, /exceeds 32 bytes/);
+
+  const sent = [];
+  const callbacks = [];
+  const sender = new BoundedIpcSendQueue(
+    (message, callback) => {
+      sent.push(message);
+      callbacks.push(callback);
+      return false;
+    },
+    4,
+    1_024,
+    (error) => assert.fail(error.message),
+  );
+  const first = { sequence: 1 };
+  const queued = { sequence: 2, nested: { value: "before" } };
+  assert.equal(sender.enqueue(first), true);
+  assert.equal(sender.enqueue(queued), true);
+  queued.nested.value = "after";
+  callbacks.shift()(null);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(sent[1], {
+    sequence: 2,
+    nested: { value: "before" },
+  });
+  callbacks.shift()(null);
+});
+
+test("bounded IPC sender caps inherited enumerable array decoration scans", () => {
+  const prototype = {};
+  for (let index = 0; index < 9_000; index += 1) {
+    prototype[`inherited_${index}`] = index;
+  }
+  const decorated = [];
+  Object.setPrototypeOf(decorated, prototype);
+  const failures = [];
+  const sender = new BoundedIpcSendQueue(
+    () => true,
+    4,
+    1_024 * 1_024,
+    (error) => failures.push(error),
+  );
+  assert.equal(sender.enqueue({ decorated }), false);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].message, /8192 enumerated keys/);
+});

--- a/packages/buzz-pi-agent/test/server.test.mjs
+++ b/packages/buzz-pi-agent/test/server.test.mjs
@@ -1,0 +1,1269 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { PassThrough, Readable } from "node:stream";
+import { test } from "node:test";
+import { AcpServer, NdjsonWriter, SessionRegistry } from "../dist/index.js";
+import {
+  fakeHandle,
+  MemoryWriter,
+  silentLogger,
+  testConfig,
+} from "./helpers.mjs";
+
+const CURRENT_LIFECYCLE_GENERATION = "a".repeat(64);
+
+function harness(handleOverrides = {}, createOverrides = {}) {
+  const handle = fakeHandle(handleOverrides);
+  const calls = {
+    create: [],
+    dispose: [],
+    get: [],
+    reset: [],
+    persistedEvents: [],
+    acknowledgements: [],
+    timeline: [],
+  };
+  const liveSessions = new Map();
+  let createCount = 0;
+  const registry = {
+    async start() {},
+    async shutdown() {},
+    async create(options) {
+      calls.create.push(options);
+      createCount += 1;
+      const sessionId =
+        createOverrides.sessionIdFactory?.(createCount) ?? "ses_test";
+      liveSessions.set(sessionId, options.conversationId);
+      return {
+        sessionId,
+        handle,
+        ...createOverrides,
+        ...(options.conversationId === undefined
+          ? {}
+          : {
+              lifecycleGeneration:
+                createOverrides.lifecycleGeneration ??
+                CURRENT_LIFECYCLE_GENERATION,
+            }),
+      };
+    },
+    get(sessionId) {
+      calls.get.push(sessionId);
+      return handle;
+    },
+    async disposeSession(sessionId, forget) {
+      calls.dispose.push({ sessionId, forget });
+      liveSessions.delete(sessionId);
+      return true;
+    },
+    async commitConversationReset(conversationId, resetToken) {
+      calls.reset.push({ conversationId, resetToken });
+      for (const [sessionId, liveConversationId] of liveSessions) {
+        if (liveConversationId === conversationId)
+          liveSessions.delete(sessionId);
+      }
+      return { committed: true, alreadyCommitted: false };
+    },
+    hasSession(sessionId) {
+      return liveSessions.has(sessionId);
+    },
+    conversationIdForSession(sessionId) {
+      return liveSessions.get(sessionId);
+    },
+    conversationIdentityForSession(sessionId) {
+      const conversationId = liveSessions.get(sessionId);
+      return conversationId === undefined
+        ? undefined
+        : {
+            conversationId,
+            lifecycleGeneration:
+              createOverrides.lifecycleGeneration ??
+              CURRENT_LIFECYCLE_GENERATION,
+          };
+    },
+    async persistConversationSessionEvent(
+      conversationId,
+      lifecycleGeneration,
+      eventId,
+      event,
+    ) {
+      if (createOverrides.persistError) throw createOverrides.persistError;
+      calls.persistedEvents.push({
+        conversationId,
+        lifecycleGeneration,
+        eventId,
+        event,
+      });
+      calls.timeline.push({ type: "persist", eventId });
+      return createOverrides.persistResult ?? true;
+    },
+    async listPendingSessionEvents() {
+      return createOverrides.pendingEvents ?? [];
+    },
+    async acknowledgeSessionEvent(conversationId, eventId) {
+      calls.acknowledgements.push({ conversationId, eventId });
+    },
+  };
+  const writer = new MemoryWriter();
+  const write = writer.write.bind(writer);
+  writer.write = (message) => {
+    calls.timeline.push({
+      type: "write",
+      method: message.method,
+      eventId: message.params?.eventId,
+    });
+    write(message);
+  };
+  const server = new AcpServer(
+    Readable.from([]),
+    writer,
+    registry,
+    testConfig(),
+    silentLogger,
+  );
+  return { server, writer, registry, handle, calls };
+}
+
+test("initialize advertises ACP v2 thread sessions, persistence, disposal, and reset tokens", async () => {
+  const { server } = harness();
+  const result = await server.handleRequest("initialize", {
+    protocolVersion: 2,
+  });
+  assert.equal(result.protocolVersion, 2);
+  assert.deepEqual(result._meta.buzz.threadSessions, {
+    supported: true,
+    persistence: true,
+    dispose: true,
+    resetToken: true,
+    resetCommit: true,
+  });
+  assert.equal(result._meta.steering.supported, true);
+  assert.deepEqual(result._meta.buzz.sessionEvents, {
+    supported: true,
+    durableReplay: true,
+    ack: true,
+    schemaVersion: 2,
+  });
+  await assert.rejects(
+    () => server.handleRequest("initialize", { protocolVersion: 2 }),
+    /initialize may only be called once/,
+  );
+});
+
+test("session/new forwards the durable Buzz conversation and authenticated reset token", async () => {
+  const { server, calls } = harness();
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  const result = await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    systemPrompt: "Buzz system prompt",
+    mcpServers: [],
+    _meta: {
+      sessionTitle: "Agent · #general",
+      buzz: { conversationId: "channel:root", resetToken: "event-reset-1" },
+    },
+  });
+  assert.deepEqual(calls.create[0], {
+    cwd: "/tmp/project",
+    systemPrompt: "Buzz system prompt",
+    title: "Agent · #general",
+    conversationId: "channel:root",
+    resetToken: "event-reset-1",
+  });
+  assert.equal(result.sessionId, "ses_test");
+  assert.equal(result._meta.buzz.contextLimitTokens, 150_000);
+  assert.equal(result._meta.buzz.compactionThresholdTokens, 133_616);
+  assert.equal(result._meta.buzz.skipRelayHistory, false);
+  assert.equal(result.models.currentModelId, "provider/model");
+});
+
+test("session/new exposes a durable reset barrier to suppress relay history seeding", async () => {
+  const { server } = harness(
+    {},
+    { resumedConversation: false, skipRelayHistory: true },
+  );
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  const result = await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    mcpServers: [],
+    _meta: { buzz: { conversationId: "channel:root" } },
+  });
+  assert.equal(result._meta.buzz.resumedConversation, false);
+  assert.equal(result._meta.buzz.skipRelayHistory, true);
+});
+
+test("session/set_config_option returns the complete stable ACP config list with applied values", async () => {
+  const fixture = JSON.parse(
+    await readFile(
+      new URL(
+        "./fixtures/acp-set-config-option-response.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  const applied = [];
+  const { server } = harness({
+    models: [
+      { id: "provider/model", name: "Model" },
+      { id: "provider/alternate", name: "Alternate" },
+    ],
+    async setModel(modelId) {
+      applied.push({ configId: "model", value: modelId });
+    },
+    async setThinkingLevel(level) {
+      applied.push({ configId: "thinking", value: level });
+    },
+  });
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+
+  assert.deepEqual(
+    await server.handleRequest("session/set_config_option", {
+      sessionId: "ses_test",
+      configId: "model",
+      value: "provider/alternate",
+    }),
+    fixture.model,
+  );
+  assert.deepEqual(
+    await server.handleRequest("session/set_config_option", {
+      sessionId: "ses_test",
+      configId: "thinking",
+      value: "high",
+    }),
+    fixture.thinking,
+  );
+  assert.deepEqual(applied, [
+    { configId: "model", value: "provider/alternate" },
+    { configId: "thinking", value: "high" },
+  ]);
+});
+
+test("exact _buzz/session/dispose contract releases or forgets a Pi session", async () => {
+  const { server, calls } = harness();
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  assert.deepEqual(
+    await server.handleRequest("_buzz/session/dispose", {
+      sessionId: "ses_test",
+      forget: true,
+    }),
+    { disposed: true, forgotten: true },
+  );
+  assert.deepEqual(calls.dispose, [{ sessionId: "ses_test", forget: true }]);
+  await assert.rejects(
+    () => server.handleRequest("_session/dispose", { sessionId: "ses_test" }),
+    /Method not found/,
+  );
+});
+
+test("conversation reset commit is bounded and does not require a live session id", async () => {
+  const { server, calls } = harness();
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  assert.deepEqual(
+    await server.handleRequest("_buzz/conversation/reset", {
+      conversationId: "channel:root",
+      resetToken: "signed-reset-1",
+    }),
+    { committed: true, alreadyCommitted: false },
+  );
+  assert.deepEqual(calls.reset, [
+    { conversationId: "channel:root", resetToken: "signed-reset-1" },
+  ]);
+  await assert.rejects(
+    () =>
+      server.handleRequest("_buzz/conversation/reset", {
+        conversationId: "x".repeat(513),
+        resetToken: "signed-reset-2",
+      }),
+    /must not exceed 512/,
+  );
+});
+
+test("usage notifications match Buzz UsageTracker and keep cached tokens a subset", () => {
+  const { server, writer } = harness();
+  server.usageUpdate(
+    "ses_test",
+    {
+      contextTokens: 140_000,
+      accumulatedInputTokens: 10_000,
+      accumulatedOutputTokens: 2_000,
+      accumulatedCachedInputTokens: 99_000,
+      accumulatedCost: 1.25,
+      model: "provider/model",
+    },
+    150_000,
+  );
+  assert.deepEqual(writer.messages[0], {
+    jsonrpc: "2.0",
+    method: "_goose/unstable/session/update",
+    params: {
+      sessionId: "ses_test",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 140_000,
+        contextLimit: 150_000,
+        accumulatedInputTokens: 10_000,
+        accumulatedOutputTokens: 2_000,
+        accumulatedCachedInputTokens: 10_000,
+        accumulatedCost: 1.25,
+        model: "provider/model",
+      },
+    },
+  });
+});
+
+test("usage notifications omit unknown current context instead of reporting a false zero", () => {
+  const { server, writer } = harness();
+  server.usageUpdate(
+    "ses_test",
+    {
+      contextTokens: null,
+      accumulatedInputTokens: 10,
+      accumulatedOutputTokens: 2,
+      accumulatedCachedInputTokens: 3,
+      accumulatedCost: null,
+      model: null,
+    },
+    150_000,
+  );
+  assert.equal("used" in writer.messages[0].params.update, false);
+});
+
+test("session update sanitization has one cycle-safe global traversal budget", () => {
+  const { server, writer } = harness();
+  const broad = {};
+  broad.self = broad;
+  for (let index = 0; index < 5_000; index += 1) {
+    broad[`field-${index}`] = { shared: broad };
+  }
+  server.sessionUpdate("ses_test", broad);
+  const update = writer.messages[0].params.update;
+  assert.equal(update.self, "[circular]");
+  assert.ok(Object.keys(update).length <= 100);
+  assert.ok(Buffer.byteLength(JSON.stringify(update)) < 256 * 1_024);
+});
+
+test("unmapped compaction and context events are suppressed under the negotiated schema-v2 contract", async () => {
+  const { server, writer, calls } = harness();
+  const initialized = await server.handleRequest("initialize", {
+    protocolVersion: 2,
+  });
+  assert.equal(initialized._meta.buzz.sessionEvents.schemaVersion, 2);
+
+  server.buzzSessionEvent(
+    "ses_unmapped",
+    {
+      type: "compaction_completed",
+      compactionId: "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Context compacted",
+      piSessionId: "pi_test",
+      reason: "threshold",
+      beforeTokens: 140_000,
+      afterTokens: 30_000,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      willRetry: false,
+      fromExtension: false,
+    },
+    "9ba32f72-e8ce-4195-96a2-7b472198bb7e",
+  );
+  const contextEvent = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:01.000Z",
+    message: "Context is at 50%.",
+    piSessionId: "pi_test",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  server.buzzSessionEvent("ses_unmapped", contextEvent);
+  assert.throws(
+    () =>
+      server.buzzSessionEvent(
+        "ses_unmapped",
+        contextEvent,
+        "9BA32F72-E8CE-4195-96A2-7B472198BB7E",
+      ),
+    /deliveryId must be a lowercase UUID/,
+  );
+
+  assert.deepEqual(
+    writer.messages.filter(
+      (message) => message.method === "_buzz/session/event",
+    ),
+    [],
+  );
+  assert.deepEqual(calls.persistedEvents, []);
+});
+
+test("session/new fences early Pi lifecycle handoffs until the durable route commits", async () => {
+  const lifecycleGeneration = "d".repeat(64);
+  const deliveryId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const conversationId = "channel:early-lifecycle";
+  const timeline = [];
+  const pendingEvents = [];
+  let mappingCommitted = false;
+  let allowMappingCommit;
+  const mappingCommitGate = new Promise((resolve) => {
+    allowMappingCommit = resolve;
+  });
+  let signalEarlyEvents;
+  const earlyEventsEmitted = new Promise((resolve) => {
+    signalEarlyEvents = resolve;
+  });
+  let childDeliveryOutcome;
+  const deliveredEvent = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Pi emitted while its durable route was still committing.",
+    piSessionId: "pi-early-lifecycle",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  const syntheticEvent = {
+    ...deliveredEvent,
+    timestamp: "2026-08-02T00:00:01.000Z",
+    message: "The adapter also emitted an early synthetic lifecycle event.",
+  };
+  const conversations = {
+    async initialize() {},
+    async resolve(resolvedConversationId, _resetToken, cwd, create) {
+      assert.equal(resolvedConversationId, conversationId);
+      const created = await create(undefined, lifecycleGeneration);
+      timeline.push("factory-returned");
+      await mappingCommitGate;
+      mappingCommitted = true;
+      timeline.push("mapping-committed");
+      return {
+        mapping: {
+          conversationId: resolvedConversationId,
+          cwd,
+          ...created,
+          lifecycleGeneration,
+        },
+        lifecycleGeneration,
+        resumed: false,
+        skipRelayHistory: false,
+        async refresh() {
+          return true;
+        },
+        async forget() {
+          return undefined;
+        },
+        async release() {},
+      };
+    },
+    async enqueueSessionEvent(
+      persistedConversationId,
+      eventId,
+      event,
+      expectedLifecycleGeneration,
+    ) {
+      assert.equal(mappingCommitted, true);
+      assert.equal(persistedConversationId, conversationId);
+      assert.equal(expectedLifecycleGeneration, lifecycleGeneration);
+      timeline.push(
+        eventId === deliveryId ? "parent-outbox" : "synthetic-parent-outbox",
+      );
+      pendingEvents.push({
+        conversationId: persistedConversationId,
+        eventId,
+        lifecycleGeneration,
+        event,
+        createdAt: "2026-08-02T00:00:02.000Z",
+      });
+      return true;
+    },
+    async listPendingSessionEvents(persistedConversationId) {
+      assert.equal(persistedConversationId, conversationId);
+      return pendingEvents;
+    },
+    async acknowledgeSessionEvent() {},
+    async deleteSessionFile() {},
+    async prune() {
+      return 0;
+    },
+  };
+  let server;
+  const forwardingSink = {
+    sessionUpdate(...args) {
+      return server.sessionUpdate(...args);
+    },
+    buzzSessionEvent(...args) {
+      return server.buzzSessionEvent(...args);
+    },
+    usageUpdate(...args) {
+      return server.usageUpdate(...args);
+    },
+  };
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        const childDelivery = options.eventSink.buzzSessionEvent(
+          options.acpSessionId,
+          deliveredEvent,
+          deliveryId,
+        );
+        childDeliveryOutcome = Promise.resolve(childDelivery).then(
+          () => {
+            timeline.push("child-ack");
+            return "acked";
+          },
+          () => "rejected",
+        );
+        options.eventSink.buzzSessionEvent(
+          options.acpSessionId,
+          syntheticEvent,
+        );
+        timeline.push("child-emitted");
+        signalEarlyEvents();
+        return fakeHandle({
+          piSessionId: "pi-early-lifecycle",
+          sessionFile: "/tmp/pi-early-lifecycle.jsonl",
+        });
+      },
+    },
+    conversations,
+    testConfig(),
+    forwardingSink,
+    silentLogger,
+  );
+  const input = new PassThrough();
+  const writer = new MemoryWriter();
+  let signalResponse;
+  const responseWritten = new Promise((resolve) => {
+    signalResponse = resolve;
+  });
+  let signalLifecycleNotification;
+  const lifecycleNotificationWritten = new Promise((resolve) => {
+    signalLifecycleNotification = resolve;
+  });
+  const write = writer.write.bind(writer);
+  writer.write = (message) => {
+    write(message);
+    if (message.id === 42) {
+      timeline.push("session-new-response");
+      signalResponse(message);
+    }
+    if (message.method === "_buzz/session/event") {
+      timeline.push("lifecycle-notification");
+      signalLifecycleNotification(message);
+    }
+  };
+  server = new AcpServer(input, writer, registry, testConfig(), silentLogger);
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  const running = server.run();
+  input.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 42,
+      method: "session/new",
+      params: {
+        cwd: "/tmp",
+        _meta: { buzz: { conversationId } },
+      },
+    })}\n`,
+  );
+
+  await earlyEventsEmitted;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(mappingCommitted, false);
+  assert.deepEqual(pendingEvents, []);
+  assert.equal(timeline.includes("child-ack"), false);
+  assert.equal(
+    writer.messages.some((message) => message.method === "_buzz/session/event"),
+    false,
+  );
+
+  allowMappingCommit();
+  const response = await responseWritten;
+  assert.equal(response.error, undefined);
+  assert.equal(response.result.sessionId.startsWith("ses_"), true);
+  assert.equal(await childDeliveryOutcome, "acked");
+  assert.equal(pendingEvents.length, 2);
+  assert.ok(
+    timeline.indexOf("mapping-committed") < timeline.indexOf("parent-outbox"),
+  );
+  assert.ok(timeline.indexOf("parent-outbox") < timeline.indexOf("child-ack"));
+  assert.equal(timeline.includes("lifecycle-notification"), false);
+
+  await lifecycleNotificationWritten;
+  await new Promise((resolve) => setImmediate(resolve));
+  const notices = writer.messages.filter(
+    (message) => message.method === "_buzz/session/event",
+  );
+  assert.equal(notices.length, 2);
+  assert.ok(
+    timeline.indexOf("session-new-response") <
+      timeline.indexOf("lifecycle-notification"),
+  );
+  assert.deepEqual(
+    new Set(notices.map((notice) => notice.params.event.message)),
+    new Set([deliveredEvent.message, syntheticEvent.message]),
+  );
+
+  input.end();
+  await running;
+});
+
+test("failed mapped creation rejects an early Pi lifecycle handoff without ACK or publication", async () => {
+  const lifecycleGeneration = "e".repeat(64);
+  const deliveryId = "73e58446-5e28-4a66-90fa-0fcba8cbf7da";
+  const event = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "This event must remain child-owned when mapping commit fails.",
+    piSessionId: "pi-failed-create",
+    usedTokens: 1,
+    remainingTokens: 149_999,
+    percent: 0,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  let persisted = false;
+  let createdSessionId;
+  let childOutcome;
+  let server;
+  const forwardingSink = {
+    sessionUpdate(...args) {
+      return server.sessionUpdate(...args);
+    },
+    buzzSessionEvent(...args) {
+      return server.buzzSessionEvent(...args);
+    },
+    usageUpdate(...args) {
+      return server.usageUpdate(...args);
+    },
+  };
+  const conversations = {
+    async initialize() {},
+    async resolve(_conversationId, _resetToken, _cwd, create) {
+      await create(undefined, lifecycleGeneration);
+      throw new Error("manifest commit failed");
+    },
+    async enqueueSessionEvent() {
+      persisted = true;
+      return true;
+    },
+    async listPendingSessionEvents() {
+      return [];
+    },
+    async acknowledgeSessionEvent() {},
+    async deleteSessionFile() {},
+    async prune() {
+      return 0;
+    },
+  };
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        createdSessionId = options.acpSessionId;
+        const handoff = options.eventSink.buzzSessionEvent(
+          options.acpSessionId,
+          event,
+          deliveryId,
+        );
+        childOutcome = Promise.resolve(handoff).then(
+          () => "acked",
+          () => "rejected",
+        );
+        return fakeHandle({
+          piSessionId: "pi-failed-create",
+          sessionFile: "/tmp/pi-failed-create.jsonl",
+        });
+      },
+    },
+    conversations,
+    testConfig(),
+    forwardingSink,
+    silentLogger,
+  );
+  const writer = new MemoryWriter();
+  server = new AcpServer(
+    Readable.from([]),
+    writer,
+    registry,
+    testConfig(),
+    silentLogger,
+  );
+  await registry.start();
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await assert.rejects(
+    () =>
+      server.handleRequest("session/new", {
+        cwd: "/tmp",
+        _meta: { buzz: { conversationId: "channel:failed-create" } },
+      }),
+    /manifest commit failed/,
+  );
+  assert.equal(await childOutcome, "rejected");
+  assert.equal(persisted, false);
+  assert.equal(
+    writer.messages.some((message) => message.method === "_buzz/session/event"),
+    false,
+  );
+  assert.equal(
+    registry.conversationIdentityForSession(createdSessionId),
+    undefined,
+  );
+  await server.shutdown();
+});
+
+test("mapped lifecycle events are durably persisted before schema-v2 publication and ACKed idempotently", async () => {
+  const { server, writer, calls } = harness();
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    _meta: { buzz: { conversationId: "channel:root" } },
+  });
+  const event = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Context is at 50%.",
+    piSessionId: "pi_test",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+
+  server.buzzSessionEvent("ses_test", event);
+  await server.handleRequest("session/prompt", {
+    sessionId: "ses_test",
+    prompt: [{ type: "text", text: "continue" }],
+  });
+
+  assert.equal(calls.persistedEvents.length, 1);
+  const persisted = calls.persistedEvents[0];
+  assert.equal(persisted.conversationId, "channel:root");
+  assert.deepEqual(persisted.event, event);
+  assert.match(persisted.eventId, /^[0-9a-f-]{36}$/u);
+  const notice = writer.messages.find(
+    (message) =>
+      message.method === "_buzz/session/event" &&
+      message.params?.schemaVersion === 2,
+  );
+  assert.deepEqual(notice.params, {
+    schemaVersion: 2,
+    sessionId: "ses_test",
+    conversationId: "channel:root",
+    eventId: persisted.eventId,
+    event,
+  });
+  assert.ok(
+    calls.timeline.findIndex(
+      (entry) =>
+        entry.type === "persist" && entry.eventId === persisted.eventId,
+    ) <
+      calls.timeline.findIndex(
+        (entry) =>
+          entry.type === "write" && entry.eventId === persisted.eventId,
+      ),
+    "the durable write must complete before the notification is published",
+  );
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    assert.deepEqual(
+      await server.handleRequest("_buzz/session/event_ack", {
+        conversationId: "channel:root",
+        eventId: persisted.eventId,
+      }),
+      { acknowledged: true },
+    );
+  }
+  assert.deepEqual(calls.acknowledgements, [
+    { conversationId: "channel:root", eventId: persisted.eventId },
+    { conversationId: "channel:root", eventId: persisted.eventId },
+  ]);
+});
+
+test("session/new replays one lifecycle epoch across non-reset Pi replacements", async () => {
+  const currentEventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const staleEventId = "b8ba08e4-65f5-4aed-9406-6c67fe8375db";
+  const common = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Context status.",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  const { server, writer, calls } = harness(
+    {},
+    {
+      pendingEvents: [
+        {
+          conversationId: "channel:root",
+          eventId: staleEventId,
+          lifecycleGeneration: CURRENT_LIFECYCLE_GENERATION,
+          event: { ...common, piSessionId: "pi_superseded" },
+          createdAt: "2026-08-02T00:00:00.000Z",
+        },
+        {
+          conversationId: "channel:root",
+          eventId: currentEventId,
+          lifecycleGeneration: CURRENT_LIFECYCLE_GENERATION,
+          event: { ...common, piSessionId: "pi_test" },
+          createdAt: "2026-08-02T00:00:01.000Z",
+        },
+      ],
+    },
+  );
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    _meta: { buzz: { conversationId: "channel:root" } },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const notices = writer.messages.filter(
+    (message) => message.method === "_buzz/session/event",
+  );
+  assert.deepEqual(
+    notices.map((message) => message.params.eventId),
+    [staleEventId, currentEventId],
+  );
+  assert.equal(notices[0].params.sessionId, "ses_test");
+  assert.deepEqual(calls.acknowledgements, []);
+});
+
+test("session/new suppresses and ACKs only an older authenticated-reset lifecycle epoch", async () => {
+  const currentEventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const resetSupersededEventId = "b8ba08e4-65f5-4aed-9406-6c67fe8375db";
+  const common = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Context status.",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  const { server, writer, calls } = harness(
+    {},
+    {
+      pendingEvents: [
+        {
+          conversationId: "channel:root",
+          eventId: resetSupersededEventId,
+          lifecycleGeneration: "b".repeat(64),
+          event: { ...common, piSessionId: "pi_before_reset" },
+          createdAt: "2026-08-02T00:00:00.000Z",
+        },
+        {
+          conversationId: "channel:root",
+          eventId: currentEventId,
+          lifecycleGeneration: CURRENT_LIFECYCLE_GENERATION,
+          event: { ...common, piSessionId: "pi_after_reset" },
+          createdAt: "2026-08-02T00:00:01.000Z",
+        },
+      ],
+    },
+  );
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    _meta: { buzz: { conversationId: "channel:root" } },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const notices = writer.messages.filter(
+    (message) => message.method === "_buzz/session/event",
+  );
+  assert.deepEqual(
+    notices.map((message) => message.params.eventId),
+    [currentEventId],
+  );
+  assert.deepEqual(calls.acknowledgements, [
+    {
+      conversationId: "channel:root",
+      eventId: resetSupersededEventId,
+    },
+  ]);
+});
+
+test("lifecycle persistence failure poisons only the live session and churn remains bounded", async () => {
+  const persistenceError = new Error("lifecycle outbox unavailable");
+  const { server, writer } = harness(
+    {},
+    {
+      persistError: persistenceError,
+      sessionIdFactory: (index) => `ses_churn_${index}`,
+    },
+  );
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+
+  for (let index = 1; index <= 24; index += 1) {
+    const conversationId = `channel:root:${index}`;
+    const created = await server.handleRequest("session/new", {
+      cwd: "/tmp/project",
+      _meta: { buzz: { conversationId } },
+    });
+    server.buzzSessionEvent(created.sessionId, {
+      type: "context_status",
+      timestamp: "2026-08-02T00:00:00.000Z",
+      message: "Context status.",
+      piSessionId: "pi_test",
+      usedTokens: 1,
+      remainingTokens: 149_999,
+      percent: 0,
+      limitTokens: 150_000,
+      effectiveLimitTokens: 150_000,
+      compactionThresholdTokens: 133_616,
+      autoCompaction: true,
+      compacting: false,
+      model: "provider/model",
+    });
+    await assert.rejects(
+      () =>
+        server.handleRequest("session/prompt", {
+          sessionId: created.sessionId,
+          prompt: [{ type: "text", text: "continue" }],
+        }),
+      /lifecycle outbox unavailable/,
+    );
+    await assert.rejects(
+      () =>
+        server.handleRequest("session/prompt", {
+          sessionId: created.sessionId,
+          prompt: [{ type: "text", text: "retry" }],
+        }),
+      /lifecycle outbox unavailable/,
+      "a live session remains fail-closed until its recovery boundary",
+    );
+
+    if (index % 2 === 0) {
+      await server.handleRequest("_buzz/conversation/reset", {
+        conversationId,
+        resetToken: `reset-${index}`,
+      });
+    } else {
+      await server.handleRequest("_buzz/session/dispose", {
+        sessionId: created.sessionId,
+      });
+    }
+    assert.equal(server.lifecycleFailures.size, 0);
+  }
+  await server.shutdown();
+  assert.equal(
+    writer.messages.some(
+      (message) =>
+        message.method === "_buzz/session/event" &&
+        message.params?.schemaVersion === 2,
+    ),
+    false,
+    "a lifecycle event that missed durable persistence must never be emitted",
+  );
+  assert.equal(server.lifecycleFailures.size, 0);
+  assert.equal(server.publishedLifecycleEventIds.size, 0);
+});
+
+test("strict context refusal has a stable terminal ACP error code", async () => {
+  const { server, writer } = harness({
+    async prompt() {
+      throw new Error(
+        "BUZZ_CONTEXT_LIMIT: final provider context exceeds 150000 tokens",
+      );
+    },
+  });
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.dispatch({
+    jsonrpc: "2.0",
+    id: 42,
+    method: "session/prompt",
+    params: {
+      sessionId: "ses_test",
+      prompt: [{ type: "text", text: "continue" }],
+    },
+  });
+  assert.deepEqual(writer.messages.at(-1).error, {
+    code: -32042,
+    message: "BUZZ_CONTEXT_LIMIT: final provider context exceeds 150000 tokens",
+    data: { kind: "context_limit", retryable: false },
+  });
+});
+
+test("transcript quota refusal is terminal and points Buzz users to /new", async () => {
+  const { server, writer } = harness({
+    async prompt() {
+      throw new Error(
+        "BUZZ_SESSION_STORAGE_LIMIT: this Pi thread transcript reached its 64.0 MiB storage ceiling; use /new to start a fresh session",
+      );
+    },
+  });
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.dispatch({
+    jsonrpc: "2.0",
+    id: 43,
+    method: "session/prompt",
+    params: {
+      sessionId: "ses_test",
+      prompt: [{ type: "text", text: "continue" }],
+    },
+  });
+  assert.deepEqual(writer.messages.at(-1).error, {
+    code: -32044,
+    message:
+      "BUZZ_SESSION_STORAGE_LIMIT: this Pi thread transcript reached its 64.0 MiB storage ceiling; use /new to start a fresh session",
+    data: {
+      kind: "session_storage_limit",
+      retryable: false,
+      recovery: "/new",
+    },
+  });
+});
+
+test("a poisoned Pi generation has a stable retryable ACP error code", async () => {
+  const { server, writer } = harness({
+    async prompt() {
+      throw new Error(
+        "BUZZ_PI_SESSION_INVALIDATED: Pi resource reload failed; create a fresh session",
+      );
+    },
+  });
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.dispatch({
+    jsonrpc: "2.0",
+    id: 44,
+    method: "session/prompt",
+    params: {
+      sessionId: "ses_test",
+      prompt: [{ type: "text", text: "continue" }],
+    },
+  });
+  assert.deepEqual(writer.messages.at(-1).error, {
+    code: -32045,
+    message:
+      "BUZZ_PI_SESSION_INVALIDATED: Pi resource reload failed; create a fresh session",
+    data: { kind: "session_invalidated", retryable: true },
+  });
+});
+
+test("stdout saturation proactively aborts a never-ending active prompt", async () => {
+  const input = new PassThrough();
+  let releasePrompt;
+  let aborts = 0;
+  const handle = fakeHandle({
+    async prompt() {
+      return new Promise((resolve) => {
+        releasePrompt = resolve;
+      });
+    },
+    async abort() {
+      aborts += 1;
+      releasePrompt?.("cancelled");
+    },
+  });
+  let registryClosing = false;
+  const registry = {
+    async start() {},
+    hasSession() {
+      return !registryClosing;
+    },
+    get() {
+      return handle;
+    },
+    async shutdown() {
+      if (registryClosing) return;
+      registryClosing = true;
+      if (handle.isBusy) await handle.abort();
+      await handle.dispose();
+    },
+  };
+  let server;
+  const writer = new NdjsonWriter(() => new Promise(() => {}), silentLogger, {
+    maxQueuedMessages: 2,
+    maxQueuedBytes: 64 * 1_024,
+    onFatal(error) {
+      input.destroy(error);
+      void server.shutdown().catch(() => {});
+    },
+  });
+  server = new AcpServer(input, writer, registry, testConfig(), silentLogger);
+  const running = server.run();
+  input.write(
+    `${[
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "session/prompt",
+        params: {
+          sessionId: "ses_test",
+          prompt: [{ type: "text", text: "wait forever" }],
+        },
+      },
+      { jsonrpc: "2.0", id: 3, method: "unknown/one", params: {} },
+      { jsonrpc: "2.0", id: 4, method: "unknown/two", params: {} },
+    ]
+      .map((message) => JSON.stringify(message))
+      .join("\n")}\n`,
+  );
+
+  const outcome = await Promise.race([
+    running.then(
+      () => "finished",
+      () => "failed",
+    ),
+    new Promise((resolve) => setTimeout(() => resolve("timed-out"), 500)),
+  ]);
+  assert.notEqual(outcome, "timed-out");
+  assert.equal(aborts, 1);
+  assert.equal(handle.disposed, true);
+});
+
+test("active request flood is bounded while cancellation keeps reserved capacity", async () => {
+  const input = new PassThrough();
+  const writer = new MemoryWriter();
+  let releasePrompt;
+  let aborts = 0;
+  const handle = fakeHandle({
+    async prompt() {
+      return new Promise((resolve) => {
+        releasePrompt = resolve;
+      });
+    },
+    async abort() {
+      aborts += 1;
+      releasePrompt?.("cancelled");
+    },
+  });
+  let registryClosing = false;
+  const registry = {
+    async start() {},
+    hasSession() {
+      return !registryClosing;
+    },
+    get() {
+      return handle;
+    },
+    async shutdown() {
+      if (registryClosing) return;
+      registryClosing = true;
+      if (handle.isBusy) await handle.abort();
+      await handle.dispose();
+    },
+  };
+  const server = new AcpServer(
+    input,
+    writer,
+    registry,
+    testConfig({ maxActiveRequests: 1 }),
+    silentLogger,
+  );
+  const running = server.run();
+  input.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`,
+  );
+  while (!writer.messages.some((message) => message.id === 1)) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  input.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "session/prompt",
+      params: {
+        sessionId: "ses_test",
+        prompt: [{ type: "text", text: "hold" }],
+      },
+    })}\n`,
+  );
+  while (!handle.isBusy) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  input.end(
+    `${[
+      ...Array.from({ length: 5 }, (_, index) => ({
+        jsonrpc: "2.0",
+        id: 3 + index,
+        method: `flood/${index}`,
+        params: {},
+      })),
+      {
+        jsonrpc: "2.0",
+        id: 8,
+        method: "session/cancel",
+        params: { sessionId: "ses_test" },
+      },
+    ]
+      .map((message) => JSON.stringify(message))
+      .join("\n")}\n`,
+  );
+  await running;
+
+  const overloads = writer.messages.filter(
+    (message) => message.error?.code === -32043,
+  );
+  assert.deepEqual(
+    overloads.map((message) => message.id),
+    [3, 4, 5, 6, 7],
+  );
+  assert.ok(
+    writer.messages.some(
+      (message) => message.id === 8 && message.result === null,
+    ),
+  );
+  assert.equal(aborts, 1);
+});
+
+test("durable mapped Buzz lifecycle v2 fixture is emitted without schema drift", async () => {
+  const fixture = JSON.parse(
+    await readFile(
+      new URL("./fixtures/buzz-session-event-v2.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const { server, writer } = harness(
+    { piSessionId: fixture.event.piSessionId },
+    { sessionIdFactory: () => fixture.sessionId },
+  );
+  await server.handleRequest("initialize", { protocolVersion: 2 });
+  await server.handleRequest("session/new", {
+    cwd: "/tmp/project",
+    _meta: { buzz: { conversationId: fixture.conversationId } },
+  });
+  await server.buzzSessionEvent(
+    fixture.sessionId,
+    fixture.event,
+    fixture.eventId,
+  );
+  const lifecycle = writer.messages.find(
+    (message) => message.method === "_buzz/session/event",
+  );
+  assert.deepEqual(lifecycle.params, fixture);
+});

--- a/packages/buzz-pi-agent/test/session-registry.test.mjs
+++ b/packages/buzz-pi-agent/test/session-registry.test.mjs
@@ -1,0 +1,986 @@
+import assert from "node:assert/strict";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  realpath,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { SessionRegistry } from "../dist/index.js";
+import { fakeHandle, silentLogger, testConfig } from "./helpers.mjs";
+
+const sink = {
+  sessionUpdate() {},
+  buzzSessionEvent() {},
+  usageUpdate() {},
+};
+
+function fakeConversationStore() {
+  const mappings = new Map();
+  const resetTombstones = new Map();
+  let lifecycleGenerationIndex = 0;
+  return {
+    async initialize() {},
+    async resolve(conversationId, resetToken, cwd, create) {
+      const existing = mappings.get(conversationId);
+      const tombstone = resetTombstones.get(conversationId);
+      const forceFresh =
+        tombstone !== undefined ||
+        (resetToken && resetToken !== existing?.resetToken);
+      const resetBoundary = forceFresh;
+      const lifecycleGeneration = resetBoundary
+        ? `${(++lifecycleGenerationIndex).toString(16).padStart(64, "0")}`
+        : (existing?.lifecycleGeneration ?? "0".repeat(64));
+      const created = await create(
+        forceFresh ? undefined : existing?.sessionFile,
+        lifecycleGeneration,
+      );
+      const mapping = {
+        conversationId,
+        resetToken: resetToken ?? tombstone?.resetToken,
+        sessionFile: created.sessionFile,
+        piSessionId: created.piSessionId,
+        lifecycleGeneration,
+        cwd,
+      };
+      mappings.set(conversationId, mapping);
+      resetTombstones.delete(conversationId);
+      return {
+        mapping,
+        lifecycleGeneration: mapping.lifecycleGeneration,
+        resumed: existing !== undefined && !forceFresh,
+        ...(forceFresh && existing
+          ? { retiredSessionFile: existing.sessionFile }
+          : {}),
+        ...(forceFresh && (existing || tombstone)
+          ? {
+              previousPiSessionId:
+                existing?.piSessionId ?? tombstone?.previousPiSessionId,
+            }
+          : {}),
+        skipRelayHistory: tombstone !== undefined || Boolean(forceFresh),
+        async refresh() {
+          return (
+            mappings.get(conversationId)?.piSessionId === mapping.piSessionId
+          );
+        },
+        async forget() {
+          const current = mappings.get(conversationId);
+          if (current?.piSessionId !== mapping.piSessionId) return undefined;
+          mappings.delete(conversationId);
+          resetTombstones.set(conversationId, {
+            previousPiSessionId: mapping.piSessionId,
+          });
+          return mapping.sessionFile;
+        },
+        async release() {},
+      };
+    },
+    async touch() {},
+    async forget(conversationId, expectedPiSessionId) {
+      const mapping = mappings.get(conversationId);
+      if (mapping?.piSessionId !== expectedPiSessionId) return undefined;
+      mappings.delete(conversationId);
+      resetTombstones.set(conversationId, {
+        previousPiSessionId: mapping.piSessionId,
+      });
+      return mapping.sessionFile;
+    },
+    async commitReset(conversationId, resetToken) {
+      const mapping = mappings.get(conversationId);
+      const tombstone = resetTombstones.get(conversationId);
+      if (
+        mapping?.resetToken === resetToken ||
+        tombstone?.resetToken === resetToken
+      ) {
+        return {
+          alreadyCommitted: true,
+          disposeLiveSession: tombstone?.resetToken === resetToken,
+        };
+      }
+      mappings.delete(conversationId);
+      resetTombstones.set(conversationId, {
+        resetToken,
+        previousPiSessionId:
+          mapping?.piSessionId ?? tombstone?.previousPiSessionId,
+      });
+      return {
+        alreadyCommitted: false,
+        disposeLiveSession: true,
+        ...(mapping ? { retiredSessionFile: mapping.sessionFile } : {}),
+      };
+    },
+    async deleteSessionFile() {},
+    async prune() {
+      return 0;
+    },
+  };
+}
+
+test("concurrent duplicate session/new for one conversation creates exactly one Pi session", async () => {
+  let creates = 0;
+  const factory = {
+    async create() {
+      creates++;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return fakeHandle({
+        piSessionId: "pi-shared",
+        sessionFile: "/tmp/pi-shared.jsonl",
+      });
+    },
+  };
+  const registry = new SessionRegistry(
+    factory,
+    fakeConversationStore(),
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const [left, right] = await Promise.all([
+    registry.create({
+      cwd: "/tmp",
+      conversationId: "thread",
+      resetToken: "reset-1",
+    }),
+    registry.create({
+      cwd: "/tmp",
+      conversationId: "thread",
+      resetToken: "reset-1",
+    }),
+  ]);
+  assert.equal(creates, 1);
+  assert.equal(left.sessionId, right.sessionId);
+  await registry.shutdown();
+});
+
+test("a live conversation never follows a workspace symlink to a new target", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-registry-live-cwd-"));
+  const workspaceA = join(root, "workspace-a");
+  const workspaceB = join(root, "workspace-b");
+  const alias = join(root, "workspace-current");
+  await mkdir(workspaceA);
+  await mkdir(workspaceB);
+  await symlink(workspaceA, alias, "dir");
+  const handles = [];
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        const handle = fakeHandle({
+          cwd: options.cwd,
+          piSessionId: `pi-${handles.length}`,
+          sessionFile: join(root, `pi-${handles.length}.jsonl`),
+        });
+        handles.push(handle);
+        return handle;
+      },
+    },
+    fakeConversationStore(),
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const first = await registry.create({ cwd: alias, conversationId: "thread" });
+  await unlink(alias);
+  await symlink(workspaceB, alias, "dir");
+  const second = await registry.create({
+    cwd: alias,
+    conversationId: "thread",
+  });
+
+  assert.notEqual(first.sessionId, second.sessionId);
+  assert.equal(first.handle.disposed, true);
+  assert.equal(second.handle.cwd, await realpath(workspaceB));
+  assert.equal(handles.length, 2);
+  await registry.shutdown();
+});
+
+test("a pending conversation create rejects a workspace symlink target swap", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-registry-pending-cwd-"));
+  const workspaceA = join(root, "workspace-a");
+  const workspaceB = join(root, "workspace-b");
+  const alias = join(root, "workspace-current");
+  await mkdir(workspaceA);
+  await mkdir(workspaceB);
+  await symlink(workspaceA, alias, "dir");
+  let releaseFactory;
+  let enteredFactory;
+  const entered = new Promise((resolve) => {
+    enteredFactory = resolve;
+  });
+  const release = new Promise((resolve) => {
+    releaseFactory = resolve;
+  });
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        enteredFactory();
+        await release;
+        return fakeHandle({
+          cwd: options.cwd,
+          piSessionId: "pi-pending",
+          sessionFile: join(root, "pi-pending.jsonl"),
+        });
+      },
+    },
+    fakeConversationStore(),
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const first = registry.create({ cwd: alias, conversationId: "thread" });
+  await entered;
+  await unlink(alias);
+  await symlink(workspaceB, alias, "dir");
+  await assert.rejects(
+    () => registry.create({ cwd: alias, conversationId: "thread" }),
+    /different workspace is already creating this conversation/,
+  );
+  releaseFactory();
+  await first;
+  await registry.shutdown();
+});
+
+test("capacity promotion cannot evict a new session while retired-file deletion is pending", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-registry-promotion-"));
+  const handles = [];
+  let enterDeletion;
+  let releaseDeletion;
+  const deletionEntered = new Promise((resolve) => {
+    enterDeletion = resolve;
+  });
+  const deletionRelease = new Promise((resolve) => {
+    releaseDeletion = resolve;
+  });
+  const conversations = fakeConversationStore();
+  conversations.deleteSessionFile = async () => {
+    enterDeletion();
+    await deletionRelease;
+  };
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        const handle = fakeHandle({
+          cwd: options.cwd,
+          piSessionId: `pi-promotion-${handles.length}`,
+          sessionFile: join(root, `pi-promotion-${handles.length}.jsonl`),
+        });
+        handles.push(handle);
+        return handle;
+      },
+    },
+    conversations,
+    testConfig({ maxSessions: 1 }),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const first = await registry.create({
+    cwd: root,
+    conversationId: "thread",
+    resetToken: "reset-1",
+  });
+  const replacementPromise = registry.create({
+    cwd: root,
+    conversationId: "thread",
+    resetToken: "reset-2",
+  });
+  await deletionEntered;
+
+  await assert.rejects(
+    () =>
+      registry.create({
+        cwd: root,
+        conversationId: "other-thread",
+      }),
+    /all slots are busy or initializing/,
+  );
+  releaseDeletion();
+  const replacement = await replacementPromise;
+  assert.equal(first.handle.disposed, true);
+  assert.equal(replacement.handle.disposed, false);
+  assert.equal(replacement.handle.isValid, true);
+  assert.equal(registry.hasSession(replacement.sessionId), true);
+  assert.equal(handles.length, 2);
+  await registry.shutdown();
+});
+
+test("LRU eviction disposes the oldest idle handle but retains durable mapping", async () => {
+  const handles = [];
+  const factory = {
+    async create() {
+      const handle = fakeHandle({
+        piSessionId: `pi-${handles.length}`,
+        sessionFile: `/tmp/pi-${handles.length}.jsonl`,
+      });
+      handles.push(handle);
+      return handle;
+    },
+  };
+  let now = 1;
+  const registry = new SessionRegistry(
+    factory,
+    fakeConversationStore(),
+    testConfig({ maxSessions: 1 }),
+    sink,
+    silentLogger,
+    () => now++,
+  );
+  await registry.start();
+  await registry.create({ cwd: "/tmp", conversationId: "one" });
+  await registry.create({ cwd: "/tmp", conversationId: "two" });
+  assert.equal(handles[0].disposed, true);
+  assert.equal(handles[1].disposed, false);
+  assert.equal(registry.size, 1);
+  await registry.shutdown();
+});
+
+test("conversation reset commit clears a cold LRU mapping before ACK and survives token-less recreation", async () => {
+  const handles = [];
+  const store = fakeConversationStore();
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        const index = handles.length;
+        const handle = fakeHandle({
+          piSessionId: `pi-${index}`,
+          sessionFile: `/tmp/pi-${index}.jsonl`,
+        });
+        handles.push(handle);
+        return handle;
+      },
+    },
+    store,
+    testConfig({ maxSessions: 1 }),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  await registry.create({ cwd: "/tmp", conversationId: "thread" });
+  await registry.create({ cwd: "/tmp", conversationId: "other" });
+  assert.equal(handles[0].disposed, true, "thread must be cold before reset");
+
+  assert.deepEqual(
+    await registry.commitConversationReset("thread", "signed-reset-1"),
+    { committed: true, alreadyCommitted: false },
+  );
+  const fresh = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+  });
+  assert.equal(fresh.resumedConversation, false);
+  assert.equal(fresh.skipRelayHistory, true);
+  assert.equal(fresh.handle.piSessionId, "pi-2");
+
+  assert.deepEqual(
+    await registry.commitConversationReset("thread", "signed-reset-1"),
+    { committed: true, alreadyCommitted: true },
+  );
+  assert.equal(
+    fresh.handle.disposed,
+    false,
+    "an idempotent replay must not discard the already-fresh session",
+  );
+  await registry.shutdown();
+});
+
+test("dispose uses the resolved owner-bound forget closure and releases SDK resources", async () => {
+  const store = fakeConversationStore();
+  store.forget = async () => {
+    throw new Error("unfenced store forget must not be called");
+  };
+  const handle = fakeHandle({
+    piSessionId: "pi-one",
+    sessionFile: "/tmp/pi-one.jsonl",
+  });
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        return handle;
+      },
+    },
+    store,
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const created = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+  });
+  assert.equal(await registry.disposeSession(created.sessionId, true), true);
+  assert.equal(handle.disposed, true);
+  assert.equal(registry.size, 0);
+  await registry.shutdown();
+});
+
+test("normal disposal deletes an unmapped transcript but retains a mapped conversation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-unmapped-dispose-"));
+  const unmappedFile = join(root, "unmapped.jsonl");
+  const mappedFile = join(root, "mapped.jsonl");
+  await writeFile(unmappedFile, "unmapped");
+  await writeFile(mappedFile, "mapped");
+  const store = fakeConversationStore();
+  store.deleteSessionFile = async (path) => unlink(path);
+  let creates = 0;
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        const mapped = creates++ > 0;
+        return fakeHandle({
+          piSessionId: mapped ? "pi-mapped" : "pi-unmapped",
+          sessionFile: mapped ? mappedFile : unmappedFile,
+        });
+      },
+    },
+    store,
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const unmapped = await registry.create({ cwd: root });
+  const mapped = await registry.create({
+    cwd: root,
+    conversationId: "thread",
+  });
+
+  assert.equal(await registry.disposeSession(unmapped.sessionId, false), true);
+  await assert.rejects(() => access(unmappedFile), { code: "ENOENT" });
+  assert.equal(await registry.disposeSession(mapped.sessionId, false), true);
+  await access(mappedFile);
+  await unlink(mappedFile);
+  await registry.shutdown();
+});
+
+test("closing a mapped session retains its lifecycle route until buffered persistence is ACK-safe", async () => {
+  const lifecycleGeneration = "c".repeat(64);
+  const eventId = "9ba32f72-e8ce-4195-96a2-7b472198bb7e";
+  const timeline = [];
+  let signalDisposeStarted;
+  const disposeStarted = new Promise((resolve) => {
+    signalDisposeStarted = resolve;
+  });
+  let allowBufferedEvent;
+  const bufferedEventGate = new Promise((resolve) => {
+    allowBufferedEvent = resolve;
+  });
+  let signalBufferedEventDone;
+  const bufferedEventDone = new Promise((resolve) => {
+    signalBufferedEventDone = resolve;
+  });
+  let allowDisposeFinish;
+  const disposeFinishGate = new Promise((resolve) => {
+    allowDisposeFinish = resolve;
+  });
+  let registry;
+  const lifecycleEvent = {
+    type: "context_status",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: "Buffered lifecycle status.",
+    piSessionId: "pi-closing-route",
+    usedTokens: 75_000,
+    remainingTokens: 75_000,
+    percent: 50,
+    limitTokens: 150_000,
+    effectiveLimitTokens: 150_000,
+    compactionThresholdTokens: 133_616,
+    autoCompaction: true,
+    compacting: false,
+    model: "provider/model",
+  };
+  const eventSink = {
+    sessionUpdate() {},
+    async buzzSessionEvent(sessionId, event, deliveryId) {
+      const identity = registry.conversationIdentityForSession(sessionId);
+      if (!identity) {
+        timeline.push("suppressed");
+        return;
+      }
+      const persisted = await registry.persistConversationSessionEvent(
+        identity.conversationId,
+        identity.lifecycleGeneration,
+        deliveryId,
+        event,
+      );
+      if (persisted) timeline.push("persisted");
+    },
+    usageUpdate() {},
+  };
+  const conversations = {
+    async initialize() {},
+    async resolve(conversationId, _resetToken, cwd, create) {
+      const created = await create(undefined, lifecycleGeneration);
+      return {
+        mapping: {
+          conversationId,
+          cwd,
+          ...created,
+          lifecycleGeneration,
+        },
+        lifecycleGeneration,
+        resumed: false,
+        skipRelayHistory: false,
+        async refresh() {
+          return true;
+        },
+        async forget() {
+          return undefined;
+        },
+        async release() {},
+      };
+    },
+    async enqueueSessionEvent(
+      conversationId,
+      persistedEventId,
+      event,
+      expectedLifecycleGeneration,
+    ) {
+      assert.equal(conversationId, "thread");
+      assert.equal(persistedEventId, eventId);
+      assert.equal(event, lifecycleEvent);
+      assert.equal(expectedLifecycleGeneration, lifecycleGeneration);
+      timeline.push("parent-outbox");
+      return true;
+    },
+    async deleteSessionFile() {},
+    async prune() {
+      return 0;
+    },
+  };
+  registry = new SessionRegistry(
+    {
+      async create(options) {
+        return fakeHandle({
+          piSessionId: "pi-closing-route",
+          sessionFile: "/tmp/pi-closing-route.jsonl",
+          async dispose() {
+            signalDisposeStarted();
+            await bufferedEventGate;
+            await eventSink.buzzSessionEvent(
+              options.acpSessionId,
+              lifecycleEvent,
+              eventId,
+            );
+            timeline.push("ackLifecycle");
+            signalBufferedEventDone();
+            await disposeFinishGate;
+          },
+        });
+      },
+    },
+    conversations,
+    testConfig(),
+    eventSink,
+    silentLogger,
+  );
+  await registry.start();
+  const created = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+  });
+  const disposal = registry.disposeSession(created.sessionId, false);
+  await disposeStarted;
+  assert.equal(registry.hasSession(created.sessionId), false);
+  assert.deepEqual(registry.conversationIdentityForSession(created.sessionId), {
+    conversationId: "thread",
+    lifecycleGeneration,
+  });
+  await assert.rejects(() => registry.get(created.sessionId), /closing/);
+
+  allowBufferedEvent();
+  await bufferedEventDone;
+  assert.deepEqual(timeline, ["parent-outbox", "persisted", "ackLifecycle"]);
+  assert.deepEqual(registry.conversationIdentityForSession(created.sessionId), {
+    conversationId: "thread",
+    lifecycleGeneration,
+  });
+  allowDisposeFinish();
+  assert.equal(await disposal, true);
+  assert.equal(
+    registry.conversationIdentityForSession(created.sessionId),
+    undefined,
+  );
+  await registry.shutdown();
+});
+
+test("TTL eviction deletes an unreachable unmapped transcript", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-unmapped-ttl-"));
+  const sessionFile = join(root, "expired.jsonl");
+  await writeFile(sessionFile, "expired");
+  const store = fakeConversationStore();
+  store.deleteSessionFile = async (path) => unlink(path);
+  let now = 0;
+  const handle = fakeHandle({ piSessionId: "pi-expired", sessionFile });
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        return handle;
+      },
+    },
+    store,
+    testConfig({ sessionTtlMs: 100 }),
+    sink,
+    silentLogger,
+    () => now,
+  );
+  await registry.start();
+  await registry.create({ cwd: root });
+  now = 101;
+
+  assert.equal(await registry.sweepExpired(), 1);
+  assert.equal(handle.disposed, true);
+  await assert.rejects(() => access(sessionFile), { code: "ENOENT" });
+  await registry.shutdown();
+});
+
+test("shutdown deletes unmapped transcripts and preserves mapped transcripts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-unmapped-shutdown-"));
+  const unmappedFile = join(root, "unmapped.jsonl");
+  const mappedFile = join(root, "mapped.jsonl");
+  await writeFile(unmappedFile, "unmapped");
+  await writeFile(mappedFile, "mapped");
+  const store = fakeConversationStore();
+  store.deleteSessionFile = async (path) => unlink(path);
+  const handles = [];
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        const sessionFile = handles.length === 0 ? unmappedFile : mappedFile;
+        const handle = fakeHandle({
+          piSessionId: `pi-shutdown-${handles.length}`,
+          sessionFile,
+        });
+        handles.push(handle);
+        return handle;
+      },
+    },
+    store,
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  await registry.create({ cwd: root });
+  await registry.create({ cwd: root, conversationId: "thread" });
+
+  await registry.shutdown();
+  assert.deepEqual(
+    handles.map((handle) => handle.disposed),
+    [true, true],
+  );
+  await assert.rejects(() => access(unmappedFile), { code: "ENOENT" });
+  await access(mappedFile);
+  await unlink(mappedFile);
+});
+
+test("runtime host invalidation deletes unmapped transcripts and preserves mapped transcripts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "buzz-pi-unmapped-invalidated-"));
+  const unmappedFile = join(root, "unmapped.jsonl");
+  const mappedFile = join(root, "mapped.jsonl");
+  await writeFile(unmappedFile, "unmapped");
+  await writeFile(mappedFile, "mapped");
+  const store = fakeConversationStore();
+  store.deleteSessionFile = async (path) => unlink(path);
+  const handles = [];
+  let invalidate;
+  const factory = {
+    setInvalidationHandler(handler) {
+      invalidate = handler;
+    },
+    async create() {
+      const sessionFile = handles.length === 0 ? unmappedFile : mappedFile;
+      const handle = fakeHandle({
+        piSessionId: `pi-invalidated-${handles.length}`,
+        sessionFile,
+      });
+      handles.push(handle);
+      return handle;
+    },
+  };
+  const registry = new SessionRegistry(
+    factory,
+    store,
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const unmapped = await registry.create({ cwd: root });
+  const mapped = await registry.create({
+    cwd: root,
+    conversationId: "thread",
+  });
+
+  await invalidate(
+    [unmapped.sessionId, mapped.sessionId],
+    new Error("runtime host crashed"),
+  );
+  assert.equal(registry.size, 0);
+  assert.deepEqual(
+    handles.map((handle) => handle.disposed),
+    [true, true],
+  );
+  await assert.rejects(() => access(unmappedFile), { code: "ENOENT" });
+  await access(mappedFile);
+  await unlink(mappedFile);
+  await registry.shutdown();
+});
+
+test("forget failure still disposes, releases the lease, and permits the next reset", async () => {
+  let leased = false;
+  let failForget = true;
+  let lifecycleGenerationIndex = 0;
+  let handleGeneration = 0;
+  const mappings = new Map();
+  const store = {
+    async initialize() {},
+    async resolve(conversationId, resetToken, cwd, create) {
+      if (leased) throw new Error("active lease");
+      const existing = mappings.get(conversationId);
+      const forceFresh =
+        resetToken !== undefined && resetToken !== existing?.resetToken;
+      const lifecycleGeneration = forceFresh
+        ? `${(++lifecycleGenerationIndex).toString(16).padStart(64, "0")}`
+        : (existing?.lifecycleGeneration ?? "0".repeat(64));
+      const created = await create(
+        forceFresh ? undefined : existing?.sessionFile,
+        lifecycleGeneration,
+      );
+      const mapping = {
+        conversationId,
+        resetToken,
+        sessionFile: created.sessionFile,
+        piSessionId: created.piSessionId,
+        lifecycleGeneration,
+        cwd,
+      };
+      mappings.set(conversationId, mapping);
+      leased = true;
+      return {
+        mapping,
+        lifecycleGeneration,
+        resumed: existing !== undefined && !forceFresh,
+        ...(forceFresh && existing
+          ? { previousPiSessionId: existing.piSessionId }
+          : {}),
+        async forget() {
+          return store.forget();
+        },
+        async release() {
+          leased = false;
+        },
+      };
+    },
+    async touch() {},
+    async forget() {
+      if (failForget) {
+        failForget = false;
+        throw new Error("injected manifest failure");
+      }
+      return undefined;
+    },
+    async deleteSessionFile() {},
+    async prune() {
+      return 0;
+    },
+  };
+  const handles = [];
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        handleGeneration++;
+        const handle = fakeHandle({
+          piSessionId: `pi-${handleGeneration}`,
+          sessionFile: `/tmp/pi-${handleGeneration}.jsonl`,
+        });
+        handles.push(handle);
+        return handle;
+      },
+    },
+    store,
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const first = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+  });
+  await assert.rejects(
+    () => registry.disposeSession(first.sessionId, true),
+    /injected manifest failure/,
+  );
+  assert.equal(handles[0].disposed, true);
+  assert.equal(registry.size, 0);
+  assert.equal(leased, false, "failed forget must not strand a live-PID lease");
+
+  const reset = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+    resetToken: "signed-reset-2",
+  });
+  assert.equal(reset.handle.piSessionId, "pi-2");
+  await registry.shutdown();
+});
+
+test("concurrent unique creates never exceed the configured session capacity", async () => {
+  let inFactory = 0;
+  let peakFactory = 0;
+  const registry = new SessionRegistry(
+    {
+      async create(options) {
+        inFactory++;
+        peakFactory = Math.max(peakFactory, inFactory);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        inFactory--;
+        return fakeHandle({
+          piSessionId: options.acpSessionId,
+          sessionFile: `/tmp/${options.acpSessionId}.jsonl`,
+        });
+      },
+    },
+    fakeConversationStore(),
+    testConfig({ maxSessions: 2 }),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const results = await Promise.allSettled([
+    registry.create({ cwd: "/tmp" }),
+    registry.create({ cwd: "/tmp" }),
+    registry.create({ cwd: "/tmp" }),
+  ]);
+  assert.equal(
+    results.filter((result) => result.status === "fulfilled").length,
+    2,
+  );
+  assert.equal(
+    results.filter((result) => result.status === "rejected").length,
+    1,
+  );
+  assert.equal(peakFactory, 2);
+  assert.equal(registry.size, 2);
+  await registry.shutdown();
+});
+
+test("a superseded conversation lease is fenced before its handle is returned", async () => {
+  let current = true;
+  let released = false;
+  const handle = fakeHandle({
+    piSessionId: "pi-fenced",
+    sessionFile: "/tmp/pi-fenced.jsonl",
+  });
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        return handle;
+      },
+    },
+    {
+      async initialize() {},
+      async resolve(conversationId, _resetToken, cwd, create) {
+        const lifecycleGeneration = "1".repeat(64);
+        const created = await create(undefined, lifecycleGeneration);
+        return {
+          mapping: {
+            conversationId,
+            cwd,
+            ...created,
+            lifecycleGeneration,
+          },
+          lifecycleGeneration,
+          resumed: false,
+          skipRelayHistory: false,
+          async refresh() {
+            return current;
+          },
+          async release() {
+            released = true;
+          },
+        };
+      },
+      async prune() {
+        return 0;
+      },
+    },
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  const created = await registry.create({
+    cwd: "/tmp",
+    conversationId: "thread",
+  });
+  current = false;
+  await assert.rejects(
+    () => registry.get(created.sessionId),
+    /lease was superseded/,
+  );
+  assert.equal(handle.disposed, true);
+  assert.equal(released, true);
+  assert.equal(registry.size, 0);
+  await registry.shutdown();
+});
+
+test("a lease refresh exception disposes the session during background sweep", async () => {
+  let released = false;
+  const handle = fakeHandle({
+    piSessionId: "pi-refresh-error",
+    sessionFile: "/tmp/pi-refresh-error.jsonl",
+  });
+  const registry = new SessionRegistry(
+    {
+      async create() {
+        return handle;
+      },
+    },
+    {
+      async initialize() {},
+      async resolve(conversationId, _resetToken, cwd, create) {
+        const lifecycleGeneration = "2".repeat(64);
+        const created = await create(undefined, lifecycleGeneration);
+        return {
+          mapping: {
+            conversationId,
+            cwd,
+            ...created,
+            lifecycleGeneration,
+          },
+          lifecycleGeneration,
+          resumed: false,
+          skipRelayHistory: false,
+          async refresh() {
+            throw new Error("manifest unavailable");
+          },
+          async release() {
+            released = true;
+          },
+        };
+      },
+      async prune() {
+        return 0;
+      },
+    },
+    testConfig(),
+    sink,
+    silentLogger,
+  );
+  await registry.start();
+  await registry.create({ cwd: "/tmp", conversationId: "thread" });
+  assert.equal(await registry.sweepExpired(), 0);
+  assert.equal(handle.disposed, true);
+  assert.equal(released, true);
+  assert.equal(registry.size, 0);
+  await registry.shutdown();
+});

--- a/packages/buzz-pi-agent/test/wire.test.mjs
+++ b/packages/buzz-pi-agent/test/wire.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { test } from "node:test";
+import { JsonRpcError, NdjsonWriter, readNdjson } from "../dist/index.js";
+import { silentLogger } from "./helpers.mjs";
+
+test("NDJSON reader handles split chunks and CRLF", async () => {
+  const stream = Readable.from([
+    Buffer.from('{"a":'),
+    Buffer.from('1}\r\n{"b":2}\n'),
+  ]);
+  const lines = [];
+  for await (const line of readNdjson(stream, 100)) lines.push(line);
+  assert.deepEqual(lines, ['{"a":1}', '{"b":2}']);
+});
+
+test("NDJSON reader stays linear across one-byte chunks and trailing frames", async () => {
+  const boundaryLine = "x".repeat(8_192);
+  const framed = Buffer.from(`${boundaryLine}\nshort\n\n`);
+  const stream = Readable.from(
+    Array.from(framed, (byte) => Buffer.from([byte])),
+  );
+  const lines = [];
+  for await (const line of readNdjson(stream, 8_192)) lines.push(line);
+  assert.deepEqual(lines, [boundaryLine, "short", ""]);
+});
+
+test("NDJSON reader enforces the exact byte boundary across tiny segments", async () => {
+  const exact = Readable.from([
+    ...Array.from(Buffer.from("界界"), (byte) => Buffer.from([byte])),
+    Buffer.from("\n"),
+  ]);
+  const lines = [];
+  for await (const line of readNdjson(exact, 6)) lines.push(line);
+  assert.deepEqual(lines, ["界界"]);
+
+  const oversized = Readable.from(
+    Array.from(Buffer.from("1234567\n"), (byte) => Buffer.from([byte])),
+  );
+  await assert.rejects(
+    async () => {
+      for await (const _line of readNdjson(oversized, 6)) {
+        // no-op
+      }
+    },
+    (error) =>
+      error instanceof JsonRpcError && /exceeds 6 bytes/.test(error.message),
+  );
+});
+
+test("NDJSON reader rejects oversized unterminated input before EOF", async () => {
+  const stream = Readable.from([Buffer.alloc(101, 0x61)]);
+  await assert.rejects(
+    async () => {
+      for await (const _line of readNdjson(stream, 100)) {
+        // no-op
+      }
+    },
+    (error) =>
+      error instanceof JsonRpcError && /exceeds 100 bytes/.test(error.message),
+  );
+});
+
+test("NDJSON reader rejects an unterminated frame", async () => {
+  await assert.rejects(async () => {
+    for await (const _line of readNdjson(Readable.from(['{"a":1}']), 100)) {
+      // no-op
+    }
+  }, /unterminated NDJSON frame/);
+});
+
+test("NDJSON writer waits for each transport drain and preserves strict order", async () => {
+  const lines = [];
+  const releases = [];
+  const writer = new NdjsonWriter(
+    (line) => {
+      lines.push(JSON.parse(line));
+      return new Promise((resolve) => releases.push(resolve));
+    },
+    silentLogger,
+    { maxQueuedMessages: 4, maxQueuedBytes: 1_024 },
+  );
+
+  writer.write({ sequence: 1 });
+  writer.write({ sequence: 2 });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(lines, [{ sequence: 1 }]);
+  releases.shift()();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(lines, [{ sequence: 1 }, { sequence: 2 }]);
+  const ending = writer.end();
+  releases.shift()();
+  await ending;
+});
+
+test("NDJSON writer poisons instead of growing beyond its bounded backlog", async () => {
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const failures = [];
+  const writer = new NdjsonWriter(() => gate, silentLogger, {
+    maxQueuedMessages: 2,
+    maxQueuedBytes: 1_024,
+    onFatal: (error) => failures.push(error),
+  });
+
+  writer.write({ sequence: 1 });
+  writer.write({ sequence: 2 });
+  writer.write({ sequence: 3 });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0].message, /queue saturated/);
+  await assert.rejects(() => writer.end(), /queue saturated/);
+  release();
+});

--- a/packages/buzz-pi-agent/tsconfig.build.json
+++ b/packages/buzz-pi-agent/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "sourceMap": true
+  }
+}

--- a/packages/buzz-pi-agent/tsconfig.json
+++ b/packages/buzz-pi-agent/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.10(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0))
 
   desktop:
     dependencies:
@@ -287,6 +287,22 @@ importers:
         specifier: ^8.0.0
         version: 8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/buzz-pi-agent:
+    dependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.83.0
+        version: 0.83.0(ws@8.21.1)(zod@4.4.3)
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.6
+        version: 2.4.16
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.13.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   web:
     dependencies:
       '@fontsource-variable/inter':
@@ -396,6 +412,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
@@ -404,6 +429,103 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    resolution: {integrity: sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    resolution: {integrity: sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.47':
+    resolution: {integrity: sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -615,6 +737,24 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
+  '@earendil-works/pi-agent-core@0.83.0':
+    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.83.0':
+    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.83.0':
+    resolution: {integrity: sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.83.0':
+    resolution: {integrity: sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==}
+    engines: {node: '>=22.19.0'}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -660,6 +800,15 @@ packages:
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@isomorphic-git/idb-keyval@3.3.2':
     resolution: {integrity: sha512-r8/AdpiS0/WJCNR/t/gsgL+M8NMVj/ek7s60uz3LmpCaTF2mEVlZJlB01ZzalgYzRLXwSPC92o+pdzjM7PN/pA==}
 
@@ -683,8 +832,84 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
   '@mediapipe/tasks-vision@0.10.35':
     resolution: {integrity: sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==}
+
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -708,6 +933,14 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -715,6 +948,33 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -1583,6 +1843,49 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2073,6 +2376,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -2083,6 +2389,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2194,6 +2503,10 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2205,10 +2518,23 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -2241,6 +2567,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -2295,6 +2625,10 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -2313,6 +2647,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@6.0.1:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
@@ -2381,6 +2719,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   electron-to-chromium@1.5.361:
     resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
@@ -2476,6 +2817,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2483,6 +2828,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   framer-motion@12.40.0:
     resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
@@ -2511,6 +2860,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2518,6 +2875,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2533,6 +2894,18 @@ packages:
 
   gitdiff-parser@0.3.1:
     resolution: {integrity: sha512-YQJnY8aew65id8okGxKCksH3efDCJ9HzV7M9rsvd65habf39Pkh4cgYJ27AaoDMqo1X98pgNJhNMrm/kpV7UVQ==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2565,6 +2938,13 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2588,6 +2968,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   indent-string@4.0.0:
@@ -2638,6 +3022,9 @@ packages:
     resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
     engines: {node: '>=18'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   isomorphic-git@1.38.7:
     resolution: {integrity: sha512-2J2rCV7gTgcpscEDT7PjU5shbsKKI10E4RqBlPDI3LmMXDjSKsN2w1jTIKiay14v87sPDfXjJkgp/Rrxc0zlSg==}
     engines: {node: '>=14.17'}
@@ -2672,6 +3059,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2682,6 +3076,12 @@ packages:
 
   just-once@1.1.0:
     resolution: {integrity: sha512-+rZVpl+6VyTilK7vB/svlMPil4pxqIJZkbnN7DKZTOzyXfun6ZiFeq2Pk4EtCEHZ0VU4EkdFzG8ZK5F3PErcDw==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2770,6 +3170,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -2805,6 +3208,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2956,11 +3364,19 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minimisted@2.0.1:
     resolution: {integrity: sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   motion-dom@12.40.0:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
@@ -2990,6 +3406,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
@@ -3018,6 +3443,18 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
@@ -3027,6 +3464,10 @@ packages:
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
   p-try@2.2.0:
@@ -3042,9 +3483,20 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3103,6 +3555,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -3144,6 +3599,10 @@ packages:
 
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -3263,6 +3722,14 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3283,6 +3750,11 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   seroval-plugins@1.5.4:
@@ -3310,12 +3782,23 @@ packages:
   shallow-equal@3.1.0:
     resolution: {integrity: sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shiki@4.1.0:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
     engines: {node: '>=20'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -3428,15 +3911,26 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3446,8 +3940,15 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3628,6 +4129,10 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -3653,6 +4158,11 @@ packages:
   which-typed-array@1.1.22:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -3704,6 +4214,11 @@ packages:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3717,6 +4232,12 @@ snapshots:
   '@adobe/css-tools@4.5.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -3735,6 +4256,220 @@ snapshots:
       lru-cache: 11.5.2
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.2
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/eventstream-handler-node': 3.972.31
+      '@aws-sdk/middleware-eventstream': 3.972.26
+      '@aws-sdk/middleware-websocket': 3.972.47
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.31':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.26':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3942,6 +4677,77 @@ snapshots:
       react: 19.2.8
       tslib: 2.8.1
 
+  '@earendil-works/pi-agent-core@0.83.0(ws@8.21.1)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.83.0(ws@8.21.1)(zod@4.4.3)
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.83.0(ws@8.21.1)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.1)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.83.0(ws@8.21.1)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.83.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.83.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.83.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.83.0':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3988,6 +4794,17 @@ snapshots:
 
   '@fontsource-variable/inter@5.2.8': {}
 
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@isomorphic-git/idb-keyval@3.3.2': {}
 
   '@isomorphic-git/lightning-fs@4.6.2':
@@ -4016,7 +4833,63 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
   '@mediapipe/tasks-vision@0.10.35': {}
+
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
+      ws: 8.21.1
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -4035,11 +4908,35 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@oxc-project/types@0.133.0': {}
 
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -4825,6 +5722,61 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.0':
@@ -5315,6 +6267,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -5326,6 +6282,8 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/retry@0.12.0': {}
 
   '@types/unist@2.0.11': {}
 
@@ -5428,6 +6386,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.32: {}
@@ -5436,6 +6396,14 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
+  bowser@2.14.1: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.32
@@ -5443,6 +6411,8 @@ snapshots:
       electron-to-chromium: 1.5.361
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@6.0.3:
     dependencies:
@@ -5477,6 +6447,8 @@ snapshots:
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5520,6 +6492,12 @@ snapshots:
 
   crc-32@1.2.2: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -5537,6 +6515,8 @@ snapshots:
       lru-cache: 11.5.2
 
   csstype@3.2.3: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@6.0.1:
     dependencies:
@@ -5592,6 +6572,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.361: {}
 
@@ -5660,6 +6644,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -5668,6 +6657,10 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   framer-motion@12.40.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -5686,9 +6679,27 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5711,6 +6722,25 @@ snapshots:
       es-object-atoms: 1.1.2
 
   gitdiff-parser@0.3.1: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -5768,6 +6798,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  highlight.js@10.7.3: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.2
+
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
@@ -5795,6 +6831,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   indent-string@4.0.0: {}
 
@@ -5828,6 +6866,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isbot@5.1.40: {}
+
+  isexe@2.0.0: {}
 
   isomorphic-git@1.38.7(patch_hash=e9b414a60d4cf1d8aa18f7a779483984e821989967c235662566e94ef0238d3f):
     dependencies:
@@ -5885,11 +6925,31 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json5@2.2.3: {}
 
   just-debounce-it@1.1.0: {}
 
   just-once@1.1.0: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5952,6 +7012,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -5986,6 +7048,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -6346,11 +7410,17 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimist@1.2.8: {}
 
   minimisted@2.0.1:
     dependencies:
       minimist: 1.2.8
+
+  minipass@7.1.3: {}
 
   motion-dom@12.40.0:
     dependencies:
@@ -6369,6 +7439,14 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.46: {}
 
@@ -6400,6 +7478,11 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  openai@6.26.0(ws@8.21.1)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.1
+      zod: 4.4.3
+
   orderedmap@2.1.1: {}
 
   p-limit@2.3.0:
@@ -6409,6 +7492,11 @@ snapshots:
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   p-try@2.2.0: {}
 
@@ -6428,7 +7516,16 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  partial-json@0.1.7: {}
+
   path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -6472,6 +7569,12 @@ snapshots:
       react-is: 17.0.2
 
   process@0.11.10: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   property-information@7.1.0: {}
 
@@ -6549,6 +7652,20 @@ snapshots:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.6.0
+      long: 5.3.2
 
   punycode.js@2.3.1: {}
 
@@ -6699,6 +7816,10 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -6732,6 +7853,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.8.0: {}
+
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
       seroval: 1.5.4
@@ -6757,6 +7880,12 @@ snapshots:
 
   shallow-equal@3.1.0: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shiki@4.1.0:
     dependencies:
       '@shikijs/core': 4.1.0
@@ -6769,6 +7898,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   simple-concat@1.0.1: {}
 
@@ -6878,9 +8009,13 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-algebra@2.0.0: {}
+
   tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
+
+  typebox@1.3.7: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -6888,11 +8023,17 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
+  undici-types@7.18.2: {}
+
   undici-types@7.19.2: {}
+
+  undici@8.5.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6992,7 +8133,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -7015,6 +8156,7 @@ snapshots:
       vite: 8.0.16(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
       jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
@@ -7029,6 +8171,8 @@ snapshots:
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -7054,6 +8198,10 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -7098,6 +8246,10 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,11 @@ packages:
   - "desktop"
   - "web"
   - "admin-web"
+  - "packages/buzz-pi-agent"
 allowBuilds:
+  "@google/genai": false
   esbuild: true
+  protobufjs: false
 overrides:
   # Force a single copy of the dismissable-layer. Radix packages otherwise
   # resolve different versions (react-menu pulled 1.1.11, react-dialog 1.1.15),


### PR DESCRIPTION
## Summary

Adds a production ACP adapter that runs the Pi coding-agent SDK as a first-class Buzz agent, plus the Buzz harness and Desktop integration needed to make durable per-thread sessions safe and visible.

The central behavior is simple: every Buzz thread gets its own persistent Pi context. An authenticated `/new` resets only that thread. Context is capped at 150,000 logical tokens, with proactive compaction around 133,616 tokens and durable, user-visible lifecycle notices.

Highlights:

- adds the workspace-local `buzz-pi-agent` package, pinned to Pi SDK 0.83.0;
- maps stable Buzz conversation identities to durable Pi JSONL sessions;
- adds idempotent reset tokens, reset commits, tombstones, lease fencing, and crash recovery;
- adds durable schema-v2 compaction/reset/status/reload events with relay outbox ACK and replay;
- enforces context safety before each turn and again at the final provider-payload boundary;
- bounds live sessions, persisted mappings, transcript bytes, IPC queues, resources, and lifecycle outboxes;
- isolates Pi and third-party extensions from ACP stdout in a child process;
- supports trusted Pi extensions, tools, hooks, providers, commands, prompts, and skills;
- adds `/context`, `/compact`, and `/reload` commands;
- adds Pi harness discovery, model selection/switching, exact active-turn correlation, and lifecycle rendering in Desktop;
- preserves the latest upstream Claude `_meta.systemPrompt` transport and Oh My Pi preset behavior;
- adds path-scoped GitHub CI and pre-push enforcement for the adapter, full ACP suite, and real cross-process contract;
- documents operations, trust, extension compatibility, recovery behavior, and platform durability limits.

### Related issue

None found after searching open issues and pull requests for Pi, `pi-coding-agent`, and Oh My Pi integrations.

### Testing

- `just pi-agent-verify` passed end to end:
  - Pi adapter: 153/153 tests, including real Pi SDK sessions/resources/extensions and SIGKILL recovery;
  - Buzz ACP harness: 772/772 tests;
  - real Rust-to-Node durable session/reset contract: 1/1.
- Desktop JavaScript: 3,935/3,935 tests.
- Desktop native: 2,112 tests passed; 14 ignored OS-keychain/real-relay tests.
- full workspace Rust Clippy and Desktop Tauri Clippy passed with warnings denied.
- root and Desktop Tauri Rust formatting checks passed.
- Desktop typecheck, lint/ratchets, frozen workspace lockfile validation, and production build passed.
- GitHub workflow/lefthook YAML and Justfile parsing passed.

Live QA used a private agent on an existing Buzz account:

1. Thread A remembered `RED MAPLE`.
2. Thread B independently remembered `BLUE ORBIT`.
3. `/new` in thread A made A answer `NONE`.
4. Thread B still answered `BLUE ORBIT`.
5. After restarting the managed agent, thread B still answered `BLUE ORBIT`.

The local QA app is ad-hoc signed, so macOS correctly prevents it from reusing the production app's Keychain item. Live relay behavior was therefore tested through the installed signed Buzz app, while the new lifecycle UI was verified through automated tests and a production frontend build.
