### PR TITLE
fix: accept buzz-admin hex secrets in desktop key import (#2815)

### DIFF
--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -28,7 +28,7 @@ use buzz_core::tenant::{relay_url_authority, TenantContext};
 use buzz_db::{Db, DbConfig};
 use buzz_pubsub::{EventTopic, PubSubManager};
 use clap::{Parser, Subcommand};
-use nostr::{EventBuilder, Keys, Kind, Tag};
+use nostr::{EventBuilder, Keys, Kind, Tag, ToBech32};
 use tracing::warn;
 
 #[derive(Parser)]
@@ -131,9 +131,17 @@ async fn run(cli: Cli) -> Result<i32> {
     match cli.command {
         Command::GenerateKey => {
             let keys = Keys::generate();
-            println!("Public key:  {}", keys.public_key().to_hex());
-            println!("Secret key:  {}", keys.secret_key().display_secret());
-            println!("\nSet BUZZ_PRIVATE_KEY to the secret key to use this identity.");
+            let nsec = keys
+                .secret_key()
+                .to_bech32()
+                .map_err(|e| anyhow::anyhow!("encode nsec: {e}"))?;
+            println!("Public key (hex):   {}", keys.public_key().to_hex());
+            println!("Public key (npub):  {}", keys.public_key().to_bech32()?);
+            println!("Secret key (hex):   {}", keys.secret_key().display_secret());
+            println!("Secret key (nsec):  {nsec}");
+            println!(
+                "\nSet BUZZ_PRIVATE_KEY to the hex or nsec secret. Desktop onboarding accepts both."
+            );
             Ok(0)
         }
         Command::Migrate => {

--- a/desktop/src/features/onboarding/lib/keyImportInput.test.mjs
+++ b/desktop/src/features/onboarding/lib/keyImportInput.test.mjs
@@ -23,10 +23,20 @@ const VALID_NSEC = nsecEncode(generateSecretKey());
 test("classify_by_hrp_with_whitespace_tolerance", () => {
   assert.equal(classifyKeyImportInput(`  ${NCRYPTSEC}\n`), "ncryptsec");
   assert.equal(classifyKeyImportInput(VALID_NSEC), "nsec");
+  assert.equal(classifyKeyImportInput("a".repeat(64)), "hex");
   assert.equal(classifyKeyImportInput("npub1whatever"), "unknown");
   assert.equal(classifyKeyImportInput(""), "unknown");
   // nsec must not be shadowed by the longer HRP check.
   assert.equal(classifyKeyImportInput("nsec1"), "nsec");
+});
+
+test("submit_gating_hex_secret_from_buzz_admin", () => {
+  const sk = generateSecretKey();
+  const hex = Buffer.from(sk).toString("hex");
+  assert.equal(classifyKeyImportInput(hex), "hex");
+  assert.equal(keyImportSubmitEnabled(hex, ""), true);
+  assert.equal(keyImportSubmitEnabled(hex.toUpperCase(), ""), true);
+  assert.equal(keyImportSubmitEnabled("ab".repeat(31), ""), false); // 62 chars
 });
 
 test("uppercase_bech32_encoding_classifies_and_gates_like_lowercase", () => {

--- a/desktop/src/features/onboarding/lib/keyImportInput.ts
+++ b/desktop/src/features/onboarding/lib/keyImportInput.ts
@@ -11,7 +11,10 @@
 
 import { nsecToNpub } from "@/shared/lib/nostrUtils";
 
-export type KeyImportKind = "nsec" | "ncryptsec" | "unknown";
+export type KeyImportKind = "nsec" | "ncryptsec" | "hex" | "unknown";
+
+/** 32-byte secret as 64 hex chars — `buzz-admin generate-key` / BUZZ_PRIVATE_KEY. */
+const HEX_SECRET_REGEX = /^[0-9a-fA-F]{64}$/;
 
 const NCRYPTSEC_HRP = "ncryptsec";
 const NIP49_VERSION = 2;
@@ -72,6 +75,7 @@ export function classifyKeyImportInput(input: string): KeyImportKind {
   // case routes there too and fails in Rust with the accurate error.
   if (trimmed.slice(0, 10).toLowerCase() === "ncryptsec1") return "ncryptsec";
   if (trimmed.startsWith("nsec1")) return "nsec";
+  if (HEX_SECRET_REGEX.test(trimmed)) return "hex";
   return "unknown";
 }
 

--- a/desktop/src/features/onboarding/lib/keyImportInput.ts
+++ b/desktop/src/features/onboarding/lib/keyImportInput.ts
@@ -9,12 +9,9 @@
  * when the form can safely switch modes.
  */
 
-import { nsecToNpub } from "@/shared/lib/nostrUtils";
+import { HEX_64_REGEX, nsecToNpub } from "@/shared/lib/nostrUtils";
 
 export type KeyImportKind = "nsec" | "ncryptsec" | "hex" | "unknown";
-
-/** 32-byte secret as 64 hex chars — `buzz-admin generate-key` / BUZZ_PRIVATE_KEY. */
-const HEX_SECRET_REGEX = /^[0-9a-fA-F]{64}$/;
 
 const NCRYPTSEC_HRP = "ncryptsec";
 const NIP49_VERSION = 2;
@@ -75,7 +72,7 @@ export function classifyKeyImportInput(input: string): KeyImportKind {
   // case routes there too and fails in Rust with the accurate error.
   if (trimmed.slice(0, 10).toLowerCase() === "ncryptsec1") return "ncryptsec";
   if (trimmed.startsWith("nsec1")) return "nsec";
-  if (HEX_SECRET_REGEX.test(trimmed)) return "hex";
+  if (HEX_64_REGEX.test(trimmed)) return "hex";
   return "unknown";
 }
 

--- a/desktop/src/features/onboarding/ui/MembershipDenied.tsx
+++ b/desktop/src/features/onboarding/ui/MembershipDenied.tsx
@@ -65,7 +65,7 @@ export function MembershipDenied({
   const handleImportKey = React.useCallback(async () => {
     if (!previewNpub) {
       setImportError(
-        "That doesn't look like a valid nsec. Paste an nsec1 key.",
+        "That doesn't look like a valid key. Paste an nsec1… or 64-char hex secret.",
       );
       return;
     }
@@ -186,7 +186,7 @@ export function MembershipDenied({
                     setNsecInput(event.target.value);
                     setImportError(null);
                   }}
-                  placeholder="nsec1..."
+                  placeholder="nsec1… or hex secret"
                   spellCheck={false}
                   type="password"
                   value={nsecInput}

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -151,7 +151,7 @@ export function NostrKeyImportForm({
           ? "Enter the password for this key backup."
           : isEncryptedInput
             ? "That doesn't look like a complete ncryptsec backup."
-            : "That doesn't look like a valid nsec. Paste an nsec1 key.",
+            : "That doesn't look like a valid key. Paste an nsec1… or 64-char hex secret.",
       );
       return;
     }
@@ -273,7 +273,7 @@ export function NostrKeyImportForm({
                 setNsecInput(event.target.value);
                 setImportError(null);
               }}
-              placeholder="nsec1..."
+              placeholder="nsec1… or hex"
               ref={inputRef}
               spellCheck={false}
               type="password"
@@ -478,7 +478,7 @@ export function NostrKeyImportForm({
             <p className="text-sm text-muted-foreground">
               {isEncryptedInput
                 ? "Waiting for a complete ncryptsec backup"
-                : "Waiting for a valid nsec1 key"}
+                : "Waiting for a valid nsec1… or hex key"}
             </p>
           ) : null}
 

--- a/desktop/src/shared/lib/nostrUtils.test.mjs
+++ b/desktop/src/shared/lib/nostrUtils.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * Pure-logic tests for private-key normalization (nsec vs buzz-admin hex).
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { hexToBytes } from "@noble/hashes/utils.js";
+import { nsecEncode } from "nostr-tools/nip19";
+import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
+
+import {
+  normalizePrivateKeyToNsec,
+  nsecToNpub,
+  pubkeyToNpub,
+} from "./nostrUtils.ts";
+
+const SECRET_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const SECRET_NSEC = nsecEncode(hexToBytes(SECRET_HEX));
+const EXPECTED_NPUB = pubkeyToNpub(getPublicKey(hexToBytes(SECRET_HEX)));
+
+describe("normalizePrivateKeyToNsec", () => {
+  test("accepts nsec1 bech32", () => {
+    assert.equal(normalizePrivateKeyToNsec(`  ${SECRET_NSEC}\n`), SECRET_NSEC);
+  });
+
+  test("accepts 64-char hex (buzz-admin generate-key output)", () => {
+    assert.equal(normalizePrivateKeyToNsec(SECRET_HEX), SECRET_NSEC);
+    assert.equal(
+      normalizePrivateKeyToNsec(SECRET_HEX.toUpperCase()),
+      SECRET_NSEC,
+    );
+  });
+
+  test("rejects garbage", () => {
+    assert.equal(normalizePrivateKeyToNsec("nsec1notvalid"), null);
+    assert.equal(normalizePrivateKeyToNsec("00"), null);
+    assert.equal(normalizePrivateKeyToNsec("npub1whatever"), null);
+  });
+});
+
+describe("nsecToNpub", () => {
+  test("derives npub from nsec and hex secrets", () => {
+    assert.equal(nsecToNpub(SECRET_NSEC), EXPECTED_NPUB);
+    assert.equal(nsecToNpub(SECRET_HEX), EXPECTED_NPUB);
+    const random = generateSecretKey();
+    const hex = Buffer.from(random).toString("hex");
+    assert.equal(nsecToNpub(hex), nsecToNpub(nsecEncode(random)));
+  });
+
+  test("returns null for incomplete input", () => {
+    assert.equal(nsecToNpub("nsec1"), null);
+    assert.equal(nsecToNpub("00"), null);
+  });
+});

--- a/desktop/src/shared/lib/nostrUtils.ts
+++ b/desktop/src/shared/lib/nostrUtils.ts
@@ -1,4 +1,5 @@
-import { decode, npubEncode } from "nostr-tools/nip19";
+import { hexToBytes } from "@noble/hashes/utils.js";
+import { decode, npubEncode, nsecEncode } from "nostr-tools/nip19";
 import { getPublicKey } from "nostr-tools/pure";
 
 /**
@@ -24,6 +25,8 @@ export function safeNpub(pubkey: string): string | null {
 }
 
 const HEX_PUBKEY_REGEX = /^[0-9a-f]{64}$/;
+/** 32-byte secret as 64 hex chars — what `buzz-admin generate-key` prints. */
+const HEX_SECRET_REGEX = /^[0-9a-fA-F]{64}$/;
 
 /**
  * Parse user-entered public key input — either a 64-character hex pubkey or
@@ -52,20 +55,51 @@ export function parsePubkeyInput(input: string): string | null {
 }
 
 /**
- * Decode a bech32 nsec string and derive the matching npub. Returns null if
- * the input is not a syntactically valid `nsec1…` (does NOT throw — this is
- * intended for live form validation where the user is mid-typing).
+ * Normalize a pasted private key to bech32 `nsec1…`.
+ *
+ * Accepts either `nsec1…` or a 64-char hex secret (what `buzz-admin
+ * generate-key` prints / `BUZZ_PRIVATE_KEY` accepts). Returns null for
+ * anything else — does not throw; intended for live form validation.
+ */
+export function normalizePrivateKeyToNsec(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed.startsWith("nsec1")) {
+    try {
+      const decoded = decode(trimmed);
+      if (decoded.type !== "nsec") {
+        return null;
+      }
+      return trimmed;
+    } catch {
+      return null;
+    }
+  }
+  if (HEX_SECRET_REGEX.test(trimmed)) {
+    try {
+      return nsecEncode(hexToBytes(trimmed.toLowerCase()));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Decode a private key (bech32 `nsec1…` or 64-char hex) and derive the
+ * matching npub. Returns null if the input is not a syntactically valid
+ * secret (does NOT throw — this is intended for live form validation where
+ * the user is mid-typing).
  *
  * The input is trimmed first; surrounding whitespace from copy-paste or a
  * dropped `.key` file is tolerated.
  */
 export function nsecToNpub(nsec: string): string | null {
-  const trimmed = nsec.trim();
-  if (!trimmed.startsWith("nsec1")) {
+  const normalized = normalizePrivateKeyToNsec(nsec);
+  if (!normalized) {
     return null;
   }
   try {
-    const decoded = decode(trimmed);
+    const decoded = decode(normalized);
     if (decoded.type !== "nsec") {
       return null;
     }

--- a/desktop/src/shared/lib/nostrUtils.ts
+++ b/desktop/src/shared/lib/nostrUtils.ts
@@ -24,9 +24,8 @@ export function safeNpub(pubkey: string): string | null {
   }
 }
 
-const HEX_PUBKEY_REGEX = /^[0-9a-f]{64}$/;
-/** 32-byte secret as 64 hex chars — what `buzz-admin generate-key` prints. */
-const HEX_SECRET_REGEX = /^[0-9a-fA-F]{64}$/;
+/** 32-byte key material as 64 hex chars (pubkey or secret; case-insensitive). */
+export const HEX_64_REGEX = /^[0-9a-fA-F]{64}$/;
 
 /**
  * Parse user-entered public key input — either a 64-character hex pubkey or
@@ -38,7 +37,7 @@ const HEX_SECRET_REGEX = /^[0-9a-fA-F]{64}$/;
  */
 export function parsePubkeyInput(input: string): string | null {
   const trimmed = input.trim().toLowerCase();
-  if (HEX_PUBKEY_REGEX.test(trimmed)) {
+  if (HEX_64_REGEX.test(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("npub1")) {
@@ -74,7 +73,7 @@ export function normalizePrivateKeyToNsec(input: string): string | null {
       return null;
     }
   }
-  if (HEX_SECRET_REGEX.test(trimmed)) {
+  if (HEX_64_REGEX.test(trimmed)) {
     try {
       return nsecEncode(hexToBytes(trimmed.toLowerCase()));
     } catch {


### PR DESCRIPTION
## Summary
- `buzz-admin generate-key` now prints both hex and `nsec1` forms (plus npub)
- desktop onboarding / membership-denied import accept 64-char hex secrets the same way `Keys::parse` / `BUZZ_PRIVATE_KEY` already do
- covers #2815 and the hex-paste ask on #3880

## Test plan
- [ ] `buzz-admin generate-key` shows hex + nsec
- [ ] paste the hex into Use an existing key → Next enables and npub preview matches
- [ ] paste nsec / ncryptsec paths still work
- [ ] `cd desktop && npm test -- src/shared/lib/nostrUtils.test.mjs src/features/onboarding/lib/keyImportInput.test.mjs`
