### PR TITLE
docs(e2e): use pnpm build:e2e in perf specs and screenshot skill (#3207)

### DIFF
--- a/desktop/src-tauri/src/managed_agents/screenshot_skill.md
+++ b/desktop/src-tauri/src/managed_agents/screenshot_skill.md
@@ -96,7 +96,7 @@ Right-click shows "Star channel".
 ## Gotchas
 
 1. **Stale server** — `reuseExistingServer: true` means a prior build serves old
-   code. Kill port 4173 and rebuild (`cd desktop && pnpm run build`) after code changes.
+   code. Kill port 4173 and rebuild (`cd desktop && pnpm build:e2e`) after code changes.
 2. **Clip for readability** — full 1280x720 screenshots are hard to read for sidebar
    features. Sidebar = 256px wide; context menus ~450px.
 3. **`post-screenshots.sh` requires `gh` auth** — the script uses `gh api` and

--- a/desktop/tests/e2e/cold-switch-longtask.perf.ts
+++ b/desktop/tests/e2e/cold-switch-longtask.perf.ts
@@ -35,7 +35,7 @@ import { installMockBridge } from "../helpers/bridge";
  * that is a separate real-wheel pass.
  *
  * Run it:
- *   pnpm build && npx playwright test --config=playwright.perf.config.ts \
+ *   pnpm build:e2e && npx playwright test --config=playwright.perf.config.ts \
  *     cold-switch-longtask.perf.ts
  */
 

--- a/desktop/tests/e2e/scroll-smoothness.perf.ts
+++ b/desktop/tests/e2e/scroll-smoothness.perf.ts
@@ -26,7 +26,7 @@ import { installMockBridge } from "../helpers/bridge";
  * only reproduces in the real desktop shell and is Tyler's real-wheel pass.
  *
  * Run headed to watch it:
- *   pnpm build && npx playwright test --config=playwright.perf.config.ts --headed
+ *   pnpm build:e2e && npx playwright test --config=playwright.perf.config.ts --headed
  */
 
 const SEED_ROWS = 600; // a genuinely busy channel, fully mounted

--- a/desktop/tests/e2e/typing-latency.perf.ts
+++ b/desktop/tests/e2e/typing-latency.perf.ts
@@ -25,7 +25,7 @@ import { installMockBridge } from "../helpers/bridge";
  *
  * Absolute ms are machine-specific; the quiet-vs-busy DELTA on one machine
  * is the signal. Run it (from desktop/):
- *   pnpm build
+ *   pnpm build:e2e
  *   npx playwright test --config=playwright.perf.config.ts typing-latency.perf.ts
  */
 

--- a/desktop/tests/e2e/warm-switch-markdown.perf.ts
+++ b/desktop/tests/e2e/warm-switch-markdown.perf.ts
@@ -37,7 +37,7 @@ import { installMockBridge } from "../helpers/bridge";
  * the same machine are.
  *
  * Run it (from desktop/):
- *   pnpm build
+ *   pnpm build:e2e
  *   npx playwright test --config=playwright.perf.config.ts warm-switch-markdown.perf.ts
  *
  * NOTE: the perf web server reuses an existing server on :4173 — if one is


### PR DESCRIPTION
## Summary
- Perf E2E header comments now say `pnpm build:e2e` instead of `pnpm build`
- Screenshot skill gotcha matches AGENTS.md (symlink copies pick it up)
- Fixes #3207: plain production builds strip the mock bridge and break smoke/perf specs

## Test plan
- [ ] Grep the touched perf headers for `pnpm build:e2e`
- [ ] `cd desktop && pnpm build:e2e && pnpm exec playwright test --project=smoke` still boots the mock bridge
