### PR TITLE
fix(cli): stamp repo announcement updates with max(head+1, now)

### DIFF
--- a/crates/buzz-cli/src/commands/repos.rs
+++ b/crates/buzz-cli/src/commands/repos.rs
@@ -142,13 +142,18 @@ fn build_updated_repo_announcement(
         ))
     })?;
 
-    // Advance only the observed head. Using wall-clock time here would let a
-    // delayed writer leapfrog an intervening update and silently erase metadata.
-    let next_created_at = existing
+    // Advance past the observed head, but never stamp into the past: relays
+    // bound timestamp drift (±15 min in buzz-relay's ingest), so `head + 1`
+    // alone is rejected once the announcement is older than that window,
+    // making protection rules permanently unchangeable (#2876, #4431, #4432).
+    // `max(head + 1, now)` stays monotonic over the head this update was
+    // derived from while producing a timestamp the relay will accept.
+    let bumped_head = existing
         .created_at
         .as_secs()
         .checked_add(1)
         .ok_or_else(|| CliError::Other("repository timestamp cannot be advanced".into()))?;
+    let next_created_at = bumped_head.max(Timestamp::now().as_secs());
     buzz_sdk::build_repo_announcement_with_tags(repo_id, &existing.content, tags)
         .map_err(|error| CliError::Other(format!("failed to build repository update: {error}")))
         .map(|builder| builder.custom_created_at(Timestamp::from(next_created_at)))
@@ -497,6 +502,7 @@ mod tests {
         let replacement = build_protection_tag("refs/heads/main", Some("admin"), true, true, false)
             .expect("valid replacement");
 
+        let before = Timestamp::now().as_secs();
         let updated = build_updated_repo_announcement(
             &existing,
             RepoChange::SetProtection(Box::new(replacement)),
@@ -504,9 +510,13 @@ mod tests {
         .expect("build update")
         .sign_with_keys(&Keys::generate())
         .expect("sign update");
+        let after = Timestamp::now().as_secs();
 
         assert_eq!(updated.content, "repository content");
-        assert_eq!(updated.created_at.as_secs(), 101);
+        // Stale head (created_at 100): the update must be stamped at current
+        // wall-clock time so the relay's drift check accepts it (#2876).
+        assert!(updated.created_at.as_secs() >= before);
+        assert!(updated.created_at.as_secs() <= after);
         assert!(!updated
             .tags
             .iter()
@@ -575,6 +585,32 @@ mod tests {
             .tags
             .iter()
             .any(|tag| { tag.as_slice() == ["buzz-protect", "refs/heads/release", "push:owner"] }));
+    }
+
+    #[test]
+    fn update_of_fresh_head_stays_monotonic_over_it() {
+        // A head slightly in the future (peer clock ahead, still within relay
+        // drift) must yield head + 1, not wall-clock now — going backward
+        // would let this update lose to the head it was derived from.
+        let head = Timestamp::now().as_secs() + 100;
+        let existing = signed_repo(
+            vec![
+                tag(&["d", "demo"]),
+                tag(&["buzz-protect", "refs/heads/main", "no-delete"]),
+            ],
+            "",
+            head,
+        );
+
+        let updated = build_updated_repo_announcement(
+            &existing,
+            RepoChange::RemoveProtection("refs/heads/main".into()),
+        )
+        .expect("build removal")
+        .sign_with_keys(&Keys::generate())
+        .expect("sign removal");
+
+        assert_eq!(updated.created_at.as_secs(), head + 1);
     }
 
     #[test]
@@ -700,7 +736,8 @@ mod tests {
                 .expect("sign bind update");
 
         assert_eq!(updated.content, "repository content");
-        assert_eq!(updated.created_at.as_secs(), 101);
+        // Stale head: stamped at wall-clock time, not head + 1 (#2876).
+        assert!(updated.created_at.as_secs() >= existing.created_at.as_secs());
         // Exactly one binding remains, and it is the requested one.
         let bindings: Vec<_> = updated
             .tags


### PR DESCRIPTION
## Summary

`build_updated_repo_announcement` stamps replacement announcements at the observed head's `created_at + 1` (an anti-leapfrog guard), while the relay's ingest gate rejects any event more than ±15 minutes from server time (`buzz-relay/src/handlers/ingest.rs`). Once an announcement is older than that window, every update built from it — `repos protect set`, `repos protect remove`, and `repos bind` — is rejected with `event timestamp too far from server time`, so branch protection becomes permanently unchangeable 15 minutes after a repo is announced.

This stamps updates with `max(head + 1, now)` instead: still strictly after the head the update was derived from (a peer-clock-ahead head within the drift window keeps winning by +1), but never in the past, so the relay accepts it.

Reproduced live today on a 0.4.x relay: a byte-fresh `protect set` against a day-old announcement was refused; re-announcing via `repos create` (which stamps wall clock) and re-running `protect set` within the window succeeded — consistent with the diagnosis in #2876.

### Related issue
Fixes #2876
Fixes #4431
Fixes #4432

No existing fix PR found (searched open PRs for "timestamp announcement" / "created_at repos").

### Testing
- Adjusted the two unit tests that pinned the old `head + 1` behavior on stale heads (`created_at` 100) to assert wall-clock stamping.
- Added `update_of_fresh_head_stays_monotonic_over_it`: a head 100 s in the future still yields `head + 1`, preserving the monotonicity guarantee the original comment protects.
- Local `cargo test -p buzz-cli` was not runnable on the authoring machine (Windows, no Rust toolchain; hermit shims are POSIX-only) — relying on CI for the run. The change is confined to one timestamp expression plus tests; flagging this explicitly rather than claiming a local pass.
