### PR TITLE
fix(workflows): separate attribution from mentions

### DIFF
--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -561,7 +561,11 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 26);
+        assert_eq!(migrations.len(), 27);
+        assert_eq!(
+            migrations.last().map(|migration| migration.version),
+            Some(27)
+        );
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -252,14 +252,15 @@ impl ActionSink for RelayActionSink {
 
             // 3. Build kind:9 Nostr event
             //    - Signed by relay keypair (event.pubkey = relay pubkey)
-            //    - `p` tag attributes the message to the workflow owner
+            //    - `actor` attributes the message to the workflow owner without
+            //      turning every workflow post into an Inbox mention
             //    - `h` tag scopes to the channel (NIP-29, canonical UUID)
             //    - `buzz:workflow` tag prevents recursive workflow triggering
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
             let mut tags = vec![
-                Tag::parse(["p", &author_pubkey_hex])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
+                Tag::parse(["actor", &author_pubkey_hex])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("actor tag: {e}")))?,
                 Tag::parse(["h", &channel_id_canonical])
                     .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
                 Tag::parse(["buzz:workflow", "true"])
@@ -267,9 +268,10 @@ impl ActionSink for RelayActionSink {
             ];
 
             // Resolve `@Name` mentions to channel-member pubkeys and append a
-            // `p` tag for each (skipping the author, already tagged above). A
-            // resolution failure must not drop the message, so log and proceed
-            // with the base tags.
+            // `p` tag for each. The workflow owner is included only when the
+            // text explicitly mentions them; `actor` attribution alone must
+            // never route a channel post into their Inbox. A resolution failure
+            // must not drop the message, so log and proceed with the base tags.
             let members = state
                 .db
                 .get_members(tenant.community(), channel_uuid)
@@ -289,9 +291,6 @@ impl ActionSink for RelayActionSink {
                 })
                 .collect();
             for mentioned in resolve_mention_pubkeys(&text, &named_members) {
-                if mentioned == author_pubkey_hex {
-                    continue;
-                }
                 tags.push(
                     Tag::parse(["p", &mentioned])
                         .map_err(|e| ActionSinkError::EventBuild(format!("mention p tag: {e}")))?,
@@ -611,7 +610,7 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore = "requires Postgres"]
-    async fn workflow_send_message_p_tags_mentioned_member() {
+    async fn workflow_send_message_only_p_tags_explicitly_mentioned_member() {
         let state = test_state().await;
 
         let author = nostr::Keys::generate();
@@ -700,12 +699,25 @@ mod integration_tests {
             .collect();
 
         assert!(
-            p_tag_targets.contains(&author_hex.as_str()),
-            "author should still be attributed via p tag; got {p_tag_targets:?}"
+            !p_tag_targets.contains(&author_hex.as_str()),
+            "workflow owner must not be implicitly mentioned; got {p_tag_targets:?}"
         );
         assert!(
             p_tag_targets.contains(&agent_hex.as_str()),
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
+        );
+
+        let actor_tag_targets: Vec<&str> = stored
+            .event
+            .tags
+            .iter()
+            .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("actor"))
+            .filter_map(|t| t.as_slice().get(1).map(|s| s.as_str()))
+            .collect();
+        assert_eq!(
+            actor_tag_targets,
+            vec![author_hex.as_str()],
+            "workflow owner should be attributed exactly once via actor tag"
         );
     }
 }

--- a/crates/buzz-workflow/src/action_sink.rs
+++ b/crates/buzz-workflow/src/action_sink.rs
@@ -56,7 +56,8 @@ pub trait ActionSink: Send + Sync {
     /// - `channel_id`: UUID string of the target channel
     /// - `text`: message body (must not be empty/whitespace-only)
     /// - `author_pubkey`: hex-encoded pubkey of the workflow owner (used for
-    ///   the `p` attribution tag; the relay keypair signs the event)
+    ///   the relay-signed `actor` attribution tag; the relay keypair signs the
+    ///   event). It is not an implicit mention recipient.
     ///
     /// Returns the event ID hex string on success.
     fn send_message(

--- a/migrations/0027_workflow_owner_mentions.sql
+++ b/migrations/0027_workflow_owner_mentions.sql
@@ -1,0 +1,37 @@
+-- Older relay-generated workflow messages used their first `p` tag to record
+-- the workflow owner. Because `p` is the Nostr mention tag, that derived index
+-- entry routed every channel automation into the owner's Inbox. The signed
+-- event remains immutable; remove only the incorrect derived mention row.
+--
+-- Relay workflow messages now use an `actor` tag for owner attribution. The
+-- missing-actor guard limits this cleanup to the legacy representation, so
+-- explicit mentions produced by the corrected relay remain indexed.
+DELETE FROM event_mentions mention
+USING events event
+WHERE mention.community_id = event.community_id
+  AND mention.event_id = event.id
+  AND event.kind = 9
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(event.tags) tag
+      WHERE jsonb_typeof(tag) = 'array'
+        AND jsonb_array_length(tag) >= 2
+        AND tag->>0 = 'buzz:workflow'
+        AND tag->>1 = 'true'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(event.tags) tag
+      WHERE jsonb_typeof(tag) = 'array'
+        AND jsonb_array_length(tag) >= 2
+        AND tag->>0 = 'actor'
+  )
+  AND mention.pubkey_hex = (
+      SELECT lower(tag->>1)
+      FROM jsonb_array_elements(event.tags) WITH ORDINALITY AS item(tag, position)
+      WHERE jsonb_typeof(tag) = 'array'
+        AND jsonb_array_length(tag) >= 2
+        AND tag->>0 = 'p'
+      ORDER BY position
+      LIMIT 1
+  );


### PR DESCRIPTION
Closes #4507.

## What changed
- keep workflow ownership as attribution instead of treating it as an implicit mention
- resolve @name tokens against channel members and emit p tags only for explicit mentions
- migrate existing workflow messages by removing owner-only derived mention rows while preserving real mentions
- add mention parsing coverage, including ambiguity, Unicode, punctuation, prefix, and deduplication cases

## Why
Routine workflow channel posts were appearing in the workflow owner's Inbox even when the message did not mention them. Ownership and notification intent are separate concepts.

## Verification
- cargo test -p buzz-workflow: 153 passed, 2 Postgres tests ignored
- cargo test -p buzz-relay workflow_sink: 17 passed, 1 Postgres integration test ignored
- commit is DCO signed