### PR TITLE
fix(acp): allow community DMs in anyone mode

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -488,6 +488,17 @@ pub struct ChannelFilter {
     pub require_mention: bool,
 }
 
+impl ChannelFilter {
+    /// Treat every event in a conversational channel as implicitly addressed
+    /// to the agent by removing the relay-level `#p` filter.
+    pub fn with_implicit_mention(mut self, implicit_mention: bool) -> Self {
+        if implicit_mention {
+            self.require_mention = false;
+        }
+        self
+    }
+}
+
 #[derive(Debug)]
 pub struct Config {
     pub keys: Keys,
@@ -1532,6 +1543,19 @@ mod tests {
 
         let f = result.get(&channels[0]).unwrap();
         assert!(!f.require_mention);
+    }
+
+    #[test]
+    fn test_dm_channel_filter_receives_unmentioned_messages() {
+        let filter = ChannelFilter {
+            kinds: Some(vec![9]),
+            require_mention: true,
+        };
+
+        let adapted = filter.with_implicit_mention(true);
+
+        assert!(!adapted.require_mention);
+        assert_eq!(adapted.kinds.as_deref(), Some([9].as_slice()));
     }
 
     #[test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -350,8 +350,9 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 /// 1. **channels** — if not `"all"`, the event's channel UUID must be in the list.
 /// 2. **kinds** — if non-empty, the event kind must be in the list.
 /// 3. **require_mention** — if `true`, a `p` tag matching `agent_pubkey_hex` must
-///    exist. Tag kind is checked via `tag.as_slice()` for stable, library-independent
-///    access.
+///    exist unless the caller marks the channel as satisfying the mention
+///    requirement implicitly. Tag kind is checked via `tag.as_slice()` for
+///    stable, library-independent access.
 /// 4. **filter** — if `Some`, the evalexpr expression must evaluate to `true`.
 ///
 /// # Fail-closed filter error handling
@@ -371,6 +372,18 @@ pub async fn match_event(
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
 ) -> Option<MatchedRule> {
+    match_event_with_implicit_mention(event, channel_id, rules, agent_pubkey_hex, false).await
+}
+
+/// Match an event while optionally treating the channel itself as an implicit
+/// mention, as conversational DM channels do in mentions subscription mode.
+pub async fn match_event_with_implicit_mention(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+    implicit_mention: bool,
+) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
     for (index, rule) in rules.iter().enumerate() {
@@ -387,7 +400,7 @@ pub async fn match_event(
         // 3. Mention check — look for a `p` tag whose first element equals
         //    agent_pubkey_hex. Uses tag.as_slice() for stable, library-independent
         //    access — avoids relying on the Display impl of tag kind.
-        if rule.require_mention {
+        if rule.require_mention && !implicit_mention {
             let mentioned = event.tags.iter().any(|tag| {
                 let s = tag.as_slice();
                 s.first().map(|k| k.as_str()) == Some("p")
@@ -661,6 +674,28 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
+    }
+
+    #[tokio::test]
+    async fn test_dm_message_satisfies_mention_rule_without_p_tag() {
+        let agent_pubkey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let event = make_event(9, "plain DM follow-up");
+        let channel_id = any_channel();
+        let rules = vec![make_rule(
+            "mention-only",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            Some("dm"),
+        )];
+
+        let matched =
+            match_event_with_implicit_mention(&event, channel_id, &rules, agent_pubkey, true)
+                .await
+                .expect("a direct-message channel should satisfy the mention requirement");
+
+        assert_eq!(matched.prompt_tag, "dm");
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -226,12 +226,15 @@ async fn is_owner_or_sibling(
 /// Clients auto-p-tag every DM participant, so in a DM *any* participant's
 /// message looks like a mention and would fire a turn. Combined with
 /// agent-initiated DMs (the agent can be asked to DM a third party), that
-/// turns `anyone`/`allowlist` modes into transitive access grants: whoever
-/// lands in a DM with the agent can prompt it. To close that hole, when
-/// `is_dm` is true only the owner and cryptographically verified same-owner
-/// siblings may fire a turn — the explicit allowlist and `anyone` mode do
-/// NOT apply inside DMs. `Nobody` still drops everything. Callers must
-/// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
+/// turns `allowlist` mode into a transitive access grant: whoever lands in a
+/// DM with the agent could otherwise prompt it. To close that hole, an
+/// explicit allowlist does not apply inside DMs; only the owner and
+/// cryptographically verified same-owner siblings may fire a turn.
+/// `Anyone` remains deliberately open to every author whose event the relay
+/// delivers, including in DMs, while `Nobody` still drops everything. On a
+/// membership-enforcing relay, relay and channel admission provide the
+/// community boundary before this gate runs. Callers must resolve `is_dm`
+/// fail-closed: unknown channel type ⇒ treat as DM.
 async fn author_allowed(
     respond_to: &RespondTo,
     allowlist: &HashSet<String>,
@@ -242,6 +245,7 @@ async fn author_allowed(
 ) -> bool {
     if is_dm {
         return match respond_to {
+            RespondTo::Anyone => true,
             RespondTo::Nobody => false,
             _ => is_owner_or_sibling(author, owner_cache, rest_client).await,
         };
@@ -4545,9 +4549,9 @@ mod author_gate_tests {
     // ── DM hardening ──────────────────────────────────────────────────────
     //
     // In a DM, clients auto-p-tag every participant, and an agent can be
-    // asked to open a DM with a third party. The gate must therefore ignore
-    // the allowlist and `anyone` mode inside DMs: only owner + verified
-    // siblings fire turns.
+    // asked to open a DM with a third party. An explicit allowlist must
+    // therefore stay owner/sibling-only inside DMs. `Anyone` is the deliberate
+    // opt-in that admits every author whose event the relay delivers.
 
     #[tokio::test]
     async fn test_dm_rejects_allowlisted_external_pubkey() {
@@ -4568,10 +4572,10 @@ mod author_gate_tests {
     }
 
     #[tokio::test]
-    async fn test_dm_rejects_stranger_under_anyone() {
+    async fn test_dm_admits_relay_delivered_author_under_anyone() {
         let cache = cache_with_sibling();
         assert!(
-            !author_allowed(
+            author_allowed(
                 &RespondTo::Anyone,
                 &HashSet::new(),
                 STRANGER,
@@ -4580,7 +4584,24 @@ mod author_gate_tests {
                 &dummy_rest_client()
             )
             .await,
-            "respond_to=anyone must still drop non-owner authors inside a DM"
+            "respond_to=anyone must admit a relay-delivered author inside a DM"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dm_rejects_untrusted_author_under_owner_only() {
+        let cache = cache_with_sibling();
+        assert!(
+            !author_allowed(
+                &RespondTo::OwnerOnly,
+                &HashSet::new(),
+                STRANGER,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "respond_to=owner-only must still reject an untrusted DM author"
         );
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1475,7 +1475,17 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters: HashMap<Uuid, config::ChannelFilter> =
+        config::resolve_channel_filters(&config, &channel_ids, &rules)
+            .into_iter()
+            .map(|(channel_id, filter)| {
+                let implicit_mention = config.subscribe_mode == SubscribeMode::Mentions
+                    && channel_info_map
+                        .get(&channel_id)
+                        .is_some_and(|info| info.channel_type == "dm");
+                (channel_id, filter.with_implicit_mention(implicit_mention))
+            })
+            .collect();
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -1971,6 +1981,9 @@ async fn tokio_main() -> Result<()> {
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
                                     } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
+                                        let implicit_mention = config.subscribe_mode == SubscribeMode::Mentions
+                                            && is_dm_channel(ch, &ctx.channel_info).await;
+                                        let filter = filter.with_implicit_mention(implicit_mention);
                                         tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
                                         if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
                                             tracing::warn!("failed to subscribe to new channel {ch}: {e}");
@@ -2146,13 +2159,13 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // Resolve channel type fail-closed for the author gate.
                                 // Allowlist remains owner/sibling-only in DMs, while
                                 // Anyone deliberately admits relay-delivered authors.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2174,7 +2187,16 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            let implicit_mention =
+                                config.subscribe_mode == SubscribeMode::Mentions && is_dm;
+                            let matched = filter::match_event_with_implicit_mention(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                                &rules,
+                                &pubkey_hex,
+                                implicit_mention,
+                            )
+                            .await;
                             let prompt_tag = match matched {
                                 Some(m) => m.prompt_tag,
                                 None => {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2148,9 +2148,9 @@ async fn tokio_main() -> Result<()> {
                             // it never revokes same-owner team bots.
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
-                                // DM hardening: resolve channel type (fail-closed
-                                // to DM) so allowlist/anyone modes cannot be
-                                // exercised by non-owner authors inside DMs.
+                                // Resolve channel type fail-closed for the author gate.
+                                // Allowlist remains owner/sibling-only in DMs, while
+                                // Anyone deliberately admits relay-delivered authors.
                                 let is_dm =
                                     is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(


### PR DESCRIPTION
## Summary

- allow `respond-to=anyone` to admit relay-delivered DM authors
- cover Robert, ROOB, existing members, and members admitted to the community later without per-person configuration
- keep behavior client-agnostic: Desktop and Mobile produce the same signed Buzz event, so the author gate does not special-case platforms
- preserve owner/sibling-only DM behavior for explicit allowlists
- preserve `owner-only` and `nobody` boundaries
- update regression coverage and documentation for the relay-enforced community boundary

## Resulting access model

With the agent configured as `respond-to=anyone`, any author whose event the membership-enforcing community relay delivers can start the agent in a shared channel or DM. This applies automatically to newly admitted community members and does not depend on Desktop versus Mobile. Removing a member at the relay boundary removes their event-delivery path.

## Validation

- 631 unit tests passed
- 9 integration tests passed
- `cargo fmt --check` passed
- clippy passed with `-D warnings`
- release build passed

## Security boundary

This behavior relies on the relay enforcing community and channel admission before `buzz-acp` evaluates the author gate. `respond-to=anyone` is the explicit opt-in; allowlist mode remains hardened in DMs.

Originating Buzz channel: `b15b3fac-7d60-4ad5-879d-b8b4360b1fce`.