### PR TITLE
fix(desktop): surface eligible relay agents in @mention

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      // JDD fork: also keep eligible relay agents (owned by another desktop,
+      // e.g. the operator) so they surface in @mention, not just agents in
+      // this desktop's own managed list.
+      if (
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys) &&
+        !mentionableAgentPubkeys.has(pubkey)
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

Desktop @mention autocomplete drops shared relay agents — agents owned by
another identity, e.g. a relay-hosted agent run by a separate operator and
shared with a team. `useMentions` filters candidates through
`isAgentIdentityInManagedList`, which only keeps agents present in the
viewer's **own local** `managed-agents` store. So an eligible relay agent is
never offered in `@`-autocomplete, even though the `+` New-DM picker lists it
and DMs to it work.

The mobile client's `buildMentionCandidates`
(`mobile/lib/features/channels/mentions/mention_candidates.dart`) has **no**
such gate — it has no local agent store — and already surfaces any relay
agent that is `anyone` and shares a channel with the viewer. This change
brings desktop in line: keep an agent candidate when it is **either** locally
managed **or** already eligible via `mentionableAgentPubkeys` (i.e. it passed
`relayAgentIsSharedWithUser`). Eligibility semantics are unchanged — the fix
only stops the managed-list filter from dropping already-eligible relay
agents.

### Related issue

Fixes #4128. Related: #3971, #3125, #3776.

### Testing

Verified against a self-hosted relay: a shared, relay-hosted agent
(`respond_to=anyone`, joined to a channel the viewer is a member of, with a
kind:10100 directory entry) now appears in desktop `@`-mention autocomplete,
matching the mobile client. Previously it was reachable only via the `+`
New-DM picker.

- No change for locally-managed agents or non-agent identities (they still
  pass `isAgentIdentityInManagedList`).
- Reuses the existing `mentionableAgentPubkeys` set, so no new eligibility
  path is introduced.

Happy to add a focused test if you'd like — the current
`useMentions.test.mjs` only covers the `hasMention` string helpers, so the
candidate-assembly path isn't unit-tested today; let me know your preference
for structuring one.
