### PR TITLE
test(desktop): close channel validation latch race

### DIFF
--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -507,26 +507,19 @@ test.describe("community rail", () => {
       );
     });
     await page.evaluate(() => {
-      const deferNextChannelsRead = (
-        window as Window & {
-          __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
-        }
-      ).__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__;
-      if (!deferNextChannelsRead) {
+      const testWindow = window as Window & {
+        __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
+        __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
+      };
+      const deferNextChannelsRead =
+        testWindow.__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__;
+      const invalidateChannels = testWindow.__BUZZ_E2E_INVALIDATE_CHANNELS__;
+      if (!deferNextChannelsRead || !invalidateChannels) {
         throw new Error("missing channel-read defer seam");
       }
+      // Arm and trigger in one browser task. A separate evaluate leaves a gap
+      // where an unrelated get_channels call can consume the one-shot latch.
       deferNextChannelsRead();
-    });
-
-    await page.evaluate(() => {
-      const invalidateChannels = (
-        window as Window & {
-          __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
-        }
-      ).__BUZZ_E2E_INVALIDATE_CHANNELS__;
-      if (!invalidateChannels) {
-        throw new Error("missing channel invalidation seam");
-      }
       void invalidateChannels();
     });
     await page.waitForFunction(


### PR DESCRIPTION
## Summary
- make the e2e-only channel-read seam claim one concrete `get_channels` invocation before its work starts
- hold only that invocation with a single resolver; later unrelated reads pass through undeferred
- reject re-arming while the identified validation read is held
- remove the test's unnecessary mid-hold re-arm, preserving strict hold/release and repair-order assertions

The identity hook remains inside the existing `maybeInstallE2eTauriMocks()` boundary and does not affect production bridge behavior.

## Failure reproductions
At the base implementation, both adversarial orderings were induced before fixing:
1. **steal before target:** an unrelated `get_channels` between arm and invalidation consumed the one-shot; the test failed waiting for the intended validation hold.
2. **join while held:** after the validation read was held, re-arm plus an unrelated `get_channels` reproduced CI's release-cardinality failure exactly: **received 2, expected 1**.

## Validation at `a21db5455e47409d695783faa29e3a3b3c50338f`
- both adversarial orderings now pass: the target claims the one-shot, and post-target traffic completes without joining its hold
- focused regression: **20/20**
- full `community-rail.spec.ts --project=smoke`: **19/19**
- desktop unit suite: **3,992/3,992**
- `pnpm check` / Biome and file-size checks: passed
- pre-push hooks reran successfully: branch-skew, desktop-check, desktop-test (**3,992/3,992**)

## Integration gate
This SHA is not authorized for integration until:
- Wren completes exact-SHA identity-model review, independent full-spec execution, and both adversarial injections; and
- this PR's own **Desktop Smoke E2E (1)** is green at this exact SHA.
