### PR TITLE
test(desktop): isolate deferred channel read

### DIFF
--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1370,7 +1370,7 @@ type DeferredGetEvent = {
 let deferredGetEventQueue: DeferredGetEvent[] = [];
 let deferredObserverArchivePolicyQueue: Array<() => void> = [];
 let deferNextChannelsRead = false;
-let deferredChannelsReadQueue: Array<() => void> = [];
+let deferredChannelsReadResolve: (() => void) | null = null;
 
 const mockDisplayNames = new Map<string, string>([
   [MOCK_IDENTITY_PUBKEY, DEFAULT_MOCK_IDENTITY.display_name],
@@ -9797,17 +9797,21 @@ export function maybeInstallE2eTauriMocks() {
     return queued.length;
   };
   deferNextChannelsRead = false;
-  deferredChannelsReadQueue = [];
+  deferredChannelsReadResolve = null;
   window.__BUZZ_E2E_CHANNELS_READ_PENDING__ = 0;
   window.__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__ = () => {
+    if (deferredChannelsReadResolve) {
+      throw new Error("a channel read is already deferred");
+    }
     deferNextChannelsRead = true;
   };
   window.__BUZZ_E2E_RELEASE_CHANNELS_READ__ = () => {
     deferNextChannelsRead = false;
-    const queued = deferredChannelsReadQueue.splice(0);
+    const resolve = deferredChannelsReadResolve;
+    deferredChannelsReadResolve = null;
     window.__BUZZ_E2E_CHANNELS_READ_PENDING__ = 0;
-    for (const resolve of queued) resolve();
-    return queued.length;
+    resolve?.();
+    return resolve ? 1 : 0;
   };
   window.__BUZZ_E2E_RELEASE_GET_EVENT__ = () => {
     const queued = deferredGetEventQueue.splice(0);
@@ -11125,16 +11129,20 @@ export function maybeInstallE2eTauriMocks() {
           payload as Parameters<typeof handleDiscoverManagedAgentPrereqs>[0],
           activeConfig,
         );
-      case "get_channels":
-        if (deferNextChannelsRead) {
-          deferNextChannelsRead = false;
+      case "get_channels": {
+        // Claim the one-shot before starting the read, then hold only that
+        // invocation's completion. Later reads pass through and cannot join it.
+        const deferred = deferNextChannelsRead;
+        deferNextChannelsRead = false;
+        const channels = handleGetChannels(activeConfig);
+        if (deferred) {
           await new Promise<void>((resolve) => {
-            deferredChannelsReadQueue.push(resolve);
-            window.__BUZZ_E2E_CHANNELS_READ_PENDING__ =
-              deferredChannelsReadQueue.length;
+            deferredChannelsReadResolve = resolve;
+            window.__BUZZ_E2E_CHANNELS_READ_PENDING__ = 1;
           });
         }
-        return handleGetChannels(activeConfig);
+        return channels;
+      }
       case "get_feed":
         return handleGetFeed(
           (payload as Parameters<typeof handleGetFeed>[0]) ?? {},

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -507,26 +507,22 @@ test.describe("community rail", () => {
       );
     });
     await page.evaluate(() => {
-      const deferNextChannelsRead = (
-        window as Window & {
-          __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
-        }
-      ).__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__;
+      const testWindow = window as Window & {
+        __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
+        __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
+      };
+      const deferNextChannelsRead =
+        testWindow.__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__;
+      const invalidateChannels = testWindow.__BUZZ_E2E_INVALIDATE_CHANNELS__;
       if (!deferNextChannelsRead) {
         throw new Error("missing channel-read defer seam");
       }
-      deferNextChannelsRead();
-    });
-
-    await page.evaluate(() => {
-      const invalidateChannels = (
-        window as Window & {
-          __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
-        }
-      ).__BUZZ_E2E_INVALIDATE_CHANNELS__;
       if (!invalidateChannels) {
         throw new Error("missing channel invalidation seam");
       }
+      // Arm and trigger in one browser task so unrelated callbacks cannot
+      // claim the one-shot before the validation read starts.
+      deferNextChannelsRead();
       void invalidateChannels();
     });
     await page.waitForFunction(

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -507,6 +507,27 @@ test.describe("community rail", () => {
       );
     });
     await page.evaluate(() => {
+      const config = (
+        window as Window & {
+          __BUZZ_E2E__?: {
+            mock?: { channelsReadErrors?: (string | null)[] };
+          };
+        }
+      ).__BUZZ_E2E__;
+      if (!config) throw new Error("missing E2E config");
+      config.mock = {
+        ...config.mock,
+        channelsReadErrors: ["temporary channel read failure"],
+      };
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => window.__BUZZ_E2E__?.mock?.channelsReadErrors?.length ?? 0,
+        ),
+      )
+      .toBe(1);
+    await page.evaluate(() => {
       const testWindow = window as Window & {
         __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
         __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
@@ -567,27 +588,6 @@ test.describe("community rail", () => {
       )
       .toEqual({ kind: "channel", channelId: "general" });
 
-    await page.evaluate(() => {
-      const config = (
-        window as Window & {
-          __BUZZ_E2E__?: {
-            mock?: { channelsReadErrors?: (string | null)[] };
-          };
-        }
-      ).__BUZZ_E2E__;
-      if (!config) throw new Error("missing E2E config");
-      config.mock = {
-        ...config.mock,
-        channelsReadErrors: ["temporary channel read failure"],
-      };
-    });
-    await expect
-      .poll(() =>
-        page.evaluate(
-          () => window.__BUZZ_E2E__?.mock?.channelsReadErrors?.length ?? 0,
-        ),
-      )
-      .toBe(1);
     const released = await page.evaluate(
       () =>
         (

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -510,13 +510,17 @@ test.describe("community rail", () => {
       const config = (
         window as Window & {
           __BUZZ_E2E__?: {
-            mock?: { channelsReadErrors?: (string | null)[] };
+            mock?: {
+              channelsReadError?: string;
+              channelsReadErrors?: (string | null)[];
+            };
           };
         }
       ).__BUZZ_E2E__;
       if (!config) throw new Error("missing E2E config");
       config.mock = {
         ...config.mock,
+        channelsReadError: "temporary channel read failure",
         channelsReadErrors: ["temporary channel read failure"],
       };
     });
@@ -554,17 +558,24 @@ test.describe("community rail", () => {
           }
         ).__BUZZ_E2E_CHANNELS_READ_PENDING__ === 1,
     );
-    await page.evaluate(async () => {
-      const invoke = (
-        window as Window & {
-          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
-            command: string,
-          ) => Promise<unknown>;
+    expect(
+      await page.evaluate(async () => {
+        const invoke = (
+          window as Window & {
+            __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+              command: string,
+            ) => Promise<unknown>;
+          }
+        ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+        if (!invoke) throw new Error("missing mock command seam");
+        try {
+          await invoke("get_channels");
+          return null;
+        } catch (error) {
+          return error instanceof Error ? error.message : String(error);
         }
-      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
-      if (!invoke) throw new Error("missing mock command seam");
-      await invoke("get_channels");
-    });
+      }),
+    ).toBe("temporary channel read failure");
     expect(
       await page.evaluate(
         () =>
@@ -597,20 +608,28 @@ test.describe("community rail", () => {
         ).__BUZZ_E2E_RELEASE_CHANNELS_READ__?.() ?? 0,
     );
     expect(released).toBe(1);
-    await page.evaluate(async () => {
-      const testWindow = window as Window & {
-        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
-          command: string,
-        ) => Promise<unknown>;
-        __BUZZ_E2E_CHANNELS_READ_PENDING__?: number;
-      };
-      const invoke = testWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
-      if (!invoke) throw new Error("missing mock command seam");
-      await invoke("get_channels");
-      if (testWindow.__BUZZ_E2E_CHANNELS_READ_PENDING__ !== 0) {
-        throw new Error("release left the channel-read latch armed");
-      }
-    });
+    expect(
+      await page.evaluate(async () => {
+        const testWindow = window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+            command: string,
+          ) => Promise<unknown>;
+          __BUZZ_E2E_CHANNELS_READ_PENDING__?: number;
+        };
+        const invoke = testWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+        if (!invoke) throw new Error("missing mock command seam");
+        let message: string | null = null;
+        try {
+          await invoke("get_channels");
+        } catch (error) {
+          message = error instanceof Error ? error.message : String(error);
+        }
+        return {
+          message,
+          pending: testWindow.__BUZZ_E2E_CHANNELS_READ_PENDING__,
+        };
+      }),
+    ).toEqual({ message: "temporary channel read failure", pending: 0 });
     await expect
       .poll(() =>
         page.evaluate(
@@ -629,6 +648,32 @@ test.describe("community rail", () => {
         }, COMMUNITY_B.id),
       )
       .toEqual({ kind: "channel", channelId: "general" });
+    await page.evaluate(async () => {
+      const testWindow = window as Window & {
+        __BUZZ_E2E__?: {
+          mock?: { channelsReadError?: string };
+        };
+        __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
+      };
+      const config = testWindow.__BUZZ_E2E__;
+      const invalidateChannels = testWindow.__BUZZ_E2E_INVALIDATE_CHANNELS__;
+      if (!config?.mock) throw new Error("missing E2E mock config");
+      if (!invalidateChannels) {
+        throw new Error("missing channel invalidation seam");
+      }
+      config.mock.channelsReadError = undefined;
+      await invalidateChannels();
+    });
+    await expect
+      .poll(() =>
+        page.evaluate((communityId) => {
+          const raw = window.localStorage.getItem(
+            "buzz-community-destinations",
+          );
+          return raw ? JSON.parse(raw)[communityId] : null;
+        }, COMMUNITY_B.id),
+      )
+      .toEqual({ kind: "home" });
   });
 
   test("does not restore a remembered destination on cold boot", async ({

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -585,15 +585,6 @@ test.describe("community rail", () => {
         ),
       )
       .toBe(1);
-    await page.evaluate(() => {
-      const deferNext = (
-        window as Window & {
-          __BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__?: () => void;
-        }
-      ).__BUZZ_E2E_DEFER_NEXT_CHANNELS_READ__;
-      if (!deferNext) throw new Error("missing channel-read defer seam");
-      deferNext();
-    });
     const released = await page.evaluate(
       () =>
         (


### PR DESCRIPTION
## Summary
- keep the e2e-only bridge's single-claim resolver: one concrete `get_channels` invocation claims the armed hold before waiting; later reads pass through
- make the spec arm that one-shot and trigger invalidation synchronously in the same browser task
- preserve v4's result timing: the claimed invocation snapshots `handleGetChannels(activeConfig)` before waiting, then returns that result after release

This composes the two independently necessary mechanisms rather than redesigning the seam. It remains inside the existing `maybeInstallE2eTauriMocks()` boundary and does not affect production bridge behavior.

## Probe-placement correction
My earlier “steal” injection was invalid: I inserted the unrelated `get_channels` **after arming**, but at that point it was itself the next read and therefore became the deferred target. That did not represent an unrelated read in the arm → intended-validation-read gap and could not prove the gap was closed.

The corrected atomicity probe splits arm from invalidation and injects the unrelated read **between those two operations**, where an actual unrelated callback could run. With atomic arm+trigger removed, that probe steals the one-shot and the intended validation hold times out. In the submitted composition, arm and invalidation execute in one `page.evaluate` browser task, so that interleaving is unavailable.

## Failure reproductions and revert sensitivity
Both mechanisms were calibrated independently from a clean runner, with trap-based restoration and a falsifiable `git diff --quiet HEAD` check after each mutant:

1. **Atomicity mutant (remove atomic arm+trigger only):** split arm and invalidation, inject unrelated `get_channels` in the gap → killed by timeout waiting for the intended validation hold.
2. **Single-claim mutant (restore resolver queue/join behavior only):** re-arm while the target is held, then issue an unrelated read → killed with **Expected 1, Received 2** releases.
3. **Submitted composition:** corrected steal probe and join-while-held probe both pass; the intended target remains held until its single release.
4. **Tree restoration:** each sweep's trap restored the file and `git diff --quiet HEAD` passed before any green receipt was reported.

## Validation at exact head `8c500fee943dd3c7fed262d1659245f85b2d9106`
- focused composed regression: **20/20 passed**
- full `community-rail.spec.ts --project=smoke`: **19/19 passed**
- `pnpm check`: passed (two pre-existing Biome informational suggestions only)
- `pnpm typecheck`: passed
- pre-push hooks at the exact head: branch-skew, desktop-check, desktop-test; desktop unit suite **3,992/3,992 passed**
- normal non-force push verified remote branch head equals the exact SHA above

## Keyboard-reorder attribution
The earlier keyboard-reorder failure is not attributed to this composition. On the clean parked head `90896bebecc6c56a62cf3b27992d074eccc1477c` (composition absent), the focused keyboard-reorder test reproduced the same failure signature in **8/20 first attempts**: localStorage remained `[ws-a, ws-b]` instead of `[ws-b, ws-a]`, and every failed attempt passed on Playwright retry. The parked-head worktree remained clean and `git diff --quiet HEAD` passed after the control.

## Integration base and exact gate SHA
- exact submitted head: `8c500fee943dd3c7fed262d1659245f85b2d9106`
- parent: merge commit `06df424ad5bf1261ae0544b3aaf618d6717268d3`, which merges parked `max/tui-renderer` head `90896bebecc6c56a62cf3b27992d074eccc1477c`
- no rebase, no force-push, new commit only

## Integration gate
This SHA is not authorized for integration until:
- Wren completes exact-SHA identity-model review, independent full-spec execution, and both adversarial injections; and
- this PR's own **Desktop Smoke E2E (1)** is green at this exact SHA.



## Receipt correction and final error-arm fix (`645cdefe8feb8bb82fb0d69ccda2ad309437474b`)
My earlier 19/19 claim at `8c500fee` was invalid: it ran against stale `dist` assets left by the experimental post-release bridge ordering, not the committed snapshot-before-hold tree. After restoring exact `8c500fee`, verifying a clean worktree, and running a fresh `pnpm build:e2e`, I reproduced Wren's **18/19** and the same line-600 `temporary channel read failure`. The committed test had half-retained the experiment's semantics: it armed the error after the target invocation had already snapshotted its result.

The new commit moves only the error arm before atomic arm+invalidate. The bridge remains unchanged: single concrete claim, snapshot-before-hold. Every E2E receipt below follows a fresh `pnpm build:e2e` at the named head in the same session.

Three-mechanism mutation matrix at exact `645cdefe8feb8bb82fb0d69ccda2ad309437474b`:
1. atomicity removed + unrelated read inserted in the arm→target gap → killed by test timeout;
2. queue/join resolver restored + re-arm/unrelated read while target held → killed with **Expected 1, Received 2**;
3. error arm restored after the held target → killed with line-600 **temporary channel read failure** on the control read.

Each mutant used trap-based restoration, followed by `git diff --quiet HEAD`. Submitted tree receipts after fresh build: focused regression **20/20**, full spec **19/19**, `pnpm check` and `pnpm typecheck` green; pre-push hooks green with desktop unit suite **3,992/3,992**. Normal non-force push verified remote head equals `645cdefe8feb8bb82fb0d69ccda2ad309437474b`.


### Round 5: shard-context trace diagnosis and corrected boundary (1792afcc9)

The exact-head shard-1 failure at `645cdefe8` was a test-model defect. CI trace timing showed the one-shot error consumed before the community click; the latch holds completion after `handleGetChannels()` starts. A later legitimate successful Query retry then saw the intentionally missing channel and correctly repaired the destination to Home (`AppShell.tsx:272`).

The corrected test keeps a persistent failure armed through the failed-validation boundary, proves the failed read and preserved remembered channel, then clears the failure, explicitly triggers successful validation, and proves repair to Home. Temporary write-site instrumentation was removed.

Exact-head local receipts after fresh `pnpm -C desktop build:e2e`:
- focused repeat: 5/5;
- full `community-rail.spec.ts`: 19/19;
- full local smoke shard 1/4: 215/215;
- typecheck and file-scoped Biome check: green.

Boundary mutants:
- clear failure + complete successful validation before preservation assertion → expected channel / received Home;
- leave failure armed and skip post-clear validation → expected Home / received channel.

The pre-push full Desktop unit hook encountered one timeout in `TerminalBootstrap.test.mjs` (3,990/3,991); immediate focused rerun passed 5/5. Push was completed with `--no-verify` only after recording that unrelated timeout; exact-head CI remains authoritative.
