### PR TITLE
fix(desktop): retain terminal focus on viewport click

### DIFF
--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -517,7 +517,17 @@ export function TerminalSubstrate({
           <span>{shortcutLabel} BUZZ</span>
         </div>
       </div>
-      <div className="buzz-terminal-viewport">
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: the hidden textarea owns keyboard semantics; this only preserves its focus across canvas clicks. */}
+      <div
+        className="buzz-terminal-viewport"
+        onMouseDown={(event) => {
+          if (owner !== "terminal") return;
+          // Preventing the canvas mousedown also suppresses selection. Revisit
+          // this when the terminal gains mouse selection support.
+          event.preventDefault();
+          textareaRef.current?.focus({ preventScroll: true });
+        }}
+      >
         <canvas ref={canvasRef} />
         {welcomeVisible && banner ? (
           <canvas className="buzz-terminal-welcome" ref={bannerCanvasRef} />

--- a/desktop/tests/e2e/terminal-wheel.spec.ts
+++ b/desktop/tests/e2e/terminal-wheel.spec.ts
@@ -187,3 +187,46 @@ test("scrollback: wheel over Buzz Term reaches terminal_scroll", async ({
   console.log("SCROLLS", JSON.stringify(scrolls));
   expect(scrolls).toEqual([-5, 2]);
 });
+
+test("terminal viewport click retains keyboard input ownership", async ({
+  page,
+}) => {
+  await reveal(page);
+  const input = page.getByLabel("Terminal input");
+  await expect(input).toBeFocused();
+
+  await page
+    .locator(".buzz-terminal-viewport")
+    .click({ position: { x: 40, y: 40 } });
+  await expect(input).toBeFocused();
+
+  await page.keyboard.type("FOCUS_KEYSTROKE");
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        (
+          window as typeof window & { __SAMI_TERM__: { inputs: string[] } }
+        ).__SAMI_TERM__.inputs.join(""),
+      ),
+    )
+    .toContain("FOCUS_KEYSTROKE");
+});
+
+test("concealed terminal viewport does not steal Buzz focus", async ({
+  page,
+}) => {
+  await reveal(page);
+  await page.keyboard.press("Meta+j");
+  await expect(page.locator(TERM)).toHaveAttribute(
+    "data-terminal-owner",
+    "buzz",
+  );
+
+  const input = page.getByLabel("Terminal input");
+  await expect(input).not.toBeFocused();
+  await page.locator(".buzz-terminal-viewport").click({
+    force: true,
+    position: { x: 40, y: 40 },
+  });
+  await expect(input).not.toBeFocused();
+});


### PR DESCRIPTION
## Summary
- preserve terminal ownership when the active terminal viewport is clicked
- prevent the canvas mousedown default before it can blur the offscreen input, then defensively refocus it
- leave tab-bar mouse semantics and concealed/Buzz-owner focus untouched

## Regression proof
At base `d8a4d63a8`, the new browser test failed after the viewport click with `Terminal input` inactive. With this commit, the full `terminal-wheel.spec.ts` passes all 3 arms:
- existing wheel delivery
- active viewport click retains `document.activeElement` and delivers `FOCUS_KEYSTROKE` to `terminal_input`
- concealed/Buzz-owner viewport click does not focus the terminal textarea

## Verification
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` — 3,992/3,992
- `pnpm build:e2e && pnpm exec playwright test tests/e2e/terminal-wheel.spec.ts --project=smoke` — 3/3
- pre-push: branch-skew, desktop-check, desktop-test, mobile-test, desktop-tauri-checks, rust-tests all green
- post-push: remote/local SHA match; `git diff --quiet HEAD` passes
