### PR TITLE
fix(desktop): show remote channel agents in mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -214,7 +214,7 @@ test("shouldHideAgentFromMentions: hides member agents with an explicit not-invo
   );
 });
 
-test("shouldHideAgentFromMentions: shows member agents with unknown invocability (not in directory)", () => {
+test("shouldHideAgentFromMentions: shows remote member agents without local managed cards when invocability is unknown", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,9 +245,6 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,
@@ -420,7 +416,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## What changed

- stop applying the local managed-agent custody filter to message mention candidates
- continue using the existing channel membership and relay invocation eligibility rules
- clarify regression coverage for a remote channel member without a local managed card

## Why

Desktop mention autocomplete dropped agents hosted on another owned device before the newer eligibility rules ran. A live remote agent could therefore be a member of the current channel and still be absent from `@` autocomplete simply because its private key was not stored on the viewing computer.

The local-only filter remains in the members-management surface, where local key custody is relevant. Message mentions now rely on the existing rules that show invocable agents and eligible channel members while hiding inaccessible non-members and explicitly non-invocable directory agents.

## User impact

Users can mention a channel agent running on another device from Buzz Desktop without copying that agent's private key to the local device.

## Validation

- `just ci`
- desktop unit suite: 3,906 passed
- desktop type-check and static checks
- Rust workspace and Tauri clippy/tests
- desktop and web production builds
- mobile analysis and 1,022 mobile tests
