### PR TITLE
fix(desktop): report agent presence from the relay, not the profile default

### DIFF
--- a/desktop/src/features/agents/lib/agentPresenceStatus.test.mjs
+++ b/desktop/src/features/agents/lib/agentPresenceStatus.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mergeAgentPresenceStatus } from "./agentPresenceStatus.ts";
+
+test("mergeAgentPresenceStatus — live presence overrides the kind:10100 offline fallback", () => {
+  // The bug this fixes: `agents_from_events` defaults every relay-discovered
+  // agent to "offline" because nothing writes `status` into kind:10100, so a
+  // running agent was reported offline.
+  const map = mergeAgentPresenceStatus([{ pubkey: "a", status: "offline" }], {
+    a: "online",
+  });
+  assert.equal(map.a, "online");
+});
+
+test("mergeAgentPresenceStatus — presence reporting away is preserved", () => {
+  const map = mergeAgentPresenceStatus([{ pubkey: "a", status: "offline" }], {
+    a: "away",
+  });
+  assert.equal(map.a, "away");
+});
+
+test("mergeAgentPresenceStatus — agents with no presence entry keep their own status", () => {
+  // Locally-managed agents derive status from the live process handle, which
+  // the relay cannot contradict for the machine running them.
+  const map = mergeAgentPresenceStatus([{ pubkey: "a", status: "online" }], {});
+  assert.equal(map.a, "online");
+});
+
+test("mergeAgentPresenceStatus — presence for an unrelated pubkey does not leak in", () => {
+  const map = mergeAgentPresenceStatus([{ pubkey: "a", status: "offline" }], {
+    b: "online",
+  });
+  assert.deepEqual(map, { a: "offline" });
+});
+
+test("mergeAgentPresenceStatus — a presence lookup that has not loaded yet is a no-op", () => {
+  const map = mergeAgentPresenceStatus(
+    [
+      { pubkey: "a", status: "online" },
+      { pubkey: "b", status: "offline" },
+    ],
+    undefined,
+  );
+  assert.deepEqual(map, { a: "online", b: "offline" });
+});
+
+test("mergeAgentPresenceStatus — presence can also move an agent to offline", () => {
+  // A managed agent whose process died still reports "online" from a stale
+  // handle; relay presence expiring is what corrects it.
+  const map = mergeAgentPresenceStatus([{ pubkey: "a", status: "online" }], {
+    a: "offline",
+  });
+  assert.equal(map.a, "offline");
+});

--- a/desktop/src/features/agents/lib/agentPresenceStatus.ts
+++ b/desktop/src/features/agents/lib/agentPresenceStatus.ts
@@ -1,0 +1,39 @@
+import type { PresenceLookup, PresenceStatus } from "@/shared/api/types";
+
+/**
+ * The status fields this merge reads off an agent, whatever its source.
+ *
+ * Kept structural rather than importing `RelayAgent` so locally-managed agents
+ * projected into the same shape can be merged without a cast.
+ */
+export type AgentStatusInput = {
+  pubkey: string;
+  status: PresenceStatus;
+};
+
+/**
+ * Build the pubkey → status map for an agent roster, preferring live relay
+ * presence over the agent's self-declared `kind:10100` status.
+ *
+ * Why presence wins: the `status` field on a `kind:10100` agent profile has no
+ * producer in-tree, so `agents_from_events` falls back to `"offline"` for every
+ * relay-discovered agent. Rendering that directly reports agents as offline
+ * whether or not they are actually running. Relay presence (kind:20001, backed
+ * by a 180s Redis TTL) is the only source that reflects the process's real
+ * state, so it takes precedence wherever it has an entry.
+ *
+ * Agents absent from `presence` keep their incoming status: locally-managed
+ * agents already derive theirs from the live process handle, which is
+ * authoritative for the machine running them and is not something the relay
+ * can contradict.
+ */
+export function mergeAgentPresenceStatus(
+  agents: readonly AgentStatusInput[],
+  presence: PresenceLookup | undefined,
+): Record<string, PresenceStatus> {
+  const map: Record<string, PresenceStatus> = {};
+  for (const agent of agents) {
+    map[agent.pubkey] = presence?.[agent.pubkey] ?? agent.status;
+  }
+  return map;
+}

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -5,6 +5,8 @@ import {
   useManagedAgentsQuery,
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
+import { mergeAgentPresenceStatus } from "@/features/agents/lib/agentPresenceStatus";
+import { usePresenceQuery } from "@/features/presence/hooks";
 import {
   useContactListQuery,
   useUsersBatchQuery,
@@ -126,13 +128,14 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
     () => new Set(agentPubkeys),
     [agentPubkeys],
   );
-  const agentStatusMap = React.useMemo(() => {
-    const map: Record<string, "online" | "away" | "offline"> = {};
-    for (const a of relayAgents) {
-      map[a.pubkey] = a.status;
-    }
-    return map;
-  }, [relayAgents]);
+  // Relay presence is the only source that reflects whether an agent process is
+  // actually up: nothing writes `status` into kind:10100, so every
+  // relay-discovered agent otherwise renders as offline regardless of state.
+  const agentPresenceQuery = usePresenceQuery(agentPubkeys);
+  const agentStatusMap = React.useMemo(
+    () => mergeAgentPresenceStatus(relayAgents, agentPresenceQuery.data),
+    [relayAgents, agentPresenceQuery.data],
+  );
 
   const mentionPubkeys = React.useMemo(
     () =>


### PR DESCRIPTION
## Problem

`agents_from_events` fills in a default when a `kind:10100` agent profile has no
`status` string:

```rust
// desktop/src-tauri/src/nostr_convert.rs
if !obj.get("status").is_some_and(Value::is_string) {
    obj.insert("status".to_string(), json!("offline"));
}
```

Nothing in-tree ever writes that field — the only in-tree writer of `kind:10100`
is `cmd_set_add_policy`, which sets `channel_add_policy` — so **the fallback is
taken for every relay-discovered agent**. The Pulse roster then builds its status
map straight off it:

```ts
for (const a of relayAgents) {
  map[a.pubkey] = a.status;   // always "offline" for relay-discovered agents
}
```

So a running agent is reported offline. The only agents that showed a real state
were locally-managed ones, whose status the view synthesizes from the local
process handle.

Meanwhile the relay already tracks genuine presence — `kind:20001` events behind
a 180s Redis TTL, surfaced to the client by `usePresenceQuery`. The two were
simply never joined.

## Change

Join them, with presence taking precedence wherever it has an entry.

Agents **absent** from the presence lookup keep their incoming status. That is
deliberate: locally-managed agents derive theirs from the live process handle,
which is authoritative for the machine running them and isn't something the
relay should override. It also makes the merge a no-op before the presence query
resolves, so the roster never flickers to offline on load.

The merge itself is a pure function (`agents/lib/agentPresenceStatus.ts`) rather
than inline logic, so it is unit-testable and reusable by the other roster
surfaces (`useMentions`, `useNewMessageRecipients`, `useTrayMenu`) in follow-ups.

## Scope

Deliberately narrow: **this changes only status truthfulness, not rendering.**
I've kept away from the roster/fleet UI in #3996 and #4169 since several PRs are
already in flight there — this composes with whichever lands rather than
competing with it. The most substantive comment on #3996 asks for exactly this
("derive online/offline from presence/heartbeat facts, not a static profile
field"), and as far as I can tell none of the open PRs do it.

## Tests

Six cases in `agentPresenceStatus.test.mjs`:

- live presence overrides the kind:10100 offline fallback (the bug)
- `away` is preserved, not flattened to online/offline
- agents with no presence entry keep their own status
- presence for an unrelated pubkey doesn't leak in
- an unloaded (`undefined`) lookup is a no-op
- presence can also correct a stale `"online"` handle to offline

Green locally:

- `just desktop-check` — pass
- `just desktop-test` — 3934 pass, 0 fail

## UI note

No visual/layout change — the same status indicator now reflects real presence
instead of a constant. Happy to attach a before/after of the Pulse agents tab if
that's wanted for review.

Refs #3996, #4169
