### PR TITLE
feat(desktop): animate the terminal splash banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ Buzz spans five repos. This one (`block/buzz`) is the OSS source for the relay, 
 | Repo | Purpose |
 |------|---------|
 | [block/buzz](https://github.com/block/buzz) | OSS source — relay, desktop app, mobile app, CLI, agent harness |
-| [squareup/sprout-releases](https://github.com/squareup/sprout-releases) | Buildkite pipeline producing Block-signed macOS + iOS builds with `-block` version suffix |
+| [squareup/buzz-releases](https://github.com/squareup/buzz-releases) | Buildkite pipelines producing Block-signed macOS + iOS builds with `-block` desktop version suffix |
 | [squareup/sprout-oss](https://github.com/squareup/sprout-oss) | CI pipeline building the relay Docker image and pushing to internal ECR |
 | [squareup/block-coder-tf-stacks](https://github.com/squareup/block-coder-tf-stacks) | Terraform + ArgoCD deploying the relay to the staging Kubernetes cluster |
 | [squareup/sprout-backend-blox](https://github.com/squareup/sprout-backend-blox) | Desktop backend provider script connecting Blox workstation agents to the relay |
 
 ```
 block/buzz (source)
-  ├─► sprout-releases    (desktop + mobile builds → Artifactory, GitHub, Mobile Releases)
+  ├─► buzz-releases      (desktop + mobile builds → Artifactory, GitHub, Mobile Releases)
   ├─► sprout-oss         (relay Docker image → ECR)
   │     └─► block-coder-tf-stacks  (Helm chart → ArgoCD → staging cluster)
   └─── sprout-backend-blox         (Blox compute provider for Desktop agent launch)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,14 +56,15 @@ or mobile GitHub Release.
    updates the PR.
 2. Review the recorded base and candidate SHA, the complete changelog, and CI.
    The required **Desktop Release Candidate** check validates the exact head.
-   Authorization is either an approval on that exact head or a permitted Default
-   ruleset bypass at merge time. Any regeneration changes the head and requires
-   the checks—and, for the review path, approval—to run again.
+   A trusted repository member, owner, or collaborator must approve that exact
+   candidate head. Any regeneration or push changes the head, invalidates the
+   prior approval, and requires both the checks and approval to run again.
 3. **Squash merge** the PR. The protected branch must still be exactly the
    recorded base; otherwise regenerate the candidate from current `main`.
 4. `auto-tag-on-release-pr-merge` verifies the frozen parent, full-tree identity,
-   required checks, and one of the two authorization paths, then tags the squash
-   commit as `desktop-v<version>`.
+   required checks, and trusted approval on the exact candidate head, then tags
+   the squash commit as `desktop-v<version>`. An admin or ruleset bypass does not
+   authorize desktop tagging.
 5. The tag triggers `release.yml`. It builds and stages Apple Silicon and Intel
    macOS, Windows, and Linux artifacts; publishes the versioned release only
    after the complete set succeeds; then updates the rolling updater manifest
@@ -184,10 +185,12 @@ Buildkite pipeline accepts only an exact candidate tag.
 
 For mobile, trigger the private
 [Release Mobile pipeline](https://buildkite.com/runway/buzz-mobile-releases) with
-an exact RC tag for the platform build being cut. For desktop, use
-[Release Desktop](https://buildkite.com/runway/sprout-releases). See the
+an exact RC tag for the platform build being cut. For desktop, start
+[Release Desktop](https://buildkite.com/runway/sprout-releases) and enter the
+exact public source tag as `desktop_ref=desktop-v<version>`; a generic
+`v<version>` tag is intentionally rejected. See the
 [buzz-releases README](https://github.com/squareup/buzz-releases#cutting-a-release)
-for the private pipeline contract.
+for the rest of the private pipeline contract.
 
 ---
 
@@ -269,9 +272,9 @@ actor list.
 
 Do not update the branch manually and do not weaken the ruleset. Run
 `just release-desktop <version>` again from current `main`; this regenerates the
-candidate, reruns CI, and requires a fresh approval when using the review path.
-The post-merge verifier refuses to tag a squash whose parent differs from the
-recorded candidate base or whose tree differs from the validated PR head.
+candidate, reruns CI, and requires a fresh trusted approval on the new exact
+head. The post-merge verifier refuses to tag a squash whose parent differs from
+the recorded candidate base or whose tree differs from the validated PR head.
 
 ### Local `just release-desktop` fails with "must be on main branch"
 Switch to `main` and pull latest before running the release recipe.

--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -13,8 +13,8 @@ use crate::mcp::McpRegistry;
 use crate::mcp::ResultBudget;
 
 use crate::types::{
-    AgentError, ContentBlock, HistoryItem, ProviderStop, StopReason, ToolCall, ToolResult,
-    ToolResultContent, TurnTotalState,
+    AgentError, ContentBlock, HistoryItem, ProviderStop, SessionUsageBaseline, StopReason,
+    ToolCall, ToolResult, ToolResultContent, TurnTotalState,
 };
 use crate::wire::{self, WireSender};
 
@@ -150,9 +150,40 @@ pub struct RunCtx<'a> {
     /// Reset to `Unseen` at turn start in `run()`. Callers must not derive a
     /// total by summing input+output — that is the UI display approximation only.
     pub turn_total_state: &'a mut TurnTotalState,
+    /// Session-cumulative counters as they stood when this turn began. Added to
+    /// the `turn_*` accumulators above to report a cumulative figure mid-turn;
+    /// the session's own copy is only advanced once, after the turn returns.
+    pub usage_baseline: SessionUsageBaseline,
 }
 
 impl RunCtx<'_> {
+    /// Send a session-cumulative `usage_update` reflecting everything observed
+    /// up to and including the most recent LLM response.
+    ///
+    /// The figure is the turn-start baseline plus this turn's running
+    /// accumulators, which is exactly what `session/prompt` will fold into the
+    /// session once the turn returns — so a mid-turn notification and the
+    /// end-of-turn one agree, and a turn that never returns has still reported
+    /// everything but its final in-flight request.
+    async fn emit_usage_update(&self) {
+        let base = self.usage_baseline;
+        let payload = wire::usage_update_payload(
+            base.input_tokens
+                .saturating_add(self.turn_input_tokens.unwrap_or(0)),
+            base.output_tokens
+                .saturating_add(self.turn_output_tokens.unwrap_or(0)),
+            base.cached_input_tokens
+                .saturating_add(self.turn_cached_input_tokens.unwrap_or(0)),
+            base.total_state.merge_session(*self.turn_total_state),
+            self.effective_model,
+        );
+        wire::send(
+            self.wire,
+            wire::goose_session_update(self.session_id, payload),
+        )
+        .await;
+    }
+
     pub async fn run(&mut self, prompt: Vec<ContentBlock>) -> Result<StopReason, AgentError> {
         let user_text = prompt_to_text(prompt)?;
         if user_text.len() > MAX_PROMPT_BYTES {
@@ -299,6 +330,23 @@ impl RunCtx<'_> {
             // this gate rather than representing absent categories as zero.
             if response.input_tokens.is_some() || response.output_tokens.is_some() {
                 *self.turn_total_state = self.turn_total_state.fold(response.total_tokens);
+                // Report what the turn has burned SO FAR, before running the
+                // next round. A turn is many provider round-trips over many
+                // minutes, and until this point the only report was the one
+                // `session/prompt` sends after the turn returns — so a turn
+                // that was cancelled, timed out, or whose process was killed
+                // reported nothing at all, and its tokens (already billed)
+                // existed only in this stack frame. Reporting per round bounds
+                // the loss to the single request in flight.
+                //
+                // Emitting more than one `usage_update` per turn is expected by
+                // the consumer: buzz-acp's UsageTracker advances its committed
+                // baseline only when the turn's metric is published, so every
+                // notification within a turn measures from the same frozen
+                // baseline and the last one seen is the turn's true total.
+                // goose behaves the same way, which is why the tracker was
+                // written to tolerate it.
+                self.emit_usage_update().await;
             }
 
             if !response.reasoning.is_empty() {

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -658,6 +658,7 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         effective_model_override,
         run_id,
         mut steer_rx,
+        usage_baseline,
     ) = match acquire_session(&app, &p.session_id).await {
         Ok(v) => v,
         Err(reason) => {
@@ -709,6 +710,7 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         turn_output_tokens: &mut turn_output_tokens,
         turn_cached_input_tokens: &mut turn_cached_input_tokens,
         turn_total_state: &mut turn_total_state,
+        usage_baseline,
     };
     let result = ctx.run(p.prompt).await;
     if let Some(s) = app.sessions.lock().await.get_mut(&sid) {
@@ -766,28 +768,16 @@ async fn run_prompt(app: Arc<App>, id: Value, params: Value, wire_tx: WireSender
         if let Some((accumulated_in, accumulated_out, accumulated_cached, accumulated_total)) =
             accumulated
         {
-            // Build the usage_update payload. `accumulatedTotalTokens` is only
-            // included when the cumulative is exactly known — never when Unseen
-            // (no total ever observed) or Unknown (at least one turn lacked a
-            // total). A goose consumer that doesn't recognise the field ignores it.
-            let mut update = serde_json::json!({
-                "sessionUpdate": "usage_update",
-                // used: total tokens as a context-usage proxy;
-                // contextLimit: 0 (buzz-agent has no context limit tracking).
-                "used": accumulated_in.saturating_add(accumulated_out),
-                "contextLimit": 0u64,
-                "accumulatedInputTokens": accumulated_in,
-                "accumulatedOutputTokens": accumulated_out,
-                // A subset of accumulatedInputTokens, not an addition to
-                // it. Extends goose's usage_update shape; a consumer that
-                // does not know the field ignores it and prices exactly as
-                // it did before.
-                "accumulatedCachedInputTokens": accumulated_cached,
-                "model": effective_model_str,
-            });
-            if let crate::types::TurnTotalState::Exact(total) = accumulated_total {
-                update["accumulatedTotalTokens"] = serde_json::json!(total);
-            }
+            // Same builder the run loop uses for its per-round reports, so the
+            // final notification is shape-identical to the ones that preceded
+            // it and a consumer taking the high-water mark lands on this one.
+            let update = wire::usage_update_payload(
+                accumulated_in,
+                accumulated_out,
+                accumulated_cached,
+                accumulated_total,
+                effective_model_str,
+            );
             wire::send(&wire_tx, goose_session_update(&sid, update)).await;
         }
     }
@@ -821,6 +811,7 @@ async fn acquire_session(
         Option<String>,
         String,
         mpsc::UnboundedReceiver<Vec<ContentBlock>>,
+        crate::types::SessionUsageBaseline,
     ),
     &'static str,
 > {
@@ -857,6 +848,17 @@ async fn acquire_session(
         effective_model,
         run_id,
         steer_rx,
+        // Snapshot rather than a handle: the run loop reports cumulative usage
+        // after every LLM round, and taking the sessions lock on each of those
+        // would serialise concurrent sessions behind one another's provider
+        // round-trips. Nothing else advances these counters while this turn
+        // holds `busy`, so the snapshot cannot go stale under it.
+        crate::types::SessionUsageBaseline {
+            input_tokens: s.accumulated_input_tokens,
+            output_tokens: s.accumulated_output_tokens,
+            cached_input_tokens: s.accumulated_cached_input_tokens,
+            total_state: s.accumulated_total_state,
+        },
     ))
 }
 

--- a/crates/buzz-agent/src/types.rs
+++ b/crates/buzz-agent/src/types.rs
@@ -308,6 +308,30 @@ impl TurnTotalState {
     }
 }
 
+/// The session-cumulative usage counters as of the START of a turn.
+///
+/// Copied out of the session under the lock when a turn begins and handed to
+/// `RunCtx` by value, so the run loop can emit a cumulative `usage_update`
+/// after every LLM round without reaching back into `App.sessions` (which it
+/// holds no handle to, and which is locked by the turn's own bookkeeping at
+/// both ends).
+///
+/// This exists so that usage is durable *during* a turn rather than only after
+/// it. The counters a turn accrues live in the prompt task's stack frame until
+/// the turn returns; a process killed mid-turn takes them with it and the
+/// tokens are billed by the provider but recorded nowhere. That is not
+/// hypothetical — it silently under-reported a long-horizon benchmark's cost by
+/// several-fold, because every phase of a `continue_until_timeout` run is
+/// terminated mid-turn by design.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SessionUsageBaseline {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// The cache-served subset of `input_tokens`, not an addition to it.
+    pub cached_input_tokens: u64,
+    pub total_state: TurnTotalState,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StopReason {
     EndTurn,

--- a/crates/buzz-agent/src/wire.rs
+++ b/crates/buzz-agent/src/wire.rs
@@ -148,6 +148,48 @@ pub fn goose_session_update(sid: &str, update: Value) -> Value {
     })
 }
 
+/// Build the `usage_update` payload for a `_goose/unstable/session/update`.
+///
+/// Shared by the two places that report usage — after each LLM round inside a
+/// turn, and once more when the turn completes — so the wire shape cannot drift
+/// between them. A consumer takes the high-water mark per session, so the
+/// mid-turn payloads are supersets of each other and the final one wins; a
+/// divergence in field names or units between the two call sites would instead
+/// show up as tokens silently vanishing, which is the failure this reporting
+/// exists to prevent.
+///
+/// All counts are SESSION-cumulative, matching goose, so buzz-acp's
+/// `UsageTracker` can compute per-turn deltas symmetrically for both agents.
+pub fn usage_update_payload(
+    accumulated_input_tokens: u64,
+    accumulated_output_tokens: u64,
+    accumulated_cached_input_tokens: u64,
+    accumulated_total: crate::types::TurnTotalState,
+    model: &str,
+) -> Value {
+    let mut update = json!({
+        "sessionUpdate": "usage_update",
+        // used: total tokens as a context-usage proxy;
+        // contextLimit: 0 (buzz-agent has no context limit tracking).
+        "used": accumulated_input_tokens.saturating_add(accumulated_output_tokens),
+        "contextLimit": 0u64,
+        "accumulatedInputTokens": accumulated_input_tokens,
+        "accumulatedOutputTokens": accumulated_output_tokens,
+        // A subset of accumulatedInputTokens, not an addition to it. Extends
+        // goose's usage_update shape; a consumer that does not know the field
+        // ignores it and prices exactly as it did before.
+        "accumulatedCachedInputTokens": accumulated_cached_input_tokens,
+        "model": model,
+    });
+    // Only when the cumulative is exactly known — never when Unseen (no total
+    // ever observed) or Unknown (at least one turn lacked a total). A goose
+    // consumer that doesn't recognise the field ignores it.
+    if let Some(total) = accumulated_total.exact_value() {
+        update["accumulatedTotalTokens"] = json!(total);
+    }
+    update
+}
+
 /// A `session/update` notification carrying a `update._meta.goose.<key>` field.
 /// Used to advertise `activeRunId` (so steer-capable clients can target the
 /// in-flight run) and `queuedSteer` (so they can correlate an accepted steer

--- a/crates/buzz-agent/tests/fake_llm.rs
+++ b/crates/buzz-agent/tests/fake_llm.rs
@@ -933,6 +933,135 @@ async fn no_usage_turn_emits_no_usage_notification() {
     h.shutdown().await;
 }
 
+/// Usage must be reported after EVERY provider round, not only once the turn
+/// returns.
+///
+/// A turn is many provider round-trips over many minutes. While the only report
+/// was the one `session/prompt` sends after the turn returns, a turn whose
+/// process was killed mid-flight reported nothing at all: its counters lived in
+/// the prompt task's stack frame, the provider had already billed them, and no
+/// consumer ever saw them. That is not a corner case for a long-horizon
+/// benchmark — every phase of a `continue_until_timeout` run is terminated
+/// mid-turn by design, which under-reported one measured run's cost several-fold.
+///
+/// Two rounds with distinct usage. The assertion that matters is the FIRST
+/// notification: it must carry round 1's counts alone, proving it was sent
+/// before round 2 had returned, so a kill between the rounds would still have
+/// left round 1 on the wire.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn usage_is_reported_after_each_round_not_only_at_turn_end() {
+    let url = spawn_fake_llm(vec![
+        openai_tool_call_with_usage("call_round1", "fake__noop", json!({}), 15, 6),
+        openai_text_with_usage("done", 20, 8),
+    ])
+    .await;
+    let mut h = Harness::spawn(&url).await;
+    let sid = init_session(&mut h).await;
+
+    let p_id = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": sid, "prompt": [{"type":"text","text":"go"}]}),
+        )
+        .await;
+
+    let (frames_before, response) = recv_until_with_drain(&mut h, |v| v["id"] == p_id).await;
+    assert_eq!(
+        response["result"]["stopReason"], "end_turn",
+        "turn must complete with end_turn"
+    );
+
+    let usage: Vec<&Value> = frames_before
+        .iter()
+        .filter(|v| is_usage_update(v))
+        .collect();
+    assert!(
+        usage.len() >= 2,
+        "expected a usage_update per round (2 rounds), got {}; frames: {frames_before:#?}",
+        usage.len()
+    );
+
+    // Round 1 alone — emitted while round 2 was still outstanding.
+    assert_eq!(
+        usage[0]["params"]["update"]["accumulatedInputTokens"],
+        json!(15u64),
+        "first notification must carry round 1's input tokens only"
+    );
+    assert_eq!(
+        usage[0]["params"]["update"]["accumulatedOutputTokens"],
+        json!(6u64),
+        "first notification must carry round 1's output tokens only"
+    );
+
+    // The last one is the turn total and is what a high-water-mark consumer keeps.
+    let last = usage[usage.len() - 1];
+    assert_eq!(
+        last["params"]["update"]["accumulatedInputTokens"],
+        json!(35u64),
+        "final notification must carry the turn total 15+20=35"
+    );
+    assert_eq!(
+        last["params"]["update"]["accumulatedOutputTokens"],
+        json!(14u64),
+        "final notification must carry the turn total 6+8=14"
+    );
+
+    h.shutdown().await;
+}
+
+/// A mid-turn report must be SESSION-cumulative, not turn-local.
+///
+/// The baseline handed to the run loop is a snapshot taken when the turn began;
+/// if it were dropped, a consumer taking the high-water mark per session would
+/// see turn 2's first round (a small number) arrive after turn 1's total and
+/// discard it, silently losing turn 2 for any turn that never completed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mid_turn_usage_includes_earlier_turns() {
+    let url = spawn_fake_llm(vec![
+        openai_text_with_usage("turn one", 10, 5),
+        openai_tool_call_with_usage("call_t2", "fake__noop", json!({}), 20, 8),
+        openai_text_with_usage("turn two done", 30, 9),
+    ])
+    .await;
+    let mut h = Harness::spawn(&url).await;
+    let sid = init_session(&mut h).await;
+
+    let p1 = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": sid, "prompt": [{"type":"text","text":"turn 1"}]}),
+        )
+        .await;
+    let (_, _) = recv_until_with_drain(&mut h, |v| v["id"] == p1).await;
+
+    let p2 = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": sid, "prompt": [{"type":"text","text":"turn 2"}]}),
+        )
+        .await;
+    let (frames_before, _) = recv_until_with_drain(&mut h, |v| v["id"] == p2).await;
+
+    let first = frames_before
+        .iter()
+        .find(|v| is_usage_update(v))
+        .unwrap_or_else(|| {
+            panic!("expected a usage_update during turn 2; frames: {frames_before:#?}")
+        });
+    assert_eq!(
+        first["params"]["update"]["accumulatedInputTokens"],
+        json!(30u64),
+        "turn 2 round 1 must report 10 (turn 1) + 20 (this round), not 20"
+    );
+    assert_eq!(
+        first["params"]["update"]["accumulatedOutputTokens"],
+        json!(13u64),
+        "turn 2 round 1 must report 5 (turn 1) + 8 (this round), not 8"
+    );
+
+    h.shutdown().await;
+}
+
 /// When a turn is cancelled AFTER the provider has already returned a response
 /// (so token counts are observed), buzz-agent must still emit the usage
 /// notification before the cancelled `session/prompt` response.

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         "**/channel-mute.spec.ts",
         "**/channel-star.spec.ts",
         "**/channel-controls.spec.ts",
+        "**/channel-activity-popover.spec.ts",
         "**/active-turn-resilience.spec.ts",
         "**/profile-active-turn.spec.ts",
         "**/config-bridge-screenshots.spec.ts",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -126,6 +126,7 @@ export default defineConfig({
         "**/agent-provider-dropdowns.spec.ts",
         "**/agent-lifecycle-feedback.spec.ts",
         "**/agent-access-warning.spec.ts",
+        "**/edit-agent-run-on.spec.ts",
         "**/inbox-live-update.spec.ts",
         "**/mesh-compute.spec.ts",
         "**/observer-archive-policy.spec.ts",

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -333,10 +333,7 @@ fn install_acp_runtime_blocking(
     // For the codex runtime, "found" is not enough — the resolved binary must also
     // pass the 1.x version gate. An outdated 0.16.x adapter must be overwritten by
     // the new npm install so the CODEX_CONFIG spawn contract works correctly.
-    let adapter_path = runtime
-        .commands
-        .iter()
-        .find_map(|cmd| crate::managed_agents::resolve_command(cmd));
+    let adapter_path = resolve_adapter_path(runtime.commands, runtime.adapter_install_commands);
     let adapter_probe_path = crate::managed_agents::readiness::cli_probe::augmented_path();
     if let Some(cmds) = plan_adapter_install(
         runtime_id,
@@ -1020,7 +1017,7 @@ use install_report::InstallReporter;
 mod managed_node;
 use managed_node::{
     ensure_managed_node_runtime_blocking, managed_node_runtime_supported, managed_npm_command,
-    npm_eacces_hint,
+    npm_eacces_hint, resolve_adapter_path,
 };
 
 #[tauri::command]
@@ -1741,7 +1738,7 @@ mod tests {
     #[test]
     fn test_powershell_command_argv_exact() {
         // Catalog format: body wrapped in one outer double-quote pair (Bash-layer serialization).
-        let body = "irm https://chatgpt.com/codex/install.ps1 | iex";
+        let body = "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-codex.ps1'; Invoke-RestMethod https://chatgpt.com/codex/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE";
         let cmd = super::install_powershell_command(&format!(
             r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "{body}""#
         ));
@@ -1771,12 +1768,12 @@ mod tests {
         );
     }
 
-    /// Claude Code catalog command (discovery.rs:107) must dequote to the bare pipeline.
+    /// Claude Code catalog command must dequote to the two-step download-then-execute body.
     #[cfg(windows)]
     #[test]
     fn test_powershell_command_claude_catalog_dequoted() {
         let cmd = super::install_powershell_command(
-            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "irm https://claude.ai/install.ps1 | iex""#,
+            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-claude.ps1'; Invoke-RestMethod https://claude.ai/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE""#,
         );
         assert_eq!(
             cmd.get_args()
@@ -1787,22 +1784,22 @@ mod tests {
                 "-ExecutionPolicy",
                 "Bypass",
                 "-Command",
-                "irm https://claude.ai/install.ps1 | iex",
+                "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-claude.ps1'; Invoke-RestMethod https://claude.ai/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE",
             ],
             "Claude catalog command must be dequoted correctly"
         );
     }
 
-    /// Goose Windows catalog command (discovery.rs:78) must dequote to a bare pipeline
-    /// with a literal `$env:` prefix — no backslash before the dollar sign.
-    /// This proves the `\$` → `$` escape fix: post-#2750 the spawn is native and
+    /// Goose Windows catalog command must dequote to the two-step download-then-execute body
+    /// with the `$env:CONFIGURE` prefix intact — no backslash before the dollar sign.
+    /// This proves the `\$` → `$` contract: post-#2750 the spawn is native and
     /// PowerShell receives the body verbatim, so a residual `\` would produce
     /// `\$env:CONFIGURE='false'` which is a malformed statement.
     #[cfg(windows)]
     #[test]
     fn test_powershell_command_goose_catalog_dequoted() {
         let cmd = super::install_powershell_command(
-            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex""#,
+            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$env:CONFIGURE='false'; $ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-goose.ps1'; Invoke-RestMethod https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE""#,
         );
         assert_eq!(
             cmd.get_args()
@@ -1813,7 +1810,7 @@ mod tests {
                 "-ExecutionPolicy",
                 "Bypass",
                 "-Command",
-                "$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex",
+                "$env:CONFIGURE='false'; $ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-goose.ps1'; Invoke-RestMethod https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE",
             ],
             "Goose catalog command must dequote with bare $env: (no backslash before $)"
         );

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
@@ -102,25 +102,155 @@ fn managed_node_failed_step(stderr: String) -> InstallStepResult {
     }
 }
 
-fn managed_node_runtime_ready() -> bool {
+pub(super) fn managed_node_runtime_ready() -> bool {
     let Some(node) = crate::managed_agents::buzz_managed_node_bin_path() else {
         return false;
     };
     if !node.is_file() {
         return false;
     }
-    let mut cmd = std::process::Command::new(&node);
+    probe_node(&node, MANAGED_NODE_VERSION, Duration::from_secs(3))
+}
+
+/// Run `executable --version` with a bounded deadline and return `true` only
+/// when it exits 0 and its trimmed stdout equals `expected_version`.
+///
+/// Transport: stdout is redirected to a temp file so no exit path can block on
+/// an inherited handle (a descendant retaining a pipe write-end would otherwise
+/// prevent EOF indefinitely).
+///
+/// Cleanup: the child runs in its own process group on Unix (`process_group(0)`)
+/// so an unconditional group SIGKILL on every exit path terminates all
+/// descendants.  On Windows, `terminate_process` issues `taskkill /T /F` for
+/// tree-wide cleanup.  SIGKILL to an already-dead group returns ESRCH (no-op).
+pub(super) fn probe_node(
+    executable: &std::path::Path,
+    expected_version: &str,
+    timeout: Duration,
+) -> bool {
+    let tmp = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let out_file = match tmp.reopen() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    let mut cmd = std::process::Command::new(executable);
     cmd.arg("--version")
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::from(out_file))
         .stderr(std::process::Stdio::null());
     crate::util::configure_no_window(&mut cmd);
-    let output = cmd.output();
-    output
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim() == MANAGED_NODE_VERSION)
-        .unwrap_or(false)
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let Ok(mut child) = cmd.spawn() else {
+        return false;
+    };
+
+    let deadline = std::time::Instant::now() + timeout;
+    let exit_status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    kill_probe_group(child.id());
+                    let _ = child.wait();
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => {
+                kill_probe_group(child.id());
+                let _ = child.wait();
+                return false;
+            }
+        }
+    };
+
+    // Group-kill unconditionally: SIGKILL to a dead group is ESRCH (no-op).
+    kill_probe_group(child.id());
+
+    if !exit_status.success() {
+        return false;
+    }
+
+    let mut output = String::new();
+    if std::io::Read::read_to_string(&mut tmp.as_file(), &mut output).is_err() {
+        return false;
+    }
+    output.trim() == expected_version
+}
+
+/// Kill the probe's process group/tree unconditionally (no TERM grace — this
+/// is a probe, not an agent session).  ESRCH on a dead group is fine.
+fn kill_probe_group(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        let _ = crate::managed_agents::terminate_process(pid);
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+    }
+}
+
+/// Returns `true` when the managed Node runtime is absent or no longer executes —
+/// meaning any existing npm adapter shims are broken and must be reinstalled.
+///
+/// This fires when the pinned Node version changes (e.g. v24.11.0 → v24.18.0):
+/// the old dir stays on disk, shims appear installed, but they fail at run time
+/// because the Node binary they reference is gone.  Treating the adapter as
+/// missing forces `ensure_managed_node_runtime_blocking` to re-download Node and
+/// npm to reinstall the shims.
+pub(super) fn managed_node_orphaned() -> bool {
+    managed_node_runtime_supported() && !managed_node_runtime_ready()
+}
+
+/// Returns `true` when an adapter at `resolved` should be invalidated.
+///
+/// Only a Buzz-managed shim (path under `managed_prefix`) with an orphaned
+/// runtime is invalidated; external adapters are always preserved.
+pub(super) fn should_invalidate_adapter(
+    resolved: &std::path::Path,
+    managed_prefix: &std::path::Path,
+    orphaned: bool,
+) -> bool {
+    orphaned && resolved.starts_with(managed_prefix)
+}
+
+/// Resolve the adapter binary path, accounting for the Node-orphan case.
+/// Resolves first; invalidates only managed-prefix shims when Node is orphaned.
+pub(super) fn resolve_adapter_path(
+    commands: &[&str],
+    adapter_install_commands: &[&str],
+) -> Option<std::path::PathBuf> {
+    let resolved = commands
+        .iter()
+        .find_map(|cmd| crate::managed_agents::resolve_command(cmd));
+
+    let needs_managed_npm = adapter_install_commands
+        .iter()
+        .any(|cmd| is_npm_global_install(cmd));
+    if needs_managed_npm {
+        if let (Some(ref path), Some(ref managed_bin)) =
+            (&resolved, crate::managed_agents::buzz_managed_npm_bin_dir())
+        {
+            if should_invalidate_adapter(path, managed_bin, managed_node_orphaned()) {
+                return None;
+            }
+        }
+    }
+
+    resolved
 }
 
 fn managed_node_install_lock() -> &'static Mutex<()> {
@@ -538,211 +668,5 @@ pub(super) fn npm_eacces_hint(stderr: &str, _command: &str) -> Option<String> {
 // ── end managed npm adapter installs ──────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_npm_eacces_hint_guidance_mentions_buzz_private_dir() {
-        let hint = npm_eacces_hint("EACCES: permission denied", "npm install -g foo").unwrap();
-        assert!(
-            hint.contains("Buzz's private Node tools directory"),
-            "hint: {hint}"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_install_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install(
-                "npm install -g @agentclientprotocol/codex-acp",
-                "'/tmp/Buzz Node'"
-            ),
-            "npm install --global --prefix '/tmp/Buzz Node' @agentclientprotocol/codex-acp"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_i_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install("npm i -g some-package", "'/tmp/buzz'"),
-            "npm i --global --prefix '/tmp/buzz' some-package"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_uninstall_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install("npm uninstall -g @zed-industries/codex-acp", "'/tmp/buzz'"),
-            "npm uninstall --global --prefix '/tmp/buzz' @zed-industries/codex-acp"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_ignores_non_global_command() {
-        assert_eq!(
-            rewrite_npm_global_install("npm install foo", "'/tmp/buzz'"),
-            "npm install foo"
-        );
-    }
-
-    #[test]
-    fn test_shell_quote_escapes_single_quotes() {
-        assert_eq!(
-            shell_quote(std::path::Path::new("/tmp/Buzz's Node")),
-            "'/tmp/Buzz'\\''s Node'"
-        );
-    }
-
-    // ── zip validation tests ──────────────────────────────────────────────────
-
-    /// Build an in-memory zip archive with the supplied entry names and return
-    /// a temporary file containing it (zip::ZipArchive requires Seek).
-    fn make_zip_with_entries(entry_names: &[&str]) -> tempfile::NamedTempFile {
-        let mut buf: Vec<u8> = Vec::new();
-        {
-            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
-            let opts = zip::write::SimpleFileOptions::default();
-            for name in entry_names {
-                writer.start_file(*name, opts).unwrap();
-            }
-            writer.finish().unwrap();
-        }
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        std::io::Write::write_all(&mut tmp, &buf).unwrap();
-        tmp
-    }
-
-    #[test]
-    fn test_validate_zip_accepts_normal_entries() {
-        let tmp = make_zip_with_entries(&[
-            "node-v24.18.0-win-x64/node.exe",
-            "node-v24.18.0-win-x64/npm.cmd",
-            "node-v24.18.0-win-x64/npm",
-        ]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        assert!(validate_managed_node_zip_entries(&archive).is_ok());
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_absolute_path() {
-        let tmp = make_zip_with_entries(&["/etc/passwd"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_path_traversal() {
-        let tmp = make_zip_with_entries(&["../../../etc/passwd"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("path traversal"),
-            "expected 'path traversal' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_backslash_rooted() {
-        // Windows-style absolute path using backslash — must reject on every host.
-        let tmp = make_zip_with_entries(&["\\Windows\\system32\\evil.dll"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_drive_prefix() {
-        // Windows drive-letter absolute path — must reject on every host.
-        let tmp = make_zip_with_entries(&["C:\\evil\\payload.exe"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_backslash_traversal() {
-        // Path traversal using Windows separator — must reject on every host.
-        let tmp = make_zip_with_entries(&["node-v24.18.0-win-x64\\..\\..\\evil"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("path traversal"),
-            "expected 'path traversal' in: {err}"
-        );
-    }
-
-    // ── verify_node_tree layout tests ─────────────────────────────────────────
-
-    #[test]
-    fn test_verify_node_tree_unix_layout_passes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let bin = tmp.path().join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        std::fs::write(bin.join("node"), b"").unwrap();
-        std::fs::write(bin.join("npm"), b"").unwrap();
-        // On non-Windows the unix branch is active — this must pass.
-        #[cfg(not(windows))]
-        assert!(verify_node_tree(tmp.path()).is_ok());
-        // On Windows the windows branch is active — unix layout must fail.
-        #[cfg(windows)]
-        assert!(verify_node_tree(tmp.path()).is_err());
-    }
-
-    #[test]
-    fn test_verify_node_tree_unix_layout_missing_npm_fails() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let bin = tmp.path().join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        std::fs::write(bin.join("node"), b"").unwrap();
-        // npm intentionally absent
-        #[cfg(not(windows))]
-        {
-            let err = verify_node_tree(tmp.path()).unwrap_err();
-            assert!(err.contains("bin/npm"), "err: {err}");
-        }
-    }
-
-    #[test]
-    fn test_verify_node_tree_windows_layout_passes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm"), b"").unwrap();
-        // On Windows the windows branch is active — this must pass.
-        #[cfg(windows)]
-        assert!(verify_node_tree(tmp.path()).is_ok());
-        // On non-Windows the unix branch is active — windows-layout root files
-        // don't satisfy bin/node + bin/npm, so this must fail.
-        #[cfg(not(windows))]
-        assert!(verify_node_tree(tmp.path()).is_err());
-    }
-
-    #[test]
-    fn test_verify_node_tree_windows_layout_missing_npm_shim_fails() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
-        // npm POSIX shim intentionally absent
-        #[cfg(windows)]
-        {
-            let err = verify_node_tree(tmp.path()).unwrap_err();
-            assert!(err.contains("npm"), "err: {err}");
-        }
-    }
-}
+#[path = "managed_node_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
@@ -1,0 +1,481 @@
+use super::*;
+
+#[test]
+fn test_npm_eacces_hint_guidance_mentions_buzz_private_dir() {
+    let hint = npm_eacces_hint("EACCES: permission denied", "npm install -g foo").unwrap();
+    assert!(
+        hint.contains("Buzz's private Node tools directory"),
+        "hint: {hint}"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_install_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install(
+            "npm install -g @agentclientprotocol/codex-acp",
+            "'/tmp/Buzz Node'"
+        ),
+        "npm install --global --prefix '/tmp/Buzz Node' @agentclientprotocol/codex-acp"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_i_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install("npm i -g some-package", "'/tmp/buzz'"),
+        "npm i --global --prefix '/tmp/buzz' some-package"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_uninstall_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install("npm uninstall -g @zed-industries/codex-acp", "'/tmp/buzz'"),
+        "npm uninstall --global --prefix '/tmp/buzz' @zed-industries/codex-acp"
+    );
+}
+
+#[test]
+fn test_rewrite_ignores_non_global_command() {
+    assert_eq!(
+        rewrite_npm_global_install("npm install foo", "'/tmp/buzz'"),
+        "npm install foo"
+    );
+}
+
+#[test]
+fn test_shell_quote_escapes_single_quotes() {
+    assert_eq!(
+        shell_quote(std::path::Path::new("/tmp/Buzz's Node")),
+        "'/tmp/Buzz'\\''s Node'"
+    );
+}
+
+// ── zip validation tests ──────────────────────────────────────────────────────
+
+/// Build an in-memory zip archive with the supplied entry names and return
+/// a temporary file containing it (zip::ZipArchive requires Seek).
+fn make_zip_with_entries(entry_names: &[&str]) -> tempfile::NamedTempFile {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = zip::write::SimpleFileOptions::default();
+        for name in entry_names {
+            writer.start_file(*name, opts).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    std::io::Write::write_all(&mut tmp, &buf).unwrap();
+    tmp
+}
+
+#[test]
+fn test_validate_zip_accepts_normal_entries() {
+    let tmp = make_zip_with_entries(&[
+        "node-v24.18.0-win-x64/node.exe",
+        "node-v24.18.0-win-x64/npm.cmd",
+        "node-v24.18.0-win-x64/npm",
+    ]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    assert!(validate_managed_node_zip_entries(&archive).is_ok());
+}
+
+#[test]
+fn test_validate_zip_rejects_absolute_path() {
+    let tmp = make_zip_with_entries(&["/etc/passwd"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_path_traversal() {
+    let tmp = make_zip_with_entries(&["../../../etc/passwd"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("path traversal"),
+        "expected 'path traversal' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_backslash_rooted() {
+    // Windows-style absolute path using backslash — must reject on every host.
+    let tmp = make_zip_with_entries(&["\\Windows\\system32\\evil.dll"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_drive_prefix() {
+    // Windows drive-letter absolute path — must reject on every host.
+    let tmp = make_zip_with_entries(&["C:\\evil\\payload.exe"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_backslash_traversal() {
+    // Path traversal using Windows separator — must reject on every host.
+    let tmp = make_zip_with_entries(&["node-v24.18.0-win-x64\\..\\..\\evil"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("path traversal"),
+        "expected 'path traversal' in: {err}"
+    );
+}
+
+// ── verify_node_tree layout tests ─────────────────────────────────────────────
+
+#[test]
+fn test_verify_node_tree_unix_layout_passes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("node"), b"").unwrap();
+    std::fs::write(bin.join("npm"), b"").unwrap();
+    // On non-Windows the unix branch is active — this must pass.
+    #[cfg(not(windows))]
+    assert!(verify_node_tree(tmp.path()).is_ok());
+    // On Windows the windows branch is active — unix layout must fail.
+    #[cfg(windows)]
+    assert!(verify_node_tree(tmp.path()).is_err());
+}
+
+#[test]
+fn test_verify_node_tree_unix_layout_missing_npm_fails() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("node"), b"").unwrap();
+    // npm intentionally absent
+    #[cfg(not(windows))]
+    {
+        let err = verify_node_tree(tmp.path()).unwrap_err();
+        assert!(err.contains("bin/npm"), "err: {err}");
+    }
+}
+
+#[test]
+fn test_verify_node_tree_windows_layout_passes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm"), b"").unwrap();
+    // On Windows the windows branch is active — this must pass.
+    #[cfg(windows)]
+    assert!(verify_node_tree(tmp.path()).is_ok());
+    // On non-Windows the unix branch is active — windows-layout root files
+    // don't satisfy bin/node + bin/npm, so this must fail.
+    #[cfg(not(windows))]
+    assert!(verify_node_tree(tmp.path()).is_err());
+}
+
+#[test]
+fn test_verify_node_tree_windows_layout_missing_npm_shim_fails() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
+    // npm POSIX shim intentionally absent
+    #[cfg(windows)]
+    {
+        let err = verify_node_tree(tmp.path()).unwrap_err();
+        assert!(err.contains("npm"), "err: {err}");
+    }
+}
+
+// ── should_invalidate_adapter / orphan policy pure unit tests ─────────────────
+
+#[test]
+fn test_should_invalidate_adapter_invalidates_managed_shim_when_orphaned() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let shim = prefix.join("codex-acp");
+    assert!(
+        should_invalidate_adapter(&shim, prefix, true),
+        "managed shim + orphaned runtime must be invalidated"
+    );
+}
+
+#[test]
+fn test_should_invalidate_adapter_keeps_external_adapter_when_orphaned() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let external = std::path::Path::new("/usr/local/bin/codex-acp");
+    assert!(
+        !should_invalidate_adapter(external, prefix, true),
+        "external adapter must not be invalidated even when Node is orphaned"
+    );
+}
+
+#[test]
+fn test_should_invalidate_adapter_keeps_managed_shim_when_node_healthy() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let shim = prefix.join("codex-acp");
+    assert!(
+        !should_invalidate_adapter(&shim, prefix, false),
+        "managed shim must not be invalidated when Node is healthy"
+    );
+}
+
+#[test]
+fn test_resolve_adapter_path_returns_none_when_binary_absent() {
+    let commands: &[&str] = &["nonexistent-buzz-test-binary-xyz"];
+    let adapter_install_commands: &[&str] = &["curl -fsSL https://example.com | bash"];
+    assert!(
+        resolve_adapter_path(commands, adapter_install_commands).is_none(),
+        "must return None when the command is not on PATH"
+    );
+}
+
+// ── probe_node seam regressions ───────────────────────────────────────────────
+//
+// All four scenarios drive probe_node() directly — the same
+// tempfile/deadline/cleanup/status/version path used by managed_node_runtime_ready.
+// Each test CAN fail if production:
+//   - drops process_group(0)          → descendant-holds-stdout assertion (d) fails
+//                                       (tempfile transport still returns promptly;
+//                                        the sleep survives and kill($!,0) returns 0)
+//   - skips group-kill on a path      → hung-binary test exceeds margin
+//   - ignores exit_status.success()   → nonzero-exit test returns true
+//   - skips version comparison        → wrong-version test returns true
+//
+// Script files are written into a TempDir (no open write fd at spawn time)
+// to avoid ETXTBSY on Linux.
+
+/// Scenario 1 — descendant holds stdout write-end, direct child exits immediately.
+///
+/// The script backgrounds a 60-second sleep (inheriting stdout), records both the
+/// script's own PID (`$$`) and the sleep's PID (`$!`) to sidecar files, then exits
+/// with the expected version string.  Four assertions:
+///   (a) bounded return — would hang ~60 s if tempfile transport regressed to pipe;
+///   (b) correct result;
+///   (c) process group dead after return — catches skipped-cleanup-on-success: if
+///       the group-kill is absent but `process_group(0)` is still present, a live
+///       member in the group is detectable;
+///   (d) descendant PID dead after return — catches dropped `process_group(0)`: if
+///       the call is removed the sleep stays in the runner's group (not the probe's),
+///       `kill(-pgid,0)` is vacuously ESRCH, but `kill(desc_pid,0)` returns 0 and
+///       this assertion fails.  This is the canonical mutation for (c).
+#[cfg(unix)]
+#[test]
+fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("probe.sh");
+    let pgid_file = tmp_dir.path().join("pgid");
+    let desc_pid_file = tmp_dir.path().join("desc_pid");
+    let pgid_file_path = pgid_file.to_str().unwrap().to_owned();
+    let desc_pid_file_path = desc_pid_file.to_str().unwrap().to_owned();
+    // Line 1 of script: record the script's own PID (= PGID after process_group(0)).
+    // Line 2: background the sleep and record its PID.
+    // Line 3: emit the expected version and exit so the direct child exits promptly.
+    let script_content = format!(
+        "#!/bin/sh\necho $$ > {pgid_file_path}\n/bin/sleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
+    );
+    std::fs::write(&script, script_content.as_bytes()).unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let probe_timeout = std::time::Duration::from_secs(3);
+    let t = std::time::Instant::now();
+    let result = probe_node(&script, "v24.18.0", probe_timeout);
+    let elapsed = t.elapsed();
+
+    // Give the group-kill a moment to propagate before checking liveness.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // (a) bounded return — tempfile transport must not hang on the descendant's
+    //     retained pipe write-end.
+    assert!(
+        elapsed < probe_timeout + std::time::Duration::from_secs(2),
+        "probe_node hung — likely descendant retained pipe write-end: elapsed {elapsed:?}"
+    );
+    // (b) correct result
+    assert!(result, "probe_node must return true for matching version");
+
+    // (c) process group dead — catches skipped-cleanup: if the group-kill on the
+    //     success path is removed while process_group(0) is still present, the
+    //     sleep remains in the probe's group and kill(-pgid,0) returns 0.
+    let pgid_str = std::fs::read_to_string(&pgid_file)
+        .expect("script must have written its PID to the pgid sidecar");
+    let pgid: i32 = pgid_str
+        .trim()
+        .parse()
+        .expect("pgid sidecar must contain a numeric PID");
+    let group_alive = unsafe { libc::kill(-pgid, 0) } == 0;
+    assert!(
+        !group_alive,
+        "process group {pgid} must be dead after probe_node"
+    );
+
+    // (d) descendant PID dead — catches dropped process_group(0): without that
+    //     call the sleep is never in the probe's group, so kill(-pgid,0) is
+    //     vacuously ESRCH while the sleep survives.  Asserting the descendant's
+    //     own PID is dead proves the sleep was actually killed.
+    let desc_pid_str = std::fs::read_to_string(&desc_pid_file)
+        .expect("script must have written the sleep PID to the desc_pid sidecar");
+    let desc_pid: libc::pid_t = desc_pid_str
+        .trim()
+        .parse()
+        .expect("desc_pid sidecar must contain a numeric PID");
+    // Pre-assert cleanup: if the descendant is somehow still alive, kill it so
+    // a failing test does not leave a 60-second sleep in the runner's process group.
+    let desc_alive = unsafe { libc::kill(desc_pid, 0) } == 0;
+    if desc_alive {
+        unsafe { libc::kill(desc_pid, libc::SIGKILL) };
+    }
+    assert!(
+        !desc_alive,
+        "descendant PID {desc_pid} must be dead after probe_node — \
+         if process_group(0) is dropped, the sleep escapes into the runner's group \
+         and is never killed by the group-kill"
+    );
+}
+
+/// Scenario 2 — direct hang: probe_node must traverse the real try_wait
+/// deadline and return false.  Does NOT call kill_probe_group directly.
+///
+/// This test FAILS if the deadline loop in probe_node is broken or if the
+/// timeout/kill path is not exercised (e.g., missing group-kill exits the
+/// loop early via a different mechanism).
+#[cfg(unix)]
+#[test]
+fn test_probe_node_times_out_on_hung_binary() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("hung.sh");
+    std::fs::write(&script, b"#!/bin/sh\n/bin/sleep 30\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let probe_timeout = std::time::Duration::from_secs(3);
+    let t = std::time::Instant::now();
+    let result = probe_node(&script, "v24.18.0", probe_timeout);
+    let elapsed = t.elapsed();
+
+    assert!(!result, "probe_node must return false for a hung binary");
+    // Must have traversed the deadline (not returned early via a bug).
+    assert!(
+        elapsed >= probe_timeout,
+        "probe_node returned before deadline: {elapsed:?} < {probe_timeout:?}"
+    );
+    // Must not hang past the deadline by more than the poll interval + margin.
+    assert!(
+        elapsed < probe_timeout + std::time::Duration::from_secs(3),
+        "probe_node exceeded deadline by too much: {elapsed:?}"
+    );
+}
+
+/// Scenario 3 — non-zero exit: probe_node must return false even when stdout
+/// contains the expected version string.
+///
+/// This test FAILS if probe_node skips or inverts the exit_status.success() check.
+#[cfg(unix)]
+#[test]
+fn test_probe_node_returns_false_on_nonzero_exit() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("fail.sh");
+    // Prints the expected version string but exits non-zero.
+    std::fs::write(&script, b"#!/bin/sh\necho v24.18.0\nexit 1\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let result = probe_node(&script, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when the process exits non-zero"
+    );
+}
+
+/// Scenario 4 — wrong version output: probe_node must return false when stdout
+/// does not match expected_version.
+///
+/// This test FAILS if probe_node skips or incorrectly performs the version comparison.
+#[cfg(unix)]
+#[test]
+fn test_probe_node_returns_false_on_wrong_version_output() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("wrongver.sh");
+    std::fs::write(&script, b"#!/bin/sh\necho v99.0.0\nexit 0\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let result = probe_node(&script, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when stdout version does not match expected"
+    );
+}
+
+/// Windows-shaped seam: non-zero exit via .bat file.
+///
+/// Drives the same probe_node path on Windows (terminate_process / taskkill /T /F).
+/// This test FAILS if probe_node ignores exit_status.success() on Windows.
+#[cfg(windows)]
+#[test]
+fn test_probe_node_windows_returns_false_on_nonzero_exit() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let bat = tmp_dir.path().join("fail.bat");
+    // Prints the expected version but exits non-zero — must still fail.
+    std::fs::write(&bat, b"@echo off\r\necho v24.18.0\r\nexit /b 1\r\n").unwrap();
+
+    let result = probe_node(&bat, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when the .bat exits non-zero (Windows)"
+    );
+}
+
+/// Windows-shaped seam: wrong version output via .bat file.
+///
+/// This test FAILS if probe_node skips the version comparison on Windows.
+#[cfg(windows)]
+#[test]
+fn test_probe_node_windows_returns_false_on_wrong_version_output() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let bat = tmp_dir.path().join("wrongver.bat");
+    std::fs::write(&bat, b"@echo off\r\necho v99.0.0\r\nexit /b 0\r\n").unwrap();
+
+    let result = probe_node(&bat, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when stdout version does not match (Windows)"
+    );
+}
+
+/// Returns false when the node binary path does not exist (fast path, no spawn).
+#[test]
+fn test_managed_node_runtime_ready_returns_false_when_binary_absent() {
+    let Some(node) = crate::managed_agents::buzz_managed_node_bin_path() else {
+        assert!(
+            !managed_node_runtime_ready(),
+            "managed_node_runtime_ready must return false when no path resolves"
+        );
+        return;
+    };
+    if node.is_file() {
+        return;
+    }
+    assert!(
+        !managed_node_runtime_ready(),
+        "managed_node_runtime_ready must return false when the binary file does not exist"
+    );
+}

--- a/desktop/src-tauri/src/commands/export_util.rs
+++ b/desktop/src-tauri/src/commands/export_util.rs
@@ -35,8 +35,8 @@ pub async fn pick_save_path(
 /// user cancelled the dialog.
 ///
 /// NOT for secrets: the write is plain `std::fs::write` (no atomic commit, no
-/// 0o600). Secret exports go through `pick_save_path` +
-/// `key_backup::write_backup_file`.
+/// 0o600). Secret exports go through `pick_save_path` and a dedicated
+/// secret-file writer such as `key_backup::write_portable_backup_file`.
 pub async fn save_bytes_with_dialog(
     app: &AppHandle,
     suggested_filename: &str,

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -297,9 +297,10 @@ pub async fn verify_ncryptsec_backup(
 /// Save a portable copy of an `ncryptsec1…` backup to a user-chosen path.
 ///
 /// The input must parse as a structurally valid NIP-49 payload. The dialog is
-/// selection-only; the write uses secret-file semantics (atomic + 0o600).
-/// Never mutates canonical app state. Returns the chosen path, or `None` when
-/// the user cancelled.
+/// selection-only; the write uses the exact save-panel-authorized path with
+/// owner-only permissions, sync, and reread verification. Existing files are
+/// preserved rather than truncated. Never mutates canonical app state. Returns
+/// the chosen path, or `None` when the user cancelled.
 #[tauri::command]
 pub async fn save_ncryptsec_copy(
     ncryptsec: String,
@@ -324,7 +325,7 @@ pub async fn save_ncryptsec_copy(
 
     let dest_for_write = dest.clone();
     tokio::task::spawn_blocking(move || {
-        crate::key_backup::write_backup_file(&dest_for_write, &normalized)
+        crate::key_backup::write_portable_backup_file(&dest_for_write, &normalized)
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))??;

--- a/desktop/src-tauri/src/key_backup.rs
+++ b/desktop/src-tauri/src/key_backup.rs
@@ -133,9 +133,14 @@ pub fn backup_file_path(data_dir: &std::path::Path) -> std::path::PathBuf {
     data_dir.join(BACKUP_FILE_NAME)
 }
 
-/// Atomically write `ncryptsec` to `path` with owner-only permissions, then
-/// reread and byte-compare. Same crash-safety pattern as
+/// Atomically write the app-managed `ncryptsec` backup with owner-only
+/// permissions, then reread and byte-compare. Same crash-safety pattern as
 /// `app_state::save_key_file`.
+///
+/// Portable exports selected through a native save panel must use
+/// [`write_portable_backup_file`] instead: sandboxed macOS grants access to the
+/// selected path, but not to the sibling temporary file this writer needs.
+#[allow(dead_code)] // Retained for durable app-managed backups; portable exports must not use it.
 pub fn write_backup_file(path: &std::path::Path, ncryptsec: &str) -> Result<(), String> {
     use atomic_write_file::AtomicWriteFile;
     use std::io::Write;
@@ -155,6 +160,56 @@ pub fn write_backup_file(path: &std::path::Path, ncryptsec: &str) -> Result<(), 
     file.commit()
         .map_err(|e| format!("commit backup file: {e}"))?;
 
+    verify_backup_file(path, ncryptsec)
+}
+
+/// Write a user-selected portable backup without creating a sibling file.
+///
+/// Native macOS save panels authorize the exact selected path in protected
+/// folders such as Downloads, not an atomic writer's hidden sibling. Opening
+/// with `create_new` uses only that authorized path and also guarantees an
+/// existing backup is never truncated: users must choose a new filename when
+/// the destination already exists. After writing, the file is synced and its
+/// persisted bytes are reread before success is reported.
+pub fn write_portable_backup_file(path: &std::path::Path, ncryptsec: &str) -> Result<(), String> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::AlreadyExists {
+            "backup file already exists; choose a new filename so the existing backup stays safe"
+                .to_string()
+        } else {
+            format!("create portable backup file: {error}")
+        }
+    })?;
+
+    let write_result = file
+        .write_all(ncryptsec.as_bytes())
+        .map_err(|e| format!("write portable backup file: {e}"))
+        .and_then(|()| {
+            file.sync_all()
+                .map_err(|e| format!("sync portable backup file: {e}"))
+        });
+    drop(file);
+
+    let result = write_result.and_then(|()| verify_backup_file(path, ncryptsec));
+    if result.is_err() {
+        // This function created the destination exclusively, so cleanup cannot
+        // clobber a backup that existed before the save attempt.
+        let _ = std::fs::remove_file(path);
+    }
+    result
+}
+
+fn verify_backup_file(path: &std::path::Path, ncryptsec: &str) -> Result<(), String> {
     // Reread and byte-compare: only report success for bytes that are
     // actually on disk.
     let on_disk = std::fs::read_to_string(path).map_err(|e| format!("reread backup file: {e}"))?;

--- a/desktop/src-tauri/src/key_backup_tests.rs
+++ b/desktop/src-tauri/src/key_backup_tests.rs
@@ -161,6 +161,45 @@ fn write_backup_file_overwrites_atomically() {
 }
 
 #[test]
+fn write_portable_backup_file_persists_0600_without_a_sibling() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("portable.ncryptsec");
+    write_portable_backup_file(&path, SPEC_NCRYPTSEC).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), SPEC_NCRYPTSEC);
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(
+        entries,
+        vec![std::ffi::OsString::from("portable.ncryptsec")]
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "portable backup must be owner-only");
+    }
+}
+
+#[test]
+fn write_portable_backup_file_preserves_an_existing_backup() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("portable.ncryptsec");
+    std::fs::write(&path, "ncryptsec1existing").unwrap();
+
+    let error = write_portable_backup_file(&path, SPEC_NCRYPTSEC).unwrap_err();
+
+    assert!(error.contains("already exists"), "{error}");
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "ncryptsec1existing"
+    );
+}
+
+#[test]
 fn delete_backup_file_is_idempotent() {
     let dir = tempfile::tempdir().unwrap();
     delete_backup_file(dir.path()).unwrap();

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -9,10 +9,10 @@ use crate::managed_agents::{
     AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus, CommandAvailabilityInfo,
     HarnessSource,
 };
-
 mod presets;
 mod runtime_metadata;
-
+#[macro_use]
+mod windows_install;
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use presets::{preset_harness_definitions, preset_harness_ids};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
@@ -85,7 +85,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         cli_install_commands: &["curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"],
         // Goose's stable release currently publishes only the Unix installer;
         // its official Windows instructions intentionally point at this main-branch script.
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("goose", "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1", "$env:CONFIGURE='false'; ")],
         adapter_install_commands: &[],
         cli_install_instructions_url: "https://goose-docs.ai/docs/getting-started/installation/",
         adapter_install_instructions_url: "",
@@ -117,7 +117,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         mcp_hooks: false,
         underlying_cli: Some("claude"),
         cli_install_commands: &["curl -fsSL https://claude.ai/install.sh | bash"],
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://claude.ai/install.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("claude", "https://claude.ai/install.ps1")],
         adapter_install_commands: &["npm install -g @agentclientprotocol/claude-agent-acp"],
         cli_install_instructions_url: "https://code.claude.com/docs/en/getting-started",
         adapter_install_instructions_url: "https://github.com/agentclientprotocol/claude-agent-acp",
@@ -149,7 +149,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         mcp_hooks: false,
         underlying_cli: Some("codex"),
         cli_install_commands: &["curl -fsSL https://chatgpt.com/codex/install.sh | sh"],
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://chatgpt.com/codex/install.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("codex", "https://chatgpt.com/codex/install.ps1")],
         adapter_install_commands: &["npm install -g @agentclientprotocol/codex-acp"],
         cli_install_instructions_url: "https://developers.openai.com/codex/cli/",
         adapter_install_instructions_url: "https://github.com/agentclientprotocol/codex-acp",

--- a/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
@@ -1,0 +1,225 @@
+//! Defender-safe construction of the Windows PowerShell CLI install commands.
+//!
+//! # Why the shape matters
+//!
+//! Windows Defender's ML classifier flags the bare `irm <url> | iex` command
+//! line as `Trojan:Win32/Commando.A!ml` — piping a downloaded string straight
+//! into `Invoke-Expression` is a textbook dropper signature, so the *command
+//! line itself* is scored, independent of what the URL actually serves. The
+//! spawn is denied before PowerShell runs, surfacing as
+//! `failed to spawn shell: Access is denied. (os error 5)`, and the block is
+//! sticky: Defender's "Allow" button does not clear it.
+//!
+//! [`windows_install_command!`] emits the two-step form instead — download the
+//! vendor script to a file, then execute the file — which does not match that
+//! signature. All three runtimes use it, not only the one observed failing:
+//! Goose and Claude escaped by scoring under the classifier threshold, which is
+//! luck rather than design, and the threshold is not ours to depend on.
+//!
+//! # Why one macro instead of three literals
+//!
+//! The catalog needs `&'static str`, so the commands must be built at compile
+//! time from literals. Emitting them from a single macro means the security
+//! shape is defined once and cannot drift between runtimes as URLs change —
+//! a per-runtime literal would let one entry silently regress to `iex`.
+//!
+//! # Exit-code fidelity
+//!
+//! [#2892](https://github.com/block/buzz/pull/2892) established that an install
+//! step must not report success when the download failed. Two pieces preserve
+//! that here, and both are load-bearing:
+//!
+//! - `$ErrorActionPreference='Stop'` makes a failed `Invoke-RestMethod`
+//!   terminate the whole command. Without it a failed download falls through to
+//!   `& $installer` on a path that does not exist, and PowerShell exits **0** —
+//!   the exact masking #2892 removed, in a new dress. `Stop` also prevents
+//!   executing a *stale* installer left in `$env:TEMP` by an earlier run.
+//! - `exit $LASTEXITCODE` propagates the vendor script's own exit code. Without
+//!   it PowerShell reports its own status and a vendor failure of `3` flattens
+//!   to `1`, losing the distinction the retry logic reads.
+//!
+//! Verified against `pwsh` over a local HTTP server: vendor exit 3 surfaces as
+//! 3, vendor exit 0 as 0, a 404 and an unresolvable host as non-zero, and a
+//! planted stale installer is never executed. The old `irm | iex` shape
+//! produces identical codes for all four, so this is not a behavior change.
+//!
+//! # Quoting contract
+//!
+//! The emitted body is wrapped in one double-quote pair, which
+//! `install_powershell_command` strips before handing the body to PowerShell.
+//! The body therefore uses **only single quotes** internally; a double quote
+//! would terminate that pair early and truncate the command.
+
+/// Build the Windows CLI install command for one runtime.
+///
+/// `slug` names the downloaded script (`buzz-install-<slug>.ps1`) so concurrent
+/// installs of different runtimes cannot overwrite each other's file. The
+/// optional third argument carries a runtime's env prefix (Goose's
+/// `$env:CONFIGURE='false'; `) and must end with `; `.
+///
+/// See the module docs for why each fragment is present.
+macro_rules! windows_install_command {
+    ($slug:literal, $url:literal) => {
+        windows_install_command!($slug, $url, "")
+    };
+    ($slug:literal, $url:literal, $env_prefix:literal) => {
+        concat!(
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"",
+            $env_prefix,
+            "$ErrorActionPreference='Stop'; ",
+            "$installer=Join-Path $env:TEMP 'buzz-install-",
+            $slug,
+            ".ps1'; ",
+            "Invoke-RestMethod ",
+            $url,
+            " -OutFile $installer; ",
+            "& $installer; ",
+            "exit $LASTEXITCODE\"",
+        )
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::managed_agents::known_acp_runtime_exact;
+
+    /// Every runtime that ships a Windows install command. `cli_install_commands_windows`
+    /// is read directly rather than through `cli_install_commands_for_os()` so these
+    /// assertions cover the Windows strings while running on the Linux CI host.
+    fn windows_install_commands() -> Vec<(&'static str, &'static str)> {
+        ["goose", "claude", "codex"]
+            .into_iter()
+            .flat_map(|id| {
+                known_acp_runtime_exact(id)
+                    .expect("runtime must exist in the catalog")
+                    .cli_install_commands_windows
+                    .iter()
+                    .map(move |command| (id, *command))
+            })
+            .collect()
+    }
+
+    /// The whole point of the change: no runtime may carry the flagged
+    /// download-and-execute-in-one-line signature.
+    #[test]
+    fn test_no_windows_install_command_pipes_a_download_into_iex() {
+        for (id, command) in windows_install_commands() {
+            assert!(
+                !command.contains("| iex"),
+                "{id}: `irm | iex` is the shape Defender flags as Trojan:Win32/Commando.A!ml; \
+                 download to a file and execute the file instead. Got: {command}"
+            );
+            assert!(
+                !command.contains("Invoke-Expression"),
+                "{id}: Invoke-Expression on downloaded content carries the same signature. \
+                 Got: {command}"
+            );
+        }
+    }
+
+    /// All three runtimes must be hardened, not just the one observed failing.
+    /// Goose and Claude escaped only by scoring under the classifier threshold.
+    #[test]
+    fn test_every_windows_install_command_downloads_to_a_file_then_executes_it() {
+        let commands = windows_install_commands();
+        assert_eq!(
+            commands.len(),
+            3,
+            "expected exactly one Windows install command for each of goose, claude, codex"
+        );
+        for (id, command) in commands {
+            assert!(
+                command.contains("-OutFile $installer"),
+                "{id}: must download the vendor script to a file. Got: {command}"
+            );
+            assert!(
+                command.contains("& $installer"),
+                "{id}: must execute the downloaded file. Got: {command}"
+            );
+            assert!(
+                command.contains(&format!("buzz-install-{id}.ps1")),
+                "{id}: script name must be runtime-specific so concurrent installs of \
+                 different runtimes cannot overwrite each other. Got: {command}"
+            );
+        }
+    }
+
+    /// Guards the #2892 regression: without `Stop`, a failed download falls
+    /// through to a missing file and PowerShell exits 0, reporting a failed
+    /// install as a success. Without `exit $LASTEXITCODE`, the vendor's own
+    /// exit code is replaced by PowerShell's.
+    #[test]
+    fn test_every_windows_install_command_preserves_failure_exit_codes() {
+        for (id, command) in windows_install_commands() {
+            assert!(
+                command.contains("$ErrorActionPreference='Stop'"),
+                "{id}: a failed download must abort instead of running a missing or stale \
+                 installer and exiting 0 (see #2892). Got: {command}"
+            );
+            assert!(
+                command.contains("exit $LASTEXITCODE"),
+                "{id}: the vendor script's exit code must propagate. Got: {command}"
+            );
+        }
+    }
+
+    /// `install_powershell_command` strips exactly one outer double-quote pair.
+    /// An inner double quote would close that pair early and truncate the body.
+    #[test]
+    fn test_every_windows_install_command_quotes_the_body_exactly_once() {
+        for (id, command) in windows_install_commands() {
+            let body = command
+                .split_once(" -Command ")
+                .map(|(_, body)| body)
+                .unwrap_or_else(|| panic!("{id}: command must pass a -Command body: {command}"));
+            assert!(
+                body.starts_with('"') && body.ends_with('"'),
+                "{id}: body must be wrapped in one double-quote pair. Got: {body}"
+            );
+            assert_eq!(
+                body.matches('"').count(),
+                2,
+                "{id}: body must contain no inner double quotes — one would terminate the \
+                 outer pair early and truncate the command. Got: {body}"
+            );
+        }
+    }
+
+    /// Goose's installer reads `CONFIGURE` to stay non-interactive; losing the
+    /// prefix hangs the install waiting on input that never comes.
+    #[test]
+    fn test_goose_windows_install_command_keeps_its_env_prefix() {
+        let goose = known_acp_runtime_exact("goose").unwrap();
+        let command = goose.cli_install_commands_windows[0];
+        assert!(
+            command.contains("$env:CONFIGURE='false'"),
+            "goose must stay non-interactive. Got: {command}"
+        );
+        assert!(
+            command.find("$env:CONFIGURE='false'").unwrap()
+                < command.find("Invoke-RestMethod").unwrap(),
+            "the env prefix must be set before the installer runs. Got: {command}"
+        );
+    }
+
+    /// The vendor URLs are the payload; pin them so a refactor of the shared
+    /// shape cannot silently retarget a download.
+    #[test]
+    fn test_windows_install_commands_target_the_official_vendor_urls() {
+        for (id, expected) in [
+            (
+                "goose",
+                "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1",
+            ),
+            ("claude", "https://claude.ai/install.ps1"),
+            ("codex", "https://chatgpt.com/codex/install.ps1"),
+        ] {
+            let runtime = known_acp_runtime_exact(id).unwrap();
+            let command = runtime.cli_install_commands_windows[0];
+            assert!(
+                command.contains(&format!("Invoke-RestMethod {expected} -OutFile")),
+                "{id}: must download from {expected}. Got: {command}"
+            );
+        }
+    }
+}

--- a/desktop/src/app/AppShell.helpers.test.mjs
+++ b/desktop/src/app/AppShell.helpers.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldBounceForChannelNotification } from "./AppShell.helpers.ts";
+import {
+  markAllReadSources,
+  shouldBounceForChannelNotification,
+} from "./AppShell.helpers.ts";
 
 test("shouldBounceForChannelNotification_allowsTopLevelChannelMessages", () => {
   assert.equal(shouldBounceForChannelNotification([["h", "channel"]]), true);
@@ -26,4 +29,44 @@ test("shouldBounceForChannelNotification_allowsBroadcastReplies", () => {
     ]),
     true,
   );
+});
+
+test("markAllReadSources clears Inbox overrides and active thread activity", () => {
+  const calls = [];
+
+  markAllReadSources({
+    activeChannelId: "active-channel",
+    channelActivityItems: [
+      { channelId: "another-channel", createdAt: 100 },
+      { channelId: "active-channel", createdAt: 200 },
+      { channelId: "active-channel", createdAt: 300 },
+    ],
+    unreadFeedItemIds: new Set(["first-inbox-item", "second-inbox-item"]),
+    undoUnreadFeedItem: (itemId) => calls.push(`inbox:${itemId}`),
+    markAllChannelReadMarkers: () => calls.push("channels"),
+    markActiveChannelRead: (channelId, createdAt) =>
+      calls.push(`active:${channelId}:${createdAt}`),
+  });
+
+  assert.deepEqual(calls, [
+    "inbox:first-inbox-item",
+    "inbox:second-inbox-item",
+    "channels",
+    "active:active-channel:300",
+  ]);
+});
+
+test("markAllReadSources skips the active marker without projected activity", () => {
+  const calls = [];
+
+  markAllReadSources({
+    activeChannelId: "active-channel",
+    channelActivityItems: [],
+    unreadFeedItemIds: new Set(),
+    undoUnreadFeedItem: () => calls.push("inbox"),
+    markAllChannelReadMarkers: () => calls.push("channels"),
+    markActiveChannelRead: () => calls.push("active"),
+  });
+
+  assert.deepEqual(calls, ["channels"]);
 });

--- a/desktop/src/app/AppShell.helpers.ts
+++ b/desktop/src/app/AppShell.helpers.ts
@@ -86,6 +86,41 @@ export function shouldBounceForChannelNotification(tags: string[][]): boolean {
   return !isThreadReply(tags);
 }
 
+export function markAllReadSources({
+  activeChannelId,
+  channelActivityItems,
+  markAllChannelReadMarkers,
+  markActiveChannelRead,
+  undoUnreadFeedItem,
+  unreadFeedItemIds,
+}: {
+  activeChannelId: string | null;
+  channelActivityItems: ReadonlyArray<{
+    channelId: string | null;
+    createdAt: number;
+  }>;
+  markAllChannelReadMarkers: () => void;
+  markActiveChannelRead: (channelId: string, createdAt: number) => void;
+  undoUnreadFeedItem: (itemId: string) => void;
+  unreadFeedItemIds: ReadonlySet<string>;
+}) {
+  for (const itemId of unreadFeedItemIds) {
+    undoUnreadFeedItem(itemId);
+  }
+  markAllChannelReadMarkers();
+
+  if (!activeChannelId) return;
+
+  let latestActivityAt: number | null = null;
+  for (const item of channelActivityItems) {
+    if (item.channelId !== activeChannelId) continue;
+    latestActivityAt = Math.max(latestActivityAt ?? 0, item.createdAt);
+  }
+  if (latestActivityAt !== null) {
+    markActiveChannelRead(activeChannelId, latestActivityAt);
+  }
+}
+
 export function toSearchHit(
   target: DesktopNotificationTarget,
 ): SearchHit | null {

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useLocation } from "@tanstack/react-router";
-import { deriveShellRoute } from "@/app/AppShell.helpers";
+import { deriveShellRoute, markAllReadSources } from "@/app/AppShell.helpers";
 import { AppShellProvider } from "@/app/AppShellContext";
 import * as BuzzTheme from "@/app/BuzzThemeSurfaces";
 import { AppShellOverlays } from "@/app/AppShellOverlays";
@@ -15,7 +15,7 @@ import { useMarkAsReadShortcuts } from "@/app/useMarkAsReadShortcuts";
 import { useSettingsShortcuts } from "@/app/useSettingsShortcuts";
 import { useAppShellDesktopNotifications } from "@/app/useAppShellDesktopNotifications";
 import { useAppShellLifecycleEffects } from "@/app/useAppShellLifecycleEffects";
-import { useThreadActivityFeedItems } from "@/app/useThreadActivityFeedItems";
+import { useChannelActivityProjection } from "@/app/useChannelActivityProjection";
 import { useTauriWindowDrag } from "@/app/useTauriWindowDrag";
 import { useWebviewZoomShortcuts } from "@/app/useWebviewZoomShortcuts";
 import {
@@ -26,7 +26,6 @@ import {
   useOpenDmMutation,
 } from "@/features/channels/hooks";
 import { useUnreadChannels } from "@/features/channels/useUnreadChannels";
-import { msgContextKey } from "@/features/channels/readState/readStateFormat";
 import { useMembershipNotifications } from "@/features/channels/useMembershipNotifications";
 import { useFeedItemState } from "@/features/home/useFeedItemState";
 import { useThreadFollows } from "@/features/messages/lib/useThreadFollows";
@@ -324,10 +323,12 @@ export function AppShell() {
   } = useThreadFollows(identityQuery.data?.pubkey);
 
   const {
-    markAllChannelsRead,
+    markAllChannelsRead: markAllChannelReadMarkers,
     markChannelRead,
     markChannelUnread,
+    clearChannelUnreadSource,
     unreadChannelIds,
+    topLevelUnreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,
     unreadChannelNotificationCount,
@@ -338,6 +339,7 @@ export function AppShell() {
     participatedRootIds,
     authoredRootIds,
     mentionedRootIds,
+    recordThreadInteraction,
     threadActivityItems,
     mutedRootIds,
     muteThread,
@@ -356,55 +358,45 @@ export function AppShell() {
     followedRootIds,
   });
 
-  const getThreadReadAt = React.useCallback(
-    (rootId: string, channelId?: string | null) => {
-      const threadReadAt = getOwnReadAt(`thread:${rootId}`);
-      if (!channelId) {
-        return threadReadAt;
-      }
-
-      const channelReadAt = getChannelReadAt(channelId);
-      if (threadReadAt === null) {
-        return channelReadAt;
-      }
-      if (channelReadAt === null) {
-        return threadReadAt;
-      }
-      return Math.max(threadReadAt, channelReadAt);
-    },
-    [getChannelReadAt, getOwnReadAt],
-  );
-
-  const markThreadRead = React.useCallback(
-    (rootId: string, timestamp: number) => {
-      markChannelRead(
-        `thread:${rootId}`,
-        new Date(timestamp * 1_000).toISOString(),
-      );
-    },
-    [markChannelRead],
-  );
-
-  // Per-message read frontier (LP4 v3): effective(msg:<id>) folds through the
-  // channel, so a channel-read clears messages older than the top-level frontier.
-  const getMessageReadAt = React.useCallback(
-    (messageId: string) => getChannelReadAt(msgContextKey(messageId)),
-    [getChannelReadAt],
-  );
-  const markMessageRead = React.useCallback(
-    (messageId: string, timestamp: number) =>
-      markChannelRead(
-        msgContextKey(messageId),
-        new Date(timestamp * 1_000).toISOString(),
-      ),
-    [markChannelRead],
-  );
-  const threadActivityFeedItems = useThreadActivityFeedItems(
+  const {
+    getThreadReadAt,
+    markThreadRead,
+    getMessageReadAt,
+    getChannelActivityItemReadAt,
+    markMessageRead,
+    threadActivityFeedItems,
+    locallyUnreadFeedItems,
+    unreadThreadFeedItems,
+    unreadThreadChannelIds,
+  } = useChannelActivityProjection({
+    channels,
+    feed: homeFeedQuery.data?.feed,
+    unreadFeedItemIds: feedItemState.unreadSet,
+    getChannelReadAt,
+    getOwnReadAt,
+    markChannelRead,
+    readStateVersion,
     threadActivityItems,
     mutedRootIds,
-    channels,
-  );
-
+  });
+  const markAllChannelsRead = React.useCallback(() => {
+    markAllReadSources({
+      activeChannelId: activeChannel?.id ?? null,
+      channelActivityItems: unreadThreadFeedItems,
+      markAllChannelReadMarkers,
+      markActiveChannelRead: (channelId, createdAt) =>
+        markChannelRead(channelId, new Date(createdAt * 1_000).toISOString()),
+      undoUnreadFeedItem: feedItemState.undoUnread,
+      unreadFeedItemIds: feedItemState.unreadSet,
+    });
+  }, [
+    activeChannel?.id,
+    feedItemState.undoUnread,
+    feedItemState.unreadSet,
+    markAllChannelReadMarkers,
+    markChannelRead,
+    unreadThreadFeedItems,
+  ]);
   // Badge count consumes the shared NIP-RS read-state from useUnreadChannels.
   const { homeBadgeCount, homeBadgeCountExcludingHighPriority } =
     useHomeFeedNotificationState(
@@ -709,6 +701,7 @@ export function AppShell() {
             markAllChannelsRead,
             markChannelRead,
             markChannelUnread,
+            clearChannelUnreadSource,
             openBrowseChannels: handleOpenBrowseChannels,
             openCreateChannel: handleOpenCreateChannel,
             openChannelManagement: (channelId?: string) => {
@@ -721,6 +714,7 @@ export function AppShell() {
             getThreadReadAt,
             markThreadRead,
             getMessageReadAt,
+            getChannelActivityItemReadAt,
             markMessageRead,
             readStateVersion,
             setContextParentResolver,
@@ -728,9 +722,15 @@ export function AppShell() {
             unfollowThread: handleUnfollowThread,
             isFollowingThread,
             isNotifiedForThread,
+            recordThreadInteraction,
             isThreadMuted: (rootId) => mutedRootIds.has(rootId),
             threadActivityItems,
             threadActivityFeedItems,
+            locallyUnreadFeedItems,
+            unreadThreadFeedItems,
+            unreadThreadChannelIds,
+            topLevelUnreadChannelIds,
+            hasSidebarUnreadProjections: true,
             feedItemState,
             onOpenSettings: handleOpenSettings,
           }}

--- a/desktop/src/app/AppShellContext.tsx
+++ b/desktop/src/app/AppShellContext.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { ForcedUnreadSource } from "@/features/channels/forcedUnreadStore";
 import type { ContextParentResolver } from "@/features/channels/readState/readStateManager";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
 import type { FeedItemState } from "@/features/home/useFeedItemState";
@@ -12,9 +13,16 @@ type AppShellContextValue = {
   markChannelRead: (
     channelId: string,
     readAt: string | null | undefined,
-    options?: { topLevelOnly?: boolean },
+    options?: {
+      preserveForcedUnread?: boolean;
+      topLevelOnly?: boolean;
+    },
   ) => void;
-  markChannelUnread: (channelId: string) => void;
+  markChannelUnread: (channelId: string, source?: ForcedUnreadSource) => void;
+  clearChannelUnreadSource: (
+    channelId: string,
+    source: ForcedUnreadSource,
+  ) => void;
   openBrowseChannels: () => void;
   openCreateChannel: () => void;
   openChannelManagement: (channelId?: string) => void;
@@ -31,6 +39,11 @@ type AppShellContextValue = {
   // read. Uses `msg:<id>` context keys folded through the active channel by the
   // parent resolver (LP4 v3 per-message badge model).
   getMessageReadAt: (messageId: string) => number | null;
+  // Read frontier for a channel-activity item, scoped to that item's own
+  // message and channel rather than the currently mounted channel resolver.
+  getChannelActivityItemReadAt: (
+    item: Pick<FeedItem, "channelId" | "id">,
+  ) => number | null;
   // Advance a single message's read marker to the given unix-seconds timestamp.
   markMessageRead: (messageId: string, timestamp: number) => void;
   // Bump-counter that invalidates whenever the read marker changes. Include
@@ -43,9 +56,25 @@ type AppShellContextValue = {
   unfollowThread: (rootId: string) => void;
   isFollowingThread: (rootId: string) => boolean;
   isNotifiedForThread: (rootId: string) => boolean;
+  recordThreadInteraction: (rootId: string) => void;
   isThreadMuted: (rootId: string) => boolean;
   threadActivityItems: ThreadActivityItem[];
   threadActivityFeedItems: FeedItem[];
+  // Home-feed items explicitly reopened from Inbox. Kept separate from live
+  // thread activity so older rows can be projected into channel hover cards
+  // without duplicating the Home feed itself.
+  locallyUnreadFeedItems: FeedItem[];
+  // Thread rows that remain unread until their own message/thread marker is
+  // advanced. Unlike the broad channel unread set, this includes the active
+  // channel so simply landing in it does not hide the wayfinding signal.
+  unreadThreadFeedItems: FeedItem[];
+  unreadThreadChannelIds: ReadonlySet<string>;
+  // Ordinary unread channel-level activity. Sidebar rows use this for text
+  // emphasis only; thread activity owns the dot.
+  topLevelUnreadChannelIds: ReadonlySet<string>;
+  // Lets isolated component tests retain the legacy hasUnread fallback while
+  // the mounted shell uses the split projections above.
+  hasSidebarUnreadProjections: boolean;
   feedItemState: FeedItemState;
   // Open the Settings panel at the given section. Available on all surfaces
   // that render under AppShell (channel, home, projects, pulse, agents).
@@ -57,6 +86,7 @@ const AppShellContext = React.createContext<AppShellContextValue>({
   markAllChannelsRead: () => {},
   markChannelRead: () => {},
   markChannelUnread: () => {},
+  clearChannelUnreadSource: () => {},
   openBrowseChannels: () => {},
   openCreateChannel: () => {},
   openChannelManagement: () => {},
@@ -64,6 +94,7 @@ const AppShellContext = React.createContext<AppShellContextValue>({
   getThreadReadAt: () => null,
   markThreadRead: () => {},
   getMessageReadAt: () => null,
+  getChannelActivityItemReadAt: () => null,
   markMessageRead: () => {},
   readStateVersion: 0,
   setContextParentResolver: () => {},
@@ -71,9 +102,15 @@ const AppShellContext = React.createContext<AppShellContextValue>({
   unfollowThread: () => {},
   isFollowingThread: () => false,
   isNotifiedForThread: () => false,
+  recordThreadInteraction: () => {},
   isThreadMuted: () => false,
   threadActivityItems: [],
   threadActivityFeedItems: [],
+  locallyUnreadFeedItems: [],
+  unreadThreadFeedItems: [],
+  unreadThreadChannelIds: EMPTY_SET,
+  topLevelUnreadChannelIds: EMPTY_SET,
+  hasSidebarUnreadProjections: false,
   feedItemState: {
     doneSet: EMPTY_SET,
     markDone: () => {},

--- a/desktop/src/app/useChannelActivityProjection.test.mjs
+++ b/desktop/src/app/useChannelActivityProjection.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveChannelActivityFeedItemReadAt } from "./useChannelActivityProjection.ts";
+
+test("channel activity read state folds the item's own message and channel markers", () => {
+  const markers = new Map([
+    ["msg:reply-general", 100],
+    ["general", 200],
+    ["random", 500],
+  ]);
+
+  assert.equal(
+    resolveChannelActivityFeedItemReadAt(
+      { id: "reply-general", channelId: "general" },
+      (contextId) => markers.get(contextId) ?? null,
+    ),
+    200,
+  );
+});
+
+test("channel activity read state honors a channel marker without a message marker", () => {
+  assert.equal(
+    resolveChannelActivityFeedItemReadAt(
+      { id: "reply-general", channelId: "general" },
+      (contextId) => (contextId === "general" ? 300 : null),
+    ),
+    300,
+  );
+});

--- a/desktop/src/app/useChannelActivityProjection.ts
+++ b/desktop/src/app/useChannelActivityProjection.ts
@@ -1,0 +1,145 @@
+import * as React from "react";
+
+import { useThreadActivityFeedItems } from "@/app/useThreadActivityFeedItems";
+import {
+  maxReadAt,
+  msgContextKey,
+} from "@/features/channels/readState/readStateFormat";
+import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
+import { isThreadReply } from "@/features/messages/lib/threading";
+import type { Channel, FeedItem, HomeFeed } from "@/shared/api/types";
+
+type ReadTimestamp = (contextKey: string) => number | null;
+type MarkChannelRead = (
+  contextKey: string,
+  readAt: string | null | undefined,
+  options?: { topLevelOnly?: boolean },
+) => void;
+
+type UseChannelActivityProjectionOptions = {
+  channels: Channel[];
+  feed: HomeFeed | undefined;
+  unreadFeedItemIds: ReadonlySet<string>;
+  getChannelReadAt: ReadTimestamp;
+  getOwnReadAt: ReadTimestamp;
+  markChannelRead: MarkChannelRead;
+  readStateVersion: number;
+  threadActivityItems: ThreadActivityItem[];
+  mutedRootIds: ReadonlySet<string>;
+};
+
+export function resolveChannelActivityFeedItemReadAt(
+  item: Pick<FeedItem, "channelId" | "id">,
+  getOwnReadAt: ReadTimestamp,
+): number | null {
+  return maxReadAt(
+    getOwnReadAt(msgContextKey(item.id)),
+    item.channelId ? getOwnReadAt(item.channelId) : null,
+  );
+}
+
+export function useChannelActivityProjection({
+  channels,
+  feed,
+  unreadFeedItemIds,
+  getChannelReadAt,
+  getOwnReadAt,
+  markChannelRead,
+  readStateVersion,
+  threadActivityItems,
+  mutedRootIds,
+}: UseChannelActivityProjectionOptions) {
+  const getThreadReadAt = React.useCallback(
+    (rootId: string, channelId?: string | null) => {
+      const threadReadAt = getOwnReadAt(`thread:${rootId}`);
+      if (!channelId) return threadReadAt;
+
+      const channelReadAt = getChannelReadAt(channelId);
+      if (threadReadAt === null) return channelReadAt;
+      if (channelReadAt === null) return threadReadAt;
+      return Math.max(threadReadAt, channelReadAt);
+    },
+    [getChannelReadAt, getOwnReadAt],
+  );
+  const markThreadRead = React.useCallback(
+    (rootId: string, timestamp: number) =>
+      markChannelRead(
+        `thread:${rootId}`,
+        new Date(timestamp * 1_000).toISOString(),
+      ),
+    [markChannelRead],
+  );
+  const getMessageReadAt = React.useCallback(
+    (messageId: string) => getChannelReadAt(msgContextKey(messageId)),
+    [getChannelReadAt],
+  );
+  const getChannelActivityItemReadAt = React.useCallback(
+    (item: Pick<FeedItem, "channelId" | "id">) =>
+      resolveChannelActivityFeedItemReadAt(item, getOwnReadAt),
+    [getOwnReadAt],
+  );
+  const markMessageRead = React.useCallback(
+    (messageId: string, timestamp: number) =>
+      markChannelRead(
+        msgContextKey(messageId),
+        new Date(timestamp * 1_000).toISOString(),
+      ),
+    [markChannelRead],
+  );
+  const threadActivityFeedItems = useThreadActivityFeedItems(
+    threadActivityItems,
+    mutedRootIds,
+    channels,
+  );
+  const locallyUnreadFeedItems = React.useMemo(() => {
+    if (!feed || unreadFeedItemIds.size === 0) return [];
+    return [
+      ...feed.mentions,
+      ...feed.needsAction,
+      ...feed.activity,
+      ...feed.agentActivity,
+    ].filter((item) => unreadFeedItemIds.has(item.id));
+  }, [feed, unreadFeedItemIds]);
+  const unreadThreadFeedItems = React.useMemo(() => {
+    void readStateVersion;
+    const candidatesById = new Map<string, FeedItem>(
+      threadActivityFeedItems.map((item) => [item.id, item]),
+    );
+    for (const item of locallyUnreadFeedItems)
+      candidatesById.set(item.id, item);
+
+    return [...candidatesById.values()].filter(
+      (item) =>
+        isThreadReply(item.tags) &&
+        (unreadFeedItemIds.has(item.id) ||
+          item.createdAt > (getChannelActivityItemReadAt(item) ?? 0)),
+    );
+  }, [
+    getChannelActivityItemReadAt,
+    locallyUnreadFeedItems,
+    readStateVersion,
+    threadActivityFeedItems,
+    unreadFeedItemIds,
+  ]);
+  const unreadThreadChannelIds = React.useMemo(
+    () =>
+      new Set(
+        unreadThreadFeedItems.flatMap((item) =>
+          item.channelId ? [item.channelId] : [],
+        ),
+      ) as ReadonlySet<string>,
+    [unreadThreadFeedItems],
+  );
+
+  return {
+    getThreadReadAt,
+    markThreadRead,
+    getMessageReadAt,
+    getChannelActivityItemReadAt,
+    markMessageRead,
+    threadActivityFeedItems,
+    locallyUnreadFeedItems,
+    unreadThreadFeedItems,
+    unreadThreadChannelIds,
+  };
+}

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -32,6 +32,7 @@ import {
   personaBehaviorDraftValid,
 } from "./personaBehaviorDraft";
 import {
+  ADVANCED_FIELDS_MOTION_TRANSITION,
   AUTO_MODEL_DROPDOWN_VALUE,
   AUTO_PROVIDER_DROPDOWN_VALUE,
   BLOCK_BUILD_HIDDEN_PROVIDER_IDS,
@@ -117,11 +118,6 @@ type AgentDefinitionDialogProps = {
 export type AgentDefinitionSubmitOptions = {
   publishCatalogUpdates: boolean;
 };
-
-const ADVANCED_FIELDS_MOTION_TRANSITION = {
-  duration: 0.18,
-  ease: [0.23, 1, 0.32, 1],
-} as const;
 
 export function AgentDefinitionDialog({
   open,

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -26,6 +26,7 @@ import { Input } from "@/shared/ui/input";
 import { setManagedAgentAutoRestart } from "@/shared/api/tauriManagedAgents";
 import { EditAgentAdvancedFields } from "./EditAgentAdvancedFields";
 import {
+  ADVANCED_FIELDS_MOTION_TRANSITION,
   AUTO_PROVIDER_DROPDOWN_VALUE,
   BLOCK_BUILD_HIDDEN_PROVIDER_IDS,
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
@@ -65,6 +66,7 @@ import { AgentCreationPreview } from "./AgentCreationPreview";
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import { useRequiredCredentialState } from "./useRequiredCredentialState";
 import { CreateAgentRespondToField } from "./RespondToField";
+import { RunOnSummarySection } from "./RunOnSummarySection";
 import { PersonaDropdownField } from "./PersonaDropdownField";
 import {
   MODEL_DISCOVERY_LOADING_VALUE,
@@ -92,11 +94,6 @@ import {
   runtimeDropdownAction,
   usePendingHarnessSelection,
 } from "./addCustomHarness";
-
-const ADVANCED_FIELDS_MOTION_TRANSITION = {
-  duration: 0.18,
-  ease: [0.23, 1, 0.32, 1],
-} as const;
 
 export function AgentInstanceEditDialog({
   agent,
@@ -948,6 +945,8 @@ export function AgentInstanceEditDialog({
               onModeChange={setRespondTo}
               variant="persona"
             />
+
+            <RunOnSummarySection backend={agent.backend} />
 
             {/* Provider (runtime) */}
             <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/RunOnSummarySection.tsx
+++ b/desktop/src/features/agents/ui/RunOnSummarySection.tsx
@@ -1,0 +1,73 @@
+import type { ManagedAgentBackend } from "@/shared/api/types";
+
+import { summarizeRunOn } from "./runOnSummary";
+
+/**
+ * Read-only "Run on" summary for the edit-agent dialog.
+ *
+ * Read-only on purpose: `UpdateManagedAgentRequest` has no backend field —
+ * where an agent runs is fixed at creation (a provider-backed agent's
+ * deployment holds its private key; there is no migrate operation). This
+ * section shows the *saved* provider config from the record, without probing
+ * the provider binary: an edit dialog must not do executable work as a side
+ * effect, and a live probe would show today's schema defaults instead of
+ * what this agent actually deployed with.
+ *
+ * Named "Run on" (matching the create flow) rather than "Provider" because
+ * this dialog already uses "Provider" for the ACP harness selector.
+ */
+export function RunOnSummarySection({
+  backend,
+}: {
+  backend: ManagedAgentBackend;
+}) {
+  const summary = summarizeRunOn(backend);
+
+  return (
+    <div className="space-y-1.5" data-testid="edit-agent-run-on">
+      <span className="text-sm font-medium text-foreground">Run on</span>
+      {summary.location === "local" ? (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="edit-agent-run-on-location"
+        >
+          This computer
+        </p>
+      ) : (
+        <div className="space-y-2 rounded-2xl border border-border bg-muted/30 px-4 py-3">
+          <p
+            className="text-sm font-medium"
+            data-testid="edit-agent-run-on-location"
+          >
+            {summary.providerId}
+          </p>
+          {summary.rows.length > 0 ? (
+            <dl className="space-y-1">
+              {summary.rows.map((row) => (
+                <div
+                  className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5"
+                  data-testid={`edit-agent-run-on-${row.key}`}
+                  key={row.key}
+                >
+                  <dt className="text-xs text-muted-foreground">{row.label}</dt>
+                  <dd className="min-w-0 break-all font-mono text-xs text-foreground">
+                    {row.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              No saved settings — the provider applies its defaults.
+            </p>
+          )}
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">
+        These are the settings saved when the agent was created. Where an agent
+        runs can&apos;t be changed afterwards — create a new agent to run
+        somewhere else.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -30,6 +30,12 @@ export const PERSONA_FIELD_CONTROL_CLASS =
 export const PERSONA_LABEL_OPTIONAL_CLASS =
   "ml-1 text-xs font-normal text-muted-foreground/50";
 
+/** Shared advanced-fields expand/collapse easing for the agent dialogs. */
+export const ADVANCED_FIELDS_MOTION_TRANSITION = {
+  duration: 0.18,
+  ease: [0.23, 1, 0.32, 1],
+} as const;
+
 export const AUTO_MODEL_DROPDOWN_VALUE = "__auto_model__";
 export const CUSTOM_MODEL_DROPDOWN_VALUE = "__custom_model__";
 export const AUTO_PROVIDER_DROPDOWN_VALUE = "__auto_provider__";

--- a/desktop/src/features/agents/ui/runOnSummary.test.mjs
+++ b/desktop/src/features/agents/ui/runOnSummary.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { humanizeConfigKey, summarizeRunOn } from "./runOnSummary.ts";
+
+test("local backend summarizes to the local location with no rows", () => {
+  assert.deepEqual(summarizeRunOn({ type: "local" }), { location: "local" });
+});
+
+test("provider backend carries the provider id", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "kubernetes",
+    config: {},
+  });
+  assert.equal(summary.location, "provider");
+  assert.equal(summary.providerId, "kubernetes");
+  assert.deepEqual(summary.rows, []);
+});
+
+test("a saved kubernetes config renders labeled scalar rows", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "kubernetes",
+    config: {
+      namespace: "buzz-agents-x7k2mp",
+      image: "ghcr.io/block/buzz-sprig@sha256:17facfc7",
+      cpu_request: "1",
+      inactivity_seconds: 7200,
+    },
+  });
+  assert.equal(summary.location, "provider");
+  const byKey = Object.fromEntries(summary.rows.map((r) => [r.key, r]));
+  assert.equal(byKey.namespace.label, "Namespace");
+  assert.equal(byKey.namespace.value, "buzz-agents-x7k2mp");
+  assert.equal(byKey.cpu_request.label, "CPU request");
+  assert.equal(byKey.cpu_request.value, "1");
+  assert.equal(byKey.inactivity_seconds.label, "Inactivity seconds");
+  assert.equal(byKey.inactivity_seconds.value, "7200");
+  assert.equal(byKey.image.value, "ghcr.io/block/buzz-sprig@sha256:17facfc7");
+  assert.ok(summary.rows.every((r) => r.redacted === false));
+});
+
+test("rows follow the provider-schema preferred order, spillover alphabetical", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "kubernetes",
+    config: {
+      // Deliberately shuffled persisted order.
+      memory_limit: "1Gi",
+      zeta_extra: "z",
+      namespace: "n",
+      cpu_limit: "1",
+      alpha_extra: "a",
+      image: "i",
+      inactivity_seconds: 7200,
+      cpu_request: "1",
+      context: "c",
+      memory_request: "1Gi",
+    },
+  });
+  assert.deepEqual(
+    summary.rows.map((r) => r.key),
+    [
+      "context",
+      "namespace",
+      "image",
+      "cpu_request",
+      "memory_request",
+      "cpu_limit",
+      "memory_limit",
+      "inactivity_seconds",
+      "alpha_extra",
+      "zeta_extra",
+    ],
+  );
+});
+
+test("null, empty-string, boolean, and number values all display honestly", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "p",
+    config: { a_null: null, b_empty: "", c_flag: true, d_num: 0, e_off: false },
+  });
+  const values = Object.fromEntries(summary.rows.map((r) => [r.key, r.value]));
+  assert.equal(values.a_null, "Not set");
+  assert.equal(values.b_empty, "Not set");
+  assert.equal(values.c_flag, "true");
+  // Falsy-but-present values must never read as missing: coerceConfigValues
+  // emits real numbers/booleans, so `value || fallback` would lie about 0/false.
+  assert.equal(values.d_num, "0");
+  assert.equal(values.e_off, "false");
+});
+
+test("every row value is a string — objects must never reach React children", () => {
+  // React throws on an object child, taking down the whole edit dialog.
+  // A hand-edited managed-agents.json with nested config is exactly the
+  // record the create-time scalar gate never saw.
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "p",
+    config: {
+      resources: { limits: { cpu: "2" } },
+      flag: true,
+      count: 3,
+      name: "x",
+      missing: null,
+    },
+  });
+  for (const row of summary.rows) {
+    assert.equal(typeof row.value, "string", `${row.key} is not a string`);
+  }
+});
+
+test("arrays and objects are summarized, never serialized", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "p",
+    config: {
+      tolerations: [{ key: "gpu" }, { key: "spot" }],
+      node_selector: { disktype: "ssd" },
+    },
+  });
+  const values = Object.fromEntries(summary.rows.map((r) => [r.key, r.value]));
+  assert.equal(values.tolerations, "List (2 items)");
+  assert.equal(values.node_selector, "Structured value");
+  // The nested content must not leak through.
+  assert.ok(!JSON.stringify(values).includes("ssd"));
+});
+
+test("secret-shaped keys are redacted, fail-safe for unknown providers", () => {
+  const summary = summarizeRunOn({
+    type: "provider",
+    id: "future-provider",
+    config: {
+      api_token: "abc123",
+      registry_password: "hunter2",
+      clientSecret: "s3cr3t",
+      authHeader: "Bearer xyz",
+      privateKey: "nsec1...",
+      namespace: "safe-to-show",
+    },
+  });
+  const byKey = Object.fromEntries(summary.rows.map((r) => [r.key, r]));
+  for (const key of [
+    "api_token",
+    "registry_password",
+    "clientSecret",
+    "authHeader",
+    "privateKey",
+  ]) {
+    assert.equal(byKey[key].redacted, true, `${key} must be redacted`);
+    assert.equal(byKey[key].value, "••••••••");
+  }
+  assert.equal(byKey.namespace.redacted, false);
+  assert.equal(byKey.namespace.value, "safe-to-show");
+  // Raw secret bytes must be absent from the whole summary.
+  const dump = JSON.stringify(summary);
+  for (const secret of ["abc123", "hunter2", "s3cr3t", "Bearer xyz", "nsec1"]) {
+    assert.ok(!dump.includes(secret), `${secret} leaked`);
+  }
+});
+
+test("humanizeConfigKey handles snake_case, camelCase, and acronyms", () => {
+  assert.equal(humanizeConfigKey("cpu_request"), "CPU request");
+  assert.equal(humanizeConfigKey("memory_limit"), "Memory limit");
+  assert.equal(humanizeConfigKey("serviceAccount"), "Service account");
+  assert.equal(humanizeConfigKey("image"), "Image");
+  assert.equal(humanizeConfigKey("api_url"), "API URL");
+  assert.equal(humanizeConfigKey(""), "");
+});

--- a/desktop/src/features/agents/ui/runOnSummary.ts
+++ b/desktop/src/features/agents/ui/runOnSummary.ts
@@ -1,0 +1,156 @@
+import type { ManagedAgentBackend } from "@/shared/api/types";
+
+/**
+ * A single saved provider-config row, ready to render.
+ *
+ * `value` is always a display string: scalars are stringified, `null` becomes
+ * an explicit "Not set", and anything non-scalar (array/object) is summarized
+ * rather than dumped — a generic "render every value" helper must not become
+ * a disclosure surface for config shapes we have never seen.
+ */
+export type RunOnConfigRow = {
+  key: string;
+  label: string;
+  value: string;
+  /** True when the key looks secret-shaped and the value was replaced. */
+  redacted: boolean;
+};
+
+export type RunOnSummary =
+  | { location: "local" }
+  | { location: "provider"; providerId: string; rows: RunOnConfigRow[] };
+
+/**
+ * Words that mark a key's value as unrenderable, checked against the same
+ * word-split the create-time gate uses (`validate_provider_config`,
+ * src-tauri managed_agents/backend.rs) so there is one definition of
+ * "looks like a secret", not two that drift. That gate already rejects
+ * secret-shaped keys on the only non-test write path to `agent.backend` —
+ * this display-side redaction is screenshot hygiene, not the missing
+ * credential fix: a value that is fine in `managed-agents.json` on the
+ * owner's own disk is not fine in a dialog that gets screenshotted into a
+ * channel or PR body, and hand-edited records never met the gate at all.
+ * The first five words mirror the Rust list; the rest are display-only
+ * extras (redacting more than create rejects fails safe).
+ */
+const SECRET_WORDS = new Set([
+  "secret",
+  "password",
+  "token",
+  "key",
+  "credential",
+  "passphrase",
+  "auth",
+  "nsec",
+]);
+
+const REDACTED_PLACEHOLDER = "••••••••";
+
+/** Acronyms that read wrong in sentence case ("Cpu request"). */
+const LABEL_ACRONYMS = new Set(["cpu", "id", "url", "api"]);
+
+/**
+ * Split a config key into lowercase words on `_`, `-`, `.`, and camelCase
+ * boundaries, keeping acronym runs together ("APIKey" → ["api", "key"]).
+ * Mirrors `split_config_key` in managed_agents/backend.rs — one split feeds
+ * both labels and redaction, and word matching (not substring) is what
+ * keeps "keyboard" from being treated as a key.
+ */
+function splitConfigKey(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/[_\s.-]+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.toLowerCase());
+}
+
+/**
+ * Humanize a stored config key: `cpu_request` → "CPU request". Labels come
+ * from the saved keys, not a live provider probe — probing during edit is
+ * executable work whose schema (titles, generated defaults) reflects the
+ * plugin *today*, not what this agent was deployed with. See PR #4411 for
+ * why dialogs must not re-probe as a side effect.
+ */
+export function humanizeConfigKey(key: string): string {
+  const words = splitConfigKey(key);
+  if (words.length === 0) return key;
+  return words
+    .map((word, index) => {
+      if (LABEL_ACRONYMS.has(word)) return word.toUpperCase();
+      if (index === 0) return word.charAt(0).toUpperCase() + word.slice(1);
+      return word;
+    })
+    .join(" ");
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined) return "Not set";
+  if (typeof value === "string") return value.length > 0 ? value : "Not set";
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  // Arrays/objects: summarize, never serialize. A nested structure could
+  // carry values its own keys would have redacted.
+  return Array.isArray(value)
+    ? `List (${value.length} items)`
+    : "Structured value";
+}
+
+/**
+ * Preferred display order, traced from the Kubernetes provider schema
+ * (crates/buzz-backend-kubernetes/src/config.rs): locate the deployment
+ * first (context → namespace), then what runs (image), then the
+ * request/limit pairs kept adjacent, then lifecycle/identity. Keys not
+ * listed here (other providers, future fields) spill over alphabetically
+ * after the known ones, so ordering stays deterministic for every record.
+ */
+const PREFERRED_KEY_ORDER = [
+  "context",
+  "namespace",
+  "image",
+  "cpu_request",
+  "memory_request",
+  "cpu_limit",
+  "memory_limit",
+  "inactivity_seconds",
+  "service_account",
+];
+
+function compareKeys(a: string, b: string): number {
+  const ia = PREFERRED_KEY_ORDER.indexOf(a);
+  const ib = PREFERRED_KEY_ORDER.indexOf(b);
+  if (ia !== -1 && ib !== -1) return ia - ib;
+  if (ia !== -1) return -1;
+  if (ib !== -1) return 1;
+  return a.localeCompare(b);
+}
+
+/**
+ * Project a `ManagedAgentBackend` into renderable rows. These are the
+ * *saved* settings — the config recorded when the agent was created — not
+ * the provider's effective settings: optional fields a record omits are
+ * defaulted by the provider at deploy time, and synthesizing today's plugin
+ * defaults here could show values that drifted from what actually deployed.
+ * (`backendAgentId` is deliberately not shown: it is deploy-time runtime
+ * state written on start, not saved creation intent, and this section's
+ * contract is the latter.) Rows follow the preferred key order with
+ * alphabetical spillover, so rendering is deterministic regardless of the
+ * JSON key order a given record happened to persist.
+ */
+export function summarizeRunOn(backend: ManagedAgentBackend): RunOnSummary {
+  if (backend.type === "local") return { location: "local" };
+  const rows = Object.entries(backend.config ?? {})
+    .sort(([a], [b]) => compareKeys(a, b))
+    .map(([key, value]): RunOnConfigRow => {
+      const redacted = splitConfigKey(key).some((word) =>
+        SECRET_WORDS.has(word),
+      );
+      return {
+        key,
+        label: humanizeConfigKey(key),
+        value: redacted ? REDACTED_PLACEHOLDER : displayValue(value),
+        redacted,
+      };
+    });
+  return { location: "provider", providerId: backend.id, rows };
+}

--- a/desktop/src/features/channels/forcedUnreadStore.test.mjs
+++ b/desktop/src/features/channels/forcedUnreadStore.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addForcedUnreadSource,
+  forcedUnreadMarker,
+  removeForcedUnreadSource,
+} from "./forcedUnreadStore.ts";
+
+test("adding an Inbox owner preserves an existing manual force", () => {
+  const entry = addForcedUnreadSource(null, 120, "inbox");
+
+  assert.deepEqual(entry, {
+    markerAtWhenForced: null,
+    sources: ["manual", "inbox"],
+  });
+});
+
+test("clearing Inbox ownership leaves a manual force intact", () => {
+  const entry = {
+    markerAtWhenForced: 120,
+    sources: ["manual", "inbox"],
+  };
+
+  assert.deepEqual(removeForcedUnreadSource(entry, "inbox"), {
+    markerAtWhenForced: 120,
+    sources: ["manual"],
+  });
+});
+
+test("clearing manual ownership leaves an Inbox force intact", () => {
+  const entry = {
+    markerAtWhenForced: 120,
+    sources: ["manual", "inbox"],
+  };
+
+  assert.deepEqual(removeForcedUnreadSource(entry, "manual"), {
+    markerAtWhenForced: 120,
+    sources: ["inbox"],
+  });
+});
+
+test("clearing the only force owner removes the entry", () => {
+  const entry = {
+    markerAtWhenForced: 120,
+    sources: ["inbox"],
+  };
+
+  assert.equal(removeForcedUnreadSource(entry, "inbox"), undefined);
+});
+
+test("legacy persisted entries retain their read-marker baseline", () => {
+  assert.equal(forcedUnreadMarker(120), 120);
+  assert.equal(forcedUnreadMarker(null), null);
+});

--- a/desktop/src/features/channels/forcedUnreadStore.ts
+++ b/desktop/src/features/channels/forcedUnreadStore.ts
@@ -1,14 +1,17 @@
+import * as React from "react";
+
 /**
- * Per-pubkey localStorage record store for channels manually marked unread via
- * right-click → "mark unread". Keyed by channelId (not thread-root). Persisted
- * so the sidebar badge survives reload and the rail observer can read it for
- * inactive communities.
+ * Per-pubkey localStorage record store for channels forced unread by manual or
+ * Inbox actions. Keyed by channelId (not thread-root). Persisted so the sidebar
+ * badge survives reload and the rail observer can read it for inactive
+ * communities.
  *
  * Each entry stores the channel's own NIP-RS read marker (unix seconds) at the
- * moment mark-unread was invoked, or null if no marker existed yet. The rail
- * observer gates the forced-unread OR on this baseline: if the observed synced
- * read marker has since advanced past markerAtWhenForced, the cross-device read
- * wins and the dot is not lit.
+ * moment the first force was added, or null if no marker existed yet, plus the
+ * sources that currently own the force. The rail observer gates the
+ * forced-unread OR on this baseline: if the observed synced read marker has
+ * since advanced past markerAtWhenForced, the cross-device read wins and the
+ * dot is not lit.
  *
  * On identity change, the in-memory map is swapped to the current pubkey's
  * persisted data. Old pubkey data is NOT wiped from localStorage.
@@ -17,8 +20,58 @@
  * a retrograde "unread" state. localStorage is best-effort (per-device).
  */
 
-/** channelId → NIP-RS read marker (unix seconds) at force-time, or null */
-export type ForcedUnreadMap = Record<string, number | null>;
+export type ForcedUnreadSource = "inbox" | "manual";
+export type ForcedUnreadEntry =
+  | number
+  | null
+  | {
+      markerAtWhenForced: number | null;
+      sources: ForcedUnreadSource[];
+    };
+/** channelId → forced-unread entry. Numbers/null are the legacy v1 shape. */
+export type ForcedUnreadMap = Record<string, ForcedUnreadEntry>;
+
+function entrySources(entry: ForcedUnreadEntry): ForcedUnreadSource[] {
+  return typeof entry === "object" && entry !== null
+    ? entry.sources
+    : ["manual"];
+}
+
+export function forcedUnreadMarker(entry: ForcedUnreadEntry): number | null {
+  return typeof entry === "object" && entry !== null
+    ? entry.markerAtWhenForced
+    : entry;
+}
+
+export function addForcedUnreadSource(
+  entry: ForcedUnreadEntry | undefined,
+  markerAtWhenForced: number | null,
+  source: ForcedUnreadSource,
+): ForcedUnreadEntry {
+  if (entry !== undefined && entrySources(entry).includes(source)) return entry;
+  return {
+    markerAtWhenForced:
+      entry === undefined ? markerAtWhenForced : forcedUnreadMarker(entry),
+    sources: [
+      ...new Set([...(entry === undefined ? [] : entrySources(entry)), source]),
+    ],
+  };
+}
+
+export function removeForcedUnreadSource(
+  entry: ForcedUnreadEntry,
+  source: ForcedUnreadSource,
+): ForcedUnreadEntry | undefined {
+  const sources = entrySources(entry);
+  if (!sources.includes(source)) return entry;
+  const remainingSources = sources.filter((candidate) => candidate !== source);
+  return remainingSources.length > 0
+    ? {
+        markerAtWhenForced: forcedUnreadMarker(entry),
+        sources: remainingSources,
+      }
+    : undefined;
+}
 
 const STORAGE_PREFIX = "buzz-forced-unread.v1";
 const storageKey = (pubkey: string) => `${STORAGE_PREFIX}:${pubkey}`;
@@ -37,8 +90,27 @@ export const forcedUnreadStore = {
         return {};
       const result: ForcedUnreadMap = {};
       for (const [k, v] of Object.entries(parsed)) {
-        if (typeof k === "string" && (v === null || typeof v === "number")) {
-          result[k] = v as number | null;
+        if (typeof k !== "string") continue;
+        if (v === null || typeof v === "number") {
+          result[k] = v;
+          continue;
+        }
+        if (
+          typeof v === "object" &&
+          v !== null &&
+          "markerAtWhenForced" in v &&
+          (v.markerAtWhenForced === null ||
+            typeof v.markerAtWhenForced === "number") &&
+          "sources" in v &&
+          Array.isArray(v.sources)
+        ) {
+          const sources = v.sources.filter(
+            (source: unknown): source is ForcedUnreadSource =>
+              source === "inbox" || source === "manual",
+          );
+          if (sources.length > 0) {
+            result[k] = { markerAtWhenForced: v.markerAtWhenForced, sources };
+          }
         }
       }
       return result;
@@ -54,3 +126,44 @@ export const forcedUnreadStore = {
     }
   },
 };
+
+export function useForcedUnreadActions(
+  forcedUnreadRef: React.MutableRefObject<ForcedUnreadMap>,
+  getOwnTimestamp: (channelId: string) => number | null,
+  pubkey: string | undefined,
+  onChange: () => void,
+) {
+  const persist = React.useCallback(() => {
+    if (pubkey) forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
+    onChange();
+  }, [forcedUnreadRef, onChange, pubkey]);
+  const markChannelUnread = React.useCallback(
+    (channelId: string, source: ForcedUnreadSource = "manual") => {
+      const current = Object.hasOwn(forcedUnreadRef.current, channelId)
+        ? forcedUnreadRef.current[channelId]
+        : undefined;
+      const next = addForcedUnreadSource(
+        current,
+        getOwnTimestamp(channelId),
+        source,
+      );
+      if (next === current) return;
+      forcedUnreadRef.current[channelId] = next;
+      persist();
+    },
+    [forcedUnreadRef, getOwnTimestamp, persist],
+  );
+  const clearChannelUnreadSource = React.useCallback(
+    (channelId: string, source: ForcedUnreadSource) => {
+      if (!Object.hasOwn(forcedUnreadRef.current, channelId)) return;
+      const current = forcedUnreadRef.current[channelId];
+      const next = removeForcedUnreadSource(current, source);
+      if (next === current) return;
+      if (next === undefined) delete forcedUnreadRef.current[channelId];
+      else forcedUnreadRef.current[channelId] = next;
+      persist();
+    },
+    [forcedUnreadRef, persist],
+  );
+  return { clearChannelUnreadSource, markChannelUnread };
+}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -80,6 +80,7 @@ import { useMessageProfiles } from "./useMessageProfiles";
 import { useChannelPanelHistoryState } from "./useChannelPanelHistoryState";
 import { useChannelProfilePanel } from "./useChannelProfilePanel";
 import { useChannelRouteTarget } from "./useChannelRouteTarget";
+import { useChannelOpenReadState } from "./useChannelOpenReadState";
 import { useChannelUnreadState } from "./useChannelUnreadState";
 import type { ChannelScreenProps } from "./ChannelScreen.types";
 const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 760,
@@ -99,7 +100,7 @@ export function ChannelScreen({
   const { goHome } = useAppNavigation();
   const { activeCommunity } = useCommunities();
   const {
-    markChannelRead,
+    clearChannelUnreadSource,
     markChannelUnread,
     getChannelReadAt,
     getMessageReadAt,
@@ -112,6 +113,7 @@ export function ChannelScreen({
     unfollowThread,
     isFollowingThread,
     isNotifiedForThread,
+    recordThreadInteraction,
     isThreadMuted,
     readStateVersion,
   } = useAppShell();
@@ -207,12 +209,11 @@ export function ChannelScreen({
   const activeReadAt = latestActiveMessage
     ? new Date(latestActiveMessage.created_at * 1_000).toISOString()
     : null;
-  React.useEffect(() => {
-    if (!activeChannelId || activeChannel?.isMember === false) {
-      return;
-    }
-    markChannelRead(activeChannelId, activeReadAt, { topLevelOnly: true });
-  }, [activeChannel?.isMember, activeChannelId, activeReadAt, markChannelRead]);
+  useChannelOpenReadState(
+    activeChannelId,
+    activeChannel?.isMember,
+    activeReadAt,
+  );
   React.useEffect(() => {
     if (!activeChannelId) {
       setContextParentResolver(null);
@@ -262,7 +263,6 @@ export function ChannelScreen({
     resolvedMessages,
     threadReplyEvents,
   );
-
   const messageEventProfilePubkeys = useMessageEventProfilePubkeys(
     resolvedMessages,
     threadReplyEvents,
@@ -472,6 +472,7 @@ export function ChannelScreen({
     threadReplyTargetId,
     expandedThreadReplyIds,
     openThreadMessages: threadPanelData.visibleReplies,
+    clearChannelUnreadSource,
     getChannelReadAt,
     getMessageReadAt,
     markChannelUnread,
@@ -484,8 +485,7 @@ export function ChannelScreen({
       timelineMessages.find((message) => message.id === editTargetId) ?? null,
     [editTargetId, timelineMessages],
   );
-  // Event id awaiting the empty-edit "Delete message?" confirmation (non-null
-  // while the dialog is open); see handleEditSave.
+  // Event id awaiting the empty-edit deletion confirmation.
   const [emptyDeleteId, setEmptyDeleteId] = React.useState<string | null>(null);
   const {
     handleCancelEdit,
@@ -508,6 +508,7 @@ export function ChannelScreen({
     getFirstReplyIdForMessage,
     getReplyDescendantIdsForMessage,
     markRevealedRepliesRead,
+    recordThreadInteraction,
     openThreadHeadId: effectiveOpenThreadHeadId,
     onOptimisticOpenThreadHeadIdChange: setOptimisticOpenThreadHeadId,
     onRequestEmptyEditDelete: setEmptyDeleteId,
@@ -688,7 +689,6 @@ export function ChannelScreen({
     threadReplyTargetId,
     threadReplyTargetMessage,
   });
-
   const hasAuxiliaryPanel = Boolean(
     effectiveOpenThreadHeadId ||
       openAgentSessionPubkey ||

--- a/desktop/src/features/channels/ui/ChannelTypeSettings.tsx
+++ b/desktop/src/features/channels/ui/ChannelTypeSettings.tsx
@@ -34,6 +34,7 @@ const CHANNEL_TYPE_RESIZE_TRANSITION = {
 
 export function ChannelTypeSettings({
   disabled,
+  label = "Channel type",
   onOpenChange,
   onTemporaryChange,
   onTtlSecondsChange,
@@ -43,6 +44,7 @@ export function ChannelTypeSettings({
   ttlSeconds,
 }: {
   disabled?: boolean;
+  label?: string;
   onOpenChange?: (open: boolean) => void;
   onTemporaryChange: (temporary: boolean) => void;
   onTtlSecondsChange: (ttlSeconds: number) => void;
@@ -77,9 +79,7 @@ export function ChannelTypeSettings({
         className="flex items-center justify-between gap-3 px-3 py-3"
         data-testid={`${testIdPrefix}-channel-type-row`}
       >
-        <span className="text-sm font-medium text-foreground">
-          Channel type
-        </span>
+        <span className="text-sm font-medium text-foreground">{label}</span>
         <ChannelTypePicker
           align="end"
           className="-mr-2.5"

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.test.mjs
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getTopLevelInboxUnreadOverrideIds } from "./useChannelOpenReadState.ts";
+
+test("opening a channel clears only its top-level Inbox overrides", () => {
+  assert.deepEqual(
+    getTopLevelInboxUnreadOverrideIds(
+      [
+        { id: "top-level", channelId: "general", tags: [] },
+        {
+          id: "thread-reply",
+          channelId: "general",
+          tags: [
+            ["e", "root", "", "root"],
+            ["e", "parent", "", "reply"],
+          ],
+        },
+        { id: "other-channel", channelId: "random", tags: [] },
+      ],
+      "general",
+    ),
+    ["top-level"],
+  );
+});

--- a/desktop/src/features/channels/ui/useChannelOpenReadState.ts
+++ b/desktop/src/features/channels/ui/useChannelOpenReadState.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+import { useAppShell } from "@/app/AppShellContext";
+import { isThreadReply } from "@/features/messages/lib/threading";
+import type { FeedItem } from "@/shared/api/types";
+
+/**
+ * Inbox overrides for top-level rows are consumed by opening the channel.
+ * Thread-reply overrides intentionally remain until their thread is read.
+ */
+export function getTopLevelInboxUnreadOverrideIds(
+  items: FeedItem[],
+  channelId: string,
+): string[] {
+  return items.flatMap((item) =>
+    item.channelId === channelId && !isThreadReply(item.tags) ? [item.id] : [],
+  );
+}
+
+export function useChannelOpenReadState(
+  activeChannelId: string | null,
+  isChannelMember: boolean | undefined,
+  activeReadAt: string | null,
+) {
+  const { feedItemState, locallyUnreadFeedItems, markChannelRead } =
+    useAppShell();
+
+  React.useEffect(() => {
+    if (!activeChannelId || isChannelMember === false) return;
+    for (const itemId of getTopLevelInboxUnreadOverrideIds(
+      locallyUnreadFeedItems,
+      activeChannelId,
+    )) {
+      feedItemState.undoUnread(itemId);
+    }
+    markChannelRead(activeChannelId, activeReadAt, { topLevelOnly: true });
+  }, [
+    activeChannelId,
+    activeReadAt,
+    feedItemState.undoUnread,
+    isChannelMember,
+    locallyUnreadFeedItems,
+    markChannelRead,
+  ]);
+}

--- a/desktop/src/features/channels/ui/useChannelUnreadState.ts
+++ b/desktop/src/features/channels/ui/useChannelUnreadState.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import type { ForcedUnreadSource } from "@/features/channels/forcedUnreadStore";
 import {
   buildCreatedAtByMessageId,
   buildDirectReplyIdsByParentId,
@@ -36,6 +37,10 @@ type UseChannelUnreadStateOptions = {
   openThreadMessages?: MainTimelineEntry[];
   getChannelReadAt: (channelId: string) => number | null;
   getMessageReadAt: (messageId: string) => number | null;
+  clearChannelUnreadSource: (
+    channelId: string,
+    source: ForcedUnreadSource,
+  ) => void;
   markChannelUnread: (channelId: string) => void;
   markMessageRead: (messageId: string, timestamp: number) => void;
   isThreadMuted: (rootId: string) => boolean;
@@ -64,6 +69,7 @@ export function useChannelUnreadState({
   openThreadMessages,
   getChannelReadAt,
   getMessageReadAt,
+  clearChannelUnreadSource,
   markChannelUnread,
   markMessageRead,
   isThreadMuted,
@@ -452,16 +458,26 @@ export function useChannelUnreadState({
         const createdAt = createdAtByMessageId.get(id);
         if (createdAt !== undefined) markMessageRead(id, createdAt);
       }
+      if (activeChannelId && forcedUnreadMsgRef.current.size === 0) {
+        clearChannelUnreadSource(activeChannelId, "manual");
+      }
       forceUnreadRender();
     },
-    [createdAtByMessageId, getReplyDescendantIdsForMessage, markMessageRead],
+    [
+      activeChannelId,
+      clearChannelUnreadSource,
+      createdAtByMessageId,
+      getReplyDescendantIdsForMessage,
+      markMessageRead,
+    ],
   );
 
   // Mark a message and its whole subtree UNREAD (LP4 v3 menu action). Markers
   // are monotonic and cannot move backward, so this writes NO marker: it adds
   // the ids to the session-local forced-unread overlay the badge predicates OR
-  // in. Cleared on channel-leave; does not survive reload (symmetric with the
-  // shipped channel mark-unread).
+  // in. It also forces the channel-level unread projection so leaving the
+  // channel restores its bold sidebar emphasis. The per-message overlay is
+  // cleared on channel-leave; the channel-level force survives until reopen.
   const handleMarkMessageUnread = React.useCallback(
     (messageId: string) => {
       for (const id of [
@@ -470,9 +486,12 @@ export function useChannelUnreadState({
       ]) {
         forcedUnreadMsgRef.current.add(id);
       }
+      if (activeChannelId) {
+        markChannelUnread(activeChannelId);
+      }
       forceUnreadRender();
     },
-    [getReplyDescendantIdsForMessage],
+    [activeChannelId, getReplyDescendantIdsForMessage, markChannelUnread],
   );
 
   return {

--- a/desktop/src/features/channels/unreadChannelCounts.ts
+++ b/desktop/src/features/channels/unreadChannelCounts.ts
@@ -78,6 +78,19 @@ export function countUnreadObservedEvents(
   return count;
 }
 
+export function hasUnreadTopLevelObservedEvent(
+  eventsById: ReadonlyMap<string, ObservedUnreadEvent> | undefined,
+  getReadAt: (event: ObservedUnreadEvent) => number | null,
+): boolean {
+  if (!eventsById) return false;
+  for (const event of eventsById.values()) {
+    if (event.rootId !== null) continue;
+    const readAt = getReadAt(event);
+    if (readAt === null || event.createdAt > readAt) return true;
+  }
+  return false;
+}
+
 export function countUnreadBadgeObservedEvents(
   eventsById: ReadonlyMap<string, ObservedUnreadEvent> | undefined,
   getReadAt: (event: ObservedUnreadEvent) => number | null,

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -7,6 +7,7 @@ import {
   countUnreadBadgeObservedEvents,
   countUnreadHighPriorityObservedEvents,
   countUnreadObservedEvents,
+  hasUnreadTopLevelObservedEvent,
   observedUnreadEventReadAt,
   recordObservedUnreadEvent,
 } from "./unreadChannelCounts.ts";
@@ -366,6 +367,30 @@ test("countUnreadObservedEvents_topLevelUsesChannelMarker", () => {
   ]);
 
   assert.equal(countUnreadObservedEvents(events, readAtFor(300, new Map())), 1);
+});
+
+test("hasUnreadTopLevelObservedEvent_ignoresUnreadThreadReplies", () => {
+  const events = new Map([
+    ["top-old", observed("top-old", 250)],
+    ["thread-new", observed("thread-new", 500, "root-1")],
+  ]);
+
+  assert.equal(
+    hasUnreadTopLevelObservedEvent(events, readAtFor(300, new Map())),
+    false,
+  );
+});
+
+test("hasUnreadTopLevelObservedEvent_detectsUnreadTopLevelMessage", () => {
+  const events = new Map([
+    ["top-new", observed("top-new", 350)],
+    ["thread-new", observed("thread-new", 500, "root-1")],
+  ]);
+
+  assert.equal(
+    hasUnreadTopLevelObservedEvent(events, readAtFor(300, new Map())),
+    true,
+  );
 });
 
 test("countUnreadBadgeObservedEvents_skipsBoldOnlyGeneralChannelItems", () => {

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -7,6 +7,7 @@ import type {
   useToggleReactionMutation,
 } from "@/features/messages/hooks";
 import { resolveThreadReplyTarget } from "@/features/messages/hooks";
+import type { TimelineMessage } from "@/features/messages/types";
 
 /**
  * Stable callback references for ChannelPane so that keystroke-driven
@@ -24,6 +25,7 @@ export function useChannelPaneHandlers({
   getFirstReplyIdForMessage,
   getReplyDescendantIdsForMessage,
   markRevealedRepliesRead,
+  recordThreadInteraction,
   onOptimisticOpenThreadHeadIdChange,
   onRequestEmptyEditDelete,
   openThreadHeadId,
@@ -43,6 +45,7 @@ export function useChannelPaneHandlers({
   getFirstReplyIdForMessage: (messageId: string) => string | null;
   getReplyDescendantIdsForMessage: (messageId: string) => string[];
   markRevealedRepliesRead: (messageId: string) => void;
+  recordThreadInteraction: (rootId: string) => void;
   onOptimisticOpenThreadHeadIdChange: React.Dispatch<
     React.SetStateAction<string | null | undefined>
   >;
@@ -344,14 +347,21 @@ export function useChannelPaneHandlers({
   );
 
   const handleToggleReaction = React.useCallback(
-    async (message: { id: string }, emoji: string, remove: boolean) => {
+    async (
+      message: Pick<TimelineMessage, "id" | "rootId">,
+      emoji: string,
+      remove: boolean,
+    ) => {
       await toggleMutateRef.current({
         emoji,
         eventId: message.id,
         remove,
       });
+      if (!remove) {
+        recordThreadInteraction(message.rootId ?? message.id);
+      }
     },
-    [],
+    [recordThreadInteraction],
   );
 
   return {

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -9,8 +9,8 @@ import {
   countUnreadBadgeObservedEvents,
   countUnreadHighPriorityObservedEvents,
   countUnreadObservedEvents,
+  hasUnreadTopLevelObservedEvent,
   makeObservedUnreadEvent,
-  mapsEqual,
   observedUnreadEventReadAt,
   recordObservedUnreadEvent,
   type ObservedUnreadEvent,
@@ -20,6 +20,7 @@ import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
 import {
   forcedUnreadStore,
   type ForcedUnreadMap,
+  useForcedUnreadActions,
 } from "@/features/channels/forcedUnreadStore";
 import {
   getThreadReference,
@@ -33,6 +34,7 @@ import {
 import type { RelayClient } from "@/shared/api/relayClientSession";
 import type { Channel, RelayEvent } from "@/shared/api/types";
 import { CHANNEL_MESSAGE_EVENT_KINDS } from "@/shared/constants/kinds";
+import { useStableMap, useStableSet } from "@/shared/hooks/useStableReference";
 import { normalizeRelayUrl } from "@/features/profile/lib/selfProfileStorage";
 import { DM_NOTIFIABLE_EVENT_KINDS } from "./isDmNotifiableKind";
 import {
@@ -123,14 +125,6 @@ export function resolveChannelReadMarker(
 
 export function resolveObservedUnreadRootId(tags: string[][]): string | null {
   return isBroadcastReply(tags) ? null : getThreadReference(tags).rootId;
-}
-
-function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const item of a) {
-    if (!b.has(item)) return false;
-  }
-  return true;
 }
 
 export function useUnreadChannels(
@@ -310,9 +304,18 @@ export function useUnreadChannels(
     (
       channelId: string,
       readAt: string | null | undefined,
-      { topLevelOnly = false }: { topLevelOnly?: boolean } = {},
+      {
+        preserveForcedUnread = false,
+        topLevelOnly = false,
+      }: {
+        preserveForcedUnread?: boolean;
+        topLevelOnly?: boolean;
+      } = {},
     ) => {
-      if (Object.hasOwn(forcedUnreadRef.current, channelId)) {
+      if (
+        !preserveForcedUnread &&
+        Object.hasOwn(forcedUnreadRef.current, channelId)
+      ) {
         delete forcedUnreadRef.current[channelId];
         if (pubkey) {
           forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
@@ -342,22 +345,13 @@ export function useUnreadChannels(
     [markContextRead, pubkey],
   );
 
-  // Manually mark a channel unread (e.g., right-click → "mark unread"). Persists
-  // the current NIP-RS read marker as baseline to localStorage so the rail
-  // observer can detect when a cross-device read has since covered the force.
-  // NIP-RS markers are monotonic, so we do not publish a lower timestamp.
-  const markChannelUnread = React.useCallback(
-    (channelId: string) => {
-      if (!Object.hasOwn(forcedUnreadRef.current, channelId)) {
-        forcedUnreadRef.current[channelId] = getOwnTimestamp(channelId);
-        if (pubkey) {
-          forcedUnreadStore.write(pubkey, forcedUnreadRef.current);
-        }
-        bumpLatestVersion();
-      }
-    },
-    [getOwnTimestamp, pubkey],
-  );
+  const { clearChannelUnreadSource, markChannelUnread } =
+    useForcedUnreadActions(
+      forcedUnreadRef,
+      getOwnTimestamp,
+      pubkey,
+      bumpLatestVersion,
+    );
 
   // Record the thread root of an EXTERNAL message that @-mentioned the user.
   // Keyed on the thread root so the badge gate trips for a mention recipient
@@ -473,6 +467,22 @@ export function useUnreadChannels(
         bumpMembershipVersion();
       }
       bumpLatestVersion();
+    },
+    [normalizedPubkey],
+  );
+
+  const recordThreadInteraction = React.useCallback(
+    (rootId: string) => {
+      const normalizedRootId = rootId.trim();
+      if (!normalizedRootId) return;
+      const target = participatedRootIdsRef.current;
+      const sizeBefore = target.size;
+      target.add(normalizedRootId);
+      if (target.size === sizeBefore) return;
+      if (normalizedPubkey !== null) {
+        participationStore.write(normalizedPubkey, target);
+      }
+      bumpMembershipVersion();
     },
     [normalizedPubkey],
   );
@@ -830,6 +840,7 @@ export function useUnreadChannels(
       if (!isReadStateReady) {
         return {
           unreadChannelIds: new Set<string>(),
+          topLevelUnreadChannelIds: new Set<string>(),
           highPriorityUnreadChannelIds: new Set<string>(),
           unreadChannelCounts: new Map<string, number>(),
           unreadChannelNotificationCount: 0,
@@ -837,6 +848,7 @@ export function useUnreadChannels(
       }
 
       const unread = new Set<string>();
+      const topLevelUnread = new Set<string>();
       const highPriority = new Set<string>();
       const counts = new Map<string, number>();
       let unreadChannelNotificationCount = 0;
@@ -844,15 +856,10 @@ export function useUnreadChannels(
       for (const channel of channels) {
         if (channel.id === activeChannelId) continue;
 
-        if (Object.hasOwn(forcedUnreadRef.current, channel.id)) {
-          // Forced-unread is dot tier only — not high-priority.
-          unread.add(channel.id);
-          counts.set(channel.id, 1);
-          unreadChannelNotificationCount += 1;
-          continue;
-        }
-
-        if (latestByChannelRef.current.get(channel.id) === undefined) continue;
+        const isForcedUnread = Object.hasOwn(
+          forcedUnreadRef.current,
+          channel.id,
+        );
 
         const observedEvents = observedUnreadEventsByChannelRef.current.get(
           channel.id,
@@ -866,13 +873,25 @@ export function useUnreadChannels(
             (messageId) => getOwnTimestamp(`msg:${messageId}`),
           );
 
-        const unreadCount = countUnreadObservedEvents(
-          observedEvents,
-          readAtForObservedEvent,
-        );
-        if (unreadCount === 0) continue;
+        const unreadCount =
+          latestByChannelRef.current.get(channel.id) === undefined
+            ? 0
+            : countUnreadObservedEvents(observedEvents, readAtForObservedEvent);
+        if (unreadCount === 0) {
+          if (!isForcedUnread) continue;
+          unread.add(channel.id);
+          topLevelUnread.add(channel.id);
+          counts.set(channel.id, 1);
+          unreadChannelNotificationCount += 1;
+          continue;
+        }
 
         unread.add(channel.id);
+        if (
+          hasUnreadTopLevelObservedEvent(observedEvents, readAtForObservedEvent)
+        ) {
+          topLevelUnread.add(channel.id);
+        }
         const badgeCount = countUnreadBadgeObservedEvents(
           observedEvents,
           readAtForObservedEvent,
@@ -900,6 +919,7 @@ export function useUnreadChannels(
 
       return {
         unreadChannelIds: unread,
+        topLevelUnreadChannelIds: topLevelUnread,
         highPriorityUnreadChannelIds: highPriority,
         unreadChannelCounts: counts,
         unreadChannelNotificationCount,
@@ -914,37 +934,14 @@ export function useUnreadChannels(
       readStateVersion,
     ]);
 
-  // Stabilize Set references: only replace when contents actually change,
-  // so downstream memos don't re-run on every render when sets are equal.
-  const prevUnreadRef = React.useRef<ReadonlySet<string>>(new Set());
-  const prevHighPriorityRef = React.useRef<ReadonlySet<string>>(new Set());
-  const prevUnreadCountsRef = React.useRef<ReadonlyMap<string, number>>(
-    new Map(),
+  const unreadChannelIds = useStableSet(rawUnread.unreadChannelIds);
+  const topLevelUnreadChannelIds = useStableSet(
+    rawUnread.topLevelUnreadChannelIds,
   );
-
-  const unreadChannelIds = setsEqual(
-    rawUnread.unreadChannelIds,
-    prevUnreadRef.current,
-  )
-    ? prevUnreadRef.current
-    : rawUnread.unreadChannelIds;
-  prevUnreadRef.current = unreadChannelIds;
-
-  const highPriorityUnreadChannelIds = setsEqual(
+  const highPriorityUnreadChannelIds = useStableSet(
     rawUnread.highPriorityUnreadChannelIds,
-    prevHighPriorityRef.current,
-  )
-    ? prevHighPriorityRef.current
-    : rawUnread.highPriorityUnreadChannelIds;
-  prevHighPriorityRef.current = highPriorityUnreadChannelIds;
-
-  const unreadChannelCounts = mapsEqual(
-    rawUnread.unreadChannelCounts,
-    prevUnreadCountsRef.current,
-  )
-    ? prevUnreadCountsRef.current
-    : rawUnread.unreadChannelCounts;
-  prevUnreadCountsRef.current = unreadChannelCounts;
+  );
+  const unreadChannelCounts = useStableMap(rawUnread.unreadChannelCounts);
   const unreadChannelNotificationCount =
     rawUnread.unreadChannelNotificationCount;
 
@@ -992,12 +989,14 @@ export function useUnreadChannels(
 
   return {
     unreadChannelIds,
+    topLevelUnreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,
     unreadChannelNotificationCount,
     markAllChannelsRead,
     markChannelRead,
     markChannelUnread,
+    clearChannelUnreadSource,
     // Exposed so other surfaces (e.g. Home) can project per-item read state
     // off the same NIP-RS read marker without instantiating a second
     // ReadStateManager. readStateVersion is the invalidation signal callers
@@ -1009,6 +1008,7 @@ export function useUnreadChannels(
     participatedRootIds,
     authoredRootIds,
     mentionedRootIds,
+    recordThreadInteraction,
     threadActivityItems: projectActivityForScope(
       threadActivityScopeRef.current,
       currentActivityScope,

--- a/desktop/src/features/communities/communityUnreadObserver.ts
+++ b/desktop/src/features/communities/communityUnreadObserver.ts
@@ -1,5 +1,6 @@
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
 import {
+  forcedUnreadMarker,
   forcedUnreadStore,
   type ForcedUnreadMap,
 } from "@/features/channels/forcedUnreadStore";
@@ -238,7 +239,9 @@ export async function fetchCommunityUnread(args: {
     // runs while the community is active, so the store may not be pruned for
     // inactive communities).
     if (!hasUnread && Object.hasOwn(forcedUnreadMap, channel.id)) {
-      const markerAtWhenForced = forcedUnreadMap[channel.id];
+      const markerAtWhenForced = forcedUnreadMarker(
+        forcedUnreadMap[channel.id],
+      );
       if (
         readAt === null ||
         (markerAtWhenForced !== null && readAt <= markerAtWhenForced)

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -234,13 +234,16 @@ export function HomeView({
     inboxListWidthPx,
   } = useResizableInboxListWidth();
   const {
+    clearChannelUnreadSource,
     getChannelReadAt,
     getThreadReadAt,
     getMessageReadAt,
     feedItemState,
     markChannelRead,
+    markChannelUnread,
     markMessageRead,
     markThreadRead,
+    recordThreadInteraction,
     readStateVersion,
   } = useAppShell();
   const { doneSet, markDone, markUnread, undoDone, undoUnread, unreadSet } =
@@ -383,7 +386,9 @@ export function HomeView({
       readStateVersion,
       localDoneSet: doneSet,
       localUnreadSet: unreadSet,
+      clearChannelUnreadSource,
       markChannelRead,
+      markChannelUnread,
       markMessageRead,
       markThreadRead,
       markDoneLocal: markDone,
@@ -861,6 +866,13 @@ export function HomeView({
                         eventId: message.id,
                         remove,
                       });
+                      if (!remove) {
+                        recordThreadInteraction(
+                          selectedItem?.conversationId ??
+                            message.rootId ??
+                            message.id,
+                        );
+                      }
                       await threadContext.refreshReactions();
                       await channelMessagesQuery.refetch();
                       onRefresh();

--- a/desktop/src/features/home/useHomeInboxReadState.test.mjs
+++ b/desktop/src/features/home/useHomeInboxReadState.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   getGroupedChannelReadTimestamp,
   getGroupedInboxItemIds,
+  hasRemainingChannelUnreadOverride,
   hasGroupedUnreadOverride,
   resolveInboxItemReadAt,
 } from "./useHomeInboxReadState.ts";
@@ -120,6 +121,47 @@ test("grouped unread override matches any item represented by the row", () => {
     hasGroupedUnreadOverride(
       inboxItem([rootItem, replyItem]),
       new Set(["other-event"]),
+    ),
+    false,
+  );
+});
+
+test("remaining channel unread override ignores the row being cleared", () => {
+  const firstReply = feedItem({
+    id: "first-reply",
+    createdAt: 200,
+    tags: [
+      ["h", CHANNEL_ID],
+      ["e", "first-root", "", "root"],
+      ["e", "first-parent", "", "reply"],
+    ],
+  });
+  const secondReply = feedItem({
+    id: "second-reply",
+    createdAt: 300,
+    tags: [
+      ["h", CHANNEL_ID],
+      ["e", "second-root", "", "root"],
+      ["e", "second-parent", "", "reply"],
+    ],
+  });
+  const items = [inboxItem([firstReply]), inboxItem([secondReply])];
+
+  assert.equal(
+    hasRemainingChannelUnreadOverride(
+      items,
+      new Set(["first-reply", "second-reply"]),
+      CHANNEL_ID,
+      new Set(["first-reply"]),
+    ),
+    true,
+  );
+  assert.equal(
+    hasRemainingChannelUnreadOverride(
+      items,
+      new Set(["first-reply"]),
+      CHANNEL_ID,
+      new Set(["first-reply"]),
     ),
     false,
   );

--- a/desktop/src/features/home/useHomeInboxReadState.ts
+++ b/desktop/src/features/home/useHomeInboxReadState.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import type { ForcedUnreadSource } from "@/features/channels/forcedUnreadStore";
 import type { InboxItem } from "@/features/home/lib/inbox";
 import {
   getThreadReference,
@@ -25,6 +26,17 @@ type UseHomeInboxReadStateOptions = {
   markChannelRead: (
     channelId: string,
     readAt: string | null | undefined,
+    options?: {
+      preserveForcedUnread?: boolean;
+      topLevelOnly?: boolean;
+    },
+  ) => void;
+  /** Force a channel's unread indicator without rolling back its NIP-RS marker. */
+  markChannelUnread: (channelId: string, source?: ForcedUnreadSource) => void;
+  /** Remove only the named owner of a channel's forced-unread indicator. */
+  clearChannelUnreadSource: (
+    channelId: string,
+    source: ForcedUnreadSource,
   ) => void;
   /** Advance the thread read marker to the given unix-seconds timestamp. */
   markThreadRead: (rootId: string, timestamp: number) => void;
@@ -32,7 +44,7 @@ type UseHomeInboxReadStateOptions = {
   markMessageRead: (messageId: string, timestamp: number) => void;
   /** Local fallback: mark a non-channel item done. */
   markDoneLocal: (id: string) => void;
-  /** Local inbox row override: mark an item unread without touching the channel. */
+  /** Local inbox row override: mark an item unread alongside its channel emphasis. */
   markUnreadLocal: (id: string) => void;
   /** Local fallback: undo a non-channel item done. */
   undoDoneLocal: (id: string) => void;
@@ -83,6 +95,21 @@ export function hasGroupedUnreadOverride(
   return getGroupedInboxItemIds(item).some((id) => localUnreadSet.has(id));
 }
 
+export function hasRemainingChannelUnreadOverride(
+  items: InboxItem[],
+  localUnreadSet: ReadonlySet<string>,
+  channelId: string,
+  clearedItemIds: ReadonlySet<string>,
+): boolean {
+  return items.some(
+    (candidate) =>
+      candidate.item.channelId === channelId &&
+      getGroupedInboxItemIds(candidate).some(
+        (id) => localUnreadSet.has(id) && !clearedItemIds.has(id),
+      ),
+  );
+}
+
 export function resolveInboxItemReadAt(
   item: InboxItem,
   options: {
@@ -114,8 +141,8 @@ export function resolveInboxItemReadAt(
  * "Mark as read" on channel-backed items is routed through `markChannelRead`;
  * thread rows advance the same per-message markers as the channel thread
  * panel, plus the aggregate `thread:<root>` marker for compatibility. "Mark
- * unread" is item-local: it only reopens the specific inbox row and must not
- * light up the channel.
+ * unread" keeps its per-item local override and also restores the source
+ * channel's forced-unread indicator so channel surfaces agree with Inbox.
  */
 export function useHomeInboxReadState({
   items,
@@ -126,6 +153,8 @@ export function useHomeInboxReadState({
   localDoneSet,
   localUnreadSet = EMPTY_ITEM_SET,
   markChannelRead,
+  markChannelUnread,
+  clearChannelUnreadSource,
   markThreadRead,
   markMessageRead,
   markDoneLocal,
@@ -182,8 +211,21 @@ export function useHomeInboxReadState({
     (itemId: string) => {
       const item = itemById.get(itemId);
       const localUnreadIds = item ? getGroupedInboxItemIds(item) : [itemId];
+      const clearedItemIds = new Set(localUnreadIds);
       for (const id of localUnreadIds) {
         undoUnreadLocal(id);
+      }
+      const channelId = item?.item.channelId ?? null;
+      if (
+        channelId &&
+        !hasRemainingChannelUnreadOverride(
+          items,
+          localUnreadSet,
+          channelId,
+          clearedItemIds,
+        )
+      ) {
+        clearChannelUnreadSource(channelId, "inbox");
       }
       const threadRootId = item ? getInboxThreadRootId(item) : null;
       if (item && threadRootId) {
@@ -201,16 +243,17 @@ export function useHomeInboxReadState({
           markChannelRead(
             groupedChannelRead.channelId,
             new Date(groupedChannelRead.timestamp * 1_000).toISOString(),
+            { preserveForcedUnread: true, topLevelOnly: true },
           );
         }
         return;
       }
 
-      const channelId = item?.item.channelId ?? null;
       if (item && channelId) {
         markChannelRead(
           channelId,
           new Date(item.latestActivityAt * 1_000).toISOString(),
+          { preserveForcedUnread: true },
         );
         return;
       }
@@ -218,6 +261,9 @@ export function useHomeInboxReadState({
     },
     [
       itemById,
+      items,
+      clearChannelUnreadSource,
+      localUnreadSet,
       markChannelRead,
       markDoneLocal,
       markMessageRead,
@@ -230,8 +276,17 @@ export function useHomeInboxReadState({
     (itemId: string) => {
       undoDoneLocal(itemId);
       markUnreadLocal(itemId);
+      const item = itemById.get(itemId);
+      const channelId = item?.item.channelId ?? null;
+      // The Inbox override owns the durable thread dot, while the channel force
+      // restores timeline-level emphasis after the user leaves the channel.
+      // Opening the channel clears the bolding but leaves the thread dot until
+      // the thread itself is opened or marked read.
+      if (channelId && item) {
+        markChannelUnread(channelId, "inbox");
+      }
     },
-    [markUnreadLocal, undoDoneLocal],
+    [itemById, markChannelUnread, markUnreadLocal, undoDoneLocal],
   );
 
   return { effectiveDoneSet, markItemRead, markItemUnread };

--- a/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
@@ -276,14 +276,16 @@ function TemplateRow({
   );
 }
 
-function TemplateFormDialog({
+export function TemplateFormDialog({
   template,
   open,
   onOpenChange,
+  onCreated,
 }: {
   template: ChannelTemplate | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onCreated?: (template: ChannelTemplate) => void;
 }) {
   const isEditing = template !== null;
   const createMutation = useCreateChannelTemplateMutation();
@@ -388,8 +390,9 @@ function TemplateFormDialog({
       };
 
       createMutation.mutate(input, {
-        onSuccess: () => {
+        onSuccess: (created) => {
           toast.success(`Created "${trimmedName}"`);
+          onCreated?.(created);
           onOpenChange(false);
         },
         onError: (error) => {

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -189,7 +189,7 @@ export const settingsSections: SettingsSectionDescriptor[] = [
   },
   {
     value: "channel-templates",
-    label: "Templates",
+    label: "Channel templates",
     icon: LayoutTemplate,
     featureGate: "channel-templates",
   },

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -62,11 +62,12 @@ const settingsNavGroups: Array<{
       "shortcuts",
       "custom-emoji",
       "local-archive",
+      "channel-templates",
     ],
   },
   {
     label: "Communities",
-    sections: ["hosted-communities", "channel-templates", "community-members"],
+    sections: ["hosted-communities", "community-members"],
   },
   {
     label: "App",

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -2,7 +2,10 @@ import * as React from "react";
 
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { useWorkingChannels } from "@/features/agents/agentWorkingSignal";
-import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export function resolveActiveWorkingChannelNames(
@@ -27,9 +30,14 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
   ActiveChannelTurnSummary
 > {
   const managedAgentsQuery = useManagedAgentsQuery();
+  const relayAgentsQuery = useRelayAgentsQuery();
   const managedAgents = React.useMemo(
     () => managedAgentsQuery.data ?? [],
     [managedAgentsQuery.data],
+  );
+  const namedAgents = React.useMemo(
+    () => [...(relayAgentsQuery.data ?? []), ...managedAgents],
+    [managedAgents, relayAgentsQuery.data],
   );
 
   // Unified working signal: observer-derived turns primary, bot typing as
@@ -42,11 +50,11 @@ export function useActiveWorkingChannelsById(): ReadonlyMap<
         activeWorkingChannels.map((summary) => {
           const resolvedSummary = resolveActiveWorkingChannelNames(
             summary,
-            managedAgents,
+            namedAgents,
           );
           return [resolvedSummary.channelId, resolvedSummary];
         }),
       ),
-    [activeWorkingChannels, managedAgents],
+    [activeWorkingChannels, namedAgents],
   );
 }

--- a/desktop/src/features/sidebar/lib/useCreateChannelForm.ts
+++ b/desktop/src/features/sidebar/lib/useCreateChannelForm.ts
@@ -46,6 +46,7 @@ export type CreateChannelFormState = {
   errorMessage: string | null;
   selectedTemplateId: string | null;
   handleTemplateChange: (templateId: string) => void;
+  handleTemplateCreated: (template: ChannelTemplate) => void;
   templates: ChannelTemplate[];
   nameInputRef: React.RefObject<HTMLInputElement | null>;
   isCreating: boolean;
@@ -120,6 +121,13 @@ export function useCreateChannelForm({
     return () => globalThis.clearTimeout(timerId);
   }, [active, autoFocusName, initialName]);
 
+  const applyTemplate = React.useCallback((template: ChannelTemplate) => {
+    setSelectedTemplateId(template.id);
+    setDescription(template.description ?? "");
+    if (!visibilityTouchedRef.current) setVisibility(template.visibility);
+    setErrorMessage(null);
+  }, []);
+
   const handleTemplateChange = React.useCallback(
     (templateId: string) => {
       if (!templateId) {
@@ -135,12 +143,9 @@ export function useCreateChannelForm({
       );
       if (!template) return;
 
-      setSelectedTemplateId(templateId);
-      setDescription(template.description ?? "");
-      if (!visibilityTouchedRef.current) setVisibility(template.visibility);
-      setErrorMessage(null);
+      applyTemplate(template);
     },
-    [templates],
+    [applyTemplate, templates],
   );
 
   const handleSubmit = React.useCallback(
@@ -211,6 +216,7 @@ export function useCreateChannelForm({
     errorMessage,
     selectedTemplateId,
     handleTemplateChange,
+    handleTemplateCreated: applyTemplate,
     templates,
     nameInputRef,
     isCreating,

--- a/desktop/src/features/sidebar/ui/ChannelActivityPopover.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelActivityPopover.tsx
@@ -1,0 +1,448 @@
+import * as React from "react";
+import { Clock, Loader2, MailOpen } from "lucide-react";
+
+import { useAppShell } from "@/app/AppShellContext";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
+import { useOpenAgentActivity } from "@/features/agents/useOpenAgentActivity";
+import { buildInboxItems, type InboxItem } from "@/features/home/lib/inbox";
+import { getGroupedInboxItemIds } from "@/features/home/useHomeInboxReadState";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { useRemindLater } from "@/features/reminders/ui/RemindMeLaterProvider";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { Channel, FeedItem, HomeFeedResponse } from "@/shared/api/types";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import { useNow } from "@/shared/lib/useNow";
+import { Markdown } from "@/shared/ui/markdown";
+import { Popover, PopoverAnchor, PopoverContent } from "@/shared/ui/popover";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+const HOVER_OPEN_DELAY_MS = 250;
+const HOVER_CLOSE_DELAY_MS = 180;
+
+function buildChannelActivityFeed(items: FeedItem[]): HomeFeedResponse {
+  return {
+    feed: {
+      mentions: items.filter((item) => item.category === "mention"),
+      needsAction: items.filter((item) => item.category === "needs_action"),
+      activity: items.filter(
+        (item) =>
+          item.category !== "mention" &&
+          item.category !== "needs_action" &&
+          item.category !== "agent_activity",
+      ),
+      agentActivity: items.filter((item) => item.category === "agent_activity"),
+    },
+    meta: {
+      since: 0,
+      total: items.length,
+      generatedAt: 0,
+    },
+  };
+}
+
+function RowActionButton({
+  children,
+  label,
+  onClick,
+}: {
+  children: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-background/80 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring [&>svg]:size-4"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onClick();
+      }}
+      title={label}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function ThreadPreviewRow({
+  item,
+  onMarkRead,
+  onOpen,
+  onRemindLater,
+}: {
+  item: InboxItem;
+  onMarkRead: () => void;
+  onOpen: () => void;
+  onRemindLater: () => void;
+}) {
+  return (
+    <div
+      className="group/activity-row relative border-t border-border/50 first:border-t-0"
+      data-testid={`channel-activity-item-${item.conversationId}`}
+    >
+      <button
+        aria-label={`Open thread from ${item.senderLabel}`}
+        className="absolute inset-0 z-0 w-full text-left"
+        onClick={onOpen}
+        type="button"
+      />
+      <div className="pointer-events-none relative z-10 flex min-w-0 items-start gap-2.5 px-3 py-3 transition-colors group-hover/activity-row:bg-muted/50 group-focus-within/activity-row:bg-muted/50">
+        <UserAvatar
+          avatarUrl={item.avatarUrl}
+          className="h-9 w-9 shrink-0"
+          displayName={item.senderLabel}
+          size="md"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-start gap-2">
+            <span className="min-w-0 flex-1 truncate text-sm font-semibold leading-4 text-foreground">
+              {item.senderLabel}
+            </span>
+            <span className="shrink-0 text-xs leading-4 text-muted-foreground/70 transition-opacity group-hover/activity-row:opacity-0 group-focus-within/activity-row:opacity-0">
+              {item.timestampLabel}
+            </span>
+          </div>
+          <div className="mt-0.5 flex items-center gap-1.5 text-xs leading-4 text-muted-foreground">
+            <span>Thread</span>
+            {item.unreadCount > 1 ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{item.unreadCount} unread</span>
+              </>
+            ) : null}
+          </div>
+          <Markdown
+            className="inbox-preview-markdown mt-1.5 line-clamp-2 text-sm font-medium leading-5 text-foreground"
+            content={item.preview}
+            interactive={false}
+            mentionNames={item.mentionNames}
+          />
+        </div>
+      </div>
+      <div className="pointer-events-none absolute right-2 top-2 z-20 flex items-center gap-0.5 rounded-full bg-muted/95 p-0.5 opacity-0 shadow-xs transition-opacity group-hover/activity-row:pointer-events-auto group-hover/activity-row:opacity-100 group-focus-within/activity-row:pointer-events-auto group-focus-within/activity-row:opacity-100">
+        <RowActionButton label="Mark as read" onClick={onMarkRead}>
+          <MailOpen />
+        </RowActionButton>
+        <RowActionButton label="Remind me later" onClick={onRemindLater}>
+          <Clock />
+        </RowActionButton>
+      </div>
+    </div>
+  );
+}
+
+function WorkingAgentRow({
+  avatarUrl,
+  elapsed,
+  name,
+  onOpen,
+  pubkey,
+}: {
+  avatarUrl: string | null;
+  elapsed: string;
+  name: string;
+  onOpen: () => void;
+  pubkey: string;
+}) {
+  return (
+    <button
+      className="flex w-full min-w-0 items-start gap-2.5 border-t border-border/50 px-3 py-3 text-left transition-colors first:border-t-0 hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-hidden"
+      data-testid={`channel-activity-agent-${pubkey}`}
+      onClick={onOpen}
+      type="button"
+    >
+      <UserAvatar
+        avatarUrl={avatarUrl}
+        className="h-9 w-9 shrink-0"
+        displayName={name}
+        size="md"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-start gap-2">
+          <span className="min-w-0 flex-1 truncate text-sm font-semibold leading-4 text-foreground">
+            {name}
+          </span>
+          <span className="shrink-0 text-xs leading-4 text-muted-foreground/70">
+            {elapsed}
+          </span>
+        </div>
+        <span className="mt-0.5 flex items-center gap-1.5 text-xs leading-4 text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary/70" />
+          Working
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function WorkingAgentRows({
+  activeWorking,
+  channelId,
+  onOpen,
+  profiles,
+}: {
+  activeWorking: ActiveChannelTurnSummary;
+  channelId: string;
+  onOpen: (pubkey: string, channelId: string) => void;
+  profiles?: UserProfileLookup;
+}) {
+  const now = useNow(1000);
+  const elapsed = formatElapsed(now - activeWorking.anchorAt);
+  const alignedAgentNames =
+    activeWorking.agentNames?.length === activeWorking.agentPubkeys.length
+      ? activeWorking.agentNames
+      : null;
+
+  return activeWorking.agentPubkeys.map((pubkey, index) => {
+    const profile = profiles?.[normalizePubkey(pubkey)];
+    const name =
+      profile?.displayName?.trim() ||
+      alignedAgentNames?.[index] ||
+      `Agent ${truncatePubkey(pubkey)}`;
+    return (
+      <WorkingAgentRow
+        avatarUrl={profile?.avatarUrl ?? null}
+        elapsed={elapsed}
+        key={pubkey}
+        name={name}
+        onOpen={() => onOpen(pubkey, channelId)}
+        pubkey={pubkey}
+      />
+    );
+  });
+}
+
+export function ChannelActivityPopover({
+  activeWorking,
+  channel,
+  children,
+}: {
+  activeWorking?: ActiveChannelTurnSummary;
+  channel: Channel;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const hoverTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const {
+    clearChannelUnreadSource,
+    getChannelActivityItemReadAt,
+    locallyUnreadFeedItems,
+    markMessageRead,
+    markThreadRead,
+    unreadThreadFeedItems,
+    feedItemState,
+  } = useAppShell();
+  const { undoUnread } = feedItemState;
+  const identityQuery = useIdentityQuery();
+  const { goChannel } = useAppNavigation();
+  const { openAgentActivity } = useOpenAgentActivity();
+  const { openReminder } = useRemindLater();
+
+  const unreadChannelFeedItems = React.useMemo(() => {
+    return unreadThreadFeedItems.filter(
+      (item) => item.channelId === channel.id,
+    );
+  }, [channel.id, unreadThreadFeedItems]);
+  const profilePubkeys = React.useMemo(
+    () => [
+      ...new Set([
+        ...unreadChannelFeedItems.map((item) => item.pubkey),
+        ...(activeWorking?.agentPubkeys ?? []),
+      ]),
+    ],
+    [activeWorking?.agentPubkeys, unreadChannelFeedItems],
+  );
+  const profilesQuery = useUsersBatchQuery(open ? profilePubkeys : [], {
+    enabled: open,
+  });
+  const profiles = profilesQuery.data?.profiles;
+  const activityReadAtByMessageId = React.useMemo(
+    () =>
+      new Map(
+        unreadChannelFeedItems.map((item) => [
+          item.id,
+          getChannelActivityItemReadAt(item),
+        ]),
+      ),
+    [getChannelActivityItemReadAt, unreadChannelFeedItems],
+  );
+  const activityItems = React.useMemo(() => {
+    if (!open) return [];
+    return buildInboxItems({
+      channels: [channel],
+      currentPubkey: identityQuery.data?.pubkey,
+      feed: buildChannelActivityFeed(unreadChannelFeedItems),
+      getMessageReadAt: (messageId) =>
+        activityReadAtByMessageId.get(messageId) ?? null,
+      profiles,
+    });
+  }, [
+    channel,
+    activityReadAtByMessageId,
+    identityQuery.data?.pubkey,
+    open,
+    profiles,
+    unreadChannelFeedItems,
+  ]);
+  const hasContent =
+    unreadChannelFeedItems.length > 0 ||
+    (activeWorking?.agentPubkeys.length ?? 0) > 0;
+
+  const clearHoverTimer = React.useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }, []);
+  const openWithDelay = React.useCallback(() => {
+    if (!hasContent) return;
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(() => {
+      setOpen(true);
+    }, HOVER_OPEN_DELAY_MS);
+  }, [clearHoverTimer, hasContent]);
+  const openImmediately = React.useCallback(() => {
+    if (!hasContent) return;
+    clearHoverTimer();
+    setOpen(true);
+  }, [clearHoverTimer, hasContent]);
+  const closeWithDelay = React.useCallback(() => {
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(() => {
+      setOpen(false);
+    }, HOVER_CLOSE_DELAY_MS);
+  }, [clearHoverTimer]);
+  const keepOpen = React.useCallback(() => {
+    clearHoverTimer();
+  }, [clearHoverTimer]);
+
+  React.useEffect(() => () => clearHoverTimer(), [clearHoverTimer]);
+  React.useEffect(() => {
+    if (!hasContent) {
+      setOpen(false);
+    }
+  }, [hasContent]);
+
+  const clearUnreadOverride = React.useCallback(
+    (item: InboxItem) => {
+      const clearedItemIds = new Set(getGroupedInboxItemIds(item));
+      for (const itemId of clearedItemIds) {
+        undoUnread(itemId);
+      }
+      const channelId = item.item.channelId ?? null;
+      const hasAnotherChannelOverride = locallyUnreadFeedItems.some(
+        (feedItem) =>
+          feedItem.channelId === channelId && !clearedItemIds.has(feedItem.id),
+      );
+      if (channelId && !hasAnotherChannelOverride) {
+        clearChannelUnreadSource(channelId, "inbox");
+      }
+    },
+    [clearChannelUnreadSource, locallyUnreadFeedItems, undoUnread],
+  );
+
+  const handleMarkRead = React.useCallback(
+    (item: InboxItem) => {
+      clearUnreadOverride(item);
+      for (const reply of item.groupItems) {
+        markMessageRead(reply.id, reply.createdAt);
+      }
+      markThreadRead(item.conversationId, item.latestActivityAt);
+    },
+    [clearUnreadOverride, markMessageRead, markThreadRead],
+  );
+
+  if (!hasContent) {
+    return children;
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverAnchor asChild>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: hover/focus events bubble from the nested channel button while this wrapper supplies the popover anchor box. */}
+        <div
+          className="w-full min-w-0"
+          onBlur={closeWithDelay}
+          onContextMenu={() => setOpen(false)}
+          onFocus={openImmediately}
+          onMouseEnter={openWithDelay}
+          onMouseLeave={closeWithDelay}
+        >
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className="w-96 overflow-hidden p-0"
+        data-testid={`channel-activity-popover-${channel.name}`}
+        onFocusCapture={keepOpen}
+        onMouseEnter={keepOpen}
+        onMouseLeave={closeWithDelay}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        side="right"
+        sideOffset={8}
+      >
+        <section
+          aria-label="Channel activity"
+          className="flex max-h-96 min-h-0 flex-col overflow-hidden"
+        >
+          <h3
+            className="relative z-20 shrink-0 border-b border-border/70 bg-background/95 px-3 py-2 text-sm font-semibold text-foreground backdrop-blur-md supports-[backdrop-filter]:bg-background/90"
+            data-testid="channel-activity-header"
+          >
+            Channel activity
+          </h3>
+          <div
+            className="buzz-channel-activity-scrollbar min-h-0 overflow-y-auto overscroll-contain"
+            data-testid="channel-activity-scroll"
+          >
+            {activeWorking?.agentPubkeys.length ? (
+              <WorkingAgentRows
+                activeWorking={activeWorking}
+                channelId={channel.id}
+                onOpen={(pubkey, channelId) => {
+                  setOpen(false);
+                  openAgentActivity(pubkey, { channelId });
+                }}
+                profiles={profiles}
+              />
+            ) : null}
+            {activityItems.length > 0
+              ? activityItems.map((item) => (
+                  <ThreadPreviewRow
+                    item={item}
+                    key={item.conversationId}
+                    onMarkRead={() => handleMarkRead(item)}
+                    onOpen={() => {
+                      clearUnreadOverride(item);
+                      setOpen(false);
+                      void goChannel(channel.id, {
+                        messageId: item.id,
+                        threadRootId: item.conversationId,
+                      });
+                    }}
+                    onRemindLater={() => {
+                      setOpen(false);
+                      openReminder({
+                        authorPubkey: item.item.pubkey,
+                        channelId: channel.id,
+                        eventId: item.id,
+                        preview: item.preview.slice(0, 100),
+                      });
+                    }}
+                  />
+                ))
+              : null}
+          </div>
+        </section>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/desktop/src/features/sidebar/ui/ChannelContextMenu.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelContextMenu.tsx
@@ -15,6 +15,7 @@ import {
   TriangleAlert,
 } from "lucide-react";
 
+import { useAppShell } from "@/app/AppShellContext";
 import {
   useArchiveChannelMutation,
   useChannelMembersQuery,
@@ -178,6 +179,22 @@ export function ChannelContextMenuItems({
   onDeleteChannel?: (channel: Channel) => void;
   onLeaveChannel?: (channel: Channel) => void;
 }) {
+  const {
+    feedItemState,
+    hasSidebarUnreadProjections,
+    locallyUnreadFeedItems,
+    unreadThreadChannelIds,
+  } = useAppShell();
+  const channelUnreadOverrideIds = locallyUnreadFeedItems.flatMap((item) =>
+    item.channelId === channel.id && feedItemState.unreadSet.has(item.id)
+      ? [item.id]
+      : [],
+  );
+  const hasProjectedUnread =
+    hasUnread ||
+    (channel.channelType !== "dm" &&
+      hasSidebarUnreadProjections &&
+      unreadThreadChannelIds.has(channel.id));
   const canLoadOwnerActions =
     channel.channelType !== "dm" && Boolean(onDeleteChannel);
   const membersQuery = useChannelMembersQuery(channel.id, canLoadOwnerActions);
@@ -204,7 +221,7 @@ export function ChannelContextMenuItems({
       canDeleteChannel,
   );
   const showStar = Boolean(onStarChannel && onUnstarChannel);
-  const showReadToggle = hasUnread
+  const showReadToggle = hasProjectedUnread
     ? Boolean(onMarkChannelRead)
     : Boolean(onMarkChannelUnread);
   const showMuteToggle = Boolean(onMuteChannel && onUnmuteChannel);
@@ -230,12 +247,15 @@ export function ChannelContextMenuItems({
         />
       ) : null}
       {showReadToggle ? <ContextMenuSeparator /> : null}
-      {hasUnread && onMarkChannelRead ? (
+      {hasProjectedUnread && onMarkChannelRead ? (
         <ContextMenuItem
           onSelect={() =>
-            deferMenuAction(() =>
-              onMarkChannelRead(channel.id, channel.lastMessageAt),
-            )
+            deferMenuAction(() => {
+              for (const itemId of channelUnreadOverrideIds) {
+                feedItemState.undoUnread(itemId);
+              }
+              onMarkChannelRead(channel.id, channel.lastMessageAt);
+            })
           }
         >
           <ContextMenuIconSlot>
@@ -243,7 +263,7 @@ export function ChannelContextMenuItems({
           </ContextMenuIconSlot>
           <span>Mark as read</span>
         </ContextMenuItem>
-      ) : !hasUnread && onMarkChannelUnread ? (
+      ) : !hasProjectedUnread && onMarkChannelUnread ? (
         <ContextMenuItem
           onSelect={() =>
             deferMenuAction(() => onMarkChannelUnread(channel.id))

--- a/desktop/src/features/sidebar/ui/CreateChannelFormFields.tsx
+++ b/desktop/src/features/sidebar/ui/CreateChannelFormFields.tsx
@@ -1,13 +1,16 @@
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
+import * as React from "react";
 
-import type { ChannelTemplate } from "@/shared/api/types";
+import { TemplateFormDialog } from "@/features/settings/ui/ChannelTemplatesSettingsCard";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { Input } from "@/shared/ui/input";
@@ -39,9 +42,27 @@ export function CreateChannelFormFields({
   form: CreateChannelFormState;
 }) {
   const { channelKind, kindLabel, isCreating } = form;
+  const [isCreateTemplateOpen, setIsCreateTemplateOpen] = React.useState(false);
   const selectedTemplate = form.templates.find(
     (template) => template.id === form.selectedTemplateId,
   );
+  const selectedTemplatePersonaCount =
+    selectedTemplate?.agents.personas.length ?? 0;
+  const selectedTemplateTeamCount = selectedTemplate?.agents.teams.length ?? 0;
+  const selectedTemplateSummary = selectedTemplate
+    ? [
+        form.visibility === "private" ? "Private" : "Open",
+        selectedTemplate.canvasTemplate ? "Canvas included" : null,
+        selectedTemplatePersonaCount > 0
+          ? `${selectedTemplatePersonaCount} ${selectedTemplatePersonaCount === 1 ? "agent" : "agents"}`
+          : null,
+        selectedTemplateTeamCount > 0
+          ? `${selectedTemplateTeamCount} ${selectedTemplateTeamCount === 1 ? "team" : "teams"}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : null;
 
   return (
     <div className="space-y-5">
@@ -107,6 +128,7 @@ export function CreateChannelFormFields({
 
       <ChannelTypeSettings
         disabled={isCreating}
+        label="Type"
         onOpenChange={form.setTypePopoverOpen}
         onTemporaryChange={form.setEphemeral}
         onTtlSecondsChange={form.setTtlSeconds}
@@ -116,69 +138,87 @@ export function CreateChannelFormFields({
         ttlSeconds={form.ttlSeconds}
       />
 
-      {form.templates.length > 0 ? (
-        <div
-          className={cn(
-            "flex min-h-12 items-center justify-between gap-4 rounded-xl border border-input bg-background px-3 py-3",
-            isCreating && "opacity-50",
-          )}
-        >
-          <span className="text-sm font-medium text-foreground">
-            Template
-            <span className={CREATE_LABEL_OPTIONAL_CLASS}>Optional</span>
-          </span>
-          <DropdownMenu modal={false}>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={`Template: ${selectedTemplate?.name ?? "No template"}`}
-                className="-mr-2.5 ml-auto h-9 min-w-0 max-w-[60%] justify-end px-2.5 text-right text-sm font-medium text-foreground hover:bg-muted/50"
-                data-testid="create-channel-template"
-                disabled={isCreating}
-                id="create-channel-template"
-                type="button"
-                variant="ghost"
-              >
-                <span className="truncate text-right">
-                  {selectedTemplate?.name ?? "No template"}
-                </span>
-                <ChevronDown className="size-4 shrink-0 text-muted-foreground/70" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              onCloseAutoFocus={(event) => event.preventDefault()}
-              style={{
-                minWidth: "var(--radix-dropdown-menu-trigger-width)",
-              }}
-            >
-              <DropdownMenuRadioGroup
-                onValueChange={(templateId) =>
-                  form.handleTemplateChange(
-                    templateId === NO_TEMPLATE_VALUE ? "" : templateId,
-                  )
-                }
-                value={form.selectedTemplateId ?? NO_TEMPLATE_VALUE}
-              >
-                <DropdownMenuRadioItem value={NO_TEMPLATE_VALUE}>
-                  No template
-                </DropdownMenuRadioItem>
-                {form.templates.map((template: ChannelTemplate) => (
-                  <DropdownMenuRadioItem key={template.id} value={template.id}>
-                    {template.name}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      ) : null}
-
       <ChannelPermissionsSettings
         disabled={isCreating}
         onVisibilityChange={form.setVisibility}
         testIdPrefix="create-channel"
         visibility={form.visibility}
       />
+
+      <div
+        className={cn(
+          "flex min-h-12 items-center justify-between gap-4 rounded-xl border border-input bg-background px-3 py-3",
+          isCreating && "opacity-50",
+        )}
+        data-testid="create-channel-template-container"
+      >
+        <span className="text-sm font-medium text-foreground">
+          Template
+          <span className={CREATE_LABEL_OPTIONAL_CLASS}>Optional</span>
+        </span>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={`Template: ${selectedTemplate?.name ?? "None"}`}
+              className="-mr-2.5 ml-auto h-9 min-w-0 max-w-[60%] justify-end px-2.5 text-right text-sm font-medium text-foreground hover:bg-muted/50"
+              data-testid="create-channel-template"
+              disabled={isCreating}
+              id="create-channel-template"
+              type="button"
+              variant="ghost"
+            >
+              <span className="truncate text-right">
+                {selectedTemplate?.name ?? "None"}
+              </span>
+              <ChevronDown className="size-4 shrink-0 text-muted-foreground/70" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            onCloseAutoFocus={(event) => event.preventDefault()}
+            style={{
+              minWidth: "var(--radix-dropdown-menu-trigger-width)",
+            }}
+          >
+            <DropdownMenuRadioGroup
+              onValueChange={(templateId) =>
+                form.handleTemplateChange(
+                  templateId === NO_TEMPLATE_VALUE ? "" : templateId,
+                )
+              }
+              value={form.selectedTemplateId ?? NO_TEMPLATE_VALUE}
+            >
+              <DropdownMenuRadioItem value={NO_TEMPLATE_VALUE}>
+                None
+              </DropdownMenuRadioItem>
+              {form.templates.map((template) => (
+                <DropdownMenuRadioItem key={template.id} value={template.id}>
+                  {template.name}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setIsCreateTemplateOpen(true)}>
+              <Plus className="size-4" />
+              Create new channel template…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <TemplateFormDialog
+          onCreated={form.handleTemplateCreated}
+          onOpenChange={setIsCreateTemplateOpen}
+          open={isCreateTemplateOpen}
+          template={null}
+        />
+      </div>
+      {selectedTemplateSummary ? (
+        <p
+          className="-mt-3 px-3 text-xs text-muted-foreground"
+          data-testid="create-channel-template-summary"
+        >
+          {selectedTemplateSummary}
+        </p>
+      ) : null}
 
       {form.errorMessage ? (
         <p className="text-sm text-destructive">{form.errorMessage}</p>

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -36,6 +36,8 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/shared/ui/sidebar";
+import { ChannelActivityPopover } from "@/features/sidebar/ui/ChannelActivityPopover";
+import { useAppShell } from "@/app/AppShellContext";
 
 const SECTION_LABEL_BUTTON_CLASS =
   "group/section-label flex w-fit max-w-[calc(100%-3rem)] cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
@@ -138,7 +140,8 @@ function ChannelWorkingBadge({
   return (
     <span
       className={cn(
-        "hidden max-w-32 shrink-0 truncate rounded-full px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums motion-safe:animate-pulse group-data-[collapsible=icon]:hidden sm:inline-flex",
+        "max-w-32 shrink-0 truncate rounded-full px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums motion-safe:animate-pulse group-data-[collapsible=icon]:hidden",
+        "hidden sm:inline-flex",
         isActive
           ? "bg-sidebar-active-foreground/20 text-sidebar-active-foreground"
           : "bg-primary/10 text-primary",
@@ -250,7 +253,6 @@ export function ChannelMenuButton({
   label,
   isActive,
   hasUnread,
-  unreadCount = 0,
   activeWorking,
   isMuted,
   dmParticipants,
@@ -270,17 +272,37 @@ export function ChannelMenuButton({
 }) {
   const resolvedLabel = label ?? channel.name;
   const ephemeralDisplay = getEphemeralChannelDisplay(channel);
+  const {
+    hasSidebarUnreadProjections,
+    topLevelUnreadChannelIds,
+    unreadThreadChannelIds,
+  } = useAppShell();
+  const hasTopLevelUnread =
+    channel.channelType === "dm"
+      ? hasUnread
+      : hasSidebarUnreadProjections
+        ? topLevelUnreadChannelIds.has(channel.id)
+        : hasUnread;
+  const hasThreadUnread =
+    channel.channelType !== "dm" &&
+    (hasSidebarUnreadProjections
+      ? unreadThreadChannelIds.has(channel.id)
+      : hasUnread);
 
-  return (
+  const button = (
     <SidebarMenuButton
       className={cn(
         isActive
           ? "group-hover/menu-item:bg-sidebar-active group-hover/menu-item:text-sidebar-active-foreground"
           : "group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground",
         !isActive &&
-          hasUnread &&
+          hasTopLevelUnread &&
           "font-semibold text-sidebar-foreground hover:text-sidebar-foreground",
-        !isActive && isMuted && !hasUnread && "opacity-50",
+        !isActive &&
+          isMuted &&
+          !hasTopLevelUnread &&
+          !hasThreadUnread &&
+          "opacity-50",
       )}
       data-channel-id={channel.id}
       data-testid={`channel-${channel.name}`}
@@ -321,18 +343,20 @@ export function ChannelMenuButton({
           )}
         />
       ) : null}
-      {hasUnread && !isActive && channel.channelType !== "dm" ? (
-        unreadCount > 0 ? (
-          <UnreadCountBadge
-            channelName={channel.name}
-            className="ml-auto"
-            count={unreadCount}
-          />
-        ) : (
-          <UnreadDotBadge channelName={channel.name} className="ml-auto" />
-        )
+      {hasThreadUnread ? (
+        <UnreadDotBadge channelName={channel.name} className="ml-auto" />
       ) : null}
     </SidebarMenuButton>
+  );
+
+  if (!activeWorking && !hasThreadUnread) {
+    return button;
+  }
+
+  return (
+    <ChannelActivityPopover activeWorking={activeWorking} channel={channel}>
+      {button}
+    </ChannelActivityPopover>
   );
 }
 

--- a/desktop/src/features/terminal/TerminalBootstrap.test.mjs
+++ b/desktop/src/features/terminal/TerminalBootstrap.test.mjs
@@ -3,7 +3,11 @@ import { after, afterEach, before, test } from "node:test";
 
 import { JSDOM } from "jsdom";
 
+// `pretendToBeVisual` is what gives jsdom requestAnimationFrame. The banner's
+// animation loop needs it; without it the loop silently never runs and every
+// paint assertion below reads as a rendering failure.
 const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  pretendToBeVisual: true,
   url: "http://localhost",
 });
 const callbacks = new Map();

--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -13,7 +13,11 @@ let ThemeProvider;
 let TerminalSubstrate;
 let reducedMotion = false;
 
+// `pretendToBeVisual` is what gives jsdom requestAnimationFrame. The banner's
+// animation loop needs it; without it the loop silently never runs and every
+// paint assertion below reads as a rendering failure.
 const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  pretendToBeVisual: true,
   url: "http://localhost",
 });
 

--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -759,3 +759,218 @@ test("the handoff chord still toggles with the tab layer installed", async () =>
   toggleChord();
   await waitFor(() => assert.equal(substrate.dataset.terminalOwner, "buzz"));
 });
+
+// ---------------------------------------------------------------------------
+// Splash animation lifecycle.
+//
+// This substrate is mounted unconditionally on every route and merely
+// CSS-concealed in Buzz mode, so "is the splash animating?" is a question about
+// `owner`, not about mounting. A loop gated only on `welcomeVisible` ran at
+// 120 rAF/s behind the whole app forever for anyone who never opened the
+// terminal; that is the defect these arms exist to keep dead.
+//
+// The rAF clock is driven by hand rather than by jsdom's visual loop: a real
+// clock can only show "frames happened", while a manual one can advance AFTER a
+// transition and prove no successor callback was scheduled. Distinguishing a
+// cancelled frame from a frame that was never scheduled needs that.
+function splashClock() {
+  const real = {
+    request: dom.window.requestAnimationFrame,
+    cancel: dom.window.cancelAnimationFrame,
+  };
+  const pending = new Map();
+  let nextHandle = 1;
+  let scheduled = 0;
+  let cancelled = 0;
+  dom.window.requestAnimationFrame = (callback) => {
+    const handle = nextHandle++;
+    pending.set(handle, callback);
+    scheduled += 1;
+    return handle;
+  };
+  dom.window.cancelAnimationFrame = (handle) => {
+    if (pending.delete(handle)) cancelled += 1;
+  };
+  return {
+    get scheduled() {
+      return scheduled;
+    },
+    get cancelled() {
+      return cancelled;
+    },
+    get outstanding() {
+      return pending.size;
+    },
+    /** Run every queued callback once, as one frame would. */
+    advance(now = 16) {
+      const due = [...pending.entries()];
+      pending.clear();
+      act(() => {
+        for (const [, callback] of due) callback(now);
+      });
+      return due.length;
+    },
+    restore() {
+      dom.window.requestAnimationFrame = real.request;
+      dom.window.cancelAnimationFrame = real.cancel;
+    },
+  };
+}
+
+/** Draws issued to the banner/splash canvas only. */
+function bannerDraws(view) {
+  const banner = view.container.querySelector(".buzz-terminal-welcome");
+  if (!banner) return [];
+  return paintLog.filter((entry) => entry.canvas === banner);
+}
+
+test("the splash animation runs only while the terminal is revealed", async () => {
+  const clock = splashClock();
+  try {
+    // ARM 1 — concealed entry. `enabled` defaults true, so this is the
+    // production-shaped state that used to animate behind the channel view.
+    const subject = fixture();
+    await ready(subject.view);
+    const substrate = subject.view.container.querySelector(
+      ".buzz-terminal-substrate",
+    );
+    assert.equal(substrate.dataset.terminalOwner, "buzz");
+    await expectWelcome(subject.view, true);
+    assert.equal(
+      clock.scheduled,
+      0,
+      "ARM 1: no splash frame is scheduled while Buzz owns the screen",
+    );
+    clock.advance();
+    assert.equal(
+      bannerDraws(subject.view).length,
+      0,
+      "ARM 1: and no hidden banner paint happens either",
+    );
+
+    // ARM 2 — revealed. The positive control: the loop must actually run, or
+    // arms 1/3 are satisfied by a loop that is simply broken everywhere.
+    await reveal(subject.view);
+    assert.ok(
+      clock.scheduled > 0,
+      "ARM 2: revealing the terminal starts the splash loop",
+    );
+    const afterReveal = clock.scheduled;
+    assert.equal(clock.advance(), 1, "ARM 2: exactly one frame was pending");
+    assert.ok(
+      bannerDraws(subject.view).length > 0,
+      "ARM 2: the revealed splash actually paints",
+    );
+    assert.ok(
+      clock.scheduled > afterReveal,
+      "ARM 2: the loop reschedules itself while revealed",
+    );
+
+    // ARM 3 — terminal -> buzz. The regression users hit: leaving the terminal
+    // must CANCEL the outstanding frame, not merely stop new ones. Advancing
+    // the clock afterwards is what separates those two.
+    const beforeConceal = clock.scheduled;
+    const cancelledBefore = clock.cancelled;
+    toggleChord();
+    await waitFor(() => assert.equal(substrate.dataset.terminalOwner, "buzz"));
+    assert.ok(
+      clock.cancelled > cancelledBefore,
+      "ARM 3: concealing cancels the frame that was already scheduled",
+    );
+    assert.equal(
+      clock.outstanding,
+      0,
+      "ARM 3: nothing is left queued after cleanup",
+    );
+    const drawsBefore = bannerDraws(subject.view).length;
+    clock.advance();
+    clock.advance();
+    assert.equal(
+      clock.scheduled,
+      beforeConceal,
+      "ARM 3: no successor callback is scheduled after concealing",
+    );
+    assert.equal(
+      bannerDraws(subject.view).length,
+      drawsBefore,
+      "ARM 3: and no further hidden banner paint occurs",
+    );
+
+    // ARM 4 — buzz -> terminal again. Proves cleanup did not poison the
+    // positive path: a fix that permanently kills the loop passes 1 and 3.
+    await reveal(subject.view);
+    assert.ok(
+      clock.scheduled > beforeConceal,
+      "ARM 4: re-revealing restarts the splash loop",
+    );
+    clock.advance();
+    assert.ok(
+      bannerDraws(subject.view).length > drawsBefore,
+      "ARM 4: and it paints again",
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+// The gate above reads `owner` alone, which is only sound because
+// `owner === "terminal"` implies `enabled`: the sole `commitOwner("terminal")`
+// call site sits behind an `!enabled` early return, and dropping `enabled`
+// forces ownership back to Buzz. That implication is true by construction
+// today and nothing else in this file pins it, so a refactor adding a second
+// reveal path outside the `enabled` guard would silently widen the gate. This
+// arm is that implication, held as a regression test in both directions.
+test("a disabled terminal cannot reveal, so owner-gating cannot widen", async () => {
+  const clock = splashClock();
+  try {
+    const subject = fixture({ enabled: false });
+    await ready(subject.view);
+    const substrate = subject.view.container.querySelector(
+      ".buzz-terminal-substrate",
+    );
+
+    toggleChord();
+    await waitFor(() => assert.ok(substrate.dataset.terminalOwner));
+    assert.equal(
+      substrate.dataset.terminalOwner,
+      "buzz",
+      "the toggle chord must not reveal a terminal that has no session",
+    );
+    assert.equal(
+      clock.scheduled,
+      0,
+      "and no splash frame is scheduled while disabled",
+    );
+    clock.advance();
+    assert.equal(
+      bannerDraws(subject.view).length,
+      0,
+      "nor any hidden banner paint",
+    );
+
+    // The other direction: losing `enabled` while revealed must concede
+    // ownership and cancel the loop, which is what makes the `enabled` term
+    // redundant in the animation gate rather than merely absent from it.
+    subject.rerender({ enabled: true });
+    await reveal(subject.view);
+    assert.ok(clock.scheduled > 0, "the enabled terminal does reveal and run");
+    const afterReveal = clock.scheduled;
+
+    subject.rerender({ enabled: false });
+    await waitFor(() => assert.equal(substrate.dataset.terminalOwner, "buzz"));
+    assert.equal(
+      clock.outstanding,
+      0,
+      "losing the session cancels the outstanding splash frame",
+    );
+    clock.advance();
+    clock.advance();
+    assert.equal(
+      clock.scheduled,
+      afterReveal,
+      "and schedules no successor once disabled",
+    );
+  } finally {
+    clock.restore();
+  }
+});

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -343,10 +343,24 @@ export function TerminalSubstrate({
     };
   }, [enabled, getAppSurface]);
 
-  // The banner's animation loop. It exists only while the splash is visible:
-  // once the terminal is in use `welcomeVisible` is false, the overlay canvas
-  // is unmounted, and this effect's teardown cancels the frame — so there is no
-  // rAF running during normal PTY work.
+  // The banner's animation loop. It runs only while the splash is ON SCREEN,
+  // which needs BOTH conditions below — they are different questions:
+  //   - `welcomeVisible`: the splash has not been dismissed by terminal output.
+  //   - `owner === "terminal"`: the terminal layer is revealed at all.
+  //
+  // `owner` is the load-bearing one and it is not optional. This substrate is
+  // mounted unconditionally by AppShell on every route and merely CSS-concealed
+  // in Buzz mode (`.buzz-terminal-substrate` is `position:absolute; inset:0`),
+  // and `welcomeVisible` starts `true` and only clears on terminal INPUT. So a
+  // loop gated on `welcomeVisible` alone runs forever behind the whole app for
+  // anyone who never opens the terminal — measured at 120 rAF/s in the channel
+  // view, repainting a canvas nobody can see and slowing every other paint.
+  //
+  // Deliberately NOT gated on `enabled`: that is `available && Boolean(active)`
+  // where `available` is `isTauri()`, and a session is auto-created on channel
+  // open (TerminalBootstrap), so `enabled` is true while still concealed in the
+  // app and permanently false in the browser — it would gate the tests green
+  // and leave real users paying the cost. `owner` is user-gestured in both.
   //
   // `prefers-reduced-motion` takes the STATIC path (no motion argument), which
   // is the shipped painter call, not a paused animation. Those are different:
@@ -354,6 +368,7 @@ export function TerminalSubstrate({
   React.useEffect(() => {
     const canvas = bannerCanvasRef.current;
     if (!canvas || !banner || !terminalPalette || !welcomeVisible) return;
+    if (owner !== "terminal") return;
 
     const dpr = window.devicePixelRatio || 1;
     if (reducedMotion) {
@@ -380,7 +395,7 @@ export function TerminalSubstrate({
     };
     frame = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(frame);
-  }, [banner, reducedMotion, terminalPalette, welcomeVisible]);
+  }, [banner, owner, reducedMotion, terminalPalette, welcomeVisible]);
 
   React.useEffect(() => {
     for (const delivered of frames) {

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -15,6 +15,7 @@ import {
 } from "./terminalState";
 import { buildTerminalBanner } from "./terminalBanner";
 import { paintTerminalBanner } from "./terminalBannerPainter";
+import { buildBannerColorTable, phaseAt } from "./terminalBannerWave";
 import {
   TERMINAL_CELL_METRICS,
   type TerminalFrame,
@@ -342,20 +343,44 @@ export function TerminalSubstrate({
     };
   }, [enabled, getAppSurface]);
 
+  // The banner's animation loop. It exists only while the splash is visible:
+  // once the terminal is in use `welcomeVisible` is false, the overlay canvas
+  // is unmounted, and this effect's teardown cancels the frame — so there is no
+  // rAF running during normal PTY work.
+  //
+  // `prefers-reduced-motion` takes the STATIC path (no motion argument), which
+  // is the shipped painter call, not a paused animation. Those are different:
+  // a stopped loop still parks on whatever phase it halted at.
   React.useEffect(() => {
     const canvas = bannerCanvasRef.current;
     if (!canvas || !banner || !terminalPalette || !welcomeVisible) return;
-    if (
-      !paintTerminalBanner(
-        canvas,
-        banner,
-        terminalPalette,
-        window.devicePixelRatio || 1,
-      )
-    ) {
-      setWelcomeVisible(false);
+
+    const dpr = window.devicePixelRatio || 1;
+    if (reducedMotion) {
+      if (!paintTerminalBanner(canvas, banner, terminalPalette, dpr))
+        setWelcomeVisible(false);
+      return;
     }
-  }, [banner, terminalPalette, welcomeVisible]);
+
+    // Built once per palette, not per frame: the table is phase-independent.
+    const table = buildBannerColorTable(terminalPalette);
+    const start = performance.now();
+    let frame = 0;
+    const tick = (now: number) => {
+      if (
+        !paintTerminalBanner(canvas, banner, terminalPalette, dpr, {
+          phase: phaseAt((now - start) / 1000),
+          table,
+        })
+      ) {
+        setWelcomeVisible(false);
+        return;
+      }
+      frame = window.requestAnimationFrame(tick);
+    };
+    frame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frame);
+  }, [banner, reducedMotion, terminalPalette, welcomeVisible]);
 
   React.useEffect(() => {
     for (const delivered of frames) {

--- a/desktop/src/features/terminal/terminalBannerColor.ts
+++ b/desktop/src/features/terminal/terminalBannerColor.ts
@@ -29,7 +29,7 @@ import type {
 // sRGB -> CIELAB -> CIEDE2000. Instrument for "are two stops visibly distinct".
 export const hex2rgb = (h: string) =>
   [1, 3, 5].map((i) => parseInt(h.slice(i, i + 2), 16));
-export const rgb2hex = (r: number[]) =>
+export const rgb2hex = (r: readonly number[]) =>
   "#" +
   r
     .map((v) =>
@@ -213,8 +213,14 @@ function lab2hex(L: number, A: number, B: number) {
  *  not a target: `atRatio` also pins DOWN, which dimmed every vivid theme to
  *  exactly 4.5 and cost chroma (tokyo-night's #f7768e sits at 6.46 natively).
  *  Use this wherever the requirement is "at least", and `atRatio` only where a
- *  specific ratio is the design (the field decay and the bevel gap). */
-const lift = (c: string, bg: string, floor: number) =>
+ *  specific ratio is the design (the field decay and the bevel gap).
+ *
+ *  Exported because the animation's colour table interpolates BETWEEN solved
+ *  samples, and a straight-line blend under a convex contrast curve lands
+ *  slightly below both endpoints — measured at 4.4766 against the 4.5 floor on
+ *  solarized-light. The blend has to be re-lifted with the same operator that
+ *  put the endpoints on the floor in the first place. */
+export const lift = (c: string, bg: string, floor: number) =>
   ratio(c, bg) >= floor ? c : away(c, bg, floor);
 
 /**
@@ -356,24 +362,41 @@ function ramp(
   return pin ? atRatio(c, bg, target) : lift(c, bg, target);
 }
 
+/**
+ * `t` and `hue` are TWO AXES, and on the field they are not the same axis.
+ *
+ * A cell's `t` from the geometry is radial: `ray * ray`, a cast outward from
+ * the chassis. It sets the field's CONTRAST decay (2.60 at the box to 1.04 at
+ * the rim) and it also used to set the hue position, because a static banner
+ * has no reason to tell them apart. An animated wave does: driving hue from
+ * the radial axis makes the colour travel outward from the box like a ripple,
+ * and driving the contrast target from a moving axis makes the rim pulse
+ * bright and breaks the monotonic fade the field is specced on.
+ *
+ * So `hue` selects the position along the three-stop ramp and `t` keeps the
+ * contrast decay. `hue` DEFAULTS TO `t`, which is exactly the coupled
+ * behaviour the static banner shipped with — callers that omit it get the
+ * shipped pixels, byte for byte.
+ */
 export function bannerColor(
   p: TerminalPalette,
   stops: [string, string, string],
   layer: Layer,
   t: number,
+  hue: number = t,
 ): string {
   const bg = p.background;
   switch (layer) {
     case "head":
       // Tyler: "fill the box with buzz term in a three color fade".
-      return ramp(stops, t, bg, WORDMARK_FLOOR, false);
+      return ramp(stops, hue, bg, WORDMARK_FLOOR, false);
     case "field":
       // Tyler: "flow to the edges, fading out" + "colour shift centre to edge".
       // Same three hues, so the field and the mark are one palette; the fade is
       // in CONTRAST, from 2.60 at the box to 1.04 at the rim.
       return ramp(
         stops,
-        t,
+        hue,
         bg,
         FIELD_CORE + (FIELD_EDGE - FIELD_CORE) * Math.max(0, Math.min(1, t)),
       );

--- a/desktop/src/features/terminal/terminalBannerPainter.ts
+++ b/desktop/src/features/terminal/terminalBannerPainter.ts
@@ -1,13 +1,35 @@
 import type { TerminalPalette } from "../../shared/theme/terminal-palette";
-import type { TerminalBanner } from "./terminalBanner";
+import type { TerminalBanner, TerminalBannerLayer } from "./terminalBanner";
 import { bannerColor, bannerStops } from "./terminalBannerColor";
+import {
+  type BannerColorTable,
+  type BannerWaves,
+  makeCellHue,
+} from "./terminalBannerWave";
 import { TERMINAL_CELL_METRICS } from "./terminalRenderer";
+
+/**
+ * Optional animation input. ABSENT means the shipped static banner, not a
+ * stopped animation — those differ, because a halted rAF loop still parks on
+ * whatever phase it stopped at. `prefers-reduced-motion` takes this path, and
+ * the painter then calls `bannerColor` with no hue argument, which is the exact
+ * coupled call the static banner shipped with. Verified as byte equality on
+ * every draw call, not asserted by inspection.
+ */
+export type TerminalBannerMotion = {
+  phase: { field: number; wordmark: number };
+  table: BannerColorTable;
+  /** Tuning override. Omitted = the shipped FIELD_WAVE/WORDMARK_WAVE constants;
+   *  supplied only by the gates that drive each knob to its documented extreme. */
+  waves?: BannerWaves;
+};
 
 export function paintTerminalBanner(
   canvas: HTMLCanvasElement,
   banner: TerminalBanner,
   palette: TerminalPalette,
   dpr: number,
+  motion?: TerminalBannerMotion,
 ): boolean {
   const bounds = canvas.getBoundingClientRect();
   const pixelWidth = Math.max(1, Math.round(bounds.width * dpr));
@@ -27,11 +49,33 @@ export function paintTerminalBanner(
   context.font = TERMINAL_CELL_METRICS.font;
   context.textBaseline = "alphabetic";
 
-  const { stops } = bannerStops(palette);
+  // Resolve the colour strategy ONCE, outside the loop: the motion and static
+  // paths differ in what they close over, not per cell. The field wave is a
+  // projection onto a direction vector, so the hue closure needs the banner's
+  // extent in BOTH axes; it is built here so the per-cell path stays four
+  // scalars with no per-cell allocation.
+  const columns = banner.cells[0]?.length ?? 1;
+  const rows = banner.cells.length || 1;
+  const colourOf = motion
+    ? (() => {
+        const hueAt = makeCellHue(columns, rows, motion.phase, motion.waves);
+        return (
+          layer: TerminalBannerLayer,
+          t: number,
+          column: number,
+          row: number,
+        ) => motion.table.lookup(layer, t, hueAt(layer, t, column, row));
+      })()
+    : (() => {
+        const { stops } = bannerStops(palette);
+        return (layer: TerminalBannerLayer, t: number) =>
+          bannerColor(palette, stops, layer, t);
+      })();
+
   for (const [row, cells] of banner.cells.entries()) {
     for (const [column, cell] of cells.entries()) {
       if (cell.char === " " || !cell.layer) continue;
-      context.fillStyle = bannerColor(palette, stops, cell.layer, cell.t);
+      context.fillStyle = colourOf(cell.layer, cell.t, column, row);
       context.fillText(
         cell.char,
         column * TERMINAL_CELL_METRICS.width,

--- a/desktop/src/features/terminal/terminalBannerWave.test.mjs
+++ b/desktop/src/features/terminal/terminalBannerWave.test.mjs
@@ -205,75 +205,196 @@ test("an animated frame at phase zero is NOT the static banner", () => {
 });
 
 /**
- * DIRECTION. Eva's spec: the field originates BOTTOM-RIGHT and travels to
- * TOP-LEFT; the wordmark stays left-to-right. A sign error is invisible in any
- * still frame, which is why this measures the movement of a crest over time
- * rather than a property of one frame.
+ * DIRECTION, OVER THE WHOLE CYCLE. Eva's spec: the field originates
+ * BOTTOM-RIGHT and travels to TOP-LEFT; the wordmark stays left-to-right. A
+ * sign error is invisible in any still frame, which is why this measures
+ * movement over time rather than a property of one frame.
  *
- * Measured INSIDE a half-cycle. `cyclicRampPosition` folds the axis into a
- * palindrome so the loop is seamless, which means the wave reverses each
- * half-cycle by design — "the direction" is only defined within one, and a gate
- * that straddled a fold turn would read the reversal as a failure.
+ * THIS GATE USED TO SAMPLE ONLY 0.1 -> 0.2, justified by a comment on
+ * `cyclicRampPosition` claiming the wave reversed each half-cycle. That claim
+ * was false (see the proof there), and the narrow sampling it licensed is what
+ * let a reviewer read the code as back-and-forth motion. The honest version
+ * sweeps the ENTIRE cycle, including the alleged turn at phase 0.5 and the
+ * 1 -> 0 wrap — the exact two places the old gate did not look.
  *
- * The crest position is tracked in VISUAL space (x px, y px), not cell indices,
- * because that is the space the requirement is stated in.
+ * Two instruments, because a crest tracker alone can hop between the level
+ * set's two branches and fake a reversal:
+ *
+ *  A. RIGID-TRANSLATION FIT. If the pattern translates, there is a shift `d`
+ *     along +direction with hue(x + d*u, phase + D) == hue(x, phase). Fit `d`
+ *     per phase and require ONE SIGN and a constant magnitude across the cycle.
+ *     Bounded inside one spatial period: a wider search aliases onto the twin
+ *     shift `d + period` and reports a wrong (though same-signed) magnitude.
+ *  B. BRANCH-CONTINUOUS CREST TRACKING. Follow the crossing nearest the
+ *     previous one — that is what "a crest" means — and require monotone travel
+ *     over 200 steps spanning the full cycle.
+ *
+ * CONTROLS, so the negative is worth something (both must be CAUGHT):
+ *   POS-1 phase folded in TIME. This is what "reverses every half-cycle"
+ *         actually looks like, and it is the mutant the false comment
+ *         described. The shipped spatial fold is not it.
+ *   POS-2 negated phase: uniform travel the WRONG way, i.e. a sign error.
  */
-test("the field wave travels toward top-left and the wordmark left to right", () => {
+
+/** Visual-space unit vector and one-spatial-period pitch, along a FIXED axis.
+ *
+ *  Anchored to the SPEC's axis, never to `FIELD_WAVE.direction`: a gate that
+ *  derives its own measurement axis from the value under test rotates with a
+ *  direction bug and reports success. Measured — flipping the default to
+ *  `{x:1,y:1}` survived this gate until the axis was hardcoded here. The config
+ *  is checked against this axis separately, below. */
+const EXPECTED_FIELD_AXIS = { x: -Math.SQRT1_2, y: -Math.SQRT1_2 };
+const fieldGeometry = (columns, rows) => {
+  const { x: unitX, y: unitY } = EXPECTED_FIELD_AXIS;
+  const span =
+    Math.abs(unitX) * Math.max(1, columns) +
+    Math.abs(unitY) * Math.max(1, rows * ASPECT);
+  return { unitX, unitY, period: span / FIELD_WAVE.wavelength };
+};
+
+/**
+ * Fit the spatial shift along +direction that undoes a phase advance of
+ * `delta`. Returns the shift and its residual; a rigid translation fits with a
+ * residual at rounding level, so a large residual means "not a translation"
+ * rather than "translated by this much".
+ */
+const fitTranslation = (fieldAt, phase, delta, geometry, bound) => {
+  const samples = [];
+  for (let row = 8; row < 42; row += 3)
+    for (let column = 8; column < 112; column += 3) samples.push([column, row]);
+  const score = (d) => {
+    let sum = 0;
+    for (const [column, row] of samples) {
+      const here = fieldAt(column, row, phase);
+      const there = fieldAt(
+        column + geometry.unitX * d,
+        row + (geometry.unitY * d) / ASPECT,
+        phase + delta,
+      );
+      sum += (here - there) ** 2;
+    }
+    return Math.sqrt(sum / samples.length);
+  };
+  let best = 0;
+  let bestResidual = Number.POSITIVE_INFINITY;
+  for (let d = -bound; d <= bound; d += 0.5) {
+    const residual = score(d);
+    if (residual < bestResidual) {
+      bestResidual = residual;
+      best = d;
+    }
+  }
+  for (let d = best - 0.5; d <= best + 0.5; d += 0.01) {
+    const residual = score(d);
+    if (residual < bestResidual) {
+      bestResidual = residual;
+      best = d;
+    }
+  }
+  return { shift: best, residual: bestResidual };
+};
+
+/** Track one crest along the direction axis by continuity, full cycle. */
+const trackCrest = (fieldAt, geometry, columns, rows, steps) => {
+  const target = 0.5;
+  const at = (s, phase) =>
+    fieldAt(
+      columns / 2 + geometry.unitX * s,
+      rows / 2 + (geometry.unitY * s) / ASPECT,
+      phase,
+    );
+  const nearest = (phase, from) => {
+    let best = from;
+    let bestKey = Number.POSITIVE_INFINITY;
+    for (let s = from - 12; s <= from + 12; s += 0.02) {
+      // Prefer the closest match to `target`, tie-broken toward `from` so the
+      // tracker stays on ONE branch instead of jumping to an equal crossing.
+      const key =
+        Math.abs(at(s, phase) - target) * 1000 + Math.abs(s - from) * 1e-6;
+      if (key < bestKey) {
+        bestKey = key;
+        best = s;
+      }
+    }
+    return best;
+  };
+  let position = nearest(0, 0);
+  const start = position;
+  let negative = 0;
+  let positive = 0;
+  for (let index = 1; index <= steps; index += 1) {
+    const next = nearest(index / steps, position);
+    const step = next - position;
+    if (step < -1e-6) negative += 1;
+    if (step > 1e-6) positive += 1;
+    position = next;
+  }
+  return { net: position - start, negative, positive };
+};
+
+/** The three arms: shipped, plus the two reversal/sign controls. `transform`
+ *  maps the animation clock onto the phase actually handed to the module, so
+ *  the controls exercise the REAL composition instead of a reimplementation. */
+const TRAVEL_ARMS = [
+  { name: "shipped", transform: (phase) => phase, oneWay: true },
+  {
+    name: "POS-1 time-folded phase (a real reversal)",
+    transform: (phase) => {
+      const wrapped = phase - Math.floor(phase);
+      return wrapped < 0.5 ? wrapped * 2 : 2 - wrapped * 2;
+    },
+    oneWay: false,
+  },
+  {
+    name: "POS-2 negated phase (sign error)",
+    transform: (phase) => -phase,
+    oneWay: false,
+  },
+];
+
+/** Verdicts for one arm, so the assertions and the controls share an oracle.
+ *
+ *  Phase is obtained through the REAL clock path (`phaseAt(seconds)`), not by
+ *  handing `makeCellHue` a phase directly. Calling the hue factory with a
+ *  hand-made phase tests the wave functions in isolation and is blind to
+ *  anything `phaseAt` does — a time-fold injected there survived this gate
+ *  until it was routed this way. Same composition gap as M9: isolation gates
+ *  compose only if something tests the composition. `transform` perturbs the
+ *  CLOCK, so every arm still runs the whole shipped chain. */
+const travelVerdict = (transform) => {
   const columns = 120;
   const rows = 50;
-  const target = 0.5;
-  const hueAt = (phase) =>
-    makeCellHue(columns, rows, { field: phase, wordmark: phase });
-
-  // Centroid of the cells nearest a fixed hue: a whole crest line moves, and a
-  // single argmin cell can jump sideways along that line without the wave
-  // having moved. The centroid of the whole level set cannot.
-  const crestCentroid = (phase) => {
-    const hue = hueAt(phase);
-    let sx = 0;
-    let sy = 0;
-    let n = 0;
-    for (let row = 0; row < rows; row += 1)
-      for (let column = 0; column < columns; column += 1) {
-        const value = hue("field", 0.5, column, row);
-        if (Math.abs(value - target) < 0.01) {
-          sx += column;
-          sy += row * ASPECT;
-          n += 1;
-        }
-      }
-    assert.ok(n > 0, `no crest cells found at phase ${phase}`);
-    return { x: sx / n, y: sy / n };
+  const geometry = fieldGeometry(columns, rows);
+  // Phase advances by 0.01 of the FIELD cycle per unit of `phase` here, via the
+  // real seconds->phase conversion, so `phaseAt`'s wrapping is in the loop.
+  const hueFor = (phase) => {
+    const clock = transform(phase) * FIELD_PERIOD_SECONDS;
+    return makeCellHue(columns, rows, phaseAt(clock));
   };
+  const fieldAt = (column, row, phase) =>
+    hueFor(phase)("field", 0.5, column, row);
+  const headAt = (t, phase) => hueFor(phase)("head", t, 0, 0);
 
-  const early = crestCentroid(0.1);
-  const later = crestCentroid(0.2);
-  assert.ok(
-    later.x < early.x - 1,
-    `crest x moved ${early.x.toFixed(1)} -> ${later.x.toFixed(1)}, expected leftward`,
+  // A: fits across the full cycle, spanning the fold turn and the wrap.
+  const fits = [
+    0, 0.1, 0.2, 0.3, 0.4, 0.45, 0.49, 0.5, 0.51, 0.55, 0.6, 0.7, 0.8, 0.9,
+    0.95, 0.99,
+  ].map((phase) => ({
+    phase,
+    ...fitTranslation(fieldAt, phase, 0.01, geometry, geometry.period / 2),
+  }));
+  const shiftSigns = new Set(
+    fits.map((fit) => Math.sign(+fit.shift.toFixed(2))),
   );
-  assert.ok(
-    later.y < early.y - 1,
-    `crest y moved ${early.y.toFixed(1)} -> ${later.y.toFixed(1)}, expected upward`,
-  );
+  const crest = trackCrest(fieldAt, geometry, columns, rows, 200);
 
-  // ASPECT CORRECTION, as an angle. Cells are 8.4x17, so projecting raw indices
-  // would render the (-1,-1) vector as a ~27-degree wave instead of 45. The
-  // crest must travel at 45 degrees in VISUAL space for a 45-degree vector.
-  const angle =
-    (Math.atan2(early.y - later.y, early.x - later.x) * 180) / Math.PI;
-  assert.ok(
-    Math.abs(angle - 45) < 6,
-    `crest travels at ${angle.toFixed(1)} degrees in visual space, expected ~45`,
-  );
-
+  // Wordmark: crest position in `t`, unwrapped, across the full cycle.
   const tOfCrest = (phase) => {
-    const hue = hueAt(phase);
     let best = 0;
     let bestError = Number.POSITIVE_INFINITY;
     for (let step = 0; step <= 200; step += 1) {
       const t = step / 200;
-      const error = Math.abs(hue("head", t, 0, 0) - target);
+      const error = Math.abs(headAt(t, phase) - 0.5);
       if (error < bestError) {
         bestError = error;
         best = t;
@@ -281,10 +402,121 @@ test("the field wave travels toward top-left and the wordmark left to right", ()
     }
     return best;
   };
-  assert.ok(
-    tOfCrest(0.2) > tOfCrest(0.1),
-    "wordmark crest did not move rightward",
+  let headBackwards = 0;
+  let headForwards = 0;
+  let previous = tOfCrest(0);
+  for (let index = 1; index <= 60; index += 1) {
+    const current = tOfCrest(index / 60);
+    let step = current - previous;
+    // The crest leaves the right edge and re-enters at the left: unwrap into
+    // (-0.5, 0.5] so a re-entry is not mistaken for backward travel.
+    if (step > 0.5) step -= 1;
+    if (step < -0.5) step += 1;
+    if (step < -1e-9) headBackwards += 1;
+    if (step > 1e-9) headForwards += 1;
+    previous = current;
+  }
+
+  return { fits, shiftSigns, crest, headBackwards, headForwards, geometry };
+};
+
+test("the field travels toward top-left and the wordmark left to right, across the WHOLE cycle", () => {
+  const { fits, shiftSigns, crest, headBackwards, headForwards, geometry } =
+    travelVerdict((phase) => phase);
+
+  // The config must agree with the axis this gate measures along. Hardcoding
+  // the axis is what gives the gate teeth against a direction flip, but it also
+  // means a config change would silently stop being measured — so assert the
+  // two match rather than trusting them to.
+  const configLength = Math.hypot(
+    FIELD_WAVE.direction.x,
+    FIELD_WAVE.direction.y,
   );
+  assert.ok(
+    Math.abs(FIELD_WAVE.direction.x / configLength - EXPECTED_FIELD_AXIS.x) <
+      1e-9 &&
+      Math.abs(FIELD_WAVE.direction.y / configLength - EXPECTED_FIELD_AXIS.y) <
+        1e-9,
+    `FIELD_WAVE.direction ${JSON.stringify(FIELD_WAVE.direction)} is not the ` +
+      "spec's bottom-right -> top-left axis this gate measures along",
+  );
+
+  // A. One sign, constant magnitude, translation-quality residual.
+  assert.deepEqual(
+    [...shiftSigns],
+    [1],
+    `field shift changed sign across the cycle: ${fits
+      .map((fit) => `${fit.phase}:${fit.shift.toFixed(2)}`)
+      .join(" ")}`,
+  );
+  const shifts = fits.map((fit) => fit.shift);
+  const spread = Math.max(...shifts) - Math.min(...shifts);
+  assert.ok(
+    spread < 0.05,
+    `field velocity is not constant across the cycle: spread ${spread.toFixed(3)}px`,
+  );
+  const worstResidual = Math.max(...fits.map((fit) => fit.residual));
+  assert.ok(
+    worstResidual < 1e-3,
+    `field is not a rigid translation: worst residual ${worstResidual.toExponential(2)}`,
+  );
+  // Magnitude matches the closed form d = D * span / wavelength, so the gate
+  // pins the aspect correction too: a wrong ASPECT changes `span`.
+  const predicted = 0.01 * geometry.period;
+  assert.ok(
+    Math.abs(shifts[0] - predicted) < 0.05,
+    `shift ${shifts[0].toFixed(3)}px disagrees with closed form ${predicted.toFixed(3)}px`,
+  );
+
+  // B. Monotone crest travel over the full cycle, and exactly one spatial
+  // period of net travel — continuous travel AND a seamless wrap together.
+  assert.equal(
+    crest.negative,
+    0,
+    `field crest moved backward on ${crest.negative}/200 steps`,
+  );
+  assert.ok(crest.positive > 190, `field crest stalled: ${crest.positive}/200`);
+  assert.ok(
+    Math.abs(crest.net - geometry.period) < geometry.period * 0.05,
+    `net travel ${crest.net.toFixed(1)}px is not one spatial period (${geometry.period.toFixed(1)}px)`,
+  );
+
+  // Wordmark: strictly rightward over the whole cycle, wrap unwrapped.
+  assert.equal(
+    headBackwards,
+    0,
+    `wordmark crest moved leftward on ${headBackwards}/60 steps`,
+  );
+  assert.ok(headForwards > 55, `wordmark crest stalled: ${headForwards}/60`);
+});
+
+/**
+ * THE GATE'S OWN NEGATIVE CONTROLS. A direction gate that a reversal can
+ * survive is worthless, and the previous one could: POS-1 is precisely the
+ * motion the old comment claimed the code had, and the old 0.1->0.2 sampling
+ * could not see it. Both controls must be CAUGHT by the assertions above.
+ */
+test("the travel gate catches a real reversal and a sign error", () => {
+  for (const arm of TRAVEL_ARMS.filter((candidate) => !candidate.oneWay)) {
+    const { shiftSigns, crest, headBackwards } = travelVerdict(arm.transform);
+    const caught =
+      shiftSigns.size > 1 ||
+      !shiftSigns.has(1) ||
+      crest.negative > 0 ||
+      headBackwards > 0;
+    assert.ok(
+      caught,
+      `${arm.name} was NOT caught: signs {${[...shiftSigns].join(",")}}, ` +
+        `crest negative ${crest.negative}, wordmark backward ${headBackwards}`,
+    );
+  }
+
+  // And the shipped arm must pass the same oracle, or "caught" above is just
+  // an instrument that fails everything.
+  const shipped = travelVerdict((phase) => phase);
+  assert.deepEqual([...shipped.shiftSigns], [1]);
+  assert.equal(shipped.crest.negative, 0);
+  assert.equal(shipped.headBackwards, 0);
 });
 
 /** The two waves must not be one wave. Same period would read as a single

--- a/desktop/src/features/terminal/terminalBannerWave.test.mjs
+++ b/desktop/src/features/terminal/terminalBannerWave.test.mjs
@@ -1,0 +1,896 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractTerminalPalette } from "../../shared/theme/terminal-palette.ts";
+import {
+  SYNTAX_THEMES,
+  loadThemeData,
+} from "../../shared/theme/theme-loader.ts";
+import { buildTerminalBanner } from "./terminalBanner.ts";
+import {
+  bannerColor,
+  bannerStops,
+  de00,
+  lab,
+  ratio,
+} from "./terminalBannerColor.ts";
+import { paintTerminalBanner } from "./terminalBannerPainter.ts";
+import {
+  CONTRAST_BUCKETS,
+  FIELD_PERIOD_SECONDS,
+  FIELD_WAVE,
+  HUE_BUCKETS,
+  WORDMARK_PERIOD_SECONDS,
+  WORDMARK_WAVE,
+  buildBannerColorTable,
+  cyclicRampPosition,
+  makeCellHue,
+  phaseAt,
+} from "./terminalBannerWave.ts";
+
+// WCAG 2.2 SC 1.4.3 for the wordmark; the field/bevel figures are the house
+// thresholds terminalBannerColor.ts is specced on.
+const WORDMARK_FLOOR = 4.5;
+const FIELD_CORE = 2.6;
+const FIELD_EDGE = 1.04;
+
+const COLUMNS = 112;
+const ROWS = 46;
+const ASPECT = 17 / 8.4;
+
+/** Phases sampled by every per-frame gate. Deliberately includes 0.5, the fold
+ *  turn, and values either side of it: the turning point is where a fold bug
+ *  would show and an evenly-spaced sweep can step right over it. */
+const PHASE_SWEEP = [
+  0, 0.07, 0.13, 0.21, 0.29, 0.37, 0.44, 0.49, 0.5, 0.51, 0.58, 0.66, 0.73,
+  0.81, 0.89, 0.95,
+];
+
+/**
+ * Every pair of cells that are NEIGHBOURS ON SCREEN and share a layer, in both
+ * axes, with their grid coordinates. This is the display's sampling rate — the
+ * only rate at which a "banding" claim means anything.
+ *
+ * Cross-layer pairs are excluded on purpose: the field/wordmark boundary is a
+ * designed contrast edge, not a gradient, and including it would swamp the
+ * measurement with an intended step.
+ */
+function adjacentSameLayerPairs(banner) {
+  const rows = banner.cells;
+  const usable = (cell) => cell && cell.char !== " " && cell.layer;
+  const pairs = [];
+  for (const [y, cells] of rows.entries())
+    for (let x = 1; x < cells.length; x += 1) {
+      const a = cells[x - 1];
+      const b = cells[x];
+      if (!usable(a) || !usable(b) || a.layer !== b.layer) continue;
+      pairs.push({ a, b, ax: x - 1, ay: y, bx: x, by: y });
+    }
+  for (let y = 1; y < rows.length; y += 1)
+    for (let x = 0; x < rows[y].length; x += 1) {
+      const a = rows[y - 1][x];
+      const b = rows[y][x];
+      if (!usable(a) || !usable(b) || a.layer !== b.layer) continue;
+      pairs.push({ a, b, ax: x, ay: y - 1, bx: x, by: y });
+    }
+  return pairs;
+}
+
+async function palettes() {
+  const out = [];
+  for (const name of SYNTAX_THEMES) {
+    out.push([name, extractTerminalPalette(await loadThemeData(name))]);
+  }
+  return out;
+}
+const THEMES = await palettes();
+
+/**
+ * PERCEPTUAL colour distance, CIEDE2000 — the metric every smoothness gate below
+ * uses, and the same one terminalBannerColor.ts already uses for its stop
+ * distinctness gate.
+ *
+ * Not interchangeable with sRGB distance, and the difference decided a verdict
+ * here: euclidean sRGB scores a hue rotation at constant lightness as harshly as
+ * a brightness cliff, and this animation is almost entirely hue rotation. See the
+ * adjacent-cell gate for the measured 20-of-62 vs 2-of-62 reversal.
+ */
+const perceptualStep = (a, b) => de00(lab(a), lab(b));
+
+/** One just-noticeable difference in dE00. The conventional threshold for "a
+ *  careful observer can tell these apart at all". */
+const JND = 1.0;
+
+function recordingCanvas() {
+  const draws = [];
+  const context = {
+    _fillStyle: "",
+    clearRect() {},
+    fillRect() {},
+    fillText(...args) {
+      draws.push({ args, color: this._fillStyle });
+    },
+    font: "",
+    set fillStyle(value) {
+      this._fillStyle = value;
+    },
+    get fillStyle() {
+      return this._fillStyle;
+    },
+    setTransform() {},
+    textBaseline: "",
+  };
+  return {
+    canvas: {
+      height: 0,
+      width: 0,
+      getBoundingClientRect: () => ({ height: 600, width: 1000 }),
+      getContext: () => context,
+    },
+    draws,
+  };
+}
+
+/**
+ * THE REDUCED-MOTION CONTRACT, as byte equality against an INDEPENDENT oracle.
+ *
+ * "prefers-reduced-motion = today's static banner" is easy to satisfy wrongly: a
+ * paused animation also stops moving, but it parks on whatever phase it halted
+ * at, which is NOT the shipped image.
+ *
+ * MY FIRST VERSION OF THIS GATE WAS VACUOUS, and a mutant proved it. It called
+ * `paintTerminalBanner` with no motion twice and compared the two results —
+ * which is a tautology: the same function on the same input. Mutating the static
+ * path to pass a hue argument (`bannerColor(..., t, 0.37)`) changed BOTH sides
+ * identically and the gate stayed green, so the single most important promise in
+ * this lane was being checked by an assertion that could not fail.
+ *
+ * The fix is an oracle the painter does not participate in: walk the banner
+ * geometry here in the test and compute each cell's colour with the shipped
+ * four-argument `bannerColor` call directly. Now "the static path is byte-identical
+ * to the shipped banner" is a claim about two independently derived things.
+ */
+test("reduced motion paints the shipped static banner, byte for byte", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  assert.ok(banner);
+  for (const [name, p] of THEMES.slice(0, 6)) {
+    const painted = recordingCanvas();
+    assert.equal(paintTerminalBanner(painted.canvas, banner, p, 2), true);
+
+    // The oracle: the shipped colour call, driven straight off the geometry,
+    // with no reference to the painter's own colour resolution.
+    const { stops } = bannerStops(p);
+    const expected = [];
+    for (const cells of banner.cells)
+      for (const cell of cells) {
+        if (cell.char === " " || !cell.layer) continue;
+        expected.push(bannerColor(p, stops, cell.layer, cell.t));
+      }
+
+    assert.ok(expected.length > 1000, `${name} drew nothing to compare`);
+    assert.deepEqual(
+      painted.draws.map((draw) => draw.color),
+      expected,
+      `${name} static path diverged from the shipped colour`,
+    );
+  }
+});
+
+/**
+ * The static path must NOT be reachable by handing it a zero phase — proof that
+ * the two arms are genuinely different code paths and that this suite's
+ * equality test above is not vacuous. If an animated frame at phase 0 already
+ * equalled the static banner, the byte-equality test would pass even with the
+ * reduced-motion branch deleted.
+ */
+test("an animated frame at phase zero is NOT the static banner", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  const still = recordingCanvas();
+  const moving = recordingCanvas();
+  paintTerminalBanner(still.canvas, banner, p, 2);
+  paintTerminalBanner(moving.canvas, banner, p, 2, {
+    phase: { field: 0, wordmark: 0 },
+    table,
+  });
+  assert.equal(still.draws.length, moving.draws.length);
+  const differing = moving.draws.filter(
+    (draw, index) => draw.color !== still.draws[index].color,
+  ).length;
+  assert.ok(
+    differing > moving.draws.length / 4,
+    `only ${differing} of ${moving.draws.length} draws differ`,
+  );
+});
+
+/**
+ * DIRECTION. Eva's spec: the field originates BOTTOM-RIGHT and travels to
+ * TOP-LEFT; the wordmark stays left-to-right. A sign error is invisible in any
+ * still frame, which is why this measures the movement of a crest over time
+ * rather than a property of one frame.
+ *
+ * Measured INSIDE a half-cycle. `cyclicRampPosition` folds the axis into a
+ * palindrome so the loop is seamless, which means the wave reverses each
+ * half-cycle by design — "the direction" is only defined within one, and a gate
+ * that straddled a fold turn would read the reversal as a failure.
+ *
+ * The crest position is tracked in VISUAL space (x px, y px), not cell indices,
+ * because that is the space the requirement is stated in.
+ */
+test("the field wave travels toward top-left and the wordmark left to right", () => {
+  const columns = 120;
+  const rows = 50;
+  const target = 0.5;
+  const hueAt = (phase) =>
+    makeCellHue(columns, rows, { field: phase, wordmark: phase });
+
+  // Centroid of the cells nearest a fixed hue: a whole crest line moves, and a
+  // single argmin cell can jump sideways along that line without the wave
+  // having moved. The centroid of the whole level set cannot.
+  const crestCentroid = (phase) => {
+    const hue = hueAt(phase);
+    let sx = 0;
+    let sy = 0;
+    let n = 0;
+    for (let row = 0; row < rows; row += 1)
+      for (let column = 0; column < columns; column += 1) {
+        const value = hue("field", 0.5, column, row);
+        if (Math.abs(value - target) < 0.01) {
+          sx += column;
+          sy += row * ASPECT;
+          n += 1;
+        }
+      }
+    assert.ok(n > 0, `no crest cells found at phase ${phase}`);
+    return { x: sx / n, y: sy / n };
+  };
+
+  const early = crestCentroid(0.1);
+  const later = crestCentroid(0.2);
+  assert.ok(
+    later.x < early.x - 1,
+    `crest x moved ${early.x.toFixed(1)} -> ${later.x.toFixed(1)}, expected leftward`,
+  );
+  assert.ok(
+    later.y < early.y - 1,
+    `crest y moved ${early.y.toFixed(1)} -> ${later.y.toFixed(1)}, expected upward`,
+  );
+
+  // ASPECT CORRECTION, as an angle. Cells are 8.4x17, so projecting raw indices
+  // would render the (-1,-1) vector as a ~27-degree wave instead of 45. The
+  // crest must travel at 45 degrees in VISUAL space for a 45-degree vector.
+  const angle =
+    (Math.atan2(early.y - later.y, early.x - later.x) * 180) / Math.PI;
+  assert.ok(
+    Math.abs(angle - 45) < 6,
+    `crest travels at ${angle.toFixed(1)} degrees in visual space, expected ~45`,
+  );
+
+  const tOfCrest = (phase) => {
+    const hue = hueAt(phase);
+    let best = 0;
+    let bestError = Number.POSITIVE_INFINITY;
+    for (let step = 0; step <= 200; step += 1) {
+      const t = step / 200;
+      const error = Math.abs(hue("head", t, 0, 0) - target);
+      if (error < bestError) {
+        bestError = error;
+        best = t;
+      }
+    }
+    return best;
+  };
+  assert.ok(
+    tOfCrest(0.2) > tOfCrest(0.1),
+    "wordmark crest did not move rightward",
+  );
+});
+
+/** The two waves must not be one wave. Same period would read as a single
+ *  sweep bouncing, and equal periods is the likeliest careless edit. */
+test("the two waves have different periods and neither is instant", () => {
+  assert.notEqual(FIELD_PERIOD_SECONDS, WORDMARK_PERIOD_SECONDS);
+  // 'Slow' means slow. Ambience, not a screensaver: a full traversal must take
+  // more than ten seconds on both waves.
+  assert.ok(FIELD_PERIOD_SECONDS > 10);
+  assert.ok(WORDMARK_PERIOD_SECONDS > 10);
+});
+
+test("phase wraps into [0,1) and advances monotonically within a cycle", () => {
+  for (const seconds of [0, 1, 7.5, 25.9, 26, 260.4, 1e5]) {
+    const { field, wordmark } = phaseAt(seconds);
+    assert.ok(field >= 0 && field < 1, `field phase ${field}`);
+    assert.ok(wordmark >= 0 && wordmark < 1, `wordmark phase ${wordmark}`);
+  }
+  // A full period returns to the start: the loop must be seamless, or the
+  // banner visibly jumps once every FIELD_PERIOD_SECONDS.
+  assert.ok(Math.abs(phaseAt(FIELD_PERIOD_SECONDS).field - 0) < 1e-9);
+  assert.ok(Math.abs(phaseAt(WORDMARK_PERIOD_SECONDS).wordmark - 0) < 1e-9);
+});
+
+/** The chassis is not part of either wave. */
+test("bevels are phase-invariant", () => {
+  for (const phase of [0, 0.13, 0.5, 0.87]) {
+    const hue = makeCellHue(COLUMNS, ROWS, { field: phase, wordmark: phase });
+    for (const layer of ["bevel_hi", "bevel_lo"]) {
+      assert.equal(hue(layer, 0, 40, 20), 0);
+    }
+  }
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  const hi = new Set();
+  const lo = new Set();
+  for (const phase of [0, 0.2, 0.4, 0.6, 0.8]) {
+    hi.add(table.lookup("bevel_hi", 0, phase));
+    lo.add(table.lookup("bevel_lo", 0, phase));
+  }
+  assert.equal(hi.size, 1);
+  assert.equal(lo.size, 1);
+});
+
+/**
+ * CONTRAST FLOORS ON EVERY FRAME, measured on the QUANTISED TABLE OUTPUT.
+ *
+ * Gating the ideal `bannerColor` function would be the wrong instrument: the
+ * pixels that ship come from the LUT, and a bucket boundary is exactly where a
+ * floor gets lost. This walks every table entry — which is every colour the
+ * animation can ever produce at any phase, since the table is
+ * phase-independent — on all 62 shipped themes.
+ */
+test("every colour the animation can produce holds its contrast floor", () => {
+  const bad = [];
+  for (const [name, p] of THEMES) {
+    const table = buildBannerColorTable(p);
+    const bg = p.background;
+    for (const colour of table.head) {
+      const cr = ratio(colour, bg);
+      if (cr < WORDMARK_FLOOR - 0.005)
+        bad.push(`${name} wordmark ${cr.toFixed(2)}`);
+    }
+    for (const [contrastIndex, row] of table.field.entries()) {
+      // The field's specced envelope: it decays from FIELD_CORE at the box to
+      // FIELD_EDGE at the rim, so a bound that holds at every bucket is the
+      // envelope itself, not a single number.
+      const t = (contrastIndex + 0.5) / CONTRAST_BUCKETS;
+      const target = FIELD_CORE + (FIELD_EDGE - FIELD_CORE) * t;
+      for (const colour of row) {
+        const cr = ratio(colour, bg);
+        if (cr < FIELD_EDGE - 0.02 || cr > FIELD_CORE + 0.25)
+          bad.push(`${name} field ${cr.toFixed(2)} outside envelope`);
+        if (Math.abs(cr - target) > 0.35)
+          bad.push(
+            `${name} field bucket ${contrastIndex} ${cr.toFixed(2)} vs target ${target.toFixed(2)}`,
+          );
+      }
+    }
+  }
+  assert.deepEqual(bad.slice(0, 8), [], `${bad.length} failures`);
+});
+
+/**
+ * The field's radial contrast decay must survive the decoupling. This is the
+ * invariant that BREAKS if hue and contrast are driven off one axis: animate
+ * the coupled `t` and the rim pulses bright. Checked at several phases, since
+ * a phase-independent monotonicity is the whole point of the split.
+ */
+test("the field still fades monotonically outward at every phase", () => {
+  for (const [name, p] of THEMES) {
+    const table = buildBannerColorTable(p);
+    for (const hue of [0, 0.17, 0.33, 0.5, 0.71, 0.94]) {
+      let previous = Number.POSITIVE_INFINITY;
+      for (let index = 0; index < CONTRAST_BUCKETS; index += 1) {
+        const t = (index + 0.5) / CONTRAST_BUCKETS;
+        const cr = ratio(table.lookup("field", t, hue), p.background);
+        assert.ok(
+          cr <= previous + 0.02,
+          `${name} non-monotone at bucket ${index} hue ${hue}`,
+        );
+        previous = cr;
+      }
+    }
+  }
+});
+
+/**
+ * BANDING, AT THE DISPLAY'S OWN SAMPLING RATE, IN A PERCEPTUAL METRIC, and
+ * benchmarked against the shipped static banner rather than an absolute number.
+ *
+ * THREE CORRECTIONS TO MY OWN EARLIER VERSIONS OF THIS GATE, each measured:
+ *
+ * 1. WRONG SAMPLING RATE. It first compared ADJACENT HUE BUCKETS, steps of
+ *    1/128 in hue. Nothing on screen samples the axis that finely — adjacent
+ *    field cells are ~1/112 apart in projected position and one 60Hz frame
+ *    advances the phase by 1/(26*60). It was reporting an inherited property of
+ *    the ramp's steep stretch, and failed on 24 themes while the pixels were fine.
+ *
+ * 2. WRONG THRESHOLD. An absolute 8-unit bound was never a standard the shipped
+ *    product meets: the STATIC banner already steps 66.3 sRGB between adjacent
+ *    cells on light-plus. Hence per-theme and relative — no worse than that
+ *    theme's own static worst.
+ *
+ * 3. WRONG METRIC, and this one reversed the verdict. Euclidean sRGB distance
+ *    counts a hue swing at constant lightness the same as a brightness cliff,
+ *    and this animation is almost entirely the former. On raw sRGB, 20 of 62
+ *    themes scored "worse than static" (max 47.1 vs 68.9); on CIEDE2000 — the
+ *    perceptual metric this module already uses for its distinctness gate — it
+ *    is 2 of 62, max 13.03 against a static 28.34. The eye is the thing being
+ *    gated, so dE00 is the instrument.
+ *
+ * Tolerance is 1.0 dE00, one just-noticeable difference, over the theme's own
+ * static worst. CALIBRATED, not guessed: at the default wavelength the worst
+ * excess across 62 themes is 0.47, it stays under 0.62 through wavelength 2.0,
+ * and at wavelength 4.0 it jumps to 8.92 and fails 24 themes. The gate
+ * discriminates a real stripe regression from measurement noise.
+ *
+ * Both axes are walked because the wave is now diagonal: aspect correction makes
+ * the vertical gradient comparable to the horizontal, so a rows-only gate would
+ * miss half the field.
+ */
+test("adjacent-cell colour steps are no worse than the shipped static banner", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const pairs = adjacentSameLayerPairs(banner);
+  assert.ok(pairs.length > 2000, `only ${pairs.length} adjacent pairs`);
+
+  const offenders = [];
+  for (const [name, p] of THEMES) {
+    const { stops } = bannerStops(p);
+    const table = buildBannerColorTable(p);
+    const staticColour = (cell) => bannerColor(p, stops, cell.layer, cell.t);
+    let staticWorst = 0;
+    for (const { a, b } of pairs)
+      staticWorst = Math.max(
+        staticWorst,
+        perceptualStep(staticColour(a), staticColour(b)),
+      );
+
+    let animatedWorst = 0;
+    for (const phase of PHASE_SWEEP) {
+      const hue = makeCellHue(COLUMNS, ROWS, { field: phase, wordmark: phase });
+      const colour = (cell, column, row) =>
+        table.lookup(cell.layer, cell.t, hue(cell.layer, cell.t, column, row));
+      for (const { a, b, ax, ay, bx, by } of pairs)
+        animatedWorst = Math.max(
+          animatedWorst,
+          perceptualStep(colour(a, ax, ay), colour(b, bx, by)),
+        );
+    }
+    if (animatedWorst > staticWorst + JND)
+      offenders.push(
+        `${name} animated ${animatedWorst.toFixed(1)} > static ${staticWorst.toFixed(1)}`,
+      );
+  }
+  assert.deepEqual(
+    offenders.slice(0, 6),
+    [],
+    `${offenders.length} themes worse than static`,
+  );
+});
+
+/**
+ * The TEMPORAL half of the same question: how far a single cell's colour can move
+ * in one 60Hz frame. Spatial smoothness does not imply temporal smoothness — a
+ * wave could be a smooth gradient that strobes.
+ *
+ * Bound is 3 dE00 per frame, three JNDs. Measured worst on the defaults is 2.071
+ * across all 62 themes, and a cell needs many frames to cross the ramp, so this
+ * is a drift rather than a flicker.
+ */
+test("no cell's colour moves more than 3 dE00 in one 60Hz frame", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const pairs = adjacentSameLayerPairs(banner);
+  const sampled = pairs.filter((_, index) => index % 17 === 0);
+  const frame = 1 / 60;
+  const offenders = [];
+  for (const [name, p] of THEMES) {
+    const table = buildBannerColorTable(p);
+    let worst = 0;
+    for (let step = 0; step < 60; step += 1) {
+      const seconds = (step / 60) * FIELD_PERIOD_SECONDS;
+      const before = makeCellHue(COLUMNS, ROWS, phaseAt(seconds));
+      const after = makeCellHue(COLUMNS, ROWS, phaseAt(seconds + frame));
+      for (const { a, ax, ay } of sampled)
+        worst = Math.max(
+          worst,
+          perceptualStep(
+            table.lookup(a.layer, a.t, before(a.layer, a.t, ax, ay)),
+            table.lookup(a.layer, a.t, after(a.layer, a.t, ax, ay)),
+          ),
+        );
+    }
+    if (worst > 3) offenders.push(`${name} ${worst.toFixed(2)}/frame`);
+  }
+  assert.deepEqual(offenders, [], `temporal steps: ${offenders.join(", ")}`);
+});
+
+/**
+ * THE SEAM GATE — the defect the banding gate actually caught first.
+ *
+ * The three-stop ramp is an open path: position 0 is stop 0, position 1 is
+ * stop 2, and they are the two most distant colours in the palette. A phase
+ * axis is cyclic, so driving the ramp with a raw wrap puts a full-palette
+ * discontinuity somewhere on screen at all times — measured at 182.5 sRGB on
+ * buzz-dark before `cyclicRampPosition` folded the axis into a palindrome.
+ *
+ * Asserting only the interior buckets cannot see this: the seam lives exactly
+ * at the wrap, which is the one adjacency an interior sweep skips. So this
+ * checks the wrap-around pair explicitly, on every theme.
+ */
+test("the hue axis has no seam at the phase wrap", () => {
+  // The fold itself: adjacent phases across the wrap map to adjacent ramp
+  // positions, and the ends of the ramp are turning points, not neighbours.
+  const epsilon = 1e-4;
+  assert.ok(
+    Math.abs(cyclicRampPosition(1 - epsilon) - cyclicRampPosition(0)) < 1e-3,
+    "fold is discontinuous at the wrap",
+  );
+  assert.ok(
+    Math.abs(cyclicRampPosition(0.5 - epsilon) - cyclicRampPosition(0.5)) <
+      1e-3,
+    "fold is discontinuous at the turn",
+  );
+
+  const offenders = [];
+  for (const [name, p] of THEMES) {
+    const table = buildBannerColorTable(p);
+    // Walk BOTH waves' real hue axes across a full cycle, including the wrap, at
+    // a fixed cell: consecutive samples must never jump. The field is the layer
+    // the 182.5 seam was measured on, so leaving it out — as my first version of
+    // this gate did — tests the wrong wave.
+    let previousHead = null;
+    let previousField = null;
+    let max = 0;
+    const steps = 1200;
+    for (let step = 0; step <= steps; step += 1) {
+      const phase = step / steps;
+      const hue = makeCellHue(COLUMNS, ROWS, { field: phase, wordmark: phase });
+      const head = table.lookup("head", 0, hue("head", 0.5, 0, 0));
+      const field = table.lookup("field", 0.5, hue("field", 0.5, 70, 30));
+      if (previousHead) max = Math.max(max, perceptualStep(previousHead, head));
+      if (previousField)
+        max = Math.max(max, perceptualStep(previousField, field));
+      previousHead = head;
+      previousField = field;
+    }
+    // Per-sample bound of 3 dE00 at 1200 samples per cycle, finer than 60Hz over
+    // a 19s period, so a real seam cannot hide between samples. Generous against
+    // sampling noise, brutal against a full-palette discontinuity: the unfolded
+    // seam measured 182.5 sRGB / 55.6 dE00 on buzz-dark.
+    if (max > 3) offenders.push(`${name} ${max.toFixed(2)}`);
+  }
+  assert.deepEqual(offenders, [], `temporal seams: ${offenders.join(", ")}`);
+});
+
+/**
+ * THE INTERPOLATED WORDMARK FLOOR — the gate that caught a real WCAG failure.
+ *
+ * The contrast gate above walks table SAMPLES. That is not what paints: `lookup`
+ * interpolates between samples, and this gate exists because the two disagree.
+ * `bannerStops` solves each wordmark stop to sit EXACTLY on 4.5, and contrast is
+ * convex along a straight sRGB blend, so the chord between two on-floor samples
+ * passes UNDER the floor. Measured 4.4766 on solarized-light at hue 0.2188
+ * before `sampleHead` re-lifted the blend.
+ *
+ * A sampled-only gate is blind to this by construction, and no bucket count
+ * fixes it — the dip shrinks asymptotically and never reaches zero. So this
+ * walks the axis at 4000 points per theme, far finer than any display samples it.
+ */
+test("interpolated wordmark colour never dips below the 4.5 WCAG floor", () => {
+  const offenders = [];
+  for (const [name, p] of THEMES) {
+    const table = buildBannerColorTable(p);
+    let worst = Number.POSITIVE_INFINITY;
+    for (let step = 0; step <= 4000; step += 1) {
+      worst = Math.min(
+        worst,
+        ratio(table.lookup("head", 0, step / 4000), p.background),
+      );
+    }
+    // No epsilon on the floor itself: 4.5 is the standard, and the whole point
+    // of this gate is that a 0.023 shortfall is still a shortfall. A tiny
+    // tolerance for float noise only.
+    if (worst < WORDMARK_FLOOR - 1e-9)
+      offenders.push(`${name} ${worst.toFixed(4)}`);
+  }
+  assert.deepEqual(offenders, [], `below floor: ${offenders.join(", ")}`);
+});
+
+/**
+ * THE INTENSITY CLAMP, asserted rather than merely documented.
+ *
+ * `BannerWaveConfig.intensity` documents its range as 0..1 and promises values
+ * outside it are clamped. A mutant proved that promise was unverified: deleting
+ * the `Math.max(0, Math.min(1, ...))` left every gate green, because all of them
+ * drove intensity to values that were already in range. Documented-and-unchecked
+ * is how a knob becomes a trap — exactly the failure mode Eva flagged.
+ *
+ * The clamp is what makes the safe-by-construction argument sound: intensity only
+ * narrows which SUBRANGE of the hue axis is used, and the floors are proven over
+ * the whole axis, so in-range values cannot reach an unproven colour. Without the
+ * clamp, intensity 9 WIDENS the position past the axis and the argument collapses.
+ * So this asserts the mechanism the argument depends on.
+ */
+test("intensity is clamped to 0..1 so it can never widen past the proven axis", () => {
+  const columns = 112;
+  const rows = 46;
+  const inRange = (value) => value >= -1e-9 && value <= 1 + 1e-9;
+
+  // Out-of-range settings must behave EXACTLY as their clamped equivalents, and
+  // must never produce a hue position outside the axis the floors are proven on.
+  const cases = [
+    [9, 1],
+    [-5, 0],
+    [1e6, 1],
+  ];
+  for (const [wild, clamped] of cases) {
+    const wildHue = makeCellHue(
+      columns,
+      rows,
+      { field: 0.3, wordmark: 0.3 },
+      {
+        field: { ...FIELD_WAVE, intensity: wild },
+        wordmark: { ...WORDMARK_WAVE, intensity: wild },
+      },
+    );
+    const clampedHue = makeCellHue(
+      columns,
+      rows,
+      { field: 0.3, wordmark: 0.3 },
+      {
+        field: { ...FIELD_WAVE, intensity: clamped },
+        wordmark: { ...WORDMARK_WAVE, intensity: clamped },
+      },
+    );
+    for (let row = 0; row < rows; row += 5)
+      for (let column = 0; column < columns; column += 5) {
+        const field = wildHue("field", 0.5, column, row);
+        assert.ok(
+          inRange(field),
+          `intensity ${wild} put field hue at ${field}, outside the proven axis`,
+        );
+        assert.equal(
+          field,
+          clampedHue("field", 0.5, column, row),
+          `intensity ${wild} did not behave as ${clamped}`,
+        );
+      }
+    for (let step = 0; step <= 20; step += 1) {
+      const head = wildHue("head", step / 20, 0, 0);
+      assert.ok(
+        inRange(head),
+        `intensity ${wild} put wordmark hue at ${head}, outside the proven axis`,
+      );
+      assert.equal(head, clampedHue("head", step / 20, 0, 0));
+    }
+  }
+});
+
+/**
+ * THE WORDMARK ACTUALLY ANIMATES, measured on PAINTED OUTPUT.
+ *
+ * A mutant found this gap, and it was a serious one: swapping the table's
+ * wordmark lookup from the wave's hue to the cell's geometric `t`
+ * (`sampleHead(hue)` -> `sampleHead(t)`) kills the wordmark wave stone dead — half
+ * of what Tyler asked for — and every other gate stayed green.
+ *
+ * Why they all missed it: the direction and seam gates call `makeCellHue` and
+ * `lookup` themselves, passing the hue in explicitly, so they verify the hue
+ * FUNCTION and the TABLE in isolation. Nothing checked that the painter feeds one
+ * into the other for the head layer. The field was covered only by luck — its
+ * gates happen to go through the painter.
+ *
+ * So this asserts the composition, on the pixels: over a phase sweep, the
+ * wordmark's painted colours must change, and within a single frame they must
+ * vary along the mark's ink span. Both halves are needed — a wordmark frozen at
+ * one colour satisfies neither, and one painted by `t` alone satisfies the second
+ * but not the first.
+ */
+test("the wordmark's painted colours animate with phase", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const [name, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+
+  const headFrame = (phase) => {
+    const target = recordingCanvas();
+    paintTerminalBanner(target.canvas, banner, p, 1, {
+      phase: { field: phase, wordmark: phase },
+      table,
+    });
+    // Pick out the head layer's draws. `paintTerminalBanner` emits one draw per
+    // non-blank layered cell in geometry order, so walking the geometry the same
+    // way keeps the two in step.
+    const heads = [];
+    let index = 0;
+    for (const cells of banner.cells)
+      for (const cell of cells) {
+        if (cell.char === " " || !cell.layer) continue;
+        if (cell.layer === "head") heads.push(target.draws[index].color);
+        index += 1;
+      }
+    return heads;
+  };
+
+  const frames = PHASE_SWEEP.map(headFrame);
+  assert.ok(
+    frames[0].length > 50,
+    `${name} painted ${frames[0].length} head cells`,
+  );
+
+  // 1. The wordmark must not be a still: distinct frames across the sweep.
+  const distinctFrames = new Set(frames.map((frame) => frame.join(""))).size;
+  assert.ok(
+    distinctFrames >= PHASE_SWEEP.length - 1,
+    `wordmark produced only ${distinctFrames} distinct frames over ${PHASE_SWEEP.length} phases`,
+  );
+
+  // 2. And within a frame it must be a WAVE, not a flat wash.
+  for (const [index, frame] of frames.entries()) {
+    assert.ok(
+      new Set(frame).size > 2,
+      `frame ${index} painted the wordmark in only ${new Set(frame).size} colour(s)`,
+    );
+  }
+});
+
+/**
+ * KNOB EXTREMES. Eva: "a knob that can silently break WCAG is a trap, not a
+ * feature" — so the floors are gated at the documented ends of each knob's
+ * range, not just at the defaults.
+ *
+ * The documented ranges, and why they are what they are:
+ *  - intensity 0..1        SAFE THROUGHOUT, and by construction rather than by
+ *                          luck: intensity only narrows which SUBRANGE of the
+ *                          hue axis is used, and the floors are proven over the
+ *                          ENTIRE axis. Out-of-range values are clamped.
+ *  - wavelength .125..2.0  SAFE. Contrast is independent of wavelength (it only
+ *                          rescales position along an axis whose floors are
+ *                          proven end to end), so the binding constraint is
+ *                          spatial busyness: MEASURED in dE00, worst excess over
+ *                          a theme's own static step is 0.47 at the default and
+ *                          under 0.62 through 2.0; at 4.0 it is 8.92 and fails
+ *                          24 themes.
+ *  - direction any vector  SAFE. Direction selects which bucket a cell reads and
+ *                          cannot reach an unsampled colour.
+ *  - seconds > 10          Not a contrast knob at all; gated separately as
+ *                          "slow".
+ */
+test("contrast floors hold at every documented knob extreme", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const extremes = {
+    "intensity=0": { intensity: 0 },
+    "intensity=1": { intensity: 1 },
+    "intensity=-5 (clamps to 0)": { intensity: -5 },
+    "intensity=9 (clamps to 1)": { intensity: 9 },
+    "wavelength=0.125": { wavelength: 0.125 },
+    "wavelength=2.0": { wavelength: 2.0 },
+    "direction=(1,1)": { direction: { x: 1, y: 1 } },
+    "direction=(-1,0)": { direction: { x: -1, y: 0 } },
+    "direction=(0,-1)": { direction: { x: 0, y: -1 } },
+  };
+  const offenders = [];
+  // Six themes, not all 62: this is the same colour surface the all-theme gates
+  // already cover, crossed against nine settings and a phase sweep. The extremes
+  // question is whether a KNOB can reach an unproven colour, and the LUT is
+  // shared across knobs, so theme breadth is covered elsewhere.
+  for (const [name, p] of THEMES.slice(0, 6)) {
+    const table = buildBannerColorTable(p);
+    for (const [label, override] of Object.entries(extremes)) {
+      const waves = {
+        field: { ...FIELD_WAVE, ...override },
+        wordmark: { ...WORDMARK_WAVE, ...override },
+      };
+      for (const phase of PHASE_SWEEP) {
+        const target = recordingCanvas();
+        paintTerminalBanner(target.canvas, banner, p, 1, {
+          phase: { field: phase, wordmark: phase },
+          table,
+          waves,
+        });
+        assert.ok(target.draws.length > 1000, `${label} drew nothing`);
+        for (const { color } of target.draws) {
+          const cr = ratio(color, p.background);
+          // Every painted colour must sit inside the union of the layers'
+          // envelopes: the wordmark at or above 4.5, the field within its decay
+          // band. Below the field's edge floor nothing is legible at all.
+          if (cr < FIELD_EDGE - 0.02)
+            offenders.push(`${name} ${label} phase ${phase}: ${cr.toFixed(3)}`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders.slice(0, 6), [], `${offenders.length} violations`);
+});
+
+/**
+ * The knob-extreme gate above is only as good as its ability to SEE a violation,
+ * and it paints through the real painter, so it is worth proving it is not
+ * vacuous. An intensity that pushed colours outside the proven axis would be
+ * caught; here the axis is deliberately overrun to show the instrument fires.
+ */
+test("the knob-extreme gate can actually detect an out-of-envelope colour", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  // A table whose field lookup returns the background itself: contrast 1.0,
+  // below the 1.04 edge floor. If the gate's predicate is wrong this passes.
+  const broken = {
+    ...table,
+    lookup: (layer, t, hue) =>
+      layer === "field" ? p.background : table.lookup(layer, t, hue),
+  };
+  const target = recordingCanvas();
+  paintTerminalBanner(target.canvas, banner, p, 1, {
+    phase: { field: 0.3, wordmark: 0.3 },
+    table: broken,
+  });
+  const violations = target.draws.filter(
+    ({ color }) => ratio(color, p.background) < FIELD_EDGE - 0.02,
+  );
+  assert.ok(
+    violations.length > 100,
+    `predicate saw only ${violations.length} violations on a deliberately broken table`,
+  );
+});
+
+/**
+ * The animated painter must colour cells by their WAVE position, not by their
+ * geometric `t`. If the painter ignored the phase argument this would pass
+ * trivially, so the assertion is that cells sharing a `t` but sitting in
+ * different columns get DIFFERENT colours — which only a projection-derived hue
+ * axis produces.
+ */
+test("animated field colour varies along a row, not just radially", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  const target = recordingCanvas();
+  paintTerminalBanner(target.canvas, banner, p, 1, {
+    phase: { field: 0.3, wordmark: 0.3 },
+    table,
+  });
+  // Group field-layer draws by y, and check colour varies across x within a row.
+  const rows = new Map();
+  for (const { args, color } of target.draws) {
+    const [, x, y] = args;
+    if (!rows.has(y)) rows.set(y, []);
+    rows.get(y).push({ x, color });
+  }
+  const varied = [...rows.values()].filter(
+    (cells) => new Set(cells.map((cell) => cell.color)).size > 2,
+  );
+  assert.ok(
+    varied.length > 5,
+    `only ${varied.length} rows show horizontal colour variation`,
+  );
+});
+
+/** Successive frames must actually differ, or the "animation" is a still. */
+test("successive frames differ and a full cycle returns to the start", () => {
+  const banner = buildTerminalBanner(COLUMNS, ROWS, ASPECT);
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  const frame = (seconds) => {
+    const target = recordingCanvas();
+    paintTerminalBanner(target.canvas, banner, p, 1, {
+      phase: phaseAt(seconds),
+      table,
+    });
+    return target.draws.map((draw) => draw.color).join("");
+  };
+  const a = frame(0);
+  // One second of a 26s traversal is ~4 columns of drift: visible, not static.
+  assert.notEqual(a, frame(1));
+  // Seamless loop: the least common period of the two waves returns both to 0.
+  assert.equal(a, frame(FIELD_PERIOD_SECONDS * WORDMARK_PERIOD_SECONDS));
+});
+
+/** The table is what makes this affordable, and its shape is load-bearing. */
+test("the colour table is phase-independent and completely populated", () => {
+  const [, p] = THEMES[0];
+  const table = buildBannerColorTable(p);
+  assert.equal(table.head.length, HUE_BUCKETS);
+  assert.equal(table.field.length, CONTRAST_BUCKETS);
+  for (const row of table.field) assert.equal(row.length, HUE_BUCKETS);
+  for (const colour of [...table.head, ...table.field.flat()])
+    assert.match(colour, /^#[0-9a-f]{6}$/);
+});

--- a/desktop/src/features/terminal/terminalBannerWave.ts
+++ b/desktop/src/features/terminal/terminalBannerWave.ts
@@ -1,0 +1,442 @@
+/**
+ * Terminal banner animation — the MOTION half of the banner contract.
+ *
+ * Geometry (terminalBanner.ts) is static and colour-free; colour
+ * (terminalBannerColor.ts) maps (layer, t, hue) -> hex. This module supplies
+ * the `hue` axis as a function of time and screen position, plus the lookup
+ * table that makes it affordable.
+ *
+ * Tyler: "slow waves of the buzz theme colors moving across the honeycomb
+ * lattice right to left, with a separate slow color wave on the `buzz term`
+ * going left to right".
+ *
+ * Two independent waves, opposite directions, different periods:
+ *   - field    -> right-to-left across the whole viewport
+ *   - wordmark -> left-to-right across the wordmark's own ink span
+ * The bevels do not animate. They are the chassis; a moving highlight would
+ * read as the box itself deforming.
+ */
+import type { TerminalPalette } from "../../shared/theme/terminal-palette";
+import {
+  type Layer,
+  bannerColor,
+  bannerStops,
+  hex2rgb,
+  lift,
+  rgb2hex,
+} from "./terminalBannerColor";
+
+/** WCAG 2.2 SC 1.4.3 body text, the wordmark's floor. Re-declared here because
+ *  the interpolated blend has to be re-lifted to it; see `sampleHead`. */
+const WORDMARK_FLOOR = 4.5;
+
+/**
+ * ============================================================================
+ * TUNING. Everything Tyler can retune lives in this one block.
+ * ============================================================================
+ *
+ * Two independent waves, one config each. Every knob states its unit and what
+ * "bigger" does. Nothing else in this file needs editing to retune the
+ * animation.
+ *
+ * `direction` is a vector in VISUAL space, not cell space. This matters: a
+ * terminal cell is 8.4 x 17 CSS px, so it is about 2:1 tall, and a naive
+ * (-1,-1) over cell indices would render as a shallow 27-degree wave rather
+ * than the intended diagonal. `projectWave` converts to visual space before
+ * projecting, so a 45-degree vector here looks like 45 degrees on screen.
+ */
+export type BannerWaveConfig = {
+  /**
+   * Travel direction in visual space; x grows right, y grows DOWN. The wave
+   * moves TOWARD this vector, so it appears to originate from the opposite
+   * corner. Magnitude is irrelevant — it is normalised.
+   */
+  direction: { x: number; y: number };
+  /**
+   * Seconds for one full traversal of the colour ramp. BIGGER = SLOWER.
+   * This is ambience, not a screensaver: the direction gate is indifferent to
+   * this value but the "slow" gate requires it to stay above 10s.
+   */
+  seconds: number;
+  /**
+   * How much of the colour ramp is visible across one screen-width of travel,
+   * in ramp traversals. BIGGER = MORE COLOUR BANDS ON SCREEN AT ONCE (a
+   * tighter, busier wave); smaller = a broader, calmer wash.
+   *
+   * 0.5 is one traversal of the ramp across the span, which is exactly the
+   * spatial colour gradient the static banner shipped with.
+   *
+   * SAFE RANGE 0.125..2.0, measured against the no-worse-than-static gate in
+   * CIEDE2000: worst excess over a theme's own static step is 0.47 at 0.5 and
+   * stays under 0.62 all the way to 2.0. At 4.0 it hits 8.92 and fails 24
+   * themes — that is where the lattice genuinely reads as stripes rather than a
+   * wash. Contrast is INDEPENDENT of this knob (it only rescales position along
+   * an axis whose floors are proven end to end), so the binding constraint here
+   * is spatial busyness, not legibility.
+   */
+  wavelength: number;
+  /**
+   * Fraction of the colour ramp the wave actually sweeps, 0..1. BIGGER = MORE
+   * COLOUR TRAVEL; 0 pins every cell to the ramp's midpoint (a still, single
+   * colour) and 1 uses the full three-stop sweep.
+   *
+   * CONTRAST-SAFE OVER ITS WHOLE RANGE, and that is a property of the design
+   * rather than of the default: intensity only narrows which part of the hue
+   * axis gets used, and the contrast gate covers the ENTIRE hue axis on all 62
+   * themes. So no value in [0,1] can reach an unsampled, unproven colour.
+   * Values outside [0,1] are clamped for the same reason.
+   */
+  intensity: number;
+};
+
+/**
+ * Tyler: field originates BOTTOM-RIGHT and travels to TOP-LEFT, so the
+ * direction vector points up-and-left. The wordmark keeps its own
+ * left-to-right sweep, anchored to the letters rather than the viewport.
+ */
+export const FIELD_WAVE: BannerWaveConfig = {
+  direction: { x: -1, y: -1 },
+  seconds: 26,
+  wavelength: 0.5,
+  intensity: 1,
+};
+
+export const WORDMARK_WAVE: BannerWaveConfig = {
+  // Left-to-right along the mark's own ink span; y is unused for the wordmark,
+  // whose axis is the geometry's `t`, not a screen position.
+  direction: { x: 1, y: 0 },
+  seconds: 19,
+  wavelength: 0.5,
+  intensity: 1,
+};
+
+/** Kept as named exports because the "slow" and seam gates assert on them. */
+export const FIELD_PERIOD_SECONDS = FIELD_WAVE.seconds;
+export const WORDMARK_PERIOD_SECONDS = WORDMARK_WAVE.seconds;
+
+/**
+ * Sampling resolution of the `hue` axis.
+ *
+ * Bucket COUNT is not what makes the gradient smooth — `lookup` interpolates
+ * between neighbouring samples, so its output is continuous in hue at any
+ * count. I measured the alternative first and it does not work: with
+ * nearest-bucket lookup the worst adjacent-sample step on light-plus only fell
+ * from 22.1 to 7.0 going from 256 buckets to 2048, because the three-stop ramp
+ * has a genuinely steep stretch rather than a quantisation artifact. Eight
+ * times the memory for a step still visible on a light theme is the wrong
+ * trade; interpolating removes the axis entirely.
+ *
+ * So this count controls FIDELITY only: how closely the piecewise-linear
+ * reconstruction tracks the true curved LCh path. 128 samples holds every
+ * shipped theme's deviation from `bannerColor` under the fidelity gate.
+ */
+export const HUE_BUCKETS = 128;
+
+/**
+ * Sampling resolution of the field's radial CONTRAST axis, also interpolated.
+ *
+ * This axis does not move, so it costs nothing per frame — but it multiplies
+ * the fill: the field's `atRatio` pin is a 28-step bisection at ~23us a call
+ * against ~0.9us for the wordmark's `lift` path, so the field table is
+ * essentially the whole build cost. Interpolation is what lets this stay small
+ * enough to fill without stalling the reveal.
+ */
+export const CONTRAST_BUCKETS = 24;
+
+/**
+ * Position on a sampled axis, as a fractional index into `buckets` samples
+ * taken at bucket CENTRES. Clamped at both ends so the half-bucket beyond the
+ * first and last centres reads as that centre rather than extrapolating.
+ */
+const axisPosition = (value: number, buckets: number) =>
+  Math.min(buckets - 1, Math.max(0, Math.min(1, value) * buckets - 0.5));
+
+/** Wrap into [0,1). Phase is cyclic; a bare modulo leaves negatives negative. */
+const wrap01 = (value: number) => value - Math.floor(value);
+
+/**
+ * THE SEAM FIX. A cyclic axis cannot drive an open ramp directly.
+ *
+ * The three-stop ramp is a PATH, not a loop: `ramp(0)` is stop 0 and `ramp(1)`
+ * is stop 2, and those two ends are as far apart as the palette gets. Feeding
+ * it a wrapping phase means that every cycle, somewhere on screen, adjacent
+ * cells straddle the 1 -> 0 wrap and jump the entire width of the palette. On
+ * buzz-dark that seam measured 182.5 in sRGB distance (#3dcf55 against
+ * #7bb7ff) — a hard colour edge sweeping across the lattice once per period,
+ * which is not "slow waves of the theme colours", it is a glitch.
+ *
+ * The fix is to make the cyclic axis traverse the ramp and come back:
+ * 0 -> 1 over the first half of the cycle, 1 -> 0 over the second. The ends
+ * are then interior turning points and adjacency holds everywhere, so the loop
+ * is seamless by construction rather than by choice of period. The cost is that
+ * the wave reverses direction each half-cycle — invisible at these periods,
+ * because a colour drift has no landmark to read a direction against, and the
+ * direction gate measures the crest inside a half-cycle where it is defined.
+ */
+export function cyclicRampPosition(phase: number): number {
+  const wrapped = wrap01(phase);
+  return wrapped < 0.5 ? wrapped * 2 : 2 - wrapped * 2;
+}
+
+/** Cell aspect: cells are 8.4 x 17 CSS px, so one row is ~2.02 columns tall. */
+const CELL_ASPECT = 17 / 8.4;
+
+/**
+ * Apply `intensity` about the ramp's midpoint. Narrowing rather than scaling
+ * keeps the sweep centred, so turning intensity down fades toward the middle
+ * colour instead of sliding toward one end.
+ */
+const applyIntensity = (position: number, intensity: number) =>
+  0.5 + (position - 0.5) * Math.max(0, Math.min(1, intensity));
+
+/**
+ * THE WAVE AXIS: a projection onto a direction vector in VISUAL space.
+ *
+ * `phase(cell) = (x*dx + y*dy)/wavelength - t*speed`, per Eva's spec, with two
+ * details that are easy to get wrong and invisible in a still frame:
+ *
+ *  - ASPECT. Row indices are multiplied by ~2.02 before projecting, because a
+ *    cell is about twice as tall as it is wide. Without this a (-1,-1) vector
+ *    renders as a ~27-degree wave, not the 45 degrees it reads as in source.
+ *  - SIGN. The projection is NEGATED so the wave travels TOWARD `direction`.
+ *    A crest sits where the projection is constant; as time advances, holding
+ *    it constant requires moving along +direction. For the field's (-1,-1)
+ *    that is up-and-left, i.e. originating bottom-right as Tyler asked.
+ *
+ * The normalisation divisor is the projection's own visual span, so
+ * `wavelength` means the same thing (ramp traversals per screen-width) at every
+ * viewport size and for every direction.
+ */
+export function projectWave(
+  config: BannerWaveConfig,
+  column: number,
+  row: number,
+  columns: number,
+  rows: number,
+): number {
+  const { x: dx, y: dy } = config.direction;
+  const length = Math.hypot(dx, dy) || 1;
+  const unitX = dx / length;
+  const unitY = dy / length;
+  const visualY = row * CELL_ASPECT;
+  const visualHeight = Math.max(1, rows * CELL_ASPECT);
+  const span =
+    Math.abs(unitX) * Math.max(1, columns) + Math.abs(unitY) * visualHeight;
+  return (-(column * unitX + visualY * unitY) / span) * config.wavelength;
+}
+
+/**
+ * The field's hue axis: projected position plus phase, folded, then narrowed by
+ * intensity.
+ */
+export function fieldHue(
+  config: BannerWaveConfig,
+  column: number,
+  row: number,
+  columns: number,
+  rows: number,
+  phase: number,
+): number {
+  return applyIntensity(
+    cyclicRampPosition(projectWave(config, column, row, columns, rows) + phase),
+    config.intensity,
+  );
+}
+
+/**
+ * The wordmark wave: LEFT TO RIGHT, over the mark's own ink span.
+ *
+ * The geometry already hands us `t` = 0 at the wordmark's left edge to 1 at its
+ * right, so the mark's wave rides that rather than viewport columns: the sweep
+ * stays anchored to the letters at every viewport width. SUBTRACTING phase is
+ * what makes it travel rightward, opposite to the field.
+ */
+export function wordmarkHue(
+  config: BannerWaveConfig,
+  t: number,
+  phase: number,
+): number {
+  const along = config.direction.x >= 0 ? t : 1 - t;
+  return applyIntensity(
+    cyclicRampPosition(along * config.wavelength - phase),
+    config.intensity,
+  );
+}
+
+/** The pair of wave configs in force. Overridable so the knob-extreme gates can
+ *  drive documented settings without mutating module state. */
+export type BannerWaves = {
+  field: BannerWaveConfig;
+  wordmark: BannerWaveConfig;
+};
+export const DEFAULT_WAVES: BannerWaves = {
+  field: FIELD_WAVE,
+  wordmark: WORDMARK_WAVE,
+};
+
+/**
+ * A cell's hue axis, as a closure over everything that is constant for a frame.
+ *
+ * The split is deliberate: viewport extent, phase and tuning are per-FRAME, and
+ * only `(layer, t, column, row)` is per-CELL. Passing the frame-constant half
+ * per cell is how this function grew to seven positional arguments and started
+ * breaking its own call sites on every signature change. Closing over them also
+ * keeps the per-cell path allocation-free, which a coordinates object would not.
+ *
+ * Bevels return the ramp midpoint — they are not part of either wave, and
+ * returning `t` here instead would tie the chassis to the field's motion.
+ */
+export function makeCellHue(
+  columns: number,
+  rows: number,
+  phase: { field: number; wordmark: number },
+  waves: BannerWaves = DEFAULT_WAVES,
+): (layer: Layer, t: number, column: number, row: number) => number {
+  return (layer, t, column, row) => {
+    if (layer === "field")
+      return fieldHue(waves.field, column, row, columns, rows, phase.field);
+    if (layer === "head") return wordmarkHue(waves.wordmark, t, phase.wordmark);
+    return 0;
+  };
+}
+
+/** Phase pair at a wall-clock time, in seconds. */
+export function phaseAt(seconds: number): { field: number; wordmark: number } {
+  return {
+    field: wrap01(seconds / FIELD_WAVE.seconds),
+    wordmark: wrap01(seconds / WORDMARK_WAVE.seconds),
+  };
+}
+
+/**
+ * Phase-INDEPENDENT colour table. This is what makes the animation affordable.
+ *
+ * Measured on this box, buzz-dark, median of 7: calling `bannerColor` per cell
+ * costs 42.7ms for a 112x46 banner (256% of a 60Hz frame) and 203ms at 228x90
+ * (1218%). Per-cell-per-frame is not a micro-optimisation problem, it is dead
+ * on arrival by 2.6-12x. The cost is concentrated: the field's `atRatio` pin is
+ * ~23us/cell against ~0.9us for the wordmark's `lift` path.
+ *
+ * The table is keyed on SAMPLED (layer, hue, contrast) and nothing else, so it
+ * does not depend on phase or on time and fills exactly once per palette.
+ * Steady-state frames are a lookup and one lerp.
+ */
+export type BannerColorTable = Readonly<{
+  head: readonly string[];
+  field: readonly (readonly string[])[];
+  bevelHi: string;
+  bevelLo: string;
+  lookup: (layer: Layer, t: number, hue: number) => string;
+}>;
+
+export function buildBannerColorTable(
+  palette: TerminalPalette,
+): BannerColorTable {
+  const { stops } = bannerStops(palette);
+  const centre = (index: number, buckets: number) => (index + 0.5) / buckets;
+
+  const head = Array.from({ length: HUE_BUCKETS }, (_, h) =>
+    bannerColor(palette, stops, "head", 0, centre(h, HUE_BUCKETS)),
+  );
+  const field = Array.from({ length: CONTRAST_BUCKETS }, (_, c) =>
+    Array.from({ length: HUE_BUCKETS }, (_, h) =>
+      bannerColor(
+        palette,
+        stops,
+        "field",
+        centre(c, CONTRAST_BUCKETS),
+        centre(h, HUE_BUCKETS),
+      ),
+    ),
+  );
+  const bevelHi = bannerColor(palette, stops, "bevel_hi", 0);
+  const bevelLo = bannerColor(palette, stops, "bevel_lo", 0);
+
+  // NUMERIC MIRRORS of the tables, parsed once at build time. The lookup path is
+  // per-cell-per-frame, and `mix()` re-parses its arguments from hex on every
+  // call — worse, `hex2rgb(b)` sits INSIDE its per-channel map, so it parses `b`
+  // four times. A bilinear field lookup is three nested mixes, so a single cell
+  // cost ~12 string parses plus 3 hex formats. Measured before this change:
+  // 13.6ms/frame of pure lookup at 228x90 (80% of the animated frame, 101.6% of a
+  // 60Hz budget). Parsing once here makes the steady-state path arithmetic.
+  const headRgb = head.map(hex2rgb);
+  const fieldRgb = field.map((row) => row.map(hex2rgb));
+
+  // Quantization is LOAD-BEARING, not incidental. `rgb2hex` rounds and clamps
+  // each channel to an integer, so the old nested-`mix` path quantized its
+  // INTERMEDIATE blend before the outer blend consumed it. Skipping that would
+  // change output bytes — and the WCAG floor and dE00 certificates were measured
+  // against the old bytes. So this reproduces `rgb2hex`'s rounding exactly at the
+  // same point the old path applied it, and byte equality is verified by an
+  // oracle over 20.4M lookups x 62 themes rather than assumed.
+  const quantize = (value: number) =>
+    Math.max(0, Math.min(255, Math.round(value)));
+  const mixRgb = (a: readonly number[], b: readonly number[], u: number) => [
+    quantize(a[0] + (b[0] - a[0]) * u),
+    quantize(a[1] + (b[1] - a[1]) * u),
+    quantize(a[2] + (b[2] - a[2]) * u),
+  ];
+  // Same short-circuits as the string `blend` it replaces: at the ends, return
+  // the endpoint untouched rather than round-tripping it.
+  const blendRgb = (a: readonly number[], b: readonly number[], u: number) =>
+    u <= 0 ? a : u >= 1 ? b : mixRgb(a, b, u);
+
+  const sampleHead = (hue: number) => {
+    const position = axisPosition(hue, HUE_BUCKETS);
+    const low = Math.floor(position);
+    const blended = rgb2hex(
+      blendRgb(
+        headRgb[low],
+        headRgb[Math.min(HUE_BUCKETS - 1, low + 1)],
+        position - low,
+      ),
+    );
+    // RE-LIFT. The endpoints are solved to sit exactly ON the 4.5 floor, and
+    // contrast is convex in the blend parameter, so the chord between two
+    // on-floor samples passes UNDER it — measured 4.4766 on solarized-light at
+    // hue 0.2188 with 128 buckets. Small, but 4.4766 < 4.5 is a WCAG failure on
+    // shipped pixels, and raising the bucket count only shrinks the dip
+    // asymptotically without ever removing it. Lifting the blend is exact.
+    // `lift` is a no-op when the blend already clears the floor, which is the
+    // overwhelming majority of lookups.
+    return lift(blended, palette.background, WORDMARK_FLOOR);
+  };
+
+  return {
+    head,
+    field,
+    bevelHi,
+    bevelLo,
+    // Bilinear on (contrast, hue) for the field, linear on hue for the
+    // wordmark. This is what makes the output continuous in hue, so bucket
+    // count is a fidelity knob rather than the thing standing between the
+    // gradient and visible banding.
+    lookup: (layer, t, hue) => {
+      switch (layer) {
+        case "head":
+          return sampleHead(hue);
+        case "field": {
+          const contrastPosition = axisPosition(t, CONTRAST_BUCKETS);
+          const contrastLow = Math.floor(contrastPosition);
+          const huePosition = axisPosition(hue, HUE_BUCKETS);
+          const hueLow = Math.floor(huePosition);
+          const hueHigh = Math.min(HUE_BUCKETS - 1, hueLow + 1);
+          const hueFraction = huePosition - hueLow;
+          const near = fieldRgb[contrastLow];
+          const far = fieldRgb[Math.min(CONTRAST_BUCKETS - 1, contrastLow + 1)];
+          return rgb2hex(
+            blendRgb(
+              blendRgb(near[hueLow], near[hueHigh], hueFraction),
+              blendRgb(far[hueLow], far[hueHigh], hueFraction),
+              contrastPosition - contrastLow,
+            ),
+          );
+        }
+        case "bevel_hi":
+          return bevelHi;
+        case "bevel_lo":
+          return bevelLo;
+      }
+    },
+  };
+}

--- a/desktop/src/features/terminal/terminalBannerWave.ts
+++ b/desktop/src/features/terminal/terminalBannerWave.ts
@@ -6,12 +6,16 @@
  * the `hue` axis as a function of time and screen position, plus the lookup
  * table that makes it affordable.
  *
- * Tyler: "slow waves of the buzz theme colors moving across the honeycomb
- * lattice right to left, with a separate slow color wave on the `buzz term`
- * going left to right".
+ * Tyler, amendment (msg 25bf80a2) — AUTHORITATIVE: the field wave
+ * "originates bottom right and travels top left", not plain right-to-left.
+ * This SUPERSEDES the original directive: "slow waves of the buzz theme colors
+ * moving across the honeycomb lattice right to left, with a separate slow
+ * color wave on the `buzz term` going left to right". The wordmark half is
+ * unchanged by the amendment; only the field's axis moved.
  *
- * Two independent waves, opposite directions, different periods:
- *   - field    -> right-to-left across the whole viewport
+ * Two independent waves, different axes, different periods:
+ *   - field    -> originates bottom-right, travels top-left across the whole
+ *                 viewport (see FIELD_WAVE.direction = {x:-1, y:-1})
  *   - wordmark -> left-to-right across the wordmark's own ink span
  * The bevels do not animate. They are the chassis; a moving highlight would
  * read as the box itself deforming.

--- a/desktop/src/features/terminal/terminalBannerWave.ts
+++ b/desktop/src/features/terminal/terminalBannerWave.ts
@@ -17,6 +17,15 @@
  *   - field    -> originates bottom-right, travels top-left across the whole
  *                 viewport (see FIELD_WAVE.direction = {x:-1, y:-1})
  *   - wordmark -> left-to-right across the wordmark's own ink span
+ *
+ * LOOP SEMANTICS. Phase advances monotonically and wraps at 1 -> 0 (`phaseAt`
+ * via `wrap01`); travel is continuous and one-way for as long as it advances,
+ * and one full cycle translates the pattern by exactly one spatial period, so
+ * the wrap is C0 with no snap and no reversal. The palette axis is folded
+ * (`cyclicRampPosition`) so the open three-stop ramp can be driven by a cyclic
+ * phase without a seam. Proof that folding the palette does NOT fold the motion
+ * is on `cyclicRampPosition` -- read it before touching either.
+ *
  * The bevels do not animate. They are the chassis; a moving highlight would
  * read as the box itself deforming.
  */
@@ -172,10 +181,35 @@ const wrap01 = (value: number) => value - Math.floor(value);
  * The fix is to make the cyclic axis traverse the ramp and come back:
  * 0 -> 1 over the first half of the cycle, 1 -> 0 over the second. The ends
  * are then interior turning points and adjacency holds everywhere, so the loop
- * is seamless by construction rather than by choice of period. The cost is that
- * the wave reverses direction each half-cycle — invisible at these periods,
- * because a colour drift has no landmark to read a direction against, and the
- * direction gate measures the crest inside a half-cycle where it is defined.
+ * is seamless by construction rather than by choice of period.
+ *
+ * THIS DOES NOT REVERSE THE WAVE, and an earlier version of this comment
+ * claimed it did. The claim was false and it cost a review round (Wren's #4541
+ * gate), so the reasoning is recorded here rather than left to be re-derived.
+ *
+ * Write the field as `hue(x, phase) = A(G(p(x) + phase))`, where `p` is affine
+ * in position (see `projectWave`), `G` is this fold, and `A` is `applyIntensity`
+ * (affine, monotone). Phase enters `G` ONLY through the sum `p(x) + phase`, so
+ * for a shift `d` along +direction, `p(x + d*u) = p(x) - d*wavelength/span` and
+ *
+ *     hue(x + d*u, phase + D) = hue(x, phase)   for   d = D * span / wavelength
+ *
+ * exactly, at every phase, FOR ANY `G` WHATSOEVER. The shape of `G` sets the
+ * spatial PROFILE; it cannot touch the direction of MOTION. `d` has the sign of
+ * `D`, so travel is uniformly one-way for as long as phase advances, and one
+ * full cycle translates the pattern by exactly one spatial period -- continuous
+ * BR->TL travel and a seamless wrap at the same time, not a trade between them.
+ *
+ * The mistake worth not repeating: the fold DOES make a fixed cell's colour
+ * oscillate (cell(60,25) reads 0.5 0.7 0.9 0.9 0.7 0.5 0.3 0.1 0.1 0.3 0.5 over
+ * one cycle). That is a property of a POINT, not of the pattern -- it is what
+ * every travelling wave does to a point it passes over -- and reading it as a
+ * direction reversal is what put the false sentence here. `travelDirection` in
+ * the test file measures the pattern across the WHOLE cycle, including the
+ * alleged turn at phase 0.5 and the wrap, with a time-folded positive control.
+ *
+ * What the fold does cost is aesthetic, not kinematic: the spatial palette
+ * profile is mirrored (A->C->A) rather than circulating (A->B->C->A).
  */
 export function cyclicRampPosition(phase: number): number {
   const wrapped = wrap01(phase);

--- a/desktop/src/shared/styles/globals/scrollbars.css
+++ b/desktop/src/shared/styles/globals/scrollbars.css
@@ -33,6 +33,27 @@
   );
 }
 
+/* Channel activity keeps its chrome outside the scrolling surface. The slim,
+ * low-contrast thumb belongs only to the activity list beneath the header. */
+.buzz-channel-activity-scrollbar {
+  scrollbar-gutter: stable;
+}
+
+.buzz-channel-activity-scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.buzz-channel-activity-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.buzz-channel-activity-scrollbar::-webkit-scrollbar-thumb {
+  background-clip: content-box;
+  background-color: hsl(var(--foreground) / 0.15);
+  border: 2px solid transparent;
+  border-radius: 999px;
+}
+
 /*
  * Main-content scroll areas that have sticky blurred chrome inside them.
  * Native overlay scrollbars paint UNDER composited descendants

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11201,6 +11201,50 @@ export function maybeInstallE2eTauriMocks() {
           created_at: template.createdAt,
           updated_at: template.updatedAt,
         }));
+      case "create_channel_template": {
+        const { input } = payload as {
+          input: {
+            name: string;
+            description?: string;
+            channelType?: "stream" | "forum";
+            visibility?: "open" | "private";
+            canvasTemplate?: string;
+            agents?: ChannelTemplate["agents"];
+          };
+        };
+        const timestamp = new Date().toISOString();
+        const created: ChannelTemplate = {
+          id: `template-${Date.now()}`,
+          name: input.name,
+          description: input.description ?? null,
+          channelType: input.channelType ?? "stream",
+          visibility: input.visibility ?? "open",
+          canvasTemplate: input.canvasTemplate ?? null,
+          agents: input.agents ?? { personas: [], teams: [] },
+          isBuiltin: false,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        };
+        if (activeConfig) {
+          activeConfig.mock ??= {};
+          activeConfig.mock.channelTemplates = [
+            ...(activeConfig.mock.channelTemplates ?? []),
+            created,
+          ];
+        }
+        return {
+          id: created.id,
+          name: created.name,
+          description: created.description,
+          channel_type: created.channelType,
+          visibility: created.visibility,
+          canvas_template: created.canvasTemplate,
+          agents: created.agents,
+          is_builtin: created.isBuiltin,
+          created_at: created.createdAt,
+          updated_at: created.updatedAt,
+        };
+      }
       case "create_team":
         return handleCreateTeam(
           payload as Parameters<typeof handleCreateTeam>[0],

--- a/desktop/tests/e2e/badge.spec.ts
+++ b/desktop/tests/e2e/badge.spec.ts
@@ -105,11 +105,11 @@ test("regular message bolds inactive channel without numeric badge", async ({
     "600",
   );
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
-  await expect(page.getByTestId("channel-unread-dot-random")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withDotOnlyBadge(baselineBadge));
 });
 
-test("numeric badge increments for @mention in inactive channel", async ({
+test("top-level @mention bolds the channel without a row badge", async ({
   page,
 }) => {
   await page.goto("/");
@@ -134,7 +134,11 @@ test("numeric badge increments for @mention in inactive channel", async ({
     },
   );
 
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
   await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
@@ -158,7 +162,7 @@ test("numeric badge increments for DM message", async ({ page }) => {
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
 
-test("numeric badge increments for interested thread reply in inactive channel", async ({
+test("interested thread reply shows the channel thread dot", async ({
   page,
 }) => {
   await page.goto("/");
@@ -190,11 +194,12 @@ test("numeric badge increments for interested thread reply in inactive channel",
     { parentEventId: rootEventId, pubkey: TEST_IDENTITIES.alice.pubkey },
   );
 
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await expect(page.getByTestId("channel-unread-dot-random")).toBeVisible();
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
 
-test("numeric badge increments for broadcast reply in inactive channel", async ({
+test("broadcast reply bolds the channel without a thread dot", async ({
   page,
 }) => {
   await page.goto("/");
@@ -219,7 +224,12 @@ test("numeric badge increments for broadcast reply in inactive channel", async (
     { pubkey: TEST_IDENTITIES.alice.pubkey },
   );
 
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
 
@@ -265,9 +275,7 @@ test("mark-as-read via context menu clears channel unread indicator", async ({
   await waitForBadgeState(page, baselineBadge);
 });
 
-test("mark-as-unread via context menu increments numeric badge", async ({
-  page,
-}) => {
+test("mark-as-unread via context menu bolds the channel", async ({ page }) => {
   await page.goto("/");
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
@@ -278,8 +286,53 @@ test("mark-as-unread via context menu increments numeric badge", async ({
   await page.getByTestId("channel-random").click({ button: "right" });
   await page.getByText("Mark unread").click();
 
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
+});
+
+test("marking a message unread bolds its channel after leaving", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  await waitForMockLiveSubscription(page, "random");
+
+  const message = await page.evaluate(
+    ({ pubkey }) =>
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "random",
+        content: "Keep this channel message unread",
+        kind: 40002,
+        pubkey,
+      }),
+    { pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+  if (!message) {
+    throw new Error("Mock message emitter is unavailable");
+  }
+
+  const messageRow = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Keep this channel message unread" });
+  await expect(messageRow).toBeVisible();
+  await messageRow.hover();
+  await page.getByTestId(`more-actions-${message.id}`).click();
+  const toggle = page.getByTestId(`mark-read-toggle-${message.id}`);
+  await expect(toggle).toHaveText("Mark unread");
+  await toggle.click();
+
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
 });
 
 test("remote read-state rollback is ignored while local mark-unread still increments badge", async ({
@@ -379,11 +432,15 @@ test("remote read-state rollback is ignored while local mark-unread still increm
 
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
 
-  // Local mark-unread remains an in-session affordance and should still show
-  // the dot immediately without publishing a lower read timestamp.
+  // Local mark-unread remains an in-session affordance and should still bold
+  // the channel immediately without publishing a lower read timestamp.
   await page.getByTestId("channel-random").click({ button: "right" });
   await page.getByText("Mark unread").click();
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-random")).toHaveCSS(
+    "font-weight",
+    "600",
+  );
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 
   // Step 3: remote advance clears the local forced-unread dot.

--- a/desktop/tests/e2e/channel-activity-popover.spec.ts
+++ b/desktop/tests/e2e/channel-activity-popover.spec.ts
@@ -1,0 +1,795 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SELF_PUBKEY = "deadbeef".repeat(8);
+const CHANNEL_GENERAL = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const AGENT_PUBKEY = TEST_IDENTITIES.charlie.pubkey;
+
+type MockMessageEvent = {
+  id: string;
+  created_at: number;
+  pubkey: string;
+};
+
+type MockInboxFeedItem = {
+  content: string;
+  id: string;
+  tags: string[][];
+};
+
+async function waitForMockLiveSubscription(page: Page, channelName: string) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (name) =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({
+            channelName: name,
+          }) ?? false,
+        channelName,
+      ),
+    )
+    .toBe(true);
+}
+
+async function emitMockMessage(
+  page: Page,
+  content: string,
+  options: {
+    parentEventId?: string;
+    pubkey: string;
+    createdAt: number;
+    mentionPubkeys?: string[];
+  },
+): Promise<MockMessageEvent> {
+  const event = await page.evaluate(
+    ({ body, parentEventId, pubkey, createdAt, mentionPubkeys }) =>
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            parentEventId?: string;
+            pubkey: string;
+            createdAt: number;
+            mentionPubkeys?: string[];
+          }) => MockMessageEvent;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: body,
+        parentEventId,
+        pubkey,
+        createdAt,
+        mentionPubkeys,
+      }),
+    {
+      body: content,
+      parentEventId: options.parentEventId,
+      pubkey: options.pubkey,
+      createdAt: options.createdAt,
+      mentionPubkeys: options.mentionPubkeys,
+    },
+  );
+  if (!event) {
+    throw new Error("Mock message emitter is unavailable");
+  }
+  return event;
+}
+
+async function pushMockInboxFeedItems(page: Page, items: MockInboxFeedItem[]) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as Window & { __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: unknown })
+        .__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__ === "function",
+  );
+  await page.evaluate(
+    ({ channelId, feedItems, senderPubkey }) => {
+      const pushFeedItem = (
+        window as Window & {
+          __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: {
+            category: "mention";
+            channel_id: string;
+            channel_name: string;
+            channel_type: "stream";
+            content: string;
+            created_at: number;
+            id: string;
+            kind: number;
+            pubkey: string;
+            tags: string[][];
+          }) => void;
+        }
+      ).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
+      if (!pushFeedItem) {
+        throw new Error("Mock feed injection helper is unavailable");
+      }
+      const createdAt = Math.floor(Date.now() / 1_000) - 300;
+      for (const item of feedItems) {
+        pushFeedItem({
+          category: "mention",
+          channel_id: channelId,
+          channel_name: "general",
+          channel_type: "stream",
+          content: item.content,
+          created_at: createdAt,
+          id: item.id,
+          kind: 9,
+          pubkey: senderPubkey,
+          tags: item.tags,
+        });
+      }
+    },
+    {
+      channelId: CHANNEL_GENERAL,
+      feedItems: items,
+      senderPubkey: TEST_IDENTITIES.alice.pubkey,
+    },
+  );
+}
+
+async function getForcedUnreadSources(page: Page): Promise<string[]> {
+  return page.evaluate(
+    ({ channelId, pubkey }) => {
+      const raw = window.localStorage.getItem(
+        `buzz-forced-unread.v1:${pubkey}`,
+      );
+      if (!raw) return [];
+      const entry = JSON.parse(raw)?.[channelId];
+      if (entry === undefined) return [];
+      return typeof entry === "object" && entry !== null
+        ? (entry.sources ?? [])
+        : ["manual"];
+    },
+    { channelId: CHANNEL_GENERAL, pubkey: SELF_PUBKEY },
+  );
+}
+
+async function seedChannelActivity(
+  page: Page,
+  {
+    extraThreadCount = 0,
+    includeAgent = true,
+  }: { extraThreadCount?: number; includeAgent?: boolean } = {},
+) {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  const ownRoot = await emitMockMessage(
+    page,
+    "How should the handoff work for longer agent tasks?",
+    {
+      pubkey: SELF_PUBKEY,
+      createdAt: Math.floor(Date.now() / 1000) - 20,
+    },
+  );
+  const extraRoots = await Promise.all(
+    Array.from({ length: extraThreadCount }, (_, index) =>
+      emitMockMessage(page, `Overflow preview thread ${index + 1}`, {
+        pubkey: SELF_PUBKEY,
+        createdAt: Math.floor(Date.now() / 1000) - 19 + index,
+      }),
+    ),
+  );
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+
+  const unreadAt = Math.floor(Date.now() / 1000) + 60;
+  await emitMockMessage(
+    page,
+    "I tightened the empty state and added the direct thread link.",
+    {
+      parentEventId: "mock-general-welcome",
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      createdAt: unreadAt,
+      mentionPubkeys: [SELF_PUBKEY],
+    },
+  );
+  await emitMockMessage(
+    page,
+    "The updated interaction keeps context visible without opening the channel first.",
+    {
+      parentEventId: ownRoot.id,
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+      createdAt: unreadAt + 1,
+    },
+  );
+  await Promise.all(
+    extraRoots.map((root, index) =>
+      emitMockMessage(
+        page,
+        `A new reply in overflow preview thread ${index + 1}`,
+        {
+          parentEventId: root.id,
+          pubkey: TEST_IDENTITIES.alice.pubkey,
+          createdAt: unreadAt + 2 + index,
+        },
+      ),
+    ),
+  );
+
+  if (includeAgent) {
+    await page.waitForFunction(
+      () =>
+        typeof (window as Window & { __BUZZ_E2E_SEED_ACTIVE_TURNS__?: unknown })
+          .__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    );
+    await page.evaluate(
+      ({ agentPubkey, channelId }) => {
+        (
+          window as Window & {
+            __BUZZ_E2E_SEED_ACTIVE_TURNS__?: (input: {
+              agentPubkey: string;
+              channelId: string;
+              turnId: string;
+            }) => void;
+          }
+        ).__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+          agentPubkey,
+          channelId,
+          turnId: "channel-hover-preview",
+        });
+      },
+      { agentPubkey: AGENT_PUBKEY, channelId: CHANNEL_GENERAL },
+    );
+  }
+
+  await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+  if (includeAgent) {
+    await expect(page.getByTestId("channel-working-general")).toBeVisible();
+  }
+}
+
+async function openActivityPopover(page: Page) {
+  await page.getByTestId("channel-general").hover();
+  const popover = page.getByTestId("channel-activity-popover-general");
+  await expect(popover).toBeVisible();
+  return popover;
+}
+
+test.describe("channel activity hover preview", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: "Charlie",
+          status: "running",
+          channelNames: ["general"],
+        },
+      ],
+    });
+  });
+
+  test("shows unread channel activity and working agents, then opens the selected thread", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page, { extraThreadCount: 5 });
+    const popover = await openActivityPopover(page);
+
+    const heading = popover.getByRole("heading", {
+      name: "Channel activity",
+    });
+    await expect(heading).toBeVisible();
+    await expect(heading).toHaveCSS("backdrop-filter", /blur/);
+    const activityScroll = popover.getByTestId("channel-activity-scroll");
+    await expect(activityScroll).toHaveCSS("overflow-y", "auto");
+    await expect(activityScroll.getByRole("heading")).toHaveCount(0);
+    await expect
+      .poll(() =>
+        activityScroll.evaluate(
+          (element) => element.scrollHeight > element.clientHeight,
+        ),
+      )
+      .toBe(true);
+    await waitForAnimations(page);
+    const headingY = (await heading.boundingBox())?.y;
+    const scrollY = (await activityScroll.boundingBox())?.y;
+    const headingBottom = await heading.evaluate(
+      (element) => element.getBoundingClientRect().bottom,
+    );
+    expect(scrollY).toBeGreaterThanOrEqual(headingBottom - 1);
+    await activityScroll.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await expect
+      .poll(() => activityScroll.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0);
+    const scrolledHeadingY = (await heading.boundingBox())?.y;
+    expect(headingY).toBeDefined();
+    expect(scrolledHeadingY).toBeDefined();
+    expect(Math.abs((scrolledHeadingY ?? 0) - (headingY ?? 0))).toBeLessThan(
+      0.5,
+    );
+    await activityScroll.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await expect
+      .poll(() =>
+        activityScroll.evaluate(
+          (element) =>
+            getComputedStyle(element, "::-webkit-scrollbar-thumb")
+              .backgroundColor,
+        ),
+      )
+      .toMatch(/0\.15\)/);
+    await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(7);
+    await expect(popover).toContainText(
+      "I tightened the empty state and added the direct thread link.",
+    );
+    await expect(popover.getByRole("heading")).toHaveCount(1);
+    await expect(
+      popover.getByTestId(`channel-activity-agent-${AGENT_PUBKEY}`),
+    ).toContainText("Charlie");
+    await expect(
+      popover.getByTestId(`channel-activity-agent-${AGENT_PUBKEY}`),
+    ).toContainText("Working");
+    const orderedRows = popover.locator(
+      '[data-testid^="channel-activity-agent-"], [data-testid^="channel-activity-item-"]',
+    );
+    await expect(orderedRows.first()).toHaveAttribute(
+      "data-testid",
+      `channel-activity-agent-${AGENT_PUBKEY}`,
+    );
+
+    await waitForAnimations(page);
+    await page.screenshot({
+      clip: { x: 0, y: 80, width: 720, height: 640 },
+      path: "test-results/channel-activity-hover/channel-activity-popover.png",
+    });
+
+    const targetRow = popover
+      .getByTestId(/^channel-activity-item-/)
+      .filter({ hasText: "direct thread link" });
+    await targetRow.getByRole("button", { name: /Open thread/ }).click();
+
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    const threadPanel = page.getByTestId("message-thread-panel");
+    await expect(threadPanel).toBeVisible();
+    await expect(threadPanel).toContainText("direct thread link");
+  });
+
+  test("removes the dot and preview after the final activity is read", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page, { includeAgent: false });
+    const popover = await openActivityPopover(page);
+    await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(2);
+
+    for (let remaining = 1; remaining >= 0; remaining -= 1) {
+      const row = popover.getByTestId(/^channel-activity-item-/).first();
+      await row.hover();
+      await row.getByRole("button", { name: "Mark as read" }).click();
+      await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(
+        remaining,
+      );
+    }
+
+    await expect(page.getByTestId("channel-unread-dot-general")).toHaveCount(0);
+    await expect(
+      page.getByTestId("channel-activity-popover-general"),
+    ).toHaveCount(0);
+  });
+
+  test("groups multiple unread replies against the previewed channel", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page, { includeAgent: false });
+    await emitMockMessage(
+      page,
+      "A second unread reply should stay grouped with this thread.",
+      {
+        parentEventId: "mock-general-welcome",
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        createdAt: Math.floor(Date.now() / 1_000) + 120,
+        mentionPubkeys: [SELF_PUBKEY],
+      },
+    );
+
+    const popover = await openActivityPopover(page);
+    const groupedRow = popover
+      .getByTestId(/^channel-activity-item-/)
+      .filter({ hasText: "direct thread link" });
+    await expect(groupedRow).toContainText("2 unread");
+  });
+
+  test("marks projected thread activity read from the active channel menu", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page, { includeAgent: false });
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+
+    await page.getByTestId("channel-general").click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Mark as read" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Mark unread" }),
+    ).toHaveCount(0);
+    await page.getByRole("menuitem", { name: "Mark as read" }).click();
+
+    await expect(page.getByTestId("channel-unread-dot-general")).toHaveCount(0);
+  });
+
+  test("marks projected thread activity read in the active channel with Shift+Escape", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page, { includeAgent: false });
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+
+    const shortcutHandled = await page.evaluate(() => {
+      const event = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Escape",
+        shiftKey: true,
+      });
+      window.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+    expect(shortcutHandled).toBe(true);
+
+    await expect(page.getByTestId("channel-unread-dot-general")).toHaveCount(0);
+    await page.getByTestId("channel-general").hover();
+    await expect(
+      page.getByTestId("channel-activity-popover-general"),
+    ).toHaveCount(0);
+  });
+
+  test("supports row actions and opens an agent's scoped activity", async ({
+    page,
+  }) => {
+    await seedChannelActivity(page);
+    let popover = await openActivityPopover(page);
+    const initialRows = popover.getByTestId(/^channel-activity-item-/);
+    await expect(initialRows).toHaveCount(2);
+
+    const firstRow = initialRows.first();
+    await firstRow.hover();
+    await firstRow.getByRole("button", { name: "Mark as read" }).click();
+    await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(1);
+
+    const remainingRow = popover.getByTestId(/^channel-activity-item-/).first();
+    await remainingRow.hover();
+    await remainingRow.getByRole("button", { name: "Remind me later" }).click();
+    await expect(
+      page.getByRole("dialog").getByText("Remind me later"),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    popover = await openActivityPopover(page);
+    await popover.getByTestId(`channel-activity-agent-${AGENT_PUBKEY}`).click();
+
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await expect(page.getByTestId("agent-session-agent-name")).toContainText(
+      "Charlie",
+    );
+    await expect(page.getByTestId("agent-session-scope-label")).toContainText(
+      "#general",
+    );
+  });
+
+  test("keeps multiple Inbox threads visible after opening their channel", async ({
+    page,
+  }) => {
+    const inboxItemIds = [
+      "older-inbox-thread-for-hover",
+      "second-inbox-thread-for-hover",
+    ];
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await page.getByRole("button", { name: "Inbox", exact: true }).click();
+    await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+    await pushMockInboxFeedItems(
+      page,
+      inboxItemIds.map((id, index) => ({
+        content:
+          index === 0
+            ? "Older Inbox thread reopened for hover testing."
+            : "A second Inbox thread reopened for hover testing.",
+        id,
+        tags: [
+          ["h", CHANNEL_GENERAL],
+          [
+            "e",
+            index === 0
+              ? "older-inbox-thread-root"
+              : "second-inbox-thread-root",
+            "",
+            "root",
+          ],
+          [
+            "e",
+            index === 0
+              ? "older-inbox-thread-parent"
+              : "second-inbox-thread-parent",
+            "",
+            "reply",
+          ],
+          ["p", TEST_IDENTITIES.tyler.pubkey],
+        ],
+      })),
+    );
+
+    for (const itemId of inboxItemIds) {
+      const inboxRow = page.getByTestId(`home-inbox-item-${itemId}`);
+      await expect(inboxRow).toBeVisible();
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark as read" }).click();
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark unread" }).click();
+    }
+
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    for (const [index, itemId] of inboxItemIds.entries()) {
+      const inboxRow = page.getByTestId(`home-inbox-item-${itemId}`);
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark as read" }).click();
+      if (index === 0) {
+        await expect(page.getByTestId("channel-general")).toHaveCSS(
+          "font-weight",
+          "600",
+        );
+      }
+    }
+    await expect(page.getByTestId("channel-general")).not.toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    for (const itemId of inboxItemIds) {
+      const inboxRow = page.getByTestId(`home-inbox-item-${itemId}`);
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark unread" }).click();
+    }
+
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+    await page.mouse.move(900, 680);
+    let popover = await openActivityPopover(page);
+    await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(2);
+    await expect(popover).toContainText("Older Inbox thread reopened");
+    await expect(popover).toContainText("A second Inbox thread reopened");
+    await expect(popover.getByText("Thread", { exact: true })).toHaveCount(2);
+
+    await popover
+      .getByTestId(/^channel-activity-item-/)
+      .filter({ hasText: "Older Inbox thread reopened" })
+      .getByRole("button", { name: /Open thread/ })
+      .click();
+    await expect(popover).toBeHidden();
+    await page.mouse.move(900, 680);
+    popover = await openActivityPopover(page);
+    await expect(popover.getByTestId(/^channel-activity-item-/)).toHaveCount(1);
+    await expect(popover).not.toContainText("Older Inbox thread reopened");
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+
+    await page.mouse.move(900, 680);
+    await expect(popover).toBeHidden();
+    await page.getByRole("button", { name: "Inbox", exact: true }).click();
+    const topLevelItemId = "top-level-inbox-item-for-channel-read";
+    await pushMockInboxFeedItems(page, [
+      {
+        content: "Top-level Inbox item reopened for channel read testing.",
+        id: topLevelItemId,
+        tags: [
+          ["h", CHANNEL_GENERAL],
+          ["p", TEST_IDENTITIES.tyler.pubkey],
+        ],
+      },
+    ]);
+    const topLevelInboxRow = page.getByTestId(
+      `home-inbox-item-${topLevelItemId}`,
+    );
+    await expect(topLevelInboxRow).toBeVisible();
+    await topLevelInboxRow.hover();
+    await topLevelInboxRow.getByRole("button", { name: "Mark unread" }).click();
+    await page.getByTestId("channel-general").click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Mark as read" }).click();
+    await topLevelInboxRow.hover();
+    await expect(
+      topLevelInboxRow.getByRole("button", { name: "Mark unread" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("channel-unread-dot-general")).toHaveCount(0);
+    await page.getByTestId("channel-general").hover();
+    await expect(
+      page.getByTestId("channel-activity-popover-general"),
+    ).toHaveCount(0);
+    await page.getByTestId("channel-random").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("random");
+    await expect(page.getByTestId("channel-general")).not.toHaveCSS(
+      "font-weight",
+      "600",
+    );
+  });
+
+  test("reading a grouped Inbox thread preserves an unrelated manual unread", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    const manualUnreadMessage = await emitMockMessage(
+      page,
+      "Keep this separate timeline message unread.",
+      {
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        createdAt: Math.floor(Date.now() / 1_000),
+      },
+    );
+    const manualUnreadRow = page
+      .getByTestId("message-row")
+      .filter({ hasText: "Keep this separate timeline message unread." });
+    await manualUnreadRow.hover();
+    await page.getByTestId(`more-actions-${manualUnreadMessage.id}`).click();
+    await page
+      .getByTestId(`mark-read-toggle-${manualUnreadMessage.id}`)
+      .click();
+
+    await page.getByRole("button", { name: "Inbox", exact: true }).click();
+    const groupedRootId = "grouped-inbox-root-preserve-manual";
+    const groupedReplyId = "grouped-inbox-reply-preserve-manual";
+    await pushMockInboxFeedItems(page, [
+      {
+        content: "Grouped Inbox root for manual unread preservation.",
+        id: groupedRootId,
+        tags: [
+          ["h", CHANNEL_GENERAL],
+          ["p", TEST_IDENTITIES.tyler.pubkey],
+        ],
+      },
+      {
+        content: "Grouped Inbox reply marked read independently.",
+        id: groupedReplyId,
+        tags: [
+          ["h", CHANNEL_GENERAL],
+          ["e", groupedRootId, "", "root"],
+          ["e", groupedRootId, "", "reply"],
+          ["p", TEST_IDENTITIES.tyler.pubkey],
+        ],
+      },
+    ]);
+    const groupedInboxRow = page.getByTestId(
+      `home-inbox-item-${groupedReplyId}`,
+    );
+    await expect(groupedInboxRow).toBeVisible();
+    await groupedInboxRow.hover();
+    await groupedInboxRow.getByRole("button", { name: "Mark as read" }).click();
+
+    await page.getByTestId("channel-random").click();
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+  });
+
+  test("preserves Inbox ownership while another top-level row remains unread", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await page.getByRole("button", { name: "Inbox", exact: true }).click();
+    const topLevelItemIds = [
+      "first-top-level-inbox-owner",
+      "second-top-level-inbox-owner",
+    ];
+    await pushMockInboxFeedItems(
+      page,
+      topLevelItemIds.map((id, index) => ({
+        content: `Top-level Inbox owner ${index + 1}.`,
+        id,
+        tags: [
+          ["h", CHANNEL_GENERAL],
+          ["p", TEST_IDENTITIES.tyler.pubkey],
+        ],
+      })),
+    );
+    for (const itemId of topLevelItemIds) {
+      const inboxRow = page.getByTestId(`home-inbox-item-${itemId}`);
+      await expect(inboxRow).toBeVisible();
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark unread" }).click();
+    }
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    await expect.poll(() => getForcedUnreadSources(page)).toEqual(["inbox"]);
+
+    await page.getByRole("button", { name: "Inbox", exact: true }).click();
+    for (const [index, itemId] of topLevelItemIds.entries()) {
+      const inboxRow = page.getByTestId(`home-inbox-item-${itemId}`);
+      await inboxRow.hover();
+      await inboxRow.getByRole("button", { name: "Mark as read" }).click();
+      if (index === 0) {
+        await expect(page.getByTestId("channel-general")).toHaveCSS(
+          "font-weight",
+          "600",
+        );
+        await expect
+          .poll(() => getForcedUnreadSources(page))
+          .toEqual(["inbox"]);
+      }
+    }
+    await expect.poll(() => getForcedUnreadSources(page)).toEqual([]);
+  });
+
+  test("surfaces future replies after the user reacts to a thread root", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    const root = await emitMockMessage(
+      page,
+      "Reacting here means I care about future replies.",
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        createdAt: Math.floor(Date.now() / 1_000) - 20,
+      },
+    );
+    const rootRow = page
+      .getByTestId("message-row")
+      .filter({ hasText: "Reacting here means I care" });
+    await expect(rootRow).toBeVisible();
+    await rootRow.hover();
+    const actionBar = page.getByTestId(`message-action-bar-${root.id}`);
+    await expect(actionBar).toBeVisible();
+    await actionBar
+      .getByRole("button", { name: /^React with / })
+      .first()
+      .click();
+    await expect(
+      rootRow.getByRole("button", { name: /^Toggle .* reaction$/ }),
+    ).toBeVisible();
+
+    await page.getByTestId("channel-random").click();
+    await emitMockMessage(
+      page,
+      "This follow-up appears because the root was reacted to.",
+      {
+        parentEventId: root.id,
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        createdAt: Math.floor(Date.now() / 1_000) + 60,
+      },
+    );
+
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
+    const popover = await openActivityPopover(page);
+    await expect(popover).toContainText(
+      "This follow-up appears because the root was reacted to.",
+    );
+  });
+});

--- a/desktop/tests/e2e/channel-mute.spec.ts
+++ b/desktop/tests/e2e/channel-mute.spec.ts
@@ -85,7 +85,7 @@ test.describe("channel muting", () => {
     await expect(engRow.locator("svg.lucide-bell-off")).toHaveCount(1);
   });
 
-  test("03 — muted channel with @mention shows unread dot", async ({
+  test("03 — muted channel with a top-level @mention is emphasized", async ({
     page,
   }) => {
     await seedMuteState(page, ENGINEERING_CHANNEL_ID);
@@ -123,7 +123,13 @@ test.describe("channel muting", () => {
       },
     );
 
-    await expect(page.getByTestId("channel-unread-engineering")).toBeVisible();
+    await expect(page.getByTestId("channel-engineering")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    await expect(
+      page.getByTestId("channel-unread-dot-engineering"),
+    ).toHaveCount(0);
   });
 
   test("04 — context menu shows Unmute channel when muted", async ({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1336,8 +1336,26 @@ test("create channel template selector matches the lifecycle controls", async ({
         description: "Coordinate a new project from planning through launch.",
         channelType: "stream",
         visibility: "private",
-        canvasTemplate: null,
-        agents: { personas: [], teams: [] },
+        canvasTemplate: "# {channel.name}\n\nKickoff notes",
+        agents: {
+          personas: [
+            {
+              personaId: "planner",
+              runtime: null,
+              model: null,
+              role: null,
+              backend: null,
+            },
+          ],
+          teams: [
+            {
+              teamId: "research-team",
+              runtime: null,
+              model: null,
+              backend: null,
+            },
+          ],
+        },
         isBuiltin: false,
         createdAt: "2026-07-23T00:00:00Z",
         updatedAt: "2026-07-23T00:00:00Z",
@@ -1350,16 +1368,73 @@ test("create channel template selector matches the lifecycle controls", async ({
 
   const templateControl = page.getByTestId("create-channel-template");
   await expect(templateControl).toHaveRole("button");
-  await expect(templateControl).toHaveText("No template");
+  await expect(templateControl).toHaveText("None");
   await templateControl.click();
+  await expect(
+    page.getByRole("menuitem", { name: "Create new channel template…" }),
+  ).toBeVisible();
   await page.getByRole("menuitemradio", { name: "Project kickoff" }).click();
 
   await expect(templateControl).toHaveText("Project kickoff");
+  await expect(page.getByTestId("create-channel-template-summary")).toHaveText(
+    "Private · Canvas included · 1 agent · 1 team",
+  );
   await expect(page.getByTestId("create-channel-description")).toHaveValue(
     "Coordinate a new project from planning through launch.",
   );
   await expect(page.getByTestId("create-channel-permissions")).toContainText(
     "Private",
+  );
+  await page.getByTestId("create-channel-permissions").click();
+  await page.getByTestId("create-channel-permissions-option-open").click();
+  await expect(page.getByTestId("create-channel-template-summary")).toHaveText(
+    "Open · Canvas included · 1 agent · 1 team",
+  );
+});
+
+test("create channel exposes templates when the library is empty", async ({
+  page,
+}) => {
+  await installMockBridge(page, { channelTemplates: [] });
+  await page.goto("/");
+  await openCreateChannelDialog(page);
+
+  const typeContainer = page.getByTestId(
+    "create-channel-channel-type-container",
+  );
+  const visibilityContainer = page.getByTestId(
+    "create-channel-permissions-container",
+  );
+  const templateContainer = page.getByTestId(
+    "create-channel-template-container",
+  );
+  await expect(templateContainer).toContainText("TemplateOptional");
+  const typeBox = await typeContainer.boundingBox();
+  const visibilityBox = await visibilityContainer.boundingBox();
+  const templateBox = await templateContainer.boundingBox();
+  expect(typeBox).not.toBeNull();
+  expect(visibilityBox).not.toBeNull();
+  expect(templateBox).not.toBeNull();
+  expect(typeBox?.y ?? 0).toBeLessThan(visibilityBox?.y ?? 0);
+  expect(visibilityBox?.y ?? 0).toBeLessThan(templateBox?.y ?? 0);
+
+  const templateControl = page.getByTestId("create-channel-template");
+  await expect(templateControl).toHaveText("None");
+  await templateControl.click();
+  await page
+    .getByRole("menuitem", { name: "Create new channel template…" })
+    .click();
+
+  await expect(
+    page.getByText("Create template", { exact: true }),
+  ).toBeVisible();
+  await page.locator("#template-name").fill("Weekly planning");
+  await page.locator("#template-description").fill("Plan the next week.");
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  await expect(templateControl).toHaveText("Weekly planning");
+  await expect(page.getByTestId("create-channel-description")).toHaveValue(
+    "Plan the next week.",
   );
 });
 

--- a/desktop/tests/e2e/edit-agent-run-on.spec.ts
+++ b/desktop/tests/e2e/edit-agent-run-on.spec.ts
@@ -1,0 +1,212 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/edit-agent-run-on";
+
+/**
+ * The exact persisted shape of a real kubernetes agent created through the
+ * app ("Loni" in managed-agents.json, traced by Sami in review): eight keys,
+ * `inactivity_seconds` a JSON number, everything else strings, and the
+ * optional `service_account` ABSENT — no schema default means the create
+ * flow never seeds it, so honest fixtures omit it too.
+ */
+const KUBERNETES_CONFIG = {
+  context: "docker-desktop",
+  cpu_limit: "1",
+  cpu_request: "1",
+  image:
+    "ghcr.io/block/buzz-sprig:sha-6530b58@sha256:17facfc7608d8ddb33bc056c9aaba1098f4ef6abe5655702fbfd7584d1f74d76",
+  inactivity_seconds: 7200,
+  memory_limit: "1Gi",
+  memory_request: "1Gi",
+  namespace: "buzz-agents-gfq7aq",
+};
+
+async function openEditDialog(
+  page: import("@playwright/test").Page,
+  agentName: string,
+) {
+  await page.goto("/");
+  await page.getByTestId("open-agents-view").click();
+  await page
+    .getByRole("button", { name: `${agentName} agent profile` })
+    .click();
+  await page.getByTestId("user-profile-edit-agent").click();
+  await expect(page.getByTestId("edit-agent-dialog")).toBeVisible();
+}
+
+test("editing a kubernetes agent shows its saved run-on settings", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Remote Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: {
+          type: "provider",
+          id: "kubernetes",
+          config: KUBERNETES_CONFIG,
+        },
+      },
+    ],
+  });
+  await openEditDialog(page, "Remote Helper");
+
+  const runOn = page.getByTestId("edit-agent-run-on");
+  await expect(runOn).toBeVisible();
+  await expect(runOn.getByTestId("edit-agent-run-on-location")).toHaveText(
+    "kubernetes",
+  );
+
+  // Every saved field renders as a labeled row with its stored value.
+  await expect(runOn.getByTestId("edit-agent-run-on-namespace")).toContainText(
+    "buzz-agents-gfq7aq",
+  );
+  await expect(runOn.getByTestId("edit-agent-run-on-context")).toContainText(
+    "docker-desktop",
+  );
+  await expect(runOn.getByTestId("edit-agent-run-on-image")).toContainText(
+    "ghcr.io/block/buzz-sprig",
+  );
+  await expect(
+    runOn.getByTestId("edit-agent-run-on-cpu_request"),
+  ).toContainText("CPU request");
+  await expect(
+    runOn.getByTestId("edit-agent-run-on-inactivity_seconds"),
+  ).toContainText("7200");
+  // Real records omit the optional service_account (no schema default): the
+  // section must show only what was saved, never synthesize a row for it.
+  await expect(
+    runOn.getByTestId("edit-agent-run-on-service_account"),
+  ).toHaveCount(0);
+
+  // The section explains immutability instead of pretending to be a form.
+  await expect(runOn).toContainText("can't be changed afterwards");
+
+  await runOn.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("edit-agent-dialog")
+    .screenshot({ path: `${SHOTS}/kubernetes-run-on.png` });
+});
+
+test("editing a local agent names this computer, with no config rows", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.tyler;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Local Helper",
+        status: "stopped",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: { type: "local" },
+      },
+    ],
+  });
+  await openEditDialog(page, "Local Helper");
+
+  const runOn = page.getByTestId("edit-agent-run-on");
+  await expect(runOn.getByTestId("edit-agent-run-on-location")).toHaveText(
+    "This computer",
+  );
+  await expect(runOn.getByTestId("edit-agent-run-on-namespace")).toHaveCount(0);
+
+  await runOn.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("edit-agent-dialog")
+    .screenshot({ path: `${SHOTS}/local-run-on.png` });
+});
+
+test("a blox agent's single saved field renders with a humanized label", async ({
+  page,
+}) => {
+  // The other real provider shape on developer machines: blox records
+  // persist exactly one key, exercising provider-generic humanization.
+  const agent = TEST_IDENTITIES.bob;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Blox Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: {
+          type: "provider",
+          id: "blox",
+          config: { workstation_name: "tlongwell-sprout-home" },
+        },
+      },
+    ],
+  });
+  await openEditDialog(page, "Blox Helper");
+
+  const runOn = page.getByTestId("edit-agent-run-on");
+  await expect(runOn.getByTestId("edit-agent-run-on-location")).toHaveText(
+    "blox",
+  );
+  const row = runOn.getByTestId("edit-agent-run-on-workstation_name");
+  await expect(row).toContainText("Workstation name");
+  await expect(row).toContainText("tlongwell-sprout-home");
+
+  await runOn.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("edit-agent-dialog")
+    .screenshot({ path: `${SHOTS}/blox-run-on.png` });
+});
+
+test("secret-shaped keys from an untrusted provider render redacted", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Future Provider Agent",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: {
+          type: "provider",
+          id: "some-future-provider",
+          config: {
+            endpoint: "https://provider.example",
+            api_token: "tok-do-not-show",
+          },
+        },
+      },
+    ],
+  });
+  await openEditDialog(page, "Future Provider Agent");
+
+  const runOn = page.getByTestId("edit-agent-run-on");
+  await expect(runOn.getByTestId("edit-agent-run-on-endpoint")).toContainText(
+    "https://provider.example",
+  );
+  const tokenRow = runOn.getByTestId("edit-agent-run-on-api_token");
+  await expect(tokenRow).toContainText("••••••••");
+  await expect(tokenRow).not.toContainText("tok-do-not-show");
+  // The raw secret must not appear anywhere in the dialog.
+  await expect(page.getByTestId("edit-agent-dialog")).not.toContainText(
+    "tok-do-not-show",
+  );
+
+  await runOn.scrollIntoViewIfNeeded();
+  await waitForAnimations(page);
+  await page
+    .getByTestId("edit-agent-dialog")
+    .screenshot({ path: `${SHOTS}/redacted-run-on.png` });
+});

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -1139,6 +1139,13 @@ test("renders settings in the app shell with a back button", async ({
   await expect(page.getByTestId("settings-back-to-app")).toBeVisible();
   await expect(page.getByPlaceholder("Search everything")).toHaveCount(0);
   await expect(page.getByText("Personal", { exact: true })).toBeVisible();
+  const personalGroup = page
+    .getByTestId("settings-nav-channel-templates")
+    .locator("xpath=ancestor::*[@data-sidebar='group']");
+  await expect(personalGroup).toContainText("Personal");
+  await expect(
+    page.getByTestId("settings-nav-channel-templates"),
+  ).toContainText("Channel templates");
   await expect(page.getByTestId("settings-nav-profile")).toHaveAttribute(
     "aria-pressed",
     "true",

--- a/desktop/tests/e2e/thread-unread.spec.ts
+++ b/desktop/tests/e2e/thread-unread.spec.ts
@@ -711,7 +711,7 @@ test.describe("thread unread indicator", () => {
     await expect(badge).toContainText("3");
   });
 
-  // Thread-only replies now also light the channel sidebar badge. Viewing the
+  // Thread-only replies now also light the channel sidebar dot. Viewing the
   // channel should leave unopened thread replies unread until the thread is read.
   test("11-thread-reply-lights-sidebar-badge-after-channel-view", async ({
     page,
@@ -748,15 +748,15 @@ test.describe("thread unread indicator", () => {
     await expect(page.getByTestId("chat-title")).toHaveText("general");
 
     // The crux: leave general. The unopened thread reply should still keep a
-    // numeric channel sidebar badge until the thread itself is read.
+    // channel sidebar dot until the thread itself is read.
     await page.getByTestId("channel-random").click();
     await expect(page.getByTestId("chat-title")).toHaveText("random");
-    await expect(page.getByTestId("channel-unread-general")).toBeVisible();
+    await expect(page.getByTestId("channel-unread-dot-general")).toBeVisible();
   });
 
   // Regression guard for the all-replies window: when the loaded window holds
   // ONLY thread replies (the top-level root has scrolled past the history
-  // limit), thread-only activity should still light the channel sidebar badge.
+  // limit), thread-only activity should still light the channel sidebar dot.
   //
   // The `all-replies` fixture carries a far-future `lastMessageAt` (standing in
   // for the backend's reply-inclusive MAX) with no top-level message in its
@@ -768,8 +768,7 @@ test.describe("thread unread indicator", () => {
     // Emit ONE reply whose parent root is NOT in the window (orphan parent id),
     // so the loaded window is all-replies: no top-level message exists for
     // `latestActiveMessage` to find. The reply mentions the current user so it
-    // clears the notify gate and creates Inbox activity without lighting the
-    // channel sidebar dot.
+    // clears the notify gate and creates Inbox thread activity.
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");
     await waitForMockLiveSubscription(page, "all-replies");
@@ -779,17 +778,21 @@ test.describe("thread unread indicator", () => {
       mentionPubkeys: [SELF_PUBKEY],
       createdAt: unreadTimestamp(),
     });
-    await expect(page.getByTestId("channel-unread-all-replies")).toHaveCount(0);
+    await expect(
+      page.getByTestId("channel-unread-dot-all-replies"),
+    ).toBeVisible();
 
     // View all-replies while the reply is unread.
     await page.getByTestId("channel-all-replies").click();
     await expect(page.getByTestId("chat-title")).toHaveText("all-replies");
 
     // The crux: leave the channel. Its unopened thread reply should still keep
-    // a numeric channel sidebar badge until the thread itself is read.
+    // a channel sidebar dot until the thread itself is read.
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");
-    await expect(page.getByTestId("channel-unread-all-replies")).toBeVisible();
+    await expect(
+      page.getByTestId("channel-unread-dot-all-replies"),
+    ).toBeVisible();
   });
 
   // Regression guard for BUG-2 (clear-on-read): opening an unread thread marks

--- a/desktop/tests/e2e/unread-pill.spec.ts
+++ b/desktop/tests/e2e/unread-pill.spec.ts
@@ -198,9 +198,12 @@ test.describe("unread pill & divider", () => {
     await page.getByTestId("channel-random").click();
     await expect(page.getByTestId("chat-title")).toHaveText("random");
 
-    // The unread indicator only renders on inactive channels, so it appears
-    // once general is no longer the active channel.
-    await expect(page.getByTestId("channel-unread-general")).toBeVisible();
+    // Forced channel unread uses channel-name emphasis, not the thread dot.
+    await expect(page.getByTestId("channel-general")).toHaveCSS(
+      "font-weight",
+      "600",
+    );
+    await expect(page.getByTestId("channel-unread-dot-general")).toHaveCount(0);
 
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -1294,7 +1294,20 @@ void main() {
         ]);
         await tester.pumpAndSettle();
 
-        expect(findRichText('Newest live update'), findsNothing);
+        // Cache-extent mounting varies by platform, so assert the reversed
+        // list's semantic boundary rather than whether item 0 is mounted.
+        final positions = tester
+            .widget<ScrollablePositionedList>(messageList)
+            .itemPositionsNotifier!
+            .itemPositions
+            .value;
+        expect(
+          positions.any(
+            (position) =>
+                position.index == 0 && position.itemLeadingEdge.abs() < 0.01,
+          ),
+          isFalse,
+        );
         expect(
           find.byKey(const ValueKey('channel-jump-to-latest')),
           findsOneWidget,


### PR DESCRIPTION
Sub-PR of #4347. Base `max/tui-renderer` @ `d8a4d63a8`. Merge commits only — no rebase, no force.

Tyler's ask: slow waves of buzz theme colours across the honeycomb lattice, plus a separate slow wave on the `buzz term` wordmark travelling left-to-right. Eva's amendment (evt `5c2182c3`): the field wave originates **bottom-right** and travels **top-left**, as a projection onto a direction vector.

## What this does

Two independent waves over the existing banner geometry — different directions, different periods. Geometry and glyphs are untouched; this only supplies a `hue` axis and the colour table that makes it affordable.

**Field wave** is a projection, not a per-axis sweep:

```
phase(cell) = (x·dx + y·dy) / wavelength − t·speed
```

normalized in **visual space**, because terminal cells are ~2:1 (8.4×17 CSS px). Without the aspect correction a "45°" direction renders at ~63°. The direction gate asserts the measured travel angle in visual space, not grid space.

**Tunability** is one config block per layer at the top of `terminalBannerWave.ts` (`FIELD_WAVE`, `WORDMARK_WAVE`) — `direction`, `seconds`, `wavelength`, `intensity`, each commented with its unit, what "bigger" does, and a **measured** contrast-safe range. Gates run at the documented extremes via a `waves?` override, so no module state is mutated to test them.

## Invariants, all gated

- **prefers-reduced-motion** takes the static painter call — the shipped banner byte for byte, not a paused animation. Those differ: a stopped loop parks on whatever phase it halted at. Gated against an independent oracle that walks the geometry and computes expected colours with `bannerColor` directly.
- **Wordmark holds WCAG 4.5:1 on every frame.** Interpolating between samples that sit *exactly on* the floor dips **under** it — contrast is convex along an sRGB chord, measured 4.4766 on solarized-light at hue 0.2188. The blend is re-lifted with the same operator that placed the endpoints. Raising bucket count only shrinks the dip asymptotically; lifting is exact.
- **Field keeps its monotonic 2.60 → 1.04 decay** and **bevels stay phase-invariant.** `hue` and the contrast axis are separated, so a moving wave cannot brighten the rim or make the chassis appear to deform.
- **Smoothness in CIEDE2000**, per theme, relative to that theme's own static worst step (+1 JND). Euclidean sRGB scores hue rotation at constant lightness as harshly as a brightness cliff and reversed the verdict on 20 themes — worst excess is 0.47 at defaults, <0.62 through wavelength 2.0, and 8.92 (24 themes failing) at 4.0, so the gate bites.
- **Seam:** a cyclic phase cannot drive an open 3-stop ramp — a raw wrap put a 182.5 sRGB edge on screen once per period. A palindrome fold fixes it, so direction is only defined inside a half-cycle and the direction gate measures a crest centroid.

## Perf

No per-cell-per-frame `ramp()`. Colour is a phase-independent LUT built once per palette; steady-state frames are a lookup plus a lerp.

REGIME: Chromium 148.0.7778.96, DPR 2, macOS, headless, **throttled** (1 paint per rAF tick, vsync ON), paired arms, 5 reps × 120 frames, buzz-dark, cell 8.4×17 CSS px, per-frame paint only. Magnitude is rig-local; only existence of an effect replicates.

LUT fill, one-time per palette: 128 hue × 24 contrast buckets, median **66.2 ms**.

| grid | glyphs | flat | pre | static | anim | anim−pre | anim %60Hz |
|---|---|---|---|---|---|---|---|
| 112×46 | 1973 | 512 | 768 | 44138 | 1467 | 699 | 8.80% |
| 152×63 | 3957 | 993 | 1502 | 94988 | 2733 | 1232 | 16.40% |
| 228×90 | 8893 | 2123 | 3254 | 210804 | 5831 | 2577 | 34.98% |

µs/frame. Two controls, because one can't interpret the animated arm: `flat` = one colour for every cell (Chromium short-circuits the fillStyle setter → glyph raster alone); `pre` = distinct *precomputed* colour per cell → raster + the per-cell CSS colour parse any multi-colour banner pays. `anim−pre` is the honest LUT cost; `anim−flat` would charge the animation for parse work the static path pays too.

**The animated banner is 11–36x cheaper than the static banner already on main.** The static path solves `ramp()` per cell — a ≤200-iteration lift loop plus a 28-step bisection — so shipped static paint is 44–211 ms/frame. It only survives because it paints once. The precompute is a large improvement to the banner's existing cost, not just a budget for the animation.

### A defect the decomposition caught

The first receipt had 228×90 at **101.6% of a 60Hz budget**, 80% of it my own LUT lookup. Cause: `mix()` re-parses hex per call and `hex2rgb(b)` sits *inside* its per-channel map, so a bilinear field lookup cost ~12 string parses + 3 hex formats per cell per frame. Fix: parse the tables to numeric mirrors once at build time and blend in RGB — **13.6 ms → 2.6 ms** of lookup at 228×90.

The intermediate `rgb2hex` rounding is **load-bearing**, not incidental: the old nested-`mix` path quantized its intermediate blend before the outer blend consumed it, and the WCAG/dE00 certificates were measured against those bytes. The new path reproduces that rounding at the same point, verified **byte-identical over 20.4M lookups × 62 themes** (`COMBINED 96cb28f6…`). The oracle's own negative control — dropping only the intermediate quantization — moves the digest to `d5be7e54…`, so it can fail.

## Verification

- Full desktop suite **4011/4011 pass, 0 fail**; `tsc --noEmit` clean; biome clean on every file this PR touches.
- **Mutation battery 9/9 killed.** It found three gate defects, all fixed: a *vacuous* reduced-motion gate that compared the static path against itself; an unasserted intensity clamp; and `sampleHead(hue)`→`sampleHead(t)`, which killed the wordmark wave entirely while every gate stayed green — the hue function and the table were each tested in isolation but nothing asserted the painter composes them. Not an equivalent mutant: head cells have 49 distinct `t`.
- **`git merge-tree` vs Mari's #4528 (`b76a9d605`): 0 conflicts** — we both touch `TerminalSubstrate.tsx`, so textual cleanliness isn't enough. I built the merged tree (`20502735…`) and ran it: `tsc` rc=0 and the full suite 4011/4011. Her change is JSX at ~L517, mine is an effect at ~L343.

Wren reviews at exact SHA `8d97ffde44e738dff10193f75cda693cf9fbc514`. Max integrates.
