### PR TITLE
fix(relay): move fleet-wide NIP-43 membership sweep off the pre-bind startup path

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -2872,39 +2872,53 @@ async fn emit_initial_ref_state(
     Ok(())
 }
 
+/// Reconcile one community's event-backed NIP-43 membership view.
+///
+/// `relay_members` is canonical. The snapshot is rebuilt only when it is
+/// absent or its member/role set differs from the canonical rows, so this is
+/// cheap (two queries) when nothing changed. Returns whether a repair
+/// publication happened.
+pub async fn reconcile_nip43_membership_snapshot(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+) -> anyhow::Result<bool> {
+    if !state
+        .db
+        .nip43_membership_snapshot_needs_reconciliation(
+            tenant.community(),
+            &state.relay_keypair.public_key(),
+        )
+        .await?
+    {
+        return Ok(false);
+    }
+
+    publish_nip43_membership_list(tenant, state).await?;
+    Ok(true)
+}
+
 /// Reconcile every community's event-backed NIP-43 membership view.
 ///
-/// `relay_members` is canonical. A snapshot is rebuilt only when it is absent
-/// or its member/role set differs from the canonical rows. This makes the sweep
-/// safe to run at startup and periodically without producing an event stream
-/// when nothing changed. A failure in one community is logged and counted but
-/// does not prevent the remaining communities from being repaired.
+/// A failure in one community is logged and counted but does not prevent the
+/// remaining communities from being repaired.
+///
+/// This sweep is O(communities) — sequential, two queries each, plus a
+/// publication per repair. On a large deployment it takes minutes, so it MUST
+/// NOT run on the pre-bind startup path (a startup probe SIGKILLs the pod
+/// mid-sweep and the restart begins again at community #1, forever). It runs
+/// post-bind, jittered, and leader-gated — see the sweep task in `main.rs`.
 pub async fn reconcile_nip43_membership_snapshots(state: &Arc<AppState>) -> anyhow::Result<usize> {
+    let started_at = std::time::Instant::now();
     let communities = state.db.usage_community_hosts().await?;
+    let total = communities.len();
+    let mut scanned = 0usize;
     let mut reconciled = 0usize;
 
     for community in communities {
         let community_id = buzz_core::CommunityId::from_uuid(community.id);
         let host = community.host;
-        let result = async {
-            if !state
-                .db
-                .nip43_membership_snapshot_needs_reconciliation(
-                    community_id,
-                    &state.relay_keypair.public_key(),
-                )
-                .await?
-            {
-                return Ok::<bool, anyhow::Error>(false);
-            }
-
-            let tenant = TenantContext::resolved(community_id, host.clone());
-            publish_nip43_membership_list(&tenant, state).await?;
-            Ok::<bool, anyhow::Error>(true)
-        }
-        .await;
-
-        match result {
+        let tenant = TenantContext::resolved(community_id, host.clone());
+        match reconcile_nip43_membership_snapshot(&tenant, state).await {
             Ok(true) => reconciled += 1,
             Ok(false) => {}
             Err(error) => {
@@ -2913,9 +2927,21 @@ pub async fn reconcile_nip43_membership_snapshots(state: &Arc<AppState>) -> anyh
                 warn!(%community_id, %host, %error, "NIP-43 membership reconciliation failed");
             }
         }
+        scanned += 1;
+        if scanned.is_multiple_of(1000) {
+            info!(
+                scanned,
+                total,
+                reconciled,
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                "NIP-43 membership sweep progress"
+            );
+        }
     }
 
     metrics::counter!("buzz_nip43_membership_reconciliations_total").increment(reconciled as u64);
+    metrics::histogram!("buzz_nip43_membership_sweep_seconds")
+        .record(started_at.elapsed().as_secs_f64());
     Ok(reconciled)
 }
 

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -90,6 +90,24 @@ const USAGE_METRICS_LOCK_KEY: i64 = 0x4255_5A5A_4D45_5452;
 /// leadership mechanism as the usage-metrics poller, different key.
 const NIP43_SWEEP_LOCK_KEY: i64 = 0x4255_5A5A_4E50_3433;
 
+/// Run `task` only after the listener-bound signal fires.
+///
+/// This is the structural guarantee that background work gated on it cannot
+/// precede `serve()` binding the listeners — a jitter delay alone is
+/// probabilistic (zero is a valid draw) and does not establish the ordering.
+/// If the sender is dropped without firing (startup failed before bind), the
+/// task never runs.
+async fn after_listener_bound<F, Fut>(bound: tokio::sync::oneshot::Receiver<()>, task: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    if bound.await.is_err() {
+        return;
+    }
+    task().await;
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Install the ring CryptoProvider for rustls. Required before any rustls
@@ -539,8 +557,11 @@ async fn main() -> anyhow::Result<()> {
     // provisioned community deliberately does NOT run here: it is
     // O(communities) — minutes at fleet scale — and a startup probe that
     // SIGKILLs the pod mid-sweep restarts it from community #1 forever
-    // (permanent crashloop). The fleet sweep runs post-bind, jittered, and
+    // (permanent crashloop). The fleet sweep runs post-bind (structurally:
+    // gated on the listener-bound signal fired inside `serve`), jittered, and
     // leader-gated in the periodic task spawned below.
+    let (listener_bound_tx, listener_bound_rx) = tokio::sync::oneshot::channel::<()>();
+    let mut listener_bound_rx = Some(listener_bound_rx);
     if config.require_relay_membership {
         // `deployment_community` is always Some here: startup fails fast above
         // when membership is enforced and the community cannot be ensured.
@@ -572,11 +593,16 @@ async fn main() -> anyhow::Result<()> {
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(60)
             .max(1);
-        tokio::spawn(async move {
+        let sweep_bound_rx = listener_bound_rx
+            .take()
+            .expect("listener_bound_rx is consumed exactly once, here");
+        tokio::spawn(after_listener_bound(sweep_bound_rx, move || async move {
             // Jitter the first tick by a random fraction of the interval so a
             // rolling deploy of N pods doesn't contend for the sweep lock (and
             // hammer `communities`) simultaneously at boot. True per-process
             // randomness — PID-derived seeds are unsafe when every pod is PID 1.
+            // Ordering vs bind is NOT the jitter's job: `after_listener_bound`
+            // already guarantees this task starts only after `serve()` binds.
             let jitter_secs = rand::random::<u64>() % interval_secs;
             tokio::time::sleep(std::time::Duration::from_secs(jitter_secs)).await;
 
@@ -630,7 +656,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 drop(leader);
             }
-        });
+        }));
     }
 
     // Emit kind:39000/39002 discovery events for channels that exist in the DB
@@ -1137,7 +1163,7 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    serve(router, health_router, Arc::clone(&state)).await?;
+    serve(router, health_router, Arc::clone(&state), listener_bound_tx).await?;
     state.community_revalidator_cancel.cancel();
 
     // Signal the audit worker to stop accepting, flush buffered entries, and
@@ -1155,6 +1181,59 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod after_listener_bound_tests {
+    use super::after_listener_bound;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    /// The invariant PR review demanded be structural: the gated task must not
+    /// start before the bound signal, even with zero delay anywhere. Uses
+    /// `tokio::task::yield_now` generously so any "task runs immediately on
+    /// spawn" regression is caught deterministically, not probabilistically.
+    #[tokio::test]
+    async fn task_does_not_run_until_listener_bound_signal() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_in_task = Arc::clone(&ran);
+        let handle = tokio::spawn(after_listener_bound(rx, move || async move {
+            ran_in_task.store(true, Ordering::SeqCst);
+        }));
+
+        // Give the spawned task every chance to (incorrectly) run early.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !ran.load(Ordering::SeqCst),
+            "sweep task ran before the listener-bound signal"
+        );
+
+        tx.send(()).expect("receiver alive");
+        handle.await.expect("gated task completes");
+        assert!(ran.load(Ordering::SeqCst), "task must run after the signal");
+    }
+
+    /// Startup that fails before bind drops the sender; the gated task must
+    /// never run in that case (no sweep against a relay that never served).
+    #[tokio::test]
+    async fn task_never_runs_if_sender_dropped_before_bind() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_in_task = Arc::clone(&ran);
+        let handle = tokio::spawn(after_listener_bound(rx, move || async move {
+            ran_in_task.store(true, Ordering::SeqCst);
+        }));
+
+        drop(tx);
+        handle.await.expect("gated task exits cleanly");
+        assert!(
+            !ran.load(Ordering::SeqCst),
+            "task must not run when startup fails before bind"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1257,6 +1336,7 @@ async fn serve(
     router: axum::Router,
     health_router: axum::Router,
     state: Arc<AppState>,
+    listener_bound_tx: tokio::sync::oneshot::Sender<()>,
 ) -> anyhow::Result<()> {
     let config = &state.config;
 
@@ -1300,6 +1380,11 @@ async fn serve(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to bind {}: {e}", config.bind_addr))?;
     info!(addr = %config.bind_addr, "buzz-relay TCP listening");
+    // Release background work gated on the listener being bound (NIP-43 fleet
+    // sweep). Fired only here — if startup fails before this point the sender
+    // drops and the gated tasks never run. A receiver dropped earlier (e.g.
+    // membership disabled) is fine; ignore the send result.
+    let _ = listener_bound_tx.send(());
 
     #[cfg(unix)]
     if let Some(ref uds_path) = config.uds_path {

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -83,6 +83,13 @@ impl EmissionScope {
 
 const USAGE_METRICS_LOCK_KEY: i64 = 0x4255_5A5A_4D45_5452;
 
+/// Session advisory lock serializing the fleet-wide NIP-43 membership sweep.
+///
+/// The sweep is O(communities) — minutes at fleet scale — so only one replica
+/// may run it at a time; the rest skip their tick. Same detached-session
+/// leadership mechanism as the usage-metrics poller, different key.
+const NIP43_SWEEP_LOCK_KEY: i64 = 0x4255_5A5A_4E50_3433;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Install the ring CryptoProvider for rustls. Required before any rustls
@@ -527,16 +534,35 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // NIP-43: reconcile the event-backed roster for every provisioned
-    // community before opening the listener. `relay_members` is canonical;
-    // this repairs pre-snapshot communities and any publication that failed
-    // after a membership transaction committed.
+    // NIP-43: reconcile the event-backed roster for the deployment's own
+    // community before opening the listener. The fleet-wide sweep across every
+    // provisioned community deliberately does NOT run here: it is
+    // O(communities) — minutes at fleet scale — and a startup probe that
+    // SIGKILLs the pod mid-sweep restarts it from community #1 forever
+    // (permanent crashloop). The fleet sweep runs post-bind, jittered, and
+    // leader-gated in the periodic task spawned below.
     if config.require_relay_membership {
-        match buzz_relay::handlers::side_effects::reconcile_nip43_membership_snapshots(&state).await
-        {
-            Ok(count) => info!(count, "NIP-43 membership snapshots reconciled on startup"),
-            Err(error) => {
-                tracing::warn!(%error, "NIP-43 membership snapshot startup reconciliation failed")
+        // `deployment_community` is always Some here: startup fails fast above
+        // when membership is enforced and the community cannot be ensured.
+        if let Some(community) = deployment_community {
+            let host = buzz_relay::tenant::relay_url_authority(&config.relay_url);
+            let tenant = buzz_core::tenant::TenantContext::resolved(community, host);
+            let started_at = std::time::Instant::now();
+            info!(community = %community, "NIP-43 startup phase: reconciling deployment community snapshot");
+            match buzz_relay::handlers::side_effects::reconcile_nip43_membership_snapshot(
+                &tenant, &state,
+            )
+            .await
+            {
+                Ok(repaired) => info!(
+                    community = %community,
+                    repaired,
+                    elapsed_ms = started_at.elapsed().as_millis() as u64,
+                    "NIP-43 startup phase: deployment community snapshot reconciled"
+                ),
+                Err(error) => {
+                    tracing::warn!(%error, "NIP-43 deployment community startup reconciliation failed")
+                }
             }
         }
 
@@ -547,24 +573,62 @@ async fn main() -> anyhow::Result<()> {
             .unwrap_or(60)
             .max(1);
         tokio::spawn(async move {
+            // Jitter the first tick by a random fraction of the interval so a
+            // rolling deploy of N pods doesn't contend for the sweep lock (and
+            // hammer `communities`) simultaneously at boot. True per-process
+            // randomness — PID-derived seeds are unsafe when every pod is PID 1.
+            let jitter_secs = rand::random::<u64>() % interval_secs;
+            tokio::time::sleep(std::time::Duration::from_secs(jitter_secs)).await;
+
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-            interval.tick().await;
+            // A fleet-scale sweep takes longer than the interval; skip ticks
+            // rather than scheduling a catch-up burst behind it.
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
+                // Per-tick leadership: hold the sweep lock only while sweeping,
+                // so a replica that dies mid-sweep releases it with its session
+                // and any peer picks up on its next tick.
+                let leader = match reconcile_state
+                    .db
+                    .try_lock_usage_metrics(NIP43_SWEEP_LOCK_KEY)
+                    .await
+                {
+                    Ok(Some(guard)) => guard,
+                    Ok(None) => continue,
+                    Err(error) => {
+                        tracing::warn!(%error, "NIP-43 sweep leadership check failed");
+                        continue;
+                    }
+                };
+                let started_at = std::time::Instant::now();
+                info!("NIP-43 membership sweep starting (leader)");
                 match buzz_relay::handlers::side_effects::reconcile_nip43_membership_snapshots(
                     &reconcile_state,
                 )
                 .await
                 {
-                    Ok(count) if count > 0 => {
-                        info!(count, "NIP-43 membership snapshots repaired")
+                    Ok(count) => {
+                        let elapsed_ms = started_at.elapsed().as_millis() as u64;
+                        if count > 0 {
+                            info!(
+                                count,
+                                elapsed_ms, "NIP-43 membership sweep complete: snapshots repaired"
+                            )
+                        } else {
+                            info!(
+                                elapsed_ms,
+                                "NIP-43 membership sweep complete: nothing to repair"
+                            )
+                        }
                     }
-                    Ok(_) => {}
                     Err(error) => tracing::warn!(
                         %error,
-                        "periodic NIP-43 membership snapshot reconciliation failed"
+                        elapsed_ms = started_at.elapsed().as_millis() as u64,
+                        "NIP-43 membership sweep failed"
                     ),
                 }
+                drop(leader);
             }
         });
     }


### PR DESCRIPTION
## Problem: silent permanent crashloop after a restart ("boot wedge")

Startup awaits `reconcile_nip43_membership_snapshots` — a sequential sweep over **every** provisioned community — before binding the listener. Per community it runs a snapshot-reconciliation check (2 queries) plus a repair publication when needed.

Measured locally (isolated docker rig): **~9.5ms/community** on the repair path; 1001 communities ≈ 9.5s of publishes, all logged *before* `buzz-relay TCP listening`. The cost is linear in community count, so on a deployment with a large number of communities the pre-bind sweep takes minutes — far past a typical startup probe window (e.g. 120s). The probe then SIGKILLs the pod mid-sweep, the restart begins again at community #1, and the pod crashloops forever with the port never bound and zero log lines at `RUST_LOG=error` (a healthy boot at that level logs nothing until failure, so the loop is silent).

## Fix (deliberately minimal — emergency scope)

- **Pre-bind:** reconcile **only the deployment community** (one bounded snapshot check), with explicit phase logs carrying `elapsed_ms` so the startup sequence is observable even when it's healthy.
- **Fleet sweep moves entirely post-bind** into the existing periodic task, now:
  - **jittered** — first tick delayed by a random fraction of the interval (same rationale and mechanism as the usage-metrics poller: PID-derived seeds are unsafe when every pod is PID 1);
  - **leader-gated** — session advisory lock (`NIP43_SWEEP_LOCK_KEY`, reusing `try_lock_usage_metrics`) so N replicas never run N concurrent fleet-wide sweeps. The lock is held only for the sweep's duration; a replica dying mid-sweep releases it with its session.
  - **skip-tick** on overrun (`MissedTickBehavior::Skip`) — a sweep longer than the interval doesn't queue a catch-up burst.
- **Sweep telemetry:** start / progress (every 1000 communities, with `scanned`/`total`/`reconciled`/`elapsed_ms`) / complete / fail logs, plus a `buzz_nip43_membership_sweep_seconds` histogram.

Pagination/resume and per-query lock/statement deadlines are a **separate follow-up PR** by agreed scope.

## Verification (live-local)

Rig: docker compose stack, postgres seeded with **1001 communities**, all 1001 kind:13534 snapshot events deleted to force the worst-case repair path. Binary built from this branch, `cargo build --release -p buzz-relay`.

**Run 1 (1001 repairs pending):**

```
15:48:44.461 NIP-43 startup phase: reconciling deployment community snapshot
15:48:44.474 NIP-43 startup phase: deployment community snapshot reconciled repaired=true elapsed_ms=12
15:48:44.475 buzz-relay TCP listening addr=127.0.0.1:33000        <- bind at +14ms, not +9.5s
15:48:46.478 NIP-43 membership sweep starting (leader)
15:48:50.024 NIP-43 membership sweep complete: snapshots repaired count=1000 elapsed_ms=3546
```

Bind happens **12ms** after the deployment-community check; the other 1000 repairs happen post-bind under the lock. DB confirms all 1001 snapshots restored.

**Run 2 (restart, converged state — idempotence):**

```
15:49:19.054 ... deployment community snapshot reconciled repaired=false elapsed_ms=7
15:49:19.055 buzz-relay TCP listening
15:49:20.330 NIP-43 membership sweep complete: nothing to repair elapsed_ms=1273
```

**Tests:** `cargo test -p buzz-relay` — 837 passed, 1 failed: `api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo`, which fails identically at the base commit (`origin/main` 5e0efb0bb) with this diff stashed — pre-existing, not introduced here. `just test-unit` (the pre-push gate) green. Clippy clean.
