### PR TITLE
feat(acp): honor AGENT_CWD when resolving NewSessionRequest.cwd

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -114,8 +114,11 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `AGENT_CWD` | no | process working directory | Absolute path passed as `NewSessionRequest.cwd`. This is the directory the agent runtime resolves `AGENTS.md`/`CLAUDE.md`, skills, hooks and settings from, so pinning it is how one supervised runtime serves a workspace other than the directory it was launched from. Must be an existing absolute directory; buzz-acp refuses to start otherwise. |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
+
+**Note:** `AGENT_CWD` sets the *session* working directory delivered over ACP; it does not change the working directory of the buzz-acp process or of the agent subprocess. One buzz-acp process still serves all its channels from a single workspace — see [#3822](https://github.com/block/buzz/issues/3822) for the channel-scoped follow-up.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -4,7 +4,7 @@
 //! Config file (TOML) for complex subscription rules.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use clap::ValueEnum;
@@ -45,6 +45,80 @@ pub enum ConfigError {
 
     #[error("config file error: {0}")]
     ConfigFile(String),
+}
+
+/// Environment variable an operator sets to pin the session working directory.
+///
+/// See `crates/buzz-persona/PERSONA_PACK_SPEC.md` § `$AGENT_CWD` Definition.
+pub const AGENT_CWD_ENV: &str = "AGENT_CWD";
+
+#[derive(Debug, Error, PartialEq)]
+pub enum AgentCwdError {
+    #[error(
+        "{AGENT_CWD_ENV} is set to `{0}`, which is not an absolute path. \
+         The session working directory must be absolute so agents can resolve \
+         workspace files without searching $HOME."
+    )]
+    NotAbsolute(String),
+
+    #[error("{AGENT_CWD_ENV} is set to `{0}`, which is not an existing directory")]
+    NotADirectory(String),
+
+    #[error(
+        "cannot determine the session working directory: {AGENT_CWD_ENV} is unset \
+         and the current directory is unavailable ({0})"
+    )]
+    Undeterminable(String),
+}
+
+/// Resolve the value buzz-acp passes as `NewSessionRequest.cwd`.
+///
+/// Implements the order the persona pack spec already documents:
+///
+/// 1. `AGENT_CWD`, when set.
+/// 2. `std::env::current_dir()` as a fallback.
+/// 3. Otherwise refuse to start.
+///
+/// An `AGENT_CWD` that is set but unusable is an error rather than a silent
+/// fall-through to step 2: an operator who pinned a workspace and got the
+/// process directory instead would only notice once an agent answered without
+/// the repository's instructions loaded.
+///
+/// `current_dir` and `is_dir` are injected so the resolution order is testable
+/// without mutating process-global state.
+pub fn resolve_agent_cwd_with(
+    env_value: Option<String>,
+    current_dir: Result<PathBuf, std::io::Error>,
+    is_dir: impl Fn(&Path) -> bool,
+) -> Result<String, AgentCwdError> {
+    if let Some(raw) = env_value {
+        let trimmed = raw.trim();
+        // An empty or whitespace-only value reads as "unset" in every shell
+        // idiom that builds it (`AGENT_CWD=${WORKSPACE}`), so fall through.
+        if !trimmed.is_empty() {
+            let path = Path::new(trimmed);
+            if !path.is_absolute() {
+                return Err(AgentCwdError::NotAbsolute(trimmed.to_string()));
+            }
+            if !is_dir(path) {
+                return Err(AgentCwdError::NotADirectory(trimmed.to_string()));
+            }
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    current_dir
+        .map(|path| path.to_string_lossy().to_string())
+        .map_err(|err| AgentCwdError::Undeterminable(err.to_string()))
+}
+
+/// Process-level entry point for [`resolve_agent_cwd_with`].
+pub fn resolve_agent_cwd() -> Result<String, AgentCwdError> {
+    resolve_agent_cwd_with(
+        std::env::var(AGENT_CWD_ENV).ok(),
+        std::env::current_dir(),
+        |path| path.is_dir(),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
@@ -2952,5 +3026,104 @@ channels = "ALL"
             "Found secret-bearing env args without hide_env_values=true. \
              Add `hide_env_values = true` to each: {violations:?}"
         );
+    }
+
+    // ── $AGENT_CWD resolution ────────────────────────────────────────────────
+    //
+    // Pins the order documented in PERSONA_PACK_SPEC.md § `$AGENT_CWD`
+    // Definition. Resolution is injected rather than read from the process, so
+    // these run in parallel without fighting over the environment.
+
+    fn io_err() -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "no such directory")
+    }
+
+    #[test]
+    fn agent_cwd_env_wins_over_the_process_directory() {
+        let resolved = resolve_agent_cwd_with(
+            Some("/srv/workspaces/api".to_string()),
+            Ok(PathBuf::from("/opt/buzz")),
+            |_| true,
+        );
+        assert_eq!(resolved, Ok("/srv/workspaces/api".to_string()));
+    }
+
+    #[test]
+    fn agent_cwd_falls_back_to_the_process_directory_when_unset() {
+        let resolved = resolve_agent_cwd_with(None, Ok(PathBuf::from("/opt/buzz")), |_| true);
+        assert_eq!(resolved, Ok("/opt/buzz".to_string()));
+    }
+
+    #[test]
+    fn agent_cwd_treats_a_blank_value_as_unset() {
+        // `AGENT_CWD=${WORKSPACE}` with an unset WORKSPACE expands to "", which
+        // every shell idiom means as "I did not set this".
+        for blank in ["", "   ", "\t\n"] {
+            let resolved = resolve_agent_cwd_with(
+                Some(blank.to_string()),
+                Ok(PathBuf::from("/opt/buzz")),
+                |_| true,
+            );
+            assert_eq!(resolved, Ok("/opt/buzz".to_string()), "blank: {blank:?}");
+        }
+    }
+
+    #[test]
+    fn agent_cwd_is_trimmed() {
+        let resolved = resolve_agent_cwd_with(
+            Some("  /srv/workspaces/api\n".to_string()),
+            Ok(PathBuf::from("/opt/buzz")),
+            |_| true,
+        );
+        assert_eq!(resolved, Ok("/srv/workspaces/api".to_string()));
+    }
+
+    #[test]
+    fn relative_agent_cwd_is_rejected_instead_of_falling_back() {
+        // Falling back here would hand the agent the process directory while the
+        // operator believes the workspace is pinned — the silent failure this
+        // resolution order exists to prevent.
+        let resolved = resolve_agent_cwd_with(
+            Some("workspaces/api".to_string()),
+            Ok(PathBuf::from("/opt/buzz")),
+            |_| true,
+        );
+        assert_eq!(
+            resolved,
+            Err(AgentCwdError::NotAbsolute("workspaces/api".to_string()))
+        );
+    }
+
+    #[test]
+    fn missing_agent_cwd_directory_is_rejected() {
+        let resolved = resolve_agent_cwd_with(
+            Some("/srv/workspaces/typo".to_string()),
+            Ok(PathBuf::from("/opt/buzz")),
+            |_| false,
+        );
+        assert_eq!(
+            resolved,
+            Err(AgentCwdError::NotADirectory(
+                "/srv/workspaces/typo".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn unset_agent_cwd_and_unavailable_process_directory_refuses_to_start() {
+        let resolved = resolve_agent_cwd_with(None, Err(io_err()), |_| true);
+        assert!(
+            matches!(resolved, Err(AgentCwdError::Undeterminable(_))),
+            "expected refusal, got {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn agent_cwd_never_silently_resolves_to_the_root_fallback() {
+        // The previous `unwrap_or_else(|_| PathBuf::from("/"))` produced a cwd of
+        // "/", which `workspace_section` drops — leaving protocol-v1 harnesses
+        // (#3148) to scan the whole filesystem. Refusing to start replaces it.
+        let resolved = resolve_agent_cwd_with(None, Err(io_err()), |_| true);
+        assert_ne!(resolved, Ok("/".to_string()));
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1345,6 +1345,12 @@ async fn tokio_main() -> Result<()> {
         return setup_mode::run_setup_listener(config, payload).await;
     }
 
+    // Resolved after the setup branch on purpose: setup mode never opens a
+    // session, so a workspace typo must not block an operator from fixing the
+    // credentials that put the agent in setup mode to begin with.
+    let agent_cwd = config::resolve_agent_cwd().map_err(|e| anyhow::anyhow!("{e}"))?;
+    tracing::info!("buzz-acp session working directory: {agent_cwd}");
+
     tracing::info!("buzz-acp starting: {}", config.summary());
 
     let observer = config
@@ -1596,10 +1602,7 @@ async fn tokio_main() -> Result<()> {
             Some(include_str!("base_prompt.md"))
         },
         heartbeat_prompt: config.heartbeat_prompt.clone(),
-        cwd: std::env::current_dir()
-            .unwrap_or_else(|_| std::path::PathBuf::from("/"))
-            .to_string_lossy()
-            .to_string(),
+        cwd: agent_cwd,
         rest_client: relay.rest_client(),
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,
@@ -4145,10 +4148,9 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
     use acp::{extract_model_config_options, extract_model_state};
 
     let agent_args = config::normalize_agent_args(&args.agent.agent_command, args.agent.agent_args);
-    let cwd = std::env::current_dir()
-        .unwrap_or_else(|_| std::path::PathBuf::from("/"))
-        .to_string_lossy()
-        .to_string();
+    // Same resolution as the long-running path, so `models` probes the agent in
+    // the workspace the operator pinned rather than wherever the CLI was run.
+    let cwd = config::resolve_agent_cwd().map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // Spawn outside the timeout so we always own the child for cleanup.
     // `models` subcommand doesn't use persona packs — no extra env, no codex config.


### PR DESCRIPTION
Implements the `$AGENT_CWD` resolution order that `crates/buzz-persona/PERSONA_PACK_SPEC.md` already specifies. Refs #3822.

## The gap

The spec, § `$AGENT_CWD` Definition:

> However, operators can control this value by setting the `AGENT_CWD` environment variable on the buzz-acp process. buzz-acp determines what value to pass as `NewSessionRequest.cwd` in this order:
> 1. The `AGENT_CWD` environment variable on the buzz-acp process, if set.
> 2. `std::env::current_dir()` as a fallback.
> 3. If both fail, buzz-acp logs an error and **refuses to start**.

Before this change, `grep -rn "AGENT_CWD" --include="*.rs"` returned **zero hits** across the repo — the identifier existed only in that markdown file. Only step 2 was implemented. An operator who followed the spec to point a supervised runtime at a workspace got the process directory instead, with no warning.

That matters because the session cwd is where the agent runtime resolves `AGENTS.md`/`CLAUDE.md`, `.claude/skills`, hooks and settings at bootstrap. An agent given the wrong cwd can still *read* files elsewhere, but it starts without any of the target repository's instructions — the user ends up re-explaining in chat what the repo already documents.

## What changed

- `config.rs` — `resolve_agent_cwd()` plus a pure, injectable `resolve_agent_cwd_with()` and an `AgentCwdError` enum.
- `lib.rs` — both call sites that resolved the session cwd now use it: the long-running `PromptContext` and the `models` subcommand.
- `README.md` — documents `AGENT_CWD` in the Core table.

Two judgement calls worth reviewing:

**A set-but-unusable `AGENT_CWD` is an error, not a fall-through to step 2.** Falling back would hand the agent the process directory while the operator believes the workspace is pinned — exactly the silent failure this order exists to prevent, and what #3822 and its commenters ask to avoid. A blank value *does* still read as unset, since `AGENT_CWD=${WORKSPACE}` with an unset `WORKSPACE` expands to `""` in every shell idiom that builds it.

**Step 3 replaces `unwrap_or_else(|_| PathBuf::from("/"))`.** A cwd of `"/"` is dropped by `workspace_section()`, so protocol-v1 harnesses lost the absolute-cwd anchor entirely and scanned from the filesystem root — the behavior reported in #3148. Refusing to start surfaces the condition instead of degrading into a full-disk ripgrep. This is the only behavior change for existing deployments, and it only triggers when `current_dir()` itself fails, which previously produced a broken session anyway.

## Scope

Resolution stays at the `session/new` boundary. The child process working directory is untouched, so the multiplexed pool (one subprocess holding `channel_id → session_id`) is unchanged and this does **not** introduce the per-channel process growth documented in #2961.

Per-channel workspaces remain the open design question in #3822. This lands the env-var form the spec already promises, which is a strict prerequisite for it: the channel-scoped version is then a matter of making the resolved value a per-channel lookup at the same call site, where `PromptSource::Channel(channel_id)` is already in scope.

## Testing

8 unit tests pin the resolution order — env wins, fallback, blank-as-unset, trimming, relative rejected, missing directory rejected, both-unavailable refuses, and a guard that the `"/"` fallback cannot come back. `current_dir` and the directory check are injected, so they run in parallel without mutating process-global state.

Verified against the built binary:

```
$ AGENT_CWD=workspaces/api buzz-acp models --agent-command /bin/false
Error: AGENT_CWD is set to `workspaces/api`, which is not an absolute path. The session
working directory must be absolute so agents can resolve workspace files without searching $HOME.

$ AGENT_CWD=/srv/typo buzz-acp models --agent-command /bin/false
Error: AGENT_CWD is set to `/srv/typo`, which is not an existing directory

$ AGENT_CWD=/tmp buzz-acp models --agent-command /bin/false
error: failed to spawn agent: ...    # cwd accepted, proceeds to spawn
```

`cargo test -p buzz-acp --lib` → 676 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

Note for reviewers: the existing `framed_system_prompt` tests already take `cwd` as a parameter, so no existing test needed changing — contrary to what I guessed when I first sketched the patch surface in #3822.

I can follow up with the channel-scoped map in a second PR if maintainers indicate the preferred configuration transport (env map, config file, or session-routing API).
