### PR TITLE
test(mobile): assert follow boundary semantics

### DIFF
--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -1294,7 +1294,20 @@ void main() {
         ]);
         await tester.pumpAndSettle();
 
-        expect(findRichText('Newest live update'), findsNothing);
+        // Cache-extent mounting varies by platform, so assert the reversed
+        // list's semantic boundary rather than whether item 0 is mounted.
+        final positions = tester
+            .widget<ScrollablePositionedList>(messageList)
+            .itemPositionsNotifier!
+            .itemPositions
+            .value;
+        expect(
+          positions.any(
+            (position) =>
+                position.index == 0 && position.itemLeadingEdge.abs() < 0.01,
+          ),
+          isFalse,
+        );
         expect(
           find.byKey(const ValueKey('channel-jump-to-latest')),
           findsOneWidget,


### PR DESCRIPTION
## Summary

- replace a platform-dependent mounted-`RichText` assertion with the production follow-mode boundary predicate
- retain the jump-to-latest assertion as the visible consequence of follow mode remaining off
- leave production behavior and desktop PR #4549 unchanged

## Why

`ScrollablePositionedList` may keep an offscreen item mounted within cache extent on macOS while Linux does not. Mounting therefore does not establish whether reversed-list item 0 is at the latest boundary. The replacement reads the list's public `itemPositionsNotifier` and applies the same `index == 0 && abs(itemLeadingEdge) < 0.01` contract used by `message_list.dart`.

## Validation

At commit `bc88617e61d8e9edf8fea832baa8d918163ee212` on macOS with repo Flutter 3.41.7:

- `cd mobile && ../bin/flutter test` — 1088 passed, 1 skipped
- `cd mobile && ../bin/flutter analyze` — no issues
- pre-push `mobile-test` and `branch-skew` hooks — passed
