### PR TITLE
fix(acp): trigger agents for untagged DMs

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -1,6 +1,6 @@
 # buzz-acp
 
-ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and the agent replies using the Buzz CLI.
+ACP harness that connects AI agents to Buzz. The harness listens for @mentions in shared channels and messages in private DMs, prompts your agent, and the agent replies using the Buzz CLI.
 
 ```
 Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
@@ -62,7 +62,7 @@ export GOOSE_MODE=auto
 buzz-acp
 ```
 
-That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent, goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
+That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent in a shared channel—or sends it a private DM—goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
 
 ## Running with Codex
 
@@ -246,20 +246,20 @@ Forum event kinds:
 - **45002** — Vote on a post or comment
 - **45003** — Comment reply on a forum post
 
-> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
+> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters shared-channel events that don't @mention the agent — forum posts will be invisible. Private DMs are the exception because every DM is already addressed to its participants.
 
 ## How It Works
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
+3. **Event loop** — Listens for @mentions in shared channels and messages in private DMs. Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
 
-> **Note:** On startup, the harness replays all unprocessed @mentions since the last run. Expect a burst of activity if there are stale events in the channel.
+> **Note:** On startup, the harness replays all unprocessed triggering events since the last run. Expect a burst of activity if there are stale events in a subscribed channel or DM.
 
 ## Bring Your Own Harness (BYOH)
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1243,6 +1243,27 @@ pub fn resolve_channel_filters(
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
+    resolve_channel_filters_with_implicit_mentions(
+        config,
+        discovered_channels,
+        rules,
+        &HashSet::new(),
+    )
+}
+
+/// Resolve per-channel filters while treating selected channels as already
+/// addressed to the agent.
+///
+/// Channels in `implicitly_addressed_channels` do not require a recipient
+/// `p` tag in mentions mode. Callers use this for DMs, where every message is
+/// already directed to the participants. Explicit config-mode rules retain
+/// their configured `require_mention` behavior.
+pub fn resolve_channel_filters_with_implicit_mentions(
+    config: &Config,
+    discovered_channels: &[Uuid],
+    rules: &[SubscriptionRule],
+    implicitly_addressed_channels: &HashSet<Uuid>,
+) -> HashMap<Uuid, ChannelFilter> {
     use buzz_core::kind::{
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
@@ -1268,13 +1289,13 @@ pub fn resolve_channel_filters(
                     KIND_STREAM_REMINDER,
                 ]
             });
-            let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
                     *ch,
                     ChannelFilter {
                         kinds: Some(kinds.clone()),
-                        require_mention,
+                        require_mention: !config.no_mention_filter
+                            && !implicitly_addressed_channels.contains(ch),
                     },
                 );
             }
@@ -1331,7 +1352,7 @@ pub fn resolve_channel_filters(
     result
 }
 
-/// Resolve the subscription filter for a single dynamically-discovered channel.
+/// Resolve a dynamic channel filter with optional implicit addressing.
 ///
 /// In Mentions/All mode, `channels_override` (--channels) is enforced — the agent
 /// won't subscribe to channels outside the operator's allowlist. In Config mode,
@@ -1340,10 +1361,14 @@ pub fn resolve_channel_filters(
 /// Returns `None` when the channel is outside the agent's configured scope:
 /// - Mentions/All: channel not in `channels_override` (if set)
 /// - Config: no subscription rules match the channel
-pub fn resolve_dynamic_channel_filter(
+///
+/// `mention_is_implicit` only affects mentions mode. Config mode continues to
+/// honor each rule's explicit `require_mention` setting.
+pub fn resolve_dynamic_channel_filter_with_implicit_mention(
     config: &Config,
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
+    mention_is_implicit: bool,
 ) -> Option<ChannelFilter> {
     use buzz_core::kind::{
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
@@ -1373,7 +1398,7 @@ pub fn resolve_dynamic_channel_filter(
                     KIND_STREAM_REMINDER,
                 ]
             })),
-            require_mention: !config.no_mention_filter,
+            require_mention: !config.no_mention_filter && !mention_is_implicit,
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
@@ -1522,6 +1547,38 @@ mod tests {
     }
 
     #[test]
+    fn test_mentions_mode_treats_dm_messages_as_implicitly_addressed() {
+        let config = test_config(SubscribeMode::Mentions);
+        let dm = Uuid::new_v4();
+        let discovered = crate::relay::merge_discovered_channels(
+            vec![dm],
+            &serde_json::json!([{
+                "tags": [["d", dm.to_string()], ["name", "DM"], ["t", "dm"]]
+            }]),
+        );
+        let channel_ids: Vec<Uuid> = discovered.keys().copied().collect();
+
+        let implicitly_addressed_channels: HashSet<Uuid> = discovered
+            .iter()
+            .filter_map(|(channel_id, info)| (info.channel_type == "dm").then_some(*channel_id))
+            .collect();
+        let result = resolve_channel_filters_with_implicit_mentions(
+            &config,
+            &channel_ids,
+            &[],
+            &implicitly_addressed_channels,
+        );
+
+        assert!(
+            !result
+                .get(&dm)
+                .expect("DM should be subscribed")
+                .require_mention,
+            "a message in a private DM is already addressed to the agent"
+        );
+    }
+
+    #[test]
     fn test_mentions_mode_custom_kinds() {
         let mut config = test_config(SubscribeMode::Mentions);
         config.kinds_override = Some(vec![1, 7]);
@@ -1541,6 +1598,22 @@ mod tests {
 
         let f = result.get(&channels[0]).unwrap();
         assert!(!f.require_mention);
+    }
+
+    #[test]
+    fn test_dynamic_mentions_mode_only_skips_mention_for_implicit_channels() {
+        let config = test_config(SubscribeMode::Mentions);
+        let channel = Uuid::new_v4();
+
+        let dm_filter =
+            resolve_dynamic_channel_filter_with_implicit_mention(&config, channel, &[], true)
+                .expect("DM should be subscribed");
+        assert!(!dm_filter.require_mention);
+
+        let stream_filter =
+            resolve_dynamic_channel_filter_with_implicit_mention(&config, channel, &[], false)
+                .expect("stream should be subscribed");
+        assert!(stream_filter.require_mention);
     }
 
     #[test]
@@ -1831,6 +1904,31 @@ mod tests {
         let f = result.get(&ch).unwrap();
         assert_eq!(f.kinds.as_ref().unwrap(), &[9]);
         assert!(!f.require_mention);
+    }
+
+    #[test]
+    fn test_config_mode_preserves_explicit_mention_rule_for_dm() {
+        let config = test_config(SubscribeMode::Config);
+        let dm = Uuid::new_v4();
+        let rules = vec![make_rule(
+            "explicit-dm-mention",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+        )];
+
+        let filters = resolve_channel_filters_with_implicit_mentions(
+            &config,
+            &[dm],
+            &rules,
+            &HashSet::from([dm]),
+        );
+        assert!(filters.get(&dm).unwrap().require_mention);
+
+        let dynamic =
+            resolve_dynamic_channel_filter_with_implicit_mention(&config, dm, &rules, true)
+                .expect("config rule should subscribe the DM");
+        assert!(dynamic.require_mention);
     }
 
     #[test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -340,6 +340,17 @@ fn build_eval_context(ctx: &FilterContext) -> Result<evalexpr::HashMapContext, S
 /// a pathological expression from silently widening the subscription.
 const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 
+/// Match an event against subscription rules with normal explicit-mention
+/// semantics.
+pub async fn match_event(
+    event: &nostr::Event,
+    channel_id: uuid::Uuid,
+    rules: &[SubscriptionRule],
+    agent_pubkey_hex: &str,
+) -> Option<MatchedRule> {
+    match_event_with_implicit_mention(event, channel_id, rules, agent_pubkey_hex, false).await
+}
+
 /// Match a Nostr event against an ordered list of subscription rules.
 ///
 /// Rules are evaluated in order; the first rule whose conditions all pass
@@ -350,8 +361,8 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 /// 1. **channels** — if not `"all"`, the event's channel UUID must be in the list.
 /// 2. **kinds** — if non-empty, the event kind must be in the list.
 /// 3. **require_mention** — if `true`, a `p` tag matching `agent_pubkey_hex` must
-///    exist. Tag kind is checked via `tag.as_slice()` for stable, library-independent
-///    access.
+///    exist unless `mention_is_implicit` is true (for example, in a DM). Tag
+///    kind is checked via `tag.as_slice()` for stable, library-independent access.
 /// 4. **filter** — if `Some`, the evalexpr expression must evaluate to `true`.
 ///
 /// # Fail-closed filter error handling
@@ -365,11 +376,12 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 /// After [`MAX_CONSECUTIVE_TIMEOUTS`] consecutive timeouts on a single rule,
 /// that rule is logged at ERROR and the call returns `None` immediately to
 /// avoid blocking the event loop indefinitely.
-pub async fn match_event(
+pub async fn match_event_with_implicit_mention(
     event: &nostr::Event,
     channel_id: uuid::Uuid,
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
+    mention_is_implicit: bool,
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
@@ -387,7 +399,7 @@ pub async fn match_event(
         // 3. Mention check — look for a `p` tag whose first element equals
         //    agent_pubkey_hex. Uses tag.as_slice() for stable, library-independent
         //    access — avoids relying on the Display impl of tag kind.
-        if rule.require_mention {
+        if rule.require_mention && !mention_is_implicit {
             let mentioned = event.tags.iter().any(|tag| {
                 let s = tag.as_slice();
                 s.first().map(|k| k.as_str()) == Some("p")
@@ -660,6 +672,19 @@ mod tests {
         let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey)
             .await
             .unwrap();
+        assert_eq!(matched.prompt_tag, "mentioned");
+
+        // A private DM is already addressed to its recipient, so callers can
+        // satisfy the mention requirement without a redundant p-tag.
+        let matched = match_event_with_implicit_mention(
+            &event_no_mention,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            true,
+        )
+        .await
+        .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1486,6 +1486,12 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let implicitly_addressed_channels: HashSet<Uuid> = channel_info_map
+        .iter()
+        .filter_map(|(channel_id, info)| {
+            matches!(info.channel_type.as_str(), "dm" | "unknown").then_some(*channel_id)
+        })
+        .collect();
 
     let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
@@ -1524,7 +1530,12 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters = config::resolve_channel_filters_with_implicit_mentions(
+        &config,
+        &channel_ids,
+        &rules,
+        &implicitly_addressed_channels,
+    );
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -2038,15 +2049,26 @@ async fn tokio_main() -> Result<()> {
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
-                                        if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
-                                            tracing::warn!("failed to subscribe to new channel {ch}: {e}");
-                                        } else {
-                                            subscribed_channel_ids.insert(ch);
-                                        }
                                     } else {
-                                        tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        let mention_is_implicit = matches!(
+                                            config.subscribe_mode,
+                                            SubscribeMode::Mentions
+                                        ) && is_dm_channel(ch, &ctx.channel_info).await;
+                                        if let Some(filter) = config::resolve_dynamic_channel_filter_with_implicit_mention(
+                                            &config,
+                                            ch,
+                                            &rules,
+                                            mention_is_implicit,
+                                        ) {
+                                            tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
+                                            if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
+                                                tracing::warn!("failed to subscribe to new channel {ch}: {e}");
+                                            } else {
+                                                subscribed_channel_ids.insert(ch);
+                                            }
+                                        } else {
+                                            tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        }
                                     }
                                 } else {
                                     subscribed_channel_ids.remove(&ch);
@@ -2214,13 +2236,13 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2242,8 +2264,18 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            let mention_is_implicit =
+                                is_dm && matches!(config.subscribe_mode, SubscribeMode::Mentions);
+                            let matched = filter::match_event_with_implicit_mention(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                                &rules,
+                                &pubkey_hex,
+                                mention_is_implicit,
+                            )
+                            .await;
                             let prompt_tag = match matched {
+                                Some(_) if mention_is_implicit => "dm".to_string(),
                                 Some(m) => m.prompt_tag,
                                 None => {
                                     tracing::debug!(channel_id = %buzz_event.channel_id, kind = buzz_event.event.kind.as_u16(), "event matched no rule — dropping");


### PR DESCRIPTION
## Summary

- treat messages in private DMs as implicitly addressed when buzz-acp runs in its default mentions mode
- keep shared channels tag-gated and preserve explicit require_mention rules in config mode
- handle both startup discovery and dynamically joined DMs, and label DM prompts accurately

## Why

The default mentions subscription required an agent p tag in every channel. In a private DM that made the human send a redundant explicit tag before the harness would trigger, even though the message was already addressed to the DM participant.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p buzz-acp --all-targets -- -D warnings
- cargo test -p buzz-acp (671 unit tests and 9 integration tests passed)
- git diff --check
- just ci: workspace clippy completed; desktop-check could not start because the repository Hermit manifest cannot resolve pnpm-11.4.0 (no source provided)

## Security boundary

DM author admission is unchanged: the existing DM author gate still limits triggering authors to the owner and sibling agents. Shared-channel subscription behavior is unchanged.
