### PR TITLE
fix(relay): scope multi-channel #h queries to all listed channels

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -847,19 +847,38 @@ fn filters_are_nip43_membership_only(filters: &[Filter]) -> bool {
         })
 }
 
-/// Extract a channel UUID from a single filter's `#h` tag.
+/// Extract the channel UUID from a single filter's `#h` tag, or `None` unless
+/// the filter is scoped to exactly one channel.
+///
+/// Mirrors [`extract_channel_id_from_filters`]: a filter naming multiple
+/// distinct channels has no single `channel_id` predicate. Taking the first
+/// value instead would silently narrow the query — `nostr::Filter` stores tag
+/// values in a sorted set, so "first" is the lexicographically smallest
+/// channel id and every other listed channel would be dropped before `LIMIT`.
+/// Multi-channel filters are pushed down as an `EventQuery::channel_ids`
+/// IN-list in [`filter_to_query_params`] instead.
 fn extract_channel_id_from_filter(filter: &Filter) -> Option<uuid::Uuid> {
-    for (tag_key, tag_values) in filter.generic_tags.iter() {
-        let key = tag_key.to_string();
-        if key == "h" {
-            for val in tag_values {
-                if let Ok(id) = val.parse::<uuid::Uuid>() {
-                    return Some(id);
-                }
-            }
-        }
+    match channel_ids_in_filter(filter).as_slice() {
+        [only] => Some(*only),
+        _ => None,
     }
-    None
+}
+
+/// All distinct parseable channel UUIDs in a single filter's `#h` values, in
+/// the set's (sorted) order. Empty when the filter carries no `#h` tag or no
+/// value parses as a UUID.
+fn channel_ids_in_filter(filter: &Filter) -> Vec<uuid::Uuid> {
+    let h_tag = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
+    filter
+        .generic_tags
+        .get(&h_tag)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|v| v.parse::<uuid::Uuid>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Convert a single NIP-01 filter into an [`EventQuery`] for the database.
@@ -978,8 +997,25 @@ fn filter_to_query_params(
         (None, None)
     };
 
+    // Multi-channel `#h` pushdown: a filter naming several channels has no
+    // single `channel_id` predicate (the extractor returns `None` for it), so
+    // push the whole set as a `channel_ids` IN-list. Without this, the query
+    // falls back to the caller's full access scope and busy unrelated channels
+    // can starve the requested channels' rows past `LIMIT` before the Rust
+    // post-filter runs. `apply_access_scope_to_query` intersects this list
+    // with the caller's accessible channels, so it never widens access.
+    let channel_ids = if channel_id.is_none() {
+        match channel_ids_in_filter(filter).as_slice() {
+            [] | [_] => None,
+            many => Some(many.to_vec()),
+        }
+    } else {
+        None
+    };
+
     EventQuery {
         channel_id,
+        channel_ids,
         kinds,
         pubkey,
         since,
@@ -998,14 +1034,26 @@ fn filter_to_query_params(
 /// Push the caller's authorized channel set into logically global historical
 /// queries so SQL `LIMIT` counts visible rows. Channel-less events remain in
 /// scope by `EventQuery::channel_ids` contract; an explicit single-channel
-/// filter keeps its narrower `channel_id` predicate.
+/// filter keeps its narrower `channel_id` predicate, and an explicit
+/// multi-channel filter keeps its `channel_ids` IN-list intersected with the
+/// access scope.
 pub(crate) fn apply_access_scope_to_query(
     query: &mut EventQuery,
     channel_id: Option<uuid::Uuid>,
     accessible_channels: &[uuid::Uuid],
 ) {
     if channel_id.is_none() {
-        query.channel_ids = Some(accessible_channels.to_vec());
+        query.channel_ids = Some(match query.channel_ids.take() {
+            // Multi-`#h` filter: keep only the requested channels the caller
+            // can access. An empty intersection stays `Some(vec![])` — the SQL
+            // layer treats that as "global events only" (fail closed), never
+            // as "no restriction".
+            Some(requested) => requested
+                .into_iter()
+                .filter(|ch| accessible_channels.contains(ch))
+                .collect(),
+            None => accessible_channels.to_vec(),
+        });
     }
 }
 
@@ -1577,6 +1625,97 @@ mod tests {
             filter_with_channel(channel_id),
         ];
         assert_eq!(extract_channel_id_from_filters(&filters), Some(channel_id));
+    }
+
+    /// Two UUIDs with a guaranteed lexicographic order, so tests can pin that
+    /// the sorted-set iteration order no longer decides the query scope.
+    fn ordered_channel_pair() -> (uuid::Uuid, uuid::Uuid) {
+        let first: uuid::Uuid = "00000000-0000-4000-8000-000000000001".parse().unwrap();
+        let last: uuid::Uuid = "ffffffff-ffff-4fff-bfff-fffffffffffe".parse().unwrap();
+        (first, last)
+    }
+
+    fn filter_with_channels(a: uuid::Uuid, b: uuid::Uuid) -> Filter {
+        Filter::new()
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::H), a.to_string())
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::H), b.to_string())
+    }
+
+    #[test]
+    fn single_filter_single_channel_extracts() {
+        let channel_id = uuid::Uuid::new_v4();
+        assert_eq!(
+            extract_channel_id_from_filter(&filter_with_channel(channel_id)),
+            Some(channel_id)
+        );
+    }
+
+    #[test]
+    fn single_filter_multi_channel_does_not_narrow_to_first() {
+        // Regression: this used to return the lexicographically smallest id,
+        // silently dropping every other listed channel from the SQL scope.
+        let (first, last) = ordered_channel_pair();
+        assert_eq!(
+            extract_channel_id_from_filter(&filter_with_channels(first, last)),
+            None
+        );
+        assert_eq!(
+            extract_channel_id_from_filter(&filter_with_channels(last, first)),
+            None
+        );
+    }
+
+    #[test]
+    fn multi_channel_filter_pushes_channel_ids_in_list() {
+        let (first, last) = ordered_channel_pair();
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+        let filter = filter_with_channels(first, last);
+        let query = filter_to_query_params(&filter, None, community);
+        assert_eq!(query.channel_id, None);
+        let ids = query.channel_ids.expect("multi-#h must push channel_ids");
+        assert!(ids.contains(&first) && ids.contains(&last));
+    }
+
+    #[test]
+    fn single_channel_filter_keeps_channel_id_predicate() {
+        let channel_id = uuid::Uuid::new_v4();
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+        let filter = filter_with_channel(channel_id);
+        let query = filter_to_query_params(&filter, Some(channel_id), community);
+        assert_eq!(query.channel_id, Some(channel_id));
+        assert_eq!(query.channel_ids, None);
+    }
+
+    #[test]
+    fn access_scope_intersects_multi_channel_filter() {
+        // The Desktop Workflows regression shape: a channel that sorts BEFORE
+        // the target (e.g. a DM) must not evict the target from the scope.
+        let (dm, apiary) = ordered_channel_pair();
+        let other = uuid::Uuid::new_v4();
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+        let filter = filter_with_channels(dm, apiary);
+        let mut query = filter_to_query_params(&filter, None, community);
+
+        apply_access_scope_to_query(&mut query, None, &[dm, apiary, other]);
+
+        let ids = query.channel_ids.expect("scope must remain channel-bound");
+        assert!(ids.contains(&apiary), "later-sorting channel must survive");
+        assert!(ids.contains(&dm));
+        assert!(!ids.contains(&other), "access scope must not widen the filter");
+    }
+
+    #[test]
+    fn access_scope_empty_intersection_fails_closed() {
+        let (a, b) = ordered_channel_pair();
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+        let filter = filter_with_channels(a, b);
+        let mut query = filter_to_query_params(&filter, None, community);
+
+        apply_access_scope_to_query(&mut query, None, &[uuid::Uuid::new_v4()]);
+
+        // Some(vec![]) = "global events only" in the SQL layer — never
+        // "no restriction".
+        assert_eq!(query.channel_ids, Some(Vec::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A `/query` or COUNT filter naming multiple channels — e.g.
`{"kinds":[30620], "#h":[<id1>,<id2>,…]}` — is silently answered as if it
named only ONE channel: the lexicographically smallest id. Events in every
other listed channel are never returned, with no error surfaced.

`extract_channel_id_from_filter` returns the first parseable UUID from the
filter's `#h` values, and `nostr::Filter` stores tag values in a sorted set,
so "first" is deterministically the smallest id. `filter_to_query_params`
bakes that single id into the SQL scope, and the Rust post-filter afterwards
can only remove rows — it can never restore the channels the SQL already
dropped. The sibling `extract_channel_id_from_filters` (plural) already has
the right semantics: multiple distinct ids → `None` → global scope.

**User-visible impact:** Buzz Desktop's Workflows screen sends exactly this
shape — one batched kind:30620 query with every member channel in `#h`
(`WorkflowsView.tsx` → `get_channels_workflows`). For any user whose
alphabetically-first channel is a DM (typical), the screen shows
"No workflows yet" even when workflows exist and run. Reproduced empirically
on a production relay with NIP-98-signed queries:

| `#h` values | Result |
| --- | --- |
| [apiary] | 2 workflow events |
| [dm-sorting-before-apiary, apiary] | 0 events |
| [dm-sorting-after-apiary, apiary] | 2 events |

### The fix

- `extract_channel_id_from_filter` now returns `Some` only when the filter
  names exactly one parseable channel id, matching the plural helper's
  semantics. (One benign divergence: the plural helper dedups case-variant
  spellings of the same id, while the singular counts elements and routes
  such filters down the multi-channel path — the IN-list then carries a
  harmless duplicate and results are identical.)
- `filter_to_query_params` pushes a multi-channel `#h` set down as an
  `EventQuery::channel_ids` IN-list, so the SQL page is scoped to the
  requested channels rather than the caller's entire access scope (busy
  unrelated channels can no longer starve the requested ones past `LIMIT`).
- `apply_access_scope_to_query` intersects a filter-supplied `channel_ids`
  list with the caller's accessible channels instead of overwriting it.
  An empty intersection stays `Some(vec![])`, which the SQL layer already
  treats as "global events only" — fail closed, never "no restriction".

The WS REQ path already used a correct inline exactly-one extractor with a
subscription-scope fallback; it now additionally benefits from the
`channel_ids` pushdown for single-filter multi-`#h` subscriptions. The
existing Rust post-filters (`filters_match` + accessible-channel check +
`event_visible_to_reader`) are unchanged and remain defense-in-depth.

### Possible follow-up (maintainer preference invited)

The COUNT fallback (`count.rs`) and the bridge query paths currently
overwrite a filter-supplied `channel_ids` pushdown with the caller's access
scope rather than intersecting the two. Correctness is unaffected —
`filter_fully_pushable` refuses multi-`#h` filters for fast COUNT and the
Rust post-filter computes exact results — but a multi-`#h` COUNT scans the
caller's entire accessible set and is likelier to hit the candidate budget,
surfacing an explicit "requires narrower constraints" error where the
pre-fix code returned a silently wrong count. Intersecting there (reusing
`apply_access_scope_to_query`) would make the scan narrower and cheaper;
it is kept out of this PR to keep the change minimal. Happy to fold it in
or file it separately, whichever the maintainers prefer.

### Related issue

Fixes #4579. A related-but-separate report on the workflow deletion path
(authorization inconsistency + ghost kind:30620 definition event observed
during the same investigation) is #4580 — not addressed by this PR.

### Testing

New unit tests in `handlers/req.rs`:

- `single_filter_multi_channel_does_not_narrow_to_first` — regression pin on
  the extractor, both insertion orders.
- `multi_channel_filter_pushes_channel_ids_in_list` /
  `single_channel_filter_keeps_channel_id_predicate` — query-builder shape.
- `access_scope_intersects_multi_channel_filter` — the Desktop Workflows
  regression shape: a channel sorting before the target must not evict it,
  and the access scope must not widen the filter.
- `access_scope_empty_intersection_fails_closed` — `Some(vec![])` preserved.

`cargo test -p buzz-relay --lib` (rust:1.95 container, no Postgres):
835 passed, 37 ignored, 9 failed — the 9 failures are DB-backed
`api::admin`/`api::media` tests (`Sqlx(PoolTimedOut)`) that fail identically
on unmodified `origin/main` `2c0ac246` in the same environment (baseline run
verified). Zero new failures introduced; all 6 new regression tests pass.
Independently re-verified by a second reviewer against the same commit,
including a fetch of current `origin/main` confirming no conflicting changes
to the touched files.

### Credits

Root cause isolated and reproduced with signed queries by the Buzz agents
operating the redirwin.com installation.
