### PR TITLE
fix(desktop): show shared relay agents in mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -106,7 +106,7 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
   );
 });
 
-test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents", () => {
+test("getMentionableAgentPubkeys: keeps managed agents and shared anyone agents", () => {
   const result = getMentionableAgentPubkeys({
     managedAgentPubkeys: [PUB_A],
     currentPubkey: CURRENT_PUBKEY,

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,6 +54,7 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+/** Used by the member-adder, which must not offer agents owned elsewhere. */
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -244,9 +243,6 @@ export function useMentions(
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
         return;
       }
       if (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -826,7 +826,7 @@ test("managed relay agents are visible in channel mentions regardless of relay p
   await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
-test("relay-only agents stay hidden from channel mentions even when allowlisted", async ({
+test("shared anyone relay agents are visible in channel mentions", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -834,8 +834,9 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
       {
         pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
         name: "quinn",
-        respondTo: "allowlist",
-        respondToAllowlist: [MOCK_VIEWER_PUBKEY],
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelNames: ["general"],
       },
     ],
   });
@@ -846,7 +847,9 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("quinn")).toBeVisible();
+  await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -852,6 +852,54 @@ test("shared anyone relay agents are visible in channel mentions", async ({
   await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
+test("allowlisted relay agents are visible to an allowlisted user", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        respondTo: "allowlist",
+        respondToAllowlist: [MOCK_VIEWER_PUBKEY],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@quinn");
+
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("quinn")).toBeVisible();
+  await expect(dropdown.getByText("agent")).toBeVisible();
+});
+
+test("non-allowlisted relay agents remain hidden from other users", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        respondTo: "allowlist",
+        respondToAllowlist: [TEST_IDENTITIES.outsider.pubkey],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@quinn");
+
+  await expect(autocomplete(page)).toHaveCount(0);
+});
+
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- preserve the owner-configured `Respond-to: Anyone` relay-agent policy in Desktop mention autocomplete
- remove the later local-managed-agent filter that incorrectly hid eligible remote agents
- cover both remote-agent access modes in browser tests

## Root cause

`getMentionableAgentPubkeys` correctly includes a remote relay agent that shares a channel and allows anyone. `useMentions` then applied `isAgentIdentityInManagedList`, which only accepts the current Desktop's local managed-agent records and discarded that candidate.

The local-ownership filter remains in the member-adder, where it prevents offering externally owned agents for management.

Fixes #2508.

## Access-policy coverage

- `anyone`: visible only when the agent shares an active channel with the user.
- `allowlist`: visible to an explicitly listed user; hidden from a user not on the list.

## Validation

- `pnpm --dir desktop typecheck`
- focused Playwright coverage for `anyone`, allowlisted, and non-allowlisted remote agents
- Full Desktop unit suite was run; the full browser suite was started but exceeds the interactive execution window.