### PR TITLE
fix(mobile): tolerate publisher clock skew in live channels

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -11,6 +11,12 @@ const _channelLiveEventKinds = [
   EventKind.channelThreadSummary,
 ];
 
+// Nostr event timestamps come from each publisher's device clock. Start the
+// live subscription with a bounded overlap so a slightly fast Android clock
+// cannot make replies from another device look "too old" to deliver. The
+// initial history sync and event-id merge below make replayed events harmless.
+const _liveSubscriptionClockSkewOverlapSeconds = 5 * 60;
+
 /// Provides the message list for a specific channel. Registers a live
 /// subscription first, then syncs history via the server-assembled channel
 /// window fast path, falling back to the legacy websocket history path when the
@@ -85,7 +91,9 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
             tags: {
               '#h': [channelId],
             },
-            since: _currentUnixSeconds(),
+            since:
+                _currentUnixSeconds() -
+                _liveSubscriptionClockSkewOverlapSeconds,
             limit: 200,
           ),
           _handleLiveEvent,

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -44,6 +44,14 @@ void main() {
         EventKind.channelThreadSummary,
       ]);
       expect(relaySession.liveFilters.single.tags['#h'], [_channelId]);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      expect(
+        relaySession.liveFilters.single.since,
+        inInclusiveRange(now - 305, now - 300),
+        reason:
+            'the live subscription must overlap history so publisher clock '
+            'skew cannot hide replies',
+      );
       expect(relaySession.liveFilters.single.limit, 200);
       expect(
         relaySession.queryFilters.first.kinds,


### PR DESCRIPTION
## Summary

- start the mobile channel live subscription with a five-minute history overlap
- prevent a fast device clock from excluding valid replies signed by another publisher
- keep replay safe through the existing event-ID deduplication and history merge
- add a focused regression assertion for the subscription boundary

## Problem

The mobile channel subscription previously used the device's exact current Unix timestamp as `since`. If the Android clock was ahead of the publisher, a valid remote reply could look older than the subscription boundary and never arrive live. Posting a local reply triggered an authoritative refetch, which made the apparently missing reply appear.

## Verification

- `flutter test test/features/channels/channel_messages_provider_test.dart` (15 tests passed)
- `dart format --output=none --set-exit-if-changed lib/features/channels/channel_messages_provider.dart test/features/channels/channel_messages_provider_test.dart`
- `flutter analyze lib/features/channels/channel_messages_provider.dart test/features/channels/channel_messages_provider_test.dart` (no issues)

## Scope

This changes only the live-subscription boundary. It does not attempt to solve causal ordering between publishers with different clocks.
