### PR TITLE
ci: run buzz-workflow and buzz-acp lib tests in the unit gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -307,6 +307,15 @@ test-unit:
         # because nothing in CI runs `cargo test --workspace` — workspace
         # membership alone buys clippy/check, not a single executed test.
         cargo nextest run -p buzz-backend-kubernetes
+        # Same reason as the block above: workspace membership buys clippy and
+        # check, not an executed test. buzz-workflow (schema, executor) and
+        # buzz-acp (queue, pool, subscriptions) were referenced by no cargo test
+        # or nextest invocation anywhere, so their lib tests compiled and never
+        # ran. Both are infra-free — the Postgres-backed cases are #[ignore]d,
+        # which nextest skips by default. buzz-relay is not added here: it needs
+        # Postgres and carries four non-#[ignore]d infra-dependent tests. See #3461.
+        cargo nextest run -p buzz-workflow --lib
+        cargo nextest run -p buzz-acp --lib
     else
         ./scripts/run-tests.sh unit
     fi


### PR DESCRIPTION
## Summary

`just test-unit` covers `buzz-core`, `buzz-auth`, `buzz-voice`, `buzz-cli`, `buzz-db --lib`, `buzz-conformance`, `buzz-push-gateway`, and `buzz-backend-kubernetes`. **`buzz-workflow` and `buzz-acp` are referenced by no `cargo test` or `nextest` invocation anywhere** in `.github/workflows/` or `scripts/run-tests.sh`. `buzz-acp` appears only in build and release contexts — the Justfile binary loops and `sprig.yml`.

This is exactly the condition the `buzz-backend-kubernetes` block immediately above already names:

> Enumerated explicitly because nothing in CI runs `cargo test --workspace` — workspace membership alone buys clippy/check, not a single executed test.

Both crates were enumerated nowhere, so `cargo clippy --workspace --all-targets` compiled their test targets while nothing executed them.

| Crate | Lib tests | Ran in CI before this PR |
|---|---|---|
| `buzz-workflow` | 154 | no |
| `buzz-acp` | 661 | no |

This is the same class of gap as #3461 (`buzz-relay`: 771 of 804 never execute). This PR does not address `buzz-relay` — see below.

## Why it matters

`buzz-acp` owns the agent concurrency model: per-channel queues with per-channel in-flight tracking (`queue.rs`), the fungible worker pool (`pool.rs`), and mention-filtered per-agent subscriptions (`relay.rs`). `buzz-workflow` owns the workflow schema and executor, including the `request_approval` definition-time validation that WF-08 work (#2377, #3327) touches.

Both are areas with active open bugs, which is consistent with neither having had a test gate.

## Verification

Both suites are infra-free and pass clean. Run on a fork, since fork PRs need maintainer approval before workflows execute:

```
Starting 154 tests across 1 binary (2 tests skipped)
Summary [0.306s] 154 tests run: 154 passed, 2 skipped

Starting 661 tests across 1 binary
Summary [13.080s] 661 tests run: 661 passed, 0 skipped
```

`buzz-acp` runs with 0 skipped — no `#[ignore]`d subset, no infra-gated early returns.

I could not run `just ci` locally (no working Rust toolchain on this machine), so local `fmt`/`clippy` were not run. The change is seven lines of Justfile and CI's own Rust Lint job covers it.

## Why `buzz-relay` is excluded

Deliberately out of scope, and it is why #3461 is not trivially fixable. `-p buzz-relay --lib` surfaces four tests that need Postgres but are **not** `#[ignore]d`:

```
api::admin::tests::feedback_attachment_rejects_unknown_feedback
api::admin::tests::report_detail_rejects_unknown_report
api::media::tests::media_get_auth_flag_off_allows_unauthenticated_read_until_sidecar_gate
api::media::tests::media_get_auth_flag_on_accepts_range_header_only_after_auth
```

Each hangs ~30s on a DB connection and then fails, and nextest's fail-fast then cancelled 628 of 840 remaining tests. Marking those four `#[ignore]` looks like the right first step for #3461, but it is a separate change against a different crate and I did not want to bundle it here.

## Note on method

I confirmed these tests were not merely passing-by-default before trusting the result: I added a test, watched CI go green, then inverted the assertion so it had to fail — CI stayed green, which is what surfaced the gap. Under nextest's default profile a test that never runs is indistinguishable from one that passes, so the green run alone proved nothing.

Context: I found this while evaluating the workflow and approval-gate layer, which is where my interest in the codebase is.
