### PR TITLE
fix(desktop): surface agent defaults validation errors

### DIFF
--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -37,6 +37,7 @@ import {
   AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
 } from "@/features/agents/ui/AgentConfigFields";
+import { agentDefaultsSaveErrorMessage } from "@/features/agents/ui/agentDefaultsSaveError";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 
@@ -230,7 +231,7 @@ export function AgentDefaultsEditor({
       }
     } catch (err) {
       setSaveState("error");
-      setSaveError(typeof err === "string" ? err : "Couldn't save.");
+      setSaveError(agentDefaultsSaveErrorMessage(err));
     } finally {
       onSavingChange?.(false);
     }

--- a/desktop/src/features/agents/ui/agentDefaultsSaveError.test.mjs
+++ b/desktop/src/features/agents/ui/agentDefaultsSaveError.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agentDefaultsSaveErrorMessage } from "./agentDefaultsSaveError.ts";
+
+test("agent defaults save preserves a normalized Tauri error message", () => {
+  const message =
+    "the following keys must be set via the structured provider/model fields, not as env vars: GOOSE_PROVIDER";
+
+  assert.equal(agentDefaultsSaveErrorMessage(new Error(message)), message);
+});
+
+test("agent defaults save preserves a legacy string rejection", () => {
+  assert.equal(
+    agentDefaultsSaveErrorMessage("provider is required"),
+    "provider is required",
+  );
+});
+
+test("agent defaults save falls back for blank or unknown failures", () => {
+  assert.equal(
+    agentDefaultsSaveErrorMessage(new Error("  ")),
+    "Couldn't save.",
+  );
+  assert.equal(
+    agentDefaultsSaveErrorMessage({ message: "ignored" }),
+    "Couldn't save.",
+  );
+});

--- a/desktop/src/features/agents/ui/agentDefaultsSaveError.ts
+++ b/desktop/src/features/agents/ui/agentDefaultsSaveError.ts
@@ -1,0 +1,12 @@
+const AGENT_DEFAULTS_SAVE_FALLBACK = "Couldn't save.";
+
+/** Preserve actionable backend validation copy across the Tauri error boundary. */
+export function agentDefaultsSaveErrorMessage(error: unknown): string {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return message.trim() || AGENT_DEFAULTS_SAVE_FALLBACK;
+}

--- a/desktop/src/shared/api/tauriGlobalAgentConfig.ts
+++ b/desktop/src/shared/api/tauriGlobalAgentConfig.ts
@@ -20,7 +20,7 @@ export async function getGlobalAgentConfig(): Promise<GlobalAgentConfig> {
  * shape and reserved-key rules, restarts running local agents whose effective
  * env changed, and returns the saved config with a restart count.
  *
- * Throws a string error message on validation failure.
+ * Throws an Error containing the backend message on validation failure.
  */
 export async function setGlobalAgentConfig(
   config: GlobalAgentConfig,


### PR DESCRIPTION
## Summary

- show the backend validation reason when saving Agent defaults instead of replacing it with a generic error
- preserve the existing fallback for blank or unexpected failures
- document the normalized Tauri error contract and add focused regression coverage

This only changes error presentation. Agent configuration modeling, validation, and persistence rules are unchanged.

Closes #4568

## Testing

- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/ui/agentDefaultsSaveError.test.mjs` — 3 passed
- focused Biome check on the four changed files — passed
- `pnpm typecheck` — passed
- `just ci` — passed