### PR TITLE
fix(desktop): include external channel agents in mentions

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -243,12 +243,12 @@ export function useMentions(
 
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
-      if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
+      if (isArchivedDiscovery(pubkey)) return;
+      const isManaged = isAgentIdentityInManagedList(
+        candidate,
+        managedAgentPubkeys,
+      );
+      if (candidate.isMember !== true && !isManaged) return;
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -187,7 +187,7 @@ async function expectAgentProfileActionsHidden(
   ).toHaveCount(0);
 }
 
-test("@ trigger prioritizes channel members before runnable personas and other managed agents", async ({
+test("@ trigger includes external channel agents and prioritizes members before runnable personas and managed agents", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -209,7 +209,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -226,6 +226,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
+  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
     text.includes("charlie"),
@@ -234,9 +235,11 @@ test("@ trigger prioritizes channel members before runnable personas and other m
     text.includes("outsider"),
   );
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
+  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
+  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
@@ -844,9 +847,12 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   const input = page.getByTestId("message-input");
-  await input.fill("@quinn");
+  await input.fill("@");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const dropdown = autocomplete(page);
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.getByText("alice")).toBeVisible();
+  await expect(dropdown.getByText("quinn")).toHaveCount(0);
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({


### PR DESCRIPTION
## Summary

Buzz Desktop's mention autocomplete excluded valid external agent identities when they were not present in the current user's local managed-agent list. This meant an externally hosted agent could be an active member of the current channel and exchange messages normally, yet remain unavailable from the `@` picker.

This change preserves the managed-agent filtering introduced by #2149 while widening the eligibility gate for current channel members:

- external agents that belong to the current channel can appear in mention autocomplete;
- locally managed agents retain their existing behavior;
- relay-only agents that are not members of the current channel remain hidden;
- the existing invocability and directory-policy checks still run afterward.

The regression coverage also fixes a previously racy negative assertion. The relay-only non-member case now waits for autocomplete processing to complete before verifying that the candidate is absent.

### Related issue

No open duplicate issue or PR found.

Regression follow-up to #2149.

### Testing

Automated verification:

- `pnpm --dir desktop build:e2e` — passed
- focused external-member and relay-only-non-member regressions — 2 passed
- `desktop/tests/e2e/mentions.spec.ts` — 49 passed
- `pnpm --dir desktop check` — passed (two pre-existing informational suggestions only)
- `pnpm --dir desktop test` — 4,022 passed, 0 failed
- `git diff --check` — passed

Red/green regression proof:

- with the broad managed-agent gate removed, the strengthened test failed because the relay-only non-member appeared;
- with the membership-aware gate, the external channel member appears and the relay-only non-member remains absent.

Manual verification against the hosted Buzz community:

- launched the branch as a production-relay development build;
- opened the existing channel containing the external agent;
- confirmed the agent appeared in `@` autocomplete;
- selected the result and confirmed the expected mention was inserted;
- confirmed Buzz retained the agent ownership label.

#### Before

The external channel member was absent from mention autocomplete.

<img width="836" height="263" alt="image" src="https://github.com/user-attachments/assets/06831880-bd15-47be-941f-11dfae923f0a" />

#### After

The external channel member appears and is recognized as an agent managed by the current user.

<img width="325" height="112" alt="image" src="https://github.com/user-attachments/assets/ddfeaf09-1309-4688-98d8-e4b21847147e" />