### PR TITLE
fix: use relay-eligible agents for mention autocomplete

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentIdentityInManagedList(candidate, mentionableAgentPubkeys)) {
         return;
       }
       if (
@@ -420,7 +420,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## Summary
- `useMentions.ts` filtered agent candidates for @-mention autocomplete through `managedAgentPubkeys` — the set of agents *locally managed* by the current device — instead of `mentionableAgentPubkeys`, which already accounts for relay-directory + allowlist eligibility.
- Practical effect: on a multi-device setup, an agent only appears in mention autocomplete on the device that created/manages it. Other devices whose identity is allowlisted and who share the channel can't tag the agent at all, even though the agent is fully eligible per the relay directory (`kind:30177`) and channel membership.
- Swapped the set used in the `isAgentIdentityInManagedList` check from `managedAgentPubkeys` to `mentionableAgentPubkeys`. `managedAgentPubkeys` was then unused in that `useMemo`, so it's dropped from the dependency array (flagged by the exhaustive-deps lint).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec biome check` on the changed file — clean
- [x] `pnpm test` — all 3870 unit tests pass
- [ ] Manual repro: create a managed agent on device A, allowlist device B's pubkey, add the agent to a shared channel; confirm the agent now appears in device B's mention autocomplete