### PR TITLE
fix(relay): require credentials for deployment admin access

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -403,8 +403,14 @@ admin: bootstrap _ensure-migrations
     [[ -d node_modules ]] || pnpm install
     pnpm -C admin-web build
     export BUZZ_ADMIN_HOST="${BUZZ_ADMIN_HOST:-admin.localhost:3000}"
+    export BUZZ_ADMIN_USERNAME="${BUZZ_ADMIN_USERNAME:-admin}"
+    if [[ -z "${BUZZ_ADMIN_PASSWORD:-}" ]]; then
+        export BUZZ_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+    fi
     export BUZZ_ADMIN_WEB_DIR="${BUZZ_ADMIN_WEB_DIR:-{{justfile_directory()}}/admin-web/dist}"
     echo "Admin dashboard: http://${BUZZ_ADMIN_HOST}/reports"
+    echo "Admin username: ${BUZZ_ADMIN_USERNAME}"
+    echo "Admin password: ${BUZZ_ADMIN_PASSWORD}"
     cargo run -p buzz-relay
 
 # Seed deterministic reports and product feedback for local admin dashboard review

--- a/crates/buzz-relay/src/api/admin/auth.rs
+++ b/crates/buzz-relay/src/api/admin/auth.rs
@@ -1,4 +1,7 @@
 use axum::http::{header, HeaderMap};
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 
 use super::error::ApiError;
 use crate::state::AppState;
@@ -29,7 +32,30 @@ pub fn authorize(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> 
     }) {
         return Err(ApiError::forbidden());
     }
+    if !has_valid_credentials(headers, &config.credential_digest) {
+        return Err(ApiError::unauthorized());
+    }
     Ok(())
+}
+
+fn has_valid_credentials(headers: &HeaderMap, expected_digest: &[u8; 32]) -> bool {
+    let Some(value) = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Some((scheme, encoded)) = value.split_once(' ') else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("basic") || encoded.is_empty() {
+        return false;
+    }
+    let Ok(actual) = base64::engine::general_purpose::STANDARD.decode(encoded) else {
+        return false;
+    };
+    let actual_digest: [u8; 32] = Sha256::digest(&actual).into();
+    bool::from(actual_digest.ct_eq(expected_digest))
 }
 
 fn origin_matches_host(origin: &str, host: &str) -> bool {
@@ -41,7 +67,9 @@ fn origin_matches_host(origin: &str, host: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::origin_matches_host;
+    use super::{has_valid_credentials, origin_matches_host};
+    use axum::http::{header, HeaderMap, HeaderValue};
+    use base64::Engine as _;
 
     #[test]
     fn browser_origin_must_match_admin_host() {
@@ -58,5 +86,21 @@ mod tests {
             "admin.example.com"
         ));
         assert!(!origin_matches_host("null", "admin.example.com"));
+    }
+
+    #[test]
+    fn admin_credentials_are_required_and_compared_exactly() {
+        let encoded = base64::engine::general_purpose::STANDARD.encode("operator:correct secret");
+        let expected = crate::config::AdminConfig::credential_digest("operator", "correct secret");
+        let mut headers = HeaderMap::new();
+        assert!(!has_valid_credentials(&headers, &expected));
+
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Basic {encoded}")).expect("valid header"),
+        );
+        assert!(has_valid_credentials(&headers, &expected));
+        let wrong = crate::config::AdminConfig::credential_digest("operator", "wrong secret");
+        assert!(!has_valid_credentials(&headers, &wrong));
     }
 }

--- a/crates/buzz-relay/src/api/admin/error.rs
+++ b/crates/buzz-relay/src/api/admin/error.rs
@@ -10,6 +10,7 @@ pub struct ApiError {
     pub status: StatusCode,
     pub code: &'static str,
     pub message: &'static str,
+    challenge_basic: bool,
 }
 
 #[derive(Serialize)]
@@ -31,6 +32,16 @@ impl ApiError {
             status: StatusCode::BAD_REQUEST,
             code,
             message,
+            challenge_basic: false,
+        }
+    }
+
+    pub fn unauthorized() -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            code: "unauthorized",
+            message: "admin credentials are required",
+            challenge_basic: true,
         }
     }
 
@@ -39,6 +50,7 @@ impl ApiError {
             status: StatusCode::FORBIDDEN,
             code: "forbidden",
             message: "request is not authorized",
+            challenge_basic: false,
         }
     }
 
@@ -47,6 +59,7 @@ impl ApiError {
             status: StatusCode::NOT_FOUND,
             code: "not_found",
             message: "record was not found",
+            challenge_basic: false,
         }
     }
 
@@ -55,13 +68,14 @@ impl ApiError {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             code: "internal_error",
             message: "request failed",
+            challenge_basic: false,
         }
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (
+        let mut response = (
             self.status,
             Json(ErrorEnvelope {
                 error: ErrorBody {
@@ -71,7 +85,16 @@ impl IntoResponse for ApiError {
                 },
             }),
         )
-            .into_response()
+            .into_response();
+        if self.challenge_basic {
+            response.headers_mut().insert(
+                axum::http::header::WWW_AUTHENTICATE,
+                axum::http::HeaderValue::from_static(
+                    "Basic realm=\"buzz-admin\", charset=\"UTF-8\"",
+                ),
+            );
+        }
+        response
     }
 }
 

--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{header, HeaderMap, HeaderValue},
     middleware::{self, Next},
-    response::{IntoResponse, Response},
+    response::Response,
     routing::get,
     Json, Router,
 };

--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::{Path, Query, State},
     http::{header, HeaderMap, HeaderValue},
     middleware::{self, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
@@ -22,6 +22,13 @@ use uuid::Uuid;
 
 pub(crate) fn is_admin_host(state: &crate::state::AppState, headers: &HeaderMap) -> bool {
     auth::is_admin_host(state, headers)
+}
+
+pub(crate) fn authorize_request(
+    state: &crate::state::AppState,
+    headers: &HeaderMap,
+) -> Result<(), Response> {
+    authorize(state, headers).map_err(|error| error.into_response())
 }
 
 /// Build the read-only deployment-admin routes.
@@ -337,6 +344,11 @@ mod tests {
         config.redis_url = "redis://127.0.0.1:1".to_string();
         config.admin = Some(crate::config::AdminConfig {
             host: "admin.example".to_string(),
+            username: "operator".to_string(),
+            credential_digest: crate::config::AdminConfig::credential_digest(
+                "operator",
+                "correct horse battery staple",
+            ),
             web_dir: None,
         });
         let pool = sqlx::PgPool::connect_lazy(&config.database_url).expect("lazy pg pool");
@@ -374,6 +386,13 @@ mod tests {
 
     const HASH: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
+    fn admin_authorization() -> String {
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode("operator:correct horse battery staple");
+        format!("Basic {encoded}")
+    }
+
     #[tokio::test]
     async fn report_detail_requires_admin_host_before_database_access() {
         let response = router(test_state().await)
@@ -396,12 +415,35 @@ mod tests {
                 Request::builder()
                     .uri(format!("/reports/{}", Uuid::nil()))
                     .header(header::HOST, "admin.example")
+                    .header(header::AUTHORIZATION, admin_authorization())
                     .body(Body::empty())
                     .expect("request"),
             )
             .await
             .expect("response");
         assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn report_detail_requires_admin_credentials_before_database_access() {
+        let response = router(test_state().await)
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/reports/{}", Uuid::nil()))
+                    .header(header::HOST, "admin.example")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::WWW_AUTHENTICATE)
+                .and_then(|value| value.to_str().ok()),
+            Some("Basic realm=\"buzz-admin\", charset=\"UTF-8\"")
+        );
     }
 
     #[tokio::test]
@@ -426,6 +468,7 @@ mod tests {
                 Request::builder()
                     .uri(format!("/feedback/{}/attachments/{HASH}", Uuid::nil()))
                     .header(header::HOST, "admin.example")
+                    .header(header::AUTHORIZATION, admin_authorization())
                     .body(Body::empty())
                     .expect("request"),
             )

--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -1,7 +1,7 @@
 //! Private, read-only deployment moderation API.
 
 mod auth;
-mod error;
+pub(crate) mod error;
 
 use std::sync::Arc;
 
@@ -27,8 +27,8 @@ pub(crate) fn is_admin_host(state: &crate::state::AppState, headers: &HeaderMap)
 pub(crate) fn authorize_request(
     state: &crate::state::AppState,
     headers: &HeaderMap,
-) -> Result<(), Response> {
-    authorize(state, headers).map_err(|error| error.into_response())
+) -> Result<(), ApiError> {
+    authorize(state, headers)
 }
 
 /// Build the read-only deployment-admin routes.

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -25,12 +25,34 @@ pub enum ConfigError {
 }
 
 /// Deny-by-default read-only deployment-admin configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AdminConfig {
     /// Exact admin HTTP authority.
     pub host: String,
+    /// HTTP Basic username presented by deployment administrators.
+    pub username: String,
+    /// SHA-256 of the expected `username:password` bytes.
+    pub credential_digest: [u8; 32],
     /// Optional admin SPA bundle directory.
     pub web_dir: Option<std::path::PathBuf>,
+}
+
+impl std::fmt::Debug for AdminConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AdminConfig")
+            .field("host", &self.host)
+            .field("username", &self.username)
+            .field("credential_digest", &"[REDACTED]")
+            .field("web_dir", &self.web_dir)
+            .finish()
+    }
+}
+
+impl AdminConfig {
+    pub(crate) fn credential_digest(username: &str, password: &str) -> [u8; 32] {
+        Sha256::digest(format!("{username}:{password}").as_bytes()).into()
+    }
 }
 
 /// Relay-hosted policy content presented on join surfaces.
@@ -883,6 +905,36 @@ impl Config {
                         "BUZZ_ADMIN_HOST must be an exact authority".to_string(),
                     ));
                 }
+                let username = std::env::var("BUZZ_ADMIN_USERNAME")
+                    .ok()
+                    .map(|value| value.trim().to_owned())
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_else(|| "admin".to_string());
+                if username.len() > 128
+                    || username.contains(':')
+                    || username.chars().any(char::is_control)
+                {
+                    return Err(ConfigError::InvalidValue(
+                        "BUZZ_ADMIN_USERNAME must be at most 128 characters and contain no colon or control characters"
+                            .to_string(),
+                    ));
+                }
+                let password = std::env::var("BUZZ_ADMIN_PASSWORD")
+                    .ok()
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        ConfigError::InvalidValue(
+                            "BUZZ_ADMIN_PASSWORD is required when BUZZ_ADMIN_HOST is set"
+                                .to_string(),
+                        )
+                    })?;
+                if !(16..=1024).contains(&password.len()) || password.chars().any(char::is_control)
+                {
+                    return Err(ConfigError::InvalidValue(
+                        "BUZZ_ADMIN_PASSWORD must be 16 to 1024 bytes and contain no control characters"
+                            .to_string(),
+                    ));
+                }
                 let web_dir = std::env::var("BUZZ_ADMIN_WEB_DIR")
                     .ok()
                     .map(|value| std::path::PathBuf::from(value.trim()))
@@ -895,7 +947,12 @@ impl Config {
                         )));
                     }
                 }
-                Some(AdminConfig { host, web_dir })
+                Some(AdminConfig {
+                    credential_digest: AdminConfig::credential_digest(&username, &password),
+                    host,
+                    username,
+                    web_dir,
+                })
             }
         };
 
@@ -1051,6 +1108,46 @@ mod tests {
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
         );
+    }
+
+    #[test]
+    fn admin_host_requires_a_strong_credential() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        const NAMES: [&str; 4] = [
+            "BUZZ_ADMIN_HOST",
+            "BUZZ_ADMIN_USERNAME",
+            "BUZZ_ADMIN_PASSWORD",
+            "BUZZ_ADMIN_WEB_DIR",
+        ];
+        let previous = NAMES.map(|name| std::env::var_os(name));
+        for name in NAMES {
+            std::env::remove_var(name);
+        }
+
+        std::env::set_var("BUZZ_ADMIN_HOST", "admin.example");
+        let missing = Config::from_env().expect_err("password must be required");
+        assert!(missing
+            .to_string()
+            .contains("BUZZ_ADMIN_PASSWORD is required"));
+
+        std::env::set_var("BUZZ_ADMIN_PASSWORD", "too-short");
+        let short = Config::from_env().expect_err("short password must be rejected");
+        assert!(short.to_string().contains("16 to 1024 bytes"));
+
+        std::env::set_var("BUZZ_ADMIN_USERNAME", "operator");
+        std::env::set_var("BUZZ_ADMIN_PASSWORD", "correct horse battery staple");
+        let config = Config::from_env().expect("valid admin credential");
+        let admin = config.admin.expect("admin config");
+        assert_eq!(admin.username, "operator");
+        assert!(!format!("{admin:?}").contains("correct horse battery staple"));
+
+        for (name, value) in NAMES.into_iter().zip(previous) {
+            if let Some(value) = value {
+                std::env::set_var(name, value);
+            } else {
+                std::env::remove_var(name);
+            }
+        }
     }
 
     #[test]

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -53,6 +53,61 @@ impl AdminConfig {
     pub(crate) fn credential_digest(username: &str, password: &str) -> [u8; 32] {
         Sha256::digest(format!("{username}:{password}").as_bytes()).into()
     }
+
+    /// Validate raw admin settings. Kept separate from `Config::from_env` so tests can
+    /// exercise the rejection cases without mutating process-global environment variables,
+    /// which other tests read concurrently via `Config::from_env`.
+    pub(crate) fn from_values(
+        host: String,
+        username: Option<String>,
+        password: Option<String>,
+        web_dir: Option<String>,
+    ) -> Result<Self, ConfigError> {
+        if host.contains(['/', '\\', '@']) {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_ADMIN_HOST must be an exact authority".to_string(),
+            ));
+        }
+        let username = username
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "admin".to_string());
+        if username.len() > 128 || username.contains(':') || username.chars().any(char::is_control)
+        {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_ADMIN_USERNAME must be at most 128 characters and contain no colon or control characters"
+                    .to_string(),
+            ));
+        }
+        let password = password.filter(|value| !value.is_empty()).ok_or_else(|| {
+            ConfigError::InvalidValue(
+                "BUZZ_ADMIN_PASSWORD is required when BUZZ_ADMIN_HOST is set".to_string(),
+            )
+        })?;
+        if !(16..=1024).contains(&password.len()) || password.chars().any(char::is_control) {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_ADMIN_PASSWORD must be 16 to 1024 bytes and contain no control characters"
+                    .to_string(),
+            ));
+        }
+        let web_dir = web_dir
+            .map(|value| std::path::PathBuf::from(value.trim()))
+            .filter(|value| !value.as_os_str().is_empty());
+        if let Some(ref dir) = web_dir {
+            if !dir.join("index.html").is_file() {
+                return Err(ConfigError::InvalidValue(format!(
+                    "BUZZ_ADMIN_WEB_DIR={} does not contain index.html",
+                    dir.display()
+                )));
+            }
+        }
+        Ok(Self {
+            credential_digest: Self::credential_digest(&username, &password),
+            host,
+            username,
+            web_dir,
+        })
+    }
 }
 
 /// Relay-hosted policy content presented on join surfaces.
@@ -899,61 +954,12 @@ impl Config {
             .filter(|value| !value.is_empty())
         {
             None => None,
-            Some(host) => {
-                if host.contains(['/', '\\', '@']) {
-                    return Err(ConfigError::InvalidValue(
-                        "BUZZ_ADMIN_HOST must be an exact authority".to_string(),
-                    ));
-                }
-                let username = std::env::var("BUZZ_ADMIN_USERNAME")
-                    .ok()
-                    .map(|value| value.trim().to_owned())
-                    .filter(|value| !value.is_empty())
-                    .unwrap_or_else(|| "admin".to_string());
-                if username.len() > 128
-                    || username.contains(':')
-                    || username.chars().any(char::is_control)
-                {
-                    return Err(ConfigError::InvalidValue(
-                        "BUZZ_ADMIN_USERNAME must be at most 128 characters and contain no colon or control characters"
-                            .to_string(),
-                    ));
-                }
-                let password = std::env::var("BUZZ_ADMIN_PASSWORD")
-                    .ok()
-                    .filter(|value| !value.is_empty())
-                    .ok_or_else(|| {
-                        ConfigError::InvalidValue(
-                            "BUZZ_ADMIN_PASSWORD is required when BUZZ_ADMIN_HOST is set"
-                                .to_string(),
-                        )
-                    })?;
-                if !(16..=1024).contains(&password.len()) || password.chars().any(char::is_control)
-                {
-                    return Err(ConfigError::InvalidValue(
-                        "BUZZ_ADMIN_PASSWORD must be 16 to 1024 bytes and contain no control characters"
-                            .to_string(),
-                    ));
-                }
-                let web_dir = std::env::var("BUZZ_ADMIN_WEB_DIR")
-                    .ok()
-                    .map(|value| std::path::PathBuf::from(value.trim()))
-                    .filter(|value| !value.as_os_str().is_empty());
-                if let Some(ref dir) = web_dir {
-                    if !dir.join("index.html").is_file() {
-                        return Err(ConfigError::InvalidValue(format!(
-                            "BUZZ_ADMIN_WEB_DIR={} does not contain index.html",
-                            dir.display()
-                        )));
-                    }
-                }
-                Some(AdminConfig {
-                    credential_digest: AdminConfig::credential_digest(&username, &password),
-                    host,
-                    username,
-                    web_dir,
-                })
-            }
+            Some(host) => Some(AdminConfig::from_values(
+                host,
+                std::env::var("BUZZ_ADMIN_USERNAME").ok(),
+                std::env::var("BUZZ_ADMIN_PASSWORD").ok(),
+                std::env::var("BUZZ_ADMIN_WEB_DIR").ok(),
+            )?),
         };
 
         // Web UI static file serving
@@ -1112,40 +1118,78 @@ mod tests {
 
     #[test]
     fn admin_host_requires_a_strong_credential() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        const NAMES: [&str; 4] = [
-            "BUZZ_ADMIN_HOST",
-            "BUZZ_ADMIN_USERNAME",
-            "BUZZ_ADMIN_PASSWORD",
-            "BUZZ_ADMIN_WEB_DIR",
-        ];
-        let previous = NAMES.map(std::env::var_os);
-        for name in NAMES {
-            std::env::remove_var(name);
-        }
+        let host = || "admin.example".to_string();
 
-        std::env::set_var("BUZZ_ADMIN_HOST", "admin.example");
-        let missing = Config::from_env().expect_err("password must be required");
+        let missing = AdminConfig::from_values(host(), None, None, None)
+            .expect_err("password must be required");
         assert!(missing
             .to_string()
             .contains("BUZZ_ADMIN_PASSWORD is required"));
 
-        std::env::set_var("BUZZ_ADMIN_PASSWORD", "too-short");
-        let short = Config::from_env().expect_err("short password must be rejected");
+        let short = AdminConfig::from_values(host(), None, Some("too-short".to_string()), None)
+            .expect_err("short password must be rejected");
         assert!(short.to_string().contains("16 to 1024 bytes"));
 
-        std::env::set_var("BUZZ_ADMIN_USERNAME", "operator");
-        std::env::set_var("BUZZ_ADMIN_PASSWORD", "correct horse battery staple");
-        let config = Config::from_env().expect("valid admin credential");
-        let admin = config.admin.expect("admin config");
+        let colon = AdminConfig::from_values(
+            host(),
+            Some("oper:ator".to_string()),
+            Some("correct horse battery staple".to_string()),
+            None,
+        )
+        .expect_err("colon in username must be rejected");
+        assert!(colon.to_string().contains("no colon"));
+
+        let admin = AdminConfig::from_values(
+            host(),
+            Some("operator".to_string()),
+            Some("correct horse battery staple".to_string()),
+            None,
+        )
+        .expect("valid admin credential");
         assert_eq!(admin.username, "operator");
+        assert_eq!(
+            admin.credential_digest,
+            AdminConfig::credential_digest("operator", "correct horse battery staple")
+        );
         assert!(!format!("{admin:?}").contains("correct horse battery staple"));
 
-        for (name, value) in NAMES.into_iter().zip(previous) {
-            if let Some(value) = value {
-                std::env::set_var(name, value);
-            } else {
-                std::env::remove_var(name);
+        let default_username =
+            AdminConfig::from_values(host(), None, Some("a".repeat(16)), None).expect("defaults");
+        assert_eq!(default_username.username, "admin");
+    }
+
+    #[test]
+    fn admin_env_vars_wire_into_config() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous = [
+            "BUZZ_ADMIN_HOST",
+            "BUZZ_ADMIN_USERNAME",
+            "BUZZ_ADMIN_PASSWORD",
+        ]
+        .map(|name| (name, std::env::var_os(name)));
+
+        // Set the password before the host. Other tests call `Config::from_env` without
+        // this mutex, and a host set without a password makes that call fail.
+        std::env::set_var("BUZZ_ADMIN_PASSWORD", "correct horse battery staple");
+        std::env::set_var("BUZZ_ADMIN_USERNAME", "operator");
+        std::env::set_var("BUZZ_ADMIN_HOST", "admin.example");
+        let admin = Config::from_env()
+            .expect("valid admin credential")
+            .admin
+            .expect("admin config");
+        std::env::remove_var("BUZZ_ADMIN_HOST");
+
+        assert_eq!(admin.host, "admin.example");
+        assert_eq!(admin.username, "operator");
+        assert_eq!(
+            admin.credential_digest,
+            AdminConfig::credential_digest("operator", "correct horse battery staple")
+        );
+
+        for (name, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
             }
         }
     }

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -1119,7 +1119,7 @@ mod tests {
             "BUZZ_ADMIN_PASSWORD",
             "BUZZ_ADMIN_WEB_DIR",
         ];
-        let previous = NAMES.map(|name| std::env::var_os(name));
+        let previous = NAMES.map(std::env::var_os);
         for name in NAMES {
             std::env::remove_var(name);
         }

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -948,18 +948,31 @@ impl Config {
         };
 
         // Read-only deployment-admin surface. The route is absent when the host is unset.
+        //
+        // A misconfigured admin host disables the dashboard rather than aborting startup.
+        // The relay is not an admin service: refusing to boot would turn a missing
+        // BUZZ_ADMIN_PASSWORD into a full relay outage, while leaving it off costs only
+        // the dashboard. Either way the surface never serves unauthenticated.
         let admin = match std::env::var("BUZZ_ADMIN_HOST")
             .ok()
             .map(|value| value.trim().to_owned())
             .filter(|value| !value.is_empty())
         {
             None => None,
-            Some(host) => Some(AdminConfig::from_values(
+            Some(host) => match AdminConfig::from_values(
                 host,
                 std::env::var("BUZZ_ADMIN_USERNAME").ok(),
                 std::env::var("BUZZ_ADMIN_PASSWORD").ok(),
                 std::env::var("BUZZ_ADMIN_WEB_DIR").ok(),
-            )?),
+            ) {
+                Ok(admin) => Some(admin),
+                Err(error) => {
+                    tracing::error!(
+                        "admin dashboard disabled — BUZZ_ADMIN_HOST is set but the configuration is invalid: {error}"
+                    );
+                    None
+                }
+            },
         };
 
         // Web UI static file serving
@@ -1159,6 +1172,30 @@ mod tests {
     }
 
     #[test]
+    fn admin_host_without_a_password_disables_the_dashboard_but_still_boots() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous =
+            ["BUZZ_ADMIN_HOST", "BUZZ_ADMIN_PASSWORD"].map(|name| (name, std::env::var_os(name)));
+
+        std::env::remove_var("BUZZ_ADMIN_PASSWORD");
+        std::env::set_var("BUZZ_ADMIN_HOST", "admin.example");
+        let config = Config::from_env().expect("relay must boot without an admin password");
+        std::env::remove_var("BUZZ_ADMIN_HOST");
+
+        assert!(
+            config.admin.is_none(),
+            "an unusable admin credential must leave the surface off, not open"
+        );
+
+        for (name, value) in previous {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+
+    #[test]
     fn admin_env_vars_wire_into_config() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let previous = [
@@ -1168,8 +1205,6 @@ mod tests {
         ]
         .map(|name| (name, std::env::var_os(name)));
 
-        // Set the password before the host. Other tests call `Config::from_env` without
-        // this mutex, and a host set without a password makes that call fail.
         std::env::set_var("BUZZ_ADMIN_PASSWORD", "correct horse battery staple");
         std::env::set_var("BUZZ_ADMIN_USERNAME", "operator");
         std::env::set_var("BUZZ_ADMIN_HOST", "admin.example");

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -161,6 +161,9 @@ pub fn build_router(state: Arc<AppState>) -> Router {
                 let path = req.uri().path();
                 let admin_host = api::admin::is_admin_host(&state, req.headers());
                 if admin_host {
+                    if let Err(response) = api::admin::authorize_request(&state, req.headers()) {
+                        return Ok(response);
+                    }
                     if let (Some(index), Some(files)) = (admin_index, admin_files) {
                         if path.starts_with("/assets/") {
                             return files.oneshot(req).await.map(IntoResponse::into_response);
@@ -271,6 +274,9 @@ async fn nip11_or_ws_handler(
     // Short-circuit the exact admin authority here and never let it serve the
     // public web bundle, NIP-11 document, or WebSocket endpoint.
     if api::admin::is_admin_host(&state, &headers) {
+        if let Err(response) = api::admin::authorize_request(&state, &headers) {
+            return response;
+        }
         if !accept.contains("text/html") {
             return StatusCode::NOT_FOUND.into_response();
         }

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -161,8 +161,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
                 let path = req.uri().path();
                 let admin_host = api::admin::is_admin_host(&state, req.headers());
                 if admin_host {
-                    if let Err(response) = api::admin::authorize_request(&state, req.headers()) {
-                        return Ok(response);
+                    if let Err(error) = api::admin::authorize_request(&state, req.headers()) {
+                        return Ok(error.into_response());
                     }
                     if let (Some(index), Some(files)) = (admin_index, admin_files) {
                         if path.starts_with("/assets/") {
@@ -274,8 +274,8 @@ async fn nip11_or_ws_handler(
     // Short-circuit the exact admin authority here and never let it serve the
     // public web bundle, NIP-11 document, or WebSocket endpoint.
     if api::admin::is_admin_host(&state, &headers) {
-        if let Err(response) = api::admin::authorize_request(&state, &headers) {
-            return response;
+        if let Err(error) = api::admin::authorize_request(&state, &headers) {
+            return error.into_response();
         }
         if !accept.contains("text/html") {
             return StatusCode::NOT_FOUND.into_response();

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -18,11 +18,17 @@ BUZZ_ADMIN_WEB_DIR=/srv/buzz/admin-web
 
 The relay requires HTTP Basic credentials before it serves the dashboard, its
 assets, any admin API, or an attachment. `BUZZ_ADMIN_USERNAME` defaults to
-`admin`; the password has no default,
-must be at least 16 bytes, and is retained by the relay only as a digest. The
-configured host and matching browser origin remain defense-in-depth checks.
-Requests and responses are bounded and uncached. Use HTTPS so the credentials
-are not exposed in transit, and route admin traffic through the private ingress.
+`admin` and must not contain a colon; the password has no default, must be 16
+to 1024 bytes, and is retained by the relay only as a digest. The configured
+host and matching browser origin remain defense-in-depth checks. Requests and
+responses are bounded and uncached. Use HTTPS so the credentials are not
+exposed in transit, and route admin traffic through the private ingress.
+
+If `BUZZ_ADMIN_HOST` is set but the credentials are missing or invalid, the
+relay logs an error, disables the dashboard, and continues serving normally —
+the admin host then behaves like any other host. The dashboard is an optional
+surface, so a missing password costs the dashboard rather than the relay. Check
+startup logs for `admin dashboard disabled` after any change to these variables.
 
 When the UI runs in a separate pod, proxy `/api/admin/v1/*` to the relay while
 preserving the admin `Host` header. A `NetworkPolicy` grants the admin pod access

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -3,19 +3,26 @@
 Buzz can expose a private, deployment-wide read-only dashboard from the existing
 relay process. It shows open moderation reports and recent product feedback.
 
-Configure `BUZZ_ADMIN_HOST` to activate the dashboard. A private ingress limits
-access to the operator VPN or approved source IPs.
+Configure `BUZZ_ADMIN_HOST` and a strong password to activate the dashboard. A
+private ingress should also limit access to the operator VPN or approved source
+IPs.
 
 Required configuration:
 
 ```text
 BUZZ_ADMIN_HOST=admin.example.com
+BUZZ_ADMIN_USERNAME=admin
+BUZZ_ADMIN_PASSWORD=<random password with at least 16 bytes>
 BUZZ_ADMIN_WEB_DIR=/srv/buzz/admin-web
 ```
 
-The relay requires the configured admin host and matching browser origin.
-Requests and responses are bounded and uncached. The deployment routes admin
-traffic through the private ingress.
+The relay requires HTTP Basic credentials before it serves the dashboard, its
+assets, any admin API, or an attachment. `BUZZ_ADMIN_USERNAME` defaults to
+`admin`; the password has no default,
+must be at least 16 bytes, and is retained by the relay only as a digest. The
+configured host and matching browser origin remain defense-in-depth checks.
+Requests and responses are bounded and uncached. Use HTTPS so the credentials
+are not exposed in transit, and route admin traffic through the private ingress.
 
 When the UI runs in a separate pod, proxy `/api/admin/v1/*` to the relay while
 preserving the admin `Host` header. A `NetworkPolicy` grants the admin pod access
@@ -62,8 +69,8 @@ content retains attachment disposition. Successful reads produce a structured
 trace containing feedback ID, community ID, and attachment hash, but no feedback
 body or attachment URL.
 
-The human trust boundary remains the private admin ingress. VPN/source-IP
-admission is not per-operator identity. Anyone admitted to the dashboard can
-read attachments for feedback records they can access. Per-person attribution
-or revocation requires authenticated operator identity at ingress/application
-level; this endpoint deliberately does not claim to provide it.
+The deployment credential identifies administrators as a group, not as
+individual people. Anyone with that credential can read attachments for
+feedback records they can access. Rotate the password when an administrator
+loses access. Per-person attribution requires identity-aware authentication at
+the ingress or application layer.


### PR DESCRIPTION
This change requires HTTP Basic credentials for every deployment admin route: the
dashboard, the admin SPA bundle it loads from `BUZZ_ADMIN_WEB_DIR`, the admin APIs,
reports, feedback, and attachments.
Unauthenticated requests get 401 with `WWW-Authenticate: Basic realm="buzz-admin"`,
so browsers hitting the dashboard now see a credential prompt.

The existing Host and Origin checks remain as boundary checks, but they no longer
act as the administrator credential.

## Configuration

| Variable | Required | Rule |
|---|---|---|
| `BUZZ_ADMIN_PASSWORD` | yes, when `BUZZ_ADMIN_HOST` is set | 16–1024 bytes, no control characters |
| `BUZZ_ADMIN_USERNAME` | no, defaults to `admin` | ≤128 chars, no colon, no control characters |

The colon ban matters: the digest covers `username:password`, so without it
`("oper:ator", "secret")` and `("oper", "ator:secret")` would authenticate as each
other. Passwords may contain colons.

The runtime keeps only a SHA-256 digest and compares it in constant time
(`subtle::ct_eq`); a hand-written `Debug` impl redacts it. `just admin` generates
and prints a random dev password when one isn't set.

## Rollout

`squareup/bb-public` sets `BUZZ_ADMIN_HOST=admin.buzz.xyz` in production with no
password configured. An earlier revision of this PR aborted startup on that
config, which would have crashlooped the entire relay fleet — websocket, media,
git — over an optional dashboard.

The relay now **logs an error and disables the dashboard** instead, so the image
is safe to ship in any order relative to the config change. `admin = None` means
`is_admin_host()` is false, the admin router is never mounted, and `authorize()`
returns `not_found` — nothing admin-scoped is reachable, and the admin SPA bundle is
never served because `web_dir` lives on the `AdminConfig` that is now absent.

In that state the admin host is treated like any unmapped host. It is not a community
subdomain, so `bind_community()` fails and both browser requests and WebSocket upgrades
get `404 relay: no community is configured for this host`. Three things do stay
reachable there without credentials, as they are on every host: the NIP-11 document
(fail-open by design), `/assets/*` from `BUZZ_WEB_DIR` (the *public* web bundle, not the
admin one), and the `/invite/<code>` SPA shell — which returns the same bytes for every
code and so is not an enumeration oracle.

Consequence: **`admin.buzz.xyz` goes dark on deploy** until `BUZZ_ADMIN_PASSWORD`
reaches the pod. To restore it, follow the `BUZZ_GIT_HOOK_HMAC_SECRET` pattern in
`squareup/bb-public`:

1. Add `/services/buzz/service-secrets/admin-password` to AWS Secrets Manager (us-west-2)
2. Map it to `secretKey: BUZZ_ADMIN_PASSWORD` in `externalsecret-buzz-secrets.yaml`
3. Add the matching `secretKeyRef` env entry to the chart's deployment template —
   the chart wires keys individually, there is no `envFrom`

Watch startup logs for `admin dashboard disabled` to confirm state either way.

## Testing

- `cargo clippy -p buzz-relay --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p buzz-relay --lib` — 833 passed; the 10 failures are pre-existing
  and infra-dependent (no local Postgres/Redis), an identical set to `main`
- Not run locally: integration suite (`just test`)

Originating Buzz thread: `buzz://message?channel=3928fe05-df61-4b5d-b9c7-d623b9b10ea1&id=3c6c02312f763fbe0d2bfc33a6c1a362f91d0354f3d18b039cf7a0558c1439d1`
