### PR TITLE
fix(db): bound runtime Postgres statements and lock waits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,9 @@ REDIS_URL=redis://localhost:6379
 
 # Postgres statement_timeout and lock_timeout applied to every runtime
 # connection. Accepts an integer (milliseconds) with an optional us/ms/s/min/h/d
-# unit; `0` disables the limit. Schema migrations always run with both lifted.
+# unit; `0` disables the limit. Postgres stores both as int milliseconds, so the
+# ceiling is 2147483647ms (~24 days); anything above it, or otherwise malformed,
+# falls back to the default. Schema migrations always run with both lifted.
 # BUZZ_DB_STATEMENT_TIMEOUT=30s
 # BUZZ_DB_LOCK_TIMEOUT=5s
 

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@ REDIS_URL=redis://localhost:6379
 # READ_DATABASE_URL is set, reader (default 50).
 # BUZZ_DB_POOL_SIZE=50
 
+# Postgres statement_timeout and lock_timeout applied to every runtime
+# connection. Accepts an integer (milliseconds) with an optional us/ms/s/min/h/d
+# unit; `0` disables the limit. Schema migrations always run with both lifted.
+# BUZZ_DB_STATEMENT_TIMEOUT=30s
+# BUZZ_DB_LOCK_TIMEOUT=5s
+
 # -----------------------------------------------------------------------------
 # Typesense (search)
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -38,13 +38,19 @@ REDIS_URL=redis://localhost:6379
 # READ_DATABASE_URL is set, reader (default 50).
 # BUZZ_DB_POOL_SIZE=50
 
-# Postgres statement_timeout and lock_timeout applied to every runtime
-# connection. Accepts an integer (milliseconds) with an optional us/ms/s/min/h/d
-# unit; `0` disables the limit. Postgres stores both as int milliseconds, so the
-# ceiling is 2147483647ms (~24 days); anything above it, or otherwise malformed,
-# falls back to the default. Schema migrations always run with both lifted.
+# Per-session Postgres limits applied to every runtime connection, so no single
+# caller can hold a pooled connection indefinitely. Each accepts an integer
+# (milliseconds) with an optional us/ms/s/min/h/d unit; `0` disables that limit.
+# Postgres stores all three as int milliseconds, so the ceiling is 2147483647ms
+# (~24 days); anything above it, or otherwise malformed, falls back to the
+# default. Schema migrations always run with all three lifted.
+#
+# IDLE_IN_TRANSACTION covers only the gaps between a transaction's statements —
+# it reclaims a session that opened a transaction and stopped working, which
+# STATEMENT_TIMEOUT cannot see because no statement is running.
 # BUZZ_DB_STATEMENT_TIMEOUT=30s
 # BUZZ_DB_LOCK_TIMEOUT=5s
+# BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT=60s
 
 # -----------------------------------------------------------------------------
 # Typesense (search)

--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use buzz_core::kind::KIND_NIP43_MEMBERSHIP_LIST;
 use buzz_core::tenant::{relay_url_authority, TenantContext};
-use buzz_db::{Db, DbConfig, PgTimeout};
+use buzz_db::{Db, DbConfig, RuntimeTimeouts};
 use buzz_pubsub::{EventTopic, PubSubManager};
 use clap::{Parser, Subcommand};
 use nostr::{EventBuilder, Keys, Kind, Tag};
@@ -426,11 +426,7 @@ async fn connect_db() -> Result<Db> {
     // env vars still apply for an operator who wants a bound here.
     let db = Db::new(&DbConfig {
         database_url: db_url,
-        statement_timeout: PgTimeout::from_env_or(
-            "BUZZ_DB_STATEMENT_TIMEOUT",
-            PgTimeout::disabled(),
-        ),
-        lock_timeout: PgTimeout::from_env_or("BUZZ_DB_LOCK_TIMEOUT", PgTimeout::disabled()),
+        timeouts: RuntimeTimeouts::from_env_or(RuntimeTimeouts::disabled()),
         ..DbConfig::default()
     })
     .await?;

--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use buzz_core::kind::KIND_NIP43_MEMBERSHIP_LIST;
 use buzz_core::tenant::{relay_url_authority, TenantContext};
-use buzz_db::{Db, DbConfig};
+use buzz_db::{Db, DbConfig, PgTimeout};
 use buzz_pubsub::{EventTopic, PubSubManager};
 use clap::{Parser, Subcommand};
 use nostr::{EventBuilder, Keys, Kind, Tag};
@@ -420,8 +420,17 @@ async fn connect_member_services() -> Result<(Db, Arc<PubSubManager>, Keys)> {
 async fn connect_db() -> Result<Db> {
     let db_url = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string());
+    // No runtime caps by default. `DbConfig`'s 30s/5s are sized for the relay's
+    // request-serving traffic on a shared pool — an operator CLI is neither, and
+    // a bulk repair that outlives 30s should finish, not get cancelled. The same
+    // env vars still apply for an operator who wants a bound here.
     let db = Db::new(&DbConfig {
         database_url: db_url,
+        statement_timeout: PgTimeout::from_env_or(
+            "BUZZ_DB_STATEMENT_TIMEOUT",
+            PgTimeout::disabled(),
+        ),
+        lock_timeout: PgTimeout::from_env_or("BUZZ_DB_LOCK_TIMEOUT", PgTimeout::disabled()),
         ..DbConfig::default()
     })
     .await?;

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -71,6 +71,13 @@ pub const RUNTIME_STATEMENT_TIMEOUT: &str = "30s";
 pub const RUNTIME_LOCK_TIMEOUT: &str = "5s";
 /// Postgres spelling of "no limit", used for schema migrations.
 pub const TIMEOUT_DISABLED: &str = "0";
+/// `statement_timeout` and `lock_timeout` are `int` GUCs measured in
+/// milliseconds, so Postgres refuses anything larger regardless of the unit it
+/// is spelled with. Callers building a [`DbConfig`] from operator input must
+/// range-check against this: [`apply_runtime_connection_timeouts`] runs on every
+/// pooled connection, so an unusable value fails all database access.
+/// `pg_timeout_max_millis_matches_postgres` pins it to the live server.
+pub const PG_TIMEOUT_MAX_MILLIS: u128 = i32::MAX as u128;
 
 /// Apply the runtime safety limits shared by writer, reader, audit, and search
 /// pools. Values are Postgres interval strings (`"30s"`, `"500ms"`), with
@@ -8520,6 +8527,67 @@ mod tests {
         drop_scratch_db(&admin, seed_pool, &name).await;
         // db pool still holds connections to the dropped DB; close it.
         db.pool.close().await;
+    }
+
+    /// [`PG_TIMEOUT_MAX_MILLIS`] is the bound callers range-check operator input
+    /// against, so it must be the server's real bound: too high and an accepted
+    /// value still fails every `after_connect`; too low and we reject settings
+    /// Postgres would have taken.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn pg_timeout_max_millis_matches_postgres() {
+        let mut conn = PgConnection::connect(&admin_url().await)
+            .await
+            .expect("connect");
+
+        let boundary = PG_TIMEOUT_MAX_MILLIS.to_string();
+        apply_runtime_connection_timeouts(&mut conn, &boundary, &boundary)
+            .await
+            .expect("PG_TIMEOUT_MAX_MILLIS must be settable");
+
+        // Same instant spelled in a coarser unit — the conversion the caller's
+        // range check performs must land inside the range too.
+        let in_seconds = (PG_TIMEOUT_MAX_MILLIS / 1_000).to_string();
+        apply_runtime_connection_timeouts(
+            &mut conn,
+            &format!("{in_seconds}s"),
+            &format!("{in_seconds}s"),
+        )
+        .await
+        .expect("the boundary in seconds must be settable");
+
+        for over in [
+            (PG_TIMEOUT_MAX_MILLIS + 1).to_string(),
+            format!("{}ms", PG_TIMEOUT_MAX_MILLIS + 1),
+            format!("{}s", PG_TIMEOUT_MAX_MILLIS / 1_000 + 1),
+            "999999999999999999999999999999999999999999d".to_string(),
+        ] {
+            let err = apply_runtime_connection_timeouts(&mut conn, &over, RUNTIME_LOCK_TIMEOUT)
+                .await
+                .expect_err(&format!("{over} must be rejected by Postgres"));
+            let code = match &err {
+                sqlx::Error::Database(db) => db.code().map(|c| c.to_string()),
+                other => panic!("expected a database error, got {other:?}"),
+            };
+            assert_eq!(
+                code.as_deref(),
+                Some("22023"),
+                "{over}: expected invalid_parameter_value"
+            );
+        }
+
+        // A rejected `set_config` leaves the session usable, so the failure mode
+        // is a poisoned pool of unbounded sessions only if the caller ignores it.
+        let statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
+            .fetch_one(&mut conn)
+            .await
+            .expect("SHOW statement_timeout");
+        assert_ne!(
+            statement_timeout, "0",
+            "a rejected value must not silently disable the limit"
+        );
+
+        conn.close().await.expect("close");
     }
 
     /// `spawn_fence_probe` must verify the floor guard before letting the

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -749,6 +749,9 @@ impl Db {
             .acquire_timeout(Self::READER_ACQUIRE_TIMEOUT)
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
+            .after_connect(|connection, _meta| {
+                Box::pin(apply_runtime_connection_timeouts(connection))
+            })
             .connect_lazy(url)?)
     }
 
@@ -8339,7 +8342,8 @@ mod tests {
         let idx = base.rfind('/').expect("db url has a path segment");
         let scratch_url = format!("{}/{}", &base[..idx], name);
         let db = Db::new(&DbConfig {
-            database_url: scratch_url,
+            database_url: scratch_url.clone(),
+            read_database_url: Some(scratch_url),
             max_connections: 2,
             ..DbConfig::default()
         })
@@ -8358,6 +8362,18 @@ mod tests {
             .expect("SHOW lock_timeout");
         assert_eq!(statement_timeout, RUNTIME_STATEMENT_TIMEOUT);
         assert_eq!(lock_timeout, RUNTIME_LOCK_TIMEOUT);
+
+        let read_pool = db.read_pool.as_ref().expect("read pool configured");
+        let reader_statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
+            .fetch_one(read_pool)
+            .await
+            .expect("SHOW reader statement_timeout");
+        let reader_lock_timeout: String = sqlx::query_scalar("SHOW lock_timeout")
+            .fetch_one(read_pool)
+            .await
+            .expect("SHOW reader lock_timeout");
+        assert_eq!(reader_statement_timeout, RUNTIME_STATEMENT_TIMEOUT);
+        assert_eq!(reader_lock_timeout, RUNTIME_LOCK_TIMEOUT);
 
         let effective: String = sqlx::query_scalar("SHOW buzz.created_at_floor")
             .fetch_one(&db.pool)

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -6562,6 +6562,65 @@ mod tests {
         .await;
     }
 
+    /// Migrations must outlive the runtime caps — an index build or an
+    /// `ACCESS EXCLUSIVE` wait routinely exceeds them, and startup treats a
+    /// migration failure as fatal — and the relaxed session must not survive
+    /// into the pool afterwards.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn migrations_ignore_runtime_timeouts_and_leak_no_relaxed_session() {
+        const TIGHT: &str = "50ms";
+
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let name = format!("migration_timeouts_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE DATABASE {name}")))
+            .execute(&admin)
+            .await
+            .expect("create scratch db");
+        let base = admin_url().await;
+        let idx = base.rfind('/').expect("db url has a path segment");
+        let scratch_url = format!("{}/{}", &base[..idx], name);
+
+        // Far shorter than the migration suite needs, ample for a pooled query.
+        let db = Db::new(&DbConfig {
+            database_url: scratch_url,
+            max_connections: 2,
+            min_connections: 2,
+            statement_timeout: TIGHT.to_string(),
+            lock_timeout: TIGHT.to_string(),
+            ..DbConfig::default()
+        })
+        .await
+        .expect("connect Db against the unmigrated scratch db");
+
+        db.migrate()
+            .await
+            .expect("migrations must not inherit the runtime caps");
+
+        // Hold every connection at once so a leaked relaxed session cannot hide
+        // behind a freshly dialed one.
+        let mut held = Vec::new();
+        for _ in 0..2 {
+            let mut connection = db.pool.acquire().await.expect("acquire pooled connection");
+            let statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
+                .fetch_one(&mut *connection)
+                .await
+                .expect("SHOW statement_timeout");
+            let lock_timeout: String = sqlx::query_scalar("SHOW lock_timeout")
+                .fetch_one(&mut *connection)
+                .await
+                .expect("SHOW lock_timeout");
+            assert_eq!(statement_timeout, TIGHT);
+            assert_eq!(lock_timeout, TIGHT);
+            held.push(connection);
+        }
+        drop(held);
+
+        drop_scratch_db(&admin, db.pool.clone(), &name).await;
+    }
+
     /// Insert identical community + channel rows into a database so the same
     /// (community, channel) ids resolve in both writer and replica.
     async fn seed_community_channel(

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -65,22 +65,27 @@ use uuid::Uuid;
 
 use buzz_core::{CommunityId, StoredEvent};
 
-/// Maximum time a runtime query may execute before Postgres cancels it.
+/// Default maximum time a runtime query may execute before Postgres cancels it.
 pub const RUNTIME_STATEMENT_TIMEOUT: &str = "30s";
-/// Maximum time a runtime query may wait to acquire a lock.
+/// Default maximum time a runtime query may wait to acquire a lock.
 pub const RUNTIME_LOCK_TIMEOUT: &str = "5s";
+/// Postgres spelling of "no limit", used for schema migrations.
+pub const TIMEOUT_DISABLED: &str = "0";
 
 /// Apply the runtime safety limits shared by writer, reader, audit, and search
-/// pools.
+/// pools. Values are Postgres interval strings (`"30s"`, `"500ms"`), with
+/// [`TIMEOUT_DISABLED`] lifting a limit entirely.
 pub async fn apply_runtime_connection_timeouts(
     connection: &mut PgConnection,
+    statement_timeout: &str,
+    lock_timeout: &str,
 ) -> std::result::Result<(), sqlx::Error> {
     sqlx::query(
         "SELECT set_config('statement_timeout', $1, false), \
                 set_config('lock_timeout', $2, false)",
     )
-    .bind(RUNTIME_STATEMENT_TIMEOUT)
-    .bind(RUNTIME_LOCK_TIMEOUT)
+    .bind(statement_timeout)
+    .bind(lock_timeout)
     .execute(connection)
     .await?;
     Ok(())
@@ -548,6 +553,14 @@ pub struct DbConfig {
     /// than the staleness gate never routes anyway, so a larger budget
     /// would only misrepresent the config.
     pub replica_read_max_age_ms: u64,
+    /// Postgres `statement_timeout` applied to every runtime connection. An
+    /// operator running a backfill or working an incident can widen this without
+    /// a code change; [`TIMEOUT_DISABLED`] removes the cap.
+    pub statement_timeout: String,
+    /// Postgres `lock_timeout` applied to every runtime connection. Bounds
+    /// heavyweight and row lock waits only — advisory-lock waits are bounded by
+    /// [`Self::statement_timeout`] instead.
+    pub lock_timeout: String,
 }
 
 impl Default for DbConfig {
@@ -565,6 +578,8 @@ impl Default for DbConfig {
             max_lifetime_secs: 1800,
             idle_timeout_secs: 600,
             replica_read_max_age_ms: 0,
+            statement_timeout: RUNTIME_STATEMENT_TIMEOUT.to_string(),
+            lock_timeout: RUNTIME_LOCK_TIMEOUT.to_string(),
         }
     }
 }
@@ -703,9 +718,13 @@ impl Db {
             .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs));
+        let statement_timeout = config.statement_timeout.clone();
+        let lock_timeout = config.lock_timeout.clone();
         options = options.after_connect(move |conn, _meta| {
+            let statement_timeout = statement_timeout.clone();
+            let lock_timeout = lock_timeout.clone();
             Box::pin(async move {
-                apply_runtime_connection_timeouts(conn).await?;
+                apply_runtime_connection_timeouts(conn, &statement_timeout, &lock_timeout).await?;
                 if arm_floor_guard {
                     // `SET` cannot take bind parameters; `set_config` can.
                     sqlx::query("SELECT set_config('buzz.created_at_floor', $1, false)")
@@ -743,14 +762,21 @@ impl Db {
     /// No floor guard: replica sessions are read-only, the trigger never
     /// fires there (see [`Db::connect_pool`]).
     fn connect_read_pool(config: &DbConfig, url: &str, max_connections: u32) -> Result<PgPool> {
+        let statement_timeout = config.statement_timeout.clone();
+        let lock_timeout = config.lock_timeout.clone();
         Ok(PgPoolOptions::new()
             .max_connections(max_connections)
             .min_connections(0)
             .acquire_timeout(Self::READER_ACQUIRE_TIMEOUT)
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
-            .after_connect(|connection, _meta| {
-                Box::pin(apply_runtime_connection_timeouts(connection))
+            .after_connect(move |connection, _meta| {
+                let statement_timeout = statement_timeout.clone();
+                let lock_timeout = lock_timeout.clone();
+                Box::pin(async move {
+                    apply_runtime_connection_timeouts(connection, &statement_timeout, &lock_timeout)
+                        .await
+                })
             })
             .connect_lazy(url)?)
     }

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -65,6 +65,27 @@ use uuid::Uuid;
 
 use buzz_core::{CommunityId, StoredEvent};
 
+/// Maximum time a runtime query may execute before Postgres cancels it.
+pub const RUNTIME_STATEMENT_TIMEOUT: &str = "30s";
+/// Maximum time a runtime query may wait to acquire a lock.
+pub const RUNTIME_LOCK_TIMEOUT: &str = "5s";
+
+/// Apply the runtime safety limits shared by writer, reader, audit, and search
+/// pools.
+pub async fn apply_runtime_connection_timeouts(
+    connection: &mut PgConnection,
+) -> std::result::Result<(), sqlx::Error> {
+    sqlx::query(
+        "SELECT set_config('statement_timeout', $1, false), \
+                set_config('lock_timeout', $2, false)",
+    )
+    .bind(RUNTIME_STATEMENT_TIMEOUT)
+    .bind(RUNTIME_LOCK_TIMEOUT)
+    .execute(connection)
+    .await?;
+    Ok(())
+}
+
 fn event_replacement_lock_key(
     community_id: CommunityId,
     kind: i32,
@@ -682,18 +703,19 @@ impl Db {
             .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs));
-        if arm_floor_guard {
-            options = options.after_connect(|conn, _meta| {
-                Box::pin(async move {
+        options = options.after_connect(move |conn, _meta| {
+            Box::pin(async move {
+                apply_runtime_connection_timeouts(conn).await?;
+                if arm_floor_guard {
                     // `SET` cannot take bind parameters; `set_config` can.
                     sqlx::query("SELECT set_config('buzz.created_at_floor', $1, false)")
                         .bind(replica_fence::CREATED_AT_FLOOR_SECS.to_string())
                         .execute(conn)
                         .await?;
-                    Ok(())
-                })
-            });
-        }
+                }
+                Ok(())
+            })
+        });
         Ok(options.connect(url).await?)
     }
 
@@ -8325,7 +8347,18 @@ mod tests {
         .expect("connect armed Db");
         let cid = CommunityId::from_uuid(community);
 
-        // Perci nit: assert the effective session value, not the intent.
+        // Assert the effective session values, not only pool-builder intent.
+        let statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
+            .fetch_one(&db.pool)
+            .await
+            .expect("SHOW statement_timeout");
+        let lock_timeout: String = sqlx::query_scalar("SHOW lock_timeout")
+            .fetch_one(&db.pool)
+            .await
+            .expect("SHOW lock_timeout");
+        assert_eq!(statement_timeout, RUNTIME_STATEMENT_TIMEOUT);
+        assert_eq!(lock_timeout, RUNTIME_LOCK_TIMEOUT);
+
         let effective: String = sqlx::query_scalar("SHOW buzz.created_at_floor")
             .fetch_one(&db.pool)
             .await

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -69,12 +69,18 @@ use buzz_core::{CommunityId, StoredEvent};
 pub const RUNTIME_STATEMENT_TIMEOUT: &str = "30s";
 /// Default maximum time a runtime query may wait to acquire a lock.
 pub const RUNTIME_LOCK_TIMEOUT: &str = "5s";
+/// Default maximum time a runtime session may sit idle inside an open
+/// transaction. Deliberately looser than [`RUNTIME_STATEMENT_TIMEOUT`]: this
+/// budget covers only the gaps *between* a transaction's statements, so a
+/// transaction doing continuous work is never at risk, and a wide bound still
+/// reclaims a session that has stopped working entirely.
+pub const RUNTIME_IDLE_IN_TRANSACTION_TIMEOUT: &str = "60s";
 /// Postgres spelling of "no limit", used for schema migrations.
 pub const TIMEOUT_DISABLED: &str = "0";
-/// `statement_timeout` and `lock_timeout` are `int` GUCs measured in
-/// milliseconds, so Postgres refuses anything larger regardless of the unit it
-/// is spelled with. Private on purpose: [`PgTimeout`] is the only way to build a
-/// timeout, so no caller needs to range-check by hand.
+/// The runtime timeouts are `int` GUCs measured in milliseconds, so Postgres
+/// refuses anything larger regardless of the unit it is spelled with. Private on
+/// purpose: [`PgTimeout`] is the only way to build a timeout, so no caller needs
+/// to range-check by hand.
 /// `pg_timeout_max_millis_matches_postgres` pins it to the live server.
 const PG_TIMEOUT_MAX_MILLIS: u128 = i32::MAX as u128;
 
@@ -127,6 +133,12 @@ impl PgTimeout {
     /// The default runtime lock timeout ([`RUNTIME_LOCK_TIMEOUT`]).
     pub fn lock_default() -> Self {
         Self(RUNTIME_LOCK_TIMEOUT.to_string())
+    }
+
+    /// The default idle-in-transaction timeout
+    /// ([`RUNTIME_IDLE_IN_TRANSACTION_TIMEOUT`]).
+    pub fn idle_in_transaction_default() -> Self {
+        Self(RUNTIME_IDLE_IN_TRANSACTION_TIMEOUT.to_string())
     }
 
     /// No limit at all — what schema migrations and one-shot operator tools
@@ -222,19 +234,75 @@ fn pg_timeout_millis(magnitude: &str, unit: &str) -> Option<u128> {
     }
 }
 
+/// The per-session limits that stop one caller from holding a pooled connection
+/// indefinitely.
+///
+/// Grouped rather than passed as three same-typed arguments, which would make a
+/// swapped pair a silent misconfiguration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeTimeouts {
+    /// Bounds a single statement's execution time.
+    pub statement: PgTimeout,
+    /// Bounds heavyweight and row lock waits. Advisory-lock waits are bounded
+    /// by [`Self::statement`] instead.
+    pub lock: PgTimeout,
+    /// Bounds a session sitting idle inside an open transaction.
+    ///
+    /// [`Self::statement`] only counts time spent *executing*, so a session
+    /// that opens a transaction and then stops issuing statements holds its
+    /// connection — and every lock it already took — with no statement running
+    /// for the statement timeout to cancel.
+    pub idle_in_transaction: PgTimeout,
+}
+
+impl Default for RuntimeTimeouts {
+    fn default() -> Self {
+        Self {
+            statement: PgTimeout::statement_default(),
+            lock: PgTimeout::lock_default(),
+            idle_in_transaction: PgTimeout::idle_in_transaction_default(),
+        }
+    }
+}
+
+impl RuntimeTimeouts {
+    /// Every limit lifted — schema migrations and one-shot operator tools.
+    pub fn disabled() -> Self {
+        Self {
+            statement: PgTimeout::disabled(),
+            lock: PgTimeout::disabled(),
+            idle_in_transaction: PgTimeout::disabled(),
+        }
+    }
+
+    /// Read each limit from its environment variable, falling back to the
+    /// corresponding field of `defaults` with a warning.
+    pub fn from_env_or(defaults: Self) -> Self {
+        Self {
+            statement: PgTimeout::from_env_or("BUZZ_DB_STATEMENT_TIMEOUT", defaults.statement),
+            lock: PgTimeout::from_env_or("BUZZ_DB_LOCK_TIMEOUT", defaults.lock),
+            idle_in_transaction: PgTimeout::from_env_or(
+                "BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT",
+                defaults.idle_in_transaction,
+            ),
+        }
+    }
+}
+
 /// Apply the runtime safety limits shared by writer, reader, audit, and search
-/// pools. [`PgTimeout::disabled`] lifts a limit entirely.
+/// pools. [`RuntimeTimeouts::disabled`] lifts them entirely.
 pub async fn apply_runtime_connection_timeouts(
     connection: &mut PgConnection,
-    statement_timeout: &PgTimeout,
-    lock_timeout: &PgTimeout,
+    timeouts: &RuntimeTimeouts,
 ) -> std::result::Result<(), sqlx::Error> {
     sqlx::query(
         "SELECT set_config('statement_timeout', $1, false), \
-                set_config('lock_timeout', $2, false)",
+                set_config('lock_timeout', $2, false), \
+                set_config('idle_in_transaction_session_timeout', $3, false)",
     )
-    .bind(statement_timeout.as_str())
-    .bind(lock_timeout.as_str())
+    .bind(timeouts.statement.as_str())
+    .bind(timeouts.lock.as_str())
+    .bind(timeouts.idle_in_transaction.as_str())
     .execute(connection)
     .await?;
     Ok(())
@@ -702,14 +770,10 @@ pub struct DbConfig {
     /// than the staleness gate never routes anyway, so a larger budget
     /// would only misrepresent the config.
     pub replica_read_max_age_ms: u64,
-    /// Postgres `statement_timeout` applied to every runtime connection. An
-    /// operator running a backfill or working an incident can widen this without
-    /// a code change; [`PgTimeout::disabled`] removes the cap.
-    pub statement_timeout: PgTimeout,
-    /// Postgres `lock_timeout` applied to every runtime connection. Bounds
-    /// heavyweight and row lock waits only — advisory-lock waits are bounded by
-    /// [`Self::statement_timeout`] instead.
-    pub lock_timeout: PgTimeout,
+    /// Per-session limits applied to every runtime connection. An operator
+    /// running a backfill or working an incident can widen these without a code
+    /// change; [`RuntimeTimeouts::disabled`] removes them.
+    pub timeouts: RuntimeTimeouts,
 }
 
 impl Default for DbConfig {
@@ -727,8 +791,7 @@ impl Default for DbConfig {
             max_lifetime_secs: 1800,
             idle_timeout_secs: 600,
             replica_read_max_age_ms: 0,
-            statement_timeout: PgTimeout::statement_default(),
-            lock_timeout: PgTimeout::lock_default(),
+            timeouts: RuntimeTimeouts::default(),
         }
     }
 }
@@ -867,13 +930,11 @@ impl Db {
             .acquire_timeout(Duration::from_secs(config.acquire_timeout_secs))
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs));
-        let statement_timeout = config.statement_timeout.clone();
-        let lock_timeout = config.lock_timeout.clone();
+        let timeouts = config.timeouts.clone();
         options = options.after_connect(move |conn, _meta| {
-            let statement_timeout = statement_timeout.clone();
-            let lock_timeout = lock_timeout.clone();
+            let timeouts = timeouts.clone();
             Box::pin(async move {
-                apply_runtime_connection_timeouts(conn, &statement_timeout, &lock_timeout).await?;
+                apply_runtime_connection_timeouts(conn, &timeouts).await?;
                 if arm_floor_guard {
                     // `SET` cannot take bind parameters; `set_config` can.
                     sqlx::query("SELECT set_config('buzz.created_at_floor', $1, false)")
@@ -911,8 +972,7 @@ impl Db {
     /// No floor guard: replica sessions are read-only, the trigger never
     /// fires there (see [`Db::connect_pool`]).
     fn connect_read_pool(config: &DbConfig, url: &str, max_connections: u32) -> Result<PgPool> {
-        let statement_timeout = config.statement_timeout.clone();
-        let lock_timeout = config.lock_timeout.clone();
+        let timeouts = config.timeouts.clone();
         Ok(PgPoolOptions::new()
             .max_connections(max_connections)
             .min_connections(0)
@@ -920,12 +980,10 @@ impl Db {
             .max_lifetime(Duration::from_secs(config.max_lifetime_secs))
             .idle_timeout(Duration::from_secs(config.idle_timeout_secs))
             .after_connect(move |connection, _meta| {
-                let statement_timeout = statement_timeout.clone();
-                let lock_timeout = lock_timeout.clone();
-                Box::pin(async move {
-                    apply_runtime_connection_timeouts(connection, &statement_timeout, &lock_timeout)
-                        .await
-                })
+                let timeouts = timeouts.clone();
+                Box::pin(
+                    async move { apply_runtime_connection_timeouts(connection, &timeouts).await },
+                )
             })
             .connect_lazy(url)?)
     }
@@ -6737,8 +6795,11 @@ mod tests {
             database_url: scratch_url,
             max_connections: 2,
             min_connections: 2,
-            statement_timeout: TIGHT.parse().expect("test timeout literal"),
-            lock_timeout: TIGHT.parse().expect("test timeout literal"),
+            timeouts: RuntimeTimeouts {
+                statement: TIGHT.parse().expect("test timeout literal"),
+                lock: TIGHT.parse().expect("test timeout literal"),
+                idle_in_transaction: TIGHT.parse().expect("test timeout literal"),
+            },
             ..DbConfig::default()
         })
         .await
@@ -6761,8 +6822,14 @@ mod tests {
                 .fetch_one(&mut *connection)
                 .await
                 .expect("SHOW lock_timeout");
+            let idle_timeout: String =
+                sqlx::query_scalar("SHOW idle_in_transaction_session_timeout")
+                    .fetch_one(&mut *connection)
+                    .await
+                    .expect("SHOW idle_in_transaction_session_timeout");
             assert_eq!(statement_timeout, TIGHT);
             assert_eq!(lock_timeout, TIGHT);
+            assert_eq!(idle_timeout, TIGHT);
             held.push(connection);
         }
         drop(held);
@@ -8586,28 +8653,36 @@ mod tests {
         let cid = CommunityId::from_uuid(community);
 
         // Assert the effective session values, not only pool-builder intent.
-        let statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
-            .fetch_one(&db.pool)
-            .await
-            .expect("SHOW statement_timeout");
-        let lock_timeout: String = sqlx::query_scalar("SHOW lock_timeout")
-            .fetch_one(&db.pool)
-            .await
-            .expect("SHOW lock_timeout");
-        assert_eq!(statement_timeout, RUNTIME_STATEMENT_TIMEOUT);
-        assert_eq!(lock_timeout, RUNTIME_LOCK_TIMEOUT);
-
-        let read_pool = db.read_pool.as_ref().expect("read pool configured");
-        let reader_statement_timeout: String = sqlx::query_scalar("SHOW statement_timeout")
-            .fetch_one(read_pool)
-            .await
-            .expect("SHOW reader statement_timeout");
-        let reader_lock_timeout: String = sqlx::query_scalar("SHOW lock_timeout")
-            .fetch_one(read_pool)
-            .await
-            .expect("SHOW reader lock_timeout");
-        assert_eq!(reader_statement_timeout, RUNTIME_STATEMENT_TIMEOUT);
-        assert_eq!(reader_lock_timeout, RUNTIME_LOCK_TIMEOUT);
+        // Compare milliseconds, not spellings: Postgres re-spells a setting on
+        // the way out (`60s` reads back as `1min`), so asserting on `SHOW`
+        // text couples the test to the server's formatting rather than to the
+        // limit actually in force.
+        for (pool, label) in [
+            (&db.pool, "writer"),
+            (
+                db.read_pool.as_ref().expect("read pool configured"),
+                "reader",
+            ),
+        ] {
+            for (setting, expected_millis) in [
+                ("statement_timeout", 30_000),
+                ("lock_timeout", 5_000),
+                ("idle_in_transaction_session_timeout", 60_000),
+            ] {
+                let millis: i64 =
+                    sqlx::query_scalar("SELECT setting::bigint FROM pg_settings WHERE name = $1")
+                        .bind(setting)
+                        .fetch_one(pool)
+                        .await
+                        .unwrap_or_else(|error| {
+                            panic!("read {setting} on the {label} pool: {error}")
+                        });
+                assert_eq!(
+                    millis, expected_millis,
+                    "{label} pool must carry the default {setting}"
+                );
+            }
+        }
 
         let effective: String = sqlx::query_scalar("SHOW buzz.created_at_floor")
             .fetch_one(&db.pool)
@@ -8669,6 +8744,16 @@ mod tests {
         drop_scratch_db(&admin, seed_pool, &name).await;
         // db pool still holds connections to the dropped DB; close it.
         db.pool.close().await;
+    }
+
+    /// Every limit set to the same value, for tests that care about one
+    /// spelling rather than about the individual limits.
+    fn uniform_timeouts(timeout: &PgTimeout) -> RuntimeTimeouts {
+        RuntimeTimeouts {
+            statement: timeout.clone(),
+            lock: timeout.clone(),
+            idle_in_transaction: timeout.clone(),
+        }
     }
 
     /// The built-in defaults bypass parsing, so prove they would survive it —
@@ -8791,7 +8876,7 @@ mod tests {
         ] {
             let parsed = PgTimeout::parse_or(Some(raw), PgTimeout::statement_default());
             assert_eq!(parsed.as_str(), canonical);
-            apply_runtime_connection_timeouts(&mut connection, &parsed, &parsed)
+            apply_runtime_connection_timeouts(&mut connection, &uniform_timeouts(&parsed))
                 .await
                 .unwrap_or_else(|error| panic!("{raw:?} normalized to {parsed}: {error}"));
         }
@@ -8811,7 +8896,7 @@ mod tests {
             .expect("connect");
 
         let boundary = PgTimeout::unchecked(PG_TIMEOUT_MAX_MILLIS.to_string());
-        apply_runtime_connection_timeouts(&mut conn, &boundary, &boundary)
+        apply_runtime_connection_timeouts(&mut conn, &uniform_timeouts(&boundary))
             .await
             .expect("PG_TIMEOUT_MAX_MILLIS must be settable");
 
@@ -8819,7 +8904,7 @@ mod tests {
         // range check performs must land inside the range too.
         let in_seconds = (PG_TIMEOUT_MAX_MILLIS / 1_000).to_string();
         let boundary_seconds = PgTimeout::unchecked(format!("{in_seconds}s"));
-        apply_runtime_connection_timeouts(&mut conn, &boundary_seconds, &boundary_seconds)
+        apply_runtime_connection_timeouts(&mut conn, &uniform_timeouts(&boundary_seconds))
             .await
             .expect("the boundary in seconds must be settable");
 
@@ -8831,8 +8916,10 @@ mod tests {
         ] {
             let err = apply_runtime_connection_timeouts(
                 &mut conn,
-                &PgTimeout::unchecked(over.clone()),
-                &PgTimeout::lock_default(),
+                &RuntimeTimeouts {
+                    statement: PgTimeout::unchecked(over.clone()),
+                    ..RuntimeTimeouts::default()
+                },
             )
             .await
             .expect_err(&format!("{over} must be rejected by Postgres"));

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -73,26 +73,168 @@ pub const RUNTIME_LOCK_TIMEOUT: &str = "5s";
 pub const TIMEOUT_DISABLED: &str = "0";
 /// `statement_timeout` and `lock_timeout` are `int` GUCs measured in
 /// milliseconds, so Postgres refuses anything larger regardless of the unit it
-/// is spelled with. Callers building a [`DbConfig`] from operator input must
-/// range-check against this: [`apply_runtime_connection_timeouts`] runs on every
-/// pooled connection, so an unusable value fails all database access.
+/// is spelled with. Private on purpose: [`PgTimeout`] is the only way to build a
+/// timeout, so no caller needs to range-check by hand.
 /// `pg_timeout_max_millis_matches_postgres` pins it to the live server.
-pub const PG_TIMEOUT_MAX_MILLIS: u128 = i32::MAX as u128;
+const PG_TIMEOUT_MAX_MILLIS: u128 = i32::MAX as u128;
+
+/// Why a string is not a timeout Postgres would accept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PgTimeoutError {
+    /// Not an integer with an optional `us`/`ms`/`s`/`min`/`h`/`d` unit.
+    Malformed,
+    /// Well-formed, but larger than Postgres can store in an `int` GUC.
+    OutOfRange {
+        /// The value in milliseconds, for the operator-facing message.
+        millis: u128,
+    },
+}
+
+impl std::fmt::Display for PgTimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed => write!(
+                f,
+                "expected an integer with an optional us/ms/s/min/h/d unit"
+            ),
+            Self::OutOfRange { millis } => write!(
+                f,
+                "{millis}ms exceeds the {PG_TIMEOUT_MAX_MILLIS}ms Postgres stores in an int GUC"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PgTimeoutError {}
+
+/// A Postgres timeout that the server is known to accept.
+///
+/// Parsing is the only way to build one from operator input, so a [`DbConfig`]
+/// cannot carry a value that would break
+/// [`apply_runtime_connection_timeouts`] — which runs on every pooled
+/// connection, and would therefore fail all database access. The stored
+/// spelling is canonical: the magnitude followed by the lowercased unit, since
+/// Postgres' unit names are case-sensitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PgTimeout(String);
+
+impl PgTimeout {
+    /// The default runtime statement timeout ([`RUNTIME_STATEMENT_TIMEOUT`]).
+    pub fn statement_default() -> Self {
+        Self(RUNTIME_STATEMENT_TIMEOUT.to_string())
+    }
+
+    /// The default runtime lock timeout ([`RUNTIME_LOCK_TIMEOUT`]).
+    pub fn lock_default() -> Self {
+        Self(RUNTIME_LOCK_TIMEOUT.to_string())
+    }
+
+    /// No limit at all — what schema migrations and one-shot operator tools
+    /// run with.
+    pub fn disabled() -> Self {
+        Self(TIMEOUT_DISABLED.to_string())
+    }
+
+    /// The canonical spelling, ready to hand to Postgres.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Parse operator input, falling back to `default` with a warning.
+    ///
+    /// Refusing to start on a bad timeout would be the same outage the limits
+    /// prevent, so a malformed or out-of-range value keeps the documented
+    /// default instead. `None` and blank mean "unset".
+    pub fn parse_or(raw: Option<&str>, default: Self) -> Self {
+        let Some(candidate) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+            return default;
+        };
+        match candidate.parse::<Self>() {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                tracing::warn!(
+                    value = candidate,
+                    default = default.as_str(),
+                    %error,
+                    "ignoring unusable Postgres timeout"
+                );
+                default
+            }
+        }
+    }
+
+    /// [`PgTimeout::parse_or`] against an environment variable.
+    pub fn from_env_or(var: &str, default: Self) -> Self {
+        Self::parse_or(std::env::var(var).ok().as_deref(), default)
+    }
+}
+
+#[cfg(test)]
+impl PgTimeout {
+    /// Build without validation, so a test can hand Postgres a value
+    /// [`FromStr`](std::str::FromStr) refuses to produce and prove the server
+    /// rejects it.
+    pub(crate) fn unchecked(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+}
+
+impl std::fmt::Display for PgTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for PgTimeout {
+    type Err = PgTimeoutError;
+
+    fn from_str(raw: &str) -> std::result::Result<Self, Self::Err> {
+        let candidate = raw.trim();
+        let digits = candidate.chars().take_while(char::is_ascii_digit).count();
+        let (magnitude, unit) = candidate.split_at(digits);
+        let unit = unit.trim().to_ascii_lowercase();
+
+        match pg_timeout_millis(magnitude, &unit) {
+            Some(millis) if millis <= PG_TIMEOUT_MAX_MILLIS => {
+                Ok(Self(format!("{magnitude}{unit}")))
+            }
+            Some(millis) => Err(PgTimeoutError::OutOfRange { millis }),
+            None => Err(PgTimeoutError::Malformed),
+        }
+    }
+}
+
+/// Convert a Postgres timeout magnitude and unit to milliseconds, mirroring the
+/// rounding Postgres applies to sub-millisecond `us` values. `None` means the
+/// spelling is not something Postgres would accept.
+fn pg_timeout_millis(magnitude: &str, unit: &str) -> Option<u128> {
+    let value = magnitude.parse::<u128>().ok()?;
+    match unit {
+        // Round half up without the `value + 500` intermediate, which overflows
+        // for the top 500 representable microsecond values.
+        "us" => Some(value / 1_000 + u128::from(value % 1_000 >= 500)),
+        "" | "ms" => Some(value),
+        "s" => value.checked_mul(1_000),
+        "min" => value.checked_mul(60_000),
+        "h" => value.checked_mul(3_600_000),
+        "d" => value.checked_mul(86_400_000),
+        _ => None,
+    }
+}
 
 /// Apply the runtime safety limits shared by writer, reader, audit, and search
-/// pools. Values are Postgres interval strings (`"30s"`, `"500ms"`), with
-/// [`TIMEOUT_DISABLED`] lifting a limit entirely.
+/// pools. [`PgTimeout::disabled`] lifts a limit entirely.
 pub async fn apply_runtime_connection_timeouts(
     connection: &mut PgConnection,
-    statement_timeout: &str,
-    lock_timeout: &str,
+    statement_timeout: &PgTimeout,
+    lock_timeout: &PgTimeout,
 ) -> std::result::Result<(), sqlx::Error> {
     sqlx::query(
         "SELECT set_config('statement_timeout', $1, false), \
                 set_config('lock_timeout', $2, false)",
     )
-    .bind(statement_timeout)
-    .bind(lock_timeout)
+    .bind(statement_timeout.as_str())
+    .bind(lock_timeout.as_str())
     .execute(connection)
     .await?;
     Ok(())
@@ -562,12 +704,12 @@ pub struct DbConfig {
     pub replica_read_max_age_ms: u64,
     /// Postgres `statement_timeout` applied to every runtime connection. An
     /// operator running a backfill or working an incident can widen this without
-    /// a code change; [`TIMEOUT_DISABLED`] removes the cap.
-    pub statement_timeout: String,
+    /// a code change; [`PgTimeout::disabled`] removes the cap.
+    pub statement_timeout: PgTimeout,
     /// Postgres `lock_timeout` applied to every runtime connection. Bounds
     /// heavyweight and row lock waits only — advisory-lock waits are bounded by
     /// [`Self::statement_timeout`] instead.
-    pub lock_timeout: String,
+    pub lock_timeout: PgTimeout,
 }
 
 impl Default for DbConfig {
@@ -585,8 +727,8 @@ impl Default for DbConfig {
             max_lifetime_secs: 1800,
             idle_timeout_secs: 600,
             replica_read_max_age_ms: 0,
-            statement_timeout: RUNTIME_STATEMENT_TIMEOUT.to_string(),
-            lock_timeout: RUNTIME_LOCK_TIMEOUT.to_string(),
+            statement_timeout: PgTimeout::statement_default(),
+            lock_timeout: PgTimeout::lock_default(),
         }
     }
 }
@@ -6595,8 +6737,8 @@ mod tests {
             database_url: scratch_url,
             max_connections: 2,
             min_connections: 2,
-            statement_timeout: TIGHT.to_string(),
-            lock_timeout: TIGHT.to_string(),
+            statement_timeout: TIGHT.parse().expect("test timeout literal"),
+            lock_timeout: TIGHT.parse().expect("test timeout literal"),
             ..DbConfig::default()
         })
         .await
@@ -8529,10 +8671,138 @@ mod tests {
         db.pool.close().await;
     }
 
-    /// [`PG_TIMEOUT_MAX_MILLIS`] is the bound callers range-check operator input
-    /// against, so it must be the server's real bound: too high and an accepted
-    /// value still fails every `after_connect`; too low and we reject settings
-    /// Postgres would have taken.
+    /// The built-in defaults bypass parsing, so prove they would survive it —
+    /// otherwise a typo in a literal ships a value Postgres refuses.
+    #[test]
+    fn builtin_timeout_defaults_are_parseable() {
+        for default in [
+            PgTimeout::statement_default(),
+            PgTimeout::lock_default(),
+            PgTimeout::disabled(),
+        ] {
+            assert_eq!(
+                default.as_str().parse::<PgTimeout>().as_ref(),
+                Ok(&default),
+                "{default} must round-trip through the parser"
+            );
+        }
+    }
+
+    #[test]
+    fn pg_timeout_accepts_postgres_spellings_and_refuses_the_rest() {
+        let default = PgTimeout::statement_default();
+        for (accepted, canonical) in [
+            ("30s", "30s"),
+            ("500ms", "500ms"),
+            ("0", "0"),
+            ("45S", "45s"),
+            ("2MIN", "2min"),
+            (" 10 H ", "10h"),
+        ] {
+            assert_eq!(
+                PgTimeout::parse_or(Some(accepted), default.clone()).as_str(),
+                canonical,
+                "{accepted} is a valid Postgres timeout"
+            );
+        }
+
+        // A rejected value must not reach Postgres: `after_connect` would fail
+        // for every connection, which is worse than the documented default.
+        for rejected in ["", "   ", "soon", "30 seconds", "s30", "-5s", "30s;DROP"] {
+            assert_eq!(
+                PgTimeout::parse_or(Some(rejected), default.clone()),
+                default,
+                "{rejected:?} must fall back to the default"
+            );
+        }
+
+        assert_eq!(
+            PgTimeout::parse_or(None, PgTimeout::lock_default()),
+            PgTimeout::lock_default()
+        );
+    }
+
+    #[test]
+    fn pg_timeout_refuses_magnitudes_postgres_cannot_store() {
+        let default = PgTimeout::statement_default();
+        // Well-formed spellings whose millisecond value exceeds the int GUC
+        // range. Postgres rejects these in `set_config`, which would fail every
+        // pool's `after_connect`.
+        for rejected in [
+            "2147483648",
+            "2147483648ms",
+            "2147484s",
+            "35792min",
+            "597h",
+            "25d",
+            // Wider than any integer type — must fall back, not overflow.
+            "999999999999999999999999999999999999999999d",
+            "99999999999999999999999999999999999999999999999999",
+            // Parses as u128, so unlike the two above it reaches the unit
+            // conversion — where rounding must not overflow on the way to the
+            // range check.
+            &format!("{}us", u128::MAX),
+            &format!("{}us", u128::MAX - 499),
+        ] {
+            assert_eq!(
+                PgTimeout::parse_or(Some(rejected), default.clone()),
+                default,
+                "{rejected:?} is out of range for Postgres and must fall back"
+            );
+        }
+
+        // The boundary itself, and the same instant in every unit, stay valid.
+        for accepted in [
+            "2147483647",
+            "2147483647ms",
+            "2147483647000us",
+            "2147483s",
+            "35791min",
+            "596h",
+            "24d",
+        ] {
+            assert_eq!(
+                PgTimeout::parse_or(Some(accepted), default.clone()).as_str(),
+                accepted,
+                "{accepted} is inside the Postgres range"
+            );
+        }
+    }
+
+    /// Every spelling the parser emits must be usable by Postgres. A
+    /// parser-only assertion missed that Postgres rejects uppercase units even
+    /// though validation lowercases them.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn pg_timeout_canonical_spellings_are_accepted_by_postgres() {
+        let mut connection = PgConnection::connect(&admin_url().await)
+            .await
+            .expect("connect test Postgres");
+
+        for (raw, canonical) in [
+            ("500US", "500us"),
+            ("500MS", "500ms"),
+            ("2S", "2s"),
+            ("2MIN", "2min"),
+            ("2H", "2h"),
+            ("2D", "2d"),
+            ("0", "0"),
+            (" 10 S ", "10s"),
+        ] {
+            let parsed = PgTimeout::parse_or(Some(raw), PgTimeout::statement_default());
+            assert_eq!(parsed.as_str(), canonical);
+            apply_runtime_connection_timeouts(&mut connection, &parsed, &parsed)
+                .await
+                .unwrap_or_else(|error| panic!("{raw:?} normalized to {parsed}: {error}"));
+        }
+
+        connection.close().await.expect("close test Postgres");
+    }
+
+    /// `PG_TIMEOUT_MAX_MILLIS` is the bound [`PgTimeout`] range-checks operator
+    /// input against, so it must be the server's real bound: too high and an
+    /// accepted value still fails every `after_connect`; too low and we reject
+    /// settings Postgres would have taken.
     #[tokio::test]
     #[ignore = "requires Postgres"]
     async fn pg_timeout_max_millis_matches_postgres() {
@@ -8540,7 +8810,7 @@ mod tests {
             .await
             .expect("connect");
 
-        let boundary = PG_TIMEOUT_MAX_MILLIS.to_string();
+        let boundary = PgTimeout::unchecked(PG_TIMEOUT_MAX_MILLIS.to_string());
         apply_runtime_connection_timeouts(&mut conn, &boundary, &boundary)
             .await
             .expect("PG_TIMEOUT_MAX_MILLIS must be settable");
@@ -8548,13 +8818,10 @@ mod tests {
         // Same instant spelled in a coarser unit — the conversion the caller's
         // range check performs must land inside the range too.
         let in_seconds = (PG_TIMEOUT_MAX_MILLIS / 1_000).to_string();
-        apply_runtime_connection_timeouts(
-            &mut conn,
-            &format!("{in_seconds}s"),
-            &format!("{in_seconds}s"),
-        )
-        .await
-        .expect("the boundary in seconds must be settable");
+        let boundary_seconds = PgTimeout::unchecked(format!("{in_seconds}s"));
+        apply_runtime_connection_timeouts(&mut conn, &boundary_seconds, &boundary_seconds)
+            .await
+            .expect("the boundary in seconds must be settable");
 
         for over in [
             (PG_TIMEOUT_MAX_MILLIS + 1).to_string(),
@@ -8562,9 +8829,13 @@ mod tests {
             format!("{}s", PG_TIMEOUT_MAX_MILLIS / 1_000 + 1),
             "999999999999999999999999999999999999999999d".to_string(),
         ] {
-            let err = apply_runtime_connection_timeouts(&mut conn, &over, RUNTIME_LOCK_TIMEOUT)
-                .await
-                .expect_err(&format!("{over} must be rejected by Postgres"));
+            let err = apply_runtime_connection_timeouts(
+                &mut conn,
+                &PgTimeout::unchecked(over.clone()),
+                &PgTimeout::lock_default(),
+            )
+            .await
+            .expect_err(&format!("{over} must be rejected by Postgres"));
             let code = match &err {
                 sqlx::Error::Database(db) => db.code().map(|c| c.to_string()),
                 other => panic!("expected a database error, got {other:?}"),

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -4,16 +4,27 @@
 //! multi-tenant rewrite owns a clean consolidated `0001`; legacy single-tenant
 //! cutover/backfill is a separate operator script, not startup migration state.
 
-use sqlx::PgPool;
+use sqlx::{Connection, PgPool};
 
 use crate::Result;
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../migrations");
 
 /// Run all pending Buzz database migrations.
+///
+/// DDL runs with the runtime `statement_timeout` and `lock_timeout` lifted. An
+/// index build on a populated table, or an `ACCESS EXCLUSIVE` wait behind live
+/// traffic, routinely outlasts the runtime caps — and because startup treats a
+/// migration failure as fatal, inheriting them would turn a slow migration into
+/// a relay that cannot boot. sqlx also takes its migration advisory lock as a
+/// single waiting statement, so a second replica rolling out would be canceled
+/// mid-wait rather than queueing behind the first.
+///
+/// The connection is closed instead of returned to the pool: its session still
+/// carries the lifted limits and must never serve traffic.
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     reject_legacy_nip_rs_cardinality_ambiguity(pool).await?;
-    MIGRATOR.run(pool).await?;
+    run_migrator_without_runtime_timeouts(pool).await?;
     // The replica-fence proof (see `replica_fence`) requires the commit-time
     // `created_at` floor trigger from migration 0021 — correctly shaped — on
     // the `events` parent and every partition. `CREATE TABLE .. PARTITION OF`
@@ -22,6 +33,23 @@ pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     // guard, so migration fails closed if any is missing. (The fence probe
     // re-runs this same check at startup on non-migrating relays.)
     crate::replica_fence::verify_floor_guard_catalog(pool).await?;
+    Ok(())
+}
+
+async fn run_migrator_without_runtime_timeouts(pool: &PgPool) -> Result<()> {
+    let mut connection = pool.acquire().await?;
+    crate::apply_runtime_connection_timeouts(
+        &mut connection,
+        crate::TIMEOUT_DISABLED,
+        crate::TIMEOUT_DISABLED,
+    )
+    .await?;
+    let migrated = MIGRATOR.run(&mut *connection).await;
+    // Retire the connection either way; report the migration outcome first so a
+    // close failure cannot mask it.
+    let closed = connection.detach().close().await;
+    migrated?;
+    closed?;
     Ok(())
 }
 

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -12,39 +12,60 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("../../migrations");
 
 /// Run all pending Buzz database migrations.
 ///
-/// DDL runs with the runtime `statement_timeout` and `lock_timeout` lifted. An
-/// index build on a populated table, or an `ACCESS EXCLUSIVE` wait behind live
-/// traffic, routinely outlasts the runtime caps — and because startup treats a
-/// migration failure as fatal, inheriting them would turn a slow migration into
-/// a relay that cannot boot. sqlx also takes its migration advisory lock as a
-/// single waiting statement, so a second replica rolling out would be canceled
-/// mid-wait rather than queueing behind the first.
+/// Everything that can be slow on a populated database — the legacy NIP-RS
+/// preflight scan and the migrator itself — runs on one dedicated connection
+/// with the runtime `statement_timeout` and `lock_timeout` lifted. An index
+/// build on a populated table, an `ACCESS EXCLUSIVE` wait behind live traffic,
+/// or a full scan of `events` with per-row JSON expansion routinely outlasts
+/// the runtime caps — and because startup treats a migration failure as fatal,
+/// inheriting them would turn a slow migration into a relay that cannot boot.
+/// sqlx also takes its migration advisory lock as a single waiting statement,
+/// so a second replica rolling out would be canceled mid-wait rather than
+/// queueing behind the first.
 ///
-/// The connection is closed instead of returned to the pool: its session still
-/// carries the lifted limits and must never serve traffic.
+/// The connection is detached from the pool before its limits are lifted and
+/// closed afterwards: a session with no caps must never serve traffic, and
+/// detaching first means even a cancellation mid-migration drops it rather than
+/// releasing it back.
 pub async fn run_migrations(pool: &PgPool) -> Result<()> {
-    reject_legacy_nip_rs_cardinality_ambiguity(pool).await?;
-    run_migrator_without_runtime_timeouts(pool).await?;
+    let mut connection = exempt_migration_connection(pool).await?;
+    let migrated = migrate_on_exempt_connection(&mut connection).await;
+    // Close the connection either way; report the migration outcome first so a
+    // close failure cannot mask it.
+    let closed = connection.close().await;
+    migrated?;
+    closed?;
     // The replica-fence proof (see `replica_fence`) requires the commit-time
     // `created_at` floor trigger from migration 0021 — correctly shaped — on
     // the `events` parent and every partition. `CREATE TABLE .. PARTITION OF`
     // clones parent triggers, but a partition attached with `ATTACH
     // PARTITION` or created by an older code path would silently escape the
     // guard, so migration fails closed if any is missing. (The fence probe
-    // re-runs this same check at startup on non-migrating relays.)
+    // re-runs this same check at startup on non-migrating relays.) Catalog-only
+    // and bounded by the number of partitions, so the runtime caps are fine.
     crate::replica_fence::verify_floor_guard_catalog(pool).await?;
     Ok(())
 }
 
-async fn run_migrator_without_runtime_timeouts(pool: &PgPool) -> Result<()> {
-    let mut connection = pool.acquire().await?;
+/// Take a connection out of the pool for good, then lift its runtime limits.
+///
+/// Detaching before lifting is what makes the exemption structurally
+/// cancellation-safe: a [`sqlx::pool::PoolConnection`] returns itself to the
+/// pool on drop, so a future cancelled after the lift would hand an unbounded
+/// session to runtime traffic. A detached [`sqlx::PgConnection`] closes on drop
+/// instead.
+async fn exempt_migration_connection(pool: &PgPool) -> Result<sqlx::PgConnection> {
+    let mut connection = pool.acquire().await?.detach();
     lift_runtime_timeouts(&mut connection).await?;
-    let migrated = MIGRATOR.run(&mut *connection).await;
-    // Retire the connection either way; report the migration outcome first so a
-    // close failure cannot mask it.
-    let retired = retire_connection(connection).await;
-    migrated?;
-    retired?;
+    Ok(connection)
+}
+
+/// The preflight *and* the migrator, both on the exempt connection. The
+/// preflight stays ahead of sqlx's migration transaction so an operator can
+/// still inspect and repair before any DDL runs.
+async fn migrate_on_exempt_connection(connection: &mut sqlx::PgConnection) -> Result<()> {
+    reject_legacy_nip_rs_cardinality_ambiguity(connection).await?;
+    MIGRATOR.run(connection).await?;
     Ok(())
 }
 
@@ -59,28 +80,28 @@ async fn lift_runtime_timeouts(connection: &mut sqlx::PgConnection) -> Result<()
     Ok(())
 }
 
-/// Close a connection instead of returning it to the pool, so a session that
-/// carries lifted limits can never serve traffic.
-async fn retire_connection(connection: sqlx::pool::PoolConnection<sqlx::Postgres>) -> Result<()> {
-    connection.detach().close().await?;
-    Ok(())
-}
-
 /// Migration 0007 is checksum-frozen and predates exact NIP-RS tag-cardinality
 /// enforcement. A populated database still on 0001-0006 must not let 0007
 /// irreversibly purge duplicate-tag history. Fail before sqlx starts its
 /// migration transaction so an operator can inspect and repair those rows.
-async fn reject_legacy_nip_rs_cardinality_ambiguity(pool: &PgPool) -> Result<()> {
+///
+/// Takes a connection, not the pool: the scan below is a full pass over
+/// `events` with per-row JSON expansion on exactly the databases that are large
+/// enough to matter, so it must run on the timeout-exempt migration connection
+/// (see [`run_migrations`]) or a slow scan becomes a fatal startup failure.
+async fn reject_legacy_nip_rs_cardinality_ambiguity(
+    connection: &mut sqlx::PgConnection,
+) -> Result<()> {
     let migrations_table: Option<String> =
         sqlx::query_scalar("SELECT to_regclass('_sqlx_migrations')::text")
-            .fetch_one(pool)
+            .fetch_one(&mut *connection)
             .await?;
     if migrations_table.is_none() {
         return Ok(());
     }
     let applied: Option<i64> =
         sqlx::query_scalar("SELECT max(version) FROM _sqlx_migrations WHERE success")
-            .fetch_one(pool)
+            .fetch_one(&mut *connection)
             .await?;
     if applied.is_none_or(|version| version >= 7) {
         return Ok(());
@@ -124,7 +145,7 @@ async fn reject_legacy_nip_rs_cardinality_ambiguity(pool: &PgPool) -> Result<()>
                )\
          )",
     )
-    .fetch_one(pool)
+    .fetch_one(&mut *connection)
     .await?;
 
     if ambiguous {
@@ -1185,15 +1206,13 @@ mod tests {
             .await
             .expect("connect to test DB");
 
-        let mut connection = pool.acquire().await.expect("acquire");
-        assert_eq!(
-            show_timeout(&mut connection, "statement_timeout").await,
-            TIGHT
-        );
+        let mut pooled = pool.acquire().await.expect("acquire");
+        assert_eq!(show_timeout(&mut pooled, "statement_timeout").await, TIGHT);
+        drop(pooled);
 
-        lift_runtime_timeouts(&mut connection)
+        let mut connection = exempt_migration_connection(&pool)
             .await
-            .expect("lift runtime timeouts");
+            .expect("acquire exempt migration connection");
         for setting in ["statement_timeout", "lock_timeout"] {
             assert_eq!(
                 show_timeout(&mut connection, setting).await,
@@ -1202,9 +1221,9 @@ mod tests {
             );
         }
 
-        retire_connection(connection)
-            .await
-            .expect("retire migration connection");
+        // Dropping without closing stands in for a cancelled migration future:
+        // the connection is detached, so the pool must still not see it.
+        drop(connection);
 
         let mut fresh = pool.acquire().await.expect("re-acquire");
         for setting in ["statement_timeout", "lock_timeout"] {
@@ -1293,6 +1312,131 @@ mod tests {
             .await
             .expect("retry succeeds after operator repair");
         assert_eq!(applied_versions(&pool).await.last().copied(), Some(27));
+    }
+
+    /// A pool whose connections carry `timeout` for both runtime limits.
+    async fn connect_capped_pool(timeout: &'static str) -> PgPool {
+        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .unwrap_or_else(|_| TEST_DB_URL.to_owned());
+
+        sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .after_connect(move |connection, _meta| {
+                Box::pin(crate::apply_runtime_connection_timeouts(
+                    connection, timeout, timeout,
+                ))
+            })
+            .connect(&database_url)
+            .await
+            .expect("connect capped test pool")
+    }
+
+    fn is_statement_timeout(error: &crate::DbError) -> bool {
+        // 57014 = query_canceled, which is what `statement_timeout` raises.
+        matches!(error, crate::DbError::Sqlx(sqlx::Error::Database(db))
+            if db.code().as_deref() == Some("57014"))
+    }
+
+    /// Conforming (never ambiguous) kind-30078 read-state rows, so the preflight
+    /// scan cannot short-circuit on an early match and has to read them all.
+    async fn seed_conforming_read_state_rows(
+        pool: &PgPool,
+        community_id: uuid::Uuid,
+        offset: i64,
+        count: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (community_id, id, pubkey, created_at, kind, tags, content, sig, received_at, d_tag) \
+             SELECT $1, \
+                    decode(md5('id' || i::text) || md5('id2' || i::text), 'hex'), \
+                    decode(md5('pk' || i::text) || md5('pk2' || i::text), 'hex'), \
+                    NOW(), 30078, \
+                    jsonb_build_array( \
+                        jsonb_build_array('d', 'read-state:' || md5(i::text)), \
+                        jsonb_build_array('t', 'read-state')), \
+                    'conforming', \
+                    decode(repeat(md5(i::text), 4), 'hex'), \
+                    NOW(), \
+                    'read-state:' || md5(i::text) \
+             FROM generate_series($2::bigint, $3::bigint) AS i",
+        )
+        .bind(community_id)
+        .bind(offset + 1)
+        .bind(offset + count)
+        .execute(pool)
+        .await
+        .expect("seed conforming read-state rows");
+    }
+
+    /// The legacy NIP-RS preflight must run on the timeout-exempt migration
+    /// connection, not on a pooled one. It scans all of `events` with per-row
+    /// JSON expansion on exactly the databases big enough for that to be slow,
+    /// and startup treats the error as fatal — so inheriting the runtime
+    /// `statement_timeout` there is a relay that cannot boot. The fresh-database
+    /// migration test returns before this scan and cannot catch the ordering.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn legacy_preflight_scan_outlives_the_runtime_statement_timeout() {
+        const TIGHT: &str = "50ms";
+        const SEED_BATCH: i64 = 20_000;
+        const MAX_SEEDED: i64 = 200_000;
+
+        let pool = connect_test_pool().await;
+        reset_public_schema(&pool).await;
+        MIGRATOR
+            .run_to(6, &pool)
+            .await
+            .expect("apply migrations 1-6");
+
+        let community_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+            .bind(community_id)
+            .bind(format!("preflight-{}.example", community_id.simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+
+        let capped = connect_capped_pool(TIGHT).await;
+
+        // Grow the table until the preflight genuinely exceeds the cap on a
+        // pooled connection. Scan cost is hardware-dependent, so calibrate
+        // instead of hardcoding a row count that is slow on one machine only.
+        let mut seeded = 0;
+        loop {
+            seed_conforming_read_state_rows(&pool, community_id, seeded, SEED_BATCH).await;
+            seeded += SEED_BATCH;
+
+            let mut capped_connection = capped.acquire().await.expect("acquire capped connection");
+            match reject_legacy_nip_rs_cardinality_ambiguity(&mut capped_connection).await {
+                Err(error) if is_statement_timeout(&error) => break,
+                Err(error) => panic!("preflight failed for an unrelated reason: {error}"),
+                Ok(()) => assert!(
+                    seeded < MAX_SEEDED,
+                    "preflight still finished inside {TIGHT} with {seeded} rows; \
+                     the test can no longer prove the exemption is load-bearing"
+                ),
+            }
+        }
+
+        // Same cap, same data — the exemption is the only difference.
+        run_migrations(&capped)
+            .await
+            .expect("migrations must not inherit the runtime caps during the legacy preflight");
+        assert_eq!(applied_versions(&pool).await.last().copied(), Some(26));
+
+        // And the caps are still in force for traffic afterwards.
+        let mut runtime = capped.acquire().await.expect("acquire after migration");
+        for setting in ["statement_timeout", "lock_timeout"] {
+            assert_eq!(
+                show_timeout(&mut runtime, setting).await,
+                TIGHT,
+                "the pool must not hand out a relaxed session after migrating"
+            );
+        }
+        drop(runtime);
+        capped.close().await;
     }
 
     #[tokio::test]

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -38,18 +38,31 @@ pub async fn run_migrations(pool: &PgPool) -> Result<()> {
 
 async fn run_migrator_without_runtime_timeouts(pool: &PgPool) -> Result<()> {
     let mut connection = pool.acquire().await?;
+    lift_runtime_timeouts(&mut connection).await?;
+    let migrated = MIGRATOR.run(&mut *connection).await;
+    // Retire the connection either way; report the migration outcome first so a
+    // close failure cannot mask it.
+    let retired = retire_connection(connection).await;
+    migrated?;
+    retired?;
+    Ok(())
+}
+
+/// Remove both runtime limits from one connection's session.
+async fn lift_runtime_timeouts(connection: &mut sqlx::PgConnection) -> Result<()> {
     crate::apply_runtime_connection_timeouts(
-        &mut connection,
+        connection,
         crate::TIMEOUT_DISABLED,
         crate::TIMEOUT_DISABLED,
     )
     .await?;
-    let migrated = MIGRATOR.run(&mut *connection).await;
-    // Retire the connection either way; report the migration outcome first so a
-    // close failure cannot mask it.
-    let closed = connection.detach().close().await;
-    migrated?;
-    closed?;
+    Ok(())
+}
+
+/// Close a connection instead of returning it to the pool, so a session that
+/// carries lifted limits can never serve traffic.
+async fn retire_connection(connection: sqlx::pool::PoolConnection<sqlx::Postgres>) -> Result<()> {
+    connection.detach().close().await?;
     Ok(())
 }
 
@@ -1147,6 +1160,69 @@ mod tests {
         .fetch_all(pool)
         .await
         .expect("read applied migrations")
+    }
+
+    /// The migration connection must have both limits lifted, and it must not
+    /// come back to the pool afterwards — a session with no statement timeout
+    /// serving traffic is the failure this exemption trades against.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn migration_connection_is_unbounded_and_is_retired_not_reused() {
+        const TIGHT: &str = "50ms";
+
+        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .unwrap_or_else(|_| TEST_DB_URL.to_owned());
+        // One slot: a reused connection would be handed straight back below.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(1)
+            .after_connect(|connection, _meta| {
+                Box::pin(crate::apply_runtime_connection_timeouts(
+                    connection, TIGHT, TIGHT,
+                ))
+            })
+            .connect(&database_url)
+            .await
+            .expect("connect to test DB");
+
+        let mut connection = pool.acquire().await.expect("acquire");
+        assert_eq!(
+            show_timeout(&mut connection, "statement_timeout").await,
+            TIGHT
+        );
+
+        lift_runtime_timeouts(&mut connection)
+            .await
+            .expect("lift runtime timeouts");
+        for setting in ["statement_timeout", "lock_timeout"] {
+            assert_eq!(
+                show_timeout(&mut connection, setting).await,
+                "0",
+                "{setting} must be lifted for the migrator"
+            );
+        }
+
+        retire_connection(connection)
+            .await
+            .expect("retire migration connection");
+
+        let mut fresh = pool.acquire().await.expect("re-acquire");
+        for setting in ["statement_timeout", "lock_timeout"] {
+            assert_eq!(
+                show_timeout(&mut fresh, setting).await,
+                TIGHT,
+                "the pool must not hand out the relaxed migration session"
+            );
+        }
+        drop(fresh);
+        pool.close().await;
+    }
+
+    async fn show_timeout(connection: &mut sqlx::PgConnection, setting: &str) -> String {
+        sqlx::query_scalar(sqlx::AssertSqlSafe(format!("SHOW {setting}")))
+            .fetch_one(connection)
+            .await
+            .unwrap_or_else(|error| panic!("SHOW {setting}: {error}"))
     }
 
     #[tokio::test]

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -1183,6 +1183,16 @@ mod tests {
         .expect("read applied migrations")
     }
 
+    /// Read the head version from `MIGRATOR` rather than hardcoding it —
+    /// otherwise every new migration file breaks these assertions.
+    fn latest_migration_version() -> i64 {
+        MIGRATOR
+            .iter()
+            .map(|migration| migration.version)
+            .max()
+            .expect("migrations exist")
+    }
+
     /// The migration connection must have both limits lifted, and it must not
     /// come back to the pool afterwards — a session with no statement timeout
     /// serving traffic is the failure this exemption trades against.
@@ -1311,7 +1321,10 @@ mod tests {
         run_migrations(&pool)
             .await
             .expect("retry succeeds after operator repair");
-        assert_eq!(applied_versions(&pool).await.last().copied(), Some(27));
+        assert_eq!(
+            applied_versions(&pool).await.last().copied(),
+            Some(latest_migration_version())
+        );
     }
 
     /// A pool whose connections carry `timeout` for both runtime limits.
@@ -1424,7 +1437,10 @@ mod tests {
         run_migrations(&capped)
             .await
             .expect("migrations must not inherit the runtime caps during the legacy preflight");
-        assert_eq!(applied_versions(&pool).await.last().copied(), Some(26));
+        assert_eq!(
+            applied_versions(&pool).await.last().copied(),
+            Some(latest_migration_version())
+        );
 
         // And the caps are still in force for traffic afterwards.
         let mut runtime = capped.acquire().await.expect("acquire after migration");

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -73,8 +73,8 @@ async fn migrate_on_exempt_connection(connection: &mut sqlx::PgConnection) -> Re
 async fn lift_runtime_timeouts(connection: &mut sqlx::PgConnection) -> Result<()> {
     crate::apply_runtime_connection_timeouts(
         connection,
-        crate::TIMEOUT_DISABLED,
-        crate::TIMEOUT_DISABLED,
+        &crate::PgTimeout::disabled(),
+        &crate::PgTimeout::disabled(),
     )
     .await?;
     Ok(())
@@ -1174,6 +1174,13 @@ mod tests {
             .expect("create public schema");
     }
 
+    /// Parse a literal the tests control, so a typo in one fails loudly here
+    /// rather than silently falling back to the runtime default.
+    fn tight_timeout(raw: &str) -> crate::PgTimeout {
+        raw.parse::<crate::PgTimeout>()
+            .expect("test timeout literal must be valid")
+    }
+
     async fn applied_versions(pool: &PgPool) -> Vec<i64> {
         sqlx::query_scalar::<_, i64>(
             "SELECT version FROM _sqlx_migrations WHERE success ORDER BY version",
@@ -1208,9 +1215,10 @@ mod tests {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .after_connect(|connection, _meta| {
-                Box::pin(crate::apply_runtime_connection_timeouts(
-                    connection, TIGHT, TIGHT,
-                ))
+                let tight = tight_timeout(TIGHT);
+                Box::pin(async move {
+                    crate::apply_runtime_connection_timeouts(connection, &tight, &tight).await
+                })
             })
             .connect(&database_url)
             .await
@@ -1336,9 +1344,10 @@ mod tests {
         sqlx::postgres::PgPoolOptions::new()
             .max_connections(2)
             .after_connect(move |connection, _meta| {
-                Box::pin(crate::apply_runtime_connection_timeouts(
-                    connection, timeout, timeout,
-                ))
+                let timeout = tight_timeout(timeout);
+                Box::pin(async move {
+                    crate::apply_runtime_connection_timeouts(connection, &timeout, &timeout).await
+                })
             })
             .connect(&database_url)
             .await

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -71,12 +71,8 @@ async fn migrate_on_exempt_connection(connection: &mut sqlx::PgConnection) -> Re
 
 /// Remove both runtime limits from one connection's session.
 async fn lift_runtime_timeouts(connection: &mut sqlx::PgConnection) -> Result<()> {
-    crate::apply_runtime_connection_timeouts(
-        connection,
-        &crate::PgTimeout::disabled(),
-        &crate::PgTimeout::disabled(),
-    )
-    .await?;
+    crate::apply_runtime_connection_timeouts(connection, &crate::RuntimeTimeouts::disabled())
+        .await?;
     Ok(())
 }
 
@@ -1174,11 +1170,18 @@ mod tests {
             .expect("create public schema");
     }
 
-    /// Parse a literal the tests control, so a typo in one fails loudly here
-    /// rather than silently falling back to the runtime default.
-    fn tight_timeout(raw: &str) -> crate::PgTimeout {
-        raw.parse::<crate::PgTimeout>()
-            .expect("test timeout literal must be valid")
+    /// Every limit set to the same tight value. Parsed rather than constructed
+    /// so a typo in a literal fails loudly here instead of silently falling
+    /// back to the runtime default.
+    fn tight_timeouts(raw: &str) -> crate::RuntimeTimeouts {
+        let timeout = raw
+            .parse::<crate::PgTimeout>()
+            .expect("test timeout literal must be valid");
+        crate::RuntimeTimeouts {
+            statement: timeout.clone(),
+            lock: timeout.clone(),
+            idle_in_transaction: timeout,
+        }
     }
 
     async fn applied_versions(pool: &PgPool) -> Vec<i64> {
@@ -1215,9 +1218,9 @@ mod tests {
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .after_connect(|connection, _meta| {
-                let tight = tight_timeout(TIGHT);
+                let tight = tight_timeouts(TIGHT);
                 Box::pin(async move {
-                    crate::apply_runtime_connection_timeouts(connection, &tight, &tight).await
+                    crate::apply_runtime_connection_timeouts(connection, &tight).await
                 })
             })
             .connect(&database_url)
@@ -1231,7 +1234,7 @@ mod tests {
         let mut connection = exempt_migration_connection(&pool)
             .await
             .expect("acquire exempt migration connection");
-        for setting in ["statement_timeout", "lock_timeout"] {
+        for setting in RUNTIME_TIMEOUT_SETTINGS {
             assert_eq!(
                 show_timeout(&mut connection, setting).await,
                 "0",
@@ -1244,7 +1247,7 @@ mod tests {
         drop(connection);
 
         let mut fresh = pool.acquire().await.expect("re-acquire");
-        for setting in ["statement_timeout", "lock_timeout"] {
+        for setting in RUNTIME_TIMEOUT_SETTINGS {
             assert_eq!(
                 show_timeout(&mut fresh, setting).await,
                 TIGHT,
@@ -1254,6 +1257,14 @@ mod tests {
         drop(fresh);
         pool.close().await;
     }
+
+    /// Every GUC `apply_runtime_connection_timeouts` sets, so a limit added
+    /// there without a matching exemption fails these assertions.
+    const RUNTIME_TIMEOUT_SETTINGS: [&str; 3] = [
+        "statement_timeout",
+        "lock_timeout",
+        "idle_in_transaction_session_timeout",
+    ];
 
     async fn show_timeout(connection: &mut sqlx::PgConnection, setting: &str) -> String {
         sqlx::query_scalar(sqlx::AssertSqlSafe(format!("SHOW {setting}")))
@@ -1344,9 +1355,9 @@ mod tests {
         sqlx::postgres::PgPoolOptions::new()
             .max_connections(2)
             .after_connect(move |connection, _meta| {
-                let timeout = tight_timeout(timeout);
+                let timeouts = tight_timeouts(timeout);
                 Box::pin(async move {
-                    crate::apply_runtime_connection_timeouts(connection, &timeout, &timeout).await
+                    crate::apply_runtime_connection_timeouts(connection, &timeouts).await
                 })
             })
             .connect(&database_url)
@@ -1453,7 +1464,7 @@ mod tests {
 
         // And the caps are still in force for traffic afterwards.
         let mut runtime = capped.acquire().await.expect("acquire after migration");
-        for setting in ["statement_timeout", "lock_timeout"] {
+        for setting in RUNTIME_TIMEOUT_SETTINGS {
             assert_eq!(
                 show_timeout(&mut runtime, setting).await,
                 TIGHT,

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -342,7 +342,12 @@ fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
     let unit = unit.trim().to_ascii_lowercase();
 
     match pg_timeout_millis(magnitude, &unit) {
-        Some(millis) if millis <= buzz_db::PG_TIMEOUT_MAX_MILLIS => candidate.to_string(),
+        // Return the spelling we validated. PostgreSQL's timeout units are
+        // case-sensitive, so returning `candidate` here would let `45S` pass
+        // validation and then fail every pool's `after_connect`.
+        Some(millis) if millis <= buzz_db::PG_TIMEOUT_MAX_MILLIS => {
+            format!("{magnitude}{unit}")
+        }
         Some(millis) => {
             tracing::warn!(
                 value = candidate,
@@ -1126,6 +1131,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::Connection;
 
     // Mutex to serialize tests that mutate environment variables.
     // Parallel env-var mutation causes `defaults_are_valid` to see the invalid
@@ -1344,10 +1350,17 @@ mod tests {
 
     #[test]
     fn pg_timeout_accepts_postgres_spellings_and_refuses_the_rest() {
-        for accepted in ["30s", "500ms", "0", "45S", "2min", " 10s "] {
+        for (accepted, canonical) in [
+            ("30s", "30s"),
+            ("500ms", "500ms"),
+            ("0", "0"),
+            ("45S", "45s"),
+            ("2MIN", "2min"),
+            (" 10 H ", "10h"),
+        ] {
             assert_eq!(
                 pg_timeout_or_default(Some(accepted), "30s"),
-                accepted.trim(),
+                canonical,
                 "{accepted} is a valid Postgres timeout"
             );
         }
@@ -1363,6 +1376,41 @@ mod tests {
         }
 
         assert_eq!(pg_timeout_or_default(None, "5s"), "5s");
+    }
+
+    /// Every supported unit spelling emitted by the parser must be usable by
+    /// PostgreSQL. A parser-only assertion missed that PostgreSQL rejects
+    /// uppercase units even though validation lowercases them.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn pg_timeout_canonical_spellings_are_accepted_by_postgres() {
+        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .unwrap_or_else(|_| {
+                "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string() // sadscan:disable np.postgres.1
+            });
+        let mut connection = sqlx::PgConnection::connect(&database_url)
+            .await
+            .expect("connect test Postgres");
+
+        for (raw, canonical) in [
+            ("500US", "500us"),
+            ("500MS", "500ms"),
+            ("2S", "2s"),
+            ("2MIN", "2min"),
+            ("2H", "2h"),
+            ("2D", "2d"),
+            ("0", "0"),
+            (" 10 S ", "10s"),
+        ] {
+            let parsed = pg_timeout_or_default(Some(raw), "30s");
+            assert_eq!(parsed, canonical);
+            buzz_db::apply_runtime_connection_timeouts(&mut connection, &parsed, &parsed)
+                .await
+                .unwrap_or_else(|error| panic!("{raw:?} normalized to {parsed:?}: {error}"));
+        }
+
+        connection.close().await.expect("close test Postgres");
     }
 
     #[test]
@@ -1431,6 +1479,12 @@ mod tests {
         let overridden = Config::from_env().expect("config");
         assert_eq!(overridden.db_statement_timeout, "90s");
         assert_eq!(overridden.db_lock_timeout, "250ms");
+
+        std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "45S");
+        std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", " 2 MIN ");
+        let canonicalized = Config::from_env().expect("config");
+        assert_eq!(canonicalized.db_statement_timeout, "45s");
+        assert_eq!(canonicalized.db_lock_timeout, "2min");
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "half a minute");
         let junk = Config::from_env().expect("config");

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -306,14 +306,30 @@ fn parse_bind_addr(raw: &str) -> Result<SocketAddr, ConfigError> {
         .map_err(|e| ConfigError::InvalidBindAddr(e.to_string()))
 }
 
-/// Postgres accepts a timeout as an integer (milliseconds) with an optional
-/// unit. Anything else is refused in favor of the default rather than failing
-/// the config: a malformed value would break every `after_connect`, taking all
-/// Postgres access with it, and a relay that keeps its documented default is a
-/// better outcome than one that will not start.
-fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
-    const UNITS: [&str; 6] = ["us", "ms", "s", "min", "h", "d"];
+/// Convert a Postgres timeout magnitude and unit to milliseconds, mirroring the
+/// rounding Postgres applies to sub-millisecond `us` values. `None` means the
+/// spelling is not something Postgres would accept.
+fn pg_timeout_millis(magnitude: &str, unit: &str) -> Option<u128> {
+    let value = magnitude.parse::<u128>().ok()?;
+    match unit {
+        "us" => Some((value + 500) / 1_000),
+        "" | "ms" => Some(value),
+        "s" => value.checked_mul(1_000),
+        "min" => value.checked_mul(60_000),
+        "h" => value.checked_mul(3_600_000),
+        "d" => value.checked_mul(86_400_000),
+        _ => None,
+    }
+}
 
+/// Postgres accepts a timeout as an integer (milliseconds) with an optional
+/// unit, bounded by `i32::MAX` ms once converted. Anything else is refused in
+/// favor of the default rather than failing the config: an unusable value would
+/// break every `after_connect`, taking all Postgres access with it, and a relay
+/// that keeps its documented default is a better outcome than one that will not
+/// start. Magnitude is range-checked, not just shape-checked — `999...9d` is a
+/// well-formed spelling that Postgres still rejects.
+fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
     let candidate = raw.map(str::trim).filter(|value| !value.is_empty());
     let Some(candidate) = candidate else {
         return default.to_string();
@@ -321,19 +337,29 @@ fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
 
     let digits = candidate.chars().take_while(char::is_ascii_digit).count();
     let (magnitude, unit) = candidate.split_at(digits);
-    let unit = unit.trim();
-    let valid = !magnitude.is_empty()
-        && (unit.is_empty() || UNITS.iter().any(|known| unit.eq_ignore_ascii_case(known)));
-    if valid {
-        candidate.to_string()
-    } else {
-        tracing::warn!(
-            value = candidate,
-            default,
-            "ignoring malformed Postgres timeout — expected an integer with an optional \
-             us/ms/s/min/h/d unit"
-        );
-        default.to_string()
+    let unit = unit.trim().to_ascii_lowercase();
+
+    match pg_timeout_millis(magnitude, &unit) {
+        Some(millis) if millis <= buzz_db::PG_TIMEOUT_MAX_MILLIS => candidate.to_string(),
+        Some(millis) => {
+            tracing::warn!(
+                value = candidate,
+                millis = %millis,
+                max_millis = %buzz_db::PG_TIMEOUT_MAX_MILLIS,
+                default,
+                "ignoring out-of-range Postgres timeout — Postgres stores it as int milliseconds"
+            );
+            default.to_string()
+        }
+        None => {
+            tracing::warn!(
+                value = candidate,
+                default,
+                "ignoring malformed Postgres timeout — expected an integer with an optional \
+                 us/ms/s/min/h/d unit"
+            );
+            default.to_string()
+        }
     }
 }
 
@@ -1338,6 +1364,47 @@ mod tests {
     }
 
     #[test]
+    fn pg_timeout_refuses_magnitudes_postgres_cannot_store() {
+        // Well-formed spellings whose millisecond value exceeds the int GUC
+        // range. Postgres rejects these in `set_config`, which would fail every
+        // pool's `after_connect`.
+        for rejected in [
+            "2147483648",
+            "2147483648ms",
+            "2147484s",
+            "35792min",
+            "597h",
+            "25d",
+            // Wider than any integer type — must fall back, not overflow.
+            "999999999999999999999999999999999999999999d",
+            "99999999999999999999999999999999999999999999999999",
+        ] {
+            assert_eq!(
+                pg_timeout_or_default(Some(rejected), "30s"),
+                "30s",
+                "{rejected:?} is out of range for Postgres and must fall back"
+            );
+        }
+
+        // The boundary itself, and the same instant in every unit, stay valid.
+        for accepted in [
+            "2147483647",
+            "2147483647ms",
+            "2147483647000us",
+            "2147483s",
+            "35791min",
+            "596h",
+            "24d",
+        ] {
+            assert_eq!(
+                pg_timeout_or_default(Some(accepted), "30s"),
+                accepted,
+                "{accepted} is inside the Postgres range"
+            );
+        }
+    }
+
+    #[test]
     fn db_timeout_env_overrides_and_invalid_fallback() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let previous_statement = std::env::var_os("BUZZ_DB_STATEMENT_TIMEOUT");
@@ -1365,6 +1432,21 @@ mod tests {
             buzz_db::RUNTIME_STATEMENT_TIMEOUT,
             "a malformed value must not be handed to Postgres"
         );
+
+        // Shape-valid but far outside the int millisecond GUC range: Postgres
+        // would reject it in every pool's `after_connect`.
+        std::env::set_var(
+            "BUZZ_DB_STATEMENT_TIMEOUT",
+            "999999999999999999999999999999999999999999d",
+        );
+        std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "25d");
+        let out_of_range = Config::from_env().expect("config");
+        assert_eq!(
+            out_of_range.db_statement_timeout,
+            buzz_db::RUNTIME_STATEMENT_TIMEOUT,
+            "an out-of-range value must not be handed to Postgres"
+        );
+        assert_eq!(out_of_range.db_lock_timeout, buzz_db::RUNTIME_LOCK_TIMEOUT);
 
         match previous_statement {
             Some(value) => std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", value),

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -3,6 +3,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use buzz_db::PgTimeout;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tracing::warn;
@@ -102,11 +103,11 @@ pub struct Config {
     /// Postgres `statement_timeout` for every runtime connection
     /// (`BUZZ_DB_STATEMENT_TIMEOUT`, e.g. `45s`, `500ms`, `0` to disable).
     /// Tunable so a backfill or an incident does not need a code change.
-    pub db_statement_timeout: String,
+    pub db_statement_timeout: PgTimeout,
     /// Postgres `lock_timeout` for every runtime connection
     /// (`BUZZ_DB_LOCK_TIMEOUT`). Schema migrations always run with both limits
     /// lifted — see `buzz_db::migration::run_migrations`.
-    pub db_lock_timeout: String,
+    pub db_lock_timeout: PgTimeout,
     /// Public WebSocket URL of this relay, advertised in NIP-11.
     pub relay_url: String,
     /// Public WebSocket URL of the dedicated device-pairing relay, when configured.
@@ -304,70 +305,6 @@ pub struct Config {
 fn parse_bind_addr(raw: &str) -> Result<SocketAddr, ConfigError> {
     raw.parse::<SocketAddr>()
         .map_err(|e| ConfigError::InvalidBindAddr(e.to_string()))
-}
-
-/// Convert a Postgres timeout magnitude and unit to milliseconds, mirroring the
-/// rounding Postgres applies to sub-millisecond `us` values. `None` means the
-/// spelling is not something Postgres would accept.
-fn pg_timeout_millis(magnitude: &str, unit: &str) -> Option<u128> {
-    let value = magnitude.parse::<u128>().ok()?;
-    match unit {
-        // Round half up without the `value + 500` intermediate, which overflows
-        // for the top 500 representable microsecond values.
-        "us" => Some(value / 1_000 + u128::from(value % 1_000 >= 500)),
-        "" | "ms" => Some(value),
-        "s" => value.checked_mul(1_000),
-        "min" => value.checked_mul(60_000),
-        "h" => value.checked_mul(3_600_000),
-        "d" => value.checked_mul(86_400_000),
-        _ => None,
-    }
-}
-
-/// Postgres accepts a timeout as an integer (milliseconds) with an optional
-/// unit, bounded by `i32::MAX` ms once converted. Anything else is refused in
-/// favor of the default rather than failing the config: an unusable value would
-/// break every `after_connect`, taking all Postgres access with it, and a relay
-/// that keeps its documented default is a better outcome than one that will not
-/// start. Magnitude is range-checked, not just shape-checked — `999...9d` is a
-/// well-formed spelling that Postgres still rejects.
-fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
-    let candidate = raw.map(str::trim).filter(|value| !value.is_empty());
-    let Some(candidate) = candidate else {
-        return default.to_string();
-    };
-
-    let digits = candidate.chars().take_while(char::is_ascii_digit).count();
-    let (magnitude, unit) = candidate.split_at(digits);
-    let unit = unit.trim().to_ascii_lowercase();
-
-    match pg_timeout_millis(magnitude, &unit) {
-        // Return the spelling we validated. PostgreSQL's timeout units are
-        // case-sensitive, so returning `candidate` here would let `45S` pass
-        // validation and then fail every pool's `after_connect`.
-        Some(millis) if millis <= buzz_db::PG_TIMEOUT_MAX_MILLIS => {
-            format!("{magnitude}{unit}")
-        }
-        Some(millis) => {
-            tracing::warn!(
-                value = candidate,
-                millis = %millis,
-                max_millis = %buzz_db::PG_TIMEOUT_MAX_MILLIS,
-                default,
-                "ignoring out-of-range Postgres timeout — Postgres stores it as int milliseconds"
-            );
-            default.to_string()
-        }
-        None => {
-            tracing::warn!(
-                value = candidate,
-                default,
-                "ignoring malformed Postgres timeout — expected an integer with an optional \
-                 us/ms/s/min/h/d unit"
-            );
-            default.to_string()
-        }
-    }
 }
 
 fn positive_u64_from_env(name: &str, default: u64) -> Result<u64, ConfigError> {
@@ -603,14 +540,10 @@ impl Config {
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&v| v > 0);
 
-        let db_statement_timeout = pg_timeout_or_default(
-            std::env::var("BUZZ_DB_STATEMENT_TIMEOUT").ok().as_deref(),
-            buzz_db::RUNTIME_STATEMENT_TIMEOUT,
-        );
-        let db_lock_timeout = pg_timeout_or_default(
-            std::env::var("BUZZ_DB_LOCK_TIMEOUT").ok().as_deref(),
-            buzz_db::RUNTIME_LOCK_TIMEOUT,
-        );
+        let db_statement_timeout =
+            PgTimeout::from_env_or("BUZZ_DB_STATEMENT_TIMEOUT", PgTimeout::statement_default());
+        let db_lock_timeout =
+            PgTimeout::from_env_or("BUZZ_DB_LOCK_TIMEOUT", PgTimeout::lock_default());
 
         let relay_url =
             std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string());
@@ -1131,7 +1064,6 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::Connection;
 
     // Mutex to serialize tests that mutate environment variables.
     // Parallel env-var mutation causes `defaults_are_valid` to see the invalid
@@ -1349,117 +1281,6 @@ mod tests {
     }
 
     #[test]
-    fn pg_timeout_accepts_postgres_spellings_and_refuses_the_rest() {
-        for (accepted, canonical) in [
-            ("30s", "30s"),
-            ("500ms", "500ms"),
-            ("0", "0"),
-            ("45S", "45s"),
-            ("2MIN", "2min"),
-            (" 10 H ", "10h"),
-        ] {
-            assert_eq!(
-                pg_timeout_or_default(Some(accepted), "30s"),
-                canonical,
-                "{accepted} is a valid Postgres timeout"
-            );
-        }
-
-        // A rejected value must not reach Postgres: `after_connect` would fail
-        // for every connection, which is worse than the documented default.
-        for rejected in ["", "   ", "soon", "30 seconds", "s30", "-5s", "30s;DROP"] {
-            assert_eq!(
-                pg_timeout_or_default(Some(rejected), "30s"),
-                "30s",
-                "{rejected:?} must fall back to the default"
-            );
-        }
-
-        assert_eq!(pg_timeout_or_default(None, "5s"), "5s");
-    }
-
-    /// Every supported unit spelling emitted by the parser must be usable by
-    /// PostgreSQL. A parser-only assertion missed that PostgreSQL rejects
-    /// uppercase units even though validation lowercases them.
-    #[tokio::test]
-    #[ignore = "requires Postgres"]
-    async fn pg_timeout_canonical_spellings_are_accepted_by_postgres() {
-        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
-            .or_else(|_| std::env::var("DATABASE_URL"))
-            .unwrap_or_else(|_| {
-                "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string() // sadscan:disable np.postgres.1
-            });
-        let mut connection = sqlx::PgConnection::connect(&database_url)
-            .await
-            .expect("connect test Postgres");
-
-        for (raw, canonical) in [
-            ("500US", "500us"),
-            ("500MS", "500ms"),
-            ("2S", "2s"),
-            ("2MIN", "2min"),
-            ("2H", "2h"),
-            ("2D", "2d"),
-            ("0", "0"),
-            (" 10 S ", "10s"),
-        ] {
-            let parsed = pg_timeout_or_default(Some(raw), "30s");
-            assert_eq!(parsed, canonical);
-            buzz_db::apply_runtime_connection_timeouts(&mut connection, &parsed, &parsed)
-                .await
-                .unwrap_or_else(|error| panic!("{raw:?} normalized to {parsed:?}: {error}"));
-        }
-
-        connection.close().await.expect("close test Postgres");
-    }
-
-    #[test]
-    fn pg_timeout_refuses_magnitudes_postgres_cannot_store() {
-        // Well-formed spellings whose millisecond value exceeds the int GUC
-        // range. Postgres rejects these in `set_config`, which would fail every
-        // pool's `after_connect`.
-        for rejected in [
-            "2147483648",
-            "2147483648ms",
-            "2147484s",
-            "35792min",
-            "597h",
-            "25d",
-            // Wider than any integer type — must fall back, not overflow.
-            "999999999999999999999999999999999999999999d",
-            "99999999999999999999999999999999999999999999999999",
-            // Parses as u128, so unlike the two above it reaches the unit
-            // conversion — where rounding must not overflow on the way to the
-            // range check.
-            &format!("{}us", u128::MAX),
-            &format!("{}us", u128::MAX - 499),
-        ] {
-            assert_eq!(
-                pg_timeout_or_default(Some(rejected), "30s"),
-                "30s",
-                "{rejected:?} is out of range for Postgres and must fall back"
-            );
-        }
-
-        // The boundary itself, and the same instant in every unit, stay valid.
-        for accepted in [
-            "2147483647",
-            "2147483647ms",
-            "2147483647000us",
-            "2147483s",
-            "35791min",
-            "596h",
-            "24d",
-        ] {
-            assert_eq!(
-                pg_timeout_or_default(Some(accepted), "30s"),
-                accepted,
-                "{accepted} is inside the Postgres range"
-            );
-        }
-    }
-
-    #[test]
     fn db_timeout_env_overrides_and_invalid_fallback() {
         let _guard = ENV_MUTEX.lock().unwrap();
         let previous_statement = std::env::var_os("BUZZ_DB_STATEMENT_TIMEOUT");
@@ -1469,27 +1290,30 @@ mod tests {
         std::env::remove_var("BUZZ_DB_LOCK_TIMEOUT");
         let defaults = Config::from_env().expect("config");
         assert_eq!(
-            defaults.db_statement_timeout,
+            defaults.db_statement_timeout.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT
         );
-        assert_eq!(defaults.db_lock_timeout, buzz_db::RUNTIME_LOCK_TIMEOUT);
+        assert_eq!(
+            defaults.db_lock_timeout.as_str(),
+            buzz_db::RUNTIME_LOCK_TIMEOUT
+        );
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "90s");
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "250ms");
         let overridden = Config::from_env().expect("config");
-        assert_eq!(overridden.db_statement_timeout, "90s");
-        assert_eq!(overridden.db_lock_timeout, "250ms");
+        assert_eq!(overridden.db_statement_timeout.as_str(), "90s");
+        assert_eq!(overridden.db_lock_timeout.as_str(), "250ms");
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "45S");
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", " 2 MIN ");
         let canonicalized = Config::from_env().expect("config");
-        assert_eq!(canonicalized.db_statement_timeout, "45s");
-        assert_eq!(canonicalized.db_lock_timeout, "2min");
+        assert_eq!(canonicalized.db_statement_timeout.as_str(), "45s");
+        assert_eq!(canonicalized.db_lock_timeout.as_str(), "2min");
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "half a minute");
         let junk = Config::from_env().expect("config");
         assert_eq!(
-            junk.db_statement_timeout,
+            junk.db_statement_timeout.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT,
             "a malformed value must not be handed to Postgres"
         );
@@ -1503,11 +1327,14 @@ mod tests {
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "25d");
         let out_of_range = Config::from_env().expect("config");
         assert_eq!(
-            out_of_range.db_statement_timeout,
+            out_of_range.db_statement_timeout.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT,
             "an out-of-range value must not be handed to Postgres"
         );
-        assert_eq!(out_of_range.db_lock_timeout, buzz_db::RUNTIME_LOCK_TIMEOUT);
+        assert_eq!(
+            out_of_range.db_lock_timeout.as_str(),
+            buzz_db::RUNTIME_LOCK_TIMEOUT
+        );
 
         match previous_statement {
             Some(value) => std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", value),

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -99,6 +99,14 @@ pub struct Config {
     /// independently so reader capacity can be tuned against the replica's
     /// headroom without touching the writer pool.
     pub db_read_pool_size: Option<u32>,
+    /// Postgres `statement_timeout` for every runtime connection
+    /// (`BUZZ_DB_STATEMENT_TIMEOUT`, e.g. `45s`, `500ms`, `0` to disable).
+    /// Tunable so a backfill or an incident does not need a code change.
+    pub db_statement_timeout: String,
+    /// Postgres `lock_timeout` for every runtime connection
+    /// (`BUZZ_DB_LOCK_TIMEOUT`). Schema migrations always run with both limits
+    /// lifted — see `buzz_db::migration::run_migrations`.
+    pub db_lock_timeout: String,
     /// Public WebSocket URL of this relay, advertised in NIP-11.
     pub relay_url: String,
     /// Public WebSocket URL of the dedicated device-pairing relay, when configured.
@@ -296,6 +304,37 @@ pub struct Config {
 fn parse_bind_addr(raw: &str) -> Result<SocketAddr, ConfigError> {
     raw.parse::<SocketAddr>()
         .map_err(|e| ConfigError::InvalidBindAddr(e.to_string()))
+}
+
+/// Postgres accepts a timeout as an integer (milliseconds) with an optional
+/// unit. Anything else is refused in favor of the default rather than failing
+/// the config: a malformed value would break every `after_connect`, taking all
+/// Postgres access with it, and a relay that keeps its documented default is a
+/// better outcome than one that will not start.
+fn pg_timeout_or_default(raw: Option<&str>, default: &str) -> String {
+    const UNITS: [&str; 6] = ["us", "ms", "s", "min", "h", "d"];
+
+    let candidate = raw.map(str::trim).filter(|value| !value.is_empty());
+    let Some(candidate) = candidate else {
+        return default.to_string();
+    };
+
+    let digits = candidate.chars().take_while(char::is_ascii_digit).count();
+    let (magnitude, unit) = candidate.split_at(digits);
+    let unit = unit.trim();
+    let valid = !magnitude.is_empty()
+        && (unit.is_empty() || UNITS.iter().any(|known| unit.eq_ignore_ascii_case(known)));
+    if valid {
+        candidate.to_string()
+    } else {
+        tracing::warn!(
+            value = candidate,
+            default,
+            "ignoring malformed Postgres timeout — expected an integer with an optional \
+             us/ms/s/min/h/d unit"
+        );
+        default.to_string()
+    }
 }
 
 fn positive_u64_from_env(name: &str, default: u64) -> Result<u64, ConfigError> {
@@ -530,6 +569,15 @@ impl Config {
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&v| v > 0);
+
+        let db_statement_timeout = pg_timeout_or_default(
+            std::env::var("BUZZ_DB_STATEMENT_TIMEOUT").ok().as_deref(),
+            buzz_db::RUNTIME_STATEMENT_TIMEOUT,
+        );
+        let db_lock_timeout = pg_timeout_or_default(
+            std::env::var("BUZZ_DB_LOCK_TIMEOUT").ok().as_deref(),
+            buzz_db::RUNTIME_LOCK_TIMEOUT,
+        );
 
         let relay_url =
             std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string());
@@ -996,6 +1044,8 @@ impl Config {
             redis_pool_size,
             db_pool_size,
             db_read_pool_size,
+            db_statement_timeout,
+            db_lock_timeout,
             relay_url,
             pairing_relay_url,
             max_connections,
@@ -1262,6 +1312,68 @@ mod tests {
         assert_eq!(overridden, 80);
         assert_eq!(zero, 50, "zero must fall back to the default");
         assert_eq!(junk, 50, "unparsable value must fall back to the default");
+    }
+
+    #[test]
+    fn pg_timeout_accepts_postgres_spellings_and_refuses_the_rest() {
+        for accepted in ["30s", "500ms", "0", "45S", "2min", " 10s "] {
+            assert_eq!(
+                pg_timeout_or_default(Some(accepted), "30s"),
+                accepted.trim(),
+                "{accepted} is a valid Postgres timeout"
+            );
+        }
+
+        // A rejected value must not reach Postgres: `after_connect` would fail
+        // for every connection, which is worse than the documented default.
+        for rejected in ["", "   ", "soon", "30 seconds", "s30", "-5s", "30s;DROP"] {
+            assert_eq!(
+                pg_timeout_or_default(Some(rejected), "30s"),
+                "30s",
+                "{rejected:?} must fall back to the default"
+            );
+        }
+
+        assert_eq!(pg_timeout_or_default(None, "5s"), "5s");
+    }
+
+    #[test]
+    fn db_timeout_env_overrides_and_invalid_fallback() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous_statement = std::env::var_os("BUZZ_DB_STATEMENT_TIMEOUT");
+        let previous_lock = std::env::var_os("BUZZ_DB_LOCK_TIMEOUT");
+
+        std::env::remove_var("BUZZ_DB_STATEMENT_TIMEOUT");
+        std::env::remove_var("BUZZ_DB_LOCK_TIMEOUT");
+        let defaults = Config::from_env().expect("config");
+        assert_eq!(
+            defaults.db_statement_timeout,
+            buzz_db::RUNTIME_STATEMENT_TIMEOUT
+        );
+        assert_eq!(defaults.db_lock_timeout, buzz_db::RUNTIME_LOCK_TIMEOUT);
+
+        std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "90s");
+        std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "250ms");
+        let overridden = Config::from_env().expect("config");
+        assert_eq!(overridden.db_statement_timeout, "90s");
+        assert_eq!(overridden.db_lock_timeout, "250ms");
+
+        std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "half a minute");
+        let junk = Config::from_env().expect("config");
+        assert_eq!(
+            junk.db_statement_timeout,
+            buzz_db::RUNTIME_STATEMENT_TIMEOUT,
+            "a malformed value must not be handed to Postgres"
+        );
+
+        match previous_statement {
+            Some(value) => std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", value),
+            None => std::env::remove_var("BUZZ_DB_STATEMENT_TIMEOUT"),
+        }
+        match previous_lock {
+            Some(value) => std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", value),
+            None => std::env::remove_var("BUZZ_DB_LOCK_TIMEOUT"),
+        }
     }
 
     #[test]

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -3,7 +3,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use buzz_db::PgTimeout;
+use buzz_db::RuntimeTimeouts;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tracing::warn;
@@ -100,14 +100,13 @@ pub struct Config {
     /// independently so reader capacity can be tuned against the replica's
     /// headroom without touching the writer pool.
     pub db_read_pool_size: Option<u32>,
-    /// Postgres `statement_timeout` for every runtime connection
-    /// (`BUZZ_DB_STATEMENT_TIMEOUT`, e.g. `45s`, `500ms`, `0` to disable).
-    /// Tunable so a backfill or an incident does not need a code change.
-    pub db_statement_timeout: PgTimeout,
-    /// Postgres `lock_timeout` for every runtime connection
-    /// (`BUZZ_DB_LOCK_TIMEOUT`). Schema migrations always run with both limits
-    /// lifted — see `buzz_db::migration::run_migrations`.
-    pub db_lock_timeout: PgTimeout,
+    /// Per-session Postgres limits for every runtime connection
+    /// (`BUZZ_DB_STATEMENT_TIMEOUT`, `BUZZ_DB_LOCK_TIMEOUT`,
+    /// `BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT`; e.g. `45s`, `500ms`, `0` to
+    /// disable). Tunable so a backfill or an incident does not need a code
+    /// change. Schema migrations always run with all of them lifted — see
+    /// `buzz_db::migration::run_migrations`.
+    pub db_timeouts: RuntimeTimeouts,
     /// Public WebSocket URL of this relay, advertised in NIP-11.
     pub relay_url: String,
     /// Public WebSocket URL of the dedicated device-pairing relay, when configured.
@@ -540,10 +539,7 @@ impl Config {
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&v| v > 0);
 
-        let db_statement_timeout =
-            PgTimeout::from_env_or("BUZZ_DB_STATEMENT_TIMEOUT", PgTimeout::statement_default());
-        let db_lock_timeout =
-            PgTimeout::from_env_or("BUZZ_DB_LOCK_TIMEOUT", PgTimeout::lock_default());
+        let db_timeouts = RuntimeTimeouts::from_env_or(RuntimeTimeouts::default());
 
         let relay_url =
             std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string());
@@ -1010,8 +1006,7 @@ impl Config {
             redis_pool_size,
             db_pool_size,
             db_read_pool_size,
-            db_statement_timeout,
-            db_lock_timeout,
+            db_timeouts,
             relay_url,
             pairing_relay_url,
             max_connections,
@@ -1285,35 +1280,43 @@ mod tests {
         let _guard = ENV_MUTEX.lock().unwrap();
         let previous_statement = std::env::var_os("BUZZ_DB_STATEMENT_TIMEOUT");
         let previous_lock = std::env::var_os("BUZZ_DB_LOCK_TIMEOUT");
+        let previous_idle = std::env::var_os("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT");
 
         std::env::remove_var("BUZZ_DB_STATEMENT_TIMEOUT");
         std::env::remove_var("BUZZ_DB_LOCK_TIMEOUT");
+        std::env::remove_var("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT");
         let defaults = Config::from_env().expect("config");
         assert_eq!(
-            defaults.db_statement_timeout.as_str(),
+            defaults.db_timeouts.statement.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT
         );
         assert_eq!(
-            defaults.db_lock_timeout.as_str(),
+            defaults.db_timeouts.lock.as_str(),
             buzz_db::RUNTIME_LOCK_TIMEOUT
+        );
+        assert_eq!(
+            defaults.db_timeouts.idle_in_transaction.as_str(),
+            buzz_db::RUNTIME_IDLE_IN_TRANSACTION_TIMEOUT
         );
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "90s");
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "250ms");
+        std::env::set_var("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT", "2min");
         let overridden = Config::from_env().expect("config");
-        assert_eq!(overridden.db_statement_timeout.as_str(), "90s");
-        assert_eq!(overridden.db_lock_timeout.as_str(), "250ms");
+        assert_eq!(overridden.db_timeouts.statement.as_str(), "90s");
+        assert_eq!(overridden.db_timeouts.lock.as_str(), "250ms");
+        assert_eq!(overridden.db_timeouts.idle_in_transaction.as_str(), "2min");
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "45S");
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", " 2 MIN ");
         let canonicalized = Config::from_env().expect("config");
-        assert_eq!(canonicalized.db_statement_timeout.as_str(), "45s");
-        assert_eq!(canonicalized.db_lock_timeout.as_str(), "2min");
+        assert_eq!(canonicalized.db_timeouts.statement.as_str(), "45s");
+        assert_eq!(canonicalized.db_timeouts.lock.as_str(), "2min");
 
         std::env::set_var("BUZZ_DB_STATEMENT_TIMEOUT", "half a minute");
         let junk = Config::from_env().expect("config");
         assert_eq!(
-            junk.db_statement_timeout.as_str(),
+            junk.db_timeouts.statement.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT,
             "a malformed value must not be handed to Postgres"
         );
@@ -1325,15 +1328,20 @@ mod tests {
             "999999999999999999999999999999999999999999d",
         );
         std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", "25d");
+        std::env::set_var("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT", "25d");
         let out_of_range = Config::from_env().expect("config");
         assert_eq!(
-            out_of_range.db_statement_timeout.as_str(),
+            out_of_range.db_timeouts.statement.as_str(),
             buzz_db::RUNTIME_STATEMENT_TIMEOUT,
             "an out-of-range value must not be handed to Postgres"
         );
         assert_eq!(
-            out_of_range.db_lock_timeout.as_str(),
+            out_of_range.db_timeouts.lock.as_str(),
             buzz_db::RUNTIME_LOCK_TIMEOUT
+        );
+        assert_eq!(
+            out_of_range.db_timeouts.idle_in_transaction.as_str(),
+            buzz_db::RUNTIME_IDLE_IN_TRANSACTION_TIMEOUT
         );
 
         match previous_statement {
@@ -1343,6 +1351,10 @@ mod tests {
         match previous_lock {
             Some(value) => std::env::set_var("BUZZ_DB_LOCK_TIMEOUT", value),
             None => std::env::remove_var("BUZZ_DB_LOCK_TIMEOUT"),
+        }
+        match previous_idle {
+            Some(value) => std::env::set_var("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT", value),
+            None => std::env::remove_var("BUZZ_DB_IDLE_IN_TRANSACTION_TIMEOUT"),
         }
     }
 

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -312,7 +312,9 @@ fn parse_bind_addr(raw: &str) -> Result<SocketAddr, ConfigError> {
 fn pg_timeout_millis(magnitude: &str, unit: &str) -> Option<u128> {
     let value = magnitude.parse::<u128>().ok()?;
     match unit {
-        "us" => Some((value + 500) / 1_000),
+        // Round half up without the `value + 500` intermediate, which overflows
+        // for the top 500 representable microsecond values.
+        "us" => Some(value / 1_000 + u128::from(value % 1_000 >= 500)),
         "" | "ms" => Some(value),
         "s" => value.checked_mul(1_000),
         "min" => value.checked_mul(60_000),
@@ -1378,6 +1380,11 @@ mod tests {
             // Wider than any integer type — must fall back, not overflow.
             "999999999999999999999999999999999999999999d",
             "99999999999999999999999999999999999999999999999999",
+            // Parses as u128, so unlike the two above it reaches the unit
+            // conversion — where rounding must not overflow on the way to the
+            // range check.
+            &format!("{}us", u128::MAX),
+            &format!("{}us", u128::MAX - 499),
         ] {
             assert_eq!(
                 pg_timeout_or_default(Some(rejected), "30s"),

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -35,6 +35,35 @@ fn buzz_auto_migrate_enabled(value: Option<&str>) -> bool {
     })
 }
 
+/// `after_connect` hook applying the configured runtime timeouts to the pools
+/// the relay owns directly. The writer and replica pools get theirs from
+/// `buzz_db::Db::new`; the audit and search pools are built here, so they need
+/// the same treatment from the same config.
+fn runtime_timeout_hook(
+    db_config: &DbConfig,
+) -> impl for<'a> Fn(
+    &'a mut sqlx::PgConnection,
+    sqlx::pool::PoolConnectionMetadata,
+) -> futures_util::future::BoxFuture<'a, Result<(), sqlx::Error>>
+       + Send
+       + Sync
+       + 'static {
+    let statement_timeout = db_config.statement_timeout.clone();
+    let lock_timeout = db_config.lock_timeout.clone();
+    move |connection, _meta| {
+        let statement_timeout = statement_timeout.clone();
+        let lock_timeout = lock_timeout.clone();
+        Box::pin(async move {
+            buzz_db::apply_runtime_connection_timeouts(
+                connection,
+                &statement_timeout,
+                &lock_timeout,
+            )
+            .await
+        })
+    }
+}
+
 /// Controls how many per-community gauge series the usage poller emits.
 ///
 /// Datadog cost is proportional to the number of unique time-series.  With ~25
@@ -169,6 +198,8 @@ async fn main() -> anyhow::Result<()> {
         replica_read_max_age_ms: config.replica_read_max_age_ms,
         max_connections: config.db_pool_size,
         read_max_connections: config.db_read_pool_size,
+        statement_timeout: config.db_statement_timeout.clone(),
+        lock_timeout: config.db_lock_timeout.clone(),
         ..DbConfig::default()
     };
     let db = Db::new(&db_config).await.map_err(|e| {
@@ -350,9 +381,7 @@ async fn main() -> anyhow::Result<()> {
         let audit_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
             .min_connections(1)
-            .after_connect(|connection, _meta| {
-                Box::pin(buzz_db::apply_runtime_connection_timeouts(connection))
-            })
+            .after_connect(runtime_timeout_hook(&db_config))
             .connect(&config.database_url)
             .await
             .map_err(|e| anyhow::anyhow!("Audit DB connection failed: {e}"))?;
@@ -407,9 +436,7 @@ async fn main() -> anyhow::Result<()> {
         .as_deref()
         .unwrap_or(&config.database_url);
     let search_pool = sqlx::postgres::PgPoolOptions::new()
-        .after_connect(|connection, _meta| {
-            Box::pin(buzz_db::apply_runtime_connection_timeouts(connection))
-        })
+        .after_connect(runtime_timeout_hook(&db_config))
         .connect(search_db_url)
         .await
         .map_err(|e| anyhow::anyhow!("Search DB connection failed: {e}"))?;

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -350,6 +350,9 @@ async fn main() -> anyhow::Result<()> {
         let audit_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
             .min_connections(1)
+            .after_connect(|connection, _meta| {
+                Box::pin(buzz_db::apply_runtime_connection_timeouts(connection))
+            })
             .connect(&config.database_url)
             .await
             .map_err(|e| anyhow::anyhow!("Audit DB connection failed: {e}"))?;
@@ -404,6 +407,9 @@ async fn main() -> anyhow::Result<()> {
         .as_deref()
         .unwrap_or(&config.database_url);
     let search_pool = sqlx::postgres::PgPoolOptions::new()
+        .after_connect(|connection, _meta| {
+            Box::pin(buzz_db::apply_runtime_connection_timeouts(connection))
+        })
         .connect(search_db_url)
         .await
         .map_err(|e| anyhow::anyhow!("Search DB connection failed: {e}"))?;

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -48,19 +48,12 @@ fn runtime_timeout_hook(
        + Send
        + Sync
        + 'static {
-    let statement_timeout = db_config.statement_timeout.clone();
-    let lock_timeout = db_config.lock_timeout.clone();
+    let timeouts = db_config.timeouts.clone();
     move |connection, _meta| {
-        let statement_timeout = statement_timeout.clone();
-        let lock_timeout = lock_timeout.clone();
-        Box::pin(async move {
-            buzz_db::apply_runtime_connection_timeouts(
-                connection,
-                &statement_timeout,
-                &lock_timeout,
-            )
-            .await
-        })
+        let timeouts = timeouts.clone();
+        Box::pin(
+            async move { buzz_db::apply_runtime_connection_timeouts(connection, &timeouts).await },
+        )
     }
 }
 
@@ -198,8 +191,7 @@ async fn main() -> anyhow::Result<()> {
         replica_read_max_age_ms: config.replica_read_max_age_ms,
         max_connections: config.db_pool_size,
         read_max_connections: config.db_read_pool_size,
-        statement_timeout: config.db_statement_timeout.clone(),
-        lock_timeout: config.db_lock_timeout.clone(),
+        timeouts: config.db_timeouts.clone(),
         ..DbConfig::default()
     };
     let db = Db::new(&db_config).await.map_err(|e| {


### PR DESCRIPTION
## The short version

Buzz talks to its database through a small, fixed set of connections — think of
them as a handful of phone lines shared by everyone using the app. Before this
change, there was no limit on how long a single call could tie up a line.

This PR adds time limits so no request can hold a line forever.

## Why that mattered

Someone using Buzz can ask for things like "search everything" or "give me all
messages matching this." Those requests are tiny to send but can be very
expensive for the database to answer.

Without a limit, one of those requests grabs a phone line and keeps it for as
long as the database is willing to work — which is indefinitely. Do that a few
times at once and every line is busy. At that point *nothing* works: not logging
in, not sending messages, not the health checks that tell us the server is
alive. And the people affected did nothing wrong; they just wanted the lines
that are now occupied.

Fixing it meant an engineer manually finding and killing the stuck queries.

## What the PR adds

**Three limits, applied automatically:**

- A query gets **30 seconds** to finish, or the database cancels it.
- A query waiting for another query to release something gets **5 seconds**,
  then gives up.
- A connection that starts a piece of work and then just sits there gets
  **60 seconds** before it's reclaimed. The first limit only counts time spent
  actively working, so it can't see this case — the connection is held, and so
  is everything it already reserved, while nothing is running.

They're attached the moment a connection is created, so every database call is
covered — nobody has to remember to add them.

Operators can change any of the three without a code release, and set them to
`0` to turn them off during an incident.

## The two tricky bits

**Database upgrades are exempt.** When Buzz starts, it sometimes updates the
database's structure, which can legitimately take minutes. If that hit the
30-second limit it would be cancelled — and a failed upgrade stops the server
from starting at all. So upgrades run on one special connection with the limits
removed. That connection is then permanently retired, because a connection with
no limits must never end up serving normal traffic.

**A typo in the setting can't take the server down.** The limits are applied to
*every* connection, so if someone sets an invalid value, every connection fails
and the database becomes unreachable — the exact outage this was meant to
prevent. So the code checks the value up front and falls back to the default if
it's wrong.

Getting that check right took four rounds of review, which found four different
ways a bad value could slip through. The fix in the end wasn't a fourth patch —
it was making the setting a dedicated type that can *only* be created by passing
the check. Now an invalid value can't exist in the first place, rather than
existing and hopefully being caught.

**One related fix:** the admin command-line tool was quietly picking up the same
30-second limit, even though it's a maintenance tool run by hand — exactly where
a long-running job is normal and expected, and where there are no shared lines
to protect. It now runs without limits by default.

## Testing

Ordinary tests cover the settings parser and the environment-variable wiring.

Tests against a real PostgreSQL prove the parts that can't be checked in
isolation:

- every value the parser accepts is actually usable by the server
- the maximum allowed value matches the server's real maximum, from both
  directions, so it can't silently drift
- every connection pool really does carry all three limits
- the upgrade connection really does have them removed, and is never handed back
  for normal use
- the slow startup scan really does exceed a tight limit, and really does
  survive on the exempt connection

Every one of these was verified by deliberately breaking the code and confirming
the test catches it.

Local run at `badc7784e`: 97 unit tests pass, all database-backed tests pass,
lint and formatting clean.

Note: the database-backed tests are marked `#[ignore]` and CI only runs them
when explicitly asked, so they're run on demand rather than on every PR.

Originating Buzz thread: `buzz://message?channel=3928fe05-df61-4b5d-b9c7-d623b9b10ea1&id=3c6c02312f763fbe0d2bfc33a6c1a362f91d0354f3d18b039cf7a0558c1439d1`
