### PR TITLE
feat(cli): expose channel visibility on `channels update`

### DIFF
--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -349,6 +349,7 @@ pub async fn cmd_update_channel(
     channel_id: &str,
     name: Option<&str>,
     description: Option<&str>,
+    visibility: Option<&str>,
     ttl: Option<i64>,
     no_ttl: bool,
 ) -> Result<(), CliError> {
@@ -360,15 +361,25 @@ pub async fn cmd_update_channel(
         (None, false) => None,
     };
 
-    if name.is_none() && description.is_none() && ttl_change.is_none() {
+    if let Some(v) = visibility {
+        if v != "open" && v != "private" {
+            return Err(CliError::Usage(format!(
+                "--visibility must be 'open' or 'private' (got: {v})"
+            )));
+        }
+    }
+
+    if name.is_none() && description.is_none() && visibility.is_none() && ttl_change.is_none() {
         return Err(CliError::Usage(
-            "at least one field required (--name, --description, --ttl, --no-ttl)".into(),
+            "at least one field required (--name, --description, --visibility, --ttl, --no-ttl)"
+                .into(),
         ));
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = buzz_sdk::build_update_channel(channel_uuid, name, description, None, ttl_change)
-        .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
+    let builder =
+        buzz_sdk::build_update_channel(channel_uuid, name, description, visibility, ttl_change)
+            .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
@@ -621,14 +632,17 @@ pub async fn dispatch(
             channel,
             name,
             description,
+            visibility,
             ttl,
             no_ttl,
         } => {
+            let vis = visibility.as_ref().map(|v| v.to_string());
             cmd_update_channel(
                 client,
                 &channel,
                 name.as_deref(),
                 description.as_deref(),
+                vis.as_deref(),
                 ttl,
                 no_ttl,
             )

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -414,7 +414,7 @@ pub enum ChannelsCmd {
         #[arg(long, value_name = "SECONDS")]
         ttl: Option<i64>,
     },
-    /// Update channel name, description, or ephemeral TTL
+    /// Update channel name, description, visibility, or ephemeral TTL
     Update {
         /// Channel UUID
         #[arg(long)]
@@ -425,6 +425,10 @@ pub enum ChannelsCmd {
         /// New channel description
         #[arg(long)]
         description: Option<String>,
+        /// Change channel visibility: "open" (publicly listable/joinable) or
+        /// "private" (invite-only). Requires owner/admin.
+        #[arg(long, value_enum)]
+        visibility: Option<ChannelVisibility>,
         /// Make the channel ephemeral (or change its lifetime): seconds until
         /// the relay archives it after the last message. Conflicts with --no-ttl.
         #[arg(long, value_name = "SECONDS", conflicts_with = "no_ttl")]


### PR DESCRIPTION
`build_update_channel` already accepts a visibility argument, but `buzz channels update` hardcoded `None`, so there was no way to convert a channel between open and private from the CLI — the only surface was the desktop app.

Adds `--visibility open|private`, threads it through `cmd_update_channel`, and includes it in the "at least one field required" guard.

```
buzz channels update --channel <uuid> --visibility private
```

The relay side is unchanged: kind:9002 already validates the `visibility` tag and authorizes it as a privileged metadata edit (channel owner/admin), so this only closes a gap in the client surface.

## Testing

- `cargo test -p buzz-cli` — 317 passed, 0 failed
- `cargo clippy -p buzz-cli --all-targets -- -D warnings` — clean
- `cargo fmt` — clean
- Verified end to end against a live relay: converting an open channel to private takes effect immediately and the resulting system message / cache invalidation behave the same as a desktop-initiated flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)