### PR TITLE
docs(acp): correct subscription auth for codex-acp and claude-agent-acp

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -72,13 +72,17 @@ That's it. The harness spawns `goose acp`, connects to the relay, discovers chan
 # Install the adapter (npm package — no Rust build required)
 npm install -g @agentclientprotocol/codex-acp
 
-# Run
-export OPENAI_API_KEY="sk-..."   # required — use an OpenAI API key, not a ChatGPT subscription
+# Authenticate once — either a ChatGPT subscription or an API key
+codex login
 
 buzz-acp
 ```
 
-> **API key note:** `codex-acp` always attempts a ChatGPT WebSocket login first, which logs a `426 Upgrade Required` error. This is expected and non-fatal — it falls back to `OPENAI_API_KEY` automatically. Set `OPENAI_API_KEY` to ensure it has a working fallback.
+> **Auth note:** a ChatGPT subscription works. `codex-acp` reuses the Codex CLI's stored
+> login at `~/.codex/auth.json`, and `buzz-acp` spawns it with the parent environment intact,
+> so no API key is involved. `CODEX_API_KEY`/`OPENAI_API_KEY` are read only when the
+> API-key auth method is selected — set one if you would rather bill the API. Do not set
+> `NO_BROWSER=1`, which hides the ChatGPT auth method.
 
 ## Running with Claude Code
 
@@ -88,12 +92,21 @@ buzz-acp
 # Install the current adapter package
 npm install -g @agentclientprotocol/claude-agent-acp
 
+# Authenticate once — a Claude Pro/Max subscription or the Anthropic Console
+claude-agent-acp --cli auth login --claudeai
+
 # Run
-export ANTHROPIC_API_KEY="sk-ant-..."
 export BUZZ_ACP_AGENT_COMMAND="claude-agent-acp"
 
 buzz-acp
 ```
+
+> **Auth note:** a Claude Pro/Max subscription works, and no `ANTHROPIC_API_KEY` is needed.
+> The adapter advertises two methods — `claude-ai-login` ("Claude Subscription") and
+> `console-login` ("Anthropic Console (API usage billing)") — and keeps its own credential
+> store, so it does **not** inherit an existing Claude Code login; run the `--claudeai`
+> command above once. Set `ANTHROPIC_API_KEY` only if you would rather bill the API.
+> Do not pass `--hide-claude-auth`, which makes the adapter reject subscription sessions.
 
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.


### PR DESCRIPTION
The `buzz-acp` README tells operators they need API keys for both Codex and Claude. Neither is true against the current adapters.

**Codex.** The section said `OPENAI_API_KEY` was "required — use an OpenAI API key, not a ChatGPT subscription", and described a `426 Upgrade Required` WebSocket fallback. `codex-acp` 1.1.9 reuses the Codex CLI's stored login at `~/.codex/auth.json`, and reads `CODEX_API_KEY`/`OPENAI_API_KEY` only when the api-key auth method is selected.

**Claude.** The section said to export `ANTHROPIC_API_KEY`. `claude-agent-acp` 0.64.2 advertises `claude-ai-login` ("Claude Subscription") alongside `console-login` ("Anthropic Console (API usage billing)"). It does keep its own credential store rather than inheriting an existing Claude Code login, so the one-time `--claudeai` command is now shown explicitly rather than left implicit.

Neither claim held because `buzz-acp` injects no auth of its own — `AcpClient::spawn` uses `tokio::process::Command` with no `env_clear()`, and gives inherited parent env precedence over anything Buzz sets, so the adapter's own login applies. This is documentation only; no behaviour changes.

## Testing

- Drove each adapter through `initialize` → `session/new` → `session/prompt` with `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `CODEX_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` removed from the child environment. Both completed a turn with `stopReason: end_turn`.
- End-to-end through `buzz-acp` against a local relay: agent replied to an `@mention` in-channel, with zero `*_API_KEY` vars in the harness process environment (`ps eww`).
- Versions: `codex-acp` 1.1.9, `claude-agent-acp` 0.64.2.

## Note on #4611

[#4611](https://github.com/block/buzz/pull/4611) proposes launching Claude ACP adapters with an allowlisted environment and a disposable home, which would deliberately stop this credential inheritance. If that lands, the Claude auth note here needs revisiting — happy to fold this into that PR instead if the maintainers prefer.