### PR TITLE
Make the Postgres writer pool minimum configurable (BUZZ_DB_MIN_POOL_SIZE, default 20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ REDIS_URL=redis://localhost:6379
 # READ_DATABASE_URL is set, reader (default 50).
 # BUZZ_DB_POOL_SIZE=50
 
+# Minimum idle connections kept in the relay's Postgres writer pool
+# (default 20). Pre-warms the pool so requests after a deploy or an idle
+# period skip the connect path. Clamped to BUZZ_DB_POOL_SIZE. Set to 0 for a
+# fully lazy pool. Does not apply to the reader pool, which stays lazy so a
+# replica that is down at boot cannot gate startup.
+# BUZZ_DB_MIN_POOL_SIZE=20
+
 # -----------------------------------------------------------------------------
 # Typesense (search)
 # -----------------------------------------------------------------------------

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -13,6 +13,11 @@ use tracing::warn;
 /// NIP-44 encryption overhead.
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 512 * 1024;
 
+/// Default minimum idle connections in the Postgres writer pool.
+///
+/// Named so the value is asserted in tests rather than duplicated as a literal.
+pub const DEFAULT_DB_POOL_MIN_SIZE: u32 = 20;
+
 /// Errors that can occur while loading relay configuration.
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -76,6 +81,21 @@ pub struct Config {
     /// the per-pod pool and requests fail on acquire timeout while the
     /// database sits idle.
     pub db_pool_size: u32,
+    /// Minimum idle connections kept in the Postgres writer pool
+    /// (`BUZZ_DB_MIN_POOL_SIZE`). Defaults to 20.
+    ///
+    /// Pre-warming the pool keeps the first requests after a deploy or an
+    /// idle period off the connect path, which against Aurora costs a TLS
+    /// handshake per connection. Clamped to [`Self::db_pool_size`]: sqlx
+    /// obeys the maximum regardless, but stores the requested minimum
+    /// verbatim, so an unclamped pair would misreport itself in
+    /// `pool.options()` for no behavioural gain.
+    ///
+    /// Applies to the writer pool only. The read-replica pool is built lazily
+    /// with a pinned minimum of 0 so a replica that is down at boot cannot
+    /// gate relay startup — pre-warming it would reintroduce exactly that
+    /// coupling.
+    pub db_pool_min_size: u32,
     /// Maximum connections in the Postgres read-replica pool
     /// (`BUZZ_DB_READ_POOL_SIZE`). Defaults to `db_pool_size`. Sized
     /// independently so reader capacity can be tuned against the replica's
@@ -472,6 +492,21 @@ impl Config {
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&v| v > 0);
+
+        // Unlike the pool maxima, `0` is honoured rather than rejected: a
+        // minimum of zero is a meaningful setting (a fully lazy pool, which is
+        // what the read-replica pool pins deliberately), whereas a maximum of
+        // zero is not. Rejecting it would make the one value an operator would
+        // reach for to stop pre-warming mean the opposite. Unparsable values
+        // still fall back to the default.
+        let db_pool_min_size = std::env::var("BUZZ_DB_MIN_POOL_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_DB_POOL_MIN_SIZE)
+            // sqlx never opens more than `max_connections` regardless, but it
+            // reports back whatever minimum it was handed; clamping here keeps
+            // the pool's own introspection honest.
+            .min(db_pool_size);
 
         let relay_url =
             std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string());
@@ -937,6 +972,7 @@ impl Config {
             redis_url,
             redis_pool_size,
             db_pool_size,
+            db_pool_min_size,
             db_read_pool_size,
             relay_url,
             pairing_relay_url,
@@ -1006,6 +1042,7 @@ mod tests {
         assert!(!config.redis_url.is_empty());
         assert_eq!(config.redis_pool_size, 16);
         assert_eq!(config.db_pool_size, 50);
+        assert_eq!(config.db_pool_min_size, DEFAULT_DB_POOL_MIN_SIZE);
         assert!(config.max_connections > 0);
         assert!(config.send_buffer_size > 0);
         assert_eq!(config.max_frame_bytes, DEFAULT_MAX_FRAME_BYTES);
@@ -1156,6 +1193,93 @@ mod tests {
         assert_eq!(overridden, 80);
         assert_eq!(zero, 50, "zero must fall back to the default");
         assert_eq!(junk, 50, "unparsable value must fall back to the default");
+    }
+
+    #[test]
+    fn db_pool_min_size_env_override_and_invalid_fallback() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous = std::env::var_os("BUZZ_DB_MIN_POOL_SIZE");
+
+        std::env::remove_var("BUZZ_DB_MIN_POOL_SIZE");
+        let unset = Config::from_env().expect("config").db_pool_min_size;
+
+        std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", "35");
+        let overridden = Config::from_env().expect("config").db_pool_min_size;
+
+        // `0` is a meaningful minimum (fully lazy pool), so unlike the maxima
+        // it must be honoured rather than falling back to the default.
+        std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", "0");
+        let zero = Config::from_env().expect("config").db_pool_min_size;
+
+        std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", "not-a-number");
+        let junk = Config::from_env().expect("config").db_pool_min_size;
+
+        if let Some(value) = previous {
+            std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", value);
+        } else {
+            std::env::remove_var("BUZZ_DB_MIN_POOL_SIZE");
+        }
+
+        assert_eq!(
+            unset, DEFAULT_DB_POOL_MIN_SIZE,
+            "unset must use the default minimum"
+        );
+        assert_eq!(overridden, 35);
+        assert_eq!(zero, 0, "zero must be honoured, not treated as unset");
+        assert_eq!(
+            junk, DEFAULT_DB_POOL_MIN_SIZE,
+            "unparsable value must fall back to the default"
+        );
+    }
+
+    /// The minimum must never exceed the maximum. sqlx obeys the maximum
+    /// regardless, but stores the requested minimum verbatim, so without this
+    /// clamp `pool.options()` would report an impossible pair.
+    #[test]
+    fn db_pool_min_size_is_clamped_to_max() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous_min = std::env::var_os("BUZZ_DB_MIN_POOL_SIZE");
+        let previous_max = std::env::var_os("BUZZ_DB_POOL_SIZE");
+
+        // Explicit minimum above an explicit maximum.
+        std::env::set_var("BUZZ_DB_POOL_SIZE", "8");
+        std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", "30");
+        let explicit = Config::from_env().expect("config");
+
+        // Default minimum (20) against a smaller explicit maximum: the clamp
+        // must fire without the operator naming a minimum at all.
+        std::env::remove_var("BUZZ_DB_MIN_POOL_SIZE");
+        let defaulted = Config::from_env().expect("config");
+
+        // A maximum above the minimum must leave the minimum untouched.
+        std::env::set_var("BUZZ_DB_POOL_SIZE", "60");
+        std::env::set_var("BUZZ_DB_MIN_POOL_SIZE", "30");
+        let headroom = Config::from_env().expect("config");
+
+        for (key, value) in [
+            ("BUZZ_DB_MIN_POOL_SIZE", previous_min),
+            ("BUZZ_DB_POOL_SIZE", previous_max),
+        ] {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+
+        assert_eq!(explicit.db_pool_size, 8);
+        assert_eq!(
+            explicit.db_pool_min_size, 8,
+            "explicit minimum above the maximum must clamp to the maximum"
+        );
+        assert_eq!(
+            defaulted.db_pool_min_size, 8,
+            "default minimum above a smaller maximum must clamp to the maximum"
+        );
+        assert_eq!(
+            headroom.db_pool_min_size, 30,
+            "a minimum below the maximum must pass through unchanged"
+        );
     }
 
     #[test]

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -168,6 +168,7 @@ async fn main() -> anyhow::Result<()> {
         read_database_url: config.read_database_url.clone(),
         replica_read_max_age_ms: config.replica_read_max_age_ms,
         max_connections: config.db_pool_size,
+        min_connections: config.db_pool_min_size,
         read_max_connections: config.db_read_pool_size,
         ..DbConfig::default()
     };


### PR DESCRIPTION
## Problem

The relay could size the Postgres pool *ceiling* but not its *floor*.

`BUZZ_DB_POOL_SIZE` has been wired to `max_connections` for a while. `DbConfig::min_connections` also exists (`crates/buzz-db/src/lib.rs:516`) and is genuinely applied to the writer pool (`lib.rs:681`) — but the only value it ever took in production was the hardcoded `2` from `DbConfig::default()` (`lib.rs:542`), because relay `main` sets max/read-max explicitly and fills the rest from `..DbConfig::default()` (`main.rs:166-173`). No env var reached it. The knob existed with no wire to the outside.

## Change

Adds `BUZZ_DB_MIN_POOL_SIZE` → `Config::db_pool_min_size` (default **20**), passed explicitly into the writer pool, mirroring how the maximum is already plumbed. Pre-warming keeps requests after a deploy or an idle period off the connect path, which against Aurora costs a TLS handshake per connection.

Three decisions worth a reviewer's attention, since each could reasonably have gone the other way:

**1. The default lives at the relay env boundary, not in `DbConfig::default()`.**
`buzz-admin` also builds `DbConfig` with `..DbConfig::default()` (`crates/buzz-admin/src/main.rs:423`) and is a short-lived CLI — `migrate` / `add-member` / `list-members` / `reconcile-channels` connect, do one operation, and exit (`main.rs:130-153`). Raising the *library* default would make every admin invocation eagerly open 20 sessions for zero throughput benefit. `DbConfig::default().min_connections` stays `2`.

**2. The value is clamped to `db_pool_size`.**
sqlx obeys `max_connections` regardless — `try_min_connections` bails when the semaphore has no permit, commented "We must always obey `max_connections`" (`sqlx-core-0.9.0/src/pool/inner.rs:400-418`). So an unclamped pair is **not** a hang or a panic. But sqlx stores the requested minimum verbatim and explicitly puts validation on the caller:

> "This value is clamped internally to not exceed `max_connections`. We've chosen not to assert `min_connections <= max_connections` anywhere because it shouldn't break anything internally... if the application allows either value to be dynamically set then it should be checking this condition itself" — `pool/options.rs:194-200`

Without the clamp, `BUZZ_DB_POOL_SIZE=8` (already legal — the max parser accepts any positive value) plus the default minimum of 20 would leave `pool.options()` reporting an impossible `min=20, max=8`. Behaviourally inert, but it misreports the pool's own configuration to anyone introspecting it. @Mari confirmed this against local Postgres: `max=2, min=3` connected fine with `live_size=2`, while `pool.options()` still claimed `min=3, max=2`.

**3. `0` is honoured rather than rejected — a deliberate divergence from the maxima.**
Every neighbouring sizing parser has `.filter(|&v| v > 0)` so zero falls back to the default. That is right for a *maximum* and wrong for a *minimum*: zero is a meaningful minimum (a fully lazy pool — exactly what the read-replica pool pins on purpose), so copying the max parser would make the one value an operator would reach for to stop pre-warming silently mean `20` instead. Unparsable values still fall back to the default.

**The reader pool is untouched.** It stays pinned at `min_connections(0)` and lazy (`lib.rs:726`) so a replica that is down at boot cannot gate relay startup. Pre-warming it would reintroduce exactly that coupling.

Deliberately out of scope, for symmetry with `BUZZ_DB_POOL_SIZE` (which also governs only the `Db` pools): the audit pool's fixed `max 5 / min 1` (`buzz-relay/src/main.rs:351-352`), the search pool's bare `PgPoolOptions::new()` (`main.rs:406`), and the push gateway's independent pools, which do not read relay `Config` at all.

## Verification

At `b380ba3e073919a487082fadcd15868e93a0c889`, hermit toolchain 1.95.0:

- `cargo build -p buzz-relay --locked` — clean
- `cargo test -p buzz-relay --locked --lib` — **839 passed, 37 ignored, 1 failed**
- `cargo clippy -p buzz-relay --locked --all-targets` — no warnings, no errors
- `cargo fmt` clean; pre-push `rust-tests` + `desktop-tauri-checks` hooks both green

The one failure is `api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo` (504 vs 200). **It is pre-existing and not caused by this change** — I stashed the entire diff, confirmed `git rev-parse HEAD` = `027a74a61c8643a1d1086d3e8307fad89d7735f7` with a clean tree, and reproduced the identical `left: 504, right: 200` failure, then restored.

Both new tests were mutation-tested rather than just observed green:

| Mutant | Result |
|---|---|
| Delete `.min(db_pool_size)` (the clamp) | **dies** — `explicit minimum above the maximum must clamp to the maximum` |
| Add `.filter(\|&v\| v > 0)` (copy the max parser's shape) | **dies** — `zero must be honoured, not treated as unset` |

The two mutants kill *different* tests, so the pair discriminates rather than overlapping. Control re-run green after each restore. One caveat worth stating: the clamp mutant also fails the two neighbouring `db_pool_size`/`db_read_pool_size` tests, but that is `ENV_MUTEX` poisoning collateral (both panic at `.lock().unwrap()`), not three independent kills — the real kill is the clamp assertion.

The clamp test covers all three arms: explicit min above explicit max, *default* min above a smaller max (fires with no min set at all), and min below max passing through unchanged.
