### PR TITLE
fix(relay): satisfy clippy lint warnings on admin auth changes

### DIFF
--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -1,7 +1,7 @@
 //! Private, read-only deployment moderation API.
 
 mod auth;
-mod error;
+pub(crate) mod error;
 
 use std::sync::Arc;
 
@@ -27,8 +27,8 @@ pub(crate) fn is_admin_host(state: &crate::state::AppState, headers: &HeaderMap)
 pub(crate) fn authorize_request(
     state: &crate::state::AppState,
     headers: &HeaderMap,
-) -> Result<(), Response> {
-    authorize(state, headers).map_err(|error| error.into_response())
+) -> Result<(), ApiError> {
+    authorize(state, headers)
 }
 
 /// Build the read-only deployment-admin routes.

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -1119,7 +1119,7 @@ mod tests {
             "BUZZ_ADMIN_PASSWORD",
             "BUZZ_ADMIN_WEB_DIR",
         ];
-        let previous = NAMES.map(|name| std::env::var_os(name));
+        let previous = NAMES.map(std::env::var_os);
         for name in NAMES {
             std::env::remove_var(name);
         }

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -161,8 +161,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
                 let path = req.uri().path();
                 let admin_host = api::admin::is_admin_host(&state, req.headers());
                 if admin_host {
-                    if let Err(response) = api::admin::authorize_request(&state, req.headers()) {
-                        return Ok(response);
+                    if let Err(error) = api::admin::authorize_request(&state, req.headers()) {
+                        return Ok(error.into_response());
                     }
                     if let (Some(index), Some(files)) = (admin_index, admin_files) {
                         if path.starts_with("/assets/") {
@@ -274,8 +274,8 @@ async fn nip11_or_ws_handler(
     // Short-circuit the exact admin authority here and never let it serve the
     // public web bundle, NIP-11 document, or WebSocket endpoint.
     if api::admin::is_admin_host(&state, &headers) {
-        if let Err(response) = api::admin::authorize_request(&state, &headers) {
-            return response;
+        if let Err(error) = api::admin::authorize_request(&state, &headers) {
+            return error.into_response();
         }
         if !accept.contains("text/html") {
             return StatusCode::NOT_FOUND.into_response();


### PR DESCRIPTION
Stacked on #4606 — targets `codex/security-admin-host-origin-auth`, not `main`.

#4606 fails **Rust Lint** and **Windows Rust** on two clippy errors under `-D warnings`. Neither is a real bug; both are style rules the repo enforces strictly enough to block a merge. No user-visible behavior changes.

## 1. `clippy::result_large_err`

`crates/buzz-relay/src/api/admin/mod.rs:30`

A `Result` is always sized to fit its larger variant, and it gets moved on every return — including the success path. `authorize_request` returned `Result<(), Response>`: nothing on success, a fully-built axum `Response` (≥128 bytes) on failure. So every successful admin request was carrying a 128-byte payload to deliver zero bytes.

The fix stops building the HTTP response inside that function. It now returns `ApiError` — a status code, two `&'static str`, and a bool — and the two `router.rs` call sites convert with `.into_response()` at the point they actually need a response. Same responses go out; the expensive object is constructed one frame later, only on the failure path.

`admin::error` was promoted to `pub(crate) mod` as bookkeeping for that: once a `pub(crate) fn` hands `ApiError` back, the type has to be nameable by its callers, or Rust flags it as a private interface leak.

## 2. `clippy::redundant_closure`

`crates/buzz-relay/src/config.rs:1122`, in a test.

```rust
NAMES.map(|name| std::env::var_os(name))   // closure whose only job is to forward its argument
NAMES.map(std::env::var_os)                // pass the function directly
```

Identical behavior, one less layer.

## Why the two jobs reported different errors

Rust Lint (Linux) hit #1 and bailed before compiling the test target, so it never saw #2. Windows Rust compiles `lib test` and caught both.

## Testing

Not built locally — no Rust toolchain on the authoring machine, so clippy never ran before push. Relying on CI. Staying a draft until Rust Lint and Windows Rust are green.