### PR TITLE
fix(mobile): keep the unread jump after a deep boundary give-up

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_list.dart
@@ -64,7 +64,6 @@ class _MessageList extends HookConsumerWidget {
         if (!hasInitialUnread ||
             hasUnreadDeepLink ||
             oldestUnreadMessageId.value != null ||
-            unreadBoundaryLoadFailed.value ||
             entries.isEmpty) {
           return null;
         }
@@ -104,6 +103,8 @@ class _MessageList extends HookConsumerWidget {
           return () => cancelled = true;
         }
 
+        // Giving up only stops further fetching. Resolution below still runs,
+        // so a target the user pages in later can still be offered.
         if (hasKnownTarget &&
             !hasLoadedFetchTarget &&
             !notifier.reachedOldest) {

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -1758,6 +1758,97 @@ void main() {
       );
     });
 
+    testWidgets(
+      'still offers the unread jump once the user pages the target in',
+      (tester) async {
+        // The unread boundary sits further back than the automatic fetch cap
+        // can reach, so the initial load gives up before the target arrives.
+        // A user who keeps scrolling brings that page in themselves, and the
+        // jump control has to come back when it does.
+        List<NostrEvent> page(int from, int to) => [
+          for (var i = from; i < to; i++)
+            _textMsg(
+              id: 'msg$i',
+              pubkey: 'alice',
+              content: 'Message $i',
+              createdAt: 1000 + i,
+            ),
+        ];
+
+        final messagesNotifier = _FakeMessagesNotifier(
+          page(250, 300),
+          olderPages: [
+            page(200, 250),
+            page(150, 200),
+            page(100, 150),
+            page(50, 100),
+            page(0, 50),
+          ],
+        );
+        final channelsNotifier = _FakeChannelsNotifier(
+          [_testChannel],
+          observedUnread: {
+            _channelId: [
+              makeObservedUnreadEvent(
+                id: 'msg5',
+                createdAt: 1005,
+                rootId: null,
+                highPriority: false,
+                channelType: 'stream',
+                isThreadedReply: false,
+              ),
+            ],
+          },
+        );
+        final readState = _SynchronousReadStateNotifier(
+          const ReadStateState(
+            isReady: true,
+            pubkey: 'self',
+            contexts: {_channelId: 1004},
+            version: 0,
+          ),
+        );
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: const [],
+            messagesNotifier: messagesNotifier,
+            channelsNotifier: channelsNotifier,
+            readStateNotifier: readState,
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The cap is spent and the target is still missing, so no control yet.
+        expect(messagesNotifier.fetchOlderCalls, 4);
+        expect(
+          find.byKey(const ValueKey('channel-jump-to-oldest-unread')),
+          findsNothing,
+        );
+
+        // The user scrolls back until the notifier runs out of history.
+        final list = find.byKey(const ValueKey('channel-message-list'));
+        for (var i = 0; i < 40 && !messagesNotifier.reachedOldest; i++) {
+          await tester.drag(list, const Offset(0, 600));
+          await tester.pumpAndSettle();
+        }
+        expect(messagesNotifier.reachedOldest, isTrue);
+
+        // Tapping has to land on the unread message, not merely render a
+        // control: presence alone would pass even if the jump did nothing.
+        final unreadButton = find.byKey(
+          const ValueKey('channel-jump-to-oldest-unread'),
+        );
+        expect(unreadButton, findsOneWidget);
+        await tester.tap(unreadButton);
+        await tester.pumpAndSettle();
+        expect(findRichText('Message 5'), findsOneWidget);
+      },
+    );
+
     testWidgets('can jump back to latest after a non-drag user scroll', (
       tester,
     ) async {


### PR DESCRIPTION
### What changed?

`_MessageList`'s unread-boundary effect used its give-up flag as a whole-effect kill switch: once the automatic fetch loop stopped paging toward the oldest unread message, the effect returned early on every later run, so the candidate resolution below it never ran again for that channel visit.

This scopes the flag to what it is named for. It still stops further fetching, but resolution keeps running, so a target that shows up later is still offered.

### Why?

A channel whose oldest unread message sits further back than the four-fetch cap can reach would show no jump-to-unread chevron at all, and would keep showing none even after the user scrolled that message into view themselves. The control was simply gone for the rest of the visit.

This is a regression against the behavior in #4239's predecessor head, which did offer a working chevron on the same fixture, so this restores rather than adds. The direction is fail-closed: the old code could only omit the control, never send you to the wrong message, which is why it was not worth holding #4239 for.

### How is it tested?

Build and run.

Added tests:

- [`ChannelDetailPage still offers the unread jump once the user pages the target in`](https://github.com/block/buzz/tree/main/mobile/test/features/channels/channel_detail_page_test.dart)

The new test drives pagination through real scroll gestures and asserts on where the chevron actually lands, not merely that it rendered. Presence alone is too weak here: in a virtualized list a control can be visible while the tap does nothing. It fails against `main` today and passes with this change.

### Reviewer guidance

Two shapes were measured before choosing this one. The alternative was deleting the flag outright at all five of its sites. Both give the same passing suite, so the tests could not distinguish them; removing the flag entirely also deletes the retry suppression it was added for, which is wider than the problem being fixed. That choice was made deliberately, not by the test suite.

Out of scope, filed separately as #4643: a mixed forced-unread plus ordinary-unread channel can still offer the *newer* message as "oldest unread". That is pre-existing at every head involved here, is a silent wrong jump rather than a missing control, and needs its own fix and its own tests.
