### PR TITLE
feat(acp): add owner broadcast routing

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -248,6 +248,19 @@ Forum event kinds:
 
 > **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
 
+### Owner broadcast routing
+
+Use `owner-broadcast` when the owner's untagged messages should wake every agent,
+but explicit recipient tags should wake only the selected agents:
+
+```bash
+buzz-acp --subscribe owner-broadcast
+```
+
+This mode includes stream messages, forum posts, and forum comments by default.
+Messages from non-owner authors still require an explicit mention. Use `--kinds`
+to override the accepted event kinds.
+
 ## How It Works
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -51,7 +51,26 @@ pub enum ConfigError {
 pub enum SubscribeMode {
     Mentions,
     All,
+    /// Broadcast unmentioned owner messages to every agent, while explicit
+    /// agent mentions remain exclusive.
+    #[value(name = "owner-broadcast")]
+    OwnerBroadcast,
     Config,
+}
+
+pub(crate) fn default_owner_broadcast_kinds() -> Vec<u32> {
+    use buzz_core::kind::{
+        KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+    };
+
+    vec![
+        KIND_STREAM_MESSAGE,
+        KIND_FORUM_POST,
+        KIND_FORUM_COMMENT,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_REMINDER,
+    ]
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -1290,6 +1309,21 @@ pub fn resolve_channel_filters(
                 );
             }
         }
+        SubscribeMode::OwnerBroadcast => {
+            let kinds = config
+                .kinds_override
+                .clone()
+                .unwrap_or_else(default_owner_broadcast_kinds);
+            for ch in &target_channels {
+                result.insert(
+                    *ch,
+                    ChannelFilter {
+                        kinds: Some(kinds.clone()),
+                        require_mention: false,
+                    },
+                );
+            }
+        }
         SubscribeMode::Config => {
             for ch in discovered_channels {
                 let mut merged_kinds: Option<Vec<u32>> = Some(vec![]);
@@ -1377,6 +1411,15 @@ pub fn resolve_dynamic_channel_filter(
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
+            require_mention: false,
+        }),
+        SubscribeMode::OwnerBroadcast => Some(ChannelFilter {
+            kinds: Some(
+                config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(default_owner_broadcast_kinds),
+            ),
             require_mention: false,
         }),
         SubscribeMode::Config => {
@@ -1794,6 +1837,26 @@ mod tests {
 
         let f = result.get(&channels[0]).unwrap();
         assert_eq!(f.kinds.as_ref().unwrap(), &[9, 7]);
+    }
+
+    #[test]
+    fn test_owner_broadcast_subscribes_to_stream_and_forum_messages() {
+        let config = test_config(SubscribeMode::OwnerBroadcast);
+        let channel = Uuid::new_v4();
+        let result = resolve_channel_filters(&config, &[channel], &[]);
+        let filter = result.get(&channel).unwrap();
+        let kinds = filter.kinds.as_ref().unwrap();
+
+        assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
+        assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_POST));
+        assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_COMMENT));
+        assert!(!filter.require_mention);
+        assert_eq!(
+            resolve_dynamic_channel_filter(&config, channel, &[])
+                .unwrap()
+                .kinds,
+            filter.kinds
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -194,24 +194,38 @@ async fn is_owner_or_sibling(
     owner_cache: &OwnerCache,
     rest_client: &relay::RestClient,
 ) -> bool {
+    is_owner_or_sibling_checked(author, owner_cache, rest_client)
+        .await
+        .unwrap_or(false)
+}
+
+/// Return `None` when sibling status cannot be resolved. Callers that use a
+/// negative result to broaden delivery must keep that distinct from failure.
+async fn is_owner_or_sibling_checked(
+    author: &str,
+    owner_cache: &OwnerCache,
+    rest_client: &relay::RestClient,
+) -> Option<bool> {
     let my_owner = match owner_cache.get() {
         Some(o) => o,
-        None => return false, // no owner configured — fail closed
+        None => return None,
     };
 
     // Direct owner check.
     if author == my_owner {
-        return true;
+        return Some(true);
     }
 
     // Check sibling cache.
     if let Some(cached) = owner_cache.is_known_sibling(author) {
-        return cached;
+        return Some(cached);
     }
 
     // Query the author's kind:0 profile to check for NIP-OA auth tag.
     let is_sibling = check_sibling_via_profile(author, my_owner, rest_client).await;
-    owner_cache.cache_sibling(author.to_string(), is_sibling);
+    if let Some(is_sibling) = is_sibling {
+        owner_cache.cache_sibling(author.to_string(), is_sibling);
+    }
     is_sibling
 }
 
@@ -257,6 +271,48 @@ async fn author_allowed(
     }
 }
 
+/// Apply owner-broadcast routing after the author gate.
+///
+/// Direct owner messages wake every agent unless the owner adds explicit
+/// recipient tags, in which case only tagged agents wake. Messages from any
+/// other allowed author still require an explicit mention of this agent.
+async fn owner_broadcast_allows(
+    event: &nostr::Event,
+    agent_pubkey: &str,
+    owner_cache: &OwnerCache,
+    rest_client: &relay::RestClient,
+) -> bool {
+    let Some(owner) = owner_cache.get() else {
+        return false;
+    };
+    let mentioned_pubkeys = event.tags.iter().filter_map(|tag| {
+        let parts = tag.as_slice();
+        (parts.first().map(String::as_str) == Some("p"))
+            .then(|| parts.get(1).map(String::as_str))
+            .flatten()
+    });
+
+    if event.pubkey.to_hex() != owner {
+        return mentioned_pubkeys.into_iter().any(|pk| pk == agent_pubkey);
+    }
+
+    let mentioned_pubkeys: Vec<_> = mentioned_pubkeys.collect();
+    if mentioned_pubkeys.contains(&agent_pubkey) {
+        return true;
+    }
+
+    for pubkey in mentioned_pubkeys {
+        if pubkey == owner {
+            continue;
+        }
+        match is_owner_or_sibling_checked(pubkey, owner_cache, rest_client).await {
+            Some(true) | None => return false,
+            Some(false) => {}
+        }
+    }
+    true
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -292,12 +348,12 @@ async fn check_sibling_via_profile(
     author: &str,
     expected_owner: &str,
     rest_client: &relay::RestClient,
-) -> bool {
+) -> Option<bool> {
     let filter = nostr::Filter::new()
         .kind(nostr::Kind::Metadata)
         .author(match nostr::PublicKey::from_hex(author) {
             Ok(pk) => pk,
-            Err(_) => return false,
+            Err(_) => return Some(false),
         })
         .limit(1);
 
@@ -305,28 +361,28 @@ async fn check_sibling_via_profile(
         .await
     {
         Ok(Ok(v)) => v,
-        _ => return false, // timeout or error — fail closed
+        _ => return None,
     };
 
     // Look for an "auth" tag in the profile event.
     let events = match resp.as_array() {
         Some(arr) => arr,
-        None => return false,
+        None => return None,
     };
     let event = match events.first() {
         Some(e) => e,
-        None => return false,
+        None => return Some(false),
     };
     let tags = match event.get("tags").and_then(|t| t.as_array()) {
         Some(t) => t,
-        None => return false,
+        None => return None,
     };
 
     // Find ["auth", owner_pk, conditions, sig] and verify the Schnorr signature.
     // Don't trust the relay — verify ourselves.
     let agent_pk = match nostr::PublicKey::from_hex(author) {
         Ok(pk) => pk,
-        Err(_) => return false,
+        Err(_) => return Some(false),
     };
 
     for tag in tags {
@@ -350,7 +406,7 @@ async fn check_sibling_via_profile(
         match buzz_sdk::nip_oa::verify_auth_tag(&tag_json, &agent_pk) {
             Ok(_) => {
                 tracing::debug!(author, expected_owner, "sibling verified via NIP-OA");
-                return true;
+                return Some(true);
             }
             Err(e) => {
                 tracing::debug!(author, "NIP-OA auth tag verification failed: {e}");
@@ -358,7 +414,7 @@ async fn check_sibling_via_profile(
         }
     }
 
-    false
+    Some(false)
 }
 
 const OBSERVER_PUBLISH_INTERVAL: Duration = Duration::from_millis(167);
@@ -1518,6 +1574,21 @@ async fn tokio_main() -> Result<()> {
                 prompt_tag: Some("all".into()),
             }]
         }
+        SubscribeMode::OwnerBroadcast => {
+            vec![SubscriptionRule {
+                name: "owner-broadcast".into(),
+                channels: filter::ChannelScope::All("all".into()),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(config::default_owner_broadcast_kinds),
+                require_mention: false,
+                filter: None,
+                compiled_filter: None,
+                consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+                prompt_tag: Some("owner-broadcast".into()),
+            }]
+        }
         SubscribeMode::Config => {
             // load_rules() already warns if the config file has zero rules.
             config::load_rules(&config.config_path)?
@@ -2240,6 +2311,22 @@ async fn tokio_main() -> Result<()> {
                                     );
                                     continue;
                                 }
+                            }
+
+                            if config.subscribe_mode == SubscribeMode::OwnerBroadcast
+                                && !owner_broadcast_allows(
+                                    &buzz_event.event,
+                                    &pubkey_hex,
+                                    &owner_cache,
+                                    &ctx.rest_client,
+                                )
+                                .await
+                            {
+                                tracing::debug!(
+                                    channel_id = %buzz_event.channel_id,
+                                    "owner-broadcast routing — event targets another agent"
+                                );
+                                continue;
                             }
 
                             let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
@@ -4521,6 +4608,16 @@ mod owner_cache_tests {
 mod author_gate_tests {
     use super::*;
 
+    fn event_with_mentions(author: &nostr::Keys, mentions: &[&str]) -> nostr::Event {
+        let tags = mentions
+            .iter()
+            .map(|pubkey| nostr::Tag::parse(["p", *pubkey]).unwrap());
+        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "hello")
+            .tags(tags)
+            .sign_with_keys(author)
+            .unwrap()
+    }
+
     /// A `RestClient` for tests. The author-gate decisions exercised here all
     /// resolve from the owner pubkey or sibling cache before any HTTP call, so
     /// this client is never actually used to make a request.
@@ -4545,6 +4642,102 @@ mod author_gate_tests {
         cache.cache_sibling(STRANGER.into(), false);
         cache.cache_sibling(EXTERNAL.into(), false);
         cache
+    }
+
+    #[tokio::test]
+    async fn owner_broadcast_is_broad_until_owner_targets_an_agent() {
+        let owner = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let other_agent = nostr::Keys::generate();
+        let human = nostr::Keys::generate();
+        let owner_hex = owner.public_key().to_hex();
+        let agent_hex = agent.public_key().to_hex();
+        let other_agent_hex = other_agent.public_key().to_hex();
+        let human_hex = human.public_key().to_hex();
+        let cache = OwnerCache::new(Some(owner_hex));
+        cache.cache_sibling(other_agent_hex.clone(), true);
+        cache.cache_sibling(human_hex.clone(), false);
+        let rest = dummy_rest_client();
+
+        assert!(
+            owner_broadcast_allows(&event_with_mentions(&owner, &[]), &agent_hex, &cache, &rest,)
+                .await
+        );
+        assert!(
+            owner_broadcast_allows(
+                &event_with_mentions(&owner, &[&agent_hex]),
+                &agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+        assert!(
+            owner_broadcast_allows(
+                &event_with_mentions(&owner, &[&agent_hex, &other_agent_hex]),
+                &other_agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+        assert!(
+            owner_broadcast_allows(
+                &event_with_mentions(&owner, &[&other_agent_hex, &agent_hex]),
+                &other_agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+        assert!(
+            !owner_broadcast_allows(
+                &event_with_mentions(&owner, &[&other_agent_hex]),
+                &agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+        assert!(
+            owner_broadcast_allows(
+                &event_with_mentions(&owner, &[&human_hex]),
+                &agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_broadcast_requires_mentions_from_non_owner_authors() {
+        let owner = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let sibling = nostr::Keys::generate();
+        let owner_hex = owner.public_key().to_hex();
+        let agent_hex = agent.public_key().to_hex();
+        let cache = OwnerCache::new(Some(owner_hex));
+        let rest = dummy_rest_client();
+
+        assert!(
+            !owner_broadcast_allows(
+                &event_with_mentions(&sibling, &[]),
+                &agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
+        assert!(
+            owner_broadcast_allows(
+                &event_with_mentions(&sibling, &[&agent_hex]),
+                &agent_hex,
+                &cache,
+                &rest,
+            )
+            .await
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add an `owner-broadcast` ACP subscription mode
- broadcast an owner's untagged messages to every owned agent
- keep explicit agent mentions exclusive to the tagged agents
- include stream messages, forum posts, forum comments, approvals, and reminders by default
- document the mode and its environment setting

## Validation

- `bin/just ci`
- ACP routing tests cover untagged owner messages, targeted agents in both tag orders, human recipients, lookup failures, non-owner messages, and forum kinds

Originating Buzz channel: `7a80f7af-3bec-4e17-a4ee-9f006a6eeac8`
