### PR TITLE
Clarify broadcast help text

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -366,7 +366,7 @@ pub enum MessagesCmd {
         /// Event ID to reply to (creates a thread)
         #[arg(long)]
         reply_to: Option<String>,
-        /// Also publish to the Nostr network
+        /// Also show this threaded reply in the channel timeline
         #[arg(long, default_value_t = false)]
         broadcast: bool,
         /// Attach file(s) — uploads and includes as imeta tags


### PR DESCRIPTION
Clarifies the CLI help for the broadcast flag so operators understand the flag's effect before using it.\n\nVerification: cargo fmt --check.