### PR TITLE
feat(deploy): add device-pairing sidecar to the compose stack

### DIFF
--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,13 @@
 {$BUZZ_DOMAIN} {
   encode zstd gzip
 
-  reverse_proxy relay:3000
+  # Device-pairing sidecar (compose.pair.yml). If the pairing overlay is
+  # disabled, requests to /pair fail with 502 instead of reaching the relay.
+  handle /pair {
+    reverse_proxy pair-relay:5000
+  }
+
+  handle {
+    reverse_proxy relay:3000
+  }
 }

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -44,6 +44,31 @@ keypair.
   `.env`; use the Helm chart or a custom Compose configuration for providers
   such as new Railway Storage Buckets that require `virtual` addressing.
 
+## Device pairing
+
+Mobile QR pairing (NIP-AB) needs the `buzz-pair-relay` sidecar: a
+membership-gated (NIP-43) relay rejects unpaired devices, so the pairing
+handshake runs through a separate ephemeral relay instead. Without it, phones
+scanning the desktop QR fail with a WebSocket 404 on `<relay>/pair`.
+
+The TLS stack includes the sidecar by default (`compose.pair.yml`):
+
+- Runs `buzz-pair-relay` from the same relay image.
+- Caddy routes `/pair` to it; everything else still goes to the relay.
+- Sets `BUZZ_PAIRING_RELAY_URL=wss://$BUZZ_DOMAIN/pair` on the relay so the
+  pairing URL is advertised in NIP-11.
+
+Set `BUZZ_COMPOSE_PAIRING=false` to opt out — `/pair` then returns 502 from
+Caddy. Pairing is not wired for the non-TLS stack: there is no reverse proxy
+to route `/pair`, and iOS requires `wss://` anyway.
+
+Verify after `./run.sh start`:
+
+```bash
+curl -fsS "https://<your-domain>" -H 'Accept: application/nostr+json' | grep -o 'pairing_relay_url[^,]*'
+curl -is "https://<your-domain>/pair" | head -1   # expect HTTP 400 (non-WebSocket request rejected)
+```
+
 Run `./run.sh backup-hint` for the backup checklist.
 
 ## Validation

--- a/deploy/compose/compose.pair.yml
+++ b/deploy/compose/compose.pair.yml
@@ -1,0 +1,29 @@
+# Device-pairing sidecar (NIP-AB) overlay. Included automatically by run.sh
+# when BUZZ_COMPOSE_TLS=true (opt out with BUZZ_COMPOSE_PAIRING=false).
+# Pairing requires the Caddy overlay: the phone connects over wss:// and the
+# Caddyfile routes /pair to this service.
+services:
+  relay:
+    environment:
+      # Advertised in the relay's NIP-11 document so clients connect here
+      # directly instead of guessing the legacy <relay>/pair path.
+      BUZZ_PAIRING_RELAY_URL: wss://${BUZZ_DOMAIN:?set BUZZ_DOMAIN}/pair
+
+  pair-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    # The image ENTRYPOINT is buzz-relay; entrypoint (not command) is required
+    # to run the sidecar binary instead.
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    # TCP connect probe over /dev/tcp because the runtime image has bash but
+    # no curl/wget/socat (same approach as the relay healthcheck).
+    healthcheck:
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net

--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -7,6 +7,9 @@ cd "${SCRIPT_DIR}"
 COMPOSE_FILES=(-f compose.yml)
 if [[ "${BUZZ_COMPOSE_TLS:-false}" == "true" ]]; then
   COMPOSE_FILES+=(-f compose.caddy.yml)
+  if [[ "${BUZZ_COMPOSE_PAIRING:-true}" == "true" ]]; then
+    COMPOSE_FILES+=(-f compose.pair.yml)
+  fi
 fi
 if [[ "${BUZZ_COMPOSE_DEV:-false}" == "true" ]]; then
   COMPOSE_FILES+=(-f compose.dev.yml)
@@ -121,8 +124,10 @@ Commands:
   roster event. Do not use parallel adds (e.g. xargs -P).
 
 Environment switches:
-  BUZZ_COMPOSE_TLS=true   Include compose.caddy.yml for automatic HTTPS
-  BUZZ_COMPOSE_DEV=true   Include compose.dev.yml for local admin ports/tools
+  BUZZ_COMPOSE_TLS=true       Include compose.caddy.yml for automatic HTTPS
+  BUZZ_COMPOSE_DEV=true       Include compose.dev.yml for local admin ports/tools
+  BUZZ_COMPOSE_PAIRING=false  Disable the device-pairing sidecar
+                              (compose.pair.yml, included by default with TLS)
 MSG
     ;;
   *)


### PR DESCRIPTION
## Problem

Mobile QR pairing fails out of the box for `deploy/compose` deployments. A membership-gated (NIP-43) relay can't accept unpaired devices, so the desktop app falls back to pointing the phone at the legacy `<relay>/pair` path (`resolve_pairing_relay_url` in `desktop/src-tauri/src/commands/pairing.rs`). The compose stack never runs the `buzz-pair-relay` sidecar or routes `/pair`, so the phone's WebSocket upgrade lands on the main relay's router and pairing always dies with **"websocket connection failed: http error: 404 not found"**.

The Helm chart already handles this (`pairingRelay.enabled` runs the sidecar from the relay image and advertises it in NIP-11); this PR brings the compose bundle to parity.

## Changes

- **`compose.pair.yml`** (new overlay): runs `/usr/local/bin/buzz-pair-relay` from the existing relay image via an `entrypoint:` override (the image `ENTRYPOINT` is `buzz-relay`, so `command:` alone would silently start a second main relay), binds `0.0.0.0:5000`, and adds a bash `/dev/tcp` healthcheck matching the relay's approach. It also sets `BUZZ_PAIRING_RELAY_URL=wss://$BUZZ_DOMAIN/pair` on the relay so clients get the pairing URL from NIP-11 instead of relying on the legacy path fallback.
- **`Caddyfile`**: exclusive `handle` blocks — `/pair` → `pair-relay:5000`, everything else → `relay:3000`.
- **`run.sh`**: includes the overlay by default when `BUZZ_COMPOSE_TLS=true`; `BUZZ_COMPOSE_PAIRING=false` opts out. Not wired for the non-TLS stack (no reverse proxy to route `/pair`, and iOS requires `wss://`).
- **`README.md`**: new "Device pairing" section with verification steps.

## Testing

- `docker compose -f compose.yml -f compose.caddy.yml -f compose.pair.yml config` renders the merged stack correctly (sidecar entrypoint/env/healthcheck, relay `BUZZ_PAIRING_RELAY_URL`).
- Verified end-to-end on a live single-node VPS deployment of this stack: NIP-11 advertises `pairing_relay_url`, `GET /pair` returns the sidecar's 400 for non-WebSocket requests (previously the relay's 404), and iOS QR pairing against the desktop app completes through SAS confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Voret84oXtBS5hfRo66uGS
