### PR TITLE
feat(desktop): render activity bar on non-managing owner devices

### DIFF
--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -49,8 +49,27 @@ export function BotActivityComposerAction({
       workingBotPubkeys.map((pubkey) => pubkey.toLowerCase()),
     );
 
-    return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
-  }, [agents, workingBotPubkeys]);
+    const managed = agents.filter((agent) =>
+      workingSet.has(agent.pubkey.toLowerCase()),
+    );
+    if (managed.length > 0 || workingBotPubkeys.length === 0) {
+      return managed;
+    }
+
+    // This install does not manage the working agents — e.g. a second desktop
+    // signed in with the same owner identity. The observer stream is scoped to
+    // the owner, not the managing install, so activity is still renderable;
+    // derive display entries from the relay profile lookup instead of the
+    // local managed-agent registry.
+    return workingBotPubkeys.map((pubkey) => {
+      const profile = profiles?.[pubkey.toLowerCase()];
+
+      return {
+        pubkey,
+        name: profile?.displayName || profile?.name || "Agent",
+      };
+    });
+  }, [agents, profiles, workingBotPubkeys]);
   const singleWorkingAgent =
     workingAgents.length === 1 ? (workingAgents[0] ?? null) : null;
   const transcript = useAgentTranscript(


### PR DESCRIPTION
## Summary

The composer activity bar only rendered when the working agent was present in
*this* install's managed-agent registry. Sign in on a second desktop with the
same owner identity and the bar stayed dark for the whole turn, even though the
observer stream was arriving normally — the stream is scoped to the owner, not
to the managing install.

When no managed agent matches the working pubkeys, fall back to display entries
derived from the relay profile lookup (`displayName` → `name` → `"Agent"`).
Managed entries are still preferred, so the single-install case is unchanged.

### Related issue

None found — searched open issues and PRs for "activity bar" / "second device"
/ "non-managing".

### Testing

- `pnpm -C desktop test` — 4041 passing
- `pnpm -C desktop typecheck` — clean
- `biome check` on the touched file — clean
- Manual: two desktops signed in with one owner identity, agent managed by the
  first. Before: bar dark on the second machine for the whole turn. After: the
  bar renders on both, with the agent's profile display name on the
  non-managing one.

<!-- SCREENSHOT: side-by-side of the second (non-managing) desktop, before/after
     — composer bar dark vs. showing "Assistant · Bash: … · 12s" -->
