### PR TITLE
fix(desktop): connect managed agents to the configured relay, not the normalized loopback identity

### DIFF
--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -332,10 +332,15 @@ pub async fn restore_managed_agents_on_launch(
                                             // mid-turn session is not resumed by an
                                             // eager child — and silently reintroduces
                                             // N idle brains on every launch.
+                                            // Connect via the configured relay
+                                            // (`relay_url`), not the normalized
+                                            // key — see spawn_agent_child: the
+                                            // loopback fold to 127.0.0.1 is
+                                            // identity-only.
                                             spawn_agent_child(
                                                 app,
                                                 record,
-                                                &key.relay_url,
+                                                &relay_url,
                                                 true,
                                                 owner_hex_ref,
                                             )

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -535,9 +535,7 @@ pub fn spawn_agent_child(
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
 
-    // The caller supplies the explicit canonical pair relay. This is the only
-    // relay this child may connect to, regardless of the record/workspace default.
-    let effective_relay_url = runtime_key.relay_url.clone();
+    let effective_relay_url = relay_url.to_string(); // CONFIGURED relay, not normalized key (multi-tenant by Host); see commit msg
 
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink
@@ -880,7 +878,7 @@ pub fn spawn_agent_child(
         super::spawn_snapshot::SpawnConfigInputs {
             record,
             descriptor: &descriptor,
-            relay_url: &effective_relay_url,
+            relay_url: &runtime_key.relay_url, // NORMALIZED: matches needs_restart recompute (see commit msg)
             team_instructions: team_instructions.as_deref(),
             system_prompt: effective_prompt.as_deref(),
             model: effective_model.as_deref(),
@@ -992,7 +990,9 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    // Connect via the configured relay (`relay_url`), not the normalized key —
+    // see spawn_agent_child: the loopback fold to 127.0.0.1 is identity-only.
+    let mut process = spawn_agent_child(app, record, &relay_url, false, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -283,7 +283,9 @@ fn start_pair(
         .lock()
         .ok()
         .map(|keys| keys.public_key().to_hex());
-    let mut process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
+    // Connect via the configured relay (`relay_url`), not the normalized key —
+    // see spawn_agent_child: the loopback fold to 127.0.0.1 is identity-only.
+    let mut process = spawn_agent_child(&app, record, &relay_url, lazy, owner.as_deref())?;
     let now = crate::util::now_iso();
     let receipt = ManagedAgentRuntimeReceipt {
         key: key.clone(),
@@ -504,7 +506,11 @@ pub async fn reconcile_managed_agent_runtimes(
                 Ok((record, key, requested)) => {
                     match start_pair(
                         record.pubkey.clone(),
-                        key.relay_url.clone(),
+                        // Connect via the raw requested community URL, not the
+                        // normalized pair key — see spawn_agent_child: the
+                        // loopback fold to 127.0.0.1 is identity-only and would
+                        // land the agent in a different, empty tenant.
+                        requested.clone(),
                         true,
                         Some(&record.updated_at),
                         app.clone(),


### PR DESCRIPTION
## Summary

Two coupled defects in Desktop-managed agents on **loopback-addressed local communities**:

1. **Agents came up online but discovered 0 channels and sat idle** whenever the workspace relay was addressed as `localhost` (the desktop default and the seeded local-dev community). They only worked when the community was addressed as `127.0.0.1`.
2. **A permanent, un-clearable "Restart required" badge** once (1) is fixed — no restart could settle it.

**Root cause (shared).** The relay is multi-tenant, keyed by the literal request `Host`, so `localhost:3000` and `127.0.0.1:3000` are *distinct communities* with isolated channels/members. `buzz_core::relay::normalize_relay_url` intentionally folds all loopback spellings to `127.0.0.1` **for the runtime identity key only** — its own doc says:

> Connection code may retain the configured URL; this canonical form is for identity, receipts, status and deduplication.

But the spawn path reused that normalized `ManagedAgentRuntimeKey::relay_url` as the child's actual `BUZZ_RELAY_URL`, so an agent for a community joined on `localhost:3000` connected to the *empty* `127.0.0.1:3000` tenant: `subscribe` resolved 0 channels and the agent never woke.

## Fix

In `desktop/src-tauri/src/managed_agents/` (`runtime.rs`, `runtime_commands.rs`, `restore.rs`):

- **Connection:** connect the child on the **configured** relay URL at the spawn sites, keeping the normalized `ManagedAgentRuntimeKey` solely as the dedup identity (receipts, pid files, logs). Honors `normalize_relay_url`'s documented contract; no identity/dedup/receipts change.
- **Restart badge (corollary):** `needs_restart` compares a `SpawnConfigSnapshot` stamped at spawn against one recomputed live (`prospective_spawn_config_snapshot`), and the recompute reads the relay from the **normalized** runtime-map key. Once the connection fix flips the spawn's `effective_relay_url` to the configured spelling, stamping the snapshot with it (`localhost`) while the recompute uses the normalized key (`127.0.0.1`) makes them mismatch forever. Stamp `SpawnConfigInputs.relay_url` with the normalized `runtime_key.relay_url` so both sides compare the same spelling.

## Validation

Reproduced and verified end-to-end on a local self-hosted stack (relay on `localhost:3000`):

- **Before:** agent log `relay=ws://127.0.0.1:3000 -> "discovered 0 channel(s)" -> "no channel subscriptions resolved -- agent will sit idle"`.
- **After:** same agent `relay=ws://localhost:3000 -> "discovered 1 channel(s)" -> "subscribed to channel <spike>"`, and two managed agents (a Codex harness and a cursor-agent harness) each replied to an owner `@mention` in-channel. Restart badge clears on restart and stays clear.
- Rebased onto current `main`; all pre-push hooks pass (`branch-skew`, `desktop-check` incl. file-size ratchet, `rust-tests`, `desktop-test`, `mobile-test`, `desktop-tauri-checks` = clippy + Tauri crate tests).

## Test plan

- [ ] Create a Desktop-managed agent in a community addressed as `localhost:<port>`, attach it to a channel, `@mention` it as owner — it should discover the channel and reply.
- [ ] Confirm receipts / pid files / logs still key on the normalized (`127.0.0.1`) identity (no dedup regression across loopback spellings).
- [ ] Edit the agent's config (e.g. instructions/model), confirm the "Restart required" badge appears, restart, confirm it clears and stays clear.