### PR TITLE
docs(linux): clarify desktop update paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ On a Mac, check the Apple menu > About This Mac: "Chip: Apple …" means Apple S
 
 The Windows build is not code-signed, so SmartScreen may show "Windows protected your PC" on first launch. If available, click **More info**, then **Run anyway**.
 
+On Linux, choose the AppImage if you want Buzz to download and install updates
+from inside the app. A `.deb` installation is package-managed: Buzz can notify
+you that a release is available, but it opens GitHub Releases instead of trying
+to replace the installed package. Install the newer `.deb` with the same package
+manager you used originally. This distinction prevents the AppImage-only Tauri
+updater from attempting to modify a `.deb` installation ([#1535](https://github.com/block/buzz/pull/1535)).
 
 By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.
 


### PR DESCRIPTION
## What changed

Clarify the two supported Linux desktop update paths in the Getting started section:

- AppImage supports in-app download and installation.
- `.deb` installs remain package-managed and open GitHub Releases when an update is available.

## Why

The release table currently presents both artifacts as equivalent choices without explaining their different update behavior. The distinction only becomes visible after an update is found, which can surprise `.deb` users and self-hosted workstation operators.

The note also explains why Buzz deliberately avoids invoking the AppImage-only Tauri updater for a `.deb` installation.

## Validation

- `git diff --check`
- Verified the referenced updater guard in #1535 and the current `manual-required` desktop flow.

## Related

- #1535
- #4679 (follow-up proposal for an optional verified user-space updater)
