### PR TITLE
docs(contributing): add pkg-config and webkit2gtk-4.1 Recommends to Linux setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ Debian/Ubuntu:
 ```bash
 sudo apt-get install -y --no-install-recommends \
   build-essential curl file libasound2-dev libayatana-appindicator3-dev \
-  libgtk-3-dev librsvg2-dev libssl-dev libwebkit2gtk-4.1-dev libxdo-dev \
-  patchelf wget
+  libgtk-3-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libssl-dev \
+  libsoup-3.0-dev libwebkit2gtk-4.1-dev libxdo-dev patchelf pkg-config wget
 ```
 
 This is the same list CI installs (see `.github/workflows/ci.yml`), so matching


### PR DESCRIPTION
Fixes #4122.

A first-time Linux contributor running `just dev` on a minimal Ubuntu box
hits `pkg-config` not found at the first `cargo build` step (via `alsa-sys`),
then the rest of the GTK3 / WebKit dependency tree one pkg-config error at a
time. The Linux section's package list omits `pkg-config` itself, and uses
`--no-install-recommends` which drops the `libwebkit2gtk-4.1-dev` Recommends
that pull in `libjavascriptcoregtk-4.1-dev` and `libsoup-3.0-dev`.

Brings the list in line with what the issue author (who hit and resolved
the full chain) verified, and with what the other release workflows already
install:

- `pkg-config` — root cause; first `cargo build` error.
- `libjavascriptcoregtk-4.1-dev`, `libsoup-3.0-dev` — `libwebkit2gtk-4.1-dev`
  Recommends that `--no-install-recommends` strips.

Not touched: `.github/workflows/ci.yml` install block. CI's `ubuntu-latest`
runner image already has `pkg-config` (CI is green today), and the
`libwebkit2gtk-4.1-dev` Recommends are pulled in transitively there. The
CONTRIBUTING.md comment that says "This is the same list CI installs" is
now slightly stale; happy to update `ci.yml` too if maintainers prefer
the docs and CI to stay in lockstep — but bundling that here would couple
a docs fix to a CI workflow change.
