### PR TITLE
fix(desktop): clarify browser handoff result

### DIFF
--- a/desktop/src/features/profile/lib/nostrBindFinishState.test.mjs
+++ b/desktop/src/features/profile/lib/nostrBindFinishState.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { nostrBindBrowserFinishState } from "./nostrBindFinishState.ts";
+
+describe("nostrBindBrowserFinishState", () => {
+  it("names Run402 as the only authoritative completion screen", () => {
+    assert.deepEqual(nostrBindBrowserFinishState(null), {
+      title: "Check Run402 in your browser",
+      description:
+        "The Run402 tab showing the six-digit code is the only place that can confirm whether co-ownership completed.",
+      fallbackLabel: "Run402 didn’t receive the approval?",
+      closeLabel: "Close",
+    });
+  });
+
+  it("does not claim the browser received anything when opening it failed", () => {
+    assert.deepEqual(nostrBindBrowserFinishState("browser unavailable"), {
+      title: "The browser did not open",
+      description:
+        "Buzz signed the approval, but could not open Run402. Use the manual recovery below; no ownership changed.",
+      fallbackLabel: "Use manual recovery",
+      closeLabel: "Close",
+    });
+  });
+});

--- a/desktop/src/features/profile/lib/nostrBindFinishState.ts
+++ b/desktop/src/features/profile/lib/nostrBindFinishState.ts
@@ -1,0 +1,28 @@
+export interface NostrBindBrowserFinishState {
+  title: string;
+  description: string;
+  fallbackLabel: string;
+  closeLabel: string;
+}
+
+export function nostrBindBrowserFinishState(
+  callbackError: string | null,
+): NostrBindBrowserFinishState {
+  if (callbackError) {
+    return {
+      title: "The browser did not open",
+      description:
+        "Buzz signed the approval, but could not open Run402. Use the manual recovery below; no ownership changed.",
+      fallbackLabel: "Use manual recovery",
+      closeLabel: "Close",
+    };
+  }
+
+  return {
+    title: "Check Run402 in your browser",
+    description:
+      "The Run402 tab showing the six-digit code is the only place that can confirm whether co-ownership completed.",
+    fallbackLabel: "Run402 didn’t receive the approval?",
+    closeLabel: "Close",
+  };
+}

--- a/desktop/src/features/profile/ui/NostrBindConsentDialog.tsx
+++ b/desktop/src/features/profile/ui/NostrBindConsentDialog.tsx
@@ -11,6 +11,7 @@ import type { NostrBindDeepLinkPayload } from "@/shared/deep-link";
 import { listenForNostrBindDeepLinks } from "@/shared/deep-link";
 import { OnboardingSlideTransition } from "@/features/onboarding/ui/OnboardingSlideTransition";
 import { buildNostrBindCallbackUrl } from "@/features/profile/lib/nostrBindCallback";
+import { nostrBindBrowserFinishState } from "@/features/profile/lib/nostrBindFinishState";
 import { signNostrIdentityBinding } from "@/features/profile/lib/nostrIdentityBinding";
 import { cn } from "@/shared/lib/cn";
 import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
@@ -636,6 +637,11 @@ export function NostrBindConsentDialog() {
     signedResponse,
   ]);
 
+  const browserFinishState =
+    payload?.returnMode === "browser_fragment_v1"
+      ? nostrBindBrowserFinishState(error)
+      : null;
+
   return (
     <DialogPrimitive.Root
       onOpenChange={handleOpenChange}
@@ -666,17 +672,14 @@ export function NostrBindConsentDialog() {
                   transitionKey="nostr-bind-finish"
                 >
                   <DialogPrimitive.Title className="mt-6 text-3xl font-semibold tracking-tight">
-                    {payload.returnMode === "browser_fragment_v1"
-                      ? "Continue in your browser"
-                      : "Finish on the Buzz website"}
+                    {browserFinishState?.title ?? "Finish on the Buzz website"}
                   </DialogPrimitive.Title>
                   <DialogPrimitive.Description
                     className="mt-3 max-w-[440px] text-sm leading-6 text-muted-foreground"
                     id="nostr-bind-description"
                   >
-                    {payload.returnMode === "browser_fragment_v1"
-                      ? "Buzz opened your browser to finish verification."
-                      : "Copy the response below, then paste it into the Buzz website to finish verification."}
+                    {browserFinishState?.description ??
+                      "Copy the response below, then paste it into the Buzz website to finish verification."}
                   </DialogPrimitive.Description>
 
                   {error ? (
@@ -695,7 +698,7 @@ export function NostrBindConsentDialog() {
                       open={isManualFallbackOpen}
                     >
                       <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-                        <span>Pairing didn’t finish automatically?</span>
+                        <span>{browserFinishState?.fallbackLabel}</span>
                         <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-150 group-open:rotate-180" />
                       </summary>
                       <div className="space-y-4 border-t border-border/55 p-4">
@@ -728,7 +731,7 @@ export function NostrBindConsentDialog() {
                       type="button"
                       variant="ghost"
                     >
-                      Continue
+                      {browserFinishState?.closeLabel ?? "Continue"}
                     </Button>
                   </div>
                 </OnboardingSlideTransition>

--- a/desktop/tests/e2e/nostr-bind.spec.ts
+++ b/desktop/tests/e2e/nostr-bind.spec.ts
@@ -364,8 +364,17 @@ test("returns a signed response in the callback fragment after consent", async (
   await expect(page.getByTestId("nostr-bind-finish-step")).toBeVisible();
 
   await expect(
-    page.getByRole("heading", { name: "Continue in your browser" }),
+    page.getByRole("heading", { name: "Check Run402 in your browser" }),
   ).toBeVisible();
+  await expect(
+    page.getByText(
+      "The Run402 tab showing the six-digit code is the only place that can confirm whether co-ownership completed.",
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Run402 didn’t receive the approval?"),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
   const manualFallback = page.getByTestId("nostr-bind-manual-fallback");
   await expect(manualFallback).not.toHaveAttribute("open", "");
   await expect(page.getByTestId("nostr-bind-signed-response")).toBeHidden();


### PR DESCRIPTION
## What changed

- names the Run402 six-digit-code tab as the only authoritative co-ownership result screen
- replaces the ambiguous terminal `Continue` action with `Close`
- distinguishes browser-open failure from successful handoff and points to manual recovery
- adds focused state-model coverage and updates the existing desktop end-to-end ceremony

## Why

In a real Run402 co-ownership attempt, Buzz successfully opened the callback, but the five-minute Run402 attempt expired before authoritative completion. Buzz then remained on `Continue in your browser`, which looked like an unfinished pairing state even though Buzz cannot observe Run402 ownership. The offer remained available and no membership changed.

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (4,131 tests)
- `pnpm build:e2e`
- focused Playwright browser-fragment success and browser-open-failure cases (2 passed)