### PR TITLE
fix(cli): make 'buzz messages edit --content -' read stdin like send

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -818,13 +818,19 @@ pub async fn cmd_edit_message(
     content: &str,
 ) -> Result<(), CliError> {
     validate_hex64(event_id)?;
-    validate_content_size(content)?;
+    // Mirror `cmd_send_message`: `--content -` reads the replacement body
+    // from stdin, so multiline answers and shell-metacharacter-heavy text
+    // don't need to be jammed through argv. Without this, a literal "-"
+    // silently replaces the message with a single dash and the edit
+    // publishes with `accepted: true`.
+    let content = read_or_stdin(content)?;
+    validate_content_size(&content)?;
 
     // Resolve channel_id from the event's h-tag
     let channel_uuid = resolve_channel_id(client, event_id).await?;
     let target_eid = parse_event_id(event_id)?;
 
-    let builder = buzz_sdk::build_edit(channel_uuid, target_eid, content)
+    let builder = buzz_sdk::build_edit(channel_uuid, target_eid, &content)
         .map_err(|e| CliError::Other(format!("build_edit failed: {e}")))?;
 
     let event = client.sign_event(builder)?;

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -476,6 +476,16 @@ mod tests {
         assert_eq!(super::read_or_stdin("").unwrap(), "");
     }
 
+    #[test]
+    fn read_or_stdin_dash_reads_stdin_not_literal_dash() {
+        // Regression for the edit-vs-send mismatch in #4361: callers passing
+        // "-" expected stdin to be read, not the literal "-" published. A
+        // test runner's stdin is empty (or closed), so `read_to_string` returns
+        // Ok("") — the point is that the result is *not* the literal "-".
+        let got = super::read_or_stdin("-").unwrap();
+        assert_ne!(got, "-", "`-` must be treated as a stdin marker, not content");
+    }
+
     // --- read_file_or_stdin ---
 
     #[test]


### PR DESCRIPTION
Fixes #4361.

`cmd_edit_message` validated and signed the literal `"-"` as the
replacement body when callers passed `--content -`, while
`cmd_send_message` correctly resolves stdin in the same situation
(introduced in PR #624). The two paths diverged in this one step.

This is hazardous for agents: an agent can send a multiline answer
through stdin, use the same `--content -` convention to correct that
answer, receive an `accepted: true` response, and silently replace
the answer with a single dash. Markdown clients then render the
edited message as an empty bullet.

Mirrors `cmd_send_message`'s exact pattern: read stdin if `-`, then
validate the resolved content, then pass the resolved string to
`build_edit`. No new public API, no behavior change for non-`-`
content, no change to `cmd_send_message`.

Includes a regression test on the `read_or_stdin` helper
(`read_or_stdin_dash_reads_stdin_not_literal_dash`) that asserts
`read_or_stdin("-")` is not the literal `"-"`. A test runner's
stdin is empty, so the result is `Ok("")` — the test is robust
against whatever the runner has on stdin as long as it isn't a
literal `"-"` (which would itself be a bug).

Verified:
- `cargo check -p buzz-cli --lib` — clean
- `cargo test -p buzz-cli --lib` — 318 passed, 0 failed (the new
  test included)
