### PR TITLE
test(relay): skip 2 PG-dependent admin report/feedback 404 tests

### DIFF
--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -389,6 +389,7 @@ mod tests {
         assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
     }
 
+    #[ignore = "requires Postgres"]
     #[tokio::test]
     async fn report_detail_rejects_unknown_report() {
         let response = router(test_state().await)
@@ -419,6 +420,7 @@ mod tests {
         assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
     }
 
+    #[ignore = "requires Postgres"]
     #[tokio::test]
     async fn feedback_attachment_rejects_unknown_feedback() {
         let response = router(test_state().await)


### PR DESCRIPTION
Fixes #4083.

`admin::tests::report_detail_rejects_unknown_report` and
`admin::tests::feedback_attachment_rejects_unknown_feedback` both call
`test_state()`, which eagerly seeds a community via
`ensure_configured_community`. Without `BUZZ_TEST_DATABASE_URL` pointing
at a live Postgres, the seed call panics with a `PoolTimedOut`-style
500 — surfaced as a 500 from the route, not the application-level
`ApiError::not_found` the assertions expect. So `cargo test -p buzz-relay`
fails on a clean dev box even though the assertions are right.

Sibling tests in the same module that assert 403 (admin-host gate,
before any DB access) keep passing — these two are the only ones
post-`authorize` DB call.

Adds the same `#[ignore = "requires Postgres"]` attribute already used
in 100+ places across `buzz-db`, `buzz-relay/src/api/{bridge,invites,operator}`,
and `buzz-search/tests/fts_integration.rs`. With the attribute in place,
`cargo test -p buzz-relay` passes in PG-less environments and
maintainers opt back in with the existing live-Postgres flag
(`BUZZ_TEST_DATABASE_URL=... cargo test -p buzz-relay -- --include-ignored`).

Not touched: the out-of-scope follow-up the issue mentions —
refactoring `test_state()` to stop eagerly seeding a community so
even more admin tests can run without PG. That's a wider DX change
than this PR's scope and would unwind the parallel work for #4080.
