### PR TITLE
fix(mobile): retain live agent replies

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -240,6 +240,13 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     if (thread?.parentId != null) {
       final rootId = thread?.rootId;
       if (rootId != null) {
+        ref
+            .read(
+              threadLiveRepliesProvider(
+                ThreadRepliesArgs(channelId: channelId, rootId: rootId),
+              ).notifier,
+            )
+            .add(event);
         ref.invalidate(
           threadRepliesProvider(
             ThreadRepliesArgs(channelId: channelId, rootId: rootId),

--- a/mobile/lib/features/channels/thread_replies_provider.dart
+++ b/mobile/lib/features/channels/thread_replies_provider.dart
@@ -97,6 +97,31 @@ final threadLocalRepliesProvider =
       ThreadRepliesArgs
     >(ThreadLocalRepliesNotifier.new);
 
+class ThreadLiveRepliesNotifier extends Notifier<List<NostrEvent>> {
+  final ThreadRepliesArgs args;
+
+  ThreadLiveRepliesNotifier(this.args);
+
+  @override
+  List<NostrEvent> build() => const [];
+
+  void add(NostrEvent event) {
+    state = _mergeReplies(state, [event]);
+  }
+}
+
+/// Replies received by the channel's live subscription.
+///
+/// Keep these independently from optimistic local replies. A thread query is
+/// still the authoritative history source, but an open thread must not hide a
+/// relay-delivered reply while that one-shot query is refreshing or failing.
+final threadLiveRepliesProvider =
+    NotifierProvider.family<
+      ThreadLiveRepliesNotifier,
+      List<NostrEvent>,
+      ThreadRepliesArgs
+    >(ThreadLiveRepliesNotifier.new);
+
 /// Relay-backed replies merged with signed local replies that are still
 /// waiting for acknowledgement.
 final threadRepliesWithLocalProvider =
@@ -105,6 +130,7 @@ final threadRepliesWithLocalProvider =
       args,
     ) {
       final relayReplies = ref.watch(threadRepliesProvider(args));
+      final liveReplies = ref.watch(threadLiveRepliesProvider(args));
       final localReplies = ref.watch(threadLocalRepliesProvider(args));
       final authoritative = relayReplies.value;
       if (authoritative != null && localReplies.isNotEmpty) {
@@ -120,11 +146,12 @@ final threadRepliesWithLocalProvider =
           });
         }
       }
-      if (localReplies.isEmpty) return relayReplies;
+      final overlays = _mergeReplies(liveReplies, localReplies);
+      if (overlays.isEmpty) return relayReplies;
       return relayReplies.when(
-        data: (events) => AsyncData(_mergeReplies(events, localReplies)),
-        loading: () => AsyncData(localReplies),
-        error: (error, stackTrace) => AsyncData(localReplies),
+        data: (events) => AsyncData(_mergeReplies(events, overlays)),
+        loading: () => AsyncData(overlays),
+        error: (error, stackTrace) => AsyncData(overlays),
       );
     });
 

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -500,6 +500,48 @@ void main() {
   );
 
   test(
+    'remote kind-9 reply stays visible when the authoritative refetch fails',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier(
+        queryResults: [
+          [_event(id: 'history', createdAt: 10), _bounds()],
+          <NostrEvent>[],
+          Exception('thread refetch failed'),
+        ],
+      );
+      final container = _buildContainer(relaySession);
+      addTearDown(container.dispose);
+
+      container.read(channelMessagesProvider(_channelId));
+      await relaySession.subscribed;
+      await _pumpEventQueue();
+      const args = ThreadRepliesArgs(channelId: _channelId, rootId: 'root');
+      container.read(threadRepliesWithLocalProvider(args));
+      await _pumpEventQueue();
+
+      relaySession.emit(
+        _event(
+          id: 'agent-reply',
+          createdAt: 20,
+          kind: EventKind.streamMessage,
+          extraTags: const [
+            ['e', 'root', '', 'reply'],
+          ],
+        ),
+      );
+      await _pumpEventQueue();
+
+      expect(
+        container
+            .read(threadRepliesWithLocalProvider(args))
+            .value
+            ?.map((event) => event.id),
+        ['agent-reply'],
+      );
+    },
+  );
+
+  test(
     'successful never-echoed send releases ownership but keeps its row across reconnect',
     () async {
       final relaySession = _RecordingRelaySessionNotifier(
@@ -623,13 +665,14 @@ ProviderContainer _buildContainer(_RecordingRelaySessionNotifier relaySession) {
 NostrEvent _event({
   required String id,
   required int createdAt,
+  int kind = EventKind.streamMessageV2,
   List<List<String>> extraTags = const [],
 }) {
   return NostrEvent(
     id: id,
     pubkey: 'alice',
     createdAt: createdAt,
-    kind: EventKind.streamMessageV2,
+    kind: kind,
     tags: [
       ['h', _channelId],
       ...extraTags,


### PR DESCRIPTION
## Summary

- retain relay-delivered thread replies immediately in the mobile thread state
- reconcile live replies with the existing authoritative thread query and optimistic local replies
- cover legacy kind-9 agent replies when the authoritative refetch fails

## Root cause

The mobile client received thread replies on the channel live subscription but only invalidated a one-shot HTTP thread query. While that refetch was pending or failed, the open thread had no copy of the reply to render. Reactions and typing use separate live paths, so those indicators could appear even though the text response remained absent.

## Impact

Agent replies now appear in an open mobile thread as soon as the relay delivers them, including legacy kind-9 events with an `e ... reply` tag. The history query remains authoritative and deduplicates the live overlay when it succeeds.

## Validation

- `just mobile-test` — 1,163 tests passed
- `just mobile-check` — formatting, Flutter analysis, and file-size checks passed

Originating Buzz channel: `50f9840e-1433-4e93-bff1-1d07caaa873d`
