### PR TITLE
feat(agents): add contextual agent conversations

### DIFF
--- a/crates/buzz-acp/src/contextual_conversation.rs
+++ b/crates/buzz-acp/src/contextual_conversation.rs
@@ -117,6 +117,73 @@ fn placement_for(input: &ContextualAgentConversationInput, audience_count: usize
     ReplyPlacement::TopLevel
 }
 
+/// ACP turn context for reply placement (mirrors client policy without I/O).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AcpTurnPlacementInput {
+    /// True when the turn is 1:1 DM-scoped.
+    pub is_dm: bool,
+    /// Human-facing turns flatten; agent-only stays unconstrained.
+    pub is_human_facing: bool,
+    pub message_position: &'static str,
+    pub thread_root_event_id: Option<String>,
+    pub triggering_event_id: String,
+    /// How many agents are addressed on the triggering human message (`p` tags).
+    /// Count of 0 is treated as 1 when the turn is human-facing (this agent alone).
+    pub addressed_agent_count: usize,
+}
+
+/// Map placement to an optional `--reply-to` event id for the agent prompt.
+pub fn reply_placement_anchor(placement: &ReplyPlacement) -> Option<&str> {
+    match placement {
+        ReplyPlacement::ThreadRoot { event_id } => Some(event_id.as_str()),
+        ReplyPlacement::TopLevel | ReplyPlacement::Unconstrained => None,
+    }
+}
+
+/// Resolve reply placement for an ACP turn.
+///
+/// - Agent-only (not human-facing): unconstrained (no forced anchor).
+/// - Direct (DM) top-level: top-level flat.
+/// - Direct (DM) in-thread: thread root (or triggering id if root missing).
+/// - Channel top-level with ≥2 addressed agents: shared thread at human event.
+/// - Channel top-level with one addressed agent: top-level flat.
+/// - Channel in-thread: always thread root (never nest under an agent reply).
+pub fn resolve_acp_turn_placement(input: &AcpTurnPlacementInput) -> ReplyPlacement {
+    if !input.is_human_facing {
+        return ReplyPlacement::Unconstrained;
+    }
+
+    let agent_count = input.addressed_agent_count.max(1);
+
+    if input.is_dm {
+        if input.message_position == "in-thread" {
+            let event_id = input
+                .thread_root_event_id
+                .clone()
+                .unwrap_or_else(|| input.triggering_event_id.clone());
+            return ReplyPlacement::ThreadRoot { event_id };
+        }
+        return ReplyPlacement::TopLevel;
+    }
+
+    // Channel
+    if input.message_position == "in-thread" {
+        if let Some(root) = &input.thread_root_event_id {
+            return ReplyPlacement::ThreadRoot {
+                event_id: root.clone(),
+            };
+        }
+    }
+
+    if agent_count >= 2 {
+        return ReplyPlacement::ThreadRoot {
+            event_id: input.triggering_event_id.clone(),
+        };
+    }
+
+    ReplyPlacement::TopLevel
+}
+
 /// Resolve audience and reply placement for a human/agent send path.
 pub fn resolve_contextual_agent_conversation(
     input: &ContextualAgentConversationInput,
@@ -272,6 +339,71 @@ mod tests {
             recipient_load_error: value["recipientLoadError"].as_bool().unwrap_or(false),
             human_message_event_id: opt_str("humanMessageEventId"),
         }
+    }
+
+    #[test]
+    fn acp_turn_placement_single_agent_top_level_is_flat() {
+        let placement = resolve_acp_turn_placement(&AcpTurnPlacementInput {
+            is_dm: false,
+            is_human_facing: true,
+            message_position: "top-level",
+            thread_root_event_id: None,
+            triggering_event_id: "trig".into(),
+            addressed_agent_count: 1,
+        });
+        assert_eq!(placement, ReplyPlacement::TopLevel);
+        assert_eq!(reply_placement_anchor(&placement), None);
+    }
+
+    #[test]
+    fn acp_turn_placement_multi_agent_top_level_threads() {
+        let placement = resolve_acp_turn_placement(&AcpTurnPlacementInput {
+            is_dm: false,
+            is_human_facing: true,
+            message_position: "top-level",
+            thread_root_event_id: None,
+            triggering_event_id: "trig".into(),
+            addressed_agent_count: 2,
+        });
+        assert_eq!(
+            placement,
+            ReplyPlacement::ThreadRoot {
+                event_id: "trig".into()
+            }
+        );
+        assert_eq!(reply_placement_anchor(&placement), Some("trig"));
+    }
+
+    #[test]
+    fn acp_turn_placement_in_thread_uses_root() {
+        let placement = resolve_acp_turn_placement(&AcpTurnPlacementInput {
+            is_dm: false,
+            is_human_facing: true,
+            message_position: "in-thread",
+            thread_root_event_id: Some("root".into()),
+            triggering_event_id: "trig".into(),
+            addressed_agent_count: 3,
+        });
+        assert_eq!(
+            placement,
+            ReplyPlacement::ThreadRoot {
+                event_id: "root".into()
+            }
+        );
+    }
+
+    #[test]
+    fn acp_turn_placement_agent_only_unconstrained() {
+        let placement = resolve_acp_turn_placement(&AcpTurnPlacementInput {
+            is_dm: false,
+            is_human_facing: false,
+            message_position: "in-thread",
+            thread_root_event_id: Some("root".into()),
+            triggering_event_id: "trig".into(),
+            addressed_agent_count: 2,
+        });
+        assert_eq!(placement, ReplyPlacement::Unconstrained);
+        assert_eq!(reply_placement_anchor(&placement), None);
     }
 
     #[test]

--- a/crates/buzz-acp/src/contextual_conversation.rs
+++ b/crates/buzz-acp/src/contextual_conversation.rs
@@ -95,7 +95,10 @@ fn filter_to_eligible(candidates: &[String], eligible: &BTreeSet<String>) -> Vec
     )
 }
 
-fn placement_for(input: &ContextualAgentConversationInput, audience_count: usize) -> ReplyPlacement {
+fn placement_for(
+    input: &ContextualAgentConversationInput,
+    audience_count: usize,
+) -> ReplyPlacement {
     if input.message_position == "in-thread" {
         if let Some(root) = input.thread_root_event_id.as_ref() {
             return ReplyPlacement::ThreadRoot {
@@ -317,10 +320,7 @@ mod tests {
         };
         ContextualAgentConversationInput {
             conversation: value["conversation"].as_str().unwrap_or("").to_string(),
-            message_position: value["messagePosition"]
-                .as_str()
-                .unwrap_or("")
-                .to_string(),
+            message_position: value["messagePosition"].as_str().unwrap_or("").to_string(),
             sender_class: value["senderClass"].as_str().unwrap_or("").to_string(),
             unaddressed_mode: mode,
             keep_addressed_agents_active: value["keepAddressedAgentsActive"]

--- a/crates/buzz-acp/src/contextual_conversation.rs
+++ b/crates/buzz-acp/src/contextual_conversation.rs
@@ -1,0 +1,331 @@
+//! Contextual agent conversation audience + reply-placement policy (ACP).
+//!
+//! Shared contract: `tests/fixtures/contextual-agent-conversation-cases.json`.
+//! Pure resolver — harness wiring comes in later ACP leaves.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Device-local unaddressed-channel agent mode (mirrors Desktop/Flutter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UnaddressedChannelAgentMode {
+    AllChannelAgents,
+    MentionsOnly,
+}
+
+/// Reply placement for agent responses on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ReplyPlacement {
+    TopLevel,
+    #[serde(rename = "thread-root")]
+    ThreadRoot {
+        #[serde(rename = "eventId")]
+        event_id: String,
+    },
+    Unconstrained,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextualAgentConversationInput {
+    pub conversation: String,
+    pub message_position: String,
+    pub sender_class: String,
+    pub unaddressed_mode: UnaddressedChannelAgentMode,
+    pub keep_addressed_agents_active: bool,
+    pub explicit_mention_pubkeys: Vec<String>,
+    pub current_agent_pubkey: Option<String>,
+    pub channel_member_pubkeys: Vec<String>,
+    pub verified_channel_agent_pubkeys: Vec<String>,
+    pub unverified_agent_pubkeys: Vec<String>,
+    pub non_member_agent_pubkeys: Vec<String>,
+    pub thread_root_event_id: Option<String>,
+    pub replying_under_event_id: Option<String>,
+    pub persistent_thread_audience: Vec<String>,
+    pub manual_removed_pubkeys: Vec<String>,
+    pub recipient_load_error: bool,
+    pub human_message_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextualAgentConversationDecision {
+    pub audience_pubkeys: Vec<String>,
+    pub reply_placement: ReplyPlacement,
+    pub shared_thread: bool,
+    pub retain_draft: bool,
+    #[serde(default)]
+    pub nest_under_agent_reply: Option<bool>,
+}
+
+fn normalize_pubkey(pubkey: &str) -> String {
+    pubkey.trim().to_ascii_lowercase()
+}
+
+fn unique_sorted(pubkeys: impl IntoIterator<Item = String>) -> Vec<String> {
+    let set: BTreeSet<String> = pubkeys
+        .into_iter()
+        .map(|p| normalize_pubkey(&p))
+        .filter(|p| !p.is_empty())
+        .collect();
+    set.into_iter().collect()
+}
+
+fn eligible_channel_agents(input: &ContextualAgentConversationInput) -> BTreeSet<String> {
+    let members: BTreeSet<String> = input
+        .channel_member_pubkeys
+        .iter()
+        .map(|p| normalize_pubkey(p))
+        .collect();
+    input
+        .verified_channel_agent_pubkeys
+        .iter()
+        .map(|p| normalize_pubkey(p))
+        .filter(|p| members.contains(p))
+        .collect()
+}
+
+fn filter_to_eligible(candidates: &[String], eligible: &BTreeSet<String>) -> Vec<String> {
+    unique_sorted(
+        candidates
+            .iter()
+            .map(|p| normalize_pubkey(p))
+            .filter(|p| eligible.contains(p)),
+    )
+}
+
+fn placement_for(input: &ContextualAgentConversationInput, audience_count: usize) -> ReplyPlacement {
+    if input.message_position == "in-thread" {
+        if let Some(root) = input.thread_root_event_id.as_ref() {
+            return ReplyPlacement::ThreadRoot {
+                event_id: root.clone(),
+            };
+        }
+    }
+    if audience_count >= 2 {
+        if let Some(event_id) = input
+            .human_message_event_id
+            .as_ref()
+            .or(input.thread_root_event_id.as_ref())
+        {
+            return ReplyPlacement::ThreadRoot {
+                event_id: event_id.clone(),
+            };
+        }
+    }
+    ReplyPlacement::TopLevel
+}
+
+/// Resolve audience and reply placement for a human/agent send path.
+pub fn resolve_contextual_agent_conversation(
+    input: &ContextualAgentConversationInput,
+) -> ContextualAgentConversationDecision {
+    if input.recipient_load_error {
+        return ContextualAgentConversationDecision {
+            audience_pubkeys: vec![],
+            reply_placement: ReplyPlacement::TopLevel,
+            shared_thread: false,
+            retain_draft: true,
+            nest_under_agent_reply: Some(false),
+        };
+    }
+
+    if input.sender_class == "agent" {
+        return ContextualAgentConversationDecision {
+            audience_pubkeys: vec![],
+            reply_placement: ReplyPlacement::Unconstrained,
+            shared_thread: false,
+            retain_draft: false,
+            nest_under_agent_reply: Some(false),
+        };
+    }
+
+    if input.conversation == "direct" {
+        let audience = input
+            .current_agent_pubkey
+            .as_ref()
+            .map(|p| vec![normalize_pubkey(p)])
+            .unwrap_or_default();
+        return ContextualAgentConversationDecision {
+            reply_placement: placement_for(input, audience.len()),
+            shared_thread: false,
+            retain_draft: false,
+            nest_under_agent_reply: Some(false),
+            audience_pubkeys: audience,
+        };
+    }
+
+    let eligible = eligible_channel_agents(input);
+    let removed: BTreeSet<String> = input
+        .manual_removed_pubkeys
+        .iter()
+        .map(|p| normalize_pubkey(p))
+        .collect();
+
+    let explicit: Vec<String> = filter_to_eligible(&input.explicit_mention_pubkeys, &eligible)
+        .into_iter()
+        .filter(|p| !removed.contains(p))
+        .collect();
+
+    let audience = if !explicit.is_empty() {
+        explicit
+    } else {
+        let persistent = if input.keep_addressed_agents_active {
+            filter_to_eligible(&input.persistent_thread_audience, &eligible)
+                .into_iter()
+                .filter(|p| !removed.contains(p))
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+
+        if !persistent.is_empty() {
+            persistent
+        } else if matches!(
+            input.unaddressed_mode,
+            UnaddressedChannelAgentMode::AllChannelAgents
+        ) {
+            eligible
+                .into_iter()
+                .filter(|p| !removed.contains(p))
+                .collect()
+        } else {
+            vec![]
+        }
+    };
+
+    let shared_thread = audience.len() >= 2;
+    ContextualAgentConversationDecision {
+        reply_placement: placement_for(input, audience.len()),
+        shared_thread,
+        retain_draft: false,
+        nest_under_agent_reply: Some(false),
+        audience_pubkeys: audience,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    const FIXTURE: &str =
+        include_str!("../../../tests/fixtures/contextual-agent-conversation-cases.json");
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureFile {
+        version: u32,
+        cases: Vec<FixtureCase>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FixtureCase {
+        id: String,
+        input: Value,
+        expected: ContextualAgentConversationDecision,
+    }
+
+    fn parse_input_manual(value: &Value) -> ContextualAgentConversationInput {
+        let mode = match value["unaddressedMode"].as_str().unwrap_or("") {
+            "mentions-only" => UnaddressedChannelAgentMode::MentionsOnly,
+            _ => UnaddressedChannelAgentMode::AllChannelAgents,
+        };
+        let str_list = |key: &str| -> Vec<String> {
+            value
+                .get(key)
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let opt_str = |key: &str| -> Option<String> {
+            match value.get(key) {
+                Some(Value::Null) | None => None,
+                Some(v) => v.as_str().map(|s| s.to_string()),
+            }
+        };
+        ContextualAgentConversationInput {
+            conversation: value["conversation"].as_str().unwrap_or("").to_string(),
+            message_position: value["messagePosition"]
+                .as_str()
+                .unwrap_or("")
+                .to_string(),
+            sender_class: value["senderClass"].as_str().unwrap_or("").to_string(),
+            unaddressed_mode: mode,
+            keep_addressed_agents_active: value["keepAddressedAgentsActive"]
+                .as_bool()
+                .unwrap_or(false),
+            explicit_mention_pubkeys: str_list("explicitMentionPubkeys"),
+            current_agent_pubkey: opt_str("currentAgentPubkey"),
+            channel_member_pubkeys: str_list("channelMemberPubkeys"),
+            verified_channel_agent_pubkeys: str_list("verifiedChannelAgentPubkeys"),
+            unverified_agent_pubkeys: str_list("unverifiedAgentPubkeys"),
+            non_member_agent_pubkeys: str_list("nonMemberAgentPubkeys"),
+            thread_root_event_id: opt_str("threadRootEventId"),
+            replying_under_event_id: opt_str("replyingUnderEventId"),
+            persistent_thread_audience: str_list("persistentThreadAudience"),
+            manual_removed_pubkeys: str_list("manualRemovedPubkeys"),
+            recipient_load_error: value["recipientLoadError"].as_bool().unwrap_or(false),
+            human_message_event_id: opt_str("humanMessageEventId"),
+        }
+    }
+
+    #[test]
+    fn fixture_loads_and_has_required_cases() {
+        let file: FixtureFile = serde_json::from_str(FIXTURE).expect("fixture json");
+        assert_eq!(file.version, 1);
+        assert!(
+            file.cases.len() >= 12,
+            "expected >=12 cases, got {}",
+            file.cases.len()
+        );
+    }
+
+    #[test]
+    fn fixture_policy_decisions_match_expected() {
+        let file: FixtureFile = serde_json::from_str(FIXTURE).expect("fixture json");
+        let mut failures = Vec::new();
+        for case in &file.cases {
+            let mut input = parse_input_manual(&case.input);
+            if case.expected.reply_placement
+                == (ReplyPlacement::ThreadRoot {
+                    event_id: "human-message-id".into(),
+                })
+            {
+                input.human_message_event_id = Some("human-message-id".into());
+            }
+            let decision = resolve_contextual_agent_conversation(&input);
+            let mut actual_audience = decision.audience_pubkeys.clone();
+            let mut expected_audience = case.expected.audience_pubkeys.clone();
+            actual_audience.sort();
+            expected_audience.sort();
+            if actual_audience != expected_audience
+                || decision.reply_placement != case.expected.reply_placement
+                || decision.shared_thread != case.expected.shared_thread
+                || decision.retain_draft != case.expected.retain_draft
+            {
+                failures.push(format!(
+                    "{}: got audience={:?} placement={:?} shared={} retain={}; expected audience={:?} placement={:?} shared={} retain={}",
+                    case.id,
+                    decision.audience_pubkeys,
+                    decision.reply_placement,
+                    decision.shared_thread,
+                    decision.retain_draft,
+                    case.expected.audience_pubkeys,
+                    case.expected.reply_placement,
+                    case.expected.shared_thread,
+                    case.expected.retain_draft,
+                ));
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "contextual fixture policy mismatches:\n{}",
+            failures.join("\n")
+        );
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod acp;
 mod config;
+mod contextual_conversation;
 mod engram_fetch;
 mod filter;
 mod observer;
@@ -12,6 +13,10 @@ mod relay;
 mod setup_mode;
 mod usage;
 
+pub use contextual_conversation::{
+    resolve_contextual_agent_conversation, ContextualAgentConversationDecision,
+    ContextualAgentConversationInput, ReplyPlacement, UnaddressedChannelAgentMode,
+};
 pub use usage::TurnUsage;
 
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -14,8 +14,9 @@ mod setup_mode;
 mod usage;
 
 pub use contextual_conversation::{
-    resolve_contextual_agent_conversation, ContextualAgentConversationDecision,
-    ContextualAgentConversationInput, ReplyPlacement, UnaddressedChannelAgentMode,
+    reply_placement_anchor, resolve_acp_turn_placement, resolve_contextual_agent_conversation,
+    AcpTurnPlacementInput, ContextualAgentConversationDecision, ContextualAgentConversationInput,
+    ReplyPlacement, UnaddressedChannelAgentMode,
 };
 pub use usage::TurnUsage;
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1203,29 +1203,57 @@ fn turn_is_human_facing(
     thread_tags.mentioned_pubkeys.iter().any(|pk| !is_agent(pk))
 }
 
+/// Count agent recipients addressed on the triggering event (`p` tags).
+///
+/// Uses NIP-OA profile classification when available. Unknown identities are
+/// not counted as agents (fail closed for multi-agent detection).
+fn count_addressed_agents(
+    thread_tags: &ThreadTags,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> usize {
+    let is_agent = |pubkey: &str| -> bool {
+        profile_lookup
+            .and_then(|m| m.get(&normalize_lookup_key(pubkey)))
+            .map(|p| p.is_agent)
+            .unwrap_or(false)
+    };
+    thread_tags
+        .mentioned_pubkeys
+        .iter()
+        .filter(|pk| is_agent(pk))
+        .count()
+}
+
 /// Resolve the `--reply-to` anchor for a non-DM turn.
 ///
-/// Returns `Some(id)` only for human-facing turns (see [`turn_is_human_facing`]):
-///   - in a thread → the thread ROOT, keeping the reply flat at layer 1
-///   - top-level   → the triggering event id, which becomes the new thread root
-///
-/// Returns `None` for agent↔agent turns, leaving the agent free to nest deeply
-/// (intentional for agent coordination).
+/// Uses the shared contextual-conversation placement policy:
+///   - human-facing, in a thread → thread ROOT (flat at layer 1)
+///   - human-facing, top-level, ≥2 addressed agents → triggering event (shared thread)
+///   - human-facing, top-level, one agent → no forced anchor (flat top-level)
+///   - agent↔agent → unconstrained (`None`)
 fn resolve_reply_anchor(
     sender_pubkey: &str,
     thread_tags: &ThreadTags,
     triggering_event_id: &str,
     profile_lookup: Option<&PromptProfileLookup>,
 ) -> Option<String> {
-    if !turn_is_human_facing(sender_pubkey, thread_tags, profile_lookup) {
-        return None;
-    }
-    Some(
-        thread_tags
-            .root_event_id
-            .clone()
-            .unwrap_or_else(|| triggering_event_id.to_string()),
-    )
+    let is_human_facing = turn_is_human_facing(sender_pubkey, thread_tags, profile_lookup);
+    let message_position = if thread_tags.root_event_id.is_some() {
+        "in-thread"
+    } else {
+        "top-level"
+    };
+    let placement = crate::contextual_conversation::resolve_acp_turn_placement(
+        &crate::contextual_conversation::AcpTurnPlacementInput {
+            is_dm: false,
+            is_human_facing,
+            message_position,
+            thread_root_event_id: thread_tags.root_event_id.clone(),
+            triggering_event_id: triggering_event_id.to_string(),
+            addressed_agent_count: count_addressed_agents(thread_tags, profile_lookup),
+        },
+    );
+    crate::contextual_conversation::reply_placement_anchor(&placement).map(str::to_string)
 }
 
 /// Format a `[Context]` hints section based on event scope.
@@ -1464,17 +1492,32 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
 
     // 2. Context hints (with a human-aware reply anchor).
     //
-    // Human-facing turns are anchored so replies stay readable at layer 1:
-    //   - in a thread  → anchor to the thread ROOT (no depth-2 nesting)
-    //   - top-level     → anchor to the triggering event (it becomes the root)
-    // Agent↔agent turns get no forced anchor — deep nesting is intentional
-    // there. DMs are always 1:1 with a human, so they always anchor.
+    // Placement follows the shared contextual-conversation policy:
+    //   - channel thread → thread ROOT (no depth-2 nesting under agent replies)
+    //   - channel top-level multi-agent → triggering event (shared sibling thread)
+    //   - channel top-level single-agent → flat (no forced --reply-to)
+    //   - DM top-level → flat; DM in-thread → root/trigger
+    //   - agent↔agent → unconstrained (no forced anchor)
     let sender_pubkey = last_event.event.pubkey.to_hex();
     let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
+        let is_human_facing =
+            turn_is_human_facing(&sender_pubkey, &thread_tags, args.profile_lookup);
+        let message_position = if thread_tags.root_event_id.is_some() {
+            "in-thread"
+        } else {
+            "top-level"
+        };
+        let placement = crate::contextual_conversation::resolve_acp_turn_placement(
+            &crate::contextual_conversation::AcpTurnPlacementInput {
+                is_dm: true,
+                is_human_facing,
+                message_position,
+                thread_root_event_id: thread_tags.root_event_id.clone(),
+                triggering_event_id: last_event.event.id.to_hex(),
+                addressed_agent_count: 1,
+            },
+        );
+        crate::contextual_conversation::reply_placement_anchor(&placement).map(str::to_string)
     } else {
         resolve_reply_anchor(
             &sender_pubkey,
@@ -1801,13 +1844,52 @@ mod tests {
         assert_eq!(batch.events[0].event.content, "oldest");
         assert_eq!(batch.events[1].event.content, "newest");
 
-        // The rendered prompt's reply anchor must cite the newest event, so
-        // the agent's reply threads under the message it is responding to.
-        let newest_id = batch.events[1].event.id.to_hex();
-        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        // Multi-agent top-level: shared-thread anchor must cite the *newest*
+        // (last) event. Build a multi-agent batch with the same chronological
+        // order to exercise placement without depending on single-agent flat.
+        let multi_oldest = make_event_with_tags(
+            "oldest",
+            vec![
+                vec!["p".into(), AGENT_A_PK.into()],
+                vec!["p".into(), AGENT_B_PK.into()],
+            ],
+        );
+        let multi_newest = make_event_with_tags(
+            "newest",
+            vec![
+                vec!["p".into(), AGENT_A_PK.into()],
+                vec!["p".into(), AGENT_B_PK.into()],
+            ],
+        );
+        let newest_id = multi_newest.id.to_hex();
+        let multi_batch = FlushBatch {
+            channel_id: ch,
+            events: vec![
+                BatchEvent {
+                    event: multi_oldest,
+                    prompt_tag: "test".into(),
+                    received_at: Instant::now(),
+                },
+                BatchEvent {
+                    event: multi_newest,
+                    prompt_tag: "test".into(),
+                    received_at: Instant::now(),
+                },
+            ],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let prompt = format_prompt(
+            &multi_batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&id_lookup()),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
         assert!(
             prompt.contains(&format!("--reply-to {newest_id}")),
-            "reply anchor must target the newest event; prompt was:\n{prompt}"
+            "multi-agent reply anchor must target the newest event; prompt was:\n{prompt}"
         );
     }
 
@@ -3288,9 +3370,17 @@ mod tests {
     }
 
     #[test]
-    fn test_anchor_human_top_level_uses_triggering_event() {
-        // Human top-level mention (no thread tags) → triggering event is root.
+    fn test_anchor_human_top_level_single_agent_is_flat() {
+        // One addressed agent → flat top-level response (no forced --reply-to).
         let tags = thread_tags(None, &[AGENT_A_PK]);
+        let anchor = resolve_reply_anchor(HUMAN_PK, &tags, TRIGGER_ID, Some(&id_lookup()));
+        assert_eq!(anchor, None);
+    }
+
+    #[test]
+    fn test_anchor_human_top_level_multi_agent_opens_shared_thread() {
+        // Two+ addressed agents → shared thread rooted at the human message.
+        let tags = thread_tags(None, &[AGENT_A_PK, AGENT_B_PK]);
         let anchor = resolve_reply_anchor(HUMAN_PK, &tags, TRIGGER_ID, Some(&id_lookup()));
         assert_eq!(anchor.as_deref(), Some(TRIGGER_ID));
     }
@@ -3914,9 +4004,8 @@ mod tests {
         let root_id = "b".repeat(64);
         let event = make_event_with_tags(
             "thanks",
-            vec![vec!["e".into(), root_id, "".into(), "reply".into()]],
+            vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
-        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {
@@ -3941,15 +4030,54 @@ mod tests {
         )
         .join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {event_id}")),
-            "DM thread reply should include reply instruction"
+            prompt.contains(&format!("--reply-to {root_id}")),
+            "DM thread reply should anchor to the thread root"
         );
     }
 
     #[test]
-    fn test_reply_instruction_present_for_top_level_human_message() {
+    fn test_reply_instruction_absent_for_single_agent_top_level_channel() {
         let ch = Uuid::new_v4();
-        let event = make_event("hello world");
+        // One agent p-tag, human sender → flat top-level response.
+        let event = make_event_with_tags(
+            "hello world",
+            vec![vec!["p".into(), AGENT_A_PK.into()]],
+        );
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&id_lookup()),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            !prompt.contains("--reply-to"),
+            "single-agent top-level channel turn should stay flat (no --reply-to)"
+        );
+    }
+
+    #[test]
+    fn test_reply_instruction_present_for_multi_agent_top_level_channel() {
+        let ch = Uuid::new_v4();
+        let event = make_event_with_tags(
+            "hello agents",
+            vec![
+                vec!["p".into(), AGENT_A_PK.into()],
+                vec!["p".into(), AGENT_B_PK.into()],
+            ],
+        );
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
@@ -3962,17 +4090,21 @@ mod tests {
             cancel_reason: None,
         };
 
-        // Top-level human message (no lookup → human): the reply opens a new
-        // thread anchored to the triggering event, preventing replies into a
-        // stale older thread.
-        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&id_lookup()),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
         assert!(
             prompt.contains(&format!("--reply-to {event_id}")),
-            "top-level human message should anchor a new thread at the triggering event"
+            "multi-agent top-level should open a shared thread at the human event"
         );
         assert!(
             prompt.contains("new top-level message"),
-            "top-level human message should use the new-thread instruction"
+            "multi-agent top-level should use the new-thread instruction"
         );
     }
 
@@ -4128,8 +4260,11 @@ mod tests {
             "earlier thread msg",
             vec![vec!["e".into(), root_id, "".into(), "reply".into()]],
         );
-        let plain = make_event("latest top-level");
-        let plain_id = plain.id.to_hex();
+        // Single-agent top-level last event → flat (no forced thread).
+        let plain = make_event_with_tags(
+            "latest top-level",
+            vec![vec!["p".into(), AGENT_A_PK.into()]],
+        );
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![
@@ -4148,16 +4283,18 @@ mod tests {
             cancel_reason: None,
         };
 
-        // Last event is top-level and human-facing → opens a new thread
-        // anchored to that top-level event (NOT the earlier thread's root).
-        let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
+        // Last event is single-agent top-level → flat (no forced --reply-to).
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&id_lookup()),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {plain_id}")),
-            "batched top-level-last prompt should anchor to the last (top-level) event"
-        );
-        assert!(
-            prompt.contains("new top-level message"),
-            "batched top-level-last prompt should use the new-thread instruction"
+            !prompt.contains("--reply-to"),
+            "batched single-agent top-level-last should stay flat"
         );
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -4039,10 +4039,7 @@ mod tests {
     fn test_reply_instruction_absent_for_single_agent_top_level_channel() {
         let ch = Uuid::new_v4();
         // One agent p-tag, human sender → flat top-level response.
-        let event = make_event_with_tags(
-            "hello world",
-            vec![vec!["p".into(), AGENT_A_PK.into()]],
-        );
+        let event = make_event_with_tags("hello world", vec![vec!["p".into(), AGENT_A_PK.into()]]);
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         "**/mentions.spec.ts",
         "**/team-mentions.spec.ts",
         "**/persistent-agent-audience.spec.ts",
+        "**/unaddressed-channel-agent-mode.spec.ts",
         "**/relay-reconnect.spec.ts",
         "**/relay-reconnect-affordance.spec.ts",
         "**/workflows.spec.ts",

--- a/desktop/src/features/channels/lib/contextualAgentConversationPolicy.test.mjs
+++ b/desktop/src/features/channels/lib/contextualAgentConversationPolicy.test.mjs
@@ -38,8 +38,16 @@ function assertDecision(actual, expected, caseId) {
     expected.replyPlacement,
     `${caseId}: replyPlacement`,
   );
-  assert.equal(actual.sharedThread, expected.sharedThread, `${caseId}: sharedThread`);
-  assert.equal(actual.retainDraft, expected.retainDraft, `${caseId}: retainDraft`);
+  assert.equal(
+    actual.sharedThread,
+    expected.sharedThread,
+    `${caseId}: sharedThread`,
+  );
+  assert.equal(
+    actual.retainDraft,
+    expected.retainDraft,
+    `${caseId}: retainDraft`,
+  );
   if (expected.nestUnderAgentReply !== undefined) {
     assert.equal(
       actual.nestUnderAgentReply ?? false,

--- a/desktop/src/features/channels/lib/contextualAgentConversationPolicy.test.mjs
+++ b/desktop/src/features/channels/lib/contextualAgentConversationPolicy.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * Red: shared contextual-agent fixture must match Desktop policy decisions.
+ * Expected: every case fails until resolveContextualAgentConversation is
+ * implemented (Green leaf).
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { resolveContextualAgentConversation } from "./contextualAgentConversationPolicy.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+  __dirname,
+  "../../../../../tests/fixtures/contextual-agent-conversation-cases.json",
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+assert.equal(fixture.version, 1);
+assert.ok(Array.isArray(fixture.cases));
+assert.ok(fixture.cases.length >= 12);
+
+function sorted(list) {
+  return [...list].sort();
+}
+
+function assertDecision(actual, expected, caseId) {
+  assert.deepEqual(
+    sorted(actual.audiencePubkeys),
+    sorted(expected.audiencePubkeys),
+    `${caseId}: audiencePubkeys`,
+  );
+  assert.deepEqual(
+    actual.replyPlacement,
+    expected.replyPlacement,
+    `${caseId}: replyPlacement`,
+  );
+  assert.equal(actual.sharedThread, expected.sharedThread, `${caseId}: sharedThread`);
+  assert.equal(actual.retainDraft, expected.retainDraft, `${caseId}: retainDraft`);
+  if (expected.nestUnderAgentReply !== undefined) {
+    assert.equal(
+      actual.nestUnderAgentReply ?? false,
+      expected.nestUnderAgentReply,
+      `${caseId}: nestUnderAgentReply`,
+    );
+  }
+}
+
+for (const c of fixture.cases) {
+  test(`contextual fixture (desktop): ${c.id}`, () => {
+    const input = {
+      ...c.input,
+      humanMessageEventId:
+        c.expected.replyPlacement?.kind === "thread-root" &&
+        c.expected.replyPlacement.eventId === "human-message-id"
+          ? "human-message-id"
+          : (c.input.humanMessageEventId ?? null),
+    };
+    const decision = resolveContextualAgentConversation(input);
+    assertDecision(decision, c.expected, c.id);
+  });
+}

--- a/desktop/src/features/channels/lib/contextualAgentConversationPolicy.ts
+++ b/desktop/src/features/channels/lib/contextualAgentConversationPolicy.ts
@@ -1,0 +1,197 @@
+/**
+ * Contextual agent audience + reply-placement policy (Desktop).
+ *
+ * Contract: tests/fixtures/contextual-agent-conversation-cases.json
+ *
+ * Pure resolver — no I/O. Device-local mode persistence lives in
+ * `unaddressedChannelAgentMode.ts`.
+ */
+
+export type UnaddressedChannelAgentMode =
+  | "all-channel-agents"
+  | "mentions-only";
+
+export type ReplyPlacement =
+  | { kind: "top-level" }
+  | { kind: "thread-root"; eventId: string }
+  | { kind: "unconstrained" };
+
+export type ContextualAgentConversationInput = {
+  conversation: "direct" | "channel";
+  messagePosition: "top-level" | "in-thread";
+  senderClass: "human" | "agent";
+  unaddressedMode: UnaddressedChannelAgentMode;
+  keepAddressedAgentsActive: boolean;
+  explicitMentionPubkeys: string[];
+  currentAgentPubkey: string | null;
+  channelMemberPubkeys: string[];
+  verifiedChannelAgentPubkeys: string[];
+  unverifiedAgentPubkeys?: string[];
+  nonMemberAgentPubkeys?: string[];
+  threadRootEventId: string | null;
+  replyingUnderEventId?: string | null;
+  persistentThreadAudience: string[];
+  manualRemovedPubkeys: string[];
+  recipientLoadError: boolean;
+  /** Id of the human message that becomes a multi-agent thread root. */
+  humanMessageEventId?: string | null;
+};
+
+export type ContextualAgentConversationDecision = {
+  audiencePubkeys: string[];
+  replyPlacement: ReplyPlacement;
+  sharedThread: boolean;
+  retainDraft: boolean;
+  nestUnderAgentReply?: boolean;
+};
+
+function normalizePubkey(pubkey: string): string {
+  return pubkey.trim().toLowerCase();
+}
+
+function uniqueSorted(pubkeys: Iterable<string>): string[] {
+  const set = new Set<string>();
+  for (const pk of pubkeys) {
+    const n = normalizePubkey(pk);
+    if (n) set.add(n);
+  }
+  return [...set].sort();
+}
+
+function asSet(pubkeys: readonly string[]): Set<string> {
+  return new Set(pubkeys.map(normalizePubkey).filter(Boolean));
+}
+
+/**
+ * Verified current-channel agents only: intersection of membership and
+ * verified agent evidence. Never community/relay-wide fanout.
+ */
+function eligibleChannelAgents(input: ContextualAgentConversationInput): Set<string> {
+  const members = asSet(input.channelMemberPubkeys);
+  const verified = asSet(input.verifiedChannelAgentPubkeys);
+  const eligible = new Set<string>();
+  for (const pk of verified) {
+    if (members.has(pk)) eligible.add(pk);
+  }
+  return eligible;
+}
+
+function filterToEligible(
+  candidates: readonly string[],
+  eligible: Set<string>,
+): string[] {
+  return uniqueSorted(candidates.filter((pk) => eligible.has(normalizePubkey(pk))));
+}
+
+/**
+ * Resolve audience and reply placement for a human/agent send path.
+ *
+ * Precedence:
+ * 1. Recipient-load errors fail closed (retain draft).
+ * 2. Agent-authored traffic is unconstrained.
+ * 3. Explicit @mentions (eligible agents only).
+ * 4. Persistent audience when Keep addressed agents active (minus manual removals).
+ * 5. Unaddressed mode: all verified channel agents, or mentions-only (none).
+ * 6. Direct conversations always resolve to the current agent.
+ */
+export function resolveContextualAgentConversation(
+  input: ContextualAgentConversationInput,
+): ContextualAgentConversationDecision {
+  if (input.recipientLoadError) {
+    return {
+      audiencePubkeys: [],
+      replyPlacement: { kind: "top-level" },
+      sharedThread: false,
+      retainDraft: true,
+      nestUnderAgentReply: false,
+    };
+  }
+
+  if (input.senderClass === "agent") {
+    return {
+      audiencePubkeys: [],
+      replyPlacement: { kind: "unconstrained" },
+      sharedThread: false,
+      retainDraft: false,
+      nestUnderAgentReply: false,
+    };
+  }
+
+  // Human path
+  if (input.conversation === "direct") {
+    const current = input.currentAgentPubkey
+      ? normalizePubkey(input.currentAgentPubkey)
+      : null;
+    const audience = current ? [current] : [];
+    return {
+      audiencePubkeys: audience,
+      replyPlacement: placementFor(input, audience.length),
+      sharedThread: false,
+      retainDraft: false,
+      nestUnderAgentReply: false,
+    };
+  }
+
+  // Channel path
+  const eligible = eligibleChannelAgents(input);
+  const removed = asSet(input.manualRemovedPubkeys);
+  const explicit = filterToEligible(input.explicitMentionPubkeys, eligible).filter(
+    (pk) => !removed.has(pk),
+  );
+
+  let audience: string[];
+
+  if (explicit.length > 0) {
+    audience = explicit;
+  } else {
+    const persistent =
+      input.keepAddressedAgentsActive
+        ? filterToEligible(input.persistentThreadAudience, eligible).filter(
+            (pk) => !removed.has(pk),
+          )
+        : [];
+
+    if (persistent.length > 0) {
+      audience = persistent;
+    } else if (input.unaddressedMode === "all-channel-agents") {
+      audience = uniqueSorted(eligible).filter((pk) => !removed.has(pk));
+    } else {
+      // mentions-only, no explicit, no persistent
+      audience = [];
+    }
+  }
+
+  const sharedThread = audience.length >= 2;
+  return {
+    audiencePubkeys: audience,
+    replyPlacement: placementFor(input, audience.length),
+    sharedThread,
+    retainDraft: false,
+    nestUnderAgentReply: false,
+  };
+}
+
+function placementFor(
+  input: ContextualAgentConversationInput,
+  audienceCount: number,
+): ReplyPlacement {
+  // Already in a thread: always continue at the existing root (never nest under
+  // an agent reply).
+  if (input.messagePosition === "in-thread" && input.threadRootEventId) {
+    return {
+      kind: "thread-root",
+      eventId: input.threadRootEventId,
+    };
+  }
+
+  // Multi-agent top-level human message creates one shared thread at the human
+  // event.
+  if (audienceCount >= 2) {
+    const eventId = input.humanMessageEventId ?? input.threadRootEventId;
+    if (eventId) {
+      return { kind: "thread-root", eventId };
+    }
+  }
+
+  return { kind: "top-level" };
+}

--- a/desktop/src/features/channels/lib/contextualAgentConversationPolicy.ts
+++ b/desktop/src/features/channels/lib/contextualAgentConversationPolicy.ts
@@ -7,6 +7,8 @@
  * `unaddressedChannelAgentMode.ts`.
  */
 
+import { normalizePubkey } from "@/shared/lib/pubkey.ts";
+
 export type UnaddressedChannelAgentMode =
   | "all-channel-agents"
   | "mentions-only";
@@ -45,10 +47,6 @@ export type ContextualAgentConversationDecision = {
   nestUnderAgentReply?: boolean;
 };
 
-function normalizePubkey(pubkey: string): string {
-  return pubkey.trim().toLowerCase();
-}
-
 function uniqueSorted(pubkeys: Iterable<string>): string[] {
   const set = new Set<string>();
   for (const pk of pubkeys) {
@@ -66,7 +64,9 @@ function asSet(pubkeys: readonly string[]): Set<string> {
  * Verified current-channel agents only: intersection of membership and
  * verified agent evidence. Never community/relay-wide fanout.
  */
-function eligibleChannelAgents(input: ContextualAgentConversationInput): Set<string> {
+function eligibleChannelAgents(
+  input: ContextualAgentConversationInput,
+): Set<string> {
   const members = asSet(input.channelMemberPubkeys);
   const verified = asSet(input.verifiedChannelAgentPubkeys);
   const eligible = new Set<string>();
@@ -80,7 +80,9 @@ function filterToEligible(
   candidates: readonly string[],
   eligible: Set<string>,
 ): string[] {
-  return uniqueSorted(candidates.filter((pk) => eligible.has(normalizePubkey(pk))));
+  return uniqueSorted(
+    candidates.filter((pk) => eligible.has(normalizePubkey(pk))),
+  );
 }
 
 /**
@@ -135,21 +137,21 @@ export function resolveContextualAgentConversation(
   // Channel path
   const eligible = eligibleChannelAgents(input);
   const removed = asSet(input.manualRemovedPubkeys);
-  const explicit = filterToEligible(input.explicitMentionPubkeys, eligible).filter(
-    (pk) => !removed.has(pk),
-  );
+  const explicit = filterToEligible(
+    input.explicitMentionPubkeys,
+    eligible,
+  ).filter((pk) => !removed.has(pk));
 
   let audience: string[];
 
   if (explicit.length > 0) {
     audience = explicit;
   } else {
-    const persistent =
-      input.keepAddressedAgentsActive
-        ? filterToEligible(input.persistentThreadAudience, eligible).filter(
-            (pk) => !removed.has(pk),
-          )
-        : [];
+    const persistent = input.keepAddressedAgentsActive
+      ? filterToEligible(input.persistentThreadAudience, eligible).filter(
+          (pk) => !removed.has(pk),
+        )
+      : [];
 
     if (persistent.length > 0) {
       audience = persistent;

--- a/desktop/src/features/channels/lib/unaddressedChannelAgentMode.test.mjs
+++ b/desktop/src/features/channels/lib/unaddressedChannelAgentMode.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE,
+  UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY,
+  parseUnaddressedChannelAgentMode,
+  readUnaddressedChannelAgentMode,
+  writeUnaddressedChannelAgentMode,
+} from "./unaddressedChannelAgentMode.ts";
+
+test("storage key matches fixture contract", () => {
+  assert.equal(
+    UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY,
+    "buzz:unaddressed-channel-agent-mode:v1",
+  );
+});
+
+test("default mode is all-channel-agents", () => {
+  assert.equal(DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE, "all-channel-agents");
+  assert.equal(parseUnaddressedChannelAgentMode(null), "all-channel-agents");
+  assert.equal(parseUnaddressedChannelAgentMode("garbage"), "all-channel-agents");
+});
+
+test("parse accepts both modes", () => {
+  assert.equal(parseUnaddressedChannelAgentMode("all-channel-agents"), "all-channel-agents");
+  assert.equal(parseUnaddressedChannelAgentMode("mentions-only"), "mentions-only");
+});
+
+test("read/write round-trip via mock storage", () => {
+  const map = new Map();
+  const storage = {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+  assert.equal(readUnaddressedChannelAgentMode(storage), "all-channel-agents");
+  writeUnaddressedChannelAgentMode("mentions-only", storage);
+  assert.equal(readUnaddressedChannelAgentMode(storage), "mentions-only");
+  assert.equal(
+    map.get(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY),
+    "mentions-only",
+  );
+});

--- a/desktop/src/features/channels/lib/unaddressedChannelAgentMode.test.mjs
+++ b/desktop/src/features/channels/lib/unaddressedChannelAgentMode.test.mjs
@@ -19,12 +19,21 @@ test("storage key matches fixture contract", () => {
 test("default mode is all-channel-agents", () => {
   assert.equal(DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE, "all-channel-agents");
   assert.equal(parseUnaddressedChannelAgentMode(null), "all-channel-agents");
-  assert.equal(parseUnaddressedChannelAgentMode("garbage"), "all-channel-agents");
+  assert.equal(
+    parseUnaddressedChannelAgentMode("garbage"),
+    "all-channel-agents",
+  );
 });
 
 test("parse accepts both modes", () => {
-  assert.equal(parseUnaddressedChannelAgentMode("all-channel-agents"), "all-channel-agents");
-  assert.equal(parseUnaddressedChannelAgentMode("mentions-only"), "mentions-only");
+  assert.equal(
+    parseUnaddressedChannelAgentMode("all-channel-agents"),
+    "all-channel-agents",
+  );
+  assert.equal(
+    parseUnaddressedChannelAgentMode("mentions-only"),
+    "mentions-only",
+  );
 });
 
 test("read/write round-trip via mock storage", () => {

--- a/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
+++ b/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
@@ -1,0 +1,47 @@
+/**
+ * Device-local setting: how unaddressed channel messages reach agents.
+ *
+ * Label: "Unaddressed channel messages"
+ * - Notify all channel agents  → "all-channel-agents" (default)
+ * - Mentions only              → "mentions-only"
+ *
+ * Semantic storage key is versioned; not community/relay policy.
+ */
+
+import type { UnaddressedChannelAgentMode } from "./contextualAgentConversationPolicy.ts";
+
+/** Versioned device-local storage key (do not change without a migration). */
+export const UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY =
+  "buzz:unaddressed-channel-agent-mode:v1";
+
+export const DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE: UnaddressedChannelAgentMode =
+  "all-channel-agents";
+
+export function parseUnaddressedChannelAgentMode(
+  value: string | null | undefined,
+): UnaddressedChannelAgentMode {
+  return value === "mentions-only" || value === "all-channel-agents"
+    ? value
+    : DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE;
+}
+
+export function readUnaddressedChannelAgentMode(
+  storage: Pick<Storage, "getItem"> | null | undefined = globalThis.localStorage,
+): UnaddressedChannelAgentMode {
+  try {
+    return parseUnaddressedChannelAgentMode(storage?.getItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY));
+  } catch {
+    return DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE;
+  }
+}
+
+export function writeUnaddressedChannelAgentMode(
+  mode: UnaddressedChannelAgentMode,
+  storage: Pick<Storage, "setItem"> | null | undefined = globalThis.localStorage,
+): void {
+  try {
+    storage?.setItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Best-effort persistence.
+  }
+}

--- a/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
+++ b/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
@@ -62,6 +62,15 @@ export function writeUnaddressedChannelAgentMode(
     | null
     | undefined = globalThis.localStorage,
 ): void {
+  if (mode === next) {
+    // Still persist in case storage was cleared while in-memory mode matched.
+    try {
+      storage?.setItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY, next);
+    } catch {
+      // Best-effort.
+    }
+    return;
+  }
   mode = next;
   try {
     storage?.setItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY, next);

--- a/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
+++ b/desktop/src/features/channels/lib/unaddressedChannelAgentMode.ts
@@ -8,6 +8,8 @@
  * Semantic storage key is versioned; not community/relay policy.
  */
 
+import * as React from "react";
+
 import type { UnaddressedChannelAgentMode } from "./contextualAgentConversationPolicy.ts";
 
 /** Versioned device-local storage key (do not change without a migration). */
@@ -17,6 +19,10 @@ export const UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY =
 export const DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE: UnaddressedChannelAgentMode =
   "all-channel-agents";
 
+const listeners = new Set<() => void>();
+
+let mode: UnaddressedChannelAgentMode = readStoredMode();
+
 export function parseUnaddressedChannelAgentMode(
   value: string | null | undefined,
 ): UnaddressedChannelAgentMode {
@@ -25,23 +31,73 @@ export function parseUnaddressedChannelAgentMode(
     : DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE;
 }
 
-export function readUnaddressedChannelAgentMode(
-  storage: Pick<Storage, "getItem"> | null | undefined = globalThis.localStorage,
+function readStoredMode(
+  storage:
+    | Pick<Storage, "getItem">
+    | null
+    | undefined = globalThis.localStorage,
 ): UnaddressedChannelAgentMode {
   try {
-    return parseUnaddressedChannelAgentMode(storage?.getItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY));
+    return parseUnaddressedChannelAgentMode(
+      storage?.getItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY),
+    );
   } catch {
     return DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE;
   }
 }
 
+export function readUnaddressedChannelAgentMode(
+  storage:
+    | Pick<Storage, "getItem">
+    | null
+    | undefined = globalThis.localStorage,
+): UnaddressedChannelAgentMode {
+  return readStoredMode(storage);
+}
+
 export function writeUnaddressedChannelAgentMode(
-  mode: UnaddressedChannelAgentMode,
-  storage: Pick<Storage, "setItem"> | null | undefined = globalThis.localStorage,
+  next: UnaddressedChannelAgentMode,
+  storage:
+    | Pick<Storage, "setItem">
+    | null
+    | undefined = globalThis.localStorage,
 ): void {
+  mode = next;
   try {
-    storage?.setItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY, mode);
+    storage?.setItem(UNADDRESSED_CHANNEL_AGENT_MODE_STORAGE_KEY, next);
   } catch {
     // Best-effort persistence.
   }
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): UnaddressedChannelAgentMode {
+  return mode;
+}
+
+function getServerSnapshot(): UnaddressedChannelAgentMode {
+  return DEFAULT_UNADDRESSED_CHANNEL_AGENT_MODE;
+}
+
+/** Device-local unaddressed-channel agent mode for React consumers. */
+export function useUnaddressedChannelAgentMode(): {
+  mode: UnaddressedChannelAgentMode;
+  setMode: (mode: UnaddressedChannelAgentMode) => void;
+} {
+  const current = React.useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+  return {
+    mode: current,
+    setMode: writeUnaddressedChannelAgentMode,
+  };
 }

--- a/desktop/src/features/messages/lib/composerSendAudience.test.mjs
+++ b/desktop/src/features/messages/lib/composerSendAudience.test.mjs
@@ -94,3 +94,73 @@ test("describeComposerAudienceHint covers modes", () => {
     null,
   );
 });
+
+test("keep-addressed persistent audience applies under mentions-only", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "mentions-only",
+    keepAddressedAgentsActive: true,
+    explicitMentionPubkeys: [],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA, agentB],
+    verifiedChannelAgentPubkeys: [agentA, agentB],
+    persistentThreadAudience: [agentA],
+  });
+  assert.deepEqual(result.agentAudiencePubkeys, [agentA]);
+  assert.equal(result.sharedThread, false);
+});
+
+test("recipient load error retains draft and clears audience", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "all-channel-agents",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA],
+    verifiedChannelAgentPubkeys: [agentA],
+    persistentThreadAudience: [],
+    recipientLoadError: true,
+  });
+  assert.deepEqual(result.mentionPubkeys, []);
+  assert.equal(result.retainDraft, true);
+});
+
+test("direct conversation addresses current agent only", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "direct",
+    messagePosition: "top-level",
+    unaddressedMode: "all-channel-agents",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: agentA,
+    channelMemberPubkeys: [human, agentA],
+    verifiedChannelAgentPubkeys: [agentA],
+    persistentThreadAudience: [],
+  });
+  assert.deepEqual(result.mentionPubkeys, [agentA]);
+  assert.equal(result.sharedThread, false);
+  assert.equal(result.replyPlacement.kind, "top-level");
+});
+
+test("manual removal drops persistent agent from audience", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "mentions-only",
+    keepAddressedAgentsActive: true,
+    explicitMentionPubkeys: [],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA, agentB],
+    verifiedChannelAgentPubkeys: [agentA, agentB],
+    persistentThreadAudience: [agentA, agentB],
+    manualRemovedPubkeys: [agentB],
+  });
+  assert.deepEqual(result.agentAudiencePubkeys, [agentA]);
+});

--- a/desktop/src/features/messages/lib/composerSendAudience.test.mjs
+++ b/desktop/src/features/messages/lib/composerSendAudience.test.mjs
@@ -148,6 +148,23 @@ test("direct conversation addresses current agent only", () => {
   assert.equal(result.replyPlacement.kind, "top-level");
 });
 
+test("direct path keeps explicit agent mentions for DM expansion", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "direct",
+    messagePosition: "top-level",
+    unaddressedMode: "all-channel-agents",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [agentB],
+    explicitAgentPubkeys: [agentB],
+    currentAgentPubkey: agentA,
+    channelMemberPubkeys: [human, agentA],
+    verifiedChannelAgentPubkeys: [agentA, agentB],
+    persistentThreadAudience: [],
+  });
+  // Both the DM peer agent and the newly @mentioned agent must remain.
+  assert.deepEqual([...result.mentionPubkeys].sort(), [agentA, agentB].sort());
+});
+
 test("manual removal drops persistent agent from audience", () => {
   const result = resolveComposerSendAudience({
     conversation: "channel",

--- a/desktop/src/features/messages/lib/composerSendAudience.test.mjs
+++ b/desktop/src/features/messages/lib/composerSendAudience.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  describeComposerAudienceHint,
+  resolveComposerSendAudience,
+} from "./composerSendAudience.ts";
+
+const human = "1".repeat(64);
+const agentA = "a".repeat(64);
+const agentB = "b".repeat(64);
+
+test("channel multi-agent unaddressed merges all verified agents into mentions", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "all-channel-agents",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA, agentB],
+    verifiedChannelAgentPubkeys: [agentA, agentB],
+    persistentThreadAudience: [],
+  });
+  assert.deepEqual([...result.mentionPubkeys].sort(), [agentA, agentB].sort());
+  assert.equal(result.sharedThread, true);
+  assert.equal(result.replyPlacement.kind, "top-level"); // no humanMessageEventId
+});
+
+test("explicit agent mention overrides implicit all-agents", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "all-channel-agents",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [agentB, human],
+    explicitAgentPubkeys: [agentB],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA, agentB],
+    verifiedChannelAgentPubkeys: [agentA, agentB],
+    persistentThreadAudience: [],
+  });
+  assert.deepEqual([...result.mentionPubkeys].sort(), [agentB, human].sort());
+  assert.deepEqual(result.agentAudiencePubkeys, [agentB]);
+});
+
+test("mentions-only with no explicit agents yields empty agent audience", () => {
+  const result = resolveComposerSendAudience({
+    conversation: "channel",
+    messagePosition: "top-level",
+    unaddressedMode: "mentions-only",
+    keepAddressedAgentsActive: false,
+    explicitMentionPubkeys: [human],
+    explicitAgentPubkeys: [],
+    currentAgentPubkey: null,
+    channelMemberPubkeys: [human, agentA],
+    verifiedChannelAgentPubkeys: [agentA],
+    persistentThreadAudience: [],
+  });
+  assert.deepEqual(result.agentAudiencePubkeys, []);
+  assert.deepEqual(result.mentionPubkeys, [human]);
+});
+
+test("describeComposerAudienceHint covers modes", () => {
+  assert.match(
+    describeComposerAudienceHint({
+      conversation: "channel",
+      unaddressedMode: "all-channel-agents",
+      explicitAgentCount: 0,
+      implicitAgentCount: 3,
+      retainDraft: false,
+    }) ?? "",
+    /all 3 channel agents/,
+  );
+  assert.match(
+    describeComposerAudienceHint({
+      conversation: "channel",
+      unaddressedMode: "mentions-only",
+      explicitAgentCount: 0,
+      implicitAgentCount: 0,
+      retainDraft: false,
+    }) ?? "",
+    /Mentions only/,
+  );
+  assert.equal(
+    describeComposerAudienceHint({
+      conversation: "direct",
+      unaddressedMode: "all-channel-agents",
+      explicitAgentCount: 0,
+      implicitAgentCount: 1,
+      retainDraft: false,
+    }),
+    null,
+  );
+});

--- a/desktop/src/features/messages/lib/composerSendAudience.ts
+++ b/desktop/src/features/messages/lib/composerSendAudience.ts
@@ -76,7 +76,12 @@ export function resolveComposerSendAudience(
   };
 
   const decision = resolveContextualAgentConversation(policyInput);
-  const agentAudience = uniqueNormalized(decision.audiencePubkeys);
+  // Always retain authored agent @mentions (e.g. DM expansion to a new agent)
+  // while still applying implicit/persistent audience from policy.
+  const agentAudience = uniqueNormalized([
+    ...decision.audiencePubkeys,
+    ...explicitAgentSet,
+  ]);
   const humanMentions = uniqueNormalized(input.explicitMentionPubkeys).filter(
     (pk) => !explicitAgentSet.has(pk),
   );
@@ -85,7 +90,7 @@ export function resolveComposerSendAudience(
   return {
     mentionPubkeys,
     agentAudiencePubkeys: agentAudience,
-    sharedThread: decision.sharedThread,
+    sharedThread: decision.sharedThread || agentAudience.length >= 2,
     retainDraft: decision.retainDraft,
     replyPlacement: decision.replyPlacement,
   };

--- a/desktop/src/features/messages/lib/composerSendAudience.ts
+++ b/desktop/src/features/messages/lib/composerSendAudience.ts
@@ -1,0 +1,128 @@
+/**
+ * Merge explicit composer mentions with implicit contextual-agent audience
+ * for the outgoing p-tag set.
+ */
+
+import {
+  resolveContextualAgentConversation,
+  type ContextualAgentConversationInput,
+  type UnaddressedChannelAgentMode,
+} from "@/features/channels/lib/contextualAgentConversationPolicy.ts";
+
+export type ComposerSendAudienceInput = {
+  conversation: "direct" | "channel";
+  messagePosition: "top-level" | "in-thread";
+  unaddressedMode: UnaddressedChannelAgentMode;
+  keepAddressedAgentsActive: boolean;
+  /** Explicit @mentions (any pubkey) from the draft body. */
+  explicitMentionPubkeys: readonly string[];
+  /** Explicit mentions that are agents (for policy). */
+  explicitAgentPubkeys: readonly string[];
+  currentAgentPubkey: string | null;
+  channelMemberPubkeys: readonly string[];
+  verifiedChannelAgentPubkeys: readonly string[];
+  persistentThreadAudience: readonly string[];
+  manualRemovedPubkeys?: readonly string[];
+  threadRootEventId?: string | null;
+  humanMessageEventId?: string | null;
+  recipientLoadError?: boolean;
+};
+
+export type ComposerSendAudienceResult = {
+  /** Full p-tag pubkey list (explicit non-agents + resolved agent audience). */
+  mentionPubkeys: string[];
+  /** Resolved agent audience only. */
+  agentAudiencePubkeys: string[];
+  sharedThread: boolean;
+  retainDraft: boolean;
+  replyPlacement: ReturnType<
+    typeof resolveContextualAgentConversation
+  >["replyPlacement"];
+};
+
+function uniqueNormalized(pubkeys: Iterable<string>): string[] {
+  return [
+    ...new Set(
+      [...pubkeys].map((pk) => pk.trim().toLowerCase()).filter(Boolean),
+    ),
+  ];
+}
+
+/**
+ * Build the effective send audience for a human message.
+ * Non-agent explicit mentions are always preserved; agent audience follows policy.
+ */
+export function resolveComposerSendAudience(
+  input: ComposerSendAudienceInput,
+): ComposerSendAudienceResult {
+  const explicitAgentSet = new Set(
+    uniqueNormalized(input.explicitAgentPubkeys),
+  );
+  const policyInput: ContextualAgentConversationInput = {
+    conversation: input.conversation,
+    messagePosition: input.messagePosition,
+    senderClass: "human",
+    unaddressedMode: input.unaddressedMode,
+    keepAddressedAgentsActive: input.keepAddressedAgentsActive,
+    explicitMentionPubkeys: [...explicitAgentSet],
+    currentAgentPubkey: input.currentAgentPubkey,
+    channelMemberPubkeys: [...input.channelMemberPubkeys],
+    verifiedChannelAgentPubkeys: [...input.verifiedChannelAgentPubkeys],
+    threadRootEventId: input.threadRootEventId ?? null,
+    persistentThreadAudience: [...input.persistentThreadAudience],
+    manualRemovedPubkeys: [...(input.manualRemovedPubkeys ?? [])],
+    recipientLoadError: input.recipientLoadError ?? false,
+    humanMessageEventId: input.humanMessageEventId ?? null,
+  };
+
+  const decision = resolveContextualAgentConversation(policyInput);
+  const agentAudience = uniqueNormalized(decision.audiencePubkeys);
+  const humanMentions = uniqueNormalized(input.explicitMentionPubkeys).filter(
+    (pk) => !explicitAgentSet.has(pk),
+  );
+  const mentionPubkeys = uniqueNormalized([...humanMentions, ...agentAudience]);
+
+  return {
+    mentionPubkeys,
+    agentAudiencePubkeys: agentAudience,
+    sharedThread: decision.sharedThread,
+    retainDraft: decision.retainDraft,
+    replyPlacement: decision.replyPlacement,
+  };
+}
+
+/** Human-readable composer hint for the unaddressed mode + draft state. */
+export function describeComposerAudienceHint({
+  conversation,
+  unaddressedMode,
+  explicitAgentCount,
+  implicitAgentCount,
+  retainDraft,
+}: {
+  conversation: "direct" | "channel";
+  unaddressedMode: UnaddressedChannelAgentMode;
+  explicitAgentCount: number;
+  implicitAgentCount: number;
+  retainDraft: boolean;
+}): string | null {
+  if (retainDraft) {
+    return "Could not resolve recipients — draft kept";
+  }
+  if (conversation === "direct") {
+    return null;
+  }
+  if (explicitAgentCount > 0) {
+    return explicitAgentCount === 1
+      ? "Notifying 1 mentioned agent"
+      : `Notifying ${explicitAgentCount} mentioned agents`;
+  }
+  if (implicitAgentCount > 0 && unaddressedMode === "all-channel-agents") {
+    return implicitAgentCount === 1
+      ? "Notifying 1 channel agent"
+      : `Notifying all ${implicitAgentCount} channel agents`;
+  }
+  if (unaddressedMode === "mentions-only") {
+    return "Mentions only — agents are not auto-notified";
+  }
+  return null;
+}

--- a/desktop/src/features/messages/ui/ComposerAudienceHint.tsx
+++ b/desktop/src/features/messages/ui/ComposerAudienceHint.tsx
@@ -1,0 +1,12 @@
+/** Compact device-local audience indicator above the message editor. */
+export function ComposerAudienceHint({ hint }: { hint: string | null }) {
+  if (!hint) return null;
+  return (
+    <p
+      className="mb-2 text-2xs text-muted-foreground"
+      data-testid="composer-agent-audience-hint"
+    >
+      {hint}
+    </p>
+  );
+}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -363,19 +363,12 @@ function MessageComposerImpl({
     const explicitAgentPubkeys = explicitMentionPubkeys.filter((pk) =>
       mentions.isAgentPubkey(pk),
     );
-    const decision = resolveComposerSendAudience({
-      conversation: conversationKind,
-      messagePosition: audienceThreadRootId ? "in-thread" : "top-level",
-      unaddressedMode,
-      keepAddressedAgentsActive: persistentAudience.enabled,
+    // Reuse the same send-path resolver so the hint cannot drift from p-tags.
+    const decision = resolveComposerAudience({
       explicitMentionPubkeys,
       explicitAgentPubkeys,
-      currentAgentPubkey,
-      channelMemberPubkeys: channelMemberPubkeyList,
-      verifiedChannelAgentPubkeys,
-      persistentThreadAudience: [...persistentAudience.pubkeys],
+      messagePosition: audienceThreadRootId ? "in-thread" : "top-level",
       threadRootEventId: audienceThreadRootId,
-      recipientLoadError: !mentions.hasResolvedMembers,
     });
     return describeComposerAudienceHint({
       conversation: conversationKind,
@@ -389,16 +382,12 @@ function MessageComposerImpl({
     });
   }, [
     audienceThreadRootId,
-    channelMemberPubkeyList,
     conversationKind,
-    currentAgentPubkey,
     editTarget,
     mentions,
-    persistentAudience.enabled,
-    persistentAudience.pubkeys,
+    resolveComposerAudience,
     richText,
     unaddressedMode,
-    verifiedChannelAgentPubkeys,
   ]);
 
   const mentionSendFlow = useMentionSendFlow({

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -24,14 +24,8 @@ import { useAttachmentEditing } from "@/features/messages/lib/useAttachmentEditi
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import { useMentions } from "@/features/messages/lib/useMentions";
 import { diffAddedMentionPubkeys } from "@/features/messages/lib/threading";
-import { useUnaddressedChannelAgentMode } from "@/features/channels/lib/unaddressedChannelAgentMode";
-import {
-  describeComposerAudienceHint,
-  resolveComposerSendAudience,
-} from "@/features/messages/lib/composerSendAudience";
 import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   hasMentionClipboardHtml,
   normalizeMentionClipboardHtml,
@@ -57,11 +51,12 @@ import {
 } from "./MentionAutocomplete";
 import { ComposerDockToolbar } from "./ComposerDockToolbar";
 import { NonMemberMentionDialog } from "./NonMemberMentionDialog";
+import { ComposerAudienceHint } from "./ComposerAudienceHint";
+import { useComposerAgentAudience } from "./useComposerAgentAudience";
 import { useMentionSendFlow } from "./useMentionSendFlow";
 import { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
 import { useComposerContentState } from "./useComposerContentState";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
-
 import type { MessageComposerProps } from "./MessageComposer.types";
 
 function MessageComposerImpl({
@@ -130,7 +125,6 @@ function MessageComposerImpl({
       : null;
   const effectiveDraftKeyRef = React.useRef(effectiveDraftKey);
   effectiveDraftKeyRef.current = effectiveDraftKey;
-  // Snapshot composer state before edit mode so cancel can restore it.
   const preEditSnapshotRef = React.useRef<{
     content: string;
     pendingImeta: ImetaMedia[];
@@ -293,102 +287,27 @@ function MessageComposerImpl({
     mentions,
     richText,
   });
-  const persistentAudience = persistentMentionHydration.audience;
   const persistentMentionHydrationRef = React.useRef(
     persistentMentionHydration,
   );
   persistentMentionHydrationRef.current = persistentMentionHydration;
-  const { mode: unaddressedMode } = useUnaddressedChannelAgentMode();
 
-  const conversationKind = channelType === "dm" ? "direct" : "channel";
-  const channelMemberPubkeyList = React.useMemo(
-    () => [...mentions.memberPubkeys],
-    [mentions.memberPubkeys],
-  );
-  const verifiedChannelAgentPubkeys = React.useMemo(
-    () => channelMemberPubkeyList.filter((pk) => mentions.isAgentPubkey(pk)),
-    [channelMemberPubkeyList, mentions.isAgentPubkey],
-  );
-  const currentAgentPubkey = React.useMemo(() => {
-    if (conversationKind !== "direct") return null;
-    const agents = verifiedChannelAgentPubkeys.filter(
-      (pk) => pk !== normalizePubkey(ownerPubkey ?? ""),
-    );
-    return agents[0] ?? null;
-  }, [conversationKind, ownerPubkey, verifiedChannelAgentPubkeys]);
-
-  const resolveComposerAudience = React.useCallback(
-    ({
-      explicitMentionPubkeys,
-      explicitAgentPubkeys,
-      messagePosition,
-      threadRootEventId,
-    }: {
-      explicitMentionPubkeys: string[];
-      explicitAgentPubkeys: string[];
-      messagePosition: "top-level" | "in-thread";
-      threadRootEventId: string | null;
-    }) =>
-      resolveComposerSendAudience({
-        conversation: conversationKind,
-        messagePosition,
-        unaddressedMode,
-        keepAddressedAgentsActive: persistentAudience.enabled,
-        explicitMentionPubkeys,
-        explicitAgentPubkeys,
-        currentAgentPubkey,
-        channelMemberPubkeys: channelMemberPubkeyList,
-        verifiedChannelAgentPubkeys,
-        persistentThreadAudience: [...persistentAudience.pubkeys],
-        threadRootEventId,
-        recipientLoadError:
-          !mentions.hasResolvedMembers && conversationKind === "channel",
-      }),
-    [
-      channelMemberPubkeyList,
-      conversationKind,
-      currentAgentPubkey,
-      mentions.hasResolvedMembers,
-      persistentAudience.enabled,
-      persistentAudience.pubkeys,
-      unaddressedMode,
-      verifiedChannelAgentPubkeys,
-    ],
-  );
-
-  const composerAudienceHint = React.useMemo(() => {
-    if (editTarget != null || conversationKind === "direct") return null;
-    const text = richText.getPlainTextAndCursor().text;
-    const explicitMentionPubkeys = mentions.extractMentionPubkeys(text);
-    const explicitAgentPubkeys = explicitMentionPubkeys.filter((pk) =>
-      mentions.isAgentPubkey(pk),
-    );
-    // Reuse the same send-path resolver so the hint cannot drift from p-tags.
-    const decision = resolveComposerAudience({
-      explicitMentionPubkeys,
-      explicitAgentPubkeys,
-      messagePosition: audienceThreadRootId ? "in-thread" : "top-level",
-      threadRootEventId: audienceThreadRootId,
-    });
-    return describeComposerAudienceHint({
-      conversation: conversationKind,
-      unaddressedMode,
-      explicitAgentCount: explicitAgentPubkeys.length,
-      implicitAgentCount:
-        explicitAgentPubkeys.length > 0
-          ? 0
-          : decision.agentAudiencePubkeys.length,
-      retainDraft: decision.retainDraft,
-    });
-  }, [
+  const {
+    composerAudienceHint,
+    audienceGeneration,
+    audienceRevision,
+    resolveComposerAudience,
+    onSuccessfulExplicitAgentAudience,
+    resolvePostSendContent,
+  } = useComposerAgentAudience({
     audienceThreadRootId,
-    conversationKind,
+    channelType,
     editTarget,
     mentions,
-    resolveComposerAudience,
+    ownerPubkey,
+    persistentMentionHydration,
     richText,
-    unaddressedMode,
-  ]);
+  });
 
   const mentionSendFlow = useMentionSendFlow({
     channelId,
@@ -406,18 +325,10 @@ function MessageComposerImpl({
     setIsEmojiPickerOpen,
     setPendingImeta: media.setPendingImeta,
     setSpoileredAttachmentUrls,
-    onSuccessfulExplicitAgentAudience:
-      persistentAudience.enabled && audienceContext && ownerPubkey
-        ? ({ channelId: successfulChannelId, ...promotion }) => {
-            const scope = getPersistentAgentAudienceScope({
-              ownerPubkey,
-              channelId: successfulChannelId,
-              threadRootId: audienceThreadRootId,
-            });
-            persistentAudience.promotePubkeys({ ...promotion, scope });
-          }
-        : undefined,
-    resolvePostSendContent: persistentMentionHydration.resolvePostSendContent,
+    onSuccessfulExplicitAgentAudience: audienceContext
+      ? onSuccessfulExplicitAgentAudience
+      : undefined,
+    resolvePostSendContent,
     resolveComposerAudience,
   });
 
@@ -572,7 +483,6 @@ function MessageComposerImpl({
     [richText.editor, mentions.clearMentions, customEmoji],
   );
 
-  // ── @ mention picker (toolbar button) ───────────────────────────────
   const openMentionPicker = React.useCallback(() => {
     if (!richText.editor) return;
     const { text, cursor } = richText.getPlainTextAndCursor();
@@ -603,11 +513,9 @@ function MessageComposerImpl({
     mentions.updateMentionQuery,
   ]);
 
-  // ── Submit message ──────────────────────────────────────────────────
   const submitMessage = React.useCallback(async () => {
     const trimmed = syncComposerContentFromEditor().trim();
 
-    // Edit mode
     if (editTargetRef.current && onEditSaveRef.current) {
       if (isSendingRef.current || isUploadingRef.current) return;
       const currentPendingImeta = media.pendingImetaRef.current;
@@ -673,7 +581,6 @@ function MessageComposerImpl({
       return;
     }
 
-    // Normal send
     const currentPendingImeta = media.pendingImetaRef.current;
     const hasMedia = currentPendingImeta.length > 0;
     if (
@@ -707,8 +614,8 @@ function MessageComposerImpl({
         ),
         spoileredAttachmentUrls,
         trimmed,
-        audienceGeneration: persistentAudience.generation,
-        audienceRevision: audienceScope ? persistentAudience.revision : null,
+        audienceGeneration,
+        audienceRevision: audienceScope ? audienceRevision : null,
       });
     } finally {
       persistentMentionHydration.endSubmit();
@@ -733,21 +640,15 @@ function MessageComposerImpl({
     onCaptureSendContext,
     onPreparingMentionSendChange,
     audienceScope,
+    audienceGeneration,
+    audienceRevision,
     persistentMentionHydration,
-    persistentAudience.generation,
-    persistentAudience.revision,
   ]);
   submitMessageRef.current = submitMessage;
 
-  // ── Auto-submit on draft send ────────────────────────────────────────────
-  // When `autoSubmitDraftKey` is set (the user clicked "Send message" in the
-  // Drafts panel and confirmed), fire `submitMessage` once after mount so the
-  // draft is sent through the real send path (mention resolution, media, etc.).
-  //
-  // Guard: only fire when the effective draft key matches the trigger so a
-  // stale URL param on a different channel never fires a spurious send.
-  //
-  // Fires at most once per mount (empty dep array after the key check) — the
+  // Auto-submit draft once when Drafts panel confirms send.
+  // Guard: effective draft key must match trigger (no cross-channel fire).
+  // Fires at most once per mount — the
   // `onAutoSubmitComplete` callback clears the trigger before `submitMessage`
   // runs, preventing re-fire on re-render or back-navigation.
   const onAutoSubmitCompleteRef = React.useRef(onAutoSubmitComplete);
@@ -786,7 +687,6 @@ function MessageComposerImpl({
 
   // ── Keyboard handling ───────────────────────────────────────────────
   // Tiptap handles formatting shortcuts (⌘B, ⌘I, etc.) natively.
-  // Plain Enter → submit is now handled inside the Tiptap `submitOnEnter`
   // extension (fires before ProseMirror's splitBlock). This wrapper only
   // handles autocomplete arrow/enter keys and Escape for edit mode.
   const handleEditorKeyDown = React.useCallback(
@@ -1054,14 +954,7 @@ function MessageComposerImpl({
               </div>
             ) : null}
 
-            {composerAudienceHint ? (
-              <p
-                className="mb-2 text-2xs text-muted-foreground"
-                data-testid="composer-agent-audience-hint"
-              >
-                {composerAudienceHint}
-              </p>
-            ) : null}
+            <ComposerAudienceHint hint={composerAudienceHint} />
 
             {(media.pendingImeta.length > 0 || media.isUploading) && (
               <div className="mb-2 flex items-center gap-2">

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -24,8 +24,14 @@ import { useAttachmentEditing } from "@/features/messages/lib/useAttachmentEditi
 import { useMediaUpload } from "@/features/messages/lib/useMediaUpload";
 import { useMentions } from "@/features/messages/lib/useMentions";
 import { diffAddedMentionPubkeys } from "@/features/messages/lib/threading";
+import { useUnaddressedChannelAgentMode } from "@/features/channels/lib/unaddressedChannelAgentMode";
+import {
+  describeComposerAudienceHint,
+  resolveComposerSendAudience,
+} from "@/features/messages/lib/composerSendAudience";
 import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
 import { useIdentityQuery } from "@/shared/api/hooks";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   hasMentionClipboardHtml,
   normalizeMentionClipboardHtml,
@@ -292,6 +298,108 @@ function MessageComposerImpl({
     persistentMentionHydration,
   );
   persistentMentionHydrationRef.current = persistentMentionHydration;
+  const { mode: unaddressedMode } = useUnaddressedChannelAgentMode();
+
+  const conversationKind = channelType === "dm" ? "direct" : "channel";
+  const channelMemberPubkeyList = React.useMemo(
+    () => [...mentions.memberPubkeys],
+    [mentions.memberPubkeys],
+  );
+  const verifiedChannelAgentPubkeys = React.useMemo(
+    () => channelMemberPubkeyList.filter((pk) => mentions.isAgentPubkey(pk)),
+    [channelMemberPubkeyList, mentions.isAgentPubkey],
+  );
+  const currentAgentPubkey = React.useMemo(() => {
+    if (conversationKind !== "direct") return null;
+    const agents = verifiedChannelAgentPubkeys.filter(
+      (pk) => pk !== normalizePubkey(ownerPubkey ?? ""),
+    );
+    return agents[0] ?? null;
+  }, [conversationKind, ownerPubkey, verifiedChannelAgentPubkeys]);
+
+  const resolveComposerAudience = React.useCallback(
+    ({
+      explicitMentionPubkeys,
+      explicitAgentPubkeys,
+      messagePosition,
+      threadRootEventId,
+    }: {
+      explicitMentionPubkeys: string[];
+      explicitAgentPubkeys: string[];
+      messagePosition: "top-level" | "in-thread";
+      threadRootEventId: string | null;
+    }) =>
+      resolveComposerSendAudience({
+        conversation: conversationKind,
+        messagePosition,
+        unaddressedMode,
+        keepAddressedAgentsActive: persistentAudience.enabled,
+        explicitMentionPubkeys,
+        explicitAgentPubkeys,
+        currentAgentPubkey,
+        channelMemberPubkeys: channelMemberPubkeyList,
+        verifiedChannelAgentPubkeys,
+        persistentThreadAudience: [...persistentAudience.pubkeys],
+        threadRootEventId,
+        recipientLoadError:
+          !mentions.hasResolvedMembers && conversationKind === "channel",
+      }),
+    [
+      channelMemberPubkeyList,
+      conversationKind,
+      currentAgentPubkey,
+      mentions.hasResolvedMembers,
+      persistentAudience.enabled,
+      persistentAudience.pubkeys,
+      unaddressedMode,
+      verifiedChannelAgentPubkeys,
+    ],
+  );
+
+  const composerAudienceHint = React.useMemo(() => {
+    if (editTarget != null || conversationKind === "direct") return null;
+    const text = richText.getPlainTextAndCursor().text;
+    const explicitMentionPubkeys = mentions.extractMentionPubkeys(text);
+    const explicitAgentPubkeys = explicitMentionPubkeys.filter((pk) =>
+      mentions.isAgentPubkey(pk),
+    );
+    const decision = resolveComposerSendAudience({
+      conversation: conversationKind,
+      messagePosition: audienceThreadRootId ? "in-thread" : "top-level",
+      unaddressedMode,
+      keepAddressedAgentsActive: persistentAudience.enabled,
+      explicitMentionPubkeys,
+      explicitAgentPubkeys,
+      currentAgentPubkey,
+      channelMemberPubkeys: channelMemberPubkeyList,
+      verifiedChannelAgentPubkeys,
+      persistentThreadAudience: [...persistentAudience.pubkeys],
+      threadRootEventId: audienceThreadRootId,
+      recipientLoadError: !mentions.hasResolvedMembers,
+    });
+    return describeComposerAudienceHint({
+      conversation: conversationKind,
+      unaddressedMode,
+      explicitAgentCount: explicitAgentPubkeys.length,
+      implicitAgentCount:
+        explicitAgentPubkeys.length > 0
+          ? 0
+          : decision.agentAudiencePubkeys.length,
+      retainDraft: decision.retainDraft,
+    });
+  }, [
+    audienceThreadRootId,
+    channelMemberPubkeyList,
+    conversationKind,
+    currentAgentPubkey,
+    editTarget,
+    mentions,
+    persistentAudience.enabled,
+    persistentAudience.pubkeys,
+    richText,
+    unaddressedMode,
+    verifiedChannelAgentPubkeys,
+  ]);
 
   const mentionSendFlow = useMentionSendFlow({
     channelId,
@@ -321,6 +429,7 @@ function MessageComposerImpl({
           }
         : undefined,
     resolvePostSendContent: persistentMentionHydration.resolvePostSendContent,
+    resolveComposerAudience,
   });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: editTarget?.id is the trigger
@@ -954,6 +1063,15 @@ function MessageComposerImpl({
                   Dismiss
                 </button>
               </div>
+            ) : null}
+
+            {composerAudienceHint ? (
+              <p
+                className="mb-2 text-2xs text-muted-foreground"
+                data-testid="composer-agent-audience-hint"
+              >
+                {composerAudienceHint}
+              </p>
             ) : null}
 
             {(media.pendingImeta.length > 0 || media.isUploading) && (

--- a/desktop/src/features/messages/ui/useComposerAgentAudience.ts
+++ b/desktop/src/features/messages/ui/useComposerAgentAudience.ts
@@ -1,0 +1,177 @@
+import * as React from "react";
+
+import { useUnaddressedChannelAgentMode } from "@/features/channels/lib/unaddressedChannelAgentMode";
+import {
+  describeComposerAudienceHint,
+  resolveComposerSendAudience,
+  type ComposerSendAudienceResult,
+} from "@/features/messages/lib/composerSendAudience";
+import { getPersistentAgentAudienceScope } from "@/features/messages/lib/persistentAgentAudience";
+import type { UseMentionsResult } from "@/features/messages/lib/useMentions";
+import type { UseRichTextEditorResult } from "@/features/messages/lib/useRichTextEditor";
+import type { ChannelType } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+import type { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
+
+type PersistentHydration = ReturnType<
+  typeof usePersistentAgentMentionHydration
+>;
+
+export function useComposerAgentAudience({
+  audienceThreadRootId,
+  channelType,
+  editTarget,
+  mentions,
+  ownerPubkey,
+  persistentMentionHydration,
+  richText,
+}: {
+  audienceThreadRootId: string | null;
+  channelType: ChannelType | null;
+  editTarget: unknown;
+  mentions: UseMentionsResult;
+  ownerPubkey: string | null | undefined;
+  persistentMentionHydration: PersistentHydration;
+  richText: UseRichTextEditorResult;
+}): {
+  composerAudienceHint: string | null;
+  audienceGeneration: number;
+  audienceRevision: number;
+  resolveComposerAudience: (input: {
+    explicitMentionPubkeys: string[];
+    explicitAgentPubkeys: string[];
+    messagePosition: "top-level" | "in-thread";
+    threadRootEventId: string | null;
+  }) => ComposerSendAudienceResult;
+  onSuccessfulExplicitAgentAudience:
+    | ((audience: {
+        channelId: string;
+        expectedGeneration: number;
+        expectedRevision: number | null;
+        explicitAgentPubkeys: string[];
+      }) => void)
+    | undefined;
+  resolvePostSendContent: PersistentHydration["resolvePostSendContent"];
+} {
+  const persistentAudience = persistentMentionHydration.audience;
+  const { mode: unaddressedMode } = useUnaddressedChannelAgentMode();
+  const conversationKind = channelType === "dm" ? "direct" : "channel";
+
+  const channelMemberPubkeyList = React.useMemo(
+    () => [...mentions.memberPubkeys],
+    [mentions.memberPubkeys],
+  );
+  const verifiedChannelAgentPubkeys = React.useMemo(
+    () => channelMemberPubkeyList.filter((pk) => mentions.isAgentPubkey(pk)),
+    [channelMemberPubkeyList, mentions.isAgentPubkey],
+  );
+  const currentAgentPubkey = React.useMemo(() => {
+    if (conversationKind !== "direct") return null;
+    const agents = verifiedChannelAgentPubkeys.filter(
+      (pk) => pk !== normalizePubkey(ownerPubkey ?? ""),
+    );
+    return agents[0] ?? null;
+  }, [conversationKind, ownerPubkey, verifiedChannelAgentPubkeys]);
+
+  const resolveComposerAudience = React.useCallback(
+    ({
+      explicitMentionPubkeys,
+      explicitAgentPubkeys,
+      messagePosition,
+      threadRootEventId,
+    }: {
+      explicitMentionPubkeys: string[];
+      explicitAgentPubkeys: string[];
+      messagePosition: "top-level" | "in-thread";
+      threadRootEventId: string | null;
+    }) =>
+      resolveComposerSendAudience({
+        conversation: conversationKind,
+        messagePosition,
+        unaddressedMode,
+        keepAddressedAgentsActive: persistentAudience.enabled,
+        explicitMentionPubkeys,
+        explicitAgentPubkeys,
+        currentAgentPubkey,
+        channelMemberPubkeys: channelMemberPubkeyList,
+        verifiedChannelAgentPubkeys,
+        persistentThreadAudience: [...persistentAudience.pubkeys],
+        threadRootEventId,
+        recipientLoadError:
+          !mentions.hasResolvedMembers && conversationKind === "channel",
+      }),
+    [
+      channelMemberPubkeyList,
+      conversationKind,
+      currentAgentPubkey,
+      mentions.hasResolvedMembers,
+      persistentAudience.enabled,
+      persistentAudience.pubkeys,
+      unaddressedMode,
+      verifiedChannelAgentPubkeys,
+    ],
+  );
+
+  const composerAudienceHint = React.useMemo(() => {
+    if (editTarget != null || conversationKind === "direct") return null;
+    const text = richText.getPlainTextAndCursor().text;
+    const explicitMentionPubkeys = mentions.extractMentionPubkeys(text);
+    const explicitAgentPubkeys = explicitMentionPubkeys.filter((pk) =>
+      mentions.isAgentPubkey(pk),
+    );
+    const decision = resolveComposerAudience({
+      explicitMentionPubkeys,
+      explicitAgentPubkeys,
+      messagePosition: audienceThreadRootId ? "in-thread" : "top-level",
+      threadRootEventId: audienceThreadRootId,
+    });
+    return describeComposerAudienceHint({
+      conversation: conversationKind,
+      unaddressedMode,
+      explicitAgentCount: explicitAgentPubkeys.length,
+      implicitAgentCount:
+        explicitAgentPubkeys.length > 0
+          ? 0
+          : decision.agentAudiencePubkeys.length,
+      retainDraft: decision.retainDraft,
+    });
+  }, [
+    audienceThreadRootId,
+    conversationKind,
+    editTarget,
+    mentions,
+    resolveComposerAudience,
+    richText,
+    unaddressedMode,
+  ]);
+
+  const onSuccessfulExplicitAgentAudience =
+    persistentAudience.enabled && ownerPubkey
+      ? ({
+          channelId: successfulChannelId,
+          ...promotion
+        }: {
+          channelId: string;
+          expectedGeneration: number;
+          expectedRevision: number | null;
+          explicitAgentPubkeys: string[];
+        }) => {
+          const scope = getPersistentAgentAudienceScope({
+            ownerPubkey,
+            channelId: successfulChannelId,
+            threadRootId: audienceThreadRootId,
+          });
+          persistentAudience.promotePubkeys({ ...promotion, scope });
+        }
+      : undefined;
+
+  return {
+    composerAudienceHint,
+    audienceGeneration: persistentAudience.generation,
+    audienceRevision: persistentAudience.revision,
+    resolveComposerAudience,
+    onSuccessfulExplicitAgentAudience,
+    resolvePostSendContent: persistentMentionHydration.resolvePostSendContent,
+  };
+}

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -13,6 +13,7 @@ import {
 import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
 import { useAddChannelMembersMutation } from "@/features/channels/hooks";
 import { filterEffectiveExplicitAgentPubkeys } from "@/features/messages/lib/effectiveExplicitAgentPubkeys";
+import type { ComposerSendAudienceResult } from "@/features/messages/lib/composerSendAudience";
 import type { UseChannelLinksResult } from "@/features/messages/lib/useChannelLinks";
 import type { UseEmojiAutocompleteResult } from "@/features/messages/lib/useEmojiAutocomplete";
 import {
@@ -109,6 +110,16 @@ type UseMentionSendFlowOptions = {
     explicitAgentPubkeys: string[];
   }) => void;
   resolvePostSendContent?: (effectiveExplicitAgentPubkeys: string[]) => string;
+  /**
+   * Optional contextual-agent audience resolver. When provided, merges
+   * implicit channel-agent audience into the outgoing p-tag set.
+   */
+  resolveComposerAudience?: (input: {
+    explicitMentionPubkeys: string[];
+    explicitAgentPubkeys: string[];
+    messagePosition: "top-level" | "in-thread";
+    threadRootEventId: string | null;
+  }) => ComposerSendAudienceResult;
 };
 
 function mergeOutgoingTagsWithReferenceMentions(
@@ -165,6 +176,7 @@ export function useMentionSendFlow({
   setSpoileredAttachmentUrls,
   onSuccessfulExplicitAgentAudience,
   resolvePostSendContent,
+  resolveComposerAudience,
 }: UseMentionSendFlowOptions) {
   const [pendingNonMemberSend, setPendingNonMemberSend] =
     React.useState<PendingNonMemberMentionSend | null>(null);
@@ -720,7 +732,34 @@ export function useMentionSendFlow({
             mentions.isAgentPubkey(pubkey) ||
             createdPersonaAgentPubkeySet.has(pubkey),
         );
-        const pubkeys = explicitMentionPubkeys;
+        const messagePosition =
+          capturedThreadContext?.parentEventId ||
+          capturedThreadContext?.threadHeadId
+            ? "in-thread"
+            : "top-level";
+        const threadRootEventId =
+          capturedThreadContext?.threadHeadId ??
+          capturedThreadContext?.parentEventId ??
+          null;
+        const audienceDecision = resolveComposerAudience?.({
+          explicitMentionPubkeys,
+          explicitAgentPubkeys,
+          messagePosition,
+          threadRootEventId,
+        });
+        if (audienceDecision?.retainDraft) {
+          setNonMemberPromptError(
+            "Could not resolve agent audience. Your draft was kept.",
+          );
+          toast.error("Could not resolve agent audience. Your draft was kept.");
+          return;
+        }
+        const pubkeys = audienceDecision
+          ? uniqueNormalizedPubkeys([
+              ...audienceDecision.mentionPubkeys,
+              ...createdPersonaAgentPubkeys,
+            ])
+          : explicitMentionPubkeys;
         const { content: finalContent, mediaTags } = buildOutgoingMessage(
           trimmed,
           pendingImeta,
@@ -794,6 +833,7 @@ export function useMentionSendFlow({
       mentions.isAgentPubkey,
       mentions.isManagedAgentPubkey,
       onPrepareSendChannel,
+      resolveComposerAudience,
     ],
   );
 

--- a/desktop/src/features/settings/ui/PreventSleepSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/PreventSleepSettingsCard.tsx
@@ -1,16 +1,28 @@
 import { usePreventSleepContext } from "@/features/agents/usePreventSleep";
-import { Switch } from "@/shared/ui/switch";
-import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import type { UnaddressedChannelAgentMode } from "@/features/channels/lib/contextualAgentConversationPolicy";
+import { useUnaddressedChannelAgentMode } from "@/features/channels/lib/unaddressedChannelAgentMode";
 import {
   setPersistentAgentAudienceEnabled,
   usePersistentAgentAudience,
 } from "@/features/messages/lib/persistentAgentAudience";
+import { Switch } from "@/shared/ui/switch";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
+
+const UNADDRESSED_MODE_OPTIONS: {
+  value: UnaddressedChannelAgentMode;
+  label: string;
+}[] = [
+  { value: "all-channel-agents", label: "Notify all channel agents" },
+  { value: "mentions-only", label: "Mentions only" },
+];
 
 export function PreventSleepSettingsCard() {
   const { enabled, setEnabled, hasRunningAgents, expired, clearExpired } =
     usePreventSleepContext();
   const persistentAudience = usePersistentAgentAudience(null);
+  const { mode: unaddressedMode, setMode: setUnaddressedMode } =
+    useUnaddressedChannelAgentMode();
 
   return (
     <section className="min-w-0" data-testid="settings-agents">
@@ -20,6 +32,47 @@ export function PreventSleepSettingsCard() {
       />
 
       <SettingsOptionGroup>
+        <SettingsOptionRow className="items-start">
+          <div className="min-w-0 flex-1">
+            <p
+              className="text-sm font-medium"
+              id="unaddressed-channel-agents-label"
+            >
+              Unaddressed channel messages
+            </p>
+            <p className="text-sm font-normal text-muted-foreground">
+              When you post in a channel without @mentioning anyone, choose who
+              is notified. Direct messages always address their current agent.
+            </p>
+            <div
+              aria-labelledby="unaddressed-channel-agents-label"
+              className="mt-3 flex flex-col gap-2"
+              data-testid="unaddressed-channel-agent-mode"
+              role="radiogroup"
+            >
+              {UNADDRESSED_MODE_OPTIONS.map((option) => (
+                <label
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                  htmlFor={`unaddressed-mode-${option.value}`}
+                  key={option.value}
+                >
+                  <input
+                    checked={unaddressedMode === option.value}
+                    className="size-4 accent-primary"
+                    data-testid={`unaddressed-mode-${option.value}`}
+                    id={`unaddressed-mode-${option.value}`}
+                    name="unaddressed-channel-agent-mode"
+                    onChange={() => setUnaddressedMode(option.value)}
+                    type="radio"
+                    value={option.value}
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </SettingsOptionRow>
+
         <SettingsOptionRow>
           <div className="min-w-0">
             <label

--- a/desktop/tests/e2e/unaddressed-channel-agent-mode.spec.ts
+++ b/desktop/tests/e2e/unaddressed-channel-agent-mode.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+import { openSettings } from "../helpers/settings";
+
+test.describe("unaddressed channel agent mode", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockBridge(page);
+  });
+
+  test("settings agents section exposes unaddressed mode radios", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "agents");
+
+    const agents = page.getByTestId("settings-agents");
+    await agents.scrollIntoViewIfNeeded();
+    await expect(agents).toBeVisible();
+
+    const group = page.getByTestId("unaddressed-channel-agent-mode");
+    await expect(group).toBeVisible();
+
+    const allAgents = page.getByTestId("unaddressed-mode-all-channel-agents");
+    const mentionsOnly = page.getByTestId("unaddressed-mode-mentions-only");
+    await expect(allAgents).toBeChecked();
+    await expect(mentionsOnly).not.toBeChecked();
+
+    await mentionsOnly.check();
+    await expect(mentionsOnly).toBeChecked();
+    await expect(allAgents).not.toBeChecked();
+
+    // Persist across settings re-open (device-local).
+    await page.keyboard.press("Escape");
+    await openSettings(page, "agents");
+    await expect(
+      page.getByTestId("unaddressed-mode-mentions-only"),
+    ).toBeChecked();
+
+    await waitForAnimations(page);
+  });
+});

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -1,10 +1,16 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/contextual_agent/composer_send_audience.dart';
+import '../../shared/contextual_agent/contextual_agent_conversation_policy.dart';
+import '../../shared/contextual_agent/unaddressed_channel_agent_mode.dart';
+import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../channels/channel_management_provider.dart';
 import '../profile/user_cache_provider.dart';
 import '../profile/user_profile.dart';
+import 'channel.dart';
 import 'channel_messages_provider.dart';
+import 'channels_provider.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
@@ -16,6 +22,9 @@ class SendMessage {
   final void Function(String channelId, String eventId) _completeLocalMessage;
   final void Function(String channelId, String eventId) _removeLocalMessage;
   final bool Function()? _isDeliveryValid;
+  final UnaddressedChannelAgentMode Function() _readUnaddressedMode;
+  final Future<List<AgentDirectoryEntry>> Function() _fetchAgentDirectory;
+  final Channel? Function(String channelId) _readChannel;
 
   SendMessage({
     required SignedEventRelay signedEventRelay,
@@ -27,13 +36,19 @@ class SendMessage {
     completeLocalMessage,
     required void Function(String channelId, String eventId) removeLocalMessage,
     bool Function()? isDeliveryValid,
+    required UnaddressedChannelAgentMode Function() readUnaddressedMode,
+    required Future<List<AgentDirectoryEntry>> Function() fetchAgentDirectory,
+    required Channel? Function(String channelId) readChannel,
   }) : _signedEventRelay = signedEventRelay,
        _fetchMembers = fetchMembers,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
        _completeLocalMessage = completeLocalMessage,
        _removeLocalMessage = removeLocalMessage,
-       _isDeliveryValid = isDeliveryValid;
+       _isDeliveryValid = isDeliveryValid,
+       _readUnaddressedMode = readUnaddressedMode,
+       _fetchAgentDirectory = fetchAgentDirectory,
+       _readChannel = readChannel;
 
   /// Send a text message to a channel.
   ///
@@ -61,10 +76,17 @@ class SendMessage {
     // the desktop's normalizeMentionPubkeys).
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
-    final normalizedMentions = <String>[
+    final explicitMentions = <String>[
       for (final pk in resolvedMentions)
-        if (seenMentions.add(pk.toLowerCase())) pk,
+        if (seenMentions.add(pk.toLowerCase())) pk.toLowerCase(),
     ];
+
+    final normalizedMentions = await _mergeContextualAudience(
+      channelId: channelId,
+      explicitMentions: explicitMentions,
+      parentEventId: parentEventId,
+      rootEventId: rootEventId,
+    );
 
     final tags = <List<String>>[
       ['h', channelId],
@@ -153,6 +175,74 @@ class SendMessage {
     return pubkeys.toList();
   }
 
+  /// Merge explicit mentions with the unaddressed-channel agent policy.
+  Future<List<String>> _mergeContextualAudience({
+    required String channelId,
+    required List<String> explicitMentions,
+    String? parentEventId,
+    String? rootEventId,
+  }) async {
+    List<ChannelMember> members;
+    var memberLoadError = false;
+    try {
+      members = await _fetchMembers(channelId);
+    } catch (_) {
+      memberLoadError = true;
+      members = const [];
+    }
+
+    final directory = await _fetchAgentDirectory();
+    final directoryPubkeys = {
+      for (final agent in directory) agent.pubkey.toLowerCase(),
+    };
+    final memberPubkeys = [for (final m in members) m.pubkey.toLowerCase()];
+    final verifiedAgents = [
+      for (final m in members)
+        if (m.isBot || directoryPubkeys.contains(m.pubkey.toLowerCase()))
+          m.pubkey.toLowerCase(),
+    ];
+    final explicitAgentPubkeys = [
+      for (final pk in explicitMentions)
+        if (verifiedAgents.contains(pk) || directoryPubkeys.contains(pk)) pk,
+    ];
+
+    final channel = _readChannel(channelId);
+    final isDm = channel?.isDm == true;
+    final conversation = isDm ? 'direct' : 'channel';
+    final messagePosition = parentEventId != null ? 'in-thread' : 'top-level';
+    String? currentAgent;
+    if (isDm) {
+      final self = _signedEventRelay.pubkey?.toLowerCase();
+      final others = [
+        for (final pk in verifiedAgents)
+          if (pk != self) pk,
+      ];
+      currentAgent = others.isEmpty ? null : others.first;
+    }
+
+    final result = resolveComposerSendAudience(
+      conversation: conversation,
+      messagePosition: messagePosition,
+      unaddressedMode: _readUnaddressedMode(),
+      keepAddressedAgentsActive: false,
+      explicitMentionPubkeys: explicitMentions,
+      explicitAgentPubkeys: explicitAgentPubkeys,
+      currentAgentPubkey: currentAgent,
+      channelMemberPubkeys: memberPubkeys,
+      verifiedChannelAgentPubkeys: verifiedAgents,
+      persistentThreadAudience: const [],
+      threadRootEventId: rootEventId ?? parentEventId,
+      recipientLoadError: memberLoadError && !isDm,
+    );
+
+    if (result.retainDraft) {
+      throw StateError(
+        'Could not resolve agent audience. Your draft was kept.',
+      );
+    }
+    return result.mentionPubkeys;
+  }
+
   /// Build `e`-tags for a thread reply, matching the desktop convention:
   /// - Direct reply to thread head: `["e", id, "", "reply"]`
   /// - Nested reply: `["e", rootId, "", "root"]` + `["e", parentId, "", "reply"]`
@@ -196,6 +286,22 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
       final currentConfig = ref.read(relayConfigProvider);
       return currentConfig.baseUrl == config.baseUrl &&
           currentConfig.nsec == config.nsec;
+    },
+    readUnaddressedMode: () => ref.read(unaddressedChannelAgentModeProvider),
+    fetchAgentDirectory: () async {
+      try {
+        return await ref.read(agentDirectoryProvider.future);
+      } catch (_) {
+        return const [];
+      }
+    },
+    readChannel: (channelId) {
+      final channels = ref.read(channelsProvider).asData?.value;
+      if (channels == null) return null;
+      for (final c in channels) {
+        if (c.id == channelId) return c;
+      }
+      return null;
     },
   );
 });

--- a/mobile/lib/features/settings/settings_page.dart
+++ b/mobile/lib/features/settings/settings_page.dart
@@ -7,6 +7,8 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../../shared/auth/auth.dart';
 import '../../shared/clipboard_utils.dart';
+import '../../shared/contextual_agent/contextual_agent_conversation_policy.dart';
+import '../../shared/contextual_agent/unaddressed_channel_agent_mode.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/app_list.dart';
@@ -16,6 +18,7 @@ import '../../shared/widgets/frosted_scaffold.dart';
 import 'accent_picker_page.dart';
 import 'theme_picker_page.dart';
 
+part 'settings_page/agents_section.dart';
 part 'settings_page/appearance_section.dart';
 part 'settings_page/connection_section.dart';
 
@@ -42,6 +45,7 @@ class SettingsPage extends HookConsumerWidget {
               children: [
                 profileHeader,
                 const _AppearanceSection(),
+                const _AgentsSection(),
                 const _ConnectionSection(),
                 const _RemoveCommunitySection(),
               ],

--- a/mobile/lib/features/settings/settings_page/agents_section.dart
+++ b/mobile/lib/features/settings/settings_page/agents_section.dart
@@ -1,0 +1,96 @@
+part of '../settings_page.dart';
+
+class _AgentsSection extends ConsumerWidget {
+  const _AgentsSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(unaddressedChannelAgentModeProvider);
+
+    return AppListCard(
+      label: 'Agents',
+      children: [
+        AppListRow(
+          icon: LucideIcons.bot,
+          title: 'Unaddressed channel messages',
+          value: mode == UnaddressedChannelAgentMode.mentionsOnly
+              ? 'Mentions only'
+              : 'Notify all channel agents',
+          trailing: const _RowChevron(),
+          onTap: () => _showUnaddressedModeSheet(context),
+        ),
+      ],
+    );
+  }
+}
+
+void _showUnaddressedModeSheet(BuildContext context) {
+  showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (_) => const _UnaddressedModeSheet(),
+  );
+}
+
+class _UnaddressedModeSheet extends ConsumerWidget {
+  const _UnaddressedModeSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(unaddressedChannelAgentModeProvider);
+    final notifier = ref.read(unaddressedChannelAgentModeProvider.notifier);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              Grid.gutter,
+              Grid.xs,
+              Grid.gutter,
+              Grid.xxs,
+            ),
+            child: Text(
+              'Unaddressed channel messages',
+              style: context.textTheme.titleMedium,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              Grid.gutter,
+              0,
+              Grid.gutter,
+              Grid.sm,
+            ),
+            child: Text(
+              'When you post in a channel without @mentioning anyone, choose who is notified.',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+          for (final option in const [
+            (
+              UnaddressedChannelAgentMode.allChannelAgents,
+              'Notify all channel agents',
+            ),
+            (UnaddressedChannelAgentMode.mentionsOnly, 'Mentions only'),
+          ])
+            ListTile(
+              title: Text(option.$2),
+              trailing: mode == option.$1
+                  ? Icon(LucideIcons.check, color: context.colors.primary)
+                  : null,
+              onTap: () {
+                notifier.setMode(option.$1);
+                Navigator.of(context).pop();
+              },
+            ),
+          const SizedBox(height: Grid.sm),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/contextual_agent/composer_send_audience.dart
+++ b/mobile/lib/shared/contextual_agent/composer_send_audience.dart
@@ -56,7 +56,12 @@ ComposerSendAudienceResult resolveComposerSendAudience({
     ),
   );
 
-  final agentAudience = _uniqueNormalized(decision.audiencePubkeys);
+  // Always retain authored agent @mentions (DM expansion to a new agent)
+  // while still applying implicit/persistent audience from policy.
+  final agentAudience = _uniqueNormalized([
+    ...decision.audiencePubkeys,
+    ...explicitAgentSet,
+  ]);
   final humanMentions = _uniqueNormalized(
     explicitMentionPubkeys,
   ).where((pk) => !explicitAgentSet.contains(pk)).toList();

--- a/mobile/lib/shared/contextual_agent/composer_send_audience.dart
+++ b/mobile/lib/shared/contextual_agent/composer_send_audience.dart
@@ -1,0 +1,69 @@
+import 'contextual_agent_conversation_policy.dart';
+
+/// Merge explicit mentions with implicit contextual-agent audience (Desktop parity).
+class ComposerSendAudienceResult {
+  const ComposerSendAudienceResult({
+    required this.mentionPubkeys,
+    required this.agentAudiencePubkeys,
+    required this.retainDraft,
+  });
+
+  final List<String> mentionPubkeys;
+  final List<String> agentAudiencePubkeys;
+  final bool retainDraft;
+}
+
+List<String> _uniqueNormalized(Iterable<String> pubkeys) {
+  final set = <String>{};
+  for (final pk in pubkeys) {
+    final n = pk.trim().toLowerCase();
+    if (n.isNotEmpty) set.add(n);
+  }
+  return set.toList();
+}
+
+ComposerSendAudienceResult resolveComposerSendAudience({
+  required String conversation,
+  required String messagePosition,
+  required UnaddressedChannelAgentMode unaddressedMode,
+  required bool keepAddressedAgentsActive,
+  required List<String> explicitMentionPubkeys,
+  required List<String> explicitAgentPubkeys,
+  required String? currentAgentPubkey,
+  required List<String> channelMemberPubkeys,
+  required List<String> verifiedChannelAgentPubkeys,
+  required List<String> persistentThreadAudience,
+  List<String> manualRemovedPubkeys = const [],
+  String? threadRootEventId,
+  bool recipientLoadError = false,
+}) {
+  final explicitAgentSet = _uniqueNormalized(explicitAgentPubkeys).toSet();
+  final decision = resolveContextualAgentConversation(
+    ContextualAgentConversationInput(
+      conversation: conversation,
+      messagePosition: messagePosition,
+      senderClass: 'human',
+      unaddressedMode: unaddressedMode,
+      keepAddressedAgentsActive: keepAddressedAgentsActive,
+      explicitMentionPubkeys: explicitAgentSet.toList(),
+      currentAgentPubkey: currentAgentPubkey,
+      channelMemberPubkeys: channelMemberPubkeys,
+      verifiedChannelAgentPubkeys: verifiedChannelAgentPubkeys,
+      threadRootEventId: threadRootEventId,
+      persistentThreadAudience: persistentThreadAudience,
+      manualRemovedPubkeys: manualRemovedPubkeys,
+      recipientLoadError: recipientLoadError,
+    ),
+  );
+
+  final agentAudience = _uniqueNormalized(decision.audiencePubkeys);
+  final humanMentions = _uniqueNormalized(
+    explicitMentionPubkeys,
+  ).where((pk) => !explicitAgentSet.contains(pk)).toList();
+
+  return ComposerSendAudienceResult(
+    mentionPubkeys: _uniqueNormalized([...humanMentions, ...agentAudience]),
+    agentAudiencePubkeys: agentAudience,
+    retainDraft: decision.retainDraft,
+  );
+}

--- a/mobile/lib/shared/contextual_agent/contextual_agent_conversation_policy.dart
+++ b/mobile/lib/shared/contextual_agent/contextual_agent_conversation_policy.dart
@@ -1,0 +1,197 @@
+/// Contextual agent audience + reply-placement policy (Flutter).
+///
+/// Contract: tests/fixtures/contextual-agent-conversation-cases.json
+/// Pure resolver — composer/settings wiring comes in later Flutter leaves.
+
+enum UnaddressedChannelAgentMode {
+  allChannelAgents,
+  mentionsOnly,
+}
+
+sealed class ReplyPlacement {
+  const ReplyPlacement();
+}
+
+class TopLevelPlacement extends ReplyPlacement {
+  const TopLevelPlacement();
+}
+
+class ThreadRootPlacement extends ReplyPlacement {
+  const ThreadRootPlacement(this.eventId);
+  final String eventId;
+}
+
+class UnconstrainedPlacement extends ReplyPlacement {
+  const UnconstrainedPlacement();
+}
+
+class ContextualAgentConversationInput {
+  const ContextualAgentConversationInput({
+    required this.conversation,
+    required this.messagePosition,
+    required this.senderClass,
+    required this.unaddressedMode,
+    required this.keepAddressedAgentsActive,
+    required this.explicitMentionPubkeys,
+    required this.currentAgentPubkey,
+    required this.channelMemberPubkeys,
+    required this.verifiedChannelAgentPubkeys,
+    this.unverifiedAgentPubkeys = const [],
+    this.nonMemberAgentPubkeys = const [],
+    required this.threadRootEventId,
+    this.replyingUnderEventId,
+    required this.persistentThreadAudience,
+    required this.manualRemovedPubkeys,
+    required this.recipientLoadError,
+    this.humanMessageEventId,
+  });
+
+  final String conversation;
+  final String messagePosition;
+  final String senderClass;
+  final UnaddressedChannelAgentMode unaddressedMode;
+  final bool keepAddressedAgentsActive;
+  final List<String> explicitMentionPubkeys;
+  final String? currentAgentPubkey;
+  final List<String> channelMemberPubkeys;
+  final List<String> verifiedChannelAgentPubkeys;
+  final List<String> unverifiedAgentPubkeys;
+  final List<String> nonMemberAgentPubkeys;
+  final String? threadRootEventId;
+  final String? replyingUnderEventId;
+  final List<String> persistentThreadAudience;
+  final List<String> manualRemovedPubkeys;
+  final bool recipientLoadError;
+  final String? humanMessageEventId;
+}
+
+class ContextualAgentConversationDecision {
+  const ContextualAgentConversationDecision({
+    required this.audiencePubkeys,
+    required this.replyPlacement,
+    required this.sharedThread,
+    required this.retainDraft,
+    this.nestUnderAgentReply = false,
+  });
+
+  final List<String> audiencePubkeys;
+  final ReplyPlacement replyPlacement;
+  final bool sharedThread;
+  final bool retainDraft;
+  final bool nestUnderAgentReply;
+}
+
+String _normalizePubkey(String pubkey) => pubkey.trim().toLowerCase();
+
+List<String> _uniqueSorted(Iterable<String> pubkeys) {
+  final set = <String>{};
+  for (final pk in pubkeys) {
+    final n = _normalizePubkey(pk);
+    if (n.isNotEmpty) set.add(n);
+  }
+  final list = set.toList()..sort();
+  return list;
+}
+
+Set<String> _eligibleChannelAgents(ContextualAgentConversationInput input) {
+  final members = input.channelMemberPubkeys.map(_normalizePubkey).toSet();
+  return input.verifiedChannelAgentPubkeys
+      .map(_normalizePubkey)
+      .where(members.contains)
+      .toSet();
+}
+
+List<String> _filterToEligible(
+  List<String> candidates,
+  Set<String> eligible,
+) {
+  return _uniqueSorted(
+    candidates.map(_normalizePubkey).where(eligible.contains),
+  );
+}
+
+ReplyPlacement _placementFor(
+  ContextualAgentConversationInput input,
+  int audienceCount,
+) {
+  if (input.messagePosition == 'in-thread' &&
+      input.threadRootEventId != null &&
+      input.threadRootEventId!.isNotEmpty) {
+    return ThreadRootPlacement(input.threadRootEventId!);
+  }
+  if (audienceCount >= 2) {
+    final eventId = input.humanMessageEventId ?? input.threadRootEventId;
+    if (eventId != null && eventId.isNotEmpty) {
+      return ThreadRootPlacement(eventId);
+    }
+  }
+  return const TopLevelPlacement();
+}
+
+/// Resolve audience and reply placement for a human/agent send path.
+ContextualAgentConversationDecision resolveContextualAgentConversation(
+  ContextualAgentConversationInput input,
+) {
+  if (input.recipientLoadError) {
+    return const ContextualAgentConversationDecision(
+      audiencePubkeys: [],
+      replyPlacement: TopLevelPlacement(),
+      sharedThread: false,
+      retainDraft: true,
+    );
+  }
+
+  if (input.senderClass == 'agent') {
+    return const ContextualAgentConversationDecision(
+      audiencePubkeys: [],
+      replyPlacement: UnconstrainedPlacement(),
+      sharedThread: false,
+      retainDraft: false,
+    );
+  }
+
+  if (input.conversation == 'direct') {
+    final current = input.currentAgentPubkey;
+    final audience =
+        current == null || current.isEmpty ? <String>[] : [_normalizePubkey(current)];
+    return ContextualAgentConversationDecision(
+      audiencePubkeys: audience,
+      replyPlacement: _placementFor(input, audience.length),
+      sharedThread: false,
+      retainDraft: false,
+    );
+  }
+
+  final eligible = _eligibleChannelAgents(input);
+  final removed = input.manualRemovedPubkeys.map(_normalizePubkey).toSet();
+
+  final explicit = _filterToEligible(input.explicitMentionPubkeys, eligible)
+      .where((pk) => !removed.contains(pk))
+      .toList();
+
+  late final List<String> audience;
+  if (explicit.isNotEmpty) {
+    audience = explicit;
+  } else {
+    final persistent = input.keepAddressedAgentsActive
+        ? _filterToEligible(input.persistentThreadAudience, eligible)
+            .where((pk) => !removed.contains(pk))
+            .toList()
+        : <String>[];
+    if (persistent.isNotEmpty) {
+      audience = persistent;
+    } else if (input.unaddressedMode ==
+        UnaddressedChannelAgentMode.allChannelAgents) {
+      audience = _uniqueSorted(eligible).where((pk) => !removed.contains(pk)).toList();
+    } else {
+      audience = [];
+    }
+  }
+
+  return ContextualAgentConversationDecision(
+    audiencePubkeys: audience,
+    replyPlacement: _placementFor(input, audience.length),
+    sharedThread: audience.length >= 2,
+    retainDraft: false,
+  );
+}

--- a/mobile/lib/shared/contextual_agent/contextual_agent_conversation_policy.dart
+++ b/mobile/lib/shared/contextual_agent/contextual_agent_conversation_policy.dart
@@ -1,12 +1,9 @@
-/// Contextual agent audience + reply-placement policy (Flutter).
-///
-/// Contract: tests/fixtures/contextual-agent-conversation-cases.json
-/// Pure resolver — composer/settings wiring comes in later Flutter leaves.
+// Contextual agent audience + reply-placement policy (Flutter).
+//
+// Contract: tests/fixtures/contextual-agent-conversation-cases.json
+// Pure resolver plus send-path helpers for unaddressed-channel mode.
 
-enum UnaddressedChannelAgentMode {
-  allChannelAgents,
-  mentionsOnly,
-}
+enum UnaddressedChannelAgentMode { allChannelAgents, mentionsOnly }
 
 sealed class ReplyPlacement {
   const ReplyPlacement();
@@ -101,10 +98,7 @@ Set<String> _eligibleChannelAgents(ContextualAgentConversationInput input) {
       .toSet();
 }
 
-List<String> _filterToEligible(
-  List<String> candidates,
-  Set<String> eligible,
-) {
+List<String> _filterToEligible(List<String> candidates, Set<String> eligible) {
   return _uniqueSorted(
     candidates.map(_normalizePubkey).where(eligible.contains),
   );
@@ -152,8 +146,9 @@ ContextualAgentConversationDecision resolveContextualAgentConversation(
 
   if (input.conversation == 'direct') {
     final current = input.currentAgentPubkey;
-    final audience =
-        current == null || current.isEmpty ? <String>[] : [_normalizePubkey(current)];
+    final audience = current == null || current.isEmpty
+        ? <String>[]
+        : [_normalizePubkey(current)];
     return ContextualAgentConversationDecision(
       audiencePubkeys: audience,
       replyPlacement: _placementFor(input, audience.length),
@@ -165,24 +160,28 @@ ContextualAgentConversationDecision resolveContextualAgentConversation(
   final eligible = _eligibleChannelAgents(input);
   final removed = input.manualRemovedPubkeys.map(_normalizePubkey).toSet();
 
-  final explicit = _filterToEligible(input.explicitMentionPubkeys, eligible)
-      .where((pk) => !removed.contains(pk))
-      .toList();
+  final explicit = _filterToEligible(
+    input.explicitMentionPubkeys,
+    eligible,
+  ).where((pk) => !removed.contains(pk)).toList();
 
   late final List<String> audience;
   if (explicit.isNotEmpty) {
     audience = explicit;
   } else {
     final persistent = input.keepAddressedAgentsActive
-        ? _filterToEligible(input.persistentThreadAudience, eligible)
-            .where((pk) => !removed.contains(pk))
-            .toList()
+        ? _filterToEligible(
+            input.persistentThreadAudience,
+            eligible,
+          ).where((pk) => !removed.contains(pk)).toList()
         : <String>[];
     if (persistent.isNotEmpty) {
       audience = persistent;
     } else if (input.unaddressedMode ==
         UnaddressedChannelAgentMode.allChannelAgents) {
-      audience = _uniqueSorted(eligible).where((pk) => !removed.contains(pk)).toList();
+      audience = _uniqueSorted(
+        eligible,
+      ).where((pk) => !removed.contains(pk)).toList();
     } else {
       audience = [];
     }

--- a/mobile/lib/shared/contextual_agent/unaddressed_channel_agent_mode.dart
+++ b/mobile/lib/shared/contextual_agent/unaddressed_channel_agent_mode.dart
@@ -1,0 +1,55 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../theme/theme_provider.dart';
+import 'contextual_agent_conversation_policy.dart';
+
+/// Versioned device-local key (matches Desktop).
+const unaddressedChannelAgentModeStorageKey =
+    'buzz:unaddressed-channel-agent-mode:v1';
+
+UnaddressedChannelAgentMode parseUnaddressedChannelAgentMode(String? raw) {
+  switch (raw) {
+    case 'mentions-only':
+      return UnaddressedChannelAgentMode.mentionsOnly;
+    case 'all-channel-agents':
+    default:
+      return UnaddressedChannelAgentMode.allChannelAgents;
+  }
+}
+
+String unaddressedChannelAgentModeToStorage(UnaddressedChannelAgentMode mode) {
+  switch (mode) {
+    case UnaddressedChannelAgentMode.mentionsOnly:
+      return 'mentions-only';
+    case UnaddressedChannelAgentMode.allChannelAgents:
+      return 'all-channel-agents';
+  }
+}
+
+class UnaddressedChannelAgentModeNotifier
+    extends Notifier<UnaddressedChannelAgentMode> {
+  @override
+  UnaddressedChannelAgentMode build() {
+    final prefs = ref.read(savedPrefsProvider);
+    return parseUnaddressedChannelAgentMode(
+      prefs.getString(unaddressedChannelAgentModeStorageKey),
+    );
+  }
+
+  void setMode(UnaddressedChannelAgentMode mode) {
+    if (state == mode) return;
+    state = mode;
+    ref
+        .read(savedPrefsProvider)
+        .setString(
+          unaddressedChannelAgentModeStorageKey,
+          unaddressedChannelAgentModeToStorage(mode),
+        );
+  }
+}
+
+final unaddressedChannelAgentModeProvider =
+    NotifierProvider<
+      UnaddressedChannelAgentModeNotifier,
+      UnaddressedChannelAgentMode
+    >(UnaddressedChannelAgentModeNotifier.new);

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:buzz/shared/contextual_agent/contextual_agent_conversation_policy.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -24,6 +25,10 @@ void main() {
         addLocalMessage: (_, event) => localMessages.add(event),
         completeLocalMessage: (_, eventId) => completedIds.add(eventId),
         removeLocalMessage: (_, eventId) => removedIds.add(eventId),
+        readUnaddressedMode: () =>
+            UnaddressedChannelAgentMode.mentionsOnly,
+        fetchAgentDirectory: () async => const [],
+        readChannel: (_) => null,
       );
 
       final result = send(channelId: _channelId, content: 'hello');
@@ -57,6 +62,9 @@ void main() {
       addLocalMessage: (_, event) => localMessages.add(event),
       completeLocalMessage: (_, eventId) => completedIds.add(eventId),
       removeLocalMessage: (_, eventId) => removedIds.add(eventId),
+      readUnaddressedMode: () => UnaddressedChannelAgentMode.mentionsOnly,
+      fetchAgentDirectory: () async => const [],
+      readChannel: (_) => null,
     );
 
     final result = send(channelId: _channelId, content: 'hello');

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -25,8 +25,7 @@ void main() {
         addLocalMessage: (_, event) => localMessages.add(event),
         completeLocalMessage: (_, eventId) => completedIds.add(eventId),
         removeLocalMessage: (_, eventId) => removedIds.add(eventId),
-        readUnaddressedMode: () =>
-            UnaddressedChannelAgentMode.mentionsOnly,
+        readUnaddressedMode: () => UnaddressedChannelAgentMode.mentionsOnly,
         fetchAgentDirectory: () async => const [],
         readChannel: (_) => null,
       );

--- a/mobile/test/shared/contextual_agent/composer_send_audience_test.dart
+++ b/mobile/test/shared/contextual_agent/composer_send_audience_test.dart
@@ -1,0 +1,64 @@
+import 'package:buzz/shared/contextual_agent/composer_send_audience.dart';
+import 'package:buzz/shared/contextual_agent/contextual_agent_conversation_policy.dart';
+import 'package:buzz/shared/contextual_agent/unaddressed_channel_agent_mode.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const human =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const agentA =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const agentB =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  test('all-channel-agents merges verified agents', () {
+    final result = resolveComposerSendAudience(
+      conversation: 'channel',
+      messagePosition: 'top-level',
+      unaddressedMode: UnaddressedChannelAgentMode.allChannelAgents,
+      keepAddressedAgentsActive: false,
+      explicitMentionPubkeys: const [],
+      explicitAgentPubkeys: const [],
+      currentAgentPubkey: null,
+      channelMemberPubkeys: const [human, agentA, agentB],
+      verifiedChannelAgentPubkeys: const [agentA, agentB],
+      persistentThreadAudience: const [],
+    );
+    expect(result.agentAudiencePubkeys.toSet(), {agentA, agentB});
+    expect(result.retainDraft, isFalse);
+  });
+
+  test('mentions-only leaves agents empty without explicit', () {
+    final result = resolveComposerSendAudience(
+      conversation: 'channel',
+      messagePosition: 'top-level',
+      unaddressedMode: UnaddressedChannelAgentMode.mentionsOnly,
+      keepAddressedAgentsActive: false,
+      explicitMentionPubkeys: const [human],
+      explicitAgentPubkeys: const [],
+      currentAgentPubkey: null,
+      channelMemberPubkeys: const [human, agentA],
+      verifiedChannelAgentPubkeys: const [agentA],
+      persistentThreadAudience: const [],
+    );
+    expect(result.agentAudiencePubkeys, isEmpty);
+    expect(result.mentionPubkeys, [human]);
+  });
+
+  test('storage parse round-trip', () {
+    expect(
+      parseUnaddressedChannelAgentMode(null),
+      UnaddressedChannelAgentMode.allChannelAgents,
+    );
+    expect(
+      parseUnaddressedChannelAgentMode('mentions-only'),
+      UnaddressedChannelAgentMode.mentionsOnly,
+    );
+    expect(
+      unaddressedChannelAgentModeToStorage(
+        UnaddressedChannelAgentMode.mentionsOnly,
+      ),
+      'mentions-only',
+    );
+  });
+}

--- a/mobile/test/shared/contextual_agent/contextual_agent_conversation_policy_test.dart
+++ b/mobile/test/shared/contextual_agent/contextual_agent_conversation_policy_test.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:buzz/shared/contextual_agent/contextual_agent_conversation_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> loadFixture() {
+  // Walk up from CWD to the monorepo root fixture.
+  var dir = Directory.current;
+  for (var i = 0; i < 8; i++) {
+    final candidate = File(
+      '${dir.path}/tests/fixtures/contextual-agent-conversation-cases.json',
+    );
+    if (candidate.existsSync()) {
+      return jsonDecode(candidate.readAsStringSync()) as Map<String, dynamic>;
+    }
+    // When tests run with CWD=mobile/, also check the parent monorepo root.
+    final parentCandidate = File(
+      '${dir.path}/../tests/fixtures/contextual-agent-conversation-cases.json',
+    );
+    if (parentCandidate.existsSync()) {
+      return jsonDecode(parentCandidate.readAsStringSync())
+          as Map<String, dynamic>;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail(
+    'could not locate tests/fixtures/contextual-agent-conversation-cases.json',
+  );
+}
+
+UnaddressedChannelAgentMode parseMode(String raw) {
+  switch (raw) {
+    case 'mentions-only':
+      return UnaddressedChannelAgentMode.mentionsOnly;
+    case 'all-channel-agents':
+    default:
+      return UnaddressedChannelAgentMode.allChannelAgents;
+  }
+}
+
+List<String> strList(Map<String, dynamic> map, String key) {
+  final value = map[key];
+  if (value is! List) return const [];
+  return value.map((e) => e.toString()).toList();
+}
+
+String? optStr(Map<String, dynamic> map, String key) {
+  final value = map[key];
+  if (value == null) return null;
+  return value.toString();
+}
+
+ContextualAgentConversationInput parseInput(Map<String, dynamic> input) {
+  return ContextualAgentConversationInput(
+    conversation: input['conversation'] as String,
+    messagePosition: input['messagePosition'] as String,
+    senderClass: input['senderClass'] as String,
+    unaddressedMode: parseMode(input['unaddressedMode'] as String),
+    keepAddressedAgentsActive: input['keepAddressedAgentsActive'] as bool,
+    explicitMentionPubkeys: strList(input, 'explicitMentionPubkeys'),
+    currentAgentPubkey: optStr(input, 'currentAgentPubkey'),
+    channelMemberPubkeys: strList(input, 'channelMemberPubkeys'),
+    verifiedChannelAgentPubkeys: strList(input, 'verifiedChannelAgentPubkeys'),
+    unverifiedAgentPubkeys: strList(input, 'unverifiedAgentPubkeys'),
+    nonMemberAgentPubkeys: strList(input, 'nonMemberAgentPubkeys'),
+    threadRootEventId: optStr(input, 'threadRootEventId'),
+    replyingUnderEventId: optStr(input, 'replyingUnderEventId'),
+    persistentThreadAudience: strList(input, 'persistentThreadAudience'),
+    manualRemovedPubkeys: strList(input, 'manualRemovedPubkeys'),
+    recipientLoadError: input['recipientLoadError'] as bool? ?? false,
+    humanMessageEventId: optStr(input, 'humanMessageEventId'),
+  );
+}
+
+ReplyPlacement parseExpectedPlacement(Map<String, dynamic> expected) {
+  final placement = expected['replyPlacement'] as Map<String, dynamic>;
+  switch (placement['kind'] as String) {
+    case 'thread-root':
+      return ThreadRootPlacement(placement['eventId'] as String);
+    case 'unconstrained':
+      return const UnconstrainedPlacement();
+    case 'top-level':
+    default:
+      return const TopLevelPlacement();
+  }
+}
+
+void main() {
+  final fixture = loadFixture();
+  final cases = (fixture['cases'] as List).cast<Map<String, dynamic>>();
+
+  test('fixture version and case count', () {
+    expect(fixture['version'], 1);
+    expect(cases.length, greaterThanOrEqualTo(12));
+  });
+
+  for (final c in cases) {
+    final id = c['id'] as String;
+    test('contextual fixture (flutter): $id', () {
+      final inputMap = Map<String, dynamic>.from(c['input'] as Map);
+      final expected = c['expected'] as Map<String, dynamic>;
+      final placement = expected['replyPlacement'] as Map<String, dynamic>;
+      if (placement['kind'] == 'thread-root' &&
+          placement['eventId'] == 'human-message-id') {
+        inputMap['humanMessageEventId'] = 'human-message-id';
+      }
+      final input = parseInput(inputMap);
+      final decision = resolveContextualAgentConversation(input);
+
+      final actualAudience = [...decision.audiencePubkeys]..sort();
+      final expectedAudience = strList(expected, 'audiencePubkeys')..sort();
+      expect(actualAudience, expectedAudience, reason: '$id audience');
+
+      final expectedPlacement = parseExpectedPlacement(expected);
+      expect(
+        decision.replyPlacement.runtimeType,
+        expectedPlacement.runtimeType,
+        reason: '$id placement kind',
+      );
+      if (expectedPlacement is ThreadRootPlacement &&
+          decision.replyPlacement is ThreadRootPlacement) {
+        expect(
+          (decision.replyPlacement as ThreadRootPlacement).eventId,
+          expectedPlacement.eventId,
+          reason: '$id thread root id',
+        );
+      }
+
+      expect(
+        decision.sharedThread,
+        expected['sharedThread'],
+        reason: '$id shared',
+      );
+      expect(
+        decision.retainDraft,
+        expected['retainDraft'],
+        reason: '$id retain',
+      );
+      if (expected.containsKey('nestUnderAgentReply')) {
+        expect(
+          decision.nestUnderAgentReply,
+          expected['nestUnderAgentReply'],
+          reason: '$id nest',
+        );
+      }
+    });
+  }
+}

--- a/tests/fixtures/contextual-agent-conversation-cases.json
+++ b/tests/fixtures/contextual-agent-conversation-cases.json
@@ -1,0 +1,446 @@
+{
+  "version": 1,
+  "description": "Test-only contract for contextual agent audience selection and reply placement. Shared by Desktop (TypeScript), ACP (Rust), and Flutter (Dart). Do not use as runtime protocol.",
+  "storageKey": "buzz:unaddressed-channel-agent-mode:v1",
+  "defaultMode": "all-channel-agents",
+  "modes": ["all-channel-agents", "mentions-only"],
+  "replyPlacementKinds": ["top-level", "thread-root", "unconstrained"],
+  "actors": {
+    "human": "1111111111111111111111111111111111111111111111111111111111111111",
+    "agentA": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "agentB": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "agentCUnverified": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "agentOutsideChannel": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "events": {
+    "threadRoot": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "agentReplyInThread": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "cases": [
+    {
+      "id": "direct-top-level-flat",
+      "description": "Direct conversation, top-level human message: address current agent; agent response is top-level (no reply e tag).",
+      "input": {
+        "conversation": "direct",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "direct-threaded-stays-at-root",
+      "description": "Direct conversation already in a thread continues at the existing root.",
+      "input": {
+        "conversation": "direct",
+        "messagePosition": "in-thread",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "threadRootEventId": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "persistentThreadAudience": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": {
+          "kind": "thread-root",
+          "eventId": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "channel-one-agent-unaddressed-flat",
+      "description": "Unaddressed channel message with one verified current-channel agent: address that agent; flat top-level response.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "channel-multi-agent-unaddressed-shared-thread",
+      "description": "Unaddressed channel message with multiple verified agents: address all; one shared thread; depth-one sibling replies.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "replyPlacement": {
+          "kind": "thread-root",
+          "eventId": "human-message-id"
+        },
+        "sharedThread": true,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "explicit-mentions-override-implicit",
+      "description": "Explicit @mentions override implicit all-channel-agents broadcast.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "mentions-only-disables-implicit",
+      "description": "Mentions-only mode: unaddressed channel message addresses no agents.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "mentions-only",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "keep-addressed-agents-persistent",
+      "description": "When Keep addressed agents active is enabled, prior addressed agents join the audience without explicit re-mention.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "mentions-only",
+        "keepAddressedAgentsActive": true,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "manual-removal-wins",
+      "description": "Manual audience removal wins over persistent Keep-addressed for the current composition.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "mentions-only",
+        "keepAddressedAgentsActive": true,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "manualRemovedPubkeys": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "exclude-unverified-and-non-members",
+      "description": "Implicit audience excludes non-members and unverified relay agents; never community-wide fanout.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "unverifiedAgentPubkeys": [
+          "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "nonMemberAgentPubkeys": [
+          "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    },
+    {
+      "id": "recipient-load-error-retains-draft",
+      "description": "Recipient-loading errors fail closed and retain the draft.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": true
+      },
+      "expected": {
+        "audiencePubkeys": [],
+        "replyPlacement": { "kind": "top-level" },
+        "sharedThread": false,
+        "retainDraft": true
+      }
+    },
+    {
+      "id": "human-followup-in-thread-targets-root",
+      "description": "Human follow-up inside a multi-agent thread targets the root and never nests under an agent reply (no depth two).",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "in-thread",
+        "senderClass": "human",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": true,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": null,
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "replyingUnderEventId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "persistentThreadAudience": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "replyPlacement": {
+          "kind": "thread-root",
+          "eventId": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        },
+        "sharedThread": true,
+        "retainDraft": false,
+        "nestUnderAgentReply": false
+      }
+    },
+    {
+      "id": "agent-authored-traffic-unchanged",
+      "description": "Agent-only traffic preserves unconstrained placement and existing audience behavior.",
+      "input": {
+        "conversation": "channel",
+        "messagePosition": "top-level",
+        "senderClass": "agent",
+        "unaddressedMode": "all-channel-agents",
+        "keepAddressedAgentsActive": false,
+        "explicitMentionPubkeys": [],
+        "currentAgentPubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "channelMemberPubkeys": [
+          "1111111111111111111111111111111111111111111111111111111111111111",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "verifiedChannelAgentPubkeys": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "threadRootEventId": null,
+        "persistentThreadAudience": [],
+        "manualRemovedPubkeys": [],
+        "recipientLoadError": false
+      },
+      "expected": {
+        "audiencePubkeys": [],
+        "replyPlacement": { "kind": "unconstrained" },
+        "sharedThread": false,
+        "retainDraft": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- define one contextual-conversation policy and shared fixture used by Desktop, Mobile, and ACP
- add Desktop and Mobile controls for unaddressed channel messages and persistent addressed-agent audiences
- include resolved agent recipients on outgoing messages while preserving explicit mentions and DM audiences
- keep single-agent ACP replies flat and place multi-agent replies in a shared thread

### Related issue

None found. #1743 is adjacent but concerns offline mention delivery, which this PR does not change.

## Behavior

- channel sends resolve contextual agent recipients from the selected unaddressed-message mode, explicit mentions, and the persisted audience
- successful explicit-agent sends can promote the addressed agents for subsequent conversation turns
- failed sends do not mutate the persistent audience
- thread, channel, owner, and DM boundaries remain isolated
- Desktop preserves explicit agent mentions when merging DM recipients

## Protocol compatibility

This uses existing Nostr `p` and reply tags. It does not add event kinds, relay behavior, HTTP endpoints, server-side fan-out, or release workflow changes.

### Testing

- `just ci`
- `cargo test -p buzz-acp --lib` (676 passed)
- focused Flutter contextual-agent/send tests (19 passed)
- `just mobile-check`
- `pnpm --dir desktop test` (4,154 passed)
- Desktop E2E build plus `unaddressed-channel-agent-mode.spec.ts` smoke test (1 passed)

Rebased and validated on `block/buzz@feccf4eabc23fdba94ce3537a194357ed17b197c`. All commits carry DCO sign-off. Fork-only private-CA and release lifecycle changes are intentionally excluded.
