### PR TITLE
fix(mobile): show npub on same-named mention suggestions

### DIFF
--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -20,6 +20,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';
+import '../../shared/utils/string_utils.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/anchored_popover_menu.dart';
 import '../../shared/widgets/buzz_loading_indicator.dart';

--- a/mobile/lib/features/channels/compose_bar/suggestions.dart
+++ b/mobile/lib/features/channels/compose_bar/suggestions.dart
@@ -111,6 +111,8 @@ class _MentionSuggestions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final collidingLabels = mentionNameCollisions(suggestions);
+
     return Material(
       key: const ValueKey('mention-suggestions-popover'),
       type: MaterialType.card,
@@ -155,6 +157,7 @@ class _MentionSuggestions extends StatelessWidget {
                 currentPubkey: currentPubkey,
                 isDmChannel: isDmChannel,
                 userCache: userCache,
+                hasNameCollision: collidingLabels.contains(name.toLowerCase()),
               ),
               onTap: () => _runComposerAction(() => onSelect(candidate)),
             );
@@ -167,7 +170,8 @@ class _MentionSuggestions extends StatelessWidget {
 
 /// The secondary info line under a mention suggestion — mirrors desktop's
 /// `MentionAutocomplete` subtitle: bot icon + "agent" (or an "admin" badge
-/// for human admins), then "managed by …" / "not in channel".
+/// for human admins), then "managed by …" / "not in channel", and — when the
+/// name is shared with another suggestion — that candidate's truncated npub.
 abstract final class _MentionSuggestionInfo {
   static Widget? build(
     BuildContext context, {
@@ -175,6 +179,7 @@ abstract final class _MentionSuggestionInfo {
     required String? currentPubkey,
     required bool isDmChannel,
     required Map<String, UserProfile> userCache,
+    bool hasNameCollision = false,
   }) {
     final ownerLabel = candidate.isAgent
         ? formatOwnerLabel(candidate.ownerPubkey, currentPubkey, userCache)
@@ -193,13 +198,24 @@ abstract final class _MentionSuggestionInfo {
       detail = null;
     }
 
-    if (!candidate.isAgent && !isAdmin && detail == null) return null;
+    // Name collisions are the impersonation vector: a vanity-ground key can
+    // wear any display name, and duplicate agent identities legitimately share
+    // one. When a name is not unique in the list, the key is the only thing
+    // that distinguishes the rows.
+    final collisionNpub = hasNameCollision ? safeNpub(candidate.pubkey) : null;
+
+    if (!candidate.isAgent &&
+        !isAdmin &&
+        detail == null &&
+        collisionNpub == null) {
+      return null;
+    }
 
     final style = context.textTheme.labelSmall?.copyWith(
       color: context.colors.onSurfaceVariant,
     );
 
-    return Row(
+    final infoRow = Row(
       children: [
         if (candidate.isAgent) ...[
           Icon(
@@ -233,6 +249,25 @@ abstract final class _MentionSuggestionInfo {
           ),
         ],
       ],
+    );
+
+    if (collisionNpub == null) return infoRow;
+
+    final npubLine = Text(
+      key: const ValueKey('mention-collision-npub'),
+      truncatePubkey(collisionNpub),
+      style: style?.copyWith(fontFamily: 'GeistMono'),
+      overflow: TextOverflow.ellipsis,
+    );
+
+    // A plain person with no badge and no detail has an empty info row; show
+    // the key on its own rather than stacking it under blank space.
+    if (!candidate.isAgent && !isAdmin && detail == null) return npubLine;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [infoRow, npubLine],
     );
   }
 }

--- a/mobile/lib/features/channels/mentions/mention_ranking.dart
+++ b/mobile/lib/features/channels/mentions/mention_ranking.dart
@@ -31,6 +31,24 @@ class MentionCandidate {
   }
 }
 
+/// The set of lowercase labels shared by more than one candidate.
+///
+/// Name collisions are the impersonation vector: a vanity-ground key can wear
+/// any display name, and duplicate agent identities legitimately share one.
+/// Callers use this to decide which rows need a key shown alongside the name.
+/// Mirrors the `nameCounts` map desktop builds in `MentionAutocomplete`.
+Set<String> mentionNameCollisions(List<MentionCandidate> candidates) {
+  final counts = <String, int>{};
+  for (final candidate in candidates) {
+    final label = candidate.label.toLowerCase();
+    counts[label] = (counts[label] ?? 0) + 1;
+  }
+  return {
+    for (final entry in counts.entries)
+      if (entry.value > 1) entry.key,
+  };
+}
+
 /// Group rank: channel members, then people, then other agents.
 /// Mirrors desktop's `getMentionCandidateGroupRank` (personas are a
 /// desktop-only concept; their slot between members and people is unused

--- a/mobile/lib/shared/utils/string_utils.dart
+++ b/mobile/lib/shared/utils/string_utils.dart
@@ -1,5 +1,36 @@
+import 'package:nostr/nostr.dart' as nostr;
+
 /// Truncates a hex pubkey to the first 8 characters with an ellipsis.
 String shortPubkey(String pubkey) {
   if (pubkey.length > 12) return '${pubkey.substring(0, 8)}\u2026';
   return pubkey;
+}
+
+/// Compact display form keeping both ends of a key: `abcd1234…wxyz`.
+///
+/// Mirrors desktop's `truncatePubkey` (desktop/src/shared/lib/pubkey.ts). The
+/// trailing characters matter: bech32 npubs all start with `npub1`, so a
+/// head-only form like [shortPubkey] leaves barely three distinguishing
+/// characters. A truncated key is a recognition aid, never an identity proof
+/// — vanity grinders forge short prefixes cheaply.
+String truncatePubkey(String pubkey) {
+  if (pubkey.length <= 12) return pubkey;
+  final head = pubkey.substring(0, 8);
+  final tail = pubkey.substring(pubkey.length - 4);
+  return '$head\u2026$tail';
+}
+
+/// Encode a hex pubkey as a bech32 `npub1…`, or null if it is not encodable.
+///
+/// Mirrors desktop's `safeNpub` (desktop/src/shared/lib/nostrUtils.ts): never
+/// throws, so display code can fall back rather than crash on malformed input.
+String? safeNpub(String pubkey) {
+  try {
+    return nostr.Bech32Entity.encode(
+      prefix: nostr.Nip19Prefix.npub,
+      data: pubkey,
+    );
+  } catch (_) {
+    return null;
+  }
 }

--- a/mobile/test/features/channels/compose_bar_mention_collision_test.dart
+++ b/mobile/test/features/channels/compose_bar_mention_collision_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/compose_bar.dart';
+import 'package:buzz/features/channels/photo_library.dart';
+import 'package:buzz/shared/custom_emoji/custom_emoji.dart';
+import 'package:buzz/shared/custom_emoji/custom_emoji_provider.dart';
+import 'package:buzz/shared/mentions/agent_identity_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/shared/theme/theme.dart';
+import 'package:buzz/shared/utils/string_utils.dart';
+
+// Two agents wearing the same display name — the shape a duplicated agent
+// identity takes in a channel roster. Without the npub line these two rows
+// are pixel-identical.
+const _liveAgentPubkey =
+    '85f63083f4702f94bdb20e604815b03cd7b30ee349333de1a271d7d52731bae5';
+const _twinAgentPubkey =
+    '5228041f95e16eb8cf0f1b8ade09c8f1499a062e001742e38ca3d54adc9ab5e3';
+const _soloAgentPubkey =
+    '09aa16bf25a0efd5aa894812a0ed21e8b491e47cf17ee9dca8df8007025848bb';
+
+late SharedPreferences _testPrefs;
+
+ChannelMember _bot(String pubkey, String displayName) => ChannelMember(
+  pubkey: pubkey,
+  role: 'bot',
+  joinedAt: DateTime.utc(2026),
+  displayName: displayName,
+);
+
+Widget _buildComposeBar({required List<ChannelMember> members}) {
+  return ProviderScope(
+    overrides: [
+      customEmojiListProvider.overrideWithValue(const <CustomEmoji>[]),
+      photoLibraryProvider.overrideWithValue(const _EmptyPhotoLibrary()),
+      currentPubkeyProvider.overrideWith((ref) => null),
+      channelMembersProvider(
+        'channel-1',
+      ).overrideWith((ref) => Future.value(members)),
+      agentDirectoryProvider.overrideWith(
+        (ref) async => const <AgentDirectoryEntry>[],
+      ),
+      agentOwnersProvider.overrideWith((ref) async => const <String, String>{}),
+      relayClientProvider.overrideWithValue(
+        RelayClient(baseUrl: 'http://localhost:3000'),
+      ),
+      relayConfigProvider.overrideWith(_FakeRelayConfigNotifier.new),
+      savedPrefsProvider.overrideWithValue(_testPrefs),
+      channelsProvider.overrideWith(() => _FakeChannelsNotifier(const [])),
+    ],
+    child: MaterialApp(
+      theme: AppTheme.light(),
+      home: Scaffold(
+        body: SafeArea(
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: ComposeBar(
+              channelId: 'channel-1',
+              onSend: (_, _, {mediaTags = const []}) async {},
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _openMentions(WidgetTester tester, String query) async {
+  await tester.tap(find.text('Message…'));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextField), query);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    _testPrefs = await SharedPreferences.getInstance();
+  });
+
+  testWidgets('same-named mention suggestions each show their npub', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildComposeBar(
+        members: [
+          _bot(_liveAgentPubkey, 'Fizz'),
+          _bot(_twinAgentPubkey, 'Fizz'),
+        ],
+      ),
+    );
+
+    await _openMentions(tester, '@fiz');
+
+    expect(find.text('Fizz'), findsNWidgets(2));
+    expect(
+      find.byKey(const ValueKey('mention-collision-npub')),
+      findsNWidgets(2),
+    );
+
+    // Each row carries its own key, so the two are actually distinguishable
+    // rather than merely annotated.
+    final live = truncatePubkey(safeNpub(_liveAgentPubkey)!);
+    final twin = truncatePubkey(safeNpub(_twinAgentPubkey)!);
+    expect(live, isNot(twin));
+    expect(find.text(live), findsOneWidget);
+    expect(find.text(twin), findsOneWidget);
+  });
+
+  testWidgets('a uniquely named suggestion shows no npub', (tester) async {
+    await tester.pumpWidget(
+      _buildComposeBar(members: [_bot(_soloAgentPubkey, 'Honey')]),
+    );
+
+    await _openMentions(tester, '@hon');
+
+    expect(find.text('Honey'), findsOneWidget);
+    expect(find.byKey(const ValueKey('mention-collision-npub')), findsNothing);
+  });
+}
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  @override
+  RelayConfig build() => RelayConfig(
+    baseUrl: 'http://localhost:3000',
+    nsec: nostr.Keys.generate().nsec,
+  );
+}
+
+class _FakeChannelsNotifier extends ChannelsNotifier {
+  final List<Channel> channels;
+
+  _FakeChannelsNotifier(this.channels);
+
+  @override
+  Future<List<Channel>> build() async => channels;
+}
+
+class _EmptyPhotoLibrary implements PhotoLibrary {
+  const _EmptyPhotoLibrary();
+
+  @override
+  Future<List<RecentPhoto>> loadRecentPhotos() async => const [];
+
+  @override
+  Future<List<XFile>> resolveSelectedPhotos(List<RecentPhoto> photos) async =>
+      const [];
+}

--- a/mobile/test/features/channels/mentions/mention_ranking_test.dart
+++ b/mobile/test/features/channels/mentions/mention_ranking_test.dart
@@ -111,4 +111,54 @@ void main() {
 
     expect(rankedPubkeys([second, first], ''), ['9' * 64, '8' * 64]);
   });
+
+  group('mentionNameCollisions', () {
+    test('is empty when every label is unique', () {
+      final candidates = [
+        candidate(displayName: 'Brain', pubkey: channelBrainPubkey),
+        candidate(displayName: 'Pinky', pubkey: otherBrainPubkey),
+      ];
+
+      expect(mentionNameCollisions(candidates), isEmpty);
+    });
+
+    test('reports a label shared by two candidates', () {
+      final candidates = [
+        candidate(displayName: 'Brain', isMember: true, pubkey: '1' * 64),
+        candidate(displayName: 'Brain', pubkey: '2' * 64),
+        candidate(displayName: 'Pinky', pubkey: '3' * 64),
+      ];
+
+      expect(mentionNameCollisions(candidates), {'brain'});
+    });
+
+    test('matches labels case-insensitively', () {
+      final candidates = [
+        candidate(displayName: 'Brain', pubkey: '1' * 64),
+        candidate(displayName: 'BRAIN', pubkey: '2' * 64),
+      ];
+
+      expect(mentionNameCollisions(candidates), {'brain'});
+    });
+
+    test('falls back to the pubkey label, which does not collide', () {
+      final candidates = [
+        candidate(displayName: null, pubkey: '1' * 64),
+        candidate(displayName: null, pubkey: '2' * 64),
+      ];
+
+      expect(mentionNameCollisions(candidates), isEmpty);
+    });
+
+    test('reports every colliding label, not just the first', () {
+      final candidates = [
+        candidate(displayName: 'Brain', pubkey: '1' * 64),
+        candidate(displayName: 'Brain', pubkey: '2' * 64),
+        candidate(displayName: 'Pinky', pubkey: '3' * 64),
+        candidate(displayName: 'Pinky', pubkey: '4' * 64),
+      ];
+
+      expect(mentionNameCollisions(candidates), {'brain', 'pinky'});
+    });
+  });
 }


### PR DESCRIPTION
## Problem

The desktop `MentionAutocomplete` counts display names in the suggestion list and, when two share a name, prints each candidate's truncated npub underneath so they can be told apart:

```tsx
// Name collisions are the impersonation vector: a vanity-ground key can
// wear any display name. When two suggestions share a name, surface each
// one's npub (truncated; full key in the hover tooltip) to tell them apart.
```

The Flutter composer has no equivalent — `grep -ri collision mobile/lib mobile/test` returns nothing.

The result on mobile is that identities sharing a display name render identically: same name, same avatar, and the same `managed by you · not in channel` subtitle. There is nothing on screen to distinguish them.

This came out of real use. An owner whose agent had been re-registered several times ended up with five identities all called the same thing — one live, the rest dormant — and could not tell which row in the `@` picker was the live one. Mentioning a dormant key is silent: nothing answers.

Worth being precise about scope: offering non-member agents is **deliberate** (`buildMentionCandidates` includes agents you own even outside the channel, mirroring desktop). The gap is only that the picker gives no way to tell them apart.

## Change

- **`mentionNameCollisions()`** in `mention_ranking.dart` returns the lowercase labels shared by more than one candidate. Extracted as a pure function rather than inlined in the widget (as desktop does) so the collision rule is unit-testable on its own.
- **The suggestion subtitle** gains a monospace npub line, for colliding names only — uniquely-named suggestions are untouched.
- **`safeNpub()` / `truncatePubkey()`** in `string_utils.dart` mirror their desktop counterparts. `truncatePubkey` keeps both ends (`abcd1234…wxyz`) rather than reusing the existing head-only `shortPubkey`: every npub begins with `npub1`, so a head-only form leaves barely three distinguishing characters.

A truncated key is a recognition aid, not identity proof. The line narrows the choice; it does not authenticate it.

## Tests

- 5 unit tests for `mentionNameCollisions` — unique labels, a shared label, case-insensitive matching, the pubkey-fallback label (which must not collide), and multiple distinct collisions.
- 2 widget tests driving the real composer: two same-named agents each render their own distinct npub; a uniquely-named agent renders none.

The collision widget test was confirmed to fail with the `suggestions.dart` change reverted, so it is load-bearing rather than merely passing.

```
flutter analyze   No issues found!
dart format       355 files (0 changed)
flutter test      All tests passed!  (1169 tests)
```

## Not in this PR

Desktop already has this behaviour, so no change there. Web has no mention autocomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
