### PR TITLE
Reject NUL bytes before event persistence

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -561,6 +561,15 @@ fn match_profiles_by_name(events: &[serde_json::Value], name: &str) -> Vec<(Stri
     matches
 }
 
+fn validate_message_content(content: &str) -> Result<(), CliError> {
+    if let Some(byte_offset) = content.find('\0') {
+        return Err(CliError::Usage(format!(
+            "content contains NUL byte at byte offset {byte_offset}"
+        )));
+    }
+    Ok(())
+}
+
 pub struct SendMessageParams {
     pub channel_id: String,
     pub content: String,
@@ -580,6 +589,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
+    validate_message_content(&p.content)?;
     validate_content_size(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
@@ -993,9 +1003,9 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
-        resolve_names_to_pubkeys,
+        cmd_send_message, event_mention_pubkeys, find_root_from_tags, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        resolve_names_to_pubkeys, SendMessageParams,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1005,6 +1015,37 @@ mod tests {
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const ID_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     const PUBKEY: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    #[tokio::test]
+    async fn send_message_rejects_nul_locally_with_byte_offset() {
+        let client = crate::client::BuzzClient::new(
+            "http://127.0.0.1:9".into(),
+            nostr::Keys::generate(),
+            None,
+            None,
+        )
+        .unwrap();
+        let error = cmd_send_message(
+            &client,
+            SendMessageParams {
+                channel_id: uuid::Uuid::nil().to_string(),
+                content: "ab\0cd".into(),
+                kind: None,
+                reply_to: None,
+                broadcast: false,
+                files: vec![],
+                mentions: vec![],
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, crate::error::CliError::Usage(_)));
+        assert_eq!(
+            error.to_string(),
+            "content contains NUL byte at byte offset 2"
+        );
+    }
 
     // Three real pubkeys (lowercase 64-char hex) used by parse_member_pubkeys tests.
     // See the test's own comment on what `PublicKey::from_hex` actually validates.

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1873,6 +1873,7 @@ async fn ingest_event_inner(
             event.content.len()
         )));
     }
+    validate_no_nul_bytes(&event)?;
 
     let is_gift_wrap = kind_u32 == KIND_GIFT_WRAP;
     if event.pubkey != *auth.pubkey() && !is_gift_wrap {
@@ -2903,6 +2904,26 @@ async fn ingest_event_inner(
     })
 }
 
+fn validate_no_nul_bytes(event: &Event) -> Result<(), IngestError> {
+    if let Some(byte_offset) = event.content.find('\0') {
+        return Err(IngestError::Rejected(format!(
+            "invalid: content contains NUL byte at byte offset {byte_offset}"
+        )));
+    }
+
+    for (tag_index, tag) in event.tags.iter().enumerate() {
+        for (value_index, value) in tag.as_slice().iter().enumerate() {
+            if let Some(byte_offset) = value.find('\0') {
+                return Err(IngestError::Rejected(format!(
+                    "invalid: tag {tag_index} value {value_index} contains NUL byte at byte offset {byte_offset}"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -3516,6 +3537,44 @@ mod tests {
             .tags(nostr_tags)
             .sign_with_keys(&keys)
             .unwrap()
+    }
+
+    #[test]
+    fn event_text_validation_rejects_nul_in_content() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "before\0after", &[]);
+        match validate_no_nul_bytes(&event) {
+            Err(IngestError::Rejected(message)) => assert_eq!(
+                message,
+                "invalid: content contains NUL byte at byte offset 6"
+            ),
+            other => panic!("content NUL must be rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_text_validation_rejects_nul_in_tag_value() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "content without NUL",
+            &[&["h", "before\0after"]],
+        );
+        match validate_no_nul_bytes(&event) {
+            Err(IngestError::Rejected(message)) => assert_eq!(
+                message,
+                "invalid: tag 0 value 1 contains NUL byte at byte offset 6"
+            ),
+            other => panic!("tag-value NUL must be rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_text_validation_accepts_same_event_without_nul() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "before-after",
+            &[&["h", "before-after"]],
+        );
+        assert!(validate_no_nul_bytes(&event).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An event whose `content` — or any tag value — contains a NUL byte (`0x00`) passes the full ingest validation and only fails inside Postgres:

```
Internal error: error: database error: ... invalid byte sequence for encoding "UTF8": 0x00
route:/events, status:500, accepted:false
```

The relay maps that database error onto a bare HTTP 500, so a plain client-side input problem is reported as an internal server error with no usable body. Reproduced with a 38-byte message — content length is irrelevant. It surfaced in practice when a client pasted text carrying a stray NUL: four sends failed in a row with `relay error 500: internal server error` and nothing actionable on the client side.

## Change

- `crates/buzz-relay/src/handlers/ingest.rs` — `ingest_event_inner` rejects NUL in `event.content` and in every tag value, right after the existing content-size check and before any database access, as `IngestError::Rejected`. The `/events` bridge already maps `Rejected` to `400 Bad Request` (`crates/buzz-relay/src/api/bridge.rs`), so no mapper change was needed.
- `crates/buzz-cli/src/commands/messages.rs` — `cmd_send_message` rejects the same input locally, before signing, and names the byte offset. No silent stripping: the content is the user's, so it is refused rather than altered.

Only `0x00` is rejected. Other control characters are valid UTF-8 and Postgres accepts them, so widening the rule would reject content that works today.

## Tests

- `event_text_validation_rejects_nul_in_content`
- `event_text_validation_rejects_nul_in_tag_value`
- `event_text_validation_accepts_same_event_without_nul` (positive control)
- `send_message_rejects_nul_locally_with_byte_offset`

`cargo test -p buzz-cli` → 318 passed, 1 ignored, exit 0. `cargo test -p buzz-relay event_text_validation` → 3 passed, exit 0. No existing test was modified.