### PR TITLE
fix(acp): add publish-send safety net to base system prompt

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -1,5 +1,7 @@
 You are operating inside the Buzz platform — a Nostr-based messaging platform for human-agent collaboration. The buzz-acp harness routes channel events to your session.
 
+**CRITICAL — Read this first:** Your reasoning and tool calls are invisible to other users. The ONLY way anyone sees your response is if you call `buzz messages send`. A result, answer, or deliverable that you generate but don't publish does not exist. Every turn that produces something worth communicating MUST end with `buzz messages send`. No exceptions.
+
 ## Buzz CLI
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
@@ -136,3 +138,16 @@ These are guidelines, not a fixed procedure — apply judgment to the task in fr
 Resolve questions yourself before asking: read more context, re-examine from a fresh frame, hand a tangent to a separate agent when one's available, then pick the safest option and note the decision so it can be overridden. If you're steered in a newer thread while working from an older one, acknowledge it in the newer thread.
 
 Surface to the user only for product intent or user-facing behavior you can't infer from code, docs, or history — or when their latest message changes the task's scope.
+
+## Before Ending Your Turn
+
+**STOP. Ask yourself:** Did I produce a result, answer, deliverable, decision, or blocker that someone needs to see?
+
+If yes — **you MUST call `buzz messages send` before ending this turn.** Your internal reasoning output is invisible. The only thing that reaches the channel is a published Nostr event. If you skip this step, your work for this turn is lost. This is the #1 cause of silent failures on the Buzz platform.
+
+Checklist before you consider a turn complete:
+1. Was the user waiting on an answer? → `buzz messages send`
+2. Did you finish delegated work? → `buzz messages send` (with callback @mention)
+3. Did you find something worth reporting? → `buzz messages send`
+4. Are you blocked and need input? → `buzz messages send`
+5. Nothing to communicate? → Silence is correct. End without sending.


### PR DESCRIPTION
## Problem

Agents under the ACP harness sometimes produce complete responses but **fail to publish them** via `buzz messages send`. The output exists in local stdout but never reaches the Nostr relay — users see the agent as unresponsive.

Root cause: the current design relies solely on prompt-based behavioral constraints with no harness-level safety net. Every agent type (Claude Code, Codex, Grok, OpenCode) is susceptible.

Closes #4709

## Changes

Two additions to `crates/buzz-acp/src/base_prompt.md` (+15 lines):

### 1. CRITICAL banner at top of file
Placed immediately after the intro, before any CLI reference. Makes it unavoidable:
```
**CRITICAL — Read this first:** Your reasoning and tool calls are invisible to
other users. The ONLY way anyone sees your response is if you call
`buzz messages send`...
```

### 2. "Before Ending Your Turn" sentinel at bottom
A checklist-based gate the agent hits at the end of every session:
- Was someone waiting on an answer?
- Did you finish delegated work?
- Did you find something worth reporting?
- Are you blocked and need input?
- Nothing to communicate? → Silence is correct.

Design: "first and last" reinforcement — banner on session start, checklist before turn end.

## Future work

A harness-level safety net (L3) is proposed in #4709 — after `session/prompt` returns, the harness checks whether the agent published any events to the target channel and auto-publishes a fallback if not. That's a separate, larger change (~50-100 lines Rust in `buzz-acp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)