### PR TITLE
fix(desktop): show cross-desktop managed agents in @mention autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -227,6 +227,26 @@ test("shouldHideAgentFromMentions: shows member agents with unknown invocability
   );
 });
 
+test("shouldHideAgentFromMentions: #4187 shows a channel-member agent managed by another Desktop instance", () => {
+  // Regression for #4187: a managed agent running on another Desktop instance
+  // appears here as a channel member (isAgent via role "bot") that is neither
+  // in this client's managed-agent list nor in the relay directory
+  // (mentionableAgentPubkeys/directoryAgentPubkeys both empty). It MUST remain
+  // visible in the mention picker. The mention path (useMentions) must rely on
+  // this policy alone and not additionally pre-filter with
+  // isAgentIdentityInManagedList, which would drop it.
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: true,
+      pubkey: PUB_A,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set(),
+    }),
+    false,
+  );
+});
+
 test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
   const mixedCase = "Ab".repeat(32);
   const normalized = mixedCase.toLowerCase();

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,9 +245,16 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
+      // Agent visibility in the mention picker is governed solely by
+      // `shouldHideAgentFromMentions` (the "Option B" member/directory policy
+      // below). We deliberately do NOT pre-filter with
+      // `isAgentIdentityInManagedList` here: that gate keeps only *locally*
+      // managed agents, which drops channel-member agents managed by another
+      // Desktop instance before the member/directory policy can show them —
+      // the root cause of #4187 (cross-desktop managed agents missing from the
+      // `@mention` autocomplete). `isAgentIdentityInManagedList` still belongs
+      // in the "add member" search (MembersSidebar), where you may only add
+      // agents you manage; it does not belong on the mention path.
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,
@@ -420,7 +426,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## Summary

Fixes #4187 — a managed agent created on one Buzz Desktop instance is not discoverable in the `@mention` autocomplete picker on another member's Desktop, even though it is a channel member (`role: "bot"`), has a valid kind:0 profile, and responds normally when mentioned via the CLI with `--mention`.

## Root cause

`useMentions` (`desktop/src/features/messages/lib/useMentions.ts`) builds mention candidates through `addCandidate`, which applies **two** agent-visibility gates in sequence:

1. `isAgentIdentityInManagedList(candidate, managedAgentPubkeys)` — keeps an agent only if it is in *this* client's **local** managed-agent list.
2. `shouldHideAgentFromMentions({ … })` — the nuanced "Option B" member/directory policy that is explicitly designed to **show** channel-member agents whose invocability is unknown, and to hide only non-member or explicitly-excluded ones.

Gate #1 runs first and short-circuits. Any agent that isn't locally managed is dropped **before** gate #2 can run — so a managed agent running on another Desktop instance (present in the channel as a `role: "bot"` member, but absent from this client's local managed list and, for the native Claude Code runtime, not in the relay kind:10100 directory) is filtered out. That makes `shouldHideAgentFromMentions`'s member-handling dead code for exactly the cross-desktop case it was written for, which is the behavior reported in #4187 (and confirmed independently on 0.5.4 in the issue thread).

## Fix

Remove the redundant `isAgentIdentityInManagedList` pre-filter from the mention path and let `shouldHideAgentFromMentions` be the **sole** visibility policy there. Its existing, tested behavior already gives the correct result:

- member agent, unknown invocability (not in directory) → **show** ✅ (the #4187 case)
- agent invocable via managed/shared-relay directory → **show** ✅
- non-member, non-invocable agent → hide
- member agent with an explicit not-invocable directory (kind:10100) entry → hide

`isAgentIdentityInManagedList` itself is **unchanged** and still used by `MembersSidebar`'s "add member" search, where restricting agent suggestions to locally-managed agents is correct (you can only add agents you manage). The fix is scoped to the mention path only.

## Tests

- `desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs` — added a named `#4187` regression test asserting a channel-member agent managed by another Desktop instance (not in the managed list, not in the relay directory) stays visible.
- Full desktop unit suite green: `pnpm test` → **4130 passed, 0 failed**.
- `pnpm typecheck` and `biome check` clean on the changed files.

## Notes for reviewers

- This is a Desktop-side fix; the previously-linked #4309 only touched `mobile/…/compose_bar*` and does not address this issue.
- `MembersSidebar`'s "add member" search still applies the same local-managed gate. That's intentional and out of scope here, but if you'd prefer relay-discovered agents to be addable there too, that's a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)