### PR TITLE
fix(relay): log event kind on accepted /events bridge requests

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -654,12 +654,13 @@ pub async fn submit_event(
         submit_event_authed(&state, &tenant, &headers, &body, pubkey, event_id_bytes).await;
 
     match &outcome {
-        SubmitOutcome::Ok { accepted, .. } => {
+        SubmitOutcome::Ok { accepted, kind, .. } => {
             tracing::info!(
                 pubkey = %pubkey_hex,
                 route = "/events",
                 status = 200u16,
                 accepted,
+                kind,
                 "HTTP bridge request"
             );
         }
@@ -713,6 +714,10 @@ enum SubmitOutcome {
     /// Ingest pipeline ran and returned a result (accepted or not).
     Ok {
         accepted: bool,
+        /// Event kind, so an accepted message (kind 9) is distinguishable in
+        /// the log from an accepted typing indicator (kind 7) or deletion
+        /// (kind 5) — all of which travel the same `/events` route.
+        kind: u32,
         response: Json<Value>,
     },
     /// JSON parse failure before ingest — log category/line/column, not msg.
@@ -843,6 +848,7 @@ async fn submit_event_authed(
             }));
             SubmitOutcome::Ok {
                 accepted: result.accepted,
+                kind: kind_u32,
                 response,
             }
         }


### PR DESCRIPTION
## What

The relay's HTTP bridge terminal attribution line for an accepted event logs `accepted` but not `kind`:

```json
{"pubkey":"d5b0ab11…","route":"/events","status":200,"accepted":true,"...":"HTTP bridge request"}
```

Typing indicators (kind 7) and their deletions (kind 5) travel the same `/events` route as real messages (kind 9), so **every agent turn produces `accepted:true` lines whether or not a message was actually sent** — a silent no-op is indistinguishable from a real send without querying Postgres directly. This has misled at least two separate debugging sessions (see #4676).

## Change

`kind_u32` is already computed in `submit_event_authed` before ingest. This PR threads it through the `SubmitOutcome::Ok` variant and adds it to the `info!` attribution line. The `Rejected` arm already logs `kind`; this closes the gap on the accepted arm.

Now an accepted message vs. an accepted typing indicator are distinguishable at a glance:

```
route:"/events" status:200 accepted:true kind:9   ← real message
route:"/events" status:200 accepted:true kind:7   ← typing indicator
```

Scope kept intentionally minimal (kind only). The issue also mentions `channel_id` as a "nice to have"; happy to add it in a follow-up if wanted — it needs the `h` tag extracted before the event is moved into `ingest_event`, so it's a slightly larger change than this one-field fix.

## Verification

- `cargo check -p buzz-relay` — clean
- `cargo clippy -p buzz-relay -- -D warnings` — clean
- `cargo fmt --check` — clean

## Testing note

The existing attribution tests (`submit_event_invalid_json_…`, `submit_event_relay_only_kind_…`) cover the ParseFail and Rejected arms and remain green — this change doesn't touch them. There is no dedicated Ok/accepted-arm attribution test; adding one requires a member pubkey + valid channel event against a live Postgres (the `#[ignore = "requires Postgres"]` tier). I'm glad to add a `T3c` asserting the accepted line carries `kind=` if you'd like it in this PR.

Fixes #4676

---
_Developed with AI assistance (Claude Code); reviewed and verified locally by me._
