### PR TITLE
ci: honor a repository-variable override for the push gateway image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,9 @@ env:
   # variable to override (e.g., for forks that want to push to their own
   # namespace without forking this file).
   IMAGE_NAME: ${{ vars.GHCR_IMAGE != '' && vars.GHCR_IMAGE || 'ghcr.io/block/buzz' }}
+  # Same override, same rationale, for the push gateway image. Set
+  # GHCR_PUSH_GATEWAY_IMAGE as a repo variable to override.
+  PUSH_GATEWAY_IMAGE: ${{ vars.GHCR_PUSH_GATEWAY_IMAGE != '' && vars.GHCR_PUSH_GATEWAY_IMAGE || 'ghcr.io/block/buzz-push-gateway' }}
 
 jobs:
   build:
@@ -387,7 +390,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
-          images: ghcr.io/block/buzz-push-gateway
+          images: ${{ env.PUSH_GATEWAY_IMAGE }}
           labels: |
             org.opencontainers.image.title=Buzz Push Gateway
             org.opencontainers.image.description=Capability-gated APNs last hop for Buzz
@@ -400,9 +403,9 @@ jobs:
           file: ./Dockerfile.push-gateway
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/block/buzz-push-gateway,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: type=registry,ref=ghcr.io/block/buzz-push-gateway-buildcache:${{ matrix.arch }}
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/block/buzz-push-gateway-buildcache:{0},mode=max,compression=zstd', matrix.arch) || '' }}
+          outputs: type=image,name=${{ env.PUSH_GATEWAY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=registry,ref=${{ env.PUSH_GATEWAY_IMAGE }}-buildcache:${{ matrix.arch }}
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref={0}-buildcache:{1},mode=max,compression=zstd', env.PUSH_GATEWAY_IMAGE, matrix.arch) || '' }}
       - name: Export digest
         if: github.event_name != 'pull_request'
         env:
@@ -447,7 +450,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
-          images: ghcr.io/block/buzz-push-gateway
+          images: ${{ env.PUSH_GATEWAY_IMAGE }}
           tags: |
             type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
             type=sha,prefix=sha-,format=short,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
@@ -458,10 +461,11 @@ jobs:
         working-directory: /tmp/gateway-digests
         env:
           META_TAGS: ${{ steps.meta.outputs.tags }}
+          PUSH_GATEWAY_IMAGE: ${{ env.PUSH_GATEWAY_IMAGE }}
         run: |
           set -euo pipefail
           tags=(); while IFS= read -r tag; do [ -n "$tag" ] && tags+=("-t" "$tag"); done <<< "$META_TAGS"
-          digests=(); for digest in *; do digests+=("ghcr.io/block/buzz-push-gateway@sha256:${digest}"); done
+          digests=(); for digest in *; do digests+=("${PUSH_GATEWAY_IMAGE}@sha256:${digest}"); done
           docker buildx imagetools create "${tags[@]}" "${digests[@]}"
           first_tag=$(echo "$META_TAGS" | head -n1)
           digest=$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest}}' | jq -r '.digest')
@@ -469,17 +473,18 @@ jobs:
       - name: Attest gateway image provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/block/buzz-push-gateway
+          subject-name: ${{ env.PUSH_GATEWAY_IMAGE }}
           subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
       - name: Gateway publication summary
         env:
           GATEWAY_DIGEST: ${{ steps.manifest.outputs.digest }}
           GATEWAY_TAGS: ${{ steps.meta.outputs.tags }}
+          PUSH_GATEWAY_IMAGE: ${{ env.PUSH_GATEWAY_IMAGE }}
         run: |
           set -euo pipefail
           {
-            echo "### Published \`ghcr.io/block/buzz-push-gateway\`"
+            echo "### Published \`${PUSH_GATEWAY_IMAGE}\`"
             echo
             printf "**Digest:** \`%s\`\n" "$GATEWAY_DIGEST"
             echo
@@ -490,6 +495,6 @@ jobs:
             echo
             echo 'Verify provenance before deployment:'
             echo "\`\`\`"
-            printf 'gh attestation verify oci://ghcr.io/block/buzz-push-gateway@%s --owner block\n' "$GATEWAY_DIGEST"
+            printf 'gh attestation verify oci://%s@%s --owner block\n' "$PUSH_GATEWAY_IMAGE" "$GATEWAY_DIGEST"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The relay/desktop image jobs already read `IMAGE_NAME` from the `GHCR_IMAGE` repository variable so forks can push to their own namespace "without forking this file" (the env block's own words). The push gateway jobs predate that pattern and hardcode `ghcr.io/block/buzz-push-gateway` in nine places — metadata, build outputs, cache refs, manifest merge, attestation subject, and the summary. On a fork, the GHCR login authenticates as the fork's owner, so the buildcache export to `ghcr.io/block/...` is denied and the job fails after an otherwise-green build. The `cache-to` same-repo guard passes for same-repo PRs *inside* a fork (both sides equal the fork), so it doesn't prevent this.

This adds `PUSH_GATEWAY_IMAGE` with the identical override shape (`GHCR_PUSH_GATEWAY_IMAGE`, defaulting to `ghcr.io/block/buzz-push-gateway`) and references it everywhere the literal appeared, mirroring how the relay job uses `IMAGE_NAME` (yaml positions via `${{ env.* }}`, run blocks via step `env:`). Defaults preserve the canonical repo's behavior byte-for-byte; a fork sets one repository variable and its docker workflow is clean.

### Related issue

Fixes #4720. Duplicate check: paged all 770 open issues via the API — no existing issue or PR covers this (nearest neighbors #3260/#3842 are different push-gateway/compose bugs).

### Testing

- `actionlint` clean on the modified workflow; YAML parses.
- Grep proof: the only remaining `ghcr.io/block/buzz-push-gateway` literal is the env default.
- The failure being fixed, observed on our fork of current `main`: [Build public push gateway dies at cache export](https://github.com/intent-solutions-io/buzz/actions/runs/30881963216/job/91905049513) with `denied: permission_denied` — builds green, fails only at the block-namespace cache write.
- No behavior change for block/buzz itself: with `GHCR_PUSH_GATEWAY_IMAGE` unset, every reference resolves to the exact prior literal.
