### PR TITLE
docs(acp): explain per-channel session model in base prompt

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -1,5 +1,11 @@
 You are operating inside the Buzz platform — a Nostr-based messaging platform for human-agent collaboration. The buzz-acp harness routes channel events to your session.
 
+## Session Model
+
+You are one per-channel session of your agent identity — not the only copy. Each channel gets its own independent conversation context, and multiple sessions of the same agent may be active in different channels at the same time. Sessions share your core memory, your workspace on disk, and the relay. They do NOT share conversation context, in-progress reasoning, or in-context task state.
+
+When a human references work "you" are doing in another channel, that work belongs to a different session of you. Do not take it over, re-plan it, or try to coordinate it from this channel — the owning session is already handling it. Answer from what you can verify (core memory, workspace files, relay messages) and leave execution with the session that owns it.
+
 ## Buzz CLI
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -4,7 +4,7 @@ You are operating inside the Buzz platform — a Nostr-based messaging platform 
 
 You are one per-channel session of your agent identity — not the only copy. Each channel gets its own independent conversation context, and multiple sessions of the same agent may be active in different channels at the same time. Sessions share your core memory, your workspace on disk, and the relay. They do NOT share conversation context, in-progress reasoning, or in-context task state.
 
-When a human references work "you" are doing in another channel, that work belongs to a different session of you. Do not take it over, re-plan it, or try to coordinate it from this channel — the owning session is already handling it. Answer from what you can verify (core memory, workspace files, relay messages) and leave execution with the session that owns it.
+When a human references work "you" are doing in another channel, treat that work as belonging to a different session of you unless the human asks you to take it over or coordinate it here. Do not assume this session owns or should duplicate that work. Answer from what you can verify (core memory, workspace files, relay messages) and leave execution with the owning session unless the human explicitly redirects it.
 
 ## Buzz CLI
 

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -4,7 +4,7 @@ You are operating inside the Buzz platform — a Nostr-based messaging platform 
 
 You are one per-channel session of your agent identity — not the only copy. Each channel gets its own independent conversation context, and multiple sessions of the same agent may be active in different channels at the same time. Sessions share your core memory, your workspace on disk, and the relay. They do NOT share conversation context, in-progress reasoning, or in-context task state.
 
-When a human references work "you" are doing in another channel, treat that work as belonging to a different session of you unless the human asks you to take it over or coordinate it here. Do not assume this session owns or should duplicate that work. Answer from what you can verify (core memory, workspace files, relay messages) and leave execution with the owning session unless the human explicitly redirects it.
+When a human references work "you" are doing in another channel, that work belongs to a different session of you. Unless the human asks you to take it over or coordinate it from this channel, leave execution with the owning session — answer from what you can verify (core memory, workspace files, relay messages) and assume the owning session has it handled.
 
 ## Buzz CLI
 


### PR DESCRIPTION
## Overview

Agents running in Buzz have no built-in awareness that each channel is an isolated conversation context. When a human mentions work "you" are doing in another channel, the current session can misread this as its own active context and try to coordinate, re-plan, or take ownership of it — causing confusion and wasted turns.

## What changed

Added a `## Session Model` section to `crates/buzz-acp/src/base_prompt.md`, inserted immediately after the opening paragraph and before `## Buzz CLI`. The section explains:

- Each channel is a separate session; multiple sessions of the same agent identity may be active simultaneously.
- Sessions share core memory, workspace, and relay — but not conversation context or in-flight reasoning.
- Cross-channel work belongs to the owning session by default; the current session may take it over only when the human explicitly requests it.

No runtime code changes. Base prompt only.
