### PR TITLE
fix(acp): kill the whole process tree on Windows, not just the wrapper

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -422,8 +422,9 @@ impl AcpClient {
         // ensures subprocesses (MCP servers, tool processes) are cleaned up
         // rather than orphaned to init.
         //
-        // Falls back to start_kill() (direct child only) on non-Unix or if
-        // the child has been polled to completion (id() returns None).
+        // Falls back to start_kill() (direct child only) when the platform
+        // has no tree-kill or the child has been polled to completion
+        // (id() returns None).
         match self.child.id() {
             Some(pid) if kill_process_group(pid) => {}
             _ => {
@@ -2232,9 +2233,37 @@ fn kill_process_group(pid: u32) -> bool {
     killpg(Pid::from_raw(pid as i32), Signal::SIGKILL).is_ok()
 }
 
-/// Fallback for non-Unix: process-group kill not available.
-/// Returns `false` so the caller falls back to `child.start_kill()`.
-#[cfg(not(unix))]
+/// Kill an entire process tree on Windows via `taskkill /T /F`.
+///
+/// `start_kill()` alone is not equivalent here. Rust runs a `.cmd`/`.bat`
+/// shim (how npm installs `claude-code-acp`, `hermes-acp` and friends)
+/// through an intermediate `cmd.exe`, so killing the direct child reaps the
+/// wrapper and leaves the real agent — and its MCP servers — running. On a
+/// timeout/respawn loop each cycle then strands another live agent for the
+/// life of the session.
+///
+/// `/T` covers the tree the way `killpg` does on Unix, keeping teardown
+/// symmetric across platforms. `CREATE_NO_WINDOW` matches
+/// [`configure_no_window`] so cleanup never flashes a console at a GUI user.
+/// Mirrors `taskkill_tree` in the desktop crate, which solved the same
+/// problem for managed-agent teardown.
+#[cfg(windows)]
+fn kill_process_group(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    std::process::Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &pid.to_string()])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Fallback for platforms that are neither Unix nor Windows: process-group
+/// kill not available. Returns `false` so the caller falls back to
+/// `child.start_kill()`.
+#[cfg(not(any(unix, windows)))]
 fn kill_process_group(_pid: u32) -> bool {
     false
 }


### PR DESCRIPTION
## Problem

`AcpClient::shutdown()` kills the process **group** on Unix and falls back to `start_kill()` everywhere else, because `kill_process_group` is `#[cfg(not(unix))] -> false` (`crates/buzz-acp/src/acp.rs`). On Windows that fallback is not equivalent.

Rust runs a `.cmd`/`.bat` shim through an intermediate `cmd.exe` (post-CVE-2024-24576 behaviour), and npm installs the ACP agents as exactly that kind of shim — `claude-code-acp`, `hermes-acp`. So `start_kill()` reaps the `cmd.exe` wrapper and leaves the real agent — plus any MCP servers it started — alive.

Every timeout-then-respawn cycle therefore strands another live agent for the rest of the session. On a repeating failure it accumulates: I found this while tracing #4098, where the 60s timeout respawns the child in a loop.

## Change

Adds the Windows arm using `taskkill /T /F`, which covers the tree the way `killpg` does on Unix, so teardown is symmetric across platforms.

It deliberately mirrors `taskkill_tree` in `desktop/src-tauri/src/managed_agents/process_lifecycle.rs` — the same problem, already solved once for managed-agent teardown — including its `CREATE_NO_WINDOW` flag so cleanup never flashes a console at a GUI user. That also matches the existing `configure_no_window` helper in this file.

- No `unsafe`, so the crate's `#![deny(unsafe_code)]` policy is preserved.
- The Unix path is untouched; the new code is `#[cfg(windows)]`.
- The `#[cfg(not(any(unix, windows)))]` fallback stays for other platforms.

## Verification

On Windows: `cargo check -p buzz-acp`, `cargo clippy -p buzz-acp --all-targets` (0 warnings) and `cargo fmt -p buzz-acp -- --check` (no diffs) are all clean.

**I am not offering the crate's test suite as evidence either way.** On this Windows box it is non-deterministic — a run against untouched `main` fails a different set each time, which is consistent with #2492 — so a before/after comparison would be noise, not a receipt. Happy to run anything specific you'd trust more.

Related: #4098 (the respawn loop that surfaced this), #2492 (`just ci` on Windows).

Duplicates: searched open PRs for `taskkill`, `kill_process_group`, and `process tree` — none found.