### PR TITLE
feat(acp): expose channel and sender identity via _meta.buzz on session/prompt

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -749,6 +749,7 @@ impl AcpClient {
         self.session_prompt_blocks_with_idle_timeout(
             session_id,
             std::slice::from_ref(&prompt_text),
+            None,
             idle_timeout,
             max_duration,
         )
@@ -756,7 +757,8 @@ impl AcpClient {
     }
 
     /// Like [`session_prompt_with_idle_timeout`](Self::session_prompt_with_idle_timeout),
-    /// but sends each entry in `prompt_blocks` as a separate text content block.
+    /// but sends each entry in `prompt_blocks` as a separate text content block,
+    /// optionally attaching structured batch metadata as `_meta.buzz`.
     ///
     /// Used for slash-command pass-through: ACP connectors detect commands via
     /// the **first** block's text starting with `/`, so the harness sends
@@ -765,10 +767,11 @@ impl AcpClient {
         &mut self,
         session_id: &str,
         prompt_blocks: &[&str],
+        meta: Option<&serde_json::Value>,
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
-        let params = build_prompt_params(session_id, prompt_blocks);
+        let params = build_prompt_params(session_id, prompt_blocks, meta);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
 
@@ -1967,15 +1970,27 @@ impl AcpClient {
 }
 
 /// Build `session/prompt` params from one or more text content blocks.
-fn build_prompt_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::Value {
+///
+/// When `meta` is provided it is attached under `_meta.buzz` — nested under a
+/// `buzz` key to keep the `_meta` root clean, matching the `_meta.goose.*`
+/// pattern. `None` leaves `_meta` off the params entirely.
+fn build_prompt_params(
+    session_id: &str,
+    prompt_blocks: &[&str],
+    meta: Option<&serde_json::Value>,
+) -> serde_json::Value {
     let blocks: Vec<serde_json::Value> = prompt_blocks
         .iter()
         .map(|text| serde_json::json!({ "type": "text", "text": text }))
         .collect();
-    serde_json::json!({
+    let mut params = serde_json::json!({
         "sessionId": session_id,
         "prompt": blocks,
-    })
+    });
+    if let Some(meta) = meta {
+        params["_meta"]["buzz"] = meta.clone();
+    }
+    params
 }
 
 /// Build `_goose/unstable/session/steer` params from one or more text
@@ -2489,6 +2504,7 @@ mod tests {
                 "/goal ship it",
                 "[Buzz event: @mention]\nContent: @Eva /goal ship it",
             ],
+            None,
         );
         let prompt = params["prompt"].as_array().unwrap();
         assert_eq!(prompt.len(), 2);
@@ -2496,6 +2512,35 @@ mod tests {
         assert_eq!(prompt[0]["text"].as_str(), Some("/goal ship it"));
         assert!(prompt[0]["text"].as_str().unwrap().starts_with('/'));
         assert_eq!(prompt[1]["type"].as_str(), Some("text"));
+    }
+
+    #[test]
+    fn session_prompt_params_omit_meta_entirely_when_none() {
+        // Batch-less prompts (heartbeats, initial_message) must not grow an
+        // empty `_meta` object — the key is absent, not null.
+        let params = build_prompt_params("sess_abc123", &["hello"], None);
+        assert!(params.get("_meta").is_none());
+        assert_eq!(params["sessionId"].as_str(), Some("sess_abc123"));
+        assert_eq!(params["prompt"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn session_prompt_params_nest_meta_under_buzz_key() {
+        let meta = serde_json::json!({
+            "channelId": "7f3a2b10-0000-0000-0000-000000000000",
+            "channelType": "dm",
+            "events": [
+                { "id": "ab".repeat(32), "sender": "cd".repeat(32), "kind": 9, "createdAt": 1785840000u64 }
+            ],
+        });
+        let params = build_prompt_params("sess_abc123", &["hello"], Some(&meta));
+        // Nested under `buzz` to keep the `_meta` root clean, matching the
+        // `_meta.goose.*` pattern.
+        assert_eq!(params["_meta"]["buzz"], meta);
+        // The prompt blocks are unaffected by the metadata.
+        let prompt = params["prompt"].as_array().unwrap();
+        assert_eq!(prompt.len(), 1);
+        assert_eq!(prompt[0]["text"].as_str(), Some("hello"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1820,6 +1820,10 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    // Structured channel/sender identity for the batch, attached to the
+    // `session/prompt` request as `_meta.buzz`. `None` for heartbeats and
+    // other batch-less prompts.
+    let mut prompt_meta: Option<serde_json::Value> = None;
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
@@ -1862,6 +1866,8 @@ pub async fn run_prompt_task(
                 "slash-command pass-through"
             );
         }
+
+        prompt_meta = Some(crate::queue::build_prompt_meta(b, channel_info.as_ref()));
 
         crate::queue::format_prompt(
             b,
@@ -1939,6 +1945,7 @@ pub async fn run_prompt_task(
                 result = agent.acp.session_prompt_blocks_with_idle_timeout(
                     &session_id,
                     &prompt_blocks,
+                    prompt_meta.as_ref(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,
@@ -1950,6 +1957,7 @@ pub async fn run_prompt_task(
                 result = agent.acp.session_prompt_blocks_with_idle_timeout(
                     &session_id,
                     &prompt_blocks,
+                    prompt_meta.as_ref(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1146,6 +1146,45 @@ pub(crate) fn format_event_block(
     block
 }
 
+/// Build the `_meta.buzz` value attached to the `session/prompt` request for
+/// a [`FlushBatch`].
+///
+/// Exposes the channel and sender identity that [`format_event_block`] already
+/// renders into the prompt *text*, but structured, so ACP agents can key
+/// memory, authorization, or routing on it without parsing the rendered
+/// prompt. Additive metadata only — the prompt text is unchanged, and agents
+/// that ignore `_meta` see no difference.
+///
+/// `channelType` is included only when channel metadata is resolved; consumers
+/// must not assume a type when the key is absent. `cancelledEvents` is omitted
+/// (rather than empty) for normal, non-merge batches.
+pub(crate) fn build_prompt_meta(
+    batch: &FlushBatch,
+    channel_info: Option<&PromptChannelInfo>,
+) -> serde_json::Value {
+    fn event_meta(be: &BatchEvent) -> serde_json::Value {
+        serde_json::json!({
+            "id": be.event.id.to_hex(),
+            "sender": be.event.pubkey.to_hex(),
+            "kind": be.event.kind.as_u16(),
+            "createdAt": be.event.created_at.as_secs(),
+        })
+    }
+
+    let mut meta = serde_json::json!({
+        "channelId": batch.channel_id,
+        "events": batch.events.iter().map(event_meta).collect::<Vec<_>>(),
+    });
+    if let Some(ci) = channel_info {
+        meta["channelType"] = serde_json::Value::String(ci.channel_type.clone());
+    }
+    if !batch.cancelled_events.is_empty() {
+        meta["cancelledEvents"] =
+            serde_json::Value::Array(batch.cancelled_events.iter().map(event_meta).collect());
+    }
+    meta
+}
+
 /// Append a reply instruction when the agent is responding to a thread event.
 ///
 /// Tells the agent to default to `--reply-to <event_id>` for ordinary replies
@@ -1895,6 +1934,83 @@ mod tests {
         assert!(prompt.contains("Event ID:"));
         // Should NOT contain "--- Event 1 ---" (that's the multi-event format).
         assert!(!prompt.contains("--- Event 1 ---"));
+    }
+
+    #[test]
+    fn test_build_prompt_meta_multi_event_batch_with_cancelled() {
+        let ch = Uuid::new_v4();
+        let e1 = make_event("first message");
+        let e2 = make_event("second message");
+        let cancelled = make_event("the original task");
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![
+                BatchEvent {
+                    event: e1.clone(),
+                    prompt_tag: "@mention".into(),
+                    received_at: Instant::now(),
+                },
+                BatchEvent {
+                    event: e2.clone(),
+                    prompt_tag: "@mention".into(),
+                    received_at: Instant::now(),
+                },
+            ],
+            cancelled_events: vec![BatchEvent {
+                event: cancelled.clone(),
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancel_reason: Some(CancelReason::Steer),
+        };
+        let info = PromptChannelInfo {
+            name: "general".into(),
+            channel_type: "dm".into(),
+        };
+
+        let meta = build_prompt_meta(&batch, Some(&info));
+
+        let expect_event = |e: &Event| {
+            serde_json::json!({
+                "id": e.id.to_hex(),
+                "sender": e.pubkey.to_hex(),
+                "kind": 9,
+                "createdAt": e.created_at.as_secs(),
+            })
+        };
+        assert_eq!(
+            meta,
+            serde_json::json!({
+                "channelId": ch,
+                "channelType": "dm",
+                "events": [expect_event(&e1), expect_event(&e2)],
+                "cancelledEvents": [expect_event(&cancelled)],
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_prompt_meta_omits_channel_type_and_cancelled_when_absent() {
+        // No resolved channel metadata → no channelType key (consumers must
+        // not assume a type); no cancelled events → no cancelledEvents key.
+        let ch = Uuid::new_v4();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event: make_event("hello"),
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let meta = build_prompt_meta(&batch, None);
+
+        assert!(meta.get("channelType").is_none());
+        assert!(meta.get("cancelledEvents").is_none());
+        assert_eq!(meta["channelId"], serde_json::json!(ch));
+        assert_eq!(meta["events"].as_array().unwrap().len(), 1);
     }
 
     /// Helper: build a merged (cancel + re-prompt) batch with one cancelled


### PR DESCRIPTION
Implements #4745: attaches the channel and sender identity that `format_event_block` already renders into the prompt *text* as structured ACP `_meta` on `session/prompt`, so agents can key memory, authorization, or routing on it without parsing the rendered prompt.

```jsonc
"_meta": {
  "buzz": {
    "channelId": "…",
    "channelType": "stream",          // omitted when channel metadata is unresolved
    "events": [ { "id", "sender", "kind", "createdAt" } ],
    "cancelledEvents": [ … ]           // present only for Steer/Interrupt merge batches
  }
}
```

- **Additive only** — prompt text unchanged; agents that ignore `_meta` see no difference. Follows the existing `_meta` merging precedent from `session/new` (`sessionTitle`/`systemPrompt`).
- Built in `queue.rs` beside `format_event_block` (whose reads it mirrors), threaded through `session_prompt_blocks_with_idle_timeout` → `build_prompt_params`, populated at the batch prompt site in `pool.rs`. Heartbeat/initial-message paths pass nothing. The goose-native steer path is untouched.
- **One deviation from the issue sketch:** `channelType` passes through the codebase's actual value set (`dm`/`private`/`stream`/`unknown` per `channel_type_from_tags`) rather than the issue's simplified `channel|dm`, and the key is omitted when channel metadata is unresolved — per the relay-side warning that consumers must not assume a type for unknown channels. Happy to normalize instead if you'd prefer.
- Tests: 4 new (meta shape incl. cancelled events and omission rules; params nesting; None ⇒ no `_meta` key), `cargo test -p buzz-acp` 672 passed, fmt + clippy clean per your CI.

Consumer context: [muxi-ai/acp-bridge](https://github.com/muxi-ai/acp-bridge) currently parses the rendered event blocks for this data and will switch to `_meta.buzz` as soon as it exists.
