### PR TITLE
fix(mobile): hide NIP-IA archived identities from mention autocomplete

### DIFF
--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -52,12 +52,22 @@ List<MentionCandidate> buildMentionCandidates({
   required Map<String, String> ownerByAgentPubkey,
   List<UserProfile> searchResults = const [],
   String? currentPubkey,
+  Set<String> archivedPubkeys = const {},
 }) {
   final candidates = <MentionCandidate>[];
   final seen = <String>{};
+  final currentLower = currentPubkey?.toLowerCase();
+
+  // Mirrors desktop's `useIsArchivedPredicate`: NIP-IA archived identities
+  // are hidden from every candidate source. Self-exempt — the current user
+  // is never folded from their own picker, even when archived, so archival
+  // stays non-silent (the anti-shadowban property of NIP-IA §Self Requests).
+  bool hiddenAsArchived(String pk) =>
+      pk != currentLower && archivedPubkeys.contains(pk);
 
   for (final member in members) {
     final pk = member.pubkey.toLowerCase();
+    if (hiddenAsArchived(pk)) continue;
     if (!seen.add(pk)) continue;
     final profile = userCache[pk];
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
@@ -89,6 +99,7 @@ List<MentionCandidate> buildMentionCandidates({
 
   for (final agent in relayAgents) {
     final pk = agent.pubkey;
+    if (hiddenAsArchived(pk)) continue;
     if (seen.contains(pk)) continue;
     if (!sharedAgentPubkeys.contains(pk)) continue;
     seen.add(pk);
@@ -108,9 +119,9 @@ List<MentionCandidate> buildMentionCandidates({
     );
   }
 
-  final currentLower = currentPubkey?.toLowerCase();
   for (final profile in searchResults) {
     final pk = profile.pubkey.toLowerCase();
+    if (hiddenAsArchived(pk)) continue;
     if (seen.contains(pk)) continue;
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile.ownerPubkey;
     final isAgent = ownerPubkey != null || directoryPubkeys.contains(pk);

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -2,6 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../shared/crypto/nip_oa.dart';
 import '../../../shared/mentions/agent_identity_provider.dart';
+import '../../../shared/mentions/archived_identities_provider.dart';
 import '../../../shared/relay/relay.dart';
 import '../../profile/user_cache_provider.dart';
 import '../../profile/user_profile.dart';
@@ -87,6 +88,11 @@ final mentionCandidatesProvider = Provider.family
       final searchResults =
           ref.watch(mentionUserSearchProvider(args.query)).asData?.value ??
           const <UserProfile>[];
+      // Fail-open while the NIP-IA snapshot loads (empty set) — mirrors
+      // desktop's `useIsArchivedPredicate`.
+      final archivedPubkeys =
+          ref.watch(archivedIdentitiesProvider).asData?.value ??
+          const <String>{};
 
       final sharedChannelIds = {
         for (final channel in channels)
@@ -101,6 +107,7 @@ final mentionCandidatesProvider = Provider.family
         ownerByAgentPubkey: owners,
         searchResults: searchResults,
         currentPubkey: currentPubkey,
+        archivedPubkeys: archivedPubkeys,
       );
 
       return rankMentionCandidates(candidates, args.query);

--- a/mobile/lib/shared/mentions/archived_identities_provider.dart
+++ b/mobile/lib/shared/mentions/archived_identities_provider.dart
@@ -1,0 +1,23 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../relay/relay.dart';
+
+/// Archived identity pubkeys from the relay's NIP-IA snapshot (kind:13535).
+///
+/// Mirrors desktop's `useArchivedIdentitiesQuery`: archived identities stay
+/// renderable in history but are hidden from forward-looking discovery
+/// surfaces such as mention autocomplete. Fail-open — the set is empty while
+/// the snapshot loads, so a cold start can't briefly hide everyone.
+///
+/// Watches the session and only fetches after the WebSocket connects.
+final archivedIdentitiesProvider = FutureProvider<Set<String>>((ref) async {
+  final sessionState = ref.watch(relaySessionProvider);
+  if (sessionState.status != SessionStatus.connected) return const {};
+  final session = ref.read(relaySessionProvider.notifier);
+  final events = await session.fetchHistory(NostrFilters.archivedIdentities());
+  if (events.isEmpty) return const {};
+  return {
+    for (final tag in events.first.tags)
+      if (tag.length >= 2 && tag[0] == 'p') tag[1].toLowerCase(),
+  };
+});

--- a/mobile/lib/shared/relay/nostr_filters.dart
+++ b/mobile/lib/shared/relay/nostr_filters.dart
@@ -209,6 +209,10 @@ abstract final class NostrFilters {
   static NostrFilter agentProfiles() =>
       const NostrFilter(kinds: [10100], limit: 100);
 
+  /// NIP-IA archived-identities snapshot (kind:13535).
+  static NostrFilter archivedIdentities() =>
+      const NostrFilter(kinds: [13535], limit: 1);
+
   /// User status (NIP-38, kind:30315).
   static NostrFilter userStatus(String pubkey) =>
       NostrFilter(kinds: [30315], authors: [pubkey], limit: 1);

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -280,5 +280,50 @@ void main() {
       expect(candidates, hasLength(1));
       expect(candidates.single.isMember, isTrue);
     });
+
+    test('archived identities are hidden from every candidate source', () {
+      final archivedMember = '4' * 64;
+      final archivedAgent = '5' * 64;
+      final archivedSearchHit = '6' * 64;
+      final candidates = buildMentionCandidates(
+        members: [member(memberPubkey), member(archivedMember)],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: archivedAgent,
+            displayName: 'Retired Helper',
+            respondTo: 'anyone',
+            channelIds: const ['chan-1'],
+          ),
+        ],
+        sharedChannelIds: {'chan-1'},
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        searchResults: [
+          UserProfile(
+            pubkey: archivedSearchHit,
+            displayName: 'Old Bot',
+            ownerPubkey: userPubkey,
+          ),
+        ],
+        currentPubkey: userPubkey,
+        archivedPubkeys: {archivedMember, archivedAgent, archivedSearchHit},
+      );
+
+      expect(candidates.map((c) => c.pubkey), [memberPubkey]);
+    });
+
+    test('the current user is never hidden by their own archival', () {
+      final candidates = buildMentionCandidates(
+        members: [member(userPubkey)],
+        relayAgents: const [],
+        sharedChannelIds: const {},
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        currentPubkey: userPubkey,
+        archivedPubkeys: {userPubkey},
+      );
+
+      expect(candidates.map((c) => c.pubkey), contains(userPubkey));
+    });
   });
 }


### PR DESCRIPTION
## What

The mobile mention picker shows NIP-IA-archived identities. On a community that has rotated its agent keys, typing `@` lists every retired agent alongside the live one — as stale channel members, and as "managed by you · not in channel" rows sourced from the kind:0 prefix search. Desktop already folds these from discovery surfaces via `useIsArchivedPredicate` (`desktop/src/features/identity-archive/hooks.ts`); mobile had no equivalent.

## How

- `NostrFilters.archivedIdentities()` — kind:13535 snapshot filter (same shape as `relayMembers()`).
- `archivedIdentitiesProvider` (`shared/mentions/`) — fetches the relay's NIP-IA snapshot after the WebSocket connects and exposes the archived pubkeys as a lowercase set. Fail-open: empty while the snapshot loads, so a cold start can't briefly hide everyone.
- `buildMentionCandidates` gains `archivedPubkeys` and folds archived identities from all three candidate sources (channel members, relay agent directory, global user search). Self-exempt: the current user is never folded from their own picker, matching desktop's predicate and NIP-IA's anti-shadowban intent.

## Tests

- `mention_candidates_test.dart`: archived identities are hidden from every candidate source; the current user is never hidden by their own archival.
- `dart format` clean, `flutter analyze` no issues, full `flutter test` suite passes (1164 tests), `check-file-sizes.mjs` passes.

## Manual verification

Reproduced on a production relay with 12 archived rotated agent identities: typing `@ma` listed three dead "MAIN" agents alongside the live one. On-device verification of this patch was not performed (no iOS/Android build environment on the contributing machine); the unit tests cover the candidate-assembly logic and the provider mirrors desktop's snapshot semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)