### PR TITLE
test(deploy): validate production Compose renders

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -1,0 +1,33 @@
+name: Production Compose
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/compose/**"
+      - "prometheus.yml"
+      - ".github/workflows/compose.yml"
+  pull_request:
+    paths:
+      - "deploy/compose/**"
+      - "prometheus.yml"
+      - ".github/workflows/compose.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compose-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: Validate production Compose renders
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check deployment scripts
+        run: shellcheck deploy/compose/run.sh deploy/compose/test.sh
+      - name: Render base, TLS, and development stacks
+        run: deploy/compose/test.sh

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -59,3 +59,13 @@ $EDITOR .env
 curl -fsS "http://127.0.0.1:$(grep -E '^BUZZ_HTTP_PORT=' .env | cut -d= -f2-)/_liveness"
 ./run.sh status
 ```
+
+The repository also validates every supported Compose merge without starting
+containers:
+
+```bash
+./test.sh
+```
+
+This renders the base stack, the Caddy/TLS override, and the development
+override using only the placeholder values from `.env.example`.

--- a/deploy/compose/test.sh
+++ b/deploy/compose/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="$(mktemp -d /tmp/buzz-compose-test.XXXXXXXXXX)"
+
+cleanup() {
+  case "${WORK_DIR}" in
+    /tmp/buzz-compose-test.*) rm -rf -- "${WORK_DIR}" ;;
+  esac
+}
+trap cleanup EXIT
+
+install -d "${WORK_DIR}/deploy/compose"
+cp \
+  "${SCRIPT_DIR}/.env.example" \
+  "${SCRIPT_DIR}/Caddyfile" \
+  "${SCRIPT_DIR}/compose.yml" \
+  "${SCRIPT_DIR}/compose.caddy.yml" \
+  "${SCRIPT_DIR}/compose.dev.yml" \
+  "${WORK_DIR}/deploy/compose/"
+cp "${SCRIPT_DIR}/../../prometheus.yml" "${WORK_DIR}/prometheus.yml"
+cp "${SCRIPT_DIR}/.env.example" "${WORK_DIR}/deploy/compose/.env"
+
+cd "${WORK_DIR}/deploy/compose"
+
+render() {
+  local name="$1"
+  shift
+  docker compose \
+    --env-file .env \
+    -f compose.yml \
+    "$@" \
+    config --quiet
+  printf 'Validated production Compose render: %s\n' "${name}"
+}
+
+render base
+render tls -f compose.caddy.yml
+render dev -f compose.dev.yml
+render tls-dev -f compose.caddy.yml -f compose.dev.yml


### PR DESCRIPTION
## Summary

- add a secret-free production Compose render test
- validate the base, Caddy/TLS, development, and combined TLS-development
  configurations
- run the test and ShellCheck in a dedicated path-filtered CI workflow

## Why

The production Compose bundle previously had only a manual validation
checklist. Override or interpolation errors could therefore merge without any
automated render coverage.

The test copies only checked-in Compose files and `.env.example` placeholders
to a disposable directory. It runs `docker compose config --quiet` and does not
start containers or create volumes or networks.

## Testing

- `shellcheck deploy/compose/run.sh deploy/compose/test.sh`
- `bash -n deploy/compose/run.sh deploy/compose/test.sh`
- `deploy/compose/test.sh`
- YAML parse of `.github/workflows/compose.yml`
- `git diff --check`

All four Compose combinations rendered successfully.

## Review

One Fable 5 xhigh review initially returned `NEEDS CHANGES`. All accepted
findings were incorporated: the draft covers the combined TLS-development
merge, triggers on `prometheus.yml`, and cancels superseded pull-request runs.
The executable mode is preserved. No second independent review was run.

## Scope

This adds a CI signal. It does not change branch-protection settings, start a
deployment, read a real `.env`, or change runtime behavior.
