### PR TITLE
fix(agents): resolve preset harness args at spawn

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -440,12 +440,25 @@ pub fn try_record_agent_command(
     Ok(default_agent_command())
 }
 
+/// Resolve the canonical invocation args for a harness command.
+///
+/// Two tiers, mirroring `canonical_harness_command`:
+///
+/// 1. **Builtins** — `KNOWN_ACP_RUNTIMES`, matched by normalised command.
+/// 2. **Static presets** — `PRESET_HARNESSES`, the source of truth for their
+///    own invocations (`devin acp`, `cursor-agent acp`, `grok agent …`).
+///
+/// Tier 2 exists because builtins alone left every preset resolving to `None`,
+/// which silently dropped the args a preset declares. An agent pinned to a
+/// preset by command (no `runtime` id on the record, so the id-keyed registry
+/// lookup in `resolve_effective_harness_descriptor` misses) then spawned bare:
+/// `devin` instead of `devin acp`, which exits immediately.
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
-        _ => None,
+        _ => presets::preset_args_for_command(command),
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -213,6 +213,27 @@ pub(super) fn preset_command_for_id(id: &str) -> Option<&'static str> {
         .map(|p| p.command)
 }
 
+/// Return the declared args for a preset harness, matched by runtime id or by
+/// normalised command, or `None` if the input is not a known preset.
+///
+/// This is the args-side counterpart to `preset_command_for_id`. It lets
+/// `normalize_agent_args` treat `PRESET_HARNESSES` as the single source of
+/// truth for preset invocations instead of duplicating them in a hardcoded
+/// builtin-only match.
+///
+/// Deliberately static-only: no loaded-registry tier. This runs inside
+/// `preset_catalog_entry`, which is called while the catalog is being built,
+/// so acquiring the registry lock here risks deadlocking against a concurrent
+/// warm/refresh. Registry-backed harnesses already resolve their args by
+/// runtime id in `resolve_effective_harness_descriptor`.
+pub(super) fn preset_args_for_command(command: &str) -> Option<Vec<String>> {
+    let normalized = super::normalize_command_identity(command);
+    PRESET_HARNESSES
+        .iter()
+        .find(|p| p.id == normalized || super::normalize_command_identity(p.command) == normalized)
+        .map(|p| p.args.iter().map(|arg| arg.to_string()).collect())
+}
+
 /// Return the primary harness command for a given runtime id, or `None`.
 ///
 /// Checks static builtins, then the static preset list (always available,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -71,6 +71,92 @@ fn normalizes_claude_and_codex_args_to_empty() {
 }
 
 #[test]
+fn preset_commands_keep_their_declared_args() {
+    // Regression: presets resolved to `None` in `default_agent_args`, so a
+    // record with empty `agent_args` spawned the harness bare. `devin` with no
+    // args opens the interactive TUI on a stdio pipe and exits immediately,
+    // which surfaced as "agent initialize failed: Agent process exited
+    // unexpectedly" for every agent in the pool.
+    assert_eq!(
+        normalize_agent_args("devin", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("cursor-agent", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("omp", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("openclaw", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    // Multi-arg preset: the whole vector survives, not just the first entry.
+    assert_eq!(
+        normalize_agent_args("grok", Vec::new()),
+        vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "stdio".to_string()
+        ]
+    );
+}
+
+#[test]
+fn preset_args_resolve_through_path_prefixes_and_runtime_ids() {
+    // Records can store a resolved binary path or the runtime id rather than
+    // the bare command; both must reach the same preset entry.
+    assert_eq!(
+        normalize_agent_args("/Users/me/.local/bin/devin", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("cursor", Vec::new()),
+        vec!["acp".to_string()]
+    );
+}
+
+#[test]
+fn explicit_preset_args_win_over_declared_defaults() {
+    assert_eq!(
+        normalize_agent_args("devin", vec!["acp".into(), "--verbose".into()]),
+        vec!["acp".to_string(), "--verbose".to_string()]
+    );
+}
+
+#[test]
+fn adapter_presets_stay_argless() {
+    // amp-acp and hermes-acp declare no args; a stray "acp" is dropped the
+    // same way it is for claude-code-acp.
+    assert_eq!(
+        normalize_agent_args("amp-acp", Vec::new()),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("amp-acp", vec!["acp".into()]),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("hermes-acp", Vec::new()),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn unknown_commands_still_resolve_to_no_args() {
+    assert_eq!(
+        normalize_agent_args("some-custom-harness", Vec::new()),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        normalize_agent_args("some-custom-harness", vec!["--flag".into()]),
+        vec!["--flag".to_string()]
+    );
+}
+
+#[test]
 fn resolves_buzz_agent_avatar() {
     assert_eq!(
         managed_agent_avatar_url("buzz-agent"),


### PR DESCRIPTION
Fixes #4764.

## Problem

`default_agent_args` matched only `KNOWN_ACP_RUNTIMES`, so every entry in `PRESET_HARNESSES` fell through to `None` and the args a preset declares were dropped. Presets have carried their own invocations since #3225 — `devin acp`, `cursor-agent acp`, `grok agent --always-approve stdio` — but nothing on the spawn path read them.

An agent pinned to a preset by command rather than by runtime id hits this. With `record.agent_args` empty and `record.runtime` unset, the id-keyed registry lookup in `resolve_effective_harness_descriptor` misses and resolution falls to `normalize_agent_args`, which returns `[]`. `runtime.rs:573` then sets `BUZZ_ACP_AGENT_ARGS=""`, which overrides buzz-acp's own `[default: acp]`, and the harness spawns bare:

```
INFO buzz_acp: buzz-acp starting: ... agent_cmd=/Users/me/.local/bin/devin  mcp_cmd= ... agents=10
ERROR buzz_acp: agent initialize failed: Agent process exited unexpectedly agent=0
...
Error: all 10 agents failed to start — cannot continue
```

`devin` with no args opens the interactive TUI on a stdio pipe and exits (`Error: Scrollback error: io error`). `devin acp` returns a valid initialize result.

Affects devin, cursor, omp, opencode, kimi, openclaw and grok. Adapter presets (amp, hermes) declare no args and are unaffected in practice.

## Relationship to #4631

Same shape, one field over. #4631 fixed preset invisibility for the harness **command** and added `canonical_harness_command` with builtins → static presets → loaded registry. The **args** kept the builtin-only blind spot.

## Fix

Add `preset_args_for_command` in `discovery/presets.rs` and consult it as tier 2 of `default_agent_args`, so `PRESET_HARNESSES` is the single source of truth for its own invocations instead of requiring a parallel entry in a hardcoded match.

Deliberately static-only — no loaded-registry tier. This runs inside `preset_catalog_entry` while the catalog is being built, so acquiring the registry lock there risks deadlocking against a concurrent warm/refresh. Registry-backed harnesses already resolve their args by runtime id in `resolve_effective_harness_descriptor`, so the tier would be redundant as well as risky.

Adding `"devin" => Some(vec!["acp".to_string()])` to the match would have fixed the reported symptom and left cursor, omp, opencode, kimi, openclaw and grok broken, plus every preset added later. Hence the lookup.

## Why existing tests passed

`devin_preset_uses_official_native_acp_invocation` asserts `entry.default_args == vec!["acp"]` and passed throughout. `preset_catalog_entry` passes `def.args` in explicitly, so the non-empty branch returns them unchanged — the catalog never exercised the empty-args path that spawn takes. The new tests cover that path directly.

## Tests

Five new tests in `discovery/tests.rs`:

- `preset_commands_keep_their_declared_args` — devin, cursor-agent, omp, openclaw resolve to `["acp"]`; grok keeps all three of its args
- `preset_args_resolve_through_path_prefixes_and_runtime_ids` — `/Users/me/.local/bin/devin` and the bare id `cursor` both resolve
- `explicit_preset_args_win_over_declared_defaults` — user args are not clobbered
- `adapter_presets_stay_argless` — amp-acp and hermes-acp stay empty; a stray `acp` is dropped as it is for claude-code-acp
- `unknown_commands_still_resolve_to_no_args` — custom harnesses unchanged

## Verification

```
just desktop-tauri-test    2204 passed / 0 failed / 14 ignored
just desktop-tauri-clippy  clean under -D warnings
just desktop-tauri-fmt     clean
```

Regression check — reverting the one-line change in `default_agent_args` to `_ => None` fails exactly the new tests:

```
preset_args_resolve_through_path_prefixes_and_runtime_ids ... FAILED
adapter_presets_stay_argless ... FAILED
preset_commands_keep_their_declared_args ... FAILED

  left: []
 right: ["acp"]
```

Restoring it returns the suite to green.

## Note for maintainers

Records already written with `"agent_args": []` are fixed by this change, since resolution is recomputed at spawn rather than read from the frozen snapshot. No migration needed.