### PR TITLE
feat(desktop): Attention — a personal triage view over the home feed (preview feature)

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/attention.spec.ts",
+        "**/catchup.spec.ts",
         "**/onboarding-docked-cta-screenshots.spec.ts",
         "**/identity-key-help.spec.ts",
         "**/key-import-reveal.spec.ts",

--- a/desktop/src/app/AppShell.helpers.ts
+++ b/desktop/src/app/AppShell.helpers.ts
@@ -9,7 +9,8 @@ export type AppView =
   | "agents"
   | "workflows"
   | "pulse"
-  | "projects";
+  | "projects"
+  | "attention";
 
 const WINDOW_DRAG_HANDLE_HEIGHT = 44;
 const TAURI_DRAG_REGION_ATTR = "data-tauri-drag-region";
@@ -185,6 +186,13 @@ export function deriveShellRoute(pathname: string): {
     return {
       selectedChannelId: null,
       selectedView: "pulse",
+    };
+  }
+
+  if (pathname === "/attention") {
+    return {
+      selectedChannelId: null,
+      selectedView: "attention",
     };
   }
 

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -135,6 +135,7 @@ export function AppShell() {
   useManagedAgentRuntimeReconciliation(communitiesHook.communities); // sync storage snapshot
   const {
     goAgents,
+    goAttention,
     goChannel,
     goHome,
     goNewMessage,
@@ -607,10 +608,6 @@ export function AppShell() {
     },
     [goSettings],
   );
-  const handleCloseSettings = React.useCallback(
-    () => closeSettings(),
-    [closeSettings],
-  );
   // Section switches rewrite the settings entry rather than stacking one
   // history entry per section, so back always exits settings in one step.
   const handleSettingsSectionChange = React.useCallback(
@@ -703,7 +700,7 @@ export function AppShell() {
     settingsOpen,
   ]);
   useSettingsShortcuts({
-    onClose: handleCloseSettings,
+    onClose: closeSettings,
     onOpenSettings: handleOpenSettings,
     open: isHuddleRoom ? undefined : settingsOpen,
   });
@@ -815,7 +812,7 @@ export function AppShell() {
                         }
                         notificationPermission={notificationSettings.permission}
                         notificationSettings={notificationSettings.settings}
-                        onClose={handleCloseSettings}
+                        onClose={closeSettings}
                         onSectionChange={handleSettingsSectionChange}
                         onSetDesktopNotificationsEnabled={
                           notificationSettings.setDesktopEnabled
@@ -901,6 +898,7 @@ export function AppShell() {
                         searchChannels={channels}
                         searchFocusRequest={searchFocusRequest}
                         onSelectHome={() => void goHome()}
+                        onSelectAttention={() => void goAttention()}
                         onSelectProjects={() => void goProjects()}
                         onSelectPulse={() => void goPulse()}
                         onSelectSettings={handleOpenSettings}

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -91,6 +91,17 @@ export function useAppNavigation() {
     [commitNavigation],
   );
 
+  const goAttention = React.useCallback(
+    (behavior?: NavigationBehavior) =>
+      commitNavigation(
+        {
+          to: "/attention",
+        },
+        behavior,
+      ),
+    [commitNavigation],
+  );
+
   const goProjects = React.useCallback(
     (behavior?: NavigationBehavior) =>
       commitNavigation(
@@ -311,6 +322,7 @@ export function useAppNavigation() {
     closeSettings,
     closeWorkflowDetail,
     goAgents,
+    goAttention,
     goChannel,
     goForumPost,
     goHome,

--- a/desktop/src/app/routeTree.gen.ts
+++ b/desktop/src/app/routeTree.gen.ts
@@ -10,6 +10,7 @@ import { Route as settingsRouteImport } from "./routes/settings";
 import { Route as remindersRouteImport } from "./routes/reminders";
 import { Route as pulseRouteImport } from "./routes/pulse";
 import { Route as projectsRouteImport } from "./routes/projects";
+import { Route as attentionRouteImport } from "./routes/attention";
 import { Route as agentsRouteImport } from "./routes/agents";
 import { Route as indexRouteImport } from "./routes/index";
 import { Route as workflowsDotworkflowIdRouteImport } from "./routes/workflows.$workflowId";
@@ -41,6 +42,11 @@ const pulseRoute = pulseRouteImport.update({
 const projectsRoute = projectsRouteImport.update({
   id: "/projects",
   path: "/projects",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const attentionRoute = attentionRouteImport.update({
+  id: "/attention",
+  path: "/attention",
   getParentRoute: () => rootRouteImport,
 } as any);
 const agentsRoute = agentsRouteImport.update({
@@ -83,6 +89,7 @@ const channelsDotchannelIdDotpostsDotpostIdRoute =
 export interface FileRoutesByFullPath {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/attention": typeof attentionRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
@@ -97,6 +104,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/attention": typeof attentionRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
@@ -112,6 +120,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/attention": typeof attentionRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
@@ -128,6 +137,7 @@ export interface FileRouteTypes {
   fullPaths:
     | "/"
     | "/agents"
+    | "/attention"
     | "/projects"
     | "/pulse"
     | "/reminders"
@@ -142,6 +152,7 @@ export interface FileRouteTypes {
   to:
     | "/"
     | "/agents"
+    | "/attention"
     | "/projects"
     | "/pulse"
     | "/reminders"
@@ -156,6 +167,7 @@ export interface FileRouteTypes {
     | "__root__"
     | "/"
     | "/agents"
+    | "/attention"
     | "/projects"
     | "/pulse"
     | "/reminders"
@@ -171,6 +183,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   indexRoute: typeof indexRoute;
   agentsRoute: typeof agentsRoute;
+  attentionRoute: typeof attentionRoute;
   projectsRoute: typeof projectsRoute;
   pulseRoute: typeof pulseRoute;
   remindersRoute: typeof remindersRoute;
@@ -218,6 +231,13 @@ declare module "@tanstack/react-router" {
       path: "/projects";
       fullPath: "/projects";
       preLoaderRoute: typeof projectsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/attention": {
+      id: "/attention";
+      path: "/attention";
+      fullPath: "/attention";
+      preLoaderRoute: typeof attentionRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/agents": {
@@ -275,6 +295,7 @@ declare module "@tanstack/react-router" {
 const rootRouteChildren: RootRouteChildren = {
   indexRoute: indexRoute,
   agentsRoute: agentsRoute,
+  attentionRoute: attentionRoute,
   projectsRoute: projectsRoute,
   pulseRoute: pulseRoute,
   remindersRoute: remindersRoute,

--- a/desktop/src/app/routes.ts
+++ b/desktop/src/app/routes.ts
@@ -3,6 +3,7 @@ import { index, rootRoute, route } from "@tanstack/virtual-file-routes";
 export const routes = rootRoute("root.tsx", [
   index("index.tsx"),
   route("/agents", "agents.tsx"),
+  route("/attention", "attention.tsx"),
   route("/pulse", "pulse.tsx"),
   route("/reminders", "reminders.tsx"),
   route("/settings", "settings.tsx"),

--- a/desktop/src/app/routes/attention.tsx
+++ b/desktop/src/app/routes/attention.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { usePreviewFeatureWarning } from "@/shared/features";
+import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
+
+const AttentionScreen = React.lazy(async () => {
+  const module = await import("@/features/attention/ui/AttentionScreen");
+  return { default: module.AttentionScreen };
+});
+
+export const Route = createFileRoute("/attention")({
+  component: AttentionRouteComponent,
+});
+
+function AttentionRouteComponent() {
+  usePreviewFeatureWarning("attention");
+  return (
+    <React.Suspense
+      fallback={<ViewLoadingFallback includeHeader kind="pulse" />}
+    >
+      <AttentionScreen />
+    </React.Suspense>
+  );
+}

--- a/desktop/src/features/attention/lib/attention.test.mjs
+++ b/desktop/src/features/attention/lib/attention.test.mjs
@@ -1,0 +1,533 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  actionPublishes,
+  attentionReason,
+  DONE_RETENTION_SECONDS,
+  HANDLED_ELSEWHERE_REPLY,
+  isAttentionWorthy,
+  offersHandledElsewhere,
+  persistableZoneState,
+  primaryGenericAction,
+  projectAttention,
+  pruneZoneState,
+} from "./attention.ts";
+
+const NOW = 1_700_000_000;
+const ASK_CONTENT = "Can you review the plan?";
+
+function makeInboxItem(overrides = {}) {
+  const {
+    conversationId = "conv-1",
+    categories = ["mention"],
+    content = ASK_CONTENT,
+    isActionRequired = false,
+    latestActivityAt = NOW - 600,
+    kind = 9,
+    groupItems,
+    tags = [],
+  } = overrides;
+  const item = {
+    id: `${conversationId}-latest`,
+    kind,
+    pubkey: "a".repeat(64),
+    content,
+    createdAt: latestActivityAt,
+    channelId: "channel-1",
+    channelName: "general",
+    tags,
+    category: categories[0] ?? "mention",
+  };
+  return {
+    avatarUrl: null,
+    conversationId,
+    id: item.id,
+    item,
+    categories,
+    categoryLabel: "Mention",
+    channelLabel: "general",
+    fullTimestampLabel: "",
+    groupItems: groupItems ?? [item],
+    isActionRequired,
+    latestActivityAt,
+    mentionNames: [],
+    preview: content,
+    senderLabel: "Alice",
+    subject: content,
+    timestampLabel: "",
+    unreadCount: 1,
+  };
+}
+
+test("mention and needs_action items are attention-worthy, plain activity is not", () => {
+  assert.equal(
+    isAttentionWorthy(makeInboxItem({ categories: ["mention"] })),
+    true,
+  );
+  assert.equal(
+    isAttentionWorthy(
+      makeInboxItem({ categories: ["needs_action"], isActionRequired: true }),
+    ),
+    true,
+  );
+  assert.equal(
+    isAttentionWorthy(makeInboxItem({ categories: ["activity"] })),
+    false,
+  );
+  assert.equal(
+    isAttentionWorthy(makeInboxItem({ categories: ["agent_activity"] })),
+    false,
+  );
+});
+
+test("ask-bearing items land in Needs Me, ask-less mentions demote to Heads up", () => {
+  const projection = projectAttention(
+    [
+      makeInboxItem({ conversationId: "conv-ask" }),
+      makeInboxItem({ conversationId: "conv-hi", content: "hello" }),
+    ],
+    {},
+    NOW,
+  );
+  assert.equal(projection.needsMe.length, 1);
+  assert.equal(projection.needsMe[0].id, "conv-ask");
+  assert.equal(projection.needsMe[0].zone, "needsMe");
+  assert.equal(projection.needsMe[0].reactivated, false);
+  assert.equal(projection.needsMe[0].askType, "review");
+  assert.equal(projection.needsMe[0].ask, ASK_CONTENT);
+  assert.equal(projection.needsMe[0].askCount, 1);
+
+  assert.equal(projection.headsUp.length, 1);
+  assert.equal(projection.headsUp[0].id, "conv-hi");
+  assert.equal(projection.headsUp[0].askType, "headsUp");
+  assert.equal(projection.headsUp[0].ask, null);
+
+  assert.equal(projection.waiting.length, 0);
+  assert.equal(projection.done.length, 0);
+});
+
+test("multi-ask messages carry askCount through the projection", () => {
+  const projection = projectAttention(
+    [
+      makeInboxItem({
+        content: "Can you approve the budget? Could you review the deck?",
+      }),
+    ],
+    {},
+    NOW,
+  );
+  assert.equal(projection.needsMe.length, 1);
+  assert.equal(projection.needsMe[0].askCount, 2);
+});
+
+test("declared asks for the viewer beat the derived tier", () => {
+  const content = [
+    "Context paragraph that mentions review casually.",
+    "**Needs Lee, decision:** Ship now or wait for the fix?",
+    "- Ship it now.",
+    "- Wait for the relay fix.",
+  ].join("\n");
+  const projection = projectAttention([makeInboxItem({ content })], {}, NOW, {
+    viewerName: "Lee Ntshudisane",
+  });
+  assert.equal(projection.needsMe.length, 1);
+  const item = projection.needsMe[0];
+  assert.equal(item.askType, "decision");
+  assert.equal(item.ask, "Ship now or wait for the fix?");
+  assert.equal(item.askCount, 1);
+  assert.equal(item.declaredAsks?.length, 1);
+  assert.deepEqual(item.declaredAsks?.[0].options, [
+    "Ship it now.",
+    "Wait for the relay fix.",
+  ]);
+});
+
+test("two declared asks for the viewer set askCount and declaredAsks", () => {
+  const content = [
+    "**Needs Lee, question:** Did the overnight backup run?",
+    "**Needs Lee, review:** Review the retention change when you can.",
+  ].join("\n");
+  const projection = projectAttention([makeInboxItem({ content })], {}, NOW, {
+    viewerName: "Lee",
+  });
+  assert.equal(projection.needsMe.length, 1);
+  assert.equal(projection.needsMe[0].askCount, 2);
+  assert.equal(projection.needsMe[0].declaredAsks?.length, 2);
+  assert.equal(projection.needsMe[0].askType, "question");
+});
+
+test("messages with only non-viewer declarations demote to Heads up", () => {
+  const content = [
+    "**Needs Axel, decision:** Ship now or wait for the fix?",
+    "- Ship it now.",
+    "- Wait for the relay fix.",
+  ].join("\n");
+  const projection = projectAttention([makeInboxItem({ content })], {}, NOW, {
+    viewerName: "Lee",
+  });
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.headsUp.length, 1);
+  assert.equal(projection.headsUp[0].askType, "headsUp");
+  assert.equal(projection.headsUp[0].declaredAsks, undefined);
+});
+
+test("without a viewer name the declared tier is inert", () => {
+  const content = "**Needs Lee, decision:** Ship now or wait for the fix?";
+  const projection = projectAttention([makeInboxItem({ content })], {}, NOW);
+  // Falls to derived: the declaration is for someone else as far as the
+  // projection knows, and stripping leaves no other ask.
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.headsUp.length, 1);
+});
+
+test("Noted on a To note item is silent; every other action publishes", () => {
+  // Regression pair: To note Noted publishes nothing…
+  assert.equal(actionPublishes("headsUp", "noted"), false);
+  // …and an actionable Noted (badge-corrected bucket) publishes.
+  for (const type of [
+    "decision",
+    "approval",
+    "question",
+    "review",
+    "blocked",
+  ]) {
+    assert.equal(actionPublishes(type, "noted"), true, `${type} noted`);
+  }
+  // Done and Waiting always publish, even from a heads-up-typed card.
+  assert.equal(actionPublishes("headsUp", "done"), true);
+  assert.equal(actionPublishes("headsUp", "waiting"), true);
+  assert.equal(actionPublishes("decision", "done"), true);
+  assert.equal(actionPublishes("question", "waiting"), true);
+});
+
+test("badge overrides rebucket items deterministically", () => {
+  const overridden = projectAttention(
+    [makeInboxItem({ content: "hello" })],
+    {},
+    NOW,
+    { badgeOverrides: { "conv-1": "decision" } },
+  );
+  assert.equal(overridden.needsMe.length, 1);
+  assert.equal(overridden.needsMe[0].askType, "decision");
+
+  const demoted = projectAttention([makeInboxItem()], {}, NOW, {
+    badgeOverrides: { "conv-1": "headsUp" },
+  });
+  assert.equal(demoted.needsMe.length, 0);
+  assert.equal(demoted.headsUp.length, 1);
+});
+
+test("config-nudge noise demotes to Heads up", () => {
+  const projection = projectAttention(
+    [makeInboxItem({ content: "Please update buzz:config-nudge settings." })],
+    {},
+    NOW,
+  );
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.headsUp.length, 1);
+  assert.equal(projection.headsUp[0].askType, "headsUp");
+});
+
+test("plain activity items are excluded from every view", () => {
+  const projection = projectAttention(
+    [makeInboxItem({ categories: ["activity"] })],
+    {},
+    NOW,
+  );
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.headsUp.length, 0);
+  assert.equal(projection.waiting.length, 0);
+  assert.equal(projection.done.length, 0);
+});
+
+test("kind 46010 is an approval, kind 40007 falls back to review", () => {
+  const approval = projectAttention(
+    [
+      makeInboxItem({
+        categories: ["needs_action"],
+        isActionRequired: true,
+        kind: 46010,
+        content: "hello",
+      }),
+    ],
+    {},
+    NOW,
+  );
+  assert.equal(approval.needsMe.length, 1);
+  assert.equal(approval.needsMe[0].askType, "approval");
+  assert.notEqual(approval.needsMe[0].ask, null);
+
+  const reminder = projectAttention(
+    [
+      makeInboxItem({
+        categories: ["needs_action"],
+        isActionRequired: true,
+        kind: 40007,
+        content: "hello",
+      }),
+    ],
+    {},
+    NOW,
+  );
+  assert.equal(reminder.needsMe.length, 1);
+  assert.equal(reminder.needsMe[0].askType, "review");
+});
+
+test("a parked waiting item stays in Waiting while activity is older than the park", () => {
+  const item = makeInboxItem({ latestActivityAt: NOW - 3_600 });
+  const projection = projectAttention(
+    [item],
+    { "conv-1": { zone: "waiting", changedAt: NOW - 60 } },
+    NOW,
+  );
+  assert.equal(projection.waiting.length, 1);
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.waiting[0].zoneChangedAt, NOW - 60);
+});
+
+test("new activity after parking reactivates ask-bearing items into Needs Me", () => {
+  const item = makeInboxItem({ latestActivityAt: NOW - 10 });
+  for (const zone of ["waiting", "done"]) {
+    const projection = projectAttention(
+      [item],
+      { "conv-1": { zone, changedAt: NOW - 3_600 } },
+      NOW,
+    );
+    assert.equal(projection.needsMe.length, 1, `${zone} should reactivate`);
+    assert.equal(projection.needsMe[0].reactivated, true);
+    assert.equal(projection.headsUp.length, 0);
+    assert.equal(projection.waiting.length, 0);
+    assert.equal(projection.done.length, 0);
+  }
+});
+
+test("new activity on an ask-less parked item reactivates into Heads up", () => {
+  const item = makeInboxItem({ content: "hello", latestActivityAt: NOW - 10 });
+  const projection = projectAttention(
+    [item],
+    { "conv-1": { zone: "waiting", changedAt: NOW - 3_600 } },
+    NOW,
+  );
+  assert.equal(projection.needsMe.length, 0);
+  assert.equal(projection.headsUp.length, 1);
+  assert.equal(projection.headsUp[0].reactivated, true);
+});
+
+test("done items show in Done until retention expires, then disappear", () => {
+  const item = makeInboxItem({ latestActivityAt: NOW - 100_000 });
+  const fresh = projectAttention(
+    [item],
+    { "conv-1": { zone: "done", changedAt: NOW - 3_600 } },
+    NOW,
+  );
+  assert.equal(fresh.done.length, 1);
+
+  const staleItem = makeInboxItem({
+    latestActivityAt: NOW - DONE_RETENTION_SECONDS - 100,
+  });
+  const expired = projectAttention(
+    [staleItem],
+    {
+      "conv-1": {
+        zone: "done",
+        changedAt: NOW - DONE_RETENTION_SECONDS - 10,
+      },
+    },
+    NOW,
+  );
+  assert.equal(expired.done.length, 0);
+  assert.equal(expired.needsMe.length, 0);
+  assert.equal(expired.headsUp.length, 0);
+  assert.equal(expired.waiting.length, 0);
+});
+
+test("needs me sorts oldest first, waiting and done by park time", () => {
+  const older = makeInboxItem({
+    conversationId: "conv-old",
+    latestActivityAt: NOW - 5_000,
+  });
+  const newer = makeInboxItem({
+    conversationId: "conv-new",
+    latestActivityAt: NOW - 100,
+  });
+  const needsMe = projectAttention([older, newer], {}, NOW).needsMe;
+  assert.deepEqual(
+    needsMe.map((entry) => entry.id),
+    ["conv-old", "conv-new"],
+  );
+
+  const waiting = projectAttention(
+    [older, newer],
+    {
+      "conv-old": { zone: "waiting", changedAt: NOW - 50 },
+      "conv-new": { zone: "waiting", changedAt: NOW - 10 },
+    },
+    NOW,
+  ).waiting;
+  assert.deepEqual(
+    waiting.map((entry) => entry.id),
+    ["conv-new", "conv-old"],
+  );
+});
+
+test("heads up sorts newest first", () => {
+  const older = makeInboxItem({
+    conversationId: "conv-old",
+    content: "hello",
+    latestActivityAt: NOW - 5_000,
+  });
+  const newer = makeInboxItem({
+    conversationId: "conv-new",
+    content: "hello",
+    latestActivityAt: NOW - 100,
+  });
+  const headsUp = projectAttention([older, newer], {}, NOW).headsUp;
+  assert.deepEqual(
+    headsUp.map((entry) => entry.id),
+    ["conv-new", "conv-old"],
+  );
+});
+
+test("attentionReason maps categories and kinds to short phrases", () => {
+  assert.equal(
+    attentionReason(
+      makeInboxItem({
+        categories: ["needs_action"],
+        isActionRequired: true,
+        kind: 46010,
+      }),
+    ),
+    "Approval requested",
+  );
+  assert.equal(
+    attentionReason(
+      makeInboxItem({
+        categories: ["needs_action"],
+        isActionRequired: true,
+        kind: 40007,
+      }),
+    ),
+    "Reminder due",
+  );
+  assert.equal(
+    attentionReason(makeInboxItem({ categories: ["mention"] })),
+    "Mentioned you",
+  );
+  const item = makeInboxItem({ categories: ["mention"] });
+  const threaded = {
+    ...item,
+    groupItems: [item.item, { ...item.item, id: "second" }],
+  };
+  assert.equal(attentionReason(threaded), "Mentioned you in an active thread");
+});
+
+test("pruneZoneState drops expired done entries and caps the map", () => {
+  const state = {
+    "conv-live": { zone: "waiting", changedAt: NOW - 10 },
+    "conv-done-fresh": { zone: "done", changedAt: NOW - 60 },
+    "conv-done-stale": {
+      zone: "done",
+      changedAt: NOW - DONE_RETENTION_SECONDS - 60,
+    },
+  };
+  const pruned = pruneZoneState(state, NOW);
+  assert.deepEqual(Object.keys(pruned).sort(), [
+    "conv-done-fresh",
+    "conv-live",
+  ]);
+
+  const crowded = Object.fromEntries(
+    Array.from({ length: 10 }, (_, index) => [
+      `conv-${index}`,
+      { zone: "waiting", changedAt: NOW - index },
+    ]),
+  );
+  const capped = pruneZoneState(crowded, NOW, 3);
+  assert.deepEqual(Object.keys(capped).sort(), ["conv-0", "conv-1", "conv-2"]);
+});
+
+test("persistableZoneState excludes held entries and persists the rest", () => {
+  const state = {
+    "conv-held": { zone: "done", changedAt: NOW - 2 },
+    "conv-settled": { zone: "waiting", changedAt: NOW - 60 },
+  };
+  const filtered = persistableZoneState(state, new Set(["conv-held"]));
+  assert.deepEqual(Object.keys(filtered), ["conv-settled"]);
+  // No holds: same map back, nothing dropped.
+  assert.equal(persistableZoneState(state, new Set()), state);
+});
+
+test("a reactivated card whose reply committed carries the responded flag", () => {
+  const parkedAt = NOW - 600;
+  const items = [
+    makeInboxItem({
+      conversationId: "conv-replied",
+      latestActivityAt: NOW - 10,
+    }),
+    makeInboxItem({
+      conversationId: "conv-silent",
+      latestActivityAt: NOW - 10,
+    }),
+  ];
+  const projection = projectAttention(
+    items,
+    {
+      "conv-replied": {
+        zone: "done",
+        changedAt: parkedAt,
+        respondedAt: parkedAt + 5,
+      },
+      "conv-silent": { zone: "done", changedAt: parkedAt },
+    },
+    NOW,
+  );
+  const replied = projection.needsMe.find((item) => item.id === "conv-replied");
+  const silent = projection.needsMe.find((item) => item.id === "conv-silent");
+  assert.equal(replied.reactivated, true);
+  assert.equal(replied.responded, true);
+  assert.equal(silent.reactivated, true);
+  assert.equal(silent.responded, false);
+});
+
+test("an exact-entry restore keeps a reactivated card in Needs Me, a re-marked one hides it", () => {
+  const parkedAt = NOW - 600;
+  const item = makeInboxItem({ latestActivityAt: NOW - 300 });
+  // Undo restores the original entry: activity is newer, card reactivates.
+  const restored = projectAttention(
+    [item],
+    { "conv-1": { zone: "waiting", changedAt: parkedAt } },
+    NOW,
+  );
+  assert.equal(restored.needsMe.length, 1);
+  assert.equal(restored.needsMe[0].reactivated, true);
+  // A revert that re-marked with a fresh timestamp would bury it in Waiting.
+  const remarked = projectAttention(
+    [item],
+    { "conv-1": { zone: "waiting", changedAt: NOW } },
+    NOW,
+  );
+  assert.equal(remarked.needsMe.length, 0);
+  assert.equal(remarked.waiting.length, 1);
+});
+
+test("locked action matrix: generic primaries and the Handled-elsewhere offer", () => {
+  assert.equal(primaryGenericAction("blocked"), "done");
+  assert.equal(primaryGenericAction("headsUp"), "noted");
+  for (const type of ["approval", "decision", "question", "review"]) {
+    assert.equal(primaryGenericAction(type), null, `${type} primary`);
+    assert.equal(offersHandledElsewhere(type), true, `${type} overflow`);
+  }
+  assert.equal(offersHandledElsewhere("blocked"), false);
+  assert.equal(offersHandledElsewhere("headsUp"), false);
+});
+
+test("Handled elsewhere publishes the frozen line and counts as publishing", () => {
+  assert.equal(
+    HANDLED_ELSEWHERE_REPLY,
+    "Handled outside this thread, no answer coming here. If you are still blocked, say so and I will pick it up.",
+  );
+  for (const type of ["approval", "decision", "question", "review"]) {
+    assert.equal(actionPublishes(type, "handledElsewhere"), true, type);
+  }
+});

--- a/desktop/src/features/attention/lib/attention.ts
+++ b/desktop/src/features/attention/lib/attention.ts
@@ -1,0 +1,365 @@
+import type { InboxItem } from "@/features/home/lib/inbox";
+import { getThreadReference } from "@/features/messages/lib/threading";
+import {
+  type DeclaredAsk,
+  parseDeclaredAsks,
+  stripDeclaredAskLines,
+  viewerAsks,
+} from "@/features/attention/lib/declaredAsks";
+import {
+  type AskType,
+  classifyAsk,
+  MAX_ASK_COUNT,
+} from "@/features/attention/lib/taskExtraction";
+
+export type { DeclaredAsk } from "@/features/attention/lib/declaredAsks";
+export type { AskType } from "@/features/attention/lib/taskExtraction";
+
+export type AttentionZone = "needsMe" | "waiting" | "done";
+
+export type ZoneStateEntry = {
+  zone: "waiting" | "done";
+  /** Unix seconds when the user parked the item in this zone. */
+  changedAt: number;
+  /**
+   * Unix seconds when the parking action's reply actually published
+   * (set at commit, absent for silent actions). Re-parking clears it.
+   */
+  respondedAt?: number;
+};
+
+/** Keyed by the inbox item's stable conversation id. */
+export type ZoneStateMap = Record<string, ZoneStateEntry>;
+
+export type AttentionItem = {
+  /** Stable identity — the inbox conversation id. */
+  id: string;
+  inboxItem: InboxItem;
+  /** Why this needs the user, in one short phrase. */
+  reason: string;
+  /** The one-line ask headline; null for headsUp items. */
+  ask: string | null;
+  askType: AskType;
+  /** Distinct qualifying asks in the message; >1 renders a multi-ask headline. */
+  askCount: number;
+  /**
+   * Tier-1 declared asks addressed to the viewer (base_prompt.md "Declare
+   * what you need" convention). Present only when the declared tier won.
+   */
+  declaredAsks?: DeclaredAsk[];
+  zone: AttentionZone;
+  zoneChangedAt: number | null;
+  /**
+   * True when the item was parked in Waiting or Done but new activity arrived
+   * afterwards, pulling it back into Needs Me.
+   */
+  reactivated: boolean;
+  /**
+   * True on a reactivated card whose parking action already published its
+   * reply. Without this flag the returning card reads as the action having
+   * failed, and the user answers twice.
+   */
+  responded: boolean;
+};
+
+export type AttentionProjection = {
+  needsMe: AttentionItem[];
+  /** Mentions with no detectable ask — demoted, never counted as Needs Me. */
+  headsUp: AttentionItem[];
+  waiting: AttentionItem[];
+  done: AttentionItem[];
+};
+
+export const DONE_RETENTION_SECONDS = 7 * 24 * 60 * 60;
+export const MAX_ZONE_ENTRIES = 500;
+
+const KIND_WORKFLOW_APPROVAL_REQUESTED = 46010;
+const KIND_STREAM_REMINDER = 40007;
+
+/**
+ * Attention only surfaces items that plausibly need the user: action-required
+ * feed items and direct mentions. Ambient channel activity stays in the
+ * Inbox — the two surfaces answer different questions.
+ */
+export function isAttentionWorthy(item: InboxItem): boolean {
+  return (
+    item.isActionRequired ||
+    item.categories.includes("mention") ||
+    item.categories.includes("needs_action")
+  );
+}
+
+export function attentionReason(item: InboxItem): string {
+  if (item.categories.includes("needs_action")) {
+    if (item.item.kind === KIND_WORKFLOW_APPROVAL_REQUESTED) {
+      return "Approval requested";
+    }
+    if (item.item.kind === KIND_STREAM_REMINDER) {
+      return "Reminder due";
+    }
+    return "Action required";
+  }
+  if (item.categories.includes("mention")) {
+    return item.groupItems.length > 1
+      ? "Mentioned you in an active thread"
+      : "Mentioned you";
+  }
+  if (item.categories.includes("agent_activity")) {
+    return "Agent update";
+  }
+  return "New activity";
+}
+
+/** NIP-10 thread root of the representative event, for deep links. */
+export function attentionThreadRootId(item: InboxItem): string | null {
+  return getThreadReference(item.item.tags).rootId;
+}
+
+function classifyInboxItem(
+  item: InboxItem,
+  viewerName: string | undefined,
+): {
+  ask: string | null;
+  askType: AskType;
+  askCount: number;
+  declaredAsks?: DeclaredAsk[];
+} {
+  // Tier 1: declared asks always beat the derived heuristics — the author
+  // stated exactly who they need and what for.
+  const declared = parseDeclaredAsks(item.item.content);
+  const mine = viewerAsks(declared, viewerName);
+  if (mine.length > 0) {
+    return {
+      ask: mine[0].ask,
+      askType: mine[0].type,
+      askCount: Math.min(mine.length, MAX_ASK_COUNT),
+      declaredAsks: mine,
+    };
+  }
+
+  // Tier 2: derived classification. Declarations addressed to other people
+  // are stripped first so a message that only needs someone else stays
+  // headsUp unless the remaining prose carries its own ask.
+  const derivedSource =
+    declared.length > 0
+      ? stripDeclaredAskLines(item.item.content)
+      : item.item.content;
+  const classification = classifyAsk(derivedSource);
+  // Kind-level needs_action events carry their type; prose is classified.
+  if (item.item.kind === KIND_WORKFLOW_APPROVAL_REQUESTED) {
+    return {
+      ask: classification.ask ?? item.preview,
+      askType: "approval",
+      askCount: Math.max(1, classification.askCount),
+    };
+  }
+  if (item.item.kind === KIND_STREAM_REMINDER) {
+    return {
+      ask: classification.ask ?? item.preview,
+      askType:
+        classification.type === "headsUp" ? "review" : classification.type,
+      askCount: Math.max(1, classification.askCount),
+    };
+  }
+  return {
+    ask: classification.ask,
+    askType: classification.type,
+    askCount: classification.askCount,
+  };
+}
+
+function toAttentionItem(
+  item: InboxItem,
+  zone: AttentionZone,
+  entry: ZoneStateEntry | undefined,
+  reactivated: boolean,
+  options: ProjectAttentionOptions | undefined,
+): AttentionItem {
+  const { ask, askType, askCount, declaredAsks } = classifyInboxItem(
+    item,
+    options?.viewerName,
+  );
+  // A local badge correction wins over both tiers; it never reclassifies
+  // the declared sub-asks, only the card's presented type (and bucket).
+  const override = options?.badgeOverrides?.[item.conversationId];
+  return {
+    id: item.conversationId,
+    inboxItem: item,
+    reason: attentionReason(item),
+    ask,
+    askType: override ?? askType,
+    askCount,
+    declaredAsks,
+    zone,
+    zoneChangedAt: entry?.changedAt ?? null,
+    reactivated,
+    responded: reactivated && entry?.respondedAt != null,
+  };
+}
+
+export type AttentionAction = "done" | "noted" | "waiting" | "handledElsewhere";
+
+/**
+ * The frozen Handled-elsewhere line (UX pass, "The wording"). Honest on
+ * all three readings of "handled": it stops the waiting, does not fake a
+ * resolution in the ask's favour, and gives the agent a defined path if
+ * it genuinely still needs the answer.
+ */
+export const HANDLED_ELSEWHERE_REPLY =
+  "Handled outside this thread, no answer coming here. If you are still blocked, say so and I will pick it up.";
+
+/**
+ * An action posts a reply when someone is waiting for it. Nobody waits on
+ * a To note item, so Noted there is local-only — nothing publishes. The
+ * check uses the item's CURRENT effective type, so a badge-corrected card
+ * follows its corrected bucket.
+ */
+export function actionPublishes(
+  askType: AskType,
+  action: AttentionAction,
+): boolean {
+  return !(action === "noted" && askType === "headsUp");
+}
+
+/**
+ * Locked action matrix: the generic action a card presents as primary.
+ * Done only where it genuinely means "I performed the manual step you
+ * needed" (Blocked); Noted only where nothing publishes (Heads up). The
+ * option-driven types (approval, decision, question, review) have option
+ * primaries instead and return null here.
+ */
+export function primaryGenericAction(
+  askType: AskType,
+): "done" | "noted" | null {
+  if (askType === "blocked") return "done";
+  if (askType === "headsUp") return "noted";
+  return null;
+}
+
+/**
+ * Handled elsewhere exists for every actionable type except Blocked
+ * (where Done already is the correct signal) and Heads up (where nothing
+ * publishes at all).
+ */
+export function offersHandledElsewhere(askType: AskType): boolean {
+  return askType !== "blocked" && askType !== "headsUp";
+}
+
+/** Whole days an item has been sitting on the user. 0 = under a day. */
+export function waitingDays(
+  latestActivityAt: number,
+  nowSeconds: number,
+): number {
+  return Math.max(0, Math.floor((nowSeconds - latestActivityAt) / 86_400));
+}
+
+/** Local-day bucket used by the Needs Me headers. */
+export function isSameLocalDay(aSeconds: number, bSeconds: number): boolean {
+  return (
+    new Date(aSeconds * 1_000).toDateString() ===
+    new Date(bSeconds * 1_000).toDateString()
+  );
+}
+
+export type ProjectAttentionOptions = {
+  /** Viewer display name for the declared-ask tier ("Needs <Name>, …"). */
+  viewerName?: string;
+  /** Local badge corrections, keyed by conversation id. */
+  badgeOverrides?: Record<string, AskType>;
+};
+
+/**
+ * Split attention-worthy inbox items into the three Attention views.
+ *
+ * Rules:
+ * - No zone entry → Needs Me.
+ * - Activity newer than the zone entry reactivates the item into Needs Me,
+ *   whether it was Waiting or Done — the underlying conversation moved, so
+ *   the user's park decision is stale.
+ * - Waiting and Done otherwise honour the stored zone.
+ * - Done items expire from view after DONE_RETENTION_SECONDS.
+ */
+export function projectAttention(
+  items: InboxItem[],
+  zoneState: ZoneStateMap,
+  nowSeconds: number,
+  options?: ProjectAttentionOptions,
+): AttentionProjection {
+  const needsMe: AttentionItem[] = [];
+  const headsUp: AttentionItem[] = [];
+  const waiting: AttentionItem[] = [];
+  const done: AttentionItem[] = [];
+
+  for (const item of items) {
+    if (!isAttentionWorthy(item)) {
+      continue;
+    }
+    const entry = zoneState[item.conversationId];
+    let projected: AttentionItem;
+    if (!entry) {
+      projected = toAttentionItem(item, "needsMe", undefined, false, options);
+    } else if (item.latestActivityAt > entry.changedAt) {
+      projected = toAttentionItem(item, "needsMe", entry, true, options);
+    } else if (entry.zone === "waiting") {
+      waiting.push(toAttentionItem(item, "waiting", entry, false, options));
+      continue;
+    } else {
+      if (nowSeconds - entry.changedAt <= DONE_RETENTION_SECONDS) {
+        done.push(toAttentionItem(item, "done", entry, false, options));
+      }
+      continue;
+    }
+    // Demotion tier: no detectable ask means it is not Needs Me.
+    if (projected.askType === "headsUp") {
+      headsUp.push(projected);
+    } else {
+      needsMe.push(projected);
+    }
+  }
+
+  // Staleness is the cost: the oldest open ask sorts to the top.
+  needsMe.sort(
+    (a, b) => a.inboxItem.latestActivityAt - b.inboxItem.latestActivityAt,
+  );
+  headsUp.sort(
+    (a, b) => b.inboxItem.latestActivityAt - a.inboxItem.latestActivityAt,
+  );
+  waiting.sort((a, b) => (b.zoneChangedAt ?? 0) - (a.zoneChangedAt ?? 0));
+  done.sort((a, b) => (b.zoneChangedAt ?? 0) - (a.zoneChangedAt ?? 0));
+
+  return { needsMe, headsUp, waiting, done };
+}
+
+/**
+ * Zone state that is safe to persist. Entries still inside an undo hold
+ * window are excluded: a held action that survives an app quit would leave
+ * the card cleared while its reply never publishes — the exact split state
+ * the undo guarantee forbids. Held entries persist only on commit.
+ */
+export function persistableZoneState(
+  state: ZoneStateMap,
+  holdIds: ReadonlySet<string>,
+): ZoneStateMap {
+  if (holdIds.size === 0) return state;
+  return Object.fromEntries(
+    Object.entries(state).filter(([id]) => !holdIds.has(id)),
+  );
+}
+
+/**
+ * Drop expired Done entries and cap the map so localStorage stays bounded.
+ * Oldest entries fall out first when over the cap.
+ */
+export function pruneZoneState(
+  state: ZoneStateMap,
+  nowSeconds: number,
+  maxEntries: number = MAX_ZONE_ENTRIES,
+): ZoneStateMap {
+  const entries = Object.entries(state).filter(
+    ([, entry]) =>
+      entry.zone !== "done" ||
+      nowSeconds - entry.changedAt <= DONE_RETENTION_SECONDS,
+  );
+  entries.sort(([, a], [, b]) => b.changedAt - a.changedAt);
+  return Object.fromEntries(entries.slice(0, maxEntries));
+}

--- a/desktop/src/features/attention/lib/declaredAsks.test.mjs
+++ b/desktop/src/features/attention/lib/declaredAsks.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseDeclaredAsks,
+  stripDeclaredAskLines,
+  viewerAsks,
+} from "./declaredAsks.ts";
+
+test("parses the bold declaration form", () => {
+  const asks = parseDeclaredAsks(
+    "**Needs Lee, decision:** Ship now or wait for the fix?",
+  );
+  assert.deepEqual(asks, [
+    {
+      name: "Lee",
+      type: "decision",
+      ask: "Ship now or wait for the fix?",
+      options: [],
+    },
+  ]);
+});
+
+test("parses the plain declaration form, case-insensitively", () => {
+  const asks = parseDeclaredAsks(
+    "needs Lee, DECISION: Ship now or wait for the fix?",
+  );
+  assert.equal(asks.length, 1);
+  assert.equal(asks[0].type, "decision");
+  assert.equal(asks[0].name, "Lee");
+});
+
+test("accepts each of the five declared types", () => {
+  for (const type of [
+    "decision",
+    "approval",
+    "question",
+    "review",
+    "blocked",
+  ]) {
+    const asks = parseDeclaredAsks(`**Needs Lee, ${type}:** Do the thing.`);
+    assert.equal(asks.length, 1, type);
+    assert.equal(asks[0].type, type);
+  }
+});
+
+test("rejects invalid types and malformed lines", () => {
+  assert.deepEqual(
+    parseDeclaredAsks("**Needs Lee, vibes:** Do the thing."),
+    [],
+  );
+  assert.deepEqual(parseDeclaredAsks("**Needs Lee decision:** no comma."), []);
+  assert.deepEqual(parseDeclaredAsks("**Needs Lee, decision:**"), []);
+  assert.deepEqual(parseDeclaredAsks("We discussed needs and decisions."), []);
+});
+
+test("full display names are captured between Needs and the comma", () => {
+  const asks = parseDeclaredAsks(
+    "Needs Lee Ntshudisane, review: Review the retention change.",
+  );
+  assert.equal(asks[0].name, "Lee Ntshudisane");
+});
+
+test("adopts 2-4 immediately following bullet options", () => {
+  const two = parseDeclaredAsks(
+    [
+      "**Needs Lee, decision:** Ship now or wait?",
+      "- Ship it now.",
+      "- Wait for the relay fix.",
+    ].join("\n"),
+  );
+  assert.deepEqual(two[0].options, ["Ship it now.", "Wait for the relay fix."]);
+
+  const four = parseDeclaredAsks(
+    [
+      "**Needs Lee, decision:** Pick a lane.",
+      "- One.",
+      "- Two.",
+      "- Three.",
+      "- Four.",
+    ].join("\n"),
+  );
+  assert.equal(four[0].options.length, 4);
+});
+
+test("a blank line detaches the option list", () => {
+  const asks = parseDeclaredAsks(
+    [
+      "**Needs Lee, decision:** Ship now or wait?",
+      "",
+      "- Ship it now.",
+      "- Wait for the relay fix.",
+    ].join("\n"),
+  );
+  assert.deepEqual(asks[0].options, []);
+});
+
+test("five or more bullets, or a lone bullet, are not options", () => {
+  const five = parseDeclaredAsks(
+    [
+      "**Needs Lee, decision:** Pick a lane.",
+      "- One.",
+      "- Two.",
+      "- Three.",
+      "- Four.",
+      "- Five.",
+    ].join("\n"),
+  );
+  assert.deepEqual(five[0].options, []);
+
+  const one = parseDeclaredAsks(
+    ["**Needs Lee, decision:** Pick a lane.", "- Only one."].join("\n"),
+  );
+  assert.deepEqual(one[0].options, []);
+});
+
+test("multi-person messages parse all declarations, viewerAsks filters", () => {
+  const asks = parseDeclaredAsks(
+    [
+      "**Needs Lee, review:** Review the retention change.",
+      "**Needs Axel, approval:** Approve the deploy window.",
+    ].join("\n"),
+  );
+  assert.equal(asks.length, 2);
+  const mine = viewerAsks(asks, "Lee");
+  assert.equal(mine.length, 1);
+  assert.equal(mine[0].name, "Lee");
+  assert.equal(viewerAsks(asks, "Axel").length, 1);
+  assert.equal(viewerAsks(asks, "Morgan").length, 0);
+  assert.equal(viewerAsks(asks, undefined).length, 0);
+});
+
+test("viewer matching accepts full display name or its first word", () => {
+  const asks = parseDeclaredAsks(
+    "**Needs Lee, question:** Did the backup run?",
+  );
+  assert.equal(viewerAsks(asks, "Lee Ntshudisane").length, 1);
+  assert.equal(viewerAsks(asks, "lee").length, 1);
+  const fullName = parseDeclaredAsks(
+    "**Needs Lee Ntshudisane, question:** Did the backup run?",
+  );
+  assert.equal(viewerAsks(fullName, "Lee Ntshudisane").length, 1);
+  // Declared full name does not match a different person named Lee X.
+  assert.equal(viewerAsks(fullName, "Lee Axelsson").length, 0);
+});
+
+test("multiple asks for the same viewer are all returned in order", () => {
+  const asks = parseDeclaredAsks(
+    [
+      "**Needs Lee, question:** Did the overnight backup run?",
+      "**Needs Lee, review:** Review the retention change when you can.",
+    ].join("\n"),
+  );
+  assert.equal(asks.length, 2);
+  const mine = viewerAsks(asks, "Lee");
+  assert.equal(mine.length, 2);
+  assert.equal(mine[0].type, "question");
+  assert.equal(mine[1].type, "review");
+});
+
+test("stripDeclaredAskLines removes declarations and attached bullets only", () => {
+  const stripped = stripDeclaredAskLines(
+    [
+      "Status update for the room.",
+      "**Needs Axel, decision:** Ship now or wait?",
+      "- Ship it now.",
+      "- Wait for the relay fix.",
+      "Everything else is on track.",
+    ].join("\n"),
+  );
+  assert.equal(
+    stripped,
+    ["Status update for the room.", "Everything else is on track."].join("\n"),
+  );
+});

--- a/desktop/src/features/attention/lib/declaredAsks.ts
+++ b/desktop/src/features/attention/lib/declaredAsks.ts
@@ -1,0 +1,139 @@
+import type { AskType } from "@/features/attention/lib/taskExtraction";
+
+/**
+ * Tier-1 declared asks, parsed from the authoring convention documented in
+ * crates/buzz-acp/src/base_prompt.md ("Declare what you need"):
+ *
+ *   **Needs <Name>, <type>:** <the ask in one sentence>
+ *   - Option one as a complete sentence.
+ *   - Option two as a complete sentence.
+ *
+ * One line per person and per ask; an optional bulleted list of two to four
+ * closed-set options follows immediately (no blank line). Declared asks
+ * always beat the derived classification tier.
+ */
+
+export type DeclaredAskType = Exclude<AskType, "headsUp">;
+
+export type DeclaredAsk = {
+  /** Addressee exactly as written between "Needs " and the comma. */
+  name: string;
+  type: DeclaredAskType;
+  ask: string;
+  /** Adopted closed-set answers; [] when absent, detached, or malformed. */
+  options: string[];
+};
+
+const DECLARED_TYPES: ReadonlySet<string> = new Set([
+  "decision",
+  "approval",
+  "question",
+  "review",
+  "blocked",
+]);
+
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 4;
+
+const BOLD_DECLARATION = /^\*\*needs\s+([^,]+),\s*([a-z]+)\s*:\*\*\s*(.+)$/i;
+const PLAIN_DECLARATION = /^needs\s+([^,]+),\s*([a-z]+)\s*:\s*(.+)$/i;
+const BULLET = /^-\s+(.+)$/;
+
+function parseDeclarationLine(
+  line: string,
+): Pick<DeclaredAsk, "name" | "type" | "ask"> | null {
+  const trimmed = line.trim();
+  const match =
+    trimmed.match(BOLD_DECLARATION) ?? trimmed.match(PLAIN_DECLARATION);
+  if (!match) {
+    return null;
+  }
+  const type = match[2].toLowerCase();
+  if (!DECLARED_TYPES.has(type)) {
+    return null;
+  }
+  const name = match[1].trim();
+  const ask = match[3].trim();
+  if (!name || !ask) {
+    return null;
+  }
+  return { name, type: type as DeclaredAskType, ask };
+}
+
+/** Consecutive "- " bullet lines starting at `start` (no blank line gap). */
+function collectBullets(lines: string[], start: number): string[] {
+  const bullets: string[] = [];
+  for (let index = start; index < lines.length; index++) {
+    const match = lines[index].trim().match(BULLET);
+    if (!match) {
+      break;
+    }
+    bullets.push(match[1].trim());
+  }
+  return bullets;
+}
+
+/**
+ * Parse every declaration line in the message, for any addressee. Options
+ * are adopted only when the immediately following consecutive bullet run
+ * has 2-4 items; a blank line detaches the list and 5+ items or a lone
+ * bullet are treated as context, not answers.
+ */
+export function parseDeclaredAsks(content: string): DeclaredAsk[] {
+  const lines = content.split("\n");
+  const asks: DeclaredAsk[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const declaration = parseDeclarationLine(lines[index]);
+    if (!declaration) {
+      continue;
+    }
+    const bullets = collectBullets(lines, index + 1);
+    const options =
+      bullets.length >= MIN_OPTIONS && bullets.length <= MAX_OPTIONS
+        ? bullets
+        : [];
+    asks.push({ ...declaration, options });
+  }
+  return asks;
+}
+
+/**
+ * The declarations addressed to the viewer: the declared name equals the
+ * viewer display name or its first word, case-insensitively ("Needs Lee"
+ * matches viewer "Lee Ntshudisane").
+ */
+export function viewerAsks(
+  asks: DeclaredAsk[],
+  viewerName: string | undefined,
+): DeclaredAsk[] {
+  const full = viewerName?.trim().toLowerCase() ?? "";
+  if (!full) {
+    return [];
+  }
+  const first = full.split(/\s+/)[0];
+  return asks.filter((entry) => {
+    const name = entry.name.trim().toLowerCase();
+    return name === full || name === first;
+  });
+}
+
+/**
+ * Remove every declaration line and its attached bullet run so the derived
+ * tier cannot re-surface asks addressed to other people. A message with
+ * only non-viewer declarations therefore classifies headsUp unless the
+ * remaining prose contains its own ask.
+ */
+export function stripDeclaredAskLines(content: string): string {
+  const lines = content.split("\n");
+  const kept: string[] = [];
+  let index = 0;
+  while (index < lines.length) {
+    if (parseDeclarationLine(lines[index])) {
+      index += 1 + collectBullets(lines, index + 1).length;
+      continue;
+    }
+    kept.push(lines[index]);
+    index++;
+  }
+  return kept.join("\n");
+}

--- a/desktop/src/features/attention/lib/quickOptions.test.mjs
+++ b/desktop/src/features/attention/lib/quickOptions.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  defaultDeclaredOptions,
+  deriveQuickOptions,
+  MORE_DETAIL_OPTION,
+} from "./quickOptions.ts";
+
+const BACKUPS_ASK =
+  "Does the Backups list show any backup dated today, or is the newest one still the 30 July entry?";
+
+test("approval gets its pair, review gets its pair (locked matrix)", () => {
+  assert.deepEqual(
+    deriveQuickOptions("approval", "Approve the staging deploy.", ""),
+    ["Approve", "Reject", MORE_DETAIL_OPTION],
+  );
+  // The matrix gives Review its own primary pair, not the approval one.
+  assert.deepEqual(
+    deriveQuickOptions("review", "Approve the staging deploy.", ""),
+    ["Looks good", "Changes needed", MORE_DETAIL_OPTION],
+  );
+});
+
+test("polar questions get yes/no", () => {
+  assert.deepEqual(
+    deriveQuickOptions("question", "Is the backup scheduled?", ""),
+    ["Yes", "No", MORE_DETAIL_OPTION],
+  );
+  assert.deepEqual(
+    deriveQuickOptions("question", "did the migration finish?", ""),
+    ["Yes", "No", MORE_DETAIL_OPTION],
+  );
+  // Word boundary: "Done" is not "Do".
+  assert.deepEqual(
+    deriveQuickOptions("question", "Done with the review yet?", ""),
+    [],
+  );
+  // Yes/no is scoped to derived questions, not other ask types.
+  assert.deepEqual(
+    deriveQuickOptions("review", "Could you look at the plan?", ""),
+    ["Looks good", "Changes needed", MORE_DETAIL_OPTION],
+  );
+  // Polar questions must end with "?".
+  assert.deepEqual(
+    deriveQuickOptions("question", "Can you ship this today.", ""),
+    [],
+  );
+});
+
+test("regression: a which-of-two question never yields yes/no", () => {
+  const options = deriveQuickOptions("question", BACKUPS_ASK, "");
+  assert.notDeepEqual(options.slice(0, 2), ["Yes", "No"]);
+  assert.deepEqual(options, [
+    "the Backups list show any backup dated today",
+    "is the newest one still the 30 July entry",
+    MORE_DETAIL_OPTION,
+  ]);
+});
+
+test("A-or-B asks become their two alternatives", () => {
+  assert.deepEqual(
+    deriveQuickOptions(
+      "decision",
+      "Should we ship Tuesday or wait for QA?",
+      "",
+    ),
+    ["ship Tuesday", "wait for QA", MORE_DETAIL_OPTION],
+  );
+});
+
+test("A-or-B outranks yes/no and approval", () => {
+  assert.deepEqual(
+    deriveQuickOptions("question", "Do we ship now or hold the release?", ""),
+    ["ship now", "hold the release", MORE_DETAIL_OPTION],
+  );
+  assert.deepEqual(
+    deriveQuickOptions("approval", "Approve the deploy or roll it back?", ""),
+    ["Approve the deploy", "roll it back", MORE_DETAIL_OPTION],
+  );
+});
+
+test("A-or-B requires exactly one or with two short sides", () => {
+  const longSide =
+    "keep the current onboarding flow exactly as designed in the last review cycle";
+  assert.deepEqual(
+    deriveQuickOptions("question", `Should we ship now or ${longSide}?`, ""),
+    [],
+  );
+  assert.deepEqual(
+    deriveQuickOptions("question", "Tea or coffee or juice?", ""),
+    [],
+  );
+});
+
+test("regression: numbered lists are context, not answers", () => {
+  const content = [
+    "Decisions pending:",
+    "1. Ship now",
+    "2. Wait for QA",
+    "3. Cancel the launch",
+  ].join("\n");
+  assert.deepEqual(deriveQuickOptions("headsUp", null, content), []);
+  assert.deepEqual(
+    deriveQuickOptions("question", "Which option do we take?", content),
+    [],
+  );
+});
+
+test("no rule matching yields no options", () => {
+  assert.deepEqual(
+    deriveQuickOptions(
+      "decision",
+      "Please weigh in on the plan.",
+      "Please weigh in on the plan.",
+    ),
+    [],
+  );
+  assert.deepEqual(deriveQuickOptions("headsUp", null, "hello"), []);
+  // Blocked is deliberately optionless here: Done is its primary action.
+  assert.deepEqual(
+    deriveQuickOptions("blocked", "I need the staging password.", ""),
+    [],
+  );
+});
+
+test("every derived option set ends with the way out", () => {
+  for (const [type, ask] of [
+    ["approval", "Approve the deploy."],
+    ["review", "Look at the plan."],
+    ["question", "Is the backup scheduled?"],
+    ["decision", "Ship now or wait for QA?"],
+  ]) {
+    const options = deriveQuickOptions(type, ask, "");
+    assert.equal(
+      options[options.length - 1],
+      MORE_DETAIL_OPTION,
+      `${type} way out`,
+    );
+  }
+});
+
+test("declared defaults cover approval, review and blocked only", () => {
+  assert.deepEqual(defaultDeclaredOptions("approval"), [
+    "Approve",
+    "Reject",
+    MORE_DETAIL_OPTION,
+  ]);
+  assert.deepEqual(defaultDeclaredOptions("review"), [
+    "Looks good",
+    "Changes needed",
+    MORE_DETAIL_OPTION,
+  ]);
+  assert.deepEqual(defaultDeclaredOptions("blocked"), [
+    "I have done it",
+    "I cannot do it",
+    MORE_DETAIL_OPTION,
+  ]);
+  assert.deepEqual(defaultDeclaredOptions("decision"), []);
+  assert.deepEqual(defaultDeclaredOptions("question"), []);
+  assert.deepEqual(defaultDeclaredOptions("headsUp"), []);
+});

--- a/desktop/src/features/attention/lib/quickOptions.ts
+++ b/desktop/src/features/attention/lib/quickOptions.ts
@@ -1,0 +1,128 @@
+import type { AskType } from "@/features/attention/lib/taskExtraction";
+
+/**
+ * The way out (declared-options rule 2): every option set we author
+ * ourselves carries an option that declines to answer, so a bad set
+ * cannot railroad a wrong one-click answer. Wording is the spec's own
+ * example; the click posts it verbatim.
+ */
+export const MORE_DETAIL_OPTION = "Not enough detail yet, tell me more";
+
+const MAX_OPTION_LENGTH = 60;
+
+/** Auxiliary-verb leads that mark a polar (yes/no) question. */
+const YES_NO_LEAD =
+  /^(?:do|does|is|are|can|could|should|will|would|has|have|did)\b/i;
+
+/** Leading auxiliary (plus a trailing pronoun) that can be trivially
+ * stripped from an A-or-B alternative: "Should we ship Tuesday" → "ship
+ * Tuesday". When stripping is not trivially possible the side is used
+ * as-is. */
+const LEADING_AUXILIARY =
+  /^(?:do|does|is|are|can|could|should|will|would|has|have|did)\s+(?:we\s+|i\s+|you\s+|they\s+)?/i;
+
+const OR_WORD = /\bor\b/gi;
+
+function cleanAlternative(text: string): string {
+  return text
+    .trim()
+    .replace(/[,;]+$/, "")
+    .trim();
+}
+
+function stripLeadingAuxiliary(text: string): string {
+  const stripped = text.replace(LEADING_AUXILIARY, "").trim();
+  return stripped.length > 0 ? stripped : text;
+}
+
+/**
+ * "A or B?" asks become their two alternatives — but only with exactly one
+ * "or" and two short sides, so mid-sentence prose "or"s never turn into
+ * answer buttons.
+ */
+function eitherOrOptions(ask: string | null): string[] | null {
+  if (!ask) {
+    return null;
+  }
+  const trimmed = ask.trim();
+  if (!trimmed.endsWith("?")) {
+    return null;
+  }
+  const body = trimmed.replace(/\?+$/, "");
+  const orMatches = [...body.matchAll(OR_WORD)];
+  if (orMatches.length !== 1) {
+    return null;
+  }
+  const at = orMatches[0].index ?? -1;
+  if (at < 0) {
+    return null;
+  }
+  const left = cleanAlternative(body.slice(0, at));
+  const right = cleanAlternative(body.slice(at + orMatches[0][0].length));
+  if (!left || !right) {
+    return null;
+  }
+  if (left.length > MAX_OPTION_LENGTH || right.length > MAX_OPTION_LENGTH) {
+    return null;
+  }
+  return [stripLeadingAuxiliary(left), right];
+}
+
+/**
+ * Polar (yes/no) questions: derived questions that end in "?", start with
+ * an auxiliary verb, and contain no "or". A which-of-two question ("Does X
+ * show A, or is it B?") must never be answerable with Yes/No.
+ */
+function isPolarQuestion(ask: string): boolean {
+  const trimmed = ask.trim();
+  return (
+    trimmed.endsWith("?") &&
+    YES_NO_LEAD.test(trimmed) &&
+    !/\bor\b/i.test(trimmed)
+  );
+}
+
+/**
+ * Closed defaults for a declared ask whose author supplied no options
+ * (declared-options spec, "Options per response type"). Decision and
+ * Question have no safe default — the author must supply the answers,
+ * or the free-text path is the way in.
+ */
+export function defaultDeclaredOptions(type: AskType): string[] {
+  switch (type) {
+    case "approval":
+      return ["Approve", "Reject", MORE_DETAIL_OPTION];
+    case "review":
+      return ["Looks good", "Changes needed", MORE_DETAIL_OPTION];
+    case "blocked":
+      return ["I have done it", "I cannot do it", MORE_DETAIL_OPTION];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Derive one-click reply options for an attention card, per the locked
+ * action matrix: A-or-B alternatives > polar yes/no (derived questions
+ * only) > the type pairs (Approval and Review). Anything else returns []
+ * and the card shows the reply box alone. Blocked is deliberately absent:
+ * its primary action is Done, not an option set. Every derived set ends
+ * with the way-out option (rule 2 — we are the author here).
+ */
+export function deriveQuickOptions(
+  askType: AskType,
+  ask: string | null,
+  _content: string,
+): string[] {
+  const alternatives = eitherOrOptions(ask);
+  if (alternatives) {
+    return [...alternatives, MORE_DETAIL_OPTION];
+  }
+  if (askType === "question" && ask && isPolarQuestion(ask)) {
+    return ["Yes", "No", MORE_DETAIL_OPTION];
+  }
+  if (askType === "approval" || askType === "review") {
+    return defaultDeclaredOptions(askType);
+  }
+  return [];
+}

--- a/desktop/src/features/attention/lib/taskExtraction.test.mjs
+++ b/desktop/src/features/attention/lib/taskExtraction.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyAsk,
+  extractTaskLine,
+  isConfigNoise,
+  stripMessageNoise,
+} from "./taskExtraction.ts";
+
+test("stripMessageNoise removes markdown, links, code and JSON blobs", () => {
+  const cleaned = stripMessageNoise(
+    '**Two emails** went out. See [the doc](https://example.com/x) and https://example.com/raw plus `inline` and ```{"a":1}``` end.',
+  );
+  assert.equal(
+    cleaned,
+    "Two emails went out. See the doc and plus inline and end.",
+  );
+});
+
+test("extractTaskLine prefers a question aimed at the reader", () => {
+  const line = extractTaskLine(
+    "Campaign 2 update. The numbers moved. Does the Backups list show any backup dated today, or is the newest one still the 30 July entry? More detail follows.",
+  );
+  assert.equal(
+    line,
+    "Does the Backups list show any backup dated today, or is the newest one still the 30 July entry?",
+  );
+});
+
+test("extractTaskLine falls back to ask language, then first sentence", () => {
+  assert.equal(
+    extractTaskLine(
+      "Context first sentence here. Please review your v02 proposal before Monday. Closing remark.",
+    ),
+    "Please review your v02 proposal before Monday.",
+  );
+  assert.equal(
+    extractTaskLine("Engineering signed off on the desktop build. All good."),
+    "Engineering signed off on the desktop build.",
+  );
+});
+
+test("regression: narrative blocked + need input status is headsUp, not blocked", () => {
+  const result = classifyAsk(
+    "Deploy status: we are blocked + need input, review of the infra config is pending.",
+  );
+  assert.equal(result.type, "headsUp");
+  assert.equal(result.ask, null);
+  assert.equal(result.askCount, 0);
+});
+
+test("regression: discussing the decision on tag costs is headsUp, not decision", () => {
+  const result = classifyAsk(
+    "The team is still weighing the decision on tag costs and will confirm the budget next week.",
+  );
+  assert.equal(result.type, "headsUp");
+  assert.equal(result.ask, null);
+  assert.equal(result.askCount, 0);
+});
+
+test("questions aimed at a named third party are deprioritised", () => {
+  const result = classifyAsk(
+    "Status update. Should @lee take the relay migration, agreed? When is the next backup run?",
+  );
+  assert.equal(result.ask, "When is the next backup run?");
+  // A direct @-addressed ask still classifies when it is the only candidate.
+  const direct = classifyAsk("Can @lee restart the relay today?");
+  assert.equal(direct.type, "question");
+  assert.equal(direct.ask, "Can @lee restart the relay today?");
+});
+
+test("askCount counts distinct reader asks", () => {
+  const two = classifyAsk(
+    "Can you approve the budget? Also, could you review the deck?",
+  );
+  assert.equal(two.askCount, 2);
+  const one = classifyAsk("Please review your plan.");
+  assert.equal(one.askCount, 1);
+  // A plain question headline still reports at least one ask.
+  const plain = classifyAsk("Is the backup scheduled?");
+  assert.equal(plain.askCount, 1);
+  const none = classifyAsk("hello there everyone.");
+  assert.equal(none.askCount, 0);
+});
+
+test("extractTaskLine truncates very long sentences on a word boundary", () => {
+  const long = `Reading your message as approval to proceed on the three fixes we converged on earlier because you want it out now rather than waiting on further confirmation from the rest of the team`;
+  const line = extractTaskLine(long);
+  assert.ok(line.length <= 111);
+  assert.ok(line.endsWith("…"));
+  assert.ok(!line.includes("  "));
+});
+
+test("isConfigNoise flags config-nudge payloads only", () => {
+  assert.equal(
+    isConfigNoise('run codex login ```buzz:config-nudge {"agent_name":"X"}```'),
+    true,
+  );
+  assert.equal(isConfigNoise("please review the config doc"), false);
+});

--- a/desktop/src/features/attention/lib/taskExtraction.ts
+++ b/desktop/src/features/attention/lib/taskExtraction.ts
@@ -1,0 +1,217 @@
+const CONFIG_NUDGE_MARKER = "buzz:config-nudge";
+
+/** Maya's reason taxonomy. headsUp = mentions you, needs nothing. */
+export type AskType =
+  | "decision"
+  | "approval"
+  | "question"
+  | "review"
+  | "blocked"
+  | "headsUp";
+
+export type AskClassification = {
+  type: AskType;
+  /** The one-line ask headline; null only for headsUp. */
+  ask: string | null;
+  /**
+   * Distinct qualifying ask sentences in the message (capped at
+   * MAX_ASK_COUNT). Cards with more than one never show a single ask as if
+   * it were the whole request.
+   */
+  askCount: number;
+};
+
+const MAX_TASK_LINE_LENGTH = 110;
+
+/**
+ * Agent configuration nudges are device-setup plumbing addressed at owners,
+ * not work that needs attention. They should never occupy a Needs Me slot.
+ */
+export function isConfigNoise(content: string): boolean {
+  return content.includes(CONFIG_NUDGE_MARKER);
+}
+
+/**
+ * Reduce raw message markdown to plain sentence text: code blocks, links,
+ * emphasis markers, JSON blobs and bare URLs all removed. Extraction input
+ * only — rendering still goes through the shared Markdown component.
+ */
+export function stripMessageNoise(content: string): string {
+  return (
+    content
+      // fenced code blocks (and any JSON payloads inside them)
+      .replace(/```[\s\S]*?```/g, " ")
+      // inline code keeps its text
+      .replace(/`([^`]*)`/g, "$1")
+      // markdown links keep their label
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // bare URLs
+      .replace(/https?:\/\/\S+/g, " ")
+      // bold / italic / strikethrough markers
+      .replace(/(\*\*|__|~~|\*|_)/g, "")
+      // heading and blockquote prefixes
+      .replace(/^[>#]+\s*/gm, "")
+      // leading list markers
+      .replace(/^\s*[-*+]\s+/gm, "")
+      // bare JSON object blobs that survived (best effort)
+      .replace(/\{"[^\n]*\}/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.?!])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 2);
+}
+
+const ASK_PATTERN =
+  /\b(please|can you|could you|would you|approve|review|confirm|decide|check|answer|unblock|need you|needs? your|waiting on you|your call|go ahead|say the word|let me know)\b/i;
+
+/** Asks must address the reader — narrative prose about work is not an ask. */
+const SECOND_PERSON = /\byou\b|\byour\b/i;
+
+/** "@lee can you…" — an ask addressed at a named third party. */
+const MENTION_TOKEN = /@[A-Za-z]/;
+
+export const MAX_ASK_COUNT = 9;
+
+function truncateTaskLine(sentence: string): string {
+  if (sentence.length <= MAX_TASK_LINE_LENGTH) {
+    return sentence;
+  }
+  const cut = sentence.slice(0, MAX_TASK_LINE_LENGTH);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${cut.slice(0, lastSpace > 60 ? lastSpace : MAX_TASK_LINE_LENGTH)}…`;
+}
+
+function contentSentences(content: string): string[] {
+  const cleaned = stripMessageNoise(content);
+  return cleaned ? splitSentences(cleaned) : [];
+}
+
+function findAskSentenceIn(sentences: string[]): string | null {
+  if (sentences.length === 0) {
+    return null;
+  }
+
+  const questions = sentences.filter((sentence) => sentence.endsWith("?"));
+  const readerQuestion = questions.find((sentence) =>
+    SECOND_PERSON.test(sentence),
+  );
+  if (readerQuestion) {
+    return readerQuestion;
+  }
+
+  // Questions addressed at a named third party ("@lee can you…") are
+  // deprioritised: only use them when no plainly-addressed question exists.
+  const nonMentionQuestions = questions.filter(
+    (sentence) => !MENTION_TOKEN.test(sentence),
+  );
+  const anyQuestion =
+    nonMentionQuestions.length > 0 ? nonMentionQuestions[0] : questions[0];
+  if (anyQuestion) {
+    return anyQuestion;
+  }
+
+  // Imperative asks only qualify when they address the reader — otherwise
+  // narrative status prose ("we are blocked…") reads as an ask.
+  return (
+    sentences.find(
+      (sentence) => ASK_PATTERN.test(sentence) && SECOND_PERSON.test(sentence),
+    ) ?? null
+  );
+}
+
+function findAskSentence(content: string): string | null {
+  return findAskSentenceIn(contentSentences(content));
+}
+
+/**
+ * Distinct qualifying ask sentences for the multi-ask safety rule: reader
+ * questions (with @-addressed ones deprioritised) plus reader-addressed
+ * imperative asks. Mirrors the findAskSentenceIn filters.
+ */
+function qualifyingAskSentences(sentences: string[]): string[] {
+  const readerQuestions = sentences.filter(
+    (sentence) => sentence.endsWith("?") && SECOND_PERSON.test(sentence),
+  );
+  const nonMentionReaderQuestions = readerQuestions.filter(
+    (sentence) => !MENTION_TOKEN.test(sentence),
+  );
+  const countedQuestions =
+    nonMentionReaderQuestions.length > 0
+      ? nonMentionReaderQuestions
+      : readerQuestions;
+  const imperativeAsks = sentences.filter(
+    (sentence) =>
+      !sentence.endsWith("?") &&
+      ASK_PATTERN.test(sentence) &&
+      SECOND_PERSON.test(sentence),
+  );
+  return [...new Set([...countedQuestions, ...imperativeAsks])].slice(
+    0,
+    MAX_ASK_COUNT,
+  );
+}
+
+const APPROVAL_PATTERN =
+  /\b(approve|approval|sign[- ]?off|authorise|authorize|green ?light|gated on you)\b/i;
+const DECISION_PATTERN =
+  /\b(decide|decision|choose|choice|your call|pick (?:one|between)|option [ab])\b/i;
+const BLOCKED_PATTERN =
+  /\b(blocked|cannot proceed|can't proceed|unblock|waiting on you|need you to|stuck until)\b/i;
+const REVIEW_PATTERN =
+  /\b(review|take a look|have a look|feedback on|ready for your)\b/i;
+
+function classifyAskSentence(sentence: string): AskType {
+  if (APPROVAL_PATTERN.test(sentence)) return "approval";
+  if (DECISION_PATTERN.test(sentence)) return "decision";
+  if (BLOCKED_PATTERN.test(sentence)) return "blocked";
+  if (REVIEW_PATTERN.test(sentence)) return "review";
+  return "question";
+}
+
+/**
+ * Tier-2 derived classification (Maya's spec): find the ask sentence,
+ * classify it by resolution verb, and demote ask-less mentions to headsUp so
+ * the Needs Me count stays honest. Tier-1 declared attention tags replace
+ * this heuristic when the contract lands.
+ */
+export function classifyAsk(content: string): AskClassification {
+  if (isConfigNoise(content)) {
+    return { type: "headsUp", ask: null, askCount: 0 };
+  }
+  const sentences = contentSentences(content);
+  const sentence = findAskSentenceIn(sentences);
+  if (!sentence) {
+    return { type: "headsUp", ask: null, askCount: 0 };
+  }
+  // The headline sentence itself may be a plain (non-reader) question that
+  // the qualifying set excludes, so an ask never reports a count of zero.
+  const askCount = Math.max(1, qualifyingAskSentences(sentences).length);
+  return {
+    type: classifyAskSentence(sentence),
+    ask: truncateTaskLine(sentence),
+    askCount,
+  };
+}
+
+/**
+ * Best-effort one-line "what do I need to do" from message prose.
+ * Falls back to the first sentence when no explicit ask is found.
+ */
+export function extractTaskLine(content: string): string {
+  const sentence = findAskSentence(content);
+  if (sentence) {
+    return truncateTaskLine(sentence);
+  }
+  const cleaned = stripMessageNoise(content);
+  if (!cleaned) {
+    return "";
+  }
+  const sentences = splitSentences(cleaned);
+  return truncateTaskLine(sentences[0] ?? cleaned);
+}

--- a/desktop/src/features/attention/ui/AttentionCard.tsx
+++ b/desktop/src/features/attention/ui/AttentionCard.tsx
@@ -1,0 +1,583 @@
+import {
+  ArrowUpRight,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Hourglass,
+  MoreHorizontal,
+  RotateCcw,
+} from "lucide-react";
+import * as React from "react";
+
+import type { AttentionItem } from "@/features/attention/lib/attention";
+import {
+  offersHandledElsewhere,
+  primaryGenericAction,
+  waitingDays,
+} from "@/features/attention/lib/attention";
+import {
+  defaultDeclaredOptions,
+  deriveQuickOptions,
+} from "@/features/attention/lib/quickOptions";
+import { extractTaskLine } from "@/features/attention/lib/taskExtraction";
+import type { AskType } from "@/features/attention/lib/taskExtraction";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Markdown } from "@/shared/ui/markdown";
+
+export type AttentionCardAction =
+  | "done"
+  | "noted"
+  | "waiting"
+  | "handledElsewhere";
+
+type AttentionCardProps = {
+  expanded: boolean;
+  isPending: boolean;
+  item: AttentionItem;
+  onAction: (item: AttentionItem, action: AttentionCardAction) => void;
+  onOpen: (item: AttentionItem) => void;
+  onOverrideBadge: (id: string, type: AskType) => void;
+  onReply: (item: AttentionItem, text: string) => void;
+  onRestore: (id: string) => void;
+  onToggleExpanded: (id: string) => void;
+  selected: boolean;
+};
+
+const BADGE_ORDER: AskType[] = [
+  "decision",
+  "approval",
+  "question",
+  "review",
+  "blocked",
+  "headsUp",
+];
+
+const BADGES: Record<AskType, { label: string; className: string }> = {
+  decision: {
+    label: "Decision",
+    className: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  },
+  approval: { label: "Approval", className: "bg-primary/10 text-primary" },
+  question: {
+    label: "Question",
+    className: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  },
+  review: {
+    label: "Review",
+    className: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+  },
+  blocked: {
+    label: "Blocked",
+    className: "bg-red-500/15 text-red-600 dark:text-red-400",
+  },
+  headsUp: { label: "Heads up", className: "bg-muted text-muted-foreground" },
+};
+
+const actionRowClassName =
+  "ml-auto flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100";
+
+function cardHeadline(item: AttentionItem): string {
+  // Multi-ask safety rule: never present one ask while hiding another —
+  // the badge still reflects the first ask's type.
+  const declaredCount = item.declaredAsks?.length ?? 0;
+  if (declaredCount > 1) {
+    return `${declaredCount} asks`;
+  }
+  if (item.askCount > 1) {
+    return `${item.askCount} questions`;
+  }
+  if (item.ask) {
+    return item.ask;
+  }
+  const extracted = extractTaskLine(item.inboxItem.item.content);
+  return extracted || item.inboxItem.preview || item.inboxItem.subject;
+}
+
+/**
+ * One attention item: a compact two-line card (badge + bold ask, then
+ * sender/channel/staleness meta with hover-revealed actions) that expands
+ * on click into the full message with quick-select options and a reply box.
+ */
+export function AttentionCard({
+  expanded,
+  isPending,
+  item,
+  onAction,
+  onOpen,
+  onOverrideBadge,
+  onReply,
+  onRestore,
+  onToggleExpanded,
+  selected,
+}: AttentionCardProps) {
+  const inboxItem = item.inboxItem;
+  const content = inboxItem.item.content;
+  const canOpen = Boolean(inboxItem.item.channelId);
+  const canPost = canOpen && !isPending;
+  const isHeadsUp = item.askType === "headsUp";
+  const badge = BADGES[item.askType];
+  const declaredAsks = item.declaredAsks ?? [];
+  const isMultiAsk = declaredAsks.length > 1;
+  const days = waitingDays(
+    inboxItem.latestActivityAt,
+    Math.floor(Date.now() / 1_000),
+  );
+
+  const [replyText, setReplyText] = React.useState("");
+  const [badgeMenuOpen, setBadgeMenuOpen] = React.useState(false);
+  const [overflowOpen, setOverflowOpen] = React.useState(false);
+  // Per-sub-ask local answers, keyed by declared-ask index.
+  const [subAnswers, setSubAnswers] = React.useState<Record<number, string>>(
+    {},
+  );
+
+  const quickOptions = React.useMemo(() => {
+    // Declared options take precedence over derived ones; multi-ask cards
+    // answer through their sub-items instead.
+    if (isMultiAsk) {
+      return [];
+    }
+    if (declaredAsks.length === 1 && declaredAsks[0].options.length > 0) {
+      return declaredAsks[0].options;
+    }
+    return deriveQuickOptions(item.askType, item.ask, content);
+  }, [isMultiAsk, declaredAsks, item.askType, item.ask, content]);
+
+  // Locked action matrix: Done only on Blocked, Noted only on Heads up,
+  // Handled elsewhere in the overflow everywhere else actionable.
+  const genericPrimary = primaryGenericAction(item.askType);
+  const hasOverflow = offersHandledElsewhere(item.askType);
+
+  const answeredCount = declaredAsks.filter(
+    (_ask, index) => (subAnswers[index] ?? "").trim().length > 0,
+  ).length;
+
+  const handleSendAll = () => {
+    const lines = declaredAsks
+      .map((_ask, index) => {
+        const answer = (subAnswers[index] ?? "").trim();
+        return answer ? `${index + 1}. ${answer}` : null;
+      })
+      .filter((line): line is string => line !== null);
+    if (lines.length === 0) {
+      return;
+    }
+    onReply(item, lines.join("\n"));
+    setSubAnswers({});
+  };
+
+  const handleBodyClick = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
+    if (target.closest("button, textarea, a, input")) {
+      return;
+    }
+    onToggleExpanded(item.id);
+  };
+
+  const handleReply = () => {
+    const text = replyText.trim();
+    if (!text) {
+      return;
+    }
+    onReply(item, text);
+    setReplyText("");
+  };
+
+  return (
+    <article
+      className={cn(
+        "group rounded-xl border border-border/60 bg-background/80 px-4 py-2.5 transition-colors hover:border-border",
+        selected && "ring-2 ring-primary/40",
+      )}
+      data-selected={selected || undefined}
+      data-testid={`attention-card-${item.id}`}
+    >
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: card body toggle is a convenience; the expand button and actions are keyboard-reachable */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard expand is handled by the view-level j/k/e bindings */}
+      <div className="cursor-pointer" onClick={handleBodyClick}>
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="relative shrink-0">
+            <button
+              aria-expanded={badgeMenuOpen}
+              aria-label={`Change type (currently ${badge.label})`}
+              className={cn(
+                "rounded-full px-2 py-0.5 text-2xs font-medium",
+                badge.className,
+              )}
+              data-testid="attention-badge"
+              onClick={() => setBadgeMenuOpen((open) => !open)}
+              type="button"
+            >
+              {badge.label}
+            </button>
+            {badgeMenuOpen ? (
+              <div className="absolute left-0 top-full z-20 mt-1 w-28 rounded-lg border border-border bg-background p-1 shadow-md">
+                {BADGE_ORDER.map((type) => (
+                  <button
+                    className={cn(
+                      "block w-full rounded-md px-2 py-1 text-left text-2xs transition-colors hover:bg-muted",
+                      type === item.askType
+                        ? "font-semibold text-foreground"
+                        : "text-muted-foreground",
+                    )}
+                    data-testid={`attention-badge-option-${type}`}
+                    key={type}
+                    onClick={() => {
+                      onOverrideBadge(item.id, type);
+                      setBadgeMenuOpen(false);
+                    }}
+                    type="button"
+                  >
+                    {BADGES[type].label}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <span
+            className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground"
+            data-testid="attention-card-ask"
+          >
+            {cardHeadline(item)}
+          </span>
+          <span className="ml-auto shrink-0 text-2xs text-muted-foreground">
+            {inboxItem.timestampLabel}
+          </span>
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-2">
+          <span className="min-w-0 truncate text-2xs text-muted-foreground">
+            {inboxItem.senderLabel}
+            {inboxItem.channelLabel ? ` in #${inboxItem.channelLabel}` : ""}
+            {days > 0
+              ? ` · waiting ${days} ${days === 1 ? "day" : "days"}`
+              : inboxItem.timestampLabel
+                ? ` · ${inboxItem.timestampLabel}`
+                : ""}
+          </span>
+          {item.reactivated ? (
+            <span className="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-2xs font-medium text-amber-600 dark:text-amber-400">
+              New activity
+            </span>
+          ) : null}
+          {item.responded ? (
+            <span
+              className="shrink-0 rounded-full bg-emerald-500/15 px-2 py-0.5 text-2xs font-medium text-emerald-600 dark:text-emerald-400"
+              data-testid="attention-responded-badge"
+            >
+              You replied
+            </span>
+          ) : null}
+          <div className={actionRowClassName}>
+            {item.zone === "needsMe" && !isHeadsUp ? (
+              <>
+                <Button
+                  data-testid="attention-action-waiting"
+                  disabled={!canPost}
+                  onClick={() => onAction(item, "waiting")}
+                  size="xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Hourglass />
+                  Waiting
+                </Button>
+                {genericPrimary === "done" ? (
+                  <Button
+                    data-testid="attention-action-done"
+                    disabled={!canPost}
+                    onClick={() => onAction(item, "done")}
+                    size="xs"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <Check />
+                    Done
+                  </Button>
+                ) : null}
+                {hasOverflow ? (
+                  <div className="relative">
+                    <Button
+                      aria-expanded={overflowOpen}
+                      aria-label="More actions"
+                      data-testid="attention-action-overflow"
+                      onClick={() => setOverflowOpen((open) => !open)}
+                      size="xs"
+                      type="button"
+                      variant="ghost"
+                    >
+                      <MoreHorizontal />
+                    </Button>
+                    {overflowOpen ? (
+                      <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-border bg-background p-1 shadow-md">
+                        <button
+                          className="block w-full rounded-md px-2 py-1 text-left text-2xs text-muted-foreground transition-colors hover:bg-muted"
+                          data-testid="attention-action-handled-elsewhere"
+                          disabled={!canPost}
+                          onClick={() => {
+                            setOverflowOpen(false);
+                            onAction(item, "handledElsewhere");
+                          }}
+                          type="button"
+                        >
+                          Handled elsewhere
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+            {item.zone === "needsMe" && isHeadsUp ? (
+              <Button
+                data-testid="attention-action-noted"
+                // Noted on a To note item is local-only — it needs no
+                // channel to post into, only a non-pending card.
+                disabled={isPending}
+                onClick={() => onAction(item, "noted")}
+                size="xs"
+                type="button"
+                variant="ghost"
+              >
+                <Check />
+                Noted
+              </Button>
+            ) : null}
+            {item.zone === "waiting" ? (
+              <>
+                <Button
+                  data-testid="attention-action-done"
+                  disabled={!canPost}
+                  onClick={() => onAction(item, "done")}
+                  size="xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Check />
+                  Done
+                </Button>
+                <Button
+                  data-testid="attention-action-restore"
+                  disabled={isPending}
+                  onClick={() => onRestore(item.id)}
+                  size="xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <RotateCcw />
+                  Needs me
+                </Button>
+              </>
+            ) : null}
+            {item.zone === "done" ? (
+              <Button
+                data-testid="attention-action-restore"
+                disabled={isPending}
+                onClick={() => onRestore(item.id)}
+                size="xs"
+                type="button"
+                variant="ghost"
+              >
+                <RotateCcw />
+                Restore
+              </Button>
+            ) : null}
+            <Button
+              data-testid="attention-action-open"
+              disabled={!canOpen}
+              onClick={() => onOpen(item)}
+              size="xs"
+              type="button"
+              variant="outline"
+            >
+              <ArrowUpRight />
+              Open
+            </Button>
+            {item.zone === "needsMe" && !isHeadsUp ? (
+              <Button
+                aria-label={expanded ? "Collapse" : "Expand"}
+                data-testid="attention-action-expand"
+                onClick={() => onToggleExpanded(item.id)}
+                size="xs"
+                type="button"
+                variant="ghost"
+              >
+                {expanded ? <ChevronUp /> : <ChevronDown />}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        {/* Options are the point of the card: visible collapsed, one click
+            clears the row without an expand. */}
+        {item.zone === "needsMe" && !isHeadsUp && !expanded ? (
+          isMultiAsk ? (
+            <div
+              className="mt-1.5 flex flex-col gap-0.5"
+              data-testid="attention-collapsed-subasks"
+            >
+              {declaredAsks.map((declaredAsk, index) => (
+                <p
+                  className="truncate text-2xs text-muted-foreground"
+                  key={`${declaredAsk.type}-${declaredAsk.ask}`}
+                >
+                  {index + 1}. {declaredAsk.ask}
+                </p>
+              ))}
+            </div>
+          ) : quickOptions.length > 0 ? (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              {quickOptions.map((option) => (
+                <Button
+                  data-testid="attention-quick-option"
+                  disabled={!canPost}
+                  key={option}
+                  onClick={() => onReply(item, option)}
+                  size="xs"
+                  type="button"
+                  variant="default"
+                >
+                  {option}
+                </Button>
+              ))}
+            </div>
+          ) : null
+        ) : null}
+      </div>
+      {expanded ? (
+        <div
+          className="mt-3 border-t border-border/60 pt-3"
+          data-testid="attention-card-expanded"
+        >
+          {/* Reading order: ask, options, body, reply — the options never
+              sit below the fold of a long message. */}
+          {isMultiAsk ? (
+            <div className="flex flex-col gap-2">
+              <p
+                className="text-2xs text-muted-foreground"
+                data-testid="attention-subitems-progress"
+              >
+                {answeredCount} of {declaredAsks.length} answered
+              </p>
+              {declaredAsks.map((declaredAsk, index) => {
+                // Optionless declared asks fall back to the closed
+                // per-type defaults (fixture 4: a bare Review sub-ask
+                // still gets its one-click pair plus the way out).
+                const subOptions =
+                  declaredAsk.options.length > 0
+                    ? declaredAsk.options
+                    : defaultDeclaredOptions(declaredAsk.type);
+                return (
+                  <div
+                    className="rounded-lg border border-border/60 p-2.5"
+                    data-testid="attention-subitem"
+                    key={`${declaredAsk.type}-${declaredAsk.ask}`}
+                  >
+                    <p className="text-sm font-medium text-foreground">
+                      {index + 1}. {declaredAsk.ask}
+                    </p>
+                    {subOptions.length > 0 ? (
+                      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                        {subOptions.map((option) => (
+                          <Button
+                            data-testid="attention-subitem-option"
+                            disabled={!canPost}
+                            key={option}
+                            onClick={() =>
+                              setSubAnswers((prev) => ({
+                                ...prev,
+                                [index]: option,
+                              }))
+                            }
+                            size="xs"
+                            type="button"
+                            variant={
+                              subAnswers[index] === option
+                                ? "default"
+                                : "outline"
+                            }
+                          >
+                            {option}
+                          </Button>
+                        ))}
+                      </div>
+                    ) : null}
+                    <input
+                      className="mt-2 w-full rounded-md border border-border/60 bg-background px-2 py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-primary/50"
+                      data-testid="attention-subitem-input"
+                      onChange={(event) =>
+                        setSubAnswers((prev) => ({
+                          ...prev,
+                          [index]: event.target.value,
+                        }))
+                      }
+                      placeholder="Type an answer…"
+                      type="text"
+                      value={subAnswers[index] ?? ""}
+                    />
+                  </div>
+                );
+              })}
+              <div className="flex items-center justify-end gap-1">
+                <Button
+                  data-testid="attention-action-reply"
+                  disabled={!canPost || answeredCount === 0}
+                  onClick={handleSendAll}
+                  size="xs"
+                  type="button"
+                >
+                  Send all
+                </Button>
+              </div>
+            </div>
+          ) : null}
+          {!isMultiAsk && quickOptions.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              {quickOptions.map((option) => (
+                <Button
+                  data-testid="attention-quick-option"
+                  disabled={!canPost}
+                  key={option}
+                  onClick={() => onReply(item, option)}
+                  size="xs"
+                  type="button"
+                  variant="default"
+                >
+                  {option}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+          <div className="mt-3 text-sm text-foreground/90">
+            <Markdown content={content} />
+          </div>
+          {isMultiAsk ? null : (
+            <div className="mt-3 flex items-end gap-2">
+              <textarea
+                // biome-ignore lint/a11y/noAutofocus: expanding a card is an explicit intent to reply
+                autoFocus
+                className="min-h-9 w-full flex-1 resize-y rounded-lg border border-border/60 bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:min-h-16 focus:border-primary/50"
+                data-testid="attention-reply-input"
+                onChange={(event) => setReplyText(event.target.value)}
+                placeholder={
+                  canOpen
+                    ? "Reply in the source thread…"
+                    : "This item has no channel to reply into."
+                }
+                value={replyText}
+              />
+              <Button
+                data-testid="attention-action-reply"
+                disabled={!canPost || replyText.trim().length === 0}
+                onClick={handleReply}
+                size="xs"
+                type="button"
+              >
+                Reply
+              </Button>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/desktop/src/features/attention/ui/AttentionScreen.tsx
+++ b/desktop/src/features/attention/ui/AttentionScreen.tsx
@@ -1,0 +1,248 @@
+import * as React from "react";
+
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { useHomeFeedQuery } from "@/features/home/hooks";
+import { buildInboxItems } from "@/features/home/lib/inbox";
+import { useSendMessageMutation } from "@/features/messages/hooks";
+import {
+  actionPublishes,
+  type AttentionItem,
+  attentionThreadRootId,
+  HANDLED_ELSEWHERE_REPLY,
+  projectAttention,
+} from "@/features/attention/lib/attention";
+import type { AttentionCardAction } from "@/features/attention/ui/AttentionCard";
+import { AttentionView } from "@/features/attention/ui/AttentionView";
+import { useActionQueue } from "@/features/attention/useActionQueue";
+import { useAttentionZoneState } from "@/features/attention/useAttentionZoneState";
+import { useBadgeOverrides } from "@/features/attention/useBadgeOverrides";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import {
+  isRelayUnreachableError,
+  RELAY_UNREACHABLE_MESSAGE,
+} from "@/shared/lib/relayError";
+
+/** Canned prose for the park actions. Replies stay human-readable. */
+const ACTION_CONFIG: Record<
+  AttentionCardAction,
+  { reply: string; toast: string; zone: "done" | "waiting" }
+> = {
+  done: {
+    reply: "Done. The manual step you needed from me is complete.",
+    toast: "Marked done — reply posts in 5s",
+    zone: "done",
+  },
+  handledElsewhere: {
+    reply: HANDLED_ELSEWHERE_REPLY,
+    toast: "Handled elsewhere — reply posts in 5s",
+    zone: "done",
+  },
+  noted: {
+    reply: "Noted. No answer needed from me, carry on.",
+    toast: "Noted — reply posts in 5s",
+    zone: "done",
+  },
+  waiting: {
+    reply: "I have this. I am waiting on someone else before I can respond.",
+    toast: "Parked as waiting — reply posts in 5s",
+    zone: "waiting",
+  },
+};
+
+export function AttentionScreen() {
+  const identityQuery = useIdentityQuery();
+  const currentPubkey = identityQuery.data?.pubkey;
+  const homeFeedQuery = useHomeFeedQuery();
+  const channelsQuery = useChannelsQuery();
+  const { goChannel } = useAppNavigation();
+  const { pendingIds, queueAction, queueBatch } = useActionQueue();
+  // Held entries stay out of localStorage until commit (see hook docs).
+  const {
+    markDone,
+    markResponded,
+    markWaiting,
+    restore,
+    restoreEntry,
+    zoneState,
+  } = useAttentionZoneState(currentPubkey, pendingIds);
+  const sendMutation = useSendMessageMutation(null, identityQuery.data);
+  const { mutateAsync: sendMessage } = sendMutation;
+
+  const feed = homeFeedQuery.data;
+  const profilePubkeys = React.useMemo(() => {
+    if (!feed) return [];
+    return [
+      ...new Set(
+        [
+          ...feed.feed.mentions,
+          ...feed.feed.needsAction,
+          ...feed.feed.activity,
+          ...feed.feed.agentActivity,
+        ]
+          .map((item) => item.pubkey)
+          // Include the viewer so the declared-ask tier can resolve the
+          // viewer display name ("Needs <Name>, …") from the same lookup.
+          .concat(currentPubkey ? [currentPubkey] : []),
+      ),
+    ];
+  }, [feed, currentPubkey]);
+  const profilesQuery = useUsersBatchQuery(profilePubkeys, {
+    enabled: profilePubkeys.length > 0,
+  });
+
+  const inboxItems = React.useMemo(
+    () =>
+      buildInboxItems({
+        channels: channelsQuery.data,
+        currentPubkey,
+        feed,
+        profiles: profilesQuery.data?.profiles,
+      }),
+    [channelsQuery.data, currentPubkey, feed, profilesQuery.data?.profiles],
+  );
+
+  const { overrides, setOverride } = useBadgeOverrides(currentPubkey);
+
+  const viewerProfile = currentPubkey
+    ? profilesQuery.data?.profiles?.[currentPubkey.toLowerCase()]
+    : undefined;
+  const viewerName =
+    viewerProfile?.displayName ?? viewerProfile?.name ?? undefined;
+
+  const projection = React.useMemo(
+    () =>
+      projectAttention(inboxItems, zoneState, Math.floor(Date.now() / 1_000), {
+        badgeOverrides: overrides,
+        viewerName,
+      }),
+    [inboxItems, zoneState, overrides, viewerName],
+  );
+
+  // Snapshot for undo/revert closures: reading via ref avoids rebinding the
+  // action handlers (and re-rendering every card) on each zone change.
+  const zoneStateRef = React.useRef(zoneState);
+  zoneStateRef.current = zoneState;
+
+  const buildRevert = React.useCallback(
+    (id: string) => {
+      const previous = zoneStateRef.current[id];
+      return () => restoreEntry(id, previous);
+    },
+    [restoreEntry],
+  );
+
+  const sendThreadReply = React.useCallback(
+    async (item: AttentionItem, content: string) => {
+      const channelId = item.inboxItem.item.channelId;
+      if (!channelId) {
+        throw new Error("This item has no source channel.");
+      }
+      const result = await sendMessage({
+        channelId,
+        content,
+        parentEventId: item.inboxItem.item.id,
+        mentionPubkeys: [item.inboxItem.item.pubkey],
+      });
+      markResponded(item.id);
+      return result;
+    },
+    [markResponded, sendMessage],
+  );
+
+  const handleAction = React.useCallback(
+    (item: AttentionItem, action: AttentionCardAction) => {
+      // Nobody waits on a To note item: Noted there is local-only. It still
+      // holds through the queue so every action type shares one code path;
+      // the commit is a no-op send.
+      if (!actionPublishes(item.askType, action)) {
+        queueAction({
+          itemId: item.id,
+          toastLabel: "Noted locally",
+          apply: () => markDone(item.id),
+          revert: buildRevert(item.id),
+          send: () => Promise.resolve(),
+        });
+        return;
+      }
+      const config = ACTION_CONFIG[action];
+      queueAction({
+        itemId: item.id,
+        toastLabel: config.toast,
+        apply: () =>
+          config.zone === "waiting" ? markWaiting(item.id) : markDone(item.id),
+        revert: buildRevert(item.id),
+        send: () => sendThreadReply(item, config.reply),
+      });
+    },
+    [buildRevert, markDone, markWaiting, queueAction, sendThreadReply],
+  );
+
+  const headsUpItems = projection.headsUp;
+  const handleNoteAll = React.useCallback(() => {
+    if (headsUpItems.length === 0) {
+      return;
+    }
+    queueBatch({
+      toastLabel:
+        headsUpItems.length === 1
+          ? "Noted 1 item locally"
+          : `Noted ${headsUpItems.length} items locally`,
+      items: headsUpItems.map((item) => ({
+        itemId: item.id,
+        apply: () => markDone(item.id),
+        revert: buildRevert(item.id),
+        send: () => Promise.resolve(),
+      })),
+    });
+  }, [buildRevert, headsUpItems, markDone, queueBatch]);
+
+  const handleReply = React.useCallback(
+    (item: AttentionItem, text: string) => {
+      queueAction({
+        itemId: item.id,
+        toastLabel: "Reply queued — posts in 5s",
+        apply: () => markDone(item.id),
+        revert: buildRevert(item.id),
+        send: () => sendThreadReply(item, text),
+      });
+    },
+    [buildRevert, markDone, queueAction, sendThreadReply],
+  );
+
+  const handleOpen = React.useCallback(
+    (item: AttentionItem) => {
+      const channelId = item.inboxItem.item.channelId;
+      if (!channelId) return;
+      void goChannel(channelId, {
+        messageId: item.inboxItem.item.id,
+        threadRootId: attentionThreadRootId(item.inboxItem),
+      });
+    },
+    [goChannel],
+  );
+
+  return (
+    <AttentionView
+      errorMessage={
+        homeFeedQuery.error !== null && homeFeedQuery.error !== undefined
+          ? isRelayUnreachableError(homeFeedQuery.error)
+            ? RELAY_UNREACHABLE_MESSAGE
+            : homeFeedQuery.error instanceof Error
+              ? homeFeedQuery.error.message
+              : undefined
+          : undefined
+      }
+      isLoading={homeFeedQuery.isLoading}
+      onAction={handleAction}
+      onNoteAll={handleNoteAll}
+      onOpen={handleOpen}
+      onOverrideBadge={setOverride}
+      onReply={handleReply}
+      onRestore={restore}
+      pendingIds={pendingIds}
+      projection={projection}
+    />
+  );
+}

--- a/desktop/src/features/attention/ui/AttentionView.tsx
+++ b/desktop/src/features/attention/ui/AttentionView.tsx
@@ -1,0 +1,354 @@
+import * as React from "react";
+
+import type {
+  AskType,
+  AttentionItem,
+  AttentionProjection,
+  AttentionZone,
+} from "@/features/attention/lib/attention";
+import { isSameLocalDay } from "@/features/attention/lib/attention";
+import {
+  AttentionCard,
+  type AttentionCardAction,
+} from "@/features/attention/ui/AttentionCard";
+import { cn } from "@/shared/lib/cn";
+import { TopChromeInsetHeader } from "@/shared/layout/TopChromeInsetHeader";
+
+type AttentionViewProps = {
+  errorMessage?: string;
+  isLoading: boolean;
+  onAction: (item: AttentionItem, action: AttentionCardAction) => void;
+  onNoteAll: () => void;
+  onOpen: (item: AttentionItem) => void;
+  onOverrideBadge: (id: string, type: AskType) => void;
+  onReply: (item: AttentionItem, text: string) => void;
+  onRestore: (id: string) => void;
+  pendingIds: ReadonlySet<string>;
+  projection: AttentionProjection;
+};
+
+const ZONE_TABS: Array<{ zone: AttentionZone; label: string }> = [
+  { zone: "needsMe", label: "Needs Me" },
+  { zone: "waiting", label: "Waiting" },
+  { zone: "done", label: "Done" },
+];
+
+const tabButtonClassName =
+  "h-7 rounded-full border border-transparent px-2.5 text-2xs font-medium text-muted-foreground transition-colors hover:text-foreground data-[active=true]:border-border/70 data-[active=true]:bg-background/80 data-[active=true]:text-foreground data-[active=true]:shadow-xs";
+
+const sectionHeaderClassName =
+  "px-1 pb-1.5 pt-3 text-2xs font-semibold uppercase tracking-wide text-muted-foreground";
+
+/**
+ * The Attention screen: tabbed Needs Me / Waiting / Done views over the
+ * attention projection, with j/k keyboard navigation and per-card actions.
+ */
+export function AttentionView({
+  errorMessage,
+  isLoading,
+  onAction,
+  onNoteAll,
+  onOpen,
+  onOverrideBadge,
+  onReply,
+  onRestore,
+  pendingIds,
+  projection,
+}: AttentionViewProps) {
+  const [activeZone, setActiveZone] = React.useState<AttentionZone>("needsMe");
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [expandedId, setExpandedId] = React.useState<string | null>(null);
+
+  const nowSeconds = Math.floor(Date.now() / 1_000);
+  const overdue = projection.needsMe.filter(
+    (item) => !isSameLocalDay(item.inboxItem.latestActivityAt, nowSeconds),
+  );
+  const today = projection.needsMe.filter((item) =>
+    isSameLocalDay(item.inboxItem.latestActivityAt, nowSeconds),
+  );
+
+  const visibleItems: AttentionItem[] =
+    activeZone === "needsMe"
+      ? [...overdue, ...today, ...projection.headsUp]
+      : activeZone === "waiting"
+        ? projection.waiting
+        : projection.done;
+
+  const switchZone = (zone: AttentionZone) => {
+    setActiveZone(zone);
+    setSelectedId(null);
+    setExpandedId(null);
+  };
+
+  const toggleExpanded = React.useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+    setSelectedId(id);
+  }, []);
+
+  const moveSelection = (delta: number) => {
+    if (visibleItems.length === 0) {
+      return;
+    }
+    const index = visibleItems.findIndex((item) => item.id === selectedId);
+    const next =
+      index === -1
+        ? delta > 0
+          ? 0
+          : visibleItems.length - 1
+        : Math.min(Math.max(index + delta, 0), visibleItems.length - 1);
+    const nextId = visibleItems[next].id;
+    setSelectedId(nextId);
+    document
+      .querySelector(`[data-testid="attention-card-${nextId}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    if (target.closest("textarea, input, [contenteditable='true']")) {
+      return;
+    }
+    const selected =
+      visibleItems.find((item) => item.id === selectedId) ?? null;
+    switch (event.key) {
+      case "j":
+        event.preventDefault();
+        moveSelection(1);
+        break;
+      case "k":
+        event.preventDefault();
+        moveSelection(-1);
+        break;
+      case "e":
+        if (selected) {
+          event.preventDefault();
+          toggleExpanded(selected.id);
+        }
+        break;
+      case "r":
+        if (selected) {
+          event.preventDefault();
+          setExpandedId(selected.id);
+        }
+        break;
+      case "w":
+        if (
+          selected &&
+          selected.zone === "needsMe" &&
+          selected.askType !== "headsUp"
+        ) {
+          event.preventDefault();
+          onAction(selected, "waiting");
+        }
+        break;
+      case "d":
+        if (
+          selected &&
+          (selected.zone === "waiting" ||
+            (selected.zone === "needsMe" && selected.askType !== "headsUp"))
+        ) {
+          event.preventDefault();
+          onAction(selected, "done");
+        }
+        break;
+      case "n":
+        if (
+          selected &&
+          selected.zone === "needsMe" &&
+          selected.askType === "headsUp"
+        ) {
+          event.preventDefault();
+          onAction(selected, "noted");
+        }
+        break;
+      case "o":
+        if (selected) {
+          event.preventDefault();
+          onOpen(selected);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderCard = (item: AttentionItem) => (
+    <AttentionCard
+      expanded={expandedId === item.id}
+      isPending={pendingIds.has(item.id)}
+      item={item}
+      key={item.id}
+      onAction={onAction}
+      onOpen={onOpen}
+      onOverrideBadge={onOverrideBadge}
+      onReply={onReply}
+      onRestore={onRestore}
+      onToggleExpanded={toggleExpanded}
+      selected={selectedId === item.id}
+    />
+  );
+
+  const needsMeEmpty =
+    projection.needsMe.length === 0 && projection.headsUp.length === 0;
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: list-level shortcuts; every action is also reachable via the focusable card buttons
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden outline-none"
+      data-testid="attention-view"
+      onKeyDown={handleKeyDown}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: the view is a keyboard command surface (j/k/e/r/w/d/n/o) like a mail list
+      tabIndex={0}
+    >
+      <TopChromeInsetHeader data-tauri-drag-region flush>
+        <header className="min-w-0 cursor-default select-none px-5 py-2">
+          <div className="flex h-9 min-w-0 items-center gap-2.5">
+            <div className="min-w-0 flex-1">
+              <h1 className="truncate text-sm font-semibold text-foreground">
+                Attention
+              </h1>
+              <p className="truncate text-2xs text-muted-foreground">
+                What needs you right now, across every channel and agent
+              </p>
+            </div>
+          </div>
+        </header>
+      </TopChromeInsetHeader>
+      <div className="flex items-center gap-1 px-5 py-2">
+        {ZONE_TABS.map((tab) => (
+          <button
+            className={tabButtonClassName}
+            data-active={activeZone === tab.zone}
+            data-testid={`attention-tab-${tab.zone}`}
+            key={tab.zone}
+            onClick={() => switchZone(tab.zone)}
+            type="button"
+          >
+            {tab.label}
+            {tab.zone === "needsMe" ? (
+              <span
+                className={cn(
+                  "ml-1.5 rounded-full px-1.5 text-3xs",
+                  activeZone === tab.zone
+                    ? "bg-primary/15 text-primary"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                <span data-testid="attention-count-needs">
+                  {projection.needsMe.length} need you
+                </span>
+                <span data-testid="attention-count-note">
+                  {" "}
+                  · {projection.headsUp.length} to note
+                </span>
+              </span>
+            ) : (
+              <span
+                className={cn(
+                  "ml-1.5 rounded-full px-1.5 text-3xs",
+                  activeZone === tab.zone
+                    ? "bg-primary/15 text-primary"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                {
+                  (tab.zone === "waiting"
+                    ? projection.waiting
+                    : projection.done
+                  ).length
+                }
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+        {errorMessage ? (
+          <div className="rounded-xl border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        ) : isLoading ? (
+          <p className="px-1 py-8 text-sm text-muted-foreground">
+            Loading your attention items…
+          </p>
+        ) : activeZone === "needsMe" ? (
+          needsMeEmpty ? (
+            <div
+              className="flex flex-1 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/60 px-4 py-12 text-center"
+              data-testid="attention-empty-state"
+            >
+              <p className="text-sm text-muted-foreground">
+                Nothing needs you. {projection.waiting.length} items are waiting
+                on other people.
+              </p>
+              <button
+                className="rounded-full border border-border/70 px-3 py-1 text-2xs font-medium text-foreground transition-colors hover:bg-muted"
+                onClick={() => switchZone("waiting")}
+                type="button"
+              >
+                Show Waiting
+              </button>
+            </div>
+          ) : (
+            <div className="flex flex-col" data-testid="attention-card-list">
+              {overdue.length > 0 ? (
+                <section data-testid="attention-section-overdue">
+                  <h2 className={sectionHeaderClassName}>
+                    Waiting on you since
+                  </h2>
+                  <div className="flex flex-col gap-2">
+                    {overdue.map(renderCard)}
+                  </div>
+                </section>
+              ) : null}
+              {today.length > 0 ? (
+                <section data-testid="attention-section-today">
+                  <h2 className={sectionHeaderClassName}>Today</h2>
+                  <div className="flex flex-col gap-2">
+                    {today.map(renderCard)}
+                  </div>
+                </section>
+              ) : null}
+              {projection.headsUp.length > 0 ? (
+                <section data-testid="attention-section-note">
+                  <div className="flex items-center justify-between">
+                    <h2 className={sectionHeaderClassName}>To note</h2>
+                    <button
+                      className="rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      data-testid="attention-note-all"
+                      onClick={onNoteAll}
+                      type="button"
+                    >
+                      Note all
+                    </button>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {projection.headsUp.map(renderCard)}
+                  </div>
+                </section>
+              ) : null}
+            </div>
+          )
+        ) : visibleItems.length === 0 ? (
+          <div
+            className="flex flex-1 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border/60 px-4 py-12 text-center"
+            data-testid="attention-empty-state"
+          >
+            <p className="text-sm text-muted-foreground">
+              {activeZone === "waiting"
+                ? "Nothing parked. Items you are waiting on others for land here."
+                : "Items you resolve stay here for 7 days."}
+            </p>
+          </div>
+        ) : (
+          <div
+            className="flex flex-col gap-2"
+            data-testid="attention-card-list"
+          >
+            {visibleItems.map(renderCard)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/attention/useActionQueue.ts
+++ b/desktop/src/features/attention/useActionQueue.ts
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+export const UNDO_WINDOW_MS = 5_000;
+
+export type QueuedActionInput = {
+  /** Attention item id — one pending action per item at a time. */
+  itemId: string;
+  /** Toast headline, e.g. "Marked done — reply queued". */
+  toastLabel: string;
+  /** Zone change to apply immediately (optimistic). */
+  apply: () => void;
+  /** Reverse of `apply`, used by Undo and by send failure. */
+  revert: () => void;
+  /** Posts the threaded reply. Called once, only after the undo window. */
+  send: () => Promise<unknown>;
+};
+
+export type QueuedBatchInput = {
+  /** One toast for the whole batch; Undo restores every item in it. */
+  toastLabel: string;
+  items: Array<Omit<QueuedActionInput, "toastLabel">>;
+};
+
+type PendingAction = {
+  timer: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Optimistic action queue with a 5-second undo window.
+ *
+ * Each action applies its zone change immediately, then waits
+ * UNDO_WINDOW_MS before posting the reply. Undo cancels the timer —
+ * nothing is ever published and then deleted. A send failure reverts
+ * the zone change and surfaces an error toast. At most one action can
+ * be pending per item, so double-clicks and key repeats cannot
+ * double-post.
+ */
+export function useActionQueue() {
+  const pendingRef = React.useRef<Map<string, PendingAction>>(new Map());
+  const [pendingIds, setPendingIds] = React.useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const markPending = React.useCallback((itemId: string, pending: boolean) => {
+    setPendingIds((prev) => {
+      const next = new Set(prev);
+      if (pending) {
+        next.add(itemId);
+      } else {
+        next.delete(itemId);
+      }
+      return next;
+    });
+  }, []);
+
+  const queueBatch = React.useCallback(
+    ({ toastLabel, items }: QueuedBatchInput) => {
+      const fresh = items.filter(
+        (item) => !pendingRef.current.has(item.itemId),
+      );
+      if (fresh.length === 0) {
+        return false;
+      }
+      for (const item of fresh) {
+        item.apply();
+      }
+
+      const finishAll = () => {
+        for (const item of fresh) {
+          pendingRef.current.delete(item.itemId);
+          markPending(item.itemId, false);
+        }
+      };
+
+      const timer = setTimeout(() => {
+        finishAll();
+        for (const item of fresh) {
+          item.send().catch(() => {
+            toast.error("Could not post your reply. The item was restored.");
+            item.revert();
+          });
+        }
+      }, UNDO_WINDOW_MS);
+
+      for (const item of fresh) {
+        pendingRef.current.set(item.itemId, { timer });
+        markPending(item.itemId, true);
+      }
+
+      toast(toastLabel, {
+        action: {
+          label: "Undo",
+          onClick: () => {
+            if (!fresh.some((item) => pendingRef.current.has(item.itemId))) {
+              return;
+            }
+            clearTimeout(timer);
+            finishAll();
+            for (const item of fresh) {
+              item.revert();
+            }
+          },
+        },
+        duration: UNDO_WINDOW_MS,
+      });
+      return true;
+    },
+    [markPending],
+  );
+
+  const queueAction = React.useCallback(
+    ({ itemId, toastLabel, apply, revert, send }: QueuedActionInput) =>
+      queueBatch({ toastLabel, items: [{ itemId, apply, revert, send }] }),
+    [queueBatch],
+  );
+
+  return { pendingIds, queueAction, queueBatch };
+}
+
+export type ActionQueue = ReturnType<typeof useActionQueue>;

--- a/desktop/src/features/attention/useAttentionZoneState.ts
+++ b/desktop/src/features/attention/useAttentionZoneState.ts
@@ -1,0 +1,159 @@
+import * as React from "react";
+
+import {
+  persistableZoneState,
+  pruneZoneState,
+  type ZoneStateEntry,
+  type ZoneStateMap,
+} from "@/features/attention/lib/attention";
+
+const EMPTY_HOLD_IDS: ReadonlySet<string> = new Set();
+
+const STORAGE_KEY = "buzz-attention-zones.v1";
+
+function storageKey(pubkey: string) {
+  return `${STORAGE_KEY}:${pubkey}`;
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1_000);
+}
+
+function isZoneStateEntry(value: unknown): value is ZoneStateEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    (entry.zone === "waiting" || entry.zone === "done") &&
+    typeof entry.changedAt === "number" &&
+    (entry.respondedAt === undefined || typeof entry.respondedAt === "number")
+  );
+}
+
+function readStoredState(key: string): ZoneStateMap {
+  if (typeof window === "undefined") return {};
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const state: ZoneStateMap = {};
+    for (const [id, entry] of Object.entries(parsed)) {
+      if (isZoneStateEntry(entry)) {
+        state[id] = entry;
+      }
+    }
+    return pruneZoneState(state, nowSeconds());
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredState(key: string, state: ZoneStateMap) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    key,
+    JSON.stringify(pruneZoneState(state, nowSeconds())),
+  );
+}
+
+/**
+ * Per-user, per-device zone state for Attention items, keyed by conversation id.
+ * Prototype persistence: localStorage, mirroring the Inbox's local done set.
+ * Durable cross-device state is a follow-up architecture decision.
+ *
+ * `holdIds` are items inside an undo hold window: their zone changes stay
+ * in memory only and persist on commit, so quitting mid-window restores
+ * the card instead of stranding it cleared with its reply unsent.
+ */
+export function useAttentionZoneState(
+  pubkey: string | undefined,
+  holdIds: ReadonlySet<string> = EMPTY_HOLD_IDS,
+) {
+  const normalizedPubkey = pubkey?.trim().toLowerCase() ?? "";
+
+  const [zoneState, setZoneState] = React.useState<ZoneStateMap>(() =>
+    readStoredState(storageKey(normalizedPubkey)),
+  );
+  const [loadedPubkey, setLoadedPubkey] = React.useState(normalizedPubkey);
+
+  React.useEffect(() => {
+    setZoneState(readStoredState(storageKey(normalizedPubkey)));
+    setLoadedPubkey(normalizedPubkey);
+  }, [normalizedPubkey]);
+
+  React.useEffect(() => {
+    if (loadedPubkey !== normalizedPubkey) return;
+    writeStoredState(
+      storageKey(normalizedPubkey),
+      persistableZoneState(zoneState, holdIds),
+    );
+  }, [holdIds, loadedPubkey, normalizedPubkey, zoneState]);
+
+  const markWaiting = React.useCallback((id: string) => {
+    setZoneState((prev) => ({
+      ...prev,
+      [id]: { zone: "waiting", changedAt: nowSeconds() },
+    }));
+  }, []);
+
+  const markDone = React.useCallback((id: string) => {
+    setZoneState((prev) => ({
+      ...prev,
+      [id]: { zone: "done", changedAt: nowSeconds() },
+    }));
+  }, []);
+
+  /**
+   * Record that the parking action's reply published. Called at commit,
+   * after the send resolves — the reactivated card uses it to show the
+   * reply went out, so the user does not answer twice.
+   */
+  const markResponded = React.useCallback((id: string) => {
+    setZoneState((prev) => {
+      const entry = prev[id];
+      if (!entry) return prev;
+      return { ...prev, [id]: { ...entry, respondedAt: nowSeconds() } };
+    });
+  }, []);
+
+  const restore = React.useCallback((id: string) => {
+    setZoneState((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  /**
+   * Put back the exact entry captured before an action, `changedAt`
+   * included. Re-marking would stamp a fresh time and defeat the
+   * reactivation rule: undoing an action on a reactivated card would
+   * hide it in its old zone instead of returning it to Needs Me.
+   */
+  const restoreEntry = React.useCallback(
+    (id: string, entry: ZoneStateEntry | undefined) => {
+      setZoneState((prev) => {
+        if (!entry) {
+          if (!(id in prev)) return prev;
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        }
+        return { ...prev, [id]: entry };
+      });
+    },
+    [],
+  );
+
+  return {
+    markDone,
+    markResponded,
+    markWaiting,
+    restore,
+    restoreEntry,
+    zoneState,
+  };
+}
+
+export type AttentionState = ReturnType<typeof useAttentionZoneState>;

--- a/desktop/src/features/attention/useBadgeOverrides.ts
+++ b/desktop/src/features/attention/useBadgeOverrides.ts
@@ -1,0 +1,84 @@
+import * as React from "react";
+
+import type { AskType } from "@/features/attention/lib/attention";
+
+const STORAGE_KEY = "buzz-attention-badge-overrides.v1";
+const MAX_OVERRIDE_ENTRIES = 500;
+
+const ASK_TYPES: ReadonlySet<string> = new Set([
+  "decision",
+  "approval",
+  "question",
+  "review",
+  "blocked",
+  "headsUp",
+]);
+
+export type BadgeOverrideMap = Record<string, AskType>;
+
+function storageKey(pubkey: string) {
+  return `${STORAGE_KEY}:${pubkey}`;
+}
+
+function readStoredOverrides(key: string): BadgeOverrideMap {
+  if (typeof window === "undefined") return {};
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const state: BadgeOverrideMap = {};
+    for (const [id, type] of Object.entries(parsed)) {
+      if (typeof type === "string" && ASK_TYPES.has(type)) {
+        state[id] = type as AskType;
+      }
+    }
+    return state;
+  } catch {
+    return {};
+  }
+}
+
+/** Newest insertions win when the map exceeds the cap. */
+function capOverrides(state: BadgeOverrideMap): BadgeOverrideMap {
+  const entries = Object.entries(state);
+  if (entries.length <= MAX_OVERRIDE_ENTRIES) {
+    return state;
+  }
+  return Object.fromEntries(entries.slice(-MAX_OVERRIDE_ENTRIES));
+}
+
+function writeStoredOverrides(key: string, state: BadgeOverrideMap) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(key, JSON.stringify(state));
+}
+
+/**
+ * Per-user, per-device badge corrections for Attention items, keyed by
+ * conversation id. Purely local and deterministic — reclassifying a card
+ * never posts anything. Mirrors the zone-state persistence pattern.
+ */
+export function useBadgeOverrides(pubkey: string | undefined) {
+  const normalizedPubkey = pubkey?.trim().toLowerCase() ?? "";
+
+  const [overrides, setOverrides] = React.useState<BadgeOverrideMap>(() =>
+    readStoredOverrides(storageKey(normalizedPubkey)),
+  );
+  const [loadedPubkey, setLoadedPubkey] = React.useState(normalizedPubkey);
+
+  React.useEffect(() => {
+    setOverrides(readStoredOverrides(storageKey(normalizedPubkey)));
+    setLoadedPubkey(normalizedPubkey);
+  }, [normalizedPubkey]);
+
+  React.useEffect(() => {
+    if (loadedPubkey !== normalizedPubkey) return;
+    writeStoredOverrides(storageKey(normalizedPubkey), overrides);
+  }, [loadedPubkey, normalizedPubkey, overrides]);
+
+  const setOverride = React.useCallback((id: string, type: AskType) => {
+    setOverrides((prev) => capOverrides({ ...prev, [id]: type }));
+  }, []);
+
+  return { overrides, setOverride };
+}

--- a/desktop/src/features/home/lib/catchUp.test.mjs
+++ b/desktop/src/features/home/lib/catchUp.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildCatchUpDigest } from "./catchUp.ts";
+
+const NOW = 1_700_000_000;
+
+function makeFeedItem(overrides = {}) {
+  const {
+    id = "msg-1",
+    channelId = "channel-1",
+    channelName = "general",
+    content = "Engineering shipped the desktop build.",
+    createdAt = NOW - 600,
+    pubkey = "a".repeat(64),
+    category = "activity",
+    tags = [],
+    kind = 9,
+  } = overrides;
+  return {
+    id,
+    kind,
+    pubkey,
+    content,
+    createdAt,
+    channelId,
+    channelName,
+    tags,
+    category,
+  };
+}
+
+function makeInboxItem(overrides = {}) {
+  const {
+    conversationId = "conv-1",
+    categories = ["activity"],
+    groupItems,
+    item = makeFeedItem(),
+    latestActivityAt = item.createdAt,
+    preview = item.content,
+  } = overrides;
+  return {
+    avatarUrl: null,
+    conversationId,
+    id: item.id,
+    item,
+    categories,
+    categoryLabel: "Activity",
+    channelLabel: item.channelName,
+    fullTimestampLabel: "",
+    groupItems: groupItems ?? [item],
+    isActionRequired: categories.includes("needs_action"),
+    latestActivityAt,
+    mentionNames: [],
+    preview,
+    senderLabel: "Alice",
+    subject: preview,
+    timestampLabel: "",
+    unreadCount: 1,
+  };
+}
+
+const noReadMarker = () => null;
+
+test("unread non-attention items become channel-grouped lines", () => {
+  const digest = buildCatchUpDigest({
+    items: [makeInboxItem()],
+    doneSet: new Set(),
+    getItemReadAt: noReadMarker,
+  });
+  assert.equal(digest.groups.length, 1);
+  assert.equal(digest.groups[0].channelId, "channel-1");
+  assert.equal(digest.groups[0].lines.length, 1);
+  assert.equal(
+    digest.groups[0].lines[0].summary,
+    "Engineering shipped the desktop build.",
+  );
+  assert.equal(digest.needsYouCount, 0);
+});
+
+test("read conversations and attention asks are excluded from lines", () => {
+  const readItem = makeInboxItem();
+  const mention = makeInboxItem({
+    conversationId: "conv-m",
+    categories: ["mention"],
+    item: makeFeedItem({ id: "msg-m", content: "Can you review the plan?" }),
+  });
+  const digest = buildCatchUpDigest({
+    items: [readItem, mention],
+    doneSet: new Set([readItem.id]),
+    getItemReadAt: noReadMarker,
+  });
+  assert.equal(digest.groups.length, 0);
+  assert.equal(digest.needsYouCount, 1);
+  assert.equal(digest.totalLineCount, 0);
+});
+
+test("lines read oldest first, groups order by most recent activity", () => {
+  const quietChannel = makeInboxItem({
+    conversationId: "conv-quiet",
+    item: makeFeedItem({
+      id: "msg-quiet",
+      channelId: "channel-quiet",
+      channelName: "quiet",
+      createdAt: NOW - 9_000,
+    }),
+  });
+  const older = makeFeedItem({ id: "msg-old", createdAt: NOW - 5_000 });
+  const newer = makeFeedItem({ id: "msg-new", createdAt: NOW - 100 });
+  const busyChannel = makeInboxItem({
+    conversationId: "conv-busy",
+    item: newer,
+    groupItems: [newer, older],
+  });
+  const digest = buildCatchUpDigest({
+    items: [quietChannel, busyChannel],
+    doneSet: new Set(),
+    getItemReadAt: noReadMarker,
+  });
+  assert.deepEqual(
+    digest.groups.map((group) => group.channelId),
+    ["channel-1", "channel-quiet"],
+  );
+  assert.deepEqual(
+    digest.groups[0].lines.map((line) => line.id),
+    ["msg-old", "msg-new"],
+  );
+});
+
+test("a read boundary hides messages at or before the marker", () => {
+  const older = makeFeedItem({ id: "msg-old", createdAt: NOW - 5_000 });
+  const newer = makeFeedItem({ id: "msg-new", createdAt: NOW - 100 });
+  const item = makeInboxItem({ item: newer, groupItems: [newer, older] });
+  const digest = buildCatchUpDigest({
+    items: [item],
+    doneSet: new Set(),
+    getItemReadAt: () => NOW - 1_000,
+  });
+  assert.deepEqual(
+    digest.groups[0].lines.map((line) => line.id),
+    ["msg-new"],
+  );
+});
+
+test("channels cap at 10 lines with an honest remainder", () => {
+  const messages = Array.from({ length: 13 }, (_, index) =>
+    makeFeedItem({ id: `msg-${index}`, createdAt: NOW - 10_000 + index * 60 }),
+  );
+  const item = makeInboxItem({
+    item: messages[messages.length - 1],
+    groupItems: messages,
+  });
+  const digest = buildCatchUpDigest({
+    items: [item],
+    doneSet: new Set(),
+    getItemReadAt: noReadMarker,
+  });
+  assert.equal(digest.groups[0].lines.length, 10);
+  assert.equal(digest.groups[0].moreCount, 3);
+  assert.equal(digest.groups[0].lines[0].id, "msg-0");
+  assert.equal(digest.totalLineCount, 13);
+});
+
+test("items without a channel are skipped (no deep-link target)", () => {
+  const digest = buildCatchUpDigest({
+    items: [makeInboxItem({ item: makeFeedItem({ channelId: null }) })],
+    doneSet: new Set(),
+    getItemReadAt: noReadMarker,
+  });
+  assert.equal(digest.groups.length, 0);
+});

--- a/desktop/src/features/home/lib/catchUp.ts
+++ b/desktop/src/features/home/lib/catchUp.ts
@@ -1,0 +1,121 @@
+import { isAttentionWorthy } from "@/features/attention/lib/attention";
+import type { InboxItem } from "@/features/home/lib/inbox";
+import { summaryLineFor } from "@/features/home/lib/summaryLine";
+import { getThreadReference } from "@/features/messages/lib/threading";
+
+export const CATCH_UP_LINES_PER_CHANNEL = 10;
+
+export type CatchUpLine = {
+  /** Message event id — the deep-link target. */
+  id: string;
+  channelId: string;
+  threadRootId: string | null;
+  authorPubkey: string;
+  createdAt: number;
+  summary: string;
+};
+
+export type CatchUpChannelGroup = {
+  channelId: string;
+  channelLabel: string;
+  latestActivityAt: number;
+  /** Oldest first (reads as narrative), capped at CATCH_UP_LINES_PER_CHANNEL. */
+  lines: CatchUpLine[];
+  /** Known unread lines beyond the cap — "N more in #channel". */
+  moreCount: number;
+};
+
+export type CatchUpDigest = {
+  /** Ordered by most recent activity. Channels with nothing unread omitted. */
+  groups: CatchUpChannelGroup[];
+  /** Unread items that qualify as attention asks — counted, never listed. */
+  needsYouCount: number;
+  totalLineCount: number;
+};
+
+/**
+ * Project the Inbox's unread state into a channel-grouped reading.
+ *
+ * Works entirely from what the Inbox already has in cache: the feed's
+ * grouped conversation items and the shared NIP-RS read boundary
+ * (`doneSet` marks fully-read conversations; `getItemReadAt` yields the
+ * per-conversation marker for the per-message cut). No new queries.
+ */
+export function buildCatchUpDigest(options: {
+  items: InboxItem[];
+  doneSet: ReadonlySet<string>;
+  getItemReadAt: (item: InboxItem) => number | null;
+}): CatchUpDigest {
+  const { items, doneSet, getItemReadAt } = options;
+  const buckets = new Map<
+    string,
+    { channelLabel: string; lines: Map<string, CatchUpLine> }
+  >();
+  let needsYouCount = 0;
+
+  for (const item of items) {
+    if (doneSet.has(item.id)) {
+      continue;
+    }
+    // Dedup vs Attention: asks live in the Attention surface; Catch up only
+    // counts them so nothing is read twice.
+    if (isAttentionWorthy(item)) {
+      needsYouCount++;
+      continue;
+    }
+    const channelId = item.item.channelId;
+    if (!channelId) {
+      continue;
+    }
+
+    const readAt = getItemReadAt(item);
+    const unreadMessages = item.groupItems.filter(
+      (message) => readAt === null || message.createdAt > readAt,
+    );
+    // The conversation is unread but every cached message predates the
+    // marker (partial cache) — fall back to the representative message.
+    const sourceMessages =
+      unreadMessages.length > 0 ? unreadMessages : [item.item];
+
+    const bucket = buckets.get(channelId) ?? {
+      channelLabel: item.channelLabel ?? item.item.channelName ?? "channel",
+      lines: new Map<string, CatchUpLine>(),
+    };
+    for (const message of sourceMessages) {
+      if (bucket.lines.has(message.id)) {
+        continue;
+      }
+      bucket.lines.set(message.id, {
+        id: message.id,
+        channelId,
+        threadRootId: getThreadReference(message.tags).rootId,
+        authorPubkey: message.pubkey,
+        createdAt: message.createdAt,
+        summary: summaryLineFor(message.content) || item.preview,
+      });
+    }
+    buckets.set(channelId, bucket);
+  }
+
+  const groups: CatchUpChannelGroup[] = [];
+  let totalLineCount = 0;
+  for (const [channelId, bucket] of buckets) {
+    const lines = [...bucket.lines.values()].sort(
+      (a, b) => a.createdAt - b.createdAt,
+    );
+    if (lines.length === 0) {
+      continue;
+    }
+    totalLineCount += lines.length;
+    groups.push({
+      channelId,
+      channelLabel: bucket.channelLabel,
+      latestActivityAt: lines[lines.length - 1].createdAt,
+      lines: lines.slice(0, CATCH_UP_LINES_PER_CHANNEL),
+      moreCount: Math.max(0, lines.length - CATCH_UP_LINES_PER_CHANNEL),
+    });
+  }
+  groups.sort((a, b) => b.latestActivityAt - a.latestActivityAt);
+
+  return { groups, needsYouCount, totalLineCount };
+}

--- a/desktop/src/features/home/lib/inbox.ts
+++ b/desktop/src/features/home/lib/inbox.ts
@@ -444,7 +444,7 @@ export function findInboxItemByEventId(
   );
 }
 
-function formatInboxTimestamp(unixSeconds: number) {
+export function formatInboxTimestamp(unixSeconds: number) {
   const date = new Date(unixSeconds * 1_000);
   const now = new Date();
   const dayDiff = diffInDays(now, date);

--- a/desktop/src/features/home/lib/summaryLine.test.mjs
+++ b/desktop/src/features/home/lib/summaryLine.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { summaryLineFor } from "./summaryLine.ts";
+
+test("bold TL;DR marker returns the remainder of that line", () => {
+  assert.equal(
+    summaryLineFor(
+      "**TL;DR** Relay migration is complete and green.\n\nLonger detail follows across several paragraphs.",
+    ),
+    "Relay migration is complete and green.",
+  );
+  assert.equal(
+    summaryLineFor("**TL;DR:** Ship it tonight.\nDetail."),
+    "Ship it tonight.",
+  );
+});
+
+test("plain TLDR marker works, case-insensitively", () => {
+  assert.equal(
+    summaryLineFor("tldr: the backup ran clean.\nEverything else is noise."),
+    "the backup ran clean.",
+  );
+  assert.equal(
+    summaryLineFor("TL;DR the launch moved to Thursday."),
+    "the launch moved to Thursday.",
+  );
+});
+
+test("blockquoted TL;DR marker is recognised", () => {
+  assert.equal(
+    summaryLineFor("> **TL;DR** we are frozen until Monday.\n\nContext…"),
+    "we are frozen until Monday.",
+  );
+});
+
+test("declared-ask tier beats a TL;DR line", () => {
+  assert.equal(
+    summaryLineFor(
+      [
+        "**TL;DR** long status here.",
+        "**Needs Lee, decision:** Ship now or wait for QA?",
+      ].join("\n"),
+    ),
+    "Ship now or wait for QA?",
+  );
+});
+
+test("no marker degrades to the first sentence of the first line", () => {
+  assert.equal(
+    summaryLineFor(
+      "Engineering shipped the desktop build. More detail in thread.",
+    ),
+    "Engineering shipped the desktop build.",
+  );
+  // No sentence terminator: the whole first line, markdown stripped.
+  assert.equal(
+    summaryLineFor("**Status update** for the launch\nSecond line here"),
+    "Status update for the launch",
+  );
+});
+
+test("a code-block-first message skips the block", () => {
+  assert.equal(
+    summaryLineFor(
+      '```json\n{"a": 1}\n```\nDeploy config updated for staging.',
+    ),
+    "Deploy config updated for staging.",
+  );
+});
+
+test("empty or code-only bodies return the empty string", () => {
+  assert.equal(summaryLineFor(""), "");
+  assert.equal(summaryLineFor("   \n\n  "), "");
+  assert.equal(summaryLineFor("```\nonly code\n```"), "");
+});
+
+test("long summaries truncate on a word boundary", () => {
+  const long = `The migration finished ${"and the relay stayed healthy ".repeat(8)}end`;
+  const line = summaryLineFor(long);
+  assert.ok(line.length <= 121);
+  assert.ok(line.endsWith("…"));
+});

--- a/desktop/src/features/home/lib/summaryLine.ts
+++ b/desktop/src/features/home/lib/summaryLine.ts
@@ -1,0 +1,75 @@
+import { parseDeclaredAsks } from "@/features/attention/lib/declaredAsks";
+import { stripMessageNoise } from "@/features/attention/lib/taskExtraction";
+
+const MAX_SUMMARY_LENGTH = 120;
+
+/**
+ * Bold or plain TL;DR / TLDR lead marker, optionally inside a blockquote,
+ * with an optional colon inside or outside the bold span. Capture group 1
+ * is the remainder of the line.
+ */
+const TLDR_MARKER =
+  /^(?:>\s*)*(?:\*\*)?\s*tl;?dr\s*:?\s*(?:\*\*)?\s*:?\s*(.*)$/i;
+
+function truncateOnWordBoundary(text: string): string {
+  if (text.length <= MAX_SUMMARY_LENGTH) {
+    return text;
+  }
+  const cut = text.slice(0, MAX_SUMMARY_LENGTH);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${cut
+    .slice(0, lastSpace > 60 ? lastSpace : MAX_SUMMARY_LENGTH)
+    .trimEnd()}…`;
+}
+
+/** A code-block-first message summarises from the prose after the block. */
+function withoutCodeBlocks(content: string): string {
+  return content.replace(/```[\s\S]*?```/g, "\n");
+}
+
+function nonEmptyLines(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * One line of "what this message said", for the Catch up reading.
+ *
+ * Tier 0: a declared ask ("Needs <Name>, <type>: …") is the author's own
+ * statement of the point — use the first declaration's ask.
+ * Tier 1: an authored TL;DR lead line wins over anything derived.
+ * Tier 2: first sentence of the first line, else the first line, truncated
+ * ~120 chars on a word boundary. Never emits raw markdown syntax; an empty
+ * body returns "" and the caller falls back to its existing preview.
+ */
+export function summaryLineFor(content: string): string {
+  const declared = parseDeclaredAsks(content);
+  if (declared.length > 0) {
+    return truncateOnWordBoundary(declared[0].ask);
+  }
+
+  const lines = nonEmptyLines(withoutCodeBlocks(content));
+  if (lines.length === 0) {
+    return "";
+  }
+
+  let lead = lines[0];
+  const marker = lead.match(TLDR_MARKER);
+  if (marker) {
+    const rest = stripMessageNoise(marker[1]);
+    if (rest) {
+      return truncateOnWordBoundary(rest);
+    }
+    // Bare "TL;DR" line with the content below it: summarise what follows.
+    lead = lines[1] ?? "";
+  }
+
+  const cleaned = stripMessageNoise(lead);
+  if (!cleaned) {
+    return "";
+  }
+  const sentence = cleaned.split(/(?<=[.?!])\s+/)[0] ?? cleaned;
+  return truncateOnWordBoundary(sentence.trim());
+}

--- a/desktop/src/features/home/ui/CatchUpView.tsx
+++ b/desktop/src/features/home/ui/CatchUpView.tsx
@@ -1,0 +1,192 @@
+import { ArrowRight, CheckCheck } from "lucide-react";
+import * as React from "react";
+
+import { useAppShell } from "@/app/AppShellContext";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { buildCatchUpDigest } from "@/features/home/lib/catchUp";
+import {
+  formatInboxTimestamp,
+  type InboxItem,
+} from "@/features/home/lib/inbox";
+import { resolveInboxItemReadAt } from "@/features/home/useHomeInboxReadState";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import { Button } from "@/shared/ui/button";
+
+type CatchUpViewProps = {
+  currentPubkey?: string;
+  doneSet: ReadonlySet<string>;
+  items: InboxItem[];
+  /** Existing Inbox read machinery — routes to NIP-RS channel markers. */
+  onMarkRead: (itemId: string) => void;
+  onOpenMessage: (
+    channelId: string,
+    messageId: string,
+    threadRootId?: string | null,
+  ) => void;
+};
+
+/**
+ * Catch up mode: a reading of what was said since the user's read boundary,
+ * grouped by channel, newest channel first, oldest line first within a
+ * channel. Rendering never moves any read marker — only the explicit
+ * "Mark all as read" button does.
+ */
+export function CatchUpView({
+  currentPubkey,
+  doneSet,
+  items,
+  onMarkRead,
+  onOpenMessage,
+}: CatchUpViewProps) {
+  const {
+    getChannelReadAt,
+    getMessageReadAt,
+    getThreadReadAt,
+    readStateVersion,
+  } = useAppShell();
+  const { goAttention, goChannel } = useAppNavigation();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: readStateVersion invalidates the stable marker getters
+  const digest = React.useMemo(
+    () =>
+      buildCatchUpDigest({
+        items,
+        doneSet,
+        getItemReadAt: (item) =>
+          resolveInboxItemReadAt(item, {
+            getChannelReadAt,
+            getMessageReadAt,
+            getThreadReadAt,
+          }),
+      }),
+    [
+      doneSet,
+      getChannelReadAt,
+      getMessageReadAt,
+      getThreadReadAt,
+      items,
+      readStateVersion,
+    ],
+  );
+
+  const authorPubkeys = React.useMemo(
+    () => [
+      ...new Set(
+        digest.groups.flatMap((group) =>
+          group.lines.map((line) => line.authorPubkey),
+        ),
+      ),
+    ],
+    [digest],
+  );
+  const profilesQuery = useUsersBatchQuery(authorPubkeys, {
+    enabled: authorPubkeys.length > 0,
+  });
+  const profiles = profilesQuery.data?.profiles;
+
+  const unreadItemIds = React.useMemo(
+    () => items.filter((item) => !doneSet.has(item.id)).map((item) => item.id),
+    [doneSet, items],
+  );
+  const handleMarkAllRead = () => {
+    for (const id of unreadItemIds) {
+      onMarkRead(id);
+    }
+  };
+
+  const isEmpty = digest.groups.length === 0 && digest.needsYouCount === 0;
+
+  return (
+    <div
+      className="-mt-13 min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain px-4 pb-6 pt-13"
+      data-testid="catchup-view"
+    >
+      <div className="flex items-center gap-2 py-2">
+        {digest.needsYouCount > 0 ? (
+          <button
+            className="flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-2xs font-medium text-primary transition-colors hover:bg-primary/15"
+            data-testid="catchup-needs-count"
+            onClick={() => void goAttention()}
+            type="button"
+          >
+            {digest.needsYouCount} need you
+            <ArrowRight className="h-3 w-3" />
+          </button>
+        ) : null}
+        <div className="ml-auto">
+          <Button
+            data-testid="catchup-mark-all-read"
+            disabled={unreadItemIds.length === 0}
+            onClick={handleMarkAllRead}
+            size="xs"
+            type="button"
+            variant="outline"
+          >
+            <CheckCheck />
+            Mark all as read
+          </Button>
+        </div>
+      </div>
+
+      {isEmpty ? (
+        <div
+          className="flex flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border/60 px-4 py-12 text-center"
+          data-testid="catchup-empty"
+        >
+          <p className="text-sm text-muted-foreground">
+            Nothing new since you last looked.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {digest.groups.map((group) => (
+            <section data-testid="catchup-channel-group" key={group.channelId}>
+              <h3 className="px-1 pb-1 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+                #{group.channelLabel}
+              </h3>
+              <div className="flex flex-col">
+                {group.lines.map((line) => (
+                  <button
+                    className="flex w-full items-baseline gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
+                    data-testid="catchup-line"
+                    key={line.id}
+                    onClick={() =>
+                      onOpenMessage(line.channelId, line.id, line.threadRootId)
+                    }
+                    type="button"
+                  >
+                    <span className="shrink-0 text-sm font-medium text-foreground">
+                      {resolveUserLabel({
+                        pubkey: line.authorPubkey,
+                        currentPubkey,
+                        profiles,
+                        preferResolvedSelfLabel: true,
+                      })}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm text-foreground/85">
+                      {line.summary}
+                    </span>
+                    <span className="shrink-0 text-2xs text-muted-foreground">
+                      {formatInboxTimestamp(line.createdAt)}
+                    </span>
+                  </button>
+                ))}
+                {group.moreCount > 0 ? (
+                  <button
+                    className="rounded-lg px-2 py-1.5 text-left text-2xs font-medium text-primary transition-colors hover:bg-muted/50"
+                    data-testid="catchup-more"
+                    onClick={() => void goChannel(group.channelId)}
+                    type="button"
+                  >
+                    {group.moreCount} more in #{group.channelLabel}
+                  </button>
+                ) : null}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -42,7 +42,9 @@ import {
 } from "@/features/home/useResizableInboxListWidth";
 import { getHomePaneLayout } from "@/features/home/lib/homePaneLayout";
 import { getHomeMessageCapabilities } from "@/features/home/lib/homeMessageCapabilities";
+import { CatchUpView } from "@/features/home/ui/CatchUpView";
 import { HomeLoadingState } from "@/features/home/ui/HomeLoadingState";
+import { useFeatureEnabled } from "@/shared/features";
 import { InboxDetailPane } from "@/features/home/ui/InboxDetailPane";
 import { InboxListPane } from "@/features/home/ui/InboxListPane";
 import { HomePersonalInboxDetail } from "@/features/home/ui/HomePersonalInboxDetail";
@@ -108,6 +110,8 @@ export function HomeView({
     homeInboxWidthPx < INBOX_SINGLE_COLUMN_BREAKPOINT_PX;
   const [filter, setFilter] = React.useState<InboxFilter>("all");
   const [unreadOnly, setUnreadOnly] = React.useState(false);
+  const catchUpEnabled = useFeatureEnabled("attention");
+  const [catchUpOpen, setCatchUpOpen] = React.useState(false);
   // Explicit selections are mirrored to the URL (`?item=`), so back/forward
   // restores the detail pane each history entry was showing and reloads
   // restore it from the URL. Default/automatic selection stays local-only —
@@ -643,11 +647,27 @@ export function HomeView({
               activeReminderEventIds={activeReminderEventIds}
               agentPubkeys={inboxAgentPubkeys}
               activeDraftCount={activeDraftCount}
+              catchUpPane={
+                catchUpEnabled && catchUpOpen ? (
+                  <CatchUpView
+                    currentPubkey={currentPubkey}
+                    doneSet={effectiveDoneSet}
+                    items={inboxItems}
+                    onMarkRead={markItemRead}
+                    onOpenMessage={onOpenContext}
+                  />
+                ) : null
+              }
               draftItems={draftItems}
               doneSet={effectiveDoneSet}
               dueReminderCount={dueReminderCount}
               filter={filter}
               items={filteredItems}
+              onCatchUpToggle={
+                catchUpEnabled
+                  ? () => setCatchUpOpen((open) => !open)
+                  : undefined
+              }
               onDeleteDraft={handleDeleteDraft}
               onFilterChange={handleFilterChange}
               onMarkRead={markItemRead}

--- a/desktop/src/features/home/ui/InboxListPane.tsx
+++ b/desktop/src/features/home/ui/InboxListPane.tsx
@@ -1,4 +1,11 @@
-import { Bell, Clock, Ellipsis, ExternalLink, MailOpen } from "lucide-react";
+import {
+  Bell,
+  Clock,
+  Ellipsis,
+  ExternalLink,
+  MailOpen,
+  Newspaper,
+} from "lucide-react";
 import * as React from "react";
 
 import {
@@ -175,10 +182,13 @@ type InboxListPaneProps = {
   activeReminderEventIds?: ReadonlySet<string>;
   agentPubkeys?: ReadonlySet<string>;
   activeDraftCount: number;
+  /** When set, Catch up mode replaces the conversation list area. */
+  catchUpPane?: React.ReactNode;
   draftItems: DraftViewItem[];
   doneSet: ReadonlySet<string>;
   filter: InboxFilter;
   items: InboxItem[];
+  onCatchUpToggle?: () => void;
   onFilterChange: (filter: InboxFilter) => void;
   onDeleteDraft: (draftKey: string) => void;
   onMarkRead: (itemId: string) => void;
@@ -203,11 +213,13 @@ export function InboxListPane({
   activeReminderEventIds,
   agentPubkeys,
   activeDraftCount,
+  catchUpPane,
   draftItems,
   doneSet,
   filter,
   items,
   onFilterChange,
+  onCatchUpToggle,
   onDeleteDraft,
   onMarkRead,
   onMarkUnread,
@@ -513,6 +525,22 @@ export function InboxListPane({
         <div className="px-5 py-2">
           <div className="flex min-h-9 w-full min-w-0 items-center justify-between gap-3">
             <div className="order-2 ml-auto flex shrink-0 items-center justify-end">
+              {onCatchUpToggle ? (
+                <button
+                  aria-label="Catch up"
+                  aria-pressed={catchUpPane != null}
+                  className={cn(
+                    INBOX_HEADER_ICON_BUTTON_CLASS,
+                    catchUpPane != null && "bg-muted text-foreground",
+                  )}
+                  data-testid="inbox-catchup-toggle"
+                  onClick={onCatchUpToggle}
+                  title="Catch up"
+                  type="button"
+                >
+                  <Newspaper className="h-4 w-4" />
+                </button>
+              ) : null}
               <Popover>
                 <PopoverTrigger asChild>
                   <button
@@ -576,7 +604,9 @@ export function InboxListPane({
         </div>
       </TopChromeInsetHeader>
 
-      {isReminders ? (
+      {catchUpPane != null ? (
+        catchUpPane
+      ) : isReminders ? (
         <div
           className="-mt-13 flex min-h-0 flex-1 flex-col overflow-hidden pt-13"
           data-testid="home-inbox-reminders"

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -1,5 +1,6 @@
 // biome-ignore format: keep compact to stay within file size limit
 import * as React from "react";
+import type { AppView } from "@/app/AppShell.helpers";
 import { FeatureGate } from "@/shared/features";
 import { SidebarDndContext } from "@/features/sidebar/ui/SidebarDnd";
 
@@ -95,14 +96,7 @@ type AppSidebarProps = {
   selfPresenceStatus: PresenceStatus;
   errorMessage?: string;
   selectedChannelId: string | null;
-  selectedView:
-    | "home"
-    | "channel"
-    | "messages"
-    | "agents"
-    | "workflows"
-    | "pulse"
-    | "projects";
+  selectedView: AppView;
   unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   previewActivityChannelIds: ReadonlySet<string>;
@@ -141,6 +135,7 @@ type AppSidebarProps = {
   onRemoveCommunity: (id: string) => void;
   onCreateAgent: () => void;
   onSelectAgents: () => void;
+  onSelectAttention: () => void;
   onSelectProjects: () => void;
   onSelectPulse: () => void;
   onSelectWorkflows: () => void;
@@ -213,6 +208,7 @@ export function AppSidebar({
   onRemoveCommunity,
   onCreateAgent,
   onSelectAgents,
+  onSelectAttention,
   onSelectProjects,
   onSelectPulse,
   onSelectWorkflows,
@@ -609,6 +605,7 @@ export function AppSidebar({
                 homeBadgeCount={homeBadgeCount}
                 onSelectAgents={onSelectAgents}
                 onSelectHome={onSelectHome}
+                onSelectAttention={onSelectAttention}
                 onSelectProjects={onSelectProjects}
                 onSelectPulse={onSelectPulse}
                 onSelectWorkflows={onSelectWorkflows}

--- a/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
@@ -1,5 +1,6 @@
-import { Activity, Bot, FolderGit2, Inbox, Zap } from "lucide-react";
+import { Activity, Bot, FolderGit2, Inbox, Target, Zap } from "lucide-react";
 
+import type { AppView } from "@/app/AppShell.helpers";
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
 import { FeatureGate } from "@/shared/features";
 import type { Channel, SearchHit } from "@/shared/api/types";
@@ -11,15 +12,6 @@ import {
   SidebarMenuItem,
 } from "@/shared/ui/sidebar";
 import { SidebarMenuLabel } from "@/shared/ui/sidebar-menu-label";
-
-type SidebarSelectedView =
-  | "home"
-  | "channel"
-  | "messages"
-  | "agents"
-  | "workflows"
-  | "pulse"
-  | "projects";
 
 type AppSidebarPinnedHeaderProps = {
   channelLabels: Record<string, string>;
@@ -39,10 +31,11 @@ type AppSidebarPrimaryMenuProps = {
   homeBadgeCount: number;
   onSelectAgents: () => void;
   onSelectHome: () => void;
+  onSelectAttention: () => void;
   onSelectProjects: () => void;
   onSelectPulse: () => void;
   onSelectWorkflows: () => void;
-  selectedView: SidebarSelectedView;
+  selectedView: AppView;
 };
 
 export function AppSidebarPinnedHeader({
@@ -84,6 +77,7 @@ export function AppSidebarPrimaryMenu({
   homeBadgeCount,
   onSelectAgents,
   onSelectHome,
+  onSelectAttention,
   onSelectProjects,
   onSelectPulse,
   onSelectWorkflows,
@@ -124,6 +118,20 @@ export function AppSidebarPrimaryMenu({
             </SidebarMenuBadge>
           ) : null}
         </SidebarMenuItem>
+        <FeatureGate feature="attention">
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              data-testid="open-attention-view"
+              isActive={selectedView === "attention"}
+              onClick={onSelectAttention}
+              tooltip="Attention"
+              type="button"
+            >
+              <Target className="h-4 w-4" />
+              <SidebarMenuLabel>Attention</SidebarMenuLabel>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </FeatureGate>
         <FeatureGate feature="pulse">
           <SidebarMenuItem>
             <SidebarMenuButton

--- a/desktop/tests/e2e/attention.spec.ts
+++ b/desktop/tests/e2e/attention.spec.ts
@@ -1,0 +1,369 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import { seedActiveIdentity } from "../helpers/onboarding";
+
+/**
+ * The Attention preview feature ships default-off. Seed the localStorage
+ * override before the app boots so the flagged UI renders under test.
+ */
+async function enableAttentionFeature(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ attention: true }),
+    );
+  });
+}
+
+const SHOTS = "test-results/attention";
+
+const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301"; // #agents
+const AGENT_PUBKEY =
+  "db0b028cd36f4d3e36c8300cce87252c1f7fc9495ffecc53f393fcac341ffd36";
+
+type MockWindow = Window & {
+  __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: {
+    category: "mention" | "needs_action" | "activity" | "agent_activity";
+    channel_id: string | null;
+    channel_name: string;
+    content: string;
+    created_at: number;
+    id: string;
+    kind: number;
+    pubkey: string;
+    tags: string[][];
+  }) => unknown;
+};
+
+/**
+ * Seed the mock feed with the injected items the redesigned view needs on
+ * top of the built-in feed (a mention with no reader-addressed ask + a
+ * 40007 reminder): a 46010 approval that has been waiting three days
+ * (overdue section) and an ask-less FYI mention (To note section).
+ */
+async function seedAttentionFeed(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () =>
+      typeof (window as MockWindow).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__ ===
+      "function",
+  );
+  await page.evaluate(
+    ({ agentPubkey, channelId, viewerPubkey }) => {
+      const push = (window as MockWindow).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__;
+      push?.({
+        category: "needs_action",
+        channel_id: channelId,
+        channel_name: "agents",
+        content:
+          "Release workflow paused: approve the desktop deploy to staging?",
+        created_at: Math.floor(Date.now() / 1_000) - 3 * 86_400,
+        id: "mock-feed-attention-approval",
+        kind: 46010,
+        pubkey: agentPubkey,
+        tags: [["p", viewerPubkey]],
+      });
+      push?.({
+        category: "mention",
+        channel_id: channelId,
+        channel_name: "agents",
+        content: "FYI the launch deck shipped last night.",
+        created_at: Math.floor(Date.now() / 1_000) - 300,
+        id: "mock-feed-attention-fyi",
+        kind: 9,
+        pubkey: agentPubkey,
+        tags: [["p", viewerPubkey]],
+      });
+      // Tier-1 declared ask with a closed option set (base_prompt.md
+      // convention). The viewer's mock display name is "tyler".
+      push?.({
+        category: "mention",
+        channel_id: channelId,
+        channel_name: "agents",
+        content: [
+          "**Needs Tyler, decision:** Ship the attention release now or wait for the relay fix?",
+          "- Ship it now.",
+          "- Wait for the relay fix.",
+          "- Need more detail before deciding.",
+        ].join("\n"),
+        created_at: Math.floor(Date.now() / 1_000) - 120,
+        id: "mock-feed-attention-declared-decision",
+        kind: 9,
+        pubkey: agentPubkey,
+        tags: [["p", viewerPubkey]],
+      });
+      // Two declared asks for the same viewer -> multi-ask card.
+      push?.({
+        category: "mention",
+        channel_id: channelId,
+        channel_name: "agents",
+        content: [
+          "**Needs Tyler, question:** Did the overnight backup complete?",
+          "**Needs Tyler, review:** Review the retention change when you can.",
+        ].join("\n"),
+        created_at: Math.floor(Date.now() / 1_000) - 60,
+        id: "mock-feed-attention-declared-multi",
+        kind: 9,
+        pubkey: agentPubkey,
+        tags: [["p", viewerPubkey]],
+      });
+      // Declared blocked ask: the one type whose primary action is Done.
+      push?.({
+        category: "mention",
+        channel_id: channelId,
+        channel_name: "agents",
+        content:
+          "**Needs Tyler, blocked:** I need the staging credentials before I can deploy.",
+        created_at: Math.floor(Date.now() / 1_000) - 30,
+        id: "mock-feed-attention-declared-blocked",
+        kind: 9,
+        pubkey: agentPubkey,
+        tags: [["p", viewerPubkey]],
+      });
+    },
+    {
+      agentPubkey: AGENT_PUBKEY,
+      channelId: AGENTS_CHANNEL_ID,
+      viewerPubkey: TEST_IDENTITIES.tyler.pubkey,
+    },
+  );
+}
+
+test.describe("attention views", () => {
+  test("action-driven cards: sections, expand, quick options, undo, posting", async ({
+    page,
+  }) => {
+    // Run as tyler so the declared-ask tier can match "Needs Tyler, …"
+    // against the viewer's mock display name. Must precede the bridge.
+    await seedActiveIdentity(page, TEST_IDENTITIES.tyler);
+    await enableAttentionFeature(page);
+    await installMockBridge(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const navItem = page.getByTestId("open-attention-view");
+    await expect(navItem).toBeVisible();
+    await seedAttentionFeed(page);
+    await navItem.click();
+
+    const view = page.getByTestId("attention-view");
+    await expect(view).toBeVisible();
+
+    // 6 real asks (approval, tyler mention, tyler reminder, declared
+    // decision, declared multi, declared blocked) + 1 to note (the seeded
+    // FYI mention).
+    const cards = page.locator('article[data-testid^="attention-card-"]');
+    await expect(cards).toHaveCount(7);
+
+    // Split Needs Me count: real asks and to-note are counted separately.
+    const needsTab = page.getByTestId("attention-tab-needsMe");
+    await expect(needsTab).toContainText("6 need you");
+    await expect(needsTab).toContainText("1 to note");
+
+    // Sections: the 3-day-old approval is overdue, the reminder is today,
+    // the ask-less mentions sit under To note.
+    await expect(page.getByTestId("attention-section-overdue")).toBeVisible();
+    await expect(page.getByTestId("attention-section-today")).toBeVisible();
+    await expect(page.getByTestId("attention-section-note")).toBeVisible();
+    await expect(
+      page.getByTestId("attention-section-overdue").locator("article"),
+    ).toHaveCount(1);
+
+    // Badges vary by ask type: Approval plus at least one other type, and
+    // the declared decision message gets the Decision badge.
+    const badges = page.getByTestId("attention-badge");
+    await expect(badges.filter({ hasText: "Approval" })).toHaveCount(1);
+    await expect(badges.filter({ hasText: "Decision" })).toHaveCount(1);
+    await expect(badges.filter({ hasText: "Review" }).first()).toBeVisible();
+    await expect(badges.filter({ hasText: "Heads up" })).toHaveCount(1);
+    await expect(badges.filter({ hasText: "Blocked" })).toHaveCount(1);
+
+    // Multi-declaration message headlines the ask count, never one ask.
+    await expect(
+      page.getByTestId("attention-card-ask").filter({ hasText: "2 asks" }),
+    ).toBeVisible();
+
+    // The headline is the ask, not the sender.
+    const firstAsk = cards.first().getByTestId("attention-card-ask");
+    await expect(firstAsk).toContainText("approve the desktop deploy");
+    const askText = (await firstAsk.textContent())?.trim() ?? "";
+    expect(askText.length).toBeGreaterThan(0);
+    expect(askText).not.toMatch(/^(Tyler|Alice|Bob)$/);
+    // Staleness is surfaced on the meta line.
+    await expect(cards.first()).toContainText("waiting 3 days");
+
+    await waitForAnimations(page);
+    await page.screenshot({ path: `${SHOTS}/01-needs-me-redesign.png` });
+
+    // Keyboard: j selects the first card, e expands it.
+    await view.focus();
+    await page.keyboard.press("j");
+    await expect(cards.first()).toHaveAttribute("data-selected", "true");
+    await page.keyboard.press("e");
+    const expanded = page.getByTestId("attention-card-expanded");
+    await expect(expanded).toBeVisible();
+
+    // Full message, quick-select options (approval pair + the way out),
+    // and a reply box. Options are scoped to the card: collapsed cards
+    // now show their own option rows too.
+    await expect(expanded).toContainText(
+      "Release workflow paused: approve the desktop deploy to staging?",
+    );
+    const quickOptions = cards.first().getByTestId("attention-quick-option");
+    await expect(quickOptions).toHaveCount(3);
+    await expect(quickOptions.first()).toHaveText("Approve");
+    await expect(quickOptions.last()).toHaveText(
+      "Not enough detail yet, tell me more",
+    );
+    await expect(page.getByTestId("attention-reply-input")).toBeFocused();
+    await expect(page.getByTestId("attention-action-reply")).toBeDisabled();
+
+    await waitForAnimations(page);
+    await page.screenshot({ path: `${SHOTS}/02-expanded-card.png` });
+
+    // To note section close-up (scoped shot keeps the three PNGs distinct).
+    await waitForAnimations(page);
+    await page
+      .getByTestId("attention-section-note")
+      .screenshot({ path: `${SHOTS}/03-to-note.png` });
+
+    // Collapse again to keep the list stable for the action flows.
+    await view.focus();
+    await page.keyboard.press("e");
+    await expect(expanded).not.toBeVisible();
+
+    // Declared options are visible on the COLLAPSED card (one click clears
+    // the row without an expand), and clicking one flows through the reply
+    // queue (posts the option text verbatim after the undo window).
+    const decisionCard = page.locator(
+      'article[data-testid^="attention-card-"]',
+      { hasText: "Ship the attention release now" },
+    );
+    const declaredOptions = decisionCard.getByTestId("attention-quick-option");
+    await expect(declaredOptions).toHaveCount(3);
+    await expect(declaredOptions.first()).toHaveText("Ship it now.");
+    await declaredOptions.first().click();
+    await expect(cards).toHaveCount(6);
+    await expect(page.getByText("Reply queued — posts in 5s")).toBeVisible();
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(cards).toHaveCount(7);
+
+    // Multi-ask: the collapsed card lists its sub-asks (never just a
+    // count), and the expanded view answers through per-ask sub-items.
+    // The optionless Review sub-ask gets its default pair (fixture 4).
+    const multiCard = page.locator('article[data-testid^="attention-card-"]', {
+      hasText: "2 asks",
+    });
+    await expect(
+      multiCard.getByTestId("attention-collapsed-subasks"),
+    ).toContainText("Did the overnight backup complete?");
+    await multiCard.getByTestId("attention-card-ask").click();
+    await expect(multiCard.getByTestId("attention-subitem")).toHaveCount(2);
+    await expect(
+      multiCard.getByTestId("attention-subitems-progress"),
+    ).toHaveText("0 of 2 answered");
+    await expect(
+      multiCard.getByTestId("attention-subitem-option").filter({
+        hasText: "Looks good",
+      }),
+    ).toBeVisible();
+    await multiCard.getByTestId("attention-card-ask").click();
+
+    // Noted on a To note item is LOCAL-ONLY: the card leaves immediately,
+    // nothing publishes — no reply-queue "posts in 5s" toast appears.
+    const notedCard = page.locator('article[data-testid^="attention-card-"]', {
+      hasText: "FYI the launch deck shipped",
+    });
+    await notedCard.hover();
+    await notedCard.getByTestId("attention-action-noted").click();
+    await expect(cards).toHaveCount(6);
+    await expect(page.getByText("Noted locally")).toBeVisible();
+    await expect(page.getByText("Noted — reply posts in 5s")).toHaveCount(0);
+    const undoButton = page.getByRole("button", { name: "Undo" });
+    await expect(undoButton).toBeVisible();
+    await undoButton.click();
+    await expect(cards).toHaveCount(7);
+
+    // Note all clears the whole To note strip locally; Undo restores it.
+    await expect(page.getByTestId("attention-section-note")).toBeVisible();
+    await page.getByTestId("attention-note-all").click();
+    await expect(page.getByTestId("attention-section-note")).not.toBeVisible();
+    await expect(cards).toHaveCount(6);
+    await expect(page.getByText("Noted 1 item locally")).toBeVisible();
+    await page
+      .locator("li", { hasText: "Noted 1 item locally" })
+      .getByRole("button", { name: "Undo" })
+      .click();
+    await expect(page.getByTestId("attention-section-note")).toBeVisible();
+    await expect(cards).toHaveCount(7);
+
+    // Locked action matrix: Done only where it means something. The
+    // Blocked card has Done as primary and no overflow; the reminder
+    // (Review) card has no Done and offers Handled elsewhere instead.
+    const blockedCard = page.locator(
+      'article[data-testid^="attention-card-"]',
+      { hasText: "staging credentials" },
+    );
+    await blockedCard.hover();
+    await expect(
+      blockedCard.getByTestId("attention-action-done"),
+    ).toBeVisible();
+    await expect(
+      blockedCard.getByTestId("attention-action-overflow"),
+    ).toHaveCount(0);
+
+    // Handled elsewhere: held like every action, publishes the shared
+    // honest line exactly once after the 5s undo window.
+    const reminderCard = page.locator(
+      'article[data-testid^="attention-card-"]',
+      {
+        hasText: "answer Bob in the launch DM thread",
+      },
+    );
+    await reminderCard.hover();
+    await expect(reminderCard.getByTestId("attention-action-done")).toHaveCount(
+      0,
+    );
+    await reminderCard.getByTestId("attention-action-overflow").click();
+    await reminderCard
+      .getByTestId("attention-action-handled-elsewhere")
+      .click();
+    await expect(cards).toHaveCount(6);
+    await expect(
+      page.getByText("Handled elsewhere — reply posts in 5s"),
+    ).toBeVisible();
+    await page.waitForTimeout(5_500);
+    await expect(cards).toHaveCount(6);
+    await expect(
+      page.getByText("Could not post your reply", { exact: false }),
+    ).not.toBeVisible();
+    await page.getByTestId("attention-tab-done").click();
+    await expect(
+      page.locator('article[data-testid^="attention-card-"]', {
+        hasText: "answer Bob in the launch DM thread",
+      }),
+    ).toBeVisible();
+
+    // Deep link: opening a card lands in the original channel conversation.
+    await page.getByTestId("attention-tab-needsMe").click();
+    const openTarget = cards.first();
+    await openTarget.hover();
+    await openTarget.getByTestId("attention-action-open").click();
+    await page.waitForURL(/\/channels\//);
+  });
+
+  test("empty waiting view explains itself", async ({ page }) => {
+    await enableAttentionFeature(page);
+    await installMockBridge(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.getByTestId("open-attention-view").click();
+    await expect(page.getByTestId("attention-view")).toBeVisible();
+    await page.getByTestId("attention-tab-waiting").click();
+    await expect(page.getByTestId("attention-empty-state")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Nothing parked. Items you are waiting on others for land here.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/desktop/tests/e2e/catchup.spec.ts
+++ b/desktop/tests/e2e/catchup.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+/**
+ * The Attention preview feature ships default-off. Seed the localStorage
+ * override before the app boots so the flagged UI renders under test.
+ */
+async function enableAttentionFeature(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ attention: true }),
+    );
+  });
+}
+
+const SHOTS = "test-results/catchup";
+
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const BOB_PUBKEY =
+  "bb22a5299220cad76ffd46190ccbeede8ab5dc260faa28b6e5a2cb31b9aff260";
+
+type MockWindow = Window & {
+  __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: {
+    category: "mention" | "needs_action" | "activity" | "agent_activity";
+    channel_id: string | null;
+    channel_name: string;
+    content: string;
+    created_at: number;
+    id: string;
+    kind: number;
+    pubkey: string;
+    tags: string[][];
+  }) => unknown;
+};
+
+test.describe("inbox catch up mode", () => {
+  test("catch up reads unread summaries, dedups asks, and marks all read", async ({
+    page,
+  }) => {
+    await enableAttentionFeature(page);
+    await installMockBridge(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    // Seed an unread activity message that leads with a TL;DR line.
+    await page.waitForFunction(
+      () =>
+        typeof (window as MockWindow).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__ ===
+        "function",
+    );
+    await page.evaluate(
+      ({ bobPubkey, channelId }) => {
+        (window as MockWindow).__BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?.({
+          category: "activity",
+          channel_id: channelId,
+          channel_name: "general",
+          content:
+            "**TL;DR** Relay migration is complete and green.\n\nLong-form detail about the cutover, dashboards, and follow-up work goes on for several paragraphs here.",
+          created_at: Math.floor(Date.now() / 1_000) - 120,
+          id: "mock-feed-catchup-tldr",
+          kind: 9,
+          pubkey: bobPubkey,
+          tags: [],
+        });
+      },
+      { bobPubkey: BOB_PUBKEY, channelId: GENERAL_CHANNEL_ID },
+    );
+
+    await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+
+    // Unread badge before opening Catch up — opening must not change it.
+    const homeBadge = page.getByTestId("sidebar-home-count");
+    const badgeBefore = (await homeBadge.count())
+      ? await homeBadge.textContent()
+      : null;
+
+    // Toggle in: the conversation list is replaced by the reading.
+    await page.getByTestId("inbox-catchup-toggle").click();
+    await expect(page.getByTestId("catchup-view")).toBeVisible();
+    await expect(page.getByTestId("home-inbox-list")).not.toBeVisible();
+
+    // The TL;DR line renders as the summary — not the truncated body, and
+    // never raw markdown.
+    const tldrLine = page
+      .getByTestId("catchup-line")
+      .filter({ hasText: "Relay migration is complete and green." });
+    await expect(tldrLine).toBeVisible();
+    await expect(tldrLine).not.toContainText("TL;DR");
+    await expect(tldrLine).not.toContainText("**");
+    await expect(tldrLine).not.toContainText("Long-form detail");
+
+    // Attention asks are counted, never listed as lines.
+    const needsCount = page.getByTestId("catchup-needs-count");
+    await expect(needsCount).toBeVisible();
+    await expect(needsCount).toContainText("need you");
+    await expect(
+      page
+        .getByTestId("catchup-line")
+        .filter({ hasText: "Please review the release checklist." }),
+    ).toHaveCount(0);
+
+    // Opening Catch up moved no read boundary.
+    if (badgeBefore !== null) {
+      await expect(page.getByTestId("sidebar-home-count")).toHaveText(
+        badgeBefore,
+      );
+    }
+
+    await waitForAnimations(page);
+    await page.screenshot({ path: `${SHOTS}/01-catch-up.png` });
+
+    // Every line deep links to its own message.
+    await tldrLine.click();
+    await page.waitForURL(/\/channels\//);
+    await page.goBack();
+    await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+
+    // The needs-you count links to the Attention surface.
+    await page.getByTestId("inbox-catchup-toggle").click();
+    await expect(page.getByTestId("catchup-view")).toBeVisible();
+    await page.getByTestId("catchup-needs-count").click();
+    await page.waitForURL(/\/attention/);
+    await page.goBack();
+    await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+
+    // Mark all as read clears the reading to the empty state.
+    await page.getByTestId("inbox-catchup-toggle").click();
+    await expect(page.getByTestId("catchup-view")).toBeVisible();
+    await page.getByTestId("catchup-mark-all-read").click();
+    await expect(page.getByTestId("catchup-empty")).toBeVisible();
+    await expect(
+      page.getByText("Nothing new since you last looked."),
+    ).toBeVisible();
+
+    await waitForAnimations(page);
+    await page.screenshot({ path: `${SHOTS}/02-empty.png` });
+
+    // Toggle back returns the conversation list.
+    await page.getByTestId("inbox-catchup-toggle").click();
+    await expect(page.getByTestId("catchup-view")).not.toBeVisible();
+    await expect(page.getByTestId("home-inbox-list")).toBeVisible();
+  });
+});

--- a/preview-features.json
+++ b/preview-features.json
@@ -26,6 +26,12 @@
       "platforms": ["desktop"]
     },
     {
+      "id": "attention",
+      "name": "Attention",
+      "description": "Personal attention layer: what needs you right now, across channels and agents",
+      "platforms": ["desktop"]
+    },
+    {
       "id": "agentManagedProfiles",
       "name": "Agent-managed profiles",
       "description": "Let agents manage their own relay name and avatar instead of restoring the desktop copy",


### PR DESCRIPTION
Implements the Attention surface proposed in #4335, as a desktop preview feature (default off).

## What this adds

**Attention** is a personal triage view that answers one question: *what needs me right now?* It projects the existing home feed — no new event kinds, no relay changes — into typed, actionable cards:

- **Six-type taxonomy.** Every feed item that addresses the viewer is classified as Needs decision, Needs approval, Needs answer, Needs review, Blocked, or To note. Classification is derived from event kind, tags, and message content.
- **Type-specific actions.** Each card carries the actions that resolve it (approve, answer, pick an option, note), posted as ordinary threaded replies with correct p-tags. A 5-second undo window holds every outgoing action before it publishes; state persists only on commit, so a crash inside the window is an implicit undo.
- **Declared asks.** Agents can declare structured asks in plain prose (`**Needs <Name>, <type>:** …` with optional verbatim reply options). The parser turns these into per-person cards with one-click replies; multi-ask messages compose a single reply. This is a prose convention, not a protocol change — messages render normally in every other client.
- **Catch up mode** (second commit): a read-only digest over the Inbox for skimming what happened without acting.

This is best read as an enhancement of the existing Inbox rather than a new silo: Catch up mode lives directly on the Inbox, and the Attention view is an actionable layer over the same feed items the Inbox already tracks.

Everything is gated behind an `attention` entry in `preview-features.json` (default off, per the flow documented in #4337). With the flag off there is no route, no sidebar entry, no Inbox toggle, and no behavior change.

## Why a projection

The hosted relay rejects unknown kinds, and an attention layer is inherently a per-viewer *view* of existing conversation — so this is implemented purely client-side over the feed the desktop app already has. Full design rationale and the decision log are in the fork: [ATTENTION_ARCHITECTURE_PROPOSAL.md](https://github.com/VenusOne-Lee/buzz/blob/buzz-one/docs/ATTENTION_ARCHITECTURE_PROPOSAL.md).

## Commits

1. `feat(desktop): Attention view behind preview flag` — the feature: projection lib (`features/attention/lib`), card UI, route, sidebar entry, flag entry, e2e spec. Includes two small enabling refactors: the `selectedView` union that was re-declared inline in three files is now the shared `AppView` type (adding a view previously meant editing three unions), and a redundant `handleCloseSettings` wrapper is removed — both keep `AppShell.tsx`/`AppSidebar.tsx` under the 1000-line ratchet.
2. `feat(desktop): Catch up mode on the Inbox` — digest mode, also gated behind the `attention` flag.

## Testing

- `pnpm test`: 4241 pass, 0 fail (includes ~1,300 lines of new unit tests over the projection, declared-ask parsing, quick options, and catch-up grouping).
- `pnpm test:e2e:smoke`: 891 passed, including the two new specs (`attention.spec.ts`, `catchup.spec.ts`), which seed the feature flag explicitly since it ships default-off. Five upstream specs failed on my machine; I rebuilt clean upstream `main` (e1287c9) in a separate worktree and verified all five are pre-existing there: three (relay-reconnect dial retry, scroll-history mounted coverage, video review mode) fail identically on the clean build, and the link-preview / avatar specs are flaky on both branches (link-preview: 1/3 fail on this branch, 2/3 fail on clean main under `--repeat-each=3`).
- `pnpm check` (biome, file-size ratchet, px-text, pubkey-truncation) and `pnpm typecheck`: clean.
- The feature has been exercised live against a hosted relay from a test build of the fork (six-fixture pass over real events; event-log verified, including proof that undo prevents publication).

Screenshots follow in a comment via `scripts/post-screenshots.sh`.

Happy to split this differently (e.g. projection lib first, UI second) if that's easier to review — packaging question also open in #4335.
