### PR TITLE
feat(acp): add same-harness model fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,10 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Use `buzz-acp models` to discover available model IDs.
 # BUZZ_ACP_MODEL=
 
+# Optional same-harness model activated after a provider error, fatal timeout,
+# or transport failure. It remains active until buzz-acp restarts.
+# BUZZ_ACP_FALLBACK_MODEL=
+
 # ── Timeouts & sessions ──────────────────────────────────────────────────────
 # Max seconds per agent turn before timeout (default 320 = ~5 min).
 # BUZZ_ACP_TURN_TIMEOUT=320

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -423,6 +423,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MODEL")]
     pub model: Option<String>,
 
+    /// Same-harness model to use after the primary model returns a provider
+    /// error, times out, or loses its transport. Remains active until restart.
+    #[arg(long, env = "BUZZ_ACP_FALLBACK_MODEL")]
+    pub fallback_model: Option<String>,
+
     /// Title for the agent's ACP sessions, passed out-of-band in `session/new`
     /// `_meta`. Adapters that recognize it name the session after this value;
     /// others ignore it. Never enters the prompt.
@@ -533,6 +538,8 @@ pub struct Config {
     pub memory_enabled: bool,
     /// Desired LLM model ID. Applied after every `session_new_full()`.
     pub model: Option<String>,
+    /// Same-harness model selected after a fatal primary-model failure.
+    pub fallback_model: Option<String>,
     /// Sanitized session title, sent as `_meta.sessionTitle` on `session/new`.
     /// `None` when unset or when the configured value sanitized to empty.
     pub session_title: Option<String>,
@@ -1094,6 +1101,12 @@ impl Config {
             typing_enabled: !args.no_typing,
             memory_enabled: args.memory && !args.no_memory,
             model,
+            fallback_model: args
+                .fallback_model
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
             session_title: args
                 .session_title
                 .as_deref()
@@ -1131,7 +1144,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} fallback_model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1151,6 +1164,7 @@ impl Config {
             self.typing_enabled,
             self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
+            self.fallback_model.as_deref().unwrap_or("(none)"),
             self.permission_mode,
             respond_to_detail,
             allowed_respond_to_detail,
@@ -1468,6 +1482,7 @@ mod tests {
             typing_enabled: true,
             memory_enabled: true,
             model: None,
+            fallback_model: None,
             session_title: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
@@ -2190,6 +2205,19 @@ channels = "ALL"
             "120",
         ]);
         assert_eq!(configured.exit_after_inactivity, 120);
+    }
+
+    #[test]
+    fn fallback_model_accepts_cli_value() {
+        let key = "0".repeat(64);
+        let args = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--fallback-model",
+            "minimax-m3:cloud",
+        ]);
+        assert_eq!(args.fallback_model.as_deref(), Some("minimax-m3:cloud"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1140,6 +1140,7 @@ fn any_respawn_in_flight(crash_history: &[SlotCircuit]) -> bool {
 /// Result of a background respawn task.
 struct RespawnResult {
     index: usize,
+    desired_model: Option<String>,
     /// Tuple: (initialized client, protocol version, agent name).
     result: Result<(AcpClient, u32, String)>,
 }
@@ -1169,14 +1170,16 @@ struct SteerAckEvent {
 /// permanently, silently losing the slot forever.
 struct RespawnGuard {
     index: usize,
+    desired_model: Option<String>,
     tx: mpsc::Sender<RespawnResult>,
     sent: bool,
 }
 
 impl RespawnGuard {
-    fn new(index: usize, tx: mpsc::Sender<RespawnResult>) -> Self {
+    fn new(index: usize, desired_model: Option<String>, tx: mpsc::Sender<RespawnResult>) -> Self {
         Self {
             index,
+            desired_model,
             tx,
             sent: false,
         }
@@ -1192,6 +1195,7 @@ impl RespawnGuard {
         // respawn_in_flight guard has drifted — that's a bug, not a transient.
         match self.tx.try_send(RespawnResult {
             index: self.index,
+            desired_model: self.desired_model.clone(),
             result,
         }) {
             Ok(()) => self.sent = true,
@@ -1216,6 +1220,7 @@ impl Drop for RespawnGuard {
             // Best-effort: try_send in Drop (can't await).
             let _ = self.tx.try_send(RespawnResult {
                 index: self.index,
+                desired_model: self.desired_model.clone(),
                 result: Err(anyhow::anyhow!("respawn task panicked or was cancelled")),
             });
         }
@@ -1829,7 +1834,7 @@ async fn tokio_main() -> Result<()> {
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
                 let observer = observer.clone();
-                let guard = RespawnGuard::new(idx, respawn_tx.clone());
+                let guard = RespawnGuard::new(idx, config.model.clone(), respawn_tx.clone());
                 respawn_tasks.spawn(async move {
                     let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
                     guard.send(result);
@@ -1860,7 +1865,7 @@ async fn tokio_main() -> Result<()> {
                         acp,
                         state: SessionState::default(),
                         model_capabilities: None,
-                        desired_model: config.model.clone(),
+                        desired_model: rr.desired_model,
                         model_overridden: false,
                         agent_name,
                         goose_system_prompt_supported: None,
@@ -3180,6 +3185,10 @@ fn handle_prompt_result(
     // branch below records what actually happened; only the hard-timeout
     // match arm in the death_message construction reads it.
     let mut hard_timeout_fate_suffix: Option<&'static str> = None;
+    let failover_available = config
+        .fallback_model
+        .as_ref()
+        .is_some_and(|fallback| result.agent.desired_model.as_ref() != Some(fallback));
 
     // Requeue BEFORE mark_complete: requeue() sets retry_after with a future
     // deadline, and mark_complete() checks for it to decide whether to preserve
@@ -3215,7 +3224,8 @@ fn handle_prompt_result(
                 PromptOutcome::Timeout(TimeoutKind::Hard {
                     recently_active: false
                 })
-            ) {
+            ) && !failover_available
+            {
                 tracing::error!(
                     channel_id = %batch.channel_id,
                     events = batch.events.len(),
@@ -3233,11 +3243,16 @@ fn handle_prompt_result(
                 PromptOutcome::Timeout(TimeoutKind::Hard {
                     recently_active: true
                 })
-            ) {
+            ) || (matches!(
+                result.outcome,
+                PromptOutcome::Timeout(TimeoutKind::Hard { .. })
+            ) && failover_available)
+            {
                 tracing::warn!(
                     channel_id = %batch.channel_id,
                     events = batch.events.len(),
-                    "hard-cap timeout with recent activity — requeueing for retry"
+                    failover_available,
+                    "hard-cap timeout — requeueing for retry"
                 );
                 if let Some(dead) = queue.requeue(batch) {
                     let content = format!(
@@ -3473,18 +3488,22 @@ fn handle_prompt_result(
                     | acp::AcpError::Timeout(_)
                     | acp::AcpError::Protocol(_)
             );
+            let is_primary_model_error = failover_available
+                && matches!(e, acp::AcpError::AgentError { .. })
+                && !is_auth_error(e);
             let error_code = match &e {
                 acp::AcpError::AgentError { code, .. } => Some(*code),
                 _ => None,
             };
-            if is_transport_error {
+            if is_transport_error || is_primary_model_error {
                 tracing::warn!(
                     agent = agent_index,
                     outcome = outcome_label,
                     configured_model = %harness_configured_model,
                     pid = harness_pid,
                     error = %e,
-                    "transport/protocol error — respawning agent"
+                    failover = is_primary_model_error,
+                    "fatal agent error — respawning agent"
                 );
                 emit_turn_error(&e.to_string(), error_code);
 
@@ -3609,7 +3628,11 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
-    let guard = RespawnGuard::new(i, respawn_tx.clone());
+    let desired_model = config
+        .fallback_model
+        .clone()
+        .or_else(|| config.model.clone());
+    let guard = RespawnGuard::new(i, desired_model, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
@@ -3770,6 +3793,18 @@ fn default_heartbeat_prompt() -> String {
 /// The result comes back through `respawn_tx` so the main loop stays responsive.
 ///
 /// Returns `true` if a respawn task was spawned, `false` if the circuit is open.
+fn next_model_after_fatal_failure(
+    current: Option<String>,
+    primary: Option<&String>,
+    fallback: Option<&String>,
+) -> Option<String> {
+    fallback
+        .filter(|fallback| current.as_ref() != Some(*fallback))
+        .cloned()
+        .or(current)
+        .or_else(|| primary.cloned())
+}
+
 fn spawn_respawn_task(
     old_agent: OwnedAgent,
     config: &Config,
@@ -3779,6 +3814,21 @@ fn spawn_respawn_task(
     observer: Option<observer::ObserverHandle>,
 ) -> bool {
     let index = old_agent.index;
+    let previous_model = old_agent.desired_model.clone();
+    let desired_model = next_model_after_fatal_failure(
+        previous_model,
+        config.model.as_ref(),
+        config.fallback_model.as_ref(),
+    );
+
+    if desired_model != old_agent.desired_model {
+        tracing::warn!(
+            agent = index,
+            from_model = ?old_agent.desired_model,
+            to_model = ?desired_model,
+            "activating same-harness fallback model"
+        );
+    }
 
     // Circuit breaker: record crash, decide whether to respawn.
     let delay = match slot.record_crash() {
@@ -3803,7 +3853,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
-    let guard = RespawnGuard::new(index, respawn_tx.clone());
+    let guard = RespawnGuard::new(index, desired_model, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
         let mut agent = old_agent;
@@ -3830,6 +3880,31 @@ fn normalized_agent_name(init_result: &serde_json::Value) -> String {
         .unwrap_or("unknown")
         .trim()
         .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod model_fallback_tests {
+    use super::next_model_after_fatal_failure;
+
+    #[test]
+    fn primary_failure_selects_fallback() {
+        let primary = "deepseek-v4-flash:cloud".to_string();
+        let fallback = "minimax-m3:cloud".to_string();
+        assert_eq!(
+            next_model_after_fatal_failure(Some(primary.clone()), Some(&primary), Some(&fallback),),
+            Some(fallback)
+        );
+    }
+
+    #[test]
+    fn fallback_failure_does_not_loop_back_to_primary() {
+        let primary = "deepseek-v4-flash:cloud".to_string();
+        let fallback = "minimax-m3:cloud".to_string();
+        assert_eq!(
+            next_model_after_fatal_failure(Some(fallback.clone()), Some(&primary), Some(&fallback),),
+            Some(fallback)
+        );
+    }
 }
 
 async fn shutdown_agent_slots(slots: &mut [Option<OwnedAgent>]) {
@@ -5124,6 +5199,7 @@ mod build_mcp_servers_tests {
             typing_enabled: true,
             memory_enabled: false,
             model: None,
+            fallback_model: None,
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
@@ -5346,6 +5422,7 @@ mod error_outcome_emission_tests {
             typing_enabled: true,
             memory_enabled: false,
             model: None,
+            fallback_model: None,
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,


### PR DESCRIPTION
## Summary

- add an optional `BUZZ_ACP_FALLBACK_MODEL` for same-harness failover
- activate the fallback after non-auth provider errors, fatal timeouts, or ACP transport failures
- preserve the fallback across slot respawns until the `buzz-acp` service restarts
- allow a silent hard-timeout batch one retry when a fallback has not yet been attempted
- document the new configuration and include the active fallback in startup summaries

## Why

Today `buzz-acp` replaces a poisoned ACP subprocess but recreates it with the same model. A provider-side model stall can therefore leave an agent unavailable or retry the same unhealthy route. Operators can select another model manually, but there is no bounded automatic recovery path within an otherwise healthy harness and provider.

This change keeps the harness and provider fixed and changes only the desired model on the replacement slot. It intentionally does not implement cross-provider or cross-harness routing.

## Behavior

- Primary failures switch to the configured fallback.
- The fallback remains selected for the process lifetime, avoiding model oscillation.
- Authentication failures retain their existing non-retryable behavior.
- If the fallback also fails, existing retry-budget and dead-letter behavior applies.
- Without `BUZZ_ACP_FALLBACK_MODEL`, behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo test -p buzz-acp --lib` — 671 passed
- `cargo build --release -p buzz-acp`
- live Goose/Ollama validation with a primary and fallback cloud model
