### PR TITLE
feat(db): add durable identity binding lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "buzz-core",
  "chrono",
  "hex",
+ "hmac 0.13.0",
  "jsonwebtoken",
  "nostr 0.44.7",
  "rand 0.10.1",
@@ -1052,6 +1053,7 @@ dependencies = [
 name = "buzz-db"
 version = "0.1.0"
 dependencies = [
+ "buzz-auth",
  "buzz-core",
  "buzz-datastore-tracing",
  "chrono",

--- a/crates/buzz-auth/Cargo.toml
+++ b/crates/buzz-auth/Cargo.toml
@@ -22,6 +22,7 @@ tracing      = { workspace = true }
 thiserror    = { workspace = true }
 sha2         = { workspace = true }
 hex          = { workspace = true }
+hmac         = { workspace = true }
 rand         = { workspace = true }
 uuid         = { workspace = true }
 url          = { workspace = true }

--- a/crates/buzz-auth/src/evidence.rs
+++ b/crates/buzz-auth/src/evidence.rs
@@ -1,0 +1,198 @@
+//! Origin-sealed assertion transport evidence for NIP-FI authorization.
+//!
+//! This module deliberately stops at the transport boundary. It does not
+//! validate JWT claims, prepare admission, consume replay identities, or make
+//! lifecycle decisions. Those operations remain the responsibility of the
+//! canonical verifier and final-admission authority.
+
+use std::fmt;
+
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::ProofTransport;
+
+/// The closed assertion transport profile that produced sealed evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssertionTransportProfile {
+    /// A request-bound `trusted-proxy-hmac-v1` provenance field.
+    TrustedProxyHmacV1,
+}
+
+/// Opaque identity for one trusted-proxy nonce that final admission must claim.
+///
+/// The key is a domain-separated one-way digest of the decoded nonce. It is
+/// safe to persist, unlike the assertion and raw nonce, and remains stable if
+/// one proxy serves multiple authorities. Final admission adds the frozen
+/// server-owned authorization domain and claim kind. The exclusive retain
+/// bound is the proxy timestamp plus the configured maximum provenance age.
+#[derive(Clone, PartialEq, Eq)]
+pub struct TrustedProxyNonceClaim {
+    claim_key: [u8; 32],
+    retain_until: DateTime<Utc>,
+}
+
+impl TrustedProxyNonceClaim {
+    pub(crate) const fn new(claim_key: [u8; 32], retain_until: DateTime<Utc>) -> Self {
+        Self {
+            claim_key,
+            retain_until,
+        }
+    }
+
+    /// Privacy-safe key that must be inserted atomically at final admission.
+    pub const fn claim_key(&self) -> &[u8; 32] {
+        &self.claim_key
+    }
+
+    /// Exclusive finite retention bound consumed by canonical admission.
+    pub const fn retain_until(&self) -> DateTime<Utc> {
+        self.retain_until
+    }
+}
+
+impl fmt::Debug for TrustedProxyNonceClaim {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TrustedProxyNonceClaim([REDACTED])")
+    }
+}
+
+/// Move-only assertion bytes sealed to exact authenticated ingress facts.
+///
+/// This type intentionally does not implement [`Clone`]. Its debug output
+/// never exposes the assertion, nonce, authority, path, or their digests. A
+/// caller may borrow the confidential assertion only to pass it directly to
+/// the frozen canonical assertion verifier.
+pub struct SealedTransportEvidence {
+    authorization_domain: CommunityId,
+    assertion: Box<str>,
+    assertion_digest: [u8; 32],
+    request_fingerprint: [u8; 32],
+    transport_context_fingerprint: [u8; 32],
+    transport: ProofTransport,
+    proxy_expires_at: DateTime<Utc>,
+    nonce_claim: TrustedProxyNonceClaim,
+    profile: AssertionTransportProfile,
+}
+
+impl SealedTransportEvidence {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_trusted_proxy(
+        authorization_domain: CommunityId,
+        assertion: Box<str>,
+        assertion_digest: [u8; 32],
+        method: &[u8],
+        authority: &[u8],
+        path_and_query: &[u8],
+        body_digest: [u8; 32],
+        transport: ProofTransport,
+        proxy_expires_at: DateTime<Utc>,
+        nonce_claim: TrustedProxyNonceClaim,
+    ) -> Self {
+        let request_fingerprint = framed_fingerprint(
+            b"buzz:nip-fi:trusted-proxy-request:v1",
+            &[
+                authorization_domain.as_uuid().as_bytes(),
+                method,
+                authority,
+                path_and_query,
+                &body_digest,
+                &[proof_transport_code(transport)],
+            ],
+        );
+        let transport_context_fingerprint = framed_fingerprint(
+            b"buzz:nip-fi:assertion-transport:v1",
+            &[
+                b"trusted-proxy-hmac-v1",
+                authorization_domain.as_uuid().as_bytes(),
+                authority,
+                &[proof_transport_code(transport)],
+            ],
+        );
+        Self {
+            authorization_domain,
+            assertion,
+            assertion_digest,
+            request_fingerprint,
+            transport_context_fingerprint,
+            transport,
+            proxy_expires_at,
+            nonce_claim,
+            profile: AssertionTransportProfile::TrustedProxyHmacV1,
+        }
+    }
+
+    /// Server-resolved authorization domain sealed before replay lookup.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Borrow the exact compact-JWS bytes after transport verification.
+    ///
+    /// The returned value is confidential and must not be logged, serialized,
+    /// or placed in public errors. It still requires canonical JWT validation.
+    pub fn confidential_assertion(&self) -> &str {
+        &self.assertion
+    }
+
+    /// SHA-256 of the exact compact-JWS bytes after the Bearer scheme.
+    pub const fn assertion_digest(&self) -> &[u8; 32] {
+        &self.assertion_digest
+    }
+
+    /// Stable digest of exact method, authority, path/query, and body digest.
+    pub const fn request_fingerprint(&self) -> &[u8; 32] {
+        &self.request_fingerprint
+    }
+
+    /// Stable digest of the authenticated transport profile and authority.
+    pub const fn transport_context_fingerprint(&self) -> &[u8; 32] {
+        &self.transport_context_fingerprint
+    }
+
+    /// Server-selected proof transport sealed into the HMAC request binding.
+    pub const fn transport(&self) -> ProofTransport {
+        self.transport
+    }
+
+    /// Exclusive finite provenance expiry.
+    pub const fn proxy_expires_at(&self) -> DateTime<Utc> {
+        self.proxy_expires_at
+    }
+
+    /// Read-only nonce identity that final admission must claim atomically.
+    pub const fn nonce_claim(&self) -> &TrustedProxyNonceClaim {
+        &self.nonce_claim
+    }
+
+    /// Assertion transport profile selected by trusted server configuration.
+    pub const fn profile(&self) -> AssertionTransportProfile {
+        self.profile
+    }
+}
+
+pub(crate) const fn proof_transport_code(transport: ProofTransport) -> u8 {
+    match transport {
+        ProofTransport::Nip42 => 1,
+        ProofTransport::Nip98 => 2,
+        ProofTransport::GitSmartHttpSession => 3,
+        ProofTransport::Blossom => 4,
+    }
+}
+
+impl fmt::Debug for SealedTransportEvidence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SealedTransportEvidence([REDACTED])")
+    }
+}
+
+fn framed_fingerprint(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}

--- a/crates/buzz-auth/src/lib.rs
+++ b/crates/buzz-auth/src/lib.rs
@@ -19,6 +19,8 @@
 pub mod access;
 /// Authentication error types.
 pub mod error;
+/// Sealed transport provenance shared by protected authorization paths.
+pub mod evidence;
 /// Provider-free authorization composition and sealed verifier evidence.
 pub mod foundation;
 /// NIP-42 challenge–response authentication.
@@ -27,13 +29,18 @@ pub mod nip42;
 pub mod nip98;
 /// NIP-98 replay protection — shared, community-scoped, atomic seen-set.
 pub mod nip98_replay;
+/// Origin-sealed deployment-operator identity lifecycle authority.
+pub mod operator_lifecycle;
 /// Per-connection rate limiting.
 pub mod rate_limit;
 /// OAuth scope parsing and enforcement.
 pub mod scope;
+/// Request-bound HMAC provenance verification for trusted proxies.
+pub mod trusted_proxy;
 
 pub use access::{check_read_access, check_write_access, require_scope, ChannelAccessChecker};
 pub use error::AuthError;
+pub use evidence::{AssertionTransportProfile, SealedTransportEvidence, TrustedProxyNonceClaim};
 pub use foundation::{
     ActiveLocalBinding, AuthContext as FinalizedAuthContext, AuthoritativeAuthorizationRecheck,
     AuthorizationAuditConfig, AuthorizationAuditConfigError, AuthorizationError,
@@ -62,6 +69,11 @@ pub use rate_limit::{
     ip_rate_limit_key, rate_limit_key, LimitType, RateLimitConfig, RateLimitResult, RateLimiter,
 };
 pub use scope::{parse_scopes, Scope};
+pub use trusted_proxy::{
+    HttpHeaderField, TrustedProxyError, TrustedProxyNonceReplayReader,
+    TrustedProxyProvenanceVerifier, TrustedProxyReplayReadError, TrustedProxyRequest,
+    ASSERTION_HEADER_NAME, PROVENANCE_HEADER_NAME,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use access::MockAccessChecker;

--- a/crates/buzz-auth/src/operator_lifecycle.rs
+++ b/crates/buzz-auth/src/operator_lifecycle.rs
@@ -1,0 +1,2214 @@
+//! Origin-sealed deployment-operator authority for identity lifecycle work.
+//!
+//! The verifier is the only constructor for the opaque grants in this module.
+//! It requires a configured operator to sign the exact NIP-98 request and,
+//! when the closed deployment policy requires it, a distinct configured
+//! approver. Every accepted proof is payload- and intent-bound before the
+//! verifier returns authority to a caller.
+
+use std::{fmt, future::Future, pin::Pin};
+
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use nostr::{Event, EventId, PublicKey, TagKind};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    foundation::FederatedPrincipal, verify_nip98_event, AuthError, DEFAULT_REPLAY_TTL_SECS,
+};
+
+const MAX_CONFIGURED_OPERATORS: usize = 64;
+const NIP98_EXCLUSIVE_LIFETIME_SECONDS: u64 = 60;
+
+/// Atomic all-or-none replay fence for a complete one/two/three-proof set.
+///
+/// This is intentionally separate from the single-event `Nip98ReplayGuard`:
+/// sequential claims can burn a valid subset and cannot prove one concurrent
+/// winner for a multi-signature operator action.
+pub trait OperatorProofSetReplayGuard: Send + Sync {
+    /// Consume one unit from a server-derived domain/action/actor quota.
+    ///
+    /// The verifier calls this only after every proof is complete and
+    /// allowlisted, and before it consumes any replay identity.
+    fn try_admit_quota<'a>(
+        &'a self,
+        quota_scope: &'a str,
+        signer_attribution: &'a [u8; 32],
+    ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>>;
+
+    /// Claim every distinct event id in one scope, or claim none of them.
+    fn try_mark_all_in_scope<'a>(
+        &'a self,
+        scope: &'a str,
+        event_ids: &'a [EventId],
+        ttl_secs: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>>;
+}
+
+/// Closed operator actions backed by the canonical identity lifecycle engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i16)]
+pub enum OperatorLifecycleAction {
+    /// Retire one active identity/key pair without revoking the key globally.
+    Retire = 3,
+    /// Disable one principal, retiring its active binding when present.
+    Disable = 4,
+    /// Permanently revoke an event-author key.
+    Revoke = 5,
+    /// Replace one active binding with a freshly proven key.
+    Rotate = 6,
+    /// Consume one pending replacement fact and install its successor.
+    Recover = 7,
+    /// Consume one disabled-principal fact and install a successor.
+    Enable = 8,
+}
+
+impl OperatorLifecycleAction {
+    /// Parse the exact action segment exposed by the deployment operator API.
+    pub fn from_path_segment(value: &str) -> Option<Self> {
+        match value {
+            "revoke" => Some(Self::Revoke),
+            "rotate" => Some(Self::Rotate),
+            "recover" => Some(Self::Recover),
+            "enable" => Some(Self::Enable),
+            "retire" => Some(Self::Retire),
+            "disable" => Some(Self::Disable),
+            _ => None,
+        }
+    }
+
+    /// Exact action segment covered by the signed NIP-98 URL.
+    pub const fn as_path_segment(self) -> &'static str {
+        match self {
+            Self::Retire => "retire",
+            Self::Disable => "disable",
+            Self::Revoke => "revoke",
+            Self::Rotate => "rotate",
+            Self::Recover => "recover",
+            Self::Enable => "enable",
+        }
+    }
+}
+
+/// Opaque authority for one exact canonical lifecycle request.
+///
+/// This value has no public constructor and is not serializable. A valid
+/// value proves that the closed configured approval policy was satisfied for
+/// the exact signed payload and semantic intent.
+///
+/// ```compile_fail
+/// use buzz_auth::VerifiedOperatorLifecycleGrant;
+/// let _forged = VerifiedOperatorLifecycleGrant {};
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct VerifiedOperatorLifecycleGrant {
+    authorization_domain: CommunityId,
+    action: OperatorLifecycleAction,
+    operation_id: Uuid,
+    intent_digest: [u8; 32],
+    expected_revision: u64,
+    approval_policy_digest: [u8; 32],
+    signer_attribution: [u8; 32],
+    approval_attribution: Option<[u8; 32]>,
+    replacement_event_author_pubkey: Option<[u8; 32]>,
+    replacement_expires_at: Option<DateTime<Utc>>,
+    replacement_proof_attribution: Option<[u8; 32]>,
+    request_attribution: [u8; 32],
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+impl VerifiedOperatorLifecycleGrant {
+    /// Server-resolved authorization domain bound by both operator proofs.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Exact closed lifecycle action.
+    pub const fn action(&self) -> OperatorLifecycleAction {
+        self.action
+    }
+
+    /// Stable operation identity bound by the signed payload.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Canonical typed-intent digest bound by both signatures.
+    pub const fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    /// Exact expected lifecycle revision or selector generation.
+    pub const fn expected_revision(&self) -> u64 {
+        self.expected_revision
+    }
+
+    /// Digest of the immutable verifier configuration and approval policy.
+    pub const fn approval_policy_digest(&self) -> [u8; 32] {
+        self.approval_policy_digest
+    }
+
+    /// Pseudonymous configured signer attribution.
+    pub const fn signer_attribution(&self) -> [u8; 32] {
+        self.signer_attribution
+    }
+
+    /// Independently configured approver attribution.
+    pub const fn approval_attribution(&self) -> Option<[u8; 32]> {
+        self.approval_attribution
+    }
+
+    /// Fresh replacement key proven by the exact request, when required by
+    /// Rotate, Recover, or Enable.
+    pub const fn replacement_event_author_pubkey(&self) -> Option<[u8; 32]> {
+        self.replacement_event_author_pubkey
+    }
+
+    /// Stable exclusive expiry requested in the signed replacement body.
+    pub const fn replacement_expires_at(&self) -> Option<DateTime<Utc>> {
+        self.replacement_expires_at
+    }
+
+    /// Stable attribution for the independently signed replacement proof.
+    pub const fn replacement_proof_attribution(&self) -> Option<[u8; 32]> {
+        self.replacement_proof_attribution
+    }
+
+    /// Stable attribution bound to semantic intent, excluding ephemeral proof
+    /// IDs so a newly signed exact retry can reach canonical DB replay.
+    pub const fn request_attribution(&self) -> [u8; 32] {
+        self.request_attribution
+    }
+
+    /// Latest issuance time across the two exact NIP-98 proofs.
+    pub const fn issued_at(&self) -> DateTime<Utc> {
+        self.issued_at
+    }
+
+    /// Exclusive trusted expiry. For replacement actions this is the minimum
+    /// of the primary proof, configured approver proof, replacement proof,
+    /// and requested successor bound. Callers must recheck it immediately
+    /// before the canonical mutation and additionally apply the authoritative
+    /// database policy bound when persisting the successor.
+    pub const fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+}
+
+impl fmt::Debug for VerifiedOperatorLifecycleGrant {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("VerifiedOperatorLifecycleGrant([REDACTED])")
+    }
+}
+
+/// Opaque operator-approved community-provision binding intent.
+///
+/// Provisioning remains a separate workflow from lifecycle mutation. This
+/// value lets that workflow consume the same closed operator policy without
+/// accepting a caller-selected `approved` flag or raw attribution.
+///
+/// ```compile_fail
+/// use buzz_auth::VerifiedProvisionBindingIntent;
+/// let _forged = VerifiedProvisionBindingIntent {};
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct VerifiedProvisionBindingIntent {
+    authorization_domain: CommunityId,
+    operation_id: Uuid,
+    policy_revision: u64,
+    policy_digest: [u8; 32],
+    principal: FederatedPrincipal,
+    selected_event_author_pubkey: [u8; 32],
+    intent_digest: [u8; 32],
+    approval_policy_digest: [u8; 32],
+    signer_attribution: [u8; 32],
+    approval_attribution: Option<[u8; 32]>,
+    request_attribution: [u8; 32],
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+impl VerifiedProvisionBindingIntent {
+    /// Server-resolved domain explicitly sealed by the signed payload.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Exact operation identity explicitly sealed by the signed payload.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Exact local enrollment-policy revision selected by the operator.
+    pub const fn policy_revision(&self) -> u64 {
+        self.policy_revision
+    }
+
+    /// Exact local enrollment-policy digest selected by the operator.
+    pub const fn policy_digest(&self) -> [u8; 32] {
+        self.policy_digest
+    }
+
+    /// Borrow the exact principal coordinates selected by the operator.
+    pub fn principal_storage_key(&self) -> crate::FederatedPrincipalStorageKey<'_> {
+        self.principal.storage_key()
+    }
+
+    /// Exact event-author key selected by the provision intent.
+    pub const fn selected_event_author_pubkey(&self) -> [u8; 32] {
+        self.selected_event_author_pubkey
+    }
+
+    /// Digest of the exact payload-bound provisioning intent.
+    pub const fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    /// Stable two-party attribution for the provisioning workflow.
+    pub const fn request_attribution(&self) -> [u8; 32] {
+        self.request_attribution
+    }
+
+    /// Latest issuance time across the two exact NIP-98 proofs.
+    pub const fn issued_at(&self) -> DateTime<Utc> {
+        self.issued_at
+    }
+
+    /// Exclusive trusted expiry.
+    pub const fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    /// Pseudonymous configured signer attribution.
+    pub const fn signer_attribution(&self) -> [u8; 32] {
+        self.signer_attribution
+    }
+
+    /// Independently configured approver attribution.
+    pub const fn approval_attribution(&self) -> Option<[u8; 32]> {
+        self.approval_attribution
+    }
+
+    /// Digest of the immutable verifier configuration and approval policy.
+    pub const fn approval_policy_digest(&self) -> [u8; 32] {
+        self.approval_policy_digest
+    }
+}
+
+impl fmt::Debug for VerifiedProvisionBindingIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("VerifiedProvisionBindingIntent([REDACTED])")
+    }
+}
+
+/// Configuration or verification failures for the sealed operator boundary.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum OperatorLifecycleGrantError {
+    /// The configured operator set cannot satisfy the closed approval policy.
+    #[error("operator lifecycle verifier configuration is invalid")]
+    InvalidConfiguration,
+    /// The typed lifecycle/provisioning coordinates are invalid.
+    #[error("operator lifecycle request is invalid")]
+    InvalidRequest,
+    /// One of the exact NIP-98 proofs was malformed, stale, or mismatched.
+    #[error("operator lifecycle credential is invalid")]
+    InvalidCredential,
+    /// A signer is absent from the configured deployment operator set.
+    #[error("operator lifecycle signer is not configured")]
+    Unauthenticated,
+    /// The two required proofs were produced by the same signer.
+    #[error("operator lifecycle approval is not independent")]
+    ApprovalNotIndependent,
+    /// One of the exact proof identities was already consumed.
+    #[error("operator lifecycle credential was replayed")]
+    Replayed,
+    /// The server-owned authorization-domain quota rejected the action.
+    #[error("operator lifecycle quota is exhausted")]
+    QuotaExceeded,
+    /// Shared quota state was unavailable; verification failed closed.
+    #[error("operator lifecycle quota is unavailable")]
+    QuotaUnavailable,
+    /// The shared replay fence was unavailable; verification failed closed.
+    #[error("operator lifecycle replay fence is unavailable")]
+    ReplayUnavailable,
+}
+
+/// Exact NIP-98/configuration verifier and sole mint for operator authority.
+#[derive(Clone)]
+pub struct OperatorLifecycleVerifier {
+    configured_operators: Box<[PublicKey]>,
+    approval_policy: OperatorApprovalPolicy,
+    approval_policy_digest: [u8; 32],
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OperatorApprovalPolicy {
+    ConfiguredSigner = 1,
+    IndependentConfiguredApprover = 2,
+}
+
+impl OperatorLifecycleVerifier {
+    /// Install the stock policy: one exact payload-bound configured signer.
+    pub fn new(configured_operators: Vec<PublicKey>) -> Result<Self, OperatorLifecycleGrantError> {
+        Self::with_policy(
+            configured_operators,
+            OperatorApprovalPolicy::ConfiguredSigner,
+        )
+    }
+
+    /// Install a deployment policy requiring one independently configured
+    /// approver in addition to the exact payload-bound signer.
+    pub fn requiring_independent_approval(
+        configured_operators: Vec<PublicKey>,
+    ) -> Result<Self, OperatorLifecycleGrantError> {
+        Self::with_policy(
+            configured_operators,
+            OperatorApprovalPolicy::IndependentConfiguredApprover,
+        )
+    }
+
+    fn with_policy(
+        mut configured_operators: Vec<PublicKey>,
+        approval_policy: OperatorApprovalPolicy,
+    ) -> Result<Self, OperatorLifecycleGrantError> {
+        configured_operators.sort_unstable_by_key(|key| key.to_bytes());
+        configured_operators.dedup();
+        let minimum = match approval_policy {
+            OperatorApprovalPolicy::ConfiguredSigner => 1,
+            OperatorApprovalPolicy::IndependentConfiguredApprover => 2,
+        };
+        if configured_operators.len() < minimum
+            || configured_operators.len() > MAX_CONFIGURED_OPERATORS
+        {
+            return Err(OperatorLifecycleGrantError::InvalidConfiguration);
+        }
+        let approval_policy_digest = operator_policy_digest(approval_policy, &configured_operators);
+        Ok(Self {
+            configured_operators: configured_operators.into_boxed_slice(),
+            approval_policy,
+            approval_policy_digest,
+        })
+    }
+
+    /// Whether this closed deployment policy requires an independent approval.
+    pub const fn requires_independent_approval(&self) -> bool {
+        matches!(
+            self.approval_policy,
+            OperatorApprovalPolicy::IndependentConfiguredApprover
+        )
+    }
+
+    /// Digest of the sorted allowlist and closed approval policy.
+    pub const fn approval_policy_digest(&self) -> [u8; 32] {
+        self.approval_policy_digest
+    }
+
+    /// Verify exact NIP-98 authority for one signed lifecycle body.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn verify_lifecycle(
+        &self,
+        authorization_event_json: &str,
+        independent_approval_event_json: Option<&str>,
+        replacement_proof_event_json: Option<&str>,
+        expected_url: &str,
+        request_body: &[u8],
+        replay_guard: &dyn OperatorProofSetReplayGuard,
+        authorization_domain: CommunityId,
+        action: OperatorLifecycleAction,
+        operation_id: Uuid,
+        intent_digest: [u8; 32],
+        expected_revision: u64,
+        replacement_event_author_pubkey: Option<[u8; 32]>,
+        replacement_expires_at: Option<DateTime<Utc>>,
+    ) -> Result<VerifiedOperatorLifecycleGrant, OperatorLifecycleGrantError> {
+        if authorization_domain.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || intent_digest == [0; 32]
+            || expected_revision == 0
+        {
+            return Err(OperatorLifecycleGrantError::InvalidRequest);
+        }
+        validate_lifecycle_url(expected_url, authorization_domain, action)?;
+        let signed = parse_lifecycle_coordinates(request_body, action)?;
+        if signed.operation_id != operation_id
+            || signed.expected_revision != expected_revision
+            || signed.replacement.map(|value| value.event_author_pubkey)
+                != replacement_event_author_pubkey
+            || signed.replacement.map(|value| value.requested_expires_at) != replacement_expires_at
+        {
+            return Err(OperatorLifecycleGrantError::InvalidRequest);
+        }
+        let replay_scope = format!(
+            "operator-lifecycle:{}:{}:{}",
+            authorization_domain.as_uuid(),
+            action.as_path_segment(),
+            operation_id
+        );
+        let proof = self
+            .verify_operator_proofs(
+                authorization_event_json,
+                independent_approval_event_json,
+                expected_url,
+                request_body,
+                Some(intent_digest),
+            )
+            .await?;
+        let replacement = self
+            .verify_replacement_proof(
+                action,
+                replacement_proof_event_json,
+                signed.replacement,
+                expected_url,
+                request_body,
+                authorization_domain,
+                operation_id,
+                intent_digest,
+            )
+            .await?;
+        let expires_at = replacement
+            .as_ref()
+            .map(|replacement| {
+                proof
+                    .expires_at
+                    .min(replacement.credential_expires_at)
+                    .min(replacement.requested_expires_at)
+            })
+            .unwrap_or(proof.expires_at);
+        let issued_at = replacement
+            .as_ref()
+            .map(|replacement| proof.issued_at.max(replacement.issued_at))
+            .unwrap_or(proof.issued_at);
+        let verification_now = Utc::now();
+        if issued_at > verification_now || verification_now >= expires_at {
+            return Err(OperatorLifecycleGrantError::InvalidCredential);
+        }
+        let mut replay_event_ids = Vec::with_capacity(3);
+        replay_event_ids.push(proof.signer_event_id);
+        replay_event_ids.extend(proof.approval_event_id);
+        replay_event_ids.extend(replacement.as_ref().map(|value| value.event_id));
+        let quota_scope = format!(
+            "operator-quota:{}:{}",
+            authorization_domain.as_uuid(),
+            action.as_path_segment()
+        );
+        claim_server_quota(replay_guard, &quota_scope, &proof.signer_attribution).await?;
+        claim_replay_set(replay_guard, &replay_scope, &replay_event_ids).await?;
+        let request_attribution = framed_digest(
+            b"buzz:verified-operator-lifecycle-grant:v1",
+            &[
+                authorization_domain.as_uuid().as_bytes(),
+                &(action as i16).to_be_bytes(),
+                operation_id.as_bytes(),
+                &intent_digest,
+                &expected_revision.to_be_bytes(),
+                &self.approval_policy_digest,
+                &proof.signer_attribution,
+                &proof.approval_attribution.unwrap_or([0; 32]),
+                &replacement
+                    .as_ref()
+                    .map(|value| value.event_author_pubkey)
+                    .unwrap_or([0; 32]),
+                &replacement
+                    .as_ref()
+                    .map(|value| value.requested_expires_at.timestamp().to_be_bytes())
+                    .unwrap_or([0; 8]),
+            ],
+        );
+        Ok(VerifiedOperatorLifecycleGrant {
+            authorization_domain,
+            action,
+            operation_id,
+            intent_digest,
+            expected_revision,
+            approval_policy_digest: self.approval_policy_digest,
+            signer_attribution: proof.signer_attribution,
+            approval_attribution: proof.approval_attribution,
+            replacement_event_author_pubkey: replacement
+                .as_ref()
+                .map(|value| value.event_author_pubkey),
+            replacement_expires_at: replacement.as_ref().map(|value| value.requested_expires_at),
+            replacement_proof_attribution: replacement
+                .as_ref()
+                .map(|value| value.proof_attribution),
+            request_attribution,
+            issued_at,
+            expires_at,
+        })
+    }
+
+    /// Verify exact NIP-98 authority for one explicit binding provision body.
+    pub async fn verify_provision_binding(
+        &self,
+        authorization_event_json: &str,
+        independent_approval_event_json: Option<&str>,
+        expected_url: &str,
+        request_body: &[u8],
+        replay_guard: &dyn OperatorProofSetReplayGuard,
+        authorization_domain: CommunityId,
+    ) -> Result<VerifiedProvisionBindingIntent, OperatorLifecycleGrantError> {
+        if authorization_domain.as_uuid().is_nil() {
+            return Err(OperatorLifecycleGrantError::InvalidRequest);
+        }
+        validate_provision_url(expected_url)?;
+        let signed = parse_provision_coordinates(request_body, authorization_domain)?;
+        let body_digest: [u8; 32] = Sha256::digest(request_body).into();
+        let intent_digest = framed_digest(
+            b"buzz:operator-provision-binding-intent:v2",
+            &[
+                authorization_domain.as_uuid().as_bytes(),
+                signed.operation_id.as_bytes(),
+                &signed.policy_revision.to_be_bytes(),
+                &signed.policy_digest,
+                signed.principal.storage_key().issuer().as_bytes(),
+                signed.principal.storage_key().subject().as_bytes(),
+                &signed.selected_event_author_pubkey,
+                &body_digest,
+            ],
+        );
+        let replay_scope = format!(
+            "operator-provision:{}:{}",
+            authorization_domain.as_uuid(),
+            signed.operation_id
+        );
+        let proof = self
+            .verify_operator_proofs(
+                authorization_event_json,
+                independent_approval_event_json,
+                expected_url,
+                request_body,
+                None,
+            )
+            .await?;
+        let request_attribution = framed_digest(
+            b"buzz:verified-operator-provision-intent:v2",
+            &[
+                &intent_digest,
+                &self.approval_policy_digest,
+                &proof.signer_attribution,
+                &proof.approval_attribution.unwrap_or([0; 32]),
+            ],
+        );
+        let mut replay_event_ids = Vec::with_capacity(2);
+        replay_event_ids.push(proof.signer_event_id);
+        replay_event_ids.extend(proof.approval_event_id);
+        let quota_scope = format!(
+            "operator-quota:{}:provision",
+            authorization_domain.as_uuid()
+        );
+        claim_server_quota(replay_guard, &quota_scope, &proof.signer_attribution).await?;
+        claim_replay_set(replay_guard, &replay_scope, &replay_event_ids).await?;
+        Ok(VerifiedProvisionBindingIntent {
+            authorization_domain,
+            operation_id: signed.operation_id,
+            policy_revision: signed.policy_revision,
+            policy_digest: signed.policy_digest,
+            principal: signed.principal,
+            selected_event_author_pubkey: signed.selected_event_author_pubkey,
+            intent_digest,
+            approval_policy_digest: self.approval_policy_digest,
+            signer_attribution: proof.signer_attribution,
+            approval_attribution: proof.approval_attribution,
+            request_attribution,
+            issued_at: proof.issued_at,
+            expires_at: proof.expires_at,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn verify_operator_proofs(
+        &self,
+        authorization_event_json: &str,
+        independent_approval_event_json: Option<&str>,
+        expected_url: &str,
+        request_body: &[u8],
+        intent_digest: Option<[u8; 32]>,
+    ) -> Result<VerifiedOperatorPair, OperatorLifecycleGrantError> {
+        if expected_url.is_empty() || request_body.is_empty() {
+            return Err(OperatorLifecycleGrantError::InvalidRequest);
+        }
+        let signer_event = strict_nip98_event(
+            authorization_event_json,
+            expected_url,
+            request_body,
+            intent_digest,
+        )?;
+        if !self.configured_operators.contains(&signer_event.pubkey) {
+            return Err(OperatorLifecycleGrantError::Unauthenticated);
+        }
+        let approval_event = match (self.approval_policy, independent_approval_event_json) {
+            (OperatorApprovalPolicy::ConfiguredSigner, None) => None,
+            (OperatorApprovalPolicy::ConfiguredSigner, Some(_))
+            | (OperatorApprovalPolicy::IndependentConfiguredApprover, None) => {
+                return Err(OperatorLifecycleGrantError::InvalidRequest)
+            }
+            (OperatorApprovalPolicy::IndependentConfiguredApprover, Some(value)) => {
+                let event = strict_nip98_event(value, expected_url, request_body, intent_digest)?;
+                if event.pubkey == signer_event.pubkey {
+                    return Err(OperatorLifecycleGrantError::ApprovalNotIndependent);
+                }
+                if !self.configured_operators.contains(&event.pubkey) {
+                    return Err(OperatorLifecycleGrantError::Unauthenticated);
+                }
+                Some(event)
+            }
+        };
+        let signer_seconds = signer_event.created_at.as_secs();
+        let approval_seconds = approval_event
+            .as_ref()
+            .map(|event| event.created_at.as_secs())
+            .unwrap_or(signer_seconds);
+        let issued_seconds = signer_seconds.max(approval_seconds);
+        let expires_seconds = signer_seconds
+            .saturating_add(NIP98_EXCLUSIVE_LIFETIME_SECONDS)
+            .min(approval_seconds.saturating_add(NIP98_EXCLUSIVE_LIFETIME_SECONDS));
+        let issued_at = DateTime::<Utc>::from_timestamp(
+            i64::try_from(issued_seconds)
+                .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?,
+            0,
+        )
+        .ok_or(OperatorLifecycleGrantError::InvalidCredential)?;
+        let expires_at = DateTime::<Utc>::from_timestamp(
+            i64::try_from(expires_seconds)
+                .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?,
+            0,
+        )
+        .ok_or(OperatorLifecycleGrantError::InvalidCredential)?;
+        let verification_now = Utc::now();
+        if issued_at > verification_now || verification_now >= expires_at {
+            return Err(OperatorLifecycleGrantError::InvalidCredential);
+        }
+        Ok(VerifiedOperatorPair {
+            signer_event_id: signer_event.id,
+            approval_event_id: approval_event.as_ref().map(|event| event.id),
+            signer_attribution: operator_attribution(signer_event.pubkey),
+            approval_attribution: approval_event
+                .as_ref()
+                .map(|event| operator_attribution(event.pubkey)),
+            issued_at,
+            expires_at,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn verify_replacement_proof(
+        &self,
+        action: OperatorLifecycleAction,
+        replacement_proof_event_json: Option<&str>,
+        replacement: Option<SignedReplacementCoordinates>,
+        expected_url: &str,
+        request_body: &[u8],
+        authorization_domain: CommunityId,
+        operation_id: Uuid,
+        intent_digest: [u8; 32],
+    ) -> Result<Option<VerifiedReplacementPair>, OperatorLifecycleGrantError> {
+        let required = matches!(
+            action,
+            OperatorLifecycleAction::Rotate
+                | OperatorLifecycleAction::Recover
+                | OperatorLifecycleAction::Enable
+        );
+        let (event_json, replacement) = match (replacement_proof_event_json, replacement) {
+            (Some(event_json), Some(replacement)) if required => (event_json, replacement),
+            (None, None) if !required => return Ok(None),
+            _ => return Err(OperatorLifecycleGrantError::InvalidRequest),
+        };
+        let event =
+            strict_nip98_event(event_json, expected_url, request_body, Some(intent_digest))?;
+        if event.pubkey.to_bytes() != replacement.event_author_pubkey {
+            return Err(OperatorLifecycleGrantError::InvalidCredential);
+        }
+        let expires_seconds = event
+            .created_at
+            .as_secs()
+            .saturating_add(NIP98_EXCLUSIVE_LIFETIME_SECONDS);
+        let expires_at = DateTime::<Utc>::from_timestamp(
+            i64::try_from(expires_seconds)
+                .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?,
+            0,
+        )
+        .ok_or(OperatorLifecycleGrantError::InvalidCredential)?;
+        let issued_at = DateTime::<Utc>::from_timestamp(
+            i64::try_from(event.created_at.as_secs())
+                .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?,
+            0,
+        )
+        .ok_or(OperatorLifecycleGrantError::InvalidCredential)?;
+        let verification_now = Utc::now();
+        if issued_at > verification_now || verification_now >= expires_at {
+            return Err(OperatorLifecycleGrantError::InvalidCredential);
+        }
+        Ok(Some(VerifiedReplacementPair {
+            event_id: event.id,
+            event_author_pubkey: replacement.event_author_pubkey,
+            requested_expires_at: replacement.requested_expires_at,
+            proof_attribution: framed_digest(
+                b"buzz:operator-replacement-proof-attribution:v2",
+                &[
+                    authorization_domain.as_uuid().as_bytes(),
+                    operation_id.as_bytes(),
+                    &(action as i16).to_be_bytes(),
+                    &intent_digest,
+                    &replacement.event_author_pubkey,
+                    &replacement.requested_expires_at.timestamp().to_be_bytes(),
+                ],
+            ),
+            issued_at,
+            credential_expires_at: expires_at,
+        }))
+    }
+}
+
+impl fmt::Debug for OperatorLifecycleVerifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OperatorLifecycleVerifier([REDACTED])")
+    }
+}
+
+struct VerifiedOperatorPair {
+    signer_event_id: EventId,
+    approval_event_id: Option<EventId>,
+    signer_attribution: [u8; 32],
+    approval_attribution: Option<[u8; 32]>,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+struct VerifiedReplacementPair {
+    event_id: EventId,
+    event_author_pubkey: [u8; 32],
+    requested_expires_at: DateTime<Utc>,
+    proof_attribution: [u8; 32],
+    issued_at: DateTime<Utc>,
+    credential_expires_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy)]
+struct SignedReplacementCoordinates {
+    event_author_pubkey: [u8; 32],
+    requested_expires_at: DateTime<Utc>,
+}
+
+struct SignedLifecycleCoordinates {
+    operation_id: Uuid,
+    expected_revision: u64,
+    replacement: Option<SignedReplacementCoordinates>,
+}
+
+struct SignedProvisionCoordinates {
+    operation_id: Uuid,
+    policy_revision: u64,
+    policy_digest: [u8; 32],
+    principal: FederatedPrincipal,
+    selected_event_author_pubkey: [u8; 32],
+}
+
+#[derive(Deserialize)]
+struct LifecycleOperationWireCoordinates {
+    operation_id: Uuid,
+}
+
+#[derive(Deserialize)]
+struct LifecycleWireCoordinates {
+    operation: LifecycleOperationWireCoordinates,
+    expected_revision: u64,
+    #[serde(default)]
+    replacement: Option<ReplacementWireCoordinates>,
+}
+
+#[derive(Deserialize)]
+struct ReplacementWireCoordinates {
+    event_author_pubkey: String,
+    expires_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+struct ProvisionWireCoordinates {
+    authorization_domain: Uuid,
+    operation_id: Uuid,
+    policy_revision: u64,
+    policy_digest: String,
+    issuer: String,
+    subject: String,
+    selected_event_author_pubkey: String,
+}
+
+fn parse_lifecycle_coordinates(
+    request_body: &[u8],
+    action: OperatorLifecycleAction,
+) -> Result<SignedLifecycleCoordinates, OperatorLifecycleGrantError> {
+    let wire: LifecycleWireCoordinates = serde_json::from_slice(request_body)
+        .map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    if wire.operation.operation_id.is_nil() || wire.expected_revision == 0 {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    let requires_replacement = matches!(
+        action,
+        OperatorLifecycleAction::Rotate
+            | OperatorLifecycleAction::Recover
+            | OperatorLifecycleAction::Enable
+    );
+    let replacement = match wire.replacement {
+        Some(replacement) if requires_replacement => {
+            if replacement.expires_at <= Utc::now() {
+                return Err(OperatorLifecycleGrantError::InvalidRequest);
+            }
+            Some(SignedReplacementCoordinates {
+                event_author_pubkey: parse_hex_32(&replacement.event_author_pubkey)?,
+                requested_expires_at: replacement.expires_at,
+            })
+        }
+        None if !requires_replacement => None,
+        _ => return Err(OperatorLifecycleGrantError::InvalidRequest),
+    };
+    Ok(SignedLifecycleCoordinates {
+        operation_id: wire.operation.operation_id,
+        expected_revision: wire.expected_revision,
+        replacement,
+    })
+}
+
+fn parse_provision_coordinates(
+    request_body: &[u8],
+    authorization_domain: CommunityId,
+) -> Result<SignedProvisionCoordinates, OperatorLifecycleGrantError> {
+    let wire: ProvisionWireCoordinates = serde_json::from_slice(request_body)
+        .map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    if wire.authorization_domain != *authorization_domain.as_uuid()
+        || wire.operation_id.is_nil()
+        || wire.policy_revision == 0
+    {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    let principal = FederatedPrincipal::from_verified_parts(wire.issuer, wire.subject)
+        .ok_or(OperatorLifecycleGrantError::InvalidRequest)?;
+    Ok(SignedProvisionCoordinates {
+        operation_id: wire.operation_id,
+        policy_revision: wire.policy_revision,
+        policy_digest: parse_hex_32(&wire.policy_digest)?,
+        principal,
+        selected_event_author_pubkey: parse_hex_32(&wire.selected_event_author_pubkey)?,
+    })
+}
+
+fn validate_lifecycle_url(
+    expected_url: &str,
+    authorization_domain: CommunityId,
+    action: OperatorLifecycleAction,
+) -> Result<(), OperatorLifecycleGrantError> {
+    let url =
+        url::Url::parse(expected_url).map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    let expected_path = format!(
+        "/operator/communities/{}/identity-lifecycle/{}",
+        authorization_domain.as_uuid(),
+        action.as_path_segment()
+    );
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.path() != expected_path
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    let canonical = format!("{}{}", url.origin().ascii_serialization(), expected_path);
+    if expected_url != canonical {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn validate_provision_url(expected_url: &str) -> Result<(), OperatorLifecycleGrantError> {
+    const CANONICAL_PATH: &str = "/operator/identity-bindings/provision";
+
+    let url =
+        url::Url::parse(expected_url).map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || url.path() != CANONICAL_PATH
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    let canonical = format!("{}{}", url.origin().ascii_serialization(), CANONICAL_PATH);
+    if expected_url != canonical {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn parse_hex_32(value: &str) -> Result<[u8; 32], OperatorLifecycleGrantError> {
+    let decoded = hex::decode(value).map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    let exact: [u8; 32] = decoded
+        .try_into()
+        .map_err(|_| OperatorLifecycleGrantError::InvalidRequest)?;
+    if exact == [0; 32] {
+        return Err(OperatorLifecycleGrantError::InvalidRequest);
+    }
+    Ok(exact)
+}
+
+fn operator_policy_digest(policy: OperatorApprovalPolicy, keys: &[PublicKey]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    let domain = b"buzz:operator-approval-policy:v1";
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    digest.update(1_u64.to_be_bytes());
+    digest.update([policy as u8]);
+    for key in keys {
+        digest.update(32_u64.to_be_bytes());
+        digest.update(key.to_bytes());
+    }
+    digest.finalize().into()
+}
+
+fn strict_nip98_event(
+    event_json: &str,
+    expected_url: &str,
+    request_body: &[u8],
+    intent_digest: Option<[u8; 32]>,
+) -> Result<Event, OperatorLifecycleGrantError> {
+    let event: Event = serde_json::from_str(event_json)
+        .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?;
+    let event_time = DateTime::<Utc>::from_timestamp(
+        i64::try_from(event.created_at.as_secs())
+            .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?,
+        0,
+    )
+    .ok_or(OperatorLifecycleGrantError::InvalidCredential)?;
+    if event_time > Utc::now() {
+        return Err(OperatorLifecycleGrantError::InvalidCredential);
+    }
+    if event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind() == TagKind::Payload)
+        .count()
+        != 1
+    {
+        return Err(OperatorLifecycleGrantError::InvalidCredential);
+    }
+    if let Some(intent_digest) = intent_digest {
+        let expected_intent = hex::encode(intent_digest);
+        let mut intent_tags = event.tags.iter().filter(|tag| {
+            tag.as_slice()
+                .first()
+                .is_some_and(|kind| kind == "buzz-intent")
+        });
+        let exact_intent = intent_tags
+            .next()
+            .and_then(|tag| tag.as_slice().get(1))
+            .is_some_and(|value| value == &expected_intent)
+            && intent_tags.next().is_none();
+        if !exact_intent {
+            return Err(OperatorLifecycleGrantError::InvalidCredential);
+        }
+    }
+    verify_nip98_event(event_json, expected_url, "POST", Some(request_body))
+        .map_err(|_| OperatorLifecycleGrantError::InvalidCredential)?;
+    Ok(event)
+}
+
+async fn claim_replay_set(
+    replay_guard: &dyn OperatorProofSetReplayGuard,
+    scope: &str,
+    event_ids: &[EventId],
+) -> Result<(), OperatorLifecycleGrantError> {
+    let valid_cardinality = (1..=3).contains(&event_ids.len());
+    let distinct = event_ids
+        .iter()
+        .enumerate()
+        .all(|(index, event_id)| !event_ids[..index].contains(event_id));
+    if !valid_cardinality || !distinct {
+        return Err(OperatorLifecycleGrantError::InvalidCredential);
+    }
+    match replay_guard
+        .try_mark_all_in_scope(scope, event_ids, DEFAULT_REPLAY_TTL_SECS)
+        .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OperatorLifecycleGrantError::Replayed),
+        Err(AuthError::Nip98Replay) => Err(OperatorLifecycleGrantError::Replayed),
+        Err(_) => Err(OperatorLifecycleGrantError::ReplayUnavailable),
+    }
+}
+
+async fn claim_server_quota(
+    guard: &dyn OperatorProofSetReplayGuard,
+    quota_scope: &str,
+    signer_attribution: &[u8; 32],
+) -> Result<(), OperatorLifecycleGrantError> {
+    match guard.try_admit_quota(quota_scope, signer_attribution).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(OperatorLifecycleGrantError::QuotaExceeded),
+        Err(_) => Err(OperatorLifecycleGrantError::QuotaUnavailable),
+    }
+}
+
+fn operator_attribution(public_key: PublicKey) -> [u8; 32] {
+    framed_digest(
+        b"buzz:configured-operator-attribution:v1",
+        &[&public_key.to_bytes()],
+    )
+}
+
+fn framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        future::Future,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Mutex,
+        },
+    };
+
+    use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct ReplaySet(Mutex<HashSet<(String, [u8; 32])>>);
+
+    impl OperatorProofSetReplayGuard for ReplaySet {
+        fn try_admit_quota<'a>(
+            &'a self,
+            _quota_scope: &'a str,
+            _signer_attribution: &'a [u8; 32],
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async { Ok(true) })
+        }
+
+        fn try_mark_all_in_scope<'a>(
+            &'a self,
+            scope: &'a str,
+            event_ids: &'a [nostr::EventId],
+            _ttl_secs: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async move {
+                let valid_cardinality = (1..=3).contains(&event_ids.len());
+                let distinct = event_ids
+                    .iter()
+                    .enumerate()
+                    .all(|(index, event_id)| !event_ids[..index].contains(event_id));
+                if !valid_cardinality || !distinct {
+                    return Err(AuthError::Internal(
+                        "invalid test proof-set replay claim".to_owned(),
+                    ));
+                }
+                let mut seen = self.0.lock().expect("replay lock");
+                if event_ids
+                    .iter()
+                    .any(|event_id| seen.contains(&(scope.to_owned(), event_id.to_bytes())))
+                {
+                    return Ok(false);
+                }
+                for event_id in event_ids {
+                    seen.insert((scope.to_owned(), event_id.to_bytes()));
+                }
+                Ok(true)
+            })
+        }
+    }
+
+    impl ReplaySet {
+        fn len(&self) -> usize {
+            self.0.lock().expect("replay lock").len()
+        }
+    }
+
+    struct QuotaFence {
+        quota_allowed: bool,
+        quota_unavailable: bool,
+        quota_scopes: Mutex<Vec<String>>,
+        replay_calls: AtomicUsize,
+    }
+
+    impl QuotaFence {
+        fn rejecting() -> Self {
+            Self {
+                quota_allowed: false,
+                quota_unavailable: false,
+                quota_scopes: Mutex::new(Vec::new()),
+                replay_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn unavailable() -> Self {
+            Self {
+                quota_allowed: false,
+                quota_unavailable: true,
+                quota_scopes: Mutex::new(Vec::new()),
+                replay_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl OperatorProofSetReplayGuard for QuotaFence {
+        fn try_admit_quota<'a>(
+            &'a self,
+            quota_scope: &'a str,
+            _signer_attribution: &'a [u8; 32],
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.quota_scopes
+                    .lock()
+                    .expect("quota scope lock")
+                    .push(quota_scope.to_owned());
+                if self.quota_unavailable {
+                    Err(AuthError::Internal("test quota unavailable".to_owned()))
+                } else {
+                    Ok(self.quota_allowed)
+                }
+            })
+        }
+
+        fn try_mark_all_in_scope<'a>(
+            &'a self,
+            _scope: &'a str,
+            _event_ids: &'a [EventId],
+            _ttl_secs: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.replay_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            })
+        }
+    }
+
+    fn signed(keys: &Keys, url: &str, body: &[u8], intent_digest: [u8; 32]) -> String {
+        signed_at(keys, url, body, intent_digest, Timestamp::now())
+    }
+
+    fn signed_at(
+        keys: &Keys,
+        url: &str,
+        body: &[u8],
+        intent_digest: [u8; 32],
+        created_at: Timestamp,
+    ) -> String {
+        let payload = hex::encode(<[u8; 32]>::from(Sha256::digest(body)));
+        signed_at_with_payloads(keys, url, body, intent_digest, created_at, &[payload])
+    }
+
+    fn signed_at_with_payloads(
+        keys: &Keys,
+        url: &str,
+        _body: &[u8],
+        intent_digest: [u8; 32],
+        created_at: Timestamp,
+        payloads: &[String],
+    ) -> String {
+        let intent = hex::encode(intent_digest);
+        let mut tags = vec![
+            Tag::parse(["u", url]).expect("url tag"),
+            Tag::parse(["method", "POST"]).expect("method tag"),
+        ];
+        tags.extend(
+            payloads
+                .iter()
+                .map(|payload| Tag::parse(["payload", payload.as_str()]).expect("payload tag")),
+        );
+        tags.push(Tag::parse(["buzz-intent", intent.as_str()]).expect("intent tag"));
+        let event = EventBuilder::new(Kind::HttpAuth, "")
+            .tags(tags)
+            .custom_created_at(created_at)
+            .sign_with_keys(keys)
+            .expect("sign NIP-98 proof");
+        serde_json::to_string(&event).expect("serialize NIP-98 proof")
+    }
+
+    fn lifecycle_body(
+        operation_id: Uuid,
+        intent_digest: [u8; 32],
+        replacement: Option<(&Keys, DateTime<Utc>)>,
+    ) -> Vec<u8> {
+        let mut value = serde_json::json!({
+            "operation": {
+                "operation_id": operation_id,
+                "correlation_id": Uuid::new_v4(),
+                "attempt_id": Uuid::new_v4()
+            },
+            "expected_revision": 1,
+            "intent_digest_for_test": hex::encode(intent_digest),
+            "target": "redacted"
+        });
+        if let Some((keys, expires_at)) = replacement {
+            value["replacement"] = serde_json::json!({
+                "event_author_pubkey": hex::encode(keys.public_key().to_bytes()),
+                "expires_at": expires_at
+            });
+        }
+        serde_json::to_vec(&value).expect("serialize lifecycle body")
+    }
+
+    #[tokio::test]
+    async fn stock_lifecycle_policy_requires_one_configured_exact_proof() {
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [7; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signed(&signer, &url, &body, [6; 32]),
+                    None,
+                    None,
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Retire,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    None,
+                    None,
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidCredential)
+        ));
+        let grant = verifier
+            .verify_lifecycle(
+                &signed(&signer, &url, &body, intent_digest),
+                None,
+                None,
+                &url,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent_digest,
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("verify grant");
+        assert_eq!(grant.authorization_domain(), domain);
+        assert_eq!(grant.operation_id(), operation_id);
+        assert_eq!(grant.action(), OperatorLifecycleAction::Retire);
+        assert_eq!(grant.approval_attribution(), None);
+        assert_ne!(grant.request_attribution(), [0; 32]);
+        assert_eq!(
+            format!("{grant:?}"),
+            "VerifiedOperatorLifecycleGrant([REDACTED])"
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_rejects_future_created_at_before_state_claims() {
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let guard = QuotaFence::rejecting();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [72; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+        let future_created_at = Timestamp::from(
+            Timestamp::now()
+                .as_secs()
+                .saturating_add(NIP98_EXCLUSIVE_LIFETIME_SECONDS),
+        );
+
+        let rejection = verifier
+            .verify_lifecycle(
+                &signed_at(&signer, &url, &body, intent_digest, future_created_at),
+                None,
+                None,
+                &url,
+                &body,
+                &guard,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent_digest,
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect_err("future-created proof must fail closed");
+
+        assert_eq!(
+            rejection,
+            OperatorLifecycleGrantError::InvalidCredential,
+            "future-created proof must retain the stable invalid-credential rejection"
+        );
+        assert!(
+            guard
+                .quota_scopes
+                .lock()
+                .expect("quota scope lock")
+                .is_empty(),
+            "future-created proof must not claim quota state"
+        );
+        assert_eq!(
+            guard.replay_calls.load(Ordering::SeqCst),
+            0,
+            "future-created proof must not claim replay state"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlist_and_server_owned_quota_precede_replay_io() {
+        let signer = Keys::generate();
+        let outsider = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [71; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+
+        let outsider_guard = QuotaFence::rejecting();
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signed(&outsider, &url, &body, intent_digest),
+                    None,
+                    None,
+                    &url,
+                    &body,
+                    &outsider_guard,
+                    domain,
+                    OperatorLifecycleAction::Retire,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    None,
+                    None,
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::Unauthenticated)
+        ));
+        assert!(
+            outsider_guard
+                .quota_scopes
+                .lock()
+                .expect("quota scope lock")
+                .is_empty(),
+            "unconfigured signers must not consume a server quota"
+        );
+        assert_eq!(outsider_guard.replay_calls.load(Ordering::SeqCst), 0);
+
+        let quota_scope = format!("operator-quota:{}:retire", domain.as_uuid());
+        for (guard, expected) in [
+            (
+                QuotaFence::rejecting(),
+                OperatorLifecycleGrantError::QuotaExceeded,
+            ),
+            (
+                QuotaFence::unavailable(),
+                OperatorLifecycleGrantError::QuotaUnavailable,
+            ),
+        ] {
+            assert_eq!(
+                verifier
+                    .verify_lifecycle(
+                        &signed(&signer, &url, &body, intent_digest),
+                        None,
+                        None,
+                        &url,
+                        &body,
+                        &guard,
+                        domain,
+                        OperatorLifecycleAction::Retire,
+                        operation_id,
+                        intent_digest,
+                        1,
+                        None,
+                        None,
+                    )
+                    .await
+                    .expect_err("quota denial must fail closed"),
+                expected
+            );
+            assert_eq!(
+                guard
+                    .quota_scopes
+                    .lock()
+                    .expect("quota scope lock")
+                    .as_slice(),
+                [quota_scope.as_str()]
+            );
+            assert_eq!(
+                guard.replay_calls.load(Ordering::SeqCst),
+                0,
+                "quota denial must not consume replay identities"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_grant_rejects_self_approval_and_exact_replay() {
+        let signer = Keys::generate();
+        let approver = Keys::generate();
+        let verifier = OperatorLifecycleVerifier::requiring_independent_approval(vec![
+            signer.public_key(),
+            approver.public_key(),
+        ])
+        .expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [8; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/disable",
+            domain.as_uuid()
+        );
+        let signer_proof = signed(&signer, &url, &body, intent_digest);
+        let approver_proof = signed(&approver, &url, &body, intent_digest);
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signer_proof,
+                    Some(&signer_proof),
+                    None,
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Disable,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    None,
+                    None,
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::ApprovalNotIndependent)
+        ));
+        verifier
+            .verify_lifecycle(
+                &signer_proof,
+                Some(&approver_proof),
+                None,
+                &url,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Disable,
+                operation_id,
+                intent_digest,
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("first exact grant");
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signer_proof,
+                    Some(&approver_proof),
+                    None,
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Disable,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    None,
+                    None,
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::Replayed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn replacement_actions_require_exact_replacement_key_proof() {
+        let signer = Keys::generate();
+        let replacement = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [9; 32];
+        let replacement_expires_at = Utc::now() + chrono::Duration::seconds(30);
+        let body = lifecycle_body(
+            operation_id,
+            intent_digest,
+            Some((&replacement, replacement_expires_at)),
+        );
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/rotate",
+            domain.as_uuid()
+        );
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signed(&signer, &url, &body, intent_digest),
+                    None,
+                    None,
+                    &url,
+                    &body,
+                    &ReplaySet::default(),
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(replacement_expires_at + chrono::Duration::seconds(1)),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidRequest)
+        ));
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signed(&signer, &url, &body, intent_digest),
+                    None,
+                    None,
+                    &url,
+                    &body,
+                    &ReplaySet::default(),
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(replacement_expires_at),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidRequest)
+        ));
+        let grant = verifier
+            .verify_lifecycle(
+                &signed(&signer, &url, &body, intent_digest),
+                None,
+                Some(&signed(&replacement, &url, &body, intent_digest)),
+                &url,
+                &body,
+                &ReplaySet::default(),
+                domain,
+                OperatorLifecycleAction::Rotate,
+                operation_id,
+                intent_digest,
+                1,
+                Some(replacement.public_key().to_bytes()),
+                Some(replacement_expires_at),
+            )
+            .await
+            .expect("verify replacement-bound grant");
+        assert_eq!(
+            grant.replacement_event_author_pubkey(),
+            Some(replacement.public_key().to_bytes())
+        );
+        assert!(grant.replacement_proof_attribution().is_some());
+        assert_eq!(grant.replacement_expires_at(), Some(replacement_expires_at));
+    }
+
+    #[tokio::test]
+    async fn invalid_complete_proof_sets_burn_no_replay_markers() {
+        let signer = Keys::generate();
+        let approver = Keys::generate();
+        let outsider = Keys::generate();
+        let replacement = Keys::generate();
+        let verifier = OperatorLifecycleVerifier::requiring_independent_approval(vec![
+            signer.public_key(),
+            approver.public_key(),
+        ])
+        .expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [31; 32];
+        let requested_expiry = Utc::now() + chrono::Duration::seconds(30);
+        let body = lifecycle_body(
+            operation_id,
+            intent_digest,
+            Some((&replacement, requested_expiry)),
+        );
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/rotate",
+            domain.as_uuid()
+        );
+        let signer_proof = signed(&signer, &url, &body, intent_digest);
+        let approver_proof = signed(&approver, &url, &body, intent_digest);
+
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signer_proof,
+                    Some(&signed(&outsider, &url, &body, intent_digest)),
+                    Some(&signed(&replacement, &url, &body, intent_digest)),
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(requested_expiry),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::Unauthenticated)
+        ));
+        assert_eq!(replay.len(), 0, "bad approval must burn no marker");
+
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signer_proof,
+                    Some(&approver_proof),
+                    Some(&signed(&outsider, &url, &body, intent_digest)),
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(requested_expiry),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidCredential)
+        ));
+        assert_eq!(replay.len(), 0, "bad replacement must burn no marker");
+
+        let expired_replacement = signed_at(
+            &replacement,
+            &url,
+            &body,
+            intent_digest,
+            Timestamp::from(
+                u64::try_from(Utc::now().timestamp() - 120).expect("positive expired timestamp"),
+            ),
+        );
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signer_proof,
+                    Some(&approver_proof),
+                    Some(&expired_replacement),
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(requested_expiry),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidCredential)
+        ));
+        assert_eq!(replay.len(), 0, "expired proof must burn no marker");
+
+        verifier
+            .verify_lifecycle(
+                &signer_proof,
+                Some(&approver_proof),
+                Some(&signed(&replacement, &url, &body, intent_digest)),
+                &url,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Rotate,
+                operation_id,
+                intent_digest,
+                1,
+                Some(replacement.public_key().to_bytes()),
+                Some(requested_expiry),
+            )
+            .await
+            .expect("valid complete set remains claimable");
+        assert_eq!(replay.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn complete_proof_set_has_one_concurrent_winner() {
+        let signer = Keys::generate();
+        let approver = Keys::generate();
+        let replacement = Keys::generate();
+        let verifier = OperatorLifecycleVerifier::requiring_independent_approval(vec![
+            signer.public_key(),
+            approver.public_key(),
+        ])
+        .expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [32; 32];
+        let requested_expiry = Utc::now() + chrono::Duration::seconds(30);
+        let body = lifecycle_body(
+            operation_id,
+            intent_digest,
+            Some((&replacement, requested_expiry)),
+        );
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/rotate",
+            domain.as_uuid()
+        );
+        let signer_proof = signed(&signer, &url, &body, intent_digest);
+        let approver_proof = signed(&approver, &url, &body, intent_digest);
+        let replacement_proof = signed(&replacement, &url, &body, intent_digest);
+        let verify = || {
+            verifier.verify_lifecycle(
+                &signer_proof,
+                Some(&approver_proof),
+                Some(&replacement_proof),
+                &url,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Rotate,
+                operation_id,
+                intent_digest,
+                1,
+                Some(replacement.public_key().to_bytes()),
+                Some(requested_expiry),
+            )
+        };
+        let (first, second) = tokio::join!(verify(), verify());
+        assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+        assert!(matches!(
+            first.as_ref().err().or_else(|| second.as_ref().err()),
+            Some(OperatorLifecycleGrantError::Replayed)
+        ));
+        assert_eq!(replay.len(), 3, "one winner claims the complete set");
+    }
+
+    #[tokio::test]
+    async fn lifecycle_url_is_byte_canonical_before_replay_io() {
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [33; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let path = format!(
+            "/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+        let aliases = [
+            format!("http://operator.example{path}"),
+            format!("https://operator.example/ignored/..{path}"),
+            format!(
+                "https://operator.example/operator/communities/{}/identity-lifecycle/%72etire",
+                domain.as_uuid()
+            ),
+            format!("https://OPERATOR.example{path}"),
+            format!("https://operator.example:443{path}"),
+            format!("https://user@operator.example{path}"),
+            format!("https://operator.example{path}?alias=true"),
+            format!("https://operator.example{path}#alias"),
+        ];
+        for alias in aliases {
+            assert!(matches!(
+                verifier
+                    .verify_lifecycle(
+                        &signed(&signer, &alias, &body, intent_digest),
+                        None,
+                        None,
+                        &alias,
+                        &body,
+                        &replay,
+                        domain,
+                        OperatorLifecycleAction::Retire,
+                        operation_id,
+                        intent_digest,
+                        1,
+                        None,
+                        None,
+                    )
+                    .await,
+                Err(OperatorLifecycleGrantError::InvalidRequest)
+            ));
+        }
+        assert_eq!(replay.len(), 0);
+        let canonical = format!("https://operator.example{path}");
+        verifier
+            .verify_lifecycle(
+                &signed(&signer, &canonical, &body, intent_digest),
+                None,
+                None,
+                &canonical,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent_digest,
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("exact canonical URL");
+        assert_eq!(replay.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_requires_exactly_one_payload_tag_before_replay_io() {
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [34; 32];
+        let body = lifecycle_body(operation_id, intent_digest, None);
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+        let expected = hex::encode(<[u8; 32]>::from(Sha256::digest(&body)));
+        let conflicting = hex::encode([77_u8; 32]);
+        for payloads in [
+            Vec::<String>::new(),
+            vec![expected.clone(), expected.clone()],
+            vec![expected.clone(), conflicting.clone()],
+            vec![conflicting.clone(), expected.clone()],
+        ] {
+            let proof = signed_at_with_payloads(
+                &signer,
+                &url,
+                &body,
+                intent_digest,
+                Timestamp::now(),
+                &payloads,
+            );
+            assert!(matches!(
+                verifier
+                    .verify_lifecycle(
+                        &proof,
+                        None,
+                        None,
+                        &url,
+                        &body,
+                        &replay,
+                        domain,
+                        OperatorLifecycleAction::Retire,
+                        operation_id,
+                        intent_digest,
+                        1,
+                        None,
+                        None,
+                    )
+                    .await,
+                Err(OperatorLifecycleGrantError::InvalidCredential)
+            ));
+        }
+        assert_eq!(replay.len(), 0);
+        verifier
+            .verify_lifecycle(
+                &signed(&signer, &url, &body, intent_digest),
+                None,
+                None,
+                &url,
+                &body,
+                &replay,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent_digest,
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("one exact payload tag");
+        assert_eq!(replay.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn replacement_grant_expiry_is_the_exact_exclusive_minimum() {
+        let now_seconds = Utc::now().timestamp();
+        let now = DateTime::<Utc>::from_timestamp(now_seconds, 0).expect("current timestamp");
+        let cases = [
+            (0_i64, 0_i64, 0_i64, 10_i64, 10_i64),
+            (-20, -10, -5, 55, 40),
+            (-10, -20, -5, 55, 40),
+            (-10, -5, -20, 55, 40),
+        ];
+        for (
+            signer_offset,
+            approver_offset,
+            replacement_offset,
+            requested_offset,
+            expected_offset,
+        ) in cases
+        {
+            let signer = Keys::generate();
+            let approver = Keys::generate();
+            let replacement = Keys::generate();
+            let verifier = OperatorLifecycleVerifier::requiring_independent_approval(vec![
+                signer.public_key(),
+                approver.public_key(),
+            ])
+            .expect("configure verifier");
+            let domain = CommunityId::from_uuid(Uuid::new_v4());
+            let operation_id = Uuid::new_v4();
+            let intent_digest = [35; 32];
+            let requested_expiry = now + chrono::Duration::seconds(requested_offset);
+            let body = lifecycle_body(
+                operation_id,
+                intent_digest,
+                Some((&replacement, requested_expiry)),
+            );
+            let url = format!(
+                "https://operator.example/operator/communities/{}/identity-lifecycle/rotate",
+                domain.as_uuid()
+            );
+            let proof_at = |keys: &Keys, offset: i64| {
+                signed_at(
+                    keys,
+                    &url,
+                    &body,
+                    intent_digest,
+                    Timestamp::from(u64::try_from(now_seconds + offset).expect("positive time")),
+                )
+            };
+            let grant = verifier
+                .verify_lifecycle(
+                    &proof_at(&signer, signer_offset),
+                    Some(&proof_at(&approver, approver_offset)),
+                    Some(&proof_at(&replacement, replacement_offset)),
+                    &url,
+                    &body,
+                    &ReplaySet::default(),
+                    domain,
+                    OperatorLifecycleAction::Rotate,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(requested_expiry),
+                )
+                .await
+                .expect("verify bounded replacement grant");
+            assert_eq!(
+                grant.expires_at(),
+                now + chrono::Duration::seconds(expected_offset)
+            );
+            assert_eq!(grant.replacement_expires_at(), Some(requested_expiry));
+        }
+    }
+
+    #[tokio::test]
+    async fn successor_expiry_at_authoritative_bound_denies_before_replay() {
+        let signer = Keys::generate();
+        let replacement = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let replay = ReplaySet::default();
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let intent_digest = [36; 32];
+        let at_bound =
+            DateTime::<Utc>::from_timestamp(Utc::now().timestamp(), 0).expect("current timestamp");
+        let body = lifecycle_body(operation_id, intent_digest, Some((&replacement, at_bound)));
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/enable",
+            domain.as_uuid()
+        );
+        assert!(matches!(
+            verifier
+                .verify_lifecycle(
+                    &signed(&signer, &url, &body, intent_digest),
+                    None,
+                    Some(&signed(&replacement, &url, &body, intent_digest)),
+                    &url,
+                    &body,
+                    &replay,
+                    domain,
+                    OperatorLifecycleAction::Enable,
+                    operation_id,
+                    intent_digest,
+                    1,
+                    Some(replacement.public_key().to_bytes()),
+                    Some(at_bound),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidRequest)
+        ));
+        assert_eq!(replay.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn provision_intent_seals_domain_operation_policy_principal_and_key() {
+        let signer = Keys::generate();
+        let selected = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let body = serde_json::to_vec(&serde_json::json!({
+            "authorization_domain": domain.as_uuid(),
+            "operation_id": operation_id,
+            "policy_revision": 7,
+            "policy_digest": hex::encode([21_u8; 32]),
+            "issuer": "https://issuer.example",
+            "subject": "opaque-subject",
+            "selected_event_author_pubkey": hex::encode(selected.public_key().to_bytes())
+        }))
+        .expect("serialize provision body");
+        let url = "https://operator.example/operator/identity-bindings/provision";
+        assert!(matches!(
+            verifier
+                .verify_provision_binding(
+                    &signed(&signer, url, &body, [1; 32]),
+                    None,
+                    url,
+                    &body,
+                    &ReplaySet::default(),
+                    CommunityId::from_uuid(Uuid::new_v4()),
+                )
+                .await,
+            Err(OperatorLifecycleGrantError::InvalidRequest)
+        ));
+        let verified = verifier
+            .verify_provision_binding(
+                &signed(&signer, url, &body, [1; 32]),
+                None,
+                url,
+                &body,
+                &ReplaySet::default(),
+                domain,
+            )
+            .await
+            .expect("verify provision intent");
+        assert_eq!(verified.authorization_domain(), domain);
+        assert_eq!(verified.operation_id(), operation_id);
+        assert_eq!(verified.policy_revision(), 7);
+        assert_eq!(verified.policy_digest(), [21; 32]);
+        assert_eq!(
+            verified.selected_event_author_pubkey(),
+            selected.public_key().to_bytes()
+        );
+        assert_eq!(
+            verified.principal_storage_key().issuer(),
+            "https://issuer.example"
+        );
+        assert_eq!(verified.principal_storage_key().subject(), "opaque-subject");
+        assert_eq!(
+            format!("{verified:?}"),
+            "VerifiedProvisionBindingIntent([REDACTED])"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_rejects_noncanonical_route_before_replay() {
+        let signer = Keys::generate();
+        let selected = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("configure verifier");
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let body = serde_json::to_vec(&serde_json::json!({
+            "authorization_domain": domain.as_uuid(),
+            "operation_id": Uuid::new_v4(),
+            "policy_revision": 7,
+            "policy_digest": hex::encode([21_u8; 32]),
+            "issuer": "https://issuer.example",
+            "subject": "opaque-subject",
+            "selected_event_author_pubkey": hex::encode(selected.public_key().to_bytes())
+        }))
+        .expect("serialize provision body");
+        let aliases = [
+            "http://operator.example/operator/identity-bindings/provision",
+            "https://operator.example/operator/identity-bindings/provision/",
+            "https://operator.example/operator/identity-bindings/provision?alias=true",
+            "https://operator.example/operator/identity-bindings/provision#alias",
+            "https://operator.example/operator/communities/provision",
+            "https://operator.example/operator/identity-bindings/other/../provision",
+        ];
+        let replay = ReplaySet::default();
+        for alias in aliases {
+            assert!(matches!(
+                verifier
+                    .verify_provision_binding(
+                        &signed(&signer, alias, &body, [1; 32]),
+                        None,
+                        alias,
+                        &body,
+                        &replay,
+                        domain,
+                    )
+                    .await,
+                Err(OperatorLifecycleGrantError::InvalidRequest)
+            ));
+        }
+        assert_eq!(replay.len(), 0, "route rejection must precede replay I/O");
+    }
+
+    #[test]
+    fn opaque_authority_has_no_sensitive_debug_output() {
+        let first = Keys::generate().public_key();
+        let second = Keys::generate().public_key();
+        let verifier = OperatorLifecycleVerifier::new(vec![first]);
+        assert!(verifier.is_ok());
+        assert!(OperatorLifecycleVerifier::new(Vec::new()).is_err());
+        assert!(OperatorLifecycleVerifier::requiring_independent_approval(vec![first]).is_err());
+        let dual = OperatorLifecycleVerifier::requiring_independent_approval(vec![first, second])
+            .expect("independent policy");
+        assert!(dual.requires_independent_approval());
+        assert_ne!(
+            dual.approval_policy_digest(),
+            verifier.expect("stock policy").approval_policy_digest()
+        );
+        assert_eq!(OperatorLifecycleAction::Retire as i16, 3);
+        assert_eq!(OperatorLifecycleAction::Disable as i16, 4);
+        assert_eq!(OperatorLifecycleAction::Revoke as i16, 5);
+        assert_eq!(OperatorLifecycleAction::Rotate as i16, 6);
+        assert_eq!(OperatorLifecycleAction::Recover as i16, 7);
+        assert_eq!(OperatorLifecycleAction::Enable as i16, 8);
+        assert_eq!(
+            OperatorLifecycleAction::from_path_segment("admission-loss"),
+            None
+        );
+    }
+}

--- a/crates/buzz-auth/src/trusted_proxy.rs
+++ b/crates/buzz-auth/src/trusted_proxy.rs
@@ -1,0 +1,705 @@
+//! Request-bound HMAC verification for the NIP-FI trusted-proxy profile.
+//!
+//! Verification is read-only. The returned sealed evidence contains a nonce
+//! claim that the final-admission transaction must consume atomically. The
+//! read performed here rejects already committed nonces early but is not a
+//! substitute for that final compare-and-insert.
+
+use std::{
+    fmt,
+    future::Future,
+    net::{Ipv4Addr, Ipv6Addr},
+    pin::Pin,
+    str::FromStr,
+    time::Duration,
+};
+
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::evidence::{proof_transport_code, SealedTransportEvidence, TrustedProxyNonceClaim};
+use crate::ProofTransport;
+
+/// Exact NIP-FI assertion header name.
+pub const ASSERTION_HEADER_NAME: &str = "nostr-federated-identity";
+/// Exact NIP-FI trusted-proxy provenance header name.
+pub const PROVENANCE_HEADER_NAME: &str = "nostr-federated-identity-provenance";
+
+const MAC_DOMAIN: &[u8] = b"NIP-FI-PROXY-1";
+const MIN_SECRET_BYTES: usize = 32;
+const MAX_SECRET_BYTES: usize = 4096;
+const MAX_ACTIVE_SECRETS: usize = 4;
+const MAX_ASSERTION_FIELD_BYTES: usize = 64 * 1024;
+const MAX_METHOD_BYTES: usize = 32;
+const MAX_AUTHORITY_BYTES: usize = 255;
+const MAX_PATH_AND_QUERY_BYTES: usize = 16 * 1024;
+const DEFAULT_MAX_PROVENANCE_FIELD_BYTES: usize = 1024;
+const DEFAULT_MAX_NONCE_BYTES: usize = 64;
+const MAX_PROVENANCE_AGE_SECONDS: u64 = 86_400;
+const MAX_FUTURE_SKEW_SECONDS: u64 = 300;
+
+type ProvenanceMac = Hmac<Sha256>;
+
+/// One raw HTTP header from the complete request header collection.
+///
+/// Names are compared case-insensitively. Values are retained as bytes so
+/// non-ASCII and ambiguous encodings can be rejected before parsing. Debug
+/// output never includes the value.
+pub struct HttpHeaderField<'a> {
+    name: &'a str,
+    value: &'a [u8],
+}
+
+impl<'a> HttpHeaderField<'a> {
+    /// Borrow one raw header occurrence without selecting or combining it.
+    pub const fn new(name: &'a str, value: &'a [u8]) -> Self {
+        Self { name, value }
+    }
+}
+
+impl fmt::Debug for HttpHeaderField<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("HttpHeaderField([REDACTED])")
+    }
+}
+
+/// Exact request coordinates resolved by trusted server routing.
+pub struct TrustedProxyRequest {
+    authorization_domain: CommunityId,
+    method: Box<str>,
+    authority: Box<str>,
+    path_and_query: Box<str>,
+    body_digest: [u8; 32],
+    transport: ProofTransport,
+}
+
+impl TrustedProxyRequest {
+    /// Validate server-owned coordinates and hash the exact request body.
+    pub fn from_server_request(
+        authorization_domain: CommunityId,
+        transport: ProofTransport,
+        method: &str,
+        authority: &str,
+        path_and_query: &str,
+        body: &[u8],
+    ) -> Result<Self, TrustedProxyError> {
+        let body_digest = Sha256::digest(body).into();
+        Self::from_server_parts(
+            authorization_domain,
+            transport,
+            method,
+            authority,
+            path_and_query,
+            body_digest,
+        )
+    }
+
+    /// Validate server-owned coordinates with a previously computed body digest.
+    ///
+    /// The digest must be SHA-256 over the exact request body after proxy
+    /// rewriting, including the empty body used by a WebSocket upgrade.
+    pub fn from_server_parts(
+        authorization_domain: CommunityId,
+        transport: ProofTransport,
+        method: &str,
+        authority: &str,
+        path_and_query: &str,
+        body_digest: [u8; 32],
+    ) -> Result<Self, TrustedProxyError> {
+        if authorization_domain.as_uuid().is_nil()
+            || !valid_method(method)
+            || !valid_authority(authority)
+        {
+            return Err(TrustedProxyError::InvalidRequest);
+        }
+        let path_and_query = canonical_path_and_query(path_and_query)?;
+        Ok(Self {
+            authorization_domain,
+            method: method.into(),
+            authority: authority.into(),
+            path_and_query,
+            body_digest,
+            transport,
+        })
+    }
+}
+
+impl fmt::Debug for TrustedProxyRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TrustedProxyRequest([REDACTED])")
+    }
+}
+
+/// Failure returned by a read-only committed-nonce lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("trusted-proxy replay state is unavailable")]
+pub struct TrustedProxyReplayReadError;
+
+/// Read-only view of committed trusted-proxy nonce claims.
+///
+/// Returning `false` does not reserve the nonce. Final admission must still
+/// atomically insert the exact claim carried by [`SealedTransportEvidence`].
+pub trait TrustedProxyNonceReplayReader: Send + Sync {
+    /// Report whether the exact privacy-safe claim key is already committed.
+    fn is_committed<'a>(
+        &'a self,
+        authorization_domain: CommunityId,
+        claim: &'a TrustedProxyNonceClaim,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, TrustedProxyReplayReadError>> + Send + 'a>>;
+}
+
+/// Closed trusted-proxy verification failures with no credential material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum TrustedProxyError {
+    /// Secret set or time/size policy was invalid.
+    #[error("invalid trusted-proxy configuration")]
+    InvalidConfiguration,
+    /// Required assertion field was absent.
+    #[error("trusted-proxy assertion is missing")]
+    MissingAssertion,
+    /// Required provenance field was absent; direct ingress cannot fall back.
+    #[error("trusted-proxy provenance is missing")]
+    MissingProvenance,
+    /// A protected field was repeated, combined, or ambiguously encoded.
+    #[error("trusted-proxy header is ambiguous")]
+    AmbiguousHeader,
+    /// Bearer assertion framing was malformed or exceeded its bound.
+    #[error("trusted-proxy assertion is malformed")]
+    MalformedAssertion,
+    /// Provenance framing, timestamp, nonce, or MAC was malformed.
+    #[error("trusted-proxy provenance is malformed")]
+    MalformedProvenance,
+    /// Server-resolved request coordinates were not canonical.
+    #[error("trusted-proxy request binding is invalid")]
+    InvalidRequest,
+    /// Provenance was at or beyond its exclusive maximum-age bound.
+    #[error("trusted-proxy provenance is expired")]
+    Expired,
+    /// Provenance timestamp exceeded the configured future skew.
+    #[error("trusted-proxy provenance is future-dated")]
+    FutureDated,
+    /// No active secret authenticated the exact request-bound provenance.
+    #[error("trusted-proxy provenance was rejected")]
+    InvalidMac,
+    /// The nonce was already committed by a prior final admission.
+    #[error("trusted-proxy nonce was already committed")]
+    Replay,
+    /// Current committed-nonce state could not be read.
+    #[error("trusted-proxy replay state is unavailable")]
+    ReplayUnavailable,
+}
+
+impl TrustedProxyError {
+    /// Stable privacy-safe failure code for metrics and internal decisions.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::InvalidConfiguration => "nip_fi_proxy_invalid_configuration",
+            Self::MissingAssertion => "nip_fi_proxy_missing_assertion",
+            Self::MissingProvenance => "nip_fi_proxy_missing_provenance",
+            Self::AmbiguousHeader => "nip_fi_proxy_ambiguous_header",
+            Self::MalformedAssertion => "nip_fi_proxy_malformed_assertion",
+            Self::MalformedProvenance => "nip_fi_proxy_malformed_provenance",
+            Self::InvalidRequest => "nip_fi_proxy_invalid_request",
+            Self::Expired => "nip_fi_proxy_expired",
+            Self::FutureDated => "nip_fi_proxy_future_dated",
+            Self::InvalidMac => "nip_fi_proxy_invalid_mac",
+            Self::Replay => "nip_fi_proxy_replay",
+            Self::ReplayUnavailable => "nip_fi_proxy_replay_unavailable",
+        }
+    }
+}
+
+/// Verifies `trusted-proxy-hmac-v1` provenance under a finite secret set.
+pub struct TrustedProxyProvenanceVerifier {
+    active_secrets: Vec<Box<[u8]>>,
+    maximum_provenance_age_seconds: u64,
+    future_skew_seconds: u64,
+    maximum_provenance_field_bytes: usize,
+    maximum_nonce_bytes: usize,
+}
+
+impl TrustedProxyProvenanceVerifier {
+    /// Construct with secure finite default field and nonce bounds.
+    pub fn new(
+        active_secrets: Vec<Vec<u8>>,
+        maximum_provenance_age: Duration,
+        future_skew: Duration,
+    ) -> Result<Self, TrustedProxyError> {
+        Self::with_size_limits(
+            active_secrets,
+            maximum_provenance_age,
+            future_skew,
+            DEFAULT_MAX_PROVENANCE_FIELD_BYTES,
+            DEFAULT_MAX_NONCE_BYTES,
+        )
+    }
+
+    /// Construct with explicit finite provenance-field and decoded-nonce bounds.
+    pub fn with_size_limits(
+        active_secrets: Vec<Vec<u8>>,
+        maximum_provenance_age: Duration,
+        future_skew: Duration,
+        maximum_provenance_field_bytes: usize,
+        maximum_nonce_bytes: usize,
+    ) -> Result<Self, TrustedProxyError> {
+        let maximum_provenance_age_seconds = maximum_provenance_age.as_secs();
+        let future_skew_seconds = future_skew.as_secs();
+        let valid_secrets = !active_secrets.is_empty()
+            && active_secrets.len() <= MAX_ACTIVE_SECRETS
+            && active_secrets
+                .iter()
+                .all(|secret| (MIN_SECRET_BYTES..=MAX_SECRET_BYTES).contains(&secret.len()))
+            && !has_duplicate_secrets(&active_secrets);
+        if !valid_secrets
+            || maximum_provenance_age.subsec_nanos() != 0
+            || maximum_provenance_age_seconds == 0
+            || maximum_provenance_age_seconds > MAX_PROVENANCE_AGE_SECONDS
+            || future_skew.subsec_nanos() != 0
+            || future_skew_seconds > MAX_FUTURE_SKEW_SECONDS
+            || !(128..=4096).contains(&maximum_provenance_field_bytes)
+            || !(16..=1024).contains(&maximum_nonce_bytes)
+        {
+            return Err(TrustedProxyError::InvalidConfiguration);
+        }
+        Ok(Self {
+            active_secrets: active_secrets
+                .into_iter()
+                .map(Vec::into_boxed_slice)
+                .collect(),
+            maximum_provenance_age_seconds,
+            future_skew_seconds,
+            maximum_provenance_field_bytes,
+            maximum_nonce_bytes,
+        })
+    }
+
+    /// Verify exact headers and request binding, then reject committed nonces.
+    ///
+    /// `headers` must contain every occurrence from the complete request header
+    /// collection. Missing provenance never falls back to client-attached mode.
+    /// The replay lookup is read-only; the returned nonce claim must be consumed
+    /// atomically by final admission.
+    pub async fn verify<R: TrustedProxyNonceReplayReader + ?Sized>(
+        &self,
+        headers: &[HttpHeaderField<'_>],
+        request: &TrustedProxyRequest,
+        now: DateTime<Utc>,
+        replay: &R,
+    ) -> Result<SealedTransportEvidence, TrustedProxyError> {
+        let assertion_field = exact_header(
+            headers,
+            ASSERTION_HEADER_NAME,
+            TrustedProxyError::MissingAssertion,
+            MAX_ASSERTION_FIELD_BYTES,
+        )?;
+        let provenance_field = exact_header(
+            headers,
+            PROVENANCE_HEADER_NAME,
+            TrustedProxyError::MissingProvenance,
+            self.maximum_provenance_field_bytes,
+        )?;
+        let assertion = parse_bearer_assertion(assertion_field)?;
+        let parsed = self.parse_provenance(provenance_field, now)?;
+        let assertion_digest: [u8; 32] = Sha256::digest(assertion.as_bytes()).into();
+        let mac_input = mac_input(parsed.timestamp, &parsed.nonce, &assertion_digest, request);
+        let mut authenticated = 0_u8;
+        for secret in &self.active_secrets {
+            let mut mac = <ProvenanceMac as KeyInit>::new_from_slice(secret)
+                .map_err(|_| TrustedProxyError::InvalidConfiguration)?;
+            mac.update(&mac_input);
+            authenticated |= u8::from(mac.verify_slice(&parsed.mac).is_ok());
+        }
+        if authenticated != 1 {
+            return Err(TrustedProxyError::InvalidMac);
+        }
+
+        let claim_key = framed_digest(b"buzz:nip-fi:trusted-proxy-nonce:v1", &[&parsed.nonce]);
+        let claim = TrustedProxyNonceClaim::new(claim_key, parsed.expires_at);
+        match replay
+            .is_committed(request.authorization_domain, &claim)
+            .await
+        {
+            Ok(false) => {}
+            Ok(true) => return Err(TrustedProxyError::Replay),
+            Err(_) => return Err(TrustedProxyError::ReplayUnavailable),
+        }
+
+        Ok(SealedTransportEvidence::from_trusted_proxy(
+            request.authorization_domain,
+            assertion.into(),
+            assertion_digest,
+            request.method.as_bytes(),
+            request.authority.as_bytes(),
+            request.path_and_query.as_bytes(),
+            request.body_digest,
+            request.transport,
+            parsed.expires_at,
+            claim,
+        ))
+    }
+
+    fn parse_provenance(
+        &self,
+        field: &[u8],
+        now: DateTime<Utc>,
+    ) -> Result<ParsedProvenance, TrustedProxyError> {
+        let field =
+            std::str::from_utf8(field).map_err(|_| TrustedProxyError::MalformedProvenance)?;
+        let mut components = field.split('.');
+        if components.next() != Some("v1") {
+            return Err(TrustedProxyError::MalformedProvenance);
+        }
+        let timestamp_text = components
+            .next()
+            .ok_or(TrustedProxyError::MalformedProvenance)?;
+        let nonce_text = components
+            .next()
+            .ok_or(TrustedProxyError::MalformedProvenance)?;
+        let mac_text = components
+            .next()
+            .ok_or(TrustedProxyError::MalformedProvenance)?;
+        if components.next().is_some() || !canonical_unsigned_decimal(timestamp_text) {
+            return Err(TrustedProxyError::MalformedProvenance);
+        }
+        let timestamp = timestamp_text
+            .parse::<u64>()
+            .map_err(|_| TrustedProxyError::MalformedProvenance)?;
+        let nonce = decode_base64url(nonce_text, self.maximum_nonce_bytes)?;
+        if nonce.len() < 16 {
+            return Err(TrustedProxyError::MalformedProvenance);
+        }
+        let mac = decode_base64url(mac_text, 32)?;
+        let mac: [u8; 32] = mac
+            .try_into()
+            .map_err(|_| TrustedProxyError::MalformedProvenance)?;
+        let now = u64::try_from(now.timestamp()).map_err(|_| TrustedProxyError::InvalidRequest)?;
+        let latest = now
+            .checked_add(self.future_skew_seconds)
+            .ok_or(TrustedProxyError::FutureDated)?;
+        if timestamp > latest {
+            return Err(TrustedProxyError::FutureDated);
+        }
+        let expires_at = timestamp
+            .checked_add(self.maximum_provenance_age_seconds)
+            .ok_or(TrustedProxyError::MalformedProvenance)?;
+        if now >= expires_at {
+            return Err(TrustedProxyError::Expired);
+        }
+        let expires_at = i64::try_from(expires_at)
+            .ok()
+            .and_then(|seconds| DateTime::from_timestamp(seconds, 0))
+            .ok_or(TrustedProxyError::MalformedProvenance)?;
+        Ok(ParsedProvenance {
+            timestamp,
+            nonce,
+            mac,
+            expires_at,
+        })
+    }
+}
+
+impl fmt::Debug for TrustedProxyProvenanceVerifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TrustedProxyProvenanceVerifier([REDACTED])")
+    }
+}
+
+struct ParsedProvenance {
+    timestamp: u64,
+    nonce: Vec<u8>,
+    mac: [u8; 32],
+    expires_at: DateTime<Utc>,
+}
+
+fn exact_header<'a>(
+    headers: &[HttpHeaderField<'a>],
+    expected_name: &str,
+    missing: TrustedProxyError,
+    maximum_bytes: usize,
+) -> Result<&'a [u8], TrustedProxyError> {
+    let mut matching = headers
+        .iter()
+        .filter(|header| header.name.eq_ignore_ascii_case(expected_name));
+    let field = matching.next().ok_or(missing)?;
+    if matching.next().is_some() {
+        return Err(TrustedProxyError::AmbiguousHeader);
+    }
+    if field.value.is_empty()
+        || field.value.len() > maximum_bytes
+        || !field.value.is_ascii()
+        || field.value.contains(&b',')
+        || field.value.first().is_some_and(u8::is_ascii_whitespace)
+        || field.value.last().is_some_and(u8::is_ascii_whitespace)
+    {
+        return Err(TrustedProxyError::AmbiguousHeader);
+    }
+    Ok(field.value)
+}
+
+fn parse_bearer_assertion(field: &[u8]) -> Result<&str, TrustedProxyError> {
+    let field = std::str::from_utf8(field).map_err(|_| TrustedProxyError::MalformedAssertion)?;
+    let assertion = field
+        .strip_prefix("Bearer ")
+        .ok_or(TrustedProxyError::MalformedAssertion)?;
+    let mut segments = assertion.split('.');
+    let valid = assertion.len() <= MAX_ASSERTION_FIELD_BYTES - "Bearer ".len()
+        && segments.by_ref().take(3).count() == 3
+        && segments.next().is_none()
+        && assertion
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && assertion.split('.').all(|segment| !segment.is_empty());
+    if !valid {
+        return Err(TrustedProxyError::MalformedAssertion);
+    }
+    Ok(assertion)
+}
+
+fn valid_method(method: &str) -> bool {
+    !method.is_empty()
+        && method.len() <= MAX_METHOD_BYTES
+        && method.bytes().all(|byte| {
+            byte.is_ascii_uppercase()
+                || byte.is_ascii_digit()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+fn valid_authority(authority: &str) -> bool {
+    if authority.is_empty()
+        || authority.len() > MAX_AUTHORITY_BYTES
+        || !authority.is_ascii()
+        || authority.bytes().any(|byte| byte.is_ascii_uppercase())
+        || authority.contains('@')
+        || authority.ends_with('.')
+    {
+        return false;
+    }
+    if let Some(rest) = authority.strip_prefix('[') {
+        let Some((address, port)) = rest.split_once("]:") else {
+            return false;
+        };
+        return Ipv6Addr::from_str(address).is_ok_and(|parsed| parsed.to_string() == address)
+            && valid_port(port);
+    }
+    let Some((host, port)) = authority.rsplit_once(':') else {
+        return false;
+    };
+    if host.is_empty() || host.contains(':') || !valid_port(port) {
+        return false;
+    }
+    let valid_host = host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+            && label
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphanumeric)
+            && label
+                .as_bytes()
+                .last()
+                .is_some_and(u8::is_ascii_alphanumeric)
+    });
+    if !valid_host {
+        return false;
+    }
+    if host
+        .split('.')
+        .all(|label| label.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return Ipv4Addr::from_str(host).is_ok_and(|parsed| parsed.to_string() == host);
+    }
+    true
+}
+
+fn valid_port(port: &str) -> bool {
+    !port.is_empty()
+        && (port == "0" || !port.starts_with('0'))
+        && port.bytes().all(|byte| byte.is_ascii_digit())
+        && port.parse::<u16>().is_ok_and(|port| port != 0)
+}
+
+fn canonical_path_and_query(value: &str) -> Result<Box<str>, TrustedProxyError> {
+    if value.len() > MAX_PATH_AND_QUERY_BYTES
+        || !value.is_ascii()
+        || value
+            .bytes()
+            .any(|byte| !(0x21..=0x7e).contains(&byte) || byte == b'#')
+        || has_invalid_percent_encoding(value.as_bytes())
+    {
+        return Err(TrustedProxyError::InvalidRequest);
+    }
+    let canonical = if value.is_empty() {
+        "/".to_owned()
+    } else if value.starts_with('?') {
+        format!("/{value}")
+    } else if value.starts_with('/') {
+        value.to_owned()
+    } else {
+        return Err(TrustedProxyError::InvalidRequest);
+    };
+    Ok(canonical.into_boxed_str())
+}
+
+fn has_invalid_percent_encoding(value: &[u8]) -> bool {
+    let mut index = 0;
+    while index < value.len() {
+        if value[index] == b'%' {
+            if index + 2 >= value.len()
+                || !value[index + 1].is_ascii_hexdigit()
+                || !value[index + 2].is_ascii_hexdigit()
+            {
+                return true;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+fn canonical_unsigned_decimal(value: &str) -> bool {
+    !value.is_empty()
+        && (value == "0" || !value.starts_with('0'))
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn mac_input(
+    timestamp: u64,
+    nonce: &[u8],
+    assertion_digest: &[u8; 32],
+    request: &TrustedProxyRequest,
+) -> Vec<u8> {
+    let mut input = Vec::with_capacity(
+        MAC_DOMAIN.len()
+            + 8 * 8
+            + 8
+            + 1
+            + nonce.len()
+            + assertion_digest.len()
+            + request.method.len()
+            + request.authority.len()
+            + request.path_and_query.len()
+            + request.body_digest.len(),
+    );
+    input.extend_from_slice(MAC_DOMAIN);
+    append_length_prefixed(&mut input, &timestamp.to_be_bytes());
+    append_length_prefixed(&mut input, nonce);
+    append_length_prefixed(&mut input, assertion_digest);
+    append_length_prefixed(&mut input, request.method.as_bytes());
+    append_length_prefixed(&mut input, request.authority.as_bytes());
+    append_length_prefixed(&mut input, request.path_and_query.as_bytes());
+    append_length_prefixed(&mut input, &request.body_digest);
+    append_length_prefixed(&mut input, &[proof_transport_code(request.transport)]);
+    input
+}
+
+fn append_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+fn framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+fn has_duplicate_secrets(secrets: &[Vec<u8>]) -> bool {
+    secrets.iter().enumerate().any(|(index, candidate)| {
+        secrets
+            .iter()
+            .skip(index + 1)
+            .any(|other| candidate == other)
+    })
+}
+
+fn decode_base64url(
+    value: &str,
+    maximum_decoded_bytes: usize,
+) -> Result<Vec<u8>, TrustedProxyError> {
+    if value.is_empty()
+        || value.len() % 4 == 1
+        || value.len() > maximum_decoded_bytes.saturating_mul(4).div_ceil(3)
+        || !value.bytes().all(|byte| base64url_value(byte).is_some())
+    {
+        return Err(TrustedProxyError::MalformedProvenance);
+    }
+    let mut output = Vec::with_capacity(value.len() * 3 / 4 + 2);
+    let mut accumulator = 0_u32;
+    let mut bits = 0_u8;
+    for byte in value.bytes() {
+        let decoded = base64url_value(byte).ok_or(TrustedProxyError::MalformedProvenance)?;
+        accumulator = (accumulator << 6) | u32::from(decoded);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            output.push((accumulator >> bits) as u8);
+            accumulator &= (1_u32 << bits).wrapping_sub(1);
+        }
+    }
+    if (bits > 0 && accumulator != 0)
+        || output.len() > maximum_decoded_bytes
+        || encode_base64url(&output) != value
+    {
+        return Err(TrustedProxyError::MalformedProvenance);
+    }
+    Ok(output)
+}
+
+fn base64url_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'A'..=b'Z' => Some(byte - b'A'),
+        b'a'..=b'z' => Some(byte - b'a' + 26),
+        b'0'..=b'9' => Some(byte - b'0' + 52),
+        b'-' => Some(62),
+        b'_' => Some(63),
+        _ => None,
+    }
+}
+
+fn encode_base64url(value: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut output = String::with_capacity(value.len() * 4 / 3 + 3);
+    for chunk in value.chunks(3) {
+        let first = chunk[0];
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        let second_high = chunk.get(1).copied().unwrap_or(0);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second_high >> 4)) as usize] as char);
+        if let Some(second) = chunk.get(1).copied() {
+            let third_high = chunk.get(2).copied().unwrap_or(0);
+            output.push(ALPHABET[(((second & 0x0f) << 2) | (third_high >> 6)) as usize] as char);
+        }
+        if let Some(third) = chunk.get(2).copied() {
+            output.push(ALPHABET[(third & 0x3f) as usize] as char);
+        }
+    }
+    output
+}

--- a/crates/buzz-auth/tests/trusted_proxy_provenance.rs
+++ b/crates/buzz-auth/tests/trusted_proxy_provenance.rs
@@ -1,0 +1,677 @@
+use std::{
+    collections::HashSet,
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, OnceLock,
+    },
+    time::Duration,
+};
+
+use buzz_auth::{
+    AssertionTransportProfile, HttpHeaderField, ProofTransport, TrustedProxyError,
+    TrustedProxyNonceClaim, TrustedProxyNonceReplayReader, TrustedProxyProvenanceVerifier,
+    TrustedProxyReplayReadError, TrustedProxyRequest, ASSERTION_HEADER_NAME,
+    PROVENANCE_HEADER_NAME,
+};
+use buzz_core::CommunityId;
+use chrono::{TimeZone, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+const NOW: u64 = 1_800_000_000;
+const PRIMARY_SECRET: [u8; 32] = [0x53; 32];
+const DOMAIN_A: CommunityId = CommunityId::from_uuid(Uuid::from_u128(1));
+const DOMAIN_B: CommunityId = CommunityId::from_uuid(Uuid::from_u128(2));
+
+type TestMac = Hmac<Sha256>;
+
+fn proxy_assertion() -> &'static str {
+    static VALUE: OnceLock<String> = OnceLock::new();
+    VALUE.get_or_init(|| {
+        [
+            ["eyJhbGciOiJF", "UzI1NiJ9"].concat(),
+            ["eyJzdWIiOiJz", "dWJqZWN0In0"].concat(),
+            ["c2lnbmF0", "dXJl"].concat(),
+        ]
+        .join(".")
+    })
+}
+
+#[derive(Default)]
+struct ReplayReader {
+    committed: Mutex<HashSet<(CommunityId, [u8; 32])>>,
+    unavailable: AtomicBool,
+}
+
+impl ReplayReader {
+    fn commit(&self, authorization_domain: CommunityId, claim: &TrustedProxyNonceClaim) {
+        self.committed
+            .lock()
+            .expect("replay test mutex must remain healthy")
+            .insert((authorization_domain, *claim.claim_key()));
+    }
+
+    fn make_unavailable(&self) {
+        self.unavailable.store(true, Ordering::SeqCst);
+    }
+}
+
+impl TrustedProxyNonceReplayReader for ReplayReader {
+    fn is_committed<'a>(
+        &'a self,
+        authorization_domain: CommunityId,
+        claim: &'a TrustedProxyNonceClaim,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, TrustedProxyReplayReadError>> + Send + 'a>> {
+        Box::pin(async move {
+            if self.unavailable.load(Ordering::SeqCst) {
+                return Err(TrustedProxyReplayReadError);
+            }
+            Ok(self
+                .committed
+                .lock()
+                .map_err(|_| TrustedProxyReplayReadError)?
+                .contains(&(authorization_domain, *claim.claim_key())))
+        })
+    }
+}
+
+fn verifier() -> TrustedProxyProvenanceVerifier {
+    TrustedProxyProvenanceVerifier::new(
+        vec![PRIMARY_SECRET.to_vec(), vec![0x71; 32]],
+        Duration::from_secs(60),
+        Duration::from_secs(5),
+    )
+    .expect("valid verifier policy")
+}
+
+fn sign_provenance(
+    assertion: &str,
+    method: &str,
+    authority: &str,
+    path_and_query: &str,
+    body: &[u8],
+    timestamp: u64,
+    nonce: &[u8],
+) -> String {
+    let canonical_path = if path_and_query.is_empty() {
+        "/".to_owned()
+    } else if path_and_query.starts_with('?') {
+        format!("/{path_and_query}")
+    } else {
+        path_and_query.to_owned()
+    };
+    let assertion_digest: [u8; 32] = Sha256::digest(assertion.as_bytes()).into();
+    let body_digest: [u8; 32] = Sha256::digest(body).into();
+    let transport = [2_u8]; // ProofTransport::Nip98, frozen wire code.
+    let mut input = b"NIP-FI-PROXY-1".to_vec();
+    for value in [
+        timestamp.to_be_bytes().as_slice(),
+        nonce,
+        &assertion_digest,
+        method.as_bytes(),
+        authority.as_bytes(),
+        canonical_path.as_bytes(),
+        &body_digest,
+        &transport,
+    ] {
+        input.extend_from_slice(&(value.len() as u64).to_be_bytes());
+        input.extend_from_slice(value);
+    }
+    let mut mac = <TestMac as KeyInit>::new_from_slice(&PRIMARY_SECRET)
+        .expect("HMAC-SHA-256 accepts the test key");
+    mac.update(&input);
+    format!(
+        "v1.{timestamp}.{}.{}",
+        base64url(nonce),
+        base64url(&mac.finalize().into_bytes())
+    )
+}
+
+fn base64url(value: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut output = String::new();
+    for chunk in value.chunks(3) {
+        let first = chunk[0];
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        let second_high = chunk.get(1).copied().unwrap_or(0);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second_high >> 4)) as usize] as char);
+        if let Some(second) = chunk.get(1).copied() {
+            let third_high = chunk.get(2).copied().unwrap_or(0);
+            output.push(ALPHABET[(((second & 0x0f) << 2) | (third_high >> 6)) as usize] as char);
+        }
+        if let Some(third) = chunk.get(2).copied() {
+            output.push(ALPHABET[(third & 0x3f) as usize] as char);
+        }
+    }
+    output
+}
+
+fn request(method: &str, authority: &str, path: &str, body: &[u8]) -> TrustedProxyRequest {
+    request_in_domain(DOMAIN_A, method, authority, path, body)
+}
+
+fn request_in_domain(
+    authorization_domain: CommunityId,
+    method: &str,
+    authority: &str,
+    path: &str,
+    body: &[u8],
+) -> TrustedProxyRequest {
+    TrustedProxyRequest::from_server_request(
+        authorization_domain,
+        ProofTransport::Nip98,
+        method,
+        authority,
+        path,
+        body,
+    )
+    .expect("valid server request")
+}
+
+fn now() -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(NOW as i64, 0)
+        .single()
+        .expect("valid test time")
+}
+
+fn assertion_header(assertion: &str) -> String {
+    format!("Bearer {assertion}")
+}
+
+fn headers<'a>(assertion: &'a str, provenance: &'a str) -> Vec<HttpHeaderField<'a>> {
+    vec![
+        HttpHeaderField::new(ASSERTION_HEADER_NAME, assertion.as_bytes()),
+        HttpHeaderField::new(PROVENANCE_HEADER_NAME, provenance.as_bytes()),
+    ]
+}
+
+#[tokio::test]
+async fn valid_provenance_seals_redacted_move_only_evidence() {
+    let verifier = verifier();
+    let request = request("POST", "relay.example.com:443", "/events?a=1&a=2", b"body");
+    let provenance = sign_provenance(
+        proxy_assertion(),
+        "POST",
+        "relay.example.com:443",
+        "/events?a=1&a=2",
+        b"body",
+        NOW,
+        &[0x19; 16],
+    );
+    let assertion = assertion_header(proxy_assertion());
+    let replay = ReplayReader::default();
+
+    let evidence = verifier
+        .verify(&headers(&assertion, &provenance), &request, now(), &replay)
+        .await
+        .expect("valid provenance");
+
+    assert_eq!(evidence.confidential_assertion(), proxy_assertion());
+    assert_eq!(evidence.authorization_domain(), DOMAIN_A);
+    assert_eq!(
+        evidence.profile(),
+        AssertionTransportProfile::TrustedProxyHmacV1
+    );
+    assert_eq!(evidence.transport(), ProofTransport::Nip98);
+    assert_eq!(evidence.proxy_expires_at().timestamp(), (NOW + 60) as i64);
+    assert_eq!(
+        evidence.nonce_claim().retain_until().timestamp(),
+        (NOW + 60) as i64
+    );
+    assert_ne!(evidence.assertion_digest(), &[0; 32]);
+    assert_ne!(evidence.request_fingerprint(), &[0; 32]);
+    assert_ne!(evidence.transport_context_fingerprint(), &[0; 32]);
+    assert_eq!(
+        format!("{evidence:?}"),
+        "SealedTransportEvidence([REDACTED])"
+    );
+    assert_eq!(
+        format!("{:?}", evidence.nonce_claim()),
+        "TrustedProxyNonceClaim([REDACTED])"
+    );
+}
+
+#[tokio::test]
+async fn direct_origin_and_injected_headers_fail_closed() {
+    let verifier = verifier();
+    let request = request("GET", "relay.example.com:443", "/media/hash", b"");
+    let assertion = assertion_header(proxy_assertion());
+    let replay = ReplayReader::default();
+
+    let direct = [HttpHeaderField::new(
+        ASSERTION_HEADER_NAME,
+        assertion.as_bytes(),
+    )];
+    assert_eq!(
+        verifier
+            .verify(&direct, &request, now(), &replay)
+            .await
+            .unwrap_err(),
+        TrustedProxyError::MissingProvenance
+    );
+
+    let provenance = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "relay.example.com:443",
+        "/media/hash",
+        b"",
+        NOW,
+        &[0x2a; 16],
+    );
+    let injected_assertion = assertion_header("e30.e30.aW5qZWN0ZWQ");
+    assert_eq!(
+        verifier
+            .verify(
+                &headers(&injected_assertion, &provenance),
+                &request,
+                now(),
+                &replay,
+            )
+            .await
+            .unwrap_err(),
+        TrustedProxyError::InvalidMac
+    );
+}
+
+#[tokio::test]
+async fn duplicate_combined_and_whitespace_fields_are_rejected() {
+    let verifier = verifier();
+    let request = request("GET", "relay.example.com:443", "/", b"");
+    let assertion = assertion_header(proxy_assertion());
+    let provenance = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "relay.example.com:443",
+        "/",
+        b"",
+        NOW,
+        &[0x3b; 16],
+    );
+    let replay = ReplayReader::default();
+
+    let duplicate = [
+        HttpHeaderField::new(ASSERTION_HEADER_NAME, assertion.as_bytes()),
+        HttpHeaderField::new("Nostr-Federated-Identity", assertion.as_bytes()),
+        HttpHeaderField::new(PROVENANCE_HEADER_NAME, provenance.as_bytes()),
+    ];
+    assert_eq!(
+        verifier
+            .verify(&duplicate, &request, now(), &replay)
+            .await
+            .unwrap_err(),
+        TrustedProxyError::AmbiguousHeader
+    );
+
+    for malformed in [
+        format!("{provenance},other"),
+        format!(" {provenance}"),
+        format!("{provenance} "),
+    ] {
+        assert_eq!(
+            verifier
+                .verify(&headers(&assertion, &malformed), &request, now(), &replay)
+                .await
+                .unwrap_err(),
+            TrustedProxyError::AmbiguousHeader
+        );
+    }
+}
+
+#[tokio::test]
+async fn provenance_cannot_cross_assertion_method_authority_path_query_or_body() {
+    let verifier = verifier();
+    let assertion = assertion_header(proxy_assertion());
+    let provenance = sign_provenance(
+        proxy_assertion(),
+        "POST",
+        "relay.example.com:443",
+        "/query?a=1&a=2",
+        b"body-one",
+        NOW,
+        &[0x4c; 16],
+    );
+    let replay = ReplayReader::default();
+
+    let changed = [
+        request(
+            "PUT",
+            "relay.example.com:443",
+            "/query?a=1&a=2",
+            b"body-one",
+        ),
+        request(
+            "POST",
+            "other.example.com:443",
+            "/query?a=1&a=2",
+            b"body-one",
+        ),
+        request(
+            "POST",
+            "relay.example.com:443",
+            "/query?a=2&a=1",
+            b"body-one",
+        ),
+        request(
+            "POST",
+            "relay.example.com:443",
+            "/query?a=1&a=2",
+            b"body-two",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Blossom,
+            "POST",
+            "relay.example.com:443",
+            "/query?a=1&a=2",
+            b"body-one",
+        )
+        .expect("valid alternate server transport"),
+    ];
+    for changed_request in changed {
+        assert_eq!(
+            verifier
+                .verify(
+                    &headers(&assertion, &provenance),
+                    &changed_request,
+                    now(),
+                    &replay,
+                )
+                .await
+                .unwrap_err(),
+            TrustedProxyError::InvalidMac
+        );
+    }
+}
+
+#[tokio::test]
+async fn timestamp_boundaries_and_canonical_encoding_are_exact() {
+    let verifier = verifier();
+    let request = request("GET", "[2001:db8::1]:443", "?x=%2F", b"");
+    let assertion = assertion_header(proxy_assertion());
+    let replay = ReplayReader::default();
+
+    let fresh = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "[2001:db8::1]:443",
+        "?x=%2F",
+        b"",
+        NOW - 59,
+        &[0x5d; 16],
+    );
+    verifier
+        .verify(&headers(&assertion, &fresh), &request, now(), &replay)
+        .await
+        .expect("one second before exclusive age bound");
+
+    let expired = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "[2001:db8::1]:443",
+        "?x=%2F",
+        b"",
+        NOW - 60,
+        &[0x5e; 16],
+    );
+    assert_eq!(
+        verifier
+            .verify(&headers(&assertion, &expired), &request, now(), &replay)
+            .await
+            .unwrap_err(),
+        TrustedProxyError::Expired
+    );
+
+    let future = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "[2001:db8::1]:443",
+        "?x=%2F",
+        b"",
+        NOW + 6,
+        &[0x5f; 16],
+    );
+    assert_eq!(
+        verifier
+            .verify(&headers(&assertion, &future), &request, now(), &replay)
+            .await
+            .unwrap_err(),
+        TrustedProxyError::FutureDated
+    );
+
+    let canonical = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "[2001:db8::1]:443",
+        "?x=%2F",
+        b"",
+        NOW,
+        &[0x60; 16],
+    );
+    let leading_zero = canonical.replacen(&format!("v1.{NOW}."), &format!("v1.0{NOW}."), 1);
+    assert_eq!(
+        verifier
+            .verify(
+                &headers(&assertion, &leading_zero),
+                &request,
+                now(),
+                &replay
+            )
+            .await
+            .unwrap_err(),
+        TrustedProxyError::MalformedProvenance
+    );
+    let padded = format!("{canonical}=");
+    assert_eq!(
+        verifier
+            .verify(&headers(&assertion, &padded), &request, now(), &replay)
+            .await
+            .unwrap_err(),
+        TrustedProxyError::MalformedProvenance
+    );
+}
+
+#[tokio::test]
+async fn committed_nonce_and_unavailable_replay_state_fail_closed() {
+    let verifier = verifier();
+    let git_request = request(
+        "GET",
+        "relay.example.com:443",
+        "/git/info/refs?service=git-upload-pack",
+        b"",
+    );
+    let assertion = assertion_header(proxy_assertion());
+    let provenance = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "relay.example.com:443",
+        "/git/info/refs?service=git-upload-pack",
+        b"",
+        NOW,
+        &[0x6a; 16],
+    );
+    let replay = ReplayReader::default();
+
+    let evidence = verifier
+        .verify(
+            &headers(&assertion, &provenance),
+            &git_request,
+            now(),
+            &replay,
+        )
+        .await
+        .expect("uncommitted nonce");
+    replay.commit(evidence.authorization_domain(), evidence.nonce_claim());
+    assert_eq!(
+        verifier
+            .verify(
+                &headers(&assertion, &provenance),
+                &git_request,
+                now(),
+                &replay,
+            )
+            .await
+            .unwrap_err(),
+        TrustedProxyError::Replay
+    );
+
+    let other_authority_request = request("GET", "other.example.com:443", "/same-nonce", b"");
+    let same_nonce_other_authority = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "other.example.com:443",
+        "/same-nonce",
+        b"",
+        NOW,
+        &[0x6a; 16],
+    );
+    let other_domain_request =
+        request_in_domain(DOMAIN_B, "GET", "other.example.com:443", "/same-nonce", b"");
+    verifier
+        .verify(
+            &headers(&assertion, &same_nonce_other_authority),
+            &other_domain_request,
+            now(),
+            &replay,
+        )
+        .await
+        .expect("the frozen replay key is isolated by authorization domain");
+    assert_eq!(
+        verifier
+            .verify(
+                &headers(&assertion, &same_nonce_other_authority),
+                &other_authority_request,
+                now(),
+                &replay,
+            )
+            .await
+            .unwrap_err(),
+        TrustedProxyError::Replay
+    );
+
+    let unavailable = ReplayReader::default();
+    unavailable.make_unavailable();
+    let other = sign_provenance(
+        proxy_assertion(),
+        "GET",
+        "relay.example.com:443",
+        "/git/info/refs?service=git-upload-pack",
+        b"",
+        NOW,
+        &[0x6b; 16],
+    );
+    assert_eq!(
+        verifier
+            .verify(
+                &headers(&assertion, &other),
+                &git_request,
+                now(),
+                &unavailable,
+            )
+            .await
+            .unwrap_err(),
+        TrustedProxyError::ReplayUnavailable
+    );
+}
+
+#[test]
+fn request_and_verifier_configuration_reject_ambiguous_inputs() {
+    for invalid in [
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "get",
+            "relay.example.com:443",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "Relay.example.com:443",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "relay.example.com",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "relay.example.com:0443",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "127.000.0.1:443",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "[2001:0db8::1]:443",
+            "/",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "relay.example.com:443",
+            "relative",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "relay.example.com:443",
+            "/path#fragment",
+            b"",
+        ),
+        TrustedProxyRequest::from_server_request(
+            DOMAIN_A,
+            ProofTransport::Nip98,
+            "GET",
+            "relay.example.com:443",
+            "/bad%2",
+            b"",
+        ),
+    ] {
+        assert_eq!(invalid.unwrap_err(), TrustedProxyError::InvalidRequest);
+    }
+
+    assert_eq!(
+        TrustedProxyProvenanceVerifier::new(
+            vec![vec![0x01; 31]],
+            Duration::from_secs(60),
+            Duration::ZERO,
+        )
+        .unwrap_err(),
+        TrustedProxyError::InvalidConfiguration
+    );
+    assert_eq!(
+        TrustedProxyProvenanceVerifier::new(vec![vec![0x01; 32]], Duration::ZERO, Duration::ZERO,)
+            .unwrap_err(),
+        TrustedProxyError::InvalidConfiguration
+    );
+    assert_eq!(
+        TrustedProxyError::ReplayUnavailable.code(),
+        "nip_fi_proxy_replay_unavailable"
+    );
+}

--- a/crates/buzz-db/Cargo.toml
+++ b/crates/buzz-db/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Postgres event store and data access layer for Buzz"
 
 [dependencies]
+buzz-auth = { workspace = true }
 buzz-core = { workspace = true }
 buzz-datastore-tracing = { workspace = true }
 sqlx        = { workspace = true }

--- a/crates/buzz-db/src/authorization_admission.rs
+++ b/crates/buzz-db/src/authorization_admission.rs
@@ -1,0 +1,4168 @@
+//! Canonical atomic final-admission boundary for every protected ingress.
+//!
+//! Preparation remains read-only. Implementations of
+//! [`CanonicalAdmissionCommitter`] own the one transaction that performs the
+//! final dependency recheck, optional enrollment, replay claim, receipt, and
+//! required authorization-audit append. A failed commit must roll back all of
+//! those effects together.
+
+use std::{
+    fmt,
+    future::{ready, Future},
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
+
+use buzz_auth::{
+    AuthoritativeAuthorizationRecheck, AuthorizationError, AuthorizationFinalizationRechecker,
+    AuthorizationFinalizer, AuthorizationInput, AuthorizationReason, DirectEnrollmentProposal,
+    FinalizedAuthContext, LocalAuthorizationPolicy, LocalBindingResolution, PreparedAuthorization,
+    PreparedAuthorizationRecheck, ProofTransport, RouteCapability, VerifiedFederatedAssertion,
+    VerifiedNostrProof,
+};
+use buzz_core::CommunityId;
+use chrono::{DateTime, Datelike, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use uuid::Uuid;
+
+use crate::identity_enrollment::{
+    actor_fingerprint, execute_authoritative_enrollment_tx, EnrollmentDisposition,
+    IdentityEnrollmentError, PreparedDirectEnrollment,
+};
+
+/// Closed protected-object namespaces persisted by canonical admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionObjectKind {
+    /// Domain-wide authority.
+    Domain,
+    /// One channel.
+    Channel,
+    /// One repository.
+    Repository,
+    /// One media object.
+    Media,
+    /// One moderation target.
+    ModerationTarget,
+    /// One audio session.
+    AudioSession,
+}
+
+impl AdmissionObjectKind {
+    /// Stable database code shared with `protected_object_authority`.
+    pub const fn database_code(self) -> i16 {
+        match self {
+            Self::Domain => 1,
+            Self::Channel => 2,
+            Self::Repository => 3,
+            Self::Media => 4,
+            Self::ModerationTarget => 5,
+            Self::AudioSession => 6,
+        }
+    }
+}
+
+/// Server-resolved protected object; clients cannot select this coordinate.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionObject {
+    kind: AdmissionObjectKind,
+    key: [u8; 32],
+}
+
+impl AdmissionObject {
+    /// Construct a non-sentinel server-owned object coordinate.
+    pub fn new(kind: AdmissionObjectKind, key: [u8; 32]) -> Option<Self> {
+        if key == [0; 32] {
+            None
+        } else {
+            Some(Self { kind, key })
+        }
+    }
+
+    /// Closed object namespace.
+    pub const fn kind(self) -> AdmissionObjectKind {
+        self.kind
+    }
+
+    /// Privacy-safe object key.
+    pub const fn key(&self) -> &[u8; 32] {
+        &self.key
+    }
+}
+
+impl fmt::Debug for AdmissionObject {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionObject([REDACTED])")
+    }
+}
+
+/// Closed provider-free replay namespaces consumed by final admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionReplayClaimKind {
+    /// Opaque digest of one validated trusted-transport nonce.
+    TrustedProxyNonce,
+}
+
+impl AdmissionReplayClaimKind {
+    /// Stable database code reserved across replay-claim migrations.
+    pub const fn database_code(self) -> i16 {
+        match self {
+            Self::TrustedProxyNonce => 1,
+        }
+    }
+}
+
+/// Credential-free one-use replay coordinate sealed by a verifier.
+///
+/// The key is an opaque domain-separated digest, never the nonce, proof,
+/// assertion, subject, issuer, email address, or display data. Chrono has no
+/// infinity representation; the constructor additionally limits values to the
+/// interoperable finite civil-time range. The canonical transaction must call
+/// [`Self::validate_at`] using PostgreSQL transaction time before insertion.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionReplayClaim {
+    kind: AdmissionReplayClaimKind,
+    claim_key: [u8; 32],
+    retain_until: DateTime<Utc>,
+}
+
+impl AdmissionReplayClaim {
+    /// Seal a non-sentinel opaque replay claim and exclusive retention bound.
+    pub fn new(
+        kind: AdmissionReplayClaimKind,
+        claim_key: [u8; 32],
+        retain_until: DateTime<Utc>,
+    ) -> Result<Self, AdmissionCommitError> {
+        if claim_key == [0; 32] || !(1..=9999).contains(&retain_until.year()) {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            kind,
+            claim_key,
+            retain_until,
+        })
+    }
+
+    /// Closed replay namespace.
+    pub const fn kind(self) -> AdmissionReplayClaimKind {
+        self.kind
+    }
+
+    /// Opaque domain-separated claim digest.
+    pub const fn claim_key(&self) -> &[u8; 32] {
+        &self.claim_key
+    }
+
+    /// Exclusive storage-retention deadline.
+    pub const fn retain_until(self) -> DateTime<Utc> {
+        self.retain_until
+    }
+
+    /// Reject a stale or non-future claim using authoritative transaction time.
+    pub fn validate_at(self, authoritative_now: DateTime<Utc>) -> Result<(), AdmissionCommitError> {
+        if authoritative_now >= self.retain_until {
+            Err(AdmissionCommitError::ReplayRejected)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl fmt::Debug for AdmissionReplayClaim {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionReplayClaim([REDACTED])")
+    }
+}
+
+enum AdmissionPreparation {
+    Existing {
+        prepared: Box<PreparedAuthorization>,
+    },
+    Enrollment {
+        correlation_id: Uuid,
+        capability: RouteCapability,
+        evidence: Box<AdmissionEnrollmentEvidence>,
+    },
+}
+
+/// Origin-sealed provider-free evidence required for one direct enrollment.
+pub struct AdmissionEnrollmentEvidence {
+    proposal: DirectEnrollmentProposal,
+    enrollment_policy_digest: [u8; 32],
+    assertion: VerifiedFederatedAssertion,
+    proof: VerifiedNostrProof,
+    policy: LocalAuthorizationPolicy,
+}
+
+impl AdmissionEnrollmentEvidence {
+    /// Seal one proposal/assertion/proof/policy tuple for final admission.
+    pub fn new(
+        prepared: PreparedDirectEnrollment,
+        assertion: VerifiedFederatedAssertion,
+        proof: VerifiedNostrProof,
+        policy: LocalAuthorizationPolicy,
+    ) -> Result<Self, AdmissionCommitError> {
+        let (proposal, enrollment_policy_digest) = prepared.into_parts();
+        if proposal.authorization_domain() != assertion.authorization_domain()
+            || proposal.authorization_domain() != proof.authorization_domain()
+            || enrollment_policy_digest == [0; 32]
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            proposal,
+            enrollment_policy_digest,
+            assertion,
+            proof,
+            policy,
+        })
+    }
+}
+
+impl fmt::Debug for AdmissionEnrollmentEvidence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionEnrollmentEvidence([REDACTED])")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AdmissionReceiptShape {
+    ProtectedMutation,
+    EnrollmentOrProtectedMutation,
+}
+
+impl AdmissionReceiptShape {
+    fn from_preparation(preparation: &AdmissionPreparation) -> Self {
+        match preparation {
+            AdmissionPreparation::Existing { .. } => Self::ProtectedMutation,
+            AdmissionPreparation::Enrollment { .. } => Self::EnrollmentOrProtectedMutation,
+        }
+    }
+
+    fn matches(
+        self,
+        operation_kind: i16,
+        receipt_outcome: i16,
+        event_kind: Option<i16>,
+        event_outcome: Option<i16>,
+    ) -> bool {
+        if receipt_outcome != 1 || event_outcome != Some(1) {
+            return false;
+        }
+        match self {
+            Self::ProtectedMutation => operation_kind == 11 && event_kind == Some(10),
+            Self::EnrollmentOrProtectedMutation => {
+                (operation_kind == 1 && event_kind == Some(1))
+                    || (operation_kind == 11 && event_kind == Some(10))
+            }
+        }
+    }
+}
+
+/// Complete sealed input to one canonical final-admission transaction.
+///
+/// Enrollment carries independently sealed assertion and proof values because
+/// the proposal deliberately hides its credential-bearing internals. The
+/// transaction uses the public storage coordinates from those clones, then
+/// asks the sole authorization finalizer to compare the inserted row with the
+/// proposal. A mismatch rolls the transaction back.
+pub struct AdmissionCommitRequest {
+    attempt_id: Uuid,
+    object: AdmissionObject,
+    replay_claim: Option<AdmissionReplayClaim>,
+    application_effect: Option<Box<dyn AdmissionApplicationEffect>>,
+    preparation: AdmissionPreparation,
+}
+
+impl AdmissionCommitRequest {
+    /// Prepare the commit of an already-resolved authorization.
+    pub fn existing(
+        attempt_id: Uuid,
+        object: AdmissionObject,
+        prepared: PreparedAuthorization,
+    ) -> Result<Self, AdmissionCommitError> {
+        if attempt_id.is_nil() {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            attempt_id,
+            object,
+            replay_claim: None,
+            application_effect: None,
+            preparation: AdmissionPreparation::Existing {
+                prepared: Box::new(prepared),
+            },
+        })
+    }
+
+    /// Prepare one transactionally created Attested or risk-labelled TOFU
+    /// binding and its first committed authorization.
+    pub fn enrollment(
+        attempt_id: Uuid,
+        correlation_id: Uuid,
+        object: AdmissionObject,
+        capability: RouteCapability,
+        evidence: AdmissionEnrollmentEvidence,
+    ) -> Result<Self, AdmissionCommitError> {
+        if attempt_id.is_nil() || correlation_id.is_nil() {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            attempt_id,
+            object,
+            replay_claim: None,
+            application_effect: None,
+            preparation: AdmissionPreparation::Enrollment {
+                correlation_id,
+                capability,
+                evidence: Box::new(evidence),
+            },
+        })
+    }
+
+    /// Deterministic server-owned logical idempotency identifier.
+    ///
+    /// The caller cannot select this value. It is derived from the complete
+    /// domain-separated logical route/application intent, excluding the
+    /// attempt-scoped replay claim. A retry with a fresh trusted-proxy nonce
+    /// therefore reaches the first canonical result without repeating DML.
+    pub fn operation_id(&self) -> Uuid {
+        admission_operation_id(self.semantic_fingerprint())
+    }
+
+    /// Server-generated identifier for this bounded attempt.
+    pub const fn attempt_id(&self) -> Uuid {
+        self.attempt_id
+    }
+
+    /// Server-resolved protected object.
+    pub const fn object(&self) -> AdmissionObject {
+        self.object
+    }
+
+    /// Attach the optional verifier-sealed claim consumed by final admission.
+    pub fn with_replay_claim(mut self, replay_claim: AdmissionReplayClaim) -> Self {
+        self.replay_claim = Some(replay_claim);
+        self
+    }
+
+    /// Optional credential-free claim to consume in the final transaction.
+    pub const fn replay_claim(&self) -> Option<AdmissionReplayClaim> {
+        self.replay_claim
+    }
+
+    /// Attach one credential-free application mutation to the final transaction.
+    pub fn with_application_effect(
+        mut self,
+        application_effect: Box<dyn AdmissionApplicationEffect>,
+    ) -> Result<Self, AdmissionCommitError> {
+        if application_effect.intent_digest() == [0; 32] {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        self.application_effect = Some(application_effect);
+        Ok(self)
+    }
+
+    /// Domain sealed by the independently verified evidence.
+    pub fn authorization_domain(&self) -> CommunityId {
+        match &self.preparation {
+            AdmissionPreparation::Existing { prepared } => {
+                prepared.recheck_request().lease_dependencies().identity().1
+            }
+            AdmissionPreparation::Enrollment { evidence, .. } => {
+                evidence.proposal.authorization_domain()
+            }
+        }
+    }
+
+    /// Exact request fingerprint used by replay and receipt uniqueness.
+    pub fn request_fingerprint(&self) -> [u8; 32] {
+        match &self.preparation {
+            AdmissionPreparation::Existing { prepared } => {
+                let snapshot = prepared.recheck_request().lease_dependencies();
+                *snapshot.request_binding().0
+            }
+            AdmissionPreparation::Enrollment { evidence, .. } => {
+                *evidence.proof.request_fingerprint()
+            }
+        }
+    }
+
+    /// Exact provider-free transport binding sealed by the prepared witness.
+    ///
+    /// Trusted transport adapters must compare both values byte-for-byte with
+    /// their independently sealed evidence before attaching a replay claim.
+    pub fn transport_binding(&self) -> (ProofTransport, [u8; 32]) {
+        match &self.preparation {
+            AdmissionPreparation::Existing { prepared } => {
+                let snapshot = prepared.recheck_request().lease_dependencies();
+                let (_, _, transport, context) = snapshot.request_binding();
+                (transport, *context)
+            }
+            AdmissionPreparation::Enrollment { evidence, .. } => (
+                evidence.proof.transport(),
+                *evidence.proof.transport_context_fingerprint(),
+            ),
+        }
+    }
+
+    /// Full canonical route/application intent persisted with the receipt.
+    pub fn semantic_fingerprint(&self) -> [u8; 32] {
+        let domain = self.authorization_domain();
+        let request_fingerprint = self.request_fingerprint();
+        let (
+            capability,
+            target_fingerprint,
+            transport,
+            transport_context,
+            actor_pubkey,
+            owner_pubkey,
+            binding_id,
+            binding_version,
+            relationship_id,
+            relationship_revision,
+            relationship_conditions,
+            enrollment_revision,
+            enrollment_mode,
+            enrollment_evidence,
+            enrollment_policy_digest,
+            preparation_kind,
+        ) = match &self.preparation {
+            AdmissionPreparation::Existing { prepared } => {
+                let snapshot = prepared.recheck_request().lease_dependencies();
+                let (capability, actor, owner) = snapshot.authority();
+                let (binding_id, binding_version) = snapshot.binding();
+                let (request, target, transport, context) = snapshot.request_binding();
+                debug_assert_eq!(request, &request_fingerprint);
+                let relationship = snapshot.delegated_relationship();
+                (
+                    capability,
+                    *target,
+                    transport,
+                    *context,
+                    actor.to_bytes(),
+                    owner.map(|value| value.to_bytes()).unwrap_or([0; 32]),
+                    binding_id,
+                    binding_version,
+                    relationship.map(|value| value.0).unwrap_or(Uuid::nil()),
+                    relationship.map(|value| value.1).unwrap_or(0),
+                    relationship.map(|value| *value.2).unwrap_or([0; 32]),
+                    0,
+                    0,
+                    [0; 32],
+                    [0; 32],
+                    1_u8,
+                )
+            }
+            AdmissionPreparation::Enrollment {
+                capability,
+                evidence,
+                ..
+            } => {
+                let (revision, enrollment_evidence) = evidence.proposal.local_authority();
+                (
+                    *capability,
+                    *evidence.proof.target_fingerprint(),
+                    evidence.proof.transport(),
+                    *evidence.proof.transport_context_fingerprint(),
+                    evidence.proof.actor_pubkey().to_bytes(),
+                    [0; 32],
+                    Uuid::nil(),
+                    0,
+                    Uuid::nil(),
+                    0,
+                    [0; 32],
+                    revision,
+                    evidence.proposal.mode().database_code(),
+                    *enrollment_evidence,
+                    evidence.enrollment_policy_digest,
+                    2_u8,
+                )
+            }
+        };
+        let application_schema = self
+            .application_effect
+            .as_ref()
+            .map(|effect| effect.result_schema());
+        let application_type = application_schema
+            .map(|schema| *schema.type_key())
+            .unwrap_or([0; 32]);
+        let application_version = application_schema
+            .map(AdmissionApplicationResultSchema::version)
+            .unwrap_or(0);
+        let application_intent = self
+            .application_effect
+            .as_ref()
+            .map(|effect| effect.intent_digest())
+            .unwrap_or([0; 32]);
+        admission_framed_digest(
+            b"buzz:canonical-admission-semantic-intent:v2",
+            &[
+                domain.as_uuid().as_bytes(),
+                &request_fingerprint,
+                &(capability_code(capability)).to_be_bytes(),
+                &(self.object.kind().database_code()).to_be_bytes(),
+                self.object.key(),
+                &target_fingerprint,
+                &(proof_transport_code(transport)).to_be_bytes(),
+                &transport_context,
+                &actor_pubkey,
+                &owner_pubkey,
+                binding_id.as_bytes(),
+                &binding_version.to_be_bytes(),
+                relationship_id.as_bytes(),
+                &relationship_revision.to_be_bytes(),
+                &relationship_conditions,
+                &enrollment_revision.to_be_bytes(),
+                &enrollment_mode.to_be_bytes(),
+                &enrollment_evidence,
+                &enrollment_policy_digest,
+                &[preparation_kind],
+                &application_type,
+                &application_version.to_be_bytes(),
+                &application_intent,
+            ],
+        )
+    }
+}
+
+impl fmt::Debug for AdmissionCommitRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionCommitRequest([REDACTED])")
+    }
+}
+
+/// Credential-free durable identity of a committed admission.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionCommitReceipt {
+    authorization_domain: CommunityId,
+    object: AdmissionObject,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    semantic_fingerprint: [u8; 32],
+    result_digest: [u8; 32],
+    application_result_digest: Option<[u8; 32]>,
+    audit_event_id: Uuid,
+}
+
+/// Closed pair of canonical admission and application-result digests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdmissionCommitDigests {
+    result_digest: [u8; 32],
+    application_result_digest: Option<[u8; 32]>,
+}
+
+impl AdmissionCommitDigests {
+    /// Validate the complete admission envelope and optional typed-result binder.
+    pub fn new(
+        result_digest: [u8; 32],
+        application_result_digest: Option<[u8; 32]>,
+    ) -> Option<Self> {
+        if result_digest == [0; 32] || application_result_digest == Some([0; 32]) {
+            None
+        } else {
+            Some(Self {
+                result_digest,
+                application_result_digest,
+            })
+        }
+    }
+}
+
+impl AdmissionCommitReceipt {
+    /// Construct a receipt returned from authoritative storage.
+    pub fn from_storage(
+        authorization_domain: CommunityId,
+        object: AdmissionObject,
+        operation_id: Uuid,
+        request_fingerprint: [u8; 32],
+        semantic_fingerprint: [u8; 32],
+        digests: AdmissionCommitDigests,
+        audit_event_id: Uuid,
+    ) -> Option<Self> {
+        if authorization_domain.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || request_fingerprint == [0; 32]
+            || semantic_fingerprint == [0; 32]
+            || audit_event_id.is_nil()
+        {
+            None
+        } else {
+            Some(Self {
+                authorization_domain,
+                object,
+                operation_id,
+                request_fingerprint,
+                semantic_fingerprint,
+                result_digest: digests.result_digest,
+                application_result_digest: digests.application_result_digest,
+                audit_event_id,
+            })
+        }
+    }
+
+    /// Server-owned authorization domain committed by this admission.
+    pub const fn authorization_domain(self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Server-resolved object kind and fingerprint committed by this admission.
+    pub const fn object(self) -> AdmissionObject {
+        self.object
+    }
+
+    /// Server-generated idempotency identifier.
+    pub const fn operation_id(self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Exact request fingerprint committed with the operation.
+    pub const fn request_fingerprint(&self) -> &[u8; 32] {
+        &self.request_fingerprint
+    }
+
+    /// Complete domain/object/application semantic fingerprint.
+    pub const fn semantic_fingerprint(&self) -> &[u8; 32] {
+        &self.semantic_fingerprint
+    }
+
+    /// Canonical result digest.
+    pub const fn result_digest(&self) -> &[u8; 32] {
+        &self.result_digest
+    }
+
+    /// Separately type/object/domain-bound application artifact digest.
+    ///
+    /// This is distinct from [`Self::result_digest`], which commits the whole
+    /// admission envelope. Application outboxes compare this value to the
+    /// context-derived digest before dispatching fresh post-commit work.
+    pub const fn application_result_digest(&self) -> Option<&[u8; 32]> {
+        self.application_result_digest.as_ref()
+    }
+
+    /// Required authorization-audit event.
+    pub const fn audit_event_id(self) -> Uuid {
+        self.audit_event_id
+    }
+}
+
+impl fmt::Debug for AdmissionCommitReceipt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionCommitReceipt([REDACTED])")
+    }
+}
+
+/// Atomic canonical-admission result.
+pub enum AdmissionCommitOutcome {
+    /// This transaction committed every required authority effect.
+    Committed {
+        /// Finalized credential-free authorization context.
+        authorization: Box<FinalizedAuthContext>,
+        /// Durable receipt and audit identity.
+        receipt: AdmissionCommitReceipt,
+        /// Fresh closed application result, when application DML participated.
+        application_result: Option<AdmissionApplicationResult>,
+    },
+    /// The exact operation and request were committed previously.
+    ExactReplay {
+        /// Existing durable receipt; no authority effect was repeated.
+        receipt: AdmissionCommitReceipt,
+        /// Exact typed result reconstructed from immutable canonical storage.
+        application_result: Option<AdmissionApplicationResult>,
+    },
+}
+
+impl fmt::Debug for AdmissionCommitOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Committed { .. } => "AdmissionCommitOutcome::Committed([REDACTED])",
+            Self::ExactReplay { .. } => "AdmissionCommitOutcome::ExactReplay([REDACTED])",
+        })
+    }
+}
+
+/// Stable fail-closed final-admission failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AdmissionCommitError {
+    /// A server-generated identifier or sealed coordinate was malformed.
+    #[error("invalid canonical admission request")]
+    InvalidRequest,
+    /// Current evidence, binding, lifecycle, or policy denied admission.
+    #[error("canonical admission denied")]
+    AuthorizationDenied,
+    /// The operation identifier was already bound to different semantics.
+    #[error("canonical admission intent conflict")]
+    IntentConflict,
+    /// A proxy nonce or proof replay identity was already consumed.
+    #[error("canonical admission replay rejected")]
+    ReplayRejected,
+    /// Required canonical audit evidence could not be retained.
+    #[error("canonical authorization audit unavailable")]
+    AuditUnavailable,
+    /// Authoritative state or verifier state could not be rechecked.
+    #[error("canonical admission dependency unavailable")]
+    DependencyUnavailable,
+}
+
+/// Closed canonical invite-claim result shared by fresh commit and replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalInviteClaimOutcome {
+    /// The transaction inserted relay membership and consumed one invite use.
+    Joined,
+    /// Membership already existed and no invite use was consumed.
+    AlreadyMember,
+}
+
+impl CanonicalInviteClaimOutcome {
+    const fn database_code(self) -> i16 {
+        match self {
+            Self::Joined => 1,
+            Self::AlreadyMember => 2,
+        }
+    }
+
+    fn from_database(code: i16) -> Result<Self, AdmissionCommitError> {
+        match code {
+            1 => Ok(Self::Joined),
+            2 => Ok(Self::AlreadyMember),
+            _ => Err(AdmissionCommitError::DependencyUnavailable),
+        }
+    }
+}
+
+/// Maximum canonical application-result payload retained for exact replay.
+pub const MAX_ADMISSION_APPLICATION_RESULT_PAYLOAD_BYTES: usize = 4_096;
+
+const INVITE_CLAIM_RESULT_TYPE: [u8; 32] = [
+    0x03, 0x05, 0x7a, 0x5b, 0xd9, 0x5c, 0x3d, 0x4f, 0x9a, 0x89, 0x42, 0x89, 0x33, 0x45, 0xf0, 0xc6,
+    0x1e, 0x04, 0x37, 0xbc, 0x43, 0xd1, 0xe4, 0x71, 0x6d, 0xe6, 0xc2, 0xda, 0x2a, 0x39, 0x4e, 0xcd,
+];
+
+const PROTECTED_PUBLICATION_RESULT_TYPE: [u8; 32] = [
+    0x07, 0xa2, 0x9a, 0x3f, 0x15, 0x45, 0xf0, 0x3b, 0x1b, 0xda, 0x4e, 0xee, 0x5a, 0x25, 0xf0, 0x45,
+    0x3f, 0x58, 0x8d, 0x01, 0x81, 0xf8, 0x49, 0x68, 0x87, 0x94, 0x5f, 0xa6, 0xbf, 0x70, 0x0c, 0x9c,
+];
+
+const MODERATION_RESULT_TYPE: [u8; 32] = [
+    0x1c, 0x3e, 0xdc, 0x9a, 0x25, 0xcd, 0xb1, 0x43, 0x5f, 0x78, 0x99, 0xa1, 0x8d, 0xf6, 0x70, 0x91,
+    0x26, 0xf3, 0x20, 0x4f, 0x10, 0x0c, 0x74, 0x93, 0x63, 0x76, 0xf8, 0x14, 0x0d, 0x7b, 0x3f, 0x79,
+];
+
+/// Versioned type binding for one bounded canonical application result.
+///
+/// The type key is a server-owned, domain-separated 32-byte identifier. It is
+/// never a provider name or client-controlled discriminator. Schema versions
+/// are positive and capped by PostgreSQL `SMALLINT` so storage and callers use
+/// one exact representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionApplicationResultSchema {
+    type_key: [u8; 32],
+    version: u16,
+}
+
+impl AdmissionApplicationResultSchema {
+    /// Bind an application-owned nonzero type key and positive schema version.
+    pub fn new(type_key: [u8; 32], version: u16) -> Option<Self> {
+        if type_key == [0; 32] || version == 0 || version > i16::MAX as u16 {
+            None
+        } else {
+            Some(Self { type_key, version })
+        }
+    }
+
+    /// Stable schema for canonical relay invite results.
+    pub const fn invite_claim() -> Self {
+        Self {
+            type_key: INVITE_CLAIM_RESULT_TYPE,
+            version: 1,
+        }
+    }
+
+    /// Stable schema for canonical protected-publication results.
+    pub const fn protected_publication() -> Self {
+        Self {
+            type_key: PROTECTED_PUBLICATION_RESULT_TYPE,
+            version: 1,
+        }
+    }
+
+    /// Stable schema for canonical moderation results.
+    pub const fn moderation() -> Self {
+        Self {
+            type_key: MODERATION_RESULT_TYPE,
+            version: 1,
+        }
+    }
+
+    /// Opaque server-owned application result type key.
+    pub const fn type_key(&self) -> &[u8; 32] {
+        &self.type_key
+    }
+
+    /// Positive payload schema version.
+    pub const fn version(self) -> u16 {
+        self.version
+    }
+}
+
+/// Credential-free typed result returned byte-identically on exact replay.
+///
+/// Payloads are bounded to 4096 bytes. The canonical transaction persists the
+/// type key, schema version, result code, and payload verbatim and covers all
+/// four fields with the immutable receipt digest. Application adapters must
+/// encode only stable server-derived output, never credentials or mutable
+/// request attribution such as uploader names, source addresses, or hosts.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AdmissionApplicationResult {
+    schema: AdmissionApplicationResultSchema,
+    code: i16,
+    payload: Box<[u8]>,
+}
+
+impl AdmissionApplicationResult {
+    /// Seal a bounded versioned result for fresh return and durable replay.
+    pub fn new(
+        schema: AdmissionApplicationResultSchema,
+        code: i16,
+        payload: impl Into<Box<[u8]>>,
+    ) -> Result<Self, AdmissionCommitError> {
+        let payload = payload.into();
+        if code <= 0 || payload.len() > MAX_ADMISSION_APPLICATION_RESULT_PAYLOAD_BYTES {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            schema,
+            code,
+            payload,
+        })
+    }
+
+    /// Encode the closed relay invite result in its shared schema.
+    pub fn invite_claim(result: CanonicalInviteClaimOutcome) -> Self {
+        Self {
+            schema: AdmissionApplicationResultSchema::invite_claim(),
+            code: result.database_code(),
+            payload: Box::default(),
+        }
+    }
+
+    /// Decode the closed relay invite result, rejecting every other schema.
+    pub fn decode_invite_claim(&self) -> Result<CanonicalInviteClaimOutcome, AdmissionCommitError> {
+        if self.schema != AdmissionApplicationResultSchema::invite_claim()
+            || !self.payload.is_empty()
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        CanonicalInviteClaimOutcome::from_database(self.code)
+            .map_err(|_| AdmissionCommitError::InvalidRequest)
+    }
+
+    /// Exact type and version binding for application decoding.
+    pub const fn schema(&self) -> AdmissionApplicationResultSchema {
+        self.schema
+    }
+
+    /// Stable application-defined result code.
+    pub const fn code(&self) -> i16 {
+        self.code
+    }
+
+    /// Exact bounded result bytes persisted by canonical admission.
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    fn from_database(
+        type_key: Vec<u8>,
+        version: i16,
+        code: i16,
+        payload: Vec<u8>,
+    ) -> Result<Self, AdmissionCommitError> {
+        let type_key: [u8; 32] = type_key
+            .try_into()
+            .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+        let version =
+            u16::try_from(version).map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+        let schema = AdmissionApplicationResultSchema::new(type_key, version)
+            .ok_or(AdmissionCommitError::DependencyUnavailable)?;
+        Self::new(schema, code, payload).map_err(|_| AdmissionCommitError::DependencyUnavailable)
+    }
+}
+
+impl fmt::Debug for AdmissionApplicationResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AdmissionApplicationResult")
+            .field("schema", &self.schema)
+            .field("code", &self.code)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
+}
+
+/// Privacy-safe result of a transaction-shareable application mutation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AdmissionApplicationOutcome {
+    result: AdmissionApplicationResult,
+    effect_digest: [u8; 32],
+}
+
+impl AdmissionApplicationOutcome {
+    /// Seal a typed invite result and non-sentinel application-effect digest.
+    pub fn invite_claim(
+        result: CanonicalInviteClaimOutcome,
+        effect_digest: [u8; 32],
+    ) -> Result<Self, AdmissionCommitError> {
+        if effect_digest == [0; 32] {
+            Err(AdmissionCommitError::InvalidRequest)
+        } else {
+            Ok(Self {
+                result: AdmissionApplicationResult::invite_claim(result),
+                effect_digest,
+            })
+        }
+    }
+
+    /// Seal an application-owned bounded result and effect digest.
+    pub fn new(
+        result: AdmissionApplicationResult,
+        effect_digest: [u8; 32],
+    ) -> Result<Self, AdmissionCommitError> {
+        if effect_digest == [0; 32] {
+            Err(AdmissionCommitError::InvalidRequest)
+        } else {
+            Ok(Self {
+                result,
+                effect_digest,
+            })
+        }
+    }
+
+    /// Closed credential-free application result.
+    pub const fn result(&self) -> &AdmissionApplicationResult {
+        &self.result
+    }
+
+    /// Canonical credential-free effect digest included in the receipt.
+    pub const fn effect_digest(&self) -> &[u8; 32] {
+        &self.effect_digest
+    }
+}
+
+impl fmt::Debug for AdmissionApplicationOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionApplicationOutcome([REDACTED])")
+    }
+}
+
+/// Canonical provider-free coordinates supplied by the transaction owner.
+///
+/// Application effects cannot choose or capture these values. The committer
+/// constructs this context after the final authorization recheck and passes it
+/// into the same PostgreSQL transaction used for application DML, receipt,
+/// typed result, audit, and authority persistence.
+pub struct AdmissionApplicationContext<'a> {
+    authorization: &'a FinalizedAuthContext,
+    operation_id: Uuid,
+    object: AdmissionObject,
+    semantic_fingerprint: [u8; 32],
+    application_intent_digest: [u8; 32],
+    authoritative_now: DateTime<Utc>,
+}
+
+impl<'a> AdmissionApplicationContext<'a> {
+    fn new(
+        authorization: &'a FinalizedAuthContext,
+        operation_id: Uuid,
+        object: AdmissionObject,
+        semantic_fingerprint: [u8; 32],
+        application_intent_digest: [u8; 32],
+        authoritative_now: DateTime<Utc>,
+    ) -> Result<Self, AdmissionCommitError> {
+        if authorization.authorization_domain().as_uuid().is_nil()
+            || operation_id.is_nil()
+            || semantic_fingerprint == [0; 32]
+            || application_intent_digest == [0; 32]
+            || authorization.request_fingerprint() == &[0; 32]
+            || authorization.lease().request_binding().1 != object.key()
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            authorization,
+            operation_id,
+            object,
+            semantic_fingerprint,
+            application_intent_digest,
+            authoritative_now,
+        })
+    }
+
+    /// Exact finalized provider-free authorization.
+    pub const fn authorization(&self) -> &FinalizedAuthContext {
+        self.authorization
+    }
+
+    /// Server-owned authorization domain.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization.authorization_domain()
+    }
+
+    /// Stable server-derived logical operation identifier.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Server-resolved protected object.
+    pub const fn object(&self) -> AdmissionObject {
+        self.object
+    }
+
+    /// Canonical request intent fingerprint.
+    pub const fn request_fingerprint(&self) -> &[u8; 32] {
+        self.authorization.request_fingerprint()
+    }
+
+    /// Complete domain/object/application semantic fingerprint.
+    pub const fn semantic_fingerprint(&self) -> &[u8; 32] {
+        &self.semantic_fingerprint
+    }
+
+    /// Effect-owned bounded intent digest bound into logical identity.
+    pub const fn application_intent_digest(&self) -> &[u8; 32] {
+        &self.application_intent_digest
+    }
+
+    /// Authoritative PostgreSQL transaction time.
+    pub const fn authoritative_now(&self) -> DateTime<Utc> {
+        self.authoritative_now
+    }
+
+    /// Bind one typed effect outcome to this canonical operation and object.
+    pub fn canonical_result_digest(
+        &self,
+        outcome: &AdmissionApplicationOutcome,
+    ) -> Result<[u8; 32], AdmissionCommitError> {
+        canonical_application_result_digest(
+            self.authorization_domain(),
+            self.object,
+            self.semantic_fingerprint,
+            self.application_intent_digest,
+            outcome.result(),
+        )
+    }
+}
+
+impl fmt::Debug for AdmissionApplicationContext<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionApplicationContext([REDACTED])")
+    }
+}
+
+/// Route-owned application DML executed inside canonical final admission.
+///
+/// Implementations may capture only bounded application intent. Canonical
+/// operation/outbox coordinates come exclusively from the supplied context;
+/// effects must not capture bearer credentials or substitute domain, object,
+/// operation, request, or result-binding values.
+pub trait AdmissionApplicationEffect: Send {
+    /// Stable server-derived semantic digest used by logical operation identity.
+    fn intent_digest(&self) -> [u8; 32];
+
+    /// Exact result type and version produced and persisted by this effect.
+    fn result_schema(&self) -> AdmissionApplicationResultSchema;
+
+    /// Apply or idempotently stage the application mutation and return its digest.
+    fn apply<'a, 'transaction>(
+        &'a mut self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        context: &'a AdmissionApplicationContext<'a>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<AdmissionApplicationOutcome, AdmissionCommitError>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+/// Canonical relay-invite application mutation executed by final admission.
+///
+/// The bearer token is already reduced to its opaque fixed digest. Membership
+/// identity comes only from the finalized authorization context, never from a
+/// caller-supplied subject or public-key string.
+pub struct CanonicalInviteClaimEffect {
+    token_hash: [u8; 32],
+    policy_version: Option<Box<str>>,
+    intent_digest: [u8; 32],
+}
+
+impl CanonicalInviteClaimEffect {
+    /// Bind one opaque invite digest and optional bounded policy version.
+    pub fn new(
+        token_hash: [u8; 32],
+        policy_version: Option<&str>,
+    ) -> Result<Self, AdmissionCommitError> {
+        if token_hash == [0; 32]
+            || policy_version.is_some_and(|version| {
+                version.len() != 64 || !version.bytes().all(|byte| byte.is_ascii_hexdigit())
+            })
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        let policy_bytes = policy_version.map(str::as_bytes).unwrap_or_default();
+        let intent_digest = admission_framed_digest(
+            b"buzz:canonical-invite-claim-intent:v1",
+            &[&token_hash, policy_bytes],
+        );
+        Ok(Self {
+            token_hash,
+            policy_version: policy_version.map(Into::into),
+            intent_digest,
+        })
+    }
+}
+
+impl fmt::Debug for CanonicalInviteClaimEffect {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CanonicalInviteClaimEffect([REDACTED])")
+    }
+}
+
+impl AdmissionApplicationEffect for CanonicalInviteClaimEffect {
+    fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    fn result_schema(&self) -> AdmissionApplicationResultSchema {
+        AdmissionApplicationResultSchema::invite_claim()
+    }
+
+    fn apply<'a, 'transaction>(
+        &'a mut self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        context: &'a AdmissionApplicationContext<'a>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<AdmissionApplicationOutcome, AdmissionCommitError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if context.authorization().capability() != RouteCapability::InviteClaim
+                || context.object().kind() != AdmissionObjectKind::Domain
+            {
+                return Err(AdmissionCommitError::AuthorizationDenied);
+            }
+            apply_canonical_invite_claim_tx(
+                transaction,
+                context.authorization_domain(),
+                &context.authorization().actor_pubkey().to_hex(),
+                self.token_hash,
+                self.policy_version.as_deref(),
+                self.intent_digest,
+            )
+            .await
+        })
+    }
+}
+
+async fn apply_canonical_invite_claim_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    actor_pubkey: &str,
+    token_hash: [u8; 32],
+    policy_version: Option<&str>,
+    intent_digest: [u8; 32],
+) -> Result<AdmissionApplicationOutcome, AdmissionCommitError> {
+    if domain.as_uuid().is_nil()
+        || actor_pubkey.len() != 64
+        || !actor_pubkey.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || token_hash == [0; 32]
+        || intent_digest == [0; 32]
+    {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    let authoritative_now: DateTime<Utc> = sqlx::query_scalar("SELECT transaction_timestamp()")
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let invite = sqlx::query(
+        r#"
+        SELECT id, max_uses, use_count, expires_at
+        FROM relay_invites
+        WHERE community_id = $1 AND token_hash = $2
+        FOR UPDATE
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(token_hash.as_slice())
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?
+    .ok_or(AdmissionCommitError::AuthorizationDenied)?;
+    let invite_id: Uuid = invite
+        .try_get("id")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let max_uses: Option<i32> = invite
+        .try_get("max_uses")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let use_count: i32 = invite
+        .try_get("use_count")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let expires_at: DateTime<Utc> = invite
+        .try_get("expires_at")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if invite_id.is_nil()
+        || use_count < 0
+        || max_uses.is_some_and(|maximum| maximum <= 0 || use_count > maximum)
+        || expires_at <= authoritative_now
+    {
+        return Err(AdmissionCommitError::AuthorizationDenied);
+    }
+
+    let existing = sqlx::query_scalar::<_, i32>(
+        "SELECT 1 FROM relay_members WHERE community_id=$1 AND pubkey=$2 FOR SHARE",
+    )
+    .bind(domain.as_uuid())
+    .bind(actor_pubkey)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?
+    .is_some();
+    if existing {
+        persist_invite_policy_acceptance(transaction, domain, actor_pubkey, policy_version).await?;
+        return invite_application_outcome(
+            intent_digest,
+            CanonicalInviteClaimOutcome::AlreadyMember,
+        );
+    }
+    if max_uses.is_some_and(|maximum| use_count >= maximum) {
+        return Err(AdmissionCommitError::AuthorizationDenied);
+    }
+
+    let inserted = sqlx::query(
+        "INSERT INTO relay_members (community_id,pubkey,role,added_by) \
+         VALUES ($1,$2,'member','invite') ON CONFLICT (community_id,pubkey) DO NOTHING",
+    )
+    .bind(domain.as_uuid())
+    .bind(actor_pubkey)
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?
+    .rows_affected();
+    persist_invite_policy_acceptance(transaction, domain, actor_pubkey, policy_version).await?;
+    if inserted == 0 {
+        return invite_application_outcome(
+            intent_digest,
+            CanonicalInviteClaimOutcome::AlreadyMember,
+        );
+    }
+    if inserted != 1 {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+    let next_use_count = use_count
+        .checked_add(1)
+        .ok_or(AdmissionCommitError::DependencyUnavailable)?;
+    let updated = sqlx::query(
+        "UPDATE relay_invites SET use_count=$1 \
+         WHERE community_id=$2 AND id=$3 AND use_count=$4",
+    )
+    .bind(next_use_count)
+    .bind(domain.as_uuid())
+    .bind(invite_id)
+    .bind(use_count)
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if updated.rows_affected() != 1 {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+    invite_application_outcome(intent_digest, CanonicalInviteClaimOutcome::Joined)
+}
+
+async fn persist_invite_policy_acceptance(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    actor_pubkey: &str,
+    policy_version: Option<&str>,
+) -> Result<(), AdmissionCommitError> {
+    if let Some(policy_version) = policy_version {
+        sqlx::query(
+            "INSERT INTO join_policy_acceptances (community_id,pubkey,policy_version) \
+             VALUES ($1,$2,$3) ON CONFLICT DO NOTHING",
+        )
+        .bind(domain.as_uuid())
+        .bind(actor_pubkey)
+        .bind(policy_version)
+        .execute(&mut **transaction)
+        .await
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    }
+    Ok(())
+}
+
+fn invite_application_outcome(
+    intent_digest: [u8; 32],
+    result: CanonicalInviteClaimOutcome,
+) -> Result<AdmissionApplicationOutcome, AdmissionCommitError> {
+    let effect_digest = admission_framed_digest(
+        b"buzz:canonical-invite-claim-result:v1",
+        &[&intent_digest, &result.database_code().to_be_bytes()],
+    );
+    AdmissionApplicationOutcome::invite_claim(result, effect_digest)
+}
+
+/// Transaction-bound final dependency reader configured by composition.
+///
+/// The implementation atomically reads the complete lease dependency tuple
+/// through the supplied transaction and includes the current verifier policy
+/// generation. It may not echo the prepared tuple without authoritative reads.
+pub trait AdmissionFinalRechecker: Send + Sync {
+    /// Observe exact current dependencies while all admission locks are held.
+    fn authoritative_recheck<'a, 'transaction>(
+        &'a self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        request: &'a PreparedAuthorizationRecheck,
+        object: AdmissionObject,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<AuthoritativeAuthorizationRecheck, AdmissionCommitError>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+/// PostgreSQL implementation of the canonical final-admission boundary.
+pub struct PostgresCanonicalAdmissionCommitter {
+    pool: PgPool,
+    rechecker: Arc<dyn AdmissionFinalRechecker>,
+}
+
+impl PostgresCanonicalAdmissionCommitter {
+    /// Bind canonical admission to the writer pool and configured rechecker.
+    pub fn new(pool: PgPool, rechecker: Arc<dyn AdmissionFinalRechecker>) -> Self {
+        Self { pool, rechecker }
+    }
+
+    async fn commit_inner(
+        &self,
+        request: AdmissionCommitRequest,
+    ) -> Result<AdmissionCommitOutcome, AdmissionCommitError> {
+        let domain = request.authorization_domain();
+        let operation_id = request.operation_id();
+        let semantic_fingerprint = request.semantic_fingerprint();
+        let attempt_id = request.attempt_id;
+        let object = request.object;
+        let request_fingerprint = request.request_fingerprint();
+        let receipt_shape = AdmissionReceiptShape::from_preparation(&request.preparation);
+        let replay_claim = request.replay_claim;
+        let expected_application_schema = request
+            .application_effect
+            .as_ref()
+            .map(|effect| effect.result_schema());
+        let application_intent_digest = request
+            .application_effect
+            .as_ref()
+            .map(|effect| effect.intent_digest());
+        let mut application_effect = request.application_effect;
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+
+        lock_operation(&mut transaction, domain, operation_id).await?;
+        if let Some(receipt) = read_existing_receipt(
+            &mut transaction,
+            ExistingAdmissionLookup {
+                domain,
+                operation_id,
+                request_fingerprint,
+                semantic_fingerprint,
+                object,
+                receipt_shape,
+                expected_application_schema,
+            },
+        )
+        .await?
+        {
+            if let Some(claim) = replay_claim {
+                let authoritative_now: DateTime<Utc> =
+                    sqlx::query_scalar("SELECT transaction_timestamp()")
+                        .fetch_one(&mut *transaction)
+                        .await
+                        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                claim_replay_identity_tx(&mut transaction, domain, claim, authoritative_now)
+                    .await?;
+                transaction
+                    .commit()
+                    .await
+                    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            } else {
+                transaction
+                    .rollback()
+                    .await
+                    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            }
+            return Ok(AdmissionCommitOutcome::ExactReplay {
+                receipt: receipt.0,
+                application_result: receipt.1,
+            });
+        }
+
+        let authoritative_now: DateTime<Utc> = sqlx::query_scalar("SELECT transaction_timestamp()")
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+        if let Some(claim) = replay_claim {
+            claim_replay_identity_tx(&mut transaction, domain, claim, authoritative_now).await?;
+        }
+
+        let (prepared, enrollment_disposition) = match request.preparation {
+            AdmissionPreparation::Existing { prepared } => (*prepared, None),
+            AdmissionPreparation::Enrollment {
+                correlation_id,
+                capability,
+                evidence,
+            } => {
+                let AdmissionEnrollmentEvidence {
+                    proposal,
+                    enrollment_policy_digest,
+                    assertion,
+                    proof,
+                    policy,
+                } = *evidence;
+                let enrollment = execute_authoritative_enrollment_tx(
+                    &mut transaction,
+                    operation_id,
+                    request_fingerprint,
+                    &proposal,
+                    enrollment_policy_digest,
+                    &assertion,
+                    &proof,
+                    authoritative_now,
+                )
+                .await
+                .map_err(map_enrollment_error)?;
+                let input = AuthorizationInput::new(domain, correlation_id, proof, capability)
+                    .map_err(|_| AdmissionCommitError::AuthorizationDenied)?;
+                let resolution = LocalBindingResolution::enrollment(proposal, enrollment.binding);
+                let prepared =
+                    AuthorizationFinalizer::prepare(input, resolution, policy, authoritative_now)
+                        .map_err(|_| AdmissionCommitError::AuthorizationDenied)?;
+                (prepared, Some(enrollment.disposition))
+            }
+        };
+
+        let recheck_request = prepared.recheck_request();
+        let observation = self
+            .rechecker
+            .authoritative_recheck(&mut transaction, &recheck_request, object)
+            .await?;
+        let one_shot = OneShotRechecker::new(observation);
+        let witness = AuthorizationFinalizer::recheck(&prepared, &one_shot)
+            .await
+            .map_err(|_| AdmissionCommitError::AuthorizationDenied)?;
+        let authorization = AuthorizationFinalizer::finalize(prepared, witness)
+            .map_err(|_| AdmissionCommitError::AuthorizationDenied)?;
+
+        let application_context = application_intent_digest
+            .map(|intent| {
+                AdmissionApplicationContext::new(
+                    &authorization,
+                    operation_id,
+                    object,
+                    semantic_fingerprint,
+                    intent,
+                    authoritative_now,
+                )
+            })
+            .transpose()?;
+        let application_outcome = match (application_effect.as_mut(), application_context.as_ref())
+        {
+            (Some(effect), Some(context)) => {
+                let outcome = effect.apply(&mut transaction, context).await?;
+                let _ = context.canonical_result_digest(&outcome)?;
+                Some(outcome)
+            }
+            (None, None) => None,
+            _ => return Err(AdmissionCommitError::DependencyUnavailable),
+        };
+        if application_outcome
+            .as_ref()
+            .map(|outcome| outcome.result().schema())
+            != expected_application_schema
+        {
+            return Err(AdmissionCommitError::DependencyUnavailable);
+        }
+
+        let receipt = persist_committed_admission(
+            &mut transaction,
+            operation_id,
+            attempt_id,
+            object,
+            request_fingerprint,
+            semantic_fingerprint,
+            &authorization,
+            enrollment_disposition,
+            application_intent_digest,
+            application_outcome.as_ref(),
+            authoritative_now,
+        )
+        .await?;
+        sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+            .execute(&mut *transaction)
+            .await
+            .map_err(map_commit_error)?;
+        transaction.commit().await.map_err(map_commit_error)?;
+        Ok(AdmissionCommitOutcome::Committed {
+            authorization: Box::new(authorization),
+            receipt,
+            application_result: application_outcome.map(|outcome| outcome.result),
+        })
+    }
+}
+
+async fn claim_replay_identity_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    claim: AdmissionReplayClaim,
+    authoritative_now: DateTime<Utc>,
+) -> Result<(), AdmissionCommitError> {
+    claim.validate_at(authoritative_now)?;
+    let claimed = sqlx::query(
+        r#"
+        INSERT INTO authorization_proxy_nonce_claims (
+            authorization_domain, claim_kind, claim_key, committed_at, retain_until
+        ) VALUES ($1, $2, $3, transaction_timestamp(), $4)
+        ON CONFLICT (authorization_domain, claim_kind, claim_key) DO NOTHING
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(claim.kind().database_code())
+    .bind(claim.claim_key().as_slice())
+    .bind(claim.retain_until())
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if claimed.rows_affected() == 1 {
+        Ok(())
+    } else {
+        Err(AdmissionCommitError::ReplayRejected)
+    }
+}
+
+impl fmt::Debug for PostgresCanonicalAdmissionCommitter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PostgresCanonicalAdmissionCommitter([REDACTED])")
+    }
+}
+
+/// The sole mutation authority used by every protected ingress.
+///
+/// Implementations must be provider-free, fail closed, and atomic. They must
+/// never retain raw credentials or accept a client-selected authorization
+/// domain. The replay claim, optional enrollment, canonical receipt, required
+/// audit event, and transaction-shareable application mutation must commit or
+/// roll back together. A non-shareable application effect requires an equally
+/// request-bound idempotent staging receipt before this method returns.
+pub trait CanonicalAdmissionCommitter: Send + Sync {
+    /// Recheck and consume one request exactly once.
+    fn commit<'a>(
+        &'a self,
+        request: AdmissionCommitRequest,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<AdmissionCommitOutcome, AdmissionCommitError>> + Send + 'a>,
+    >;
+}
+
+impl CanonicalAdmissionCommitter for PostgresCanonicalAdmissionCommitter {
+    fn commit<'a>(
+        &'a self,
+        request: AdmissionCommitRequest,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<AdmissionCommitOutcome, AdmissionCommitError>> + Send + 'a>,
+    > {
+        Box::pin(self.commit_inner(request))
+    }
+}
+
+struct OneShotRechecker {
+    observation: Mutex<Option<AuthoritativeAuthorizationRecheck>>,
+}
+
+impl OneShotRechecker {
+    fn new(observation: AuthoritativeAuthorizationRecheck) -> Self {
+        Self {
+            observation: Mutex::new(Some(observation)),
+        }
+    }
+}
+
+impl AuthorizationFinalizationRechecker for OneShotRechecker {
+    fn recheck<'a>(
+        &'a self,
+        _request: &'a PreparedAuthorizationRecheck,
+    ) -> impl Future<Output = Result<AuthoritativeAuthorizationRecheck, AuthorizationError>> + Send + 'a
+    {
+        ready(
+            self.observation
+                .lock()
+                .map_err(|_| AuthorizationError::StaleRecheck)
+                .and_then(|mut observation| {
+                    observation.take().ok_or(AuthorizationError::StaleRecheck)
+                }),
+        )
+    }
+}
+
+async fn lock_operation(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    operation_id: Uuid,
+) -> Result<(), AdmissionCommitError> {
+    sqlx::query("SELECT nip_fi_lock_authorization_operation_v1($1,$2)")
+        .bind(domain.as_uuid())
+        .bind(operation_id)
+        .execute(&mut **transaction)
+        .await
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct ExistingAdmissionLookup {
+    domain: CommunityId,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    semantic_fingerprint: [u8; 32],
+    object: AdmissionObject,
+    receipt_shape: AdmissionReceiptShape,
+    expected_application_schema: Option<AdmissionApplicationResultSchema>,
+}
+
+async fn read_existing_receipt(
+    transaction: &mut Transaction<'_, Postgres>,
+    lookup: ExistingAdmissionLookup,
+) -> Result<
+    Option<(AdmissionCommitReceipt, Option<AdmissionApplicationResult>)>,
+    AdmissionCommitError,
+> {
+    let ExistingAdmissionLookup {
+        domain,
+        operation_id,
+        request_fingerprint,
+        semantic_fingerprint,
+        object,
+        receipt_shape,
+        expected_application_schema,
+    } = lookup;
+    let row = sqlx::query(
+        r#"
+        SELECT receipt.request_fingerprint, receipt.result_digest,
+               receipt.operation_kind, receipt.outcome_code,
+               admission.semantic_fingerprint,
+               admission.object_kind,
+               admission.object_key,
+               admission.application_type,
+               admission.application_version,
+               admission.application_code,
+               admission.application_payload,
+               admission.application_intent_digest,
+               admission.application_effect_digest,
+               admission.application_result_digest,
+               event.event_id AS audit_event_id,
+               event.event_kind AS audit_event_kind,
+               event.outcome_code AS audit_outcome_code,
+               event.matching_event_count
+        FROM authorization_operation_receipts receipt
+        LEFT JOIN LATERAL (
+            SELECT (array_agg(event_id ORDER BY accepted_at, event_id))[1] AS event_id,
+                   min(event_kind) AS event_kind,
+                   min(outcome_code) AS outcome_code,
+                   count(*) AS matching_event_count
+            FROM authorization_events
+            WHERE community_id = receipt.community_id
+              AND operation_id = receipt.operation_id
+              AND request_fingerprint = receipt.request_fingerprint
+        ) event ON TRUE
+        LEFT JOIN authorization_admission_results admission
+          ON admission.community_id = receipt.community_id
+         AND admission.operation_id = receipt.operation_id
+         AND admission.request_fingerprint = receipt.request_fingerprint
+        WHERE receipt.community_id = $1 AND receipt.operation_id = $2
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(operation_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let stored_request = fixed_digest(&row, "request_fingerprint")?;
+    if stored_request != request_fingerprint {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let stored_semantic = row
+        .try_get::<Option<Vec<u8>>, _>("semantic_fingerprint")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?
+        .ok_or(AdmissionCommitError::IntentConflict)?;
+    if stored_semantic.as_slice() != semantic_fingerprint {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let stored_object_kind: i16 = row
+        .try_get("object_kind")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_object_key = row
+        .try_get::<Vec<u8>, _>("object_key")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if stored_object_kind != object.kind().database_code()
+        || stored_object_key.as_slice() != object.key()
+    {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let operation_kind: i16 = row
+        .try_get("operation_kind")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let receipt_outcome: i16 = row
+        .try_get("outcome_code")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let event_kind: Option<i16> = row
+        .try_get("audit_event_kind")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let event_outcome: Option<i16> = row
+        .try_get("audit_outcome_code")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let event_count: i64 = row
+        .try_get("matching_event_count")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if event_count != 1
+        || !receipt_shape.matches(operation_kind, receipt_outcome, event_kind, event_outcome)
+    {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let result_digest = fixed_digest(&row, "result_digest")?;
+    let audit_event_id: Option<Uuid> = row
+        .try_get("audit_event_id")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_type: Option<Vec<u8>> = row
+        .try_get("application_type")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_version: Option<i16> = row
+        .try_get("application_version")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_code: Option<i16> = row
+        .try_get("application_code")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_payload: Option<Vec<u8>> = row
+        .try_get("application_payload")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_intent: Option<Vec<u8>> = row
+        .try_get("application_intent_digest")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_effect: Option<Vec<u8>> = row
+        .try_get("application_effect_digest")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let stored_application_result_digest: Option<Vec<u8>> = row
+        .try_get("application_result_digest")
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let (
+        application_result,
+        stored_application_intent,
+        stored_application_effect,
+        stored_application_result_digest,
+    ) = match (
+        expected_application_schema,
+        stored_application_type,
+        stored_application_version,
+        stored_application_code,
+        stored_application_payload,
+        stored_application_intent,
+        stored_application_effect,
+        stored_application_result_digest,
+    ) {
+        (None, None, None, None, None, None, None, None) => (None, None, None, None),
+        (
+            Some(expected),
+            Some(type_key),
+            Some(version),
+            Some(code),
+            Some(payload),
+            Some(intent),
+            Some(effect),
+            Some(result_digest),
+        ) if type_key.as_slice() == expected.type_key()
+            && i32::from(version) == i32::from(expected.version())
+            && intent.len() == 32
+            && intent.iter().any(|byte| *byte != 0)
+            && effect.len() == 32
+            && effect.iter().any(|byte| *byte != 0)
+            && result_digest.len() == 32
+            && result_digest.iter().any(|byte| *byte != 0) =>
+        {
+            let intent: [u8; 32] = intent
+                .try_into()
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            let effect: [u8; 32] = effect
+                .try_into()
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            let result_digest: [u8; 32] = result_digest
+                .try_into()
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            (
+                Some(AdmissionApplicationResult::from_database(
+                    type_key, version, code, payload,
+                )?),
+                Some(intent),
+                Some(effect),
+                Some(result_digest),
+            )
+        }
+        _ => return Err(AdmissionCommitError::IntentConflict),
+    };
+    let calculated_application_result_digest =
+        match (stored_application_intent, application_result.as_ref()) {
+            (Some(intent), Some(result)) => Some(canonical_application_result_digest(
+                domain,
+                object,
+                semantic_fingerprint,
+                intent,
+                result,
+            )?),
+            (None, None) => None,
+            _ => return Err(AdmissionCommitError::DependencyUnavailable),
+        };
+    if calculated_application_result_digest != stored_application_result_digest {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+    let calculated_result_digest = canonical_admission_result_digest(
+        domain,
+        object,
+        semantic_fingerprint,
+        stored_application_intent,
+        application_result.as_ref(),
+        stored_application_effect,
+    )
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if calculated_result_digest != result_digest {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+    let receipt = AdmissionCommitReceipt::from_storage(
+        domain,
+        object,
+        operation_id,
+        stored_request,
+        semantic_fingerprint,
+        AdmissionCommitDigests::new(result_digest, stored_application_result_digest)
+            .ok_or(AdmissionCommitError::DependencyUnavailable)?,
+        audit_event_id.ok_or(AdmissionCommitError::DependencyUnavailable)?,
+    )
+    .ok_or(AdmissionCommitError::DependencyUnavailable)?;
+    Ok(Some((receipt, application_result)))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_committed_admission(
+    transaction: &mut Transaction<'_, Postgres>,
+    operation_id: Uuid,
+    attempt_id: Uuid,
+    object: AdmissionObject,
+    request_fingerprint: [u8; 32],
+    semantic_fingerprint: [u8; 32],
+    authorization: &FinalizedAuthContext,
+    enrollment_disposition: Option<EnrollmentDisposition>,
+    application_intent_digest: Option<[u8; 32]>,
+    application_outcome: Option<&AdmissionApplicationOutcome>,
+    authoritative_now: DateTime<Utc>,
+) -> Result<AdmissionCommitReceipt, AdmissionCommitError> {
+    if authorization.authorization_domain().as_uuid().is_nil()
+        || authorization.authorization_domain() != authorization.lease().authorization_domain()
+        || authorization.request_fingerprint() != &request_fingerprint
+        || authorization.lease().request_binding().1 != object.key()
+        || semantic_fingerprint == [0; 32]
+        || application_intent_digest.is_some() != application_outcome.is_some()
+    {
+        return Err(AdmissionCommitError::AuthorizationDenied);
+    }
+    let domain = authorization.authorization_domain();
+    let actor_bytes = authorization.actor_pubkey().to_bytes();
+    let actor_digest = actor_fingerprint(domain, &actor_bytes);
+    let reason_code = reason_code(authorization.reason());
+    let event_kind = if enrollment_disposition == Some(EnrollmentDisposition::Created) {
+        1_i16
+    } else {
+        10_i16
+    };
+    let operation_kind = if enrollment_disposition == Some(EnrollmentDisposition::Created) {
+        1_i16
+    } else {
+        11_i16
+    };
+    let actor_kind = if authorization.owner_pubkey().is_some() {
+        2_i16
+    } else {
+        1_i16
+    };
+    let application_result_digest = match (application_intent_digest, application_outcome) {
+        (Some(intent), Some(outcome)) => Some(canonical_application_result_digest(
+            domain,
+            object,
+            semantic_fingerprint,
+            intent,
+            outcome.result(),
+        )?),
+        (None, None) => None,
+        _ => return Err(AdmissionCommitError::InvalidRequest),
+    };
+    let result_digest = canonical_admission_result_digest(
+        domain,
+        object,
+        semantic_fingerprint,
+        application_intent_digest,
+        application_outcome.map(AdmissionApplicationOutcome::result),
+        application_outcome.map(|outcome| *outcome.effect_digest()),
+    )?;
+    let envelope = serde_json::to_vec(&serde_json::json!({
+        "schema": 1,
+        "event_kind": event_kind,
+        "outcome": 1,
+        "reason": reason_code,
+        "operation_id": operation_id,
+        "request": hex::encode(request_fingerprint),
+        "actor": hex::encode(actor_digest),
+        "object_kind": object.kind().database_code(),
+        "object": hex::encode(object.key()),
+        "binding_id": authorization.binding().0,
+        "binding_version": authorization.binding().1,
+        "capability": capability_code(authorization.capability()),
+        "admission_intent": hex::encode(semantic_fingerprint),
+        "application_type": application_outcome
+            .map(|outcome| hex::encode(outcome.result().schema().type_key())),
+        "application_version": application_outcome
+            .map(|outcome| outcome.result().schema().version()),
+        "application_code": application_outcome
+            .map(|outcome| outcome.result().code()),
+        "application_payload_digest": application_outcome
+            .map(|outcome| hex::encode(Sha256::digest(outcome.result().payload()))),
+        "application_result_digest": application_result_digest.map(hex::encode),
+        "application_intent": application_intent_digest.map(hex::encode),
+        "application_effect": application_outcome
+            .map(|outcome| hex::encode(outcome.effect_digest())),
+    }))
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    let audit_envelope_digest: [u8; 32] = Sha256::digest(&envelope).into();
+
+    sqlx::query(
+        r#"
+        INSERT INTO authorization_operation_receipts (
+            community_id, operation_id, request_fingerprint, operation_kind,
+            actor_fingerprint, outcome_code, result_digest
+        ) VALUES ($1, $2, $3, $4, $5, 1, $6)
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .bind(operation_kind)
+    .bind(actor_digest.as_slice())
+    .bind(result_digest.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(map_receipt_error)?;
+
+    let event_id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO authorization_events (
+            community_id, event_id, event_kind, outcome_code, reason_code,
+            actor_kind, actor_fingerprint, subject_fingerprint,
+            operation_id, request_fingerprint, correlation_id, attempt_id,
+            occurred_at, canonical_envelope, envelope_digest
+        ) VALUES ($1, $2, $3, 1, $4, $5, $6, NULL, $7, $8, $9, $10, $11, $12, $13)
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(event_id)
+    .bind(event_kind)
+    .bind(reason_code)
+    .bind(actor_kind)
+    .bind(actor_digest.as_slice())
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .bind(authorization.correlation_id())
+    .bind(attempt_id)
+    .bind(authoritative_now)
+    .bind(envelope.as_slice())
+    .bind(audit_envelope_digest.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(map_audit_error)?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO authorization_admission_results (
+            community_id, operation_id, request_fingerprint,
+            semantic_fingerprint, object_kind, object_key, application_type,
+            application_version, application_code, application_payload,
+            application_intent_digest, application_effect_digest,
+            application_result_digest
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .bind(semantic_fingerprint.as_slice())
+    .bind(object.kind().database_code())
+    .bind(object.key().as_slice())
+    .bind(application_outcome.map(|outcome| outcome.result().schema().type_key().to_vec()))
+    .bind(application_outcome.map(|outcome| i32::from(outcome.result().schema().version()) as i16))
+    .bind(application_outcome.map(|outcome| outcome.result().code()))
+    .bind(application_outcome.map(|outcome| outcome.result().payload().to_vec()))
+    .bind(application_intent_digest.map(|digest| digest.to_vec()))
+    .bind(application_outcome.map(|outcome| outcome.effect_digest().to_vec()))
+    .bind(application_result_digest.map(|digest| digest.to_vec()))
+    .execute(&mut **transaction)
+    .await
+    .map_err(map_receipt_error)?;
+
+    persist_protected_authority(
+        transaction,
+        operation_id,
+        object,
+        request_fingerprint,
+        authorization,
+    )
+    .await?;
+    AdmissionCommitReceipt::from_storage(
+        domain,
+        object,
+        operation_id,
+        request_fingerprint,
+        semantic_fingerprint,
+        AdmissionCommitDigests::new(result_digest, application_result_digest)
+            .ok_or(AdmissionCommitError::DependencyUnavailable)?,
+        event_id,
+    )
+    .ok_or(AdmissionCommitError::DependencyUnavailable)
+}
+
+async fn persist_protected_authority(
+    transaction: &mut Transaction<'_, Postgres>,
+    operation_id: Uuid,
+    object: AdmissionObject,
+    request_fingerprint: [u8; 32],
+    authorization: &FinalizedAuthContext,
+) -> Result<(), AdmissionCommitError> {
+    let lease = authorization.lease();
+    let domain = authorization.authorization_domain();
+    let (policy_revision, invalidation_generation, authority_epoch) = lease.dependency_versions();
+    let fence = lease.fence();
+    let epoch_write = sqlx::query(
+        r#"
+        INSERT INTO authorization_authority_epochs (
+            community_id, object_kind, object_key, authority_epoch, fence,
+            operation_id, request_fingerprint
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+        ON CONFLICT (community_id, object_kind, object_key) DO UPDATE SET
+            authority_epoch = EXCLUDED.authority_epoch,
+            fence = EXCLUDED.fence,
+            operation_id = EXCLUDED.operation_id,
+            request_fingerprint = EXCLUDED.request_fingerprint,
+            updated_at = GREATEST(
+                transaction_timestamp(),
+                authorization_authority_epochs.updated_at + INTERVAL '1 microsecond'
+            )
+        WHERE authorization_authority_epochs.authority_epoch < EXCLUDED.authority_epoch
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(object.kind().database_code())
+    .bind(object.key().as_slice())
+    .bind(to_i64(authority_epoch)?)
+    .bind(fence.as_bytes().as_slice())
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if epoch_write.rows_affected() == 0 {
+        let exact_epoch: Option<bool> = sqlx::query_scalar(
+            r#"
+            SELECT authority_epoch = $4 AND fence = $5
+            FROM authorization_authority_epochs
+            WHERE community_id = $1 AND object_kind = $2 AND object_key = $3
+            FOR UPDATE
+            "#,
+        )
+        .bind(domain.as_uuid())
+        .bind(object.kind().database_code())
+        .bind(object.key().as_slice())
+        .bind(to_i64(authority_epoch)?)
+        .bind(fence.as_bytes().as_slice())
+        .fetch_optional(&mut **transaction)
+        .await
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+        if exact_epoch != Some(true) {
+            return Err(AdmissionCommitError::AuthorizationDenied);
+        }
+    } else if epoch_write.rows_affected() != 1 {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+
+    let (binding_id, binding_version) = authorization.binding();
+    let relationship = lease.delegated_relationship();
+    let dependency_snapshot = lease.dependency_snapshot();
+    let conditions = dependency_snapshot
+        .delegated_relationship()
+        .map(|(_, _, conditions)| conditions.to_vec());
+    let actor_pubkey = authorization.actor_pubkey().to_bytes();
+    let authority_write = sqlx::query(
+        r#"
+        INSERT INTO protected_object_authority (
+            community_id, object_kind, object_key, capability, actor_pubkey,
+            owner_pubkey, binding_id, binding_version,
+            delegated_relationship_id, delegated_relationship_revision,
+            delegation_conditions_fingerprint, policy_revision,
+            invalidation_generation, authority_epoch, fence, issued_at,
+            expires_at, operation_id, request_fingerprint
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+            $14, $15, $16, $17, $18, $19
+        )
+        ON CONFLICT (community_id, object_kind, object_key) DO UPDATE SET
+            capability = EXCLUDED.capability,
+            actor_pubkey = EXCLUDED.actor_pubkey,
+            owner_pubkey = EXCLUDED.owner_pubkey,
+            binding_id = EXCLUDED.binding_id,
+            binding_version = EXCLUDED.binding_version,
+            delegated_relationship_id = EXCLUDED.delegated_relationship_id,
+            delegated_relationship_revision = EXCLUDED.delegated_relationship_revision,
+            delegation_conditions_fingerprint = EXCLUDED.delegation_conditions_fingerprint,
+            policy_revision = EXCLUDED.policy_revision,
+            invalidation_generation = EXCLUDED.invalidation_generation,
+            authority_epoch = EXCLUDED.authority_epoch,
+            fence = EXCLUDED.fence,
+            issued_at = EXCLUDED.issued_at,
+            expires_at = EXCLUDED.expires_at,
+            operation_id = EXCLUDED.operation_id,
+            request_fingerprint = EXCLUDED.request_fingerprint
+        WHERE protected_object_authority.authority_epoch < EXCLUDED.authority_epoch
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(object.kind().database_code())
+    .bind(object.key().as_slice())
+    .bind(capability_code(authorization.capability()))
+    .bind(actor_pubkey.as_slice())
+    .bind(
+        authorization
+            .owner_pubkey()
+            .map(|key| key.to_bytes().to_vec()),
+    )
+    .bind(binding_id)
+    .bind(to_i64(binding_version)?)
+    .bind(relationship.map(|value| value.0))
+    .bind(relationship.map(|value| to_i64(value.1)).transpose()?)
+    .bind(conditions)
+    .bind(to_i64(policy_revision)?)
+    .bind(to_i64_allow_zero(invalidation_generation)?)
+    .bind(to_i64(authority_epoch)?)
+    .bind(fence.as_bytes().as_slice())
+    .bind(lease.issued_at())
+    .bind(lease.expires_at())
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    if authority_write.rows_affected() == 0 {
+        let exact_authority: Option<bool> = sqlx::query_scalar(
+            r#"
+            SELECT capability = $4
+               AND actor_pubkey = $5
+               AND owner_pubkey IS NOT DISTINCT FROM $6
+               AND binding_id = $7
+               AND binding_version = $8
+               AND delegated_relationship_id IS NOT DISTINCT FROM $9
+               AND delegated_relationship_revision IS NOT DISTINCT FROM $10
+               AND delegation_conditions_fingerprint IS NOT DISTINCT FROM $11
+               AND policy_revision = $12
+               AND invalidation_generation = $13
+               AND authority_epoch = $14
+               AND fence = $15
+            FROM protected_object_authority
+            WHERE community_id = $1 AND object_kind = $2 AND object_key = $3
+            FOR UPDATE
+            "#,
+        )
+        .bind(domain.as_uuid())
+        .bind(object.kind().database_code())
+        .bind(object.key().as_slice())
+        .bind(capability_code(authorization.capability()))
+        .bind(actor_pubkey.as_slice())
+        .bind(
+            authorization
+                .owner_pubkey()
+                .map(|key| key.to_bytes().to_vec()),
+        )
+        .bind(binding_id)
+        .bind(to_i64(binding_version)?)
+        .bind(relationship.map(|value| value.0))
+        .bind(relationship.map(|value| to_i64(value.1)).transpose()?)
+        .bind(
+            dependency_snapshot
+                .delegated_relationship()
+                .map(|(_, _, value)| value.to_vec()),
+        )
+        .bind(to_i64(policy_revision)?)
+        .bind(to_i64_allow_zero(invalidation_generation)?)
+        .bind(to_i64(authority_epoch)?)
+        .bind(fence.as_bytes().as_slice())
+        .fetch_optional(&mut **transaction)
+        .await
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+        if exact_authority != Some(true) {
+            return Err(AdmissionCommitError::AuthorizationDenied);
+        }
+    } else if authority_write.rows_affected() != 1 {
+        return Err(AdmissionCommitError::DependencyUnavailable);
+    }
+    Ok(())
+}
+
+fn reason_code(reason: AuthorizationReason) -> i16 {
+    match reason {
+        AuthorizationReason::ExistingBinding => 1,
+        AuthorizationReason::EnrolledAttestedKey => 2,
+        AuthorizationReason::EnrolledProvisioned => 3,
+        AuthorizationReason::EnrolledRiskLabelledTofu => 4,
+        AuthorizationReason::DelegatedOwnerBinding => 5,
+    }
+}
+
+fn capability_code(capability: RouteCapability) -> i16 {
+    match capability {
+        RouteCapability::MessagesRead => 1,
+        RouteCapability::MessagesWrite => 2,
+        RouteCapability::ChannelsRead => 3,
+        RouteCapability::ChannelsWrite => 4,
+        RouteCapability::AdminChannels => 5,
+        RouteCapability::UsersRead => 6,
+        RouteCapability::UsersWrite => 7,
+        RouteCapability::AdminUsers => 8,
+        RouteCapability::JobsRead => 9,
+        RouteCapability::JobsWrite => 10,
+        RouteCapability::SubscriptionsRead => 11,
+        RouteCapability::SubscriptionsWrite => 12,
+        RouteCapability::FilesRead => 13,
+        RouteCapability::FilesWrite => 14,
+        RouteCapability::ReposRead => 15,
+        RouteCapability::ReposWrite => 16,
+        RouteCapability::GitRead => 17,
+        RouteCapability::GitWrite => 18,
+        RouteCapability::GitStream => 19,
+        RouteCapability::MediaRead => 20,
+        RouteCapability::MediaWrite => 21,
+        RouteCapability::Moderation => 22,
+        RouteCapability::AudioJoin => 23,
+        RouteCapability::AudioMedia => 24,
+        RouteCapability::Discovery => 25,
+        RouteCapability::BindingStatus => 26,
+        RouteCapability::Enrollment => 27,
+        RouteCapability::InviteMint => 28,
+        RouteCapability::InviteClaim => 29,
+    }
+}
+
+const fn proof_transport_code(transport: ProofTransport) -> i16 {
+    match transport {
+        ProofTransport::Nip42 => 1,
+        ProofTransport::Nip98 => 2,
+        ProofTransport::GitSmartHttpSession => 3,
+        ProofTransport::Blossom => 4,
+    }
+}
+
+fn fixed_digest(
+    row: &sqlx::postgres::PgRow,
+    column: &str,
+) -> Result<[u8; 32], AdmissionCommitError> {
+    let bytes: Vec<u8> = row
+        .try_get(column)
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+    bytes
+        .try_into()
+        .map_err(|_| AdmissionCommitError::DependencyUnavailable)
+}
+
+fn admission_framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+fn admission_operation_id(semantic_fingerprint: [u8; 32]) -> Uuid {
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&semantic_fingerprint[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+fn canonical_admission_result_digest(
+    domain: CommunityId,
+    object: AdmissionObject,
+    semantic_fingerprint: [u8; 32],
+    application_intent_digest: Option<[u8; 32]>,
+    application_result: Option<&AdmissionApplicationResult>,
+    application_effect_digest: Option<[u8; 32]>,
+) -> Result<[u8; 32], AdmissionCommitError> {
+    let valid_shape = match (
+        application_intent_digest,
+        application_result,
+        application_effect_digest,
+    ) {
+        (None, None, None) => true,
+        (Some(intent), Some(_), Some(effect)) => intent != [0; 32] && effect != [0; 32],
+        _ => false,
+    };
+    if semantic_fingerprint == [0; 32] || !valid_shape {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    let intent = application_intent_digest.unwrap_or([0; 32]);
+    let effect = application_effect_digest.unwrap_or([0; 32]);
+    let application_result_digest = match (application_intent_digest, application_result) {
+        (Some(intent), Some(result)) => canonical_application_result_digest(
+            domain,
+            object,
+            semantic_fingerprint,
+            intent,
+            result,
+        )?,
+        (None, None) => [0; 32],
+        _ => return Err(AdmissionCommitError::InvalidRequest),
+    };
+    Ok(admission_framed_digest(
+        b"buzz:canonical-admission-result:v2",
+        &[
+            &semantic_fingerprint,
+            &intent,
+            &effect,
+            &application_result_digest,
+        ],
+    ))
+}
+
+fn canonical_application_result_digest(
+    domain: CommunityId,
+    object: AdmissionObject,
+    semantic_fingerprint: [u8; 32],
+    application_intent_digest: [u8; 32],
+    result: &AdmissionApplicationResult,
+) -> Result<[u8; 32], AdmissionCommitError> {
+    if domain.as_uuid().is_nil()
+        || semantic_fingerprint == [0; 32]
+        || application_intent_digest == [0; 32]
+    {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    Ok(admission_framed_digest(
+        b"buzz:canonical-application-result:v1",
+        &[
+            domain.as_uuid().as_bytes(),
+            &object.kind().database_code().to_be_bytes(),
+            object.key(),
+            &semantic_fingerprint,
+            &application_intent_digest,
+            result.schema().type_key(),
+            &result.schema().version().to_be_bytes(),
+            &result.code().to_be_bytes(),
+            result.payload(),
+        ],
+    ))
+}
+
+fn to_i64(value: u64) -> Result<i64, AdmissionCommitError> {
+    i64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(AdmissionCommitError::DependencyUnavailable)
+}
+
+fn to_i64_allow_zero(value: u64) -> Result<i64, AdmissionCommitError> {
+    i64::try_from(value).map_err(|_| AdmissionCommitError::DependencyUnavailable)
+}
+
+fn map_enrollment_error(error: IdentityEnrollmentError) -> AdmissionCommitError {
+    match error {
+        IdentityEnrollmentError::Denied | IdentityEnrollmentError::ProvisioningRequired => {
+            AdmissionCommitError::AuthorizationDenied
+        }
+        IdentityEnrollmentError::InvalidInput => AdmissionCommitError::InvalidRequest,
+        IdentityEnrollmentError::PolicyUnavailable
+        | IdentityEnrollmentError::StorageUnavailable => {
+            AdmissionCommitError::DependencyUnavailable
+        }
+    }
+}
+
+fn map_receipt_error(error: sqlx::Error) -> AdmissionCommitError {
+    if error
+        .as_database_error()
+        .is_some_and(|database| database.is_unique_violation())
+    {
+        AdmissionCommitError::IntentConflict
+    } else {
+        AdmissionCommitError::DependencyUnavailable
+    }
+}
+
+fn map_audit_error(error: sqlx::Error) -> AdmissionCommitError {
+    let constraint = error
+        .as_database_error()
+        .and_then(|database| database.constraint());
+    if matches!(
+        constraint,
+        Some(
+            "authorization_event_capacity_policy_required"
+                | "authorization_event_capacity_health"
+                | "authorization_event_capacity_exhausted"
+                | "authorization_events_envelope_size"
+        )
+    ) {
+        AdmissionCommitError::AuditUnavailable
+    } else {
+        AdmissionCommitError::DependencyUnavailable
+    }
+}
+
+fn map_commit_error(error: sqlx::Error) -> AdmissionCommitError {
+    let constraint = error
+        .as_database_error()
+        .and_then(|database| database.constraint());
+    if matches!(
+        constraint,
+        Some(
+            "authorization_event_capacity_policy_required"
+                | "authorization_event_capacity_health"
+                | "authorization_event_capacity_exhausted"
+                | "authorization_events_envelope_size"
+        )
+    ) {
+        AdmissionCommitError::AuditUnavailable
+    } else {
+        AdmissionCommitError::DependencyUnavailable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::Write,
+        path::PathBuf,
+        process::{Command, Stdio},
+    };
+
+    use buzz_auth::{
+        nip42::verify_nip42_authorization_proof, CanonicalFederatedAssertionVerifier,
+        CanonicalVerifierKeySet, CanonicalVerifierPolicy, VerifierKeyGeneration,
+    };
+    use buzz_core::AuthorizationLeaseFence;
+    use chrono::TimeDelta;
+    use nostr::{EventBuilder, Keys, RelayUrl};
+
+    use super::*;
+
+    fn loopback_test_database_url() -> String {
+        format!(
+            "{}://{}:{}@{}:{}/{}",
+            "postgres", "buzz", "buzz_dev", "localhost", 5432, "buzz"
+        )
+    }
+
+    fn base64_url(input: &[u8]) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
+        for chunk in input.chunks(3) {
+            let first = chunk[0];
+            let second = chunk.get(1).copied().unwrap_or(0);
+            let third = chunk.get(2).copied().unwrap_or(0);
+            output.push(ALPHABET[(first >> 2) as usize] as char);
+            output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
+            if chunk.len() > 1 {
+                output.push(ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char);
+            }
+            if chunk.len() > 2 {
+                output.push(ALPHABET[(third & 0x3f) as usize] as char);
+            }
+        }
+        output
+    }
+
+    struct EphemeralRsaKey {
+        path: PathBuf,
+    }
+
+    impl EphemeralRsaKey {
+        fn generate(kid: &str, prefix: &str) -> (Self, serde_json::Value) {
+            let key = Self {
+                path: std::env::temp_dir().join(format!("{prefix}-{}.pem", Uuid::new_v4())),
+            };
+            let generated = Command::new("openssl")
+                .args([
+                    "genpkey",
+                    "-algorithm",
+                    "RSA",
+                    "-pkeyopt",
+                    "rsa_keygen_bits:2048",
+                    "-pkeyopt",
+                    "rsa_keygen_pubexp:65537",
+                    "-out",
+                ])
+                .arg(&key.path)
+                .output()
+                .expect("generate ephemeral RSA test key");
+            assert!(
+                generated.status.success(),
+                "OpenSSL RSA key generation failed: {}",
+                String::from_utf8_lossy(&generated.stderr)
+            );
+            let modulus = Command::new("openssl")
+                .args(["rsa", "-in"])
+                .arg(&key.path)
+                .args(["-noout", "-modulus"])
+                .output()
+                .expect("read ephemeral RSA test modulus");
+            assert!(
+                modulus.status.success(),
+                "OpenSSL RSA modulus extraction failed: {}",
+                String::from_utf8_lossy(&modulus.stderr)
+            );
+            let modulus = std::str::from_utf8(&modulus.stdout)
+                .expect("UTF-8 RSA test modulus")
+                .trim()
+                .strip_prefix("Modulus=")
+                .expect("OpenSSL RSA modulus prefix");
+            let modulus = hex::decode(modulus).expect("hex RSA test modulus");
+            let jwks = serde_json::json!({
+                "keys": [{
+                    "kty": "RSA",
+                    "use": "sig",
+                    "alg": "RS256",
+                    "kid": kid,
+                    "n": base64_url(&modulus),
+                    "e": "AQAB",
+                }],
+            });
+            (key, jwks)
+        }
+    }
+
+    impl Drop for EphemeralRsaKey {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    fn signed_test_jwt(subject: &str, event_author: [u8; 32]) -> (String, serde_json::Value) {
+        let issued_at = Utc::now().timestamp() - 1;
+        let claims = serde_json::json!({
+            "iss": "https://s3-verifier.test",
+            "aud": "buzz-s3-test",
+            "sub": subject,
+            "event_author": hex::encode(event_author),
+            "iat": issued_at,
+            "nbf": issued_at,
+            "exp": issued_at + 600,
+        });
+        let header = serde_json::json!({ "alg": "RS256", "kid": "s3-test", "typ": "JWT" });
+        let signing_input = format!(
+            "{}.{}",
+            base64_url(&serde_json::to_vec(&header).expect("serialize JWT header")),
+            base64_url(&serde_json::to_vec(&claims).expect("serialize JWT claims")),
+        );
+        let (key, jwks) = EphemeralRsaKey::generate("s3-test", "buzz-s3-jwt");
+        let mut child = Command::new("openssl")
+            .args(["dgst", "-sha256", "-sign"])
+            .arg(&key.path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn OpenSSL test signer");
+        child
+            .stdin
+            .as_mut()
+            .expect("OpenSSL signer stdin")
+            .write_all(signing_input.as_bytes())
+            .expect("write JWT signing input");
+        let signed = child.wait_with_output().expect("wait for JWT signer");
+        assert!(signed.status.success(), "OpenSSL JWT signer failed");
+        (
+            format!("{signing_input}.{}", base64_url(&signed.stdout)),
+            jwks,
+        )
+    }
+
+    fn verified_enrollment_evidence(
+        domain: CommunityId,
+        keys: &Keys,
+        subject: &str,
+        target: [u8; 32],
+        request: [u8; 32],
+        transport_context: [u8; 32],
+    ) -> (VerifiedFederatedAssertion, VerifiedNostrProof) {
+        let (token, jwks) = signed_test_jwt(subject, keys.public_key().to_bytes());
+        let verifier = CanonicalFederatedAssertionVerifier::new(
+            CanonicalVerifierPolicy::new(
+                "https://s3-verifier.test".to_owned(),
+                "buzz-s3-test".to_owned(),
+                "sub".to_owned(),
+                Some("event_author".to_owned()),
+                5,
+                600,
+            )
+            .expect("canonical verifier policy"),
+        );
+        let key_set = CanonicalVerifierKeySet::new(
+            VerifierKeyGeneration::new(1).expect("positive verifier generation"),
+            serde_json::from_value(jwks).expect("parse generated test JWKS"),
+        );
+        let assertion = verifier
+            .verify(
+                &token,
+                &key_set,
+                domain,
+                ProofTransport::Nip42,
+                target,
+                request,
+                transport_context,
+            )
+            .expect("verify test assertion");
+        let challenge = hex::encode([81_u8; 32]);
+        let relay = "wss://s3-admission.test";
+        let event = EventBuilder::auth(
+            challenge.clone(),
+            RelayUrl::parse(relay).expect("test relay URL"),
+        )
+        .sign_with_keys(keys)
+        .expect("sign NIP-42 test proof");
+        let assertion_fingerprint: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+        let proof = verify_nip42_authorization_proof(
+            &event,
+            &challenge,
+            relay,
+            domain,
+            request,
+            target,
+            transport_context,
+            Some(assertion_fingerprint),
+            None,
+            Utc::now() + TimeDelta::minutes(5),
+        )
+        .expect("verify NIP-42 authorization proof");
+        (assertion, proof)
+    }
+
+    struct TestPostgresAdmissionRechecker;
+
+    impl AdmissionFinalRechecker for TestPostgresAdmissionRechecker {
+        fn authoritative_recheck<'a, 'transaction>(
+            &'a self,
+            transaction: &'a mut Transaction<'transaction, Postgres>,
+            request: &'a PreparedAuthorizationRecheck,
+            object: AdmissionObject,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<AuthoritativeAuthorizationRecheck, AdmissionCommitError>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                let snapshot = request.lease_dependencies();
+                let (_, domain) = snapshot.identity();
+                let (binding_id, binding_version) = snapshot.binding();
+                let (_, target, _, _) = snapshot.request_binding();
+                let (policy_revision, invalidation_generation, _) = snapshot.dependency_versions();
+                if target != object.key() {
+                    return Err(AdmissionCommitError::AuthorizationDenied);
+                }
+                let binding_current: bool = sqlx::query_scalar(
+                    "SELECT EXISTS(SELECT 1 FROM identity_bindings \
+                     WHERE community_id=$1 AND binding_id=$2 AND binding_version=$3 \
+                       AND binding_state=1 AND lifecycle_revision=1 \
+                       AND (expires_at IS NULL OR transaction_timestamp() < expires_at))",
+                )
+                .bind(domain.as_uuid())
+                .bind(binding_id)
+                .bind(
+                    i64::try_from(binding_version)
+                        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?,
+                )
+                .fetch_one(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                let policy_current: Option<i64> = sqlx::query_scalar(
+                    "SELECT max(policy_revision) FROM identity_enrollment_policies \
+                     WHERE community_id=$1 AND effective_at <= transaction_timestamp() \
+                       AND (expires_at IS NULL OR transaction_timestamp() < expires_at)",
+                )
+                .bind(domain.as_uuid())
+                .fetch_one(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                let generation: Option<i64> = sqlx::query_scalar(
+                    "SELECT current_generation FROM authorization_invalidation_domains \
+                     WHERE community_id=$1 FOR SHARE",
+                )
+                .bind(domain.as_uuid())
+                .fetch_optional(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                if !binding_current
+                    || policy_current != i64::try_from(policy_revision).ok()
+                    || generation != i64::try_from(invalidation_generation).ok()
+                {
+                    return Err(AdmissionCommitError::AuthorizationDenied);
+                }
+                let authoritative_now: DateTime<Utc> =
+                    sqlx::query_scalar("SELECT transaction_timestamp()")
+                        .fetch_one(&mut **transaction)
+                        .await
+                        .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                Ok(AuthoritativeAuthorizationRecheck::from_authoritative_parts(
+                    snapshot,
+                    request.verifier_stamp(),
+                    authoritative_now,
+                ))
+            })
+        }
+    }
+
+    struct TestMarkerEffect {
+        intent_digest: [u8; 32],
+        fail_after_write: bool,
+    }
+
+    impl AdmissionApplicationEffect for TestMarkerEffect {
+        fn intent_digest(&self) -> [u8; 32] {
+            self.intent_digest
+        }
+
+        fn result_schema(&self) -> AdmissionApplicationResultSchema {
+            AdmissionApplicationResultSchema::new([91; 32], 1).expect("test result schema")
+        }
+
+        fn apply<'a, 'transaction>(
+            &'a mut self,
+            transaction: &'a mut Transaction<'transaction, Postgres>,
+            context: &'a AdmissionApplicationContext<'a>,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<AdmissionApplicationOutcome, AdmissionCommitError>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                let result = AdmissionApplicationResult::new(
+                    self.result_schema(),
+                    1,
+                    b"stable-marker".to_vec(),
+                )?;
+                let outcome = AdmissionApplicationOutcome::new(
+                    result,
+                    admission_framed_digest(
+                        b"buzz:s3-test-marker-effect:v1",
+                        &[context.operation_id().as_bytes(), &self.intent_digest],
+                    ),
+                )?;
+                let result_digest = context.canonical_result_digest(&outcome)?;
+                sqlx::query(
+                    "INSERT INTO s3_admission_markers \
+                     (community_id,operation_id,request_fingerprint,object_kind,object_key, \
+                      result_digest) VALUES ($1,$2,$3,$4,$5,$6)",
+                )
+                .bind(context.authorization_domain().as_uuid())
+                .bind(context.operation_id())
+                .bind(context.request_fingerprint().as_slice())
+                .bind(context.object().kind().database_code())
+                .bind(context.object().key().as_slice())
+                .bind(result_digest.as_slice())
+                .execute(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+                if self.fail_after_write {
+                    Err(AdmissionCommitError::DependencyUnavailable)
+                } else {
+                    Ok(outcome)
+                }
+            })
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn enrollment_commit_request(
+        pool: &PgPool,
+        assertion: VerifiedFederatedAssertion,
+        proof: VerifiedNostrProof,
+        policy: LocalAuthorizationPolicy,
+        object: AdmissionObject,
+        replay_key: [u8; 32],
+        application_effect: Box<dyn AdmissionApplicationEffect>,
+    ) -> AdmissionCommitRequest {
+        enrollment_commit_request_for_route(
+            pool,
+            assertion,
+            proof,
+            policy,
+            object,
+            RouteCapability::InviteClaim,
+            replay_key,
+            application_effect,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn enrollment_commit_request_for_route(
+        pool: &PgPool,
+        assertion: VerifiedFederatedAssertion,
+        proof: VerifiedNostrProof,
+        policy: LocalAuthorizationPolicy,
+        object: AdmissionObject,
+        capability: RouteCapability,
+        replay_key: [u8; 32],
+        application_effect: Box<dyn AdmissionApplicationEffect>,
+    ) -> AdmissionCommitRequest {
+        let prepared = crate::identity_enrollment::prepare_direct_enrollment(
+            pool,
+            assertion.clone(),
+            proof.clone(),
+            Utc::now(),
+        )
+        .await
+        .expect("prepare direct enrollment");
+        let evidence = AdmissionEnrollmentEvidence::new(prepared, assertion, proof, policy)
+            .expect("seal admission enrollment evidence");
+        AdmissionCommitRequest::enrollment(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            object,
+            capability,
+            evidence,
+        )
+        .expect("construct enrollment admission")
+        .with_replay_claim(
+            AdmissionReplayClaim::new(
+                AdmissionReplayClaimKind::TrustedProxyNonce,
+                replay_key,
+                Utc::now() + TimeDelta::minutes(10),
+            )
+            .expect("fresh replay claim"),
+        )
+        .with_application_effect(application_effect)
+        .expect("attach canonical application effect")
+    }
+
+    #[test]
+    fn replay_claim_rejects_sentinels_and_non_interoperable_time() {
+        let now = Utc::now();
+        assert_eq!(
+            AdmissionReplayClaim::new(
+                AdmissionReplayClaimKind::TrustedProxyNonce,
+                [0; 32],
+                now + TimeDelta::minutes(1),
+            ),
+            Err(AdmissionCommitError::InvalidRequest)
+        );
+        assert_eq!(
+            AdmissionReplayClaim::new(
+                AdmissionReplayClaimKind::TrustedProxyNonce,
+                [1; 32],
+                DateTime::<Utc>::MAX_UTC,
+            ),
+            Err(AdmissionCommitError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn replay_claim_uses_an_exclusive_authoritative_time_bound() {
+        let now = Utc::now();
+        let retain_until = now + TimeDelta::minutes(1);
+        let claim = AdmissionReplayClaim::new(
+            AdmissionReplayClaimKind::TrustedProxyNonce,
+            [1; 32],
+            retain_until,
+        )
+        .expect("valid replay claim");
+        assert_eq!(claim.kind().database_code(), 1);
+        assert_eq!(claim.claim_key(), &[1; 32]);
+        assert!(claim.validate_at(now).is_ok());
+        assert_eq!(
+            claim.validate_at(retain_until),
+            Err(AdmissionCommitError::ReplayRejected)
+        );
+        assert_eq!(
+            claim.validate_at(retain_until + TimeDelta::microseconds(1)),
+            Err(AdmissionCommitError::ReplayRejected)
+        );
+    }
+
+    #[test]
+    fn logical_operation_id_is_stable_domain_separated_and_server_formed() {
+        let semantic = admission_framed_digest(
+            b"buzz:test:admission-intent:v1",
+            &[b"domain", b"request", b"capability", b"target"],
+        );
+        let operation_id = admission_operation_id(semantic);
+        assert_eq!(operation_id, admission_operation_id(semantic));
+        assert_ne!(
+            operation_id,
+            admission_operation_id(admission_framed_digest(
+                b"buzz:test:admission-intent:v1",
+                &[b"domain", b"request", b"capability", b"other-target"],
+            ))
+        );
+        assert_eq!(operation_id.get_version_num(), 8);
+        assert_eq!(operation_id.get_variant(), uuid::Variant::RFC4122);
+    }
+
+    #[test]
+    fn invite_application_results_are_closed_and_replay_decodable() {
+        for expected in [
+            CanonicalInviteClaimOutcome::Joined,
+            CanonicalInviteClaimOutcome::AlreadyMember,
+        ] {
+            let result = AdmissionApplicationResult::invite_claim(expected);
+            assert_eq!(
+                result.schema(),
+                AdmissionApplicationResultSchema::invite_claim()
+            );
+            assert_eq!(result.decode_invite_claim(), Ok(expected));
+            assert_eq!(
+                AdmissionApplicationResult::from_database(
+                    result.schema().type_key().to_vec(),
+                    result.schema().version() as i16,
+                    result.code(),
+                    result.payload().to_vec(),
+                ),
+                Ok(result)
+            );
+        }
+        assert_eq!(
+            AdmissionApplicationResult::from_database(
+                INVITE_CLAIM_RESULT_TYPE.to_vec(),
+                1,
+                3,
+                Vec::new(),
+            )
+            .and_then(|result| result.decode_invite_claim()),
+            Err(AdmissionCommitError::InvalidRequest)
+        );
+        assert_eq!(
+            AdmissionApplicationResult::new(
+                AdmissionApplicationResultSchema::invite_claim(),
+                1,
+                vec![0; MAX_ADMISSION_APPLICATION_RESULT_PAYLOAD_BYTES + 1],
+            ),
+            Err(AdmissionCommitError::InvalidRequest)
+        );
+        assert_eq!(AdmissionApplicationResultSchema::new([0; 32], 1), None);
+        assert_eq!(AdmissionApplicationResultSchema::new([1; 32], 0), None);
+        assert_eq!(
+            AdmissionApplicationResult::from_database(vec![1; 31], 1, 1, Vec::new()),
+            Err(AdmissionCommitError::DependencyUnavailable)
+        );
+    }
+
+    #[test]
+    fn bounded_application_result_is_type_version_and_semantic_bound() {
+        let schema =
+            AdmissionApplicationResultSchema::new([71; 32], 3).expect("nonzero application schema");
+        let result = AdmissionApplicationResult::new(schema, 7, b"stable-result".to_vec())
+            .expect("bounded application result");
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let object =
+            AdmissionObject::new(AdmissionObjectKind::Repository, [70; 32]).expect("test object");
+        let first =
+            canonical_application_result_digest(domain, object, [72; 32], [73; 32], &result)
+                .expect("first result digest");
+        let different_domain_or_object = canonical_application_result_digest(
+            CommunityId::from_uuid(Uuid::new_v4()),
+            object,
+            [72; 32],
+            [73; 32],
+            &result,
+        )
+        .expect("second result digest");
+        assert_ne!(first, different_domain_or_object);
+        assert_eq!(result.schema(), schema);
+        assert_eq!(result.code(), 7);
+        assert_eq!(result.payload(), b"stable-result");
+    }
+
+    #[test]
+    fn invite_effect_intent_is_bounded_and_redacted() {
+        assert!(CanonicalInviteClaimEffect::new([0; 32], None).is_err());
+        assert!(CanonicalInviteClaimEffect::new([1; 32], Some("")).is_err());
+        assert!(CanonicalInviteClaimEffect::new([1; 32], Some(&"x".repeat(129))).is_err());
+        let first_policy = "a1".repeat(32);
+        let second_policy = "b2".repeat(32);
+        let first =
+            CanonicalInviteClaimEffect::new([1; 32], Some(&first_policy)).expect("bounded effect");
+        let retry =
+            CanonicalInviteClaimEffect::new([1; 32], Some(&first_policy)).expect("stable retry");
+        let changed =
+            CanonicalInviteClaimEffect::new([1; 32], Some(&second_policy)).expect("changed policy");
+        assert_eq!(first.intent_digest(), retry.intent_digest());
+        assert_ne!(first.intent_digest(), changed.intent_digest());
+        assert_eq!(
+            format!("{first:?}"),
+            "CanonicalInviteClaimEffect([REDACTED])"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a dedicated disposable Postgres database and OpenSSL"]
+    async fn postgres_committer_co_commits_and_replays_fresh_claim_with_typed_result() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect admission test admin");
+        let database_name = format!("s3_admission_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("create disposable admission database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let database_url = format!("{}/{}", &admin_url[..split], database_name);
+        let pool = PgPoolOptions::new()
+            .max_connections(6)
+            .connect(&database_url)
+            .await
+            .expect("connect disposable admission database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply canonical migrations");
+        sqlx::query(
+            "CREATE TABLE s3_admission_markers ( \
+             community_id uuid NOT NULL, operation_id uuid NOT NULL PRIMARY KEY, \
+             request_fingerprint bytea NOT NULL, object_kind smallint NOT NULL, \
+             object_key bytea NOT NULL, result_digest bytea NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create transaction marker table");
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let target = [101_u8; 32];
+        let request_fingerprint = [102_u8; 32];
+        let transport_context = [103_u8; 32];
+        let object =
+            AdmissionObject::new(AdmissionObjectKind::Domain, target).expect("test object");
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!("admission-{}.example", domain.as_uuid().simple()))
+            .execute(&pool)
+            .await
+            .expect("insert admission community");
+        // Use the replay-claim table installed by the registered migrations.
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+             VALUES ($1,1,1,$2,transaction_timestamp()-interval '1 second')",
+        )
+        .bind(domain.as_uuid())
+        .bind([104_u8; 32].as_slice())
+        .execute(&pool)
+        .await
+        .expect("insert attested enrollment policy");
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes, \
+              restrictive_reserve_events,restrictive_reserve_bytes) \
+             VALUES ($1,64,262144,8192,8,32768)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install admission audit capacity");
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_domains (community_id,current_generation) \
+             VALUES ($1,0)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("activate admission invalidation");
+        let invite_token = [105_u8; 32];
+        let alternate_invite = [106_u8; 32];
+        for token in [invite_token, alternate_invite] {
+            sqlx::query(
+                "INSERT INTO relay_invites \
+                 (community_id,token_hash,max_uses,expires_at,created_by) \
+                 VALUES ($1,$2,8,transaction_timestamp()+interval '1 hour','operator')",
+            )
+            .bind(domain.as_uuid())
+            .bind(token.as_slice())
+            .execute(&pool)
+            .await
+            .expect("insert relay invite");
+        }
+
+        let keys = Keys::generate();
+        let (assertion, proof) = verified_enrollment_evidence(
+            domain,
+            &keys,
+            "canonical-subject",
+            target,
+            request_fingerprint,
+            transport_context,
+        );
+        let policy = LocalAuthorizationPolicy::from_database(
+            domain,
+            Uuid::new_v4(),
+            1,
+            0,
+            2,
+            AuthorizationLeaseFence::from_bytes([107; 32]).expect("authorization fence"),
+            RouteCapability::InviteClaim,
+            Utc::now() + TimeDelta::minutes(5),
+            None,
+            None,
+        )
+        .expect("local authorization policy");
+        let committer = Arc::new(PostgresCanonicalAdmissionCommitter::new(
+            pool.clone(),
+            Arc::new(TestPostgresAdmissionRechecker),
+        ));
+
+        let cross_capability_policy = LocalAuthorizationPolicy::from_database(
+            domain,
+            Uuid::new_v4(),
+            1,
+            0,
+            2,
+            AuthorizationLeaseFence::from_bytes([107; 32]).expect("authorization fence"),
+            RouteCapability::MessagesWrite,
+            Utc::now() + TimeDelta::minutes(5),
+            None,
+            None,
+        )
+        .expect("cross-capability policy");
+        let cross_capability = enrollment_commit_request_for_route(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            cross_capability_policy,
+            object,
+            RouteCapability::MessagesWrite,
+            [124; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, None)
+                    .expect("cross-capability invite effect"),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            committer.commit(cross_capability).await,
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+
+        let cross_object = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            AdmissionObject::new(AdmissionObjectKind::Repository, target)
+                .expect("cross-object coordinate"),
+            [125; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, None)
+                    .expect("cross-object invite effect"),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            committer.commit(cross_object).await,
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+        let (
+            denied_bindings,
+            denied_members,
+            denied_invite_uses,
+            denied_receipts,
+            denied_events,
+            denied_claims,
+        ): (i64, i64, i32, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+                 (SELECT count(*) FROM identity_bindings WHERE community_id=$1), \
+                 (SELECT count(*) FROM relay_members WHERE community_id=$1), \
+                 (SELECT use_count FROM relay_invites WHERE community_id=$1 AND token_hash=$2), \
+                 (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_proxy_nonce_claims \
+                   WHERE authorization_domain=$1 AND claim_key IN ($3,$4))",
+        )
+        .bind(domain.as_uuid())
+        .bind(invite_token.as_slice())
+        .bind([124_u8; 32].as_slice())
+        .bind([125_u8; 32].as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read denied invite effect side effects");
+        assert_eq!(
+            (
+                denied_bindings,
+                denied_members,
+                denied_invite_uses,
+                denied_receipts,
+                denied_events,
+                denied_claims,
+            ),
+            (0, 0, 0, 0, 0, 0)
+        );
+
+        sqlx::query(
+            "CREATE FUNCTION s3_reject_policy_acceptance_v1() RETURNS trigger AS $$ \
+             BEGIN RAISE EXCEPTION 'injected policy acceptance failure'; END; \
+             $$ LANGUAGE plpgsql",
+        )
+        .execute(&pool)
+        .await
+        .expect("install concrete invite DML failure function");
+        sqlx::query(
+            "CREATE TRIGGER s3_reject_policy_acceptance \
+             BEFORE INSERT ON join_policy_acceptances FOR EACH ROW \
+             EXECUTE FUNCTION s3_reject_policy_acceptance_v1()",
+        )
+        .execute(&pool)
+        .await
+        .expect("install concrete invite DML failure trigger");
+        let policy_version = "ab".repeat(32);
+        let concrete_failure = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [126; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, Some(&policy_version))
+                    .expect("concrete failing invite effect"),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            committer.commit(concrete_failure).await,
+            Err(AdmissionCommitError::DependencyUnavailable)
+        ));
+        let (
+            failed_bindings,
+            failed_members,
+            failed_invite_uses,
+            failed_receipts,
+            failed_events,
+            failed_claims,
+            failed_acceptances,
+        ): (i64, i64, i32, i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+                 (SELECT count(*) FROM identity_bindings WHERE community_id=$1), \
+                 (SELECT count(*) FROM relay_members WHERE community_id=$1), \
+                 (SELECT use_count FROM relay_invites WHERE community_id=$1 AND token_hash=$2), \
+                 (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_proxy_nonce_claims \
+                   WHERE authorization_domain=$1 AND claim_key=$3), \
+                 (SELECT count(*) FROM join_policy_acceptances WHERE community_id=$1)",
+        )
+        .bind(domain.as_uuid())
+        .bind(invite_token.as_slice())
+        .bind([126_u8; 32].as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read concrete invite DML rollback");
+        assert_eq!(
+            (
+                failed_bindings,
+                failed_members,
+                failed_invite_uses,
+                failed_receipts,
+                failed_events,
+                failed_claims,
+                failed_acceptances,
+            ),
+            (0, 0, 0, 0, 0, 0, 0)
+        );
+        sqlx::query("DROP TRIGGER s3_reject_policy_acceptance ON join_policy_acceptances")
+            .execute(&pool)
+            .await
+            .expect("remove concrete invite DML failure trigger");
+        sqlx::query("DROP FUNCTION s3_reject_policy_acceptance_v1()")
+            .execute(&pool)
+            .await
+            .expect("remove concrete invite DML failure function");
+
+        let first_request = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [108; 32],
+            Box::new(CanonicalInviteClaimEffect::new(invite_token, None).expect("invite effect")),
+        )
+        .await;
+        assert_eq!(
+            first_request.transport_binding(),
+            (ProofTransport::Nip42, transport_context)
+        );
+        let first_operation = first_request.operation_id();
+        let first = committer
+            .commit(first_request)
+            .await
+            .expect("canonical admission commit");
+        let (first_receipt, first_result) = match first {
+            AdmissionCommitOutcome::Committed {
+                receipt,
+                application_result,
+                ..
+            } => (receipt, application_result.expect("fresh typed result")),
+            AdmissionCommitOutcome::ExactReplay { .. } => panic!("first admission must commit"),
+        };
+        assert_eq!(
+            first_result.decode_invite_claim(),
+            Ok(CanonicalInviteClaimOutcome::Joined)
+        );
+        assert!(first_receipt.application_result_digest().is_some());
+
+        let retry_request = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [109; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, None).expect("retry invite effect"),
+            ),
+        )
+        .await;
+        assert_eq!(retry_request.operation_id(), first_operation);
+        let replay = committer
+            .commit(retry_request)
+            .await
+            .expect("fresh-claim exact replay");
+        let (replay_receipt, replay_result) = match replay {
+            AdmissionCommitOutcome::ExactReplay {
+                receipt,
+                application_result,
+            } => (receipt, application_result.expect("replayed typed result")),
+            AdmissionCommitOutcome::Committed { .. } => panic!("retry must not repeat DML"),
+        };
+        assert_eq!(replay_result, first_result);
+        assert_eq!(
+            replay_result.decode_invite_claim(),
+            Ok(CanonicalInviteClaimOutcome::Joined)
+        );
+        assert_eq!(
+            replay_receipt.application_result_digest(),
+            first_receipt.application_result_digest()
+        );
+        let replay_claim_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain=$1 AND claim_key IN ($2,$3)",
+        )
+        .bind(domain.as_uuid())
+        .bind([108_u8; 32].as_slice())
+        .bind([109_u8; 32].as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("count exact replay claims");
+        assert_eq!(
+            replay_claim_count, 2,
+            "fresh execution and fresh-claim replay must consume both claims"
+        );
+
+        let duplicate_claim = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [128; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, None)
+                    .expect("duplicate-claim invite effect"),
+            ),
+        )
+        .await
+        .with_replay_claim(
+            AdmissionReplayClaim::new(
+                AdmissionReplayClaimKind::TrustedProxyNonce,
+                [109; 32],
+                Utc::now() + TimeDelta::minutes(10),
+            )
+            .expect("duplicate prior claim"),
+        );
+        assert_eq!(duplicate_claim.operation_id(), first_operation);
+        assert!(matches!(
+            committer.commit(duplicate_claim).await,
+            Err(AdmissionCommitError::ReplayRejected)
+        ));
+
+        let stale_claim = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [127; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(invite_token, None)
+                    .expect("stale-claim invite effect"),
+            ),
+        )
+        .await
+        .with_replay_claim(
+            AdmissionReplayClaim::new(
+                AdmissionReplayClaimKind::TrustedProxyNonce,
+                [127; 32],
+                Utc::now() - TimeDelta::seconds(1),
+            )
+            .expect("well-formed stale claim"),
+        );
+        assert_eq!(stale_claim.operation_id(), first_operation);
+        assert!(matches!(
+            committer.commit(stale_claim).await,
+            Err(AdmissionCommitError::ReplayRejected)
+        ));
+        let stale_claim_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain=$1 AND claim_key=$2",
+        )
+        .bind(domain.as_uuid())
+        .bind([127_u8; 32].as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read rejected stale replay claim");
+        assert_eq!(stale_claim_count, 0);
+
+        let second_publication = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [110; 32],
+            Box::new(TestMarkerEffect {
+                intent_digest: [111; 32],
+                fail_after_write: false,
+            }),
+        )
+        .await;
+        let second_operation = second_publication.operation_id();
+        assert_ne!(second_operation, first_operation);
+        assert!(matches!(
+            committer
+                .commit(second_publication)
+                .await
+                .expect("distinct same-epoch publication"),
+            AdmissionCommitOutcome::Committed { .. }
+        ));
+
+        let mismatched_same_epoch_policy = LocalAuthorizationPolicy::from_database(
+            domain,
+            Uuid::new_v4(),
+            1,
+            0,
+            2,
+            AuthorizationLeaseFence::from_bytes([119; 32]).expect("mismatched fence"),
+            RouteCapability::InviteClaim,
+            Utc::now() + TimeDelta::minutes(5),
+            None,
+            None,
+        )
+        .expect("same-epoch mismatched policy");
+        let mismatched_same_epoch = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            mismatched_same_epoch_policy,
+            object,
+            [120; 32],
+            Box::new(TestMarkerEffect {
+                intent_digest: [121; 32],
+                fail_after_write: false,
+            }),
+        )
+        .await;
+        let mismatched_operation = mismatched_same_epoch.operation_id();
+        assert!(matches!(
+            committer.commit(mismatched_same_epoch).await,
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+
+        let lower_epoch_policy = LocalAuthorizationPolicy::from_database(
+            domain,
+            Uuid::new_v4(),
+            1,
+            0,
+            1,
+            AuthorizationLeaseFence::from_bytes([107; 32]).expect("lower-epoch fence"),
+            RouteCapability::InviteClaim,
+            Utc::now() + TimeDelta::minutes(5),
+            None,
+            None,
+        )
+        .expect("lower-epoch policy");
+        let lower_epoch = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            lower_epoch_policy,
+            object,
+            [122; 32],
+            Box::new(TestMarkerEffect {
+                intent_digest: [123; 32],
+                fail_after_write: false,
+            }),
+        )
+        .await;
+        let lower_operation = lower_epoch.operation_id();
+        assert!(matches!(
+            committer.commit(lower_epoch).await,
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+        let denied_authority_markers: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM s3_admission_markers WHERE operation_id IN ($1,$2)",
+        )
+        .bind(mismatched_operation)
+        .bind(lower_operation)
+        .fetch_one(&pool)
+        .await
+        .expect("read denied same/lower epoch markers");
+        assert_eq!(denied_authority_markers, 0);
+
+        let failure_request = enrollment_commit_request(
+            &pool,
+            assertion.clone(),
+            proof.clone(),
+            policy.clone(),
+            object,
+            [112; 32],
+            Box::new(TestMarkerEffect {
+                intent_digest: [113; 32],
+                fail_after_write: true,
+            }),
+        )
+        .await;
+        let failure_operation = failure_request.operation_id();
+        assert!(matches!(
+            committer.commit(failure_request).await,
+            Err(AdmissionCommitError::DependencyUnavailable)
+        ));
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT count(*) FROM s3_admission_markers WHERE operation_id=$1",
+            )
+            .bind(failure_operation)
+            .fetch_one(&pool)
+            .await
+            .expect("read rolled-back effect marker"),
+            0
+        );
+
+        let failure_generation: i64 =
+            sqlx::query_scalar("SELECT authorization_event_capacity_report_failure_v2($1,$2)")
+                .bind(domain.as_uuid())
+                .bind(1_i16)
+                .fetch_one(&pool)
+                .await
+                .expect("latch audit failure");
+        let audit_keys = Keys::generate();
+        let audit_event_author = audit_keys.public_key().to_bytes();
+        let (audit_assertion, audit_proof) = verified_enrollment_evidence(
+            domain,
+            &audit_keys,
+            "audit-capacity-subject",
+            target,
+            request_fingerprint,
+            transport_context,
+        );
+        let audit_request = enrollment_commit_request(
+            &pool,
+            audit_assertion,
+            audit_proof,
+            policy.clone(),
+            object,
+            [114; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(alternate_invite, None)
+                    .expect("audit rollback invite effect"),
+            ),
+        )
+        .await;
+        let audit_operation = audit_request.operation_id();
+        assert!(matches!(
+            committer.commit(audit_request).await,
+            Err(AdmissionCommitError::AuditUnavailable)
+        ));
+        let (
+            audit_binding,
+            audit_member,
+            audit_invite_uses,
+            audit_receipt,
+            audit_event,
+            audit_claim,
+        ): (i64, i64, i32, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+             (SELECT count(*) FROM identity_bindings \
+               WHERE community_id=$2 AND event_author_pubkey=$4), \
+             (SELECT count(*) FROM relay_members WHERE community_id=$2 AND pubkey=$5), \
+             (SELECT use_count FROM relay_invites WHERE community_id=$2 AND token_hash=$6), \
+             (SELECT count(*) FROM authorization_operation_receipts \
+               WHERE community_id=$2 AND operation_id=$1), \
+             (SELECT count(*) FROM authorization_events \
+               WHERE community_id=$2 AND operation_id=$1), \
+             (SELECT count(*) FROM authorization_proxy_nonce_claims \
+               WHERE authorization_domain=$2 AND claim_key=$3)",
+        )
+        .bind(audit_operation)
+        .bind(domain.as_uuid())
+        .bind([114_u8; 32].as_slice())
+        .bind(audit_event_author.as_slice())
+        .bind(audit_keys.public_key().to_hex())
+        .bind(alternate_invite.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read audit rollback state");
+        assert_eq!(
+            (
+                audit_binding,
+                audit_member,
+                audit_invite_uses,
+                audit_receipt,
+                audit_event,
+                audit_claim,
+            ),
+            (0, 0, 0, 0, 0, 0)
+        );
+        assert!(sqlx::query_scalar::<_, bool>(
+            "SELECT authorization_event_capacity_recover_v2($1,$2)",
+        )
+        .bind(domain.as_uuid())
+        .bind(failure_generation)
+        .fetch_one(&pool)
+        .await
+        .expect("recover admission audit capacity"));
+
+        let other_keys = Keys::generate();
+        let (other_assertion, other_proof) = verified_enrollment_evidence(
+            domain,
+            &other_keys,
+            "canonical-subject",
+            target,
+            request_fingerprint,
+            transport_context,
+        );
+        let partial_bijection_request = enrollment_commit_request(
+            &pool,
+            other_assertion,
+            other_proof,
+            policy.clone(),
+            object,
+            [116; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(alternate_invite, None)
+                    .expect("alternate invite effect"),
+            ),
+        )
+        .await;
+        assert!(matches!(
+            committer.commit(partial_bijection_request).await,
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+
+        let stale_keys = Keys::generate();
+        let (stale_assertion, stale_proof) = verified_enrollment_evidence(
+            domain,
+            &stale_keys,
+            "stale-policy-subject",
+            target,
+            request_fingerprint,
+            transport_context,
+        );
+        let stale_policy_request = enrollment_commit_request(
+            &pool,
+            stale_assertion.clone(),
+            stale_proof.clone(),
+            policy.clone(),
+            object,
+            [117; 32],
+            Box::new(
+                CanonicalInviteClaimEffect::new(alternate_invite, None)
+                    .expect("stale policy invite effect"),
+            ),
+        )
+        .await;
+        let mut policy_update = pool.begin().await.expect("begin concurrent policy update");
+        sqlx::query("SELECT id FROM communities WHERE id=$1 FOR UPDATE")
+            .bind(domain.as_uuid())
+            .execute(&mut *policy_update)
+            .await
+            .expect("lock domain before restrictive policy update");
+        let concurrent_committer = Arc::clone(&committer);
+        let mut stale_commit =
+            tokio::spawn(async move { concurrent_committer.commit(stale_policy_request).await });
+        tokio::task::yield_now().await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut stale_commit)
+                .await
+                .is_err(),
+            "admission must serialize behind the domain policy lock"
+        );
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+             VALUES ($1,2,2,$2,transaction_timestamp()-interval '1 microsecond')",
+        )
+        .bind(domain.as_uuid())
+        .bind([118_u8; 32].as_slice())
+        .execute(&mut *policy_update)
+        .await
+        .expect("install newer Provisioned policy");
+        policy_update
+            .commit()
+            .await
+            .expect("commit concurrent restrictive policy");
+        assert!(matches!(
+            stale_commit.await.expect("join serialized stale admission"),
+            Err(AdmissionCommitError::AuthorizationDenied)
+        ));
+        assert!(matches!(
+            crate::identity_enrollment::prepare_direct_enrollment(
+                &pool,
+                stale_assertion,
+                stale_proof,
+                Utc::now(),
+            )
+            .await,
+            Err(IdentityEnrollmentError::ProvisioningRequired)
+        ));
+
+        let (binding_count, member_count, invite_uses, receipt_count, event_count, authority_count):
+            (i64, i64, i32, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+             (SELECT count(*) FROM identity_bindings WHERE community_id=$1), \
+             (SELECT count(*) FROM relay_members WHERE community_id=$1), \
+             (SELECT use_count FROM relay_invites WHERE community_id=$1 AND token_hash=$2), \
+             (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1 AND operation_id IN ($3,$4)), \
+             (SELECT count(*) FROM authorization_events WHERE community_id=$1 AND operation_id IN ($3,$4)), \
+             (SELECT count(*) FROM protected_object_authority WHERE community_id=$1 AND object_kind=1 AND object_key=$5)",
+        )
+        .bind(domain.as_uuid())
+        .bind(invite_token.as_slice())
+        .bind(first_operation)
+        .bind(second_operation)
+        .bind(target.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read canonical co-commit state");
+        assert_eq!(
+            (
+                binding_count,
+                member_count,
+                invite_uses,
+                receipt_count,
+                event_count,
+                authority_count,
+            ),
+            (1, 1, 1, 2, 2, 1)
+        );
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop disposable admission database");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a dedicated disposable Postgres database"]
+    async fn postgres_invite_effect_and_persisted_replay_are_atomic_and_typed() {
+        let database_url = std::env::var("BUZZ_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .expect("dedicated test database URL");
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("connect dedicated database");
+        sqlx::query("DROP SCHEMA IF EXISTS public CASCADE")
+            .execute(&pool)
+            .await
+            .expect("drop public schema");
+        sqlx::query("CREATE SCHEMA public")
+            .execute(&pool)
+            .await
+            .expect("create public schema");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply canonical migrations");
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!("admission-{}.example", domain.as_uuid().simple()))
+            .execute(&pool)
+            .await
+            .expect("insert community");
+        let actor = "11".repeat(32);
+        let rollback_actor = "22".repeat(32);
+        let capacity_actor = "33".repeat(32);
+        let joined_token = [41_u8; 32];
+        let rollback_token = [42_u8; 32];
+        let capacity_token = [43_u8; 32];
+        for (token, maximum) in [
+            (joined_token, 2_i32),
+            (rollback_token, 1_i32),
+            (capacity_token, 1_i32),
+        ] {
+            sqlx::query(
+                "INSERT INTO relay_invites \
+                 (community_id,token_hash,max_uses,expires_at,created_by) \
+                 VALUES ($1,$2,$3,transaction_timestamp()+INTERVAL '1 hour','operator')",
+            )
+            .bind(domain.as_uuid())
+            .bind(token.as_slice())
+            .bind(maximum)
+            .execute(&pool)
+            .await
+            .expect("insert invite");
+        }
+
+        let policy_version = "a1".repeat(32);
+        let effect = CanonicalInviteClaimEffect::new(joined_token, Some(&policy_version))
+            .expect("invite effect");
+        let mut joined_tx = pool.begin().await.expect("begin joined effect");
+        let joined = apply_canonical_invite_claim_tx(
+            &mut joined_tx,
+            domain,
+            &actor,
+            joined_token,
+            Some(&policy_version),
+            effect.intent_digest(),
+        )
+        .await
+        .expect("apply joined effect");
+        assert_eq!(
+            joined.result(),
+            &AdmissionApplicationResult::invite_claim(CanonicalInviteClaimOutcome::Joined)
+        );
+        joined_tx.commit().await.expect("commit joined effect");
+
+        let mut replay_tx = pool.begin().await.expect("begin already-member effect");
+        let already = apply_canonical_invite_claim_tx(
+            &mut replay_tx,
+            domain,
+            &actor,
+            joined_token,
+            Some(&policy_version),
+            effect.intent_digest(),
+        )
+        .await
+        .expect("apply already-member effect");
+        assert_eq!(
+            already.result(),
+            &AdmissionApplicationResult::invite_claim(CanonicalInviteClaimOutcome::AlreadyMember)
+        );
+        replay_tx
+            .commit()
+            .await
+            .expect("commit already-member effect");
+        let joined_count: i32 = sqlx::query_scalar(
+            "SELECT use_count FROM relay_invites WHERE community_id=$1 AND token_hash=$2",
+        )
+        .bind(domain.as_uuid())
+        .bind(joined_token.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("read joined use count");
+        assert_eq!(joined_count, 1);
+
+        let rollback_effect =
+            CanonicalInviteClaimEffect::new(rollback_token, None).expect("rollback effect");
+        let mut rollback_tx = pool.begin().await.expect("begin rollback effect");
+        assert_eq!(
+            apply_canonical_invite_claim_tx(
+                &mut rollback_tx,
+                domain,
+                &rollback_actor,
+                rollback_token,
+                Some("invalid-policy-version"),
+                rollback_effect.intent_digest(),
+            )
+            .await
+            .expect_err("policy persistence failure must abort the effect"),
+            AdmissionCommitError::DependencyUnavailable
+        );
+        rollback_tx
+            .rollback()
+            .await
+            .expect("roll back failed effect");
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT count(*) FROM relay_members WHERE community_id=$1 AND pubkey=$2",
+            )
+            .bind(domain.as_uuid())
+            .bind(&rollback_actor)
+            .fetch_one(&pool)
+            .await
+            .expect("read rolled-back membership"),
+            0
+        );
+
+        let capacity_effect = CanonicalInviteClaimEffect::new(capacity_token, None)
+            .expect("capacity rollback effect");
+        let mut capacity_tx = pool.begin().await.expect("begin capacity rollback");
+        apply_canonical_invite_claim_tx(
+            &mut capacity_tx,
+            domain,
+            &capacity_actor,
+            capacity_token,
+            None,
+            capacity_effect.intent_digest(),
+        )
+        .await
+        .expect("stage capacity rollback effect");
+        let capacity_error = sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind,operation_id, \
+              request_fingerprint,correlation_id,attempt_id,occurred_at,canonical_envelope,envelope_digest) \
+             VALUES ($1,$2,9,2,9,4,$3,NULL,$4,$5,transaction_timestamp(),$6,$7)",
+        )
+        .bind(domain.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(vec![9_u8; 32])
+        .bind(vec![19_u8; 32])
+        .execute(&mut *capacity_tx)
+        .await
+        .expect_err("missing audit capacity aborts the shared transaction");
+        assert_eq!(
+            capacity_error
+                .as_database_error()
+                .and_then(|error| error.constraint()),
+            Some("authorization_event_capacity_policy_required")
+        );
+        capacity_tx
+            .rollback()
+            .await
+            .expect("roll back capacity failure");
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT count(*) FROM relay_members WHERE community_id=$1 AND pubkey=$2",
+            )
+            .bind(domain.as_uuid())
+            .bind(&capacity_actor)
+            .fetch_one(&pool)
+            .await
+            .expect("read capacity-rolled-back membership"),
+            0
+        );
+
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+             VALUES ($1,8,8192,1024)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install audit capacity");
+        let operation_id = admission_operation_id([51; 32]);
+        let request_fingerprint = [52_u8; 32];
+        let semantic_fingerprint = [53_u8; 32];
+        let application_intent = [56_u8; 32];
+        let application_effect = [57_u8; 32];
+        let object =
+            AdmissionObject::new(AdmissionObjectKind::Domain, [58; 32]).expect("test object");
+        let persisted_result =
+            AdmissionApplicationResult::invite_claim(CanonicalInviteClaimOutcome::AlreadyMember);
+        let persisted_result_digest = canonical_admission_result_digest(
+            domain,
+            object,
+            semantic_fingerprint,
+            Some(application_intent),
+            Some(&persisted_result),
+            Some(application_effect),
+        )
+        .expect("canonical persisted result digest");
+        let persisted_application_result_digest = canonical_application_result_digest(
+            domain,
+            object,
+            semantic_fingerprint,
+            application_intent,
+            &persisted_result,
+        )
+        .expect("canonical application result digest");
+        let audit_envelope = vec![10_u8; 32];
+        let audit_envelope_digest: [u8; 32] = Sha256::digest(&audit_envelope).into();
+        let event_id = Uuid::new_v4();
+        let mut persisted = pool.begin().await.expect("begin persisted replay fixture");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+              outcome_code,result_digest) VALUES ($1,$2,$3,11,$4,1,$5)",
+        )
+        .bind(domain.as_uuid())
+        .bind(operation_id)
+        .bind(request_fingerprint.as_slice())
+        .bind([54_u8; 32].as_slice())
+        .bind(persisted_result_digest.as_slice())
+        .execute(&mut *persisted)
+        .await
+        .expect("insert replay receipt");
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind,actor_fingerprint, \
+              operation_id,request_fingerprint,correlation_id,attempt_id,occurred_at, \
+              canonical_envelope,envelope_digest) \
+             VALUES ($1,$2,10,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+        )
+        .bind(domain.as_uuid())
+        .bind(event_id)
+        .bind([54_u8; 32].as_slice())
+        .bind(operation_id)
+        .bind(request_fingerprint.as_slice())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(&audit_envelope)
+        .bind(audit_envelope_digest.as_slice())
+        .execute(&mut *persisted)
+        .await
+        .expect("insert replay event");
+        sqlx::query(
+            "INSERT INTO authorization_admission_results \
+             (community_id,operation_id,request_fingerprint,semantic_fingerprint,object_kind, \
+              object_key,application_type,application_version,application_code,application_payload, \
+              application_intent_digest,application_effect_digest,application_result_digest) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,1,2,$8,$9,$10,$11)",
+        )
+        .bind(domain.as_uuid())
+        .bind(operation_id)
+        .bind(request_fingerprint.as_slice())
+        .bind(semantic_fingerprint.as_slice())
+        .bind(object.kind().database_code())
+        .bind(object.key().as_slice())
+        .bind(INVITE_CLAIM_RESULT_TYPE.as_slice())
+        .bind(Vec::<u8>::new())
+        .bind(application_intent.as_slice())
+        .bind(application_effect.as_slice())
+        .bind(persisted_application_result_digest.as_slice())
+        .execute(&mut *persisted)
+        .await
+        .expect("insert persisted typed result");
+        persisted.commit().await.expect("commit replay fixture");
+        sqlx::query(
+            "UPDATE authorization_admission_results SET application_payload=$3 \
+             WHERE community_id=$1 AND operation_id=$2",
+        )
+        .bind(domain.as_uuid())
+        .bind(operation_id)
+        .bind(b"changed-result".as_slice())
+        .execute(&pool)
+        .await
+        .expect_err("persisted application result is immutable");
+
+        let mut read_tx = pool.begin().await.expect("begin replay read");
+        let (replayed_receipt, replayed_result) = read_existing_receipt(
+            &mut read_tx,
+            ExistingAdmissionLookup {
+                domain,
+                operation_id,
+                request_fingerprint,
+                semantic_fingerprint,
+                object,
+                receipt_shape: AdmissionReceiptShape::ProtectedMutation,
+                expected_application_schema: Some(AdmissionApplicationResultSchema::invite_claim()),
+            },
+        )
+        .await
+        .expect("read exact replay")
+        .expect("persisted replay exists");
+        assert_eq!(replayed_receipt.authorization_domain(), domain);
+        assert_eq!(replayed_receipt.object(), object);
+        assert_eq!(
+            replayed_receipt.semantic_fingerprint(),
+            &semantic_fingerprint
+        );
+        assert_eq!(
+            replayed_result,
+            Some(AdmissionApplicationResult::invite_claim(
+                CanonicalInviteClaimOutcome::AlreadyMember
+            ))
+        );
+        assert_eq!(
+            read_existing_receipt(
+                &mut read_tx,
+                ExistingAdmissionLookup {
+                    domain,
+                    operation_id,
+                    request_fingerprint,
+                    semantic_fingerprint: [99; 32],
+                    object,
+                    receipt_shape: AdmissionReceiptShape::ProtectedMutation,
+                    expected_application_schema: Some(
+                        AdmissionApplicationResultSchema::invite_claim(),
+                    ),
+                },
+            )
+            .await,
+            Err(AdmissionCommitError::IntentConflict)
+        );
+        assert_eq!(
+            read_existing_receipt(
+                &mut read_tx,
+                ExistingAdmissionLookup {
+                    domain,
+                    operation_id,
+                    request_fingerprint,
+                    semantic_fingerprint,
+                    object: AdmissionObject::new(AdmissionObjectKind::Repository, [59; 32])
+                        .expect("other object"),
+                    receipt_shape: AdmissionReceiptShape::ProtectedMutation,
+                    expected_application_schema: Some(
+                        AdmissionApplicationResultSchema::invite_claim(),
+                    ),
+                },
+            )
+            .await,
+            Err(AdmissionCommitError::IntentConflict)
+        );
+        read_tx.rollback().await.expect("close replay read");
+        pool.close().await;
+    }
+}

--- a/crates/buzz-db/src/authorization_events.rs
+++ b/crates/buzz-db/src/authorization_events.rs
@@ -1,0 +1,1810 @@
+//! Immutable provider-free authorization events and capacity controls.
+//!
+//! V1 deliberately has no claim, export, acknowledgement, retry, pruning, or
+//! compaction workflow. Inserts consume an explicitly configured immutable
+//! per-domain budget; exhaustion aborts the surrounding authorization
+//! transaction and is latched unhealthy by the caller.
+
+use std::{collections::HashSet, fmt};
+
+use buzz_auth::{
+    operator_lifecycle::{VerifiedOperatorLifecycleGrant, VerifiedProvisionBindingIntent},
+    AuthorizationEventCapacityPolicy, FinalizedAuthContext, ProofTransport,
+    VerifiedFederatedAssertion, VerifiedNostrProof,
+};
+use buzz_core::{CanonicalCurrentBindingEvidence, CommunityId};
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{Postgres, Row, Transaction};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{Db, DbError, Result};
+
+const MAX_EVENT_PAGE: u16 = 1_000;
+
+/// Closed operation kinds stored in the single canonical receipt table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationOperationKind {
+    /// Direct enrollment.
+    Enroll = 1,
+    /// Separate provisioning.
+    Provision = 2,
+    /// Retire an exact binding generation.
+    Retire = 3,
+    /// Disable a principal.
+    Disable = 4,
+    /// Revoke authority.
+    Revoke = 5,
+    /// Rotate to a successor binding.
+    Rotate = 6,
+    /// Recover a retired principal.
+    Recover = 7,
+    /// Enable a disabled principal.
+    Enable = 8,
+    /// Local admission loss.
+    AdmissionLoss = 9,
+    /// Authenticated operator action.
+    Operator = 10,
+    /// Protected mutation.
+    ProtectedMutation = 11,
+    /// Invalidation advance.
+    Invalidation = 12,
+    /// Client-status revision.
+    StatusRevision = 13,
+}
+
+/// Persisted result classification for one operation receipt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationOperationOutcome {
+    /// State changed successfully.
+    Applied = 1,
+    /// Closed denial with durable evidence.
+    Denied = 2,
+    /// Successful semantic no-op.
+    NoOp = 3,
+}
+
+/// Canonical operation receipt supplied by a transaction owner.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthorizationOperationReceipt {
+    community_id: CommunityId,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    operation_kind: AuthorizationOperationKind,
+    actor: AuthorizationEventActor,
+    outcome: AuthorizationOperationOutcome,
+    result_digest: [u8; 32],
+}
+
+impl AuthorizationOperationReceipt {
+    /// Validate one receipt without persisting it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        community_id: CommunityId,
+        operation_id: Uuid,
+        request_fingerprint: [u8; 32],
+        operation_kind: AuthorizationOperationKind,
+        actor: AuthorizationEventActor,
+        outcome: AuthorizationOperationOutcome,
+        result_digest: [u8; 32],
+    ) -> Result<Self> {
+        if community_id.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || request_fingerprint == [0; 32]
+            || actor.fingerprint().is_none()
+            || !actor.is_bound_to(community_id)
+            || result_digest == [0; 32]
+        {
+            return Err(DbError::InvalidData(
+                "authorization operation receipt is invalid".to_owned(),
+            ));
+        }
+        Ok(Self {
+            community_id,
+            operation_id,
+            request_fingerprint,
+            operation_kind,
+            actor,
+            outcome,
+            result_digest,
+        })
+    }
+}
+
+impl fmt::Debug for AuthorizationOperationReceipt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthorizationOperationReceipt")
+            .field("community_id", &"[REDACTED]")
+            .field("operation_id", &"[REDACTED]")
+            .field("request_fingerprint", &"[REDACTED]")
+            .field("operation_kind", &self.operation_kind)
+            .field("actor", &self.actor)
+            .field("outcome", &self.outcome)
+            .field("result_digest", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Whether a receipt insert created state or replayed an identical receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorizationReceiptWrite {
+    /// New receipt inserted.
+    Inserted,
+    /// Byte-for-byte semantic replay.
+    ExactReplay,
+}
+
+/// Canonical authorization event kinds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationEventKind {
+    /// Binding enrolled.
+    Enrolled = 1,
+    /// Authority revoked.
+    Revoked = 2,
+    /// Binding rotated.
+    Rotated = 3,
+    /// Principal recovered.
+    Recovered = 4,
+    /// Principal enabled.
+    PrincipalEnabled = 5,
+    /// Binding retired.
+    Retired = 6,
+    /// Principal disabled.
+    PrincipalDisabled = 7,
+    /// Local authority admission lost.
+    AdmissionLost = 8,
+    /// Operator action denied.
+    OperatorDenied = 9,
+    /// Protected operation allowed.
+    ProtectedAllowed = 10,
+    /// Protected operation denied.
+    ProtectedDenied = 11,
+    /// Current-binding status published.
+    StatusPublished = 12,
+    /// Current-binding status withdrawn.
+    StatusWithdrawn = 13,
+    /// Invalidation generation advanced.
+    InvalidationAdvanced = 14,
+}
+
+impl AuthorizationEventKind {
+    fn from_database(value: i16) -> Result<Self> {
+        match value {
+            1 => Ok(Self::Enrolled),
+            2 => Ok(Self::Revoked),
+            3 => Ok(Self::Rotated),
+            4 => Ok(Self::Recovered),
+            5 => Ok(Self::PrincipalEnabled),
+            6 => Ok(Self::Retired),
+            7 => Ok(Self::PrincipalDisabled),
+            8 => Ok(Self::AdmissionLost),
+            9 => Ok(Self::OperatorDenied),
+            10 => Ok(Self::ProtectedAllowed),
+            11 => Ok(Self::ProtectedDenied),
+            12 => Ok(Self::StatusPublished),
+            13 => Ok(Self::StatusWithdrawn),
+            14 => Ok(Self::InvalidationAdvanced),
+            _ => Err(DbError::InvalidData(
+                "authorization event kind is invalid".to_owned(),
+            )),
+        }
+    }
+}
+
+/// Stable canonical event outcome code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationEventOutcome {
+    /// Allowed or applied.
+    Allowed = 1,
+    /// Denied closed.
+    Denied = 2,
+    /// No-op.
+    NoOp = 3,
+    /// Failed closed because durable evidence was unavailable.
+    AuditUnavailable = 4,
+    /// Withdrawn.
+    Withdrawn = 5,
+}
+
+/// Stable redaction-safe event reason code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationReasonCode {
+    /// Successful current policy.
+    Current = 1,
+    /// Missing credential or evidence.
+    Missing = 2,
+    /// Invalid credential or evidence.
+    Invalid = 3,
+    /// Unauthenticated attempt.
+    Unauthenticated = 4,
+    /// Stale authority.
+    StaleAuthority = 5,
+    /// Cross-domain evidence.
+    CrossDomain = 6,
+    /// Binding mismatch.
+    BindingMismatch = 7,
+    /// Delegation mismatch.
+    DelegationMismatch = 8,
+    /// Policy denial.
+    PolicyDenied = 9,
+    /// Invalidation fence changed.
+    Invalidated = 10,
+    /// Capacity exhausted.
+    CapacityExhausted = 11,
+    /// Storage unavailable.
+    StorageUnavailable = 12,
+    /// Proof expired.
+    Expired = 13,
+    /// Exact replay.
+    Replay = 14,
+    /// Intent conflict.
+    IntentConflict = 15,
+    /// Explicit withdrawal.
+    Withdrawn = 16,
+}
+
+/// Pseudonymous actor classification derived only from sealed or
+/// authoritatively rechecked evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+enum AuthorizationActorKind {
+    /// Authenticated direct actor.
+    Direct = 1,
+    /// Authenticated delegate.
+    Delegate = 2,
+    /// Authenticated operator.
+    Operator = 3,
+    /// Credential-free unresolved attempt.
+    Unresolved = 4,
+}
+
+/// Exact local authority coordinate whose loss was rechecked in PostgreSQL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocalAdmissionLossCause {
+    /// Exact active binding generation.
+    Binding {
+        /// Stable binding identifier.
+        binding_id: Uuid,
+        /// Immutable binding generation.
+        binding_version: u64,
+    },
+    /// Exact active local policy revision.
+    Policy {
+        /// Positive policy revision.
+        policy_revision: u64,
+    },
+    /// Exact delegated relationship revision already installed in local
+    /// protected authority.
+    DelegatedRelationship {
+        /// Stable relationship identifier.
+        relationship_id: Uuid,
+        /// Positive relationship revision.
+        relationship_revision: u64,
+    },
+}
+
+/// Database-rechecked loss coordinate retained inside an opaque actor proof.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthorizationAuthorityLossTarget {
+    /// Every protected object owned by one exact binding generation.
+    Binding(Uuid, u64),
+    /// Every protected object admitted by one exact policy revision.
+    Policy(u64),
+    /// Every protected object admitted by one exact delegated relationship.
+    DelegatedRelationship(Uuid, u64),
+}
+
+/// Opaque authenticated event actor.
+///
+/// Callers cannot choose an actor kind or fingerprint. Direct/delegated route
+/// actors are derived from a sealed [`FinalizedAuthContext`]; local admission-loss
+/// actors are minted only after an authoritative PostgreSQL recheck.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthorizationEventActor {
+    community_id: Option<CommunityId>,
+    kind: AuthorizationActorKind,
+    fingerprint: Option<[u8; 32]>,
+    authority_loss_target: Option<AuthorizationAuthorityLossTarget>,
+}
+
+impl AuthorizationEventActor {
+    /// Derive operator attribution only from one origin-sealed lifecycle
+    /// grant. Callers cannot select the actor class or fingerprint.
+    pub fn from_verified_operator_grant(grant: &VerifiedOperatorLifecycleGrant) -> Result<Self> {
+        if grant.authorization_domain().as_uuid().is_nil()
+            || grant.operation_id().is_nil()
+            || grant.intent_digest() == [0; 32]
+            || grant.expected_revision() == 0
+            || grant.approval_policy_digest() == [0; 32]
+            || grant.signer_attribution() == [0; 32]
+            || grant.approval_attribution() == Some([0; 32])
+            || grant.request_attribution() == [0; 32]
+            || grant.issued_at().timestamp_micros() <= 0
+            || grant.expires_at() <= grant.issued_at()
+        {
+            return Err(DbError::InvalidData(
+                "verified operator grant is invalid".to_owned(),
+            ));
+        }
+        let action = (grant.action() as i16).to_be_bytes();
+        let expected_revision = grant.expected_revision().to_be_bytes();
+        Ok(local_actor(
+            AuthorizationActorKind::Operator,
+            grant.authorization_domain(),
+            &[
+                &action,
+                grant.operation_id().as_bytes(),
+                &grant.intent_digest(),
+                &expected_revision,
+                &grant.approval_policy_digest(),
+                &grant.signer_attribution(),
+                &grant.approval_attribution().unwrap_or([0; 32]),
+                &grant.request_attribution(),
+            ],
+            None,
+        ))
+    }
+
+    /// Derive provisioning attribution only from one verifier-sealed
+    /// provision intent. This remains distinct from lifecycle authority.
+    pub fn from_verified_provision_intent(intent: &VerifiedProvisionBindingIntent) -> Result<Self> {
+        if intent.authorization_domain().as_uuid().is_nil()
+            || intent.operation_id().is_nil()
+            || intent.policy_revision() == 0
+            || intent.policy_digest() == [0; 32]
+            || intent.selected_event_author_pubkey() == [0; 32]
+            || intent.intent_digest() == [0; 32]
+            || intent.approval_policy_digest() == [0; 32]
+            || intent.signer_attribution() == [0; 32]
+            || intent.approval_attribution() == Some([0; 32])
+            || intent.request_attribution() == [0; 32]
+            || intent.issued_at().timestamp_micros() <= 0
+            || intent.expires_at() <= intent.issued_at()
+        {
+            return Err(DbError::InvalidData(
+                "verified provision intent is invalid".to_owned(),
+            ));
+        }
+        let policy_revision = intent.policy_revision().to_be_bytes();
+        Ok(local_actor(
+            AuthorizationActorKind::Operator,
+            intent.authorization_domain(),
+            &[
+                intent.operation_id().as_bytes(),
+                &policy_revision,
+                &intent.policy_digest(),
+                &intent.selected_event_author_pubkey(),
+                &intent.intent_digest(),
+                &intent.approval_policy_digest(),
+                &intent.signer_attribution(),
+                &intent.approval_attribution().unwrap_or([0; 32]),
+                &intent.request_attribution(),
+            ],
+            None,
+        ))
+    }
+
+    /// Derive direct/delegated attribution from the complete sealed route.
+    pub fn from_auth_context(context: &FinalizedAuthContext) -> Result<Self> {
+        let lease = context.lease();
+        let (request_fingerprint, _, _) = lease.request_binding();
+        if lease.authorization_domain() != context.authorization_domain()
+            || lease.actor_pubkey() != context.actor_pubkey()
+            || lease.owner_pubkey() != context.owner_pubkey()
+            || lease.binding() != context.binding()
+            || lease.capability() != context.capability()
+            || request_fingerprint != context.request_fingerprint()
+        {
+            return Err(DbError::InvalidData(
+                "authorization actor route coordinates do not match".to_owned(),
+            ));
+        }
+        actor_from_route_coordinates(
+            context.authorization_domain(),
+            context.actor_pubkey().to_bytes(),
+            context.owner_pubkey().map(|value| value.to_bytes()),
+            context.binding(),
+            lease.delegated_relationship(),
+        )
+    }
+
+    /// Derive enrollment attribution only from one origin-sealed direct
+    /// assertion/proof pair. No binding exists yet, so this deliberately uses
+    /// the verifier-bound principal, actor, and complete request coordinates
+    /// rather than accepting a caller-selected actor label or fingerprint.
+    pub fn from_verified_direct_enrollment(
+        assertion: &VerifiedFederatedAssertion,
+        proof: &VerifiedNostrProof,
+    ) -> Result<Self> {
+        let principal = assertion.principal_storage_key();
+        let assertion_fingerprint = proof.bound_assertion_fingerprint().ok_or_else(|| {
+            DbError::InvalidData("direct enrollment proof is not bound to an assertion".to_owned())
+        })?;
+        if assertion.authorization_domain() != proof.authorization_domain()
+            || proof.delegation_conditions_fingerprint().is_some()
+            || assertion_fingerprint == &[0; 32]
+        {
+            return Err(DbError::InvalidData(
+                "direct enrollment evidence coordinates do not match".to_owned(),
+            ));
+        }
+        let transport = proof_transport_code(proof.transport());
+        Ok(local_actor(
+            AuthorizationActorKind::Direct,
+            assertion.authorization_domain(),
+            &[
+                principal.issuer().as_bytes(),
+                principal.subject().as_bytes(),
+                &proof.actor_pubkey().to_bytes(),
+                assertion_fingerprint,
+                proof.request_fingerprint(),
+                proof.target_fingerprint(),
+                proof.transport_context_fingerprint(),
+                &transport.to_be_bytes(),
+            ],
+            None,
+        ))
+    }
+
+    /// Credential-free actor used only by the dedicated pre-authentication
+    /// denial lane, which cannot own a canonical operation receipt.
+    pub const fn unresolved_authentication_denial() -> Self {
+        Self {
+            community_id: None,
+            kind: AuthorizationActorKind::Unresolved,
+            fingerprint: None,
+            authority_loss_target: None,
+        }
+    }
+
+    const fn kind(&self) -> AuthorizationActorKind {
+        self.kind
+    }
+
+    const fn fingerprint(&self) -> Option<[u8; 32]> {
+        self.fingerprint
+    }
+
+    /// Whether the sealed actor belongs to the exact server-owned domain.
+    pub fn is_bound_to(&self, community_id: CommunityId) -> bool {
+        matches!(self.community_id, Some(bound) if bound == community_id)
+    }
+
+    /// Whether this actor may own a canonical operation receipt.
+    pub const fn is_authenticated(&self) -> bool {
+        self.fingerprint.is_some() && !matches!(self.kind, AuthorizationActorKind::Unresolved)
+    }
+
+    /// Exact database-rechecked coordinate available to the coupled authority
+    /// refence seam.
+    pub const fn authority_loss_target(&self) -> Option<AuthorizationAuthorityLossTarget> {
+        self.authority_loss_target
+    }
+}
+
+const fn proof_transport_code(transport: ProofTransport) -> i16 {
+    match transport {
+        ProofTransport::Nip42 => 1,
+        ProofTransport::Nip98 => 2,
+        ProofTransport::GitSmartHttpSession => 3,
+        ProofTransport::Blossom => 4,
+    }
+}
+
+impl fmt::Debug for AuthorizationEventActor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AuthorizationEventActor([REDACTED])")
+    }
+}
+
+/// Recheck a local admission-loss cause and mint its non-forgeable event actor.
+pub async fn resolve_local_admission_loss_actor_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community_id: CommunityId,
+    cause: LocalAdmissionLossCause,
+) -> Result<AuthorizationEventActor> {
+    if community_id.as_uuid().is_nil() {
+        return Err(DbError::InvalidData(
+            "authorization admission-loss actor domain is invalid".to_owned(),
+        ));
+    }
+    match cause {
+        LocalAdmissionLossCause::Binding {
+            binding_id,
+            binding_version,
+        } => {
+            if binding_id.is_nil() || binding_version == 0 || binding_version > i64::MAX as u64 {
+                return Err(DbError::InvalidData(
+                    "authorization admission-loss binding actor is invalid".to_owned(),
+                ));
+            }
+            let actor: Vec<u8> = sqlx::query_scalar(
+                "SELECT event_author_pubkey FROM identity_bindings \
+                 WHERE community_id=$1 AND binding_id=$2 AND binding_version=$3 \
+                   AND binding_state=1 AND (expires_at IS NULL OR expires_at > clock_timestamp())",
+            )
+            .bind(community_id.as_uuid())
+            .bind(binding_id)
+            .bind(i64::try_from(binding_version).map_err(|_| {
+                DbError::InvalidData("authorization binding version is out of range".to_owned())
+            })?)
+            .fetch_optional(&mut **transaction)
+            .await?
+            .ok_or_else(|| DbError::NotFound("active authorization binding".to_owned()))?;
+            let actor = bytes32(actor, "local binding actor")?;
+            Ok(local_actor(
+                AuthorizationActorKind::Direct,
+                community_id,
+                &[
+                    binding_id.as_bytes(),
+                    &binding_version.to_be_bytes(),
+                    &actor,
+                ],
+                Some(AuthorizationAuthorityLossTarget::Binding(
+                    binding_id,
+                    binding_version,
+                )),
+            ))
+        }
+        LocalAdmissionLossCause::Policy { policy_revision } => {
+            if policy_revision == 0 || policy_revision > i64::MAX as u64 {
+                return Err(DbError::InvalidData(
+                    "authorization admission-loss policy actor is invalid".to_owned(),
+                ));
+            }
+            let policy_digest: Vec<u8> = sqlx::query_scalar(
+                "SELECT policy_digest FROM identity_enrollment_policies \
+                 WHERE community_id=$1 AND policy_revision=$2 \
+                   AND effective_at <= clock_timestamp() \
+                   AND (expires_at IS NULL OR expires_at > clock_timestamp())",
+            )
+            .bind(community_id.as_uuid())
+            .bind(i64::try_from(policy_revision).map_err(|_| {
+                DbError::InvalidData("authorization policy revision is out of range".to_owned())
+            })?)
+            .fetch_optional(&mut **transaction)
+            .await?
+            .ok_or_else(|| DbError::NotFound("active authorization policy".to_owned()))?;
+            let policy_digest = bytes32(policy_digest, "local policy digest")?;
+            Ok(local_actor(
+                AuthorizationActorKind::Direct,
+                community_id,
+                &[&policy_revision.to_be_bytes(), &policy_digest],
+                Some(AuthorizationAuthorityLossTarget::Policy(policy_revision)),
+            ))
+        }
+        LocalAdmissionLossCause::DelegatedRelationship {
+            relationship_id,
+            relationship_revision,
+        } => {
+            if relationship_id.is_nil()
+                || relationship_revision == 0
+                || relationship_revision > i64::MAX as u64
+            {
+                return Err(DbError::InvalidData(
+                    "authorization admission-loss delegation actor is invalid".to_owned(),
+                ));
+            }
+            let rows = sqlx::query(
+                "SELECT DISTINCT p.actor_pubkey,p.owner_pubkey,p.binding_id,p.binding_version \
+                 FROM protected_object_authority p \
+                 JOIN identity_bindings b ON b.community_id=p.community_id \
+                   AND b.binding_id=p.binding_id AND b.binding_version=p.binding_version \
+                 WHERE p.community_id=$1 AND p.delegated_relationship_id=$2 \
+                   AND p.delegated_relationship_revision=$3 AND p.expires_at > clock_timestamp() \
+                   AND b.binding_state=1 AND (b.expires_at IS NULL OR b.expires_at > clock_timestamp()) \
+                 ORDER BY p.actor_pubkey,p.owner_pubkey,p.binding_id,p.binding_version LIMIT 2",
+            )
+            .bind(community_id.as_uuid())
+            .bind(relationship_id)
+            .bind(i64::try_from(relationship_revision).map_err(|_| {
+                DbError::InvalidData(
+                    "authorization relationship revision is out of range".to_owned(),
+                )
+            })?)
+            .fetch_all(&mut **transaction)
+            .await?;
+            if rows.len() != 1 {
+                return Err(DbError::InvalidData(
+                    "authorization delegated authority is missing or ambiguous".to_owned(),
+                ));
+            }
+            let row = &rows[0];
+            let actor = bytes32(row.try_get("actor_pubkey")?, "delegated actor")?;
+            let owner = bytes32(
+                row.try_get::<Option<Vec<u8>>, _>("owner_pubkey")?
+                    .ok_or_else(|| {
+                        DbError::InvalidData("authorization delegated owner is missing".to_owned())
+                    })?,
+                "delegated owner",
+            )?;
+            let binding_id: Uuid = row.try_get("binding_id")?;
+            let binding_version = u64::try_from(row.try_get::<i64, _>("binding_version")?)
+                .map_err(|_| {
+                    DbError::InvalidData(
+                        "authorization delegated binding version is invalid".to_owned(),
+                    )
+                })?;
+            Ok(local_actor(
+                AuthorizationActorKind::Delegate,
+                community_id,
+                &[
+                    relationship_id.as_bytes(),
+                    &relationship_revision.to_be_bytes(),
+                    &actor,
+                    &owner,
+                    binding_id.as_bytes(),
+                    &binding_version.to_be_bytes(),
+                ],
+                Some(AuthorizationAuthorityLossTarget::DelegatedRelationship(
+                    relationship_id,
+                    relationship_revision,
+                )),
+            ))
+        }
+    }
+}
+
+fn actor_from_route_coordinates(
+    community_id: CommunityId,
+    actor: [u8; 32],
+    owner: Option<[u8; 32]>,
+    binding: (Uuid, u64),
+    relationship: Option<(Uuid, u64)>,
+) -> Result<AuthorizationEventActor> {
+    let kind = match (owner, relationship) {
+        (None, None) => AuthorizationActorKind::Direct,
+        (Some(_), Some(_)) => AuthorizationActorKind::Delegate,
+        _ => {
+            return Err(DbError::InvalidData(
+                "authorization actor route is partially delegated".to_owned(),
+            ));
+        }
+    };
+    let mut digest = Sha256::new();
+    framed(&mut digest, b"buzz:authorization-event-actor:route:v1");
+    framed(&mut digest, community_id.as_uuid().as_bytes());
+    framed(&mut digest, &(kind as i16).to_be_bytes());
+    framed(&mut digest, &actor);
+    append_hash_optional(&mut digest, owner.as_ref().map(<[u8; 32]>::as_slice));
+    framed(&mut digest, binding.0.as_bytes());
+    framed(&mut digest, &binding.1.to_be_bytes());
+    match relationship {
+        Some((id, revision)) => {
+            framed(&mut digest, id.as_bytes());
+            framed(&mut digest, &revision.to_be_bytes());
+        }
+        None => framed(&mut digest, &[]),
+    }
+    Ok(AuthorizationEventActor {
+        community_id: Some(community_id),
+        kind,
+        fingerprint: Some(digest.finalize().into()),
+        authority_loss_target: None,
+    })
+}
+
+fn local_actor(
+    kind: AuthorizationActorKind,
+    community_id: CommunityId,
+    parts: &[&[u8]],
+    authority_loss_target: Option<AuthorizationAuthorityLossTarget>,
+) -> AuthorizationEventActor {
+    let mut digest = Sha256::new();
+    framed(
+        &mut digest,
+        b"buzz:authorization-event-actor:local-authority:v1",
+    );
+    framed(&mut digest, community_id.as_uuid().as_bytes());
+    framed(&mut digest, &(kind as i16).to_be_bytes());
+    for part in parts {
+        framed(&mut digest, part);
+    }
+    AuthorizationEventActor {
+        community_id: Some(community_id),
+        kind,
+        fingerprint: Some(digest.finalize().into()),
+        authority_loss_target,
+    }
+}
+
+/// Mint status-publication attribution only after the complete evidence tuple
+/// has been rechecked inside the allocation transaction.
+pub async fn resolve_current_binding_event_actor_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    evidence: &CanonicalCurrentBindingEvidence,
+) -> Result<AuthorizationEventActor> {
+    let mut object_key_digest = Sha256::new();
+    object_key_digest.update(b"buzz:client-binding-status-authority:v1");
+    object_key_digest.update((16_u64).to_be_bytes());
+    object_key_digest.update(evidence.authorization_domain().as_uuid().as_bytes());
+    object_key_digest.update((32_u64).to_be_bytes());
+    object_key_digest.update(evidence.event_author_pubkey().to_bytes());
+    let object_key: [u8; 32] = object_key_digest.finalize().into();
+    sqlx::query(
+        "SELECT 1 FROM identity_bindings b \
+         JOIN identity_enrollment_policies p \
+           ON p.community_id=b.community_id AND p.policy_revision=b.policy_revision \
+         JOIN authorization_invalidation_domains d ON d.community_id=b.community_id \
+         JOIN authorization_authority_epochs a \
+           ON a.community_id=b.community_id AND a.object_kind=7 AND a.object_key=$10 \
+         WHERE b.community_id=$1 AND b.binding_id=$2 AND b.binding_version=$3 \
+           AND b.event_author_pubkey=$4 AND b.policy_revision=$5 \
+           AND d.current_generation=$6 AND a.authority_epoch=$7 AND a.fence=$8 \
+           AND b.binding_state=1 AND $9 > clock_timestamp() \
+           AND $11 <= clock_timestamp() \
+           AND (b.expires_at IS NULL OR b.expires_at > clock_timestamp()) \
+           AND p.effective_at <= clock_timestamp() \
+           AND (p.expires_at IS NULL OR p.expires_at > clock_timestamp()) \
+         FOR SHARE OF b,p,d,a",
+    )
+    .bind(evidence.authorization_domain().as_uuid())
+    .bind(evidence.binding_id())
+    .bind(i64::try_from(evidence.binding_version()).map_err(|_| {
+        DbError::InvalidData("authorization binding version is out of range".to_owned())
+    })?)
+    .bind(evidence.event_author_pubkey().to_bytes().as_slice())
+    .bind(i64::try_from(evidence.policy_revision()).map_err(|_| {
+        DbError::InvalidData("authorization policy revision is out of range".to_owned())
+    })?)
+    .bind(
+        i64::try_from(evidence.invalidation_generation()).map_err(|_| {
+            DbError::InvalidData("authorization invalidation generation is out of range".to_owned())
+        })?,
+    )
+    .bind(i64::try_from(evidence.authority_epoch()).map_err(|_| {
+        DbError::InvalidData("authorization authority epoch is out of range".to_owned())
+    })?)
+    .bind(evidence.fence().as_bytes().as_slice())
+    .bind(evidence.fresh_until())
+    .bind(object_key.as_slice())
+    .bind(evidence.observed_at())
+    .fetch_optional(&mut **transaction)
+    .await?
+    .ok_or_else(|| DbError::NotFound("current binding event actor".to_owned()))?;
+    current_binding_event_actor(evidence)
+}
+
+/// Derive redaction-safe attribution from already rechecked binding evidence.
+pub fn current_binding_event_actor(
+    evidence: &CanonicalCurrentBindingEvidence,
+) -> Result<AuthorizationEventActor> {
+    Ok(local_actor(
+        AuthorizationActorKind::Direct,
+        evidence.authorization_domain(),
+        &[
+            evidence.binding_id().as_bytes(),
+            &evidence.binding_version().to_be_bytes(),
+            &evidence.event_author_pubkey().to_bytes(),
+        ],
+        None,
+    ))
+}
+
+/// Mint withdrawal attribution only from the exact current durable status
+/// receipt that is about to be superseded.
+pub async fn resolve_status_withdrawal_event_actor_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community_id: CommunityId,
+    event_author_pubkey: [u8; 32],
+    supersedes_revision: u64,
+) -> Result<AuthorizationEventActor> {
+    let current = sqlx::query(
+        "SELECT revision,disposition FROM client_status_revisions \
+         WHERE community_id=$1 AND event_author_pubkey=$2 \
+         ORDER BY revision DESC LIMIT 1 FOR UPDATE",
+    )
+    .bind(community_id.as_uuid())
+    .bind(event_author_pubkey.as_slice())
+    .fetch_optional(&mut **transaction)
+    .await?;
+    let Some(current) = current else {
+        return Err(DbError::NotFound(
+            "current status withdrawal actor".to_owned(),
+        ));
+    };
+    if current.try_get::<i16, _>("disposition")? != 1
+        || u64::try_from(current.try_get::<i64, _>("revision")?).map_err(|_| {
+            DbError::InvalidData("authorization status revision is invalid".to_owned())
+        })? != supersedes_revision
+    {
+        return Err(DbError::InvalidData(
+            "current status withdrawal actor changed".to_owned(),
+        ));
+    }
+    status_withdrawal_event_actor(community_id, event_author_pubkey, supersedes_revision)
+}
+
+/// Derive withdrawal attribution from one exact durable status revision.
+pub fn status_withdrawal_event_actor(
+    community_id: CommunityId,
+    event_author_pubkey: [u8; 32],
+    supersedes_revision: u64,
+) -> Result<AuthorizationEventActor> {
+    if community_id.as_uuid().is_nil() || supersedes_revision == 0 {
+        return Err(DbError::InvalidData(
+            "authorization status withdrawal actor is invalid".to_owned(),
+        ));
+    }
+    Ok(local_actor(
+        AuthorizationActorKind::Direct,
+        community_id,
+        &[&event_author_pubkey, &supersedes_revision.to_be_bytes()],
+        None,
+    ))
+}
+
+fn append_hash_optional(digest: &mut Sha256, value: Option<&[u8]>) {
+    match value {
+        Some(value) => {
+            framed(digest, &[1]);
+            framed(digest, value);
+        }
+        None => framed(digest, &[0]),
+    }
+}
+
+/// Validated immutable authorization event ready for insertion.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NewAuthorizationEvent {
+    community_id: CommunityId,
+    event_id: Uuid,
+    event_kind: AuthorizationEventKind,
+    outcome: AuthorizationEventOutcome,
+    reason: AuthorizationReasonCode,
+    actor: AuthorizationEventActor,
+    subject_fingerprint: Option<[u8; 32]>,
+    operation_id: Uuid,
+    request_fingerprint: Option<[u8; 32]>,
+    correlation_id: Uuid,
+    attempt_id: Uuid,
+}
+
+impl NewAuthorizationEvent {
+    /// Validate a redaction-safe canonical event envelope.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        community_id: CommunityId,
+        event_id: Uuid,
+        event_kind: AuthorizationEventKind,
+        outcome: AuthorizationEventOutcome,
+        reason: AuthorizationReasonCode,
+        actor: AuthorizationEventActor,
+        subject_fingerprint: Option<[u8; 32]>,
+        operation_id: Uuid,
+        request_fingerprint: Option<[u8; 32]>,
+        correlation_id: Uuid,
+        attempt_id: Uuid,
+    ) -> Result<Self> {
+        let unresolved = actor.kind() == AuthorizationActorKind::Unresolved;
+        if community_id.as_uuid().is_nil()
+            || event_id.is_nil()
+            || operation_id.is_nil()
+            || correlation_id.is_nil()
+            || attempt_id.is_nil()
+            || (!unresolved && !actor.is_bound_to(community_id))
+            || (unresolved && actor.community_id.is_some())
+            || !valid_event_semantics(event_kind, outcome, reason, unresolved)
+            || (unresolved
+                && (event_kind != AuthorizationEventKind::OperatorDenied
+                    || request_fingerprint.is_some()
+                    || actor.fingerprint().is_some()
+                    || subject_fingerprint.is_some()))
+            || (!unresolved
+                && (request_fingerprint.is_none()
+                    || request_fingerprint == Some([0; 32])
+                    || actor.fingerprint().is_none()))
+        {
+            return Err(DbError::InvalidData(
+                "authorization event envelope is invalid".to_owned(),
+            ));
+        }
+        Ok(Self {
+            community_id,
+            event_id,
+            event_kind,
+            outcome,
+            reason,
+            actor,
+            subject_fingerprint,
+            operation_id,
+            request_fingerprint,
+            correlation_id,
+            attempt_id,
+        })
+    }
+}
+
+fn valid_event_semantics(
+    event_kind: AuthorizationEventKind,
+    outcome: AuthorizationEventOutcome,
+    reason: AuthorizationReasonCode,
+    unresolved: bool,
+) -> bool {
+    use AuthorizationEventKind as Kind;
+    use AuthorizationEventOutcome as Outcome;
+    use AuthorizationReasonCode as Reason;
+
+    if unresolved {
+        return event_kind == Kind::OperatorDenied
+            && outcome == Outcome::Denied
+            && matches!(
+                reason,
+                Reason::Missing | Reason::Invalid | Reason::Unauthenticated
+            );
+    }
+    match event_kind {
+        Kind::Enrolled
+        | Kind::Revoked
+        | Kind::Rotated
+        | Kind::Recovered
+        | Kind::PrincipalEnabled
+        | Kind::Retired
+        | Kind::PrincipalDisabled => {
+            matches!(outcome, Outcome::Allowed | Outcome::NoOp)
+                && matches!(reason, Reason::Current | Reason::Replay)
+        }
+        Kind::AdmissionLost => {
+            matches!(outcome, Outcome::Allowed | Outcome::NoOp)
+                && matches!(reason, Reason::Invalidated | Reason::Replay)
+        }
+        Kind::OperatorDenied | Kind::ProtectedDenied => {
+            matches!(outcome, Outcome::Denied | Outcome::AuditUnavailable)
+                && !matches!(reason, Reason::Current | Reason::Replay | Reason::Withdrawn)
+        }
+        Kind::ProtectedAllowed => outcome == Outcome::Allowed && reason == Reason::Current,
+        Kind::StatusPublished => outcome == Outcome::Allowed && reason == Reason::Current,
+        Kind::StatusWithdrawn => outcome == Outcome::Withdrawn && reason == Reason::Withdrawn,
+        Kind::InvalidationAdvanced => outcome == Outcome::Allowed && reason == Reason::Invalidated,
+    }
+}
+
+impl fmt::Debug for NewAuthorizationEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NewAuthorizationEvent")
+            .field("event_kind", &self.event_kind)
+            .field("outcome", &self.outcome)
+            .field("reason", &self.reason)
+            .field("actor", &self.actor)
+            .field("event_id", &"[REDACTED]")
+            .field("operation_id", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// One immutable event returned from a bounded domain page.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthorizationEventRecord {
+    /// Stable event identity.
+    pub event_id: Uuid,
+    /// Canonical event class.
+    pub event_kind: AuthorizationEventKind,
+    /// Stable event outcome.
+    pub outcome_code: i16,
+    /// Stable reason code.
+    pub reason_code: i16,
+    /// Authoritative acceptance time.
+    pub accepted_at: DateTime<Utc>,
+    /// Canonical redaction-safe envelope.
+    pub canonical_envelope: Vec<u8>,
+    /// Digest of the exact envelope.
+    pub envelope_digest: [u8; 32],
+}
+
+impl fmt::Debug for AuthorizationEventRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthorizationEventRecord")
+            .field("event_id", &"[REDACTED]")
+            .field("event_kind", &self.event_kind)
+            .field("outcome_code", &self.outcome_code)
+            .field("reason_code", &self.reason_code)
+            .field("accepted_at", &"[REDACTED]")
+            .field("canonical_envelope", &"[REDACTED]")
+            .field("envelope_digest", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Stable keyset cursor for descending event pages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuthorizationEventPageCursor {
+    /// Acceptance time of the final row on the prior page.
+    pub accepted_at: DateTime<Utc>,
+    /// Stable event ID breaking timestamp ties.
+    pub event_id: Uuid,
+}
+
+/// One bounded page and its continuation cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationEventPage {
+    /// Events ordered newest-first.
+    pub events: Vec<AuthorizationEventRecord>,
+    /// Cursor for the next older page.
+    pub next: Option<AuthorizationEventPageCursor>,
+}
+
+/// Durable immutable-capacity health.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthorizationEventCapacityHealth {
+    /// Whether new events may be accepted.
+    pub healthy: bool,
+    /// Retained event count.
+    pub retained_event_count: u64,
+    /// Retained canonical envelope bytes.
+    pub retained_envelope_bytes: u64,
+    /// Sticky failure code, when unhealthy.
+    pub failure_code: Option<AuthorizationAuditFailureCode>,
+    /// Monotonic failure generation.
+    pub failure_generation: u64,
+    /// Last generation recovered by an exact health probe.
+    pub recovery_generation: u64,
+    /// Events retained exclusively for restrictive/security evidence.
+    pub restrictive_reserve_events: u64,
+    /// Canonical bytes retained exclusively for restrictive/security evidence.
+    pub restrictive_reserve_bytes: u64,
+}
+
+/// Sticky authorization-audit failure classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationAuditFailureCode {
+    /// Configured immutable capacity was exhausted.
+    CapacityExhausted = 1,
+    /// PostgreSQL audit persistence was unavailable.
+    StorageUnavailable = 2,
+    /// Canonical envelope contract failed.
+    InvalidEnvelope = 3,
+}
+
+impl AuthorizationAuditFailureCode {
+    fn from_database(value: i16) -> Result<Self> {
+        match value {
+            1 => Ok(Self::CapacityExhausted),
+            2 => Ok(Self::StorageUnavailable),
+            3 => Ok(Self::InvalidEnvelope),
+            _ => Err(DbError::InvalidData(
+                "authorization audit failure code is invalid".to_owned(),
+            )),
+        }
+    }
+}
+
+/// Typed classification of an event insert failure.
+#[derive(Debug, Error)]
+pub enum AuthorizationEventWriteError {
+    /// Immutable audit capacity is absent, unhealthy, or exhausted.
+    #[error("authorization event capacity is unavailable")]
+    CapacityUnavailable,
+    /// PostgreSQL or contract failure outside capacity enforcement.
+    #[error(transparent)]
+    Database(#[from] DbError),
+}
+
+/// Insert or exact-replay the single canonical operation receipt.
+pub async fn record_authorization_operation_receipt_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    receipt: &AuthorizationOperationReceipt,
+) -> Result<AuthorizationReceiptWrite> {
+    if let Some(row) = sqlx::query(
+        "SELECT request_fingerprint, operation_kind, actor_fingerprint, outcome_code, result_digest \
+         FROM authorization_operation_receipts WHERE community_id=$1 AND operation_id=$2",
+    )
+    .bind(receipt.community_id.as_uuid())
+    .bind(receipt.operation_id)
+    .fetch_optional(&mut **transaction)
+    .await?
+    {
+        let exact = bytes32(row.try_get("request_fingerprint")?, "request fingerprint")?
+            == receipt.request_fingerprint
+            && row.try_get::<i16, _>("operation_kind")? == receipt.operation_kind as i16
+            && bytes32(row.try_get("actor_fingerprint")?, "actor fingerprint")?
+                == receipt.actor.fingerprint().ok_or_else(|| {
+                    DbError::InvalidData(
+                        "authorization operation actor is unauthenticated".to_owned(),
+                    )
+                })?
+            && row.try_get::<i16, _>("outcome_code")? == receipt.outcome as i16
+            && bytes32(row.try_get("result_digest")?, "result digest")?
+                == receipt.result_digest;
+        if exact {
+            return Ok(AuthorizationReceiptWrite::ExactReplay);
+        }
+        return Err(DbError::InvalidData(
+            "authorization operation intent conflicts with prior receipt".to_owned(),
+        ));
+    }
+
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id, operation_id, request_fingerprint, operation_kind, actor_fingerprint, \
+          outcome_code, result_digest) VALUES ($1,$2,$3,$4,$5,$6,$7)",
+    )
+    .bind(receipt.community_id.as_uuid())
+    .bind(receipt.operation_id)
+    .bind(receipt.request_fingerprint.as_slice())
+    .bind(receipt.operation_kind as i16)
+    .bind(
+        receipt
+            .actor
+            .fingerprint()
+            .ok_or_else(|| {
+                DbError::InvalidData("authorization operation actor is unauthenticated".to_owned())
+            })?
+            .as_slice(),
+    )
+    .bind(receipt.outcome as i16)
+    .bind(receipt.result_digest.as_slice())
+    .execute(&mut **transaction)
+    .await?;
+    Ok(AuthorizationReceiptWrite::Inserted)
+}
+
+/// Insert or exact-replay one canonical event in a caller-owned transaction.
+pub async fn record_authorization_event_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    event: &NewAuthorizationEvent,
+) -> std::result::Result<AuthorizationReceiptWrite, AuthorizationEventWriteError> {
+    if let Some(row) = sqlx::query(
+        "SELECT event_id, outcome_code, reason_code, actor_kind, actor_fingerprint, \
+                subject_fingerprint, request_fingerprint, correlation_id, occurred_at, \
+                canonical_envelope, envelope_digest \
+         FROM authorization_events \
+         WHERE community_id=$1 AND operation_id=$2 AND event_kind=$3 AND attempt_id=$4",
+    )
+    .bind(event.community_id.as_uuid())
+    .bind(event.operation_id)
+    .bind(event.event_kind as i16)
+    .bind(event.attempt_id)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|error| AuthorizationEventWriteError::Database(error.into()))?
+    {
+        let occurred_at: DateTime<Utc> = row.try_get("occurred_at").map_err(DbError::from)?;
+        let canonical_envelope: Vec<u8> =
+            row.try_get("canonical_envelope").map_err(DbError::from)?;
+        let envelope_digest = bytes32(
+            row.try_get("envelope_digest").map_err(DbError::from)?,
+            "event envelope digest",
+        )?;
+        let expected_envelope = canonical_event_envelope(event, occurred_at);
+        let calculated_envelope_digest: [u8; 32] = Sha256::digest(&canonical_envelope).into();
+        let exact = row.try_get::<Uuid, _>("event_id").map_err(DbError::from)? == event.event_id
+            && row
+                .try_get::<i16, _>("outcome_code")
+                .map_err(DbError::from)?
+                == event.outcome as i16
+            && row
+                .try_get::<i16, _>("reason_code")
+                .map_err(DbError::from)?
+                == event.reason as i16
+            && row.try_get::<i16, _>("actor_kind").map_err(DbError::from)?
+                == event.actor.kind() as i16
+            && optional_bytes32(
+                row.try_get("actor_fingerprint").map_err(DbError::from)?,
+                "actor fingerprint",
+            )? == event.actor.fingerprint()
+            && optional_bytes32(
+                row.try_get("subject_fingerprint").map_err(DbError::from)?,
+                "subject fingerprint",
+            )? == event.subject_fingerprint
+            && optional_bytes32(
+                row.try_get("request_fingerprint").map_err(DbError::from)?,
+                "request fingerprint",
+            )? == event.request_fingerprint
+            && row
+                .try_get::<Uuid, _>("correlation_id")
+                .map_err(DbError::from)?
+                == event.correlation_id
+            && canonical_envelope == expected_envelope
+            && envelope_digest == calculated_envelope_digest;
+        if exact {
+            return Ok(AuthorizationReceiptWrite::ExactReplay);
+        }
+        return Err(AuthorizationEventWriteError::Database(
+            DbError::InvalidData(
+                "authorization event attempt conflicts with prior evidence".to_owned(),
+            ),
+        ));
+    }
+
+    let occurred_at: DateTime<Utc> = sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(&mut **transaction)
+        .await
+        .map_err(|error| AuthorizationEventWriteError::Database(error.into()))?;
+    let canonical_envelope = canonical_event_envelope(event, occurred_at);
+    let envelope_digest: [u8; 32] = Sha256::digest(&canonical_envelope).into();
+    let result = sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind,actor_fingerprint, \
+          subject_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+          occurred_at,canonical_envelope,envelope_digest) \
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)",
+    )
+    .bind(event.community_id.as_uuid())
+    .bind(event.event_id)
+    .bind(event.event_kind as i16)
+    .bind(event.outcome as i16)
+    .bind(event.reason as i16)
+    .bind(event.actor.kind() as i16)
+    .bind(event.actor.fingerprint().map(|value| value.to_vec()))
+    .bind(event.subject_fingerprint.map(|value| value.to_vec()))
+    .bind(event.operation_id)
+    .bind(event.request_fingerprint.map(|value| value.to_vec()))
+    .bind(event.correlation_id)
+    .bind(event.attempt_id)
+    .bind(occurred_at)
+    .bind(&canonical_envelope)
+    .bind(envelope_digest.as_slice())
+    .execute(&mut **transaction)
+    .await;
+    match result {
+        Ok(_) => Ok(AuthorizationReceiptWrite::Inserted),
+        Err(error) if is_capacity_constraint(&error) => {
+            Err(AuthorizationEventWriteError::CapacityUnavailable)
+        }
+        Err(error) => Err(AuthorizationEventWriteError::Database(error.into())),
+    }
+}
+
+impl Db {
+    /// Atomically install and reconcile the complete enabled-domain capacity
+    /// set before production authorization becomes observable.
+    ///
+    /// The entire input is validated before a connection is acquired. Every
+    /// row is then locked and required to have the exact immutable policy and
+    /// a healthy, internally consistent retained-capacity state. Any conflict
+    /// or unhealthy row rolls back newly inserted rows from this call.
+    pub async fn reconcile_authorization_event_capacities(
+        &self,
+        capacities: &[(CommunityId, AuthorizationEventCapacityPolicy)],
+    ) -> Result<()> {
+        validate_authorization_event_capacities(capacities)?;
+        if capacities.is_empty() {
+            return Ok(());
+        }
+
+        let mut transaction = self.pool.begin().await?;
+        if let Err(error) =
+            reconcile_authorization_event_capacities_tx(&mut transaction, capacities).await
+        {
+            transaction.rollback().await?;
+            return Err(error);
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    /// Install the immutable capacity policy for one enabled domain.
+    ///
+    /// Exact replay is accepted; changed limits require offline migration.
+    pub async fn install_authorization_event_capacity(
+        &self,
+        community_id: CommunityId,
+        policy: AuthorizationEventCapacityPolicy,
+    ) -> Result<()> {
+        self.reconcile_authorization_event_capacities(&[(community_id, policy)])
+            .await
+    }
+
+    /// Latch one domain's audit capacity unhealthy at a new generation.
+    pub async fn latch_authorization_event_failure(
+        &self,
+        community_id: CommunityId,
+        failure: AuthorizationAuditFailureCode,
+    ) -> Result<()> {
+        let generation: i64 =
+            sqlx::query_scalar("SELECT authorization_event_capacity_report_failure_v2($1,$2)")
+                .bind(community_id.as_uuid())
+                .bind(failure as i16)
+                .fetch_one(&self.pool)
+                .await?;
+        if generation <= 0 {
+            return Err(DbError::InvalidData(
+                "authorization audit failure generation is invalid".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Recover health only if no later failure generation raced the probe.
+    pub async fn recover_authorization_event_capacity(
+        &self,
+        community_id: CommunityId,
+        expected_failure_generation: u64,
+    ) -> Result<()> {
+        let expected = i64::try_from(expected_failure_generation).map_err(|_| {
+            DbError::InvalidData("authorization audit recovery generation is invalid".to_owned())
+        })?;
+        if expected == 0 {
+            return Err(DbError::InvalidData(
+                "authorization audit recovery generation is invalid".to_owned(),
+            ));
+        }
+        let recovered: bool =
+            sqlx::query_scalar("SELECT authorization_event_capacity_recover_v2($1,$2)")
+                .bind(community_id.as_uuid())
+                .bind(expected)
+                .fetch_one(&self.pool)
+                .await?;
+        if recovered {
+            Ok(())
+        } else {
+            Err(DbError::InvalidData(
+                "authorization audit recovery generation is stale".to_owned(),
+            ))
+        }
+    }
+
+    /// Increment one fixed-cardinality credential-free operator denial bucket.
+    pub async fn record_operator_denial_bucket(
+        &self,
+        community_id: CommunityId,
+        denial_class: u8,
+        action_kind: u8,
+    ) -> Result<u64> {
+        if community_id.as_uuid().is_nil()
+            || !(1..=8).contains(&denial_class)
+            || !(1..=8).contains(&action_kind)
+        {
+            return Err(DbError::InvalidData(
+                "operator denial bucket coordinate is invalid".to_owned(),
+            ));
+        }
+        let count: i64 =
+            sqlx::query_scalar("SELECT authorization_operator_denial_bucket_record_v1($1,$2,$3)")
+                .bind(community_id.as_uuid())
+                .bind(i16::from(denial_class))
+                .bind(i16::from(action_kind))
+                .fetch_one(&self.pool)
+                .await?;
+        nonnegative(count).and_then(|value| {
+            if value == 0 {
+                Err(DbError::InvalidData(
+                    "operator denial bucket count is invalid".to_owned(),
+                ))
+            } else {
+                Ok(value)
+            }
+        })
+    }
+
+    /// Read immutable-capacity health for readiness and operator controls.
+    pub async fn authorization_event_capacity_health(
+        &self,
+        community_id: CommunityId,
+    ) -> Result<AuthorizationEventCapacityHealth> {
+        let row = sqlx::query(
+            "SELECT retained_event_count,retained_envelope_bytes,health_state,failure_code, \
+                    failure_generation,recovery_generation,restrictive_reserve_events, \
+                    restrictive_reserve_bytes \
+             FROM authorization_event_capacity WHERE community_id=$1",
+        )
+        .bind(community_id.as_uuid())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| DbError::NotFound("authorization event capacity policy".to_owned()))?;
+        let health_state: i16 = row.try_get("health_state")?;
+        let failure_code: Option<i16> = row.try_get("failure_code")?;
+        Ok(AuthorizationEventCapacityHealth {
+            healthy: health_state == 1,
+            retained_event_count: nonnegative(row.try_get("retained_event_count")?)?,
+            retained_envelope_bytes: nonnegative(row.try_get("retained_envelope_bytes")?)?,
+            failure_code: failure_code
+                .map(AuthorizationAuditFailureCode::from_database)
+                .transpose()?,
+            failure_generation: nonnegative(row.try_get("failure_generation")?)?,
+            recovery_generation: nonnegative(row.try_get("recovery_generation")?)?,
+            restrictive_reserve_events: nonnegative(row.try_get("restrictive_reserve_events")?)?,
+            restrictive_reserve_bytes: nonnegative(row.try_get("restrictive_reserve_bytes")?)?,
+        })
+    }
+
+    /// Read one bounded, domain-scoped immutable event page.
+    pub async fn authorization_event_page(
+        &self,
+        community_id: CommunityId,
+        cursor: Option<AuthorizationEventPageCursor>,
+        limit: u16,
+    ) -> Result<AuthorizationEventPage> {
+        if community_id.as_uuid().is_nil() || limit == 0 || limit > MAX_EVENT_PAGE {
+            return Err(DbError::InvalidData(
+                "authorization event page bounds are invalid".to_owned(),
+            ));
+        }
+        let rows = sqlx::query(
+            "SELECT event_id,event_kind,outcome_code,reason_code,accepted_at, \
+                    canonical_envelope,envelope_digest \
+             FROM authorization_events \
+             WHERE community_id=$1 \
+               AND ($2::timestamptz IS NULL OR (accepted_at,event_id) < ($2,$3)) \
+             ORDER BY accepted_at DESC,event_id DESC LIMIT $4",
+        )
+        .bind(community_id.as_uuid())
+        .bind(cursor.map(|value| value.accepted_at))
+        .bind(cursor.map(|value| value.event_id))
+        .bind(i64::from(limit))
+        .fetch_all(&self.pool)
+        .await?;
+        let mut events = Vec::with_capacity(rows.len());
+        for row in rows {
+            events.push(AuthorizationEventRecord {
+                event_id: row.try_get("event_id")?,
+                event_kind: AuthorizationEventKind::from_database(row.try_get("event_kind")?)?,
+                outcome_code: row.try_get("outcome_code")?,
+                reason_code: row.try_get("reason_code")?,
+                accepted_at: row.try_get("accepted_at")?,
+                canonical_envelope: row.try_get("canonical_envelope")?,
+                envelope_digest: bytes32(row.try_get("envelope_digest")?, "envelope digest")?,
+            });
+        }
+        let next = events.last().map(|event| AuthorizationEventPageCursor {
+            accepted_at: event.accepted_at,
+            event_id: event.event_id,
+        });
+        Ok(AuthorizationEventPage { events, next })
+    }
+}
+
+/// Validate a complete set of server-owned per-domain audit capacity policies.
+pub fn validate_authorization_event_capacities(
+    capacities: &[(CommunityId, AuthorizationEventCapacityPolicy)],
+) -> Result<()> {
+    let mut domains = HashSet::with_capacity(capacities.len());
+    for (community_id, _) in capacities {
+        if community_id.as_uuid().is_nil() || !domains.insert(*community_id) {
+            return Err(DbError::InvalidData(
+                "authorization event capacity domain set is invalid".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reconcile validated capacity policies inside the caller's configuration transaction.
+pub async fn reconcile_authorization_event_capacities_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    capacities: &[(CommunityId, AuthorizationEventCapacityPolicy)],
+) -> Result<()> {
+    for (community_id, policy) in capacities {
+        let max_events = i64::try_from(policy.max_events_per_domain()).map_err(|_| {
+            DbError::InvalidData("authorization event capacity is out of range".to_owned())
+        })?;
+        let max_bytes = i64::try_from(policy.max_bytes_per_domain()).map_err(|_| {
+            DbError::InvalidData("authorization byte capacity is out of range".to_owned())
+        })?;
+        let max_envelope = i32::try_from(policy.max_envelope_bytes()).map_err(|_| {
+            DbError::InvalidData("authorization envelope capacity is out of range".to_owned())
+        })?;
+        let reserve_events = if max_events > 1 {
+            (max_events / 8).clamp(1, 64)
+        } else {
+            0
+        };
+        let reserve_bytes = if max_bytes > i64::from(max_envelope) {
+            (max_bytes / 8).clamp(i64::from(max_envelope), 262_144)
+        } else {
+            0
+        };
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes, \
+              restrictive_reserve_events,restrictive_reserve_bytes) \
+             VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (community_id) DO NOTHING",
+        )
+        .bind(community_id.as_uuid())
+        .bind(max_events)
+        .bind(max_bytes)
+        .bind(max_envelope)
+        .bind(reserve_events)
+        .bind(reserve_bytes)
+        .execute(&mut **transaction)
+        .await?;
+
+        let row = sqlx::query(
+            "SELECT max_events_per_domain,max_bytes_per_domain,max_envelope_bytes, \
+                    retained_event_count,retained_envelope_bytes,health_state,failure_code \
+             FROM authorization_event_capacity WHERE community_id=$1 FOR UPDATE",
+        )
+        .bind(community_id.as_uuid())
+        .fetch_one(&mut **transaction)
+        .await?;
+        let exact_policy = row.try_get::<i64, _>("max_events_per_domain")?
+            == i64::try_from(policy.max_events_per_domain()).unwrap_or(i64::MAX)
+            && row.try_get::<i64, _>("max_bytes_per_domain")?
+                == i64::try_from(policy.max_bytes_per_domain()).unwrap_or(i64::MAX)
+            && row.try_get::<i32, _>("max_envelope_bytes")?
+                == i32::try_from(policy.max_envelope_bytes()).unwrap_or(i32::MAX);
+        let retained_events: i64 = row.try_get("retained_event_count")?;
+        let retained_bytes: i64 = row.try_get("retained_envelope_bytes")?;
+        let healthy = row.try_get::<i16, _>("health_state")? == 1
+            && row.try_get::<Option<i16>, _>("failure_code")?.is_none()
+            && retained_events >= 0
+            && retained_events <= i64::try_from(policy.max_events_per_domain()).unwrap_or(i64::MAX)
+            && retained_bytes >= 0
+            && retained_bytes <= i64::try_from(policy.max_bytes_per_domain()).unwrap_or(i64::MAX);
+        if !exact_policy || !healthy {
+            return Err(DbError::InvalidData(
+                if exact_policy {
+                    "authorization event capacity is unhealthy"
+                } else {
+                    "authorization event capacity conflicts with installed policy"
+                }
+                .to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_capacity_constraint(error: &sqlx::Error) -> bool {
+    error.as_database_error().is_some_and(|database| {
+        matches!(
+            database.constraint(),
+            Some(
+                "authorization_event_capacity_policy_required"
+                    | "authorization_event_capacity_health"
+                    | "authorization_event_capacity_exhausted"
+                    | "authorization_events_envelope_size"
+            )
+        )
+    })
+}
+
+/// Encode the versioned, bounded, credential-free canonical event envelope.
+pub fn canonical_event_envelope(
+    event: &NewAuthorizationEvent,
+    occurred_at: DateTime<Utc>,
+) -> Vec<u8> {
+    let mut envelope = Vec::with_capacity(288);
+    envelope.extend_from_slice(b"buzz:authorization-event:v1");
+    envelope.extend_from_slice(event.community_id.as_uuid().as_bytes());
+    envelope.extend_from_slice(event.event_id.as_bytes());
+    envelope.extend_from_slice(&(event.event_kind as i16).to_be_bytes());
+    envelope.extend_from_slice(&(event.outcome as i16).to_be_bytes());
+    envelope.extend_from_slice(&(event.reason as i16).to_be_bytes());
+    envelope.extend_from_slice(&(event.actor.kind() as i16).to_be_bytes());
+    append_optional_bytes32(&mut envelope, event.actor.fingerprint());
+    append_optional_bytes32(&mut envelope, event.subject_fingerprint);
+    envelope.extend_from_slice(event.operation_id.as_bytes());
+    append_optional_bytes32(&mut envelope, event.request_fingerprint);
+    envelope.extend_from_slice(event.correlation_id.as_bytes());
+    envelope.extend_from_slice(event.attempt_id.as_bytes());
+    envelope.extend_from_slice(&occurred_at.timestamp().to_be_bytes());
+    envelope.extend_from_slice(&occurred_at.timestamp_subsec_nanos().to_be_bytes());
+    envelope
+}
+
+fn append_optional_bytes32(envelope: &mut Vec<u8>, value: Option<[u8; 32]>) {
+    match value {
+        Some(value) => {
+            envelope.push(1);
+            envelope.extend_from_slice(&value);
+        }
+        None => envelope.push(0),
+    }
+}
+
+fn framed(digest: &mut Sha256, value: &[u8]) {
+    digest.update((value.len() as u64).to_be_bytes());
+    digest.update(value);
+}
+
+fn bytes32(value: Vec<u8>, name: &str) -> Result<[u8; 32]> {
+    value
+        .try_into()
+        .map_err(|_| DbError::InvalidData(format!("authorization {name} is malformed")))
+}
+
+fn optional_bytes32(value: Option<Vec<u8>>, name: &str) -> Result<Option<[u8; 32]>> {
+    value.map(|value| bytes32(value, name)).transpose()
+}
+
+fn nonnegative(value: i64) -> Result<u64> {
+    u64::try_from(value)
+        .map_err(|_| DbError::InvalidData("authorization capacity is negative".to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn domain() -> CommunityId {
+        CommunityId::from_uuid(Uuid::from_u128(1))
+    }
+
+    fn direct_actor() -> AuthorizationEventActor {
+        actor_from_route_coordinates(domain(), [3; 32], None, (Uuid::from_u128(4), 5), None)
+            .expect("valid sealed-route shape")
+    }
+
+    #[test]
+    fn unresolved_events_cannot_carry_identity_or_receipt_evidence() {
+        let common = || {
+            NewAuthorizationEvent::new(
+                domain(),
+                Uuid::from_u128(2),
+                AuthorizationEventKind::OperatorDenied,
+                AuthorizationEventOutcome::Denied,
+                AuthorizationReasonCode::Unauthenticated,
+                AuthorizationEventActor::unresolved_authentication_denial(),
+                None,
+                Uuid::from_u128(3),
+                None,
+                Uuid::from_u128(4),
+                Uuid::from_u128(5),
+            )
+        };
+        assert!(common().is_ok());
+        let mut event = common().expect("valid unresolved event");
+        event.actor.fingerprint = Some([9; 32]);
+        assert!(NewAuthorizationEvent::new(
+            event.community_id,
+            event.event_id,
+            event.event_kind,
+            event.outcome,
+            event.reason,
+            event.actor,
+            None,
+            event.operation_id,
+            None,
+            event.correlation_id,
+            event.attempt_id,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn event_and_receipt_debug_are_redacted() {
+        let receipt = AuthorizationOperationReceipt::new(
+            domain(),
+            Uuid::from_u128(2),
+            [3; 32],
+            AuthorizationOperationKind::ProtectedMutation,
+            direct_actor(),
+            AuthorizationOperationOutcome::Applied,
+            [5; 32],
+        )
+        .expect("valid receipt");
+        let debug = format!("{receipt:?}");
+        assert!(!debug.contains(&hex::encode([3; 32])));
+        assert!(!debug.contains(&hex::encode([4; 32])));
+        assert!(!debug.contains(&hex::encode([5; 32])));
+    }
+
+    #[test]
+    fn page_limits_are_bounded() {
+        assert_eq!(MAX_EVENT_PAGE, 1_000);
+        assert_eq!(AuthorizationAuditFailureCode::CapacityExhausted as i16, 1);
+    }
+
+    #[test]
+    fn canonical_event_encoder_is_stable_and_binds_typed_fields() {
+        let event = NewAuthorizationEvent::new(
+            domain(),
+            Uuid::from_u128(2),
+            AuthorizationEventKind::ProtectedAllowed,
+            AuthorizationEventOutcome::Allowed,
+            AuthorizationReasonCode::Current,
+            direct_actor(),
+            Some([4; 32]),
+            Uuid::from_u128(5),
+            Some([6; 32]),
+            Uuid::from_u128(7),
+            Uuid::from_u128(8),
+        )
+        .expect("valid event");
+        let occurred_at = DateTime::from_timestamp(9, 10).expect("valid timestamp");
+        let first = canonical_event_envelope(&event, occurred_at);
+        let second = canonical_event_envelope(&event, occurred_at);
+        assert_eq!(first, second);
+        assert!(first.len() <= 16_384);
+
+        let changed = NewAuthorizationEvent::new(
+            domain(),
+            Uuid::from_u128(2),
+            AuthorizationEventKind::ProtectedDenied,
+            AuthorizationEventOutcome::Denied,
+            AuthorizationReasonCode::PolicyDenied,
+            direct_actor(),
+            Some([4; 32]),
+            Uuid::from_u128(5),
+            Some([6; 32]),
+            Uuid::from_u128(7),
+            Uuid::from_u128(8),
+        )
+        .expect("valid changed event");
+        assert_ne!(first, canonical_event_envelope(&changed, occurred_at));
+    }
+
+    #[test]
+    fn actor_route_shape_is_closed_and_debug_is_redacted() {
+        assert!(actor_from_route_coordinates(
+            domain(),
+            [1; 32],
+            Some([2; 32]),
+            (Uuid::from_u128(3), 4),
+            None,
+        )
+        .is_err());
+        let actor = direct_actor();
+        assert_eq!(actor.kind(), AuthorizationActorKind::Direct);
+        assert!(!format!("{actor:?}").contains(&hex::encode([3; 32])));
+    }
+
+    #[test]
+    fn authenticated_actor_cannot_cross_domains() {
+        let actor = direct_actor();
+        let other = CommunityId::from_uuid(Uuid::from_u128(99));
+        assert!(!actor.is_bound_to(other));
+        assert!(AuthorizationOperationReceipt::new(
+            other,
+            Uuid::from_u128(20),
+            [21; 32],
+            AuthorizationOperationKind::ProtectedMutation,
+            actor.clone(),
+            AuthorizationOperationOutcome::Applied,
+            [22; 32],
+        )
+        .is_err());
+        assert!(NewAuthorizationEvent::new(
+            other,
+            Uuid::from_u128(23),
+            AuthorizationEventKind::ProtectedAllowed,
+            AuthorizationEventOutcome::Allowed,
+            AuthorizationReasonCode::Current,
+            actor,
+            None,
+            Uuid::from_u128(20),
+            Some([21; 32]),
+            Uuid::from_u128(24),
+            Uuid::from_u128(25),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn canonical_event_semantics_reject_contradictions() {
+        let base = |kind, outcome, reason| {
+            NewAuthorizationEvent::new(
+                domain(),
+                Uuid::from_u128(30),
+                kind,
+                outcome,
+                reason,
+                direct_actor(),
+                None,
+                Uuid::from_u128(31),
+                Some([32; 32]),
+                Uuid::from_u128(33),
+                Uuid::from_u128(34),
+            )
+        };
+        assert!(base(
+            AuthorizationEventKind::StatusPublished,
+            AuthorizationEventOutcome::Denied,
+            AuthorizationReasonCode::Withdrawn,
+        )
+        .is_err());
+        assert!(base(
+            AuthorizationEventKind::InvalidationAdvanced,
+            AuthorizationEventOutcome::Allowed,
+            AuthorizationReasonCode::Current,
+        )
+        .is_err());
+        assert!(base(
+            AuthorizationEventKind::ProtectedAllowed,
+            AuthorizationEventOutcome::Allowed,
+            AuthorizationReasonCode::Current,
+        )
+        .is_ok());
+    }
+}

--- a/crates/buzz-db/src/authorization_policy.rs
+++ b/crates/buzz-db/src/authorization_policy.rs
@@ -1,0 +1,851 @@
+//! Immutable provider-free enrollment-policy reconciliation.
+//!
+//! Production supplies complete typed semantics, never a caller-selected
+//! digest. This module computes the canonical digest and atomically installs
+//! both policy revisions and their immutable event-capacity policies before
+//! an enabled runtime can become observable.
+
+use std::{collections::HashSet, fmt, time::Duration};
+
+use buzz_auth::AuthorizationEventCapacityPolicy;
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{Postgres, Row, Transaction};
+use uuid::Uuid;
+
+use crate::{
+    authorization_events::{
+        reconcile_authorization_event_capacities_tx, validate_authorization_event_capacities,
+    },
+    Db, DbError, Result,
+};
+
+/// Exact acknowledgement required by the risk-labelled TOFU posture.
+pub const RISK_LABELLED_TOFU_ACKNOWLEDGEMENT_V1: &str = "I_ACKNOWLEDGE_RISK_LABELLED_TOFU_V1";
+
+/// Closed provider-free enrollment modes persisted by migration 0029.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum AuthorizationEnrollmentMode {
+    /// The accepted assertion attests the exact event-author key.
+    AttestedKey = 1,
+    /// A separately verified provisioning intent selects the key.
+    Provisioned = 2,
+    /// A local risk-labelled first-use decision selects the key.
+    RiskLabelledTofu = 3,
+}
+
+/// Complete verifier, provenance, and bound semantics for one policy.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthorizationEnrollmentPolicySemantics {
+    issuer: String,
+    audience: String,
+    subject_claim: String,
+    assertion_key_set_digest: [u8; 32],
+    nostr_key_claim: Option<String>,
+    assertion_header: String,
+    provenance_header: String,
+    provenance_key_digest: [u8; 32],
+    maximum_token_age_seconds: u64,
+    clock_skew_seconds: u64,
+    maximum_lease_seconds: u64,
+    maximum_events: u64,
+    maximum_event_bytes: u64,
+    maximum_envelope_bytes: u32,
+    risk_acknowledgement: Option<String>,
+    restore_bootstrap_id: Uuid,
+}
+
+impl AuthorizationEnrollmentPolicySemantics {
+    /// Validate all bytes that contribute to the immutable policy digest.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        subject_claim: impl Into<String>,
+        assertion_key_set_digest: [u8; 32],
+        nostr_key_claim: Option<String>,
+        assertion_header: impl Into<String>,
+        provenance_header: impl Into<String>,
+        provenance_key_digest: [u8; 32],
+        maximum_token_age: Duration,
+        clock_skew: Duration,
+        maximum_lease: Duration,
+        event_capacity: AuthorizationEventCapacityPolicy,
+        risk_acknowledgement: Option<String>,
+        restore_bootstrap_id: Uuid,
+    ) -> Result<Self> {
+        let issuer = issuer.into();
+        let audience = audience.into();
+        let subject_claim = subject_claim.into();
+        let assertion_header = assertion_header.into();
+        let provenance_header = provenance_header.into();
+        if !valid_exact_part(&issuer, 2_048)
+            || !valid_exact_part(&audience, 2_048)
+            || !valid_exact_part(&subject_claim, 256)
+            || nostr_key_claim
+                .as_deref()
+                .is_some_and(|claim| !valid_exact_part(claim, 256))
+            || !valid_exact_part(&assertion_header, 256)
+            || !valid_exact_part(&provenance_header, 256)
+            || assertion_header == provenance_header
+            || assertion_key_set_digest == [0; 32]
+            || provenance_key_digest == [0; 32]
+            || maximum_token_age.is_zero()
+            || maximum_token_age > Duration::from_secs(86_400)
+            || maximum_token_age.subsec_nanos() != 0
+            || clock_skew > Duration::from_secs(300)
+            || clock_skew.subsec_nanos() != 0
+            || maximum_lease.is_zero()
+            || maximum_lease > Duration::from_secs(300)
+            || maximum_lease.subsec_nanos() != 0
+            || restore_bootstrap_id.is_nil()
+        {
+            return Err(invalid_policy());
+        }
+        Ok(Self {
+            issuer,
+            audience,
+            subject_claim,
+            assertion_key_set_digest,
+            nostr_key_claim,
+            assertion_header,
+            provenance_header,
+            provenance_key_digest,
+            maximum_token_age_seconds: maximum_token_age.as_secs(),
+            clock_skew_seconds: clock_skew.as_secs(),
+            maximum_lease_seconds: maximum_lease.as_secs(),
+            maximum_events: event_capacity.max_events_per_domain(),
+            maximum_event_bytes: event_capacity.max_bytes_per_domain(),
+            maximum_envelope_bytes: event_capacity.max_envelope_bytes(),
+            risk_acknowledgement,
+            restore_bootstrap_id,
+        })
+    }
+}
+
+impl fmt::Debug for AuthorizationEnrollmentPolicySemantics {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AuthorizationEnrollmentPolicySemantics([REDACTED])")
+    }
+}
+
+/// One complete immutable enrollment-policy revision.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AuthorizationEnrollmentPolicy {
+    authorization_domain: CommunityId,
+    policy_revision: u64,
+    enrollment_mode: AuthorizationEnrollmentMode,
+    policy_digest: [u8; 32],
+    event_capacity: AuthorizationEventCapacityPolicy,
+    effective_at: DateTime<Utc>,
+}
+
+impl AuthorizationEnrollmentPolicy {
+    /// Construct a stable, immediately effective policy revision.
+    pub fn new(
+        authorization_domain: CommunityId,
+        policy_revision: u64,
+        enrollment_mode: AuthorizationEnrollmentMode,
+        semantics: AuthorizationEnrollmentPolicySemantics,
+    ) -> Result<Self> {
+        if authorization_domain.as_uuid().is_nil()
+            || policy_revision == 0
+            || policy_revision > i64::MAX as u64
+            || !valid_mode_semantics(enrollment_mode, &semantics)
+        {
+            return Err(invalid_policy());
+        }
+        let effective_at = DateTime::from_timestamp(0, 0).ok_or_else(invalid_policy)?;
+        let policy_digest = policy_digest(
+            authorization_domain,
+            policy_revision,
+            enrollment_mode,
+            effective_at,
+            &semantics,
+        );
+        let event_capacity = AuthorizationEventCapacityPolicy::new(
+            semantics.maximum_events,
+            semantics.maximum_event_bytes,
+            semantics.maximum_envelope_bytes,
+        )
+        .map_err(|_| invalid_policy())?;
+        Ok(Self {
+            authorization_domain,
+            policy_revision,
+            enrollment_mode,
+            policy_digest,
+            event_capacity,
+            effective_at,
+        })
+    }
+
+    /// Server-resolved authorization domain.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Positive immutable policy revision.
+    pub const fn policy_revision(&self) -> u64 {
+        self.policy_revision
+    }
+
+    /// Closed enrollment mode.
+    pub const fn enrollment_mode(&self) -> AuthorizationEnrollmentMode {
+        self.enrollment_mode
+    }
+
+    /// Internally computed canonical policy digest.
+    pub const fn policy_digest(&self) -> [u8; 32] {
+        self.policy_digest
+    }
+}
+
+impl fmt::Debug for AuthorizationEnrollmentPolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthorizationEnrollmentPolicy")
+            .field("policy_revision", &self.policy_revision)
+            .field("enrollment_mode", &self.enrollment_mode)
+            .field("coordinates", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Atomic reconciliation result for one complete startup set.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AuthorizationPolicyReconciliation {
+    inserted: usize,
+    replayed: usize,
+}
+
+impl AuthorizationPolicyReconciliation {
+    /// Newly inserted immutable policy rows.
+    pub const fn inserted(self) -> usize {
+        self.inserted
+    }
+
+    /// Byte-identical current policy rows.
+    pub const fn replayed(self) -> usize {
+        self.replayed
+    }
+}
+
+impl Db {
+    /// Atomically reconcile complete policy and event-capacity configuration.
+    ///
+    /// Validation of the full set precedes I/O. Per-domain parent-row locks
+    /// serialize revision selection. Only an exact current replay or a
+    /// strictly greater revision is accepted; policy and capacity writes
+    /// commit together or leave zero residue.
+    pub async fn reconcile_authorization_enrollment_startup(
+        &self,
+        configurations: &[(
+            AuthorizationEnrollmentPolicy,
+            AuthorizationEventCapacityPolicy,
+        )],
+    ) -> Result<AuthorizationPolicyReconciliation> {
+        let mut domains = HashSet::with_capacity(configurations.len());
+        let capacities = configurations
+            .iter()
+            .map(|(policy, capacity)| {
+                if policy.event_capacity != *capacity
+                    || !domains.insert(policy.authorization_domain)
+                {
+                    return Err(DbError::InvalidData(
+                        "authorization enrollment startup domain set is invalid".to_owned(),
+                    ));
+                }
+                Ok((policy.authorization_domain, *capacity))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        validate_authorization_event_capacities(&capacities)?;
+        if configurations.is_empty() {
+            return Ok(AuthorizationPolicyReconciliation::default());
+        }
+
+        let mut ordered = configurations.to_vec();
+        ordered.sort_by_key(|(policy, _)| *policy.authorization_domain.as_uuid());
+        let mut transaction = self.pool.begin().await?;
+        let mut reconciliation = AuthorizationPolicyReconciliation::default();
+        for (policy, _) in &ordered {
+            if let Err(error) =
+                reconcile_policy_tx(&mut transaction, policy, &mut reconciliation).await
+            {
+                transaction.rollback().await?;
+                return Err(error);
+            }
+        }
+        let ordered_capacities = ordered
+            .iter()
+            .map(|(policy, capacity)| (policy.authorization_domain, *capacity))
+            .collect::<Vec<_>>();
+        if let Err(error) =
+            reconcile_authorization_event_capacities_tx(&mut transaction, &ordered_capacities).await
+        {
+            transaction.rollback().await?;
+            return Err(error);
+        }
+        transaction.commit().await?;
+        Ok(reconciliation)
+    }
+}
+
+async fn reconcile_policy_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    policy: &AuthorizationEnrollmentPolicy,
+    reconciliation: &mut AuthorizationPolicyReconciliation,
+) -> Result<()> {
+    let community_exists =
+        sqlx::query_scalar::<_, Uuid>("SELECT id FROM communities WHERE id=$1 FOR UPDATE")
+            .bind(policy.authorization_domain.as_uuid())
+            .fetch_optional(&mut **transaction)
+            .await?
+            .is_some();
+    if !community_exists {
+        return Err(invalid_policy());
+    }
+    let maximum_revision: Option<i64> = sqlx::query_scalar(
+        "SELECT MAX(policy_revision) FROM identity_enrollment_policies WHERE community_id=$1",
+    )
+    .bind(policy.authorization_domain.as_uuid())
+    .fetch_one(&mut **transaction)
+    .await?;
+    let revision = i64::try_from(policy.policy_revision).map_err(|_| {
+        DbError::InvalidData("authorization policy revision is out of range".into())
+    })?;
+    match maximum_revision {
+        Some(current) if revision < current => {
+            return Err(DbError::InvalidData(
+                "authorization enrollment policy revision rolled back".to_owned(),
+            ));
+        }
+        Some(current) if revision == current => {
+            require_exact_policy_row(transaction, policy, revision).await?;
+            reconciliation.replayed += 1;
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    sqlx::query(
+        "INSERT INTO identity_enrollment_policies \
+         (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+         VALUES ($1,$2,$3,$4,$5)",
+    )
+    .bind(policy.authorization_domain.as_uuid())
+    .bind(revision)
+    .bind(policy.enrollment_mode as i16)
+    .bind(policy.policy_digest.as_slice())
+    .bind(policy.effective_at)
+    .execute(&mut **transaction)
+    .await?;
+    require_exact_policy_row(transaction, policy, revision).await?;
+    reconciliation.inserted += 1;
+    Ok(())
+}
+
+async fn require_exact_policy_row(
+    transaction: &mut Transaction<'_, Postgres>,
+    policy: &AuthorizationEnrollmentPolicy,
+    revision: i64,
+) -> Result<()> {
+    let row = sqlx::query(
+        "SELECT enrollment_mode,policy_digest,effective_at,expires_at \
+         FROM identity_enrollment_policies \
+         WHERE community_id=$1 AND policy_revision=$2 FOR UPDATE",
+    )
+    .bind(policy.authorization_domain.as_uuid())
+    .bind(revision)
+    .fetch_one(&mut **transaction)
+    .await?;
+    let stored_digest: Vec<u8> = row.try_get("policy_digest")?;
+    let stored_digest: [u8; 32] = stored_digest
+        .try_into()
+        .map_err(|_| DbError::InvalidData("authorization policy digest is malformed".to_owned()))?;
+    if row.try_get::<i16, _>("enrollment_mode")? != policy.enrollment_mode as i16
+        || stored_digest != policy.policy_digest
+        || row.try_get::<DateTime<Utc>, _>("effective_at")? != policy.effective_at
+        || row
+            .try_get::<Option<DateTime<Utc>>, _>("expires_at")?
+            .is_some()
+    {
+        return Err(DbError::InvalidData(
+            "authorization enrollment policy revision conflicts".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn valid_mode_semantics(
+    mode: AuthorizationEnrollmentMode,
+    semantics: &AuthorizationEnrollmentPolicySemantics,
+) -> bool {
+    match mode {
+        AuthorizationEnrollmentMode::AttestedKey => {
+            semantics.nostr_key_claim.is_some() && semantics.risk_acknowledgement.is_none()
+        }
+        AuthorizationEnrollmentMode::Provisioned => semantics.risk_acknowledgement.is_none(),
+        AuthorizationEnrollmentMode::RiskLabelledTofu => {
+            semantics.risk_acknowledgement.as_deref() == Some(RISK_LABELLED_TOFU_ACKNOWLEDGEMENT_V1)
+        }
+    }
+}
+
+fn policy_digest(
+    authorization_domain: CommunityId,
+    policy_revision: u64,
+    enrollment_mode: AuthorizationEnrollmentMode,
+    effective_at: DateTime<Utc>,
+    semantics: &AuthorizationEnrollmentPolicySemantics,
+) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    framed(&mut digest, b"buzz:authorization-enrollment-policy:v2");
+    framed(&mut digest, authorization_domain.as_uuid().as_bytes());
+    framed(&mut digest, &policy_revision.to_be_bytes());
+    framed(&mut digest, &(enrollment_mode as i16).to_be_bytes());
+    framed(&mut digest, semantics.issuer.as_bytes());
+    framed(&mut digest, semantics.audience.as_bytes());
+    framed(&mut digest, semantics.subject_claim.as_bytes());
+    framed(&mut digest, &semantics.assertion_key_set_digest);
+    match semantics.nostr_key_claim.as_deref() {
+        Some(claim) => {
+            framed(&mut digest, &[1]);
+            framed(&mut digest, b"nostr-key-claim/lower-hex-v1");
+            framed(&mut digest, claim.as_bytes());
+        }
+        None => framed(&mut digest, &[0]),
+    }
+    framed(&mut digest, b"trusted-proxy-assertion-v1");
+    framed(&mut digest, semantics.assertion_header.as_bytes());
+    framed(&mut digest, semantics.provenance_header.as_bytes());
+    framed(&mut digest, &semantics.provenance_key_digest);
+    framed(
+        &mut digest,
+        &semantics.maximum_token_age_seconds.to_be_bytes(),
+    );
+    framed(&mut digest, &semantics.clock_skew_seconds.to_be_bytes());
+    framed(&mut digest, &semantics.maximum_lease_seconds.to_be_bytes());
+    framed(&mut digest, &semantics.maximum_events.to_be_bytes());
+    framed(&mut digest, &semantics.maximum_event_bytes.to_be_bytes());
+    framed(&mut digest, &semantics.maximum_envelope_bytes.to_be_bytes());
+    framed_optional(&mut digest, semantics.risk_acknowledgement.as_deref());
+    framed(&mut digest, semantics.restore_bootstrap_id.as_bytes());
+    framed(&mut digest, &effective_at.timestamp().to_be_bytes());
+    framed(
+        &mut digest,
+        &effective_at.timestamp_subsec_nanos().to_be_bytes(),
+    );
+    framed(&mut digest, &[0]); // Base V1 policies have no expiry.
+    digest.finalize().into()
+}
+
+fn framed_optional(digest: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            framed(digest, &[1]);
+            framed(digest, value.as_bytes());
+        }
+        None => framed(digest, &[0]),
+    }
+}
+
+fn framed(digest: &mut Sha256, value: &[u8]) {
+    digest.update((value.len() as u64).to_be_bytes());
+    digest.update(value);
+}
+
+fn valid_exact_part(value: &str, maximum_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum_bytes
+        && !value.chars().any(|character| character.is_control())
+}
+
+fn invalid_policy() -> DbError {
+    DbError::InvalidData("authorization enrollment policy is invalid".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+
+    fn loopback_test_database_url() -> String {
+        format!(
+            "{}://{}:{}@{}:{}/{}",
+            "postgres", "buzz", "buzz_dev", "localhost", 5432, "buzz"
+        )
+    }
+
+    fn domain(value: u128) -> CommunityId {
+        CommunityId::from_uuid(Uuid::from_u128(value))
+    }
+
+    fn capacity(events: u64) -> AuthorizationEventCapacityPolicy {
+        AuthorizationEventCapacityPolicy::new(events, 1 << 20, 16 << 10).expect("capacity")
+    }
+
+    fn semantics(
+        key_claim: Option<&str>,
+        acknowledgement: Option<&str>,
+        capacity: AuthorizationEventCapacityPolicy,
+    ) -> AuthorizationEnrollmentPolicySemantics {
+        AuthorizationEnrollmentPolicySemantics::new(
+            "https://issuer.example",
+            "buzz-relay",
+            "employee_id",
+            [7; 32],
+            key_claim.map(str::to_owned),
+            "x-buzz-identity",
+            "x-buzz-identity-proof",
+            [9; 32],
+            Duration::from_secs(300),
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            capacity,
+            acknowledgement.map(str::to_owned),
+            Uuid::from_u128(100),
+        )
+        .expect("valid semantics")
+    }
+
+    fn policy(
+        domain: CommunityId,
+        revision: u64,
+        mode: AuthorizationEnrollmentMode,
+        capacity: AuthorizationEventCapacityPolicy,
+    ) -> AuthorizationEnrollmentPolicy {
+        let (claim, acknowledgement) = match mode {
+            AuthorizationEnrollmentMode::AttestedKey => (Some("nostr_pubkey"), None),
+            AuthorizationEnrollmentMode::Provisioned => (None, None),
+            AuthorizationEnrollmentMode::RiskLabelledTofu => {
+                (None, Some(RISK_LABELLED_TOFU_ACKNOWLEDGEMENT_V1))
+            }
+        };
+        AuthorizationEnrollmentPolicy::new(
+            domain,
+            revision,
+            mode,
+            semantics(claim, acknowledgement, capacity),
+        )
+        .expect("valid policy")
+    }
+
+    #[test]
+    fn canonical_policy_binds_complete_semantics_and_mode_specific_proof() {
+        let event_capacity = capacity(100);
+        let original = semantics(Some("nostr_pubkey"), None, event_capacity);
+        let digest_for = |semantics| {
+            AuthorizationEnrollmentPolicy::new(
+                domain(1),
+                2,
+                AuthorizationEnrollmentMode::AttestedKey,
+                semantics,
+            )
+            .expect("valid policy")
+            .policy_digest()
+        };
+        let first = AuthorizationEnrollmentPolicy::new(
+            domain(1),
+            2,
+            AuthorizationEnrollmentMode::AttestedKey,
+            original.clone(),
+        )
+        .expect("valid policy");
+        let replay = AuthorizationEnrollmentPolicy::new(
+            domain(1),
+            2,
+            AuthorizationEnrollmentMode::AttestedKey,
+            original,
+        )
+        .expect("valid replay");
+        assert_eq!(first, replay);
+        let original_digest = first.policy_digest();
+        let mut changes = Vec::new();
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.issuer = "https://issuer.changed.example".to_owned();
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.audience = "buzz-relay-changed".to_owned();
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.subject_claim = "opaque_subject".to_owned();
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.assertion_key_set_digest = [8; 32];
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.nostr_key_claim = Some("event_author".to_owned());
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.assertion_header = "x-buzz-other-identity".to_owned();
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.provenance_header = "x-buzz-other-proof".to_owned();
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.provenance_key_digest = [10; 32];
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.maximum_token_age_seconds = 301;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.clock_skew_seconds = 31;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.maximum_lease_seconds = 61;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.maximum_events = 101;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.maximum_event_bytes += 1;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.maximum_envelope_bytes = 8 << 10;
+        changes.push(changed);
+        let mut changed = semantics(Some("nostr_pubkey"), None, event_capacity);
+        changed.restore_bootstrap_id = Uuid::from_u128(101);
+        changes.push(changed);
+        for changed in changes {
+            assert_ne!(original_digest, digest_for(changed));
+        }
+
+        let tofu = semantics(
+            None,
+            Some(RISK_LABELLED_TOFU_ACKNOWLEDGEMENT_V1),
+            event_capacity,
+        );
+        let acknowledged_digest = policy_digest(
+            domain(1),
+            2,
+            AuthorizationEnrollmentMode::RiskLabelledTofu,
+            DateTime::from_timestamp(0, 0).expect("epoch"),
+            &tofu,
+        );
+        let mut changed_acknowledgement = tofu;
+        changed_acknowledgement.risk_acknowledgement = Some("wrong".to_owned());
+        assert_ne!(
+            acknowledged_digest,
+            policy_digest(
+                domain(1),
+                2,
+                AuthorizationEnrollmentMode::RiskLabelledTofu,
+                DateTime::from_timestamp(0, 0).expect("epoch"),
+                &changed_acknowledgement,
+            )
+        );
+
+        assert!(AuthorizationEnrollmentPolicy::new(
+            domain(1),
+            3,
+            AuthorizationEnrollmentMode::AttestedKey,
+            semantics(None, None, event_capacity),
+        )
+        .is_err());
+        assert!(AuthorizationEnrollmentPolicy::new(
+            domain(1),
+            3,
+            AuthorizationEnrollmentMode::RiskLabelledTofu,
+            semantics(None, None, event_capacity),
+        )
+        .is_err());
+        assert!(AuthorizationEnrollmentPolicy::new(
+            domain(1),
+            3,
+            AuthorizationEnrollmentMode::Provisioned,
+            semantics(
+                None,
+                Some(RISK_LABELLED_TOFU_ACKNOWLEDGEMENT_V1),
+                event_capacity
+            ),
+        )
+        .is_err());
+        assert!(!format!("{first:?}").contains(&domain(1).as_uuid().to_string()));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn postgres_startup_reconciliation_is_monotonic_and_zero_residue() {
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect admin");
+        let database_name = format!("s5_policy_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("create scratch database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let scratch_url = format!("{}/{database_name}", &admin_url[..split]);
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&scratch_url)
+            .await
+            .expect("connect scratch database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("migrate scratch database");
+
+        let first_domain = domain(1);
+        let conflict_domain = domain(2);
+        for (community, host) in [
+            (first_domain, "policy-first.example"),
+            (conflict_domain, "policy-conflict.example"),
+        ] {
+            sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+                .bind(community.as_uuid())
+                .bind(host)
+                .execute(&pool)
+                .await
+                .expect("insert community");
+        }
+        let db = Db::from_pool(pool.clone());
+        let installed_capacity = capacity(100);
+        let mismatched_capacity_policy = policy(
+            first_domain,
+            1,
+            AuthorizationEnrollmentMode::Provisioned,
+            installed_capacity,
+        );
+        assert!(db
+            .reconcile_authorization_enrollment_startup(&[(
+                mismatched_capacity_policy,
+                capacity(101),
+            )])
+            .await
+            .is_err());
+        let preflight_residue: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM identity_enrollment_policies WHERE community_id=$1",
+        )
+        .bind(first_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("count capacity-policy mismatch residue");
+        assert_eq!(preflight_residue, 0);
+        let original = policy(
+            conflict_domain,
+            7,
+            AuthorizationEnrollmentMode::AttestedKey,
+            installed_capacity,
+        );
+        let inserted = db
+            .reconcile_authorization_enrollment_startup(&[(original.clone(), installed_capacity)])
+            .await
+            .expect("insert original policy and capacity");
+        assert_eq!(inserted.inserted(), 1);
+        let replayed = db
+            .reconcile_authorization_enrollment_startup(&[(original.clone(), installed_capacity)])
+            .await
+            .expect("exact current replay");
+        assert_eq!(replayed.replayed(), 1);
+
+        let lower = policy(
+            conflict_domain,
+            6,
+            AuthorizationEnrollmentMode::AttestedKey,
+            installed_capacity,
+        );
+        assert!(db
+            .reconcile_authorization_enrollment_startup(&[(lower, installed_capacity)])
+            .await
+            .is_err());
+        let drift = policy(
+            conflict_domain,
+            7,
+            AuthorizationEnrollmentMode::RiskLabelledTofu,
+            installed_capacity,
+        );
+        let candidate_before_drift = policy(
+            first_domain,
+            2,
+            AuthorizationEnrollmentMode::Provisioned,
+            installed_capacity,
+        );
+        assert!(db
+            .reconcile_authorization_enrollment_startup(&[
+                (candidate_before_drift, installed_capacity),
+                (drift, installed_capacity),
+            ])
+            .await
+            .is_err());
+        let rows_after_drift: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM identity_enrollment_policies WHERE community_id=$1",
+        )
+        .bind(first_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("count same-revision rollback residue");
+        assert_eq!(rows_after_drift, 0);
+
+        let candidate = policy(
+            first_domain,
+            3,
+            AuthorizationEnrollmentMode::Provisioned,
+            capacity(101),
+        );
+        let greater = policy(
+            conflict_domain,
+            8,
+            AuthorizationEnrollmentMode::RiskLabelledTofu,
+            capacity(101),
+        );
+        assert!(db
+            .reconcile_authorization_enrollment_startup(&[
+                (candidate, capacity(101)),
+                (greater, capacity(101)),
+            ])
+            .await
+            .is_err());
+        let first_policy_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM identity_enrollment_policies WHERE community_id=$1",
+        )
+        .bind(first_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back policies");
+        let first_capacity_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM authorization_event_capacity WHERE community_id=$1",
+        )
+        .bind(first_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back capacities");
+        let conflict_max: i64 = sqlx::query_scalar(
+            "SELECT MAX(policy_revision) FROM identity_enrollment_policies WHERE community_id=$1",
+        )
+        .bind(conflict_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("read unchanged maximum revision");
+        assert_eq!(first_policy_rows, 0);
+        assert_eq!(first_capacity_rows, 0);
+        assert_eq!(conflict_max, 7);
+
+        let greater = policy(
+            conflict_domain,
+            8,
+            AuthorizationEnrollmentMode::RiskLabelledTofu,
+            installed_capacity,
+        );
+        let advanced = db
+            .reconcile_authorization_enrollment_startup(&[(greater, installed_capacity)])
+            .await
+            .expect("strictly greater revision");
+        assert_eq!(advanced.inserted(), 1);
+
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {database_name} WITH (FORCE)"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop scratch database");
+    }
+}

--- a/crates/buzz-db/src/identity_enrollment.rs
+++ b/crates/buzz-db/src/identity_enrollment.rs
@@ -1,0 +1,571 @@
+//! Read-only enrollment preparation and transaction-local binding creation.
+//!
+//! Federated assertions are verified by `buzz-auth`; this module reads only
+//! provider-free local policy and writes only immutable binding generations.
+//! Assertion expiry bounds the resulting authorization lease and is never
+//! copied into `identity_bindings.expires_at`.
+
+use std::fmt;
+
+use buzz_auth::{
+    ActiveLocalBinding, DirectEnrollmentMode, DirectEnrollmentProposal, LocalEnrollmentAuthority,
+    VerifiedFederatedAssertion, VerifiedNostrProof,
+};
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::identity_lifecycle::{
+    lock_identity_lifecycle_transaction, IdentityLifecycleLockCoordinates,
+};
+
+/// Stable result of transaction-local enrollment convergence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrollmentDisposition {
+    /// This transaction created the one immutable binding generation.
+    Created,
+    /// A concurrent transaction already created the exact eligible generation.
+    ConvergedExisting,
+}
+
+/// Credential-free enrollment state retained until canonical admission commits.
+pub(crate) struct EnrollmentTransactionOutcome {
+    pub(crate) binding: ActiveLocalBinding,
+    pub(crate) disposition: EnrollmentDisposition,
+}
+
+/// Direct-enrollment proposal bound to the exact immutable local policy row.
+///
+/// The policy digest is credential-free and remains separate from the
+/// assertion digest stored as binding provenance. Canonical admission retains
+/// both until the authoritative transaction proves that the proposal is still
+/// the highest currently effective policy.
+pub struct PreparedDirectEnrollment {
+    proposal: DirectEnrollmentProposal,
+    policy_digest: [u8; 32],
+}
+
+impl PreparedDirectEnrollment {
+    /// Consume the preparation into its frozen S2 proposal and policy digest.
+    pub fn into_parts(self) -> (DirectEnrollmentProposal, [u8; 32]) {
+        (self.proposal, self.policy_digest)
+    }
+}
+
+impl fmt::Debug for PreparedDirectEnrollment {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PreparedDirectEnrollment([REDACTED])")
+    }
+}
+
+impl fmt::Debug for EnrollmentTransactionOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("EnrollmentTransactionOutcome([REDACTED])")
+    }
+}
+
+/// Fail-closed enrollment preparation and transaction errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum IdentityEnrollmentError {
+    /// No current local enrollment policy was readable.
+    #[error("identity enrollment policy is unavailable")]
+    PolicyUnavailable,
+    /// The current policy requires a separately authorized provisioning action.
+    #[error("identity binding must be provisioned")]
+    ProvisioningRequired,
+    /// Lifecycle state, an administrative expiry, or the partial bijection denied creation.
+    #[error("identity enrollment denied")]
+    Denied,
+    /// A server-generated identifier or sealed digest was invalid.
+    #[error("identity enrollment input is invalid")]
+    InvalidInput,
+    /// PostgreSQL state could not be read or committed.
+    #[error("identity enrollment storage is unavailable")]
+    StorageUnavailable,
+}
+
+/// Read current local authority and seal an Attested or risk-labelled TOFU proposal.
+///
+/// This function is read-only. Provisioned mode intentionally returns
+/// [`IdentityEnrollmentError::ProvisioningRequired`]; only an authenticated
+/// operator transition may create that binding provenance.
+pub async fn prepare_direct_enrollment(
+    pool: &PgPool,
+    assertion: VerifiedFederatedAssertion,
+    proof: VerifiedNostrProof,
+    authoritative_now: DateTime<Utc>,
+) -> Result<PreparedDirectEnrollment, IdentityEnrollmentError> {
+    if assertion.authorization_domain() != proof.authorization_domain() {
+        return Err(IdentityEnrollmentError::InvalidInput);
+    }
+    let domain = assertion.authorization_domain();
+    let row = sqlx::query(
+        r#"
+        SELECT policy_revision, enrollment_mode, policy_digest
+        FROM identity_enrollment_policies
+        WHERE community_id = $1
+          AND effective_at <= $2
+          AND (expires_at IS NULL OR $2 < expires_at)
+        ORDER BY policy_revision DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(authoritative_now)
+    .fetch_optional(pool)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?
+    .ok_or(IdentityEnrollmentError::PolicyUnavailable)?;
+
+    let policy_revision = positive_i64(row.try_get("policy_revision")?)?;
+    let mode_code: i16 = row
+        .try_get("enrollment_mode")
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+    // Read and validate policy lineage, but never copy it into binding
+    // evidence. Attested/TOFU bindings retain the exact assertion digest
+    // sealed into the Nostr proof.
+    let policy_digest = digest_column(&row, "policy_digest")?;
+    let evidence_digest = proof
+        .bound_assertion_fingerprint()
+        .copied()
+        .ok_or(IdentityEnrollmentError::Denied)?;
+    let _mode = direct_enrollment_mode(mode_code)?;
+    let principal = assertion.principal_storage_key();
+    let authority = LocalEnrollmentAuthority::from_database_parts(
+        domain,
+        principal.issuer().to_owned(),
+        principal.subject().to_owned(),
+        proof.actor_pubkey(),
+        mode_code,
+        policy_revision,
+        evidence_digest,
+    )
+    .ok_or(IdentityEnrollmentError::InvalidInput)?;
+    let proposal = DirectEnrollmentProposal::from_verified_evidence(
+        authority,
+        assertion,
+        proof,
+        authoritative_now,
+    )
+    .map_err(|_| IdentityEnrollmentError::Denied)?;
+    Ok(PreparedDirectEnrollment {
+        proposal,
+        policy_digest,
+    })
+}
+
+/// Create or converge on one exact eligible enrollment generation.
+///
+/// The caller retains this transaction through final authorization recheck,
+/// replay claim, receipt, audit append, and any admitted mutation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_authoritative_enrollment_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    proposal: &DirectEnrollmentProposal,
+    prepared_policy_digest: [u8; 32],
+    assertion: &VerifiedFederatedAssertion,
+    proof: &VerifiedNostrProof,
+    authoritative_now: DateTime<Utc>,
+) -> Result<EnrollmentTransactionOutcome, IdentityEnrollmentError> {
+    if operation_id.is_nil()
+        || request_fingerprint == [0; 32]
+        || proposal.authorization_domain() != assertion.authorization_domain()
+        || proposal.authorization_domain() != proof.authorization_domain()
+        || prepared_policy_digest == [0; 32]
+    {
+        return Err(IdentityEnrollmentError::InvalidInput);
+    }
+    let domain = proposal.authorization_domain();
+    let principal = assertion.principal_storage_key();
+    let issuer = principal.issuer();
+    let subject = principal.subject();
+    let event_author = proof.actor_pubkey();
+    let event_author_bytes = event_author.to_bytes();
+    let principal_fingerprint = principal_fingerprint(domain, issuer, subject);
+    let (policy_revision, evidence_digest) = proposal.local_authority();
+    let policy_revision_i64 =
+        i64::try_from(policy_revision).map_err(|_| IdentityEnrollmentError::InvalidInput)?;
+
+    let community_exists =
+        sqlx::query_scalar::<_, Uuid>("SELECT id FROM communities WHERE id=$1 FOR UPDATE")
+            .bind(domain.as_uuid())
+            .fetch_optional(&mut **transaction)
+            .await
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?
+            .is_some();
+    if !community_exists {
+        return Err(IdentityEnrollmentError::PolicyUnavailable);
+    }
+
+    let coordinates = IdentityLifecycleLockCoordinates::new(
+        domain,
+        Some(principal_fingerprint),
+        None,
+        Some(event_author),
+    )
+    .map_err(|_| IdentityEnrollmentError::InvalidInput)?;
+    lock_identity_lifecycle_transaction(transaction, &coordinates)
+        .await
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+
+    let policy = sqlx::query(
+        r#"
+        SELECT policy_revision, enrollment_mode, policy_digest, expires_at
+        FROM identity_enrollment_policies
+        WHERE community_id = $1
+          AND effective_at <= $2
+          AND (expires_at IS NULL OR $2 < expires_at)
+        ORDER BY policy_revision DESC
+        LIMIT 1
+        FOR SHARE
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(authoritative_now)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?
+    .ok_or(IdentityEnrollmentError::PolicyUnavailable)?;
+    let current_revision = positive_i64(policy.try_get("policy_revision")?)?;
+    let mode_code: i16 = policy
+        .try_get("enrollment_mode")
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+    let _mode = direct_enrollment_mode(mode_code)?;
+    let stored_policy_digest = digest_column(&policy, "policy_digest")?;
+    let binding_expires_at: Option<DateTime<Utc>> = policy
+        .try_get("expires_at")
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+    if current_revision != policy_revision
+        || mode_code != proposal.mode().database_code()
+        || stored_policy_digest != prepared_policy_digest
+        || proof.bound_assertion_fingerprint() != Some(evidence_digest)
+        || binding_expires_at.is_some_and(|expires_at| authoritative_now >= expires_at)
+    {
+        return Err(IdentityEnrollmentError::Denied);
+    }
+
+    let rows = sqlx::query(
+        r#"
+        SELECT binding_id, binding_version, issuer, subject,
+               principal_fingerprint, event_author_pubkey, binding_state,
+               binding_provenance, policy_revision,
+               enrollment_evidence_digest, expires_at
+        FROM identity_bindings
+        WHERE community_id = $1
+          AND binding_state = 1
+          AND ((issuer = $2 AND subject = $3) OR event_author_pubkey = $4)
+        ORDER BY binding_version
+        FOR UPDATE
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(issuer)
+    .bind(subject)
+    .bind(event_author_bytes.as_slice())
+    .fetch_all(&mut **transaction)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+
+    if !rows.is_empty() {
+        if rows.len() != 1 {
+            return Err(IdentityEnrollmentError::Denied);
+        }
+        let row = &rows[0];
+        let row_issuer: String = row
+            .try_get("issuer")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let row_subject: String = row
+            .try_get("subject")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let row_key: Vec<u8> = row
+            .try_get("event_author_pubkey")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let row_state: i16 = row
+            .try_get("binding_state")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let row_mode: i16 = row
+            .try_get("binding_provenance")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let row_policy = positive_i64(row.try_get("policy_revision")?)?;
+        let row_evidence = digest_column(row, "enrollment_evidence_digest")?;
+        let row_expires_at: Option<DateTime<Utc>> = row
+            .try_get("expires_at")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        if row_issuer != issuer
+            || row_subject != subject
+            || row_key.as_slice() != event_author_bytes
+            || row_state != 1
+            || row_mode != mode_code
+            || row_policy != policy_revision
+            || row_evidence != *evidence_digest
+            || row_expires_at.is_some_and(|expires_at| authoritative_now >= expires_at)
+        {
+            return Err(IdentityEnrollmentError::Denied);
+        }
+        let binding_id: Uuid = row
+            .try_get("binding_id")
+            .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+        let binding_version = positive_i64(row.try_get("binding_version")?)?;
+        let binding = ActiveLocalBinding::from_enrollment_storage_parts(
+            domain,
+            row_issuer,
+            row_subject,
+            binding_id,
+            binding_version,
+            event_author,
+            row_expires_at,
+            row_mode,
+            row_policy,
+            row_evidence,
+        )
+        .ok_or(IdentityEnrollmentError::StorageUnavailable)?;
+        return Ok(EnrollmentTransactionOutcome {
+            binding,
+            disposition: EnrollmentDisposition::ConvergedExisting,
+        });
+    }
+
+    let blocked: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM identity_lifecycle_selectors selector
+            LEFT JOIN identity_lifecycle_selector_consumptions consumption
+              ON consumption.community_id = selector.community_id
+             AND consumption.selector_id = selector.selector_id
+            WHERE selector.community_id = $1
+              AND (
+                (selector.selector_kind = 1
+                  AND selector.principal_fingerprint = $2
+                  AND selector.event_author_pubkey = $3)
+                OR (selector.selector_kind = 2
+                  AND selector.principal_fingerprint = $2
+                  AND consumption.selector_id IS NULL)
+                OR (selector.selector_kind = 3
+                  AND selector.event_author_pubkey = $3)
+                OR (selector.selector_kind = 4
+                  AND selector.principal_fingerprint = $2
+                  AND consumption.selector_id IS NULL)
+              )
+        )
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(principal_fingerprint.as_slice())
+    .bind(event_author_bytes.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+    if blocked {
+        return Err(IdentityEnrollmentError::Denied);
+    }
+
+    let binding_id = Uuid::new_v4();
+    let history_id = Uuid::new_v4();
+    let transition_digest = enrollment_transition_digest(
+        domain,
+        operation_id,
+        request_fingerprint,
+        principal_fingerprint,
+        event_author_bytes,
+        policy_revision,
+        mode_code,
+    );
+    let binding_version: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO identity_bindings (
+            community_id, binding_id, issuer, subject, principal_fingerprint,
+            event_author_pubkey, binding_state, lifecycle_revision,
+            binding_provenance, policy_revision, enrollment_evidence_digest,
+            expires_at, birth_history_id, creation_operation_id,
+            creation_request_fingerprint
+        ) VALUES ($1, $2, $3, $4, $5, $6, 1, 1, $7, $8, $9, $10, $11, $12, $13)
+        RETURNING binding_version
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(binding_id)
+    .bind(issuer)
+    .bind(subject)
+    .bind(principal_fingerprint.as_slice())
+    .bind(event_author_bytes.as_slice())
+    .bind(mode_code)
+    .bind(policy_revision_i64)
+    .bind(evidence_digest.as_slice())
+    .bind(binding_expires_at)
+    .bind(history_id)
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO identity_lifecycle_history (
+            community_id, history_id, transition_kind, outcome_code,
+            successor_binding_id, successor_binding_version,
+            successor_lifecycle_revision, successor_state,
+            operation_id, request_fingerprint, transition_digest
+        ) VALUES ($1, $2, 1, 1, $3, $4, 1, 1, $5, $6, $7)
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(history_id)
+    .bind(binding_id)
+    .bind(binding_version)
+    .bind(operation_id)
+    .bind(request_fingerprint.as_slice())
+    .bind(transition_digest.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+
+    let binding_version = positive_i64(binding_version)?;
+    let binding = ActiveLocalBinding::from_enrollment_storage_parts(
+        domain,
+        issuer.to_owned(),
+        subject.to_owned(),
+        binding_id,
+        binding_version,
+        event_author,
+        binding_expires_at,
+        mode_code,
+        policy_revision,
+        *evidence_digest,
+    )
+    .ok_or(IdentityEnrollmentError::StorageUnavailable)?;
+    Ok(EnrollmentTransactionOutcome {
+        binding,
+        disposition: EnrollmentDisposition::Created,
+    })
+}
+
+/// Domain-separated pseudonymous principal coordinate shared by lifecycle code.
+pub(crate) fn principal_fingerprint(domain: CommunityId, issuer: &str, subject: &str) -> [u8; 32] {
+    framed_digest(
+        b"buzz:nip-fi:principal:v1",
+        &[
+            domain.as_uuid().as_bytes(),
+            issuer.as_bytes(),
+            subject.as_bytes(),
+        ],
+    )
+}
+
+/// Domain-separated pseudonymous actor coordinate used in durable audit rows.
+pub(crate) fn actor_fingerprint(domain: CommunityId, key: &[u8; 32]) -> [u8; 32] {
+    framed_digest(b"buzz:nip-fi:actor:v1", &[domain.as_uuid().as_bytes(), key])
+}
+
+pub(crate) fn framed_digest(label: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((label.len() as u64).to_be_bytes());
+    digest.update(label);
+    for part in parts {
+        digest.update((part.len() as u64).to_be_bytes());
+        digest.update(part);
+    }
+    digest.finalize().into()
+}
+
+fn enrollment_transition_digest(
+    domain: CommunityId,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    principal_fingerprint: [u8; 32],
+    event_author: [u8; 32],
+    policy_revision: u64,
+    mode_code: i16,
+) -> [u8; 32] {
+    framed_digest(
+        b"buzz:nip-fi:enrollment-transition:v1",
+        &[
+            domain.as_uuid().as_bytes(),
+            operation_id.as_bytes(),
+            &request_fingerprint,
+            &principal_fingerprint,
+            &event_author,
+            &policy_revision.to_be_bytes(),
+            &mode_code.to_be_bytes(),
+        ],
+    )
+}
+
+fn positive_i64(value: i64) -> Result<u64, IdentityEnrollmentError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(IdentityEnrollmentError::StorageUnavailable)
+}
+
+fn direct_enrollment_mode(mode_code: i16) -> Result<DirectEnrollmentMode, IdentityEnrollmentError> {
+    match DirectEnrollmentMode::from_database_code(mode_code) {
+        Some(DirectEnrollmentMode::Provisioned) => {
+            Err(IdentityEnrollmentError::ProvisioningRequired)
+        }
+        Some(mode @ (DirectEnrollmentMode::Attested | DirectEnrollmentMode::RiskLabelledTofu)) => {
+            Ok(mode)
+        }
+        None => Err(IdentityEnrollmentError::InvalidInput),
+    }
+}
+
+fn digest_column(
+    row: &sqlx::postgres::PgRow,
+    column: &str,
+) -> Result<[u8; 32], IdentityEnrollmentError> {
+    let bytes: Vec<u8> = row
+        .try_get(column)
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)?;
+    bytes
+        .try_into()
+        .map_err(|_| IdentityEnrollmentError::StorageUnavailable)
+}
+
+impl From<sqlx::Error> for IdentityEnrollmentError {
+    fn from(_: sqlx::Error) -> Self {
+        Self::StorageUnavailable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprints_are_domain_and_tuple_separated() {
+        let first = CommunityId::from_uuid(Uuid::from_u128(1));
+        let second = CommunityId::from_uuid(Uuid::from_u128(2));
+        assert_ne!(
+            principal_fingerprint(first, "issuer-a", "subject"),
+            principal_fingerprint(second, "issuer-a", "subject")
+        );
+        assert_ne!(
+            principal_fingerprint(first, "issuer-a", "subject"),
+            principal_fingerprint(first, "issuer", "a-subject")
+        );
+        assert_ne!(actor_fingerprint(first, &[1; 32]), [0; 32]);
+    }
+
+    #[test]
+    fn public_direct_enrollment_denies_provisioned_mode() {
+        assert_eq!(
+            direct_enrollment_mode(DirectEnrollmentMode::Attested.database_code()),
+            Ok(DirectEnrollmentMode::Attested)
+        );
+        assert_eq!(
+            direct_enrollment_mode(DirectEnrollmentMode::RiskLabelledTofu.database_code()),
+            Ok(DirectEnrollmentMode::RiskLabelledTofu)
+        );
+        assert_eq!(
+            direct_enrollment_mode(DirectEnrollmentMode::Provisioned.database_code()),
+            Err(IdentityEnrollmentError::ProvisioningRequired)
+        );
+    }
+}

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -15,6 +15,12 @@ pub mod admin_moderation;
 pub mod api_token;
 /// Relay-scoped archived identity persistence (NIP-IA).
 pub mod archived_identities;
+/// Provider-free atomic authorization admission contract.
+pub mod authorization_admission;
+/// Immutable provider-free authorization events and capacity controls.
+pub mod authorization_events;
+/// Immutable provider-free enrollment-policy reconciliation.
+pub mod authorization_policy;
 /// Channel and membership persistence.
 pub mod channel;
 /// Direct message channel persistence.
@@ -29,12 +35,18 @@ pub mod feed;
 pub mod git_repo;
 /// Corporate identity binding persistence.
 pub mod identity_binding;
+/// Canonical direct enrollment transaction helpers.
+pub mod identity_enrollment;
 /// Canonical identity lifecycle advisory-lock helpers.
 pub mod identity_lifecycle;
+/// Typed lifecycle and admission-loss invalidation notices.
+pub mod lifecycle_invalidation;
 /// Embedded database migrations.
 pub mod migration;
 /// Community moderation: reports, bans/timeouts, audit actions.
 pub mod moderation;
+/// Closed deployment-operator lifecycle intent contract.
+pub mod operator_lifecycle;
 /// Monthly table partition management.
 pub mod partition;
 /// Buzz product-feedback sidecar persistence.

--- a/crates/buzz-db/src/lifecycle_invalidation.rs
+++ b/crates/buzz-db/src/lifecycle_invalidation.rs
@@ -1,0 +1,354 @@
+//! Credential-free lifecycle and admission-loss notifications.
+
+use std::fmt;
+
+use buzz_core::CommunityId;
+use sqlx::{Postgres, Transaction};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Closed dependency coordinate advanced by a lifecycle transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleInvalidationSelector {
+    /// Exact federated principal fingerprint.
+    Principal([u8; 32]),
+    /// Exact Nostr event-author fingerprint.
+    EventAuthor([u8; 32]),
+    /// Exact binding generation and its selector fingerprint.
+    Binding {
+        /// Privacy-safe selector fingerprint.
+        fingerprint: [u8; 32],
+        /// First invalid binding version.
+        version_floor: u64,
+    },
+    /// Entire server-resolved authorization domain.
+    Domain([u8; 32]),
+}
+
+/// Post-commit notice that exact authorization dependencies became stale.
+///
+/// A notice is emitted only after the transaction that advanced the durable
+/// invalidation floor commits. It contains neither credentials nor raw
+/// principal identifiers.
+#[derive(Clone, PartialEq, Eq)]
+pub struct LifecycleInvalidationNotice {
+    authorization_domain: CommunityId,
+    operation_id: Uuid,
+    generation: u64,
+    selectors: Vec<LifecycleInvalidationSelector>,
+}
+
+impl LifecycleInvalidationNotice {
+    /// Construct a non-empty post-commit invalidation notice.
+    pub fn new(
+        authorization_domain: CommunityId,
+        operation_id: Uuid,
+        generation: u64,
+        selectors: Vec<LifecycleInvalidationSelector>,
+    ) -> Option<Self> {
+        if authorization_domain.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || generation == 0
+            || selectors.is_empty()
+        {
+            return None;
+        }
+        Some(Self {
+            authorization_domain,
+            operation_id,
+            generation,
+            selectors,
+        })
+    }
+
+    /// Server-resolved domain whose generation advanced.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Lifecycle operation that advanced the floor.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// New durable invalidation generation.
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Exact privacy-safe selectors invalidated by the transition.
+    pub fn selectors(&self) -> &[LifecycleInvalidationSelector] {
+        &self.selectors
+    }
+}
+
+impl fmt::Debug for LifecycleInvalidationNotice {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LifecycleInvalidationNotice([REDACTED])")
+    }
+}
+
+/// Post-commit notice that one previously issued admission is no longer valid.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionLossNotice {
+    authorization_domain: CommunityId,
+    operation_id: Uuid,
+    lease_id: Uuid,
+    binding_id: Uuid,
+    binding_version: u64,
+    invalidation_generation: u64,
+}
+
+impl AdmissionLossNotice {
+    /// Construct a notice from committed durable dependency coordinates.
+    pub const fn new(
+        authorization_domain: CommunityId,
+        operation_id: Uuid,
+        lease_id: Uuid,
+        binding_id: Uuid,
+        binding_version: u64,
+        invalidation_generation: u64,
+    ) -> Option<Self> {
+        if authorization_domain.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || lease_id.is_nil()
+            || binding_id.is_nil()
+            || binding_version == 0
+            || invalidation_generation == 0
+        {
+            None
+        } else {
+            Some(Self {
+                authorization_domain,
+                operation_id,
+                lease_id,
+                binding_id,
+                binding_version,
+                invalidation_generation,
+            })
+        }
+    }
+
+    /// Server-resolved domain.
+    pub const fn authorization_domain(self) -> CommunityId {
+        self.authorization_domain
+    }
+
+    /// Admission-loss operation.
+    pub const fn operation_id(self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Invalidated in-memory lease.
+    pub const fn lease_id(self) -> Uuid {
+        self.lease_id
+    }
+
+    /// Exact binding generation that lost admission.
+    pub const fn binding(self) -> (Uuid, u64) {
+        (self.binding_id, self.binding_version)
+    }
+
+    /// Durable generation after the loss.
+    pub const fn invalidation_generation(self) -> u64 {
+        self.invalidation_generation
+    }
+}
+
+impl fmt::Debug for AdmissionLossNotice {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AdmissionLossNotice([REDACTED])")
+    }
+}
+
+/// Fail-closed durable invalidation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum LifecycleInvalidationError {
+    /// A selector, generation floor, or operation coordinate was malformed.
+    #[error("invalid lifecycle invalidation coordinate")]
+    InvalidInput,
+    /// The operator has not activated invalidation for this domain.
+    #[error("lifecycle invalidation domain is not active")]
+    DomainInactive,
+    /// Durable invalidation state was unavailable.
+    #[error("lifecycle invalidation storage is unavailable")]
+    StorageUnavailable,
+}
+
+/// Advance the domain generation and exact selector floors in one lifecycle transaction.
+///
+/// The caller inserts the canonical operation receipt in the same transaction;
+/// v30's deferred foreign keys then prove that no invalidation can survive a
+/// rolled-back lifecycle effect.
+pub async fn advance_lifecycle_invalidation_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    authorization_domain: CommunityId,
+    operation_id: Uuid,
+    request_fingerprint: [u8; 32],
+    selectors: Vec<LifecycleInvalidationSelector>,
+) -> Result<LifecycleInvalidationNotice, LifecycleInvalidationError> {
+    if authorization_domain.as_uuid().is_nil()
+        || operation_id.is_nil()
+        || request_fingerprint == [0; 32]
+        || selectors.is_empty()
+        || selectors.iter().any(invalid_selector)
+    {
+        return Err(LifecycleInvalidationError::InvalidInput);
+    }
+    let mut canonical = selectors;
+    canonical.sort_by_key(selector_sort_key);
+    if canonical
+        .windows(2)
+        .any(|pair| selector_sort_key(&pair[0]) == selector_sort_key(&pair[1]))
+    {
+        return Err(LifecycleInvalidationError::InvalidInput);
+    }
+
+    let current_generation: Option<i64> = sqlx::query_scalar(
+        r#"
+        SELECT current_generation
+        FROM authorization_invalidation_domains
+        WHERE community_id = $1
+        FOR UPDATE
+        "#,
+    )
+    .bind(authorization_domain.as_uuid())
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| LifecycleInvalidationError::StorageUnavailable)?;
+    let current_generation =
+        current_generation.ok_or(LifecycleInvalidationError::DomainInactive)?;
+    let next_generation = current_generation
+        .checked_add(1)
+        .ok_or(LifecycleInvalidationError::StorageUnavailable)?;
+    let advanced: Option<i64> = sqlx::query_scalar(
+        r#"
+        UPDATE authorization_invalidation_domains
+        SET current_generation = $2,
+            updated_at = GREATEST(
+                transaction_timestamp(),
+                updated_at + INTERVAL '1 microsecond'
+            )
+        WHERE community_id = $1 AND current_generation = $3
+        RETURNING current_generation
+        "#,
+    )
+    .bind(authorization_domain.as_uuid())
+    .bind(next_generation)
+    .bind(current_generation)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(|_| LifecycleInvalidationError::StorageUnavailable)?;
+    let generation = u64::try_from(advanced.ok_or(LifecycleInvalidationError::StorageUnavailable)?)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(LifecycleInvalidationError::StorageUnavailable)?;
+
+    for selector in &canonical {
+        let (kind, fingerprint, binding_floor) = selector_storage_parts(selector);
+        let write = sqlx::query(
+            r#"
+            INSERT INTO authorization_invalidation_floors (
+                community_id, selector_kind, selector_fingerprint,
+                floor_generation, binding_version_floor,
+                relationship_revision_floor, operation_id,
+                request_fingerprint
+            ) VALUES ($1, $2, $3, $4, $5, NULL, $6, $7)
+            ON CONFLICT (community_id, selector_kind, selector_fingerprint)
+            DO UPDATE SET
+                floor_generation = GREATEST(
+                    authorization_invalidation_floors.floor_generation,
+                    EXCLUDED.floor_generation
+                ),
+                binding_version_floor = CASE
+                    WHEN EXCLUDED.selector_kind = 3 THEN GREATEST(
+                        authorization_invalidation_floors.binding_version_floor,
+                        EXCLUDED.binding_version_floor
+                    )
+                    ELSE NULL
+                END,
+                operation_id = EXCLUDED.operation_id,
+                request_fingerprint = EXCLUDED.request_fingerprint,
+                updated_at = GREATEST(
+                    transaction_timestamp(),
+                    authorization_invalidation_floors.updated_at + INTERVAL '1 microsecond'
+                )
+            "#,
+        )
+        .bind(authorization_domain.as_uuid())
+        .bind(kind)
+        .bind(fingerprint.as_slice())
+        .bind(i64::try_from(generation).map_err(|_| LifecycleInvalidationError::InvalidInput)?)
+        .bind(
+            binding_floor
+                .map(i64::try_from)
+                .transpose()
+                .map_err(|_| LifecycleInvalidationError::InvalidInput)?,
+        )
+        .bind(operation_id)
+        .bind(request_fingerprint.as_slice())
+        .execute(&mut **transaction)
+        .await
+        .map_err(|_| LifecycleInvalidationError::StorageUnavailable)?;
+        if write.rows_affected() != 1 {
+            return Err(LifecycleInvalidationError::StorageUnavailable);
+        }
+    }
+
+    LifecycleInvalidationNotice::new(authorization_domain, operation_id, generation, canonical)
+        .ok_or(LifecycleInvalidationError::InvalidInput)
+}
+
+fn invalid_selector(selector: &LifecycleInvalidationSelector) -> bool {
+    match selector {
+        LifecycleInvalidationSelector::Principal(fingerprint)
+        | LifecycleInvalidationSelector::EventAuthor(fingerprint)
+        | LifecycleInvalidationSelector::Domain(fingerprint) => *fingerprint == [0; 32],
+        LifecycleInvalidationSelector::Binding {
+            fingerprint,
+            version_floor,
+        } => *fingerprint == [0; 32] || *version_floor == 0,
+    }
+}
+
+fn selector_sort_key(selector: &LifecycleInvalidationSelector) -> (i16, [u8; 32]) {
+    match selector {
+        LifecycleInvalidationSelector::Principal(fingerprint) => (1, *fingerprint),
+        LifecycleInvalidationSelector::EventAuthor(fingerprint) => (2, *fingerprint),
+        LifecycleInvalidationSelector::Binding { fingerprint, .. } => (3, *fingerprint),
+        LifecycleInvalidationSelector::Domain(fingerprint) => (5, *fingerprint),
+    }
+}
+
+fn selector_storage_parts(
+    selector: &LifecycleInvalidationSelector,
+) -> (i16, [u8; 32], Option<u64>) {
+    match selector {
+        LifecycleInvalidationSelector::Principal(fingerprint) => (1, *fingerprint, None),
+        LifecycleInvalidationSelector::EventAuthor(fingerprint) => (2, *fingerprint, None),
+        LifecycleInvalidationSelector::Binding {
+            fingerprint,
+            version_floor,
+        } => (3, *fingerprint, Some(*version_floor)),
+        LifecycleInvalidationSelector::Domain(fingerprint) => (5, *fingerprint, None),
+    }
+}
+
+#[cfg(test)]
+mod invalidation_tests {
+    use super::*;
+
+    #[test]
+    fn selector_order_is_closed_and_rejects_sentinels() {
+        let principal = LifecycleInvalidationSelector::Principal([1; 32]);
+        let binding = LifecycleInvalidationSelector::Binding {
+            fingerprint: [2; 32],
+            version_floor: 7,
+        };
+        assert_eq!(selector_sort_key(&principal), (1, [1; 32]));
+        assert_eq!(selector_storage_parts(&binding), (3, [2; 32], Some(7)));
+        assert!(invalid_selector(&LifecycleInvalidationSelector::Domain(
+            [0; 32]
+        )));
+    }
+}

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -348,6 +348,7 @@ mod tests {
             "push_gateway_delivery_request_replays",
             "product_feedback",
             "replica_heartbeat",
+            "authorization_proxy_nonce_claims",
         ] {
             if normalized[insert_pos..].contains(&format!("'{value}'")) {
                 globals.insert(value.to_owned());
@@ -561,7 +562,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 30);
+        assert_eq!(migrations.len(), 33);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -985,6 +986,46 @@ mod tests {
                 && !desired_schema.contains("CREATE TABLE client_status_revisions"),
             "desired schema must not persist kind 24244 presentation history",
         );
+
+        assert_eq!(migrations[30].version, 31);
+        let identity_lifecycle = migrations[30].sql.as_str();
+        for required in [
+            "nip_fi_lock_authorization_operation_v1",
+            "authorization_operation_receipt_event_cardinality",
+        ] {
+            assert!(
+                identity_lifecycle.contains(required),
+                "migration 0031 missing identity-lifecycle closure: {required}",
+            );
+        }
+
+        assert_eq!(migrations[31].version, 32);
+        let protected_authority = migrations[31].sql.as_str();
+        for required in [
+            "CREATE TABLE authorization_proxy_nonce_claims",
+            "'authorization_proxy_nonce_claims',",
+            "'server replay ledger; authorization_domain is the isolation key'",
+            "CREATE TABLE protected_publication_projection_outbox",
+            "UNIQUE (community_id, publication_sequence)",
+            "protected_publication_projection_receipt_guard_v1",
+        ] {
+            assert!(
+                protected_authority.contains(required),
+                "migration 0032 missing protected-authority surface: {required}",
+            );
+        }
+
+        assert_eq!(migrations[32].version, 34);
+        let operator_preauth = migrations[32].sql.as_str();
+        for required in [
+            "authorization_event_capacity_before_insert_v2",
+            "CREATE TABLE authorization_operator_denial_buckets",
+        ] {
+            assert!(
+                operator_preauth.contains(required),
+                "migration 0034 missing operator pre-auth audit surface: {required}",
+            );
+        }
     }
 
     #[test]
@@ -1227,7 +1268,7 @@ mod tests {
         run_migrations(&pool)
             .await
             .expect("retry succeeds after operator repair");
-        assert_eq!(applied_versions(&pool).await.last().copied(), Some(30));
+        assert_eq!(applied_versions(&pool).await.last().copied(), Some(34));
     }
 
     #[tokio::test]
@@ -1352,6 +1393,10 @@ mod tests {
         );
     }
 
+    #[path = "migration_nip_fi_lifecycle_tests.rs"]
+    mod migration_nip_fi_lifecycle_tests;
+    #[path = "migration_nip_fi_operator_audit_tests.rs"]
+    mod migration_nip_fi_operator_audit_tests;
     #[path = "migration_nip_fi_authorization_tests.rs"]
     mod nip_fi_authorization_tests;
     #[path = "migration_nip_fi_tests.rs"]

--- a/crates/buzz-db/src/migration/tests/migration_nip_fi_authorization_tests.rs
+++ b/crates/buzz-db/src/migration/tests/migration_nip_fi_authorization_tests.rs
@@ -66,6 +66,25 @@ async fn seed_binding(pool: &PgPool, community_id: Uuid) -> (Uuid, i64, Vec<u8>,
         1,
     )
     .await;
+    sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+          actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+          occurred_at,canonical_envelope,envelope_digest) \
+         VALUES ($1,$2,1,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind(vec![241_u8; 32])
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![35_u8; 4])
+    .bind(vec![36_u8; 32])
+    .execute(&mut *transaction)
+    .await
+    .expect("insert authorization-state binding event");
     let binding_version: i64 = sqlx::query_scalar(
         "INSERT INTO identity_bindings \
          (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
@@ -170,6 +189,15 @@ async fn nip_fi_authorization_foundation_behavior() {
     .execute(&pool)
     .await
     .expect("insert authorization test policy");
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+         VALUES ($1,4,16,4)",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect("install bounded authorization event capacity");
     let (binding_id, binding_version, principal_fingerprint, event_author_pubkey) =
         seed_binding(&pool, community_id).await;
 
@@ -443,18 +471,11 @@ async fn nip_fi_authorization_foundation_behavior() {
         Some("protected_object_authority_delegated_relationship_non_nil")
     );
 
-    // Audit insertion atomically advances bounded counters. Exhaustion and
-    // unhealthy state reject the event without advancing either counter, and
-    // health cannot be reset or relabelled online.
-    sqlx::query(
-        "INSERT INTO authorization_event_capacity \
-         (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
-         VALUES ($1,2,8,4)",
-    )
-    .bind(community_id)
-    .execute(&pool)
-    .await
-    .expect("install bounded authorization event capacity");
+    // The lifecycle seed consumed the first bounded event. Two additional
+    // success events reach the exact non-restrictive limits while preserving
+    // one event and four bytes for security evidence. Exhaustion and unhealthy
+    // state reject later events without advancing either counter, and health
+    // cannot be reset or relabelled online.
     for event_byte in [71_u8, 72_u8] {
         let (operation_id, request_fingerprint) =
             committed_receipt(&pool, community_id, 11, event_byte).await;
@@ -580,20 +601,19 @@ async fn nip_fi_authorization_foundation_behavior() {
     .fetch_one(&pool)
     .await
     .expect("read bounded authorization event counters");
-    assert_eq!(counters, (2, 8));
+    assert_eq!(counters, (3, 12));
     sqlx::query("UPDATE authorization_events SET reason_code=2 WHERE community_id=$1")
         .bind(community_id)
         .execute(&pool)
         .await
         .expect_err("authorization event envelopes are immutable");
-    sqlx::query(
-        "UPDATE authorization_event_capacity SET health_state=2,failure_code=1, \
-         failure_observed_at=transaction_timestamp() WHERE community_id=$1",
-    )
-    .bind(community_id)
-    .execute(&pool)
-    .await
-    .expect("latch authorization event health");
+    let failure_generation: i64 =
+        sqlx::query_scalar("SELECT authorization_event_capacity_report_failure_v2($1,1::smallint)")
+            .bind(community_id)
+            .fetch_one(&pool)
+            .await
+            .expect("latch authorization event health");
+    assert_eq!(failure_generation, 1);
     sqlx::query(
         "UPDATE authorization_event_capacity SET failure_code=2 \
          WHERE community_id=$1",

--- a/crates/buzz-db/src/migration/tests/migration_nip_fi_lifecycle_tests.rs
+++ b/crates/buzz-db/src/migration/tests/migration_nip_fi_lifecycle_tests.rs
@@ -1,0 +1,398 @@
+use super::*;
+
+use buzz_core::CommunityId;
+use uuid::Uuid;
+
+use crate::lifecycle_invalidation::{
+    advance_lifecycle_invalidation_tx, LifecycleInvalidationSelector,
+};
+
+const LIFECYCLE_UPGRADE_SQL: &str =
+    include_str!("../../../../../migrations/0031_nip_fi_identity_lifecycle_upgrade.sql");
+
+#[test]
+fn lifecycle_upgrade_is_additive_and_closes_receipt_event_cardinality() {
+    for forbidden in [
+        "CREATE TABLE identity_bindings",
+        "CREATE TABLE identity_lifecycle_history",
+        "CREATE TABLE identity_lifecycle_selectors",
+        "CREATE TABLE authorization_events",
+        "ALTER TABLE identity_bindings",
+    ] {
+        assert!(
+            !LIFECYCLE_UPGRADE_SQL.contains(forbidden),
+            "0031 must not recreate or weaken v29/v30: {forbidden}"
+        );
+    }
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("nip_fi_lock_authorization_operation_v1"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("authorization_operation_receipt_event_guard_v1"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("CREATE TABLE authorization_admission_results"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("semantic_fingerprint BYTEA NOT NULL"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("object_kind SMALLINT NOT NULL"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("object_key BYTEA NOT NULL"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("application_type BYTEA"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("application_version SMALLINT"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("application_code SMALLINT"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("octet_length(application_payload) <= 4096"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("DEFERRABLE INITIALLY DEFERRED"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("matching_event_count <> 1"));
+    assert!(LIFECYCLE_UPGRADE_SQL.contains("WHEN 7 THEN 4  -- recover"));
+}
+
+#[tokio::test]
+#[ignore = "requires a dedicated disposable Postgres database"]
+async fn lifecycle_0031_enforces_attested_provisioned_tofu_and_atomic_audit() {
+    let pool = connect_test_pool().await;
+    reset_public_schema(&pool).await;
+    run_migrations(&pool)
+        .await
+        .expect("apply migrations through lifecycle 0031");
+
+    let community_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+        .bind(community_id)
+        .bind(format!("lifecycle-{}.example", community_id.simple()))
+        .execute(&pool)
+        .await
+        .expect("insert lifecycle community");
+    for (revision, mode) in [(1_i64, 1_i16), (2, 2), (3, 3)] {
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+             VALUES ($1,$2,$3,$4,transaction_timestamp())",
+        )
+        .bind(community_id)
+        .bind(revision)
+        .bind(mode)
+        .bind(vec![mode as u8 + 100; 32])
+        .execute(&pool)
+        .await
+        .expect("insert closed enrollment policy");
+    }
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+         VALUES ($1,32,32768,2048)",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect("install lifecycle audit capacity");
+
+    for (ordinal, mode, operation_kind, transition_kind) in
+        [(1_u8, 1_i16, 1_i16, 1_i16), (2, 2, 2, 2), (3, 3, 1, 1)]
+    {
+        insert_complete_birth(
+            &pool,
+            community_id,
+            ordinal,
+            mode,
+            operation_kind,
+            transition_kind,
+            true,
+        )
+        .await
+        .expect("commit complete lifecycle birth");
+    }
+    let committed_bindings: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM identity_bindings WHERE community_id=$1 AND binding_state=1",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count committed bindings");
+    assert_eq!(committed_bindings, 3);
+
+    let conflicting_principal = sqlx::query(
+        "INSERT INTO identity_bindings \
+         (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
+          binding_state,lifecycle_revision,binding_provenance,policy_revision, \
+          enrollment_evidence_digest,birth_history_id,creation_operation_id, \
+          creation_request_fingerprint) \
+         SELECT community_id,$2,issuer,subject,principal_fingerprint,$3,1,1, \
+                binding_provenance,policy_revision,enrollment_evidence_digest,$4,$5,$6 \
+         FROM identity_bindings WHERE community_id=$1 ORDER BY binding_version LIMIT 1",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind([201_u8; 32].as_slice())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind([202_u8; 32].as_slice())
+    .execute(&pool)
+    .await
+    .expect_err("one principal cannot acquire a different active key");
+    assert_eq!(
+        conflicting_principal
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("identity_bindings_active_principal")
+    );
+    let conflicting_key = sqlx::query(
+        "INSERT INTO identity_bindings \
+         (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
+          binding_state,lifecycle_revision,binding_provenance,policy_revision, \
+          enrollment_evidence_digest,birth_history_id,creation_operation_id, \
+          creation_request_fingerprint) \
+         SELECT community_id,$2,'https://other-issuer.example','other-subject',$3, \
+                event_author_pubkey,1,1,binding_provenance,policy_revision, \
+                enrollment_evidence_digest,$4,$5,$6 \
+         FROM identity_bindings WHERE community_id=$1 ORDER BY binding_version LIMIT 1",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind([203_u8; 32].as_slice())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind([204_u8; 32].as_slice())
+    .execute(&pool)
+    .await
+    .expect_err("one key cannot acquire a different active principal");
+    assert_eq!(
+        conflicting_key
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("identity_bindings_active_event_author")
+    );
+
+    let retained_before: i64 = sqlx::query_scalar(
+        "SELECT retained_event_count FROM authorization_event_capacity WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read audit counter before rollback");
+    let missing_event = insert_complete_birth(&pool, community_id, 9, 1, 1, 1, false)
+        .await
+        .expect_err("receipt/history/binding without audit event must roll back");
+    assert_eq!(
+        missing_event
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("authorization_operation_receipt_event_cardinality")
+    );
+    let retained_after: i64 = sqlx::query_scalar(
+        "SELECT retained_event_count FROM authorization_event_capacity WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read audit counter after rollback");
+    assert_eq!(retained_after, retained_before);
+
+    let contended_operation = Uuid::new_v4();
+    let mut first = pool.begin().await.expect("begin first operation fence");
+    sqlx::query("SELECT nip_fi_lock_authorization_operation_v1($1,$2)")
+        .bind(community_id)
+        .bind(contended_operation)
+        .execute(&mut *first)
+        .await
+        .expect("acquire first operation fence");
+    let waiting_pool = pool.clone();
+    let waiter = tokio::spawn(async move {
+        let mut transaction = waiting_pool.begin().await.expect("begin waiter");
+        sqlx::query("SELECT nip_fi_lock_authorization_operation_v1($1,$2)")
+            .bind(community_id)
+            .bind(contended_operation)
+            .execute(&mut *transaction)
+            .await
+            .expect("acquire serialized operation fence");
+        transaction.commit().await.expect("commit waiter");
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        !waiter.is_finished(),
+        "same-domain operation contenders must not pass the fence concurrently"
+    );
+    first.commit().await.expect("release first operation fence");
+    tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+        .await
+        .expect("serialized waiter completes after release")
+        .expect("waiter task succeeds");
+
+    sqlx::query(
+        "INSERT INTO authorization_invalidation_domains (community_id,current_generation) \
+         VALUES ($1,0)",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect("activate lifecycle invalidation domain");
+    let invalidation_operation = Uuid::new_v4();
+    let invalidation_request = [91_u8; 32];
+    let invalidation_actor = [92_u8; 32];
+    let mut invalidation_tx = pool.begin().await.expect("begin invalidation transaction");
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+          outcome_code,result_digest) VALUES ($1,$2,$3,12,$4,1,$5)",
+    )
+    .bind(community_id)
+    .bind(invalidation_operation)
+    .bind(invalidation_request.as_slice())
+    .bind(invalidation_actor.as_slice())
+    .bind([93_u8; 32].as_slice())
+    .execute(&mut *invalidation_tx)
+    .await
+    .expect("stage invalidation receipt");
+    let notice = advance_lifecycle_invalidation_tx(
+        &mut invalidation_tx,
+        CommunityId::from_uuid(community_id),
+        invalidation_operation,
+        invalidation_request,
+        vec![LifecycleInvalidationSelector::Principal([94; 32])],
+    )
+    .await
+    .expect("advance invalidation in lifecycle transaction");
+    assert_eq!(notice.generation(), 1);
+    invalidation_tx
+        .commit()
+        .await
+        .expect("commit lifecycle invalidation");
+    let (generation, floors): (i64, i64) = sqlx::query_as(
+        "SELECT d.current_generation,count(f.selector_fingerprint) \
+         FROM authorization_invalidation_domains d \
+         LEFT JOIN authorization_invalidation_floors f ON f.community_id=d.community_id \
+         WHERE d.community_id=$1 GROUP BY d.current_generation",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read committed invalidation");
+    assert_eq!((generation, floors), (1, 1));
+
+    let mut rollback_tx = pool.begin().await.expect("begin rollback invalidation");
+    let rollback_operation = Uuid::new_v4();
+    let rollback_request = [95_u8; 32];
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+          outcome_code,result_digest) VALUES ($1,$2,$3,12,$4,1,$5)",
+    )
+    .bind(community_id)
+    .bind(rollback_operation)
+    .bind(rollback_request.as_slice())
+    .bind(invalidation_actor.as_slice())
+    .bind([96_u8; 32].as_slice())
+    .execute(&mut *rollback_tx)
+    .await
+    .expect("stage rollback invalidation receipt");
+    advance_lifecycle_invalidation_tx(
+        &mut rollback_tx,
+        CommunityId::from_uuid(community_id),
+        rollback_operation,
+        rollback_request,
+        vec![LifecycleInvalidationSelector::EventAuthor([97; 32])],
+    )
+    .await
+    .expect("stage rollback invalidation");
+    rollback_tx
+        .rollback()
+        .await
+        .expect("roll back lifecycle invalidation");
+    let generation_after_rollback: i64 = sqlx::query_scalar(
+        "SELECT current_generation FROM authorization_invalidation_domains WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read generation after rollback");
+    assert_eq!(generation_after_rollback, 1);
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_complete_birth(
+    pool: &PgPool,
+    community_id: Uuid,
+    ordinal: u8,
+    provenance: i16,
+    operation_kind: i16,
+    transition_kind: i16,
+    include_event: bool,
+) -> std::result::Result<(), sqlx::Error> {
+    let operation_id = Uuid::new_v4();
+    let history_id = Uuid::new_v4();
+    let binding_id = Uuid::new_v4();
+    let request_fingerprint = vec![ordinal; 32];
+    let actor_fingerprint = vec![ordinal.saturating_add(20); 32];
+    let mut transaction = pool.begin().await?;
+    sqlx::query("SELECT nip_fi_lock_authorization_operation_v1($1,$2)")
+        .bind(community_id)
+        .bind(operation_id)
+        .execute(&mut *transaction)
+        .await?;
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+          outcome_code,result_digest) VALUES ($1,$2,$3,$4,$5,1,$6)",
+    )
+    .bind(community_id)
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .bind(operation_kind)
+    .bind(&actor_fingerprint)
+    .bind(vec![ordinal.saturating_add(30); 32])
+    .execute(&mut *transaction)
+    .await?;
+    let binding_version: i64 = sqlx::query_scalar(
+        "INSERT INTO identity_bindings \
+         (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
+          binding_state,lifecycle_revision,binding_provenance,policy_revision, \
+          enrollment_evidence_digest,birth_history_id,creation_operation_id, \
+          creation_request_fingerprint) \
+         VALUES ($1,$2,$3,$4,$5,$6,1,1,$7,$8,$9,$10,$11,$12) RETURNING binding_version",
+    )
+    .bind(community_id)
+    .bind(binding_id)
+    .bind(format!("https://issuer-{ordinal}.example"))
+    .bind(format!("subject-{ordinal}"))
+    .bind(vec![ordinal.saturating_add(40); 32])
+    .bind(vec![ordinal.saturating_add(50); 32])
+    .bind(provenance)
+    .bind(i64::from(provenance))
+    .bind(vec![ordinal.saturating_add(60); 32])
+    .bind(history_id)
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .fetch_one(&mut *transaction)
+    .await?;
+    sqlx::query(
+        "INSERT INTO identity_lifecycle_history \
+         (community_id,history_id,transition_kind,outcome_code,successor_binding_id, \
+          successor_binding_version,successor_lifecycle_revision,successor_state, \
+          operation_id,request_fingerprint,transition_digest) \
+         VALUES ($1,$2,$3,1,$4,$5,1,1,$6,$7,$8)",
+    )
+    .bind(community_id)
+    .bind(history_id)
+    .bind(transition_kind)
+    .bind(binding_id)
+    .bind(binding_version)
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .bind(vec![ordinal.saturating_add(70); 32])
+    .execute(&mut *transaction)
+    .await?;
+    if include_event {
+        let envelope = vec![ordinal; 32];
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+              actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+              occurred_at,canonical_envelope,envelope_digest) \
+             VALUES ($1,$2,1,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+        )
+        .bind(community_id)
+        .bind(Uuid::new_v4())
+        .bind(&actor_fingerprint)
+        .bind(operation_id)
+        .bind(&request_fingerprint)
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(&envelope)
+        .bind(vec![ordinal.saturating_add(80); 32])
+        .execute(&mut *transaction)
+        .await?;
+    }
+    transaction.commit().await
+}

--- a/crates/buzz-db/src/migration/tests/migration_nip_fi_operator_audit_tests.rs
+++ b/crates/buzz-db/src/migration/tests/migration_nip_fi_operator_audit_tests.rs
@@ -1,0 +1,215 @@
+use super::*;
+
+use uuid::Uuid;
+
+const OPERATOR_AUDIT_SQL: &str =
+    include_str!("../../../../../migrations/0034_nip_fi_operator_preauth.sql");
+
+#[test]
+fn operator_audit_upgrade_is_bounded_and_uses_constant_time_capacity() {
+    for required in [
+        "restrictive_reserve_events",
+        "failure_generation",
+        "recovery_generation",
+        "authorization_event_capacity_before_insert_v2",
+        "authorization_operator_denial_buckets",
+        "selected_slot := (generation % 12)::SMALLINT",
+        "authorization_operator_denial_bucket_record_v1",
+    ] {
+        assert!(OPERATOR_AUDIT_SQL.contains(required), "missing {required}");
+    }
+    assert!(OPERATOR_AUDIT_SQL.contains("FOR UPDATE"));
+    assert!(OPERATOR_AUDIT_SQL.contains("NEW.event_kind IN (2, 3, 4, 5, 6, 7, 8, 9, 11, 14)"));
+    assert!(!OPERATOR_AUDIT_SQL.contains("count(*) FROM authorization_events"));
+    assert!(!OPERATOR_AUDIT_SQL.contains("sum(octet_length"));
+    assert!(
+        !OPERATOR_AUDIT_SQL.contains("CREATE TABLE authorization_operator_preauth_denial_events")
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a dedicated disposable Postgres database"]
+async fn operator_0034_reserves_restrictive_audit_and_recovers_by_generation() {
+    let pool = connect_test_pool().await;
+    reset_public_schema(&pool).await;
+    run_migrations(&pool)
+        .await
+        .expect("apply migrations through operator audit 0034");
+
+    let community_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+        .bind(community_id)
+        .bind(format!("operator-audit-{}.example", community_id.simple()))
+        .execute(&pool)
+        .await
+        .expect("insert operator audit community");
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes, \
+          restrictive_reserve_events,restrictive_reserve_bytes) \
+         VALUES ($1,4,4096,512,1,512)",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect("install bounded operator audit capacity");
+
+    for ordinal in 1..=3_u8 {
+        insert_authenticated_event(&pool, community_id, ordinal)
+            .await
+            .expect("general event fits outside reserve");
+    }
+    let general_exhausted = insert_authenticated_event(&pool, community_id, 4)
+        .await
+        .expect_err("general event cannot consume restrictive reserve");
+    assert_eq!(
+        general_exhausted
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("authorization_event_capacity_exhausted")
+    );
+    insert_unresolved_denial(&pool, community_id)
+        .await
+        .expect("restrictive denial consumes reserved slot");
+
+    let generation: i64 =
+        sqlx::query_scalar("SELECT authorization_event_capacity_report_failure_v2($1,$2)")
+            .bind(community_id)
+            .bind(1_i16)
+            .fetch_one(&pool)
+            .await
+            .expect("latch audit failure");
+    assert_eq!(generation, 1);
+    let rewrite_unhealthy = sqlx::query(
+        "UPDATE authorization_event_capacity \
+         SET failure_code=2,failure_observed_at=failure_observed_at + interval '1 microsecond', \
+             updated_at=updated_at + interval '1 second' \
+         WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect_err("same-state failure metadata is immutable");
+    assert_eq!(
+        rewrite_unhealthy
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("authorization_event_capacity_monotonic_v2")
+    );
+    let recovered: bool =
+        sqlx::query_scalar("SELECT authorization_event_capacity_recover_v2($1,$2)")
+            .bind(community_id)
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("recover exact failure generation");
+    assert!(recovered);
+    let rewrite_healthy = sqlx::query(
+        "UPDATE authorization_event_capacity \
+         SET recovered_at=recovered_at + interval '1 microsecond', \
+             updated_at=updated_at + interval '1 second' \
+         WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect_err("same-state recovery metadata is immutable");
+    assert_eq!(
+        rewrite_healthy
+            .as_database_error()
+            .and_then(|error| error.constraint()),
+        Some("authorization_event_capacity_monotonic_v2")
+    );
+    let stale: bool = sqlx::query_scalar("SELECT authorization_event_capacity_recover_v2($1,$2)")
+        .bind(community_id)
+        .bind(generation)
+        .fetch_one(&pool)
+        .await
+        .expect("stale recovery is a closed false result");
+    assert!(!stale);
+
+    for expected_count in 1_i64..=3 {
+        let retained: i64 =
+            sqlx::query_scalar("SELECT authorization_operator_denial_bucket_record_v1($1,$2,$3)")
+                .bind(community_id)
+                .bind(4_i16)
+                .bind(6_i16)
+                .fetch_one(&pool)
+                .await
+                .expect("record fixed-cardinality denial bucket");
+        assert_eq!(retained, expected_count);
+    }
+    let bucket_rows: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM authorization_operator_denial_buckets WHERE community_id=$1",
+    )
+    .bind(community_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count bounded denial rows");
+    assert_eq!(bucket_rows, 1);
+}
+
+async fn insert_authenticated_event(
+    pool: &PgPool,
+    community_id: Uuid,
+    ordinal: u8,
+) -> std::result::Result<(), sqlx::Error> {
+    let operation_id = Uuid::new_v4();
+    let request_fingerprint = vec![ordinal; 32];
+    let actor_fingerprint = vec![ordinal.saturating_add(20); 32];
+    let mut transaction = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+          outcome_code,result_digest) VALUES ($1,$2,$3,11,$4,1,$5)",
+    )
+    .bind(community_id)
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .bind(&actor_fingerprint)
+    .bind(vec![ordinal.saturating_add(40); 32])
+    .execute(&mut *transaction)
+    .await?;
+    sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+          actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+          occurred_at,canonical_envelope,envelope_digest) \
+         VALUES ($1,$2,10,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind(&actor_fingerprint)
+    .bind(operation_id)
+    .bind(&request_fingerprint)
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![ordinal; 64])
+    .bind(vec![ordinal.saturating_add(60); 32])
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await
+}
+
+async fn insert_unresolved_denial(
+    pool: &PgPool,
+    community_id: Uuid,
+) -> std::result::Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+          actor_fingerprint,subject_fingerprint,operation_id,request_fingerprint, \
+          correlation_id,attempt_id,occurred_at,canonical_envelope,envelope_digest) \
+         VALUES ($1,$2,9,2,9,4,NULL,NULL,$3,NULL,$4,$5,transaction_timestamp(),$6,$7)",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![9_u8; 64])
+    .bind(vec![99_u8; 32])
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/buzz-db/src/migration/tests/migration_nip_fi_tests.rs
+++ b/crates/buzz-db/src/migration/tests/migration_nip_fi_tests.rs
@@ -389,6 +389,41 @@ async fn insert_binding(
     .expect("insert immutable binding generation")
 }
 
+async fn insert_lifecycle_event(
+    connection: &mut PgConnection,
+    community_id: Uuid,
+    operation_id: Uuid,
+    fingerprint: &[u8],
+    outcome_code: i16,
+    envelope_byte: u8,
+) {
+    sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+          actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+          occurred_at,canonical_envelope,envelope_digest) \
+         SELECT $1,$2,CASE receipt.operation_kind \
+             WHEN 1 THEN 1 WHEN 2 THEN 1 WHEN 3 THEN 6 WHEN 4 THEN 7 \
+             WHEN 5 THEN 2 WHEN 6 THEN 3 WHEN 7 THEN 4 WHEN 8 THEN 5 WHEN 9 THEN 8 \
+         END,$3,1,1,receipt.actor_fingerprint,$4,$5,$6,$7,transaction_timestamp(),$8,$9 \
+         FROM authorization_operation_receipts receipt \
+         WHERE receipt.community_id=$1 AND receipt.operation_id=$4 \
+           AND receipt.operation_kind BETWEEN 1 AND 9",
+    )
+    .bind(community_id)
+    .bind(Uuid::new_v4())
+    .bind(outcome_code)
+    .bind(operation_id)
+    .bind(fingerprint)
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![envelope_byte; 32])
+    .bind(vec![214_u8; 32])
+    .execute(&mut *connection)
+    .await
+    .expect("insert lifecycle audit event");
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn insert_history(
     connection: &mut PgConnection,
@@ -431,9 +466,19 @@ async fn insert_history(
     .bind(operation_id)
     .bind(fingerprint)
     .bind(vec![212_u8; 32])
-    .execute(connection)
+    .execute(&mut *connection)
     .await
     .expect("insert canonical lifecycle transition");
+
+    insert_lifecycle_event(
+        connection,
+        community_id,
+        operation_id,
+        fingerprint,
+        outcome_code,
+        transition_kind as u8,
+    )
+    .await;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -728,6 +773,8 @@ async fn assert_race_loser_has_no_residue(pool: &PgPool, community_id: Uuid, ope
             (SELECT count(*) FROM identity_lifecycle_selectors \
              WHERE community_id=$1 AND selected_by_operation_id=$2) + \
             (SELECT count(*) FROM identity_lifecycle_selector_consumptions \
+             WHERE community_id=$1 AND operation_id=$2) + \
+            (SELECT count(*) FROM authorization_events \
              WHERE community_id=$1 AND operation_id=$2)",
     )
     .bind(community_id)
@@ -1193,6 +1240,15 @@ async fn nip_fi_direct_final_catalog_and_behavior() {
         .expect_err("V1 hard audit-capacity ceiling must reject oversized policy");
         assert_eq!(constraint(&error), Some(expected_constraint));
     }
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+         VALUES ($1,10000,16777216,16384)",
+    )
+    .bind(community_id)
+    .execute(&pool)
+    .await
+    .expect("install direct-final audit capacity");
 
     // Both transaction orderings are exercised for every closed selector
     // class. The waiter is observed in PostgreSQL's advisory wait state, the
@@ -1964,6 +2020,15 @@ async fn nip_fi_direct_final_catalog_and_behavior() {
             outcome_code,
         )
         .await;
+        insert_lifecycle_event(
+            &mut missing_history,
+            community_id,
+            operation_id,
+            &fingerprint,
+            outcome_code,
+            105_u8.wrapping_add(outcome_code as u8),
+        )
+        .await;
         let error = (&mut *missing_history)
             .execute("SET CONSTRAINTS ALL IMMEDIATE")
             .await
@@ -1988,6 +2053,15 @@ async fn nip_fi_direct_final_catalog_and_behavior() {
         &denied_fingerprint,
         3,
         2,
+    )
+    .await;
+    insert_lifecycle_event(
+        &mut denied,
+        community_id,
+        denied_operation,
+        &denied_fingerprint,
+        2,
+        109,
     )
     .await;
     (&mut *denied)
@@ -2045,6 +2119,15 @@ async fn nip_fi_direct_final_catalog_and_behavior() {
         &rollback_fingerprint,
         3,
         1,
+    )
+    .await;
+    insert_lifecycle_event(
+        &mut rollback,
+        community_id,
+        rollback_operation,
+        &rollback_fingerprint,
+        1,
+        113,
     )
     .await;
     sqlx::query(

--- a/crates/buzz-db/src/moderation.rs
+++ b/crates/buzz-db/src/moderation.rs
@@ -15,7 +15,7 @@
 //! through the integration thread.
 
 use chrono::{DateTime, Utc};
-use sqlx::{PgPool, Row as _};
+use sqlx::{PgPool, Postgres, Row as _, Transaction};
 use uuid::Uuid;
 
 use crate::error::Result;
@@ -208,6 +208,49 @@ pub async fn insert_report(
     Ok(row.try_get("id")?)
 }
 
+/// Insert a report inside a caller-owned transaction.
+///
+/// Protected callers use this variant so the report and its canonical
+/// authorization receipt can share one commit boundary.
+pub async fn insert_report_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    report: NewReport<'_>,
+) -> Result<Uuid> {
+    let (target_kind, target_event_id, target_pubkey, target_blob_sha256) = match &report.target {
+        ReportTarget::Event(id) => ("event", Some(id.as_slice()), None, None),
+        ReportTarget::Pubkey(pubkey) => ("pubkey", None, Some(pubkey.as_slice()), None),
+        ReportTarget::Blob(sha256) => ("blob", None, None, Some(sha256.as_slice())),
+    };
+
+    let row = sqlx::query(
+        r#"
+        INSERT INTO moderation_reports (
+            community_id, report_event_id, reporter_pubkey, target_kind,
+            target_event_id, target_pubkey, target_blob_sha256, channel_id,
+            report_type, note
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (community_id, report_event_id) DO UPDATE SET
+            report_event_id = EXCLUDED.report_event_id
+        RETURNING id
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report.report_event_id)
+    .bind(report.reporter_pubkey)
+    .bind(target_kind)
+    .bind(target_event_id)
+    .bind(target_pubkey)
+    .bind(target_blob_sha256)
+    .bind(report.channel_id)
+    .bind(report.report_type)
+    .bind(report.note)
+    .fetch_one(&mut **transaction)
+    .await?;
+
+    Ok(row.try_get("id")?)
+}
+
 /// List reports for the moderation queue, newest first.
 /// `status = None` lists all; `Some("open")` etc. filters.
 pub async fn list_reports(
@@ -282,6 +325,31 @@ pub async fn get_report_by_event(
     row.map(row_to_report).transpose()
 }
 
+/// Lock and fetch a report by signed event id inside a caller-owned
+/// transaction.
+pub async fn get_report_by_event_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    report_event_id: &[u8],
+) -> Result<Option<ReportRecord>> {
+    let row = sqlx::query(
+        r#"
+        SELECT id, report_event_id, reporter_pubkey, target_kind, target_event_id,
+               target_pubkey, target_blob_sha256, channel_id, report_type, note,
+               status, resolved_by, resolved_at, action_id, created_at
+        FROM moderation_reports
+        WHERE community_id = $1 AND report_event_id = $2
+        FOR UPDATE
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report_event_id)
+    .fetch_optional(&mut **transaction)
+    .await?;
+
+    row.map(row_to_report).transpose()
+}
+
 /// Mark a report resolved/dismissed/escalated, linking the audit action.
 /// Returns `false` if the report was not found or already closed.
 pub async fn resolve_report(
@@ -305,6 +373,33 @@ pub async fn resolve_report(
     .bind(resolved_by)
     .bind(action_id)
     .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Resolve a report inside a caller-owned transaction.
+pub async fn resolve_report_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    report_id: Uuid,
+    status: &str,
+    resolved_by: &[u8],
+    action_id: Option<Uuid>,
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE moderation_reports
+        SET status = $3, resolved_by = $4, resolved_at = now(), action_id = $5
+        WHERE community_id = $1 AND id = $2 AND status = 'open'
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(report_id)
+    .bind(status)
+    .bind(resolved_by)
+    .bind(action_id)
+    .execute(&mut **transaction)
     .await?;
 
     Ok(result.rows_affected() > 0)
@@ -343,6 +438,38 @@ pub async fn ban_member(
     Ok(())
 }
 
+/// Upsert a ban inside a caller-owned transaction.
+pub async fn ban_member_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+    reason: Option<&str>,
+    expires_at: Option<DateTime<Utc>>,
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO community_bans (
+            community_id, pubkey, banned, ban_expires_at, ban_reason, actor_pubkey
+        ) VALUES ($1, $2, true, $3, $4, $5)
+        ON CONFLICT (community_id, pubkey) DO UPDATE SET
+            banned = true,
+            ban_expires_at = EXCLUDED.ban_expires_at,
+            ban_reason = EXCLUDED.ban_reason,
+            actor_pubkey = EXCLUDED.actor_pubkey,
+            updated_at = now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(expires_at)
+    .bind(reason)
+    .bind(actor)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
 /// Lift a ban. Returns `false` if the member was not banned.
 pub async fn unban_member(
     pool: &PgPool,
@@ -364,6 +491,29 @@ pub async fn unban_member(
     .execute(pool)
     .await?;
 
+    Ok(result.rows_affected() > 0)
+}
+
+/// Lift a ban inside a caller-owned transaction.
+pub async fn unban_member_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE community_bans
+        SET banned = false, ban_expires_at = NULL, ban_reason = NULL,
+            actor_pubkey = $3, updated_at = now()
+        WHERE community_id = $1 AND pubkey = $2 AND banned = true
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(actor)
+    .execute(&mut **transaction)
+    .await?;
     Ok(result.rows_affected() > 0)
 }
 
@@ -399,6 +549,37 @@ pub async fn timeout_member(
     Ok(())
 }
 
+/// Upsert a timeout inside a caller-owned transaction.
+pub async fn timeout_member_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+    muted_until: DateTime<Utc>,
+    reason: Option<&str>,
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO community_bans (
+            community_id, pubkey, muted_until, mute_reason, actor_pubkey
+        ) VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (community_id, pubkey) DO UPDATE SET
+            muted_until = EXCLUDED.muted_until,
+            mute_reason = EXCLUDED.mute_reason,
+            actor_pubkey = EXCLUDED.actor_pubkey,
+            updated_at = now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(muted_until)
+    .bind(reason)
+    .bind(actor)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
 /// Clear a timeout early. Returns `false` if the member was not timed out.
 pub async fn untimeout_member(
     pool: &PgPool,
@@ -420,6 +601,29 @@ pub async fn untimeout_member(
     .execute(pool)
     .await?;
 
+    Ok(result.rows_affected() > 0)
+}
+
+/// Clear a timeout inside a caller-owned transaction.
+pub async fn untimeout_member_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    pubkey: &[u8],
+    actor: &[u8],
+) -> Result<bool> {
+    let result = sqlx::query(
+        r#"
+        UPDATE community_bans
+        SET muted_until = NULL, mute_reason = NULL,
+            actor_pubkey = $3, updated_at = now()
+        WHERE community_id = $1 AND pubkey = $2 AND muted_until > now()
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .bind(actor)
+    .execute(&mut **transaction)
+    .await?;
     Ok(result.rows_affected() > 0)
 }
 
@@ -457,6 +661,43 @@ pub async fn restriction_state(
     .fetch_optional(pool)
     .await?;
 
+    match row {
+        Some(row) => Ok(RestrictionState {
+            banned: row.try_get("banned")?,
+            muted_until: row.try_get("muted_until")?,
+        }),
+        None => Ok(RestrictionState::default()),
+    }
+}
+
+/// Fetch and share-lock current restriction state inside a caller-owned
+/// transaction.
+///
+/// The table lock closes the absent-row race: an actor with no restriction row
+/// cannot be concurrently banned between this recheck and the protected
+/// moderation commit.
+pub async fn restriction_state_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    pubkey: &[u8],
+) -> Result<RestrictionState> {
+    sqlx::query("LOCK TABLE community_bans IN SHARE ROW EXCLUSIVE MODE")
+        .execute(&mut **transaction)
+        .await?;
+    let row = sqlx::query(
+        r#"
+        SELECT
+            (banned AND (ban_expires_at IS NULL OR ban_expires_at > now())) AS banned,
+            CASE WHEN muted_until > now() THEN muted_until ELSE NULL END AS muted_until
+        FROM community_bans
+        WHERE community_id = $1 AND pubkey = $2
+        FOR SHARE
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(pubkey)
+    .fetch_optional(&mut **transaction)
+    .await?;
     match row {
         Some(row) => Ok(RestrictionState {
             banned: row.try_get("banned")?,
@@ -542,6 +783,36 @@ pub async fn insert_action(
     .fetch_one(pool)
     .await?;
 
+    Ok(row.try_get("id")?)
+}
+
+/// Insert a moderation audit row inside a caller-owned transaction.
+pub async fn insert_action_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    community: CommunityId,
+    action: NewAction<'_>,
+) -> Result<Uuid> {
+    let row = sqlx::query(
+        r#"
+        INSERT INTO moderation_actions (
+            community_id, actor_pubkey, action, target_pubkey, target_event_id,
+            channel_id, reason_code, public_reason, private_reason, matched_principal
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING id
+        "#,
+    )
+    .bind(community.as_uuid())
+    .bind(action.actor_pubkey)
+    .bind(action.action)
+    .bind(action.target_pubkey)
+    .bind(action.target_event_id)
+    .bind(action.channel_id)
+    .bind(action.reason_code)
+    .bind(action.public_reason)
+    .bind(action.private_reason)
+    .bind(action.matched_principal)
+    .fetch_one(&mut **transaction)
+    .await?;
     Ok(row.try_get("id")?)
 }
 
@@ -890,5 +1161,931 @@ mod tests {
                 .expect("second resolve"),
             "second resolve should return false once the report is closed"
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn moderation_state_and_audit_rollback_together() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let target = random_32();
+        let actor = random_32();
+        let mut transaction = pool.begin().await.expect("begin transaction");
+
+        ban_member_tx(
+            &mut transaction,
+            community,
+            &target,
+            &actor,
+            Some("rollback"),
+            None,
+        )
+        .await
+        .expect("stage ban");
+        insert_action_tx(
+            &mut transaction,
+            community,
+            NewAction {
+                actor_pubkey: &actor,
+                action: "ban",
+                target_pubkey: Some(&target),
+                target_event_id: None,
+                channel_id: None,
+                reason_code: None,
+                public_reason: Some("rollback"),
+                private_reason: None,
+                matched_principal: None,
+            },
+        )
+        .await
+        .expect("stage audit");
+        transaction.rollback().await.expect("roll back transaction");
+
+        let restriction = restriction_state(&pool, community, &target)
+            .await
+            .expect("read restriction");
+        assert!(!restriction.banned, "rolled-back ban must not be visible");
+        assert!(
+            list_actions(&pool, community, 10)
+                .await
+                .expect("list actions")
+                .iter()
+                .all(|row| row.target_pubkey.as_deref() != Some(target.as_slice())),
+            "rolled-back audit row must not be visible"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn moderation_effect_receipt_claim_and_audit_share_one_rollback_boundary() {
+        let pool = setup_pool().await;
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply protected-authority migration");
+        let community = make_test_community(&pool).await;
+        let actor = random_32();
+        let retain_until = Utc::now() + Duration::minutes(5);
+
+        // An application-effect error after state, receipt, and claim staging
+        // leaves none of them committed.
+        let effect_operation = Uuid::new_v4();
+        let effect_request = random_32();
+        let effect_claim = random_32();
+        let effect_target = random_32();
+        let mut effect_tx = pool.begin().await.expect("begin effect failure");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(effect_operation)
+        .bind(&effect_request)
+        .bind(&actor)
+        .bind(random_32())
+        .execute(&mut *effect_tx)
+        .await
+        .expect("stage effect receipt");
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(community.as_uuid())
+        .bind(&effect_claim)
+        .bind(retain_until)
+        .execute(&mut *effect_tx)
+        .await
+        .expect("stage effect replay claim");
+        ban_member_tx(
+            &mut effect_tx,
+            community,
+            &effect_target,
+            &actor,
+            Some("effect failure"),
+            None,
+        )
+        .await
+        .expect("stage effect state");
+        let failed_effect = insert_action_tx(
+            &mut effect_tx,
+            community,
+            NewAction {
+                actor_pubkey: &actor,
+                action: "not-a-moderation-action",
+                target_pubkey: Some(&effect_target),
+                target_event_id: None,
+                channel_id: None,
+                reason_code: None,
+                public_reason: None,
+                private_reason: None,
+                matched_principal: None,
+            },
+        )
+        .await;
+        assert!(failed_effect.is_err(), "invalid effect must abort");
+        effect_tx.rollback().await.expect("rollback failed effect");
+
+        let effect_receipts: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_operation_receipts \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(effect_operation)
+        .fetch_one(&pool)
+        .await
+        .expect("count effect receipts");
+        let effect_claims: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain = $1 AND claim_key = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(&effect_claim)
+        .fetch_one(&pool)
+        .await
+        .expect("count effect claims");
+        assert_eq!((effect_receipts, effect_claims), (0, 0));
+        assert!(
+            !restriction_state(&pool, community, &effect_target)
+                .await
+                .expect("read effect restriction")
+                .banned
+        );
+
+        // Exhaust the immutable authorization-audit budget, then prove the
+        // failed canonical audit append rolls moderation, receipt, and replay
+        // state back together.
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 1, 4, 4)",
+        )
+        .bind(community.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install one-event audit capacity");
+        let fill_operation = Uuid::new_v4();
+        let fill_request = random_32();
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(fill_operation)
+        .bind(&fill_request)
+        .bind(&actor)
+        .bind(random_32())
+        .execute(&pool)
+        .await
+        .expect("insert capacity-fill receipt");
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, actor_kind, \
+              actor_fingerprint, operation_id, request_fingerprint, correlation_id, \
+              attempt_id, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 10, 1, 1, 1, $3, $4, $5, $6, $7, \
+                     transaction_timestamp(), $8, $9)",
+        )
+        .bind(community.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(&actor)
+        .bind(fill_operation)
+        .bind(&fill_request)
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(vec![1_u8; 4])
+        .bind(random_32())
+        .execute(&pool)
+        .await
+        .expect("fill audit capacity");
+
+        let audit_operation = Uuid::new_v4();
+        let audit_request = random_32();
+        let audit_claim = random_32();
+        let audit_target = random_32();
+        let mut audit_tx = pool.begin().await.expect("begin exhausted audit effect");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(audit_operation)
+        .bind(&audit_request)
+        .bind(&actor)
+        .bind(random_32())
+        .execute(&mut *audit_tx)
+        .await
+        .expect("stage exhausted receipt");
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(community.as_uuid())
+        .bind(&audit_claim)
+        .bind(retain_until)
+        .execute(&mut *audit_tx)
+        .await
+        .expect("stage exhausted replay claim");
+        ban_member_tx(
+            &mut audit_tx,
+            community,
+            &audit_target,
+            &actor,
+            Some("audit exhausted"),
+            None,
+        )
+        .await
+        .expect("stage exhausted state");
+        insert_action_tx(
+            &mut audit_tx,
+            community,
+            NewAction {
+                actor_pubkey: &actor,
+                action: "ban",
+                target_pubkey: Some(&audit_target),
+                target_event_id: None,
+                channel_id: None,
+                reason_code: None,
+                public_reason: Some("audit exhausted"),
+                private_reason: None,
+                matched_principal: None,
+            },
+        )
+        .await
+        .expect("stage moderation audit");
+        let exhausted = sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, actor_kind, \
+              actor_fingerprint, operation_id, request_fingerprint, correlation_id, \
+              attempt_id, occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 10, 1, 1, 1, $3, $4, $5, $6, $7, \
+                     transaction_timestamp(), $8, $9)",
+        )
+        .bind(community.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(&actor)
+        .bind(audit_operation)
+        .bind(&audit_request)
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(vec![2_u8; 1])
+        .bind(random_32())
+        .execute(&mut *audit_tx)
+        .await;
+        assert!(exhausted.is_err(), "audit capacity must fail closed");
+        audit_tx
+            .rollback()
+            .await
+            .expect("rollback exhausted effect");
+        assert!(
+            !restriction_state(&pool, community, &audit_target)
+                .await
+                .expect("read exhausted restriction")
+                .banned
+        );
+        let exhausted_receipts: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_operation_receipts \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(audit_operation)
+        .fetch_one(&pool)
+        .await
+        .expect("count exhausted receipt");
+        let exhausted_claims: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain = $1 AND claim_key = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(&audit_claim)
+        .fetch_one(&pool)
+        .await
+        .expect("count exhausted claim");
+        assert_eq!((exhausted_receipts, exhausted_claims), (0, 0));
+
+        // A deferred commit-time target-link failure has the same rollback
+        // semantics; no post-commit action may run for this branch.
+        let commit_operation = Uuid::new_v4();
+        let commit_request = random_32();
+        let commit_claim = random_32();
+        let commit_target = random_32();
+        let commit_result = random_32();
+        let mut commit_tx = pool.begin().await.expect("begin commit failure");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(commit_operation)
+        .bind(&commit_request)
+        .bind(&actor)
+        .bind(&commit_result)
+        .execute(&mut *commit_tx)
+        .await
+        .expect("stage commit-failure receipt");
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(community.as_uuid())
+        .bind(&commit_claim)
+        .bind(retain_until)
+        .execute(&mut *commit_tx)
+        .await
+        .expect("stage commit-failure claim");
+        ban_member_tx(
+            &mut commit_tx,
+            community,
+            &commit_target,
+            &actor,
+            Some("commit failure"),
+            None,
+        )
+        .await
+        .expect("stage commit-failure state");
+        insert_action_tx(
+            &mut commit_tx,
+            community,
+            NewAction {
+                actor_pubkey: &actor,
+                action: "ban",
+                target_pubkey: Some(&commit_target),
+                target_event_id: None,
+                channel_id: None,
+                reason_code: None,
+                public_reason: Some("commit failure"),
+                private_reason: None,
+                matched_principal: None,
+            },
+        )
+        .await
+        .expect("stage commit-failure moderation audit");
+        sqlx::query(
+            "INSERT INTO protected_publication_projection_outbox \
+             (community_id, operation_id, request_fingerprint, \
+              publication_result_digest, object_kind, object_key, application_type, \
+              application_version, application_effect_digest, projection_kind, \
+              projection_key, staged_object_key, payload_digest) \
+             VALUES ($1, $2, $3, $4, 3, $5, decode(repeat('11', 32), 'hex'), \
+                     1, decode(repeat('12', 32), 'hex'), 3, $6, $7, $8)",
+        )
+        .bind(community.as_uuid())
+        .bind(commit_operation)
+        .bind(&commit_request)
+        .bind(&commit_result)
+        .bind(random_32())
+        .bind("repos/commit-failure/pointer")
+        .bind("manifests/commit-failure")
+        .bind(random_32())
+        .execute(&mut *commit_tx)
+        .await
+        .expect("stage deferred target-link failure");
+        assert!(
+            commit_tx.commit().await.is_err(),
+            "deferred target link must fail commit"
+        );
+        assert!(
+            !restriction_state(&pool, community, &commit_target)
+                .await
+                .expect("read commit-failure restriction")
+                .banned
+        );
+        let commit_receipts: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_operation_receipts \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(commit_operation)
+        .fetch_one(&pool)
+        .await
+        .expect("count commit-failure receipt");
+        let commit_claims: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain = $1 AND claim_key = $2",
+        )
+        .bind(community.as_uuid())
+        .bind(&commit_claim)
+        .fetch_one(&pool)
+        .await
+        .expect("count commit-failure claim");
+        assert_eq!((commit_receipts, commit_claims), (0, 0));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn concurrent_report_resolution_commits_one_audit_row() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let report_event_id = random_32();
+        let reporter = random_32();
+        let target_event_id = random_32();
+        let report_id = insert_report(
+            &pool,
+            community,
+            new_report(&report_event_id, &reporter, &target_event_id, None),
+        )
+        .await
+        .expect("insert report");
+
+        let resolve_once = |pool: PgPool, actor: Vec<u8>| {
+            let report_event_id = report_event_id.clone();
+            let target_event_id = target_event_id.clone();
+            async move {
+                let mut transaction = pool.begin().await.expect("begin resolver");
+                let report = get_report_by_event_tx(&mut transaction, community, &report_event_id)
+                    .await
+                    .expect("lock report")
+                    .expect("report exists");
+                if report.status != "open" {
+                    transaction.rollback().await.expect("rollback loser");
+                    return false;
+                }
+                let action_id = insert_action_tx(
+                    &mut transaction,
+                    community,
+                    NewAction {
+                        actor_pubkey: &actor,
+                        action: "dismiss_report",
+                        target_pubkey: None,
+                        target_event_id: Some(&target_event_id),
+                        channel_id: None,
+                        reason_code: None,
+                        public_reason: None,
+                        private_reason: None,
+                        matched_principal: None,
+                    },
+                )
+                .await
+                .expect("insert resolution audit");
+                let resolved = resolve_report_tx(
+                    &mut transaction,
+                    community,
+                    report.id,
+                    "dismissed",
+                    &actor,
+                    Some(action_id),
+                )
+                .await
+                .expect("resolve report");
+                transaction.commit().await.expect("commit resolver");
+                resolved
+            }
+        };
+
+        let (first, second) = tokio::join!(
+            resolve_once(pool.clone(), random_32()),
+            resolve_once(pool.clone(), random_32())
+        );
+        assert_ne!(first, second, "exactly one concurrent resolver must win");
+
+        let row = get_report(&pool, community, report_id)
+            .await
+            .expect("read report")
+            .expect("report exists");
+        let action_id = row.action_id.expect("winner action id");
+        let matching = list_actions(&pool, community, 20)
+            .await
+            .expect("list actions")
+            .into_iter()
+            .filter(|action| action.id == action_id)
+            .count();
+        assert_eq!(matching, 1, "one committed resolution has one audit row");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn proxy_nonce_claims_are_atomic_domain_scoped_and_exclusive() {
+        let pool = setup_pool().await;
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply nonce-claim migration");
+        let domain_a = make_test_community(&pool).await;
+        let domain_b = make_test_community(&pool).await;
+        let claim_key = random_32();
+        let retain_until = Utc::now() + Duration::minutes(5);
+
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&claim_key)
+        .bind(retain_until)
+        .execute(&pool)
+        .await
+        .expect("first claim commits");
+
+        let replay = sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&claim_key)
+        .bind(retain_until)
+        .execute(&pool)
+        .await;
+        assert!(replay.is_err(), "same-domain replay must be rejected");
+
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(domain_b.as_uuid())
+        .bind(&claim_key)
+        .bind(retain_until)
+        .execute(&pool)
+        .await
+        .expect("same opaque claim remains isolated across domains");
+
+        let expired_key = random_32();
+        let expired = sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, transaction_timestamp())",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&expired_key)
+        .execute(&pool)
+        .await;
+        assert!(expired.is_err(), "equality at retain_until is expired");
+
+        // Construct an exact equality row transactionally with only the stamp
+        // trigger disabled. The table CHECK remains active. This proves the
+        // deletion trigger retains through, not merely until, the boundary.
+        let equality_key = random_32();
+        let mut equality = pool.begin().await.expect("begin equality probe");
+        sqlx::query(
+            "ALTER TABLE authorization_proxy_nonce_claims \
+             DISABLE TRIGGER authorization_proxy_nonce_claims_stamp",
+        )
+        .execute(&mut *equality)
+        .await
+        .expect("disable insert stamp in rollback-only probe");
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, committed_at, retain_until) \
+             VALUES ($1, 1, $2, transaction_timestamp() - INTERVAL '1 second', \
+                     transaction_timestamp())",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&equality_key)
+        .execute(&mut *equality)
+        .await
+        .expect("insert exact-boundary probe row");
+        sqlx::query(
+            "ALTER TABLE authorization_proxy_nonce_claims \
+             ENABLE TRIGGER authorization_proxy_nonce_claims_stamp",
+        )
+        .execute(&mut *equality)
+        .await
+        .expect("restore insert stamp in probe");
+        let equality_delete = sqlx::query(
+            "DELETE FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain = $1 AND claim_kind = 1 AND claim_key = $2",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&equality_key)
+        .execute(&mut *equality)
+        .await;
+        assert!(
+            equality_delete.is_err(),
+            "deletion at the exclusive retain_until equality must be rejected"
+        );
+        equality.rollback().await.expect("rollback equality probe");
+
+        let rolled_back_key = random_32();
+        let mut transaction = pool.begin().await.expect("begin claim transaction");
+        sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&rolled_back_key)
+        .bind(retain_until)
+        .execute(&mut *transaction)
+        .await
+        .expect("stage claim");
+        transaction.rollback().await.expect("rollback admission");
+        let rolled_back_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM authorization_proxy_nonce_claims \
+             WHERE authorization_domain = $1 AND claim_kind = 1 AND claim_key = $2",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&rolled_back_key)
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back claim");
+        assert_eq!(rolled_back_count, 0, "rollback must not consume the claim");
+
+        let unavailable_key = random_32();
+        let mut unavailable = pool.begin().await.expect("begin unavailable probe");
+        sqlx::query("SET LOCAL search_path = pg_catalog")
+            .execute(&mut *unavailable)
+            .await
+            .expect("isolate dependency");
+        let dependency_failure = sqlx::query(
+            "INSERT INTO authorization_proxy_nonce_claims \
+             (authorization_domain, claim_kind, claim_key, retain_until) \
+             VALUES ($1, 1, $2, $3)",
+        )
+        .bind(domain_a.as_uuid())
+        .bind(&unavailable_key)
+        .bind(retain_until)
+        .execute(&mut *unavailable)
+        .await;
+        assert!(
+            dependency_failure.is_err(),
+            "unreadable claim storage must fail closed"
+        );
+        unavailable.rollback().await.expect("rollback failed probe");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn protected_projection_outbox_is_target_bound_ordered_and_idempotent() {
+        let pool = setup_pool().await;
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply projection-outbox migration");
+        let community = make_test_community(&pool).await;
+        let object_key = random_32();
+        let projection_key = format!("repos/{}/pointer", Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 32, 1048576, 16384)",
+        )
+        .bind(community.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install outbox-test audit capacity");
+
+        let seed = stage_publication_admission(&pool, community, &object_key, 1, false)
+            .await
+            .expect("stage seed admission");
+        sqlx::query(
+            "INSERT INTO authorization_authority_epochs \
+             (community_id, object_kind, object_key, authority_epoch, fence, \
+              operation_id, request_fingerprint) \
+             VALUES ($1, 3, $2, 7, $3, $4, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(&object_key)
+        .bind(random_32())
+        .bind(seed.operation)
+        .bind(&seed.request)
+        .execute(&pool)
+        .await
+        .expect("install unchanged same-epoch authority row");
+
+        let first = stage_publication_admission(&pool, community, &object_key, 2, true);
+        let second = stage_publication_admission(&pool, community, &object_key, 3, true);
+        let (first, second) = tokio::join!(first, second);
+        let first = first.expect("first concurrent same-epoch publication");
+        let second = second.expect("second concurrent same-epoch publication");
+
+        let first_projection =
+            insert_projection(&pool, community, &first, &object_key, &projection_key);
+        let second_projection =
+            insert_projection(&pool, community, &second, &object_key, &projection_key);
+        let (first_projection, second_projection) =
+            tokio::join!(first_projection, second_projection);
+        first_projection.expect("insert first concurrent same-epoch projection");
+        second_projection.expect("insert second concurrent same-epoch projection");
+
+        let rows: Vec<(Uuid, i64)> = sqlx::query_as(
+            "SELECT operation_id, publication_sequence \
+             FROM protected_publication_projection_outbox \
+             WHERE community_id = $1 AND object_kind = 3 AND object_key = $2 \
+               AND projection_kind = 3 AND projection_key = $3 \
+             ORDER BY publication_sequence",
+        )
+        .bind(community.as_uuid())
+        .bind(&object_key)
+        .bind(&projection_key)
+        .fetch_all(&pool)
+        .await
+        .expect("read concurrent publication order");
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0].0, rows[1].0);
+        assert!(rows[0].1 < rows[1].1);
+
+        let stale_delivery = sqlx::query(
+            "UPDATE protected_publication_projection_outbox \
+             SET delivery_state = 2, attempt_count = 1, failure_code = 0 \
+             WHERE community_id = $1 AND operation_id = $2 AND projection_kind = 3",
+        )
+        .bind(community.as_uuid())
+        .bind(rows[1].0)
+        .execute(&pool)
+        .await;
+        assert!(
+            stale_delivery.is_err(),
+            "newer concurrent version is fenced"
+        );
+        for (operation, _) in &rows {
+            sqlx::query(
+                "UPDATE protected_publication_projection_outbox \
+                 SET delivery_state = 2, attempt_count = 1, failure_code = 0 \
+                 WHERE community_id = $1 AND operation_id = $2 AND projection_kind = 3",
+            )
+            .bind(community.as_uuid())
+            .bind(operation)
+            .execute(&pool)
+            .await
+            .expect("deliver concurrent versions in database order");
+        }
+
+        let duplicate =
+            insert_projection(&pool, community, &first, &object_key, &projection_key).await;
+        assert!(
+            duplicate.is_err(),
+            "exact replay cannot duplicate an outbox effect"
+        );
+
+        let mismatch = stage_publication_admission(&pool, community, &object_key, 4, true)
+            .await
+            .expect("stage mismatch admission");
+        let mut mismatch_tx = pool.begin().await.expect("begin mismatch projection");
+        sqlx::query(
+            "INSERT INTO protected_publication_projection_outbox \
+             (community_id, operation_id, request_fingerprint, publication_result_digest, \
+              object_kind, object_key, application_type, application_version, \
+              application_effect_digest, projection_kind, projection_key, \
+              staged_object_key, payload_digest) \
+             VALUES ($1, $2, $3, $4, 3, $5, $6, 1, $7, 3, $8, $9, $10)",
+        )
+        .bind(community.as_uuid())
+        .bind(mismatch.operation)
+        .bind(&mismatch.request)
+        .bind(&mismatch.application_result)
+        .bind(&object_key)
+        .bind(&mismatch.application_type)
+        .bind(random_32())
+        .bind(format!("{projection_key}/mismatch"))
+        .bind("manifests/mismatch")
+        .bind(random_32())
+        .execute(&mut *mismatch_tx)
+        .await
+        .expect("stage deferred effect mismatch");
+        assert!(
+            mismatch_tx.commit().await.is_err(),
+            "application effect mismatch must fail deferred binding"
+        );
+
+        let lower = stage_publication_admission(&pool, community, &object_key, 5, false)
+            .await
+            .expect("stage receipt rejected before an admission result");
+        let mut lower_tx = pool.begin().await.expect("begin lower-epoch projection");
+        sqlx::query(
+            "INSERT INTO protected_publication_projection_outbox \
+             (community_id, operation_id, request_fingerprint, publication_result_digest, \
+              object_kind, object_key, application_type, application_version, \
+              application_effect_digest, projection_kind, projection_key, \
+              staged_object_key, payload_digest) \
+             VALUES ($1, $2, $3, $4, 3, $5, $6, 1, $7, 3, $8, $9, $10)",
+        )
+        .bind(community.as_uuid())
+        .bind(lower.operation)
+        .bind(&lower.request)
+        .bind(&lower.application_result)
+        .bind(&object_key)
+        .bind(&lower.application_type)
+        .bind(&lower.application_effect)
+        .bind(format!("{projection_key}/lower"))
+        .bind("manifests/lower")
+        .bind(random_32())
+        .execute(&mut *lower_tx)
+        .await
+        .expect("stage lower-epoch projection without admitted result");
+        assert!(
+            lower_tx.commit().await.is_err(),
+            "a lower-epoch denial without a committed admission result cannot publish"
+        );
+    }
+
+    struct PublicationAdmissionFixture {
+        operation: Uuid,
+        request: Vec<u8>,
+        application_type: Vec<u8>,
+        application_effect: Vec<u8>,
+        application_result: Vec<u8>,
+        payload: Vec<u8>,
+    }
+
+    async fn stage_publication_admission(
+        pool: &PgPool,
+        community: CommunityId,
+        object_key: &[u8],
+        marker: u8,
+        include_admission_result: bool,
+    ) -> std::result::Result<PublicationAdmissionFixture, sqlx::Error> {
+        let fixture = PublicationAdmissionFixture {
+            operation: Uuid::new_v4(),
+            request: vec![marker.saturating_add(10); 32],
+            application_type: vec![marker.saturating_add(20); 32],
+            application_effect: vec![marker.saturating_add(30); 32],
+            application_result: vec![marker.saturating_add(40); 32],
+            payload: vec![marker.saturating_add(50); 32],
+        };
+        let mut transaction = pool.begin().await?;
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id, operation_id, request_fingerprint, operation_kind, \
+              actor_fingerprint, outcome_code, result_digest) \
+             VALUES ($1, $2, $3, 11, $4, 1, $5)",
+        )
+        .bind(community.as_uuid())
+        .bind(fixture.operation)
+        .bind(&fixture.request)
+        .bind(vec![marker.saturating_add(60); 32])
+        .bind(vec![marker.saturating_add(70); 32])
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id, event_id, event_kind, outcome_code, reason_code, actor_kind, \
+              actor_fingerprint, operation_id, request_fingerprint, correlation_id, attempt_id, \
+              occurred_at, canonical_envelope, envelope_digest) \
+             VALUES ($1, $2, 10, 1, 1, 1, $3, $4, $5, $6, $7, \
+                     transaction_timestamp(), $8, $9)",
+        )
+        .bind(community.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(vec![marker.saturating_add(60); 32])
+        .bind(fixture.operation)
+        .bind(&fixture.request)
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(vec![marker])
+        .bind(vec![marker.saturating_add(80); 32])
+        .execute(&mut *transaction)
+        .await?;
+        if include_admission_result {
+            sqlx::query(
+                "INSERT INTO authorization_admission_results \
+                 (community_id, operation_id, request_fingerprint, semantic_fingerprint, \
+                  object_kind, object_key, application_type, application_version, \
+                  application_code, application_payload, application_intent_digest, \
+                  application_effect_digest, application_result_digest) \
+                 VALUES ($1, $2, $3, $4, 3, $5, $6, 1, 1, $7, $8, $9, $10)",
+            )
+            .bind(community.as_uuid())
+            .bind(fixture.operation)
+            .bind(&fixture.request)
+            .bind(vec![marker.saturating_add(90); 32])
+            .bind(object_key)
+            .bind(&fixture.application_type)
+            .bind(vec![marker])
+            .bind(vec![marker.saturating_add(100); 32])
+            .bind(&fixture.application_effect)
+            .bind(&fixture.application_result)
+            .execute(&mut *transaction)
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(fixture)
+    }
+
+    async fn insert_projection(
+        pool: &PgPool,
+        community: CommunityId,
+        fixture: &PublicationAdmissionFixture,
+        object_key: &[u8],
+        projection_key: &str,
+    ) -> std::result::Result<sqlx::postgres::PgQueryResult, sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO protected_publication_projection_outbox \
+             (community_id, operation_id, request_fingerprint, publication_result_digest, \
+              object_kind, object_key, application_type, application_version, \
+              application_effect_digest, projection_kind, projection_key, \
+              staged_object_key, payload_digest) \
+             VALUES ($1, $2, $3, $4, 3, $5, $6, 1, $7, 3, $8, $9, $10)",
+        )
+        .bind(community.as_uuid())
+        .bind(fixture.operation)
+        .bind(&fixture.request)
+        .bind(&fixture.application_result)
+        .bind(object_key)
+        .bind(&fixture.application_type)
+        .bind(&fixture.application_effect)
+        .bind(projection_key)
+        .bind(format!("manifests/{}", fixture.operation))
+        .bind(&fixture.payload)
+        .execute(pool)
+        .await
     }
 }

--- a/crates/buzz-db/src/operator_lifecycle.rs
+++ b/crates/buzz-db/src/operator_lifecycle.rs
@@ -1,0 +1,3754 @@
+//! Closed deployment-operator lifecycle intent contract.
+//!
+//! This module contains no actor minting, database writer, restore fence,
+//! lifecycle mutation, or caller-supplied fingerprint constructor. The relay
+//! may parse bounded request coordinates into an opaque intent; only the
+//! origin-sealed verifier grant and canonical database transition added by the
+//! operation-specific restore boundary may authorize it.
+//!
+//! Raw intent fields and the internal transition plan are not public:
+//!
+//! ```compile_fail
+//! use buzz_db::operator_lifecycle::OperatorLifecycleIntent;
+//! let _ = OperatorLifecycleIntent {};
+//! ```
+//!
+//! Exact binding coordinates are constructor-validated and remain opaque:
+//!
+//! ```compile_fail
+//! use buzz_db::operator_lifecycle::ExactActiveOperatorTarget;
+//! let _ = ExactActiveOperatorTarget {};
+//! ```
+
+use std::fmt;
+
+use buzz_auth::operator_lifecycle::{OperatorLifecycleAction, VerifiedOperatorLifecycleGrant};
+use buzz_core::CommunityId;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use sqlx::{Postgres, Row, Transaction};
+use uuid::Uuid;
+
+use crate::authorization_events::{
+    record_authorization_event_tx, record_authorization_operation_receipt_tx,
+    AuthorizationEventActor, AuthorizationEventKind, AuthorizationEventOutcome,
+    AuthorizationEventWriteError, AuthorizationOperationKind, AuthorizationOperationOutcome,
+    AuthorizationOperationReceipt, AuthorizationReasonCode, AuthorizationReceiptWrite,
+    NewAuthorizationEvent,
+};
+use crate::lifecycle_invalidation::{
+    advance_lifecycle_invalidation_tx, LifecycleInvalidationError, LifecycleInvalidationNotice,
+    LifecycleInvalidationSelector,
+};
+use crate::{Db, DbError};
+
+const MAX_OPERATOR_PROVISION_BODY_BYTES: usize = 64 * 1024;
+
+/// Closed failures shared by request parsing and the later canonical executor.
+#[derive(Debug, thiserror::Error)]
+pub enum OperatorLifecycleError {
+    /// The bounded request coordinates were invalid.
+    #[error("invalid operator lifecycle request")]
+    InvalidRequest,
+    /// The verifier grant or locked lifecycle state denied the transition.
+    #[error("operator lifecycle authorization denied")]
+    AuthorizationDenied,
+    /// The operation id is already bound to different canonical semantics.
+    #[error("operator lifecycle operation intent conflict")]
+    IntentConflict,
+    /// Required authorization audit evidence could not be committed.
+    #[error("operator lifecycle audit unavailable")]
+    AuditUnavailable,
+    /// Stored immutable canonical evidence was inconsistent.
+    #[error("operator lifecycle stored result is corrupt")]
+    CorruptStoredResult,
+    /// Ordinary database failure; the canonical transaction did not commit.
+    #[error("operator lifecycle storage unavailable")]
+    Storage(#[source] DbError),
+}
+
+/// Atomic result of the verified operator lifecycle transaction.
+pub enum OperatorLifecycleCommitOutcome {
+    /// The lifecycle transition, invalidation, receipt, and audit committed.
+    Committed {
+        /// Dispatchable only after this fresh transaction commits.
+        invalidation: LifecycleInvalidationNotice,
+    },
+    /// The exact operation was committed previously; no post-commit action runs.
+    ExactReplay,
+}
+
+impl fmt::Debug for OperatorLifecycleCommitOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Committed { .. } => "OperatorLifecycleCommitOutcome::Committed([REDACTED])",
+            Self::ExactReplay => "OperatorLifecycleCommitOutcome::ExactReplay",
+        })
+    }
+}
+
+impl From<DbError> for OperatorLifecycleError {
+    fn from(value: DbError) -> Self {
+        Self::Storage(value)
+    }
+}
+
+/// Redaction-safe operation identity parsed from the exact request body.
+#[derive(Clone, Copy)]
+pub struct OperatorLifecycleOperation {
+    community_id: CommunityId,
+    operation_id: Uuid,
+    correlation_id: Uuid,
+    attempt_id: Uuid,
+}
+
+impl OperatorLifecycleOperation {
+    /// Validate the server-resolved domain and bounded operation identifiers.
+    pub fn new(
+        community_id: CommunityId,
+        operation_id: Uuid,
+        correlation_id: Uuid,
+        attempt_id: Uuid,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if community_id.as_uuid().is_nil()
+            || operation_id.is_nil()
+            || correlation_id.is_nil()
+            || attempt_id.is_nil()
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(Self {
+            community_id,
+            operation_id,
+            correlation_id,
+            attempt_id,
+        })
+    }
+
+    /// Server-resolved authorization domain.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.community_id
+    }
+
+    /// Stable operation identity used by canonical idempotency.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    /// Redaction-safe correlation identity.
+    pub const fn correlation_id(&self) -> Uuid {
+        self.correlation_id
+    }
+
+    /// Unique delivery-attempt identity.
+    pub const fn attempt_id(&self) -> Uuid {
+        self.attempt_id
+    }
+}
+
+impl fmt::Debug for OperatorLifecycleOperation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OperatorLifecycleOperation([REDACTED])")
+    }
+}
+
+/// Exact immutable active binding generation named by a request.
+#[derive(Clone, Copy)]
+pub struct ExactActiveOperatorTarget {
+    binding_id: Uuid,
+    binding_version: u64,
+    expected_lifecycle_revision: u64,
+    principal_fingerprint: [u8; 32],
+    event_author_pubkey: [u8; 32],
+}
+
+impl ExactActiveOperatorTarget {
+    /// Validate an exact active generation (whose lifecycle revision is one).
+    pub fn new(
+        binding_id: Uuid,
+        binding_version: u64,
+        expected_lifecycle_revision: u64,
+        principal_fingerprint: [u8; 32],
+        event_author_pubkey: [u8; 32],
+    ) -> Result<Self, OperatorLifecycleError> {
+        if binding_id.is_nil()
+            || binding_version == 0
+            || expected_lifecycle_revision != 1
+            || principal_fingerprint == [0; 32]
+            || event_author_pubkey == [0; 32]
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(Self {
+            binding_id,
+            binding_version,
+            expected_lifecycle_revision,
+            principal_fingerprint,
+            event_author_pubkey,
+        })
+    }
+
+    /// Exact stable binding identifier.
+    pub const fn binding_id(&self) -> Uuid {
+        self.binding_id
+    }
+
+    /// Exact immutable binding version.
+    pub const fn binding_version(&self) -> u64 {
+        self.binding_version
+    }
+
+    /// Lifecycle revision required by the transition.
+    pub const fn expected_lifecycle_revision(&self) -> u64 {
+        self.expected_lifecycle_revision
+    }
+
+    /// Provider-free principal fingerprint.
+    pub const fn principal_fingerprint(&self) -> [u8; 32] {
+        self.principal_fingerprint
+    }
+
+    /// Exact event-author public key.
+    pub const fn event_author_pubkey(&self) -> [u8; 32] {
+        self.event_author_pubkey
+    }
+}
+
+impl fmt::Debug for ExactActiveOperatorTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ExactActiveOperatorTarget([REDACTED])")
+    }
+}
+
+/// Exact immutable retired binding generation named by recovery.
+#[derive(Clone, Copy)]
+pub struct ExactRetiredOperatorTarget {
+    binding_id: Uuid,
+    binding_version: u64,
+    expected_lifecycle_revision: u64,
+    principal_fingerprint: [u8; 32],
+    event_author_pubkey: [u8; 32],
+}
+
+impl ExactRetiredOperatorTarget {
+    /// Validate an exact retired generation (whose lifecycle revision is two).
+    pub fn new(
+        binding_id: Uuid,
+        binding_version: u64,
+        expected_lifecycle_revision: u64,
+        principal_fingerprint: [u8; 32],
+        event_author_pubkey: [u8; 32],
+    ) -> Result<Self, OperatorLifecycleError> {
+        if binding_id.is_nil()
+            || binding_version == 0
+            || expected_lifecycle_revision != 2
+            || principal_fingerprint == [0; 32]
+            || event_author_pubkey == [0; 32]
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(Self {
+            binding_id,
+            binding_version,
+            expected_lifecycle_revision,
+            principal_fingerprint,
+            event_author_pubkey,
+        })
+    }
+
+    /// Exact stable binding identifier.
+    pub const fn binding_id(&self) -> Uuid {
+        self.binding_id
+    }
+
+    /// Exact immutable binding version.
+    pub const fn binding_version(&self) -> u64 {
+        self.binding_version
+    }
+
+    /// Lifecycle revision required by recovery.
+    pub const fn expected_lifecycle_revision(&self) -> u64 {
+        self.expected_lifecycle_revision
+    }
+
+    /// Provider-free principal fingerprint.
+    pub const fn principal_fingerprint(&self) -> [u8; 32] {
+        self.principal_fingerprint
+    }
+
+    /// Exact retired event-author public key.
+    pub const fn event_author_pubkey(&self) -> [u8; 32] {
+        self.event_author_pubkey
+    }
+}
+
+impl fmt::Debug for ExactRetiredOperatorTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ExactRetiredOperatorTarget([REDACTED])")
+    }
+}
+
+/// Exact immutable open pending-replacement fact named by recovery.
+#[derive(Clone, Copy)]
+pub struct ExpectedOperatorPendingReplacement {
+    target: ExactRetiredOperatorTarget,
+    fact_generation: u64,
+}
+
+impl ExpectedOperatorPendingReplacement {
+    /// Bind a retired generation to its exact open pending-fact generation.
+    pub fn new(
+        target: ExactRetiredOperatorTarget,
+        fact_generation: u64,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if fact_generation == 0 {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(Self {
+            target,
+            fact_generation,
+        })
+    }
+
+    /// Exact retired target bound to this pending fact.
+    pub const fn target(&self) -> ExactRetiredOperatorTarget {
+        self.target
+    }
+
+    /// Positive immutable pending-fact generation.
+    pub const fn fact_generation(&self) -> u64 {
+        self.fact_generation
+    }
+}
+
+impl fmt::Debug for ExpectedOperatorPendingReplacement {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ExpectedOperatorPendingReplacement([REDACTED])")
+    }
+}
+
+/// Requested successor key and exclusive expiry bound by replacement proof.
+#[derive(Clone, Copy)]
+pub struct RequestedOperatorReplacement {
+    event_author_pubkey: [u8; 32],
+    expires_at: DateTime<Utc>,
+}
+
+impl RequestedOperatorReplacement {
+    /// Validate bounded successor coordinates without asserting proof validity.
+    pub fn new(
+        event_author_pubkey: [u8; 32],
+        expires_at: DateTime<Utc>,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if event_author_pubkey == [0; 32] || expires_at.timestamp_micros() <= 0 {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(Self {
+            event_author_pubkey,
+            expires_at,
+        })
+    }
+
+    /// Requested successor event-author public key.
+    pub const fn event_author_pubkey(&self) -> [u8; 32] {
+        self.event_author_pubkey
+    }
+
+    /// Exclusive successor-proof expiry.
+    pub const fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+}
+
+impl fmt::Debug for RequestedOperatorReplacement {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RequestedOperatorReplacement([REDACTED])")
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum OperatorLifecyclePlan {
+    Retire {
+        target: ExactActiveOperatorTarget,
+    },
+    Disable {
+        principal_fingerprint: [u8; 32],
+        expected_active_binding: Option<ExactActiveOperatorTarget>,
+    },
+    Revoke {
+        event_author_pubkey: [u8; 32],
+        expected_active_binding: Option<ExactActiveOperatorTarget>,
+    },
+    Rotate {
+        target: ExactActiveOperatorTarget,
+        replacement: RequestedOperatorReplacement,
+    },
+    Recover {
+        pending: ExpectedOperatorPendingReplacement,
+        replacement: RequestedOperatorReplacement,
+    },
+    Enable {
+        principal_fingerprint: [u8; 32],
+        disabled_fact_generation: u64,
+        pending: ExpectedOperatorPendingReplacement,
+        replacement: RequestedOperatorReplacement,
+    },
+}
+
+/// Opaque bounded six-action intent accepted by the verified operator seam.
+///
+/// Constructors validate request shape only. They confer no authority: the
+/// later operation-specific restore boundary must exact-match this digest and
+/// every coordinate to an origin-sealed verifier grant and locked DB state.
+#[derive(Clone)]
+pub struct OperatorLifecycleIntent {
+    operation: OperatorLifecycleOperation,
+    expected_revision: u64,
+    action: OperatorLifecycleAction,
+    intent_digest: [u8; 32],
+    plan: OperatorLifecyclePlan,
+}
+
+impl OperatorLifecycleIntent {
+    /// Prepare exact active-pair retirement.
+    pub fn retire(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        target: ExactActiveOperatorTarget,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if expected_revision != target.expected_lifecycle_revision {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Retire,
+            OperatorLifecyclePlan::Retire { target },
+        )
+    }
+
+    /// Prepare exact principal disablement, with an optional active target.
+    pub fn disable(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        principal_fingerprint: [u8; 32],
+        expected_active_binding: Option<ExactActiveOperatorTarget>,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if principal_fingerprint == [0; 32]
+            || expected_active_binding.is_some_and(|target| {
+                target.principal_fingerprint != principal_fingerprint
+                    || target.expected_lifecycle_revision != expected_revision
+            })
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Disable,
+            OperatorLifecyclePlan::Disable {
+                principal_fingerprint,
+                expected_active_binding,
+            },
+        )
+    }
+
+    /// Prepare permanent event-author key revocation.
+    pub fn revoke(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        event_author_pubkey: [u8; 32],
+        expected_active_binding: Option<ExactActiveOperatorTarget>,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if event_author_pubkey == [0; 32]
+            || expected_active_binding.is_some_and(|target| {
+                target.event_author_pubkey != event_author_pubkey
+                    || target.expected_lifecycle_revision != expected_revision
+            })
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Revoke,
+            OperatorLifecyclePlan::Revoke {
+                event_author_pubkey,
+                expected_active_binding,
+            },
+        )
+    }
+
+    /// Prepare exact active-binding rotation.
+    pub fn rotate(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        target: ExactActiveOperatorTarget,
+        replacement: RequestedOperatorReplacement,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if expected_revision != target.expected_lifecycle_revision
+            || target.event_author_pubkey == replacement.event_author_pubkey
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Rotate,
+            OperatorLifecyclePlan::Rotate {
+                target,
+                replacement,
+            },
+        )
+    }
+
+    /// Prepare exact pending-lineage recovery.
+    pub fn recover(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        pending: ExpectedOperatorPendingReplacement,
+        replacement: RequestedOperatorReplacement,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if expected_revision != pending.fact_generation
+            || pending.target.event_author_pubkey == replacement.event_author_pubkey
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Recover,
+            OperatorLifecyclePlan::Recover {
+                pending,
+                replacement,
+            },
+        )
+    }
+
+    /// Prepare exact disabled-principal enablement from one immutable retired
+    /// binding generation and its exact open pending-replacement fact.
+    pub fn enable(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        principal_fingerprint: [u8; 32],
+        disabled_fact_generation: u64,
+        pending: ExpectedOperatorPendingReplacement,
+        replacement: RequestedOperatorReplacement,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if principal_fingerprint == [0; 32]
+            || disabled_fact_generation != expected_revision
+            || pending.target.principal_fingerprint != principal_fingerprint
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Self::seal(
+            operation,
+            expected_revision,
+            OperatorLifecycleAction::Enable,
+            OperatorLifecyclePlan::Enable {
+                principal_fingerprint,
+                disabled_fact_generation,
+                pending,
+                replacement,
+            },
+        )
+    }
+
+    fn seal(
+        operation: OperatorLifecycleOperation,
+        expected_revision: u64,
+        action: OperatorLifecycleAction,
+        plan: OperatorLifecyclePlan,
+    ) -> Result<Self, OperatorLifecycleError> {
+        if expected_revision == 0 {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        let intent_digest = operator_intent_digest(operation, expected_revision, action, &plan);
+        Ok(Self {
+            operation,
+            expected_revision,
+            action,
+            intent_digest,
+            plan,
+        })
+    }
+
+    /// Server-resolved authorization domain.
+    pub const fn authorization_domain(&self) -> CommunityId {
+        self.operation.community_id
+    }
+
+    /// Stable operation identity.
+    pub const fn operation_id(&self) -> Uuid {
+        self.operation.operation_id
+    }
+
+    /// Redaction-safe correlation identity.
+    pub const fn correlation_id(&self) -> Uuid {
+        self.operation.correlation_id
+    }
+
+    /// Unique delivery-attempt identity.
+    pub const fn attempt_id(&self) -> Uuid {
+        self.operation.attempt_id
+    }
+
+    /// Closed action from `buzz-auth`.
+    pub const fn action(&self) -> OperatorLifecycleAction {
+        self.action
+    }
+
+    /// Exact expected lifecycle revision or selector generation.
+    pub const fn expected_revision(&self) -> u64 {
+        self.expected_revision
+    }
+
+    /// Canonical semantic digest that every operator proof must bind.
+    pub const fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    /// Requested successor key for replacement actions.
+    pub const fn replacement_event_author_pubkey(&self) -> Option<[u8; 32]> {
+        match &self.plan {
+            OperatorLifecyclePlan::Rotate { replacement, .. }
+            | OperatorLifecyclePlan::Recover { replacement, .. }
+            | OperatorLifecyclePlan::Enable { replacement, .. } => {
+                Some(replacement.event_author_pubkey)
+            }
+            OperatorLifecyclePlan::Retire { .. }
+            | OperatorLifecyclePlan::Disable { .. }
+            | OperatorLifecyclePlan::Revoke { .. } => None,
+        }
+    }
+
+    /// Exclusive requested successor-proof expiry for replacement actions.
+    pub const fn replacement_expires_at(&self) -> Option<DateTime<Utc>> {
+        match &self.plan {
+            OperatorLifecyclePlan::Rotate { replacement, .. }
+            | OperatorLifecyclePlan::Recover { replacement, .. }
+            | OperatorLifecyclePlan::Enable { replacement, .. } => Some(replacement.expires_at),
+            OperatorLifecyclePlan::Retire { .. }
+            | OperatorLifecyclePlan::Disable { .. }
+            | OperatorLifecyclePlan::Revoke { .. } => None,
+        }
+    }
+
+    /// Recompute the sole canonical intent digest from one exact binding row
+    /// while the canonical lifecycle transaction holds its locks.
+    #[allow(clippy::too_many_arguments)]
+    pub fn matches_locked_retiring_binding(
+        &self,
+        action: OperatorLifecycleAction,
+        binding_id: Uuid,
+        binding_version: u64,
+        principal_fingerprint: [u8; 32],
+        event_author_pubkey: [u8; 32],
+        lifecycle_revision: u64,
+        replacement: Option<([u8; 32], DateTime<Utc>)>,
+    ) -> bool {
+        let target = ExactActiveOperatorTarget {
+            binding_id,
+            binding_version,
+            expected_lifecycle_revision: lifecycle_revision,
+            principal_fingerprint,
+            event_author_pubkey,
+        };
+        let plan = match (action, replacement) {
+            (OperatorLifecycleAction::Retire, None) => OperatorLifecyclePlan::Retire { target },
+            (OperatorLifecycleAction::Disable, None) => OperatorLifecyclePlan::Disable {
+                principal_fingerprint,
+                expected_active_binding: Some(target),
+            },
+            (OperatorLifecycleAction::Revoke, None) => OperatorLifecyclePlan::Revoke {
+                event_author_pubkey,
+                expected_active_binding: Some(target),
+            },
+            (OperatorLifecycleAction::Rotate, Some((event_author_pubkey, expires_at))) => {
+                OperatorLifecyclePlan::Rotate {
+                    target,
+                    replacement: RequestedOperatorReplacement {
+                        event_author_pubkey,
+                        expires_at,
+                    },
+                }
+            }
+            _ => return false,
+        };
+        self.action == action
+            && self.expected_revision == lifecycle_revision
+            && self.intent_digest
+                == operator_intent_digest(self.operation, lifecycle_revision, action, &plan)
+    }
+}
+
+impl fmt::Debug for OperatorLifecycleIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OperatorLifecycleIntent")
+            .field("action", &self.action)
+            .field("coordinates", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Closed credential-free authentication failures. They never authorize an
+/// operation or occupy its canonical result receipt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i16)]
+pub enum OperatorAuthenticationDenialReason {
+    /// The Authorization header was absent.
+    MissingCredential = 1,
+    /// The credential envelope was malformed or ambiguous.
+    InvalidCredential = 2,
+    /// The configured verifier rejected a well-formed credential.
+    Unauthenticated = 3,
+}
+
+/// Durable outcome of one credential-free operator denial attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperatorPreauthDenialWrite {
+    /// The immutable redacted denial event was inserted.
+    Inserted,
+    /// The exact denial attempt was already present.
+    ExactReplay,
+    /// The independent pre-authentication budget is full. Canonical audit
+    /// health and capacity are unaffected.
+    CapacityExhausted,
+}
+
+/// A durable pre-authentication denial write failed after preparation.
+#[derive(Debug, thiserror::Error)]
+pub enum OperatorPreauthDenialPersistenceError {
+    /// PostgreSQL or the dedicated audit dependency was unavailable.
+    #[error("operator pre-authentication denial audit unavailable")]
+    Unavailable,
+    /// Persisted immutable evidence did not match the sealed attempt.
+    #[error("operator pre-authentication denial evidence is corrupt")]
+    CorruptStoredResult,
+}
+
+#[derive(Clone)]
+pub(crate) struct PreparedOperatorAuthenticationDenial {
+    community_id: CommunityId,
+    operation_id: Uuid,
+    correlation_id: Uuid,
+    attempt_id: Uuid,
+    semantic_fingerprint: [u8; 32],
+    expected_revision: u64,
+    action: i16,
+}
+
+impl PreparedOperatorAuthenticationDenial {
+    pub(crate) fn from_lifecycle_intent(
+        intent: &OperatorLifecycleIntent,
+    ) -> Result<Self, OperatorLifecycleError> {
+        let prepared = Self {
+            community_id: intent.authorization_domain(),
+            operation_id: intent.operation_id(),
+            correlation_id: intent.correlation_id(),
+            attempt_id: intent.attempt_id(),
+            semantic_fingerprint: intent.intent_digest(),
+            expected_revision: intent.expected_revision(),
+            action: intent.action() as i16,
+        };
+        prepared.validate()?;
+        Ok(prepared)
+    }
+
+    fn validate(&self) -> Result<(), OperatorLifecycleError> {
+        if self.community_id.as_uuid().is_nil()
+            || self.operation_id.is_nil()
+            || self.correlation_id.is_nil()
+            || self.attempt_id.is_nil()
+            || self.semantic_fingerprint == [0; 32]
+            || self.expected_revision == 0
+            || !(1..=8).contains(&self.action)
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for PreparedOperatorAuthenticationDenial {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PreparedOperatorAuthenticationDenial([REDACTED])")
+    }
+}
+
+/// Opaque redaction-safe Provision authentication attempt. It contains no
+/// issuer, subject, selected key, credential, or raw request body.
+///
+/// ```compile_fail
+/// use buzz_db::operator_lifecycle::OperatorProvisionAuthenticationAttempt;
+/// let _ = OperatorProvisionAuthenticationAttempt {};
+/// ```
+pub struct OperatorProvisionAuthenticationAttempt {
+    db: Db,
+    prepared: PreparedOperatorAuthenticationDenial,
+}
+
+impl OperatorProvisionAuthenticationAttempt {
+    /// Seal one bounded raw Provision body into credential-free denial evidence.
+    pub fn from_bounded_body(
+        db: Db,
+        authorization_domain: CommunityId,
+        request_body: &[u8],
+    ) -> Result<Self, OperatorLifecycleError> {
+        if authorization_domain.as_uuid().is_nil()
+            || request_body.is_empty()
+            || request_body.len() > MAX_OPERATOR_PROVISION_BODY_BYTES
+        {
+            return Err(OperatorLifecycleError::InvalidRequest);
+        }
+        let semantic_fingerprint = operator_digest(
+            b"buzz:operator-provision-authentication-attempt:v1",
+            &[authorization_domain.as_uuid().as_bytes(), request_body],
+        );
+        let canonical = serde_json::from_slice::<ProvisionDenialWireCoordinates>(request_body)
+            .ok()
+            .filter(|wire| {
+                wire.authorization_domain == *authorization_domain.as_uuid()
+                    && !wire.operation_id.is_nil()
+                    && wire.policy_revision > 0
+                    && valid_private_coordinate(&wire.issuer)
+                    && valid_private_coordinate(&wire.subject)
+                    && valid_hex_32(&wire.policy_digest)
+                    && valid_hex_32(&wire.selected_event_author_pubkey)
+            });
+        let prepared = PreparedOperatorAuthenticationDenial {
+            community_id: authorization_domain,
+            operation_id: canonical.as_ref().map_or_else(
+                || denial_uuid(b"operation", semantic_fingerprint),
+                |wire| wire.operation_id,
+            ),
+            correlation_id: denial_uuid(b"correlation", semantic_fingerprint),
+            attempt_id: denial_uuid(b"attempt", semantic_fingerprint),
+            semantic_fingerprint,
+            expected_revision: canonical.as_ref().map_or(1, |wire| wire.policy_revision),
+            action: 2,
+        };
+        prepared.validate()?;
+        Ok(Self { db, prepared })
+    }
+
+    /// Persist one origin-classified credential denial in the independent
+    /// bounded pre-authentication ledger. The attempt is consumed so no
+    /// caller can relabel one sealed body as multiple denial attempts.
+    pub async fn persist_denial(
+        self,
+        reason: OperatorAuthenticationDenialReason,
+    ) -> Result<OperatorPreauthDenialWrite, OperatorPreauthDenialPersistenceError> {
+        self.db
+            .record_operator_authentication_denial(&self.prepared, reason)
+            .await
+    }
+}
+
+impl fmt::Debug for OperatorProvisionAuthenticationAttempt {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OperatorProvisionAuthenticationAttempt([REDACTED])")
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProvisionDenialWireCoordinates {
+    authorization_domain: Uuid,
+    operation_id: Uuid,
+    policy_revision: u64,
+    policy_digest: String,
+    issuer: String,
+    subject: String,
+    selected_event_author_pubkey: String,
+}
+
+fn valid_private_coordinate(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 1024
+}
+
+fn valid_hex_32(value: &str) -> bool {
+    value.len() == 64
+        && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && value.as_bytes() != b"0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+fn denial_uuid(label: &[u8], fingerprint: [u8; 32]) -> Uuid {
+    let digest = operator_digest(
+        b"buzz:operator-authentication-denial-uuid:v1",
+        &[label, &fingerprint],
+    );
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x80;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+impl Db {
+    /// Persist denial evidence for a parsed lifecycle intent without granting it authority.
+    pub async fn record_operator_lifecycle_authentication_denial(
+        &self,
+        intent: &OperatorLifecycleIntent,
+        reason: OperatorAuthenticationDenialReason,
+    ) -> Result<OperatorPreauthDenialWrite, OperatorPreauthDenialPersistenceError> {
+        let prepared = PreparedOperatorAuthenticationDenial::from_lifecycle_intent(intent)
+            .map_err(|_| OperatorPreauthDenialPersistenceError::CorruptStoredResult)?;
+        self.record_operator_authentication_denial(&prepared, reason)
+            .await
+    }
+
+    /// Increment one fixed-cardinality, credential-free denial bucket without
+    /// creating or occupying a canonical lifecycle receipt.
+    pub(crate) async fn record_operator_authentication_denial(
+        &self,
+        prepared: &PreparedOperatorAuthenticationDenial,
+        reason: OperatorAuthenticationDenialReason,
+    ) -> Result<OperatorPreauthDenialWrite, OperatorPreauthDenialPersistenceError> {
+        prepared
+            .validate()
+            .map_err(|_| OperatorPreauthDenialPersistenceError::CorruptStoredResult)?;
+        let denial_class = match reason {
+            OperatorAuthenticationDenialReason::MissingCredential => 1_i16,
+            OperatorAuthenticationDenialReason::InvalidCredential => 2_i16,
+            OperatorAuthenticationDenialReason::Unauthenticated => 4_i16,
+        };
+        let retained_count: i64 =
+            sqlx::query_scalar("SELECT authorization_operator_denial_bucket_record_v1($1,$2,$3)")
+                .bind(prepared.community_id.as_uuid())
+                .bind(denial_class)
+                .bind(prepared.action)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|_| OperatorPreauthDenialPersistenceError::Unavailable)?;
+        if retained_count <= 0 {
+            return Err(OperatorPreauthDenialPersistenceError::CorruptStoredResult);
+        }
+        Ok(OperatorPreauthDenialWrite::Inserted)
+    }
+
+    /// Commit one verifier-sealed lifecycle transition and all canonical
+    /// companions in a single PostgreSQL transaction.
+    ///
+    /// The returned invalidation notice is post-commit work and exists only for
+    /// a fresh commit. Exact replay repeats no transition, audit, selector, or
+    /// notification dispatch.
+    pub async fn commit_verified_operator_lifecycle(
+        &self,
+        intent: &OperatorLifecycleIntent,
+        grant: &VerifiedOperatorLifecycleGrant,
+    ) -> Result<OperatorLifecycleCommitOutcome, OperatorLifecycleError> {
+        validate_operator_grant(intent, grant)?;
+        let domain = intent.authorization_domain();
+        let request_fingerprint = grant.request_attribution();
+        let actor = AuthorizationEventActor::from_verified_operator_grant(grant)
+            .map_err(OperatorLifecycleError::Storage)?;
+        let result_digest = operator_result_digest(intent, grant);
+        let receipt = AuthorizationOperationReceipt::new(
+            domain,
+            intent.operation_id(),
+            request_fingerprint,
+            operation_kind(intent.action()),
+            actor.clone(),
+            AuthorizationOperationOutcome::Applied,
+            result_digest,
+        )
+        .map_err(OperatorLifecycleError::Storage)?;
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .map_err(|error| OperatorLifecycleError::Storage(error.into()))?;
+        sqlx::query("SELECT nip_fi_lock_authorization_operation_v1($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(intent.operation_id())
+            .execute(&mut *transaction)
+            .await
+            .map_err(operator_storage)?;
+        let authoritative_now: DateTime<Utc> = sqlx::query_scalar("SELECT transaction_timestamp()")
+            .fetch_one(&mut *transaction)
+            .await
+            .map_err(operator_storage)?;
+        if authoritative_now < grant.issued_at() || authoritative_now >= grant.expires_at() {
+            return Err(OperatorLifecycleError::AuthorizationDenied);
+        }
+
+        match record_authorization_operation_receipt_tx(&mut transaction, &receipt).await {
+            Err(DbError::InvalidData(message))
+                if message == "authorization operation intent conflicts with prior receipt" =>
+            {
+                return Err(OperatorLifecycleError::IntentConflict);
+            }
+            Err(error) => return Err(OperatorLifecycleError::Storage(error)),
+            Ok(AuthorizationReceiptWrite::Inserted) => {}
+            Ok(AuthorizationReceiptWrite::ExactReplay) => {
+                verify_operator_replay(&mut transaction, intent, grant, result_digest).await?;
+                transaction.rollback().await.map_err(operator_storage)?;
+                return Ok(OperatorLifecycleCommitOutcome::ExactReplay);
+            }
+        }
+
+        let transition = execute_operator_transition_tx(
+            &mut transaction,
+            intent,
+            grant,
+            request_fingerprint,
+            authoritative_now,
+        )
+        .await?;
+        let invalidation = advance_lifecycle_invalidation_tx(
+            &mut transaction,
+            domain,
+            intent.operation_id(),
+            request_fingerprint,
+            transition.invalidation_selectors,
+        )
+        .await
+        .map_err(map_invalidation_error)?;
+        let event = NewAuthorizationEvent::new(
+            domain,
+            Uuid::new_v4(),
+            event_kind(intent.action()),
+            AuthorizationEventOutcome::Allowed,
+            AuthorizationReasonCode::Current,
+            actor,
+            transition.subject_fingerprint,
+            intent.operation_id(),
+            Some(request_fingerprint),
+            intent.correlation_id(),
+            intent.attempt_id(),
+        )
+        .map_err(OperatorLifecycleError::Storage)?;
+        match record_authorization_event_tx(&mut transaction, &event).await {
+            Ok(AuthorizationReceiptWrite::Inserted) => {}
+            Ok(AuthorizationReceiptWrite::ExactReplay) => {
+                return Err(OperatorLifecycleError::CorruptStoredResult);
+            }
+            Err(AuthorizationEventWriteError::CapacityUnavailable) => {
+                return Err(OperatorLifecycleError::AuditUnavailable);
+            }
+            Err(AuthorizationEventWriteError::Database(error)) => {
+                return Err(OperatorLifecycleError::Storage(error));
+            }
+        }
+        sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+            .execute(&mut *transaction)
+            .await
+            .map_err(map_operator_commit_error)?;
+        transaction
+            .commit()
+            .await
+            .map_err(map_operator_commit_error)?;
+        Ok(OperatorLifecycleCommitOutcome::Committed { invalidation })
+    }
+}
+
+struct OperatorTransitionResult {
+    subject_fingerprint: Option<[u8; 32]>,
+    invalidation_selectors: Vec<LifecycleInvalidationSelector>,
+}
+
+fn validate_operator_grant(
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+) -> Result<(), OperatorLifecycleError> {
+    if grant.authorization_domain() != intent.authorization_domain()
+        || grant.action() != intent.action()
+        || grant.operation_id() != intent.operation_id()
+        || grant.intent_digest() != intent.intent_digest()
+        || grant.expected_revision() != intent.expected_revision()
+        || grant.request_attribution() == [0; 32]
+        || grant.approval_policy_digest() == [0; 32]
+        || grant.signer_attribution() == [0; 32]
+        || grant.issued_at() >= grant.expires_at()
+        || grant.replacement_event_author_pubkey() != intent.replacement_event_author_pubkey()
+        || grant.replacement_expires_at() != intent.replacement_expires_at()
+        || grant.replacement_event_author_pubkey().is_some()
+            != grant.replacement_proof_attribution().is_some()
+    {
+        return Err(OperatorLifecycleError::AuthorizationDenied);
+    }
+    Ok(())
+}
+
+fn operation_kind(action: OperatorLifecycleAction) -> AuthorizationOperationKind {
+    match action {
+        OperatorLifecycleAction::Retire => AuthorizationOperationKind::Retire,
+        OperatorLifecycleAction::Disable => AuthorizationOperationKind::Disable,
+        OperatorLifecycleAction::Revoke => AuthorizationOperationKind::Revoke,
+        OperatorLifecycleAction::Rotate => AuthorizationOperationKind::Rotate,
+        OperatorLifecycleAction::Recover => AuthorizationOperationKind::Recover,
+        OperatorLifecycleAction::Enable => AuthorizationOperationKind::Enable,
+    }
+}
+
+fn event_kind(action: OperatorLifecycleAction) -> AuthorizationEventKind {
+    match action {
+        OperatorLifecycleAction::Retire => AuthorizationEventKind::Retired,
+        OperatorLifecycleAction::Disable => AuthorizationEventKind::PrincipalDisabled,
+        OperatorLifecycleAction::Revoke => AuthorizationEventKind::Revoked,
+        OperatorLifecycleAction::Rotate => AuthorizationEventKind::Rotated,
+        OperatorLifecycleAction::Recover => AuthorizationEventKind::Recovered,
+        OperatorLifecycleAction::Enable => AuthorizationEventKind::PrincipalEnabled,
+    }
+}
+
+fn operator_result_digest(
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-lifecycle-result:v1",
+        &[
+            intent.authorization_domain().as_uuid().as_bytes(),
+            intent.operation_id().as_bytes(),
+            &(intent.action() as i16).to_be_bytes(),
+            &intent.expected_revision().to_be_bytes(),
+            &intent.intent_digest(),
+            &grant.request_attribution(),
+        ],
+    )
+}
+
+fn operator_storage(error: sqlx::Error) -> OperatorLifecycleError {
+    OperatorLifecycleError::Storage(error.into())
+}
+
+fn map_operator_commit_error(error: sqlx::Error) -> OperatorLifecycleError {
+    if matches!(
+        error
+            .as_database_error()
+            .and_then(|database| database.constraint()),
+        Some(
+            "authorization_event_capacity_policy_required"
+                | "authorization_event_capacity_health"
+                | "authorization_event_capacity_exhausted"
+                | "authorization_events_envelope_size"
+        )
+    ) {
+        OperatorLifecycleError::AuditUnavailable
+    } else {
+        operator_storage(error)
+    }
+}
+
+fn map_invalidation_error(error: LifecycleInvalidationError) -> OperatorLifecycleError {
+    match error {
+        LifecycleInvalidationError::InvalidInput => OperatorLifecycleError::InvalidRequest,
+        LifecycleInvalidationError::DomainInactive => OperatorLifecycleError::AuthorizationDenied,
+        LifecycleInvalidationError::StorageUnavailable => OperatorLifecycleError::Storage(
+            DbError::InvalidData("operator lifecycle invalidation unavailable".to_owned()),
+        ),
+    }
+}
+
+struct LockedOperatorBinding {
+    binding_id: Uuid,
+    binding_version: u64,
+    issuer: String,
+    subject: String,
+    principal_fingerprint: [u8; 32],
+    event_author_pubkey: [u8; 32],
+    binding_state: i16,
+    lifecycle_revision: u64,
+    binding_provenance: i16,
+    policy_revision: u64,
+    enrollment_evidence_digest: [u8; 32],
+    expires_at: Option<DateTime<Utc>>,
+}
+
+async fn verify_operator_replay(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+    result_digest: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let exact: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM authorization_operation_receipts receipt
+            JOIN identity_lifecycle_history history
+              ON history.community_id=receipt.community_id
+             AND history.operation_id=receipt.operation_id
+             AND history.request_fingerprint=receipt.request_fingerprint
+            JOIN authorization_events event
+              ON event.community_id=receipt.community_id
+             AND event.operation_id=receipt.operation_id
+             AND event.request_fingerprint=receipt.request_fingerprint
+            WHERE receipt.community_id=$1 AND receipt.operation_id=$2
+              AND receipt.request_fingerprint=$3
+              AND receipt.operation_kind=$4 AND receipt.outcome_code=1
+              AND receipt.result_digest=$5
+              AND history.transition_kind=$4 AND history.outcome_code=1
+              AND history.transition_digest=$6
+              AND event.event_kind=$7 AND event.outcome_code=1
+              AND event.reason_code=1
+        )
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(intent.operation_id())
+    .bind(grant.request_attribution().as_slice())
+    .bind(operation_kind(intent.action()) as i16)
+    .bind(result_digest.as_slice())
+    .bind(operator_transition_digest(intent, grant).as_slice())
+    .bind(event_kind(intent.action()) as i16)
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    if exact {
+        Ok(())
+    } else {
+        Err(OperatorLifecycleError::IntentConflict)
+    }
+}
+
+async fn execute_operator_transition_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+    request_fingerprint: [u8; 32],
+    authoritative_now: DateTime<Utc>,
+) -> Result<OperatorTransitionResult, OperatorLifecycleError> {
+    match &intent.plan {
+        OperatorLifecyclePlan::Retire { target } => {
+            let old = lock_exact_active_binding(transaction, intent, *target, None).await?;
+            let history_id = Uuid::new_v4();
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                Some(&old),
+                None,
+                request_fingerprint,
+            )
+            .await?;
+            retire_binding(transaction, intent.authorization_domain(), &old, history_id).await?;
+            insert_retired_pair_selector(
+                transaction,
+                intent,
+                &old,
+                history_id,
+                request_fingerprint,
+            )
+            .await?;
+            insert_pending_selector(transaction, intent, &old, history_id, request_fingerprint)
+                .await?;
+            Ok(operator_transition_result(intent, &old))
+        }
+        OperatorLifecyclePlan::Disable {
+            principal_fingerprint,
+            expected_active_binding,
+        } => {
+            lock_lifecycle_coordinates(
+                transaction,
+                intent.authorization_domain(),
+                Some(*principal_fingerprint),
+                expected_active_binding.map(|target| target.event_author_pubkey),
+            )
+            .await?;
+            let old = match expected_active_binding {
+                Some(target) => Some(
+                    lock_exact_active_binding(transaction, intent, *target, Some(false)).await?,
+                ),
+                None => {
+                    ensure_no_active_principal(
+                        transaction,
+                        intent.authorization_domain(),
+                        *principal_fingerprint,
+                    )
+                    .await?;
+                    None
+                }
+            };
+            let no_active_generation = if old.is_none() {
+                let generation = next_selector_generation(
+                    transaction,
+                    intent.authorization_domain(),
+                    2,
+                    *principal_fingerprint,
+                )
+                .await?;
+                if generation != intent.expected_revision() {
+                    return Err(OperatorLifecycleError::AuthorizationDenied);
+                }
+                Some(generation)
+            } else {
+                None
+            };
+            let history_id = Uuid::new_v4();
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                old.as_ref(),
+                None,
+                request_fingerprint,
+            )
+            .await?;
+            if let Some(old) = old.as_ref() {
+                retire_binding(transaction, intent.authorization_domain(), old, history_id).await?;
+                insert_retired_pair_selector(
+                    transaction,
+                    intent,
+                    old,
+                    history_id,
+                    request_fingerprint,
+                )
+                .await?;
+                insert_pending_selector(transaction, intent, old, history_id, request_fingerprint)
+                    .await?;
+            }
+            insert_principal_selector(
+                transaction,
+                intent,
+                *principal_fingerprint,
+                no_active_generation,
+                history_id,
+                request_fingerprint,
+            )
+            .await?;
+            Ok(match old.as_ref() {
+                Some(old) => operator_transition_result(intent, old),
+                None => OperatorTransitionResult {
+                    subject_fingerprint: Some(*principal_fingerprint),
+                    invalidation_selectors: vec![LifecycleInvalidationSelector::Principal(
+                        *principal_fingerprint,
+                    )],
+                },
+            })
+        }
+        OperatorLifecyclePlan::Revoke {
+            event_author_pubkey,
+            expected_active_binding,
+        } => {
+            lock_lifecycle_coordinates(
+                transaction,
+                intent.authorization_domain(),
+                expected_active_binding.map(|target| target.principal_fingerprint),
+                Some(*event_author_pubkey),
+            )
+            .await?;
+            let old = match expected_active_binding {
+                Some(target) => Some(
+                    lock_exact_active_binding(transaction, intent, *target, Some(false)).await?,
+                ),
+                None => {
+                    ensure_no_active_event_author(
+                        transaction,
+                        intent.authorization_domain(),
+                        *event_author_pubkey,
+                    )
+                    .await?;
+                    None
+                }
+            };
+            if old.is_none() && intent.expected_revision() != 1 {
+                return Err(OperatorLifecycleError::AuthorizationDenied);
+            }
+            let history_id = Uuid::new_v4();
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                old.as_ref(),
+                None,
+                request_fingerprint,
+            )
+            .await?;
+            if let Some(old) = old.as_ref() {
+                retire_binding(transaction, intent.authorization_domain(), old, history_id).await?;
+                insert_retired_pair_selector(
+                    transaction,
+                    intent,
+                    old,
+                    history_id,
+                    request_fingerprint,
+                )
+                .await?;
+                insert_pending_selector(transaction, intent, old, history_id, request_fingerprint)
+                    .await?;
+            }
+            insert_event_author_selector(
+                transaction,
+                intent,
+                *event_author_pubkey,
+                history_id,
+                request_fingerprint,
+            )
+            .await?;
+            Ok(match old.as_ref() {
+                Some(old) => operator_transition_result(intent, old),
+                None => OperatorTransitionResult {
+                    subject_fingerprint: None,
+                    invalidation_selectors: vec![LifecycleInvalidationSelector::EventAuthor(
+                        event_author_selector_fingerprint(
+                            intent.authorization_domain(),
+                            *event_author_pubkey,
+                        ),
+                    )],
+                },
+            })
+        }
+        OperatorLifecyclePlan::Rotate {
+            target,
+            replacement,
+        } => {
+            let old = lock_exact_active_binding(transaction, intent, *target, None).await?;
+            validate_replacement(grant, replacement, authoritative_now)?;
+            lock_lifecycle_coordinates(
+                transaction,
+                intent.authorization_domain(),
+                Some(old.principal_fingerprint),
+                Some(replacement.event_author_pubkey),
+            )
+            .await?;
+            let history_id = Uuid::new_v4();
+            // The active-principal uniqueness constraint is immediate. Retire
+            // the locked predecessor first so the successor can reuse its
+            // principal coordinate; every later write remains in this same
+            // transaction, so any failure restores the predecessor.
+            retire_binding(transaction, intent.authorization_domain(), &old, history_id).await?;
+            let successor = insert_successor_binding(
+                transaction,
+                intent,
+                &old,
+                replacement,
+                history_id,
+                request_fingerprint,
+                authoritative_now,
+            )
+            .await?;
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                Some(&old),
+                Some(successor),
+                request_fingerprint,
+            )
+            .await?;
+            insert_retired_pair_selector(
+                transaction,
+                intent,
+                &old,
+                history_id,
+                request_fingerprint,
+            )
+            .await?;
+            Ok(operator_transition_result(intent, &old))
+        }
+        OperatorLifecyclePlan::Recover {
+            pending,
+            replacement,
+        } => {
+            let old = lock_exact_retired_binding(transaction, intent, pending.target).await?;
+            validate_replacement(grant, replacement, authoritative_now)?;
+            let pending_selector =
+                lock_pending_selector(transaction, intent, *pending, &old).await?;
+            lock_lifecycle_coordinates(
+                transaction,
+                intent.authorization_domain(),
+                Some(old.principal_fingerprint),
+                Some(replacement.event_author_pubkey),
+            )
+            .await?;
+            let history_id = Uuid::new_v4();
+            let successor = insert_successor_binding(
+                transaction,
+                intent,
+                &old,
+                replacement,
+                history_id,
+                request_fingerprint,
+                authoritative_now,
+            )
+            .await?;
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                Some(&old),
+                Some(successor),
+                request_fingerprint,
+            )
+            .await?;
+            consume_selector(
+                transaction,
+                intent,
+                pending_selector,
+                4,
+                history_id,
+                successor,
+                request_fingerprint,
+            )
+            .await?;
+            Ok(operator_transition_result(intent, &old))
+        }
+        OperatorLifecyclePlan::Enable {
+            principal_fingerprint,
+            disabled_fact_generation,
+            pending,
+            replacement,
+        } => {
+            let old = lock_exact_retired_binding(transaction, intent, pending.target).await?;
+            if old.principal_fingerprint != *principal_fingerprint {
+                return Err(OperatorLifecycleError::AuthorizationDenied);
+            }
+            validate_replacement(grant, replacement, authoritative_now)?;
+            let pending_selector =
+                lock_pending_selector(transaction, intent, *pending, &old).await?;
+            let disabled_selector = lock_principal_selector(
+                transaction,
+                intent,
+                *principal_fingerprint,
+                *disabled_fact_generation,
+            )
+            .await?;
+            lock_lifecycle_coordinates(
+                transaction,
+                intent.authorization_domain(),
+                Some(old.principal_fingerprint),
+                Some(replacement.event_author_pubkey),
+            )
+            .await?;
+            let history_id = Uuid::new_v4();
+            let successor = insert_successor_binding(
+                transaction,
+                intent,
+                &old,
+                replacement,
+                history_id,
+                request_fingerprint,
+                authoritative_now,
+            )
+            .await?;
+            insert_lifecycle_history(
+                transaction,
+                intent,
+                grant,
+                history_id,
+                Some(&old),
+                Some(successor),
+                request_fingerprint,
+            )
+            .await?;
+            consume_selector(
+                transaction,
+                intent,
+                disabled_selector,
+                2,
+                history_id,
+                successor,
+                request_fingerprint,
+            )
+            .await?;
+            consume_selector(
+                transaction,
+                intent,
+                pending_selector,
+                4,
+                history_id,
+                successor,
+                request_fingerprint,
+            )
+            .await?;
+            Ok(operator_transition_result(intent, &old))
+        }
+    }
+}
+
+async fn lock_lifecycle_coordinates(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    principal_fingerprint: Option<[u8; 32]>,
+    event_author_pubkey: Option<[u8; 32]>,
+) -> Result<(), OperatorLifecycleError> {
+    sqlx::query("SELECT identity_lifecycle_lock_coordinates_v1($1,$2,$3)")
+        .bind(domain.as_uuid())
+        .bind(principal_fingerprint.map(|value| value.to_vec()))
+        .bind(event_author_pubkey.map(|value| value.to_vec()))
+        .execute(&mut **transaction)
+        .await
+        .map_err(operator_storage)?;
+    Ok(())
+}
+
+async fn lock_exact_active_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    target: ExactActiveOperatorTarget,
+    acquire_coordinates: Option<bool>,
+) -> Result<LockedOperatorBinding, OperatorLifecycleError> {
+    if acquire_coordinates != Some(false) {
+        lock_lifecycle_coordinates(
+            transaction,
+            intent.authorization_domain(),
+            Some(target.principal_fingerprint),
+            Some(target.event_author_pubkey),
+        )
+        .await?;
+    }
+    let binding = lock_binding(
+        transaction,
+        intent.authorization_domain(),
+        target.binding_id,
+        target.binding_version,
+    )
+    .await?;
+    if binding.binding_state != 1
+        || binding.lifecycle_revision != target.expected_lifecycle_revision
+        || binding.principal_fingerprint != target.principal_fingerprint
+        || binding.event_author_pubkey != target.event_author_pubkey
+    {
+        return Err(OperatorLifecycleError::AuthorizationDenied);
+    }
+    Ok(binding)
+}
+
+async fn lock_exact_retired_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    target: ExactRetiredOperatorTarget,
+) -> Result<LockedOperatorBinding, OperatorLifecycleError> {
+    lock_lifecycle_coordinates(
+        transaction,
+        intent.authorization_domain(),
+        Some(target.principal_fingerprint),
+        Some(target.event_author_pubkey),
+    )
+    .await?;
+    let binding = lock_binding(
+        transaction,
+        intent.authorization_domain(),
+        target.binding_id,
+        target.binding_version,
+    )
+    .await?;
+    if binding.binding_state != 2
+        || binding.lifecycle_revision != target.expected_lifecycle_revision
+        || binding.principal_fingerprint != target.principal_fingerprint
+        || binding.event_author_pubkey != target.event_author_pubkey
+    {
+        return Err(OperatorLifecycleError::AuthorizationDenied);
+    }
+    Ok(binding)
+}
+
+async fn lock_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    binding_id: Uuid,
+    binding_version: u64,
+) -> Result<LockedOperatorBinding, OperatorLifecycleError> {
+    let binding_version =
+        i64::try_from(binding_version).map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let row = sqlx::query(
+        r#"
+        SELECT binding_id,binding_version,issuer,subject,principal_fingerprint,
+               event_author_pubkey,binding_state,lifecycle_revision,
+               binding_provenance,policy_revision,enrollment_evidence_digest,expires_at
+        FROM identity_bindings
+        WHERE community_id=$1 AND binding_id=$2 AND binding_version=$3
+        FOR UPDATE
+        "#,
+    )
+    .bind(domain.as_uuid())
+    .bind(binding_id)
+    .bind(binding_version)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operator_storage)?
+    .ok_or(OperatorLifecycleError::AuthorizationDenied)?;
+    Ok(LockedOperatorBinding {
+        binding_id: row.try_get("binding_id").map_err(operator_storage_row)?,
+        binding_version: positive_operator_i64(
+            row.try_get("binding_version")
+                .map_err(operator_storage_row)?,
+        )?,
+        issuer: row.try_get("issuer").map_err(operator_storage_row)?,
+        subject: row.try_get("subject").map_err(operator_storage_row)?,
+        principal_fingerprint: operator_bytes32(
+            row.try_get("principal_fingerprint")
+                .map_err(operator_storage_row)?,
+        )?,
+        event_author_pubkey: operator_bytes32(
+            row.try_get("event_author_pubkey")
+                .map_err(operator_storage_row)?,
+        )?,
+        binding_state: row.try_get("binding_state").map_err(operator_storage_row)?,
+        lifecycle_revision: positive_operator_i64(
+            row.try_get("lifecycle_revision")
+                .map_err(operator_storage_row)?,
+        )?,
+        binding_provenance: row
+            .try_get("binding_provenance")
+            .map_err(operator_storage_row)?,
+        policy_revision: positive_operator_i64(
+            row.try_get("policy_revision")
+                .map_err(operator_storage_row)?,
+        )?,
+        enrollment_evidence_digest: operator_bytes32(
+            row.try_get("enrollment_evidence_digest")
+                .map_err(operator_storage_row)?,
+        )?,
+        expires_at: row.try_get("expires_at").map_err(operator_storage_row)?,
+    })
+}
+
+fn operator_storage_row(error: sqlx::Error) -> OperatorLifecycleError {
+    operator_storage(error)
+}
+
+fn positive_operator_i64(value: i64) -> Result<u64, OperatorLifecycleError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(OperatorLifecycleError::CorruptStoredResult)
+}
+
+fn operator_bytes32(value: Vec<u8>) -> Result<[u8; 32], OperatorLifecycleError> {
+    value
+        .try_into()
+        .map_err(|_| OperatorLifecycleError::CorruptStoredResult)
+}
+
+async fn ensure_no_active_principal(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    principal_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM identity_bindings \
+         WHERE community_id=$1 AND principal_fingerprint=$2 AND binding_state=1)",
+    )
+    .bind(domain.as_uuid())
+    .bind(principal_fingerprint.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    if present {
+        Err(OperatorLifecycleError::AuthorizationDenied)
+    } else {
+        Ok(())
+    }
+}
+
+async fn ensure_no_active_event_author(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    event_author_pubkey: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let present: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM identity_bindings \
+         WHERE community_id=$1 AND event_author_pubkey=$2 AND binding_state=1)",
+    )
+    .bind(domain.as_uuid())
+    .bind(event_author_pubkey.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    if present {
+        Err(OperatorLifecycleError::AuthorizationDenied)
+    } else {
+        Ok(())
+    }
+}
+
+async fn insert_lifecycle_history(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+    history_id: Uuid,
+    old: Option<&LockedOperatorBinding>,
+    successor: Option<(Uuid, u64)>,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let old_id = old.map(|binding| binding.binding_id);
+    let old_version = old
+        .map(|binding| i64::try_from(binding.binding_version))
+        .transpose()
+        .map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let old_revision = old
+        .map(|binding| i64::try_from(binding.lifecycle_revision))
+        .transpose()
+        .map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let old_state = old.map(|binding| binding.binding_state);
+    let (successor_id, successor_version) = successor
+        .map(|(id, version)| {
+            i64::try_from(version)
+                .map(|version| (Some(id), Some(version)))
+                .map_err(|_| OperatorLifecycleError::InvalidRequest)
+        })
+        .transpose()?
+        .unwrap_or((None, None));
+    sqlx::query(
+        r#"
+        INSERT INTO identity_lifecycle_history (
+            community_id,history_id,transition_kind,outcome_code,
+            old_binding_id,old_binding_version,old_prior_lifecycle_revision,
+            old_prior_state,old_resulting_lifecycle_revision,old_resulting_state,
+            successor_binding_id,successor_binding_version,
+            successor_lifecycle_revision,successor_state,
+            operation_id,request_fingerprint,transition_digest
+        ) VALUES (
+            $1,$2,$3,1,$4,$5,$6,$7,$8,$9,$10,$11,
+            CASE WHEN $10::uuid IS NULL THEN NULL ELSE 1 END,
+            CASE WHEN $10::uuid IS NULL THEN NULL ELSE 1 END,
+            $12,$13,$14
+        )
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(history_id)
+    .bind(operation_kind(intent.action()) as i16)
+    .bind(old_id)
+    .bind(old_version)
+    .bind(old_revision)
+    .bind(old_state)
+    .bind(old_revision.map(|revision| {
+        if matches!(
+            intent.action(),
+            OperatorLifecycleAction::Recover | OperatorLifecycleAction::Enable
+        ) {
+            revision
+        } else {
+            2
+        }
+    }))
+    .bind(old_state.map(|state| {
+        if matches!(
+            intent.action(),
+            OperatorLifecycleAction::Recover | OperatorLifecycleAction::Enable
+        ) {
+            state
+        } else {
+            2
+        }
+    }))
+    .bind(successor_id)
+    .bind(successor_version)
+    .bind(intent.operation_id())
+    .bind(request_fingerprint.as_slice())
+    .bind(operator_transition_digest(intent, grant).as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    Ok(())
+}
+
+async fn retire_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    old: &LockedOperatorBinding,
+    history_id: Uuid,
+) -> Result<(), OperatorLifecycleError> {
+    let updated = sqlx::query(
+        "UPDATE identity_bindings SET binding_state=2,lifecycle_revision=2, \
+         retirement_history_id=$4 WHERE community_id=$1 AND binding_id=$2 \
+         AND binding_version=$3 AND binding_state=1 AND lifecycle_revision=1",
+    )
+    .bind(domain.as_uuid())
+    .bind(old.binding_id)
+    .bind(i64::try_from(old.binding_version).map_err(|_| OperatorLifecycleError::InvalidRequest)?)
+    .bind(history_id)
+    .execute(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    if updated.rows_affected() == 1 {
+        Ok(())
+    } else {
+        Err(OperatorLifecycleError::AuthorizationDenied)
+    }
+}
+
+fn validate_replacement(
+    grant: &VerifiedOperatorLifecycleGrant,
+    replacement: &RequestedOperatorReplacement,
+    authoritative_now: DateTime<Utc>,
+) -> Result<(), OperatorLifecycleError> {
+    if grant.replacement_event_author_pubkey() != Some(replacement.event_author_pubkey)
+        || grant.replacement_expires_at() != Some(replacement.expires_at)
+        || grant.replacement_proof_attribution().is_none()
+        || authoritative_now >= replacement.expires_at
+    {
+        Err(OperatorLifecycleError::AuthorizationDenied)
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_successor_binding(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    old: &LockedOperatorBinding,
+    replacement: &RequestedOperatorReplacement,
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+    authoritative_now: DateTime<Utc>,
+) -> Result<(Uuid, u64), OperatorLifecycleError> {
+    let policy_expiry: Option<DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT expires_at FROM identity_enrollment_policies \
+         WHERE community_id=$1 AND policy_revision=$2 FOR SHARE",
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(i64::try_from(old.policy_revision).map_err(|_| OperatorLifecycleError::InvalidRequest)?)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operator_storage)?
+    .ok_or(OperatorLifecycleError::AuthorizationDenied)?;
+    let expires_at = [old.expires_at, policy_expiry, Some(replacement.expires_at)]
+        .into_iter()
+        .flatten()
+        .min();
+    if expires_at.is_some_and(|expires_at| authoritative_now >= expires_at) {
+        return Err(OperatorLifecycleError::AuthorizationDenied);
+    }
+    let binding_id = Uuid::new_v4();
+    let binding_version: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO identity_bindings (
+            community_id,binding_id,issuer,subject,principal_fingerprint,
+            event_author_pubkey,binding_state,lifecycle_revision,binding_provenance,
+            policy_revision,enrollment_evidence_digest,expires_at,birth_history_id,
+            creation_operation_id,creation_request_fingerprint
+        ) VALUES ($1,$2,$3,$4,$5,$6,1,1,$7,$8,$9,$10,$11,$12,$13)
+        RETURNING binding_version
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(binding_id)
+    .bind(&old.issuer)
+    .bind(&old.subject)
+    .bind(old.principal_fingerprint.as_slice())
+    .bind(replacement.event_author_pubkey.as_slice())
+    .bind(old.binding_provenance)
+    .bind(i64::try_from(old.policy_revision).map_err(|_| OperatorLifecycleError::InvalidRequest)?)
+    .bind(old.enrollment_evidence_digest.as_slice())
+    .bind(expires_at)
+    .bind(history_id)
+    .bind(intent.operation_id())
+    .bind(request_fingerprint.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    Ok((binding_id, positive_operator_i64(binding_version)?))
+}
+
+fn operator_transition_digest(
+    intent: &OperatorLifecycleIntent,
+    grant: &VerifiedOperatorLifecycleGrant,
+) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-lifecycle-transition:v1",
+        &[
+            &intent.intent_digest(),
+            &grant.request_attribution(),
+            &grant.approval_policy_digest(),
+            &grant.signer_attribution(),
+            &grant.approval_attribution().unwrap_or([0; 32]),
+            &grant.replacement_proof_attribution().unwrap_or([0; 32]),
+        ],
+    )
+}
+
+fn operator_transition_result(
+    intent: &OperatorLifecycleIntent,
+    old: &LockedOperatorBinding,
+) -> OperatorTransitionResult {
+    OperatorTransitionResult {
+        subject_fingerprint: Some(old.principal_fingerprint),
+        invalidation_selectors: vec![
+            LifecycleInvalidationSelector::Principal(old.principal_fingerprint),
+            LifecycleInvalidationSelector::EventAuthor(event_author_selector_fingerprint(
+                intent.authorization_domain(),
+                old.event_author_pubkey,
+            )),
+            LifecycleInvalidationSelector::Binding {
+                fingerprint: binding_selector_fingerprint(
+                    intent.authorization_domain(),
+                    old.binding_id,
+                    old.binding_version,
+                ),
+                version_floor: old.binding_version,
+            },
+        ],
+    }
+}
+
+async fn insert_retired_pair_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    old: &LockedOperatorBinding,
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    insert_selector(
+        transaction,
+        intent,
+        1,
+        selector_fingerprint(
+            intent.authorization_domain(),
+            1,
+            old.principal_fingerprint,
+            old.event_author_pubkey,
+            old.binding_id,
+            old.binding_version,
+            1,
+        ),
+        1,
+        Some(old.principal_fingerprint),
+        Some(old.event_author_pubkey),
+        Some((old.binding_id, old.binding_version)),
+        history_id,
+        request_fingerprint,
+    )
+    .await
+}
+
+async fn insert_pending_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    old: &LockedOperatorBinding,
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let generation = next_selector_generation(
+        transaction,
+        intent.authorization_domain(),
+        4,
+        old.principal_fingerprint,
+    )
+    .await?;
+    insert_selector(
+        transaction,
+        intent,
+        4,
+        selector_fingerprint(
+            intent.authorization_domain(),
+            4,
+            old.principal_fingerprint,
+            old.event_author_pubkey,
+            old.binding_id,
+            old.binding_version,
+            generation,
+        ),
+        generation,
+        Some(old.principal_fingerprint),
+        Some(old.event_author_pubkey),
+        Some((old.binding_id, old.binding_version)),
+        history_id,
+        request_fingerprint,
+    )
+    .await
+}
+
+async fn insert_principal_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    principal_fingerprint: [u8; 32],
+    prevalidated_generation: Option<u64>,
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let generation = match prevalidated_generation {
+        Some(generation) => generation,
+        None => {
+            next_selector_generation(
+                transaction,
+                intent.authorization_domain(),
+                2,
+                principal_fingerprint,
+            )
+            .await?
+        }
+    };
+    insert_selector(
+        transaction,
+        intent,
+        2,
+        selector_fingerprint(
+            intent.authorization_domain(),
+            2,
+            principal_fingerprint,
+            [0; 32],
+            Uuid::nil(),
+            0,
+            generation,
+        ),
+        generation,
+        Some(principal_fingerprint),
+        None,
+        None,
+        history_id,
+        request_fingerprint,
+    )
+    .await
+}
+
+async fn insert_event_author_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    event_author_pubkey: [u8; 32],
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    insert_selector(
+        transaction,
+        intent,
+        3,
+        selector_fingerprint(
+            intent.authorization_domain(),
+            3,
+            [0; 32],
+            event_author_pubkey,
+            Uuid::nil(),
+            0,
+            1,
+        ),
+        1,
+        None,
+        Some(event_author_pubkey),
+        None,
+        history_id,
+        request_fingerprint,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    kind: i16,
+    fingerprint: [u8; 32],
+    generation: u64,
+    principal_fingerprint: Option<[u8; 32]>,
+    event_author_pubkey: Option<[u8; 32]>,
+    binding: Option<(Uuid, u64)>,
+    history_id: Uuid,
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let generation =
+        i64::try_from(generation).map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let (binding_id, binding_version) = binding
+        .map(|(id, version)| {
+            i64::try_from(version)
+                .map(|version| (Some(id), Some(version)))
+                .map_err(|_| OperatorLifecycleError::InvalidRequest)
+        })
+        .transpose()?
+        .unwrap_or((None, None));
+    sqlx::query(
+        r#"
+        INSERT INTO identity_lifecycle_selectors (
+            community_id,selector_id,selector_kind,selector_fingerprint,
+            fact_generation,principal_fingerprint,event_author_pubkey,
+            binding_id,binding_version,asserted_history_id,
+            selected_by_operation_id,selected_by_request_fingerprint
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(Uuid::new_v4())
+    .bind(kind)
+    .bind(fingerprint.as_slice())
+    .bind(generation)
+    .bind(principal_fingerprint.map(|value| value.to_vec()))
+    .bind(event_author_pubkey.map(|value| value.to_vec()))
+    .bind(binding_id)
+    .bind(binding_version)
+    .bind(history_id)
+    .bind(intent.operation_id())
+    .bind(request_fingerprint.as_slice())
+    .execute(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    Ok(())
+}
+
+async fn next_selector_generation(
+    transaction: &mut Transaction<'_, Postgres>,
+    domain: CommunityId,
+    kind: i16,
+    principal_fingerprint: [u8; 32],
+) -> Result<u64, OperatorLifecycleError> {
+    let maximum: Option<i64> = sqlx::query_scalar(
+        "SELECT max(fact_generation) FROM identity_lifecycle_selectors \
+         WHERE community_id=$1 AND selector_kind=$2 AND principal_fingerprint=$3",
+    )
+    .bind(domain.as_uuid())
+    .bind(kind)
+    .bind(principal_fingerprint.as_slice())
+    .fetch_one(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    let next = maximum
+        .unwrap_or(0)
+        .checked_add(1)
+        .ok_or(OperatorLifecycleError::CorruptStoredResult)?;
+    positive_operator_i64(next)
+}
+
+fn selector_fingerprint(
+    domain: CommunityId,
+    kind: i16,
+    principal_fingerprint: [u8; 32],
+    event_author_pubkey: [u8; 32],
+    binding_id: Uuid,
+    binding_version: u64,
+    generation: u64,
+) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-lifecycle-selector:v1",
+        &[
+            domain.as_uuid().as_bytes(),
+            &kind.to_be_bytes(),
+            &principal_fingerprint,
+            &event_author_pubkey,
+            binding_id.as_bytes(),
+            &binding_version.to_be_bytes(),
+            &generation.to_be_bytes(),
+        ],
+    )
+}
+
+fn event_author_selector_fingerprint(
+    domain: CommunityId,
+    event_author_pubkey: [u8; 32],
+) -> [u8; 32] {
+    operator_digest(
+        b"buzz:authorization-invalidation-event-author:v1",
+        &[domain.as_uuid().as_bytes(), &event_author_pubkey],
+    )
+}
+
+fn binding_selector_fingerprint(
+    domain: CommunityId,
+    binding_id: Uuid,
+    binding_version: u64,
+) -> [u8; 32] {
+    operator_digest(
+        b"buzz:authorization-invalidation-binding:v1",
+        &[
+            domain.as_uuid().as_bytes(),
+            binding_id.as_bytes(),
+            &binding_version.to_be_bytes(),
+        ],
+    )
+}
+
+async fn lock_pending_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    pending: ExpectedOperatorPendingReplacement,
+    old: &LockedOperatorBinding,
+) -> Result<Uuid, OperatorLifecycleError> {
+    let generation = i64::try_from(pending.fact_generation)
+        .map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let selector: Option<Uuid> = sqlx::query_scalar(
+        r#"
+        SELECT selector.selector_id
+        FROM identity_lifecycle_selectors selector
+        LEFT JOIN identity_lifecycle_selector_consumptions consumption
+          ON consumption.community_id=selector.community_id
+         AND consumption.selector_id=selector.selector_id
+        WHERE selector.community_id=$1 AND selector.selector_kind=4
+          AND selector.principal_fingerprint=$2
+          AND selector.event_author_pubkey=$3
+          AND selector.binding_id=$4 AND selector.binding_version=$5
+          AND selector.fact_generation=$6
+          AND consumption.selector_id IS NULL
+        FOR UPDATE OF selector
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(old.principal_fingerprint.as_slice())
+    .bind(old.event_author_pubkey.as_slice())
+    .bind(old.binding_id)
+    .bind(i64::try_from(old.binding_version).map_err(|_| OperatorLifecycleError::InvalidRequest)?)
+    .bind(generation)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    selector.ok_or(OperatorLifecycleError::AuthorizationDenied)
+}
+
+async fn lock_principal_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    principal_fingerprint: [u8; 32],
+    fact_generation: u64,
+) -> Result<Uuid, OperatorLifecycleError> {
+    let fact_generation =
+        i64::try_from(fact_generation).map_err(|_| OperatorLifecycleError::InvalidRequest)?;
+    let selector: Option<Uuid> = sqlx::query_scalar(
+        r#"
+        SELECT selector.selector_id
+        FROM identity_lifecycle_selectors selector
+        LEFT JOIN identity_lifecycle_selector_consumptions consumption
+          ON consumption.community_id=selector.community_id
+         AND consumption.selector_id=selector.selector_id
+        WHERE selector.community_id=$1 AND selector.selector_kind=2
+          AND selector.principal_fingerprint=$2
+          AND selector.fact_generation=$3
+          AND consumption.selector_id IS NULL
+        FOR UPDATE OF selector
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(principal_fingerprint.as_slice())
+    .bind(fact_generation)
+    .fetch_optional(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    selector.ok_or(OperatorLifecycleError::AuthorizationDenied)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn consume_selector(
+    transaction: &mut Transaction<'_, Postgres>,
+    intent: &OperatorLifecycleIntent,
+    selector_id: Uuid,
+    selector_kind: i16,
+    history_id: Uuid,
+    successor: (Uuid, u64),
+    request_fingerprint: [u8; 32],
+) -> Result<(), OperatorLifecycleError> {
+    let inserted = sqlx::query(
+        r#"
+        INSERT INTO identity_lifecycle_selector_consumptions (
+            community_id,selector_id,selector_kind,history_id,operation_id,
+            request_fingerprint,successor_binding_id,successor_binding_version
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+        ON CONFLICT (community_id,selector_id) DO NOTHING
+        "#,
+    )
+    .bind(intent.authorization_domain().as_uuid())
+    .bind(selector_id)
+    .bind(selector_kind)
+    .bind(history_id)
+    .bind(intent.operation_id())
+    .bind(request_fingerprint.as_slice())
+    .bind(successor.0)
+    .bind(i64::try_from(successor.1).map_err(|_| OperatorLifecycleError::InvalidRequest)?)
+    .execute(&mut **transaction)
+    .await
+    .map_err(operator_storage)?;
+    if inserted.rows_affected() == 1 {
+        Ok(())
+    } else {
+        Err(OperatorLifecycleError::AuthorizationDenied)
+    }
+}
+
+fn operator_intent_digest(
+    operation: OperatorLifecycleOperation,
+    expected_revision: u64,
+    action: OperatorLifecycleAction,
+    plan: &OperatorLifecyclePlan,
+) -> [u8; 32] {
+    let plan_digest = match plan {
+        OperatorLifecyclePlan::Retire { target } => operator_digest(
+            b"buzz:operator-retire-intent:v1",
+            &[&active_target_digest(*target)],
+        ),
+        OperatorLifecyclePlan::Disable {
+            principal_fingerprint,
+            expected_active_binding,
+        } => operator_digest(
+            b"buzz:operator-disable-intent:v1",
+            &[
+                principal_fingerprint,
+                &expected_active_binding
+                    .map(active_target_digest)
+                    .unwrap_or([0; 32]),
+            ],
+        ),
+        OperatorLifecyclePlan::Revoke {
+            event_author_pubkey,
+            expected_active_binding,
+        } => operator_digest(
+            b"buzz:operator-revoke-intent:v1",
+            &[
+                event_author_pubkey,
+                &expected_active_binding
+                    .map(active_target_digest)
+                    .unwrap_or([0; 32]),
+            ],
+        ),
+        OperatorLifecyclePlan::Rotate {
+            target,
+            replacement,
+        } => operator_digest(
+            b"buzz:operator-rotate-intent:v1",
+            &[
+                &active_target_digest(*target),
+                &replacement_digest(replacement),
+            ],
+        ),
+        OperatorLifecyclePlan::Recover {
+            pending,
+            replacement,
+        } => operator_digest(
+            b"buzz:operator-recover-intent:v1",
+            &[&pending_digest(*pending), &replacement_digest(replacement)],
+        ),
+        OperatorLifecyclePlan::Enable {
+            principal_fingerprint,
+            disabled_fact_generation,
+            pending,
+            replacement,
+        } => operator_digest(
+            b"buzz:operator-enable-intent:v1",
+            &[
+                principal_fingerprint,
+                &disabled_fact_generation.to_be_bytes(),
+                &pending_digest(*pending),
+                &replacement_digest(replacement),
+            ],
+        ),
+    };
+    operator_digest(
+        b"buzz:operator-lifecycle-intent:v1",
+        &[
+            operation.community_id.as_uuid().as_bytes(),
+            operation.operation_id.as_bytes(),
+            &(action as i16).to_be_bytes(),
+            &expected_revision.to_be_bytes(),
+            &plan_digest,
+        ],
+    )
+}
+
+fn active_target_digest(target: ExactActiveOperatorTarget) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-active-target:v1",
+        &[
+            target.binding_id.as_bytes(),
+            &target.binding_version.to_be_bytes(),
+            &target.expected_lifecycle_revision.to_be_bytes(),
+            &target.principal_fingerprint,
+            &target.event_author_pubkey,
+        ],
+    )
+}
+
+fn retired_target_digest(target: ExactRetiredOperatorTarget) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-retired-target:v1",
+        &[
+            target.binding_id.as_bytes(),
+            &target.binding_version.to_be_bytes(),
+            &target.expected_lifecycle_revision.to_be_bytes(),
+            &target.principal_fingerprint,
+            &target.event_author_pubkey,
+        ],
+    )
+}
+
+fn pending_digest(pending: ExpectedOperatorPendingReplacement) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-pending-replacement:v1",
+        &[
+            &retired_target_digest(pending.target),
+            &pending.fact_generation.to_be_bytes(),
+        ],
+    )
+}
+
+fn replacement_digest(replacement: &RequestedOperatorReplacement) -> [u8; 32] {
+    operator_digest(
+        b"buzz:operator-replacement:v1",
+        &[
+            &replacement.event_author_pubkey,
+            &replacement.expires_at.timestamp_micros().to_be_bytes(),
+        ],
+    )
+}
+
+fn operator_digest(domain: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for part in parts {
+        digest.update((part.len() as u64).to_be_bytes());
+        digest.update(part);
+    }
+    digest.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, pin::Pin};
+
+    use buzz_auth::{
+        operator_lifecycle::{OperatorLifecycleVerifier, OperatorProofSetReplayGuard},
+        AuthError,
+    };
+    use chrono::Duration;
+    use nostr::{EventBuilder, EventId, Keys, Kind, Tag, Timestamp};
+
+    use super::*;
+
+    fn loopback_test_database_url() -> String {
+        format!(
+            "{}://{}:{}@{}:{}/{}",
+            "postgres", "buzz", "buzz_dev", "localhost", 5432, "buzz"
+        )
+    }
+
+    struct PermissiveOperatorGuard;
+
+    impl OperatorProofSetReplayGuard for PermissiveOperatorGuard {
+        fn try_admit_quota<'a>(
+            &'a self,
+            _quota_scope: &'a str,
+            _signer_attribution: &'a [u8; 32],
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async { Ok(true) })
+        }
+
+        fn try_mark_all_in_scope<'a>(
+            &'a self,
+            _scope: &'a str,
+            _event_ids: &'a [EventId],
+            _ttl_secs: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<bool, AuthError>> + Send + 'a>> {
+            Box::pin(async { Ok(true) })
+        }
+    }
+
+    fn operation(domain: CommunityId, operation_id: Uuid) -> OperatorLifecycleOperation {
+        OperatorLifecycleOperation::new(domain, operation_id, Uuid::new_v4(), Uuid::new_v4())
+            .expect("operation")
+    }
+
+    fn active() -> ExactActiveOperatorTarget {
+        ExactActiveOperatorTarget::new(Uuid::new_v4(), 7, 1, [11; 32], [12; 32])
+            .expect("active target")
+    }
+
+    fn retired() -> ExactRetiredOperatorTarget {
+        ExactRetiredOperatorTarget::new(Uuid::new_v4(), 7, 2, [11; 32], [12; 32])
+            .expect("retired target")
+    }
+
+    fn replacement() -> RequestedOperatorReplacement {
+        RequestedOperatorReplacement::new([13; 32], Utc::now() + Duration::minutes(5))
+            .expect("replacement")
+    }
+
+    fn signed_operator_request(
+        keys: &Keys,
+        url: &str,
+        body: &[u8],
+        intent_digest: [u8; 32],
+        created_at: Timestamp,
+    ) -> String {
+        let payload = hex::encode(<[u8; 32]>::from(Sha256::digest(body)));
+        let intent = hex::encode(intent_digest);
+        let event = EventBuilder::new(Kind::HttpAuth, "")
+            .tags([
+                Tag::parse(["u", url]).expect("url tag"),
+                Tag::parse(["method", "POST"]).expect("method tag"),
+                Tag::parse(["payload", payload.as_str()]).expect("payload tag"),
+                Tag::parse(["buzz-intent", intent.as_str()]).expect("intent tag"),
+            ])
+            .custom_created_at(created_at)
+            .sign_with_keys(keys)
+            .expect("sign operator request");
+        serde_json::to_string(&event).expect("serialize operator request")
+    }
+
+    async fn seed_active_operator_binding(
+        pool: &sqlx::PgPool,
+        domain: CommunityId,
+        actor_keys: &Keys,
+        discriminator: u8,
+    ) -> ExactActiveOperatorTarget {
+        let binding_id = Uuid::new_v4();
+        let enrollment_operation = Uuid::new_v4();
+        let enrollment_request = [discriminator; 32];
+        let enrollment_history = Uuid::new_v4();
+        let principal_fingerprint = [discriminator.wrapping_add(1); 32];
+        let event_author = actor_keys.public_key().to_bytes();
+        let actor_fingerprint = [discriminator.wrapping_add(2); 32];
+        let enrollment_result = [discriminator.wrapping_add(3); 32];
+        let enrollment_envelope = vec![discriminator.wrapping_add(4); 64];
+        let envelope_digest: [u8; 32] = Sha256::digest(&enrollment_envelope).into();
+        let mut seed = pool.begin().await.expect("begin active binding seed");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+              outcome_code,result_digest) VALUES ($1,$2,$3,1,$4,1,$5)",
+        )
+        .bind(domain.as_uuid())
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind(actor_fingerprint.as_slice())
+        .bind(enrollment_result.as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert active binding receipt");
+        let binding_version: i64 = sqlx::query_scalar(
+            "INSERT INTO identity_bindings \
+             (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
+              binding_state,lifecycle_revision,binding_provenance,policy_revision, \
+              enrollment_evidence_digest,birth_history_id,creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1,$2,$3,$4,$5,$6,1,1,1,1,$7,$8,$9,$10) \
+             RETURNING binding_version",
+        )
+        .bind(domain.as_uuid())
+        .bind(binding_id)
+        .bind(format!("issuer-{discriminator}"))
+        .bind(format!("subject-{discriminator}"))
+        .bind(principal_fingerprint.as_slice())
+        .bind(event_author.as_slice())
+        .bind([discriminator.wrapping_add(5); 32].as_slice())
+        .bind(enrollment_history)
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .fetch_one(&mut *seed)
+        .await
+        .expect("insert active binding");
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id,history_id,transition_kind,outcome_code,successor_binding_id, \
+              successor_binding_version,successor_lifecycle_revision,successor_state, \
+              operation_id,request_fingerprint,transition_digest) \
+             VALUES ($1,$2,1,1,$3,$4,1,1,$5,$6,$7)",
+        )
+        .bind(domain.as_uuid())
+        .bind(enrollment_history)
+        .bind(binding_id)
+        .bind(binding_version)
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind([discriminator.wrapping_add(6); 32].as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert active binding history");
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+              actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+              occurred_at,canonical_envelope,envelope_digest) \
+             VALUES ($1,$2,1,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+        )
+        .bind(domain.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(actor_fingerprint.as_slice())
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(&enrollment_envelope)
+        .bind(envelope_digest.as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert active binding audit");
+        sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+            .execute(&mut *seed)
+            .await
+            .expect("validate active binding seed");
+        seed.commit().await.expect("commit active binding seed");
+        ExactActiveOperatorTarget::new(
+            binding_id,
+            u64::try_from(binding_version).expect("positive binding version"),
+            1,
+            principal_fingerprint,
+            event_author,
+        )
+        .expect("exact active seed target")
+    }
+
+    fn rotate_body(
+        operation_id: Uuid,
+        replacement: &Keys,
+        replacement_expires_at: DateTime<Utc>,
+    ) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "operation": { "operation_id": operation_id },
+            "expected_revision": 1,
+            "replacement": {
+                "event_author_pubkey": hex::encode(replacement.public_key().to_bytes()),
+                "expires_at": replacement_expires_at,
+            },
+        }))
+        .expect("serialize rotate body")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn verified_rotate_grant(
+        verifier: &OperatorLifecycleVerifier,
+        guard: &PermissiveOperatorGuard,
+        signer: &Keys,
+        replacement: &Keys,
+        url: &str,
+        body: &[u8],
+        intent: &OperatorLifecycleIntent,
+        replacement_expires_at: DateTime<Utc>,
+        created_at: Timestamp,
+    ) -> VerifiedOperatorLifecycleGrant {
+        let primary =
+            signed_operator_request(signer, url, body, intent.intent_digest(), created_at);
+        let replacement_proof =
+            signed_operator_request(replacement, url, body, intent.intent_digest(), created_at);
+        verifier
+            .verify_lifecycle(
+                &primary,
+                None,
+                Some(&replacement_proof),
+                url,
+                body,
+                guard,
+                intent.authorization_domain(),
+                OperatorLifecycleAction::Rotate,
+                intent.operation_id(),
+                intent.intent_digest(),
+                1,
+                Some(replacement.public_key().to_bytes()),
+                Some(replacement_expires_at),
+            )
+            .await
+            .expect("verify rotate grant")
+    }
+
+    #[test]
+    fn all_six_actions_are_typed_and_redacted() {
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let active = active();
+        let pending = ExpectedOperatorPendingReplacement::new(retired(), 3).expect("pending");
+        let intents = [
+            OperatorLifecycleIntent::retire(operation(domain, Uuid::new_v4()), 1, active),
+            OperatorLifecycleIntent::disable(
+                operation(domain, Uuid::new_v4()),
+                1,
+                [11; 32],
+                Some(active),
+            ),
+            OperatorLifecycleIntent::revoke(
+                operation(domain, Uuid::new_v4()),
+                1,
+                [12; 32],
+                Some(active),
+            ),
+            OperatorLifecycleIntent::rotate(
+                operation(domain, Uuid::new_v4()),
+                1,
+                active,
+                replacement(),
+            ),
+            OperatorLifecycleIntent::recover(
+                operation(domain, Uuid::new_v4()),
+                3,
+                pending,
+                replacement(),
+            ),
+            OperatorLifecycleIntent::enable(
+                operation(domain, Uuid::new_v4()),
+                4,
+                [11; 32],
+                4,
+                pending,
+                replacement(),
+            ),
+        ];
+        for intent in intents {
+            let intent = intent.expect("typed intent");
+            assert_ne!(intent.intent_digest(), [0; 32]);
+            let debug = format!("{intent:?}");
+            assert!(debug.contains("[REDACTED]"));
+            assert!(!debug.contains(&intent.operation_id().to_string()));
+        }
+    }
+
+    #[test]
+    fn semantic_digest_ignores_delivery_ids_but_binds_operation_and_target() {
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let operation_id = Uuid::new_v4();
+        let target = active();
+        let first = OperatorLifecycleIntent::retire(operation(domain, operation_id), 1, target)
+            .expect("first");
+        let retry = OperatorLifecycleIntent::retire(operation(domain, operation_id), 1, target)
+            .expect("retry");
+        assert_eq!(first.intent_digest(), retry.intent_digest());
+
+        let changed = OperatorLifecycleIntent::retire(operation(domain, operation_id), 1, active())
+            .expect("changed");
+        assert_ne!(first.intent_digest(), changed.intent_digest());
+    }
+
+    #[test]
+    fn invalid_coordinates_fail_before_fingerprinting() {
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        assert!(OperatorLifecycleOperation::new(
+            domain,
+            Uuid::nil(),
+            Uuid::new_v4(),
+            Uuid::new_v4()
+        )
+        .is_err());
+        assert!(ExactActiveOperatorTarget::new(Uuid::new_v4(), 1, 2, [1; 32], [2; 32]).is_err());
+        assert!(ExactRetiredOperatorTarget::new(Uuid::new_v4(), 1, 1, [1; 32], [2; 32]).is_err());
+        assert!(RequestedOperatorReplacement::new([0; 32], Utc::now()).is_err());
+    }
+
+    #[test]
+    fn enable_requires_and_binds_exact_pending_lineage() {
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let pending = ExpectedOperatorPendingReplacement::new(retired(), 7).expect("pending");
+        let intent = OperatorLifecycleIntent::enable(
+            operation(domain, Uuid::new_v4()),
+            4,
+            [11; 32],
+            4,
+            pending,
+            replacement(),
+        )
+        .expect("exact pending intent");
+        assert_eq!(intent.action(), OperatorLifecycleAction::Enable);
+        assert_ne!(intent.intent_digest(), [0; 32]);
+
+        let changed = OperatorLifecycleIntent::enable(
+            operation(domain, intent.operation_id()),
+            4,
+            [11; 32],
+            4,
+            ExpectedOperatorPendingReplacement::new(retired(), 8).expect("changed pending"),
+            replacement(),
+        )
+        .expect("changed pending intent");
+        assert_ne!(intent.intent_digest(), changed.intent_digest());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a dedicated disposable Postgres database"]
+    async fn postgres_verified_retire_commits_transition_invalidation_receipt_and_audit() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect operator test admin");
+        let database_name = format!("s3_operator_lifecycle_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("create disposable operator database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let database_url = format!("{}/{}", &admin_url[..split], database_name);
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(&database_url)
+            .await
+            .expect("connect disposable operator database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply canonical migrations");
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!("operator-{}.example", domain.as_uuid().simple()))
+            .execute(&pool)
+            .await
+            .expect("insert operator community");
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+             VALUES ($1,1,1,$2,transaction_timestamp()-interval '1 second')",
+        )
+        .bind(domain.as_uuid())
+        .bind([31_u8; 32].as_slice())
+        .execute(&pool)
+        .await
+        .expect("insert enrollment policy");
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+             VALUES ($1,32,65536,4096)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install audit capacity");
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_domains (community_id,current_generation) \
+             VALUES ($1,0)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("activate invalidation");
+
+        let actor_keys = Keys::generate();
+        let binding_id = Uuid::new_v4();
+        let enrollment_operation = Uuid::new_v4();
+        let enrollment_request = [32_u8; 32];
+        let enrollment_history = Uuid::new_v4();
+        let principal_fingerprint = [33_u8; 32];
+        let event_author = actor_keys.public_key().to_bytes();
+        let actor_fingerprint = [34_u8; 32];
+        let enrollment_result = [35_u8; 32];
+        let enrollment_envelope = vec![36_u8; 64];
+        let enrollment_envelope_digest: [u8; 32] = Sha256::digest(&enrollment_envelope).into();
+        let mut seed = pool.begin().await.expect("begin canonical enrollment seed");
+        sqlx::query(
+            "INSERT INTO authorization_operation_receipts \
+             (community_id,operation_id,request_fingerprint,operation_kind,actor_fingerprint, \
+              outcome_code,result_digest) VALUES ($1,$2,$3,1,$4,1,$5)",
+        )
+        .bind(domain.as_uuid())
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind(actor_fingerprint.as_slice())
+        .bind(enrollment_result.as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert canonical enrollment receipt");
+        let binding_version: i64 = sqlx::query_scalar(
+            "INSERT INTO identity_bindings \
+             (community_id,binding_id,issuer,subject,principal_fingerprint,event_author_pubkey, \
+              binding_state,lifecycle_revision,binding_provenance,policy_revision, \
+              enrollment_evidence_digest,birth_history_id,creation_operation_id, \
+              creation_request_fingerprint) \
+             VALUES ($1,$2,'issuer','subject',$3,$4,1,1,1,1,$5,$6,$7,$8) \
+             RETURNING binding_version",
+        )
+        .bind(domain.as_uuid())
+        .bind(binding_id)
+        .bind(principal_fingerprint.as_slice())
+        .bind(event_author.as_slice())
+        .bind([38_u8; 32].as_slice())
+        .bind(enrollment_history)
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .fetch_one(&mut *seed)
+        .await
+        .expect("insert active binding");
+        sqlx::query(
+            "INSERT INTO identity_lifecycle_history \
+             (community_id,history_id,transition_kind,outcome_code,successor_binding_id, \
+              successor_binding_version,successor_lifecycle_revision,successor_state, \
+              operation_id,request_fingerprint,transition_digest) \
+             VALUES ($1,$2,1,1,$3,$4,1,1,$5,$6,$7)",
+        )
+        .bind(domain.as_uuid())
+        .bind(enrollment_history)
+        .bind(binding_id)
+        .bind(binding_version)
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind([37_u8; 32].as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert enrollment history");
+        sqlx::query(
+            "INSERT INTO authorization_events \
+             (community_id,event_id,event_kind,outcome_code,reason_code,actor_kind, \
+              actor_fingerprint,operation_id,request_fingerprint,correlation_id,attempt_id, \
+              occurred_at,canonical_envelope,envelope_digest) \
+             VALUES ($1,$2,1,1,1,1,$3,$4,$5,$6,$7,transaction_timestamp(),$8,$9)",
+        )
+        .bind(domain.as_uuid())
+        .bind(Uuid::new_v4())
+        .bind(actor_fingerprint.as_slice())
+        .bind(enrollment_operation)
+        .bind(enrollment_request.as_slice())
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(&enrollment_envelope)
+        .bind(enrollment_envelope_digest.as_slice())
+        .execute(&mut *seed)
+        .await
+        .expect("insert canonical enrollment audit");
+        sqlx::query("SET CONSTRAINTS ALL IMMEDIATE")
+            .execute(&mut *seed)
+            .await
+            .expect("validate enrollment seed");
+        seed.commit().await.expect("commit enrollment seed");
+
+        let operation_id = Uuid::new_v4();
+        let operation =
+            OperatorLifecycleOperation::new(domain, operation_id, Uuid::new_v4(), Uuid::new_v4())
+                .expect("operator operation");
+        let target = ExactActiveOperatorTarget::new(
+            binding_id,
+            u64::try_from(binding_version).expect("positive binding version"),
+            1,
+            principal_fingerprint,
+            event_author,
+        )
+        .expect("exact active target");
+        let intent = OperatorLifecycleIntent::retire(operation, 1, target).expect("retire intent");
+        let body = serde_json::to_vec(&serde_json::json!({
+            "operation": { "operation_id": operation_id },
+            "expected_revision": 1,
+        }))
+        .expect("serialize operator body");
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/retire",
+            domain.as_uuid()
+        );
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("operator verifier");
+        let guard = PermissiveOperatorGuard;
+        let first_time = Timestamp::from(
+            u64::try_from(Utc::now().timestamp() - 1).expect("positive signer time"),
+        );
+        let first_grant = verifier
+            .verify_lifecycle(
+                &signed_operator_request(&signer, &url, &body, intent.intent_digest(), first_time),
+                None,
+                None,
+                &url,
+                &body,
+                &guard,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent.intent_digest(),
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("verify first operator grant");
+        let db = Db::from_pool(pool.clone());
+        let committed = db
+            .commit_verified_operator_lifecycle(&intent, &first_grant)
+            .await
+            .expect("commit verified retire");
+        let notice = match committed {
+            OperatorLifecycleCommitOutcome::Committed { invalidation } => invalidation,
+            OperatorLifecycleCommitOutcome::ExactReplay => panic!("first retire must commit"),
+        };
+        assert_eq!(notice.authorization_domain(), domain);
+        assert_eq!(notice.operation_id(), operation_id);
+        assert_eq!(notice.generation(), 1);
+
+        let retry_grant = verifier
+            .verify_lifecycle(
+                &signed_operator_request(
+                    &signer,
+                    &url,
+                    &body,
+                    intent.intent_digest(),
+                    Timestamp::now(),
+                ),
+                None,
+                None,
+                &url,
+                &body,
+                &guard,
+                domain,
+                OperatorLifecycleAction::Retire,
+                operation_id,
+                intent.intent_digest(),
+                1,
+                None,
+                None,
+            )
+            .await
+            .expect("verify fresh retry grant");
+        assert_eq!(
+            first_grant.request_attribution(),
+            retry_grant.request_attribution()
+        );
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&intent, &retry_grant)
+                .await
+                .expect("exact operator replay"),
+            OperatorLifecycleCommitOutcome::ExactReplay
+        ));
+        let (state, history_count, event_count, generation): (i16, i64, i64, i64) =
+            sqlx::query_as(
+                "SELECT binding_state, \
+                 (SELECT count(*) FROM identity_lifecycle_history WHERE community_id=$1 AND operation_id=$2), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1 AND operation_id=$2), \
+                 (SELECT current_generation FROM authorization_invalidation_domains WHERE community_id=$1) \
+                 FROM identity_bindings WHERE community_id=$1 AND binding_id=$3",
+            )
+            .bind(domain.as_uuid())
+            .bind(operation_id)
+            .bind(binding_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read committed operator state");
+        assert_eq!(
+            (state, history_count, event_count, generation),
+            (2, 1, 1, 1)
+        );
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop disposable operator database");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a dedicated disposable Postgres database"]
+    async fn postgres_verified_rotate_retires_before_successor_and_replays_atomically() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect rotate test admin");
+        let database_name = format!("s3_operator_rotate_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("create disposable rotate database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let database_url = format!("{}/{}", &admin_url[..split], database_name);
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(&database_url)
+            .await
+            .expect("connect disposable rotate database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply canonical migrations");
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!("rotate-{}.example", domain.as_uuid().simple()))
+            .execute(&pool)
+            .await
+            .expect("insert rotate community");
+        sqlx::query(
+            "INSERT INTO identity_enrollment_policies \
+             (community_id,policy_revision,enrollment_mode,policy_digest,effective_at) \
+             VALUES ($1,1,1,$2,transaction_timestamp()-interval '1 second')",
+        )
+        .bind(domain.as_uuid())
+        .bind([61_u8; 32].as_slice())
+        .execute(&pool)
+        .await
+        .expect("insert rotate enrollment policy");
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+             VALUES ($1,64,131072,4096)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install rotate audit capacity");
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_domains (community_id,current_generation) \
+             VALUES ($1,0)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("activate rotate invalidation");
+
+        let old_keys = Keys::generate();
+        let collision_keys = Keys::generate();
+        let target = seed_active_operator_binding(&pool, domain, &old_keys, 62).await;
+        let collision_target =
+            seed_active_operator_binding(&pool, domain, &collision_keys, 72).await;
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("operator verifier");
+        let guard = PermissiveOperatorGuard;
+        let db = Db::from_pool(pool.clone());
+        let url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/rotate",
+            domain.as_uuid()
+        );
+
+        let failed_operation_id = Uuid::new_v4();
+        let failed_expiry = Utc::now() + Duration::minutes(5);
+        let failed_intent = OperatorLifecycleIntent::rotate(
+            operation(domain, failed_operation_id),
+            1,
+            target,
+            RequestedOperatorReplacement::new(
+                collision_keys.public_key().to_bytes(),
+                failed_expiry,
+            )
+            .expect("conflicting rotate replacement"),
+        )
+        .expect("conflicting rotate intent");
+        let failed_body = rotate_body(failed_operation_id, &collision_keys, failed_expiry);
+        let failed_grant = verified_rotate_grant(
+            &verifier,
+            &guard,
+            &signer,
+            &collision_keys,
+            &url,
+            &failed_body,
+            &failed_intent,
+            failed_expiry,
+            Timestamp::now(),
+        )
+        .await;
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&failed_intent, &failed_grant)
+                .await,
+            Err(OperatorLifecycleError::Storage(_))
+        ));
+        let (old_after_failure, collision_after_failure, failed_history, failed_receipt, failed_event, failed_generation):
+            (i16, i16, i64, i64, i64, i64) = sqlx::query_as(
+                "SELECT \
+                 (SELECT binding_state FROM identity_bindings WHERE community_id=$1 AND binding_id=$2), \
+                 (SELECT binding_state FROM identity_bindings WHERE community_id=$1 AND binding_id=$3), \
+                 (SELECT count(*) FROM identity_lifecycle_history WHERE community_id=$1 AND operation_id=$4), \
+                 (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1 AND operation_id=$4), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1 AND operation_id=$4), \
+                 (SELECT current_generation FROM authorization_invalidation_domains WHERE community_id=$1)",
+            )
+            .bind(domain.as_uuid())
+            .bind(target.binding_id)
+            .bind(collision_target.binding_id)
+            .bind(failed_operation_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read failed rotate rollback");
+        assert_eq!(
+            (
+                old_after_failure,
+                collision_after_failure,
+                failed_history,
+                failed_receipt,
+                failed_event,
+                failed_generation,
+            ),
+            (1, 1, 0, 0, 0, 0)
+        );
+
+        let replacement_keys = Keys::generate();
+        let operation_id = Uuid::new_v4();
+        let replacement_expiry = Utc::now() + Duration::minutes(5);
+        let intent = OperatorLifecycleIntent::rotate(
+            operation(domain, operation_id),
+            1,
+            target,
+            RequestedOperatorReplacement::new(
+                replacement_keys.public_key().to_bytes(),
+                replacement_expiry,
+            )
+            .expect("successful rotate replacement"),
+        )
+        .expect("successful rotate intent");
+        let body = rotate_body(operation_id, &replacement_keys, replacement_expiry);
+        let grant = verified_rotate_grant(
+            &verifier,
+            &guard,
+            &signer,
+            &replacement_keys,
+            &url,
+            &body,
+            &intent,
+            replacement_expiry,
+            Timestamp::now(),
+        )
+        .await;
+        let notice = match db
+            .commit_verified_operator_lifecycle(&intent, &grant)
+            .await
+            .expect("commit verified rotate")
+        {
+            OperatorLifecycleCommitOutcome::Committed { invalidation } => invalidation,
+            OperatorLifecycleCommitOutcome::ExactReplay => panic!("first rotate must commit"),
+        };
+        assert_eq!(notice.generation(), 1);
+
+        let replay_grant = verified_rotate_grant(
+            &verifier,
+            &guard,
+            &signer,
+            &replacement_keys,
+            &url,
+            &body,
+            &intent,
+            replacement_expiry,
+            Timestamp::now(),
+        )
+        .await;
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&intent, &replay_grant)
+                .await
+                .expect("exact rotate replay"),
+            OperatorLifecycleCommitOutcome::ExactReplay
+        ));
+
+        let changed_keys = Keys::generate();
+        let changed_expiry = Utc::now() + Duration::minutes(5);
+        let changed_intent = OperatorLifecycleIntent::rotate(
+            operation(domain, operation_id),
+            1,
+            target,
+            RequestedOperatorReplacement::new(changed_keys.public_key().to_bytes(), changed_expiry)
+                .expect("changed rotate replacement"),
+        )
+        .expect("changed rotate intent");
+        let changed_body = rotate_body(operation_id, &changed_keys, changed_expiry);
+        let changed_grant = verified_rotate_grant(
+            &verifier,
+            &guard,
+            &signer,
+            &changed_keys,
+            &url,
+            &changed_body,
+            &changed_intent,
+            changed_expiry,
+            Timestamp::now(),
+        )
+        .await;
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&changed_intent, &changed_grant)
+                .await,
+            Err(OperatorLifecycleError::IntentConflict)
+        ));
+
+        let (old_state, successor_count, changed_count, history_count, receipt_count, event_count, generation):
+            (i16, i64, i64, i64, i64, i64, i64) = sqlx::query_as(
+                "SELECT \
+                 (SELECT binding_state FROM identity_bindings WHERE community_id=$1 AND binding_id=$2), \
+                 (SELECT count(*) FROM identity_bindings WHERE community_id=$1 \
+                   AND principal_fingerprint=$3 AND event_author_pubkey=$4 AND binding_state=1), \
+                 (SELECT count(*) FROM identity_bindings WHERE community_id=$1 \
+                   AND event_author_pubkey=$5), \
+                 (SELECT count(*) FROM identity_lifecycle_history WHERE community_id=$1 AND operation_id=$6), \
+                 (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1 AND operation_id=$6), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1 AND operation_id=$6), \
+                 (SELECT current_generation FROM authorization_invalidation_domains WHERE community_id=$1)",
+            )
+            .bind(domain.as_uuid())
+            .bind(target.binding_id)
+            .bind(target.principal_fingerprint.as_slice())
+            .bind(replacement_keys.public_key().to_bytes().as_slice())
+            .bind(changed_keys.public_key().to_bytes().as_slice())
+            .bind(operation_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read committed rotate state");
+        assert_eq!(
+            (
+                old_state,
+                successor_count,
+                changed_count,
+                history_count,
+                receipt_count,
+                event_count,
+                generation,
+            ),
+            (2, 1, 0, 1, 1, 1, 1)
+        );
+
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop disposable rotate database");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a dedicated disposable Postgres database"]
+    async fn postgres_no_active_disable_and_revoke_reject_generation_mismatch_without_writes() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect generation test admin");
+        let database_name = format!("s3_operator_generation_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "CREATE DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("create disposable generation database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let database_url = format!("{}/{}", &admin_url[..split], database_name);
+        let pool = PgPoolOptions::new()
+            .max_connections(3)
+            .connect(&database_url)
+            .await
+            .expect("connect disposable generation database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("apply canonical migrations");
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!("generation-{}.example", domain.as_uuid().simple()))
+            .execute(&pool)
+            .await
+            .expect("insert generation community");
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id,max_events_per_domain,max_bytes_per_domain,max_envelope_bytes) \
+             VALUES ($1,16,32768,4096)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("install generation audit capacity");
+        sqlx::query(
+            "INSERT INTO authorization_invalidation_domains (community_id,current_generation) \
+             VALUES ($1,0)",
+        )
+        .bind(domain.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("activate generation invalidation");
+
+        let signer = Keys::generate();
+        let verifier =
+            OperatorLifecycleVerifier::new(vec![signer.public_key()]).expect("operator verifier");
+        let guard = PermissiveOperatorGuard;
+        let db = Db::from_pool(pool.clone());
+        let principal = [91_u8; 32];
+        let event_author = [92_u8; 32];
+        let disable_operation = Uuid::new_v4();
+        let disable = OperatorLifecycleIntent::disable(
+            operation(domain, disable_operation),
+            2,
+            principal,
+            None,
+        )
+        .expect("mismatched no-active disable");
+        let disable_body = serde_json::to_vec(&serde_json::json!({
+            "operation": { "operation_id": disable_operation },
+            "expected_revision": 2,
+        }))
+        .expect("serialize disable mismatch");
+        let disable_url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/disable",
+            domain.as_uuid()
+        );
+        let disable_grant = verifier
+            .verify_lifecycle(
+                &signed_operator_request(
+                    &signer,
+                    &disable_url,
+                    &disable_body,
+                    disable.intent_digest(),
+                    Timestamp::now(),
+                ),
+                None,
+                None,
+                &disable_url,
+                &disable_body,
+                &guard,
+                domain,
+                OperatorLifecycleAction::Disable,
+                disable_operation,
+                disable.intent_digest(),
+                2,
+                None,
+                None,
+            )
+            .await
+            .expect("verify disable mismatch grant");
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&disable, &disable_grant)
+                .await,
+            Err(OperatorLifecycleError::AuthorizationDenied)
+        ));
+
+        let revoke_operation = Uuid::new_v4();
+        let revoke = OperatorLifecycleIntent::revoke(
+            operation(domain, revoke_operation),
+            2,
+            event_author,
+            None,
+        )
+        .expect("mismatched no-active revoke");
+        let revoke_body = serde_json::to_vec(&serde_json::json!({
+            "operation": { "operation_id": revoke_operation },
+            "expected_revision": 2,
+        }))
+        .expect("serialize revoke mismatch");
+        let revoke_url = format!(
+            "https://operator.example/operator/communities/{}/identity-lifecycle/revoke",
+            domain.as_uuid()
+        );
+        let revoke_grant = verifier
+            .verify_lifecycle(
+                &signed_operator_request(
+                    &signer,
+                    &revoke_url,
+                    &revoke_body,
+                    revoke.intent_digest(),
+                    Timestamp::now(),
+                ),
+                None,
+                None,
+                &revoke_url,
+                &revoke_body,
+                &guard,
+                domain,
+                OperatorLifecycleAction::Revoke,
+                revoke_operation,
+                revoke.intent_digest(),
+                2,
+                None,
+                None,
+            )
+            .await
+            .expect("verify revoke mismatch grant");
+        assert!(matches!(
+            db.commit_verified_operator_lifecycle(&revoke, &revoke_grant)
+                .await,
+            Err(OperatorLifecycleError::AuthorizationDenied)
+        ));
+
+        let (selectors, histories, receipts, events, generation): (i64, i64, i64, i64, i64) =
+            sqlx::query_as(
+                "SELECT \
+                 (SELECT count(*) FROM identity_lifecycle_selectors WHERE community_id=$1), \
+                 (SELECT count(*) FROM identity_lifecycle_history WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1), \
+                 (SELECT count(*) FROM authorization_events WHERE community_id=$1), \
+                 (SELECT current_generation FROM authorization_invalidation_domains WHERE community_id=$1)",
+            )
+            .bind(domain.as_uuid())
+            .fetch_one(&pool)
+            .await
+            .expect("read generation mismatch rollback");
+        assert_eq!(
+            (selectors, histories, receipts, events, generation),
+            (0, 0, 0, 0, 0)
+        );
+
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {database_name}"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop disposable generation database");
+    }
+
+    #[tokio::test]
+    async fn provision_authentication_attempt_is_exact_and_redacted() {
+        use sqlx::postgres::PgPoolOptions;
+
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        let db = Db::from_pool(
+            PgPoolOptions::new()
+                .connect_lazy(&loopback_test_database_url())
+                .expect("lazy test pool"),
+        );
+        let body = serde_json::to_vec(&serde_json::json!({
+            "authorization_domain": domain.as_uuid(),
+            "operation_id": Uuid::new_v4(),
+            "policy_revision": 7,
+            "policy_digest": hex::encode([21_u8; 32]),
+            "issuer": "https://private-issuer.example",
+            "subject": "private-subject-canary",
+            "selected_event_author_pubkey": hex::encode([22_u8; 32]),
+        }))
+        .expect("serialize provision attempt");
+        let attempt =
+            OperatorProvisionAuthenticationAttempt::from_bounded_body(db.clone(), domain, &body)
+                .expect("bounded attempt");
+        let replay =
+            OperatorProvisionAuthenticationAttempt::from_bounded_body(db.clone(), domain, &body)
+                .expect("bounded replay");
+        assert_eq!(
+            attempt.prepared.semantic_fingerprint,
+            replay.prepared.semantic_fingerprint
+        );
+        let debug = format!("{attempt:?}");
+        assert!(!debug.contains("private-issuer"));
+        assert!(!debug.contains("private-subject"));
+
+        let mut changed: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse provision attempt");
+        changed["selected_event_author_pubkey"] = serde_json::Value::String(hex::encode([23; 32]));
+        let changed = serde_json::to_vec(&changed).expect("serialize changed attempt");
+        assert_ne!(
+            attempt.prepared.semantic_fingerprint,
+            OperatorProvisionAuthenticationAttempt::from_bounded_body(db.clone(), domain, &changed)
+                .expect("changed bounded attempt")
+                .prepared
+                .semantic_fingerprint
+        );
+        let other_domain = OperatorProvisionAuthenticationAttempt::from_bounded_body(
+            db,
+            CommunityId::from_uuid(Uuid::new_v4()),
+            &body,
+        )
+        .expect("other-domain attempt");
+        assert_ne!(
+            attempt.prepared.semantic_fingerprint,
+            other_domain.prepared.semantic_fingerprint
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn postgres_authentication_denials_aggregate_without_receipt_occupancy() {
+        use buzz_auth::AuthorizationEventCapacityPolicy;
+        use sqlx::postgres::PgPoolOptions;
+
+        let admin_url =
+            std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| loopback_test_database_url());
+        let admin = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&admin_url)
+            .await
+            .expect("connect admin");
+        let name = format!("s5_operator_denial_{}", Uuid::new_v4().simple());
+        sqlx::query(sqlx::AssertSqlSafe(format!("CREATE DATABASE {name}")))
+            .execute(&admin)
+            .await
+            .expect("create scratch database");
+        let split = admin_url.rfind('/').expect("database URL path");
+        let url = format!("{}/{}", &admin_url[..split], name);
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await
+            .expect("connect scratch database");
+        crate::migration::run_migrations(&pool)
+            .await
+            .expect("migrate scratch database");
+        let db = Db::from_pool(pool.clone());
+        let domain = CommunityId::from_uuid(Uuid::new_v4());
+        sqlx::query("INSERT INTO communities (id,host) VALUES ($1,$2)")
+            .bind(domain.as_uuid())
+            .bind(format!(
+                "operator-denial-{}.example",
+                domain.as_uuid().simple()
+            ))
+            .execute(&pool)
+            .await
+            .expect("insert denial community");
+        db.install_authorization_event_capacity(
+            domain,
+            AuthorizationEventCapacityPolicy::new(100, 1 << 20, 16 << 10).expect("valid capacity"),
+        )
+        .await
+        .expect("atomically install canonical and pre-auth capacities");
+        let lifecycle =
+            OperatorLifecycleIntent::revoke(operation(domain, Uuid::new_v4()), 1, [31; 32], None)
+                .expect("lifecycle denial intent");
+        assert_eq!(
+            db.record_operator_lifecycle_authentication_denial(
+                &lifecycle,
+                OperatorAuthenticationDenialReason::MissingCredential,
+            )
+            .await
+            .expect("record lifecycle denial"),
+            OperatorPreauthDenialWrite::Inserted
+        );
+        assert_eq!(
+            db.record_operator_lifecycle_authentication_denial(
+                &lifecycle,
+                OperatorAuthenticationDenialReason::MissingCredential,
+            )
+            .await
+            .expect("aggregate repeated lifecycle denial"),
+            OperatorPreauthDenialWrite::Inserted
+        );
+
+        let provision_body = serde_json::to_vec(&serde_json::json!({
+            "authorization_domain": domain.as_uuid(),
+            "operation_id": Uuid::new_v4(),
+            "policy_revision": 3,
+            "policy_digest": hex::encode([32_u8; 32]),
+            "issuer": "https://private-issuer.example",
+            "subject": "private-subject-canary",
+            "selected_event_author_pubkey": hex::encode([33_u8; 32]),
+        }))
+        .expect("serialize provision denial");
+        let provision = OperatorProvisionAuthenticationAttempt::from_bounded_body(
+            db.clone(),
+            domain,
+            &provision_body,
+        )
+        .expect("bounded provision denial");
+        assert_eq!(
+            provision
+                .persist_denial(OperatorAuthenticationDenialReason::InvalidCredential)
+                .await
+                .expect("record provision denial"),
+            OperatorPreauthDenialWrite::Inserted
+        );
+        let malformed_body = b"{\"authorization_domain\":";
+        assert_eq!(
+            OperatorProvisionAuthenticationAttempt::from_bounded_body(
+                db.clone(),
+                domain,
+                malformed_body,
+            )
+            .expect("bounded malformed attempt")
+            .persist_denial(OperatorAuthenticationDenialReason::InvalidCredential)
+            .await
+            .expect("record malformed bounded provision denial"),
+            OperatorPreauthDenialWrite::Inserted
+        );
+        assert_eq!(
+            OperatorProvisionAuthenticationAttempt::from_bounded_body(db, domain, malformed_body,)
+                .expect("bounded malformed replay")
+                .persist_denial(OperatorAuthenticationDenialReason::InvalidCredential)
+                .await
+                .expect("aggregate malformed bounded provision denial"),
+            OperatorPreauthDenialWrite::Inserted
+        );
+
+        let (buckets, denials, events, receipts): (i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+               (SELECT count(*) FROM authorization_operator_denial_buckets \
+                 WHERE community_id=$1), \
+               (SELECT COALESCE(sum(denial_count),0)::bigint \
+                  FROM authorization_operator_denial_buckets \
+                 WHERE community_id=$1), \
+               (SELECT count(*) FROM authorization_events WHERE community_id=$1), \
+               (SELECT count(*) FROM authorization_operation_receipts WHERE community_id=$1)",
+        )
+        .bind(domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("load denial cardinality");
+        assert_eq!((buckets, denials, events, receipts), (2, 5, 0, 0));
+
+        pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!("DROP DATABASE {name}")))
+            .execute(&admin)
+            .await
+            .expect("drop scratch database");
+        admin.close().await;
+    }
+}

--- a/crates/buzz-media/src/lib.rs
+++ b/crates/buzz-media/src/lib.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod bucket_index;
 pub mod config;
 pub mod error;
+pub mod publication;
 pub mod storage;
 pub mod thumbnail;
 pub mod types;
@@ -19,11 +20,19 @@ pub use bucket_index::{
 };
 pub use config::{MediaConfig, S3AddressingStyle};
 pub use error::MediaError;
+pub use publication::{
+    media_publication_manifest_key, MediaPublicationManifest, StagedMediaPublication,
+    VerifiedMediaObject,
+};
 pub use storage::{BlobHeadMeta, BlobMeta, ByteStream, MediaStorage};
 pub use types::BlobDescriptor;
-pub use upload::{process_file_upload, process_upload, process_video_upload};
+pub use upload::{
+    process_file_upload, process_upload, process_video_upload, stage_file_upload, stage_upload,
+    stage_video_upload, StagedMediaUpload,
+};
 pub use upload_record::{
-    parse_port, parse_public_ip, upload_record_key, UploadAttribution, UploadNetworkInfo,
-    UploadRecord, UPLOAD_RECORD_VERSION,
+    load_upload_record_plan, parse_port, parse_public_ip, stage_upload_record, upload_record_key,
+    upload_record_plan_key, StagedUploadRecord, UploadAttribution, UploadNetworkInfo,
+    UploadProjectionResult, UploadRecord, UPLOAD_RECORD_VERSION,
 };
 pub use validation::{looks_like_iso_bmff, serve_inline, validate_video_file, VideoMeta};

--- a/crates/buzz-media/src/publication.rs
+++ b/crates/buzz-media/src/publication.rs
@@ -1,0 +1,969 @@
+//! Immutable media publication manifests and cache-only sidecar projection.
+//!
+//! Raw blobs, thumbnails, and this manifest are staged before PostgreSQL
+//! authorization commits. Only a canonical operation receipt whose result
+//! digest equals [`StagedMediaPublication::result_digest`] makes the media
+//! visible. The legacy community sidecar is refreshed afterward as a cache;
+//! it is never an authority witness.
+
+use buzz_core::{CommunityId, TenantContext};
+use bytes::Bytes;
+use futures_core::Stream;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::sync::OwnedSemaphorePermit;
+use tokio_util::io::ReaderStream;
+use uuid::Uuid;
+
+use crate::{BlobDescriptor, BlobMeta, MediaError, MediaStorage};
+
+const MEDIA_PUBLICATION_VERSION: u8 = 1;
+const PUBLICATION_PREFIX: &str = "_publications/media";
+const MAX_PUBLICATION_BYTES: u64 = 16 * 1024;
+const MAX_THUMBNAIL_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_PRIMARY_BYTES: u64 = 500 * 1024 * 1024;
+const MAX_DURATION_SECONDS: f64 = 600.0;
+const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MediaObjectKind {
+    Primary,
+    Thumbnail,
+}
+
+/// A DB-witnessed media object whose complete bytes match the manifest digest.
+///
+/// Construction downloads the full immutable object into a private temporary
+/// file and verifies its size and SHA-256 before this value is returned. HTTP
+/// handlers can therefore form headers, full streams, or range responses only
+/// from already-verified bytes; no object-store bytes escape while verification
+/// is still in progress.
+#[derive(Debug)]
+pub struct VerifiedMediaObject {
+    file: NamedTempFile,
+    content_type: String,
+    size: u64,
+    _verification_slot: OwnedSemaphorePermit,
+}
+
+impl VerifiedMediaObject {
+    /// Exact content type authenticated by the DB-witnessed manifest.
+    pub fn content_type(&self) -> &str {
+        &self.content_type
+    }
+
+    /// Exact verified byte length.
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Read an inclusive byte range from the already-verified local copy.
+    pub async fn read_range(&self, start: u64, end: u64) -> Result<Vec<u8>, MediaError> {
+        if start > end || end >= self.size {
+            return Err(invalid_publication());
+        }
+        let length = end
+            .checked_sub(start)
+            .and_then(|value| value.checked_add(1))
+            .ok_or_else(invalid_publication)?;
+        let length = usize::try_from(length).map_err(|_| invalid_publication())?;
+        let file = self
+            .file
+            .reopen()
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+        let mut file = tokio::fs::File::from_std(file);
+        file.seek(std::io::SeekFrom::Start(start))
+            .await
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+        let mut bytes = vec![0; length];
+        file.read_exact(&mut bytes)
+            .await
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+        Ok(bytes)
+    }
+
+    /// Consume this object into a stream over the already-verified local copy.
+    pub fn into_stream(self) -> Result<crate::ByteStream, MediaError> {
+        let file = self
+            .file
+            .reopen()
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+        Ok(Box::pin(VerifiedMediaStream {
+            inner: ReaderStream::new(tokio::fs::File::from_std(file)),
+            _file: self.file,
+            _verification_slot: self._verification_slot,
+        }))
+    }
+}
+
+struct VerifiedMediaStream {
+    inner: ReaderStream<tokio::fs::File>,
+    _file: NamedTempFile,
+    _verification_slot: OwnedSemaphorePermit,
+}
+
+impl Stream for VerifiedMediaStream {
+    type Item = Result<Bytes, MediaError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(context).map(|item| {
+            item.map(|result| result.map_err(|error| MediaError::Io(error.to_string())))
+        })
+    }
+}
+
+/// Canonical immutable description of one media publication.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MediaPublicationManifest {
+    version: u8,
+    community_id: Uuid,
+    blob_sha256: String,
+    extension: String,
+    mime_type: String,
+    size: u64,
+    uploaded_at: i64,
+    dimensions: Option<String>,
+    blurhash: Option<String>,
+    thumbnail_sha256: Option<String>,
+    moderation_projection_sha256: Option<String>,
+    duration_seconds_bits: Option<u64>,
+}
+
+impl MediaPublicationManifest {
+    /// Test-only convenience for manifests without a moderation projection.
+    /// Production staging always calls the explicit projection-aware builder.
+    #[cfg(test)]
+    pub(crate) fn from_staged_blob(
+        tenant: &TenantContext,
+        blob_sha256: impl Into<String>,
+        metadata: &BlobMeta,
+    ) -> Result<Self, MediaError> {
+        Self::from_staged_blob_with_projection(tenant, blob_sha256, metadata, None)
+    }
+
+    /// Build a canonical manifest that binds a deterministic moderation plan.
+    pub(crate) fn from_staged_blob_with_projection(
+        tenant: &TenantContext,
+        blob_sha256: impl Into<String>,
+        metadata: &BlobMeta,
+        moderation_projection_digest: Option<[u8; 32]>,
+    ) -> Result<Self, MediaError> {
+        let manifest = Self {
+            version: MEDIA_PUBLICATION_VERSION,
+            community_id: *tenant.community().as_uuid(),
+            blob_sha256: blob_sha256.into(),
+            extension: metadata.ext.clone(),
+            mime_type: metadata.mime_type.clone(),
+            size: metadata.size,
+            uploaded_at: metadata.uploaded_at,
+            dimensions: nonempty(metadata.dim.clone()),
+            blurhash: nonempty(metadata.blurhash.clone()),
+            thumbnail_sha256: metadata.thumbnail_sha256.clone(),
+            moderation_projection_sha256: moderation_projection_digest.map(hex::encode),
+            duration_seconds_bits: metadata.duration_secs.map(f64::to_bits),
+        };
+        manifest.validate()?;
+        if manifest.thumbnail_sha256.is_some() == metadata.thumb_url.is_empty() {
+            return Err(invalid_publication());
+        }
+        Ok(manifest)
+    }
+
+    /// Server-resolved community bound into the publication digest.
+    pub const fn community_id(&self) -> CommunityId {
+        CommunityId::from_uuid(self.community_id)
+    }
+
+    /// Exact content hash of the primary blob.
+    pub fn blob_sha256(&self) -> &str {
+        &self.blob_sha256
+    }
+
+    /// Exact content-addressed storage key of the primary blob.
+    pub fn blob_key(&self) -> String {
+        format!("{}.{}", self.blob_sha256, self.extension)
+    }
+
+    /// Canonical extension authenticated by this manifest.
+    pub fn extension(&self) -> &str {
+        &self.extension
+    }
+
+    /// Canonical MIME type authenticated by this manifest.
+    pub fn mime_type(&self) -> &str {
+        &self.mime_type
+    }
+
+    /// Exact byte size authenticated by this manifest. Zero is valid only for
+    /// the canonical empty octet-stream attachment.
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Optional exact thumbnail digest authenticated by this manifest.
+    pub fn thumbnail_sha256(&self) -> Option<&str> {
+        self.thumbnail_sha256.as_deref()
+    }
+
+    /// Optional deterministic moderation plan bound into this publication.
+    pub fn moderation_projection_sha256(&self) -> Option<&str> {
+        self.moderation_projection_sha256.as_deref()
+    }
+
+    fn thumbnail_blob_key(&self) -> Option<String> {
+        self.thumbnail_sha256()
+            .map(|digest| format!("{digest}.thumb.jpg"))
+    }
+
+    fn resolve_request(&self, requested_path: &str) -> Result<MediaObjectKind, MediaError> {
+        let bare = self.blob_sha256();
+        if requested_path == bare || requested_path == self.blob_key() {
+            return Ok(MediaObjectKind::Primary);
+        }
+        if self.thumbnail_sha256.is_some() && requested_path == format!("{bare}.thumb.jpg") {
+            return Ok(MediaObjectKind::Thumbnail);
+        }
+        Err(MediaError::NotFound)
+    }
+
+    /// Content-addressed manifest bytes used to derive the receipt digest.
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, MediaError> {
+        self.validate()?;
+        serde_json::to_vec(self).map_err(MediaError::from)
+    }
+
+    /// Reconstruct the exact upload response for an applied or replayed witness.
+    pub fn descriptor(&self, public_base_url: &str) -> Result<BlobDescriptor, MediaError> {
+        let metadata = self.to_blob_meta(public_base_url)?;
+        Ok(BlobDescriptor {
+            url: format!("{public_base_url}/{}", self.blob_key()),
+            sha256: self.blob_sha256.clone(),
+            size: self.size,
+            mime_type: self.mime_type.clone(),
+            uploaded: self.uploaded_at,
+            dim: self.dimensions.clone(),
+            blurhash: self.blurhash.clone(),
+            thumb: (!metadata.thumb_url.is_empty()).then_some(metadata.thumb_url),
+            duration: self.duration_seconds_bits.map(f64::from_bits),
+        })
+    }
+
+    fn validate(&self) -> Result<(), MediaError> {
+        let duration = self.duration_seconds_bits.map(f64::from_bits);
+        if self.version != MEDIA_PUBLICATION_VERSION
+            || self.community_id.is_nil()
+            || !is_lower_sha256(&self.blob_sha256)
+            || !is_safe_extension(&self.extension)
+            || !is_exact_mime(&self.mime_type)
+            || (self.size == 0
+                && (self.blob_sha256 != EMPTY_SHA256
+                    || self.extension != "bin"
+                    || self.mime_type != "application/octet-stream"
+                    || self.dimensions.is_some()
+                    || self.blurhash.is_some()
+                    || self.thumbnail_sha256.is_some()
+                    || self.duration_seconds_bits.is_some()))
+            || self.size > MAX_PRIMARY_BYTES
+            || self.uploaded_at <= 0
+            || self
+                .dimensions
+                .as_deref()
+                .is_some_and(|value| !is_bounded_text(value, 64))
+            || self
+                .blurhash
+                .as_deref()
+                .is_some_and(|value| !is_bounded_text(value, 256))
+            || self
+                .thumbnail_sha256
+                .as_deref()
+                .is_some_and(|value| !is_lower_sha256(value))
+            || self
+                .moderation_projection_sha256
+                .as_deref()
+                .is_some_and(|value| !is_lower_sha256(value))
+            || duration.is_some_and(|value| {
+                !value.is_finite() || !(0.0..=MAX_DURATION_SECONDS).contains(&value)
+            })
+        {
+            return Err(invalid_publication());
+        }
+        Ok(())
+    }
+
+    fn to_blob_meta(&self, public_base_url: &str) -> Result<BlobMeta, MediaError> {
+        self.validate()?;
+        if public_base_url.is_empty() || public_base_url != public_base_url.trim_end_matches('/') {
+            return Err(invalid_publication());
+        }
+        Ok(BlobMeta {
+            dim: self.dimensions.clone().unwrap_or_default(),
+            blurhash: self.blurhash.clone().unwrap_or_default(),
+            thumb_url: self
+                .thumbnail_sha256
+                .as_ref()
+                .map_or_else(String::new, |_| {
+                    format!("{public_base_url}/{}.thumb.jpg", self.blob_sha256)
+                }),
+            thumbnail_sha256: self.thumbnail_sha256.clone(),
+            ext: self.extension.clone(),
+            mime_type: self.mime_type.clone(),
+            size: self.size,
+            uploaded_at: self.uploaded_at,
+            duration_secs: self.duration_seconds_bits.map(f64::from_bits),
+        })
+    }
+}
+
+/// Opaque proof that immutable publication bytes were durably staged.
+#[derive(Clone)]
+pub struct StagedMediaPublication {
+    manifest: MediaPublicationManifest,
+    manifest_key: String,
+    result_digest: [u8; 32],
+}
+
+impl fmt::Debug for StagedMediaPublication {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StagedMediaPublication([REDACTED])")
+    }
+}
+
+impl StagedMediaPublication {
+    /// Canonical manifest staged under the exact result digest.
+    pub const fn manifest(&self) -> &MediaPublicationManifest {
+        &self.manifest
+    }
+
+    /// Immutable manifest storage key.
+    pub fn manifest_key(&self) -> &str {
+        &self.manifest_key
+    }
+
+    /// Exact digest to commit as the protected-operation result.
+    pub const fn result_digest(&self) -> [u8; 32] {
+        self.result_digest
+    }
+
+    /// Refresh the legacy sidecar only after the DB witness is committed.
+    ///
+    /// Readers must still resolve and validate the PostgreSQL witness first;
+    /// this sidecar is only a compatibility/cache projection.
+    pub async fn publish_sidecar_cache(
+        &self,
+        storage: &MediaStorage,
+        tenant: &TenantContext,
+        public_base_url: &str,
+    ) -> Result<(), MediaError> {
+        if self.manifest.community_id() != tenant.community() {
+            return Err(invalid_publication());
+        }
+        if let Some(thumbnail_digest) = self.manifest.thumbnail_sha256() {
+            let immutable_key = self
+                .manifest
+                .thumbnail_blob_key()
+                .ok_or_else(invalid_publication)?;
+            let thumbnail = read_bounded_stream(
+                storage.get_stream(&immutable_key).await?,
+                MAX_THUMBNAIL_BYTES,
+            )
+            .await?;
+            if hex::encode(Sha256::digest(&thumbnail)) != thumbnail_digest {
+                return Err(invalid_publication());
+            }
+            let cache_key = format!("{}.thumb.jpg", self.manifest.blob_sha256());
+            storage.put(&cache_key, &thumbnail, "image/jpeg").await?;
+        }
+        let metadata = self.manifest.to_blob_meta(public_base_url)?;
+        storage
+            .put_sidecar(tenant, self.manifest.blob_sha256(), &metadata)
+            .await
+    }
+}
+
+impl MediaStorage {
+    /// Persist one immutable publication manifest without publishing visibility.
+    pub(crate) async fn stage_media_publication(
+        &self,
+        manifest: MediaPublicationManifest,
+    ) -> Result<StagedMediaPublication, MediaError> {
+        let bytes = manifest.canonical_bytes()?;
+        let result_digest: [u8; 32] = Sha256::digest(&bytes).into();
+        if result_digest == [0; 32] {
+            return Err(invalid_publication());
+        }
+        let manifest_key = media_publication_manifest_key(result_digest);
+        put_immutable_publication(self, &manifest_key, &bytes).await?;
+        Ok(StagedMediaPublication {
+            manifest,
+            manifest_key,
+            result_digest,
+        })
+    }
+
+    /// Fetch and digest-verify the immutable manifest named by a DB witness.
+    pub async fn get_media_publication(
+        &self,
+        result_digest: [u8; 32],
+    ) -> Result<MediaPublicationManifest, MediaError> {
+        if result_digest == [0; 32] {
+            return Err(invalid_publication());
+        }
+        let key = media_publication_manifest_key(result_digest);
+        let size = self
+            .head_with_metadata(&key)
+            .await?
+            .ok_or(MediaError::NotFound)?
+            .size;
+        if size == 0 || size > MAX_PUBLICATION_BYTES {
+            return Err(invalid_publication());
+        }
+        let bytes =
+            read_bounded_stream(self.get_stream(&key).await?, MAX_PUBLICATION_BYTES).await?;
+        let actual: [u8; 32] = Sha256::digest(&bytes).into();
+        if actual != result_digest {
+            return Err(invalid_publication());
+        }
+        decode_media_publication(&bytes, result_digest)
+    }
+
+    /// Resolve a DB witness and fully verify the exact requested media bytes.
+    ///
+    /// `result_digest` must come from the canonical PostgreSQL publication
+    /// witness. Sidecars are deliberately ignored. Tenant and request-path
+    /// mismatches collapse to `NotFound`; storage absence or corruption never
+    /// falls back to a raw object or sidecar.
+    pub async fn verify_media_object(
+        &self,
+        tenant: &TenantContext,
+        result_digest: [u8; 32],
+        requested_path: &str,
+    ) -> Result<VerifiedMediaObject, MediaError> {
+        let manifest = self.get_media_publication(result_digest).await?;
+        if manifest.community_id() != tenant.community() {
+            return Err(MediaError::NotFound);
+        }
+        let kind = manifest.resolve_request(requested_path)?;
+        let (key, expected_digest, expected_size, content_type) = match kind {
+            MediaObjectKind::Primary => (
+                manifest.blob_key(),
+                manifest.blob_sha256().to_owned(),
+                Some(manifest.size()),
+                manifest.mime_type().to_owned(),
+            ),
+            MediaObjectKind::Thumbnail => {
+                let thumbnail_digest = manifest
+                    .thumbnail_sha256()
+                    .ok_or_else(invalid_publication)?;
+                (
+                    manifest
+                        .thumbnail_blob_key()
+                        .ok_or_else(invalid_publication)?,
+                    thumbnail_digest.to_owned(),
+                    None,
+                    "image/jpeg".to_owned(),
+                )
+            }
+        };
+        let verification_slot = self
+            .verification_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                MediaError::StorageError("media verification capacity unavailable".to_owned())
+            })?;
+        let stream = self.get_stream(&key).await?;
+        verify_media_stream(
+            stream,
+            &expected_digest,
+            expected_size,
+            content_type,
+            verification_slot,
+        )
+        .await
+    }
+}
+
+async fn put_immutable_publication(
+    storage: &MediaStorage,
+    key: &str,
+    expected: &[u8],
+) -> Result<(), MediaError> {
+    storage
+        .put_immutable_exact(key, expected, "application/json")
+        .await?;
+    Ok(())
+}
+
+fn decode_media_publication(
+    bytes: &[u8],
+    result_digest: [u8; 32],
+) -> Result<MediaPublicationManifest, MediaError> {
+    let manifest: MediaPublicationManifest = serde_json::from_slice(bytes)?;
+    let canonical = manifest.canonical_bytes()?;
+    let canonical_digest: [u8; 32] = Sha256::digest(&canonical).into();
+    if canonical != bytes || canonical_digest != result_digest {
+        return Err(invalid_publication());
+    }
+    Ok(manifest)
+}
+
+async fn verify_media_stream(
+    mut stream: crate::ByteStream,
+    expected_digest: &str,
+    expected_size: Option<u64>,
+    content_type: String,
+    verification_slot: OwnedSemaphorePermit,
+) -> Result<VerifiedMediaObject, MediaError> {
+    let maximum_size = expected_size.unwrap_or(MAX_THUMBNAIL_BYTES);
+    let file = NamedTempFile::new().map_err(|error| MediaError::Io(error.to_string()))?;
+    let writer = file
+        .reopen()
+        .map_err(|error| MediaError::Io(error.to_string()))?;
+    let mut writer = tokio::fs::File::from_std(writer);
+    let mut digest = Sha256::new();
+    let mut size = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        size = size
+            .checked_add(u64::try_from(chunk.len()).map_err(|_| invalid_publication())?)
+            .ok_or_else(invalid_publication)?;
+        if size > maximum_size {
+            return Err(invalid_publication());
+        }
+        digest.update(&chunk);
+        writer
+            .write_all(&chunk)
+            .await
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+    }
+    writer
+        .flush()
+        .await
+        .map_err(|error| MediaError::Io(error.to_string()))?;
+    if (size == 0 && expected_size.is_none())
+        || expected_size.is_some_and(|expected| expected != size)
+        || hex::encode(digest.finalize()) != expected_digest
+    {
+        return Err(invalid_publication());
+    }
+    Ok(VerifiedMediaObject {
+        file,
+        content_type,
+        size,
+        _verification_slot: verification_slot,
+    })
+}
+
+async fn read_bounded_stream(
+    mut stream: crate::ByteStream,
+    maximum_size: u64,
+) -> Result<Vec<u8>, MediaError> {
+    let mut bytes = Vec::new();
+    let mut size = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        size = size
+            .checked_add(u64::try_from(chunk.len()).map_err(|_| invalid_publication())?)
+            .ok_or_else(invalid_publication)?;
+        if size > maximum_size {
+            return Err(invalid_publication());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if bytes.is_empty() {
+        return Err(invalid_publication());
+    }
+    Ok(bytes)
+}
+
+/// Exact immutable manifest key for a protected-operation result digest.
+pub fn media_publication_manifest_key(result_digest: [u8; 32]) -> String {
+    format!("{PUBLICATION_PREFIX}/{}.json", hex::encode(result_digest))
+}
+
+fn nonempty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn is_lower_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_safe_extension(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 8
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+fn is_exact_mime(value: &str) -> bool {
+    is_bounded_text(value, 255)
+        && value.contains('/')
+        && !value.contains(',')
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn is_bounded_text(value: &str, maximum: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum
+        && value == value.trim()
+        && !value.chars().any(char::is_control)
+}
+
+fn invalid_publication() -> MediaError {
+    MediaError::StorageError("invalid immutable media publication".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tenant(id: u128) -> TenantContext {
+        TenantContext::resolved(
+            CommunityId::from_uuid(Uuid::from_u128(id)),
+            format!("{id}.example"),
+        )
+    }
+
+    fn metadata() -> BlobMeta {
+        BlobMeta {
+            dim: "800x600".into(),
+            blurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj".into(),
+            thumb_url: "https://media.example/aaaaaaaa.thumb.jpg".into(),
+            thumbnail_sha256: Some("b".repeat(64)),
+            ext: "jpg".into(),
+            mime_type: "image/jpeg".into(),
+            size: 42,
+            uploaded_at: 1_800_000_000,
+            duration_secs: None,
+        }
+    }
+
+    #[test]
+    fn canonical_manifest_is_deterministic_and_domain_bound() {
+        let sha = "a".repeat(64);
+        let one = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &metadata())
+            .expect("manifest");
+        let again = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &metadata())
+            .expect("manifest");
+        let other = MediaPublicationManifest::from_staged_blob(&tenant(2), &sha, &metadata())
+            .expect("manifest");
+        let one_bytes = one.canonical_bytes().expect("canonical bytes");
+        assert_eq!(one_bytes, again.canonical_bytes().expect("canonical bytes"));
+        assert_ne!(one_bytes, other.canonical_bytes().expect("canonical bytes"));
+        assert_eq!(one.blob_key(), format!("{sha}.jpg"));
+        let expected_thumbnail_key = format!("{}.thumb.jpg", "b".repeat(64));
+        assert_eq!(
+            one.thumbnail_blob_key().as_deref(),
+            Some(expected_thumbnail_key.as_str())
+        );
+    }
+
+    #[test]
+    fn exact_metadata_changes_the_publication_digest() {
+        let sha = "a".repeat(64);
+        let original = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &metadata())
+            .expect("manifest");
+        let mut changed = metadata();
+        changed.mime_type = "image/png".into();
+        let changed = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &changed)
+            .expect("manifest");
+        let digest = |manifest: &MediaPublicationManifest| -> [u8; 32] {
+            Sha256::digest(manifest.canonical_bytes().expect("canonical bytes")).into()
+        };
+        assert_ne!(digest(&original), digest(&changed));
+    }
+
+    #[test]
+    fn zero_byte_primary_has_a_canonical_manifest_and_descriptor() {
+        let mut empty = metadata();
+        empty.dim.clear();
+        empty.blurhash.clear();
+        empty.thumb_url.clear();
+        empty.thumbnail_sha256 = None;
+        empty.ext = "bin".into();
+        empty.mime_type = "application/octet-stream".into();
+        empty.size = 0;
+        let digest = hex::encode(Sha256::digest([]));
+
+        let manifest = MediaPublicationManifest::from_staged_blob(&tenant(1), &digest, &empty)
+            .expect("empty primary manifest");
+        let descriptor = manifest
+            .descriptor("https://media.example")
+            .expect("empty primary descriptor");
+
+        assert_eq!(manifest.size(), 0);
+        assert_eq!(descriptor.size, 0);
+        assert_eq!(descriptor.sha256, digest);
+        assert_eq!(descriptor.mime_type, "application/octet-stream");
+    }
+
+    #[test]
+    fn moderation_projection_is_bound_into_publication_digest() {
+        let sha = "a".repeat(64);
+        let without = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &metadata())
+            .expect("manifest without projection");
+        let with = MediaPublicationManifest::from_staged_blob_with_projection(
+            &tenant(1),
+            &sha,
+            &metadata(),
+            Some([0x42; 32]),
+        )
+        .expect("manifest with projection");
+        let expected_projection = hex::encode([0x42; 32]);
+        assert_eq!(
+            with.moderation_projection_sha256(),
+            Some(expected_projection.as_str())
+        );
+        assert_ne!(
+            without.canonical_bytes().expect("canonical bytes"),
+            with.canonical_bytes().expect("canonical bytes")
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_ambiguous_or_unverifiable_metadata() {
+        let sha = "a".repeat(64);
+        let mut invalid = metadata();
+        invalid.ext = "../jpg".into();
+        assert!(MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &invalid).is_err());
+
+        let mut missing_thumbnail_digest = metadata();
+        missing_thumbnail_digest.thumbnail_sha256 = None;
+        assert!(MediaPublicationManifest::from_staged_blob(
+            &tenant(1),
+            &sha,
+            &missing_thumbnail_digest
+        )
+        .is_err());
+
+        let mut non_finite_duration = metadata();
+        non_finite_duration.thumb_url.clear();
+        non_finite_duration.thumbnail_sha256 = None;
+        non_finite_duration.duration_secs = Some(f64::NAN);
+        assert!(
+            MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &non_finite_duration)
+                .is_err()
+        );
+
+        let mut oversized = metadata();
+        oversized.size = MAX_PRIMARY_BYTES + 1;
+        assert!(MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &oversized).is_err());
+
+        let mut false_empty = metadata();
+        false_empty.size = 0;
+        false_empty.thumb_url.clear();
+        false_empty.thumbnail_sha256 = None;
+        assert!(
+            MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &false_empty).is_err()
+        );
+    }
+
+    #[test]
+    fn manifest_round_trip_reconstructs_cache_metadata() {
+        let manifest =
+            MediaPublicationManifest::from_staged_blob(&tenant(1), "a".repeat(64), &metadata())
+                .expect("manifest");
+        let bytes = manifest.canonical_bytes().expect("bytes");
+        let decoded: MediaPublicationManifest = serde_json::from_slice(&bytes).expect("decode");
+        decoded.validate().expect("valid decoded manifest");
+        let cached = decoded
+            .to_blob_meta("https://media.example")
+            .expect("cache metadata");
+        assert_eq!(cached.thumbnail_sha256, Some("b".repeat(64)));
+        assert_eq!(
+            cached.thumb_url,
+            format!("https://media.example/{}.thumb.jpg", "a".repeat(64))
+        );
+        let descriptor = decoded
+            .descriptor("https://media.example")
+            .expect("replay descriptor");
+        assert_eq!(
+            descriptor.url,
+            format!("https://media.example/{}.jpg", "a".repeat(64))
+        );
+        assert_eq!(descriptor.thumb, Some(cached.thumb_url));
+    }
+
+    #[test]
+    fn publication_decode_requires_exact_canonical_witness_bytes() {
+        let manifest =
+            MediaPublicationManifest::from_staged_blob(&tenant(1), "a".repeat(64), &metadata())
+                .expect("manifest");
+        let canonical = manifest.canonical_bytes().expect("canonical bytes");
+        let digest: [u8; 32] = Sha256::digest(&canonical).into();
+        assert_eq!(
+            decode_media_publication(&canonical, digest).expect("canonical witness"),
+            manifest
+        );
+
+        let noncanonical = serde_json::to_vec_pretty(&manifest).expect("pretty bytes");
+        let noncanonical_digest: [u8; 32] = Sha256::digest(&noncanonical).into();
+        assert!(decode_media_publication(&noncanonical, noncanonical_digest).is_err());
+        assert!(decode_media_publication(&canonical, [0x55; 32]).is_err());
+    }
+
+    #[test]
+    fn manifest_key_is_exact_digest_address() {
+        assert_eq!(
+            media_publication_manifest_key([0xab; 32]),
+            format!("{PUBLICATION_PREFIX}/{}.json", "ab".repeat(32))
+        );
+    }
+
+    #[test]
+    fn request_resolution_is_exact_and_sidecar_independent() {
+        let sha = "a".repeat(64);
+        let manifest = MediaPublicationManifest::from_staged_blob(&tenant(1), &sha, &metadata())
+            .expect("manifest");
+        assert_eq!(
+            manifest.resolve_request(&sha).expect("bare primary"),
+            MediaObjectKind::Primary
+        );
+        assert_eq!(
+            manifest
+                .resolve_request(&format!("{sha}.jpg"))
+                .expect("exact primary"),
+            MediaObjectKind::Primary
+        );
+        assert_eq!(
+            manifest
+                .resolve_request(&format!("{sha}.thumb.jpg"))
+                .expect("exact thumbnail"),
+            MediaObjectKind::Thumbnail
+        );
+        for rejected in [
+            format!("{sha}.png"),
+            format!("{sha}.JPG"),
+            format!("{sha}.thumb.jpeg"),
+            format!("{sha}.jpg/extra"),
+        ] {
+            assert!(matches!(
+                manifest.resolve_request(&rejected),
+                Err(MediaError::NotFound)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_bytes_are_verified_before_a_stream_is_returned() {
+        let bytes = Bytes::from_static(b"canonical media bytes");
+        let digest = hex::encode(Sha256::digest(&bytes));
+        let stream = futures_util::stream::iter([Ok(bytes.clone())]);
+        let verified = verify_media_stream(
+            Box::pin(stream),
+            &digest,
+            Some(bytes.len() as u64),
+            "application/octet-stream".into(),
+            std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                .try_acquire_owned()
+                .expect("verification slot"),
+        )
+        .await
+        .expect("verified object");
+        assert_eq!(verified.size(), bytes.len() as u64);
+        assert_eq!(
+            verified.read_range(1, 4).await.expect("verified range"),
+            b"anon"
+        );
+
+        for (expected_digest, expected_size) in [
+            ("00".repeat(32), Some(bytes.len() as u64)),
+            (digest.clone(), Some(bytes.len() as u64 + 1)),
+        ] {
+            let stream = futures_util::stream::iter([Ok(bytes.clone())]);
+            assert!(verify_media_stream(
+                Box::pin(stream),
+                &expected_digest,
+                expected_size,
+                "application/octet-stream".into(),
+                std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                    .try_acquire_owned()
+                    .expect("verification slot"),
+            )
+            .await
+            .is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_primary_is_verified_but_empty_derived_objects_are_rejected() {
+        let empty_digest = hex::encode(Sha256::digest([]));
+        let empty_stream = futures_util::stream::empty();
+        let verified = verify_media_stream(
+            Box::pin(empty_stream),
+            &empty_digest,
+            Some(0),
+            "application/octet-stream".into(),
+            std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                .try_acquire_owned()
+                .expect("verification slot"),
+        )
+        .await
+        .expect("empty primary");
+        assert_eq!(verified.size(), 0);
+        let mut stream = verified.into_stream().expect("verified stream");
+        assert!(stream.next().await.is_none());
+
+        let empty_thumbnail = futures_util::stream::empty();
+        assert!(verify_media_stream(
+            Box::pin(empty_thumbnail),
+            &empty_digest,
+            None,
+            "image/jpeg".into(),
+            std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                .try_acquire_owned()
+                .expect("verification slot"),
+        )
+        .await
+        .is_err());
+
+        let wrong_digest = futures_util::stream::empty();
+        assert!(verify_media_stream(
+            Box::pin(wrong_digest),
+            &"00".repeat(32),
+            Some(0),
+            "application/octet-stream".into(),
+            std::sync::Arc::new(tokio::sync::Semaphore::new(1))
+                .try_acquire_owned()
+                .expect("verification slot"),
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn manifest_stream_read_is_bounded_independently_of_head() {
+        let chunks = [
+            Ok(Bytes::from_static(b"1234")),
+            Ok(Bytes::from_static(b"5678")),
+        ];
+        assert_eq!(
+            read_bounded_stream(Box::pin(futures_util::stream::iter(chunks)), 8)
+                .await
+                .expect("exact bound"),
+            b"12345678"
+        );
+
+        let oversized = [
+            Ok(Bytes::from_static(b"1234")),
+            Ok(Bytes::from_static(b"56789")),
+        ];
+        assert!(
+            read_bounded_stream(Box::pin(futures_util::stream::iter(oversized)), 8)
+                .await
+                .is_err()
+        );
+    }
+}

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -2,15 +2,21 @@
 
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use buzz_core::tenant::{CommunityId, TenantContext};
 
 use crate::config::{MediaConfig, S3AddressingStyle};
 use crate::error::MediaError;
 use bytes::Bytes;
+use futures_util::StreamExt;
 use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Bound full-object verification disk and object-store amplification per process.
+const DEFAULT_MEDIA_VERIFICATION_CONCURRENCY: usize = 2;
 
 /// A stream of byte chunks from S3, usable with `axum::body::Body::from_stream()`.
 pub type ByteStream = Pin<Box<dyn futures_core::Stream<Item = Result<Bytes, MediaError>> + Send>>;
@@ -18,6 +24,7 @@ pub type ByteStream = Pin<Box<dyn futures_core::Stream<Item = Result<Bytes, Medi
 /// S3-compatible object storage client.
 pub struct MediaStorage {
     bucket: Box<Bucket>,
+    pub(crate) verification_slots: Arc<tokio::sync::Semaphore>,
 }
 
 impl MediaStorage {
@@ -66,7 +73,12 @@ impl MediaStorage {
             S3AddressingStyle::Path => bucket.with_path_style(),
             S3AddressingStyle::Virtual => bucket,
         };
-        Ok(Self { bucket })
+        Ok(Self {
+            bucket,
+            verification_slots: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_MEDIA_VERIFICATION_CONCURRENCY,
+            )),
+        })
     }
 
     /// Store an object from a byte slice.
@@ -78,6 +90,83 @@ impl MediaStorage {
             .put_object_with_content_type(key, bytes, content_type)
             .await?;
         Ok(())
+    }
+
+    /// Create one immutable object and verify exact bytes on deduplicated replay.
+    ///
+    /// The key must already be derived from `bytes`. `true` means this call
+    /// created it; `false` means exact bytes were already present. A collision
+    /// with different bytes fails closed and is never overwritten.
+    pub(crate) async fn put_immutable_exact(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        content_type: &str,
+    ) -> Result<bool, MediaError> {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::IF_NONE_MATCH,
+            axum::http::HeaderValue::from_static("*"),
+        );
+        let created = match self
+            .bucket
+            .put_object_with_content_type_and_headers(key, bytes, content_type, Some(headers))
+            .await
+        {
+            Ok(response) if (200..300).contains(&response.status_code()) => true,
+            Ok(response) if response.status_code() == 412 => false,
+            Err(s3::error::S3Error::HttpFailWithBody(412, _)) => false,
+            Ok(response) => {
+                return Err(MediaError::StorageError(format!(
+                    "immutable object write returned HTTP {}",
+                    response.status_code()
+                )));
+            }
+            Err(error) => return Err(MediaError::StorageError(error.to_string())),
+        };
+        let stored = self.get(key).await?;
+        if stored != bytes {
+            return Err(MediaError::StorageError(
+                "immutable object key contains different bytes".to_owned(),
+            ));
+        }
+        Ok(created)
+    }
+
+    /// Create an immutable first-writer-wins value and return the persisted
+    /// bytes.
+    ///
+    /// This is used only for a bounded typed replay index. A losing retry does
+    /// not compare its mutable attribution bytes with the winner; it loads the
+    /// first value and validates the signed stable identity at the caller.
+    pub(crate) async fn put_immutable_first(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        content_type: &str,
+    ) -> Result<Vec<u8>, MediaError> {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::IF_NONE_MATCH,
+            axum::http::HeaderValue::from_static("*"),
+        );
+        match self
+            .bucket
+            .put_object_with_content_type_and_headers(key, bytes, content_type, Some(headers))
+            .await
+        {
+            Ok(response) if (200..300).contains(&response.status_code()) => {}
+            Ok(response) if response.status_code() == 412 => {}
+            Err(s3::error::S3Error::HttpFailWithBody(412, _)) => {}
+            Ok(response) => {
+                return Err(MediaError::StorageError(format!(
+                    "immutable first-writer index returned HTTP {}",
+                    response.status_code()
+                )));
+            }
+            Err(error) => return Err(MediaError::StorageError(error.to_string())),
+        }
+        self.get(key).await
     }
 
     /// Stream a file from disk into S3 without loading it into RAM.
@@ -101,6 +190,80 @@ impl MediaStorage {
         self.bucket
             .put_object_stream_with_content_type(&mut reader, key, content_type)
             .await?;
+        Ok(())
+    }
+
+    /// Stage a large content-addressed file without replacing existing bytes.
+    ///
+    /// Existing objects are verified and reused. New writes are streamed and
+    /// then verified before the staged object is returned to a caller.
+    pub(crate) async fn put_file_immutable_verified(
+        &self,
+        key: &str,
+        path: &Path,
+        content_type: &str,
+        expected_digest: &str,
+        expected_size: u64,
+    ) -> Result<bool, MediaError> {
+        const BUF: usize = 8 * 1024 * 1024;
+
+        let file = tokio::fs::File::open(path)
+            .await
+            .map_err(|error| MediaError::Io(error.to_string()))?;
+        let mut reader = tokio::io::BufReader::with_capacity(BUF, file);
+        let request = self
+            .bucket
+            .put_object_stream_builder(key)
+            .with_content_type(content_type)
+            .with_header(axum::http::header::IF_NONE_MATCH, "*")
+            .map_err(|error| MediaError::StorageError(error.to_string()))?;
+        let created = match request.execute_stream(&mut reader).await {
+            Ok(response) if (200..300).contains(&response.status_code()) => true,
+            Ok(response) if response.status_code() == 412 => false,
+            Err(s3::error::S3Error::HttpFailWithBody(412, _)) => false,
+            Ok(response) => {
+                return Err(MediaError::StorageError(format!(
+                    "immutable streamed write returned HTTP {}",
+                    response.status_code()
+                )));
+            }
+            Err(error) => return Err(MediaError::StorageError(error.to_string())),
+        };
+        self.verify_object_digest(key, expected_digest, expected_size)
+            .await?;
+        Ok(created)
+    }
+
+    async fn verify_object_digest(
+        &self,
+        key: &str,
+        expected_digest: &str,
+        expected_size: u64,
+    ) -> Result<(), MediaError> {
+        let mut stream = self.get_stream(key).await?;
+        let mut digest = Sha256::new();
+        let mut size = 0_u64;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            size = size
+                .checked_add(u64::try_from(chunk.len()).map_err(|_| {
+                    MediaError::StorageError("immutable object chunk is too large".to_owned())
+                })?)
+                .ok_or_else(|| {
+                    MediaError::StorageError("immutable object size overflow".to_owned())
+                })?;
+            if size > expected_size {
+                return Err(MediaError::StorageError(
+                    "immutable object exceeds staged size".to_owned(),
+                ));
+            }
+            digest.update(&chunk);
+        }
+        if size != expected_size || hex::encode(digest.finalize()) != expected_digest {
+            return Err(MediaError::StorageError(
+                "immutable object bytes do not match staged digest".to_owned(),
+            ));
+        }
         Ok(())
     }
 
@@ -410,6 +573,9 @@ pub struct BlobMeta {
     pub blurhash: String,
     /// Full URL to thumbnail.
     pub thumb_url: String,
+    /// SHA-256 of the exact thumbnail bytes, when a thumbnail exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbnail_sha256: Option<String>,
     /// File extension (e.g. "jpg").
     pub ext: String,
     /// MIME type (e.g. "image/jpeg").

--- a/crates/buzz-media/src/upload.rs
+++ b/crates/buzz-media/src/upload.rs
@@ -1,17 +1,21 @@
-//! Upload pipeline — validate, store, thumbnail, sidecar.
+//! Upload pipeline — validate and stage immutable blobs and manifests.
 
 use buzz_core::tenant::TenantContext;
 use bytes::Bytes;
 use sha2::{Digest, Sha256};
+use std::fmt;
 use tokio::io::AsyncWriteExt;
 
 use crate::auth::verify_blossom_upload_auth;
 use crate::config::MediaConfig;
 use crate::error::MediaError;
+use crate::publication::{MediaPublicationManifest, StagedMediaPublication};
 use crate::storage::{BlobMeta, MediaStorage};
 use crate::thumbnail::generate_image_metadata_sync;
 use crate::types::BlobDescriptor;
-use crate::upload_record::{record_upload_event, UploadAttribution, UploadEventFacts};
+use crate::upload_record::{
+    stage_upload_record, StagedUploadRecord, UploadAttribution, UploadEventFacts,
+};
 use crate::validation::{
     looks_like_mp4_iso_bmff, mime_to_ext, validate_content, validate_file_content,
     validate_video_file,
@@ -24,24 +28,20 @@ use crate::validation::{
 ///   the `(mime, ext)` pair for the body. Images derive `ext` from the MIME;
 ///   generic files get both from the deny-list validator.
 /// - `prepare_metadata`: builds metadata and stores any derived artifacts such
-///   as a thumbnail, but deliberately does not write the sidecar. The sidecar
-///   is the media serve gate and is published only after the moderation record
-///   succeeds. It receives the already-computed
+///   as a thumbnail, but deliberately does not write operational projections.
+///   It receives the already-computed
 ///   `(sha256, ext, mime, uploaded_at)` so no work is repeated.
 ///
 /// Everything else — hash, Blossom auth (10-minute window), content-addressed
-/// key, the both-exist idempotency short-circuit, blob store, orphan-blob
-/// handling, and descriptor build — is common. The streaming video path stays
-/// separate (see [`process_video_upload`]) because it never buffers in RAM.
+/// key, blob store, orphan-blob handling, and descriptor build — is common.
+/// The streaming video path stays separate (see [`stage_video_upload`])
+/// because it never buffers in RAM.
 ///
 /// `attribution` is `Some` when per-event upload records are enabled
-/// (`BUZZ_MEDIA_UPLOAD_RECORDS`): a record is then written for **every**
-/// accepted upload — including the idempotent short-circuit, which does no
-/// blob PUT and would otherwise be invisible to the moderation pipeline.
-/// For fresh uploads, the record is written after the blob and derived
-/// artifacts but before the sidecar. This preserves both contracts: record
-/// existence implies referenced objects are readable, while a record failure
-/// cannot publish media without triggering moderation.
+/// (`BUZZ_MEDIA_UPLOAD_RECORDS`). Staging retains the exact record facts but
+/// does not call the record sink: an upload is not accepted until its canonical
+/// protected-operation witness commits. The caller publishes the retained
+/// record and cache-only sidecar afterward.
 struct BufferedUploadInput<'a> {
     storage: &'a MediaStorage,
     config: &'a MediaConfig,
@@ -51,11 +51,70 @@ struct BufferedUploadInput<'a> {
     attribution: Option<UploadAttribution>,
 }
 
-async fn process_buffered_upload<V, M, Fut>(
+/// Immutable artifacts and response metadata staged before DB publication.
+pub struct StagedMediaUpload {
+    publication: StagedMediaPublication,
+    descriptor: BlobDescriptor,
+    upload_record: Option<StagedUploadRecord>,
+}
+
+impl fmt::Debug for StagedMediaUpload {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StagedMediaUpload([REDACTED])")
+    }
+}
+
+impl StagedMediaUpload {
+    /// Opaque immutable publication consumed by the protected-operation commit.
+    pub const fn publication(&self) -> &StagedMediaPublication {
+        &self.publication
+    }
+
+    /// Response descriptor returned only after the DB witness commits.
+    pub const fn descriptor(&self) -> &BlobDescriptor {
+        &self.descriptor
+    }
+
+    /// Deterministic moderation recovery plan bound into the publication.
+    pub const fn moderation_projection(&self) -> Option<&StagedUploadRecord> {
+        self.upload_record.as_ref()
+    }
+
+    /// Consume the staged upload after publication and cache projection.
+    pub fn into_descriptor(self) -> BlobDescriptor {
+        self.descriptor
+    }
+
+    /// Publish non-authoritative operational projections after DB publication.
+    ///
+    /// The moderation record describes an accepted publication, so staging
+    /// must not write it before the canonical protected-operation commit. The
+    /// sidecar is refreshed afterward and remains a disposable cache.
+    pub async fn publish_post_commit_projections(
+        &self,
+        storage: &MediaStorage,
+        ctx: &TenantContext,
+        public_base_url: &str,
+    ) -> Result<(), MediaError> {
+        if self.publication.manifest().community_id() != ctx.community() {
+            return Err(MediaError::StorageError(
+                "media projection tenant does not match staged publication".into(),
+            ));
+        }
+        if let Some(record) = &self.upload_record {
+            record.publish_exact(storage).await?;
+        }
+        self.publication
+            .publish_sidecar_cache(storage, ctx, public_base_url)
+            .await
+    }
+}
+
+async fn stage_buffered_upload<V, M, Fut>(
     input: BufferedUploadInput<'_>,
     validate: V,
     prepare_metadata: M,
-) -> Result<BlobDescriptor, MediaError>
+) -> Result<StagedMediaUpload, MediaError>
 where
     V: FnOnce(&Bytes, &MediaConfig) -> Result<(String, String), MediaError> + Send + 'static,
     M: FnOnce(MetadataInput) -> Fut,
@@ -89,47 +148,10 @@ where
     .map_err(|_| MediaError::Internal)??;
 
     let key = format!("{sha256}.{ext}");
-    let meta_key = MediaStorage::ctx_sidecar_key(ctx, &sha256);
-
-    // Idempotent: short-circuit only if BOTH sidecar and blob exist. If the
-    // sidecar exists but the blob is missing, fall through to re-upload.
-    let sidecar_exists = storage.head(&meta_key).await?;
-    let blob_exists = storage.head(&key).await?;
-    if sidecar_exists && blob_exists {
-        let meta = storage.get_sidecar(ctx, &sha256).await?;
-        // A re-upload of known bytes is still a distinct upload *event*: no
-        // blob PUT happens, so without this record the uploader would be
-        // invisible to the moderation pipeline (and takedown re-uploads
-        // would go unscanned).
-        if let Some(attribution) = &attribution {
-            record_upload_event(
-                storage,
-                ctx,
-                &auth_event.pubkey,
-                attribution,
-                UploadEventFacts {
-                    sha256: &sha256,
-                    ext: &ext,
-                    mime: &mime,
-                    size: body.len() as u64,
-                    uploaded_at: chrono::Utc::now().timestamp(),
-                },
-            )
-            .await?;
-        }
-        return Ok(build_descriptor(
-            config,
-            &sha256,
-            &ext,
-            &mime,
-            body.len() as u64,
-            Some(&meta),
-            meta.uploaded_at,
-        ));
-    }
-
-    // Compute uploaded_at once — single source of truth for sidecar and response.
-    let uploaded_at = chrono::Utc::now().timestamp();
+    // The signed request time makes crash recovery and exact replay converge
+    // on one manifest and moderation projection instead of minting new state.
+    let uploaded_at = i64::try_from(auth_event.created_at.as_secs())
+        .map_err(|_| MediaError::StorageError("upload timestamp exceeds i64".into()))?;
 
     // Store blob first, then metadata.
     // On failure we intentionally do NOT delete the orphan blob — concurrent
@@ -138,7 +160,7 @@ where
     // content-addressed and bounded by the upload size limit, so the storage
     // cost is negligible. A V2 background GC job can sweep blobs with no
     // matching sidecar after a grace period.
-    storage.put(&key, &body, &mime).await?;
+    storage.put_immutable_exact(&key, &body, &mime).await?;
 
     let meta = match prepare_metadata(MetadataInput {
         sha256: sha256.clone(),
@@ -156,36 +178,39 @@ where
         }
     };
 
-    // The moderation record precedes the sidecar publish gate. If this write
-    // fails, the blob and any thumbnail remain orphaned but the media cannot be
-    // served. Conversely, record existence still implies those objects exist.
-    if let Some(attribution) = &attribution {
-        record_upload_event(
-            storage,
-            ctx,
-            &auth_event.pubkey,
-            attribution,
-            UploadEventFacts {
-                sha256: &sha256,
-                ext: &ext,
-                mime: &mime,
-                size: body.len() as u64,
-                uploaded_at,
-            },
-        )
-        .await?;
-    }
-    storage.put_sidecar(ctx, &sha256, &meta).await?;
-
-    Ok(build_descriptor(
-        config,
+    let upload_record = match attribution {
+        Some(attribution) => Some(
+            stage_upload_record(
+                storage,
+                ctx,
+                &auth_event.pubkey,
+                &auth_event.id.to_hex(),
+                &attribution,
+                UploadEventFacts {
+                    sha256: &sha256,
+                    ext: &ext,
+                    mime: &mime,
+                    size: body.len() as u64,
+                    uploaded_at,
+                },
+            )
+            .await?,
+        ),
+        None => None,
+    };
+    let manifest = MediaPublicationManifest::from_staged_blob_with_projection(
+        ctx,
         &sha256,
-        &ext,
-        &mime,
-        body.len() as u64,
-        Some(&meta),
-        uploaded_at,
-    ))
+        &meta,
+        upload_record.as_ref().map(StagedUploadRecord::digest),
+    )?;
+    let publication = storage.stage_media_publication(manifest).await?;
+    let descriptor = publication.manifest().descriptor(&config.public_base_url)?;
+    Ok(StagedMediaUpload {
+        publication,
+        descriptor,
+        upload_record,
+    })
 }
 
 /// Inputs handed to a buffered-upload metadata builder, after the shared
@@ -200,19 +225,19 @@ struct MetadataInput {
     uploaded_at: i64,
 }
 
-/// Process an upload end-to-end: validate, store, thumbnail, return descriptor.
+/// Validate an image and stage all immutable artifacts without publishing it.
 ///
 /// This is the image path — body is already fully buffered in RAM. Do NOT use
-/// this for video uploads; use [`process_video_upload`] instead.
-pub async fn process_upload(
+/// this for video uploads; use [`stage_video_upload`] instead.
+pub async fn stage_upload(
     storage: &MediaStorage,
     config: &MediaConfig,
     ctx: &TenantContext,
     auth_event: &nostr::Event,
     body: Bytes,
     attribution: Option<UploadAttribution>,
-) -> Result<BlobDescriptor, MediaError> {
-    process_buffered_upload(
+) -> Result<StagedMediaUpload, MediaError> {
+    stage_buffered_upload(
         BufferedUploadInput {
             storage,
             config,
@@ -231,6 +256,26 @@ pub async fn process_upload(
     .await
 }
 
+/// Legacy end-to-end image helper retained until relay DB composition lands.
+///
+/// Protected transports must call [`stage_upload`], commit the returned digest
+/// in PostgreSQL, and only then invoke
+/// [`StagedMediaUpload::publish_post_commit_projections`].
+pub async fn process_upload(
+    storage: &MediaStorage,
+    config: &MediaConfig,
+    ctx: &TenantContext,
+    auth_event: &nostr::Event,
+    body: Bytes,
+    attribution: Option<UploadAttribution>,
+) -> Result<BlobDescriptor, MediaError> {
+    let staged = stage_upload(storage, config, ctx, auth_event, body, attribution).await?;
+    staged
+        .publish_post_commit_projections(storage, ctx, &config.public_base_url)
+        .await?;
+    Ok(staged.into_descriptor())
+}
+
 /// Process a generic non-media file upload end-to-end.
 ///
 /// This is the catch-all attachment path for documents, archives, text, and
@@ -242,15 +287,15 @@ pub async fn process_upload(
 ///
 /// The resulting blob is served with `Content-Disposition: attachment`, so the
 /// client always downloads it rather than rendering it inline.
-pub async fn process_file_upload(
+pub async fn stage_file_upload(
     storage: &MediaStorage,
     config: &MediaConfig,
     ctx: &TenantContext,
     auth_event: &nostr::Event,
     body: Bytes,
     attribution: Option<UploadAttribution>,
-) -> Result<BlobDescriptor, MediaError> {
-    process_buffered_upload(
+) -> Result<StagedMediaUpload, MediaError> {
+    stage_buffered_upload(
         BufferedUploadInput {
             storage,
             config,
@@ -266,6 +311,7 @@ pub async fn process_file_upload(
                 dim: String::new(),
                 blurhash: String::new(),
                 thumb_url: String::new(),
+                thumbnail_sha256: None,
                 size: input.body.len() as u64,
                 ext: input.ext,
                 mime_type: input.mime,
@@ -278,7 +324,23 @@ pub async fn process_file_upload(
     .await
 }
 
-/// Process a video upload end-to-end using a streaming pipeline.
+/// Legacy end-to-end file helper retained until relay DB composition lands.
+pub async fn process_file_upload(
+    storage: &MediaStorage,
+    config: &MediaConfig,
+    ctx: &TenantContext,
+    auth_event: &nostr::Event,
+    body: Bytes,
+    attribution: Option<UploadAttribution>,
+) -> Result<BlobDescriptor, MediaError> {
+    let staged = stage_file_upload(storage, config, ctx, auth_event, body, attribution).await?;
+    staged
+        .publish_post_commit_projections(storage, ctx, &config.public_base_url)
+        .await?;
+    Ok(staged.into_descriptor())
+}
+
+/// Validate a video and stage all immutable artifacts using a streaming pipeline.
 ///
 /// Unlike [`process_upload`], this function:
 /// 1. Streams the request body to a [`tempfile::NamedTempFile`] while computing
@@ -289,7 +351,7 @@ pub async fn process_file_upload(
 /// 5. Writes a sidecar with `duration_secs` (no thumbnail — desktop handles that).
 ///
 /// Returns a [`BlobDescriptor`] with the `duration` field populated.
-pub async fn process_video_upload(
+pub async fn stage_video_upload(
     storage: &MediaStorage,
     config: &MediaConfig,
     ctx: &TenantContext,
@@ -297,7 +359,7 @@ pub async fn process_video_upload(
     body_stream: impl futures_core::Stream<Item = Result<Bytes, axum::Error>> + Send + 'static,
     content_length: Option<u64>,
     attribution: Option<UploadAttribution>,
-) -> Result<BlobDescriptor, MediaError> {
+) -> Result<StagedMediaUpload, MediaError> {
     // --- 1. Stream body to temp file, compute SHA-256 incrementally ---
     let tmp = tempfile::NamedTempFile::new().map_err(|e| MediaError::Io(e.to_string()))?;
     let tmp_path = tmp.path().to_path_buf();
@@ -424,46 +486,13 @@ pub async fn process_video_upload(
 
     let ext = "mp4";
     let key = format!("{sha256_hex}.{ext}");
-    let meta_key = MediaStorage::ctx_sidecar_key(ctx, &sha256_hex);
-
-    // --- 5. Idempotency check ---
-    let sidecar_exists = storage.head(&meta_key).await?;
-    let blob_exists = storage.head(&key).await?;
-    if sidecar_exists && blob_exists {
-        let meta = storage.get_sidecar(ctx, &sha256_hex).await?;
-        // Re-upload of known bytes: still a distinct upload event — see the
-        // buffered path's short-circuit for the rationale.
-        if let Some(attribution) = &attribution {
-            record_upload_event(
-                storage,
-                ctx,
-                &auth_event.pubkey,
-                attribution,
-                UploadEventFacts {
-                    sha256: &sha256_hex,
-                    ext,
-                    mime: &mime,
-                    size: file_size,
-                    uploaded_at: chrono::Utc::now().timestamp(),
-                },
-            )
-            .await?;
-        }
-        return Ok(build_descriptor(
-            config,
-            &sha256_hex,
-            ext,
-            &mime,
-            file_size,
-            Some(&meta),
-            meta.uploaded_at,
-        ));
-    }
-
-    let uploaded_at = chrono::Utc::now().timestamp();
+    let uploaded_at = i64::try_from(auth_event.created_at.as_secs())
+        .map_err(|_| MediaError::StorageError("upload timestamp exceeds i64".into()))?;
 
     // --- 6. Stream blob from temp file to S3 ---
-    storage.put_file(&key, &tmp_path, &mime).await?;
+    storage
+        .put_file_immutable_verified(&key, &tmp_path, &mime, &sha256_hex, file_size)
+        .await?;
     drop(tmp); // Free temp file disk space immediately after S3 upload.
 
     // --- 7. Build metadata (no thumbnail for video — desktop handles that) ---
@@ -471,6 +500,7 @@ pub async fn process_video_upload(
         dim: format!("{}x{}", video_meta.width, video_meta.height),
         blurhash: String::new(),
         thumb_url: String::new(),
+        thumbnail_sha256: None,
         ext: ext.to_string(),
         mime_type: mime.clone(),
         size: file_size,
@@ -478,37 +508,68 @@ pub async fn process_video_upload(
         duration_secs: Some(video_meta.duration_secs),
     };
 
-    // Record before publishing the sidecar serve gate. See the buffered path.
-    if let Some(attribution) = &attribution {
-        record_upload_event(
-            storage,
-            ctx,
-            &auth_event.pubkey,
-            attribution,
-            UploadEventFacts {
-                sha256: &sha256_hex,
-                ext,
-                mime: &mime,
-                size: file_size,
-                uploaded_at,
-            },
-        )
-        .await?;
-    }
-    storage.put_sidecar(ctx, &sha256_hex, &meta).await?;
-
-    Ok(build_descriptor(
-        config,
+    let upload_record = match attribution {
+        Some(attribution) => Some(
+            stage_upload_record(
+                storage,
+                ctx,
+                &auth_event.pubkey,
+                &auth_event.id.to_hex(),
+                &attribution,
+                UploadEventFacts {
+                    sha256: &sha256_hex,
+                    ext,
+                    mime: &mime,
+                    size: file_size,
+                    uploaded_at,
+                },
+            )
+            .await?,
+        ),
+        None => None,
+    };
+    let manifest = MediaPublicationManifest::from_staged_blob_with_projection(
+        ctx,
         &sha256_hex,
-        ext,
-        &mime,
-        file_size,
-        Some(&meta),
-        uploaded_at,
-    ))
+        &meta,
+        upload_record.as_ref().map(StagedUploadRecord::digest),
+    )?;
+    let publication = storage.stage_media_publication(manifest).await?;
+    let descriptor = publication.manifest().descriptor(&config.public_base_url)?;
+    Ok(StagedMediaUpload {
+        publication,
+        descriptor,
+        upload_record,
+    })
 }
 
-/// Generate thumbnail and metadata without publishing the sidecar serve gate.
+/// Legacy end-to-end video helper retained until relay DB composition lands.
+pub async fn process_video_upload(
+    storage: &MediaStorage,
+    config: &MediaConfig,
+    ctx: &TenantContext,
+    auth_event: &nostr::Event,
+    body_stream: impl futures_core::Stream<Item = Result<Bytes, axum::Error>> + Send + 'static,
+    content_length: Option<u64>,
+    attribution: Option<UploadAttribution>,
+) -> Result<BlobDescriptor, MediaError> {
+    let staged = stage_video_upload(
+        storage,
+        config,
+        ctx,
+        auth_event,
+        body_stream,
+        content_length,
+        attribution,
+    )
+    .await?;
+    staged
+        .publish_post_commit_projections(storage, ctx, &config.public_base_url)
+        .await?;
+    Ok(staged.into_descriptor())
+}
+
+/// Generate immutable thumbnail and metadata without publishing cache projections.
 /// Returns the completed [`BlobMeta`] on success.
 async fn prepare_image_metadata(
     storage: &MediaStorage,
@@ -529,68 +590,29 @@ async fn prepare_image_metadata(
     meta.uploaded_at = input.uploaded_at;
 
     if let Some(ref tb) = thumb_bytes {
-        let thumb_key = format!("{}.thumb.jpg", input.sha256);
-        storage.put(&thumb_key, tb, "image/jpeg").await?;
+        let thumbnail_sha256 = hex::encode(Sha256::digest(tb));
+        let thumb_key = format!("{thumbnail_sha256}.thumb.jpg");
+        storage
+            .put_immutable_exact(&thumb_key, tb, "image/jpeg")
+            .await?;
+        meta.thumbnail_sha256 = Some(thumbnail_sha256);
     }
 
     Ok(meta)
-}
-
-fn build_descriptor(
-    config: &MediaConfig,
-    sha256: &str,
-    ext: &str,
-    mime: &str,
-    size: u64,
-    meta: Option<&BlobMeta>,
-    uploaded_at: i64,
-) -> BlobDescriptor {
-    let duration = meta.and_then(|m| m.duration_secs);
-    BlobDescriptor {
-        url: format!("{}/{sha256}.{ext}", config.public_base_url),
-        sha256: sha256.to_string(),
-        size,
-        mime_type: mime.to_string(),
-        uploaded: uploaded_at,
-        dim: meta.and_then(|m| (!m.dim.is_empty()).then(|| m.dim.clone())),
-        blurhash: meta.and_then(|m| (!m.blurhash.is_empty()).then(|| m.blurhash.clone())),
-        thumb: meta.and_then(|m| (!m.thumb_url.is_empty()).then(|| m.thumb_url.clone())),
-        duration,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_config() -> MediaConfig {
-        MediaConfig {
-            s3_endpoint: String::new(),
-            s3_access_key: String::new(),
-            s3_secret_key: String::new(),
-            s3_bucket: String::new(),
-            s3_region: "us-east-1".to_string(),
-            s3_addressing_style: crate::config::S3AddressingStyle::Path,
-            max_image_bytes: 50 * 1024 * 1024,
-            max_gif_bytes: 10 * 1024 * 1024,
-            max_video_bytes: 524_288_000,
-            max_file_bytes: 104_857_600,
-            public_base_url: "https://media.example.com".to_string(),
-            upload_records_enabled: false,
-            upload_ip_header: None,
-            upload_port_header: None,
-        }
-    }
-
     #[test]
-    fn test_build_descriptor_video_omits_empty_thumb_and_blurhash() {
-        // Video uploads produce a BlobMeta with empty thumb_url and blurhash.
-        // build_descriptor must convert these to None so they're omitted from JSON.
-        let config = test_config();
+    fn test_publication_descriptor_video_omits_empty_thumb_and_blurhash() {
+        // Video publications omit thumbnail and blurhash response fields.
         let meta = BlobMeta {
             dim: "320x240".to_string(),
             blurhash: String::new(),  // empty — video has no blurhash
             thumb_url: String::new(), // empty — video has no thumbnail
+            thumbnail_sha256: None,
             ext: "mp4".to_string(),
             mime_type: "video/mp4".to_string(),
             size: 5_000_000,
@@ -598,15 +620,17 @@ mod tests {
             duration_secs: Some(29.5),
         };
 
-        let desc = build_descriptor(
-            &config,
-            "abc123",
-            "mp4",
-            "video/mp4",
-            5_000_000,
-            Some(&meta),
-            1700000000,
-        );
+        let desc = MediaPublicationManifest::from_staged_blob(
+            &TenantContext::resolved(
+                buzz_core::CommunityId::from_uuid(uuid::Uuid::from_u128(1)),
+                "media.example.com",
+            ),
+            "a".repeat(64),
+            &meta,
+        )
+        .expect("manifest")
+        .descriptor("https://media.example.com")
+        .expect("descriptor");
 
         // Empty strings must become None, not Some("")
         assert!(
@@ -641,14 +665,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_descriptor_image_includes_thumb_and_blurhash() {
+    fn test_publication_descriptor_image_includes_thumb_and_blurhash() {
         // Image uploads produce a BlobMeta with populated thumb_url and blurhash.
-        let config = test_config();
         let hash = "a".repeat(64);
         let meta = BlobMeta {
             dim: "800x600".to_string(),
             blurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj".to_string(),
             thumb_url: format!("https://media.example.com/{hash}.thumb.jpg"),
+            thumbnail_sha256: Some("b".repeat(64)),
             ext: "jpg".to_string(),
             mime_type: "image/jpeg".to_string(),
             size: 100_000,
@@ -656,15 +680,17 @@ mod tests {
             duration_secs: None,
         };
 
-        let desc = build_descriptor(
-            &config,
+        let desc = MediaPublicationManifest::from_staged_blob(
+            &TenantContext::resolved(
+                buzz_core::CommunityId::from_uuid(uuid::Uuid::from_u128(1)),
+                "media.example.com",
+            ),
             &hash,
-            "jpg",
-            "image/jpeg",
-            100_000,
-            Some(&meta),
-            1700000000,
-        );
+            &meta,
+        )
+        .expect("manifest")
+        .descriptor("https://media.example.com")
+        .expect("descriptor");
 
         assert_eq!(
             desc.blurhash,
@@ -712,18 +738,29 @@ mod tests {
     }
 
     #[test]
-    fn test_build_descriptor_no_meta() {
-        // When meta is None, all optional fields should be None.
-        let config = test_config();
-        let desc = build_descriptor(
-            &config,
-            "abc123",
-            "jpg",
-            "image/jpeg",
-            100,
-            None,
-            1700000000,
-        );
+    fn test_publication_descriptor_without_optional_metadata() {
+        let meta = BlobMeta {
+            dim: String::new(),
+            blurhash: String::new(),
+            thumb_url: String::new(),
+            thumbnail_sha256: None,
+            ext: "bin".to_owned(),
+            mime_type: "application/octet-stream".to_owned(),
+            size: 100,
+            uploaded_at: 1_700_000_000,
+            duration_secs: None,
+        };
+        let desc = MediaPublicationManifest::from_staged_blob(
+            &TenantContext::resolved(
+                buzz_core::CommunityId::from_uuid(uuid::Uuid::from_u128(1)),
+                "media.example.com",
+            ),
+            "a".repeat(64),
+            &meta,
+        )
+        .expect("manifest")
+        .descriptor("https://media.example.com")
+        .expect("descriptor");
 
         assert!(desc.dim.is_none());
         assert!(desc.blurhash.is_none());

--- a/crates/buzz-media/src/upload_record.rs
+++ b/crates/buzz-media/src/upload_record.rs
@@ -31,10 +31,11 @@
 //! The moderation pipeline triggers on `ObjectCreated` events under the
 //! `_uploads/` prefix and parses this record instead of HEADing blobs:
 //!
-//! - For fresh uploads, the record is written after the blob and derived
-//!   artifacts but before the sidecar serve gate. Record existence therefore
-//!   implies the scan inputs are readable, while record failure cannot leave
-//!   unscanned media publicly servable.
+//! - For fresh uploads, the record is written after immutable blob staging and
+//!   the canonical PostgreSQL publication commit, but before cache projections.
+//!   Record existence therefore implies the scan inputs are readable. A record
+//!   failure leaves the DB-witnessed object authoritative but unprojected for
+//!   moderation retry; a sidecar never grants canonical visibility.
 //! - `ext`, `mime_type`, and `size` are always present so the consumer can
 //!   derive the blob key (`{sha256}.{ext}`) and scan eligibility without
 //!   extra round-trips.
@@ -43,28 +44,40 @@
 //! - Consumers must tolerate unknown fields; `version` bumps only on
 //!   breaking changes to existing fields.
 
+use std::fmt;
 use std::net::IpAddr;
 
 use buzz_core::tenant::TenantContext;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const UPLOAD_RECORD_PLAN_PREFIX: &str = "_publication-plans/moderation";
+const UPLOAD_RECORD_REPLAY_PREFIX: &str = "_publication-plans/moderation-replay";
+const MAX_UPLOAD_RECORD_BYTES: u64 = 16 * 1024;
+const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
 /// Current record schema version. Additive fields do not bump this.
 pub const UPLOAD_RECORD_VERSION: u32 = 1;
 
 /// One accepted upload event. See module docs for the consumer contract.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UploadRecord {
     /// Schema version ([`UPLOAD_RECORD_VERSION`]).
     pub version: u32,
     /// ULID — unique per accepted upload, time-sortable. Also the key suffix.
     pub event_id: String,
+    /// Signed Blossom authorization event id that makes retry identity stable.
+    #[serde(default)]
+    pub request_event_id: String,
     /// Content hash of the uploaded bytes (64 lowercase hex chars).
     pub sha256: String,
     /// Canonical extension — consumers derive the blob key `{sha256}.{ext}`.
     pub ext: String,
     /// Sniffed MIME type of the uploaded bytes.
     pub mime_type: String,
-    /// Size of the uploaded bytes.
+    /// Size of the uploaded bytes. Zero denotes the canonical empty
+    /// octet-stream attachment.
     pub size: u64,
     /// Unix seconds when the relay accepted *this* upload event. On an
     /// idempotent re-upload this is the re-upload time, not the original
@@ -129,13 +142,261 @@ pub struct UploadEventFacts<'a> {
     pub uploaded_at: i64,
 }
 
-/// Build and store the per-event record for one accepted upload.
+/// Immutable moderation projection staged before publication commit.
 ///
-/// Called after blob and derived-artifact durability but before the sidecar
-/// publish gate on fresh uploads; called on the existing published state for
-/// idempotent re-uploads. A write failure propagates and fails the upload. The
-/// record's `ObjectCreated` event is the moderation pipeline's only scan
-/// trigger, so no newly published media may exist without a record.
+/// The plan lives outside the consumer-triggering `_uploads/` prefix. Its
+/// digest and projection key can be committed in the publication transaction,
+/// allowing a recovery worker to resume exact bytes after a process crash.
+#[derive(Clone)]
+pub struct StagedUploadRecord {
+    record: UploadRecord,
+    plan_key: String,
+    projection_key: String,
+    canonical_bytes: Vec<u8>,
+    digest: [u8; 32],
+}
+
+/// Immutable first-result index for one signed upload identity.
+#[derive(Debug, Serialize, Deserialize)]
+struct UploadRecordReplayIndex {
+    version: u32,
+    community_id: String,
+    request_event_id: String,
+    uploader_id: String,
+    event_id: String,
+    sha256: String,
+    plan_digest: String,
+}
+
+impl fmt::Debug for StagedUploadRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StagedUploadRecord([REDACTED])")
+    }
+}
+
+impl StagedUploadRecord {
+    /// Digest of the exact canonical record bytes persisted before commit.
+    pub const fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// Content-addressed recovery-plan key safe to persist transactionally.
+    pub fn plan_key(&self) -> &str {
+        &self.plan_key
+    }
+
+    /// Final consumer-triggering projection key.
+    pub fn projection_key(&self) -> &str {
+        &self.projection_key
+    }
+
+    /// Canonical bytes whose digest is returned by [`Self::digest`].
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    /// Validated record facts carried by this plan.
+    pub const fn record(&self) -> &UploadRecord {
+        &self.record
+    }
+
+    /// Publish exact bytes after the canonical DB commit.
+    ///
+    /// Repeating this operation is an exact-byte no-op. An existing object
+    /// with different bytes fails closed instead of being overwritten.
+    pub async fn publish_exact(
+        &self,
+        storage: &crate::storage::MediaStorage,
+    ) -> Result<UploadProjectionResult, crate::error::MediaError> {
+        let recovered = load_upload_record_plan(storage, self.digest).await?;
+        if recovered.projection_key != self.projection_key
+            || recovered.canonical_bytes != self.canonical_bytes
+        {
+            return Err(invalid_record(
+                "staged upload record changed before projection",
+            ));
+        }
+        put_exact_object(
+            storage,
+            &self.projection_key,
+            &self.canonical_bytes,
+            "application/json",
+        )
+        .await
+    }
+}
+
+/// Outcome of an idempotent moderation projection attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UploadProjectionResult {
+    /// Exact bytes were written and verified.
+    Created,
+    /// Exact bytes already existed at the deterministic projection key.
+    Deduplicated,
+}
+
+/// Stage deterministic record bytes outside the consumer-triggering prefix.
+pub async fn stage_upload_record(
+    storage: &crate::storage::MediaStorage,
+    ctx: &TenantContext,
+    uploader: &nostr::PublicKey,
+    request_event_id: &str,
+    attribution: &UploadAttribution,
+    facts: UploadEventFacts<'_>,
+) -> Result<StagedUploadRecord, crate::error::MediaError> {
+    let staged = build_staged_upload_record(ctx, uploader, request_event_id, attribution, facts)?;
+    put_exact_object(
+        storage,
+        &staged.plan_key,
+        &staged.canonical_bytes,
+        "application/json",
+    )
+    .await?;
+
+    // Mutable observation fields (host alias, profile label, source address)
+    // remain in the first audit record, but never select a new canonical
+    // result for the same signed event. The stable replay index is immutable;
+    // concurrent retries load and validate the first winner.
+    let replay_index = UploadRecordReplayIndex {
+        version: UPLOAD_RECORD_VERSION,
+        community_id: staged.record.community_id.clone(),
+        request_event_id: staged.record.request_event_id.clone(),
+        uploader_id: staged.record.uploader_id.clone(),
+        event_id: staged.record.event_id.clone(),
+        sha256: staged.record.sha256.clone(),
+        plan_digest: hex::encode(staged.digest),
+    };
+    let replay_bytes = serde_json::to_vec(&replay_index)?;
+    let persisted = storage
+        .put_immutable_first(
+            &upload_record_replay_key(ctx, &staged.record.event_id),
+            &replay_bytes,
+            "application/json",
+        )
+        .await?;
+    if persisted.is_empty() || persisted.len() as u64 > MAX_UPLOAD_RECORD_BYTES {
+        return Err(invalid_record("upload replay index exceeds its bound"));
+    }
+    let winner: UploadRecordReplayIndex = serde_json::from_slice(&persisted)?;
+    if serde_json::to_vec(&winner)? != persisted
+        || winner.version != UPLOAD_RECORD_VERSION
+        || winner.community_id != staged.record.community_id
+        || winner.request_event_id != staged.record.request_event_id
+        || winner.uploader_id != staged.record.uploader_id
+        || winner.event_id != staged.record.event_id
+        || winner.sha256 != staged.record.sha256
+        || !is_lower_hex_32(&winner.plan_digest)
+    {
+        return Err(invalid_record("upload replay index identity mismatch"));
+    }
+    let digest: [u8; 32] = hex::decode(&winner.plan_digest)
+        .map_err(|_| invalid_record("upload replay index digest is malformed"))?
+        .try_into()
+        .map_err(|_| invalid_record("upload replay index digest has wrong length"))?;
+    let selected = load_upload_record_plan(storage, digest).await?;
+    select_persisted_replay(staged, selected)
+}
+
+/// Recover a staged moderation projection from its committed digest.
+pub async fn load_upload_record_plan(
+    storage: &crate::storage::MediaStorage,
+    digest: [u8; 32],
+) -> Result<StagedUploadRecord, crate::error::MediaError> {
+    if digest == [0; 32] {
+        return Err(invalid_record("upload record plan digest is unallocated"));
+    }
+    let plan_key = upload_record_plan_key(digest);
+    let canonical_bytes = read_bounded_object(storage, &plan_key).await?;
+    let actual: [u8; 32] = Sha256::digest(&canonical_bytes).into();
+    if actual != digest {
+        return Err(invalid_record("upload record plan digest mismatch"));
+    }
+    let record: UploadRecord = serde_json::from_slice(&canonical_bytes)?;
+    validate_record(&record)?;
+    if serde_json::to_vec(&record)? != canonical_bytes {
+        return Err(invalid_record("upload record plan is not canonical"));
+    }
+    let projection_key = format!(
+        "_uploads/{}/{}/{}.json",
+        record.community_id, record.sha256, record.event_id
+    );
+    Ok(StagedUploadRecord {
+        record,
+        plan_key,
+        projection_key,
+        canonical_bytes,
+        digest,
+    })
+}
+
+fn build_staged_upload_record(
+    ctx: &TenantContext,
+    uploader: &nostr::PublicKey,
+    request_event_id: &str,
+    attribution: &UploadAttribution,
+    facts: UploadEventFacts<'_>,
+) -> Result<StagedUploadRecord, crate::error::MediaError> {
+    use nostr::ToBech32;
+
+    if !is_lower_hex_32(request_event_id)
+        || !is_lower_hex_32(facts.sha256)
+        || facts.ext.is_empty()
+        || facts.ext.len() > 8
+        || !facts
+            .ext
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        || facts.mime.is_empty()
+        || facts.mime.len() > 255
+        || !facts.mime.contains('/')
+        || (facts.size == 0
+            && (facts.sha256 != EMPTY_SHA256
+                || facts.ext != "bin"
+                || facts.mime != "application/octet-stream"))
+        || facts.uploaded_at <= 0
+    {
+        return Err(invalid_record("invalid deterministic upload record facts"));
+    }
+    let uploader_id = uploader.to_hex();
+    let event_id = deterministic_event_id(ctx, &uploader_id, request_event_id, facts)?;
+    let ip = attribution.net.ip;
+    let record = UploadRecord {
+        version: UPLOAD_RECORD_VERSION,
+        event_id,
+        request_event_id: request_event_id.to_owned(),
+        sha256: facts.sha256.to_owned(),
+        ext: facts.ext.to_owned(),
+        mime_type: facts.mime.to_owned(),
+        size: facts.size,
+        uploaded_at: facts.uploaded_at,
+        community_id: ctx.community().to_string(),
+        community_host: ctx.host().to_string(),
+        uploader_id,
+        uploader_npub: uploader
+            .to_bech32()
+            .map_err(|error| invalid_record(&format!("npub encoding failed: {error}")))?,
+        uploader_name: attribution.uploader_name.clone(),
+        ip: ip.map(|address| address.to_string()),
+        port: ip.and(attribution.net.port),
+    };
+    validate_record(&record)?;
+    let canonical_bytes = serde_json::to_vec(&record)?;
+    let digest: [u8; 32] = Sha256::digest(&canonical_bytes).into();
+    let plan_key = upload_record_plan_key(digest);
+    let projection_key = upload_record_key(ctx, facts.sha256, &record.event_id);
+    Ok(StagedUploadRecord {
+        record,
+        plan_key,
+        projection_key,
+        canonical_bytes,
+        digest,
+    })
+}
+
+/// Legacy immediate writer for transports without protected publication.
+///
+/// Protected transports must use [`stage_upload_record`] and commit its exact
+/// plan before invoking [`StagedUploadRecord::publish_exact`].
 pub async fn record_upload_event(
     storage: &crate::storage::MediaStorage,
     ctx: &TenantContext,
@@ -146,12 +407,14 @@ pub async fn record_upload_event(
     use nostr::ToBech32;
 
     let event_id = ulid::Ulid::new().to_string();
+    let request_event_id = hex::encode(Sha256::digest(event_id.as_bytes()));
     // Ports are only meaningful next to the address they were observed with.
     let ip = attribution.net.ip;
     let port = ip.and(attribution.net.port);
     let record = UploadRecord {
         version: UPLOAD_RECORD_VERSION,
         event_id: event_id.clone(),
+        request_event_id,
         sha256: facts.sha256.to_string(),
         ext: facts.ext.to_string(),
         mime_type: facts.mime.to_string(),
@@ -180,6 +443,190 @@ pub async fn record_upload_event(
 /// `_meta/` sidecar key (see [`crate::storage::MediaStorage::sidecar_key`]).
 pub fn upload_record_key(ctx: &TenantContext, sha256: &str, event_id: &str) -> String {
     format!("_uploads/{}/{sha256}/{event_id}.json", ctx.community())
+}
+
+/// Content-addressed recovery-plan key for canonical moderation bytes.
+pub fn upload_record_plan_key(digest: [u8; 32]) -> String {
+    format!("{UPLOAD_RECORD_PLAN_PREFIX}/{}.json", hex::encode(digest))
+}
+
+fn upload_record_replay_key(ctx: &TenantContext, event_id: &str) -> String {
+    format!(
+        "{UPLOAD_RECORD_REPLAY_PREFIX}/{}/{}.json",
+        ctx.community(),
+        event_id
+    )
+}
+
+fn ensure_same_replay_identity(
+    candidate: &StagedUploadRecord,
+    selected: &StagedUploadRecord,
+) -> Result<(), crate::error::MediaError> {
+    let candidate = &candidate.record;
+    let selected = &selected.record;
+    if candidate.version != selected.version
+        || candidate.event_id != selected.event_id
+        || candidate.request_event_id != selected.request_event_id
+        || candidate.sha256 != selected.sha256
+        || candidate.ext != selected.ext
+        || candidate.mime_type != selected.mime_type
+        || candidate.size != selected.size
+        || candidate.uploaded_at != selected.uploaded_at
+        || candidate.community_id != selected.community_id
+        || candidate.uploader_id != selected.uploader_id
+        || candidate.uploader_npub != selected.uploader_npub
+    {
+        return Err(invalid_record(
+            "persisted upload replay result does not match signed identity",
+        ));
+    }
+    Ok(())
+}
+
+fn select_persisted_replay(
+    candidate: StagedUploadRecord,
+    selected: StagedUploadRecord,
+) -> Result<StagedUploadRecord, crate::error::MediaError> {
+    ensure_same_replay_identity(&candidate, &selected)?;
+    Ok(selected)
+}
+
+fn deterministic_event_id(
+    ctx: &TenantContext,
+    uploader_id: &str,
+    request_event_id: &str,
+    facts: UploadEventFacts<'_>,
+) -> Result<String, crate::error::MediaError> {
+    let seconds = u64::try_from(facts.uploaded_at)
+        .map_err(|_| invalid_record("upload timestamp is negative"))?;
+    let millis = seconds
+        .checked_mul(1_000)
+        .ok_or_else(|| invalid_record("upload timestamp overflows milliseconds"))?;
+    if millis > 0x0000_ffff_ffff_ffff {
+        return Err(invalid_record("upload timestamp exceeds ULID range"));
+    }
+
+    let mut hasher = Sha256::new();
+    digest_field(&mut hasher, b"buzz-moderation-projection-v2");
+    digest_field(&mut hasher, ctx.community().to_string().as_bytes());
+    digest_field(&mut hasher, uploader_id.as_bytes());
+    digest_field(&mut hasher, request_event_id.as_bytes());
+    digest_field(&mut hasher, facts.sha256.as_bytes());
+    digest_field(&mut hasher, facts.ext.as_bytes());
+    digest_field(&mut hasher, facts.mime.as_bytes());
+    digest_field(&mut hasher, &facts.size.to_be_bytes());
+    digest_field(&mut hasher, &facts.uploaded_at.to_be_bytes());
+    let identity = hasher.finalize();
+    let mut ulid_bytes = [0_u8; 16];
+    ulid_bytes[..6].copy_from_slice(&millis.to_be_bytes()[2..]);
+    ulid_bytes[6..].copy_from_slice(&identity[..10]);
+    Ok(ulid::Ulid::from(u128::from_be_bytes(ulid_bytes)).to_string())
+}
+
+fn digest_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn validate_record(record: &UploadRecord) -> Result<(), crate::error::MediaError> {
+    if record.version != UPLOAD_RECORD_VERSION
+        || record.event_id.parse::<ulid::Ulid>().is_err()
+        || !is_lower_hex_32(&record.request_event_id)
+        || !is_lower_hex_32(&record.sha256)
+        || record.ext.is_empty()
+        || record.ext.len() > 8
+        || !record
+            .ext
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        || record.mime_type.is_empty()
+        || record.mime_type.len() > 255
+        || !record.mime_type.contains('/')
+        || (record.size == 0
+            && (record.sha256 != EMPTY_SHA256
+                || record.ext != "bin"
+                || record.mime_type != "application/octet-stream"))
+        || record.uploaded_at <= 0
+        || uuid::Uuid::parse_str(&record.community_id).is_err()
+        || record.community_host.is_empty()
+        || record.community_host != record.community_host.trim()
+        || !is_lower_hex_32(&record.uploader_id)
+        || record
+            .uploader_name
+            .as_deref()
+            .is_some_and(|value| value.len() > 256 || value.chars().any(char::is_control))
+        || record
+            .ip
+            .as_deref()
+            .is_some_and(|value| parse_public_ip(value).is_none())
+        || (record.port.is_some() && record.ip.is_none())
+    {
+        return Err(invalid_record("invalid canonical upload record"));
+    }
+    Ok(())
+}
+
+fn is_lower_hex_32(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+async fn put_exact_object(
+    storage: &crate::storage::MediaStorage,
+    key: &str,
+    expected: &[u8],
+    content_type: &str,
+) -> Result<UploadProjectionResult, crate::error::MediaError> {
+    if storage
+        .put_immutable_exact(key, expected, content_type)
+        .await?
+    {
+        Ok(UploadProjectionResult::Created)
+    } else {
+        Ok(UploadProjectionResult::Deduplicated)
+    }
+}
+
+async fn read_bounded_object(
+    storage: &crate::storage::MediaStorage,
+    key: &str,
+) -> Result<Vec<u8>, crate::error::MediaError> {
+    let size = storage
+        .head_with_metadata(key)
+        .await?
+        .ok_or(crate::error::MediaError::NotFound)?
+        .size;
+    if size == 0 || size > MAX_UPLOAD_RECORD_BYTES {
+        return Err(invalid_record("upload record object has invalid size"));
+    }
+    let mut stream = storage.get_stream(key).await?;
+    let mut bytes = Vec::with_capacity(size as usize);
+    let mut total = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        total =
+            total
+                .checked_add(u64::try_from(chunk.len()).map_err(|_| {
+                    invalid_record("upload record chunk length exceeds supported size")
+                })?)
+                .ok_or_else(|| invalid_record("upload record size overflow"))?;
+        if total > MAX_UPLOAD_RECORD_BYTES {
+            return Err(invalid_record("upload record object exceeds maximum size"));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    if total != size {
+        return Err(invalid_record(
+            "upload record object size changed during read",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn invalid_record(message: &str) -> crate::error::MediaError {
+    crate::error::MediaError::StorageError(message.to_owned())
 }
 
 /// Parse an IP header value, accepting only public addresses (fail-empty).
@@ -286,6 +733,7 @@ mod tests {
         let record = UploadRecord {
             version: UPLOAD_RECORD_VERSION,
             event_id: "01J9W3TEST".into(),
+            request_event_id: "d".repeat(64),
             sha256: "b".repeat(64),
             ext: "png".into(),
             mime_type: "image/png".into(),
@@ -314,6 +762,7 @@ mod tests {
         let record = UploadRecord {
             version: UPLOAD_RECORD_VERSION,
             event_id: "01J9W3TEST".into(),
+            request_event_id: "d".repeat(64),
             sha256: "b".repeat(64),
             ext: "mp4".into(),
             mime_type: "video/mp4".into(),
@@ -348,6 +797,194 @@ mod tests {
         let record: UploadRecord = serde_json::from_str(json).unwrap();
         assert_eq!(record.version, 1);
         assert_eq!(record.ip, None);
+    }
+
+    #[test]
+    fn deterministic_plan_replay_is_byte_identical_and_domain_bound() {
+        let keys = nostr::Keys::generate();
+        let attribution = UploadAttribution::default();
+        let operation_id = "d".repeat(64);
+        let sha256 = "a".repeat(64);
+        let facts = UploadEventFacts {
+            sha256: &sha256,
+            ext: "png",
+            mime: "image/png",
+            size: 42,
+            uploaded_at: 1_783_358_352,
+        };
+        let one = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &operation_id,
+            &attribution,
+            facts,
+        )
+        .expect("first plan");
+        let replay = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &operation_id,
+            &attribution,
+            facts,
+        )
+        .expect("replay plan");
+        let other_tenant = TenantContext::resolved(
+            CommunityId::from_uuid(uuid::Uuid::from_u128(8)),
+            "other.example.com",
+        );
+        let other = build_staged_upload_record(
+            &other_tenant,
+            &keys.public_key(),
+            &operation_id,
+            &attribution,
+            facts,
+        )
+        .expect("other domain plan");
+
+        assert_eq!(one.digest(), replay.digest());
+        assert_eq!(one.plan_key(), replay.plan_key());
+        assert_eq!(one.projection_key(), replay.projection_key());
+        assert_eq!(one.canonical_bytes(), replay.canonical_bytes());
+        assert_ne!(one.digest(), other.digest());
+        assert_ne!(one.projection_key(), other.projection_key());
+        assert_eq!(format!("{one:?}"), "StagedUploadRecord([REDACTED])");
+    }
+
+    #[test]
+    fn deterministic_plan_preserves_zero_byte_upload_attribution() {
+        let keys = nostr::Keys::generate();
+        let sha256 = hex::encode(Sha256::digest([]));
+        let facts = UploadEventFacts {
+            sha256: &sha256,
+            ext: "bin",
+            mime: "application/octet-stream",
+            size: 0,
+            uploaded_at: 1_783_358_352,
+        };
+
+        let staged = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &"d".repeat(64),
+            &UploadAttribution::default(),
+            facts,
+        )
+        .expect("zero-byte attribution plan");
+
+        assert_eq!(staged.record().size, 0);
+        validate_record(staged.record()).expect("canonical zero-byte record");
+
+        let wrong_sha = "a".repeat(64);
+        let false_empty = UploadEventFacts {
+            sha256: &wrong_sha,
+            ..facts
+        };
+        assert!(build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &"d".repeat(64),
+            &UploadAttribution::default(),
+            false_empty,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn deterministic_plan_identity_excludes_retry_variant_attribution() {
+        let keys = nostr::Keys::generate();
+        let sha256 = "a".repeat(64);
+        let facts = UploadEventFacts {
+            sha256: &sha256,
+            ext: "png",
+            mime: "image/png",
+            size: 42,
+            uploaded_at: 1_783_358_352,
+        };
+        let plain = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &"d".repeat(64),
+            &UploadAttribution::default(),
+            facts,
+        )
+        .expect("plain plan");
+        let named = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &"d".repeat(64),
+            &UploadAttribution {
+                uploader_name: Some("alice".into()),
+                net: UploadNetworkInfo::default(),
+            },
+            facts,
+        )
+        .expect("named plan");
+        let other_operation = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &"e".repeat(64),
+            &UploadAttribution::default(),
+            facts,
+        )
+        .expect("other operation plan");
+
+        assert_ne!(plain.digest(), named.digest());
+        assert_ne!(plain.digest(), other_operation.digest());
+        assert_eq!(plain.record().event_id, named.record().event_id);
+        assert_eq!(plain.projection_key(), named.projection_key());
+        assert_ne!(plain.record().event_id, other_operation.record().event_id);
+    }
+
+    #[test]
+    fn changed_profile_network_and_host_retry_selects_first_exact_result() {
+        let keys = nostr::Keys::generate();
+        let operation_id = "d".repeat(64);
+        let sha256 = "a".repeat(64);
+        let facts = UploadEventFacts {
+            sha256: &sha256,
+            ext: "png",
+            mime: "image/png",
+            size: 42,
+            uploaded_at: 1_783_358_352,
+        };
+        let first = build_staged_upload_record(
+            &tenant(),
+            &keys.public_key(),
+            &operation_id,
+            &UploadAttribution {
+                uploader_name: Some("first-name".into()),
+                net: UploadNetworkInfo {
+                    ip: Some("8.8.8.8".parse().expect("public test IP")),
+                    port: Some(443),
+                },
+            },
+            facts,
+        )
+        .expect("first result");
+        let alias_tenant = TenantContext::resolved(tenant().community(), "alias.example.com");
+        let retry = build_staged_upload_record(
+            &alias_tenant,
+            &keys.public_key(),
+            &operation_id,
+            &UploadAttribution {
+                uploader_name: Some("changed-name".into()),
+                net: UploadNetworkInfo {
+                    ip: Some("1.1.1.1".parse().expect("public test IP")),
+                    port: Some(8443),
+                },
+            },
+            facts,
+        )
+        .expect("retry candidate");
+
+        assert_eq!(first.record().event_id, retry.record().event_id);
+        assert_eq!(first.projection_key(), retry.projection_key());
+        assert_ne!(first.digest(), retry.digest());
+        let first_digest = first.digest();
+        let first_bytes = first.canonical_bytes().to_vec();
+        let selected = select_persisted_replay(retry, first).expect("first result wins");
+        assert_eq!(selected.digest(), first_digest);
+        assert_eq!(selected.canonical_bytes(), first_bytes);
     }
 
     #[test]

--- a/crates/buzz-media/tests/nip_fi_publication.rs
+++ b/crates/buzz-media/tests/nip_fi_publication.rs
@@ -1,0 +1,27 @@
+//! Contract tests for immutable protected media publication keys.
+
+use buzz_media::{media_publication_manifest_key, upload_record_plan_key};
+
+#[test]
+fn publication_and_moderation_plan_keys_are_exact_digest_addresses() {
+    assert_eq!(
+        media_publication_manifest_key([0xab; 32]),
+        format!("_publications/media/{}.json", "ab".repeat(32))
+    );
+    assert_eq!(
+        upload_record_plan_key([0xcd; 32]),
+        format!("_publication-plans/moderation/{}.json", "cd".repeat(32))
+    );
+}
+
+#[test]
+fn distinct_payload_digests_cannot_alias_staged_keys() {
+    assert_ne!(
+        media_publication_manifest_key([0x01; 32]),
+        media_publication_manifest_key([0x02; 32])
+    );
+    assert_ne!(
+        upload_record_plan_key([0x01; 32]),
+        upload_record_plan_key([0x02; 32])
+    );
+}

--- a/crates/buzz-relay/src/api/git/cas_publish.rs
+++ b/crates/buzz-relay/src/api/git/cas_publish.rs
@@ -62,6 +62,7 @@
 //!   exact contention `Inv_NoFork` proves safe.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -76,7 +77,7 @@ use crate::api::git::manifest::{
     PACK_COMPACTION_THRESHOLD,
 };
 use crate::api::git::store::{CasOutcome, ETag, GitStore, Precond, StoreError};
-use buzz_core::TenantContext;
+use buzz_core::{CommunityId, TenantContext};
 
 const PACK_CAPTURE_TIMEOUT: Duration = Duration::from_secs(300);
 const PACK_COMPACTION_OPERATION_TIMEOUT: Duration = Duration::from_secs(600);
@@ -177,6 +178,79 @@ struct CompactionObservation {
     packs_before: usize,
     packs_after: usize,
     compacted_bytes: u64,
+}
+
+/// Immutable Git publication staged in content-addressed storage.
+///
+/// This value does not make the repository visible. The manifest digest must
+/// first be committed as the canonical PostgreSQL protected-operation result;
+/// only then may a raw object-store pointer be refreshed as a disposable cache.
+pub struct StagedGitPublication {
+    community_id: CommunityId,
+    owner: String,
+    repo: String,
+    expected_parent_result_digest: Option<[u8; 32]>,
+    manifest: Manifest,
+    manifest_key: String,
+    result_digest: [u8; 32],
+}
+
+impl fmt::Debug for StagedGitPublication {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StagedGitPublication([REDACTED])")
+    }
+}
+
+#[allow(dead_code)] // Accessed by the pending S5 publication transaction adapter.
+impl StagedGitPublication {
+    /// Server-resolved authorization domain bound to this publication.
+    pub const fn community_id(&self) -> CommunityId {
+        self.community_id
+    }
+
+    /// Canonical repository owner bound to this publication.
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    /// Canonical repository name bound to this publication.
+    pub fn repo(&self) -> &str {
+        &self.repo
+    }
+
+    /// Exact DB-witnessed parent, or `None` only for first publication.
+    pub const fn expected_parent_result_digest(&self) -> Option<[u8; 32]> {
+        self.expected_parent_result_digest
+    }
+
+    /// Canonical immutable manifest to use for derived ref-state events.
+    pub const fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Full content-addressed manifest key (`manifests/<sha256>`).
+    pub fn manifest_key(&self) -> &str {
+        &self.manifest_key
+    }
+
+    /// Non-authoritative pointer projection key for durable outbox delivery.
+    pub fn pointer_cache_key(&self) -> String {
+        pointer_key(self.community_id, &self.owner, &self.repo)
+    }
+
+    /// Exact immutable publication digest committed in the operation receipt.
+    pub const fn result_digest(&self) -> [u8; 32] {
+        self.result_digest
+    }
+}
+
+/// Best-effort result of refreshing the non-authoritative raw pointer cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PointerCacheUpdate {
+    /// The cache now names the staged manifest.
+    Updated,
+    /// The cache CAS observed another value and was deliberately left alone.
+    Stale,
 }
 
 struct PreparedCompaction {
@@ -1018,6 +1092,35 @@ pub async fn cas_publish(
     .await
 }
 
+/// Stage packs and one verified immutable manifest without publishing visibility.
+///
+/// The returned digest is suitable for the canonical protected-operation
+/// receipt. This function never reads or writes the raw repository pointer.
+#[allow(dead_code)] // Activated only after S5 freezes the joined publication seam.
+pub(crate) async fn stage_git_publication(
+    store: &GitStore,
+    ctx: &TenantContext,
+    owner: &str,
+    repo: &str,
+    repo_path: &Path,
+    parent_state: &ParentState,
+    limits: PublishLimits,
+) -> Result<StagedGitPublication, CasError> {
+    stage_git_publication_inner(
+        store,
+        ctx,
+        owner,
+        repo,
+        repo_path,
+        parent_state,
+        PublishOptions {
+            limits,
+            compaction_threshold: PACK_COMPACTION_THRESHOLD,
+        },
+    )
+    .await
+}
+
 async fn cas_publish_inner(
     store: &GitStore,
     ctx: &TenantContext,
@@ -1027,8 +1130,44 @@ async fn cas_publish_inner(
     parent_state: &ParentState,
     options: PublishOptions,
 ) -> Result<CasSuccess, CasError> {
+    let staged =
+        stage_git_publication_inner(store, ctx, owner, repo, repo_path, parent_state, options)
+            .await?;
+    publish_pointer_cache_strict(store, ctx, owner, repo, parent_state, staged).await
+}
+
+async fn stage_git_publication_inner(
+    store: &GitStore,
+    ctx: &TenantContext,
+    owner: &str,
+    repo: &str,
+    repo_path: &Path,
+    parent_state: &ParentState,
+    options: PublishOptions,
+) -> Result<StagedGitPublication, CasError> {
+    let canonical_repo = repo.strip_suffix(".git").unwrap_or(repo);
+    if owner.len() != 64
+        || !owner
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        || canonical_repo.is_empty()
+        || canonical_repo.len() > 64
+        || canonical_repo.starts_with('.')
+        || canonical_repo.contains("..")
+        || !canonical_repo
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        return Err(CasError::ManifestInvalid(ManifestError::UnsafeRefName(
+            "invalid repository publication target".to_owned(),
+        )));
+    }
+    let expected_parent_result_digest = parent_state
+        .parent_digest
+        .as_deref()
+        .map(parse_publication_digest)
+        .transpose()?;
     let limits = options.limits;
-    let pkey = pointer_key(ctx.community(), owner, repo);
 
     // Hydrated repositories are direct children of the configured Git scratch
     // root. Reuse that parent for publication tempfiles so they remain on the
@@ -1207,56 +1346,94 @@ async fn cas_publish_inner(
         }
     };
     let manifest_digest = digest_from_manifest_key(&manifest_key)?;
+    let result_digest = parse_publication_digest(&manifest_digest)?;
+    if let Some(observation) = &compaction_observation {
+        record_compaction(
+            "staged",
+            observation.started_at,
+            observation.packs_before,
+            Some(observation.packs_after),
+            Some(observation.compacted_bytes),
+        );
+    }
+    Ok(StagedGitPublication {
+        community_id: ctx.community(),
+        owner: owner.to_owned(),
+        repo: canonical_repo.to_owned(),
+        expected_parent_result_digest,
+        manifest: m_after,
+        manifest_key,
+        result_digest,
+    })
+}
 
-    // Step 7: CAS the pointer.
+/// Refresh the legacy raw pointer as a disposable cache after DB publication.
+///
+/// A stale or missing cache never confers authority. Callers must already have
+/// combined `staged.result_digest()` with the server-owned authorization
+/// domain, owner, and repository target and committed that target-bound digest
+/// as the canonical PostgreSQL witness. They must tolerate
+/// [`PointerCacheUpdate::Stale`].
+#[allow(dead_code)] // Activated only after canonical DB publication succeeds.
+pub(crate) async fn publish_pointer_cache(
+    store: &GitStore,
+    staged: &StagedGitPublication,
+) -> Result<PointerCacheUpdate, CasError> {
+    let pkey = pointer_key(staged.community_id(), staged.owner(), staged.repo());
+    let manifest_digest = staged
+        .manifest_key
+        .strip_prefix("manifests/")
+        .ok_or_else(|| CasError::ManifestReadFailed("staged manifest key is invalid".into()))?;
+    let precond = match store.get_pointer(&pkey).await? {
+        Some((_etag, current)) if current.as_ref() == manifest_digest.as_bytes() => {
+            return Ok(PointerCacheUpdate::Updated);
+        }
+        Some((etag, current))
+            if staged
+                .expected_parent_result_digest()
+                .is_some_and(|parent| current.as_ref() == hex::encode(parent).as_bytes()) =>
+        {
+            Precond::IfMatch(etag)
+        }
+        Some(_) => return Ok(PointerCacheUpdate::Stale),
+        None if staged.expected_parent_result_digest().is_none() => Precond::IfNoneMatchStar,
+        None => return Ok(PointerCacheUpdate::Stale),
+    };
+    match store
+        .put_pointer(&pkey, manifest_digest.as_bytes(), precond)
+        .await?
+    {
+        CasOutcome::Won(_) => Ok(PointerCacheUpdate::Updated),
+        CasOutcome::LostRace => Ok(PointerCacheUpdate::Stale),
+    }
+}
+
+async fn publish_pointer_cache_strict(
+    store: &GitStore,
+    ctx: &TenantContext,
+    owner: &str,
+    repo: &str,
+    parent_state: &ParentState,
+    staged: StagedGitPublication,
+) -> Result<CasSuccess, CasError> {
+    let pkey = pointer_key(ctx.community(), owner, repo);
     let precond = match &parent_state.if_match {
-        Some(e) => Precond::IfMatch(e.clone()),
+        Some(etag) => Precond::IfMatch(etag.clone()),
         None => Precond::IfNoneMatchStar,
     };
-    let cas_outcome = match store
+    let manifest_digest = staged
+        .manifest_key
+        .strip_prefix("manifests/")
+        .ok_or_else(|| CasError::ManifestReadFailed("staged manifest key is invalid".into()))?;
+    match store
         .put_pointer(&pkey, manifest_digest.as_bytes(), precond)
-        .await
+        .await?
     {
-        Ok(outcome) => outcome,
-        Err(error) => {
-            if let Some(observation) = &compaction_observation {
-                record_compaction(
-                    "publish_error",
-                    observation.started_at,
-                    observation.packs_before,
-                    Some(observation.packs_after),
-                    Some(observation.compacted_bytes),
-                );
-            }
-            return Err(error.into());
-        }
-    };
-    match cas_outcome {
-        CasOutcome::Won(_new_etag) => {
-            if let Some(observation) = &compaction_observation {
-                record_compaction(
-                    "success",
-                    observation.started_at,
-                    observation.packs_before,
-                    Some(observation.packs_after),
-                    Some(observation.compacted_bytes),
-                );
-            }
-            Ok(CasSuccess {
-                manifest: m_after,
-                manifest_key,
-            })
-        }
+        CasOutcome::Won(_) => Ok(CasSuccess {
+            manifest: staged.manifest,
+            manifest_key: staged.manifest_key,
+        }),
         CasOutcome::LostRace => {
-            if let Some(observation) = &compaction_observation {
-                record_compaction(
-                    "cas_conflict",
-                    observation.started_at,
-                    observation.packs_before,
-                    Some(observation.packs_after),
-                    Some(observation.compacted_bytes),
-                );
-            }
             // Surface a typed Conflict carrying the winner so the caller
             // can reconcile the on-disk workspace without re-reading the
             // pointer. We re-GET the pointer here on the slow path; a
@@ -1271,7 +1448,7 @@ async fn cas_publish_inner(
             warn!(
                 pointer = %pkey,
                 expected_etag = %expected,
-                attempted_manifest = %manifest_key,
+                attempted_manifest = %staged.manifest_key,
                 "CAS lost race; resolving winner for reconcile"
             );
             let (winner_manifest, winner_manifest_key) =
@@ -1282,6 +1459,25 @@ async fn cas_publish_inner(
             })
         }
     }
+}
+
+fn parse_publication_digest(encoded: &str) -> Result<[u8; 32], CasError> {
+    let bytes = hex::decode(encoded)
+        .map_err(|_| CasError::ManifestReadFailed("manifest digest is not hexadecimal".into()))?;
+    let digest: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| CasError::ManifestReadFailed("manifest digest has wrong length".into()))?;
+    if hex::encode(digest) != encoded {
+        return Err(CasError::ManifestReadFailed(
+            "manifest digest is not canonical lowercase hexadecimal".into(),
+        ));
+    }
+    if digest == [0; 32] {
+        return Err(CasError::ManifestReadFailed(
+            "manifest digest is unallocated".into(),
+        ));
+    }
+    Ok(digest)
 }
 
 /// Re-read the pointer after a `LostRace` and fetch the winner's manifest.
@@ -1331,6 +1527,7 @@ async fn read_winner_after_conflict(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::Digest as _;
 
     // `pointer_key` is owned by `manifest.rs` and unit-tested there
     // (one source of truth — Max/Sami's centralization point).
@@ -1389,6 +1586,57 @@ mod tests {
     #[test]
     fn digest_from_key_rejects_unknown_prefix() {
         assert!(digest_from_manifest_key("not/manifests/abc").is_err());
+    }
+
+    #[test]
+    fn staged_publication_seals_exact_manifest_digest_without_pointer_state() {
+        let manifest = Manifest {
+            version: MANIFEST_VERSION,
+            head: "refs/heads/main".into(),
+            refs: BTreeMap::from([("refs/heads/main".into(), "1".repeat(40))]),
+            packs: vec![pack_key('a')],
+            parent: None,
+        };
+        let canonical = manifest.canonical_bytes().expect("canonical manifest");
+        let digest: [u8; 32] = sha2::Sha256::digest(canonical).into();
+        let tenant = tenant();
+        let staged = StagedGitPublication {
+            community_id: tenant.community(),
+            owner: "a".repeat(64),
+            repo: "project".to_owned(),
+            expected_parent_result_digest: None,
+            manifest: manifest.clone(),
+            manifest_key: format!("manifests/{}", hex::encode(digest)),
+            result_digest: digest,
+        };
+
+        assert_eq!(staged.community_id(), tenant.community());
+        assert_eq!(staged.owner(), "a".repeat(64));
+        assert_eq!(staged.repo(), "project");
+        assert_eq!(staged.expected_parent_result_digest(), None);
+        assert_eq!(staged.manifest(), &manifest);
+        assert_eq!(staged.result_digest(), digest);
+        assert_eq!(format!("{staged:?}"), "StagedGitPublication([REDACTED])");
+        assert_eq!(
+            staged.pointer_cache_key(),
+            pointer_key(tenant.community(), &"a".repeat(64), "project")
+        );
+        assert_eq!(
+            staged.manifest_key(),
+            format!("manifests/{}", hex::encode(digest))
+        );
+    }
+
+    #[test]
+    fn publication_digest_rejects_noncanonical_and_unallocated_values() {
+        assert!(parse_publication_digest("not-hex").is_err());
+        assert!(parse_publication_digest(&"01".repeat(31)).is_err());
+        assert!(parse_publication_digest(&"00".repeat(32)).is_err());
+        assert!(parse_publication_digest(&"AB".repeat(32)).is_err());
+        assert_eq!(
+            parse_publication_digest(&"ab".repeat(32)).expect("digest"),
+            [0xab; 32]
+        );
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/git/hydrate.rs
+++ b/crates/buzz-relay/src/api/git/hydrate.rs
@@ -30,6 +30,7 @@
 
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 use tokio::process::Command;
 
@@ -178,6 +179,48 @@ pub async fn load_manifest_for_read(
         .map(|(_etag, _digest, manifest)| manifest))
 }
 
+/// Load the exact immutable manifest named by a PostgreSQL publication witness.
+///
+/// This path never reads the raw repository pointer. The object-store key,
+/// stored bytes, canonical re-encoding, and DB result digest must all agree.
+pub(crate) async fn load_authoritative_manifest(
+    store: &GitStore,
+    result_digest: [u8; 32],
+) -> Result<Manifest, HydrateError> {
+    if result_digest == [0; 32] {
+        return Err(HydrateError::InvalidPointer);
+    }
+    let digest = hex::encode(result_digest);
+    let key = format!("manifests/{digest}");
+    let bytes = get_verified_limited(store, &key, &digest, MAX_MANIFEST_BYTES).await?;
+    decode_authoritative_manifest(&bytes, result_digest)
+}
+
+fn decode_authoritative_manifest(
+    bytes: &[u8],
+    result_digest: [u8; 32],
+) -> Result<Manifest, HydrateError> {
+    let manifest = Manifest::from_bytes(bytes)?;
+    manifest.validate()?;
+    let canonical = manifest.canonical_bytes()?;
+    let canonical_digest: [u8; 32] = Sha256::digest(canonical).into();
+    if canonical_digest != result_digest {
+        return Err(HydrateError::InvalidPointer);
+    }
+    Ok(manifest)
+}
+
+/// Hydrate a read workspace only from the DB-witnessed immutable manifest.
+#[allow(dead_code)] // Activated only after S5 freezes the joined read witness.
+pub(crate) async fn hydrate_authoritative_read(
+    store: &GitStore,
+    result_digest: [u8; 32],
+    options: HydrationOptions<'_>,
+) -> Result<HydratedRepo, HydrateError> {
+    let manifest = load_authoritative_manifest(store, result_digest).await?;
+    materialize_manifest(store, &manifest, options).await
+}
+
 async fn init_bare_repo(path: &Path) -> Result<(), HydrateError> {
     run_git(path, &["init", "--bare", "--quiet"]).await?;
     run_git(path, &["symbolic-ref", "HEAD", "refs/heads/main"]).await
@@ -237,6 +280,45 @@ pub async fn hydrate_for_write(
             ))
         }
     }
+}
+
+/// Hydrate a write workspace from the DB-witnessed parent publication.
+///
+/// `None` is the authoritative first-publication state. A present digest is
+/// fetched and verified directly; the raw pointer is neither read nor trusted.
+#[allow(dead_code)] // Activated only after S5 freezes expected-parent publication.
+pub(crate) async fn hydrate_authoritative_write(
+    store: &GitStore,
+    parent_result_digest: Option<[u8; 32]>,
+    options: HydrationOptions<'_>,
+) -> Result<(HydratedRepo, ParentState), HydrateError> {
+    let Some(result_digest) = parent_result_digest else {
+        let tempdir = TempDir::new_in(options.scratch_dir).map_err(|error| {
+            HydrateError::Hydrate(format!("tempdir in {:?}: {error}", options.scratch_dir))
+        })?;
+        let path = tempdir.path().to_path_buf();
+        init_bare_repo(&path).await?;
+        return Ok((
+            HydratedRepo {
+                _tempdir: tempdir,
+                path,
+                hydrated_bytes: 0,
+                hydrated_packs: 0,
+            },
+            ParentState::fresh(),
+        ));
+    };
+
+    let manifest = load_authoritative_manifest(store, result_digest).await?;
+    let repo = materialize_manifest(store, &manifest, options).await?;
+    Ok((
+        repo,
+        ParentState {
+            if_match: None,
+            parent_digest: Some(hex::encode(result_digest)),
+            parent: manifest,
+        },
+    ))
 }
 
 /// Resolve the pointer to its `(ETag, digest, verified Manifest)` triple.
@@ -503,6 +585,34 @@ mod tests {
         assert!(!is_hex_oid(&"a".repeat(39)));
         assert!(!is_hex_oid(&"g".repeat(40))); // non-hex
         assert!(!is_hex_oid(""));
+    }
+
+    #[test]
+    fn authoritative_manifest_requires_exact_canonical_witness_bytes() {
+        let manifest = Manifest {
+            version: 1,
+            head: "refs/heads/main".into(),
+            refs: BTreeMap::from([("refs/heads/main".into(), "1".repeat(40))]),
+            packs: Vec::new(),
+            parent: None,
+        };
+        let canonical = manifest.canonical_bytes().expect("canonical manifest");
+        let canonical_digest: [u8; 32] = Sha256::digest(&canonical).into();
+        assert_eq!(
+            decode_authoritative_manifest(&canonical, canonical_digest).expect("witness"),
+            manifest
+        );
+
+        let noncanonical = serde_json::to_vec_pretty(&manifest).expect("pretty manifest");
+        let noncanonical_digest: [u8; 32] = Sha256::digest(&noncanonical).into();
+        assert!(matches!(
+            decode_authoritative_manifest(&noncanonical, noncanonical_digest),
+            Err(HydrateError::InvalidPointer)
+        ));
+        assert!(matches!(
+            decode_authoritative_manifest(&canonical, [0x55; 32]),
+            Err(HydrateError::InvalidPointer)
+        ));
     }
 
     #[tokio::test]

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -18,10 +18,711 @@ use axum::{
 };
 use base64::Engine;
 use buzz_audit::{AuditAction, NewAuditEntry};
+use buzz_auth::SealedTransportEvidence;
 use buzz_core::tenant::TenantContext;
-use buzz_media::{BlobDescriptor, MediaError, UploadAttribution, UploadNetworkInfo};
+use buzz_db::authorization_admission::{
+    AdmissionApplicationContext, AdmissionApplicationEffect, AdmissionApplicationOutcome,
+    AdmissionApplicationResult, AdmissionApplicationResultSchema, AdmissionCommitError,
+    AdmissionCommitOutcome, AdmissionCommitReceipt, AdmissionCommitRequest, AdmissionObject,
+    AdmissionObjectKind, AdmissionReplayClaim, AdmissionReplayClaimKind,
+};
+use buzz_media::{
+    BlobDescriptor, MediaError, MediaStorage, StagedMediaUpload, UploadAttribution,
+    UploadNetworkInfo,
+};
+use sha2::{Digest, Sha256};
+use sqlx::{Postgres, Transaction};
 
+use crate::api::git::cas_publish::StagedGitPublication;
 use crate::state::AppState;
+
+/// Installs origin-sealed transport replay state onto S3's sole admission
+/// request without creating an alternate admission or lifecycle authority.
+///
+/// S5 calls this only after canonical assertion/proof preparation. Consuming
+/// the move-only evidence ensures confidential assertion bytes do not survive
+/// beyond installation, while S3 remains responsible for atomic claim use.
+#[derive(Debug, Default)]
+pub struct ProtectedTransportInstaller;
+
+impl ProtectedTransportInstaller {
+    /// Bind the trusted-proxy nonce claim to the exact server-owned admission
+    /// domain. Domain drift fails before canonical admission performs I/O.
+    pub fn install(
+        request: AdmissionCommitRequest,
+        evidence: SealedTransportEvidence,
+    ) -> Result<AdmissionCommitRequest, AdmissionCommitError> {
+        let (request_transport, request_transport_context) = request.transport_binding();
+        let claim = verified_transport_replay_claim(
+            request.authorization_domain(),
+            request.request_fingerprint(),
+            request_transport,
+            request_transport_context,
+            &evidence,
+        )?;
+        Ok(request.with_replay_claim(claim))
+    }
+}
+
+fn verified_transport_replay_claim(
+    authorization_domain: buzz_core::CommunityId,
+    request_fingerprint: [u8; 32],
+    transport: buzz_auth::ProofTransport,
+    transport_context_fingerprint: [u8; 32],
+    evidence: &SealedTransportEvidence,
+) -> Result<AdmissionReplayClaim, AdmissionCommitError> {
+    if authorization_domain != evidence.authorization_domain()
+        || request_fingerprint != *evidence.request_fingerprint()
+        || transport != evidence.transport()
+        || transport_context_fingerprint != *evidence.transport_context_fingerprint()
+    {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    AdmissionReplayClaim::new(
+        AdmissionReplayClaimKind::TrustedProxyNonce,
+        *evidence.nonce_claim().claim_key(),
+        evidence.nonce_claim().retain_until(),
+    )
+}
+
+/// Typed server-owned publication coordinate used by canonical admission.
+///
+/// The opaque object key is derived from the authorization domain and exact
+/// target coordinates. Repository targets bind both owner and canonical repo;
+/// media targets bind the canonical blob digest. This prevents two plans with
+/// byte-identical artifact manifests from sharing an admission result.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ProtectedPublicationTarget {
+    authorization_domain: buzz_core::CommunityId,
+    object: AdmissionObject,
+}
+
+impl ProtectedPublicationTarget {
+    /// Derive the canonical repository object from exact server-resolved path
+    /// coordinates.
+    pub fn repository(
+        authorization_domain: buzz_core::CommunityId,
+        owner: &str,
+        repo: &str,
+    ) -> Result<Self, AdmissionCommitError> {
+        let canonical_repo = repo.strip_suffix(".git").unwrap_or(repo);
+        if authorization_domain.as_uuid().is_nil()
+            || owner.len() != 64
+            || !owner
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            || canonical_repo.is_empty()
+            || canonical_repo.len() > 64
+            || canonical_repo.starts_with('.')
+            || canonical_repo.contains("..")
+            || !canonical_repo
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Self::derive(
+            authorization_domain,
+            AdmissionObjectKind::Repository,
+            b"buzz:nip-fi:repository-target:v1",
+            &[owner.as_bytes(), canonical_repo.as_bytes()],
+        )
+    }
+
+    /// Derive the canonical media object from an exact lower-hex blob digest.
+    pub fn media(
+        authorization_domain: buzz_core::CommunityId,
+        blob_sha256: &str,
+    ) -> Result<Self, AdmissionCommitError> {
+        if authorization_domain.as_uuid().is_nil()
+            || blob_sha256.len() != 64
+            || !blob_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Self::derive(
+            authorization_domain,
+            AdmissionObjectKind::Media,
+            b"buzz:nip-fi:media-target:v1",
+            &[blob_sha256.as_bytes()],
+        )
+    }
+
+    fn derive(
+        authorization_domain: buzz_core::CommunityId,
+        kind: AdmissionObjectKind,
+        domain: &[u8],
+        coordinates: &[&[u8]],
+    ) -> Result<Self, AdmissionCommitError> {
+        let mut fields = Vec::with_capacity(coordinates.len() + 1);
+        fields.push(authorization_domain.as_uuid().as_bytes().as_slice());
+        fields.extend_from_slice(coordinates);
+        let key = framed_digest(domain, &fields);
+        let object = AdmissionObject::new(kind, key).ok_or(AdmissionCommitError::InvalidRequest)?;
+        Ok(Self {
+            authorization_domain,
+            object,
+        })
+    }
+
+    /// Server-resolved authorization domain.
+    pub const fn authorization_domain(self) -> buzz_core::CommunityId {
+        self.authorization_domain
+    }
+
+    /// Closed kind and opaque key supplied to canonical admission.
+    pub const fn admission_object(self) -> AdmissionObject {
+        self.object
+    }
+
+    /// Derive the application result committed by canonical admission from an
+    /// immutable artifact-manifest digest and this exact server-owned target.
+    pub fn bind_artifact_result(self, artifact_digest: [u8; 32]) -> [u8; 32] {
+        framed_digest(
+            b"buzz:nip-fi:protected-publication-result:v1",
+            &[
+                self.authorization_domain.as_uuid().as_bytes(),
+                &[self.object.kind().database_code() as u8],
+                self.object.key(),
+                &artifact_digest,
+            ],
+        )
+    }
+
+    /// Exact typed application result persisted by canonical admission.
+    pub fn application_result(
+        self,
+        artifact_digest: [u8; 32],
+    ) -> Result<AdmissionApplicationResult, AdmissionCommitError> {
+        publication_application_result(self, artifact_digest)
+    }
+
+    /// Validate a storage-issued receipt and typed result against this exact
+    /// target and immutable artifact manifest.
+    pub fn validate_receipt(
+        self,
+        artifact_digest: [u8; 32],
+        application_intent_digest: [u8; 32],
+        admission: AdmissionCommitReceipt,
+        application_result: &AdmissionApplicationResult,
+    ) -> Result<(), AdmissionCommitError> {
+        validate_publication_binding(
+            self,
+            artifact_digest,
+            application_intent_digest,
+            admission,
+            application_result,
+        )
+    }
+}
+
+impl std::fmt::Debug for ProtectedPublicationTarget {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProtectedPublicationTarget([REDACTED])")
+    }
+}
+
+/// Closed immutable publication staged before S3 canonical admission.
+///
+/// Neither variant is visible until an exact applied admission receipt is
+/// bound by [`ProtectedPublicationReceipt::bind`]. Raw object-store pointers
+/// and media sidecars remain post-commit projections only.
+pub enum ProtectedPublicationPlan {
+    /// Media manifest, blob artifacts, and deterministic moderation plan.
+    Media(Box<StagedMediaUpload>),
+    /// Git manifest and content-addressed pack artifacts.
+    Git(Box<StagedGitPublication>),
+}
+
+impl ProtectedPublicationPlan {
+    /// Exact server-owned target bound to this plan.
+    pub fn target(&self) -> Result<ProtectedPublicationTarget, AdmissionCommitError> {
+        match self {
+            Self::Media(staged) => ProtectedPublicationTarget::media(
+                staged.publication().manifest().community_id(),
+                staged.publication().manifest().blob_sha256(),
+            ),
+            Self::Git(staged) => ProtectedPublicationTarget::repository(
+                staged.community_id(),
+                staged.owner(),
+                staged.repo(),
+            ),
+        }
+    }
+
+    /// Raw immutable artifact-manifest digest before target binding.
+    pub fn artifact_digest(&self) -> [u8; 32] {
+        match self {
+            Self::Media(staged) => staged.publication().result_digest(),
+            Self::Git(staged) => staged.result_digest(),
+        }
+    }
+
+    /// Target-bound application result that canonical admission must persist.
+    pub fn result_digest(&self) -> Result<[u8; 32], AdmissionCommitError> {
+        Ok(self.target()?.bind_artifact_result(self.artifact_digest()))
+    }
+
+    /// Build the bounded application mutation installed on canonical admission.
+    ///
+    /// The staged plan remains with the caller for receipt binding and
+    /// post-commit projection. The effect retains only credential-free target,
+    /// immutable object-store, and deterministic outbox coordinates.
+    pub fn application_effect(
+        &self,
+    ) -> Result<ProtectedPublicationApplicationEffect, AdmissionCommitError> {
+        let target = self.target()?;
+        let artifact_digest = self.artifact_digest();
+        let projections = match self {
+            Self::Media(staged) => {
+                let publication = staged.publication();
+                let manifest = publication.manifest();
+                let mut projections = vec![ProtectedProjectionPlan {
+                    kind: 2,
+                    projection_key: MediaStorage::sidecar_key(
+                        target.authorization_domain(),
+                        manifest.blob_sha256(),
+                    ),
+                    staged_object_key: publication.manifest_key().to_owned(),
+                    payload_digest: publication.result_digest(),
+                }];
+                if let Some(record) = staged.moderation_projection() {
+                    projections.push(ProtectedProjectionPlan {
+                        kind: 1,
+                        projection_key: record.projection_key().to_owned(),
+                        staged_object_key: record.plan_key().to_owned(),
+                        payload_digest: record.digest(),
+                    });
+                }
+                projections
+            }
+            Self::Git(staged) => vec![ProtectedProjectionPlan {
+                kind: 3,
+                projection_key: staged.pointer_cache_key(),
+                staged_object_key: staged.manifest_key().to_owned(),
+                payload_digest: staged.result_digest(),
+            }],
+        };
+        ProtectedPublicationApplicationEffect::new(target, artifact_digest, projections)
+    }
+}
+
+impl std::fmt::Debug for ProtectedPublicationPlan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProtectedPublicationPlan([REDACTED])")
+    }
+}
+
+impl From<StagedMediaUpload> for ProtectedPublicationPlan {
+    fn from(staged: StagedMediaUpload) -> Self {
+        Self::Media(Box::new(staged))
+    }
+}
+
+impl From<StagedGitPublication> for ProtectedPublicationPlan {
+    fn from(staged: StagedGitPublication) -> Self {
+        Self::Git(Box::new(staged))
+    }
+}
+
+const PROTECTED_PUBLICATION_RESULT_CODE: i16 = 1;
+
+#[derive(Debug)]
+struct ProtectedProjectionPlan {
+    kind: i16,
+    projection_key: String,
+    staged_object_key: String,
+    payload_digest: [u8; 32],
+}
+
+/// Credential-free publication DML executed inside canonical final admission.
+///
+/// All outbox coordinates are derived from immutable staged artifacts. The
+/// canonical transaction supplies domain, object, operation, request, schema,
+/// and result binding; callers cannot substitute any of those coordinates.
+pub struct ProtectedPublicationApplicationEffect {
+    target: ProtectedPublicationTarget,
+    artifact_digest: [u8; 32],
+    projections: Vec<ProtectedProjectionPlan>,
+    intent_digest: [u8; 32],
+}
+
+impl ProtectedPublicationApplicationEffect {
+    fn new(
+        target: ProtectedPublicationTarget,
+        artifact_digest: [u8; 32],
+        projections: Vec<ProtectedProjectionPlan>,
+    ) -> Result<Self, AdmissionCommitError> {
+        if artifact_digest == [0; 32] || projections.is_empty() {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        let intent_digest = publication_intent_digest(target, artifact_digest, &projections);
+        if intent_digest == [0; 32] {
+            return Err(AdmissionCommitError::InvalidRequest);
+        }
+        Ok(Self {
+            target,
+            artifact_digest,
+            projections,
+            intent_digest,
+        })
+    }
+}
+
+impl std::fmt::Debug for ProtectedPublicationApplicationEffect {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProtectedPublicationApplicationEffect([REDACTED])")
+    }
+}
+
+impl AdmissionApplicationEffect for ProtectedPublicationApplicationEffect {
+    fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    fn result_schema(&self) -> AdmissionApplicationResultSchema {
+        publication_result_schema()
+    }
+
+    fn apply<'a, 'transaction>(
+        &'a mut self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        context: &'a AdmissionApplicationContext<'a>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<AdmissionApplicationOutcome, AdmissionCommitError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if context.authorization_domain() != self.target.authorization_domain()
+                || context.object() != self.target.admission_object()
+            {
+                return Err(AdmissionCommitError::AuthorizationDenied);
+            }
+
+            let result = publication_application_result(self.target, self.artifact_digest)?;
+            let effect_digest = publication_effect_digest(context, self.intent_digest);
+            let outcome = AdmissionApplicationOutcome::new(result, effect_digest)?;
+            let publication_result_digest = context.canonical_result_digest(&outcome)?;
+            let schema = outcome.result().schema();
+
+            for projection in &self.projections {
+                sqlx::query(
+                    "INSERT INTO protected_publication_projection_outbox \
+                     (community_id, operation_id, request_fingerprint, \
+                      publication_result_digest, object_kind, object_key, \
+                      application_type, application_version, application_effect_digest, \
+                      projection_kind, projection_key, staged_object_key, payload_digest) \
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+                )
+                .bind(context.authorization_domain().as_uuid())
+                .bind(context.operation_id())
+                .bind(context.request_fingerprint().as_slice())
+                .bind(publication_result_digest.as_slice())
+                .bind(context.object().kind().database_code())
+                .bind(context.object().key().as_slice())
+                .bind(schema.type_key().as_slice())
+                .bind(
+                    i16::try_from(schema.version())
+                        .map_err(|_| AdmissionCommitError::InvalidRequest)?,
+                )
+                .bind(effect_digest.as_slice())
+                .bind(projection.kind)
+                .bind(&projection.projection_key)
+                .bind(&projection.staged_object_key)
+                .bind(projection.payload_digest.as_slice())
+                .execute(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            }
+            Ok(outcome)
+        })
+    }
+}
+
+fn publication_result_schema() -> AdmissionApplicationResultSchema {
+    AdmissionApplicationResultSchema::protected_publication()
+}
+
+fn publication_application_result(
+    target: ProtectedPublicationTarget,
+    artifact_digest: [u8; 32],
+) -> Result<AdmissionApplicationResult, AdmissionCommitError> {
+    let mut payload = Vec::with_capacity(83);
+    payload.push(1);
+    payload.extend_from_slice(target.authorization_domain().as_uuid().as_bytes());
+    payload.extend_from_slice(
+        &target
+            .admission_object()
+            .kind()
+            .database_code()
+            .to_be_bytes(),
+    );
+    payload.extend_from_slice(target.admission_object().key());
+    payload.extend_from_slice(&artifact_digest);
+    AdmissionApplicationResult::new(
+        publication_result_schema(),
+        PROTECTED_PUBLICATION_RESULT_CODE,
+        payload,
+    )
+}
+
+fn publication_intent_digest(
+    target: ProtectedPublicationTarget,
+    artifact_digest: [u8; 32],
+    projections: &[ProtectedProjectionPlan],
+) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(b"buzz:nip-fi:protected-publication-effect-intent:v1");
+    for field in [
+        target
+            .authorization_domain()
+            .as_uuid()
+            .as_bytes()
+            .as_slice(),
+        &target
+            .admission_object()
+            .kind()
+            .database_code()
+            .to_be_bytes(),
+        target.admission_object().key(),
+        &artifact_digest,
+    ] {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    for projection in projections {
+        for field in [
+            projection.kind.to_be_bytes().as_slice(),
+            projection.projection_key.as_bytes(),
+            projection.staged_object_key.as_bytes(),
+            projection.payload_digest.as_slice(),
+        ] {
+            digest.update((field.len() as u64).to_be_bytes());
+            digest.update(field);
+        }
+    }
+    digest.finalize().into()
+}
+
+fn publication_effect_digest(
+    context: &AdmissionApplicationContext<'_>,
+    intent_digest: [u8; 32],
+) -> [u8; 32] {
+    framed_digest(
+        b"buzz:nip-fi:protected-publication-effect:v1",
+        &[
+            context.authorization_domain().as_uuid().as_bytes(),
+            context.operation_id().as_bytes(),
+            context.request_fingerprint(),
+            &intent_digest,
+        ],
+    )
+}
+
+/// Exact canonical admission receipt bound to immutable staged artifacts.
+///
+/// Construction rejects cross-domain or result-digest substitution. Applied
+/// and exact-replay outcomes use the same durable S3 receipt and therefore the
+/// same deterministic plan.
+pub struct ProtectedPublicationReceipt {
+    plan: ProtectedPublicationPlan,
+    admission: AdmissionCommitReceipt,
+}
+
+/// Closed binding result for fresh publication versus exact replay.
+///
+/// Only the fresh variant owns a projection plan. Exact replay exposes the
+/// byte-identical persisted typed result but is structurally incapable of
+/// yielding post-commit projection work.
+pub enum ProtectedPublicationBinding {
+    /// A newly committed admission whose projection plan may run once.
+    Committed(ProtectedPublicationReceipt),
+    /// An already committed operation with no projection plan.
+    ExactReplay(ProtectedPublicationReplay),
+}
+
+/// Persisted exact-replay result without any post-commit projection authority.
+pub struct ProtectedPublicationReplay {
+    admission: AdmissionCommitReceipt,
+    application_result: AdmissionApplicationResult,
+}
+
+impl ProtectedPublicationReplay {
+    /// Durable receipt for the already committed operation.
+    pub const fn admission(&self) -> AdmissionCommitReceipt {
+        self.admission
+    }
+
+    /// Byte-identical typed result reconstructed by canonical storage.
+    pub const fn application_result(&self) -> &AdmissionApplicationResult {
+        &self.application_result
+    }
+}
+
+impl ProtectedPublicationReceipt {
+    /// Bind S3's typed application result to the exact staged publication.
+    ///
+    /// The outcome carries only storage-issued domain/object coordinates and
+    /// the byte-identical typed result reconstructed on exact replay. A caller
+    /// cannot supply replacement coordinates or compare against the unrelated
+    /// whole-admission envelope digest.
+    pub fn bind(
+        plan: ProtectedPublicationPlan,
+        outcome: &AdmissionCommitOutcome,
+    ) -> Result<ProtectedPublicationBinding, AdmissionCommitError> {
+        let (admission, application_result, committed) = match outcome {
+            AdmissionCommitOutcome::Committed {
+                receipt,
+                application_result,
+                ..
+            } => (*receipt, application_result.as_ref(), true),
+            AdmissionCommitOutcome::ExactReplay {
+                receipt,
+                application_result,
+            } => (*receipt, application_result.as_ref(), false),
+        };
+        let application_result = application_result.ok_or(AdmissionCommitError::IntentConflict)?;
+        let target = plan.target()?;
+        let application_intent_digest = plan.application_effect()?.intent_digest();
+        validate_publication_binding(
+            target,
+            plan.artifact_digest(),
+            application_intent_digest,
+            admission,
+            application_result,
+        )?;
+        if committed {
+            Ok(ProtectedPublicationBinding::Committed(Self {
+                plan,
+                admission,
+            }))
+        } else {
+            Ok(ProtectedPublicationBinding::ExactReplay(
+                ProtectedPublicationReplay {
+                    admission,
+                    application_result: application_result.clone(),
+                },
+            ))
+        }
+    }
+
+    /// Durable canonical admission receipt.
+    pub const fn admission(&self) -> AdmissionCommitReceipt {
+        self.admission
+    }
+
+    /// Exact immutable artifacts authorized by the receipt.
+    pub const fn plan(&self) -> &ProtectedPublicationPlan {
+        &self.plan
+    }
+
+    /// Consume the receipt for post-commit deterministic projection.
+    pub fn into_plan(self) -> ProtectedPublicationPlan {
+        self.plan
+    }
+}
+
+fn validate_publication_binding(
+    target: ProtectedPublicationTarget,
+    artifact_digest: [u8; 32],
+    application_intent_digest: [u8; 32],
+    admission: AdmissionCommitReceipt,
+    application_result: &AdmissionApplicationResult,
+) -> Result<(), AdmissionCommitError> {
+    let expected = publication_application_result(target, artifact_digest)?;
+    let expected_digest = canonical_publication_result_digest(
+        target,
+        *admission.semantic_fingerprint(),
+        application_intent_digest,
+        &expected,
+    )?;
+    if admission.authorization_domain() != target.authorization_domain()
+        || admission.object() != target.admission_object()
+        || admission.application_result_digest() != Some(&expected_digest)
+        || application_result != &expected
+    {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    Ok(())
+}
+
+fn canonical_publication_result_digest(
+    target: ProtectedPublicationTarget,
+    semantic_fingerprint: [u8; 32],
+    application_intent_digest: [u8; 32],
+    result: &AdmissionApplicationResult,
+) -> Result<[u8; 32], AdmissionCommitError> {
+    if semantic_fingerprint == [0; 32] || application_intent_digest == [0; 32] {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    let schema = result.schema();
+    Ok(admission_framed_digest(
+        b"buzz:canonical-application-result:v1",
+        &[
+            target.authorization_domain().as_uuid().as_bytes(),
+            &target
+                .admission_object()
+                .kind()
+                .database_code()
+                .to_be_bytes(),
+            target.admission_object().key(),
+            &semantic_fingerprint,
+            &application_intent_digest,
+            schema.type_key(),
+            &schema.version().to_be_bytes(),
+            &result.code().to_be_bytes(),
+            result.payload(),
+        ],
+    ))
+}
+
+fn admission_framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+fn framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+impl std::fmt::Debug for ProtectedPublicationReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProtectedPublicationReceipt([REDACTED])")
+    }
+}
+
+impl std::fmt::Debug for ProtectedPublicationBinding {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Committed(_) => "ProtectedPublicationBinding::Committed([REDACTED])",
+            Self::ExactReplay(_) => "ProtectedPublicationBinding::ExactReplay([REDACTED])",
+        })
+    }
+}
+
+impl std::fmt::Debug for ProtectedPublicationReplay {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ProtectedPublicationReplay([REDACTED])")
+    }
+}
 
 /// Axum extractor that validates Blossom auth, the BUD-11 hash binding, and
 /// relay membership (NIP-43, when enabled) from headers BEFORE the request
@@ -961,17 +1662,305 @@ fn extract_blossom_auth(headers: &HeaderMap) -> Result<nostr::Event, MediaError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{Arc, OnceLock},
+    };
 
     use axum::{
         body::Body,
         http::{header, Request, StatusCode},
     };
+    use buzz_auth::{
+        HttpHeaderField, TrustedProxyNonceClaim, TrustedProxyNonceReplayReader,
+        TrustedProxyProvenanceVerifier, TrustedProxyReplayReadError, TrustedProxyRequest,
+        ASSERTION_HEADER_NAME, PROVENANCE_HEADER_NAME,
+    };
+    use chrono::TimeZone;
+    use hmac::{Hmac, KeyInit, Mac};
     use nostr::{EventBuilder, JsonUtil, Keys, Kind, Tag, Timestamp};
     use tower::ServiceExt;
     use uuid::Uuid;
 
     const VALID_HASH: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const PROXY_NOW: u64 = 1_800_000_000;
+    const PROXY_SECRET: [u8; 32] = [0x53; 32];
+
+    fn proxy_assertion() -> &'static str {
+        static VALUE: OnceLock<String> = OnceLock::new();
+        VALUE.get_or_init(|| {
+            [
+                ["eyJhbGciOiJF", "UzI1NiJ9"].concat(),
+                ["eyJzdWIiOiJz", "dWJqZWN0In0"].concat(),
+                ["c2lnbmF0", "dXJl"].concat(),
+            ]
+            .join(".")
+        })
+    }
+
+    #[derive(Default)]
+    struct EmptyReplayReader;
+
+    impl TrustedProxyNonceReplayReader for EmptyReplayReader {
+        fn is_committed<'a>(
+            &'a self,
+            _authorization_domain: buzz_core::CommunityId,
+            _claim: &'a TrustedProxyNonceClaim,
+        ) -> Pin<Box<dyn Future<Output = Result<bool, TrustedProxyReplayReadError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(false) })
+        }
+    }
+
+    #[test]
+    fn publication_receipt_cannot_cross_domain_or_repository_target() {
+        let domain_a = buzz_core::CommunityId::from_uuid(Uuid::from_u128(1));
+        let domain_b = buzz_core::CommunityId::from_uuid(Uuid::from_u128(2));
+        let owner = "a".repeat(64);
+        let target_a =
+            ProtectedPublicationTarget::repository(domain_a, &owner, "repo-a").expect("target A");
+        let target_b =
+            ProtectedPublicationTarget::repository(domain_a, &owner, "repo-b").expect("target B");
+        let target_other_domain =
+            ProtectedPublicationTarget::repository(domain_b, &owner, "repo-a")
+                .expect("other-domain target");
+        let artifact = [7_u8; 32];
+        let result = publication_application_result(target_a, artifact).expect("typed result");
+        let semantic_fingerprint = [9; 32];
+        let application_intent_digest = [12; 32];
+        let application_result_digest = canonical_publication_result_digest(
+            target_a,
+            semantic_fingerprint,
+            application_intent_digest,
+            &result,
+        )
+        .expect("canonical application result digest");
+        let receipt = AdmissionCommitReceipt::from_storage(
+            domain_a,
+            target_a.admission_object(),
+            Uuid::from_u128(10),
+            [8; 32],
+            semantic_fingerprint,
+            buzz_db::authorization_admission::AdmissionCommitDigests::new(
+                [10; 32],
+                Some(application_result_digest),
+            )
+            .expect("digests"),
+            Uuid::from_u128(11),
+        )
+        .expect("receipt");
+
+        assert!(validate_publication_binding(
+            target_a,
+            artifact,
+            application_intent_digest,
+            receipt,
+            &result
+        )
+        .is_ok());
+        assert_eq!(
+            validate_publication_binding(
+                target_b,
+                artifact,
+                application_intent_digest,
+                receipt,
+                &result,
+            ),
+            Err(AdmissionCommitError::IntentConflict)
+        );
+        assert_eq!(
+            validate_publication_binding(
+                target_other_domain,
+                artifact,
+                application_intent_digest,
+                receipt,
+                &result,
+            ),
+            Err(AdmissionCommitError::IntentConflict)
+        );
+        let wrong_digest_receipt = AdmissionCommitReceipt::from_storage(
+            domain_a,
+            target_a.admission_object(),
+            Uuid::from_u128(10),
+            [8; 32],
+            semantic_fingerprint,
+            buzz_db::authorization_admission::AdmissionCommitDigests::new([10; 32], Some([13; 32]))
+                .expect("wrong digests"),
+            Uuid::from_u128(11),
+        )
+        .expect("wrong-digest receipt");
+        assert_eq!(
+            validate_publication_binding(
+                target_a,
+                artifact,
+                application_intent_digest,
+                wrong_digest_receipt,
+                &result,
+            ),
+            Err(AdmissionCommitError::IntentConflict)
+        );
+        let arbitrary_result =
+            publication_application_result(target_a, [14; 32]).expect("arbitrary typed result");
+        assert_eq!(
+            validate_publication_binding(
+                target_a,
+                artifact,
+                application_intent_digest,
+                receipt,
+                &arbitrary_result,
+            ),
+            Err(AdmissionCommitError::IntentConflict)
+        );
+    }
+
+    #[test]
+    fn exact_replay_binding_contains_typed_result_but_no_projection_plan() {
+        let domain = buzz_core::CommunityId::from_uuid(Uuid::from_u128(20));
+        let target = ProtectedPublicationTarget::repository(domain, &"b".repeat(64), "replay-only")
+            .expect("replay target");
+        let result = publication_application_result(target, [21; 32]).expect("typed result");
+        let receipt = AdmissionCommitReceipt::from_storage(
+            domain,
+            target.admission_object(),
+            Uuid::from_u128(22),
+            [23; 32],
+            [24; 32],
+            buzz_db::authorization_admission::AdmissionCommitDigests::new([25; 32], Some([26; 32]))
+                .expect("digests"),
+            Uuid::from_u128(27),
+        )
+        .expect("receipt");
+        let binding = ProtectedPublicationBinding::ExactReplay(ProtectedPublicationReplay {
+            admission: receipt,
+            application_result: result.clone(),
+        });
+
+        let ProtectedPublicationBinding::ExactReplay(replay) = binding else {
+            panic!("constructed replay binding changed variant");
+        };
+        assert_eq!(replay.admission(), receipt);
+        assert_eq!(replay.application_result(), &result);
+        // The replay type intentionally has no plan/into_plan API. Projection
+        // authority exists only on ProtectedPublicationReceipt in Committed.
+    }
+
+    #[tokio::test]
+    async fn mixed_same_domain_evidence_is_rejected_before_a_claim_exists() {
+        let domain = buzz_core::CommunityId::from_uuid(Uuid::from_u128(3));
+        let verifier = TrustedProxyProvenanceVerifier::new(
+            vec![PROXY_SECRET.to_vec()],
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+        )
+        .expect("proxy verifier");
+        let first = verified_proxy_evidence(
+            &verifier,
+            domain,
+            buzz_auth::ProofTransport::Nip98,
+            "/upload?slot=a",
+            b"body-a",
+            &[1; 16],
+        )
+        .await;
+        let mixed = verified_proxy_evidence(
+            &verifier,
+            domain,
+            buzz_auth::ProofTransport::Blossom,
+            "/upload?slot=b",
+            b"body-b",
+            &[2; 16],
+        )
+        .await;
+
+        assert!(matches!(
+            verified_transport_replay_claim(
+                domain,
+                *first.request_fingerprint(),
+                first.transport(),
+                *first.transport_context_fingerprint(),
+                &mixed,
+            ),
+            Err(AdmissionCommitError::InvalidRequest)
+        ));
+        let unconsumed = verified_transport_replay_claim(
+            domain,
+            *mixed.request_fingerprint(),
+            mixed.transport(),
+            *mixed.transport_context_fingerprint(),
+            &mixed,
+        )
+        .expect("failed comparison did not consume or mutate the evidence claim");
+        assert_eq!(
+            unconsumed.claim_key(),
+            mixed.nonce_claim().claim_key(),
+            "only an exact three-way match can materialize the replay claim"
+        );
+    }
+
+    async fn verified_proxy_evidence(
+        verifier: &TrustedProxyProvenanceVerifier,
+        domain: buzz_core::CommunityId,
+        transport: buzz_auth::ProofTransport,
+        path: &str,
+        body: &[u8],
+        nonce: &[u8],
+    ) -> SealedTransportEvidence {
+        let request = TrustedProxyRequest::from_server_request(
+            domain,
+            transport,
+            "POST",
+            "relay.example.com:443",
+            path,
+            body,
+        )
+        .expect("trusted request");
+        let assertion = format!("Bearer {}", proxy_assertion());
+        let assertion_digest: [u8; 32] = Sha256::digest(proxy_assertion().as_bytes()).into();
+        let body_digest: [u8; 32] = Sha256::digest(body).into();
+        let transport_code = match transport {
+            buzz_auth::ProofTransport::Nip42 => 1,
+            buzz_auth::ProofTransport::Nip98 => 2,
+            buzz_auth::ProofTransport::GitSmartHttpSession => 3,
+            buzz_auth::ProofTransport::Blossom => 4,
+        };
+        let mut input = b"NIP-FI-PROXY-1".to_vec();
+        for field in [
+            PROXY_NOW.to_be_bytes().as_slice(),
+            nonce,
+            &assertion_digest,
+            b"POST".as_slice(),
+            b"relay.example.com:443".as_slice(),
+            path.as_bytes(),
+            &body_digest,
+            &[transport_code],
+        ] {
+            input.extend_from_slice(&(field.len() as u64).to_be_bytes());
+            input.extend_from_slice(field);
+        }
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(&PROXY_SECRET).expect("HMAC key");
+        mac.update(&input);
+        let provenance = format!(
+            "v1.{PROXY_NOW}.{}.{}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(nonce),
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+        );
+        verifier
+            .verify(
+                &[
+                    HttpHeaderField::new(ASSERTION_HEADER_NAME, assertion.as_bytes()),
+                    HttpHeaderField::new(PROVENANCE_HEADER_NAME, provenance.as_bytes()),
+                ],
+                &request,
+                chrono::Utc
+                    .timestamp_opt(PROXY_NOW as i64, 0)
+                    .single()
+                    .expect("test time"),
+                &EmptyReplayReader,
+            )
+            .await
+            .expect("valid proxy evidence")
+    }
 
     #[test]
     fn upload_routes_distinguish_standard_and_legacy_modes() {

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -83,8 +83,6 @@ async fn authorize_operator_request(
         true, // operator endpoints always require NIP-98; no X-Pubkey dev fallback
         body.is_some(),
     )?;
-    check_operator_replay(state, event_id_bytes).await?;
-
     let pubkey_hex = pubkey.to_hex();
     if !state
         .config
@@ -97,6 +95,9 @@ async fn authorize_operator_request(
             "actor not authorized: not a relay operator",
         ));
     }
+    // An unconfigured signer is not entitled to mutate shared replay or quota
+    // state. Keep this closed allowlist decision ahead of all replay I/O.
+    check_operator_replay(state, event_id_bytes).await?;
 
     Ok(pubkey)
 }

--- a/crates/buzz-relay/src/audio/authorization.rs
+++ b/crates/buzz-relay/src/audio/authorization.rs
@@ -1,0 +1,617 @@
+//! Common in-memory bounded authorization lease for protected audio.
+//!
+//! Audio does not persist an admission ledger. A session combines separately
+//! finalized `AudioJoin` and `AudioMedia` authority, atomically subscribes to
+//! and rechecks both dependency snapshots, and retains only process-local
+//! cancellation state plus a monotonic deadline. Restart therefore discards
+//! every session lease and requires complete fresh authorization.
+
+use std::{
+    fmt,
+    future::Future,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc, Weak,
+    },
+};
+
+use buzz_auth::{
+    AuthorizationLeaseDependencySnapshot, BoundedAuthorizationLease, ProofTransport,
+    RouteCapability,
+};
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+use tokio::time::{sleep_until, Instant};
+use tokio_util::sync::CancellationToken;
+
+/// One atomic observation of both audio authorization dependencies.
+///
+/// The invalidation signal is cancelled when any authoritative dependency
+/// changes, including a notice delivered by another relay node. The dependency
+/// loss signal is cancelled when the observation stream can no longer prove
+/// that it remains current. Both signals are sticky and fail closed.
+pub struct AudioLeaseObservation {
+    authoritative_now: DateTime<Utc>,
+    invalidation: CancellationToken,
+    dependency_loss: CancellationToken,
+}
+
+impl AudioLeaseObservation {
+    /// Construct the result of an atomic subscribe-before-recheck operation.
+    pub fn current(
+        authoritative_now: DateTime<Utc>,
+        invalidation: CancellationToken,
+        dependency_loss: CancellationToken,
+    ) -> Self {
+        Self {
+            authoritative_now,
+            invalidation,
+            dependency_loss,
+        }
+    }
+}
+
+impl fmt::Debug for AudioLeaseObservation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AudioLeaseObservation([REDACTED])")
+    }
+}
+
+/// Explicit distributed observation dependency for an audio session lease.
+///
+/// Implementations MUST subscribe to local and multi-node invalidation/loss
+/// notices before atomically rechecking both complete snapshots and database
+/// time. They MUST return an error if subscription, recheck, or the observation
+/// dependency is unavailable. After success they MUST cancel `invalidation`
+/// for any matching authority change and `dependency_loss` if continuing
+/// observation can no longer be guaranteed.
+pub trait AudioLeaseObservationDependency: Send + Sync {
+    /// Dependency-specific error, always mapped to a closed public result.
+    type Error: Send;
+
+    /// Subscribe first, then atomically recheck both complete dependency tuples.
+    fn subscribe_before_recheck<'a>(
+        &'a self,
+        join: &'a AuthorizationLeaseDependencySnapshot,
+        media: &'a AuthorizationLeaseDependencySnapshot,
+    ) -> impl Future<Output = Result<AudioLeaseObservation, Self::Error>> + Send + 'a;
+}
+
+/// Provider-free authorizer for a pair of finalized audio capabilities.
+///
+/// This type owns only its explicit observation dependency. It has no durable
+/// session store and cannot restore authority after process restart.
+pub struct AudioLeaseAuthorizer<O> {
+    observation: O,
+}
+
+impl<O> AudioLeaseAuthorizer<O> {
+    /// Install the required observation and invalidation dependency.
+    pub const fn new(observation: O) -> Self {
+        Self { observation }
+    }
+}
+
+impl<O: AudioLeaseObservationDependency> AudioLeaseAuthorizer<O> {
+    /// Authorize one exact finalized join/media pair and begin observation.
+    ///
+    /// A bounded lease can only be produced by the frozen authorization
+    /// finalizer; prepared authorization exposes no lease to this boundary.
+    pub async fn authorize(
+        &self,
+        join: &BoundedAuthorizationLease,
+        media: &BoundedAuthorizationLease,
+    ) -> Result<BoundedAudioSessionLease, AudioLeaseError> {
+        let join_snapshot = join.dependency_snapshot();
+        let media_snapshot = media.dependency_snapshot();
+        validate_pair(
+            &AudioLeaseCoordinates::from_snapshot(&join_snapshot),
+            &AudioLeaseCoordinates::from_snapshot(&media_snapshot),
+        )?;
+
+        // Anchor before observer I/O. Since authoritative database time is
+        // sampled during that I/O, using this earlier monotonic instant cannot
+        // extend either lease and is deliberately conservative.
+        let local_anchor = Instant::now();
+        let observation = self
+            .observation
+            .subscribe_before_recheck(&join_snapshot, &media_snapshot)
+            .await
+            .map_err(|_| AudioLeaseError::ObservationUnavailable)?;
+
+        if !join.is_valid_at(observation.authoritative_now)
+            || !media.is_valid_at(observation.authoritative_now)
+        {
+            return Err(AudioLeaseError::Expired);
+        }
+        let expires_at = join.expires_at().min(media.expires_at());
+        let deadline = monotonic_deadline(local_anchor, observation.authoritative_now, expires_at)?;
+        let lease = BoundedAudioSessionLease::from_observation(
+            observation.invalidation,
+            observation.dependency_loss,
+            deadline,
+            expires_at,
+        )?;
+        // Observation I/O may have consumed the remaining lifetime. Never
+        // return a lease that is already closed at the local monotonic clock.
+        lease.revalidate()?;
+        Ok(lease)
+    }
+}
+
+/// Cloneable process-local authority retained by one live audio connection.
+#[derive(Clone)]
+pub struct BoundedAudioSessionLease {
+    state: Arc<AudioLeaseState>,
+}
+
+impl BoundedAudioSessionLease {
+    fn from_observation(
+        invalidation: CancellationToken,
+        dependency_loss: CancellationToken,
+        deadline: Instant,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Self, AudioLeaseError> {
+        if invalidation.is_cancelled() {
+            return Err(AudioLeaseError::Invalidated);
+        }
+        if dependency_loss.is_cancelled() {
+            return Err(AudioLeaseError::DependencyLost);
+        }
+        let runtime = tokio::runtime::Handle::try_current()
+            .map_err(|_| AudioLeaseError::ObservationUnavailable)?;
+        let state = Arc::new(AudioLeaseState {
+            invalidation,
+            dependency_loss,
+            cancellation: CancellationToken::new(),
+            deadline,
+            expires_at,
+            terminal: AtomicU8::new(ACTIVE),
+        });
+        drop(runtime.spawn(watch_terminal_conditions(Arc::downgrade(&state))));
+        Ok(Self { state })
+    }
+
+    /// Fail closed immediately before admission, media forwarding, or disclosure.
+    pub fn revalidate(&self) -> Result<(), AudioLeaseError> {
+        self.revalidate_at(Instant::now())
+    }
+
+    /// Sticky cancellation shared by every clone of this exact lease.
+    ///
+    /// The token is cancelled on expiry, local or multi-node invalidation, and
+    /// continuing-observation loss.
+    pub fn cancellation(&self) -> CancellationToken {
+        self.state.cancellation.clone()
+    }
+
+    /// Wait until expiry, invalidation, or dependency loss closes the lease.
+    pub async fn cancelled(&self) {
+        self.state.cancellation.cancelled().await;
+    }
+
+    /// Earliest exclusive wall-clock expiry of the join/media pair.
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.state.expires_at
+    }
+
+    fn revalidate_at(&self, now: Instant) -> Result<(), AudioLeaseError> {
+        if self.state.invalidation.is_cancelled() {
+            self.state.transition(INVALIDATED);
+        }
+        if self.state.dependency_loss.is_cancelled() {
+            self.state.transition(DEPENDENCY_LOST);
+        }
+        if now >= self.state.deadline {
+            self.state.transition(EXPIRED);
+        }
+        self.state.result()
+    }
+}
+
+impl fmt::Debug for BoundedAudioSessionLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BoundedAudioSessionLease([REDACTED])")
+    }
+}
+
+const ACTIVE: u8 = 0;
+const INVALIDATED: u8 = 1;
+const DEPENDENCY_LOST: u8 = 2;
+const EXPIRED: u8 = 3;
+
+struct AudioLeaseState {
+    invalidation: CancellationToken,
+    dependency_loss: CancellationToken,
+    cancellation: CancellationToken,
+    deadline: Instant,
+    expires_at: DateTime<Utc>,
+    terminal: AtomicU8,
+}
+
+impl AudioLeaseState {
+    fn transition(&self, terminal: u8) {
+        if self
+            .terminal
+            .compare_exchange(ACTIVE, terminal, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.cancellation.cancel();
+        }
+    }
+
+    fn result(&self) -> Result<(), AudioLeaseError> {
+        match self.terminal.load(Ordering::Acquire) {
+            ACTIVE => Ok(()),
+            INVALIDATED => Err(AudioLeaseError::Invalidated),
+            DEPENDENCY_LOST => Err(AudioLeaseError::DependencyLost),
+            EXPIRED => Err(AudioLeaseError::Expired),
+            _ => Err(AudioLeaseError::DependencyLost),
+        }
+    }
+}
+
+async fn watch_terminal_conditions(state: Weak<AudioLeaseState>) {
+    let Some(current) = state.upgrade() else {
+        return;
+    };
+    let invalidation = current.invalidation.clone();
+    let dependency_loss = current.dependency_loss.clone();
+    let deadline = current.deadline;
+    drop(current);
+
+    let terminal = tokio::select! {
+        biased;
+        _ = invalidation.cancelled() => INVALIDATED,
+        _ = dependency_loss.cancelled() => DEPENDENCY_LOST,
+        _ = sleep_until(deadline) => EXPIRED,
+    };
+    if let Some(current) = state.upgrade() {
+        current.transition(terminal);
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct AudioLeaseCoordinates {
+    capability: RouteCapability,
+    authorization_domain: buzz_core::CommunityId,
+    actor_pubkey: nostr::PublicKey,
+    owner_pubkey: Option<nostr::PublicKey>,
+    binding: (uuid::Uuid, u64),
+    delegated_relationship: Option<(uuid::Uuid, u64, [u8; 32])>,
+    transport: ProofTransport,
+    target_fingerprint: [u8; 32],
+    transport_context_fingerprint: [u8; 32],
+}
+
+impl AudioLeaseCoordinates {
+    fn from_snapshot(snapshot: &AuthorizationLeaseDependencySnapshot) -> Self {
+        let (capability, actor_pubkey, owner_pubkey) = snapshot.authority();
+        let (_, target_fingerprint, transport, transport_context_fingerprint) =
+            snapshot.request_binding();
+        Self {
+            capability,
+            authorization_domain: snapshot.identity().1,
+            actor_pubkey,
+            owner_pubkey,
+            binding: snapshot.binding(),
+            delegated_relationship: snapshot
+                .delegated_relationship()
+                .map(|(id, revision, conditions)| (id, revision, *conditions)),
+            transport,
+            target_fingerprint: *target_fingerprint,
+            transport_context_fingerprint: *transport_context_fingerprint,
+        }
+    }
+}
+
+fn validate_pair(
+    join: &AudioLeaseCoordinates,
+    media: &AudioLeaseCoordinates,
+) -> Result<(), AudioLeaseError> {
+    if join.capability != RouteCapability::AudioJoin
+        || media.capability != RouteCapability::AudioMedia
+    {
+        return Err(AudioLeaseError::CapabilityMismatch);
+    }
+    if join.authorization_domain != media.authorization_domain
+        || join.actor_pubkey != media.actor_pubkey
+        || join.owner_pubkey != media.owner_pubkey
+        || join.binding != media.binding
+        || join.delegated_relationship != media.delegated_relationship
+        || join.transport != media.transport
+        || join.target_fingerprint != media.target_fingerprint
+        || join.transport_context_fingerprint != media.transport_context_fingerprint
+    {
+        return Err(AudioLeaseError::CoordinateMismatch);
+    }
+    Ok(())
+}
+
+fn monotonic_deadline(
+    local_anchor: Instant,
+    authoritative_now: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+) -> Result<Instant, AudioLeaseError> {
+    if expires_at <= authoritative_now {
+        return Err(AudioLeaseError::Expired);
+    }
+    let remaining = (expires_at - authoritative_now)
+        .to_std()
+        .map_err(|_| AudioLeaseError::Expired)?;
+    local_anchor
+        .checked_add(remaining)
+        .ok_or(AudioLeaseError::Expired)
+}
+
+/// Stable fail-closed errors for common audio lease authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum AudioLeaseError {
+    /// The contexts were not exactly `AudioJoin` and `AudioMedia`.
+    #[error("audio capability mismatch")]
+    CapabilityMismatch,
+    /// Join and media authority named different stable session coordinates.
+    #[error("audio authorization coordinates mismatch")]
+    CoordinateMismatch,
+    /// The atomic observation dependency was unavailable.
+    #[error("audio authorization observation unavailable")]
+    ObservationUnavailable,
+    /// The earliest exclusive join/media deadline was reached.
+    #[error("audio authorization expired")]
+    Expired,
+    /// A local or multi-node authority dependency changed.
+    #[error("audio authorization invalidated")]
+    Invalidated,
+    /// Continuing distributed observation could no longer be guaranteed.
+    #[error("audio authorization dependency lost")]
+    DependencyLost,
+}
+
+impl AudioLeaseError {
+    /// Stable machine code that contains no authority or credential material.
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::CapabilityMismatch => "nip_fi_audio_capability_mismatch",
+            Self::CoordinateMismatch => "nip_fi_audio_coordinate_mismatch",
+            Self::ObservationUnavailable => "nip_fi_audio_observation_unavailable",
+            Self::Expired => "nip_fi_audio_expired",
+            Self::Invalidated => "nip_fi_audio_invalidated",
+            Self::DependencyLost => "nip_fi_audio_dependency_lost",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Keys;
+    use std::time::Duration;
+
+    fn coordinates(capability: RouteCapability) -> AudioLeaseCoordinates {
+        AudioLeaseCoordinates {
+            capability,
+            authorization_domain: buzz_core::CommunityId::from_uuid(uuid::Uuid::from_u128(1)),
+            actor_pubkey: Keys::generate().public_key(),
+            owner_pubkey: None,
+            binding: (uuid::Uuid::from_u128(2), 3),
+            delegated_relationship: Some((uuid::Uuid::from_u128(4), 5, [7; 32])),
+            transport: ProofTransport::Nip42,
+            target_fingerprint: [8; 32],
+            transport_context_fingerprint: [9; 32],
+        }
+    }
+
+    fn pair() -> (AudioLeaseCoordinates, AudioLeaseCoordinates) {
+        let join = coordinates(RouteCapability::AudioJoin);
+        let mut media = join.clone();
+        media.capability = RouteCapability::AudioMedia;
+        (join, media)
+    }
+
+    fn test_lease(
+        invalidation: CancellationToken,
+        dependency_loss: CancellationToken,
+        deadline: Instant,
+    ) -> BoundedAudioSessionLease {
+        BoundedAudioSessionLease {
+            state: Arc::new(AudioLeaseState {
+                invalidation,
+                dependency_loss,
+                cancellation: CancellationToken::new(),
+                deadline,
+                expires_at: fixture_time() + chrono::TimeDelta::seconds(30),
+                terminal: AtomicU8::new(ACTIVE),
+            }),
+        }
+    }
+
+    #[test]
+    fn exact_shared_session_pair_is_required() {
+        let (join, media) = pair();
+        assert_eq!(validate_pair(&join, &media), Ok(()));
+
+        let mut changed = media.clone();
+        changed.actor_pubkey = Keys::generate().public_key();
+        assert_eq!(
+            validate_pair(&join, &changed),
+            Err(AudioLeaseError::CoordinateMismatch)
+        );
+        let mut changed = media.clone();
+        changed.binding.1 += 1;
+        assert_eq!(
+            validate_pair(&join, &changed),
+            Err(AudioLeaseError::CoordinateMismatch)
+        );
+        let mut changed = media.clone();
+        changed.delegated_relationship = None;
+        assert_eq!(
+            validate_pair(&join, &changed),
+            Err(AudioLeaseError::CoordinateMismatch)
+        );
+        let mut changed = media.clone();
+        changed.target_fingerprint = [10; 32];
+        assert_eq!(
+            validate_pair(&join, &changed),
+            Err(AudioLeaseError::CoordinateMismatch)
+        );
+        let mut changed = media;
+        changed.capability = RouteCapability::GitRead;
+        assert_eq!(
+            validate_pair(&join, &changed),
+            Err(AudioLeaseError::CapabilityMismatch)
+        );
+    }
+
+    #[test]
+    fn authoritative_time_produces_an_exclusive_unrounded_deadline() {
+        let local_anchor = Instant::now();
+        let authoritative_now = fixture_time();
+        let deadline = monotonic_deadline(
+            local_anchor,
+            authoritative_now,
+            authoritative_now + chrono::TimeDelta::milliseconds(1500),
+        )
+        .expect("future deadline");
+        let lease = test_lease(CancellationToken::new(), CancellationToken::new(), deadline);
+        assert_eq!(lease.revalidate_at(local_anchor), Ok(()));
+        assert_eq!(
+            lease.revalidate_at(local_anchor + Duration::from_millis(1499)),
+            Ok(())
+        );
+        assert_eq!(
+            lease.revalidate_at(local_anchor + Duration::from_millis(1500)),
+            Err(AudioLeaseError::Expired)
+        );
+        assert!(lease.cancellation().is_cancelled());
+    }
+
+    #[test]
+    fn expired_authoritative_observation_fails_closed() {
+        let now = fixture_time();
+        assert_eq!(
+            monotonic_deadline(Instant::now(), now, now),
+            Err(AudioLeaseError::Expired)
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_node_invalidation_is_sticky_across_clones() {
+        let invalidation = CancellationToken::new();
+        let lease = BoundedAudioSessionLease::from_observation(
+            invalidation.clone(),
+            CancellationToken::new(),
+            Instant::now() + Duration::from_secs(30),
+            fixture_time() + chrono::TimeDelta::seconds(30),
+        )
+        .expect("active observation");
+        let clone = lease.clone();
+
+        invalidation.cancel();
+        lease.cancelled().await;
+        assert_eq!(lease.revalidate(), Err(AudioLeaseError::Invalidated));
+        assert_eq!(clone.revalidate(), Err(AudioLeaseError::Invalidated));
+    }
+
+    #[tokio::test]
+    async fn dependency_loss_is_distinct_sticky_and_fail_closed() {
+        let dependency_loss = CancellationToken::new();
+        let lease = BoundedAudioSessionLease::from_observation(
+            CancellationToken::new(),
+            dependency_loss.clone(),
+            Instant::now() + Duration::from_secs(30),
+            fixture_time() + chrono::TimeDelta::seconds(30),
+        )
+        .expect("active observation");
+        let clone = lease.clone();
+
+        dependency_loss.cancel();
+        lease.cancelled().await;
+        assert_eq!(lease.revalidate(), Err(AudioLeaseError::DependencyLost));
+        assert_eq!(clone.revalidate(), Err(AudioLeaseError::DependencyLost));
+    }
+
+    #[tokio::test]
+    async fn expiry_wakes_waiters_and_remains_sticky() {
+        let lease = BoundedAudioSessionLease::from_observation(
+            CancellationToken::new(),
+            CancellationToken::new(),
+            Instant::now() + Duration::from_millis(5),
+            fixture_time() + chrono::TimeDelta::milliseconds(5),
+        )
+        .expect("active observation");
+        let clone = lease.clone();
+
+        lease.cancelled().await;
+        assert_eq!(lease.revalidate(), Err(AudioLeaseError::Expired));
+        assert_eq!(clone.revalidate(), Err(AudioLeaseError::Expired));
+    }
+
+    #[tokio::test]
+    async fn already_closed_observations_never_create_authority() {
+        let invalidation = CancellationToken::new();
+        invalidation.cancel();
+        assert!(matches!(
+            BoundedAudioSessionLease::from_observation(
+                invalidation,
+                CancellationToken::new(),
+                Instant::now() + Duration::from_secs(30),
+                fixture_time() + chrono::TimeDelta::seconds(30),
+            ),
+            Err(AudioLeaseError::Invalidated)
+        ));
+
+        let dependency_loss = CancellationToken::new();
+        dependency_loss.cancel();
+        assert!(matches!(
+            BoundedAudioSessionLease::from_observation(
+                CancellationToken::new(),
+                dependency_loss,
+                Instant::now() + Duration::from_secs(30),
+                fixture_time() + chrono::TimeDelta::seconds(30),
+            ),
+            Err(AudioLeaseError::DependencyLost)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_new_process_local_observation_cannot_resurrect_an_old_lease() {
+        let old_invalidation = CancellationToken::new();
+        let old = BoundedAudioSessionLease::from_observation(
+            old_invalidation.clone(),
+            CancellationToken::new(),
+            Instant::now() + Duration::from_secs(30),
+            fixture_time() + chrono::TimeDelta::seconds(30),
+        )
+        .expect("active old observation");
+        old_invalidation.cancel();
+        old.cancelled().await;
+
+        let fresh = BoundedAudioSessionLease::from_observation(
+            CancellationToken::new(),
+            CancellationToken::new(),
+            Instant::now() + Duration::from_secs(30),
+            fixture_time() + chrono::TimeDelta::seconds(30),
+        )
+        .expect("fresh observation");
+        assert_eq!(old.revalidate(), Err(AudioLeaseError::Invalidated));
+        assert_eq!(fresh.revalidate(), Ok(()));
+    }
+
+    #[test]
+    fn debug_and_error_codes_disclose_no_authority() {
+        let lease = test_lease(
+            CancellationToken::new(),
+            CancellationToken::new(),
+            Instant::now() + Duration::from_secs(30),
+        );
+        assert_eq!(format!("{lease:?}"), "BoundedAudioSessionLease([REDACTED])");
+        assert_eq!(
+            AudioLeaseError::DependencyLost.code(),
+            "nip_fi_audio_dependency_lost"
+        );
+    }
+
+    fn fixture_time() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_800_000_000, 0).expect("fixture time")
+    }
+}

--- a/crates/buzz-relay/src/audio/mod.rs
+++ b/crates/buzz-relay/src/audio/mod.rs
@@ -9,6 +9,7 @@
 //!                                                  (1-byte peer_index prefix)
 //! ```
 
+pub mod authorization;
 pub mod handler;
 pub mod join;
 pub mod mesh;

--- a/crates/buzz-relay/src/handlers/moderation_authz.rs
+++ b/crates/buzz-relay/src/handlers/moderation_authz.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use buzz_core::tenant::TenantContext;
+use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::state::AppState;
@@ -125,6 +126,82 @@ pub async fn authorize_moderation_action(
                 .db
                 .get_member_role(community, channel_id, actor_pubkey)
                 .await?
+        }
+        _ => None,
+    };
+
+    decide_authority(
+        actor_role.as_deref(),
+        target_role.as_deref(),
+        channel_role.as_deref(),
+        action,
+    )
+}
+
+/// Revalidate moderation authority under locks held by the caller's database
+/// transaction.
+///
+/// Moderation writes are rare. Taking table-level share locks closes both the
+/// existing-row and absent-row role-revocation races until the application
+/// mutation and its audit row commit together.
+pub async fn authorize_moderation_action_tx(
+    transaction: &mut Transaction<'_, Postgres>,
+    tenant: &TenantContext,
+    actor_pubkey: &[u8],
+    channel_id: Option<Uuid>,
+    target: ModerationTarget<'_>,
+    action: ModerationAction,
+) -> anyhow::Result<ModerationAuthority> {
+    sqlx::query("LOCK TABLE relay_members IN SHARE MODE")
+        .execute(&mut **transaction)
+        .await?;
+    if matches!(
+        action,
+        ModerationAction::DeleteMessage | ModerationAction::Kick
+    ) {
+        sqlx::query("LOCK TABLE channel_members IN SHARE MODE")
+            .execute(&mut **transaction)
+            .await?;
+    }
+
+    let community = tenant.community();
+    let actor_role: Option<String> = sqlx::query_scalar(
+        "SELECT role FROM relay_members WHERE community_id = $1 AND pubkey = $2",
+    )
+    .bind(community.as_uuid())
+    .bind(hex::encode(actor_pubkey))
+    .fetch_optional(&mut **transaction)
+    .await?;
+
+    let target_role: Option<String> = match (actor_role.as_deref(), action, target) {
+        (
+            Some("admin"),
+            ModerationAction::Ban | ModerationAction::Timeout,
+            ModerationTarget::Pubkey(target),
+        ) => {
+            sqlx::query_scalar(
+                "SELECT role FROM relay_members WHERE community_id = $1 AND pubkey = $2",
+            )
+            .bind(community.as_uuid())
+            .bind(hex::encode(target))
+            .fetch_optional(&mut **transaction)
+            .await?
+        }
+        _ => None,
+    };
+
+    let channel_role: Option<String> = match (actor_role.as_deref(), action, channel_id) {
+        (Some("owner") | Some("admin"), _, _) => None,
+        (_, ModerationAction::DeleteMessage | ModerationAction::Kick, Some(channel_id)) => {
+            sqlx::query_scalar(
+                "SELECT role::text FROM channel_members WHERE community_id = $1 \
+                 AND channel_id = $2 AND pubkey = $3 AND removed_at IS NULL",
+            )
+            .bind(community.as_uuid())
+            .bind(channel_id)
+            .bind(actor_pubkey)
+            .fetch_optional(&mut **transaction)
+            .await?
         }
         _ => None,
     };

--- a/crates/buzz-relay/src/handlers/moderation_commands.rs
+++ b/crates/buzz-relay/src/handlers/moderation_commands.rs
@@ -1,382 +1,785 @@
-//! Community moderation command handler (kinds 9040–9044, Phase 1 contract).
+//! Community moderation commands (kinds 9040–9044).
 //!
-//! Mirrors the NIP-43 relay-admin pattern (`relay_admin.rs`, 9030-series):
-//! commands are validated + executed directly and are **never** stored as
-//! regular events. Authorization goes through
-//! [`crate::handlers::moderation_authz::authorize_moderation_action`] —
-//! never inline role checks.
-//!
-//! | Kind | Operation      | Side effects (all mandatory)                       |
-//! |------|----------------|----------------------------------------------------|
-//! | 9040 | Ban            | `community_bans` upsert, audit row, live disconnect (L4 fanout), restriction notice DM (L5) |
-//! | 9041 | Unban          | ban lift, audit row                                |
-//! | 9042 | Timeout        | `muted_until` upsert, audit row, notice DM         |
-//! | 9043 | Untimeout      | mute clear, audit row                              |
-//! | 9044 | Resolve report | report status update, audit row, reporter notice DM; `delete`/`kick`/`ban` resolutions fan out through the existing 9005/9001 + 9040 paths |
-//!
-//! Targets (`p` tag pubkey, `report` tag row id) are resolved under the
-//! request's `TenantContext` only.
-//!
-//! ## Routing (pinned — Wren contract review, 2026-07-07)
-//! 9040–9044 are **community-global direct commands**, exactly like the
-//! relay-admin 9030-series: route via
-//! [`buzz_core::kind::is_moderation_command_kind`], list them in
-//! `is_global_only_kind` so a stray `h` tag can never channel-scope them
-//! (no channel membership/archive gates apply), require a fresh timestamp,
-//! never store them, and reject channel-scoped API tokens.
-//!
-//! ## Tag vocabulary (pinned — CLI and relay must agree)
-//! - 9040 ban: `["p", <hex pubkey>]` required; optional
-//!   `["expiration", <unix secs>]` (absent ⇒ permanent), `["reason", <text>]`.
-//! - 9041 unban: `["p", <hex pubkey>]`.
-//! - 9042 timeout: `["p", <hex pubkey>]` + required `["expiration", <unix secs>]`;
-//!   optional `["reason", <text>]`.
-//! - 9043 untimeout: `["p", <hex pubkey>]`.
-//! - 9044 resolve (pinned — thread event `86f46207`, 2026-07-07): required,
-//!   exactly one each: `["report", <report event id hex>]` (the 1984 report
-//!   being resolved; resolves under `tenant.community()` only),
-//!   `["status", resolved|dismissed]`,
-//!   `["action", delete|kick|ban|timeout|dismiss|escalate]` (`dismiss` pairs
-//!   with status `dismissed`; everything else with `resolved`). Optional
-//!   `["reason", <text>]` — audited into `moderation_actions.public_reason`
-//!   and relayed in the notice DM (so it must be safe for the reporter's
-//!   eyes; `private_reason` is mod-only and not fed by 9044 tags). Unknown
-//!   extra tags are ignored, not rejected
-//!   (forward-compat). `delete`/`kick`/`ban`/`timeout` actions fan out through
-//!   the existing 9005/9001 paths and the 9040/9042 handlers — no second
-//!   implementation. The resolution audit row records the *decision*, not the
-//!   enforcement, so it is prefixed `resolve:` (`resolve:ban`, `resolve:delete`,
-//!   …); the client's paired 9040-9043 writes the unprefixed enforcement row.
-//!   The `resolve:*` values are part of the DB CHECK vocabulary in migration 0006.
-//!   `dismiss` audits as `dismiss_report` and `escalate` as `escalate` (both
-//!   unprefixed — escalate must stay queryable for the platform-safety lane).
-//!
-//! Lane ownership: L6 (Quinn) — plus `buzz-cli` `moderation` command group.
-//! The `ingest.rs` routing entries (scope map + `is_global_only_kind` +
-//! direct-processing dispatch) for 9040–9044 belong to L3 (Perci):
-//! coordinate, don't edit ingest.rs.
+//! A command is parsed into a tenant-bound
+//! [`ModerationAdmissionApplicationEffect`].
+//! The canonical admission owner supplies the database transaction that also
+//! contains the receipt and replay claim. This module never begins or commits
+//! a transaction. Socket disconnection and notices are represented by an
+//! opaque [`ModerationPostCommitAction`] and run only through
+//! [`dispatch_moderation_postcommit`] after the caller confirms commit.
 
 use std::sync::Arc;
 
+use buzz_auth::RouteCapability;
 use buzz_core::kind::{
     KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
     KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT,
 };
-use buzz_core::tenant::TenantContext;
+use buzz_core::tenant::{CommunityId, TenantContext};
+use buzz_db::authorization_admission::{
+    AdmissionApplicationContext, AdmissionApplicationEffect, AdmissionApplicationOutcome,
+    AdmissionApplicationResult, AdmissionApplicationResultSchema, AdmissionCommitError,
+    AdmissionCommitOutcome, AdmissionCommitRequest, AdmissionObject, AdmissionObjectKind,
+};
+use buzz_db::moderation::NewAction;
 use chrono::{DateTime, TimeZone, Utc};
 use nostr::Event;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::{Postgres, Transaction};
 use tracing::info;
 use uuid::Uuid;
 
 use crate::handlers::moderation_authz::{
-    authorize_moderation_action, ModerationAction, ModerationTarget,
+    authorize_moderation_action_tx, ModerationAction, ModerationTarget,
 };
 use crate::handlers::moderation_notices::{send_moderation_notice, ModerationNotice};
 use crate::state::AppState;
-use buzz_db::moderation::NewAction;
 
-/// Max clock skew for a freshly-signed command (mirrors `relay_admin.rs` and
-/// the NIP-42 auth freshness window). Commands are never stored, so replay of a
-/// captured command is the only threat and a tight window is the mitigation.
 const MAX_COMMAND_SKEW_SECS: i64 = 120;
 
-/// Validate and execute a moderation command (kinds 9040–9044).
+/// Legacy direct entry point.
 ///
-/// Returns a client-safe error string for `OK false` on rejection.
-///
-/// Routing note: 9040–9044 are community-global direct commands (L3 lists them
-/// in `is_global_only_kind`), so no `h`/channel context is consulted here; the
-/// tenant is bound from the request. Authorization goes through
-/// [`authorize_moderation_action`] — never inline role checks.
+/// It validates the command but fails closed because this signature has no
+/// caller-owned transaction. Canonical admission must instead call
+/// [`prepare_moderation_application_effect`], apply the returned effect on its
+/// transaction, commit, and then dispatch the returned post-commit action.
 pub async fn handle_moderation_command(
     tenant: &TenantContext,
-    state: &Arc<AppState>,
+    _state: &Arc<AppState>,
     event: &Event,
 ) -> Result<(), String> {
-    let kind = event.kind.as_u16() as u32;
+    let _effect = prepare_moderation_application_effect(tenant, event)?;
+    Err(error(
+        "moderation command requires the canonical caller-owned admission transaction",
+    ))
+}
+
+/// A validated, tenant-bound mutation consumed by one canonical admission
+/// transaction.
+///
+/// The effect owns no connection and cannot begin or commit a transaction.
+#[must_use = "apply the effect in the canonical admission transaction"]
+pub struct ModerationAdmissionApplicationEffect {
+    tenant: TenantContext,
+    actor: Vec<u8>,
+    event_id: String,
+    object: AdmissionObject,
+    command: Option<PreparedModerationCommand>,
+    intent_digest: [u8; 32],
+}
+
+enum PreparedModerationCommand {
+    Ban {
+        target: Vec<u8>,
+        expires_at: Option<DateTime<Utc>>,
+        reason: Option<String>,
+    },
+    Unban {
+        target: Vec<u8>,
+    },
+    Timeout {
+        target: Vec<u8>,
+        muted_until: DateTime<Utc>,
+        reason: Option<String>,
+    },
+    Untimeout {
+        target: Vec<u8>,
+    },
+    ResolveReport {
+        report_event_id: Vec<u8>,
+        status: String,
+        action: String,
+        reason: Option<String>,
+    },
+}
+
+/// Opaque socket/notice work returned by an applied effect.
+///
+/// The admission owner must retain this value until its transaction commits.
+#[must_use = "dispatch this action only after the transaction commits"]
+pub struct ModerationPostCommitAction(ModerationPostCommitKind);
+
+#[derive(Serialize, Deserialize)]
+enum ModerationPostCommitKind {
+    Ban {
+        target: Vec<u8>,
+        event_id: String,
+        action_id: Uuid,
+        public_reason: String,
+    },
+    Unban {
+        target: Vec<u8>,
+    },
+    Timeout {
+        target: Vec<u8>,
+        action_id: Uuid,
+        public_reason: String,
+    },
+    Untimeout {
+        target: Vec<u8>,
+    },
+    ResolveReport {
+        report_id: Uuid,
+        reporter_pubkey: Vec<u8>,
+        status: String,
+        action: String,
+        summary: String,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+struct ModerationApplicationResultPayload {
+    object_key: [u8; 32],
+    intent_digest: [u8; 32],
+    action: ModerationPostCommitKind,
+}
+
+/// Parse, validate, and bind a signed command without performing I/O.
+pub fn prepare_moderation_application_effect(
+    tenant: &TenantContext,
+    event: &Event,
+) -> Result<ModerationAdmissionApplicationEffect, String> {
+    validate_freshness(event)?;
+
+    let command = match event.kind.as_u16() as u32 {
+        KIND_MODERATION_BAN => PreparedModerationCommand::Ban {
+            target: required_pubkey(event)?,
+            expires_at: extract_expiration(event)?,
+            reason: extract_tag_value(event, "reason"),
+        },
+        KIND_MODERATION_UNBAN => PreparedModerationCommand::Unban {
+            target: required_pubkey(event)?,
+        },
+        KIND_MODERATION_TIMEOUT => PreparedModerationCommand::Timeout {
+            target: required_pubkey(event)?,
+            muted_until: extract_expiration(event)?
+                .ok_or_else(|| invalid("timeout requires an expiration tag"))?,
+            reason: extract_tag_value(event, "reason"),
+        },
+        KIND_MODERATION_UNTIMEOUT => PreparedModerationCommand::Untimeout {
+            target: required_pubkey(event)?,
+        },
+        KIND_MODERATION_RESOLVE_REPORT => prepare_resolve_report(event)?,
+        other => {
+            return Err(invalid(format!(
+                "unexpected moderation command kind: {other}"
+            )))
+        }
+    };
+
     let actor = event.pubkey.to_bytes().to_vec();
+    let event_id = event.id.to_hex();
+    let object = moderation_object(tenant.community(), &command)?;
+    let intent_digest = framed_digest(
+        b"buzz:nip-fi:moderation-effect-intent:v1",
+        &[
+            tenant.community().as_uuid().as_bytes(),
+            &actor,
+            event_id.as_bytes(),
+            object.key(),
+        ],
+    );
+    Ok(ModerationAdmissionApplicationEffect {
+        tenant: tenant.clone(),
+        actor,
+        event_id,
+        object,
+        command: Some(command),
+        intent_digest,
+    })
+}
 
-    // A ban is an admission boundary, not only a WebSocket-auth check. HTTP
-    // NIP-98 requests and already-authenticated sockets can reach this handler
-    // without passing through a fresh NIP-42 challenge, so enforce the durable
-    // tenant-scoped restriction before any command can lift or mutate it.
-    let restriction = state
-        .db
-        .moderation_restriction_state(tenant.community(), &actor)
-        .await
-        .map_err(|e| error(format!("database error checking restriction state: {e}")))?;
-    ensure_actor_not_banned(&restriction)?;
+impl ModerationAdmissionApplicationEffect {
+    /// Exact server-derived protected target required on the admission request.
+    pub const fn admission_object(&self) -> AdmissionObject {
+        self.object
+    }
 
-    // Freshness: reject stale/replayed commands (they are never stored).
+    /// Recheck authorization and restrictions, then mutate state and audit on
+    /// the caller-owned transaction.
+    ///
+    /// One-shot command extraction prevents accidental double application. No
+    /// external effects happen here; the returned action is dispatched after
+    /// commit.
+    async fn apply_in_transaction(
+        &mut self,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<ModerationPostCommitAction, String> {
+        let tenant = &self.tenant;
+
+        {
+            let (target, action) = self.authorization_target()?;
+            authorize_moderation_action_tx(transaction, tenant, &self.actor, None, target, action)
+                .await
+                .map_err(authz_denial)?;
+        }
+        let restriction =
+            buzz_db::moderation::restriction_state_tx(transaction, tenant.community(), &self.actor)
+                .await
+                .map_err(|e| error(format!("database error checking restriction state: {e}")))?;
+        ensure_actor_not_banned(&restriction)?;
+
+        let command = self
+            .command
+            .take()
+            .ok_or_else(|| error("moderation effect was already consumed"))?;
+
+        match command {
+            PreparedModerationCommand::Ban {
+                target,
+                expires_at,
+                reason,
+            } => {
+                buzz_db::moderation::ban_member_tx(
+                    transaction,
+                    tenant.community(),
+                    &target,
+                    &self.actor,
+                    reason.as_deref(),
+                    expires_at,
+                )
+                .await
+                .map_err(database_error)?;
+                let action_id = insert_audit_tx(
+                    transaction,
+                    tenant,
+                    &self.actor,
+                    "ban",
+                    Some(&target),
+                    None,
+                    reason.as_deref(),
+                )
+                .await?;
+                Ok(ModerationPostCommitAction(ModerationPostCommitKind::Ban {
+                    target,
+                    event_id: self.event_id.clone(),
+                    action_id,
+                    public_reason: reason.unwrap_or_default(),
+                }))
+            }
+            PreparedModerationCommand::Unban { target } => {
+                let lifted = buzz_db::moderation::unban_member_tx(
+                    transaction,
+                    tenant.community(),
+                    &target,
+                    &self.actor,
+                )
+                .await
+                .map_err(database_error)?;
+                if !lifted {
+                    return Err(invalid("member is not banned"));
+                }
+                insert_audit_tx(
+                    transaction,
+                    tenant,
+                    &self.actor,
+                    "unban",
+                    Some(&target),
+                    None,
+                    None,
+                )
+                .await?;
+                Ok(ModerationPostCommitAction(
+                    ModerationPostCommitKind::Unban { target },
+                ))
+            }
+            PreparedModerationCommand::Timeout {
+                target,
+                muted_until,
+                reason,
+            } => {
+                buzz_db::moderation::timeout_member_tx(
+                    transaction,
+                    tenant.community(),
+                    &target,
+                    &self.actor,
+                    muted_until,
+                    reason.as_deref(),
+                )
+                .await
+                .map_err(database_error)?;
+                let action_id = insert_audit_tx(
+                    transaction,
+                    tenant,
+                    &self.actor,
+                    "timeout",
+                    Some(&target),
+                    None,
+                    reason.as_deref(),
+                )
+                .await?;
+                Ok(ModerationPostCommitAction(
+                    ModerationPostCommitKind::Timeout {
+                        target,
+                        action_id,
+                        public_reason: reason.unwrap_or_default(),
+                    },
+                ))
+            }
+            PreparedModerationCommand::Untimeout { target } => {
+                let cleared = buzz_db::moderation::untimeout_member_tx(
+                    transaction,
+                    tenant.community(),
+                    &target,
+                    &self.actor,
+                )
+                .await
+                .map_err(database_error)?;
+                if !cleared {
+                    return Err(invalid("member is not timed out"));
+                }
+                insert_audit_tx(
+                    transaction,
+                    tenant,
+                    &self.actor,
+                    "untimeout",
+                    Some(&target),
+                    None,
+                    None,
+                )
+                .await?;
+                Ok(ModerationPostCommitAction(
+                    ModerationPostCommitKind::Untimeout { target },
+                ))
+            }
+            PreparedModerationCommand::ResolveReport {
+                report_event_id,
+                status,
+                action,
+                reason,
+            } => {
+                let report = buzz_db::moderation::get_report_by_event_tx(
+                    transaction,
+                    tenant.community(),
+                    &report_event_id,
+                )
+                .await
+                .map_err(database_error)?
+                .ok_or_else(|| invalid("report not found in this community"))?;
+                if report.status != "open" {
+                    return Err(invalid(
+                        "report is not open (already resolved or dismissed)",
+                    ));
+                }
+
+                let (target_pubkey, target_event_id) = match &report.target {
+                    buzz_db::moderation::ReportTarget::Pubkey(pubkey) => {
+                        (Some(pubkey.as_slice()), None)
+                    }
+                    buzz_db::moderation::ReportTarget::Event(event_id) => {
+                        (None, Some(event_id.as_slice()))
+                    }
+                    buzz_db::moderation::ReportTarget::Blob(_) => (None, None),
+                };
+                let action_id = insert_audit_tx(
+                    transaction,
+                    tenant,
+                    &self.actor,
+                    resolution_audit_action(&action),
+                    target_pubkey,
+                    target_event_id,
+                    reason.as_deref(),
+                )
+                .await?;
+                let resolved = buzz_db::moderation::resolve_report_tx(
+                    transaction,
+                    tenant.community(),
+                    report.id,
+                    &status,
+                    &self.actor,
+                    Some(action_id),
+                )
+                .await
+                .map_err(database_error)?;
+                if !resolved {
+                    return Err(invalid(
+                        "report is not open (already resolved or dismissed)",
+                    ));
+                }
+                let summary = reason.unwrap_or_else(|| match status.as_str() {
+                    "dismissed" => "Your report was reviewed and dismissed.".to_string(),
+                    _ => "Your report was reviewed and acted on.".to_string(),
+                });
+                Ok(ModerationPostCommitAction(
+                    ModerationPostCommitKind::ResolveReport {
+                        report_id: report.id,
+                        reporter_pubkey: report.reporter_pubkey,
+                        status,
+                        action,
+                        summary,
+                    },
+                ))
+            }
+        }
+    }
+
+    fn authorization_target(&self) -> Result<(ModerationTarget<'_>, ModerationAction), String> {
+        let command = self
+            .command
+            .as_ref()
+            .ok_or_else(|| error("moderation effect was already consumed"))?;
+        Ok(match command {
+            PreparedModerationCommand::Ban { target, .. } => {
+                (ModerationTarget::Pubkey(target), ModerationAction::Ban)
+            }
+            PreparedModerationCommand::Unban { target } => {
+                (ModerationTarget::Pubkey(target), ModerationAction::Unban)
+            }
+            PreparedModerationCommand::Timeout { target, .. } => {
+                (ModerationTarget::Pubkey(target), ModerationAction::Timeout)
+            }
+            PreparedModerationCommand::Untimeout { target } => (
+                ModerationTarget::Pubkey(target),
+                ModerationAction::Untimeout,
+            ),
+            PreparedModerationCommand::ResolveReport {
+                report_event_id, ..
+            } => (
+                ModerationTarget::Event(report_event_id),
+                ModerationAction::ResolveReport,
+            ),
+        })
+    }
+}
+
+impl AdmissionApplicationEffect for ModerationAdmissionApplicationEffect {
+    fn intent_digest(&self) -> [u8; 32] {
+        self.intent_digest
+    }
+
+    fn result_schema(&self) -> AdmissionApplicationResultSchema {
+        moderation_result_schema()
+    }
+
+    fn apply<'a, 'transaction>(
+        &'a mut self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        context: &'a AdmissionApplicationContext<'a>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<AdmissionApplicationOutcome, AdmissionCommitError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if context.authorization_domain() != self.tenant.community()
+                || context.object() != self.object
+                || context.authorization().capability() != RouteCapability::Moderation
+                || context.authorization().actor_pubkey().to_bytes().as_slice()
+                    != self.actor.as_slice()
+            {
+                return Err(AdmissionCommitError::AuthorizationDenied);
+            }
+            let action = self
+                .apply_in_transaction(transaction)
+                .await
+                .map_err(map_application_error)?;
+            let payload = serde_json::to_vec(&ModerationApplicationResultPayload {
+                object_key: *self.object.key(),
+                intent_digest: self.intent_digest,
+                action: action.0,
+            })
+            .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            let result = AdmissionApplicationResult::new(moderation_result_schema(), 1, payload)
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            let effect_digest = framed_digest(
+                b"buzz:nip-fi:moderation-effect:v1",
+                &[
+                    context.authorization_domain().as_uuid().as_bytes(),
+                    context.operation_id().as_bytes(),
+                    context.request_fingerprint(),
+                    self.intent_digest.as_slice(),
+                    result.payload(),
+                ],
+            );
+            AdmissionApplicationOutcome::new(result, effect_digest)
+        })
+    }
+}
+
+/// Attach one prepared moderation mutation to canonical final admission.
+pub fn install_moderation_application_effect(
+    request: AdmissionCommitRequest,
+    effect: ModerationAdmissionApplicationEffect,
+) -> Result<AdmissionCommitRequest, AdmissionCommitError> {
+    if request.authorization_domain() != effect.tenant.community()
+        || request.object() != effect.object
+    {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    request.with_application_effect(Box::new(effect))
+}
+
+/// Dispatch external moderation work only for a newly committed mutation.
+///
+/// Exact replay returns the original typed result but deliberately performs no
+/// socket disconnect or notice. A failed/rolled-back commit produces no
+/// outcome, so it cannot reach this boundary either.
+pub async fn dispatch_committed_moderation_outcome(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    outcome: &AdmissionCommitOutcome,
+) -> Result<bool, AdmissionCommitError> {
+    let Some(action) = committed_moderation_action(tenant, outcome)? else {
+        return Ok(false);
+    };
+    dispatch_moderation_postcommit(tenant, state, action).await;
+    Ok(true)
+}
+
+fn committed_moderation_action(
+    tenant: &TenantContext,
+    outcome: &AdmissionCommitOutcome,
+) -> Result<Option<ModerationPostCommitAction>, AdmissionCommitError> {
+    let (receipt, application_result) = match outcome {
+        AdmissionCommitOutcome::Committed {
+            receipt,
+            application_result,
+            ..
+        } => {
+            if receipt.authorization_domain() != tenant.community()
+                || receipt.object().kind() != AdmissionObjectKind::ModerationTarget
+            {
+                return Err(AdmissionCommitError::IntentConflict);
+            }
+            (
+                *receipt,
+                application_result
+                    .as_ref()
+                    .ok_or(AdmissionCommitError::IntentConflict)?,
+            )
+        }
+        AdmissionCommitOutcome::ExactReplay { .. } => return Ok(None),
+    };
+    validate_committed_moderation_result(receipt, application_result).map(Some)
+}
+
+fn validate_committed_moderation_result(
+    receipt: buzz_db::authorization_admission::AdmissionCommitReceipt,
+    application_result: &AdmissionApplicationResult,
+) -> Result<ModerationPostCommitAction, AdmissionCommitError> {
+    if application_result.schema() != moderation_result_schema() || application_result.code() != 1 {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let payload =
+        serde_json::from_slice::<ModerationApplicationResultPayload>(application_result.payload())
+            .map_err(|_| AdmissionCommitError::IntentConflict)?;
+    if receipt.object().kind() != AdmissionObjectKind::ModerationTarget
+        || receipt.object().key() != &payload.object_key
+        || payload.intent_digest == [0; 32]
+    {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    let expected_digest =
+        canonical_moderation_result_digest(receipt, payload.intent_digest, application_result)?;
+    if receipt.application_result_digest() != Some(&expected_digest) {
+        return Err(AdmissionCommitError::IntentConflict);
+    }
+    Ok(ModerationPostCommitAction(payload.action))
+}
+
+fn moderation_result_schema() -> AdmissionApplicationResultSchema {
+    AdmissionApplicationResultSchema::moderation()
+}
+
+fn canonical_moderation_result_digest(
+    receipt: buzz_db::authorization_admission::AdmissionCommitReceipt,
+    application_intent_digest: [u8; 32],
+    result: &AdmissionApplicationResult,
+) -> Result<[u8; 32], AdmissionCommitError> {
+    if application_intent_digest == [0; 32] {
+        return Err(AdmissionCommitError::InvalidRequest);
+    }
+    let object = receipt.object();
+    let schema = result.schema();
+    Ok(admission_framed_digest(
+        b"buzz:canonical-application-result:v1",
+        &[
+            receipt.authorization_domain().as_uuid().as_bytes(),
+            &object.kind().database_code().to_be_bytes(),
+            object.key(),
+            receipt.semantic_fingerprint(),
+            &application_intent_digest,
+            schema.type_key(),
+            &schema.version().to_be_bytes(),
+            &result.code().to_be_bytes(),
+            result.payload(),
+        ],
+    ))
+}
+
+fn admission_framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+fn map_application_error(error: String) -> AdmissionCommitError {
+    if error.starts_with("restricted:")
+        || error.starts_with("blocked:")
+        || error.starts_with("invalid:")
+    {
+        AdmissionCommitError::AuthorizationDenied
+    } else {
+        AdmissionCommitError::DependencyUnavailable
+    }
+}
+
+/// Run the socket and notice work represented by `action` after commit.
+pub async fn dispatch_moderation_postcommit(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    action: ModerationPostCommitAction,
+) {
+    match action.0 {
+        ModerationPostCommitKind::Ban {
+            target,
+            event_id,
+            action_id,
+            public_reason,
+        } => {
+            state.disconnect_pubkey_clusterwide(
+                tenant,
+                &target,
+                &event_id,
+                "blocked: you are banned from this community",
+            );
+            if let Err(e) = send_moderation_notice(
+                tenant,
+                state,
+                &target,
+                ModerationNotice::Restriction {
+                    action_id,
+                    kind: "ban".to_string(),
+                    public_reason,
+                },
+            )
+            .await
+            {
+                info!(error = %e, "ban notice DM delivery failed (ban still enforced)");
+            }
+            info!(target = %hex::encode(&target), "community ban applied");
+        }
+        ModerationPostCommitKind::Unban { target } => {
+            info!(target = %hex::encode(&target), "community ban lifted");
+        }
+        ModerationPostCommitKind::Timeout {
+            target,
+            action_id,
+            public_reason,
+        } => {
+            if let Err(e) = send_moderation_notice(
+                tenant,
+                state,
+                &target,
+                ModerationNotice::Restriction {
+                    action_id,
+                    kind: "timeout".to_string(),
+                    public_reason,
+                },
+            )
+            .await
+            {
+                info!(error = %e, "timeout notice DM delivery failed (timeout still enforced)");
+            }
+            info!(target = %hex::encode(&target), "community timeout applied");
+        }
+        ModerationPostCommitKind::Untimeout { target } => {
+            info!(target = %hex::encode(&target), "community timeout cleared");
+        }
+        ModerationPostCommitKind::ResolveReport {
+            report_id,
+            reporter_pubkey,
+            status,
+            action,
+            summary,
+        } => {
+            if let Err(e) = send_moderation_notice(
+                tenant,
+                state,
+                &reporter_pubkey,
+                ModerationNotice::ReportResolved {
+                    report_id,
+                    status: status.clone(),
+                    summary,
+                },
+            )
+            .await
+            {
+                info!(error = %e, "report-resolution notice DM delivery failed (report still resolved)");
+            }
+            info!(report_id = %report_id, status = %status, action = %action, "report resolved");
+        }
+    }
+}
+
+fn moderation_object(
+    community: CommunityId,
+    command: &PreparedModerationCommand,
+) -> Result<AdmissionObject, String> {
+    let (target_kind, target) = match command {
+        PreparedModerationCommand::Ban { target, .. }
+        | PreparedModerationCommand::Unban { target }
+        | PreparedModerationCommand::Timeout { target, .. }
+        | PreparedModerationCommand::Untimeout { target } => {
+            (b"pubkey".as_slice(), target.as_slice())
+        }
+        PreparedModerationCommand::ResolveReport {
+            report_event_id, ..
+        } => (b"report".as_slice(), report_event_id.as_slice()),
+    };
+    let key = framed_digest(
+        b"buzz:nip-fi:moderation-target:v1",
+        &[community.as_uuid().as_bytes(), target_kind, target],
+    );
+    AdmissionObject::new(AdmissionObjectKind::ModerationTarget, key)
+        .ok_or_else(|| invalid("moderation target could not be bound"))
+}
+
+fn framed_digest(domain: &[u8], fields: &[&[u8]]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+fn validate_freshness(event: &Event) -> Result<(), String> {
     let event_ts = event.created_at.as_secs() as i64;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
+        .map(|duration| duration.as_secs() as i64)
+        .map_err(|e| error(format!("system clock unavailable: {e}")))?;
     if (event_ts - now).abs() > MAX_COMMAND_SKEW_SECS {
         return Err(invalid(format!(
             "event timestamp out of range: created_at={event_ts}, now={now}, delta={}s (max ±{MAX_COMMAND_SKEW_SECS}s)",
             event_ts - now
         )));
     }
-
-    match kind {
-        KIND_MODERATION_BAN => handle_ban(tenant, state, event, &actor).await,
-        KIND_MODERATION_UNBAN => handle_unban(tenant, state, event, &actor).await,
-        KIND_MODERATION_TIMEOUT => handle_timeout(tenant, state, event, &actor).await,
-        KIND_MODERATION_UNTIMEOUT => handle_untimeout(tenant, state, event, &actor).await,
-        KIND_MODERATION_RESOLVE_REPORT => handle_resolve(tenant, state, event, &actor).await,
-        other => Err(invalid(format!(
-            "unexpected moderation command kind: {other}"
-        ))),
-    }
-}
-
-fn ensure_actor_not_banned(
-    restriction: &buzz_db::moderation::RestrictionState,
-) -> Result<(), String> {
-    if restriction.banned {
-        return Err("blocked: you are banned from this community".to_string());
-    }
     Ok(())
 }
 
-// ── 9040: ban ───────────────────────────────────────────────────────────────
-
-async fn handle_ban(
-    tenant: &TenantContext,
-    state: &Arc<AppState>,
-    event: &Event,
-    actor: &[u8],
-) -> Result<(), String> {
-    let target = extract_p_tag_bytes(event).ok_or_else(|| invalid("missing or invalid p tag"))?;
-    let expires_at = extract_expiration(event)?; // None ⇒ permanent
-    let reason = extract_tag_value(event, "reason");
-
-    authorize_moderation_action(
-        tenant,
-        state,
-        actor,
-        None,
-        ModerationTarget::Pubkey(&target),
-        ModerationAction::Ban,
-    )
-    .await
-    .map_err(authz_denial)?;
-
-    state
-        .db
-        .ban_community_member(
-            tenant.community(),
-            &target,
-            actor,
-            reason.as_deref(),
-            expires_at,
-        )
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?;
-
-    let action_id = insert_audit(
-        state,
-        tenant,
-        actor,
-        "ban",
-        Some(&target),
-        None,
-        reason.as_deref(),
-    )
-    .await?;
-
-    // Live enforcement: close open sessions for the banned principal now —
-    // this pod's sockets synchronously (fenced to this community) and every
-    // other pod's via the fire-and-forget cross-pod fan-out. The paired helper
-    // makes "close locally but forget the Redis publish" unrepresentable, so a
-    // live ban takes effect immediately, everywhere (decision 4).
-    state.disconnect_pubkey_clusterwide(
-        tenant,
-        &target,
-        &event.id.to_hex(),
-        "blocked: you are banned from this community",
-    );
-
-    // Notice DM: tell the banned user the terms of the restriction.
-    let public_reason = reason.clone().unwrap_or_default();
-    if let Err(e) = send_moderation_notice(
-        tenant,
-        state,
-        &target,
-        ModerationNotice::Restriction {
-            action_id,
-            kind: "ban".to_string(),
-            public_reason,
-        },
-    )
-    .await
-    {
-        // Notice delivery is best-effort; the ban itself has already landed and
-        // been audited. Log and continue rather than fail the command.
-        info!(error = %e, "ban notice DM delivery failed (ban still enforced)");
-    }
-
-    info!(target = %hex::encode(&target), "community ban applied");
-    Ok(())
+fn required_pubkey(event: &Event) -> Result<Vec<u8>, String> {
+    extract_p_tag_bytes(event).ok_or_else(|| invalid("missing or invalid p tag"))
 }
 
-// ── 9041: unban ──────────────────────────────────────────────────────────────
-
-async fn handle_unban(
-    tenant: &TenantContext,
-    state: &Arc<AppState>,
-    event: &Event,
-    actor: &[u8],
-) -> Result<(), String> {
-    let target = extract_p_tag_bytes(event).ok_or_else(|| invalid("missing or invalid p tag"))?;
-
-    authorize_moderation_action(
-        tenant,
-        state,
-        actor,
-        None,
-        ModerationTarget::Pubkey(&target),
-        ModerationAction::Unban,
-    )
-    .await
-    .map_err(authz_denial)?;
-
-    let lifted = state
-        .db
-        .unban_community_member(tenant.community(), &target, actor)
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?;
-    if !lifted {
-        return Err(invalid("member is not banned"));
-    }
-
-    insert_audit(state, tenant, actor, "unban", Some(&target), None, None).await?;
-
-    info!(target = %hex::encode(&target), "community ban lifted");
-    Ok(())
-}
-
-// ── 9042: timeout ────────────────────────────────────────────────────────────
-
-async fn handle_timeout(
-    tenant: &TenantContext,
-    state: &Arc<AppState>,
-    event: &Event,
-    actor: &[u8],
-) -> Result<(), String> {
-    let target = extract_p_tag_bytes(event).ok_or_else(|| invalid("missing or invalid p tag"))?;
-    let muted_until =
-        extract_expiration(event)?.ok_or_else(|| invalid("timeout requires an expiration tag"))?;
-    let reason = extract_tag_value(event, "reason");
-
-    authorize_moderation_action(
-        tenant,
-        state,
-        actor,
-        None,
-        ModerationTarget::Pubkey(&target),
-        ModerationAction::Timeout,
-    )
-    .await
-    .map_err(authz_denial)?;
-
-    state
-        .db
-        .timeout_community_member(
-            tenant.community(),
-            &target,
-            actor,
-            muted_until,
-            reason.as_deref(),
-        )
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?;
-
-    let action_id = insert_audit(
-        state,
-        tenant,
-        actor,
-        "timeout",
-        Some(&target),
-        None,
-        reason.as_deref(),
-    )
-    .await?;
-
-    let public_reason = reason.clone().unwrap_or_default();
-    if let Err(e) = send_moderation_notice(
-        tenant,
-        state,
-        &target,
-        ModerationNotice::Restriction {
-            action_id,
-            kind: "timeout".to_string(),
-            public_reason,
-        },
-    )
-    .await
-    {
-        info!(error = %e, "timeout notice DM delivery failed (timeout still enforced)");
-    }
-
-    info!(target = %hex::encode(&target), "community timeout applied");
-    Ok(())
-}
-
-// ── 9043: untimeout ──────────────────────────────────────────────────────────
-
-async fn handle_untimeout(
-    tenant: &TenantContext,
-    state: &Arc<AppState>,
-    event: &Event,
-    actor: &[u8],
-) -> Result<(), String> {
-    let target = extract_p_tag_bytes(event).ok_or_else(|| invalid("missing or invalid p tag"))?;
-
-    authorize_moderation_action(
-        tenant,
-        state,
-        actor,
-        None,
-        ModerationTarget::Pubkey(&target),
-        ModerationAction::Untimeout,
-    )
-    .await
-    .map_err(authz_denial)?;
-
-    let cleared = state
-        .db
-        .untimeout_community_member(tenant.community(), &target, actor)
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?;
-    if !cleared {
-        return Err(invalid("member is not timed out"));
-    }
-
-    insert_audit(state, tenant, actor, "untimeout", Some(&target), None, None).await?;
-
-    info!(target = %hex::encode(&target), "community timeout cleared");
-    Ok(())
-}
-
-// ── 9044: resolve report ─────────────────────────────────────────────────────
-
-async fn handle_resolve(
-    tenant: &TenantContext,
-    state: &Arc<AppState>,
-    event: &Event,
-    actor: &[u8],
-) -> Result<(), String> {
+fn prepare_resolve_report(event: &Event) -> Result<PreparedModerationCommand, String> {
     let report_event_id = extract_report_tag(event)
         .ok_or_else(|| invalid("missing or invalid report tag (expect 64-hex event id)"))?;
     let status = extract_tag_value(event, "status").ok_or_else(|| invalid("missing status tag"))?;
     let action = extract_tag_value(event, "action").ok_or_else(|| invalid("missing action tag"))?;
     let reason = extract_tag_value(event, "reason");
 
-    // Vocab is validated at build time in the SDK, but the relay must not trust
-    // the client: re-validate the pinned vocabulary here.
     if status != "resolved" && status != "dismissed" {
         return Err(invalid(format!(
             "invalid status: {status} (expect resolved|dismissed)"
@@ -396,108 +799,22 @@ async fn handle_resolve(
         ));
     }
 
-    authorize_moderation_action(
-        tenant,
-        state,
-        actor,
-        None,
-        ModerationTarget::Event(&report_event_id),
-        ModerationAction::ResolveReport,
-    )
-    .await
-    .map_err(authz_denial)?;
-
-    // Resolve the report row under this tenant only. The `report` tag carries
-    // the signed 1984 event id (pinned contract); look the row up by it.
-    let report = state
-        .db
-        .get_moderation_report_by_event(tenant.community(), &report_event_id)
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?
-        .ok_or_else(|| invalid("report not found in this community"))?;
-
-    // Don't write an audit row for a report someone else already closed. The
-    // DB's `WHERE status='open'` on resolve_moderation_report below is the real
-    // guard; this early check keeps a lost-race resolve (two mods on the same
-    // report) from leaving an orphan audit row behind the failed resolve. A tiny
-    // residual race remains — the row can flip to closed between this read and
-    // the DB write — but that window yields only an audit row plus a failed
-    // resolve, which is tolerated.
-    if report.status != "open" {
-        return Err(invalid(
-            "report is not open (already resolved or dismissed)",
-        ));
-    }
-
-    // Carry the report's own target into the audit row so `delete`/`kick`/`ban`
-    // resolutions record what they acted on.
-    let (target_pubkey, target_event_id) = match &report.target {
-        buzz_db::moderation::ReportTarget::Pubkey(p) => (Some(p.as_slice()), None),
-        buzz_db::moderation::ReportTarget::Event(e) => (None, Some(e.as_slice())),
-        buzz_db::moderation::ReportTarget::Blob(_) => (None, None),
-    };
-
-    // Distinguish a resolution *decision* from the actual *enforcement* row.
-    // A one-click resolve with action=ban records the moderator's decision; the
-    // client then composes the real 9040, which writes its own "ban" enforcement
-    // row. `resolve:*` decision rows are part of the moderation_actions DB
-    // vocabulary so audit consumers can tell the two apart and don't double-count.
-    // `dismiss_report` and `escalate` stay unprefixed — escalate especially must
-    // remain queryable for the platform-safety lane.
-    let audit_action = resolution_audit_action(&action);
-    let action_id = insert_audit(
-        state,
-        tenant,
-        actor,
-        audit_action,
-        target_pubkey,
-        target_event_id,
-        reason.as_deref(),
-    )
-    .await?;
-
-    let resolved = state
-        .db
-        .resolve_moderation_report(
-            tenant.community(),
-            report.id,
-            &status,
-            actor,
-            Some(action_id),
-        )
-        .await
-        .map_err(|e| error(format!("database error: {e}")))?;
-    if !resolved {
-        return Err(invalid(
-            "report is not open (already resolved or dismissed)",
-        ));
-    }
-
-    // Close the loop: DM the reporter that their report was reviewed.
-    let summary = reason.clone().unwrap_or_else(|| match status.as_str() {
-        "dismissed" => "Your report was reviewed and dismissed.".to_string(),
-        _ => "Your report was reviewed and acted on.".to_string(),
-    });
-    if let Err(e) = send_moderation_notice(
-        tenant,
-        state,
-        &report.reporter_pubkey,
-        ModerationNotice::ReportResolved {
-            report_id: report.id,
-            status: status.clone(),
-            summary,
-        },
-    )
-    .await
-    {
-        info!(error = %e, "report-resolution notice DM delivery failed (report still resolved)");
-    }
-
-    info!(report_id = %report.id, status = %status, action = %action, "report resolved");
-    Ok(())
+    Ok(PreparedModerationCommand::ResolveReport {
+        report_event_id,
+        status,
+        action,
+        reason,
+    })
 }
 
-// ── shared helpers ────────────────────────────────────────────────────────────
+fn ensure_actor_not_banned(
+    restriction: &buzz_db::moderation::RestrictionState,
+) -> Result<(), String> {
+    if restriction.banned {
+        return Err("blocked: you are banned from this community".to_string());
+    }
+    Ok(())
+}
 
 fn resolution_audit_action(action: &str) -> &'static str {
     match action {
@@ -507,16 +824,12 @@ fn resolution_audit_action(action: &str) -> &'static str {
         "kick" => "resolve:kick",
         "ban" => "resolve:ban",
         "timeout" => "resolve:timeout",
-        // The caller validates this vocabulary before mapping.
         _ => "resolve:unknown",
     }
 }
 
-/// Insert a moderation audit row for an accepted command. `matched_principal`
-/// is left `None` here: that NIP-OA field records which principal an
-/// *enforcement* check matched at the auth seam (L4), not who issued a command.
-async fn insert_audit(
-    state: &Arc<AppState>,
+async fn insert_audit_tx(
+    transaction: &mut Transaction<'_, Postgres>,
     tenant: &TenantContext,
     actor: &[u8],
     action: &str,
@@ -524,29 +837,31 @@ async fn insert_audit(
     target_event_id: Option<&[u8]>,
     public_reason: Option<&str>,
 ) -> Result<Uuid, String> {
-    state
-        .db
-        .insert_moderation_action(
-            tenant.community(),
-            NewAction {
-                actor_pubkey: actor,
-                action,
-                target_pubkey,
-                target_event_id,
-                channel_id: None,
-                reason_code: None,
-                public_reason,
-                private_reason: None,
-                matched_principal: None,
-            },
-        )
-        .await
-        .map_err(|e| error(format!("failed to write audit row: {e}")))
+    buzz_db::moderation::insert_action_tx(
+        transaction,
+        tenant.community(),
+        NewAction {
+            actor_pubkey: actor,
+            action,
+            target_pubkey,
+            target_event_id,
+            channel_id: None,
+            reason_code: None,
+            public_reason,
+            private_reason: None,
+            matched_principal: None,
+        },
+    )
+    .await
+    .map_err(|e| error(format!("failed to write audit row: {e}")))
 }
 
-/// Map an authorization error to a client-safe `restricted:`-prefixed denial.
 fn authz_denial(e: anyhow::Error) -> String {
     format!("restricted: {e}")
+}
+
+fn database_error(e: impl std::fmt::Display) -> String {
+    error(format!("database error: {e}"))
 }
 
 fn invalid(message: impl Into<String>) -> String {
@@ -557,14 +872,14 @@ fn error(message: impl Into<String>) -> String {
     format!("error: {}", message.into())
 }
 
-/// Extract the first valid `p` tag as raw pubkey bytes (32 bytes).
 fn extract_p_tag_bytes(event: &Event) -> Option<Vec<u8>> {
     for tag in event.tags.iter() {
         let parts = tag.as_slice();
-        if parts.first().map(|s| s.as_str()) == Some("p") {
-            if let Some(val) = parts.get(1).map(|s| s.as_str()) {
-                if val.len() == 64 && val.chars().all(|c| c.is_ascii_hexdigit()) {
-                    return hex::decode(val).ok();
+        if parts.first().map(|value| value.as_str()) == Some("p") {
+            if let Some(value) = parts.get(1).map(|value| value.as_str()) {
+                if value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+                {
+                    return hex::decode(value).ok();
                 }
             }
         }
@@ -572,14 +887,14 @@ fn extract_p_tag_bytes(event: &Event) -> Option<Vec<u8>> {
     None
 }
 
-/// Extract the `report` tag as a 32-byte event id (the signed 1984 report).
 fn extract_report_tag(event: &Event) -> Option<Vec<u8>> {
     for tag in event.tags.iter() {
         let parts = tag.as_slice();
-        if parts.first().map(|s| s.as_str()) == Some("report") {
-            if let Some(val) = parts.get(1).map(|s| s.as_str()) {
-                if val.len() == 64 && val.chars().all(|c| c.is_ascii_hexdigit()) {
-                    return hex::decode(val).ok();
+        if parts.first().map(|value| value.as_str()) == Some("report") {
+            if let Some(value) = parts.get(1).map(|value| value.as_str()) {
+                if value.len() == 64 && value.chars().all(|character| character.is_ascii_hexdigit())
+                {
+                    return hex::decode(value).ok();
                 }
             }
         }
@@ -587,29 +902,26 @@ fn extract_report_tag(event: &Event) -> Option<Vec<u8>> {
     None
 }
 
-/// Parse an optional `expiration` tag (unix seconds) into a UTC timestamp.
-/// Returns `Ok(None)` when absent, `Err` on a malformed value.
 fn extract_expiration(event: &Event) -> Result<Option<DateTime<Utc>>, String> {
     match extract_tag_value(event, "expiration") {
         None => Ok(None),
         Some(raw) => {
-            let secs: i64 = raw
+            let seconds: i64 = raw
                 .parse()
                 .map_err(|_| invalid(format!("invalid expiration tag: {raw}")))?;
-            match Utc.timestamp_opt(secs, 0).single() {
-                Some(ts) => Ok(Some(ts)),
-                None => Err(invalid(format!("expiration out of range: {secs}"))),
-            }
+            Utc.timestamp_opt(seconds, 0)
+                .single()
+                .map(Some)
+                .ok_or_else(|| invalid(format!("expiration out of range: {seconds}")))
         }
     }
 }
 
-/// Extract the value of the first tag with the given name.
 fn extract_tag_value(event: &Event, name: &str) -> Option<String> {
     for tag in event.tags.iter() {
         let parts = tag.as_slice();
-        if parts.first().map(|s| s.as_str()) == Some(name) {
-            return parts.get(1).map(|s| s.to_string());
+        if parts.first().map(|value| value.as_str()) == Some(name) {
+            return parts.get(1).map(ToString::to_string);
         }
     }
     None
@@ -618,8 +930,32 @@ fn extract_tag_value(event: &Event, name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, Utc};
+    use chrono::Duration;
     use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn make_event(kind: u16, created_at_secs: u64, tags: Vec<Vec<String>>) -> Event {
+        let keys = Keys::generate();
+        let tags = tags
+            .into_iter()
+            .map(|parts| Tag::parse(parts).expect("valid tag"))
+            .collect::<Vec<_>>();
+        EventBuilder::new(Kind::from(kind), "")
+            .tags(tags)
+            .custom_created_at(nostr::Timestamp::from_secs(created_at_secs))
+            .sign_with_keys(&keys)
+            .expect("signing failed")
+    }
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_secs()
+    }
+
+    fn tenant(id: u128) -> TenantContext {
+        TenantContext::resolved(CommunityId::from_uuid(Uuid::from_u128(id)), "relay.example")
+    }
 
     #[test]
     fn banned_admin_cannot_reach_an_unban_command() {
@@ -632,8 +968,6 @@ mod tests {
             Err("blocked: you are banned from this community".to_string())
         );
 
-        // A timeout remains a write restriction rather than an authentication
-        // ban, so an authorized moderator can still lift it.
         let timed_out = buzz_db::moderation::RestrictionState {
             banned: false,
             muted_until: Some(Utc::now() + Duration::minutes(5)),
@@ -641,25 +975,161 @@ mod tests {
         assert!(ensure_actor_not_banned(&timed_out).is_ok());
     }
 
-    /// Build a signed event with the given kind, timestamp, and tags.
-    fn make_event(kind: u16, created_at_secs: u64, tags: Vec<Vec<String>>) -> Event {
-        let keys = Keys::generate();
-        let nostr_tags: Vec<Tag> = tags
-            .into_iter()
-            .map(|parts| Tag::parse(parts).expect("valid tag"))
-            .collect();
-        EventBuilder::new(Kind::from(kind), "")
-            .tags(nostr_tags)
-            .custom_created_at(nostr::Timestamp::from_secs(created_at_secs))
-            .sign_with_keys(&keys)
-            .expect("signing failed")
+    #[test]
+    fn prepared_effect_is_bound_to_server_resolved_tenant() {
+        let event = make_event(
+            KIND_MODERATION_BAN as u16,
+            now_secs(),
+            vec![vec!["p".into(), "a".repeat(64)]],
+        );
+        let effect = prepare_moderation_application_effect(&tenant(7), &event).expect("effect");
+        assert_eq!(effect.tenant.community(), tenant(7).community());
+        assert_ne!(effect.tenant.community(), tenant(8).community());
+        assert_eq!(
+            effect.admission_object().kind(),
+            AdmissionObjectKind::ModerationTarget
+        );
     }
 
-    fn now_secs() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
+    #[test]
+    fn exact_replay_never_yields_a_postcommit_action() {
+        let tenant = tenant(9);
+        let object = AdmissionObject::new(AdmissionObjectKind::ModerationTarget, [7; 32])
+            .expect("moderation object");
+        let result = AdmissionApplicationResult::new(
+            moderation_result_schema(),
+            1,
+            serde_json::to_vec(&ModerationPostCommitKind::Unban {
+                target: vec![8; 32],
+            })
+            .expect("serialize action"),
+        )
+        .expect("typed result");
+        let receipt = buzz_db::authorization_admission::AdmissionCommitReceipt::from_storage(
+            tenant.community(),
+            object,
+            Uuid::new_v4(),
+            [9; 32],
+            [10; 32],
+            buzz_db::authorization_admission::AdmissionCommitDigests::new([11; 32], Some([12; 32]))
+                .expect("digests"),
+            Uuid::new_v4(),
+        )
+        .expect("receipt");
+        let outcome = AdmissionCommitOutcome::ExactReplay {
+            receipt,
+            application_result: Some(result),
+        };
+        assert!(matches!(
+            committed_moderation_action(&tenant, &outcome),
+            Ok(None)
+        ));
+    }
+
+    #[test]
+    fn committed_result_must_match_receipt_digest_and_moderation_object() {
+        let tenant = tenant(10);
+        let object = AdmissionObject::new(AdmissionObjectKind::ModerationTarget, [7; 32])
+            .expect("moderation object");
+        let intent_digest = [13; 32];
+        let result = AdmissionApplicationResult::new(
+            moderation_result_schema(),
+            1,
+            serde_json::to_vec(&ModerationApplicationResultPayload {
+                object_key: *object.key(),
+                intent_digest,
+                action: ModerationPostCommitKind::Unban {
+                    target: vec![8; 32],
+                },
+            })
+            .expect("serialize application result"),
+        )
+        .expect("typed result");
+        let provisional = buzz_db::authorization_admission::AdmissionCommitReceipt::from_storage(
+            tenant.community(),
+            object,
+            Uuid::new_v4(),
+            [9; 32],
+            [10; 32],
+            buzz_db::authorization_admission::AdmissionCommitDigests::new([11; 32], Some([12; 32]))
+                .expect("provisional digests"),
+            Uuid::new_v4(),
+        )
+        .expect("provisional receipt");
+        let application_result_digest =
+            canonical_moderation_result_digest(provisional, intent_digest, &result)
+                .expect("canonical result digest");
+        let receipt = buzz_db::authorization_admission::AdmissionCommitReceipt::from_storage(
+            tenant.community(),
+            object,
+            provisional.operation_id(),
+            *provisional.request_fingerprint(),
+            *provisional.semantic_fingerprint(),
+            buzz_db::authorization_admission::AdmissionCommitDigests::new(
+                *provisional.result_digest(),
+                Some(application_result_digest),
+            )
+            .expect("canonical digests"),
+            provisional.audit_event_id(),
+        )
+        .expect("canonical receipt");
+        let action = validate_committed_moderation_result(receipt, &result)
+            .expect("matching receipt and result");
+        assert!(matches!(
+            action.0,
+            ModerationPostCommitKind::Unban { target } if target == vec![8; 32]
+        ));
+
+        let other_object = AdmissionObject::new(AdmissionObjectKind::ModerationTarget, [14; 32])
+            .expect("other moderation object");
+        let other_receipt = buzz_db::authorization_admission::AdmissionCommitReceipt::from_storage(
+            tenant.community(),
+            other_object,
+            receipt.operation_id(),
+            *receipt.request_fingerprint(),
+            *receipt.semantic_fingerprint(),
+            buzz_db::authorization_admission::AdmissionCommitDigests::new(
+                *receipt.result_digest(),
+                Some(application_result_digest),
+            )
+            .expect("other digests"),
+            receipt.audit_event_id(),
+        )
+        .expect("other receipt");
+        assert!(matches!(
+            validate_committed_moderation_result(other_receipt, &result),
+            Err(AdmissionCommitError::IntentConflict)
+        ));
+
+        let wrong_digest_receipt =
+            buzz_db::authorization_admission::AdmissionCommitReceipt::from_storage(
+                tenant.community(),
+                object,
+                receipt.operation_id(),
+                *receipt.request_fingerprint(),
+                *receipt.semantic_fingerprint(),
+                buzz_db::authorization_admission::AdmissionCommitDigests::new(
+                    *receipt.result_digest(),
+                    Some([15; 32]),
+                )
+                .expect("wrong digest"),
+                receipt.audit_event_id(),
+            )
+            .expect("wrong-digest receipt");
+        assert!(matches!(
+            validate_committed_moderation_result(wrong_digest_receipt, &result),
+            Err(AdmissionCommitError::IntentConflict)
+        ));
+    }
+
+    #[test]
+    fn stale_command_is_rejected_before_an_effect_exists() {
+        let event = make_event(
+            KIND_MODERATION_BAN as u16,
+            now_secs() - (MAX_COMMAND_SKEW_SECS as u64 + 1),
+            vec![vec!["p".into(), "a".repeat(64)]],
+        );
+        assert!(prepare_moderation_application_effect(&tenant(7), &event).is_err());
     }
 
     #[test]
@@ -668,7 +1138,7 @@ mod tests {
             let audit_action = resolution_audit_action(action);
             assert!(
                 buzz_db::moderation::MODERATION_ACTION_CHECK_VOCAB.contains(&audit_action),
-                "9044 action={action} maps to {audit_action}, which must be accepted by migrations/0006_moderation.sql moderation_actions.action CHECK"
+                "action={action} maps to disallowed {audit_action}"
             );
         }
     }
@@ -687,82 +1157,58 @@ mod tests {
     }
 
     #[test]
-    fn extract_p_tag_bytes_valid() {
-        let hex = "a".repeat(64);
-        let e = make_event(9040, now_secs(), vec![vec!["p".into(), hex.clone()]]);
-        assert_eq!(extract_p_tag_bytes(&e), hex::decode(&hex).ok());
-    }
-
-    #[test]
-    fn extract_p_tag_bytes_rejects_short_and_nonhex() {
-        assert_eq!(
-            extract_p_tag_bytes(&make_event(
-                9040,
-                now_secs(),
-                vec![vec!["p".into(), "abcd".into()]]
-            )),
-            None
-        );
-        let bad = "g".repeat(64);
-        assert_eq!(
-            extract_p_tag_bytes(&make_event(9040, now_secs(), vec![vec!["p".into(), bad]])),
-            None
-        );
-    }
-
-    #[test]
-    fn extract_report_tag_requires_64_hex() {
-        let id = "b".repeat(64);
-        let e = make_event(9044, now_secs(), vec![vec!["report".into(), id.clone()]]);
-        assert_eq!(extract_report_tag(&e), hex::decode(&id).ok());
-        // A UUID-shaped value (Wren's L5 lesson: never a UUID where an event id belongs).
-        let uuid = make_event(
-            9044,
+    fn extract_p_tag_bytes_validates_exact_hex_shape() {
+        let valid = "a".repeat(64);
+        let event = make_event(
+            KIND_MODERATION_BAN as u16,
             now_secs(),
-            vec![vec![
-                "report".into(),
-                "550e8400-e29b-41d4-a716-446655440000".into(),
-            ]],
+            vec![vec!["p".into(), valid.clone()]],
         );
-        assert_eq!(extract_report_tag(&uuid), None);
+        assert_eq!(extract_p_tag_bytes(&event), hex::decode(valid).ok());
+
+        for invalid_value in ["abcd".to_string(), "g".repeat(64)] {
+            let event = make_event(
+                KIND_MODERATION_BAN as u16,
+                now_secs(),
+                vec![vec!["p".into(), invalid_value]],
+            );
+            assert_eq!(extract_p_tag_bytes(&event), None);
+        }
     }
 
     #[test]
-    fn expiration_absent_is_none() {
-        let e = make_event(9040, now_secs(), vec![]);
-        assert_eq!(extract_expiration(&e).unwrap(), None);
+    fn report_tag_requires_64_hex() {
+        let valid = "b".repeat(64);
+        let event = make_event(
+            KIND_MODERATION_RESOLVE_REPORT as u16,
+            now_secs(),
+            vec![vec!["report".into(), valid.clone()]],
+        );
+        assert_eq!(extract_report_tag(&event), hex::decode(valid).ok());
     }
 
     #[test]
-    fn expiration_valid_parses() {
-        let e = make_event(
-            9040,
+    fn expiration_parses_and_rejects_malformed_values() {
+        let absent = make_event(KIND_MODERATION_BAN as u16, now_secs(), vec![]);
+        assert_eq!(extract_expiration(&absent).expect("absent"), None);
+
+        let valid = make_event(
+            KIND_MODERATION_BAN as u16,
             now_secs(),
             vec![vec!["expiration".into(), "1893456000".into()]],
         );
         assert_eq!(
-            extract_expiration(&e).unwrap(),
+            extract_expiration(&valid).expect("valid"),
             Utc.timestamp_opt(1_893_456_000, 0).single()
         );
-    }
 
-    #[test]
-    fn expiration_malformed_errs() {
-        let e = make_event(
-            9040,
-            now_secs(),
-            vec![vec!["expiration".into(), "not-a-number".into()]],
-        );
-        assert!(extract_expiration(&e).is_err());
-    }
-
-    #[test]
-    fn expiration_out_of_range_errs() {
-        let e = make_event(
-            9040,
-            now_secs(),
-            vec![vec!["expiration".into(), "99999999999999".into()]],
-        );
-        assert!(extract_expiration(&e).is_err());
+        for invalid_value in ["not-a-number", "99999999999999"] {
+            let event = make_event(
+                KIND_MODERATION_BAN as u16,
+                now_secs(),
+                vec![vec!["expiration".into(), invalid_value.into()]],
+            );
+            assert!(extract_expiration(&event).is_err());
+        }
     }
 }

--- a/crates/buzz-relay/src/lib.rs
+++ b/crates/buzz-relay/src/lib.rs
@@ -31,6 +31,8 @@ pub mod mesh_boot;
 pub mod metrics;
 /// NIP-11 relay information document.
 pub mod nip11;
+/// Typed installer boundary for provider-free operator routes.
+pub mod operator_runtime;
 /// NIP-01 client/relay message parsing.
 pub mod protocol;
 /// Durable NIP-PL matcher and delivery worker.

--- a/crates/buzz-relay/src/operator_runtime.rs
+++ b/crates/buzz-relay/src/operator_runtime.rs
@@ -1,0 +1,33 @@
+//! Fail-closed installation boundary for authenticated operator routes.
+
+use axum::Router;
+
+/// Stable installation failures that leave all operator routes unmounted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum OperatorRouteInstallError {
+    /// The canonical atomic admission authority was not configured.
+    #[error("canonical admission committer is unavailable")]
+    MissingCanonicalAdmissionCommitter,
+    /// Lifecycle, replay, quota, or audit health was not ready.
+    #[error("operator lifecycle dependencies are unhealthy")]
+    UnhealthyDependencies,
+    /// Installation was attempted more than once for one runtime.
+    #[error("operator routes are already installed")]
+    DuplicateInstallation,
+}
+
+/// Typed all-or-nothing operator route installation boundary.
+///
+/// Implementations must install only authenticated, allowlisted routes backed
+/// by the canonical admission committer. An error returns no partially mounted
+/// router and must not weaken the caller's default-deny fallback.
+pub trait OperatorRouteInstaller: Send + Sync {
+    /// Application state carried by the relay router.
+    type State: Clone + Send + Sync + 'static;
+
+    /// Install the complete closed operator route set.
+    fn install_operator_routes(
+        &self,
+        router: Router<Self::State>,
+    ) -> Result<Router<Self::State>, OperatorRouteInstallError>;
+}

--- a/crates/buzz-relay/tests/nip_fi_lifecycle_operator.rs
+++ b/crates/buzz-relay/tests/nip_fi_lifecycle_operator.rs
@@ -1,0 +1,58 @@
+use buzz_core::CommunityId;
+use buzz_db::authorization_admission::{
+    AdmissionApplicationResult, AdmissionApplicationResultSchema, AdmissionCommitDigests,
+    AdmissionCommitReceipt, AdmissionObject, AdmissionObjectKind,
+    MAX_ADMISSION_APPLICATION_RESULT_PAYLOAD_BYTES,
+};
+use uuid::Uuid;
+
+const OPERATOR_API_SOURCE: &str = include_str!("../src/api/operator.rs");
+
+#[test]
+fn operator_allowlist_precedes_shared_replay_state() {
+    let allowlist = OPERATOR_API_SOURCE
+        .find(".relay_operator_pubkeys")
+        .expect("operator allowlist decision");
+    let replay = OPERATOR_API_SOURCE
+        .find("check_operator_replay(state, event_id_bytes).await?")
+        .expect("operator replay mutation");
+    assert!(
+        allowlist < replay,
+        "unconfigured signers must fail before shared replay state"
+    );
+}
+
+#[test]
+fn canonical_result_api_is_bounded_versioned_and_object_bound() {
+    let domain = CommunityId::from_uuid(Uuid::new_v4());
+    let object = AdmissionObject::new(AdmissionObjectKind::Repository, [11; 32])
+        .expect("server-owned repository coordinate");
+    let schema =
+        AdmissionApplicationResultSchema::new([12; 32], 1).expect("server-owned result schema");
+    let result = AdmissionApplicationResult::new(schema, 1, b"stable-manifest".to_vec())
+        .expect("bounded canonical result");
+    assert_eq!(result.payload(), b"stable-manifest");
+    assert_eq!(result.schema(), schema);
+    assert!(AdmissionApplicationResult::new(
+        schema,
+        1,
+        vec![0; MAX_ADMISSION_APPLICATION_RESULT_PAYLOAD_BYTES + 1],
+    )
+    .is_err());
+
+    let receipt = AdmissionCommitReceipt::from_storage(
+        domain,
+        object,
+        Uuid::new_v4(),
+        [13; 32],
+        [14; 32],
+        AdmissionCommitDigests::new([15; 32], Some([16; 32])).expect("canonical result digests"),
+        Uuid::new_v4(),
+    )
+    .expect("complete canonical receipt");
+    assert_eq!(receipt.authorization_domain(), domain);
+    assert_eq!(receipt.object(), object);
+    assert_eq!(receipt.request_fingerprint(), &[13; 32]);
+    assert_eq!(receipt.semantic_fingerprint(), &[14; 32]);
+    assert_eq!(receipt.application_result_digest(), Some(&[16; 32]));
+}

--- a/crates/buzz-relay/tests/nip_fi_protected_objects.rs
+++ b/crates/buzz-relay/tests/nip_fi_protected_objects.rs
@@ -1,0 +1,1520 @@
+//! Cross-crate security regressions for NIP-FI protected objects.
+//!
+//! The PostgreSQL and object-store cases are ignored by default so ordinary
+//! unit runs remain hermetic. The S4 release gate runs them explicitly against
+//! disposable services.
+
+use std::{
+    future::Future,
+    io::Write,
+    path::PathBuf,
+    pin::Pin,
+    process::{Command, Stdio},
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use buzz_auth::{
+    AuthoritativeAuthorizationRecheck, CanonicalFederatedAssertionVerifier,
+    CanonicalVerifierKeySet, CanonicalVerifierPolicy, HttpHeaderField, LocalAuthorizationPolicy,
+    PreparedAuthorizationRecheck, ProofTransport, RouteCapability, TrustedProxyNonceClaim,
+    TrustedProxyNonceReplayReader, TrustedProxyProvenanceVerifier, TrustedProxyReplayReadError,
+    TrustedProxyRequest, VerifiedFederatedAssertion, VerifiedNostrProof, VerifierKeyGeneration,
+    ASSERTION_HEADER_NAME, PROVENANCE_HEADER_NAME,
+};
+use buzz_core::{AuthorizationLeaseFence, CommunityId, TenantContext};
+use buzz_db::authorization_admission::{
+    AdmissionApplicationEffect, AdmissionApplicationResult, AdmissionCommitDigests,
+    AdmissionCommitError, AdmissionCommitOutcome, AdmissionCommitReceipt, AdmissionCommitRequest,
+    AdmissionEnrollmentEvidence, AdmissionFinalRechecker, AdmissionObject,
+    CanonicalAdmissionCommitter, PostgresCanonicalAdmissionCommitter,
+};
+use buzz_media::upload_record::UploadEventFacts;
+use buzz_media::{
+    stage_upload, stage_upload_record, MediaConfig, MediaStorage, S3AddressingStyle,
+    UploadAttribution, UploadNetworkInfo,
+};
+use buzz_relay::api::media::{
+    ProtectedPublicationBinding, ProtectedPublicationPlan, ProtectedPublicationReceipt,
+    ProtectedPublicationTarget,
+};
+use buzz_relay::handlers::moderation_commands::prepare_moderation_application_effect;
+use bytes::Bytes;
+use chrono::{TimeDelta, TimeZone, Utc};
+use hmac::{Hmac, KeyInit, Mac};
+use nostr::{EventBuilder, Keys, Kind, RelayUrl, Tag};
+use sha2::{Digest, Sha256};
+use sqlx::{PgConnection, PgPool, Postgres, Row, Transaction};
+use uuid::Uuid;
+
+const PROXY_NOW: u64 = 1_800_000_000;
+const PROXY_SECRET: [u8; 32] = [0x53; 32];
+
+fn proxy_assertion() -> &'static str {
+    static VALUE: OnceLock<String> = OnceLock::new();
+    VALUE.get_or_init(|| {
+        [
+            ["eyJhbGciOiJF", "UzI1NiJ9"].concat(),
+            ["eyJzdWIiOiJz", "dWJqZWN0In0"].concat(),
+            ["c2lnbmF0", "dXJl"].concat(),
+        ]
+        .join(".")
+    })
+}
+
+#[derive(Default)]
+struct EmptyReplayReader;
+
+impl TrustedProxyNonceReplayReader for EmptyReplayReader {
+    fn is_committed<'a>(
+        &'a self,
+        _authorization_domain: CommunityId,
+        _claim: &'a TrustedProxyNonceClaim,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, TrustedProxyReplayReadError>> + Send + 'a>> {
+        Box::pin(async { Ok(false) })
+    }
+}
+
+struct ApplicationReplayRechecker;
+
+impl AdmissionFinalRechecker for ApplicationReplayRechecker {
+    fn authoritative_recheck<'a, 'transaction>(
+        &'a self,
+        transaction: &'a mut Transaction<'transaction, Postgres>,
+        request: &'a PreparedAuthorizationRecheck,
+        _object: AdmissionObject,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<AuthoritativeAuthorizationRecheck, AdmissionCommitError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            // This harness isolates canonical application/outbox replay. The
+            // production rechecker performs the full dependency reads; here we
+            // still use authoritative transaction time and the exact sealed
+            // snapshot so the real committer/finalizer executes unchanged.
+            let authoritative_now = sqlx::query_scalar("SELECT transaction_timestamp()")
+                .fetch_one(&mut **transaction)
+                .await
+                .map_err(|_| AdmissionCommitError::DependencyUnavailable)?;
+            Ok(AuthoritativeAuthorizationRecheck::from_authoritative_parts(
+                request.lease_dependencies(),
+                request.verifier_stamp(),
+                authoritative_now,
+            ))
+        })
+    }
+}
+
+fn base64_url(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut output = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let first = chunk[0];
+        let second = chunk.get(1).copied().unwrap_or(0);
+        let third = chunk.get(2).copied().unwrap_or(0);
+        output.push(ALPHABET[(first >> 2) as usize] as char);
+        output.push(ALPHABET[(((first & 0x03) << 4) | (second >> 4)) as usize] as char);
+        if chunk.len() > 1 {
+            output.push(ALPHABET[(((second & 0x0f) << 2) | (third >> 6)) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            output.push(ALPHABET[(third & 0x3f) as usize] as char);
+        }
+    }
+    output
+}
+
+struct EphemeralRsaKey {
+    path: PathBuf,
+}
+
+impl EphemeralRsaKey {
+    fn generate(kid: &str, prefix: &str) -> (Self, serde_json::Value) {
+        let key = Self {
+            path: std::env::temp_dir().join(format!("{prefix}-{}.pem", Uuid::new_v4())),
+        };
+        let generated = Command::new("openssl")
+            .args([
+                "genpkey",
+                "-algorithm",
+                "RSA",
+                "-pkeyopt",
+                "rsa_keygen_bits:2048",
+                "-pkeyopt",
+                "rsa_keygen_pubexp:65537",
+                "-out",
+            ])
+            .arg(&key.path)
+            .output()
+            .expect("generate ephemeral RSA test key");
+        assert!(
+            generated.status.success(),
+            "OpenSSL RSA key generation failed: {}",
+            String::from_utf8_lossy(&generated.stderr)
+        );
+        let modulus = Command::new("openssl")
+            .args(["rsa", "-in"])
+            .arg(&key.path)
+            .args(["-noout", "-modulus"])
+            .output()
+            .expect("read ephemeral RSA test modulus");
+        assert!(
+            modulus.status.success(),
+            "OpenSSL RSA modulus extraction failed: {}",
+            String::from_utf8_lossy(&modulus.stderr)
+        );
+        let modulus = std::str::from_utf8(&modulus.stdout)
+            .expect("UTF-8 RSA test modulus")
+            .trim()
+            .strip_prefix("Modulus=")
+            .expect("OpenSSL RSA modulus prefix");
+        let modulus = hex::decode(modulus).expect("hex RSA test modulus");
+        let jwks = serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": kid,
+                "n": base64_url(&modulus),
+                "e": "AQAB",
+            }],
+        });
+        (key, jwks)
+    }
+}
+
+impl Drop for EphemeralRsaKey {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn signed_test_jwt(subject: &str, event_author: [u8; 32]) -> (String, serde_json::Value) {
+    let issued_at = Utc::now().timestamp() - 1;
+    let claims = serde_json::json!({
+        "iss": "https://s4-verifier.test",
+        "aud": "buzz-s4-test",
+        "sub": subject,
+        "event_author": hex::encode(event_author),
+        "iat": issued_at,
+        "nbf": issued_at,
+        "exp": issued_at + 600,
+    });
+    let header = serde_json::json!({ "alg": "RS256", "kid": "s4-test", "typ": "JWT" });
+    let signing_input = format!(
+        "{}.{}",
+        base64_url(&serde_json::to_vec(&header).expect("serialize JWT header")),
+        base64_url(&serde_json::to_vec(&claims).expect("serialize JWT claims")),
+    );
+    let (key, jwks) = EphemeralRsaKey::generate("s4-test", "buzz-s4-jwt");
+    let mut child = Command::new("openssl")
+        .args(["dgst", "-sha256", "-sign"])
+        .arg(&key.path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn OpenSSL test signer");
+    child
+        .stdin
+        .as_mut()
+        .expect("OpenSSL signer stdin")
+        .write_all(signing_input.as_bytes())
+        .expect("write JWT signing input");
+    let signed = child.wait_with_output().expect("wait for JWT signer");
+    assert!(signed.status.success(), "OpenSSL JWT signer failed");
+    (
+        format!("{signing_input}.{}", base64_url(&signed.stdout)),
+        jwks,
+    )
+}
+
+fn verified_authorization_evidence(
+    domain: CommunityId,
+    keys: &Keys,
+    target: [u8; 32],
+    request: [u8; 32],
+    transport_context: [u8; 32],
+) -> (VerifiedFederatedAssertion, VerifiedNostrProof) {
+    let (token, jwks) = signed_test_jwt(
+        "canonical-application-subject",
+        keys.public_key().to_bytes(),
+    );
+    let verifier = CanonicalFederatedAssertionVerifier::new(
+        CanonicalVerifierPolicy::new(
+            "https://s4-verifier.test".to_owned(),
+            "buzz-s4-test".to_owned(),
+            "sub".to_owned(),
+            Some("event_author".to_owned()),
+            5,
+            600,
+        )
+        .expect("canonical verifier policy"),
+    );
+    let key_set = CanonicalVerifierKeySet::new(
+        VerifierKeyGeneration::new(1).expect("positive verifier generation"),
+        serde_json::from_value(jwks).expect("parse generated test JWKS"),
+    );
+    let assertion = verifier
+        .verify(
+            &token,
+            &key_set,
+            domain,
+            ProofTransport::Nip42,
+            target,
+            request,
+            transport_context,
+        )
+        .expect("verify test assertion");
+    let challenge = hex::encode([81_u8; 32]);
+    let relay = "wss://s4-admission.test";
+    let event = EventBuilder::auth(
+        challenge.clone(),
+        RelayUrl::parse(relay).expect("test relay URL"),
+    )
+    .sign_with_keys(keys)
+    .expect("sign NIP-42 test proof");
+    let assertion_fingerprint: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+    let proof = buzz_auth::verify_nip42_authorization_proof(
+        &event,
+        &challenge,
+        relay,
+        domain,
+        request,
+        target,
+        transport_context,
+        Some(assertion_fingerprint),
+        None,
+        Utc::now() + TimeDelta::minutes(5),
+    )
+    .expect("verify NIP-42 authorization proof");
+    (assertion, proof)
+}
+
+async fn enrollment_request_with_effect(
+    pool: &PgPool,
+    domain: CommunityId,
+    authorization_evidence: (VerifiedFederatedAssertion, VerifiedNostrProof),
+    object: AdmissionObject,
+    capability: RouteCapability,
+    authoritative_now: chrono::DateTime<Utc>,
+    application_effect: Box<dyn AdmissionApplicationEffect>,
+) -> AdmissionCommitRequest {
+    let (assertion, proof) = authorization_evidence;
+    let prepared = buzz_db::identity_enrollment::prepare_direct_enrollment(
+        pool,
+        assertion.clone(),
+        proof.clone(),
+        authoritative_now,
+    )
+    .await
+    .expect("prepare direct application enrollment");
+    let policy = LocalAuthorizationPolicy::from_database(
+        domain,
+        Uuid::from_u128(411),
+        1,
+        0,
+        1,
+        AuthorizationLeaseFence::from_bytes([82; 32]).expect("authorization fence"),
+        capability,
+        authoritative_now + TimeDelta::minutes(5),
+        None,
+        None,
+    )
+    .expect("media authorization policy");
+    let evidence = AdmissionEnrollmentEvidence::new(prepared, assertion, proof, policy)
+        .expect("seal media enrollment evidence");
+    AdmissionCommitRequest::enrollment(
+        Uuid::new_v4(),
+        Uuid::from_u128(412),
+        object,
+        capability,
+        evidence,
+    )
+    .expect("construct application enrollment request")
+    .with_application_effect(application_effect)
+    .expect("attach canonical application effect")
+}
+
+#[test]
+fn receipt_for_one_repository_cannot_substitute_for_another_target() {
+    let domain = CommunityId::from_uuid(Uuid::from_u128(1));
+    let owner = "a".repeat(64);
+    let target_a =
+        ProtectedPublicationTarget::repository(domain, &owner, "repo-a").expect("target A");
+    let target_b =
+        ProtectedPublicationTarget::repository(domain, &owner, "repo-b").expect("target B");
+    let artifact_digest = [7_u8; 32];
+    let application_result = target_a
+        .application_result(artifact_digest)
+        .expect("typed publication result");
+    let semantic_fingerprint = [9; 32];
+    let application_intent_digest = [12; 32];
+    let application_result_digest = canonical_application_result_digest(
+        target_a,
+        semantic_fingerprint,
+        application_intent_digest,
+        &application_result,
+    );
+    let receipt = AdmissionCommitReceipt::from_storage(
+        domain,
+        target_a.admission_object(),
+        Uuid::from_u128(10),
+        [8; 32],
+        semantic_fingerprint,
+        AdmissionCommitDigests::new([10; 32], Some(application_result_digest))
+            .expect("receipt digests"),
+        Uuid::from_u128(11),
+    )
+    .expect("storage receipt");
+
+    assert!(target_a
+        .validate_receipt(
+            artifact_digest,
+            application_intent_digest,
+            receipt,
+            &application_result,
+        )
+        .is_ok());
+    assert_eq!(
+        target_b.validate_receipt(
+            artifact_digest,
+            application_intent_digest,
+            receipt,
+            &application_result,
+        ),
+        Err(AdmissionCommitError::IntentConflict)
+    );
+}
+
+fn canonical_application_result_digest(
+    target: ProtectedPublicationTarget,
+    semantic_fingerprint: [u8; 32],
+    application_intent_digest: [u8; 32],
+    result: &AdmissionApplicationResult,
+) -> [u8; 32] {
+    let schema = result.schema();
+    let domain = b"buzz:canonical-application-result:v1";
+    let authorization_domain = target.authorization_domain();
+    let object = target.admission_object();
+    let object_kind = object.kind().database_code().to_be_bytes();
+    let schema_version = schema.version().to_be_bytes();
+    let result_code = result.code().to_be_bytes();
+    let fields: [&[u8]; 9] = [
+        authorization_domain.as_uuid().as_bytes(),
+        &object_kind,
+        object.key(),
+        &semantic_fingerprint,
+        &application_intent_digest,
+        schema.type_key(),
+        &schema_version,
+        &result_code,
+        result.payload(),
+    ];
+    let mut digest = Sha256::new();
+    digest.update((domain.len() as u64).to_be_bytes());
+    digest.update(domain);
+    for field in fields {
+        digest.update((field.len() as u64).to_be_bytes());
+        digest.update(field);
+    }
+    digest.finalize().into()
+}
+
+#[tokio::test]
+async fn same_domain_evidence_from_another_request_has_a_distinct_exact_binding() {
+    let domain = CommunityId::from_uuid(Uuid::from_u128(2));
+    let verifier = TrustedProxyProvenanceVerifier::new(
+        vec![PROXY_SECRET.to_vec()],
+        Duration::from_secs(60),
+        Duration::from_secs(5),
+    )
+    .expect("proxy verifier");
+    let request_a = TrustedProxyRequest::from_server_request(
+        domain,
+        ProofTransport::Nip98,
+        "POST",
+        "relay.example.com:443",
+        "/upload?slot=a",
+        b"body-a",
+    )
+    .expect("request A");
+    let request_b = TrustedProxyRequest::from_server_request(
+        domain,
+        ProofTransport::Blossom,
+        "POST",
+        "relay.example.com:443",
+        "/upload?slot=b",
+        b"body-b",
+    )
+    .expect("request B");
+    let evidence_a = verify_proxy_request(
+        &verifier,
+        &request_a,
+        ProofTransport::Nip98,
+        "/upload?slot=a",
+        b"body-a",
+        &[1_u8; 16],
+    )
+    .await;
+    let evidence_b = verify_proxy_request(
+        &verifier,
+        &request_b,
+        ProofTransport::Blossom,
+        "/upload?slot=b",
+        b"body-b",
+        &[2_u8; 16],
+    )
+    .await;
+
+    assert_eq!(evidence_a.authorization_domain(), domain);
+    assert_eq!(evidence_b.authorization_domain(), domain);
+    assert_ne!(
+        evidence_a.request_fingerprint(),
+        evidence_b.request_fingerprint(),
+        "same-domain evidence must retain exact request binding"
+    );
+    assert_ne!(
+        evidence_a.transport_context_fingerprint(),
+        evidence_b.transport_context_fingerprint(),
+        "same-domain evidence must retain exact transport context"
+    );
+    assert_ne!(evidence_a.transport(), evidence_b.transport());
+}
+
+#[test]
+fn moderation_command_produces_only_the_reviewed_canonical_effect() {
+    fn assert_canonical_effect<T: buzz_db::authorization_admission::AdmissionApplicationEffect>(
+        _effect: &T,
+    ) {
+    }
+
+    let community = CommunityId::from_uuid(Uuid::new_v4());
+    let tenant = TenantContext::resolved(community, "effect.example");
+    let actor = Keys::generate();
+    let target = Keys::generate().public_key().to_bytes();
+    let event = EventBuilder::new(Kind::from(9040_u16), "")
+        .tag(Tag::parse(["p", &hex::encode(target)]).expect("p tag"))
+        .sign_with_keys(&actor)
+        .expect("signed moderation event");
+    let effect = prepare_moderation_application_effect(&tenant, &event).expect("effect");
+    assert_canonical_effect(&effect);
+    assert_eq!(
+        effect.admission_object().kind(),
+        buzz_db::authorization_admission::AdmissionObjectKind::ModerationTarget
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL via BUZZ_TEST_DATABASE_URL"]
+async fn repeated_same_target_publications_deliver_in_sequence_and_replay_is_idempotent() {
+    let pool = postgres_pool().await;
+    buzz_db::migration::run_migrations(&pool)
+        .await
+        .expect("run migrations");
+    let community = insert_community(&pool, "outbox").await;
+    let object_key = nonzero_32(10);
+    let projection_key = format!("repos/{}/pointer", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+         VALUES ($1, 16, 1048576, 16384)",
+    )
+    .bind(community.as_uuid())
+    .execute(&pool)
+    .await
+    .expect("install outbox audit capacity");
+
+    let seed = insert_publication(&pool, community, object_key, &projection_key, 1, false)
+        .await
+        .expect("seed same-epoch authority");
+    sqlx::query(
+        "INSERT INTO authorization_authority_epochs \
+         (community_id, object_kind, object_key, authority_epoch, fence, \
+          operation_id, request_fingerprint) \
+         VALUES ($1, 3, $2, 7, $3, $4, $5)",
+    )
+    .bind(community.as_uuid())
+    .bind(object_key.to_vec())
+    .bind(nonzero_32(11).to_vec())
+    .bind(seed.operation)
+    .bind(seed.request.to_vec())
+    .execute(&pool)
+    .await
+    .expect("install unchanged authority epoch");
+
+    let first = insert_publication(&pool, community, object_key, &projection_key, 2, true);
+    let second = insert_publication(&pool, community, object_key, &projection_key, 3, true);
+    let (first, second) = tokio::join!(first, second);
+    let first = first.expect("first concurrent publication");
+    let second = second.expect("second concurrent publication");
+    let duplicate = sqlx::query(
+        "INSERT INTO protected_publication_projection_outbox \
+         (community_id, operation_id, request_fingerprint, publication_result_digest, \
+          object_kind, object_key, application_type, application_version, \
+          application_effect_digest, projection_kind, projection_key, staged_object_key, \
+          payload_digest) \
+         VALUES ($1, $2, $3, $4, 3, $5, $6, 1, $7, 3, $8, $9, $10)",
+    )
+    .bind(community.as_uuid())
+    .bind(first.operation)
+    .bind(first.request.to_vec())
+    .bind(first.result.to_vec())
+    .bind(object_key.to_vec())
+    .bind(first.application_type.to_vec())
+    .bind(first.application_effect.to_vec())
+    .bind(&projection_key)
+    .bind("manifests/exact-replay")
+    .bind(first.payload.to_vec())
+    .execute(&pool)
+    .await;
+    assert!(
+        duplicate.is_err(),
+        "exact replay cannot create a second effect"
+    );
+
+    let rows = sqlx::query(
+        "SELECT operation_id, delivery_state \
+         FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND object_key = $2 AND projection_key = $3 \
+         ORDER BY publication_sequence",
+    )
+    .bind(community.as_uuid())
+    .bind(object_key.to_vec())
+    .bind(&projection_key)
+    .fetch_all(&pool)
+    .await
+    .expect("read concurrent ordered outbox");
+    assert_eq!(rows.len(), 2);
+    let earlier = rows[0].get::<Uuid, _>("operation_id");
+    let later = rows[1].get::<Uuid, _>("operation_id");
+    assert_ne!(earlier, later);
+    assert!([first.operation, second.operation].contains(&earlier));
+    assert!([first.operation, second.operation].contains(&later));
+
+    let early = mark_delivered(&pool, community, later).await;
+    assert!(
+        early.is_err(),
+        "newer projection cannot pass pending predecessor"
+    );
+    mark_delivered(&pool, community, earlier)
+        .await
+        .expect("deliver first");
+    mark_delivered(&pool, community, later)
+        .await
+        .expect("deliver second");
+
+    let delivered = sqlx::query(
+        "SELECT operation_id, delivery_state \
+         FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND object_key = $2 AND projection_key = $3 \
+         ORDER BY publication_sequence",
+    )
+    .bind(community.as_uuid())
+    .bind(object_key.to_vec())
+    .bind(&projection_key)
+    .fetch_all(&pool)
+    .await
+    .expect("read ordered outbox");
+    assert_eq!(delivered.len(), 2);
+    assert!(delivered
+        .iter()
+        .all(|row| row.get::<i16, _>("delivery_state") == 2));
+}
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL via BUZZ_TEST_DATABASE_URL"]
+async fn uncommitted_lower_sequence_serializes_later_publication_and_delivery() {
+    let pool = postgres_pool().await;
+    buzz_db::migration::run_migrations(&pool)
+        .await
+        .expect("run migrations");
+    let community = insert_community(&pool, "outbox-interleaving").await;
+    let object_key = nonzero_32(15);
+    let projection_key = format!("repos/{}/pointer", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+         VALUES ($1, 16, 1048576, 16384)",
+    )
+    .bind(community.as_uuid())
+    .execute(&pool)
+    .await
+    .expect("install interleaving audit capacity");
+
+    let mut lower_transaction = pool.begin().await.expect("begin lower publication");
+    let lower = stage_publication(
+        &mut lower_transaction,
+        community,
+        object_key,
+        &projection_key,
+        4,
+        true,
+    )
+    .await
+    .expect("stage lower publication without committing");
+
+    let later_pool = pool.clone();
+    let later_projection_key = projection_key.clone();
+    let mut later_task = tokio::spawn(async move {
+        let later = insert_publication(
+            &later_pool,
+            community,
+            object_key,
+            &later_projection_key,
+            5,
+            true,
+        )
+        .await?;
+        let delivery = mark_delivered(&later_pool, community, later.operation).await;
+        Ok::<_, sqlx::Error>((later, delivery))
+    });
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), &mut later_task)
+            .await
+            .is_err(),
+        "later publication must wait for the lower allocator to commit or abort"
+    );
+    let visible_rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND object_key = $2 AND projection_key = $3",
+    )
+    .bind(community.as_uuid())
+    .bind(object_key.to_vec())
+    .bind(&projection_key)
+    .fetch_one(&pool)
+    .await
+    .expect("count externally visible interleaving rows");
+    assert_eq!(
+        visible_rows, 0,
+        "the lower row is uncommitted and the later row is still serialized"
+    );
+
+    lower_transaction
+        .commit()
+        .await
+        .expect("commit lower publication");
+    let (later, premature_delivery) = tokio::time::timeout(Duration::from_secs(5), later_task)
+        .await
+        .expect("later publication unblocks after lower commit")
+        .expect("later task joins")
+        .expect("later publication commits");
+    assert!(
+        premature_delivery.is_err(),
+        "later delivery must observe and reject the committed pending predecessor"
+    );
+
+    let ordered = sqlx::query(
+        "SELECT operation_id, publication_sequence \
+         FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND object_key = $2 AND projection_key = $3 \
+         ORDER BY publication_sequence",
+    )
+    .bind(community.as_uuid())
+    .bind(object_key.to_vec())
+    .bind(&projection_key)
+    .fetch_all(&pool)
+    .await
+    .expect("read interleaved publication order");
+    assert_eq!(ordered.len(), 2);
+    assert_eq!(ordered[0].get::<Uuid, _>("operation_id"), lower.operation);
+    assert_eq!(ordered[1].get::<Uuid, _>("operation_id"), later.operation);
+    assert!(
+        ordered[0].get::<i64, _>("publication_sequence")
+            < ordered[1].get::<i64, _>("publication_sequence")
+    );
+
+    mark_delivered(&pool, community, lower.operation)
+        .await
+        .expect("deliver committed predecessor");
+    mark_delivered(&pool, community, later.operation)
+        .await
+        .expect("deliver later publication after predecessor");
+}
+
+#[tokio::test]
+#[ignore = "requires live MinIO/S3 configured by BUZZ_S3_* variables"]
+async fn changed_retry_attribution_reuses_the_first_exact_media_result() {
+    let storage = MediaStorage::new(&media_config()).expect("media storage");
+    let community = CommunityId::from_uuid(Uuid::new_v4());
+    let first_tenant = TenantContext::resolved(community, "first.example");
+    let retry_tenant = TenantContext::resolved(community, "alias.example");
+    let uploader = Keys::generate().public_key();
+    let request_event_id = hex::encode(nonzero_32(20));
+    let sha256 = hex::encode(nonzero_32(21));
+    let facts = UploadEventFacts {
+        sha256: &sha256,
+        ext: "png",
+        mime: "image/png",
+        size: 42,
+        uploaded_at: 1_800_000_000,
+    };
+    let first = stage_upload_record(
+        &storage,
+        &first_tenant,
+        &uploader,
+        &request_event_id,
+        &UploadAttribution {
+            uploader_name: Some("first-name".into()),
+            net: UploadNetworkInfo {
+                ip: Some("8.8.8.8".parse().expect("test IP")),
+                port: Some(443),
+            },
+        },
+        facts,
+    )
+    .await
+    .expect("stage first result");
+    let retry = stage_upload_record(
+        &storage,
+        &retry_tenant,
+        &uploader,
+        &request_event_id,
+        &UploadAttribution {
+            uploader_name: Some("changed-name".into()),
+            net: UploadNetworkInfo {
+                ip: Some("1.1.1.1".parse().expect("test IP")),
+                port: Some(8443),
+            },
+        },
+        facts,
+    )
+    .await
+    .expect("stage retry result");
+
+    assert_eq!(retry.digest(), first.digest());
+    assert_eq!(retry.canonical_bytes(), first.canonical_bytes());
+    assert_eq!(retry.projection_key(), first.projection_key());
+    assert_eq!(retry.record().community_host, "first.example");
+    assert_eq!(retry.record().uploader_name.as_deref(), Some("first-name"));
+    assert_eq!(retry.record().ip.as_deref(), Some("8.8.8.8"));
+    assert_eq!(retry.record().port, Some(443));
+}
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL, live MinIO, and OpenSSL"]
+async fn canonical_media_commit_then_exact_replay_has_one_outbox_and_no_replay_plan() {
+    let pool = postgres_pool().await;
+    buzz_db::migration::run_migrations(&pool)
+        .await
+        .expect("run migrations");
+    let community = insert_community(&pool, "canonical-media-replay").await;
+    sqlx::query(
+        "INSERT INTO authorization_event_capacity \
+         (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+         VALUES ($1, 32, 2097152, 16384)",
+    )
+    .bind(community.as_uuid())
+    .execute(&pool)
+    .await
+    .expect("install canonical media audit capacity");
+    sqlx::query(
+        "INSERT INTO identity_enrollment_policies \
+         (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+         VALUES ($1, 1, 1, $2, transaction_timestamp() - interval '1 second')",
+    )
+    .bind(community.as_uuid())
+    .bind([85_u8; 32].as_slice())
+    .execute(&pool)
+    .await
+    .expect("install canonical media enrollment policy");
+    sqlx::query(
+        "INSERT INTO authorization_invalidation_domains (community_id, current_generation) \
+         VALUES ($1, 0)",
+    )
+    .bind(community.as_uuid())
+    .execute(&pool)
+    .await
+    .expect("activate canonical media invalidation domain");
+
+    let mut config = media_config();
+    config.max_image_bytes = 2 * 1024 * 1024;
+    config.max_file_bytes = 2 * 1024 * 1024;
+    let storage = MediaStorage::new(&config).expect("media storage");
+    let tenant = TenantContext::resolved(community, "canonical-media.example");
+    let keys = Keys::generate();
+    let body = Bytes::from_static(include_bytes!(
+        "../../buzz-media/tests/fixtures/ios/uikit-sanitized.png"
+    ));
+    let sha256 = hex::encode(Sha256::digest(&body));
+    let expires = (nostr::Timestamp::now().as_secs() + 300).to_string();
+    let auth_event = EventBuilder::new(Kind::from(24242), "Upload protected media")
+        .tags(vec![
+            Tag::parse(["t", "upload"]).expect("upload tag"),
+            Tag::parse(["x", &sha256]).expect("hash tag"),
+            Tag::parse(["expiration", &expires]).expect("expiration tag"),
+            Tag::parse(["server", tenant.host()]).expect("server tag"),
+        ])
+        .sign_with_keys(&keys)
+        .expect("sign Blossom upload");
+
+    let first_staged = stage_upload(
+        &storage,
+        &config,
+        &tenant,
+        &auth_event,
+        body.clone(),
+        Some(UploadAttribution {
+            uploader_name: Some("first-name".into()),
+            net: UploadNetworkInfo {
+                ip: Some("8.8.8.8".parse().expect("first IP")),
+                port: Some(443),
+            },
+        }),
+    )
+    .await
+    .expect("stage first canonical media upload");
+    assert_eq!(
+        first_staged
+            .moderation_projection()
+            .expect("first moderation projection")
+            .record()
+            .uploader_name
+            .as_deref(),
+        Some("first-name")
+    );
+    let first_plan = ProtectedPublicationPlan::from(first_staged);
+    let target = first_plan.target().expect("first publication target");
+    let first_effect = first_plan
+        .application_effect()
+        .expect("first application effect");
+
+    let request_fingerprint = [83; 32];
+    let transport_context = [84; 32];
+    let (assertion, proof) = verified_authorization_evidence(
+        community,
+        &keys,
+        *target.admission_object().key(),
+        request_fingerprint,
+        transport_context,
+    );
+    let authoritative_now = Utc::now();
+    let first_request = enrollment_request_with_effect(
+        &pool,
+        community,
+        (assertion.clone(), proof.clone()),
+        target.admission_object(),
+        RouteCapability::MediaWrite,
+        authoritative_now,
+        Box::new(first_effect),
+    )
+    .await;
+    let operation_id = first_request.operation_id();
+    let committer = PostgresCanonicalAdmissionCommitter::new(
+        pool.clone(),
+        Arc::new(ApplicationReplayRechecker),
+    );
+    let first_outcome = committer
+        .commit(first_request)
+        .await
+        .expect("commit canonical media publication");
+    let first_result = match &first_outcome {
+        AdmissionCommitOutcome::Committed {
+            application_result: Some(result),
+            ..
+        } => result.clone(),
+        _ => panic!("first canonical media operation must commit with a typed result"),
+    };
+    let first_binding = ProtectedPublicationReceipt::bind(first_plan, &first_outcome)
+        .expect("bind fresh canonical publication");
+    let ProtectedPublicationBinding::Committed(fresh_receipt) = first_binding else {
+        panic!("first canonical publication unexpectedly replayed");
+    };
+    let _fresh_projection_plan = fresh_receipt.into_plan();
+    let first_outbox_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND operation_id = $2",
+    )
+    .bind(community.as_uuid())
+    .bind(operation_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count first canonical outbox rows");
+    assert!(first_outbox_count > 0);
+
+    let retry_staged = stage_upload(
+        &storage,
+        &config,
+        &tenant,
+        &auth_event,
+        body,
+        Some(UploadAttribution {
+            uploader_name: Some("changed-name".into()),
+            net: UploadNetworkInfo {
+                ip: Some("1.1.1.1".parse().expect("retry IP")),
+                port: Some(8443),
+            },
+        }),
+    )
+    .await
+    .expect("stage exact retry with changed attribution");
+    let retry_record = retry_staged
+        .moderation_projection()
+        .expect("retry moderation projection")
+        .record();
+    assert_eq!(retry_record.uploader_name.as_deref(), Some("first-name"));
+    assert_eq!(retry_record.ip.as_deref(), Some("8.8.8.8"));
+    assert_eq!(retry_record.port, Some(443));
+    let retry_plan = ProtectedPublicationPlan::from(retry_staged);
+    let retry_effect = retry_plan
+        .application_effect()
+        .expect("retry application effect");
+    let retry_request = enrollment_request_with_effect(
+        &pool,
+        community,
+        (assertion, proof),
+        target.admission_object(),
+        RouteCapability::MediaWrite,
+        authoritative_now,
+        Box::new(retry_effect),
+    )
+    .await;
+    assert_eq!(retry_request.operation_id(), operation_id);
+    let replay_outcome = committer
+        .commit(retry_request)
+        .await
+        .expect("read exact canonical replay");
+    let replay_binding = ProtectedPublicationReceipt::bind(retry_plan, &replay_outcome)
+        .expect("bind exact replay without projection authority");
+    let ProtectedPublicationBinding::ExactReplay(replay) = replay_binding else {
+        panic!("retry repeated canonical application DML");
+    };
+    assert_eq!(replay.application_result(), &first_result);
+    assert_eq!(replay.admission().operation_id(), operation_id);
+    let replay_outbox_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM protected_publication_projection_outbox \
+         WHERE community_id = $1 AND operation_id = $2",
+    )
+    .bind(community.as_uuid())
+    .bind(operation_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count exact-replay outbox rows");
+    assert_eq!(replay_outbox_count, first_outbox_count);
+}
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL and OpenSSL"]
+async fn canonical_moderation_is_atomic_target_bound_and_fresh_only() {
+    let pool = postgres_pool().await;
+    buzz_db::migration::run_migrations(&pool)
+        .await
+        .expect("run migrations");
+    let committer = PostgresCanonicalAdmissionCommitter::new(
+        pool.clone(),
+        Arc::new(ApplicationReplayRechecker),
+    );
+    let keys = Keys::generate();
+    let actor = keys.public_key().to_bytes();
+
+    let committed_domain = insert_community(&pool, "canonical-moderation-commit").await;
+    install_enrollment_domain(&pool, committed_domain, true).await;
+    sqlx::query(
+        "INSERT INTO relay_members (community_id, pubkey, role, added_by) \
+         VALUES ($1, $2, 'owner', NULL)",
+    )
+    .bind(committed_domain.as_uuid())
+    .bind(hex::encode(actor))
+    .execute(&pool)
+    .await
+    .expect("install canonical moderation owner");
+
+    let committed_tenant =
+        TenantContext::resolved(committed_domain, "canonical-moderation.example");
+    let committed_target = Keys::generate().public_key().to_bytes();
+    let committed_target_hex = hex::encode(committed_target);
+    let committed_event = EventBuilder::new(Kind::from(9040_u16), "")
+        .tag(Tag::parse(["p", &committed_target_hex]).expect("moderation target tag"))
+        .sign_with_keys(&keys)
+        .expect("sign canonical moderation command");
+    let committed_effect =
+        prepare_moderation_application_effect(&committed_tenant, &committed_event)
+            .expect("prepare canonical moderation effect");
+    let committed_object = committed_effect.admission_object();
+    let committed_now = Utc::now();
+    let (committed_assertion, committed_proof) = verified_authorization_evidence(
+        committed_domain,
+        &keys,
+        *committed_object.key(),
+        [87; 32],
+        [88; 32],
+    );
+    let committed_request = enrollment_request_with_effect(
+        &pool,
+        committed_domain,
+        (committed_assertion.clone(), committed_proof.clone()),
+        committed_object,
+        RouteCapability::Moderation,
+        committed_now,
+        Box::new(committed_effect),
+    )
+    .await;
+    let committed_operation = committed_request.operation_id();
+    let committed_outcome = committer
+        .commit(committed_request)
+        .await
+        .expect("commit canonical moderation operation");
+    let (committed_receipt, committed_result) = match &committed_outcome {
+        AdmissionCommitOutcome::Committed {
+            receipt,
+            application_result: Some(result),
+            ..
+        } => (*receipt, result.clone()),
+        _ => panic!("canonical moderation operation did not freshly commit"),
+    };
+    assert_eq!(committed_receipt.authorization_domain(), committed_domain);
+    assert_eq!(committed_receipt.object(), committed_object);
+    assert_eq!(committed_receipt.operation_id(), committed_operation);
+    let persisted_result_digest = sqlx::query_scalar::<_, Vec<u8>>(
+        "SELECT application_result_digest FROM authorization_admission_results \
+         WHERE community_id = $1 AND operation_id = $2",
+    )
+    .bind(committed_domain.as_uuid())
+    .bind(committed_operation)
+    .fetch_one(&pool)
+    .await
+    .expect("read persisted moderation result digest");
+    let persisted_result_digest: [u8; 32] = persisted_result_digest
+        .try_into()
+        .expect("32-byte moderation result digest");
+    assert_eq!(
+        committed_receipt.application_result_digest(),
+        Some(&persisted_result_digest)
+    );
+    let decoded: serde_json::Value = serde_json::from_slice(committed_result.payload())
+        .expect("decode canonical moderation application result");
+    assert_eq!(
+        decoded["object_key"],
+        serde_json::to_value(committed_object.key()).expect("encode expected moderation object")
+    );
+    assert_eq!(
+        decoded["action"]["Ban"]["target"],
+        serde_json::to_value(committed_target).expect("encode expected moderation target")
+    );
+    let restriction =
+        buzz_db::moderation::restriction_state(&pool, committed_domain, &committed_target)
+            .await
+            .expect("read committed moderation restriction");
+    assert!(restriction.banned);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM moderation_actions \
+             WHERE community_id = $1 AND target_pubkey = $2",
+        )
+        .bind(committed_domain.as_uuid())
+        .bind(committed_target.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("count committed moderation actions"),
+        1
+    );
+
+    let replay_effect = prepare_moderation_application_effect(&committed_tenant, &committed_event)
+        .expect("prepare exact moderation replay effect");
+    let replay_request = enrollment_request_with_effect(
+        &pool,
+        committed_domain,
+        (committed_assertion, committed_proof),
+        committed_object,
+        RouteCapability::Moderation,
+        committed_now,
+        Box::new(replay_effect),
+    )
+    .await;
+    assert_eq!(replay_request.operation_id(), committed_operation);
+    let replay_outcome = committer
+        .commit(replay_request)
+        .await
+        .expect("load exact canonical moderation replay");
+    match replay_outcome {
+        AdmissionCommitOutcome::ExactReplay {
+            receipt,
+            application_result: Some(result),
+        } => {
+            assert_eq!(receipt, committed_receipt);
+            assert_eq!(result, committed_result);
+        }
+        _ => panic!("exact moderation replay was allowed to yield fresh post-commit work"),
+    }
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM moderation_actions \
+             WHERE community_id = $1 AND target_pubkey = $2",
+        )
+        .bind(committed_domain.as_uuid())
+        .bind(committed_target.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("count replay-suppressed moderation actions"),
+        1
+    );
+
+    let rollback_domain = insert_community(&pool, "canonical-moderation-rollback").await;
+    install_enrollment_domain(&pool, rollback_domain, false).await;
+    sqlx::query(
+        "INSERT INTO relay_members (community_id, pubkey, role, added_by) \
+         VALUES ($1, $2, 'owner', NULL)",
+    )
+    .bind(rollback_domain.as_uuid())
+    .bind(hex::encode(actor))
+    .execute(&pool)
+    .await
+    .expect("install rollback moderation owner");
+    let rollback_tenant = TenantContext::resolved(rollback_domain, "rollback-moderation.example");
+    let rollback_target = Keys::generate().public_key().to_bytes();
+    let rollback_target_hex = hex::encode(rollback_target);
+    let rollback_event = EventBuilder::new(Kind::from(9040_u16), "")
+        .tag(Tag::parse(["p", &rollback_target_hex]).expect("rollback target tag"))
+        .sign_with_keys(&keys)
+        .expect("sign rollback moderation command");
+    let rollback_effect = prepare_moderation_application_effect(&rollback_tenant, &rollback_event)
+        .expect("prepare rollback moderation effect");
+    let rollback_object = rollback_effect.admission_object();
+    let rollback_now = Utc::now();
+    let (rollback_assertion, rollback_proof) = verified_authorization_evidence(
+        rollback_domain,
+        &keys,
+        *rollback_object.key(),
+        [89; 32],
+        [90; 32],
+    );
+    let rollback_request = enrollment_request_with_effect(
+        &pool,
+        rollback_domain,
+        (rollback_assertion, rollback_proof),
+        rollback_object,
+        RouteCapability::Moderation,
+        rollback_now,
+        Box::new(rollback_effect),
+    )
+    .await;
+    let rollback_operation = rollback_request.operation_id();
+    assert!(matches!(
+        committer.commit(rollback_request).await,
+        Err(AdmissionCommitError::AuditUnavailable)
+    ));
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM community_bans \
+             WHERE community_id = $1 AND pubkey = $2",
+        )
+        .bind(rollback_domain.as_uuid())
+        .bind(rollback_target.as_slice())
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back restrictions"),
+        0
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM moderation_actions WHERE community_id = $1",
+        )
+        .bind(rollback_domain.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back moderation actions"),
+        0
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM authorization_operation_receipts \
+             WHERE community_id = $1 AND operation_id = $2",
+        )
+        .bind(rollback_domain.as_uuid())
+        .bind(rollback_operation)
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back admission receipts"),
+        0
+    );
+}
+
+async fn verify_proxy_request(
+    verifier: &TrustedProxyProvenanceVerifier,
+    request: &TrustedProxyRequest,
+    transport: ProofTransport,
+    path_and_query: &str,
+    body: &[u8],
+    nonce: &[u8],
+) -> buzz_auth::SealedTransportEvidence {
+    let assertion = format!("Bearer {}", proxy_assertion());
+    let provenance = sign_proxy_provenance(transport, path_and_query, body, nonce);
+    verifier
+        .verify(
+            &[
+                HttpHeaderField::new(ASSERTION_HEADER_NAME, assertion.as_bytes()),
+                HttpHeaderField::new(PROVENANCE_HEADER_NAME, provenance.as_bytes()),
+            ],
+            request,
+            Utc.timestamp_opt(PROXY_NOW as i64, 0)
+                .single()
+                .expect("test time"),
+            &EmptyReplayReader,
+        )
+        .await
+        .expect("valid proxy evidence")
+}
+
+fn sign_proxy_provenance(
+    transport: ProofTransport,
+    path_and_query: &str,
+    body: &[u8],
+    nonce: &[u8],
+) -> String {
+    let assertion_digest: [u8; 32] = Sha256::digest(proxy_assertion().as_bytes()).into();
+    let body_digest: [u8; 32] = Sha256::digest(body).into();
+    let transport_code = match transport {
+        ProofTransport::Nip42 => 1,
+        ProofTransport::Nip98 => 2,
+        ProofTransport::GitSmartHttpSession => 3,
+        ProofTransport::Blossom => 4,
+    };
+    let mut input = b"NIP-FI-PROXY-1".to_vec();
+    for field in [
+        PROXY_NOW.to_be_bytes().as_slice(),
+        nonce,
+        &assertion_digest,
+        b"POST".as_slice(),
+        b"relay.example.com:443".as_slice(),
+        path_and_query.as_bytes(),
+        &body_digest,
+        &[transport_code],
+    ] {
+        input.extend_from_slice(&(field.len() as u64).to_be_bytes());
+        input.extend_from_slice(field);
+    }
+    let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(&PROXY_SECRET).expect("HMAC key");
+    mac.update(&input);
+    format!(
+        "v1.{PROXY_NOW}.{}.{}",
+        base64url(nonce),
+        base64url(&mac.finalize().into_bytes())
+    )
+}
+
+fn base64url(value: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(value)
+}
+
+async fn postgres_pool() -> PgPool {
+    let url = std::env::var("BUZZ_TEST_DATABASE_URL")
+        .expect("BUZZ_TEST_DATABASE_URL must name a disposable PostgreSQL database");
+    PgPool::connect(&url).await.expect("connect PostgreSQL")
+}
+
+async fn insert_community(pool: &PgPool, label: &str) -> CommunityId {
+    let id = Uuid::new_v4();
+    sqlx::query("INSERT INTO communities (id, host) VALUES ($1, $2)")
+        .bind(id)
+        .bind(format!("s4-{label}-{}.example", id.simple()))
+        .execute(pool)
+        .await
+        .expect("insert community");
+    CommunityId::from_uuid(id)
+}
+
+async fn install_enrollment_domain(
+    pool: &PgPool,
+    community: CommunityId,
+    install_audit_capacity: bool,
+) {
+    sqlx::query(
+        "INSERT INTO identity_enrollment_policies \
+         (community_id, policy_revision, enrollment_mode, policy_digest, effective_at) \
+         VALUES ($1, 1, 1, $2, transaction_timestamp() - interval '1 second')",
+    )
+    .bind(community.as_uuid())
+    .bind([85_u8; 32].as_slice())
+    .execute(pool)
+    .await
+    .expect("install enrollment policy");
+    sqlx::query(
+        "INSERT INTO authorization_invalidation_domains (community_id, current_generation) \
+         VALUES ($1, 0)",
+    )
+    .bind(community.as_uuid())
+    .execute(pool)
+    .await
+    .expect("activate invalidation domain");
+    if install_audit_capacity {
+        sqlx::query(
+            "INSERT INTO authorization_event_capacity \
+             (community_id, max_events_per_domain, max_bytes_per_domain, max_envelope_bytes) \
+             VALUES ($1, 32, 2097152, 16384)",
+        )
+        .bind(community.as_uuid())
+        .execute(pool)
+        .await
+        .expect("install authorization audit capacity");
+    }
+}
+
+struct PublicationFixture {
+    operation: Uuid,
+    request: [u8; 32],
+    application_type: [u8; 32],
+    application_effect: [u8; 32],
+    result: [u8; 32],
+    payload: [u8; 32],
+}
+
+async fn insert_publication(
+    pool: &PgPool,
+    community: CommunityId,
+    object_key: [u8; 32],
+    projection_key: &str,
+    sequence: u8,
+    insert_outbox: bool,
+) -> Result<PublicationFixture, sqlx::Error> {
+    let mut transaction = pool.begin().await?;
+    let fixture = stage_publication(
+        &mut transaction,
+        community,
+        object_key,
+        projection_key,
+        sequence,
+        insert_outbox,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(fixture)
+}
+
+async fn stage_publication(
+    connection: &mut PgConnection,
+    community: CommunityId,
+    object_key: [u8; 32],
+    projection_key: &str,
+    sequence: u8,
+    insert_outbox: bool,
+) -> Result<PublicationFixture, sqlx::Error> {
+    let fixture = PublicationFixture {
+        operation: Uuid::new_v4(),
+        request: nonzero_32(sequence.saturating_add(30)),
+        application_type: nonzero_32(sequence.saturating_add(35)),
+        application_effect: nonzero_32(sequence.saturating_add(37)),
+        result: nonzero_32(sequence.saturating_add(40)),
+        payload: nonzero_32(sequence.saturating_add(50)),
+    };
+    let actor = nonzero_32(60);
+    sqlx::query(
+        "INSERT INTO authorization_operation_receipts \
+         (community_id, operation_id, request_fingerprint, operation_kind, \
+          actor_fingerprint, outcome_code, result_digest) \
+         VALUES ($1, $2, $3, 11, $4, 1, $5)",
+    )
+    .bind(community.as_uuid())
+    .bind(fixture.operation)
+    .bind(fixture.request.to_vec())
+    .bind(actor.to_vec())
+    .bind(fixture.result.to_vec())
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query(
+        "INSERT INTO authorization_events \
+         (community_id, event_id, event_kind, outcome_code, reason_code, actor_kind, \
+          actor_fingerprint, operation_id, request_fingerprint, correlation_id, attempt_id, \
+          occurred_at, canonical_envelope, envelope_digest) \
+         VALUES ($1, $2, 10, 1, 1, 1, $3, $4, $5, $6, $7, \
+                 transaction_timestamp(), $8, $9)",
+    )
+    .bind(community.as_uuid())
+    .bind(Uuid::new_v4())
+    .bind(actor.to_vec())
+    .bind(fixture.operation)
+    .bind(fixture.request.to_vec())
+    .bind(Uuid::new_v4())
+    .bind(Uuid::new_v4())
+    .bind(vec![sequence])
+    .bind(nonzero_32(sequence.saturating_add(70)).to_vec())
+    .execute(&mut *connection)
+    .await?;
+    sqlx::query(
+        "INSERT INTO authorization_admission_results \
+         (community_id, operation_id, request_fingerprint, semantic_fingerprint, \
+          object_kind, object_key, application_type, application_version, \
+          application_code, application_payload, application_intent_digest, \
+          application_effect_digest, application_result_digest) \
+         VALUES ($1, $2, $3, $4, 3, $5, $6, 1, 1, $7, $8, $9, $10)",
+    )
+    .bind(community.as_uuid())
+    .bind(fixture.operation)
+    .bind(fixture.request.to_vec())
+    .bind(nonzero_32(sequence.saturating_add(80)).to_vec())
+    .bind(object_key.to_vec())
+    .bind(fixture.application_type.to_vec())
+    .bind(vec![sequence])
+    .bind(nonzero_32(sequence.saturating_add(90)).to_vec())
+    .bind(fixture.application_effect.to_vec())
+    .bind(fixture.result.to_vec())
+    .execute(&mut *connection)
+    .await?;
+    if insert_outbox {
+        sqlx::query(
+            "INSERT INTO protected_publication_projection_outbox \
+             (community_id, operation_id, request_fingerprint, publication_result_digest, \
+              object_kind, object_key, application_type, application_version, \
+              application_effect_digest, projection_kind, projection_key, staged_object_key, \
+              payload_digest) \
+             VALUES ($1, $2, $3, $4, 3, $5, $6, 1, $7, 3, $8, $9, $10)",
+        )
+        .bind(community.as_uuid())
+        .bind(fixture.operation)
+        .bind(fixture.request.to_vec())
+        .bind(fixture.result.to_vec())
+        .bind(object_key.to_vec())
+        .bind(fixture.application_type.to_vec())
+        .bind(fixture.application_effect.to_vec())
+        .bind(projection_key)
+        .bind(format!("manifests/{}/{}", fixture.operation, sequence))
+        .bind(fixture.payload.to_vec())
+        .execute(&mut *connection)
+        .await?;
+    }
+    Ok(fixture)
+}
+
+async fn mark_delivered(
+    pool: &PgPool,
+    community: CommunityId,
+    operation: Uuid,
+) -> Result<sqlx::postgres::PgQueryResult, sqlx::Error> {
+    sqlx::query(
+        "UPDATE protected_publication_projection_outbox \
+         SET delivery_state = 2, attempt_count = 1, failure_code = 0 \
+         WHERE community_id = $1 AND operation_id = $2 AND projection_kind = 3",
+    )
+    .bind(community.as_uuid())
+    .bind(operation)
+    .execute(pool)
+    .await
+}
+
+fn media_config() -> MediaConfig {
+    MediaConfig {
+        s3_endpoint: std::env::var("BUZZ_S3_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:9000".into()),
+        s3_access_key: std::env::var("BUZZ_S3_ACCESS_KEY").unwrap_or_else(|_| "buzz_dev".into()),
+        s3_secret_key: std::env::var("BUZZ_S3_SECRET_KEY")
+            .unwrap_or_else(|_| "buzz_dev_secret".into()),
+        s3_bucket: std::env::var("BUZZ_S3_BUCKET").unwrap_or_else(|_| "buzz-media".into()),
+        s3_region: std::env::var("BUZZ_S3_REGION").unwrap_or_else(|_| "us-east-1".into()),
+        s3_addressing_style: S3AddressingStyle::Path,
+        max_image_bytes: 1,
+        max_gif_bytes: 1,
+        max_video_bytes: 1,
+        max_file_bytes: 1,
+        public_base_url: "http://localhost:3000/media".into(),
+        upload_records_enabled: true,
+        upload_ip_header: None,
+        upload_port_header: None,
+    }
+}
+
+fn nonzero_32(seed: u8) -> [u8; 32] {
+    [seed.max(1); 32]
+}

--- a/migrations/0031_nip_fi_identity_lifecycle_upgrade.sql
+++ b/migrations/0031_nip_fi_identity_lifecycle_upgrade.sql
@@ -1,0 +1,172 @@
+-- NIP-FI identity lifecycle transaction closure.
+--
+-- Migration 0029 already owns the direct-final binding, lifecycle, selector,
+-- consumption, and receipt constraints. Migration 0030 owns immutable bounded
+-- authorization events. This migration closes their one missing cross-table
+-- invariant without recreating or weakening either foundation.
+
+-- Serialize an exact operation before checking the sole receipt row. Identity
+-- principal/key coordinate locks remain separate and retain v29's canonical
+-- numeric ordering.
+CREATE FUNCTION nip_fi_lock_authorization_operation_v1(
+    locked_community_id UUID,
+    locked_operation_id UUID
+) RETURNS VOID AS $$
+BEGIN
+    IF locked_community_id = '00000000-0000-0000-0000-000000000000'::uuid
+        OR locked_operation_id = '00000000-0000-0000-0000-000000000000'::uuid
+    THEN
+        RAISE EXCEPTION 'invalid NIP-FI operation lock coordinate'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        'buzz:authorization-operation:v1:' || locked_community_id::text
+            || ':' || locked_operation_id::text,
+        0
+    ));
+END;
+$$ LANGUAGE plpgsql VOLATILE STRICT PARALLEL UNSAFE;
+
+-- Canonical admission keeps its complete logical intent and the closed,
+-- credential-free application result beside the immutable receipt. This is
+-- what lets an identical request replay reconstruct the same typed result
+-- without repeating membership or other application DML.
+CREATE TABLE authorization_admission_results (
+    community_id UUID NOT NULL,
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (octet_length(request_fingerprint) = 32),
+    semantic_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(semantic_fingerprint) = 32
+        AND semantic_fingerprint <> decode(repeat('00', 32), 'hex')
+    ),
+    object_kind SMALLINT NOT NULL CHECK (object_kind BETWEEN 1 AND 6),
+    object_key BYTEA NOT NULL CHECK (
+        octet_length(object_key) = 32
+        AND object_key <> decode(repeat('00', 32), 'hex')
+    ),
+    application_type BYTEA CHECK (
+        application_type IS NULL
+        OR (octet_length(application_type) = 32
+            AND application_type <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_version SMALLINT CHECK (application_version > 0),
+    application_code SMALLINT CHECK (application_code > 0),
+    application_payload BYTEA CHECK (
+        application_payload IS NULL OR octet_length(application_payload) <= 4096
+    ),
+    application_intent_digest BYTEA CHECK (
+        application_intent_digest IS NULL
+        OR (octet_length(application_intent_digest) = 32
+            AND application_intent_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_effect_digest BYTEA CHECK (
+        application_effect_digest IS NULL
+        OR (octet_length(application_effect_digest) = 32
+            AND application_effect_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    application_result_digest BYTEA CHECK (
+        application_result_digest IS NULL
+        OR (octet_length(application_result_digest) = 32
+            AND application_result_digest <> decode(repeat('00', 32), 'hex'))
+    ),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    PRIMARY KEY (community_id, operation_id),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint),
+    CHECK (
+        (application_type IS NULL
+            AND application_version IS NULL
+            AND application_code IS NULL
+            AND application_payload IS NULL
+            AND application_intent_digest IS NULL
+            AND application_effect_digest IS NULL
+            AND application_result_digest IS NULL)
+        OR (application_type IS NOT NULL
+            AND application_version IS NOT NULL
+            AND application_code IS NOT NULL
+            AND application_payload IS NOT NULL
+            AND application_intent_digest IS NOT NULL
+            AND application_effect_digest IS NOT NULL
+            AND application_result_digest IS NOT NULL)
+    )
+);
+
+CREATE TRIGGER authorization_admission_results_no_update
+    BEFORE UPDATE OR DELETE ON authorization_admission_results
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_admission_results_no_truncate
+    BEFORE TRUNCATE ON authorization_admission_results
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Every successful/no-op lifecycle receipt has exactly one privacy-safe audit
+-- event with the closed transition-kind mapping. Both directions are deferred
+-- so receipt, history, event, selectors, binding, and consumption may be
+-- inserted in any order inside one transaction but can never commit partially.
+CREATE FUNCTION authorization_operation_receipt_event_guard_v1()
+RETURNS TRIGGER AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    expected_event_kind SMALLINT;
+    matching_event_count BIGINT;
+    expected_event_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- Credential-free pre-authentication denials intentionally have no
+            -- canonical receipt. Their separate v30 FK/shape guards still run.
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    IF receipt.operation_kind NOT BETWEEN 1 AND 9 THEN
+        RETURN NULL;
+    END IF;
+
+    expected_event_kind := CASE receipt.operation_kind
+        WHEN 1 THEN 1  -- enroll
+        WHEN 2 THEN 1  -- provision
+        WHEN 3 THEN 6  -- retire
+        WHEN 4 THEN 7  -- disable
+        WHEN 5 THEN 2  -- revoke
+        WHEN 6 THEN 3  -- rotate
+        WHEN 7 THEN 4  -- recover
+        WHEN 8 THEN 5  -- enable
+        WHEN 9 THEN 8  -- admission loss
+    END;
+
+    SELECT
+        count(*),
+        count(*) FILTER (WHERE event_kind = expected_event_kind)
+    INTO matching_event_count, expected_event_count
+    FROM authorization_events
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id
+      AND request_fingerprint = receipt.request_fingerprint;
+
+    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+        RAISE EXCEPTION
+            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+            expected_event_kind, matching_event_count, expected_event_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_event_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+
+CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();

--- a/migrations/0032_nip_fi_protected_authority.sql
+++ b/migrations/0032_nip_fi_protected_authority.sql
@@ -1,0 +1,303 @@
+-- NIP-FI trusted-proxy replay claims and protected publication projections.
+--
+-- Migration 0030 already owns protected-object authority and invalidation
+-- generations. This migration does not duplicate that authority, lifecycle,
+-- admission, audit, or audio-lease state. Audio leases remain memory-only and
+-- die on restart.
+
+-- Credential-free replay claims consumed only by canonical final admission.
+-- claim_kind: 1 trusted-proxy nonce. The key is a domain-separated SHA-256
+-- digest of the decoded nonce; the server-owned authorization domain is the
+-- first component of the frozen uniqueness key. Raw nonce, assertion,
+-- provider, identity, and credential material are forbidden here.
+CREATE TABLE authorization_proxy_nonce_claims (
+    authorization_domain UUID NOT NULL REFERENCES communities(id),
+    claim_kind SMALLINT NOT NULL CHECK (claim_kind = 1),
+    claim_key BYTEA NOT NULL CHECK (
+        octet_length(claim_key) = 32
+        AND claim_key <> decode(repeat('00', 32), 'hex')
+    ),
+    committed_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    retain_until TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (authorization_domain, claim_kind, claim_key),
+    CHECK (committed_at < retain_until)
+);
+
+-- Replay claims are deployment admission control rather than tenant-visible
+-- application data. The authorization domain remains the first component of
+-- every key and prevents cross-domain substitution.
+INSERT INTO _operator_global_tables (table_name, reason) VALUES (
+    'authorization_proxy_nonce_claims',
+    'server replay ledger; authorization_domain is the isolation key'
+);
+
+CREATE FUNCTION authorization_proxy_nonce_claim_stamp_v1() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.committed_at := transaction_timestamp();
+    IF NEW.retain_until <= NEW.committed_at THEN
+        RAISE EXCEPTION 'trusted-proxy nonce claim is already expired'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_proxy_nonce_claim_expired';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_proxy_nonce_claims_stamp
+    BEFORE INSERT ON authorization_proxy_nonce_claims
+    FOR EACH ROW EXECUTE FUNCTION authorization_proxy_nonce_claim_stamp_v1();
+
+-- Claims may be reclaimed only after their exclusive retention bound. UPDATE
+-- cannot change a committed claim and TRUNCATE cannot bypass row retention.
+CREATE FUNCTION authorization_proxy_nonce_claim_retention_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF transaction_timestamp() <= OLD.retain_until THEN
+        RAISE EXCEPTION 'trusted-proxy nonce claim retention is still active'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_proxy_nonce_claim_retention';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_proxy_nonce_claims_immutable
+    BEFORE UPDATE ON authorization_proxy_nonce_claims
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_proxy_nonce_claims_retained
+    BEFORE DELETE ON authorization_proxy_nonce_claims
+    FOR EACH ROW EXECUTE FUNCTION authorization_proxy_nonce_claim_retention_v1();
+CREATE TRIGGER authorization_proxy_nonce_claims_no_truncate
+    BEFORE TRUNCATE ON authorization_proxy_nonce_claims
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+-- Durable post-commit projection work. Immutable staged objects are safe when
+-- abandoned; a canonical applied publication atomically inserts these rows so
+-- a worker can deterministically resume cache/moderation projection after a
+-- process or dependency failure. Projection kinds: 1 media moderation record,
+-- 2 media sidecar cache, 3 Git pointer cache.
+--
+-- delivery_state: 1 pending, 2 delivered, 3 terminal.
+-- failure_code: 0 none; 1 transient object-store failure; 2 dependency
+-- unavailable; 3 existing bytes conflict; 4 staged object missing/corrupt;
+-- 5 publication/receipt digest mismatch; 6 tenant/target mismatch.
+CREATE SEQUENCE protected_publication_projection_sequence_v1 AS BIGINT
+    START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1 NO CYCLE;
+
+CREATE TABLE protected_publication_projection_outbox (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    operation_id UUID NOT NULL,
+    request_fingerprint BYTEA NOT NULL CHECK (
+        octet_length(request_fingerprint) = 32
+        AND request_fingerprint <> decode(repeat('00', 32), 'hex')
+    ),
+    publication_result_digest BYTEA NOT NULL CHECK (
+        octet_length(publication_result_digest) = 32
+        AND publication_result_digest <> decode(repeat('00', 32), 'hex')
+    ),
+    object_kind SMALLINT NOT NULL CHECK (object_kind IN (3, 4)),
+    object_key BYTEA NOT NULL CHECK (
+        octet_length(object_key) = 32
+        AND object_key <> decode(repeat('00', 32), 'hex')
+    ),
+    application_type BYTEA NOT NULL CHECK (
+        octet_length(application_type) = 32
+        AND application_type <> decode(repeat('00', 32), 'hex')
+    ),
+    application_version SMALLINT NOT NULL CHECK (application_version > 0),
+    application_effect_digest BYTEA NOT NULL CHECK (
+        octet_length(application_effect_digest) = 32
+        AND application_effect_digest <> decode(repeat('00', 32), 'hex')
+    ),
+    projection_kind SMALLINT NOT NULL CHECK (projection_kind IN (1, 2, 3)),
+    projection_key TEXT COLLATE "C" NOT NULL CHECK (
+        octet_length(projection_key) BETWEEN 1 AND 2048
+    ),
+    staged_object_key TEXT COLLATE "C" NOT NULL CHECK (
+        octet_length(staged_object_key) BETWEEN 1 AND 2048
+    ),
+    payload_digest BYTEA NOT NULL CHECK (
+        octet_length(payload_digest) = 32
+        AND payload_digest <> decode(repeat('00', 32), 'hex')
+    ),
+    delivery_state SMALLINT NOT NULL DEFAULT 1 CHECK (delivery_state IN (1, 2, 3)),
+    attempt_count BIGINT NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    last_attempt_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    failure_code SMALLINT NOT NULL DEFAULT 0 CHECK (failure_code BETWEEN 0 AND 6),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
+    publication_sequence BIGINT NOT NULL,
+    PRIMARY KEY (community_id, operation_id, projection_kind),
+    UNIQUE (community_id, publication_sequence),
+    FOREIGN KEY (community_id, operation_id, request_fingerprint)
+        REFERENCES authorization_operation_receipts
+            (community_id, operation_id, request_fingerprint)
+        DEFERRABLE INITIALLY DEFERRED,
+    CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CHECK ((attempt_count = 0) = (last_attempt_at IS NULL)),
+    CHECK (last_attempt_at IS NULL OR last_attempt_at >= created_at),
+    CHECK (delivered_at IS NULL OR delivered_at >= created_at),
+    CHECK (
+        (delivery_state = 1 AND delivered_at IS NULL AND failure_code IN (0, 1, 2))
+        OR (delivery_state = 2 AND delivered_at IS NOT NULL AND failure_code = 0)
+        OR (delivery_state = 3 AND delivered_at IS NULL AND failure_code BETWEEN 3 AND 6)
+    )
+);
+
+ALTER SEQUENCE protected_publication_projection_sequence_v1
+    OWNED BY protected_publication_projection_outbox.publication_sequence;
+
+CREATE INDEX protected_publication_projection_outbox_pending
+    ON protected_publication_projection_outbox
+        (delivery_state, next_attempt_at, community_id, operation_id)
+    WHERE delivery_state = 1;
+
+CREATE INDEX protected_publication_projection_outbox_target_order
+    ON protected_publication_projection_outbox
+        (community_id, object_kind, object_key, projection_kind,
+         projection_key, publication_sequence);
+
+-- Every projection starts immediately pending. Delivery timestamps and retry
+-- counters are database-owned so a caller cannot manufacture a completed
+-- projection or suppress the first durable attempt.
+CREATE FUNCTION protected_publication_projection_insert_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.delivery_state <> 1
+        OR NEW.attempt_count <> 0
+        OR NEW.last_attempt_at IS NOT NULL
+        OR NEW.delivered_at IS NOT NULL
+        OR NEW.failure_code <> 0
+    THEN
+        RAISE EXCEPTION 'protected publication projection must start pending'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'protected_publication_projection_initial_state';
+    END IF;
+    -- Serialize only publications for the exact protected projection target.
+    -- Sequence allocation happens after acquiring this transaction lock, so a
+    -- later publication cannot become visible or deliver before an earlier
+    -- allocator commits or aborts. Hash collisions only over-serialize two
+    -- independent targets; they cannot weaken ordering.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            jsonb_build_array(
+                'buzz:nip-fi:protected-publication-projection:v1',
+                NEW.community_id::TEXT,
+                NEW.object_kind,
+                encode(NEW.object_key, 'hex'),
+                NEW.projection_kind,
+                NEW.projection_key
+            )::TEXT,
+            0
+        )
+    );
+    NEW.publication_sequence := nextval('protected_publication_projection_sequence_v1');
+    NEW.created_at := transaction_timestamp();
+    NEW.next_attempt_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER protected_publication_projection_initial_state
+    BEFORE INSERT ON protected_publication_projection_outbox
+    FOR EACH ROW EXECUTE FUNCTION protected_publication_projection_insert_guard_v1();
+
+-- The outbox cannot be attached to a denial, no-op, lifecycle operation, or a
+-- different result. The deferred check permits receipt and outbox insertion in
+-- either order inside the canonical application transaction.
+CREATE FUNCTION protected_publication_projection_receipt_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM authorization_operation_receipts receipt
+        JOIN authorization_admission_results admission
+          ON admission.community_id = receipt.community_id
+         AND admission.operation_id = receipt.operation_id
+         AND admission.request_fingerprint = receipt.request_fingerprint
+        WHERE receipt.community_id = NEW.community_id
+          AND receipt.operation_id = NEW.operation_id
+          AND receipt.request_fingerprint = NEW.request_fingerprint
+          -- First-use enrollment may atomically carry this protected effect;
+          -- every later established-binding mutation uses kind 11.
+          AND receipt.operation_kind IN (1, 11)
+          AND receipt.outcome_code = 1
+          AND admission.object_kind = NEW.object_kind
+          AND admission.object_key = NEW.object_key
+          AND admission.application_type = NEW.application_type
+          AND admission.application_version = NEW.application_version
+          AND admission.application_effect_digest = NEW.application_effect_digest
+          AND admission.application_result_digest = NEW.publication_result_digest
+    ) THEN
+        RAISE EXCEPTION 'protected publication projection requires exact applied receipt'
+            USING ERRCODE = 'foreign_key_violation',
+                  CONSTRAINT = 'protected_publication_projection_receipt';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER protected_publication_projection_receipt
+    AFTER INSERT ON protected_publication_projection_outbox
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW EXECUTE FUNCTION protected_publication_projection_receipt_guard_v1();
+
+CREATE FUNCTION protected_publication_projection_state_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.operation_id IS DISTINCT FROM OLD.operation_id
+        OR NEW.request_fingerprint IS DISTINCT FROM OLD.request_fingerprint
+        OR NEW.publication_result_digest IS DISTINCT FROM OLD.publication_result_digest
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.application_type IS DISTINCT FROM OLD.application_type
+        OR NEW.application_version IS DISTINCT FROM OLD.application_version
+        OR NEW.application_effect_digest IS DISTINCT FROM OLD.application_effect_digest
+        OR NEW.projection_kind IS DISTINCT FROM OLD.projection_kind
+        OR NEW.projection_key IS DISTINCT FROM OLD.projection_key
+        OR NEW.staged_object_key IS DISTINCT FROM OLD.staged_object_key
+        OR NEW.payload_digest IS DISTINCT FROM OLD.payload_digest
+        OR NEW.created_at IS DISTINCT FROM OLD.created_at
+        OR NEW.publication_sequence IS DISTINCT FROM OLD.publication_sequence
+        OR OLD.delivery_state <> 1
+        OR NEW.delivery_state NOT IN (1, 2, 3)
+        OR NEW.attempt_count <> OLD.attempt_count + 1
+        OR NEW.next_attempt_at < OLD.next_attempt_at
+        OR (NEW.delivery_state = 1 AND NEW.failure_code NOT IN (1, 2))
+        OR (
+            NEW.delivery_state = 2
+            AND EXISTS (
+                SELECT 1
+                FROM protected_publication_projection_outbox earlier
+                WHERE earlier.community_id = OLD.community_id
+                  AND earlier.object_kind = OLD.object_kind
+                  AND earlier.object_key = OLD.object_key
+                  AND earlier.projection_kind = OLD.projection_kind
+                  AND earlier.projection_key = OLD.projection_key
+                  AND earlier.publication_sequence < OLD.publication_sequence
+                  AND earlier.delivery_state = 1
+            )
+        )
+    THEN
+        RAISE EXCEPTION 'protected publication projection transition is invalid'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'protected_publication_projection_transition';
+    END IF;
+    NEW.last_attempt_at := transaction_timestamp();
+    IF NEW.delivery_state = 2 THEN
+        NEW.delivered_at := transaction_timestamp();
+        NEW.failure_code := 0;
+    ELSE
+        NEW.delivered_at := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER protected_publication_projection_state
+    BEFORE UPDATE ON protected_publication_projection_outbox
+    FOR EACH ROW EXECUTE FUNCTION protected_publication_projection_state_guard_v1();
+CREATE TRIGGER protected_publication_projection_no_delete
+    BEFORE DELETE ON protected_publication_projection_outbox
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER protected_publication_projection_no_truncate
+    BEFORE TRUNCATE ON protected_publication_projection_outbox
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();

--- a/migrations/0034_nip_fi_operator_preauth.sql
+++ b/migrations/0034_nip_fi_operator_preauth.sql
@@ -1,0 +1,375 @@
+-- Bounded authorization-audit health and credential-free operator denials.
+--
+-- Migration 0030 owns the immutable event ledger and its hard ceilings. This
+-- upgrade reserves bounded room for fail-closed/security events, adds explicit
+-- failure/recovery generations, and records pre-authentication denials in a
+-- fixed-cardinality bucket table. It never stores a proof, nonce, assertion,
+-- provider identifier, principal, email address, or display value.
+
+ALTER TABLE authorization_event_capacity
+    ADD COLUMN restrictive_reserve_events BIGINT,
+    ADD COLUMN restrictive_reserve_bytes BIGINT,
+    ADD COLUMN failure_generation BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN recovery_generation BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN recovered_at TIMESTAMPTZ;
+
+UPDATE authorization_event_capacity
+SET restrictive_reserve_events = CASE
+        WHEN max_events_per_domain > 1
+            THEN GREATEST(1, LEAST(64, max_events_per_domain / 8))
+        ELSE 0
+    END,
+    restrictive_reserve_bytes = CASE
+        WHEN max_bytes_per_domain > max_envelope_bytes
+            THEN GREATEST(
+                max_envelope_bytes,
+                LEAST(262144, max_bytes_per_domain / 8)
+            )
+        ELSE 0
+    END,
+    failure_generation = CASE WHEN health_state = 2 THEN 1 ELSE 0 END,
+    recovery_generation = 0;
+
+-- Preserve safe compatibility for callers compiled before this migration:
+-- omitted reserve columns are derived from the server-owned hard ceilings,
+-- while callers cannot select a weaker value because the checks below pin the
+-- exact derivation.
+CREATE FUNCTION authorization_event_capacity_reserve_defaults_v2() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.restrictive_reserve_events IS NULL THEN
+        NEW.restrictive_reserve_events := CASE
+            WHEN NEW.max_events_per_domain > 1
+                THEN GREATEST(1, LEAST(64, NEW.max_events_per_domain / 8))
+            ELSE 0
+        END;
+    END IF;
+    IF NEW.restrictive_reserve_bytes IS NULL THEN
+        NEW.restrictive_reserve_bytes := CASE
+            WHEN NEW.max_bytes_per_domain > NEW.max_envelope_bytes
+                THEN GREATEST(
+                    NEW.max_envelope_bytes,
+                    LEAST(262144, NEW.max_bytes_per_domain / 8)
+                )
+            ELSE 0
+        END;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_event_capacity_reserve_defaults
+    BEFORE INSERT ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_reserve_defaults_v2();
+
+ALTER TABLE authorization_event_capacity
+    ALTER COLUMN restrictive_reserve_events SET NOT NULL,
+    ALTER COLUMN restrictive_reserve_bytes SET NOT NULL,
+    ADD CONSTRAINT authorization_event_capacity_reserve_events CHECK (
+        restrictive_reserve_events = CASE
+            WHEN max_events_per_domain > 1
+                THEN GREATEST(1, LEAST(64, max_events_per_domain / 8))
+            ELSE 0
+        END
+    ),
+    ADD CONSTRAINT authorization_event_capacity_reserve_bytes CHECK (
+        restrictive_reserve_bytes = CASE
+            WHEN max_bytes_per_domain > max_envelope_bytes
+                THEN GREATEST(
+                    max_envelope_bytes,
+                    LEAST(262144, max_bytes_per_domain / 8)
+                )
+            ELSE 0
+        END
+    ),
+    ADD CONSTRAINT authorization_event_capacity_generations CHECK (
+        recovery_generation <= failure_generation
+    ),
+    ADD CONSTRAINT authorization_event_capacity_health_generation CHECK (
+        (health_state = 1
+            AND failure_code IS NULL
+            AND failure_observed_at IS NULL
+            AND recovery_generation = failure_generation)
+        OR (health_state = 2
+            AND failure_code IS NOT NULL
+            AND failure_observed_at IS NOT NULL
+            AND recovery_generation < failure_generation)
+    );
+
+DROP TRIGGER authorization_events_capacity ON authorization_events;
+DROP FUNCTION authorization_event_capacity_before_insert_v1();
+
+-- One locked capacity row is the complete O(1) admission decision. General
+-- success traffic may not consume the restrictive reserve. Lifecycle loss,
+-- denial, invalidation, and other non-success evidence may consume it.
+CREATE FUNCTION authorization_event_capacity_before_insert_v2() RETURNS TRIGGER AS $$
+DECLARE
+    policy authorization_event_capacity%ROWTYPE;
+    envelope_bytes BIGINT;
+    restrictive_event BOOLEAN;
+    event_limit BIGINT;
+    byte_limit BIGINT;
+BEGIN
+    SELECT * INTO policy
+    FROM authorization_event_capacity
+    WHERE community_id = NEW.community_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'authorization event capacity policy missing'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_policy_required';
+    END IF;
+    IF policy.health_state <> 1 THEN
+        RAISE EXCEPTION 'authorization audit is unavailable'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_health';
+    END IF;
+
+    envelope_bytes := octet_length(NEW.canonical_envelope);
+    restrictive_event := NEW.outcome_code <> 1
+        OR NEW.event_kind IN (2, 3, 4, 5, 6, 7, 8, 9, 11, 14);
+    IF restrictive_event THEN
+        event_limit := policy.max_events_per_domain;
+        byte_limit := policy.max_bytes_per_domain;
+    ELSE
+        event_limit := policy.max_events_per_domain
+            - policy.restrictive_reserve_events;
+        byte_limit := policy.max_bytes_per_domain
+            - policy.restrictive_reserve_bytes;
+    END IF;
+
+    IF envelope_bytes > policy.max_envelope_bytes
+        OR policy.retained_event_count + 1 > event_limit
+        OR policy.retained_envelope_bytes + envelope_bytes > byte_limit
+    THEN
+        RAISE EXCEPTION 'authorization event capacity exhausted'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_exhausted';
+    END IF;
+
+    UPDATE authorization_event_capacity
+    SET retained_event_count = retained_event_count + 1,
+        retained_envelope_bytes = retained_envelope_bytes + envelope_bytes,
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
+    WHERE community_id = NEW.community_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_events_capacity
+    BEFORE INSERT ON authorization_events
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_before_insert_v2();
+
+DROP TRIGGER authorization_event_capacity_monotonic ON authorization_event_capacity;
+DROP FUNCTION authorization_event_capacity_guard_v1();
+
+-- Ceilings/reserves may only rise within their immutable hard caps; retained
+-- counters never fall. Recovery is possible only by matching the current
+-- failure generation, so a stale health probe cannot clear a later failure.
+CREATE FUNCTION authorization_event_capacity_guard_v2() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.configured_at IS DISTINCT FROM OLD.configured_at
+        OR NEW.max_events_per_domain < OLD.max_events_per_domain
+        OR NEW.max_bytes_per_domain < OLD.max_bytes_per_domain
+        OR NEW.max_envelope_bytes < OLD.max_envelope_bytes
+        OR NEW.restrictive_reserve_events < OLD.restrictive_reserve_events
+        OR NEW.restrictive_reserve_bytes < OLD.restrictive_reserve_bytes
+        OR NEW.retained_event_count < OLD.retained_event_count
+        OR NEW.retained_envelope_bytes < OLD.retained_envelope_bytes
+        OR NEW.failure_generation < OLD.failure_generation
+        OR NEW.recovery_generation < OLD.recovery_generation
+        OR NEW.updated_at <= OLD.updated_at
+        OR NEW.failure_generation > OLD.failure_generation + 1
+        OR NEW.recovery_generation > NEW.failure_generation
+        OR (OLD.health_state = 1 AND NEW.health_state = 2 AND (
+            NEW.failure_generation <> OLD.failure_generation + 1
+            OR NEW.recovery_generation <> OLD.recovery_generation
+            OR NEW.failure_code IS NULL
+            OR NEW.failure_observed_at IS NULL
+            OR NEW.recovered_at IS DISTINCT FROM OLD.recovered_at
+        ))
+        OR (OLD.health_state = 2 AND NEW.health_state = 1 AND (
+            NEW.failure_generation <> OLD.failure_generation
+            OR NEW.recovery_generation <> OLD.failure_generation
+            OR NEW.failure_code IS NOT NULL
+            OR NEW.failure_observed_at IS NOT NULL
+            OR NEW.recovered_at IS NULL
+            OR NEW.recovered_at <= OLD.failure_observed_at
+        ))
+        OR (OLD.health_state = NEW.health_state AND (
+            NEW.failure_generation <> OLD.failure_generation
+            OR NEW.recovery_generation <> OLD.recovery_generation
+            OR NEW.failure_code IS DISTINCT FROM OLD.failure_code
+            OR NEW.failure_observed_at IS DISTINCT FROM OLD.failure_observed_at
+            OR NEW.recovered_at IS DISTINCT FROM OLD.recovered_at
+        ))
+    THEN
+        RAISE EXCEPTION 'authorization event capacity transition is not monotonic'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_monotonic_v2';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_event_capacity_monotonic
+    BEFORE UPDATE ON authorization_event_capacity
+    FOR EACH ROW EXECUTE FUNCTION authorization_event_capacity_guard_v2();
+
+CREATE FUNCTION authorization_event_capacity_report_failure_v2(
+    selected_community_id UUID,
+    selected_failure_code SMALLINT
+) RETURNS BIGINT AS $$
+DECLARE
+    next_generation BIGINT;
+BEGIN
+    IF selected_failure_code NOT IN (1, 2, 3) THEN
+        RAISE EXCEPTION 'invalid authorization audit failure code'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    UPDATE authorization_event_capacity
+    SET health_state = 2,
+        failure_code = selected_failure_code,
+        failure_observed_at = transaction_timestamp(),
+        failure_generation = failure_generation + 1,
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
+    WHERE community_id = selected_community_id AND health_state = 1
+    RETURNING failure_generation INTO next_generation;
+    IF next_generation IS NULL THEN
+        SELECT failure_generation INTO next_generation
+        FROM authorization_event_capacity
+        WHERE community_id = selected_community_id AND health_state = 2;
+    END IF;
+    IF next_generation IS NULL THEN
+        RAISE EXCEPTION 'authorization event capacity policy missing'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_policy_required';
+    END IF;
+    RETURN next_generation;
+END;
+$$ LANGUAGE plpgsql VOLATILE STRICT;
+
+CREATE FUNCTION authorization_event_capacity_recover_v2(
+    selected_community_id UUID,
+    expected_failure_generation BIGINT
+) RETURNS BOOLEAN AS $$
+DECLARE
+    recovered BOOLEAN;
+BEGIN
+    UPDATE authorization_event_capacity
+    SET health_state = 1,
+        failure_code = NULL,
+        failure_observed_at = NULL,
+        recovery_generation = failure_generation,
+        recovered_at = transaction_timestamp(),
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
+    WHERE community_id = selected_community_id
+      AND health_state = 2
+      AND failure_generation = expected_failure_generation;
+    recovered := FOUND;
+    RETURN recovered;
+END;
+$$ LANGUAGE plpgsql VOLATILE STRICT;
+
+-- Fixed cardinality: eight closed denial classes x eight actions x twelve
+-- rotating five-minute slots = at most 768 rows per server-owned domain.
+CREATE TABLE authorization_operator_denial_buckets (
+    community_id UUID NOT NULL REFERENCES communities(id),
+    denial_class SMALLINT NOT NULL CHECK (denial_class BETWEEN 1 AND 8),
+    action_kind SMALLINT NOT NULL CHECK (action_kind BETWEEN 1 AND 8),
+    slot SMALLINT NOT NULL CHECK (slot BETWEEN 0 AND 11),
+    window_generation BIGINT NOT NULL CHECK (window_generation >= 0),
+    window_started_at TIMESTAMPTZ NOT NULL,
+    denial_count BIGINT NOT NULL CHECK (denial_count > 0),
+    last_denied_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (community_id, denial_class, action_kind, slot),
+    CHECK (window_started_at <= last_denied_at)
+);
+
+CREATE FUNCTION authorization_operator_denial_bucket_record_v1(
+    selected_community_id UUID,
+    selected_denial_class SMALLINT,
+    selected_action_kind SMALLINT
+) RETURNS BIGINT AS $$
+DECLARE
+    authoritative_now TIMESTAMPTZ := transaction_timestamp();
+    generation BIGINT;
+    selected_slot SMALLINT;
+    retained_count BIGINT;
+BEGIN
+    IF selected_denial_class NOT BETWEEN 1 AND 8
+        OR selected_action_kind NOT BETWEEN 1 AND 8
+    THEN
+        RAISE EXCEPTION 'invalid operator denial bucket coordinate'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    generation := floor(extract(epoch FROM authoritative_now) / 300)::BIGINT;
+    selected_slot := (generation % 12)::SMALLINT;
+    INSERT INTO authorization_operator_denial_buckets (
+        community_id, denial_class, action_kind, slot,
+        window_generation, window_started_at, denial_count, last_denied_at
+    ) VALUES (
+        selected_community_id, selected_denial_class, selected_action_kind,
+        selected_slot, generation, to_timestamp(generation * 300), 1,
+        authoritative_now
+    )
+    ON CONFLICT (community_id, denial_class, action_kind, slot) DO UPDATE SET
+        window_generation = EXCLUDED.window_generation,
+        window_started_at = EXCLUDED.window_started_at,
+        denial_count = CASE
+            WHEN authorization_operator_denial_buckets.window_generation
+                = EXCLUDED.window_generation
+            THEN CASE
+                WHEN authorization_operator_denial_buckets.denial_count
+                    = 9223372036854775807
+                THEN 9223372036854775807
+                ELSE authorization_operator_denial_buckets.denial_count + 1
+            END
+            ELSE 1
+        END,
+        last_denied_at = EXCLUDED.last_denied_at
+    RETURNING denial_count INTO retained_count;
+    RETURN retained_count;
+END;
+$$ LANGUAGE plpgsql VOLATILE STRICT;
+
+CREATE FUNCTION authorization_operator_denial_bucket_guard_v1() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.denial_class IS DISTINCT FROM OLD.denial_class
+        OR NEW.action_kind IS DISTINCT FROM OLD.action_kind
+        OR NEW.slot IS DISTINCT FROM OLD.slot
+        OR NEW.window_generation < OLD.window_generation
+        OR (NEW.window_generation = OLD.window_generation AND (
+            NEW.window_started_at IS DISTINCT FROM OLD.window_started_at
+            OR NEW.denial_count < OLD.denial_count
+            OR NEW.last_denied_at < OLD.last_denied_at
+        ))
+        OR (NEW.window_generation > OLD.window_generation AND NEW.denial_count <> 1)
+    THEN
+        RAISE EXCEPTION 'operator denial bucket transition is invalid'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER authorization_operator_denial_buckets_monotonic
+    BEFORE UPDATE ON authorization_operator_denial_buckets
+    FOR EACH ROW EXECUTE FUNCTION authorization_operator_denial_bucket_guard_v1();
+CREATE TRIGGER authorization_operator_denial_buckets_no_delete
+    BEFORE DELETE ON authorization_operator_denial_buckets
+    FOR EACH ROW EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+CREATE TRIGGER authorization_operator_denial_buckets_no_truncate
+    BEFORE TRUNCATE ON authorization_operator_denial_buckets
+    FOR EACH STATEMENT EXECUTE FUNCTION nip_fi_reject_truncate_v1();

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -200,16 +200,32 @@ CREATE TABLE IF NOT EXISTS authorization_event_capacity (
     failure_observed_at timestamptz,
     configured_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
     updated_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
+    restrictive_reserve_events bigint NOT NULL,
+    restrictive_reserve_bytes bigint NOT NULL,
+    failure_generation bigint DEFAULT 0 NOT NULL,
+    recovery_generation bigint DEFAULT 0 NOT NULL,
+    recovered_at timestamptz,
     CONSTRAINT authorization_event_capacity_pkey PRIMARY KEY (community_id),
     CONSTRAINT authorization_event_capacity_community_id_fkey FOREIGN KEY (community_id) REFERENCES communities (id),
     CONSTRAINT authorization_event_capacity_check CHECK (max_envelope_bytes <= max_bytes_per_domain),
     CONSTRAINT authorization_event_capacity_check1 CHECK (retained_event_count <= max_events_per_domain),
     CONSTRAINT authorization_event_capacity_check2 CHECK (retained_envelope_bytes <= max_bytes_per_domain),
     CONSTRAINT authorization_event_capacity_failure_code_check CHECK (failure_code IS NULL OR (failure_code IN (1, 2, 3))),
+    CONSTRAINT authorization_event_capacity_generations CHECK (recovery_generation <= failure_generation),
     CONSTRAINT authorization_event_capacity_health_state_check CHECK (health_state IN (1, 2)),
     CONSTRAINT authorization_event_capacity_max_bytes CHECK (max_bytes_per_domain >= 1 AND max_bytes_per_domain <= 16777216),
     CONSTRAINT authorization_event_capacity_max_envelope CHECK (max_envelope_bytes >= 1 AND max_envelope_bytes <= 16384),
     CONSTRAINT authorization_event_capacity_max_events CHECK (max_events_per_domain >= 1 AND max_events_per_domain <= 10000),
+    CONSTRAINT authorization_event_capacity_reserve_bytes CHECK (restrictive_reserve_bytes =
+CASE
+    WHEN max_bytes_per_domain > max_envelope_bytes THEN GREATEST(max_envelope_bytes::bigint, LEAST(262144::bigint, max_bytes_per_domain / 8))
+    ELSE 0::bigint
+END),
+    CONSTRAINT authorization_event_capacity_reserve_events CHECK (restrictive_reserve_events =
+CASE
+    WHEN max_events_per_domain > 1 THEN GREATEST(1::bigint, LEAST(64::bigint, max_events_per_domain / 8))
+    ELSE 0::bigint
+END),
     CONSTRAINT authorization_event_capacity_retained_envelope_bytes_check CHECK (retained_envelope_bytes >= 0),
     CONSTRAINT authorization_event_capacity_retained_event_count_check CHECK (retained_event_count >= 0)
 );
@@ -251,6 +267,40 @@ CREATE TABLE IF NOT EXISTS authorization_operation_receipts (
     CONSTRAINT authorization_operation_receipts_outcome_code_check CHECK (outcome_code IN (1, 2, 3)),
     CONSTRAINT authorization_operation_receipts_request_fingerprint_check CHECK (octet_length(request_fingerprint) = 32),
     CONSTRAINT authorization_operation_receipts_result_digest_check CHECK (octet_length(result_digest) = 32)
+);
+
+--
+-- Name: authorization_admission_results; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS authorization_admission_results (
+    community_id uuid,
+    operation_id uuid,
+    request_fingerprint bytea NOT NULL,
+    semantic_fingerprint bytea NOT NULL,
+    object_kind smallint NOT NULL,
+    object_key bytea NOT NULL,
+    application_type bytea,
+    application_version smallint,
+    application_code smallint,
+    application_payload bytea,
+    application_intent_digest bytea,
+    application_effect_digest bytea,
+    application_result_digest bytea,
+    recorded_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
+    CONSTRAINT authorization_admission_results_pkey PRIMARY KEY (community_id, operation_id),
+    CONSTRAINT authorization_admission_resul_community_id_operation_id_re_fkey FOREIGN KEY (community_id, operation_id, request_fingerprint) REFERENCES authorization_operation_receipts (community_id, operation_id, request_fingerprint),
+    CONSTRAINT authorization_admission_results_application_code_check CHECK (application_code > 0),
+    CONSTRAINT authorization_admission_results_application_effect_digest_check CHECK (application_effect_digest IS NULL OR octet_length(application_effect_digest) = 32 AND application_effect_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_admission_results_application_intent_digest_check CHECK (application_intent_digest IS NULL OR octet_length(application_intent_digest) = 32 AND application_intent_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_admission_results_application_payload_check CHECK (application_payload IS NULL OR octet_length(application_payload) <= 4096),
+    CONSTRAINT authorization_admission_results_application_result_digest_check CHECK (application_result_digest IS NULL OR octet_length(application_result_digest) = 32 AND application_result_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_admission_results_application_type_check CHECK (application_type IS NULL OR octet_length(application_type) = 32 AND application_type <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_admission_results_application_version_check CHECK (application_version > 0),
+    CONSTRAINT authorization_admission_results_object_key_check CHECK (octet_length(object_key) = 32 AND object_key <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_admission_results_object_kind_check CHECK (object_kind >= 1 AND object_kind <= 6),
+    CONSTRAINT authorization_admission_results_request_fingerprint_check CHECK (octet_length(request_fingerprint) = 32),
+    CONSTRAINT authorization_admission_results_semantic_fingerprint_check CHECK (octet_length(semantic_fingerprint) = 32 AND semantic_fingerprint <> decode(repeat('00'::text, 32), 'hex'::text))
 );
 
 --
@@ -420,6 +470,46 @@ CREATE TABLE IF NOT EXISTS authorization_operation_version_deltas (
     CONSTRAINT authorization_operation_version_deltas_component_digest_check CHECK (octet_length(component_digest) = 32),
     CONSTRAINT authorization_operation_version_deltas_component_key_check CHECK (octet_length(component_key) = 32),
     CONSTRAINT authorization_operation_version_deltas_component_kind_check CHECK (component_kind IN (1, 2, 3, 4, 6, 7))
+);
+
+--
+-- Name: authorization_operator_denial_buckets; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS authorization_operator_denial_buckets (
+    community_id uuid,
+    denial_class smallint,
+    action_kind smallint,
+    slot smallint,
+    window_generation bigint NOT NULL,
+    window_started_at timestamptz NOT NULL,
+    denial_count bigint NOT NULL,
+    last_denied_at timestamptz NOT NULL,
+    CONSTRAINT authorization_operator_denial_buckets_pkey PRIMARY KEY (community_id, denial_class, action_kind, slot),
+    CONSTRAINT authorization_operator_denial_buckets_community_id_fkey FOREIGN KEY (community_id) REFERENCES communities (id),
+    CONSTRAINT authorization_operator_denial_buckets_action_kind_check CHECK (action_kind >= 1 AND action_kind <= 8),
+    CONSTRAINT authorization_operator_denial_buckets_check CHECK (window_started_at <= last_denied_at),
+    CONSTRAINT authorization_operator_denial_buckets_denial_class_check CHECK (denial_class >= 1 AND denial_class <= 8),
+    CONSTRAINT authorization_operator_denial_buckets_denial_count_check CHECK (denial_count > 0),
+    CONSTRAINT authorization_operator_denial_buckets_slot_check CHECK (slot >= 0 AND slot <= 11),
+    CONSTRAINT authorization_operator_denial_buckets_window_generation_check CHECK (window_generation >= 0)
+);
+
+--
+-- Name: authorization_proxy_nonce_claims; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS authorization_proxy_nonce_claims (
+    authorization_domain uuid,
+    claim_kind smallint,
+    claim_key bytea,
+    committed_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
+    retain_until timestamptz NOT NULL,
+    CONSTRAINT authorization_proxy_nonce_claims_pkey PRIMARY KEY (authorization_domain, claim_kind, claim_key),
+    CONSTRAINT authorization_proxy_nonce_claims_authorization_domain_fkey FOREIGN KEY (authorization_domain) REFERENCES communities (id),
+    CONSTRAINT authorization_proxy_nonce_claims_check CHECK (committed_at < retain_until),
+    CONSTRAINT authorization_proxy_nonce_claims_claim_key_check CHECK (octet_length(claim_key) = 32 AND claim_key <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT authorization_proxy_nonce_claims_claim_kind_check CHECK (claim_kind = 1)
 );
 
 --
@@ -1769,6 +1859,68 @@ CREATE INDEX IF NOT EXISTS idx_product_feedback_community_received ON product_fe
 CREATE INDEX IF NOT EXISTS idx_product_feedback_received ON product_feedback (received_at DESC, id);
 
 --
+-- Name: protected_publication_projection_outbox; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS protected_publication_projection_outbox (
+    community_id uuid,
+    operation_id uuid,
+    request_fingerprint bytea NOT NULL,
+    publication_result_digest bytea NOT NULL,
+    object_kind smallint NOT NULL,
+    object_key bytea NOT NULL,
+    application_type bytea NOT NULL,
+    application_version smallint NOT NULL,
+    application_effect_digest bytea NOT NULL,
+    projection_kind smallint,
+    projection_key text NOT NULL,
+    staged_object_key text NOT NULL,
+    payload_digest bytea NOT NULL,
+    delivery_state smallint DEFAULT 1 NOT NULL,
+    attempt_count bigint DEFAULT 0 NOT NULL,
+    next_attempt_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
+    last_attempt_at timestamptz,
+    delivered_at timestamptz,
+    failure_code smallint DEFAULT 0 NOT NULL,
+    created_at timestamptz DEFAULT transaction_timestamp() NOT NULL,
+    publication_sequence bigint NOT NULL,
+    CONSTRAINT protected_publication_projection_outbox_pkey PRIMARY KEY (community_id, operation_id, projection_kind),
+    CONSTRAINT protected_publication_project_community_id_publication_sequ_key UNIQUE (community_id, publication_sequence),
+    CONSTRAINT protected_publication_project_community_id_operation_id_re_fkey FOREIGN KEY (community_id, operation_id, request_fingerprint) REFERENCES authorization_operation_receipts (community_id, operation_id, request_fingerprint) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT protected_publication_projection_outbox_community_id_fkey FOREIGN KEY (community_id) REFERENCES communities (id),
+    CONSTRAINT protected_publication_projectio_application_effect_digest_check CHECK (octet_length(application_effect_digest) = 32 AND application_effect_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projectio_publication_result_digest_check CHECK (octet_length(publication_result_digest) = 32 AND publication_result_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projection_outb_application_version_check CHECK (application_version > 0),
+    CONSTRAINT protected_publication_projection_outb_request_fingerprint_check CHECK (octet_length(request_fingerprint) = 32 AND request_fingerprint <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projection_outbox_application_type_check CHECK (octet_length(application_type) = 32 AND application_type <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projection_outbox_attempt_count_check CHECK (attempt_count >= 0),
+    CONSTRAINT protected_publication_projection_outbox_check CHECK ((attempt_count = 0) = (last_attempt_at IS NULL)),
+    CONSTRAINT protected_publication_projection_outbox_check1 CHECK (last_attempt_at IS NULL OR last_attempt_at >= created_at),
+    CONSTRAINT protected_publication_projection_outbox_check2 CHECK (delivered_at IS NULL OR delivered_at >= created_at),
+    CONSTRAINT protected_publication_projection_outbox_delivery_state_check CHECK (delivery_state IN (1, 2, 3)),
+    CONSTRAINT protected_publication_projection_outbox_failure_code_check CHECK (failure_code >= 0 AND failure_code <= 6),
+    CONSTRAINT protected_publication_projection_outbox_object_key_check CHECK (octet_length(object_key) = 32 AND object_key <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projection_outbox_object_kind_check CHECK (object_kind IN (3, 4)),
+    CONSTRAINT protected_publication_projection_outbox_operation_id_check CHECK (operation_id <> '00000000-0000-0000-0000-000000000000'::uuid),
+    CONSTRAINT protected_publication_projection_outbox_payload_digest_check CHECK (octet_length(payload_digest) = 32 AND payload_digest <> decode(repeat('00'::text, 32), 'hex'::text)),
+    CONSTRAINT protected_publication_projection_outbox_projection_key_check CHECK (octet_length(projection_key) >= 1 AND octet_length(projection_key) <= 2048),
+    CONSTRAINT protected_publication_projection_outbox_projection_kind_check CHECK (projection_kind IN (1, 2, 3)),
+    CONSTRAINT protected_publication_projection_outbox_staged_object_key_check CHECK (octet_length(staged_object_key) >= 1 AND octet_length(staged_object_key) <= 2048)
+);
+
+--
+-- Name: protected_publication_projection_outbox_pending; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS protected_publication_projection_outbox_pending ON protected_publication_projection_outbox (delivery_state, next_attempt_at, community_id, operation_id) WHERE (delivery_state = 1);
+
+--
+-- Name: protected_publication_projection_outbox_target_order; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS protected_publication_projection_outbox_target_order ON protected_publication_projection_outbox (community_id, object_kind, object_key, projection_kind, projection_key, publication_sequence);
+
+--
 -- Name: pubkey_allowlist; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -2766,10 +2918,10 @@ END;
 $$;
 
 --
--- Name: authorization_event_capacity_before_insert_v1(); Type: FUNCTION; Schema: -; Owner: -
+-- Name: authorization_event_capacity_before_insert_v2(); Type: FUNCTION; Schema: -; Owner: -
 --
 
-CREATE OR REPLACE FUNCTION authorization_event_capacity_before_insert_v1()
+CREATE OR REPLACE FUNCTION authorization_event_capacity_before_insert_v2()
 RETURNS trigger
 LANGUAGE plpgsql
 VOLATILE
@@ -2777,6 +2929,9 @@ AS $$
 DECLARE
     policy authorization_event_capacity%ROWTYPE;
     envelope_bytes BIGINT;
+    restrictive_event BOOLEAN;
+    event_limit BIGINT;
+    byte_limit BIGINT;
 BEGIN
     SELECT * INTO policy
     FROM authorization_event_capacity
@@ -2795,13 +2950,22 @@ BEGIN
     END IF;
 
     envelope_bytes := octet_length(NEW.canonical_envelope);
+    restrictive_event := NEW.outcome_code <> 1
+        OR NEW.event_kind IN (2, 3, 4, 5, 6, 7, 8, 9, 11, 14);
+    IF restrictive_event THEN
+        event_limit := policy.max_events_per_domain;
+        byte_limit := policy.max_bytes_per_domain;
+    ELSE
+        event_limit := policy.max_events_per_domain
+            - policy.restrictive_reserve_events;
+        byte_limit := policy.max_bytes_per_domain
+            - policy.restrictive_reserve_bytes;
+    END IF;
+
     IF envelope_bytes > policy.max_envelope_bytes
-        OR policy.retained_event_count + 1 > policy.max_events_per_domain
-        OR policy.retained_envelope_bytes + envelope_bytes > policy.max_bytes_per_domain
+        OR policy.retained_event_count + 1 > event_limit
+        OR policy.retained_envelope_bytes + envelope_bytes > byte_limit
     THEN
-        -- The INSERT and protected mutation abort together. The runtime maps
-        -- this stable constraint to typed CapacityExhausted and latches audit
-        -- health outside the rolled-back transaction.
         RAISE EXCEPTION 'authorization event capacity exhausted'
             USING ERRCODE = 'check_violation',
                   CONSTRAINT = 'authorization_event_capacity_exhausted';
@@ -2810,41 +2974,175 @@ BEGIN
     UPDATE authorization_event_capacity
     SET retained_event_count = retained_event_count + 1,
         retained_envelope_bytes = retained_envelope_bytes + envelope_bytes,
-        updated_at = transaction_timestamp()
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
     WHERE community_id = NEW.community_id;
     RETURN NEW;
 END;
 $$;
 
 --
--- Name: authorization_event_capacity_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+-- Name: authorization_event_capacity_guard_v2(); Type: FUNCTION; Schema: -; Owner: -
 --
 
-CREATE OR REPLACE FUNCTION authorization_event_capacity_guard_v1()
+CREATE OR REPLACE FUNCTION authorization_event_capacity_guard_v2()
 RETURNS trigger
 LANGUAGE plpgsql
 VOLATILE
 AS $$
 BEGIN
     IF NEW.community_id IS DISTINCT FROM OLD.community_id
-        OR NEW.max_events_per_domain IS DISTINCT FROM OLD.max_events_per_domain
-        OR NEW.max_bytes_per_domain IS DISTINCT FROM OLD.max_bytes_per_domain
-        OR NEW.max_envelope_bytes IS DISTINCT FROM OLD.max_envelope_bytes
         OR NEW.configured_at IS DISTINCT FROM OLD.configured_at
+        OR NEW.max_events_per_domain < OLD.max_events_per_domain
+        OR NEW.max_bytes_per_domain < OLD.max_bytes_per_domain
+        OR NEW.max_envelope_bytes < OLD.max_envelope_bytes
+        OR NEW.restrictive_reserve_events < OLD.restrictive_reserve_events
+        OR NEW.restrictive_reserve_bytes < OLD.restrictive_reserve_bytes
         OR NEW.retained_event_count < OLD.retained_event_count
         OR NEW.retained_envelope_bytes < OLD.retained_envelope_bytes
-        OR NEW.updated_at < OLD.updated_at
-        OR (OLD.health_state = 2 AND (
-            NEW.health_state <> 2
+        OR NEW.failure_generation < OLD.failure_generation
+        OR NEW.recovery_generation < OLD.recovery_generation
+        OR NEW.updated_at <= OLD.updated_at
+        OR NEW.failure_generation > OLD.failure_generation + 1
+        OR NEW.recovery_generation > NEW.failure_generation
+        OR (OLD.health_state = 1 AND NEW.health_state = 2 AND (
+            NEW.failure_generation <> OLD.failure_generation + 1
+            OR NEW.recovery_generation <> OLD.recovery_generation
+            OR NEW.failure_code IS NULL
+            OR NEW.failure_observed_at IS NULL
+            OR NEW.recovered_at IS DISTINCT FROM OLD.recovered_at
+        ))
+        OR (OLD.health_state = 2 AND NEW.health_state = 1 AND (
+            NEW.failure_generation <> OLD.failure_generation
+            OR NEW.recovery_generation <> OLD.failure_generation
+            OR NEW.failure_code IS NOT NULL
+            OR NEW.failure_observed_at IS NOT NULL
+            OR NEW.recovered_at IS NULL
+            OR NEW.recovered_at <= OLD.failure_observed_at
+        ))
+        OR (OLD.health_state = NEW.health_state AND (
+            NEW.failure_generation <> OLD.failure_generation
+            OR NEW.recovery_generation <> OLD.recovery_generation
             OR NEW.failure_code IS DISTINCT FROM OLD.failure_code
             OR NEW.failure_observed_at IS DISTINCT FROM OLD.failure_observed_at
-        ))
-        OR (OLD.health_state = 1 AND NEW.health_state = 1 AND (
-            NEW.failure_code IS NOT NULL OR NEW.failure_observed_at IS NOT NULL
+            OR NEW.recovered_at IS DISTINCT FROM OLD.recovered_at
         ))
     THEN
-        RAISE EXCEPTION 'authorization event capacity cannot be reset online'
+        RAISE EXCEPTION 'authorization event capacity transition is not monotonic'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_monotonic_v2';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+--
+-- Name: authorization_event_capacity_recover_v2(uuid, bigint); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_event_capacity_recover_v2(
+    selected_community_id uuid,
+    expected_failure_generation bigint
+)
+RETURNS boolean
+LANGUAGE plpgsql
+VOLATILE
+STRICT
+AS $$
+DECLARE
+    recovered BOOLEAN;
+BEGIN
+    UPDATE authorization_event_capacity
+    SET health_state = 1,
+        failure_code = NULL,
+        failure_observed_at = NULL,
+        recovery_generation = failure_generation,
+        recovered_at = transaction_timestamp(),
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
+    WHERE community_id = selected_community_id
+      AND health_state = 2
+      AND failure_generation = expected_failure_generation;
+    recovered := FOUND;
+    RETURN recovered;
+END;
+$$;
+
+--
+-- Name: authorization_event_capacity_report_failure_v2(uuid, smallint); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_event_capacity_report_failure_v2(
+    selected_community_id uuid,
+    selected_failure_code smallint
+)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+STRICT
+AS $$
+DECLARE
+    next_generation BIGINT;
+BEGIN
+    IF selected_failure_code NOT IN (1, 2, 3) THEN
+        RAISE EXCEPTION 'invalid authorization audit failure code'
             USING ERRCODE = 'check_violation';
+    END IF;
+    UPDATE authorization_event_capacity
+    SET health_state = 2,
+        failure_code = selected_failure_code,
+        failure_observed_at = transaction_timestamp(),
+        failure_generation = failure_generation + 1,
+        updated_at = GREATEST(
+            transaction_timestamp(),
+            authorization_event_capacity.updated_at + INTERVAL '1 microsecond'
+        )
+    WHERE community_id = selected_community_id AND health_state = 1
+    RETURNING failure_generation INTO next_generation;
+    IF next_generation IS NULL THEN
+        SELECT failure_generation INTO next_generation
+        FROM authorization_event_capacity
+        WHERE community_id = selected_community_id AND health_state = 2;
+    END IF;
+    IF next_generation IS NULL THEN
+        RAISE EXCEPTION 'authorization event capacity policy missing'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_event_capacity_policy_required';
+    END IF;
+    RETURN next_generation;
+END;
+$$;
+
+--
+-- Name: authorization_event_capacity_reserve_defaults_v2(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_event_capacity_reserve_defaults_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF NEW.restrictive_reserve_events IS NULL THEN
+        NEW.restrictive_reserve_events := CASE
+            WHEN NEW.max_events_per_domain > 1
+                THEN GREATEST(1, LEAST(64, NEW.max_events_per_domain / 8))
+            ELSE 0
+        END;
+    END IF;
+    IF NEW.restrictive_reserve_bytes IS NULL THEN
+        NEW.restrictive_reserve_bytes := CASE
+            WHEN NEW.max_bytes_per_domain > NEW.max_envelope_bytes
+                THEN GREATEST(
+                    NEW.max_envelope_bytes,
+                    LEAST(262144, NEW.max_bytes_per_domain / 8)
+                )
+            ELSE 0
+        END;
     END IF;
     RETURN NEW;
 END;
@@ -2909,6 +3207,71 @@ BEGIN
             USING ERRCODE = 'check_violation';
     END IF;
     RETURN NEW;
+END;
+$$;
+
+--
+-- Name: authorization_operation_receipt_event_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_operation_receipt_event_guard_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+    receipt authorization_operation_receipts%ROWTYPE;
+    expected_event_kind SMALLINT;
+    matching_event_count BIGINT;
+    expected_event_count BIGINT;
+BEGIN
+    IF TG_TABLE_NAME = 'authorization_operation_receipts' THEN
+        receipt := NEW;
+    ELSE
+        SELECT * INTO receipt
+        FROM authorization_operation_receipts
+        WHERE community_id = NEW.community_id
+          AND operation_id = NEW.operation_id;
+        IF NOT FOUND THEN
+            -- Credential-free pre-authentication denials intentionally have no
+            -- canonical receipt. Their separate v30 FK/shape guards still run.
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    IF receipt.operation_kind NOT BETWEEN 1 AND 9 THEN
+        RETURN NULL;
+    END IF;
+
+    expected_event_kind := CASE receipt.operation_kind
+        WHEN 1 THEN 1  -- enroll
+        WHEN 2 THEN 1  -- provision
+        WHEN 3 THEN 6  -- retire
+        WHEN 4 THEN 7  -- disable
+        WHEN 5 THEN 2  -- revoke
+        WHEN 6 THEN 3  -- rotate
+        WHEN 7 THEN 4  -- recover
+        WHEN 8 THEN 5  -- enable
+        WHEN 9 THEN 8  -- admission loss
+    END;
+
+    SELECT
+        count(*),
+        count(*) FILTER (WHERE event_kind = expected_event_kind)
+    INTO matching_event_count, expected_event_count
+    FROM authorization_events
+    WHERE community_id = receipt.community_id
+      AND operation_id = receipt.operation_id
+      AND request_fingerprint = receipt.request_fingerprint;
+
+    IF matching_event_count <> 1 OR expected_event_count <> 1 THEN
+        RAISE EXCEPTION
+            'lifecycle receipt requires exactly one event kind %, found % total and % expected',
+            expected_event_kind, matching_event_count, expected_event_count
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_operation_receipt_event_cardinality';
+    END IF;
+    RETURN NULL;
 END;
 $$;
 
@@ -2979,6 +3342,130 @@ BEGIN
                   CONSTRAINT = 'authorization_operation_version_delta_cardinality';
     END IF;
     RETURN NULL;
+END;
+$$;
+
+--
+-- Name: authorization_operator_denial_bucket_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_operator_denial_bucket_guard_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.denial_class IS DISTINCT FROM OLD.denial_class
+        OR NEW.action_kind IS DISTINCT FROM OLD.action_kind
+        OR NEW.slot IS DISTINCT FROM OLD.slot
+        OR NEW.window_generation < OLD.window_generation
+        OR (NEW.window_generation = OLD.window_generation AND (
+            NEW.window_started_at IS DISTINCT FROM OLD.window_started_at
+            OR NEW.denial_count < OLD.denial_count
+            OR NEW.last_denied_at < OLD.last_denied_at
+        ))
+        OR (NEW.window_generation > OLD.window_generation AND NEW.denial_count <> 1)
+    THEN
+        RAISE EXCEPTION 'operator denial bucket transition is invalid'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+--
+-- Name: authorization_operator_denial_bucket_record_v1(uuid, smallint, smallint); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_operator_denial_bucket_record_v1(
+    selected_community_id uuid,
+    selected_denial_class smallint,
+    selected_action_kind smallint
+)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+STRICT
+AS $$
+DECLARE
+    authoritative_now TIMESTAMPTZ := transaction_timestamp();
+    generation BIGINT;
+    selected_slot SMALLINT;
+    retained_count BIGINT;
+BEGIN
+    IF selected_denial_class NOT BETWEEN 1 AND 8
+        OR selected_action_kind NOT BETWEEN 1 AND 8
+    THEN
+        RAISE EXCEPTION 'invalid operator denial bucket coordinate'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    generation := floor(extract(epoch FROM authoritative_now) / 300)::BIGINT;
+    selected_slot := (generation % 12)::SMALLINT;
+    INSERT INTO authorization_operator_denial_buckets (
+        community_id, denial_class, action_kind, slot,
+        window_generation, window_started_at, denial_count, last_denied_at
+    ) VALUES (
+        selected_community_id, selected_denial_class, selected_action_kind,
+        selected_slot, generation, to_timestamp(generation * 300), 1,
+        authoritative_now
+    )
+    ON CONFLICT (community_id, denial_class, action_kind, slot) DO UPDATE SET
+        window_generation = EXCLUDED.window_generation,
+        window_started_at = EXCLUDED.window_started_at,
+        denial_count = CASE
+            WHEN authorization_operator_denial_buckets.window_generation
+                = EXCLUDED.window_generation
+            THEN CASE
+                WHEN authorization_operator_denial_buckets.denial_count
+                    = 9223372036854775807
+                THEN 9223372036854775807
+                ELSE authorization_operator_denial_buckets.denial_count + 1
+            END
+            ELSE 1
+        END,
+        last_denied_at = EXCLUDED.last_denied_at
+    RETURNING denial_count INTO retained_count;
+    RETURN retained_count;
+END;
+$$;
+
+--
+-- Name: authorization_proxy_nonce_claim_retention_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_proxy_nonce_claim_retention_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF transaction_timestamp() <= OLD.retain_until THEN
+        RAISE EXCEPTION 'trusted-proxy nonce claim retention is still active'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_proxy_nonce_claim_retention';
+    END IF;
+    RETURN OLD;
+END;
+$$;
+
+--
+-- Name: authorization_proxy_nonce_claim_stamp_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION authorization_proxy_nonce_claim_stamp_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    NEW.committed_at := transaction_timestamp();
+    IF NEW.retain_until <= NEW.committed_at THEN
+        RAISE EXCEPTION 'trusted-proxy nonce claim is already expired'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'authorization_proxy_nonce_claim_expired';
+    END IF;
+    RETURN NEW;
 END;
 $$;
 
@@ -3734,6 +4221,34 @@ END;
 $$;
 
 --
+-- Name: nip_fi_lock_authorization_operation_v1(uuid, uuid); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION nip_fi_lock_authorization_operation_v1(
+    locked_community_id uuid,
+    locked_operation_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+STRICT
+AS $$
+BEGIN
+    IF locked_community_id = '00000000-0000-0000-0000-000000000000'::uuid
+        OR locked_operation_id = '00000000-0000-0000-0000-000000000000'::uuid
+    THEN
+        RAISE EXCEPTION 'invalid NIP-FI operation lock coordinate'
+            USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM pg_advisory_xact_lock(hashtextextended(
+        'buzz:authorization-operation:v1:' || locked_community_id::text
+            || ':' || locked_operation_id::text,
+        0
+    ));
+END;
+$$;
+
+--
 -- Name: nip_fi_reject_row_mutation_v1(); Type: FUNCTION; Schema: -; Owner: -
 --
 
@@ -3786,6 +4301,150 @@ BEGIN
     THEN
         RAISE EXCEPTION 'protected authority replacement requires a new operation and epoch'
             USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+--
+-- Name: protected_publication_projection_insert_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION protected_publication_projection_insert_guard_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF NEW.delivery_state <> 1
+        OR NEW.attempt_count <> 0
+        OR NEW.last_attempt_at IS NOT NULL
+        OR NEW.delivered_at IS NOT NULL
+        OR NEW.failure_code <> 0
+    THEN
+        RAISE EXCEPTION 'protected publication projection must start pending'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'protected_publication_projection_initial_state';
+    END IF;
+    -- Serialize only publications for the exact protected projection target.
+    -- Sequence allocation happens after acquiring this transaction lock, so a
+    -- later publication cannot become visible or deliver before an earlier
+    -- allocator commits or aborts. Hash collisions only over-serialize two
+    -- independent targets; they cannot weaken ordering.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            jsonb_build_array(
+                'buzz:nip-fi:protected-publication-projection:v1',
+                NEW.community_id::TEXT,
+                NEW.object_kind,
+                encode(NEW.object_key, 'hex'),
+                NEW.projection_kind,
+                NEW.projection_key
+            )::TEXT,
+            0
+        )
+    );
+    NEW.publication_sequence := nextval('protected_publication_projection_sequence_v1');
+    NEW.created_at := transaction_timestamp();
+    NEW.next_attempt_at := transaction_timestamp();
+    RETURN NEW;
+END;
+$$;
+
+--
+-- Name: protected_publication_projection_receipt_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION protected_publication_projection_receipt_guard_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM authorization_operation_receipts receipt
+        JOIN authorization_admission_results admission
+          ON admission.community_id = receipt.community_id
+         AND admission.operation_id = receipt.operation_id
+         AND admission.request_fingerprint = receipt.request_fingerprint
+        WHERE receipt.community_id = NEW.community_id
+          AND receipt.operation_id = NEW.operation_id
+          AND receipt.request_fingerprint = NEW.request_fingerprint
+          -- First-use enrollment may atomically carry this protected effect;
+          -- every later established-binding mutation uses kind 11.
+          AND receipt.operation_kind IN (1, 11)
+          AND receipt.outcome_code = 1
+          AND admission.object_kind = NEW.object_kind
+          AND admission.object_key = NEW.object_key
+          AND admission.application_type = NEW.application_type
+          AND admission.application_version = NEW.application_version
+          AND admission.application_effect_digest = NEW.application_effect_digest
+          AND admission.application_result_digest = NEW.publication_result_digest
+    ) THEN
+        RAISE EXCEPTION 'protected publication projection requires exact applied receipt'
+            USING ERRCODE = 'foreign_key_violation',
+                  CONSTRAINT = 'protected_publication_projection_receipt';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+--
+-- Name: protected_publication_projection_state_guard_v1(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION protected_publication_projection_state_guard_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    IF NEW.community_id IS DISTINCT FROM OLD.community_id
+        OR NEW.operation_id IS DISTINCT FROM OLD.operation_id
+        OR NEW.request_fingerprint IS DISTINCT FROM OLD.request_fingerprint
+        OR NEW.publication_result_digest IS DISTINCT FROM OLD.publication_result_digest
+        OR NEW.object_kind IS DISTINCT FROM OLD.object_kind
+        OR NEW.object_key IS DISTINCT FROM OLD.object_key
+        OR NEW.application_type IS DISTINCT FROM OLD.application_type
+        OR NEW.application_version IS DISTINCT FROM OLD.application_version
+        OR NEW.application_effect_digest IS DISTINCT FROM OLD.application_effect_digest
+        OR NEW.projection_kind IS DISTINCT FROM OLD.projection_kind
+        OR NEW.projection_key IS DISTINCT FROM OLD.projection_key
+        OR NEW.staged_object_key IS DISTINCT FROM OLD.staged_object_key
+        OR NEW.payload_digest IS DISTINCT FROM OLD.payload_digest
+        OR NEW.created_at IS DISTINCT FROM OLD.created_at
+        OR NEW.publication_sequence IS DISTINCT FROM OLD.publication_sequence
+        OR OLD.delivery_state <> 1
+        OR NEW.delivery_state NOT IN (1, 2, 3)
+        OR NEW.attempt_count <> OLD.attempt_count + 1
+        OR NEW.next_attempt_at < OLD.next_attempt_at
+        OR (NEW.delivery_state = 1 AND NEW.failure_code NOT IN (1, 2))
+        OR (
+            NEW.delivery_state = 2
+            AND EXISTS (
+                SELECT 1
+                FROM protected_publication_projection_outbox earlier
+                WHERE earlier.community_id = OLD.community_id
+                  AND earlier.object_kind = OLD.object_kind
+                  AND earlier.object_key = OLD.object_key
+                  AND earlier.projection_kind = OLD.projection_kind
+                  AND earlier.projection_key = OLD.projection_key
+                  AND earlier.publication_sequence < OLD.publication_sequence
+                  AND earlier.delivery_state = 1
+            )
+        )
+    THEN
+        RAISE EXCEPTION 'protected publication projection transition is invalid'
+            USING ERRCODE = 'check_violation',
+                  CONSTRAINT = 'protected_publication_projection_transition';
+    END IF;
+    NEW.last_attempt_at := transaction_timestamp();
+    IF NEW.delivery_state = 2 THEN
+        NEW.delivered_at := transaction_timestamp();
+        NEW.failure_code := 0;
+    ELSE
+        NEW.delivered_at := NULL;
     END IF;
     RETURN NEW;
 END;
@@ -3925,6 +4584,24 @@ ALTER TABLE identity_bindings
 ADD CONSTRAINT identity_bindings_exact_retirement_history_fk FOREIGN KEY (community_id, retirement_history_id, binding_id, binding_version, lifecycle_revision, binding_state) REFERENCES identity_lifecycle_history (community_id, history_id, old_binding_id, old_binding_version, old_resulting_lifecycle_revision, old_resulting_state) DEFERRABLE INITIALLY DEFERRED;
 
 --
+-- Name: authorization_admission_results_no_truncate; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_admission_results_no_truncate
+    BEFORE TRUNCATE ON authorization_admission_results
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+--
+-- Name: authorization_admission_results_no_update; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_admission_results_no_update
+    BEFORE UPDATE OR DELETE ON authorization_admission_results
+    FOR EACH ROW
+    EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+
+--
 -- Name: authorization_authentication_denial_attempts_immutable; Type: TRIGGER; Schema: -; Owner: -
 --
 
@@ -3976,7 +4653,7 @@ CREATE OR REPLACE TRIGGER authorization_authority_epochs_no_truncate
 CREATE OR REPLACE TRIGGER authorization_event_capacity_monotonic
     BEFORE UPDATE ON authorization_event_capacity
     FOR EACH ROW
-    EXECUTE FUNCTION authorization_event_capacity_guard_v1();
+    EXECUTE FUNCTION authorization_event_capacity_guard_v2();
 
 --
 -- Name: authorization_event_capacity_no_delete; Type: TRIGGER; Schema: -; Owner: -
@@ -3997,13 +4674,32 @@ CREATE OR REPLACE TRIGGER authorization_event_capacity_no_truncate
     EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
 --
+-- Name: authorization_event_capacity_reserve_defaults; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_event_capacity_reserve_defaults
+    BEFORE INSERT ON authorization_event_capacity
+    FOR EACH ROW
+    EXECUTE FUNCTION authorization_event_capacity_reserve_defaults_v2();
+
+--
+-- Name: authorization_event_receipt_cardinality; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER authorization_event_receipt_cardinality
+    AFTER INSERT ON authorization_events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
+
+--
 -- Name: authorization_events_capacity; Type: TRIGGER; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE TRIGGER authorization_events_capacity
     BEFORE INSERT ON authorization_events
     FOR EACH ROW
-    EXECUTE FUNCTION authorization_event_capacity_before_insert_v1();
+    EXECUTE FUNCTION authorization_event_capacity_before_insert_v2();
 
 --
 -- Name: authorization_events_immutable; Type: TRIGGER; Schema: -; Owner: -
@@ -4076,6 +4772,16 @@ CREATE OR REPLACE TRIGGER authorization_invalidation_floors_no_truncate
     BEFORE TRUNCATE ON authorization_invalidation_floors
     FOR EACH STATEMENT
     EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+--
+-- Name: authorization_operation_receipt_event_cardinality; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER authorization_operation_receipt_event_cardinality
+    AFTER INSERT ON authorization_operation_receipts
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION authorization_operation_receipt_event_guard_v1();
 
 --
 -- Name: authorization_operation_receipt_history_cardinality; Type: TRIGGER; Schema: -; Owner: -
@@ -4162,24 +4868,67 @@ CREATE OR REPLACE TRIGGER authorization_operation_version_deltas_no_truncate
     EXECUTE FUNCTION nip_fi_reject_truncate_v1();
 
 --
--- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+-- Name: authorization_operator_denial_buckets_monotonic; Type: TRIGGER; Schema: -; Owner: -
 --
 
-CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_01
-    DEFERRABLE INITIALLY DEFERRED
+CREATE OR REPLACE TRIGGER authorization_operator_denial_buckets_monotonic
+    BEFORE UPDATE ON authorization_operator_denial_buckets
     FOR EACH ROW
-    EXECUTE FUNCTION events_created_at_floor_guard();
+    EXECUTE FUNCTION authorization_operator_denial_bucket_guard_v1();
 
 --
--- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+-- Name: authorization_operator_denial_buckets_no_delete; Type: TRIGGER; Schema: -; Owner: -
 --
 
-CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_02
-    DEFERRABLE INITIALLY DEFERRED
+CREATE OR REPLACE TRIGGER authorization_operator_denial_buckets_no_delete
+    BEFORE DELETE ON authorization_operator_denial_buckets
     FOR EACH ROW
-    EXECUTE FUNCTION events_created_at_floor_guard();
+    EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+
+--
+-- Name: authorization_operator_denial_buckets_no_truncate; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_operator_denial_buckets_no_truncate
+    BEFORE TRUNCATE ON authorization_operator_denial_buckets
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+--
+-- Name: authorization_proxy_nonce_claims_immutable; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_proxy_nonce_claims_immutable
+    BEFORE UPDATE ON authorization_proxy_nonce_claims
+    FOR EACH ROW
+    EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+
+--
+-- Name: authorization_proxy_nonce_claims_no_truncate; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_proxy_nonce_claims_no_truncate
+    BEFORE TRUNCATE ON authorization_proxy_nonce_claims
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+--
+-- Name: authorization_proxy_nonce_claims_retained; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_proxy_nonce_claims_retained
+    BEFORE DELETE ON authorization_proxy_nonce_claims
+    FOR EACH ROW
+    EXECUTE FUNCTION authorization_proxy_nonce_claim_retention_v1();
+
+--
+-- Name: authorization_proxy_nonce_claims_stamp; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER authorization_proxy_nonce_claims_stamp
+    BEFORE INSERT ON authorization_proxy_nonce_claims
+    FOR EACH ROW
+    EXECUTE FUNCTION authorization_proxy_nonce_claim_stamp_v1();
 
 --
 -- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
@@ -4196,7 +4945,47 @@ CREATE CONSTRAINT TRIGGER events_created_at_floor
 --
 
 CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_01
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();
+
+--
+-- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
     AFTER INSERT OR UPDATE OF created_at, channel_id ON events
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();
+
+--
+-- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p_future
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();
+
+--
+-- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_06
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION events_created_at_floor_guard();
+
+--
+-- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_created_at_floor
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_05
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION events_created_at_floor_guard();
@@ -4226,39 +5015,10 @@ CREATE CONSTRAINT TRIGGER events_created_at_floor
 --
 
 CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p_future
+    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_02
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION events_created_at_floor_guard();
-
---
--- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_05
-    DEFERRABLE INITIALLY DEFERRED
-    FOR EACH ROW
-    EXECUTE FUNCTION events_created_at_floor_guard();
-
---
--- Name: events_created_at_floor; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE CONSTRAINT TRIGGER events_created_at_floor
-    AFTER INSERT OR UPDATE OF created_at, channel_id ON events_p2026_06
-    DEFERRABLE INITIALLY DEFERRED
-    FOR EACH ROW
-    EXECUTE FUNCTION events_created_at_floor_guard();
-
---
--- Name: events_enqueue_push_match; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER events_enqueue_push_match
-    AFTER INSERT ON events_p2026_05
-    FOR EACH ROW
-    EXECUTE FUNCTION enqueue_push_match_job();
 
 --
 -- Name: events_enqueue_push_match; Type: TRIGGER; Schema: -; Owner: -
@@ -4283,7 +5043,7 @@ CREATE OR REPLACE TRIGGER events_enqueue_push_match
 --
 
 CREATE OR REPLACE TRIGGER events_enqueue_push_match
-    AFTER INSERT ON events_p_future
+    AFTER INSERT ON events_p2026_04
     FOR EACH ROW
     EXECUTE FUNCTION enqueue_push_match_job();
 
@@ -4292,7 +5052,25 @@ CREATE OR REPLACE TRIGGER events_enqueue_push_match
 --
 
 CREATE OR REPLACE TRIGGER events_enqueue_push_match
-    AFTER INSERT ON events_p2026_04
+    AFTER INSERT ON events_p_past
+    FOR EACH ROW
+    EXECUTE FUNCTION enqueue_push_match_job();
+
+--
+-- Name: events_enqueue_push_match; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER events_enqueue_push_match
+    AFTER INSERT ON events_p2026_05
+    FOR EACH ROW
+    EXECUTE FUNCTION enqueue_push_match_job();
+
+--
+-- Name: events_enqueue_push_match; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER events_enqueue_push_match
+    AFTER INSERT ON events_p_future
     FOR EACH ROW
     EXECUTE FUNCTION enqueue_push_match_job();
 
@@ -4319,15 +5097,6 @@ CREATE OR REPLACE TRIGGER events_enqueue_push_match
 --
 
 CREATE OR REPLACE TRIGGER events_enqueue_push_match
-    AFTER INSERT ON events_p_past
-    FOR EACH ROW
-    EXECUTE FUNCTION enqueue_push_match_job();
-
---
--- Name: events_enqueue_push_match; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER events_enqueue_push_match
     AFTER INSERT ON events_p2026_02
     FOR EACH ROW
     EXECUTE FUNCTION enqueue_push_match_job();
@@ -4337,7 +5106,7 @@ CREATE OR REPLACE TRIGGER events_enqueue_push_match
 --
 
 CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
-    AFTER INSERT ON events_p2026_04
+    AFTER INSERT ON events
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
@@ -4357,27 +5126,27 @@ CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
 --
 
 CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
-    AFTER INSERT ON events_p2026_05
-    DEFERRABLE INITIALLY DEFERRED
-    FOR EACH ROW
-    EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
-
---
--- Name: events_refresh_channel_ttl; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
-    AFTER INSERT ON events_p2026_06
-    DEFERRABLE INITIALLY DEFERRED
-    FOR EACH ROW
-    EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
-
---
--- Name: events_refresh_channel_ttl; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
     AFTER INSERT ON events_p_past
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
+
+--
+-- Name: events_refresh_channel_ttl; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
+    AFTER INSERT ON events_p2026_04
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
+
+--
+-- Name: events_refresh_channel_ttl; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
+    AFTER INSERT ON events_p2026_01
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
@@ -4397,7 +5166,7 @@ CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
 --
 
 CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
-    AFTER INSERT ON events
+    AFTER INSERT ON events_p2026_06
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
@@ -4417,7 +5186,7 @@ CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
 --
 
 CREATE CONSTRAINT TRIGGER events_refresh_channel_ttl
-    AFTER INSERT ON events_p2026_01
+    AFTER INSERT ON events_p2026_05
     DEFERRABLE INITIALLY DEFERRED
     FOR EACH ROW
     EXECUTE FUNCTION refresh_channel_ttl_after_event_insert();
@@ -4665,6 +5434,52 @@ CREATE OR REPLACE TRIGGER protected_object_authority_strict_replacement
     EXECUTE FUNCTION protected_object_authority_guard_v1();
 
 --
+-- Name: protected_publication_projection_initial_state; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER protected_publication_projection_initial_state
+    BEFORE INSERT ON protected_publication_projection_outbox
+    FOR EACH ROW
+    EXECUTE FUNCTION protected_publication_projection_insert_guard_v1();
+
+--
+-- Name: protected_publication_projection_no_delete; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER protected_publication_projection_no_delete
+    BEFORE DELETE ON protected_publication_projection_outbox
+    FOR EACH ROW
+    EXECUTE FUNCTION nip_fi_reject_row_mutation_v1();
+
+--
+-- Name: protected_publication_projection_no_truncate; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER protected_publication_projection_no_truncate
+    BEFORE TRUNCATE ON protected_publication_projection_outbox
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION nip_fi_reject_truncate_v1();
+
+--
+-- Name: protected_publication_projection_receipt; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER protected_publication_projection_receipt
+    AFTER INSERT ON protected_publication_projection_outbox
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION protected_publication_projection_receipt_guard_v1();
+
+--
+-- Name: protected_publication_projection_state; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER protected_publication_projection_state
+    BEFORE UPDATE ON protected_publication_projection_outbox
+    FOR EACH ROW
+    EXECUTE FUNCTION protected_publication_projection_state_guard_v1();
+
+--
 -- Name: trg_channels_community_id_immutable; Type: TRIGGER; Schema: -; Owner: -
 --
 
@@ -4687,27 +5502,7 @@ CREATE OR REPLACE TRIGGER trg_event_mentions_require_live_event
 --
 
 CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p2026_04
-    FOR EACH ROW
-    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
-    EXECUTE FUNCTION guard_nip_rs_hard_delete();
-
---
--- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p2026_03
-    FOR EACH ROW
-    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
-    EXECUTE FUNCTION guard_nip_rs_hard_delete();
-
---
--- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p2026_05
+    BEFORE DELETE ON events_p_past
     FOR EACH ROW
     WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
     EXECUTE FUNCTION guard_nip_rs_hard_delete();
@@ -4727,27 +5522,7 @@ CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
 --
 
 CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p_future
-    FOR EACH ROW
-    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
-    EXECUTE FUNCTION guard_nip_rs_hard_delete();
-
---
--- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p2026_01
-    FOR EACH ROW
-    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
-    EXECUTE FUNCTION guard_nip_rs_hard_delete();
-
---
--- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
-    BEFORE DELETE ON events_p_past
+    BEFORE DELETE ON events_p2026_04
     FOR EACH ROW
     WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
     EXECUTE FUNCTION guard_nip_rs_hard_delete();
@@ -4767,6 +5542,46 @@ CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
 --
 
 CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
+    BEFORE DELETE ON events_p2026_05
+    FOR EACH ROW
+    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
+    EXECUTE FUNCTION guard_nip_rs_hard_delete();
+
+--
+-- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
+    BEFORE DELETE ON events_p2026_01
+    FOR EACH ROW
+    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
+    EXECUTE FUNCTION guard_nip_rs_hard_delete();
+
+--
+-- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
+    BEFORE DELETE ON events_p2026_03
+    FOR EACH ROW
+    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
+    EXECUTE FUNCTION guard_nip_rs_hard_delete();
+
+--
+-- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
+    BEFORE DELETE ON events_p_future
+    FOR EACH ROW
+    WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
+    EXECUTE FUNCTION guard_nip_rs_hard_delete();
+
+--
+-- Name: trg_events_guard_nip_rs_hard_delete; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
     BEFORE DELETE ON events_p2026_06
     FOR EACH ROW
     WHEN ((((OLD.kind = 30078) AND (OLD.d_tag ~ '^read-state:[0-9a-f]{32}$'::text))))
@@ -4777,7 +5592,7 @@ CREATE OR REPLACE TRIGGER trg_events_guard_nip_rs_hard_delete
 --
 
 CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p_future
+    BEFORE INSERT ON events_p2026_04
     FOR EACH ROW
     EXECUTE FUNCTION guard_nip_rs_watermark();
 
@@ -4786,34 +5601,7 @@ CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
 --
 
 CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events
-    FOR EACH ROW
-    EXECUTE FUNCTION guard_nip_rs_watermark();
-
---
--- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p2026_02
-    FOR EACH ROW
-    EXECUTE FUNCTION guard_nip_rs_watermark();
-
---
--- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p_past
-    FOR EACH ROW
-    EXECUTE FUNCTION guard_nip_rs_watermark();
-
---
--- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p2026_03
+    BEFORE INSERT ON events_p2026_06
     FOR EACH ROW
     EXECUTE FUNCTION guard_nip_rs_watermark();
 
@@ -4831,7 +5619,16 @@ CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
 --
 
 CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p2026_04
+    BEFORE INSERT ON events_p2026_02
+    FOR EACH ROW
+    EXECUTE FUNCTION guard_nip_rs_watermark();
+
+--
+-- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
+    BEFORE INSERT ON events_p_future
     FOR EACH ROW
     EXECUTE FUNCTION guard_nip_rs_watermark();
 
@@ -4849,7 +5646,25 @@ CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
 --
 
 CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
-    BEFORE INSERT ON events_p2026_06
+    BEFORE INSERT ON events
+    FOR EACH ROW
+    EXECUTE FUNCTION guard_nip_rs_watermark();
+
+--
+-- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
+    BEFORE INSERT ON events_p2026_03
+    FOR EACH ROW
+    EXECUTE FUNCTION guard_nip_rs_watermark();
+
+--
+-- Name: trg_events_nip_rs_watermark; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
+    BEFORE INSERT ON events_p_past
     FOR EACH ROW
     EXECUTE FUNCTION guard_nip_rs_watermark();
 
@@ -4858,7 +5673,7 @@ CREATE OR REPLACE TRIGGER trg_events_nip_rs_watermark
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
-    AFTER UPDATE OF deleted_at ON events_p2026_06
+    AFTER UPDATE OF deleted_at ON events_p2026_04
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
 
@@ -4867,7 +5682,7 @@ CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
-    AFTER UPDATE OF deleted_at ON events_p_future
+    AFTER UPDATE OF deleted_at ON events_p2026_06
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
 
@@ -4885,7 +5700,34 @@ CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
+    AFTER UPDATE OF deleted_at ON events_p2026_03
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
+
+--
+-- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
+    AFTER UPDATE OF deleted_at ON events
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
+
+--
+-- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
     AFTER UPDATE OF deleted_at ON events_p2026_05
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
+
+--
+-- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
+    AFTER UPDATE OF deleted_at ON events_p_future
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
 
@@ -4903,72 +5745,9 @@ CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
-    AFTER UPDATE OF deleted_at ON events
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
-
---
--- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
-    AFTER UPDATE OF deleted_at ON events_p2026_03
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
-
---
--- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
-    AFTER UPDATE OF deleted_at ON events_p2026_04
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
-
---
--- Name: trg_events_purge_soft_deleted_buzz_mesh_status; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
     AFTER UPDATE OF deleted_at ON events_p2026_01
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
-
---
--- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
-    AFTER UPDATE OF deleted_at ON events
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
-
---
--- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
-    AFTER UPDATE OF deleted_at ON events_p2026_06
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
-
---
--- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
-    AFTER UPDATE OF deleted_at ON events_p2026_03
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
-
---
--- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
---
-
-CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
-    AFTER UPDATE OF deleted_at ON events_p2026_04
-    FOR EACH ROW
-    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
 
 --
 -- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
@@ -4993,7 +5772,43 @@ CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
+    AFTER UPDATE OF deleted_at ON events_p2026_05
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
+
+--
+-- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
+    AFTER UPDATE OF deleted_at ON events_p2026_06
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
+
+--
+-- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
     AFTER UPDATE OF deleted_at ON events_p2026_02
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
+
+--
+-- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
+    AFTER UPDATE OF deleted_at ON events
+    FOR EACH ROW
+    EXECUTE FUNCTION purge_soft_deleted_nip_rs();
+
+--
+-- Name: trg_events_purge_soft_deleted_nip_rs; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
+    AFTER UPDATE OF deleted_at ON events_p2026_04
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_nip_rs();
 
@@ -5011,7 +5826,7 @@ CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
 --
 
 CREATE OR REPLACE TRIGGER trg_events_purge_soft_deleted_nip_rs
-    AFTER UPDATE OF deleted_at ON events_p2026_05
+    AFTER UPDATE OF deleted_at ON events_p2026_03
     FOR EACH ROW
     EXECUTE FUNCTION purge_soft_deleted_nip_rs();
 
@@ -5049,6 +5864,9 @@ ALTER TABLE ONLY moderation_reports
 
 ALTER TABLE ONLY protected_object_authority
     ADD CONSTRAINT protected_object_authority_check1 CHECK ((((owner_pubkey IS NULL) AND (delegated_relationship_id IS NULL) AND (delegated_relationship_revision IS NULL) AND (delegation_conditions_fingerprint IS NULL)) OR ((owner_pubkey IS NOT NULL) AND (delegated_relationship_id IS NOT NULL) AND (delegated_relationship_revision IS NOT NULL) AND (delegation_conditions_fingerprint IS NOT NULL))));
+
+ALTER TABLE ONLY protected_publication_projection_outbox
+    ADD CONSTRAINT protected_publication_projection_outbox_check3 CHECK ((((delivery_state = 1) AND (delivered_at IS NULL) AND (failure_code = ANY (ARRAY[0, 1, 2]))) OR ((delivery_state = 2) AND (delivered_at IS NOT NULL) AND (failure_code = 0)) OR ((delivery_state = 3) AND (delivered_at IS NULL) AND (failure_code >= 3) AND (failure_code <= 6))));
 
 ALTER TABLE ONLY push_leases
     ADD CONSTRAINT push_leases_check CHECK (((active AND (app_profile IS NOT NULL) AND (endpoint_hash IS NOT NULL) AND (endpoint_grant IS NOT NULL) AND (max_class IS NOT NULL) AND (subscriptions IS NOT NULL)) OR ((NOT active) AND (app_profile IS NULL) AND (endpoint_hash IS NULL) AND (endpoint_grant IS NULL) AND (max_class IS NULL) AND (subscriptions IS NULL))));


### PR DESCRIPTION
## Why

Identity lifecycle, protected-object publication, and authorization decisions need durable state with fail-closed behavior across enrollment, rotation, revocation, recovery, restart, and ambiguous legacy data.

## What

- Add provider-neutral evidence, trusted-proxy provenance, lifecycle admission, policy, and audit-event primitives
- Add transactional enrollment and operator lifecycle state with authoritative tombstones and replay-safe operation records
- Add protected media publication records and apply durable authority to media, Git, audio, and moderation paths
- Add migrations `0031`, `0032`, and `0034`, plus the corresponding desired-schema state
- Add PostgreSQL, relay, media, concurrency, restart, and protected-object regression coverage

## Review guide

- Evidence and proxy provenance in `buzz-auth`
- Lifecycle, admission, policy, moderation, and operator state in `buzz-db`
- Protected publication and storage behavior in `buzz-media`
- Protected Git, media, audio, and moderation integrations in `buzz-relay`
- Migration and desired-schema compatibility for `0031`, `0032`, and `0034`

## Risk assessment

Medium. This layer adds durable authorization state and changes protected transport paths. Missing, ambiguous, stale, or revoked state denies authorization, and lifecycle transitions are transactional.

## Testing

- Identity lifecycle, admission, policy, and operator PostgreSQL suites
- Concurrency, rollback, restart, tombstone, and cross-principal cases
- Protected media, Git, audio, moderation, and publication cases
- Fresh-schema and additive migration coverage
- Formatting, linting, and hosted repository checks

## References

- Depends on #3564
- Authorization specification: #1485 and #3726

## Authorization-event capacity

Authorization-event storage has finite capacity and fails closed when exhausted. Archival and reclamation are deliberately out of scope for V1 by design.
