### PR TITLE
fix(buzz-agent): replay reasoning_content on tool-calling turns; gate image_url

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -213,6 +213,7 @@ impl RunCtx<'_> {
                 self.history.push(HistoryItem::Assistant {
                     text: response.text,
                     tool_calls: Vec::new(),
+                    reasoning: std::mem::take(&mut response.reasoning),
                 });
                 let stop = map_stop(response.stop);
                 // Only gate genuine end_turn — don't override max_tokens/refusal.
@@ -249,6 +250,7 @@ impl RunCtx<'_> {
             self.history.push(HistoryItem::Assistant {
                 text: response.text,
                 tool_calls: calls.clone(),
+                reasoning: std::mem::take(&mut response.reasoning),
             });
 
             if let Some(stop) = self.execute_calls(&calls).await {
@@ -680,6 +682,7 @@ pub(crate) fn push_hook_outputs_as_tool_results(
                 name: tool_name,
                 arguments: serde_json::json!({}),
             }],
+            reasoning: String::new(),
         });
         history.push(HistoryItem::ToolResult(ToolResult {
             provider_id,

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -723,6 +723,11 @@ pub struct Config {
     pub api_key: String,
     pub model: String,
     pub base_url: String,
+    /// When true, OpenAI-chat-compatible requests may include image_url content
+    /// parts in user messages (e.g. for multimodal providers). When false,
+    /// only text placeholder content is sent. Text-only providers such as
+    /// DeepSeek must set this to false to avoid 400s.
+    pub supports_image_url: bool,
     pub anthropic_api_version: String,
     /// OpenAI endpoint selection. See [`OpenAiApi`].
     pub openai_api: OpenAiApi,
@@ -823,6 +828,7 @@ impl Config {
             stop_max_rejections: parse_env("BUZZ_AGENT_STOP_MAX_REJECTIONS", 3u32)?,
             hook_servers: parse_hook_servers_env("MCP_HOOK_SERVERS"),
             hints_enabled: parse_env("BUZZ_AGENT_NO_HINTS", 0u8)? == 0,
+            supports_image_url: parse_env("BUZZ_AGENT_SUPPORTS_IMAGE_URL", 1u8)? != 0,
             thinking_effort: parse_thinking_effort(env("BUZZ_AGENT_THINKING_EFFORT").as_deref())?,
         };
         cfg.validate()?;
@@ -863,6 +869,7 @@ impl Config {
             stop_max_rejections: 0,
             hook_servers: HookServers::None,
             hints_enabled: false,
+            supports_image_url: true,
             thinking_effort: None,
         }
     }

--- a/crates/buzz-agent/src/handoff.rs
+++ b/crates/buzz-agent/src/handoff.rs
@@ -259,7 +259,7 @@ fn push_history_snippet(out: &mut String, item: &HistoryItem) {
             out.push_str(s);
             out.push('\n');
         }
-        HistoryItem::Assistant { text, tool_calls } => {
+        HistoryItem::Assistant { text, tool_calls, .. } => {
             out.push_str("[assistant] ");
             if !text.is_empty() {
                 out.push_str(text);

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -410,7 +410,7 @@ fn anthropic_body(
                 messages.push(json!({ "role": "user",
                     "content": [{ "type": "text", "text": text }] }));
             }
-            HistoryItem::Assistant { text, tool_calls } => {
+            HistoryItem::Assistant { text, tool_calls, .. } => {
                 flush(&mut messages, &mut pending);
                 let mut content: Vec<Value> = Vec::new();
                 if !text.is_empty() {
@@ -502,7 +502,7 @@ fn openai_body(
                 flush_images(&mut messages, &mut pending_images);
                 messages.push(json!({ "role": "user", "content": text }));
             }
-            HistoryItem::Assistant { text, tool_calls } => {
+            HistoryItem::Assistant { text, tool_calls, reasoning } => {
                 flush_images(&mut messages, &mut pending_images);
                 let mut msg = serde_json::Map::new();
                 msg.insert("role".into(), json!("assistant"));
@@ -519,6 +519,12 @@ fn openai_body(
                         })
                         .collect();
                     msg.insert("tool_calls".into(), Value::Array(calls));
+                    // DeepSeek requires reasoning_content echoed back on assistant
+                    // messages that carry tool_calls, or it 400s.
+                    // https://api-docs.deepseek.com/guides/thinking_mode
+                    if !reasoning.is_empty() {
+                        msg.insert("reasoning_content".into(), json!(reasoning.as_str()));
+                    }
                 }
                 messages.push(Value::Object(msg));
             }
@@ -526,7 +532,9 @@ fn openai_body(
                 messages.push(json!({
                     "role": "tool", "tool_call_id": r.provider_id,
                     "content": openai_tool_text_content(&r.content) }));
-                pending_images.extend(openai_image_user_content(&r.content));
+                if cfg.supports_image_url {
+                    pending_images.extend(openai_image_user_content(&r.content));
+                }
             }
         }
     }
@@ -601,7 +609,7 @@ fn responses_body(
                 "role": "user",
                 "content": [{ "type": "input_text", "text": text }],
             })),
-            HistoryItem::Assistant { text, tool_calls } => {
+            HistoryItem::Assistant { text, tool_calls, .. } => {
                 if !text.is_empty() {
                     input.push(json!({
                         "role": "assistant",
@@ -636,7 +644,7 @@ fn responses_body(
                         ToolResultContent::Text(_) => None,
                     })
                     .collect();
-                if !images.is_empty() {
+                if cfg.supports_image_url && !images.is_empty() {
                     input.push(json!({ "role": "user", "content": images }));
                 }
             }
@@ -1264,6 +1272,7 @@ mod tests {
                     name: "dev__view_image".into(),
                     arguments: serde_json::json!({"source":"x.png"}),
                 }],
+                reasoning: String::new(),
             },
             HistoryItem::ToolResult(ToolResult {
                 provider_id: "toolu_1".into(),
@@ -1313,6 +1322,7 @@ mod tests {
                     name: "dev__shell".into(),
                     arguments: serde_json::json!({"command": "ls"}),
                 }],
+                reasoning: String::new(),
             },
             HistoryItem::ToolResult(ToolResult {
                 provider_id: "call_abc".into(),
@@ -1411,6 +1421,7 @@ mod tests {
                     name: "t".into(),
                     arguments: serde_json::json!({}),
                 }],
+                reasoning: String::new(),
             },
         ];
         let body = responses_body(&cfg_responses(), "system", &history, &[], "model", None);
@@ -1610,6 +1621,7 @@ mod tests {
                         arguments: serde_json::json!({"source": "b.png"}),
                     },
                 ],
+                reasoning: String::new(),
             },
             HistoryItem::ToolResult(ToolResult {
                 provider_id: "toolu_a".into(),

--- a/crates/buzz-agent/src/types.rs
+++ b/crates/buzz-agent/src/types.rs
@@ -62,6 +62,7 @@ pub enum HistoryItem {
     Assistant {
         text: String,
         tool_calls: Vec<ToolCall>,
+        reasoning: String,
     },
     ToolResult(ToolResult),
 }


### PR DESCRIPTION
## Problem

Two interrelated issues cause HTTP 400 errors from DeepSeek (and other text-only OpenAI-compatible providers):

1. **reasoning_content replay**: The response parser in `llm.rs` already extracts DeepSeek's `reasoning_content` field into `LlmResponse.reasoning`, but `openai_body` never writes it back into assistant history. DeepSeek requires it echoed on assistant messages that carry `tool_calls` (see [Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode)).

2. **image_url gating**: `openai_image_user_content` emits `image_url` parts to every OpenAI-compatible provider with no capability check. DeepSeek only accepts text parts and 400s on `image_url`.

## Changes

- `types.rs`: Added `reasoning: String` to `HistoryItem::Assistant`
- `agent.rs`: Populate `reasoning` from `LlmResponse` at all construction sites (3 sites: plain turn, tool-calling turn, hook output)
- `llm.rs` (`openai_body`): Emit `reasoning_content` on assistant messages when `tool_calls` are present and `reasoning` is non-empty
- `llm.rs` (`openai_body` + `responses_body`): Gate `image_url` content behind `Config::supports_image_url`
- `handoff.rs`: Pattern match updated with `..`
- `config.rs`: Added `supports_image_url` field with env override `BUZZ_AGENT_SUPPORTS_IMAGE_URL` (default: `on` / `1`)

## Testing

No Rust toolchain available on the dev host. CI on this PR will run `cargo test -p buzz-agent`. Manual verification steps:

1. Set `BUZZ_AGENT_SUPPORTS_IMAGE_URL=0` and confirm DeepSeek turns succeed
2. Verify reasoning_content is replayed only on tool-calling turns
3. Verify image_url still works for OpenAI/Anthropic with default `1`

## Ref

DeepSeek Thinking Mode: https://api-docs.deepseek.com/guides/thinking_mode