### PR TITLE
feat(cli): resolve @everyone / @channel to all channel members

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -9,7 +9,8 @@ use crate::validate::{
     validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
 };
 use buzz_sdk::mentions::{
-    extract_at_mentions_with_known, extract_nostr_uris, strip_code_regions, MENTION_CAP,
+    contains_everyone_keyword, extract_at_mentions_with_known, extract_nostr_uris,
+    is_everyone_keyword, strip_code_regions, MENTION_CAP,
 };
 
 /// Extract the thread root event ID from a Nostr tag array.
@@ -161,6 +162,7 @@ async fn resolve_content_mentions(
     has_explicit_mentions: bool,
 ) -> Result<(Vec<String>, Vec<String>), CliError> {
     let stripped = strip_code_regions(content);
+    let everyone = contains_everyone_keyword(&stripped);
     if !stripped.contains('@') && !has_explicit_mentions {
         return Ok((vec![], vec![]));
     }
@@ -176,8 +178,23 @@ async fn resolve_content_mentions(
             CliError::Other("could not load channel membership for mention preflight".into())
         })?;
 
+    // `@everyone` / `@channel` expands to every current member, minus the
+    // sender (you don't notify yourself on a broadcast). This runs before
+    // name resolution so the broadcast still works even if profiles fail to
+    // load or a channel has no display names.
+    let sender_hex = client.keys().public_key().to_hex();
+    let broadcast: Vec<String> = if everyone {
+        member_pubkeys
+            .iter()
+            .filter(|pk| **pk != sender_hex)
+            .cloned()
+            .collect()
+    } else {
+        vec![]
+    };
+
     if !stripped.contains('@') {
-        return Ok((member_pubkeys, vec![]));
+        return Ok((member_pubkeys, broadcast));
     }
 
     let profiles_filter = serde_json::json!({
@@ -220,8 +237,20 @@ async fn resolve_content_mentions(
     }
 
     let known_refs: Vec<&str> = display_names.iter().map(String::as_str).collect();
-    let names = extract_at_mentions_with_known(&stripped, &known_refs);
-    let resolved = resolve_names_to_pubkeys(&names, &name_to_pubkeys, has_explicit_mentions)?;
+    // Drop the reserved broadcast keywords from ordinary name resolution — they
+    // are handled by `broadcast` above and must not be treated as (missing)
+    // member display names.
+    let names: Vec<String> = extract_at_mentions_with_known(&stripped, &known_refs)
+        .into_iter()
+        .filter(|n| !is_everyone_keyword(n))
+        .collect();
+    let mut resolved = resolve_names_to_pubkeys(&names, &name_to_pubkeys, has_explicit_mentions)?;
+    // Merge the broadcast set in, de-duplicating against name-resolved pubkeys.
+    for pk in broadcast {
+        if !resolved.contains(&pk) {
+            resolved.push(pk);
+        }
+    }
     Ok((member_pubkeys, resolved))
 }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -357,7 +357,7 @@ pub enum MessagesCmd {
         /// Channel UUID (from 'buzz channels list')
         #[arg(long)]
         channel: String,
-        /// Message text — supports @mentions and markdown. Use '-' to read from stdin.
+        /// Message text — supports @mentions and markdown. Use '-' to read from stdin. `@everyone` or `@channel` notifies every current channel member (except you).
         #[arg(long)]
         content: String,
         /// Nostr event kind (default: channel default)

--- a/crates/buzz-sdk/src/mentions.rs
+++ b/crates/buzz-sdk/src/mentions.rs
@@ -157,6 +157,62 @@ fn is_word_boundary(s: &str) -> bool {
     })
 }
 
+/// Reserved broadcast keywords that expand to *every* member of the channel.
+///
+/// Matched case-insensitively as `@everyone` / `@channel`. These are the two
+/// keywords people reach for (Slack/Discord `@channel`, Discord/Slack
+/// `@everyone`). `@here` is intentionally excluded: it implies presence-based
+/// filtering ("active members only") that Buzz does not track, so honoring it
+/// would silently over- or under-notify.
+pub const EVERYONE_KEYWORDS: &[&str] = &["everyone", "channel"];
+
+/// Returns `true` when `content` contains an `@everyone` / `@channel` broadcast
+/// keyword.
+///
+/// The keyword must obey the same boundary rules as a regular `@mention`: the
+/// `@` sits at start-of-input or is preceded by ASCII whitespace, and the
+/// keyword is followed by a word boundary (whitespace, common punctuation, or
+/// end-of-input). Matching is case-insensitive.
+///
+/// Callers should pass content that has already had code regions removed via
+/// [`strip_code_regions`] so keywords inside code spans/blocks are ignored,
+/// mirroring how ordinary mentions are scanned.
+pub fn contains_everyone_keyword(content: &str) -> bool {
+    if content.is_empty() || !content.contains('@') {
+        return false;
+    }
+    for (i, _) in content.match_indices('@') {
+        let preceded = i == 0 || content.as_bytes()[i - 1].is_ascii_whitespace();
+        if !preceded {
+            continue;
+        }
+        let rest = &content[i + 1..];
+        for kw in EVERYONE_KEYWORDS {
+            // `get(..len)` guards against a keyword length landing mid-character
+            // in multi-byte UTF-8 content (would otherwise panic on slicing).
+            let matches_kw = rest
+                .get(..kw.len())
+                .is_some_and(|s| s.eq_ignore_ascii_case(kw) && is_word_boundary(&rest[kw.len()..]));
+            if matches_kw {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns `true` if `name` is a reserved broadcast keyword (`everyone` /
+/// `channel`), compared case-insensitively.
+///
+/// Used to drop these tokens from ordinary name-resolution so they are not
+/// treated as (missing) member display names, since they are expanded to the
+/// full member set separately.
+pub fn is_everyone_keyword(name: &str) -> bool {
+    EVERYONE_KEYWORDS
+        .iter()
+        .any(|k| k.eq_ignore_ascii_case(name))
+}
+
 /// Match extracted `@names` against channel-member profiles.
 ///
 /// For each profile, parses its `content_json` and reads the
@@ -540,6 +596,65 @@ mod tests {
         // Reverse case: multi-byte known name against ASCII content.
         let result = extract_at_mentions_with_known("@alice hello", &["日本語"]);
         assert_eq!(result, vec!["alice"]);
+    }
+
+    #[test]
+    fn everyone_keyword_matches_basic_forms() {
+        assert!(contains_everyone_keyword("heads up @everyone"));
+        assert!(contains_everyone_keyword("@channel standup in 5"));
+        assert!(contains_everyone_keyword("@everyone"));
+        assert!(contains_everyone_keyword("@channel"));
+    }
+
+    #[test]
+    fn everyone_keyword_is_case_insensitive() {
+        assert!(contains_everyone_keyword("@Everyone"));
+        assert!(contains_everyone_keyword("@CHANNEL now"));
+        assert!(contains_everyone_keyword("@EveryOne please"));
+    }
+
+    #[test]
+    fn everyone_keyword_respects_word_boundary() {
+        // A keyword glued to more name characters is NOT a broadcast.
+        assert!(!contains_everyone_keyword("@everyonehere"));
+        assert!(!contains_everyone_keyword("@channels"));
+        assert!(!contains_everyone_keyword("@channel-ops"));
+        // Punctuation boundary IS allowed.
+        assert!(contains_everyone_keyword("cc @everyone, please review"));
+        assert!(contains_everyone_keyword("@channel."));
+    }
+
+    #[test]
+    fn everyone_keyword_requires_leading_boundary() {
+        // Mid-word / email-like @ does not trigger a broadcast.
+        assert!(!contains_everyone_keyword("user@channel.com"));
+        assert!(!contains_everyone_keyword("foo@everyone"));
+    }
+
+    #[test]
+    fn everyone_keyword_absent_and_empty() {
+        assert!(!contains_everyone_keyword(""));
+        assert!(!contains_everyone_keyword("no mentions here"));
+        assert!(!contains_everyone_keyword("@alice and @bob"));
+        assert!(!contains_everyone_keyword("@here")); // deliberately excluded
+    }
+
+    #[test]
+    fn everyone_keyword_multibyte_does_not_panic() {
+        // Multi-byte content following '@' must not panic on the length slice.
+        assert!(!contains_everyone_keyword("@日本語 hello"));
+        // A real broadcast still resolves amid unicode prose.
+        assert!(contains_everyone_keyword("こんにちは @everyone"));
+    }
+
+    #[test]
+    fn is_everyone_keyword_recognizes_reserved_tokens() {
+        assert!(is_everyone_keyword("everyone"));
+        assert!(is_everyone_keyword("Everyone"));
+        assert!(is_everyone_keyword("CHANNEL"));
+        assert!(!is_everyone_keyword("alice"));
+        assert!(!is_everyone_keyword("here"));
+        assert!(!is_everyone_keyword(""));
     }
 
     fn profile<'a>(pk: &'a str, json: &'a str) -> MentionProfile<'a> {


### PR DESCRIPTION
## What

Adds a first-class **`@everyone` / `@channel`** broadcast keyword to `buzz messages send`. Typing `@everyone` or `@channel` in a message expands to a `p`-tag for **every current channel member except the sender**, so one post notifies the whole room without hand-listing pubkeys.

Motivation: users kept asking "is there a way to tag everyone at once?" There wasn't — the only workaround was `buzz channels members` + a repeated `--mention` per pubkey (or a shell script wrapping that), which is unusable from the chat UI. This makes the natural thing work.

## How

**`buzz-sdk` (`mentions.rs`)** — two pure, network-free helpers alongside the existing mention pipeline:
- `contains_everyone_keyword(content)` — detects `@everyone` / `@channel`, case-insensitive, using the *same* boundary rules as ordinary `@mention`: the `@` must be at start-of-input or preceded by ASCII whitespace, and the keyword must be followed by a word boundary (whitespace / common punctuation / end-of-input). Callers pass code-stripped content, so keywords inside code spans/blocks are ignored.
- `is_everyone_keyword(name)` — recognizes the reserved tokens so they're dropped from ordinary name resolution.
- `@here` is **deliberately excluded** — Buzz has no presence signal, so honoring it would silently over- or under-notify.

**`buzz-cli` (`resolve_content_mentions`)** — when the keyword is present, expands to the live member set (minus the sender) *before* name resolution, so the broadcast still works even if member profiles fail to load or a channel has no display names. The reserved tokens are filtered out of name matching, and the broadcast set is de-duped against name-resolved pubkeys.

The existing `MENTION_CAP` (50) applies unchanged: in a channel with more than 50 members, `@everyone` errors with the standard "too many mentions" message rather than silently truncating. Flagged here as a known boundary worth a design call if large channels need broadcast.

## Tests

7 new unit tests in `buzz-sdk`: basic forms, case-insensitivity, trailing word-boundary, leading-boundary rule (email-like `user@channel.com` does not trigger), multibyte-safety (no panic), and `@here` exclusion.

- `cargo test -p buzz-sdk`: 259 passed / 0 failed
- `cargo test -p buzz-cli`: 317 passed / 0 failed
- `cargo clippy -p buzz-sdk -p buzz-cli --all-targets`: clean
- `cargo fmt`: applied

## Notes

Originated from a request in the Buzz Welcome channel. Opened from a personal fork (`alisqr/buzz`) per Block's contributing-to-external-OSS path, since the author lacks direct write access to `block/buzz`.
