### PR TITLE
fix(mobile): keep paste menu stable during typing updates

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -131,6 +131,7 @@ class ChannelDetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final composerDockHeight = useState(0.0);
+    final typingIndicatorHeight = useState(0.0);
     final sendMessage = ref.read(sendMessageProvider);
     final detailsAsync = ref.watch(channelDetailsProvider(channel.id));
     final channelsAsync = ref.watch(channelsProvider);
@@ -461,7 +462,8 @@ class ChannelDetailPage extends HookConsumerWidget {
                               appBarTitleContentHeight:
                                   appBarTitleContentHeight,
                               composerBottomInset: showsComposer
-                                  ? composerDockHeight.value
+                                  ? composerDockHeight.value +
+                                        typingIndicatorHeight.value
                                   : 0,
                             );
                           },
@@ -487,6 +489,36 @@ class ChannelDetailPage extends HookConsumerWidget {
             ],
           ),
           if (showsComposer)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: composerDockHeight.value,
+              child: ComposerDockSizeReporter(
+                key: const ValueKey('channel-typing-overlay'),
+                onHeightChanged: (height) {
+                  if ((typingIndicatorHeight.value - height).abs() < 0.5) {
+                    return;
+                  }
+                  typingIndicatorHeight.value = height;
+                },
+                child: IgnorePointer(
+                  child: AnimatedSwitcher(
+                    duration: MediaQuery.disableAnimationsOf(context)
+                        ? Duration.zero
+                        : const Duration(milliseconds: 180),
+                    child: typingEntries.isEmpty
+                        ? const SizedBox.shrink(
+                            key: ValueKey('channel-typing-hidden'),
+                          )
+                        : ChannelTypingIndicator(
+                            key: const ValueKey('channel-typing-visible'),
+                            entries: typingEntries,
+                          ),
+                  ),
+                ),
+              ),
+            ),
+          if (showsComposer)
             Align(
               alignment: Alignment.bottomCenter,
               child: ComposerDockSizeReporter(
@@ -495,19 +527,11 @@ class ChannelDetailPage extends HookConsumerWidget {
                   if ((composerDockHeight.value - height).abs() < 0.5) return;
                   composerDockHeight.value = height;
                 },
+                // Keep remote typing status outside the editable dock. Its
+                // appearance must not invalidate iOS's native Paste menu.
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    AnimatedSize(
-                      duration: MediaQuery.disableAnimationsOf(context)
-                          ? Duration.zero
-                          : const Duration(milliseconds: 180),
-                      curve: Curves.easeOutCubic,
-                      alignment: Alignment.bottomCenter,
-                      child: typingEntries.isEmpty
-                          ? const SizedBox.shrink()
-                          : ChannelTypingIndicator(entries: typingEntries),
-                    ),
                     ComposeBar(
                       channelId: channel.id,
                       channelName: resolvedChannel.isDm

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -60,6 +60,7 @@ class ThreadDetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final composerDockHeight = useState(0.0);
+    final typingIndicatorHeight = useState(0.0);
     final sendMessage = ref.read(sendMessageProvider);
     // Relay thread queries are keyed by the outermost root, even when this
     // page displays a nested branch. Query that root, then select this head's
@@ -364,7 +365,10 @@ class ThreadDetailPage extends HookConsumerWidget {
                       left: Grid.gutter,
                       right: Grid.gutter,
                       top: frostedAppBarHeight(context),
-                      bottom: Grid.xs + composerDockHeight.value,
+                      bottom:
+                          Grid.xs +
+                          composerDockHeight.value +
+                          typingIndicatorHeight.value,
                     ),
                     itemCount: replies.length + 1, // +1 for thread head
                     itemBuilder: (context, index) {
@@ -506,24 +510,47 @@ class ThreadDetailPage extends HookConsumerWidget {
             ],
           ),
           if (isMember && !isArchived)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: composerDockHeight.value,
+              child: ComposerDockSizeReporter(
+                key: const ValueKey('thread-typing-overlay'),
+                onHeightChanged: (height) {
+                  if ((typingIndicatorHeight.value - height).abs() < 0.5) {
+                    return;
+                  }
+                  typingIndicatorHeight.value = height;
+                },
+                child: IgnorePointer(
+                  child: AnimatedSwitcher(
+                    duration: MediaQuery.disableAnimationsOf(context)
+                        ? Duration.zero
+                        : const Duration(milliseconds: 180),
+                    child: threadTyping.isEmpty
+                        ? const SizedBox.shrink(
+                            key: ValueKey('thread-typing-hidden'),
+                          )
+                        : ChannelTypingIndicator(
+                            key: const ValueKey('thread-typing-visible'),
+                            entries: threadTyping,
+                          ),
+                  ),
+                ),
+              ),
+            ),
+          if (isMember && !isArchived)
             Align(
               alignment: Alignment.bottomCenter,
               child: ComposerDockSizeReporter(
                 key: const ValueKey('thread-composer-dock'),
                 onHeightChanged: updateComposerDockHeight,
+                // The typing indicator is an independent overlay above this
+                // dock. Remote typing updates must not resize an editable
+                // ancestor: iOS dismisses its native Paste menu on that churn.
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    AnimatedSize(
-                      duration: MediaQuery.disableAnimationsOf(context)
-                          ? Duration.zero
-                          : const Duration(milliseconds: 180),
-                      curve: Curves.easeOutCubic,
-                      alignment: Alignment.bottomCenter,
-                      child: threadTyping.isEmpty
-                          ? const SizedBox.shrink()
-                          : ChannelTypingIndicator(entries: threadTyping),
-                    ),
                     ComposeBar(
                       channelId: channelId,
                       hintText: 'Reply in thread\u2026',

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -163,6 +163,7 @@ NostrEvent _edit({
 Widget _buildTestable({
   required List<NostrEvent> messages,
   List<TypingEntry> typing = const [],
+  _FakeTypingNotifier? typingNotifier,
   Map<String, UserProfile> users = const {},
   List<ChannelMember> members = const [],
   Channel? channel,
@@ -194,7 +195,7 @@ Widget _buildTestable({
       ).overrideWith(() => fakeMessagesNotifier),
       channelTypingProvider(
         _channelId,
-      ).overrideWith(() => _FakeTypingNotifier(typing)),
+      ).overrideWith(() => typingNotifier ?? _FakeTypingNotifier(typing)),
       userCacheProvider.overrideWith(() => _FakeUserCacheNotifier(users)),
       profileProvider.overrideWith(() => _FakeProfileNotifier()),
       channelsProvider.overrideWith(() => fakeChannelsNotifier),
@@ -2804,6 +2805,180 @@ void main() {
   });
 
   group('Typing indicator', () {
+    testWidgets(
+      'channel typing updates do not resize a focused composer dock',
+      (tester) async {
+        final typingNotifier = _FakeTypingNotifier([]);
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [
+              _textMsg(
+                id: 'channel-message',
+                pubkey: 'alice',
+                content: 'Channel message',
+              ),
+            ],
+            typingNotifier: typingNotifier,
+            users: const {
+              'jarvis': UserProfile(pubkey: 'jarvis', displayName: 'Jarvis'),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Message #general'));
+        await tester.pumpAndSettle();
+
+        final textField = find.byType(TextField);
+        final composerDock = find.byKey(
+          const ValueKey('channel-composer-dock'),
+        );
+        final messageList = find.byKey(const ValueKey('channel-message-list'));
+        await tester.enterText(textField, 'pasted channel text');
+        await tester.pump();
+        final field = tester.widget<TextField>(textField);
+        final controller = field.controller!;
+        final focusNode = field.focusNode!;
+        final selection = controller.selection;
+        final composerTop = tester.getTopLeft(textField).dy;
+        final composerDockHeight = tester.getSize(composerDock).height;
+        final initialListBottomPadding =
+            (tester.widget<ScrollablePositionedList>(messageList).padding!)
+                .bottom;
+
+        typingNotifier.setEntries([
+          TypingEntry(
+            pubkey: 'jarvis',
+            expiresAtMs: DateTime.now().millisecondsSinceEpoch + 8000,
+          ),
+        ]);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.text('Jarvis is typing…'), findsOneWidget);
+        expect(tester.getTopLeft(textField).dy, composerTop);
+        expect(tester.getSize(composerDock).height, composerDockHeight);
+        expect(controller.text, 'pasted channel text');
+        expect(controller.selection, selection);
+        expect(focusNode.hasFocus, isTrue);
+        expect(
+          (tester.widget<ScrollablePositionedList>(messageList).padding!)
+              .bottom,
+          greaterThan(initialListBottomPadding),
+        );
+
+        typingNotifier.setEntries([]);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.pump();
+
+        expect(find.text('Jarvis is typing…'), findsNothing);
+        expect(tester.getTopLeft(textField).dy, composerTop);
+        expect(tester.getSize(composerDock).height, composerDockHeight);
+        expect(controller.text, 'pasted channel text');
+        expect(controller.selection, selection);
+        expect(focusNode.hasFocus, isTrue);
+        expect(
+          (tester.widget<ScrollablePositionedList>(messageList).padding!)
+              .bottom,
+          initialListBottomPadding,
+        );
+      },
+    );
+
+    testWidgets('thread typing updates do not move a focused composer', (
+      tester,
+    ) async {
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+      );
+      final typingNotifier = _FakeTypingNotifier([]);
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          typingNotifier: typingNotifier,
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'jarvis': UserProfile(pubkey: 'jarvis', displayName: 'Jarvis'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reply in thread…'));
+      await tester.pumpAndSettle();
+
+      final textField = find.byType(TextField);
+      final composerDock = find.byKey(const ValueKey('thread-composer-dock'));
+      final messageList = find.byKey(const ValueKey('thread-message-list'));
+      expect(textField, findsOneWidget);
+      expect(composerDock, findsOneWidget);
+      await tester.enterText(textField, 'pasted thread text');
+      await tester.pump();
+      final field = tester.widget<TextField>(textField);
+      final controller = field.controller!;
+      final focusNode = field.focusNode!;
+      final selection = controller.selection;
+      final composerTop = tester.getTopLeft(textField).dy;
+      final composerDockHeight = tester.getSize(composerDock).height;
+      final initialListBottomPadding =
+          (tester.widget<ScrollablePositionedList>(messageList).padding!)
+              .bottom;
+
+      typingNotifier.setEntries([
+        TypingEntry(
+          pubkey: 'jarvis',
+          threadHeadId: 'thread-root',
+          expiresAtMs: DateTime.now().millisecondsSinceEpoch + 8000,
+        ),
+      ]);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Jarvis is typing…'), findsOneWidget);
+      expect(tester.getTopLeft(textField).dy, composerTop);
+      expect(tester.getSize(composerDock).height, composerDockHeight);
+      expect(controller.text, 'pasted thread text');
+      expect(controller.selection, selection);
+      expect(focusNode.hasFocus, isTrue);
+      expect(
+        (tester.widget<ScrollablePositionedList>(messageList).padding!).bottom,
+        greaterThan(initialListBottomPadding),
+      );
+
+      typingNotifier.setEntries([]);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pump();
+
+      expect(find.text('Jarvis is typing…'), findsNothing);
+      expect(tester.getTopLeft(textField).dy, composerTop);
+      expect(tester.getSize(composerDock).height, composerDockHeight);
+      expect(controller.text, 'pasted thread text');
+      expect(controller.selection, selection);
+      expect(focusNode.hasFocus, isTrue);
+      expect(
+        (tester.widget<ScrollablePositionedList>(messageList).padding!).bottom,
+        initialListBottomPadding,
+      );
+    });
+
     testWidgets('shows single typer', (tester) async {
       await tester.pumpWidget(
         _buildTestable(
@@ -3889,12 +4064,17 @@ class _ReconnectingRelaySession extends RelaySessionNotifier {
 }
 
 class _FakeTypingNotifier extends ChannelTypingNotifier {
-  final List<TypingEntry> _entries;
+  List<TypingEntry> _entries;
   _FakeTypingNotifier(this._entries, {String channelId = _channelId})
     : super(channelId);
 
   @override
   List<TypingEntry> build() => _entries;
+
+  void setEntries(List<TypingEntry> entries) {
+    _entries = entries;
+    state = entries;
+  }
 }
 
 class _SynchronousReadStateNotifier extends ReadStateNotifier {


### PR DESCRIPTION
## Summary
- keep channel and thread typing indicators outside the measured editable composer dock
- reserve independently measured timeline space for typing feedback without moving or remounting the focused TextField
- keep informational typing overlays non-interactive
- add channel and thread regressions for dock geometry, focus, draft text, cursor selection, and timeline padding across typing show/hide

## Root cause
Typing indicators were children of the measured composer dock. Their appearance and expiry changed an ancestor layout while iOS had its native Paste menu open, invalidating the menu and causing visible flicker.

## Verification
- targeted channel/thread regressions: 2 passed
- channel detail suite: 78 passed
- complete mobile Flutter suite: 1,165 passed
- targeted `flutter analyze`: no issues
- independent review: passed after fixing timeline-content overlap found in the first review
- added-lines security scan: no secrets or dangerous APIs detected

## Remaining platform check
Native iOS paste-menu persistence still needs confirmation on a real device or platform-faithful simulator before release.