### PR TITLE
fix(compose): disable MSYS path conversion in run.sh

### DIFF
--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Git Bash (MSYS) rewrites absolute container paths in arguments — e.g.
+# `/usr/local/bin/buzz-admin` becomes `C:/Program Files/Git/usr/local/bin/...`
+# before docker ever sees it, breaking every `docker compose exec` below with
+# "OCI runtime exec failed". Disabling the conversion is a no-op everywhere
+# except MSYS shells.
+export MSYS_NO_PATHCONV=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 


### PR DESCRIPTION
## Problem

Under Git Bash on Windows, MSYS rewrites absolute container paths in command arguments before docker receives them:

```
$ ./run.sh add-member <pubkey>
OCI runtime exec failed: exec failed: unable to start container process:
exec: "C:/Program Files/Git/usr/local/bin/buzz-admin":
stat C:/Program Files/Git/usr/local/bin/buzz-admin: no such file or directory
```

`/usr/local/bin/buzz-admin` was converted to a Windows Git-installation path inside the container. This breaks `add-member`, `remove-member`, and `list-members` — the documented way to populate a closed relay — on the platform most likely to be running a first local deployment (Windows users must already use Git Bash to run `run.sh` at all).

## Fix

`export MSYS_NO_PATHCONV=1` at the top of `run.sh`. The variable is only interpreted by Git-for-Windows' MSYS layer; it is a no-op in every other shell, so macOS/Linux behavior is unchanged.

## Testing

- Reproduced the failure in Git Bash on Windows 11; with `MSYS_NO_PATHCONV=1` exported, `add-member`/`list-members` work against a live compose stack.
- Not re-tested on macOS/Linux; the variable is only read by Git for Windows' MSYS layer, so non-MSYS shells ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
