### PR TITLE
docs(compose): add Windows notes to the compose deployment README

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -46,6 +46,29 @@ keypair.
 
 Run `./run.sh backup-hint` for the backup checklist.
 
+## Windows notes
+
+- `run.sh` is a bash script. Run it from **Git Bash** or WSL, not PowerShell —
+  Windows hands `.sh` files to the associated editor instead of executing them.
+  In Git Bash, drive paths are written `/d/path/to/buzz/deploy/compose`.
+- `$EDITOR .env` is a Unix convention; in PowerShell use `notepad .env`
+  (or any editor). A file named `.env` can look nameless in File Explorer
+  unless "File name extensions" is enabled.
+- Git Bash (MSYS) rewrites absolute container paths in command arguments,
+  which breaks `docker compose exec` container paths with "OCI runtime exec
+  failed". `run.sh` disables this itself via `MSYS_NO_PATHCONV=1`; export the
+  same variable before running `docker compose exec ...` by hand.
+- For a **local (loopback) deployment**, set `BUZZ_DOMAIN=127.0.0.1` and use
+  `ws://127.0.0.1:3000` everywhere — clients canonicalize loopback URLs to
+  `127.0.0.1`, so a relay bound to the literal host `localhost` is unreachable
+  by agent harnesses (they get 404 on the WebSocket upgrade). This applies to
+  all platforms, not just Windows.
+- Generate hex secrets in PowerShell with:
+
+  ```powershell
+  -join ((0..31) | ForEach-Object { '{0:x2}' -f (Get-Random -Maximum 256) })
+  ```
+
 ## Validation
 
 Before sharing an install link publicly, verify a fresh install with:


### PR DESCRIPTION
## What

Adds a "Windows notes" section to `deploy/compose/README.md` covering the pitfalls a Windows operator hits on a first self-hosted deployment, each of which was hit in a real setup:

- `run.sh` must run under Git Bash/WSL — PowerShell hands `.sh` files to the associated editor instead of executing them (and Git Bash drive-path syntax).
- `$EDITOR .env` is a Unix-ism → `notepad .env`; `.env` looks nameless in File Explorer unless "File name extensions" is enabled.
- MSYS path conversion breaks hand-typed `docker compose exec` container paths (`MSYS_NO_PATHCONV=1`); complements the `run.sh` fix in #4785.
- A PowerShell one-liner for generating the hex secrets.
- The loopback deployment rule (applies to all platforms): use `127.0.0.1`, not `localhost`, for `BUZZ_DOMAIN`/relay URLs, because clients canonicalize loopback URLs to `127.0.0.1` and a relay bound to the literal `localhost` host is unreachable by agent harnesses (404 on WebSocket upgrade). This note documents the current behavior and remains correct (as a "one spelling everywhere" recommendation) if the normalization fix in #4784 lands.

Docs only; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

