### PR TITLE
fix(ci): make desktop cache test version agnostic

### DIFF
--- a/scripts/test-desktop-release-cache-key.sh
+++ b/scripts/test-desktop-release-cache-key.sh
@@ -12,13 +12,27 @@ args=(--platform Linux --target x86_64-unknown-linux-gnu --features mesh-llm --n
 original=$("$key_script" "${args[@]}")
 python3 - <<'PY'
 from pathlib import Path
+import re
+
 manifest = Path("desktop/src-tauri/Cargo.toml")
-manifest.write_text(manifest.read_text().replace('version = "0.5.4"', 'version = "9.8.7"', 1))
+manifest_text = manifest.read_text()
+package = re.search(r'(?ms)^\[package\]\n.*?^version = "([^"]+)"', manifest_text)
+if package is None:
+    raise SystemExit("desktop package version not found")
+current_version = package.group(1)
+manifest.write_text(
+    manifest_text[: package.start(1)] + "9.8.7" + manifest_text[package.end(1) :]
+)
+
 lock = Path("desktop/src-tauri/Cargo.lock")
 text = lock.read_text()
 start = text.index('name = "buzz-desktop"')
-version = text.index('version = "0.5.4"', start)
-lock.write_text(text[:version] + 'version = "9.8.7"' + text[version + len('version = "0.5.4"'):])
+version = text.index(f'version = "{current_version}"', start)
+lock.write_text(
+    text[:version]
+    + 'version = "9.8.7"'
+    + text[version + len(f'version = "{current_version}"') :]
+)
 PY
 version_only=$("$key_script" "${args[@]}")
 [[ "$original" == "$version_only" ]] || { echo "desktop version changed cache key" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- derive the current desktop package version in the release cache-key contract test
- mutate that version in both `Cargo.toml` and `Cargo.lock` instead of assuming `0.5.4`
- prevent desktop release version bumps from failing generic CI

## Context

PR #4788 bumped Desktop to `0.5.5`, exposing the hard-coded fixture. The dedicated release candidate check passed, while generic CI failed with `desktop version changed cache key`.

## Verification

- pre-commit hooks passed
- pre-push hooks passed
- CI will validate the full contract
