### PR TITLE
fix(desktop): widen post-Enter timeouts in empty-edit-delete spec

### DIFF
--- a/desktop/tests/e2e/empty-edit-delete.spec.ts
+++ b/desktop/tests/e2e/empty-edit-delete.spec.ts
@@ -59,7 +59,7 @@ test("clearing an edit to empty prompts to delete, then deletes on confirm", asy
   // The same "Delete message?" confirmation the Delete menu action shows — an
   // empty edit is routed through it, not silently deleted.
   const dialog = page.getByRole("alertdialog");
-  await expect(dialog).toBeVisible({ timeout: 5_000 });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
   await expect(dialog).toContainText("Delete message?");
   // Edit mode stays active while the dialog is open — it exits only on confirm.
   await expect(page.getByTestId("edit-target")).toBeVisible();
@@ -78,7 +78,7 @@ test("cancelling the empty-edit delete keeps the message", async ({ page }) => {
   await submitEmptyEdit(page, OWN_MESSAGE_ID);
 
   const dialog = page.getByRole("alertdialog");
-  await expect(dialog).toBeVisible({ timeout: 5_000 });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
 
   // Cancel → nothing is deleted, the original message survives, and the user is
   // left in edit mode (the editing session is preserved, not discarded).
@@ -109,7 +109,7 @@ test("a non-empty edit still edits and never deletes", async ({ page }) => {
 
   // No delete confirmation, edit mode exits, the row survives with new text.
   await expect(page.getByRole("alertdialog")).toHaveCount(0);
-  await expect(page.getByTestId("edit-target")).toBeHidden({ timeout: 5_000 });
+  await expect(page.getByTestId("edit-target")).toBeHidden({ timeout: 10_000 });
   await expect(row).toBeVisible();
   await expect(page.getByTestId("message-timeline")).toContainText(
     editedContent,


### PR DESCRIPTION
## Summary

Increases three Playwright assertion timeouts in `tests/e2e/empty-edit-delete.spec.ts` from 5s to 10s to fix a shard-composition flake introduced by PR #4694.

## Root Cause

PR #4694 added `huddle-transcription.spec.ts` (477 lines, 22+ tests) to the Desktop Smoke E2E suite, shifting shard 2 composition so that `empty-edit-delete` now runs with significantly more accumulated browser state. The three affected assertions all wait for a React state update triggered by pressing Enter in edit mode:

- `alertdialog` becoming visible after an empty edit (tests 1 and 2)
- `edit-target` hiding after a successful non-empty edit (test 3)

These transitions go through the React scheduler. In isolation they complete in milliseconds. In a loaded headless shard with accumulated GC pressure, the 5s window became insufficient — test 3 failed 3/3 times in CI run [30946444168](https://github.com/block/buzz/actions/runs/30946444168) with `edit-target` still visible after Enter.

No product code is changed. The empty-edit-delete flow is correct and untouched by #4694. This is a test-environment timing adjustment only.

## What Changed

- `tests/e2e/empty-edit-delete.spec.ts` — three `{ timeout: 5_000 }` → `{ timeout: 10_000 }` for the post-Enter React-update waits

## Validation

- `just desktop-check` — passed
- `just desktop-test` — 4194 passed, 0 failed