### PR TITLE
fix(acp): forward agent env vars into the MCP tool server

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4277,6 +4277,49 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
     Ok(())
 }
 
+/// Identity and secret env keys that must NEVER be re-forwarded to the MCP
+/// tool server under their own name via [`forwarded_env_names`].
+///
+/// These mirror the desktop's reserved-key contract (identity/secrets and the
+/// relay URL). The desktop already strips them from an agent's configured
+/// env_vars before spawn, so they should never appear in `BUZZ_ACP_FORWARD_ENV`
+/// — this is a defense-in-depth guard so a bug or crafted list can't smuggle a
+/// forged nsec/auth-tag/relay into the tool shell. Comparison is
+/// case-insensitive, matching the desktop's `is_reserved_env_key`.
+const RESERVED_FORWARD_KEYS: &[&str] = &[
+    "BUZZ_PRIVATE_KEY",
+    "NOSTR_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_PRIVATE_KEY",
+    "BUZZ_ACP_API_TOKEN",
+    "BUZZ_RELAY_URL",
+];
+
+/// True when `key` is a reserved identity/secret key that must not be forwarded.
+fn is_reserved_forward_key(key: &str) -> bool {
+    RESERVED_FORWARD_KEYS
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(key))
+}
+
+/// Parse the comma-separated agent-configured env key names the desktop set in
+/// `BUZZ_ACP_FORWARD_ENV`. Blank entries are dropped and surrounding whitespace
+/// trimmed. Returns an empty vec when the var is unset — so agents launched
+/// without the desktop (or on older desktops) keep the prior fixed-allowlist
+/// behavior unchanged.
+fn forwarded_env_names() -> Vec<String> {
+    match std::env::var("BUZZ_ACP_FORWARD_ENV") {
+        Ok(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
 fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
     if config.mcp_command.is_empty() {
         return vec![];
@@ -4327,6 +4370,38 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                         name: "BUZZ_ACP_DISPLAY_NAME".into(),
                         value: display_name,
                     });
+                }
+            }
+            // Forward the agent's own configured env_vars into the MCP tool
+            // server so they reach the tool shell. Without this, a var the
+            // operator sets on the agent (e.g. NOTION_FULL_TOKEN) reaches the
+            // buzz-acp process but is dropped at the buzz-acp -> buzz-dev-mcp
+            // spawn, and no tool command ever sees it.
+            //
+            // The desktop lists the exact agent-configured key NAMES in
+            // BUZZ_ACP_FORWARD_ENV (comma-separated). We forward ONLY those
+            // names, reading each value from this process's env — never the
+            // whole environment, so unrelated process vars (git config,
+            // internal BUZZ_ACP_* plumbing) stay out of the tool shell.
+            for name in forwarded_env_names() {
+                // Defense in depth: never re-forward an identity/secret key
+                // under its own name, even if one somehow appears in the list.
+                // These are already provided (or deliberately withheld) above.
+                if is_reserved_forward_key(&name) {
+                    tracing::warn!(
+                        "buzz-acp: refusing to forward reserved env key `{name}` to MCP server"
+                    );
+                    continue;
+                }
+                // Skip names the fixed allowlist already set, so the forward
+                // list can't silently override BUZZ_RELAY_URL/BUZZ_PRIVATE_KEY.
+                if env.iter().any(|e| e.name == name) {
+                    continue;
+                }
+                // Listed-but-unset names are skipped (not forwarded as empty):
+                // absence and empty are semantically distinct downstream.
+                if let Ok(value) = std::env::var(&name) {
+                    env.push(EnvVar { name, value });
                 }
             }
             env
@@ -5240,6 +5315,132 @@ mod build_mcp_servers_tests {
                 .iter()
                 .any(|e| e.name == "BUZZ_ACP_DISPLAY_NAME"),
             "empty display name should not be forwarded"
+        );
+    }
+
+    // ── Agent-configured env forwarding (BUZZ_ACP_FORWARD_ENV) ───────────
+    //
+    // The desktop writes each agent's configured env_vars onto the buzz-acp
+    // process and lists their key names in BUZZ_ACP_FORWARD_ENV. build_mcp_servers
+    // must forward exactly those names (values read from the process env) into
+    // the MCP server's env so they reach the tool shell — without leaking any
+    // other process env var. See the env-forwarding bug: agent secrets reached
+    // buzz-acp but were dropped at the buzz-acp -> buzz-dev-mcp spawn.
+
+    #[test]
+    fn forward_env_named_vars_reach_mcp_server() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(
+            "BUZZ_ACP_FORWARD_ENV",
+            "NOTION_FULL_TOKEN,ANTHROPIC_API_KEY",
+        );
+        std::env::set_var("NOTION_FULL_TOKEN", "notion-value");
+        std::env::set_var("ANTHROPIC_API_KEY", "anthropic-value");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+        std::env::remove_var("BUZZ_ACP_FORWARD_ENV");
+        std::env::remove_var("NOTION_FULL_TOKEN");
+        std::env::remove_var("ANTHROPIC_API_KEY");
+
+        let env = &servers[0].env;
+        let notion = env.iter().find(|e| e.name == "NOTION_FULL_TOKEN");
+        let anthropic = env.iter().find(|e| e.name == "ANTHROPIC_API_KEY");
+        assert_eq!(
+            notion.map(|e| e.value.as_str()),
+            Some("notion-value"),
+            "a forwarded agent env var must reach the MCP server verbatim"
+        );
+        assert_eq!(
+            anthropic.map(|e| e.value.as_str()),
+            Some("anthropic-value"),
+            "all names in BUZZ_ACP_FORWARD_ENV must be forwarded"
+        );
+    }
+
+    #[test]
+    fn forward_env_does_not_leak_unlisted_process_vars() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Only NOTION_FULL_TOKEN is listed; UNLISTED_SECRET is present in the
+        // process env but not named, so it must NOT be forwarded.
+        std::env::set_var("BUZZ_ACP_FORWARD_ENV", "NOTION_FULL_TOKEN");
+        std::env::set_var("NOTION_FULL_TOKEN", "notion-value");
+        std::env::set_var("UNLISTED_SECRET", "must-not-leak");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+        std::env::remove_var("BUZZ_ACP_FORWARD_ENV");
+        std::env::remove_var("NOTION_FULL_TOKEN");
+        std::env::remove_var("UNLISTED_SECRET");
+
+        let env = &servers[0].env;
+        assert!(
+            env.iter().any(|e| e.name == "NOTION_FULL_TOKEN"),
+            "listed var must be forwarded"
+        );
+        assert!(
+            !env.iter().any(|e| e.name == "UNLISTED_SECRET"),
+            "an unlisted process env var must never be forwarded (least privilege)"
+        );
+    }
+
+    #[test]
+    fn forward_env_never_forwards_reserved_keys() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Defense in depth: even if a reserved identity/secret key is somehow
+        // named in the forward list, build_mcp_servers must refuse to re-forward
+        // it under that name. BUZZ_PRIVATE_KEY / BUZZ_RELAY_URL are set by the
+        // fixed allowlist below; a forwarded NOSTR_PRIVATE_KEY must never appear.
+        std::env::set_var("BUZZ_ACP_FORWARD_ENV", "NOSTR_PRIVATE_KEY,BUZZ_AUTH_TAG");
+        std::env::set_var("NOSTR_PRIVATE_KEY", "leaked-nsec");
+        std::env::remove_var("BUZZ_AUTH_TAG");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+        std::env::remove_var("BUZZ_ACP_FORWARD_ENV");
+        std::env::remove_var("NOSTR_PRIVATE_KEY");
+
+        assert!(
+            !servers[0].env.iter().any(|e| e.name == "NOSTR_PRIVATE_KEY"),
+            "reserved identity/secret keys must never be forwarded via BUZZ_ACP_FORWARD_ENV"
+        );
+    }
+
+    #[test]
+    fn forward_env_skips_listed_but_unset_vars() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("BUZZ_ACP_FORWARD_ENV", "PRESENT_VAR,ABSENT_VAR");
+        std::env::set_var("PRESENT_VAR", "present-value");
+        std::env::remove_var("ABSENT_VAR");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+        std::env::remove_var("BUZZ_ACP_FORWARD_ENV");
+        std::env::remove_var("PRESENT_VAR");
+
+        let env = &servers[0].env;
+        assert!(
+            env.iter().any(|e| e.name == "PRESENT_VAR"),
+            "a present listed var must be forwarded"
+        );
+        assert!(
+            !env.iter().any(|e| e.name == "ABSENT_VAR"),
+            "a listed-but-unset var must be skipped, not forwarded as empty"
+        );
+    }
+
+    #[test]
+    fn forward_env_unset_leaves_fixed_allowlist_unchanged() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("BUZZ_ACP_FORWARD_ENV");
+        std::env::remove_var("BUZZ_AUTH_TAG");
+        std::env::remove_var("BUZZ_ACP_DISPLAY_NAME");
+        let config = test_config();
+        let servers = build_mcp_servers(&config);
+
+        let names: Vec<&str> = servers[0].env.iter().map(|e| e.name.as_str()).collect();
+        // With no forward list and no optional vars, only the two always-present
+        // fixed-allowlist entries remain — existing behavior is unchanged.
+        assert_eq!(
+            names,
+            vec!["BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"],
+            "with BUZZ_ACP_FORWARD_ENV unset the fixed allowlist must be untouched; got {names:?}"
         );
     }
 

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -88,6 +88,11 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     // ambient env var must not be able to forge setup mode (NotReady) on a
     // Ready agent or suppress it (empty/stale payload) on a NotReady one.
     "BUZZ_ACP_SETUP_PAYLOAD",
+    // MCP env-forwarding manifest: desktop derives the exact key names that
+    // buzz-acp forwards into the tool server from the layered env. A user
+    // override could smuggle unrelated process vars into the tool shell or
+    // suppress legitimate forwarding, so it is Buzz-controlled only.
+    "BUZZ_ACP_FORWARD_ENV",
     // Desktop ownership markers: these brand every spawned harness with the
     // launching Desktop instance. A user-supplied override would let a
     // definition masquerade as a different instance or fake the nonce used
@@ -316,6 +321,23 @@ pub(crate) fn merged_user_env(
         true
     });
     merged
+}
+
+/// Build the `BUZZ_ACP_FORWARD_ENV` manifest value: a comma-separated list of
+/// the env key NAMES to forward into the MCP tool server, derived from the
+/// fully-layered agent env (`descriptor.env`).
+///
+/// Returns `None` when there is nothing to forward, so the caller leaves the
+/// var unset and buzz-acp keeps its prior fixed-allowlist behavior. A
+/// well-formed POSIX env key (see [`is_well_formed_env_key`]) cannot contain a
+/// comma, so the joined list is unambiguous. Reserved identity/secret keys are
+/// already stripped from `descriptor.env`; buzz-acp additionally refuses to
+/// forward them, so no filtering is needed here.
+pub(crate) fn mcp_forward_env_manifest(env: &BTreeMap<String, String>) -> Option<String> {
+    if env.is_empty() {
+        return None;
+    }
+    Some(env.keys().map(String::as_str).collect::<Vec<_>>().join(","))
 }
 
 /// Look up the live env map of `persona_id` within an already-loaded persona

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use super::{
     display_invalid_key, is_derived_provider_model_key, is_reserved_env_key,
-    is_well_formed_env_key, merged_user_env, validate_user_env_keys,
+    is_well_formed_env_key, mcp_forward_env_manifest, merged_user_env, validate_user_env_keys,
     DERIVED_PROVIDER_MODEL_ENV_KEYS, MAX_ENV_TOTAL_BYTES, MAX_ENV_VALUE_BYTES, RESERVED_ENV_KEYS,
 };
 
@@ -496,4 +496,38 @@ fn deploy_model_precedence_none_when_both_absent() {
 
     let effective = persona_model.clone().or(record_model.clone());
     assert_eq!(effective, None);
+}
+
+// ── mcp_forward_env_manifest: BUZZ_ACP_FORWARD_ENV derivation ──────────
+
+#[test]
+fn forward_manifest_empty_env_returns_none() {
+    // No env → var left unset → buzz-acp keeps its fixed-allowlist behavior.
+    assert_eq!(mcp_forward_env_manifest(&BTreeMap::new()), None);
+}
+
+#[test]
+fn forward_manifest_lists_all_key_names_comma_separated() {
+    // BTreeMap iterates keys in sorted order, so the joined list is stable.
+    let env = map(&[
+        ("NOTION_FULL_TOKEN", "notion"),
+        ("ANTHROPIC_API_KEY", "anthropic"),
+    ]);
+    assert_eq!(
+        mcp_forward_env_manifest(&env).as_deref(),
+        Some("ANTHROPIC_API_KEY,NOTION_FULL_TOKEN"),
+        "manifest must carry every layered env key NAME, comma-separated"
+    );
+}
+
+#[test]
+fn forward_manifest_carries_names_only_not_values() {
+    // The manifest is names-only; secret values never appear in it.
+    let env = map(&[("NOTION_FULL_TOKEN", "super-secret-value")]);
+    let manifest = mcp_forward_env_manifest(&env).expect("non-empty env yields a manifest");
+    assert_eq!(manifest, "NOTION_FULL_TOKEN");
+    assert!(
+        !manifest.contains("super-secret-value"),
+        "the forward manifest must never embed env values"
+    );
 }

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -850,6 +850,33 @@ pub fn spawn_agent_child(
     for (key, value) in &descriptor.env {
         command.env(key, value);
     }
+
+    // ── Forward agent env vars into the MCP tool server ───────────────────
+    //
+    // `descriptor.env` reaches the buzz-acp agent process (written just above),
+    // but the harness spawns the MCP tool server (buzz-dev-mcp) with a fixed
+    // env allowlist — so without this, an operator-set env var (e.g. a Notion
+    // or provider API token) never reaches the shell that tool calls run in.
+    //
+    // We hand buzz-acp the exact set of key NAMES to forward, comma-separated,
+    // via BUZZ_ACP_FORWARD_ENV. buzz-acp reads each value from its own process
+    // env and adds only these names to the MCP server's env — never the whole
+    // environment, so Buzz's own plumbing (git config, BUZZ_ACP_* internals)
+    // stays out of the tool shell. Reserved identity/secret keys were already
+    // stripped from `descriptor.env`, and buzz-acp additionally refuses to
+    // forward them as a defense-in-depth guard.
+    //
+    // A well-formed POSIX key cannot contain a comma, so a comma-separated list
+    // is unambiguous. Empty set → the var is left unset and buzz-acp keeps its
+    // prior fixed-allowlist behavior.
+    match crate::managed_agents::env_vars::mcp_forward_env_manifest(&descriptor.env) {
+        Some(manifest) => {
+            command.env("BUZZ_ACP_FORWARD_ENV", manifest);
+        }
+        None => {
+            command.env_remove("BUZZ_ACP_FORWARD_ENV");
+        }
+    }
     configure_runtime_cli(&mut command, runtime_meta);
 
     // Buzz shared compute is stored as a native provider; derive the OpenAI-compatible


### PR DESCRIPTION
## Problem

Agent-configured environment variables never reach the MCP tool shell.

When an operator sets an env var on an agent (e.g. a Notion token, a provider API key), the variable reaches the `buzz-acp` agent process but is dropped when the harness spawns the MCP tool server (`buzz-dev-mcp`). Every shell/tool the agent runs is a child of that server, so tool calls never see the variable — even though it is set correctly and shows in the agent's Edit form.

Process chain:

```
buzz-desktop -> buzz-acp -> buzz-agent -> buzz-dev-mcp -> tool shell
```

`build_mcp_servers` (in `buzz-acp`) constructs the MCP server's `env` from a small fixed allowlist (`BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, optionally `BUZZ_AUTH_TAG` / `BUZZ_ACP_DISPLAY_NAME`). The tool shell inherits `buzz-dev-mcp`'s process env, so that fixed set is the whole world a tool sees. Agent-configured vars are never added, so they are silently unavailable to tools.

## Fix

Forward the agent's configured env vars into the MCP tool server, scoped per-agent and least-privilege:

- **Desktop** derives the exact set of env key **names** from the fully-layered agent env (`descriptor.env`) and passes them to `buzz-acp` via a new Buzz-controlled `BUZZ_ACP_FORWARD_ENV` manifest (comma-separated). A new helper `mcp_forward_env_manifest` builds it; `BUZZ_ACP_FORWARD_ENV` is added to `RESERVED_ENV_KEYS` so a user override cannot smuggle unrelated vars in or suppress forwarding.
- **`buzz-acp`** (`build_mcp_servers`) forwards **only** those named keys, reading each value from its own process env — never the whole environment, so Buzz's own plumbing (git config, internal `BUZZ_ACP_*` vars) stays out of the tool shell. Listed-but-unset names are skipped (absence ≠ empty). Names the fixed allowlist already set are not overridden.
- **Defense in depth:** `buzz-acp` refuses to forward reserved identity/secret keys (nsec, auth tag, relay URL, API tokens) even if one somehow appears in the manifest. The desktop already strips these from `descriptor.env`.

When `BUZZ_ACP_FORWARD_ENV` is unset (older desktops, non-desktop launches), the prior fixed-allowlist behavior is unchanged.

## Tests

- `buzz-acp` (`build_mcp_servers_tests`): named vars reach the MCP server; unlisted process vars are never forwarded; reserved keys are refused; listed-but-unset vars are skipped; unset manifest leaves the fixed allowlist untouched. Full `buzz-acp` lib suite green (675 passed).
- `buzz-desktop` (`managed_agents::env_vars`): `mcp_forward_env_manifest` returns `None` for empty env, lists all key names comma-separated, and carries names only (never values). Module suite green (45 passed).

Note: the full `buzz-desktop` Tauri bundle build requires prebuilt sidecar binaries not present in a fresh clone; the desktop unit tests above were validated with placeholder sidecars locally, and CI builds the real sidecars.
