### PR TITLE
fix(acp): treat model-switch timeouts as non-fatal; raise agent startup budgets

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -1520,6 +1520,15 @@ impl AcpClient {
 
                     tracing::debug!(target: "acp::wire", "← {trimmed}");
 
+                    // Any stdout line means the agent is alive — reset the idle
+                    // deadline even for non-JSON lines (thinking/reasoning output
+                    // from opencode and similar ACP adapters). The hard deadline
+                    // (max_turn_duration) is the real safety valve for runaway
+                    // agents; the idle timer only guards against total silence.
+                    let activity_now = Instant::now();
+                    idle_deadline = activity_now + idle_timeout;
+                    last_activity_at = activity_now;
+
                     let msg: serde_json::Value = match serde_json::from_str(trimmed) {
                         Ok(v) => v,
                         Err(e) => {
@@ -1538,10 +1547,6 @@ impl AcpClient {
                         }
                     };
                     self.observe("acp_read", msg.clone());
-
-                    let activity_now = Instant::now();
-                    idle_deadline = activity_now + idle_timeout;
-                    last_activity_at = activity_now;
 
                     // Steer response routing must come BEFORE the prompt
                     // response check: a steer response is a regular

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -699,9 +699,10 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "opencode" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        "hermes" | "hermes-agent" | "hermes-acp" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -1599,6 +1600,35 @@ mod tests {
             normalize_agent_args("buzz-agent", vec!["acp".into()]),
             Vec::<String>::new()
         );
+    }
+
+    #[test]
+    fn normalizes_hermes_args_to_empty() {
+        // `hermes-acp` is itself an ACP-mode launcher, so it must never receive
+        // the legacy `acp` argument — that would double it up to `hermes acp acp`
+        // and abort startup, leaving the model dropdown empty.
+        for command in [
+            "hermes",
+            "hermes-agent",
+            "hermes-acp",
+            "/opt/hermes/bin/hermes-acp",
+        ] {
+            assert_eq!(
+                normalize_agent_args(command, Vec::new()),
+                Vec::<String>::new(),
+                "unexpected defaults for {command}"
+            );
+            assert_eq!(
+                normalize_agent_args(command, vec!["acp".into()]),
+                Vec::<String>::new(),
+                "unexpected legacy-acp handling for {command}"
+            );
+            assert_eq!(
+                normalize_agent_args(command, vec!["".into()]),
+                Vec::<String>::new(),
+                "unexpected empty-arg handling for {command}"
+            );
+        }
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -60,7 +60,9 @@ fn is_subcommand(name: &str) -> bool {
 }
 
 /// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
-const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Hermes launches its full MCP server set during session/new and can exceed 10s,
+/// so keep this generous enough for heavy adapters without blocking long.
+const MODELS_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -821,7 +821,15 @@ const CONTEXT_COUNT_TIMEOUT: Duration = Duration::from_millis(500);
 const CONTEXT_FETCH_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Timeout for model-switch requests (`session/set_config_option`, `session/set_model`).
-const MODEL_SWITCH_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// Applied right after `session/new`, while a heavy ACP adapter (opencode with
+/// a large skill/plugin set, hermes with its MCP server tree) is still booting.
+/// 5s was too short: opencode answered `session/new` but took longer than 5s
+/// to answer the follow-up `session/set_model`, which surfaced as a fatal
+/// transport error → respawn → circuit-open → the agent never responded.
+/// Mirrors the MODELS_TIMEOUT 10s→30s raise (hermes MCP boot exceeding the
+/// probe budget) — startup-time RPCs get a startup-sized budget.
+const MODEL_SWITCH_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Bounded grace window for the post-cancel drain after a control-signal
 /// cancellation (steer fallback, interrupt, or explicit stop). This is a
@@ -831,7 +839,9 @@ const MODEL_SWITCH_TIMEOUT: Duration = Duration::from_secs(5);
 const CONTROL_CANCEL_GRACE: Duration = Duration::from_secs(5);
 
 /// Timeout for permission-mode requests (`session/set_config_option` with `configId: "mode"`).
-const PERMISSION_MODE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Also applied right after `session/new` during agent boot — same reasoning as
+/// `MODEL_SWITCH_TIMEOUT` (heavy adapters answer slowly while starting up).
+const PERMISSION_MODE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Placeholder [`fetch_channel_info`] substitutes when a channel's metadata
 /// event carries no `name` tag. Not a real channel name — consumers that need
@@ -1097,11 +1107,16 @@ async fn apply_model_switch(
                 "applied model {desired} via {method_label} on session {session_id}"
             );
         }
-        // Transport-class errors may have corrupted the stdio stream — propagate
-        // so the caller can respawn the agent instead of reusing a poisoned one.
+        // Transport-class errors may have corrupted the stdio stream — but a
+        // timeout is NOT evidence of corruption: heavy adapters (opencode
+        // answers `session/new` but never responds to `session/set_model` /
+        // `session/set_config_option` model RPCs — it only emits a terminal
+        // escape) simply don't support the RPC. Respawn-looping on that was
+        // killing agents outright: 3 attempts → circuit open → never responds.
+        // Io/WriteTimeout/Protocol/AgentExited still propagate (real pipe
+        // damage); Timeout is downgraded to the graceful arm below.
         Ok(Err(e @ AcpError::Io(_)))
         | Ok(Err(e @ AcpError::WriteTimeout(_)))
-        | Ok(Err(e @ AcpError::Timeout(_)))
         | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
@@ -1110,7 +1125,15 @@ async fn apply_model_switch(
             );
             return Err(e);
         }
-        // Application-level errors (Json, etc.) — agent is fine, just uses default model.
+        // Application-level errors and timeouts — agent is fine, just uses its
+        // default model (matching this function's documented "intentionally
+        // non-fatal" contract).
+        Ok(Err(AcpError::Timeout(_))) => {
+            tracing::warn!(
+                target: "pool::model",
+                "timed out setting model {desired} via {method_label} — proceeding with agent default"
+            );
+        }
         Ok(Err(e)) => {
             tracing::warn!(
                 target: "pool::model",
@@ -1118,13 +1141,13 @@ async fn apply_model_switch(
             );
         }
         Err(_) => {
-            // Outer timeout fired — the inner send_request may have left the
-            // stream in an unknown state. Treat as transport error.
-            tracing::error!(
+            // Outer timeout fired — same reasoning as above: the agent is
+            // alive (it answered session/new) but doesn't answer the model
+            // RPC. Non-fatal; proceed with the agent's default model.
+            tracing::warn!(
                 target: "pool::model",
-                "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
+                "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — proceeding with agent default"
             );
-            return Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT));
         }
     }
     Ok(())

--- a/crates/buzz-relay/src/api/mod.rs
+++ b/crates/buzz-relay/src/api/mod.rs
@@ -74,6 +74,7 @@ pub mod relay_members {
             .is_relay_member(community, &pubkey_hex)
             .await
             .map_err(|e| format!("relay membership check failed: {e}"))?;
+        tracing::debug!(community = %community, pubkey = %pubkey_hex, direct_member = is_member, allow_nip_oa = state.config.allow_nip_oa_auth, tag = auth_tag_header.is_some(), "relay membership check");
         if is_member {
             return Ok(MembershipDecision::Member);
         }

--- a/crates/buzz-relay/src/handlers/auth.rs
+++ b/crates/buzz-relay/src/handlers/auth.rs
@@ -76,6 +76,14 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
     // The tag is integrity-protected by the event's Schnorr signature — if
     // tampered, NIP-42 verification will fail before we ever inspect it.
     let auth_tag_json = extract_auth_tag_json(&event);
+    tracing::debug!(
+        agent = %event.pubkey,
+        tag_present = auth_tag_json.is_some(),
+        raw_tags = format!("{:?}", event.tags),
+        "auth: extracted NIP-OA tag present={} raw_tags={:?}",
+        auth_tag_json.is_some(),
+        event.tags
+    );
 
     let relay_url =
         crate::api::bridge::nip42_expected_relay_url(&state.config.relay_url, &conn.tenant);

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -445,6 +445,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        "hermes" | "hermes-agent" | "hermes-acp" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -95,6 +95,35 @@ fn normalizes_buzz_agent_args_to_empty() {
 }
 
 #[test]
+fn normalizes_hermes_args_to_empty() {
+    // `hermes-acp` is itself an ACP-mode launcher, so it must never receive
+    // the legacy `acp` argument — that would double it up to `hermes acp acp`
+    // and abort startup, leaving the model dropdown empty.
+    for command in [
+        "hermes",
+        "hermes-agent",
+        "hermes-acp",
+        "/opt/hermes/bin/hermes-acp",
+    ] {
+        assert_eq!(
+            normalize_agent_args(command, Vec::new()),
+            Vec::<String>::new(),
+            "unexpected defaults for {command}"
+        );
+        assert_eq!(
+            normalize_agent_args(command, vec!["acp".into()]),
+            Vec::<String>::new(),
+            "unexpected legacy-acp handling for {command}"
+        );
+        assert_eq!(
+            normalize_agent_args(command, vec!["".into()]),
+            Vec::<String>::new(),
+            "unexpected empty-arg handling for {command}"
+        );
+    }
+}
+
+#[test]
 fn login_shell_lookup_treats_command_as_data() {
     let marker =
         std::env::temp_dir().join(format!("buzz-discovery-marker-{}", uuid::Uuid::new_v4()));

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -716,7 +716,8 @@ pub fn spawn_agent_child(
     if let Some(max_dur) = record.max_turn_duration_seconds {
         command.env("BUZZ_ACP_MAX_TURN_DURATION", max_dur.to_string());
     }
-    command.env("BUZZ_ACP_AGENTS", record.parallelism.to_string());
+    let capped_parallelism = record.parallelism.min(crate::managed_agents::MAX_AGENT_PARALLELISM);
+    command.env("BUZZ_ACP_AGENTS", capped_parallelism.to_string());
     command.env("BUZZ_ACP_MULTIPLE_EVENT_HANDLING", "steer");
     command.env("BUZZ_ACP_DEDUP", "queue");
     if let Some(meta) = runtime_meta {
@@ -992,7 +993,7 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    let mut process = spawn_agent_child(app, record, &key.relay_url, true, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -811,7 +811,9 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 10;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 3;
+/// Hard cap on agent subprocess count — prevents config-driven process explosion.
+pub const MAX_AGENT_PARALLELISM: u32 = 5;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -16,7 +16,6 @@ import { asRecord, asString, titleCase } from "./agentSessionUtils";
 import {
   describeTurnStarted,
   describeSessionResolved,
-  extractBlockText,
   extractContentText,
   extractPlanText,
   extractPromptText,
@@ -759,16 +758,10 @@ export function processTranscriptEvent(
       event.kind,
     );
   } else if (event.kind === "acp_parse_error") {
-    upsertTextItem(
-      d,
-      `parse-error:${ch}:${event.seq}`,
-      "lifecycle",
-      "Wire parse error",
-      extractBlockText(event.payload),
-      event.timestamp,
-      ctx,
-      event.kind,
-    );
+    // Non-JSON lines from ACP adapters (e.g. opencode thinking/reasoning
+    // chunks) are normal — the idle timer already resets on any stdout
+    // line, so no silent-agent issue either. Silently discard; never
+    // render as transcript noise.
   } else if (event.kind === "turn_error" || event.kind === "agent_panic") {
     const payload = asRecord(event.payload);
     const outcome = asString(payload.outcome) ?? "error";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,12 @@ services:
       com.buzz.env: "dev"
     restart: unless-stopped
 
+  # Optional heavyweight services — NOT started by default (`just relay`).
+  # Bring them up on demand with: docker compose --profile optional up -d
+  # - adminer: DB browser (8082), keycloak: NIP-AB pairing SSO (8180),
+  #   prometheus: relay metrics (9090).
   adminer:
+    profiles: ["optional"]
     image: adminer:latest
     container_name: buzz-adminer
     ports:
@@ -71,9 +76,10 @@ services:
     labels:
       com.buzz.service: "adminer"
       com.buzz.env: "dev"
-    restart: unless-stopped
+    restart: "no"
 
   keycloak:
+    profiles: ["optional"]
     image: quay.io/keycloak/keycloak:26.0
     container_name: buzz-keycloak
     command: start-dev --http-port=8080
@@ -98,7 +104,7 @@ services:
     labels:
       com.buzz.service: "keycloak"
       com.buzz.env: "dev"
-    restart: unless-stopped
+    restart: "no"
 
   minio:
     image: minio/minio:latest
@@ -149,6 +155,7 @@ services:
     restart: "no"
 
   prometheus:
+    profiles: ["optional"]
     image: prom/prometheus:latest
     container_name: buzz-prometheus
     ports:
@@ -167,7 +174,7 @@ services:
     labels:
       com.buzz.service: "prometheus"
       com.buzz.env: "dev"
-    restart: unless-stopped
+    restart: "no"
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary

Makes agent startup and model-switching resilient against slow-but-healthy ACP adapters (opencode with large skill/plugin sets, hermes with its MCP server tree).

**Startup RPC budgets (5s → 30s)**
`MODEL_SWITCH_TIMEOUT` and `PERMISSION_MODE_TIMEOUT` are applied right after `session/new`, while a heavy adapter is still booting. 5s was too short: adapters answered `session/new` but took longer to answer the follow-up model/config RPCs, which surfaced as fatal transport errors → respawn loop → circuit-open → the agent never responded.

**Timeouts on model-switch are now non-fatal**
A `Timeout` is not evidence of stream corruption — the agent is alive but doesn't answer the RPC (opencode emits only terminal escapes for `session/set_model`). It's downgraded to a warn and the agent proceeds with its default model. Real pipe damage (`Io`/`WriteTimeout`/`Protocol`/`AgentExited`) still propagates and respawns.

**Idle detection matches reality**
The idle deadline now resets on *any* stdout line, including non-JSON thinking/reasoning output; the hard `max_turn_duration` remains the safety valve for runaway agents. The desktop transcript correspondingly stops rendering `acp_parse_error` events as errors.

**Cherry-picked from the earlier `fix/acp-agent-startup` line**
Normalize hermes args, raise `MODELS_TIMEOUT`, cap parallelism (the only copy of this work was on a stale fork branch).

**Housekeeping**
- Downgrade NIP-OA membership/auth tracing from ad-hoc `info!` DBG lines to `debug!` (raw tag dumps no longer log on every auth attempt).
- Gate adminer/keycloak/prometheus behind `docker compose --profile optional up -d`.

## Verification

- `cargo check -p buzz-acp -p buzz-relay` — clean
- `cargo fmt --check` — clean
- `pnpm exec tsc --noEmit` (desktop) — clean
- `biome check` on changed TS — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
