### PR TITLE
fix(desktop): derive the hosted-community limit from the relay instead of hardcoding 5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ RELAY_URL=ws://localhost:3000
 # positive integer; missing, unparsable, or non-positive values fall back to
 # the default. Read once at startup and cached for the process lifetime. The
 # effective value is exposed to clients as `max_communities_per_owner` on
-# operator list/provision responses.
+# operator list/provision responses and on `limit_reached` 409 rejections.
 # BUZZ_MAX_COMMUNITIES_PER_OWNER=5
 
 # Shared Redis-backed admission limits. Defaults shown below; each value must

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,13 @@ RELAY_URL=ws://localhost:3000
 # (use `just web` for Vite HMR instead).
 # BUZZ_WEB_DIR=./web/dist
 
+# Maximum number of communities a single pubkey can own (default 5). Must be a
+# positive integer; missing, unparsable, or non-positive values fall back to
+# the default. Read once at startup and cached for the process lifetime. The
+# effective value is exposed to clients as `max_communities_per_owner` on
+# operator list/provision responses.
+# BUZZ_MAX_COMMUNITIES_PER_OWNER=5
+
 # Shared Redis-backed admission limits. Defaults shown below; each value must
 # be a positive integer.
 # BUZZ_RATE_LIMIT_HUMAN_MESSAGES_PER_MIN=60

--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,7 @@ RELAY_URL=ws://localhost:3000
 
 # Maximum number of communities a single pubkey can own (default 5). Must be a
 # positive integer; missing, unparsable, or non-positive values fall back to
-# the default. Read once at startup and cached for the process lifetime. The
+# the default. Read once on first use and cached for the process lifetime. The
 # effective value is exposed to clients as `max_communities_per_owner` on
 # operator list/provision responses and on `limit_reached` 409 rejections.
 # BUZZ_MAX_COMMUNITIES_PER_OWNER=5

--- a/TESTING.md
+++ b/TESTING.md
@@ -281,6 +281,7 @@ out of the box with `just setup` or `just relay`. Common overrides:
 | `BUZZ_AUDIT_ENABLED`            | `true`                      | Tamper-evident event/media audit log. Set `false`/`0`/`off` to skip its DB pool and writes. Does not disable the separate moderation audit trail. |
 | `BUZZ_AUTO_MIGRATE`             | `false`                     | Opt in with `true`/`1`/`yes`/`on` to run embedded SQLx migrations on relay startup |
 | `RELAY_OWNER_PUBKEY`              | unset                       | Bootstrapped as `owner` in `relay_members` at first start |
+| `BUZZ_MAX_COMMUNITIES_PER_OWNER` | `5`                         | Communities one pubkey may own. Positive integer; invalid values fall back to the default. The effective value is reported as `max_communities_per_owner` on operator list/provision responses and `limit_reached` 409s, so clients gate on the deployment's value instead of a hardcoded 5 |
 | `BUZZ_ALLOW_NIP_OA_AUTH`        | `false`                     | Enable NIP-OA owner attestation for membership |
 | `BUZZ_WEB_DIR`                  | unset (source), `/srv/buzz/web` (container) | Directory containing the invite landing bundle; the production container enables it so `/invite/{code}` always works |
 | `BUZZ_SERVE_GIT_WEB_GUI`        | `false`                     | Set to `true` or `1` to expose the bundled Git repository browser at `/` and `/repos/...`; invite routes do not depend on this flag |

--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -403,6 +403,11 @@ pub enum TransferResult {
 /// Default maximum number of communities a single pubkey can own. Enforced at
 /// the relay layer — the authoritative layer — so that concurrent transfers or
 /// transfer-vs-create races cannot both pass a preflight count.
+///
+/// The desktop keeps a fallback copy of this default
+/// (`DEFAULT_HOSTED_COMMUNITY_LIMIT` in
+/// `desktop/src/features/communities/hostedCommunityLimit.ts`) for responses
+/// that don't carry the wire field yet — change the two together (#4160).
 pub const MAX_COMMUNITIES_PER_OWNER: i64 = 5;
 
 /// Effective per-owner community limit for this deployment.

--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -340,7 +340,7 @@ pub async fn update_relay_member_role(
 /// **Deployment-root authority exception:** This function is called only by
 /// startup initialization and legacy operator provisioning
 /// (`community_provisioning.rs`). It is NOT an end-user path and does NOT
-/// enforce the per-owner community limit (`MAX_COMMUNITIES_PER_OWNER`) or
+/// enforce the per-owner community limit ([`max_communities_per_owner`]) or
 /// acquire the per-recipient advisory lock. The per-owner limit is an
 /// end-user invariant enforced by `create_community_with_owner` and
 /// `transfer_ownership`; deployment-root operations may exceed it by design.
@@ -458,7 +458,8 @@ pub fn owner_count_advisory_lock_key(pubkey_hex: &str) -> i64 {
 /// 2. Locks the current owner row `FOR UPDATE` and verifies
 ///    `expected_owner_pubkey` matches. This prevents a stale-owner race where
 ///    a delayed/retried request overwrites a completed transfer.
-/// 3. Enforces the [`MAX_COMMUNITIES_PER_OWNER`] limit on the transferee by
+/// 3. Enforces the effective per-owner limit ([`max_communities_per_owner`],
+///    which honors `BUZZ_MAX_COMMUNITIES_PER_OWNER`) on the transferee by
 ///    counting owned communities inside the same transaction.
 /// 4. Upserts `new_owner_pubkey` as `owner` (insert or promote).
 /// 5. Demotes every other owner in this community to `member` — **not**

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -163,6 +163,11 @@ async fn check_operator_replay(
 /// The request is authenticated against `RELAY_OPERATOR_API_ORIGIN` and does
 /// not bind the inbound host to a tenant. The operator allowlist is the
 /// authority for this deployment-root control-plane surface.
+///
+/// Successful responses carry `max_communities_per_owner` — this deployment's
+/// effective per-owner limit (`BUZZ_MAX_COMMUNITIES_PER_OWNER`); a
+/// `limit_reached:` rejection returns HTTP 409 with the same field beside the
+/// `error` message.
 pub async fn provision_community(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -315,6 +320,11 @@ pub async fn unarchive_community(
 }
 
 /// List communities where a pubkey currently holds the `owner` role.
+///
+/// `GET /operator/communities?owner_pubkey=<hex>`. Beside `communities`, the
+/// response carries `max_communities_per_owner` — this deployment's effective
+/// per-owner limit (`BUZZ_MAX_COMMUNITIES_PER_OWNER`) — so clients gate on the
+/// deployment's configuration instead of a hardcoded default.
 pub async fn list_owned_communities(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -365,12 +375,24 @@ pub async fn list_owned_communities(
 /// `RELAY_OPERATOR_PUBKEYS`, body:
 ///
 /// ```json
-/// { "community_id": "<uuid>", "new_owner_pubkey": "<hex>" }
+/// {
+///   "community_id": "<uuid>",
+///   "new_owner_pubkey": "<hex>",
+///   "expected_owner_pubkey": "<hex>"
+/// }
 /// ```
+///
+/// All three fields are required; `expected_owner_pubkey` is the compare-and-set
+/// guard against a stale-owner race.
 ///
 /// The previous owner is demoted to `member` (not `admin`). The transfer is
 /// instant and atomic at the database layer. Publication of the updated
 /// NIP-43 membership list is best-effort, matching the provision path.
+///
+/// The relay rejects a transfer on the *transferee's* quota: that rejection is
+/// HTTP 409 carrying `max_communities_per_owner` — this deployment's effective
+/// per-owner limit (`BUZZ_MAX_COMMUNITIES_PER_OWNER`) — beside the
+/// `limit_reached:` `error` message.
 pub async fn transfer_community(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -1265,6 +1287,53 @@ mod tests {
                 .get("max_communities_per_owner")
                 .and_then(Value::as_i64),
             Some(effective_limit)
+        );
+    }
+
+    /// The `limit_reached` 409 body is the surface clients read the number
+    /// from, and it must report whatever `BUZZ_MAX_COMMUNITIES_PER_OWNER`
+    /// resolved to for this process rather than a literal 5 (#4160). The
+    /// Postgres-backed tests above assert the same field end-to-end through
+    /// the handlers; this one covers the body itself on the unit gate, and
+    /// prints it so the wire shape under a given env value is inspectable.
+    #[test]
+    fn limit_reached_conflict_body_reports_the_deployment_limit() {
+        use crate::handlers::community_provisioning::{
+            limit_reached_error, ProvisionCommunityResponse,
+        };
+
+        let effective_limit = buzz_db::relay_members::max_communities_per_owner();
+        let (status, axum::Json(body)) = super::limit_reached_conflict(&limit_reached_error(
+            "owner already owns the maximum number of communities",
+        ));
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            body.get("error").and_then(Value::as_str),
+            Some("limit_reached: owner already owns the maximum number of communities")
+        );
+        assert_eq!(
+            body.get("max_communities_per_owner")
+                .and_then(Value::as_i64),
+            Some(effective_limit)
+        );
+
+        println!(
+            "BUZZ_MAX_COMMUNITIES_PER_OWNER={} -> HTTP 409 {}",
+            std::env::var("BUZZ_MAX_COMMUNITIES_PER_OWNER").unwrap_or_else(|_| "<unset>".into()),
+            serde_json::to_string(&body).expect("serialize 409 body")
+        );
+        println!(
+            "BUZZ_MAX_COMMUNITIES_PER_OWNER={} -> HTTP 200 {}",
+            std::env::var("BUZZ_MAX_COMMUNITIES_PER_OWNER").unwrap_or_else(|_| "<unset>".into()),
+            serde_json::to_string(&ProvisionCommunityResponse {
+                community_id: "b8f7f4a0-0000-0000-0000-000000000000".to_string(),
+                host: "acme.communities.buzz.xyz".to_string(),
+                status: "created",
+                owner_pubkey: None,
+                max_communities_per_owner: effective_limit,
+            })
+            .expect("serialize provision response")
         );
     }
 

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use buzz_core::{CommunityId, TenantContext};
 
 use crate::handlers::community_provisioning::{
-    normalize_candidate_host, validate_pubkey_hex, ProvisionCommunityRequest,
+    limit_reached_error, normalize_candidate_host, validate_pubkey_hex, ProvisionCommunityRequest,
 };
 use crate::state::AppState;
 
@@ -330,6 +330,10 @@ pub async fn list_owned_communities(
 
     Ok(Json(serde_json::json!({
         "owner_pubkey": owner_pubkey,
+        // Effective per-owner community limit, so clients render limit gates
+        // and copy from the deployment's configuration instead of hardcoding
+        // the stock default (#4160).
+        "max_communities_per_owner": buzz_db::relay_members::max_communities_per_owner(),
         "communities": rows.into_iter().map(|row| serde_json::json!({
             "community_id": row.id.to_string(),
             "host": row.host,
@@ -423,7 +427,7 @@ pub async fn transfer_community(
         buzz_db::relay_members::TransferResult::LimitReached => {
             return Err(api_error(
                 StatusCode::CONFLICT,
-                "limit_reached: transferee already owns the maximum number of communities",
+                &limit_reached_error("transferee already owns the maximum number of communities"),
             ));
         }
     };
@@ -1083,7 +1087,7 @@ mod tests {
             return;
         };
 
-        for _ in 0..buzz_db::relay_members::MAX_COMMUNITIES_PER_OWNER {
+        for _ in 0..buzz_db::relay_members::max_communities_per_owner() {
             let host = format!("community-{}.example", Uuid::new_v4().simple());
             assert_eq!(
                 provision_community(state.clone(), &operator, &host, &owner)
@@ -1106,6 +1110,140 @@ mod tests {
             .await
             .expect("look up rejected fresh host")
             .is_none());
+    }
+
+    /// Every operator response that clients derive limit UI from must carry
+    /// the effective per-owner limit (#4160). Asserted against the env-aware
+    /// `max_communities_per_owner()` function, never a literal — the value is
+    /// deployment-configurable and the desktop only falls back to its own
+    /// default when the field is absent.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn list_and_provision_responses_report_effective_owner_limit() {
+        let operator = Keys::generate();
+        let owner = Keys::generate();
+        let Some(state) = operator_test_state(std::slice::from_ref(&operator)).await else {
+            return;
+        };
+        let effective_limit = buzz_db::relay_members::max_communities_per_owner();
+
+        let host = format!("community-{}.example", Uuid::new_v4().simple());
+        let create_response = provision_community(state.clone(), &operator, &host, &owner).await;
+        assert_eq!(create_response.status(), StatusCode::OK);
+        let create_json = read_json(create_response).await;
+        assert_eq!(
+            create_json
+                .get("max_communities_per_owner")
+                .and_then(Value::as_i64),
+            Some(effective_limit)
+        );
+
+        let owner_hex = owner.public_key().to_hex();
+        let query = format!("owner_pubkey={owner_hex}");
+        let list_response = signed_operator_request(
+            state,
+            &operator,
+            "GET",
+            &format!("/operator/communities?{query}"),
+            None,
+        )
+        .await;
+        assert_eq!(list_response.status(), StatusCode::OK);
+        let list_json = read_json(list_response).await;
+        assert_eq!(
+            list_json
+                .get("max_communities_per_owner")
+                .and_then(Value::as_i64),
+            Some(effective_limit)
+        );
+    }
+
+    /// Both `limit_reached:` rejections (create and transfer) must embed the
+    /// effective limit after the routing prefix so clients can surface the
+    /// deployment's real number (#4160). The prefix stays intact for the
+    /// `starts_with`-based 409 routing.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn limit_reached_rejections_embed_effective_limit() {
+        let operator = Keys::generate();
+        let full_owner = Keys::generate();
+        let other_owner = Keys::generate();
+        let Some(state) = operator_test_state(std::slice::from_ref(&operator)).await else {
+            return;
+        };
+        let effective_limit = buzz_db::relay_members::max_communities_per_owner();
+        let embedded_limit = format!("({effective_limit})");
+
+        for _ in 0..effective_limit {
+            let host = format!("community-{}.example", Uuid::new_v4().simple());
+            assert_eq!(
+                provision_community(state.clone(), &operator, &host, &full_owner)
+                    .await
+                    .status(),
+                StatusCode::OK
+            );
+        }
+
+        // Create rejection embeds the number.
+        let host = format!("community-{}.example", Uuid::new_v4().simple());
+        let create_response =
+            provision_community(state.clone(), &operator, &host, &full_owner).await;
+        assert_eq!(create_response.status(), StatusCode::CONFLICT);
+        let create_error = read_json(create_response).await["error"]
+            .as_str()
+            .expect("create rejection error string")
+            .to_string();
+        assert!(
+            create_error.starts_with("limit_reached:"),
+            "error: {create_error}"
+        );
+        assert!(
+            create_error.contains(&embedded_limit),
+            "error: {create_error}"
+        );
+
+        // Transfer rejection embeds the number too: hand a fresh community to
+        // the already-full owner.
+        let transferable_host = format!("community-{}.example", Uuid::new_v4().simple());
+        assert_eq!(
+            provision_community(state.clone(), &operator, &transferable_host, &other_owner)
+                .await
+                .status(),
+            StatusCode::OK
+        );
+        let community = state
+            .db
+            .lookup_community_by_host(&transferable_host)
+            .await
+            .expect("lookup transferable community")
+            .expect("transferable community exists");
+        let transfer_body = serde_json::json!({
+            "community_id": community.id.to_string(),
+            "new_owner_pubkey": full_owner.public_key().to_hex(),
+            "expected_owner_pubkey": other_owner.public_key().to_hex(),
+        })
+        .to_string();
+        let transfer_response = signed_operator_request(
+            state,
+            &operator,
+            "POST",
+            "/operator/communities/transfer",
+            Some(transfer_body),
+        )
+        .await;
+        assert_eq!(transfer_response.status(), StatusCode::CONFLICT);
+        let transfer_error = read_json(transfer_response).await["error"]
+            .as_str()
+            .expect("transfer rejection error string")
+            .to_string();
+        assert!(
+            transfer_error.starts_with("limit_reached:"),
+            "error: {transfer_error}"
+        );
+        assert!(
+            transfer_error.contains(&embedded_limit),
+            "error: {transfer_error}"
+        );
     }
 
     /// Happy path: POST /operator/communities/transfer swaps ownership, demotes

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -24,6 +24,23 @@ use crate::state::AppState;
 
 use super::{api_error, bridge, internal_error};
 
+/// HTTP 409 envelope for `limit_reached:` rejections.
+///
+/// Carries the effective per-owner limit as a structured
+/// `max_communities_per_owner` field next to the stable `error` message, so
+/// clients render the deployment's real number without parsing the message and
+/// intermediaries that match the message keep resolving it to a
+/// `limit_reached` code (#4160).
+fn limit_reached_conflict(msg: &str) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::CONFLICT,
+        Json(serde_json::json!({
+            "error": msg,
+            "max_communities_per_owner": buzz_db::relay_members::max_communities_per_owner(),
+        })),
+    )
+}
+
 /// Query parameters for `GET /operator/communities`.
 #[derive(Debug, Deserialize)]
 pub struct ListCommunitiesQuery {
@@ -178,9 +195,8 @@ pub async fn provision_community(
         Err(msg) if msg.starts_with("actor not authorized") => {
             Err(api_error(StatusCode::FORBIDDEN, &msg))
         }
-        Err(msg) if msg == "community already exists" || msg.starts_with("limit_reached:") => {
-            Err(api_error(StatusCode::CONFLICT, &msg))
-        }
+        Err(msg) if msg.starts_with("limit_reached:") => Err(limit_reached_conflict(&msg)),
+        Err(msg) if msg == "community already exists" => Err(api_error(StatusCode::CONFLICT, &msg)),
         Err(msg)
             if msg.starts_with("failed to create community:")
                 || msg.starts_with("community provisioned but owner bootstrap failed:") =>
@@ -425,10 +441,9 @@ pub async fn transfer_community(
             ));
         }
         buzz_db::relay_members::TransferResult::LimitReached => {
-            return Err(api_error(
-                StatusCode::CONFLICT,
-                &limit_reached_error("transferee already owns the maximum number of communities"),
-            ));
+            return Err(limit_reached_conflict(&limit_reached_error(
+                "transferee already owns the maximum number of communities",
+            )));
         }
     };
 
@@ -1158,13 +1173,15 @@ mod tests {
         );
     }
 
-    /// Both `limit_reached:` rejections (create and transfer) must embed the
-    /// effective limit after the routing prefix so clients can surface the
-    /// deployment's real number (#4160). The prefix stays intact for the
-    /// `starts_with`-based 409 routing.
+    /// Both `limit_reached:` rejections (create and transfer) must report the
+    /// effective limit as a structured `max_communities_per_owner` field so
+    /// clients can surface the deployment's real number without parsing the
+    /// message (#4160). The message itself stays a stable contract — prefix
+    /// intact for the `starts_with`-based 409 routing, and free of the
+    /// deployment-specific number that intermediaries would have to tolerate.
     #[tokio::test]
     #[ignore = "requires Postgres"]
-    async fn limit_reached_rejections_embed_effective_limit() {
+    async fn limit_reached_rejections_report_effective_limit() {
         let operator = Keys::generate();
         let full_owner = Keys::generate();
         let other_owner = Keys::generate();
@@ -1172,7 +1189,6 @@ mod tests {
             return;
         };
         let effective_limit = buzz_db::relay_members::max_communities_per_owner();
-        let embedded_limit = format!("({effective_limit})");
 
         for _ in 0..effective_limit {
             let host = format!("community-{}.example", Uuid::new_v4().simple());
@@ -1184,25 +1200,28 @@ mod tests {
             );
         }
 
-        // Create rejection embeds the number.
+        // Create rejection reports the number.
         let host = format!("community-{}.example", Uuid::new_v4().simple());
         let create_response =
             provision_community(state.clone(), &operator, &host, &full_owner).await;
         assert_eq!(create_response.status(), StatusCode::CONFLICT);
-        let create_error = read_json(create_response).await["error"]
+        let create_body = read_json(create_response).await;
+        let create_error = create_body["error"]
             .as_str()
             .expect("create rejection error string")
             .to_string();
-        assert!(
-            create_error.starts_with("limit_reached:"),
-            "error: {create_error}"
+        assert_eq!(
+            create_error,
+            "limit_reached: owner already owns the maximum number of communities"
         );
-        assert!(
-            create_error.contains(&embedded_limit),
-            "error: {create_error}"
+        assert_eq!(
+            create_body
+                .get("max_communities_per_owner")
+                .and_then(Value::as_i64),
+            Some(effective_limit)
         );
 
-        // Transfer rejection embeds the number too: hand a fresh community to
+        // Transfer rejection reports the number too: hand a fresh community to
         // the already-full owner.
         let transferable_host = format!("community-{}.example", Uuid::new_v4().simple());
         assert_eq!(
@@ -1232,17 +1251,20 @@ mod tests {
         )
         .await;
         assert_eq!(transfer_response.status(), StatusCode::CONFLICT);
-        let transfer_error = read_json(transfer_response).await["error"]
+        let transfer_body_json = read_json(transfer_response).await;
+        let transfer_error = transfer_body_json["error"]
             .as_str()
             .expect("transfer rejection error string")
             .to_string();
-        assert!(
-            transfer_error.starts_with("limit_reached:"),
-            "error: {transfer_error}"
+        assert_eq!(
+            transfer_error,
+            "limit_reached: transferee already owns the maximum number of communities"
         );
-        assert!(
-            transfer_error.contains(&embedded_limit),
-            "error: {transfer_error}"
+        assert_eq!(
+            transfer_body_json
+                .get("max_communities_per_owner")
+                .and_then(Value::as_i64),
+            Some(effective_limit)
         );
     }
 

--- a/crates/buzz-relay/src/handlers/community_provisioning.rs
+++ b/crates/buzz-relay/src/handlers/community_provisioning.rs
@@ -66,6 +66,24 @@ pub struct ProvisionCommunityResponse {
     /// Echoes the validated owner pubkey when an owner bootstrap/rotation ran.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_pubkey: Option<String>,
+    /// Effective per-owner community limit for this deployment
+    /// ([`buzz_db::relay_members::max_communities_per_owner`]). Clients render
+    /// limit gates and copy from this value instead of hardcoding the stock
+    /// default (#4160).
+    pub max_communities_per_owner: i64,
+}
+
+/// Builds a `limit_reached:` rejection message with the effective per-owner
+/// limit embedded, e.g. `limit_reached: <detail> (5)`.
+///
+/// The `limit_reached:` prefix is load-bearing: the operator API routes it to
+/// HTTP 409 via `starts_with` (see `crate::api::operator`), so the number is
+/// appended after the detail rather than spliced into the prefix.
+pub(crate) fn limit_reached_error(detail: &str) -> String {
+    format!(
+        "limit_reached: {detail} ({})",
+        buzz_db::relay_members::max_communities_per_owner()
+    )
 }
 
 pub(crate) fn validate_pubkey_hex(value: &str) -> Option<String> {
@@ -292,10 +310,9 @@ pub async fn provision_community(
                 return Err("community already exists".to_string());
             }
             buzz_db::CreateCommunityWithOwnerResult::LimitReached => {
-                return Err(
-                    "limit_reached: owner already owns the maximum number of communities"
-                        .to_string(),
-                );
+                return Err(limit_reached_error(
+                    "owner already owns the maximum number of communities",
+                ));
             }
         };
 
@@ -312,6 +329,7 @@ pub async fn provision_community(
             host: record.host,
             status: "created",
             owner_pubkey: initial_owner,
+            max_communities_per_owner: buzz_db::relay_members::max_communities_per_owner(),
         });
     }
 
@@ -347,12 +365,53 @@ pub async fn provision_community(
         host: record.host,
         status: if record.created { "created" } else { "existed" },
         owner_pubkey: initial_owner,
+        max_communities_per_owner: buzz_db::relay_members::max_communities_per_owner(),
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The provisioning response must carry the effective per-owner limit so
+    /// clients can stop hardcoding it (#4160). Asserted against the env-aware
+    /// function, never a literal — the whole point is that the value is
+    /// deployment-configurable.
+    #[test]
+    fn provision_response_serializes_effective_owner_limit() {
+        let response = ProvisionCommunityResponse {
+            community_id: "b8f7f4a0-0000-0000-0000-000000000000".to_string(),
+            host: "acme.communities.buzz.xyz".to_string(),
+            status: "created",
+            owner_pubkey: None,
+            max_communities_per_owner: buzz_db::relay_members::max_communities_per_owner(),
+        };
+        let json = serde_json::to_value(&response).expect("serialize response");
+        assert_eq!(
+            json.get("max_communities_per_owner")
+                .and_then(serde_json::Value::as_i64),
+            Some(buzz_db::relay_members::max_communities_per_owner())
+        );
+    }
+
+    /// The rejection message keeps the `limit_reached:` routing prefix intact
+    /// and embeds the effective (env-aware) limit for user-facing copy.
+    #[test]
+    fn limit_reached_error_keeps_prefix_and_embeds_effective_limit() {
+        let message = limit_reached_error("owner already owns the maximum number of communities");
+        assert!(message.starts_with("limit_reached:"), "message: {message}");
+        assert!(
+            message.contains("owner already owns the maximum number of communities"),
+            "message: {message}"
+        );
+        assert!(
+            message.contains(&format!(
+                "({})",
+                buzz_db::relay_members::max_communities_per_owner()
+            )),
+            "message: {message}"
+        );
+    }
 
     #[test]
     fn host_valid_bare_domain() {

--- a/crates/buzz-relay/src/handlers/community_provisioning.rs
+++ b/crates/buzz-relay/src/handlers/community_provisioning.rs
@@ -73,17 +73,17 @@ pub struct ProvisionCommunityResponse {
     pub max_communities_per_owner: i64,
 }
 
-/// Builds a `limit_reached:` rejection message with the effective per-owner
-/// limit embedded, e.g. `limit_reached: <detail> (5)`.
+/// Builds a `limit_reached:` rejection message, e.g.
+/// `limit_reached: <detail>`.
 ///
 /// The `limit_reached:` prefix is load-bearing: the operator API routes it to
-/// HTTP 409 via `starts_with` (see `crate::api::operator`), so the number is
-/// appended after the detail rather than spliced into the prefix.
+/// HTTP 409 via `starts_with` (see `crate::api::operator`), and intermediaries
+/// map the message onto a `limit_reached` error code for clients. The message
+/// is therefore a stable contract — the effective limit rides alongside it as
+/// the structured `max_communities_per_owner` field on the 409 body instead of
+/// being spliced into this string.
 pub(crate) fn limit_reached_error(detail: &str) -> String {
-    format!(
-        "limit_reached: {detail} ({})",
-        buzz_db::relay_members::max_communities_per_owner()
-    )
+    format!("limit_reached: {detail}")
 }
 
 pub(crate) fn validate_pubkey_hex(value: &str) -> Option<String> {
@@ -394,22 +394,23 @@ mod tests {
         );
     }
 
-    /// The rejection message keeps the `limit_reached:` routing prefix intact
-    /// and embeds the effective (env-aware) limit for user-facing copy.
+    /// The rejection message is a stable wire contract: the `limit_reached:`
+    /// routing prefix plus the detail, and nothing deployment-specific. The
+    /// effective limit travels as a structured field on the 409 body (see
+    /// `crate::api::operator`), so intermediaries that map this message onto a
+    /// `limit_reached` error code keep matching whatever the deployment's
+    /// configured limit is (#4160).
     #[test]
-    fn limit_reached_error_keeps_prefix_and_embeds_effective_limit() {
+    fn limit_reached_error_is_a_stable_message_without_the_limit() {
         let message = limit_reached_error("owner already owns the maximum number of communities");
+        assert_eq!(
+            message,
+            "limit_reached: owner already owns the maximum number of communities"
+        );
         assert!(message.starts_with("limit_reached:"), "message: {message}");
         assert!(
-            message.contains("owner already owns the maximum number of communities"),
-            "message: {message}"
-        );
-        assert!(
-            message.contains(&format!(
-                "({})",
-                buzz_db::relay_members::max_communities_per_owner()
-            )),
-            "message: {message}"
+            !message.contains(&buzz_db::relay_members::max_communities_per_owner().to_string()),
+            "message must not embed the effective limit: {message}"
         );
     }
 

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         "**/channel-add-screenshots.spec.ts",
         "**/add-community-screenshots.spec.ts",
         "**/hosted-communities-settings-screenshots.spec.ts",
+        "**/hosted-community-limit-screenshots.spec.ts",
         "**/invites-settings-screenshots.spec.ts",
         "**/messaging.spec.ts",
         "**/message-feedback-snapshots.spec.ts",

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -1,7 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import {
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  resolveHostedCommunityLimit,
+} from "./hostedCommunityLimit";
+
+export {
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  resolveHostedCommunityLimit,
+} from "./hostedCommunityLimit";
+
 export const HOSTED_COMMUNITY_SUFFIX = "communities.buzz.xyz";
-export const HOSTED_COMMUNITY_LIMIT = 5;
 export const VALID_HOSTED_COMMUNITY_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export type BuilderlabAuth = {
@@ -38,6 +47,8 @@ export type HostedCommunity = {
 
 export type HostedCommunitiesResponse = {
   communities?: HostedCommunity[];
+  /** Effective per-owner limit reported by the relay (absent on old servers). */
+  max_communities_per_owner?: number;
   error?: HostedCommunityApiError;
   correlation_id?: string;
 };
@@ -51,6 +62,8 @@ export type HostedCommunityAvailabilityResponse = {
 
 export type HostedCommunityMutationResponse = {
   community?: HostedCommunity;
+  /** Effective per-owner limit reported by the relay (absent on old servers). */
+  max_communities_per_owner?: number;
   error?: HostedCommunityApiError;
   correlation_id?: string;
 };
@@ -58,18 +71,21 @@ export type HostedCommunityMutationResponse = {
 export type HostedCommunityAccount = {
   communities: HostedCommunity[];
   identity: HostedNostrIdentity | null;
+  /** Effective per-owner community limit resolved from the relay response. */
+  communityLimit: number;
 };
 
 export function hostedCommunityErrorMessage(
   error: HostedCommunityApiError | undefined,
   correlationId: string | undefined,
   fallback: string,
+  communityLimit: number = DEFAULT_HOSTED_COMMUNITY_LIMIT,
 ) {
   const messages: Record<string, string> = {
     missing_mapping: "Connect your Buzz identity before creating a community.",
     invalid_name: "Use lowercase letters, numbers, and hyphens.",
     taken: "That Buzz address is already taken.",
-    limit_reached: `You've reached the limit of ${HOSTED_COMMUNITY_LIMIT} hosted communities.`,
+    limit_reached: `You've reached the limit of ${communityLimit} hosted communities.`,
     relay_unavailable: "Community provisioning is temporarily unavailable.",
     identity_already_bound:
       "This Builderlab account is connected to another Buzz identity.",
@@ -136,6 +152,7 @@ export async function loadHostedCommunityAccount(): Promise<HostedCommunityAccou
   return {
     identity: identityResponse.identity ?? null,
     communities: communitiesResponse.communities ?? [],
+    communityLimit: resolveHostedCommunityLimit(communitiesResponse),
   };
 }
 

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import {
-  DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  hostedCommunityLimitReachedMessage,
   resolveHostedCommunityLimit,
 } from "./hostedCommunityLimit";
 
@@ -47,7 +47,11 @@ export type HostedCommunity = {
 
 export type HostedCommunitiesResponse = {
   communities?: HostedCommunity[];
-  /** Effective per-owner limit reported by the relay (absent on old servers). */
+  /**
+   * Effective per-owner limit originating at the relay, forwarded by
+   * Builderlab. Absent until that hop forwards it (and on older relays), so
+   * always read it through `resolveHostedCommunityLimit`.
+   */
   max_communities_per_owner?: number;
   error?: HostedCommunityApiError;
   correlation_id?: string;
@@ -62,7 +66,11 @@ export type HostedCommunityAvailabilityResponse = {
 
 export type HostedCommunityMutationResponse = {
   community?: HostedCommunity;
-  /** Effective per-owner limit reported by the relay (absent on old servers). */
+  /**
+   * Effective per-owner limit originating at the relay (including on its
+   * `limit_reached` rejections), forwarded by Builderlab. Resolve it against
+   * the limit already in hand so an omitted field never clobbers a known one.
+   */
   max_communities_per_owner?: number;
   error?: HostedCommunityApiError;
   correlation_id?: string;
@@ -79,13 +87,13 @@ export function hostedCommunityErrorMessage(
   error: HostedCommunityApiError | undefined,
   correlationId: string | undefined,
   fallback: string,
-  communityLimit: number = DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  communityLimit?: number,
 ) {
   const messages: Record<string, string> = {
     missing_mapping: "Connect your Buzz identity before creating a community.",
     invalid_name: "Use lowercase letters, numbers, and hyphens.",
     taken: "That Buzz address is already taken.",
-    limit_reached: `You've reached the limit of ${communityLimit} hosted communities.`,
+    limit_reached: hostedCommunityLimitReachedMessage(communityLimit),
     relay_unavailable: "Community provisioning is temporarily unavailable.",
     identity_already_bound:
       "This Builderlab account is connected to another Buzz identity.",
@@ -130,6 +138,9 @@ export async function loadHostedCommunityAccount(): Promise<HostedCommunityAccou
   if (
     identityResponse.error &&
     identityResponse.error.code !== "unauthorized" &&
+    // `missing_mapping` (setup_needed) just means this account hasn't linked a
+    // Buzz identity yet — that's the connect-card empty state, not an error to
+    // surface at the top of the page.
     !identityResponse.error.setup_needed
   ) {
     throw new Error(

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -2,11 +2,13 @@ import { invoke } from "@tauri-apps/api/core";
 
 import {
   hostedCommunityLimitReachedMessage,
-  resolveHostedCommunityLimit,
+  readHostedCommunityLimit,
 } from "./hostedCommunityLimit";
 
 export {
   DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  hostedCommunityLimitReachedMessage,
+  readHostedCommunityLimit,
   resolveHostedCommunityLimit,
 } from "./hostedCommunityLimit";
 
@@ -50,7 +52,8 @@ export type HostedCommunitiesResponse = {
   /**
    * Effective per-owner limit originating at the relay, forwarded by
    * Builderlab. Absent until that hop forwards it (and on older relays), so
-   * always read it through `resolveHostedCommunityLimit`.
+   * always read it through `readHostedCommunityLimit` /
+   * `resolveHostedCommunityLimit`.
    */
   max_communities_per_owner?: number;
   error?: HostedCommunityApiError;
@@ -79,8 +82,14 @@ export type HostedCommunityMutationResponse = {
 export type HostedCommunityAccount = {
   communities: HostedCommunity[];
   identity: HostedNostrIdentity | null;
-  /** Effective per-owner community limit resolved from the relay response. */
-  communityLimit: number;
+  /**
+   * Per-owner community limit this response reported, or `null` when it
+   * reported none. Apply it over the limit already in hand (`next ?? previous`)
+   * — same rule as {@link HostedCommunityMutationResponse}, so a reload that
+   * omits the field never drags an adopted limit back to
+   * {@link DEFAULT_HOSTED_COMMUNITY_LIMIT}.
+   */
+  communityLimit: number | null;
 };
 
 export function hostedCommunityErrorMessage(
@@ -163,7 +172,7 @@ export async function loadHostedCommunityAccount(): Promise<HostedCommunityAccou
   return {
     identity: identityResponse.identity ?? null,
     communities: communitiesResponse.communities ?? [],
-    communityLimit: resolveHostedCommunityLimit(communitiesResponse),
+    communityLimit: readHostedCommunityLimit(communitiesResponse),
   };
 }
 

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -2,12 +2,14 @@ import { invoke } from "@tauri-apps/api/core";
 
 import {
   hostedCommunityLimitReachedMessage,
+  type HostedCommunityLimitSubject,
   readHostedCommunityLimit,
 } from "./hostedCommunityLimit";
 
 export {
   DEFAULT_HOSTED_COMMUNITY_LIMIT,
   hostedCommunityLimitReachedMessage,
+  type HostedCommunityLimitSubject,
   readHostedCommunityLimit,
   resolveHostedCommunityLimit,
 } from "./hostedCommunityLimit";
@@ -92,17 +94,38 @@ export type HostedCommunityAccount = {
   communityLimit: number | null;
 };
 
+/**
+ * Request-shaped context the generic error copy cannot infer from the payload.
+ */
+export type HostedCommunityErrorContext = {
+  /**
+   * Effective per-owner limit this surface resolved from a server response, so
+   * `limit_reached` copy names the deployment's real number instead of a
+   * hardcoded one.
+   */
+  communityLimit?: number;
+  /**
+   * Which party the `limit_reached` rejection is about. Defaults to the
+   * requester; transfers must pass `"transferee"` because the relay rejects
+   * them on the *recipient's* quota.
+   */
+  limitSubject?: HostedCommunityLimitSubject;
+};
+
 export function hostedCommunityErrorMessage(
   error: HostedCommunityApiError | undefined,
   correlationId: string | undefined,
   fallback: string,
-  communityLimit?: number,
+  { communityLimit, limitSubject }: HostedCommunityErrorContext = {},
 ) {
   const messages: Record<string, string> = {
     missing_mapping: "Connect your Buzz identity before creating a community.",
     invalid_name: "Use lowercase letters, numbers, and hyphens.",
     taken: "That Buzz address is already taken.",
-    limit_reached: hostedCommunityLimitReachedMessage(communityLimit),
+    limit_reached: hostedCommunityLimitReachedMessage(
+      communityLimit,
+      limitSubject,
+    ),
     relay_unavailable: "Community provisioning is temporarily unavailable.",
     identity_already_bound:
       "This Builderlab account is connected to another Buzz identity.",

--- a/desktop/src/features/communities/hostedCommunityLimit.test.mjs
+++ b/desktop/src/features/communities/hostedCommunityLimit.test.mjs
@@ -14,6 +14,7 @@ import test from "node:test";
 import {
   DEFAULT_HOSTED_COMMUNITY_LIMIT,
   hostedCommunityLimitReachedMessage,
+  readHostedCommunityLimit,
   resolveHostedCommunityLimit,
 } from "./hostedCommunityLimit.ts";
 
@@ -162,6 +163,66 @@ test("mutation_reply_without_the_field_keeps_the_loaded_limit", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Nullable read. `loadHostedCommunityAccount` reports what the list response
+// carried rather than a pre-applied fallback, so a reload obeys the same
+// "an omitted field never clobbers a known one" rule as a mutation reply.
+// ---------------------------------------------------------------------------
+
+test("read_returns_null_when_the_response_reports_no_limit", () => {
+  assert.equal(readHostedCommunityLimit(undefined), null);
+  assert.equal(readHostedCommunityLimit(null), null);
+  assert.equal(readHostedCommunityLimit({}), null);
+  assert.equal(readHostedCommunityLimit({ communities: [] }), null);
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: 0 }),
+    null,
+  );
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: -5 }),
+    null,
+  );
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: 2.5 }),
+    null,
+  );
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: "7" }),
+    null,
+  );
+});
+
+test("read_returns_the_server_value_when_reported", () => {
+  assert.equal(readHostedCommunityLimit({ max_communities_per_owner: 7 }), 7);
+  assert.equal(readHostedCommunityLimit({ max_communities_per_owner: 1 }), 1);
+});
+
+test("reload_without_the_field_keeps_the_adopted_limit", () => {
+  // A 409 reports 7 and the UI adopts it; the reload that follows a successful
+  // create/transfer omits the field. `next ?? previous` must hold 7 — resolving
+  // the reload against the stock default would re-gate the owner at 5, the
+  // exact #4160 regression.
+  const adopted = resolveHostedCommunityLimit(
+    { error: { code: "limit_reached" }, max_communities_per_owner: 7 },
+    DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  );
+  const reload = { communities: [] };
+  assert.equal(readHostedCommunityLimit(reload) ?? adopted, 7);
+});
+
+test("reload_with_a_new_limit_replaces_the_adopted_one", () => {
+  // Stickiness must not outrank a fresh server value in either direction.
+  const adopted = 7;
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: 3 }) ?? adopted,
+    3,
+  );
+  assert.equal(
+    readHostedCommunityLimit({ max_communities_per_owner: 9 }) ?? adopted,
+    9,
+  );
+});
+
+// ---------------------------------------------------------------------------
 // The `limit_reached` copy must never invent a number: without a
 // server-resolved limit it omits the count instead of asserting 5.
 // ---------------------------------------------------------------------------
@@ -169,18 +230,18 @@ test("mutation_reply_without_the_field_keeps_the_loaded_limit", () => {
 test("limit_reached_copy_names_the_resolved_limit", () => {
   assert.equal(
     hostedCommunityLimitReachedMessage(7),
-    "You've reached the limit of 7 hosted communities.",
+    "You’ve reached the limit of 7 hosted communities.",
   );
   assert.equal(
     hostedCommunityLimitReachedMessage(3),
-    "You've reached the limit of 3 hosted communities.",
+    "You’ve reached the limit of 3 hosted communities.",
   );
 });
 
 test("limit_reached_copy_omits_the_number_when_unresolved", () => {
-  for (const unresolved of [undefined, 0]) {
+  for (const unresolved of [undefined, null, 0]) {
     const message = hostedCommunityLimitReachedMessage(unresolved);
-    assert.equal(message, "You've reached your limit of hosted communities.");
+    assert.equal(message, "You’ve reached your limit of hosted communities.");
     assert.equal(
       /\d/.test(message),
       false,

--- a/desktop/src/features/communities/hostedCommunityLimit.test.mjs
+++ b/desktop/src/features/communities/hostedCommunityLimit.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the hosted-community per-owner limit resolver (#4160).
+ *
+ * The relay derives the effective limit from BUZZ_MAX_COMMUNITIES_PER_OWNER
+ * (crates/buzz-db/src/relay_members.rs) and exposes it on operator wire
+ * responses as `max_communities_per_owner`. The desktop must consume that
+ * value instead of hardcoding 5 — these tests pin the resolver's fallback
+ * rules (mirroring the relay's effective_owner_limit) and the gating
+ * regression that motivated the fix.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  resolveHostedCommunityLimit,
+} from "./hostedCommunityLimit.ts";
+
+// ---------------------------------------------------------------------------
+// Fallback cases — mirror the relay's effective_owner_limit rules: a missing,
+// non-numeric, non-integer, or non-positive value falls back to the default.
+// ---------------------------------------------------------------------------
+
+test("default_limit_is_five", () => {
+  // The stock default must stay in lockstep with MAX_COMMUNITIES_PER_OWNER
+  // in crates/buzz-db/src/relay_members.rs.
+  assert.equal(DEFAULT_HOSTED_COMMUNITY_LIMIT, 5);
+});
+
+test("resolve_falls_back_when_response_is_absent", () => {
+  assert.equal(resolveHostedCommunityLimit(undefined), 5);
+  assert.equal(resolveHostedCommunityLimit(null), 5);
+});
+
+test("resolve_falls_back_when_field_is_absent", () => {
+  assert.equal(resolveHostedCommunityLimit({}), 5);
+  assert.equal(resolveHostedCommunityLimit({ communities: [] }), 5);
+});
+
+test("resolve_falls_back_on_invalid_values", () => {
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 0 }),
+    5,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: -5 }),
+    5,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 2.5 }),
+    5,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: Number.NaN }),
+    5,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({
+      max_communities_per_owner: Number.POSITIVE_INFINITY,
+    }),
+    5,
+  );
+  assert.equal(
+    // Untyped IPC payloads can smuggle strings; a string "7" is not a limit.
+    resolveHostedCommunityLimit({ max_communities_per_owner: "7" }),
+    5,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Server-provided values win.
+// ---------------------------------------------------------------------------
+
+test("resolve_uses_server_value_above_default", () => {
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 7 }),
+    7,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 100 }),
+    100,
+  );
+});
+
+test("resolve_uses_server_value_below_default", () => {
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 3 }),
+    3,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 1 }),
+    1,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The regression that IS the bug (#4160): the UI gate `owned >= limit` must
+// track the server-reported limit in both directions, not the hardcoded 5.
+// ---------------------------------------------------------------------------
+
+test("owner_of_five_is_not_gated_when_server_limit_is_seven", () => {
+  const limit = resolveHostedCommunityLimit({ max_communities_per_owner: 7 });
+  const ownedCommunities = 5;
+  assert.equal(ownedCommunities >= limit, false);
+});
+
+test("owner_of_three_is_gated_when_server_limit_is_three", () => {
+  const limit = resolveHostedCommunityLimit({ max_communities_per_owner: 3 });
+  const ownedCommunities = 3;
+  assert.equal(ownedCommunities >= limit, true);
+});
+
+test("owner_of_five_is_gated_at_stock_default", () => {
+  const limit = resolveHostedCommunityLimit({});
+  const ownedCommunities = 5;
+  assert.equal(ownedCommunities >= limit, true);
+});

--- a/desktop/src/features/communities/hostedCommunityLimit.test.mjs
+++ b/desktop/src/features/communities/hostedCommunityLimit.test.mjs
@@ -249,3 +249,47 @@ test("limit_reached_copy_omits_the_number_when_unresolved", () => {
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// The relay rejects a transfer on the *transferee's* quota, not the requesting
+// owner's, and Builderlab collapses both rejections onto one `limit_reached`
+// code — so the copy must name whichever party the call site knows about.
+// ---------------------------------------------------------------------------
+
+test("transfer_limit_reached_copy_names_the_recipient", () => {
+  const message = hostedCommunityLimitReachedMessage(7, "transferee");
+  assert.equal(
+    message,
+    "That person already owns the limit of 7 hosted communities, so they can’t receive another.",
+  );
+  assert.equal(
+    /you/i.test(message),
+    false,
+    `transfer copy must not blame the owner giving the community away: ${message}`,
+  );
+});
+
+test("transfer_limit_reached_copy_omits_the_number_when_unresolved", () => {
+  for (const unresolved of [undefined, null, 0]) {
+    const message = hostedCommunityLimitReachedMessage(
+      unresolved,
+      "transferee",
+    );
+    assert.equal(
+      message,
+      "That person already owns their limit of hosted communities, so they can’t receive another.",
+    );
+    assert.equal(
+      /\d/.test(message),
+      false,
+      `copy must not fabricate a limit: ${message}`,
+    );
+  }
+});
+
+test("limit_reached_copy_defaults_to_the_requesting_owner", () => {
+  assert.equal(
+    hostedCommunityLimitReachedMessage(7, "owner"),
+    hostedCommunityLimitReachedMessage(7),
+  );
+});

--- a/desktop/src/features/communities/hostedCommunityLimit.test.mjs
+++ b/desktop/src/features/communities/hostedCommunityLimit.test.mjs
@@ -13,6 +13,7 @@ import test from "node:test";
 
 import {
   DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  hostedCommunityLimitReachedMessage,
   resolveHostedCommunityLimit,
 } from "./hostedCommunityLimit.ts";
 
@@ -114,4 +115,76 @@ test("owner_of_five_is_gated_at_stock_default", () => {
   const limit = resolveHostedCommunityLimit({});
   const ownedCommunities = 5;
   assert.equal(ownedCommunities >= limit, true);
+});
+
+// ---------------------------------------------------------------------------
+// Caller-supplied fallback. Mutation replies (create/transfer) may omit the
+// field, so resolving one must never drag an already-known limit back down to
+// the stock default.
+// ---------------------------------------------------------------------------
+
+test("resolve_uses_caller_fallback_when_field_is_absent", () => {
+  assert.equal(resolveHostedCommunityLimit({}, 7), 7);
+  assert.equal(resolveHostedCommunityLimit(undefined, 7), 7);
+  assert.equal(resolveHostedCommunityLimit({ error: { code: "taken" } }, 3), 3);
+});
+
+test("resolve_uses_caller_fallback_on_invalid_values", () => {
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 0 }, 7),
+    7,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: "7" }, 7),
+    7,
+  );
+});
+
+test("resolve_prefers_server_value_over_caller_fallback", () => {
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 9 }, 7),
+    9,
+  );
+  assert.equal(
+    resolveHostedCommunityLimit({ max_communities_per_owner: 2 }, 7),
+    2,
+  );
+});
+
+test("mutation_reply_without_the_field_keeps_the_loaded_limit", () => {
+  // A relay reporting 7 at load time, then a create rejection that carries no
+  // limit: the copy and gate must stay on 7, not silently revert to 5.
+  const loadedLimit = resolveHostedCommunityLimit({
+    max_communities_per_owner: 7,
+  });
+  const rejection = { error: { code: "limit_reached" } };
+  assert.equal(resolveHostedCommunityLimit(rejection, loadedLimit), 7);
+});
+
+// ---------------------------------------------------------------------------
+// The `limit_reached` copy must never invent a number: without a
+// server-resolved limit it omits the count instead of asserting 5.
+// ---------------------------------------------------------------------------
+
+test("limit_reached_copy_names_the_resolved_limit", () => {
+  assert.equal(
+    hostedCommunityLimitReachedMessage(7),
+    "You've reached the limit of 7 hosted communities.",
+  );
+  assert.equal(
+    hostedCommunityLimitReachedMessage(3),
+    "You've reached the limit of 3 hosted communities.",
+  );
+});
+
+test("limit_reached_copy_omits_the_number_when_unresolved", () => {
+  for (const unresolved of [undefined, 0]) {
+    const message = hostedCommunityLimitReachedMessage(unresolved);
+    assert.equal(message, "You've reached your limit of hosted communities.");
+    assert.equal(
+      /\d/.test(message),
+      false,
+      `copy must not fabricate a limit: ${message}`,
+    );
+  }
 });

--- a/desktop/src/features/communities/hostedCommunityLimit.ts
+++ b/desktop/src/features/communities/hostedCommunityLimit.ts
@@ -79,6 +79,20 @@ export function resolveHostedCommunityLimit(
 }
 
 /**
+ * Whose quota a `limit_reached` rejection is about.
+ *
+ * The relay rejects a create when the *owner* is at the limit and a transfer
+ * when the *transferee* is (`transfer_community` in
+ * `crates/buzz-relay/src/api/operator.rs`), but both rejections carry the same
+ * `limit_reached:` message prefix and Builderlab collapses them onto a single
+ * `limit_reached` code. The requesting call site is therefore the only place
+ * that knows which party the number describes — telling an owner who is giving
+ * a community away that *they* are out of slots sends them right back to the
+ * action that just failed.
+ */
+export type HostedCommunityLimitSubject = "owner" | "transferee";
+
+/**
  * User-facing copy for a `limit_reached` rejection — the single owner of this
  * sentence, so the surfaces that render it cannot drift apart.
  *
@@ -88,7 +102,13 @@ export function resolveHostedCommunityLimit(
  */
 export function hostedCommunityLimitReachedMessage(
   communityLimit?: number | null,
+  subject: HostedCommunityLimitSubject = "owner",
 ): string {
+  if (subject === "transferee") {
+    return communityLimit
+      ? `That person already owns the limit of ${communityLimit} hosted communities, so they can’t receive another.`
+      : "That person already owns their limit of hosted communities, so they can’t receive another.";
+  }
   return communityLimit
     ? `You’ve reached the limit of ${communityLimit} hosted communities.`
     : "You’ve reached your limit of hosted communities.";

--- a/desktop/src/features/communities/hostedCommunityLimit.ts
+++ b/desktop/src/features/communities/hostedCommunityLimit.ts
@@ -8,6 +8,16 @@
  * value rather than hardcode its own copy — otherwise gates and copy drift in
  * both directions the moment a deployment overrides the default.
  *
+ * The desktop does not call the relay's operator API directly: every hosted
+ * community request goes through Builderlab (`app.builderlab.xyz`, see
+ * `desktop/src-tauri/src/builderlab.rs`), which reshapes the relay payload —
+ * the desktop sees `id`/`slug`/`normalized_host` where the relay emits
+ * `community_id`/`host`. Builderlab must therefore forward
+ * `max_communities_per_owner` for a non-default limit to reach these surfaces;
+ * until it does, every resolution falls back and the UI behaves exactly as it
+ * did before. That fallback is the reason this stays a soft dependency rather
+ * than a breaking one.
+ *
  * This module stays free of `@tauri-apps` imports (and any other value
  * imports) so `node:test` can load it directly.
  */
@@ -35,14 +45,35 @@ type LimitBearingResponse = {
  *
  * A positive-integer `max_communities_per_owner` wins; anything else (absent
  * response, absent field, non-number, non-integer, or non-positive value)
- * falls back to {@link DEFAULT_HOSTED_COMMUNITY_LIMIT} — the same fallback
- * rules the relay applies to its own env override.
+ * falls back to `fallback` — the same fallback rules the relay applies to its
+ * own env override.
+ *
+ * Pass the limit already in hand as `fallback` when resolving a response that
+ * may omit the field (e.g. a mutation reply) so a known-good value from an
+ * earlier response is never clobbered by
+ * {@link DEFAULT_HOSTED_COMMUNITY_LIMIT}.
  */
 export function resolveHostedCommunityLimit(
   response: LimitBearingResponse | null | undefined,
+  fallback: number = DEFAULT_HOSTED_COMMUNITY_LIMIT,
 ): number {
   const limit = response?.max_communities_per_owner;
   return typeof limit === "number" && Number.isInteger(limit) && limit > 0
     ? limit
-    : DEFAULT_HOSTED_COMMUNITY_LIMIT;
+    : fallback;
+}
+
+/**
+ * User-facing copy for a `limit_reached` rejection.
+ *
+ * Names a number only when the caller resolved one from a server response.
+ * There is deliberately no default: a limit this deployment may not use is
+ * worse than copy that omits the number.
+ */
+export function hostedCommunityLimitReachedMessage(
+  communityLimit?: number,
+): string {
+  return communityLimit
+    ? `You've reached the limit of ${communityLimit} hosted communities.`
+    : "You've reached your limit of hosted communities.";
 }

--- a/desktop/src/features/communities/hostedCommunityLimit.ts
+++ b/desktop/src/features/communities/hostedCommunityLimit.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure resolution of the hosted-community per-owner limit (#4160).
+ *
+ * The relay is the single authority for this limit: it derives the effective
+ * value from `BUZZ_MAX_COMMUNITIES_PER_OWNER` (see `max_communities_per_owner`
+ * in `crates/buzz-db/src/relay_members.rs`) and exposes it on operator wire
+ * responses as `max_communities_per_owner`. The desktop must consume that
+ * value rather than hardcode its own copy — otherwise gates and copy drift in
+ * both directions the moment a deployment overrides the default.
+ *
+ * This module stays free of `@tauri-apps` imports (and any other value
+ * imports) so `node:test` can load it directly.
+ */
+
+/**
+ * Fallback used only when a server response does not carry a usable
+ * `max_communities_per_owner` — e.g. a relay or intermediary that predates
+ * the field. Mirrors `MAX_COMMUNITIES_PER_OWNER` in
+ * `crates/buzz-db/src/relay_members.rs`; change the two together.
+ */
+export const DEFAULT_HOSTED_COMMUNITY_LIMIT = 5;
+
+/**
+ * Any response that may carry the relay-reported effective limit. Structural
+ * on purpose: importing the response types from `hostedCommunityApi.ts` would
+ * pull `@tauri-apps/api/core` into node tests and cycle with that module's
+ * re-export of this one.
+ */
+type LimitBearingResponse = {
+  max_communities_per_owner?: unknown;
+};
+
+/**
+ * Resolve the effective hosted-community limit from a server response.
+ *
+ * A positive-integer `max_communities_per_owner` wins; anything else (absent
+ * response, absent field, non-number, non-integer, or non-positive value)
+ * falls back to {@link DEFAULT_HOSTED_COMMUNITY_LIMIT} — the same fallback
+ * rules the relay applies to its own env override.
+ */
+export function resolveHostedCommunityLimit(
+  response: LimitBearingResponse | null | undefined,
+): number {
+  const limit = response?.max_communities_per_owner;
+  return typeof limit === "number" && Number.isInteger(limit) && limit > 0
+    ? limit
+    : DEFAULT_HOSTED_COMMUNITY_LIMIT;
+}

--- a/desktop/src/features/communities/hostedCommunityLimit.ts
+++ b/desktop/src/features/communities/hostedCommunityLimit.ts
@@ -41,12 +41,30 @@ type LimitBearingResponse = {
 };
 
 /**
- * Resolve the effective hosted-community limit from a server response.
+ * Read the limit a server response actually reports, or `null` when it reports
+ * none.
  *
- * A positive-integer `max_communities_per_owner` wins; anything else (absent
- * response, absent field, non-number, non-integer, or non-positive value)
- * falls back to `fallback` — the same fallback rules the relay applies to its
- * own env override.
+ * A positive-integer `max_communities_per_owner` is a limit; anything else
+ * (absent response, absent field, non-number, non-integer, or non-positive
+ * value) is not — the same rules the relay applies to its own env override.
+ *
+ * This is the shape to use when a caller already holds a limit and only wants
+ * to replace it with a better one (`next ?? previous`): responses that omit the
+ * field are indistinguishable from ones that predate it, so they must leave a
+ * known-good value alone rather than reset it.
+ */
+export function readHostedCommunityLimit(
+  response: LimitBearingResponse | null | undefined,
+): number | null {
+  const limit = response?.max_communities_per_owner;
+  return typeof limit === "number" && Number.isInteger(limit) && limit > 0
+    ? limit
+    : null;
+}
+
+/**
+ * Resolve the effective hosted-community limit from a server response, falling
+ * back when it reports none.
  *
  * Pass the limit already in hand as `fallback` when resolving a response that
  * may omit the field (e.g. a mutation reply) so a known-good value from an
@@ -57,23 +75,21 @@ export function resolveHostedCommunityLimit(
   response: LimitBearingResponse | null | undefined,
   fallback: number = DEFAULT_HOSTED_COMMUNITY_LIMIT,
 ): number {
-  const limit = response?.max_communities_per_owner;
-  return typeof limit === "number" && Number.isInteger(limit) && limit > 0
-    ? limit
-    : fallback;
+  return readHostedCommunityLimit(response) ?? fallback;
 }
 
 /**
- * User-facing copy for a `limit_reached` rejection.
+ * User-facing copy for a `limit_reached` rejection — the single owner of this
+ * sentence, so the surfaces that render it cannot drift apart.
  *
  * Names a number only when the caller resolved one from a server response.
  * There is deliberately no default: a limit this deployment may not use is
  * worse than copy that omits the number.
  */
 export function hostedCommunityLimitReachedMessage(
-  communityLimit?: number,
+  communityLimit?: number | null,
 ): string {
   return communityLimit
-    ? `You've reached the limit of ${communityLimit} hosted communities.`
-    : "You've reached your limit of hosted communities.";
+    ? `You’ve reached the limit of ${communityLimit} hosted communities.`
+    : "You’ve reached your limit of hosted communities.";
 }

--- a/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
@@ -17,6 +17,7 @@ import {
   type HostedCommunity,
   type HostedNostrIdentity,
   loadHostedCommunityAccount,
+  resolveHostedCommunityLimit,
   startBuilderlabLogin,
   VALID_HOSTED_COMMUNITY_NAME,
 } from "@/features/communities/hostedCommunityApi";
@@ -241,12 +242,17 @@ export function HostedCommunityCreateFlow({
       }
       const response = await createHostedCommunity(normalizedName);
       if (response.error || !response.community) {
+        // A rejection carries the relay's effective limit; adopt it so the copy
+        // and the gate reflect the server rather than whatever was current at
+        // load time.
+        const limit = resolveHostedCommunityLimit(response, communityLimit);
+        setCommunityLimit(limit);
         throw new Error(
           hostedCommunityErrorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            communityLimit,
+            limit,
           ),
         );
       }

--- a/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
@@ -12,6 +12,7 @@ import {
   getBuilderlabAuth,
   HOSTED_COMMUNITY_SUFFIX,
   hostedCommunityErrorMessage,
+  hostedCommunityLimitReachedMessage,
   hostedCommunityRelayUrl,
   type BuilderlabAuth,
   type HostedCommunity,
@@ -62,7 +63,7 @@ export function HostedCommunityCreateFlow({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit(account.communityLimit);
+    setCommunityLimit((previous) => account.communityLimit ?? previous);
   }, []);
 
   React.useEffect(() => {
@@ -383,7 +384,7 @@ export function HostedCommunityCreateFlow({
   }
 
   const feedback = atCommunityLimit
-    ? `You’ve reached the limit of ${communityLimit} hosted communities.`
+    ? hostedCommunityLimitReachedMessage(communityLimit)
     : name && !validName
       ? "Use lowercase letters, numbers, and single hyphens."
       : checkingName

--- a/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
@@ -7,9 +7,9 @@ import {
   checkHostedCommunityName,
   clearBuilderlabAuth,
   createHostedCommunity,
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   deleteBuilderlabIdentity,
   getBuilderlabAuth,
-  HOSTED_COMMUNITY_LIMIT,
   HOSTED_COMMUNITY_SUFFIX,
   hostedCommunityErrorMessage,
   hostedCommunityRelayUrl,
@@ -45,6 +45,9 @@ export function HostedCommunityCreateFlow({
     null,
   );
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
+  const [communityLimit, setCommunityLimit] = React.useState(
+    DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  );
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
   const [checkingName, setCheckingName] = React.useState(false);
@@ -58,6 +61,7 @@ export function HostedCommunityCreateFlow({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
+    setCommunityLimit(account.communityLimit);
   }, []);
 
   React.useEffect(() => {
@@ -189,7 +193,7 @@ export function HostedCommunityCreateFlow({
   const validName =
     normalizedName.length <= 63 &&
     VALID_HOSTED_COMMUNITY_NAME.test(normalizedName);
-  const atCommunityLimit = communities.length >= HOSTED_COMMUNITY_LIMIT;
+  const atCommunityLimit = communities.length >= communityLimit;
   const ready = Boolean(auth && identity && !identityMismatch);
 
   React.useEffect(() => {
@@ -242,6 +246,7 @@ export function HostedCommunityCreateFlow({
             response.error,
             response.correlation_id,
             "Could not create the community.",
+            communityLimit,
           ),
         );
       }
@@ -372,7 +377,7 @@ export function HostedCommunityCreateFlow({
   }
 
   const feedback = atCommunityLimit
-    ? `You’ve reached the limit of ${HOSTED_COMMUNITY_LIMIT} hosted communities.`
+    ? `You’ve reached the limit of ${communityLimit} hosted communities.`
     : name && !validName
       ? "Use lowercase letters, numbers, and single hyphens."
       : checkingName

--- a/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
@@ -7,7 +7,6 @@ import {
   checkHostedCommunityName,
   clearBuilderlabAuth,
   createHostedCommunity,
-  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   deleteBuilderlabIdentity,
   getBuilderlabAuth,
   HOSTED_COMMUNITY_SUFFIX,
@@ -18,10 +17,10 @@ import {
   type HostedCommunity,
   type HostedNostrIdentity,
   loadHostedCommunityAccount,
-  resolveHostedCommunityLimit,
   startBuilderlabLogin,
   VALID_HOSTED_COMMUNITY_NAME,
 } from "@/features/communities/hostedCommunityApi";
+import { useHostedCommunityLimit } from "@/features/communities/useHostedCommunityLimit";
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
 import {
   CHANNEL_FORM_FIELD_CONTROL_CLASS,
@@ -47,9 +46,8 @@ export function HostedCommunityCreateFlow({
     null,
   );
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
-  const [communityLimit, setCommunityLimit] = React.useState(
-    DEFAULT_HOSTED_COMMUNITY_LIMIT,
-  );
+  const { communityLimit, applyFromAccount, adoptFromResponse } =
+    useHostedCommunityLimit();
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
   const [checkingName, setCheckingName] = React.useState(false);
@@ -63,8 +61,8 @@ export function HostedCommunityCreateFlow({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit((previous) => account.communityLimit ?? previous);
-  }, []);
+    applyFromAccount(account);
+  }, [applyFromAccount]);
 
   React.useEffect(() => {
     let active = true;
@@ -246,14 +244,13 @@ export function HostedCommunityCreateFlow({
         // A rejection carries the relay's effective limit; adopt it so the copy
         // and the gate reflect the server rather than whatever was current at
         // load time.
-        const limit = resolveHostedCommunityLimit(response, communityLimit);
-        setCommunityLimit(limit);
+        const limit = adoptFromResponse(response);
         throw new Error(
           hostedCommunityErrorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            limit,
+            { communityLimit: limit },
           ),
         );
       }

--- a/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
@@ -18,6 +18,7 @@ import {
   type HostedCommunity,
   type HostedNostrIdentity,
   loadHostedCommunityAccount,
+  resolveHostedCommunityLimit,
   startBuilderlabLogin,
   VALID_HOSTED_COMMUNITY_NAME,
 } from "@/features/communities/hostedCommunityApi";
@@ -314,12 +315,17 @@ export function HostedCommunityOnboarding({
       }
       const response = await createHostedCommunity(normalizedName);
       if (response.error || !response.community) {
+        // A rejection carries the relay's effective limit; adopt it so the copy
+        // and the gate reflect the server rather than whatever was current at
+        // load time.
+        const limit = resolveHostedCommunityLimit(response, communityLimit);
+        setCommunityLimit(limit);
         throw new Error(
           hostedCommunityErrorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            communityLimit,
+            limit,
           ),
         );
       }

--- a/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
@@ -8,9 +8,9 @@ import {
   checkHostedCommunityName,
   clearBuilderlabAuth,
   createHostedCommunity,
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   deleteBuilderlabIdentity,
   getBuilderlabAuth,
-  HOSTED_COMMUNITY_LIMIT,
   HOSTED_COMMUNITY_SUFFIX,
   hostedCommunityErrorMessage,
   hostedCommunityRelayUrl,
@@ -84,6 +84,9 @@ export function HostedCommunityOnboarding({
     null,
   );
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
+  const [communityLimit, setCommunityLimit] = React.useState(
+    DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  );
   const [showCreate, setShowCreate] = React.useState(false);
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
@@ -97,6 +100,7 @@ export function HostedCommunityOnboarding({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
+    setCommunityLimit(account.communityLimit);
   }, []);
 
   React.useEffect(() => {
@@ -240,7 +244,7 @@ export function HostedCommunityOnboarding({
   const validName =
     normalizedName.length <= 63 &&
     VALID_HOSTED_COMMUNITY_NAME.test(normalizedName);
-  const atCommunityLimit = communities.length >= HOSTED_COMMUNITY_LIMIT;
+  const atCommunityLimit = communities.length >= communityLimit;
   const hasCommunities = activeCommunities.length > 0;
 
   React.useEffect(() => {
@@ -315,6 +319,7 @@ export function HostedCommunityOnboarding({
             response.error,
             response.correlation_id,
             "Could not create the community.",
+            communityLimit,
           ),
         );
       }
@@ -353,7 +358,7 @@ export function HostedCommunityOnboarding({
   ) : null;
 
   const creationFeedback = atCommunityLimit
-    ? `You’ve reached the limit of ${HOSTED_COMMUNITY_LIMIT} hosted communities.`
+    ? `You’ve reached the limit of ${communityLimit} hosted communities.`
     : name && !validName
       ? "Use lowercase letters, numbers, and single hyphens."
       : checkingName

--- a/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
@@ -8,7 +8,6 @@ import {
   checkHostedCommunityName,
   clearBuilderlabAuth,
   createHostedCommunity,
-  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   deleteBuilderlabIdentity,
   getBuilderlabAuth,
   HOSTED_COMMUNITY_SUFFIX,
@@ -19,10 +18,10 @@ import {
   type HostedCommunity,
   type HostedNostrIdentity,
   loadHostedCommunityAccount,
-  resolveHostedCommunityLimit,
   startBuilderlabLogin,
   VALID_HOSTED_COMMUNITY_NAME,
 } from "@/features/communities/hostedCommunityApi";
+import { useHostedCommunityLimit } from "@/features/communities/useHostedCommunityLimit";
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { safeNpub } from "@/shared/lib/nostrUtils";
@@ -86,9 +85,8 @@ export function HostedCommunityOnboarding({
     null,
   );
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
-  const [communityLimit, setCommunityLimit] = React.useState(
-    DEFAULT_HOSTED_COMMUNITY_LIMIT,
-  );
+  const { communityLimit, applyFromAccount, adoptFromResponse } =
+    useHostedCommunityLimit();
   const [showCreate, setShowCreate] = React.useState(false);
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
@@ -102,8 +100,8 @@ export function HostedCommunityOnboarding({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit((previous) => account.communityLimit ?? previous);
-  }, []);
+    applyFromAccount(account);
+  }, [applyFromAccount]);
 
   React.useEffect(() => {
     let active = true;
@@ -319,14 +317,13 @@ export function HostedCommunityOnboarding({
         // A rejection carries the relay's effective limit; adopt it so the copy
         // and the gate reflect the server rather than whatever was current at
         // load time.
-        const limit = resolveHostedCommunityLimit(response, communityLimit);
-        setCommunityLimit(limit);
+        const limit = adoptFromResponse(response);
         throw new Error(
           hostedCommunityErrorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            limit,
+            { communityLimit: limit },
           ),
         );
       }

--- a/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
@@ -13,6 +13,7 @@ import {
   getBuilderlabAuth,
   HOSTED_COMMUNITY_SUFFIX,
   hostedCommunityErrorMessage,
+  hostedCommunityLimitReachedMessage,
   hostedCommunityRelayUrl,
   type BuilderlabAuth,
   type HostedCommunity,
@@ -101,7 +102,7 @@ export function HostedCommunityOnboarding({
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit(account.communityLimit);
+    setCommunityLimit((previous) => account.communityLimit ?? previous);
   }, []);
 
   React.useEffect(() => {
@@ -364,7 +365,7 @@ export function HostedCommunityOnboarding({
   ) : null;
 
   const creationFeedback = atCommunityLimit
-    ? `You’ve reached the limit of ${communityLimit} hosted communities.`
+    ? hostedCommunityLimitReachedMessage(communityLimit)
     : name && !validName
       ? "Use lowercase letters, numbers, and single hyphens."
       : checkingName

--- a/desktop/src/features/communities/useHostedCommunityLimit.ts
+++ b/desktop/src/features/communities/useHostedCommunityLimit.ts
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import type {
+  HostedCommunityAccount,
+  HostedCommunityMutationResponse,
+} from "./hostedCommunityApi";
+import {
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  resolveHostedCommunityLimit,
+} from "./hostedCommunityLimit";
+
+/**
+ * Owns the hosted-community per-owner limit for one surface (#4160).
+ *
+ * Every surface that creates or transfers communities needs the same three
+ * moves — seed the stock default, apply what a reload reported, adopt what a
+ * rejection reported — and all three share one invariant: a response that omits
+ * `max_communities_per_owner` is indistinguishable from one that predates the
+ * field, so it must leave a known-good value alone (`next ?? previous`) rather
+ * than drag it back to {@link DEFAULT_HOSTED_COMMUNITY_LIMIT}. Keeping that
+ * rule in a hook means a new surface cannot lose the stickiness by writing a
+ * plain `setCommunityLimit(...)`.
+ *
+ * Lives apart from `hostedCommunityLimit.ts` because that module stays free of
+ * value imports so `node:test` can load it directly.
+ */
+export function useHostedCommunityLimit() {
+  const [communityLimit, setCommunityLimit] = React.useState(
+    DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  );
+  // Mirrors the state so the appliers stay referentially stable (they are
+  // called from `useCallback` loaders) while still resolving against the limit
+  // currently in hand.
+  const current = React.useRef(communityLimit);
+
+  const apply = React.useCallback((next: number) => {
+    current.current = next;
+    setCommunityLimit(next);
+    return next;
+  }, []);
+
+  /** Apply the limit an account reload reported, keeping the current one if it reported none. */
+  const applyFromAccount = React.useCallback(
+    (account: HostedCommunityAccount) =>
+      apply(account.communityLimit ?? current.current),
+    [apply],
+  );
+
+  /**
+   * Adopt the limit a mutation reply (including a `limit_reached` rejection)
+   * reported, and return the effective limit so the caller can render copy
+   * against it without waiting for the re-render.
+   */
+  const adoptFromResponse = React.useCallback(
+    (response: HostedCommunityMutationResponse | null | undefined) =>
+      apply(resolveHostedCommunityLimit(response, current.current)),
+    [apply],
+  );
+
+  return { communityLimit, applyFromAccount, adoptFromResponse };
+}

--- a/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
@@ -19,10 +19,10 @@ import {
   HOSTED_COMMUNITY_SUFFIX as HOST_SUFFIX,
   hostedCommunityErrorMessage as errorMessage,
   hostedCommunityRelayUrl as relayUrl,
+  loadHostedCommunityAccount,
   resolveHostedCommunityLimit,
   type BuilderlabAuth,
   type HostedCommunityAvailabilityResponse as AvailabilityResponse,
-  type HostedCommunitiesResponse as CommunitiesResponse,
   type HostedCommunity,
   type HostedCommunityMutationResponse as CommunityMutationResponse,
   type HostedIdentityResponse as IdentityResponse,
@@ -83,38 +83,10 @@ export function HostedCommunitiesSettingsCard() {
 
   const loadAccount = React.useCallback(async () => {
     setError(null);
-    const [identityResponse, communitiesResponse] = await Promise.all([
-      invoke<IdentityResponse>("get_builderlab_nostr_identity"),
-      invoke<CommunitiesResponse>("list_builderlab_communities"),
-    ]);
-    if (
-      identityResponse.error &&
-      identityResponse.error.code !== "unauthorized" &&
-      // `missing_mapping` (setup_needed) just means this account hasn't linked a
-      // Buzz identity yet — that's the connect-card empty state, not an error to
-      // surface at the top of the page.
-      !identityResponse.error.setup_needed
-    ) {
-      throw new Error(
-        errorMessage(
-          identityResponse.error,
-          identityResponse.correlation_id,
-          "Could not load the connected Buzz identity.",
-        ),
-      );
-    }
-    if (communitiesResponse.error && !communitiesResponse.error.setup_needed) {
-      throw new Error(
-        errorMessage(
-          communitiesResponse.error,
-          communitiesResponse.correlation_id,
-          "Could not load communities.",
-        ),
-      );
-    }
-    setIdentity(identityResponse.identity ?? null);
-    setCommunities(communitiesResponse.communities ?? []);
-    setCommunityLimit(resolveHostedCommunityLimit(communitiesResponse));
+    const account = await loadHostedCommunityAccount();
+    setIdentity(account.identity);
+    setCommunities(account.communities);
+    setCommunityLimit(account.communityLimit);
   }, []);
 
   React.useEffect(() => {
@@ -309,12 +281,17 @@ export function HostedCommunitiesSettingsCard() {
         { communityId: community.id, transfereeNpub: npub },
       );
       if (response.error) {
+        // A rejection carries the relay's effective limit; adopt it so the copy
+        // and the gate reflect the server rather than whatever was current at
+        // load time.
+        const limit = resolveHostedCommunityLimit(response, communityLimit);
+        setCommunityLimit(limit);
         throw new Error(
           errorMessage(
             response.error,
             response.correlation_id,
             "Could not transfer ownership.",
-            communityLimit,
+            limit,
           ),
         );
       }
@@ -389,12 +366,14 @@ export function HostedCommunitiesSettingsCard() {
         { name: normalizedName },
       );
       if (response.error || !response.community) {
+        const limit = resolveHostedCommunityLimit(response, communityLimit);
+        setCommunityLimit(limit);
         throw new Error(
           errorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            communityLimit,
+            limit,
           ),
         );
       }

--- a/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_HOSTED_COMMUNITY_LIMIT,
   HOSTED_COMMUNITY_SUFFIX as HOST_SUFFIX,
   hostedCommunityErrorMessage as errorMessage,
+  hostedCommunityLimitReachedMessage as limitReachedMessage,
   hostedCommunityRelayUrl as relayUrl,
   loadHostedCommunityAccount,
   resolveHostedCommunityLimit,
@@ -86,7 +87,7 @@ export function HostedCommunitiesSettingsCard() {
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit(account.communityLimit);
+    setCommunityLimit((previous) => account.communityLimit ?? previous);
   }, []);
 
   React.useEffect(() => {
@@ -605,9 +606,8 @@ export function HostedCommunitiesSettingsCard() {
             </div>
             {atCommunityLimit ? (
               <p className="text-sm text-muted-foreground">
-                You&apos;ve reached the limit of {communityLimit} hosted
-                communities. Transfer one to free up a slot before creating
-                another.
+                {limitReachedMessage(communityLimit)} Transfer one to free up a
+                slot before creating another.
               </p>
             ) : null}
             <div className="flex max-w-xl items-center gap-2">

--- a/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
@@ -15,10 +15,11 @@ import {
 
 import { useIdentityQuery } from "@/shared/api/hooks";
 import {
-  HOSTED_COMMUNITY_LIMIT as MAX_COMMUNITIES,
+  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   HOSTED_COMMUNITY_SUFFIX as HOST_SUFFIX,
   hostedCommunityErrorMessage as errorMessage,
   hostedCommunityRelayUrl as relayUrl,
+  resolveHostedCommunityLimit,
   type BuilderlabAuth,
   type HostedCommunityAvailabilityResponse as AvailabilityResponse,
   type HostedCommunitiesResponse as CommunitiesResponse,
@@ -69,6 +70,9 @@ export function HostedCommunitiesSettingsCard() {
   const localPubkey = useIdentityQuery().data?.pubkey ?? null;
   const [auth, setAuth] = React.useState<BuilderlabAuth | null>(null);
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
+  const [communityLimit, setCommunityLimit] = React.useState(
+    DEFAULT_HOSTED_COMMUNITY_LIMIT,
+  );
   const [identity, setIdentity] = React.useState<NostrIdentity | null>(null);
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
@@ -110,6 +114,7 @@ export function HostedCommunitiesSettingsCard() {
     }
     setIdentity(identityResponse.identity ?? null);
     setCommunities(communitiesResponse.communities ?? []);
+    setCommunityLimit(resolveHostedCommunityLimit(communitiesResponse));
   }, []);
 
   React.useEffect(() => {
@@ -309,6 +314,7 @@ export function HostedCommunitiesSettingsCard() {
             response.error,
             response.correlation_id,
             "Could not transfer ownership.",
+            communityLimit,
           ),
         );
       }
@@ -360,7 +366,7 @@ export function HostedCommunitiesSettingsCard() {
       !validName ||
       !identity ||
       identityMismatch ||
-      communities.length >= MAX_COMMUNITIES
+      communities.length >= communityLimit
     )
       return;
     void run("Creating community…", async () => {
@@ -388,6 +394,7 @@ export function HostedCommunitiesSettingsCard() {
             response.error,
             response.correlation_id,
             "Could not create the community.",
+            communityLimit,
           ),
         );
       }
@@ -412,7 +419,7 @@ export function HostedCommunitiesSettingsCard() {
   };
 
   const busy = action != null;
-  const atCommunityLimit = communities.length >= MAX_COMMUNITIES;
+  const atCommunityLimit = communities.length >= communityLimit;
 
   return (
     <section className="space-y-6" data-testid="hosted-communities-settings">
@@ -555,7 +562,7 @@ export function HostedCommunitiesSettingsCard() {
               <h3 className="font-medium">
                 Your communities
                 <span className="ml-2 text-xs font-normal text-muted-foreground">
-                  {communities.length} of {MAX_COMMUNITIES} used
+                  {communities.length} of {communityLimit} used
                 </span>
               </h3>
               <Button
@@ -619,7 +626,7 @@ export function HostedCommunitiesSettingsCard() {
             </div>
             {atCommunityLimit ? (
               <p className="text-sm text-muted-foreground">
-                You&apos;ve reached the limit of {MAX_COMMUNITIES} hosted
+                You&apos;ve reached the limit of {communityLimit} hosted
                 communities. Transfer one to free up a slot before creating
                 another.
               </p>

--- a/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
@@ -15,13 +15,11 @@ import {
 
 import { useIdentityQuery } from "@/shared/api/hooks";
 import {
-  DEFAULT_HOSTED_COMMUNITY_LIMIT,
   HOSTED_COMMUNITY_SUFFIX as HOST_SUFFIX,
   hostedCommunityErrorMessage as errorMessage,
   hostedCommunityLimitReachedMessage as limitReachedMessage,
   hostedCommunityRelayUrl as relayUrl,
   loadHostedCommunityAccount,
-  resolveHostedCommunityLimit,
   type BuilderlabAuth,
   type HostedCommunityAvailabilityResponse as AvailabilityResponse,
   type HostedCommunity,
@@ -32,6 +30,7 @@ import {
 } from "@/features/communities/hostedCommunityApi";
 import { CommunityIconSettingsCard } from "@/features/communities/ui/CommunityIconSettingsCard";
 import { useCommunities } from "@/features/communities/useCommunities";
+import { useHostedCommunityLimit } from "@/features/communities/useHostedCommunityLimit";
 import { safeNpub } from "@/shared/lib/nostrUtils";
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
 import {
@@ -71,9 +70,8 @@ export function HostedCommunitiesSettingsCard() {
   const localPubkey = useIdentityQuery().data?.pubkey ?? null;
   const [auth, setAuth] = React.useState<BuilderlabAuth | null>(null);
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
-  const [communityLimit, setCommunityLimit] = React.useState(
-    DEFAULT_HOSTED_COMMUNITY_LIMIT,
-  );
+  const { communityLimit, applyFromAccount, adoptFromResponse } =
+    useHostedCommunityLimit();
   const [identity, setIdentity] = React.useState<NostrIdentity | null>(null);
   const [name, setName] = React.useState("");
   const [availability, setAvailability] = React.useState<boolean | null>(null);
@@ -87,8 +85,8 @@ export function HostedCommunitiesSettingsCard() {
     const account = await loadHostedCommunityAccount();
     setIdentity(account.identity);
     setCommunities(account.communities);
-    setCommunityLimit((previous) => account.communityLimit ?? previous);
-  }, []);
+    applyFromAccount(account);
+  }, [applyFromAccount]);
 
   React.useEffect(() => {
     let active = true;
@@ -284,15 +282,15 @@ export function HostedCommunitiesSettingsCard() {
       if (response.error) {
         // A rejection carries the relay's effective limit; adopt it so the copy
         // and the gate reflect the server rather than whatever was current at
-        // load time.
-        const limit = resolveHostedCommunityLimit(response, communityLimit);
-        setCommunityLimit(limit);
+        // load time. The relay rejects a transfer on the *recipient's* quota,
+        // so the copy has to name them and not the owner giving it away.
+        const limit = adoptFromResponse(response);
         throw new Error(
           errorMessage(
             response.error,
             response.correlation_id,
             "Could not transfer ownership.",
-            limit,
+            { communityLimit: limit, limitSubject: "transferee" },
           ),
         );
       }
@@ -367,14 +365,13 @@ export function HostedCommunitiesSettingsCard() {
         { name: normalizedName },
       );
       if (response.error || !response.community) {
-        const limit = resolveHostedCommunityLimit(response, communityLimit);
-        setCommunityLimit(limit);
+        const limit = adoptFromResponse(response);
         throw new Error(
           errorMessage(
             response.error,
             response.correlation_id,
             "Could not create the community.",
-            limit,
+            { communityLimit: limit },
           ),
         );
       }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -206,6 +206,32 @@ type E2eConfig = {
       normalized_host?: string;
       archived_at?: string | null;
     }>;
+    /**
+     * Effective per-owner community limit the relay reports through Builderlab
+     * as `max_communities_per_owner`. Omitted = a relay (or hop) that doesn't
+     * report one, so the desktop falls back to its own default (#4160).
+     */
+    builderlabCommunityLimit?: number;
+    /**
+     * Rejection returned by hosted community creation. `limit` rides alongside
+     * the error as the relay's `max_communities_per_owner`, matching the 409
+     * body shape.
+     */
+    builderlabCreateError?: {
+      code?: string;
+      message?: string;
+      limit?: number;
+    };
+    /**
+     * Rejection returned by hosted community transfer. `limit` rides alongside
+     * the error as the relay's `max_communities_per_owner` — the relay rejects
+     * a transfer on the *transferee's* quota.
+     */
+    builderlabTransferError?: {
+      code?: string;
+      message?: string;
+      limit?: number;
+    };
     /** Override the community returned after hosted creation. */
     builderlabCreatedCommunity?: {
       id?: string;
@@ -10726,16 +10752,31 @@ export function maybeInstallE2eTauriMocks() {
       case "delete_builderlab_nostr_identity":
         if (activeConfig?.mock) activeConfig.mock.builderlabIdentity = null;
         return {};
-      case "list_builderlab_communities":
+      case "list_builderlab_communities": {
+        const limit = activeConfig?.mock?.builderlabCommunityLimit;
         return {
           communities: activeConfig?.mock?.builderlabCommunities ?? [],
+          ...(typeof limit === "number"
+            ? { max_communities_per_owner: limit }
+            : {}),
         };
+      }
       case "check_builderlab_community_name":
         return {
           available: true,
           normalized_host: `${(payload as { name?: string })?.name ?? "community"}.communities.buzz.xyz`,
         };
       case "create_builderlab_community": {
+        const rejection = activeConfig?.mock?.builderlabCreateError;
+        if (rejection) {
+          const { limit, ...error } = rejection;
+          return {
+            error,
+            ...(typeof limit === "number"
+              ? { max_communities_per_owner: limit }
+              : {}),
+          };
+        }
         const name = (payload as { name?: string })?.name ?? "community";
         return {
           community: activeConfig?.mock?.builderlabCreatedCommunity ?? {
@@ -10744,6 +10785,19 @@ export function maybeInstallE2eTauriMocks() {
             normalized_host: `${name}.communities.buzz.xyz`,
           },
         };
+      }
+      case "transfer_builderlab_community": {
+        const rejection = activeConfig?.mock?.builderlabTransferError;
+        if (rejection) {
+          const { limit, ...error } = rejection;
+          return {
+            error,
+            ...(typeof limit === "number"
+              ? { max_communities_per_owner: limit }
+              : {}),
+          };
+        }
+        return {};
       }
       case "mesh_installed_models":
         return mockMeshState.models;

--- a/desktop/tests/e2e/hosted-community-limit-screenshots.spec.ts
+++ b/desktop/tests/e2e/hosted-community-limit-screenshots.spec.ts
@@ -1,0 +1,239 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+import { openSettings } from "../helpers/settings";
+
+/**
+ * Hosted-community per-owner limit (#4160).
+ *
+ * The relay derives the limit from `BUZZ_MAX_COMMUNITIES_PER_OWNER` and reports
+ * it as `max_communities_per_owner`; the desktop used to hardcode 5, so any
+ * deployment that overrode the default gated and worded its copy wrong in both
+ * directions. These specs drive the settings card through the mock bridge with
+ * the relay reporting different limits and capture what the owner actually
+ * sees.
+ */
+const OUTDIR = "test-results/hosted-community-limit";
+const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
+const RECIPIENT_NPUB = `npub1${"q".repeat(58)}`;
+
+// The card scrolls inside the settings pane: at the stock 720px viewport an
+// element screenshot clips before the create form, which is where the limit
+// gate and its copy live. Give it room so one frame shows the count, the rows,
+// and the create form together.
+test.use({ viewport: { width: 1280, height: 1200 } });
+
+const CONNECTED_COMMUNITIES = [
+  {
+    id: "ws-a",
+    name: "Alpha",
+    relayUrl: "ws://localhost:3000",
+    addedAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    id: "ws-b",
+    name: "Bravo",
+    relayUrl: "ws://localhost:3001",
+    addedAt: "2026-01-02T00:00:00.000Z",
+  },
+];
+
+function communities(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `community-${index + 1}`,
+    name: `Team ${index + 1}`,
+    normalized_host: `team-${index + 1}.communities.buzz.xyz`,
+  }));
+}
+
+async function openHostedCommunities(page: Page) {
+  await page.goto("/");
+  await openSettings(page, "hosted-communities");
+  await expect(page.getByTestId("hosted-communities-settings")).toBeVisible();
+}
+
+async function capture(page: Page, name: string) {
+  await waitForAnimations(page);
+  await page
+    .getByTestId("hosted-communities-settings")
+    .screenshot({ path: `${OUTDIR}/${name}.png` });
+}
+
+test("capture: a relay-reported limit above the default ungates a sixth community", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    builderlabAuth: {
+      email: "owner@example.com",
+      expiresAt: "2099-01-01T00:00:00Z",
+    },
+    builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+    builderlabCommunities: communities(5),
+    builderlabCommunityLimit: 7,
+  });
+  await openHostedCommunities(page);
+
+  // The owner has exactly as many communities as the old hardcoded limit, so
+  // before the fix this page read "5 of 5 used" and refused to create another.
+  await expect(page.getByText("5 of 7 used")).toBeVisible();
+  await expect(page.getByText(/reached the limit of/)).toHaveCount(0);
+  await expect(page.getByLabel("Community address")).toBeEnabled();
+
+  await capture(page, "01-limit-above-default-ungated");
+});
+
+test("capture: a relay-reported limit below the default gates early with its own number", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    builderlabAuth: {
+      email: "owner@example.com",
+      expiresAt: "2099-01-01T00:00:00Z",
+    },
+    builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+    builderlabCommunities: communities(3),
+    builderlabCommunityLimit: 3,
+  });
+  await openHostedCommunities(page);
+
+  await expect(page.getByText("3 of 3 used")).toBeVisible();
+  await expect(
+    page.getByText(
+      "You’ve reached the limit of 3 hosted communities. Transfer one to free up a slot before creating another.",
+    ),
+  ).toBeVisible();
+  await expect(page.getByLabel("Community address")).toBeDisabled();
+
+  await capture(page, "02-limit-below-default-gated");
+});
+
+test("capture: a relay that reports no limit keeps the stock default", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    builderlabAuth: {
+      email: "owner@example.com",
+      expiresAt: "2099-01-01T00:00:00Z",
+    },
+    builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+    builderlabCommunities: communities(5),
+  });
+  await openHostedCommunities(page);
+
+  // No `max_communities_per_owner` on the wire (older relay, or a Builderlab
+  // hop that doesn't forward it yet) must behave exactly as it did before.
+  await expect(page.getByText("5 of 5 used")).toBeVisible();
+  await expect(
+    page.getByText(
+      "You’ve reached the limit of 5 hosted communities. Transfer one to free up a slot before creating another.",
+    ),
+  ).toBeVisible();
+
+  await capture(page, "03-no-reported-limit-falls-back");
+});
+
+test("capture: a limit_reached create rejection adopts the relay's number", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    builderlabAuth: {
+      email: "owner@example.com",
+      expiresAt: "2099-01-01T00:00:00Z",
+    },
+    builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+    builderlabCommunities: communities(3),
+    // The list response carried no limit, so the page opens on the fallback.
+    builderlabCreateError: { code: "limit_reached", limit: 3 },
+  });
+  await openHostedCommunities(page);
+  await expect(page.getByText("3 of 5 used")).toBeVisible();
+
+  await page.getByLabel("Community address").fill("north-star");
+  await expect(page.getByText("That address is available.")).toBeVisible();
+  await page.getByRole("button", { name: "Create and connect" }).click();
+
+  // The 409 reports the deployment's real limit: the copy names it and the
+  // card re-gates against it instead of the hardcoded 5.
+  await expect(
+    page.getByText("You’ve reached the limit of 3 hosted communities.").first(),
+  ).toBeVisible();
+  await expect(page.getByText("3 of 3 used")).toBeVisible();
+  await expect(page.getByLabel("Community address")).toBeDisabled();
+
+  await capture(page, "04-create-rejection-adopts-limit");
+});
+
+test("capture: the add-community create flow gates on the relay's limit", async ({
+  page,
+}) => {
+  // The community rail (and its add button) only renders with more than one
+  // connected community, so seed them the way add-community-screenshots does.
+  await page.addInitScript((connected) => {
+    window.localStorage.setItem("buzz-communities", JSON.stringify(connected));
+    window.localStorage.setItem("buzz-active-community-id", connected[0].id);
+  }, CONNECTED_COMMUNITIES);
+  await installMockBridge(
+    page,
+    {
+      builderlabAuth: {
+        email: "owner@example.com",
+        expiresAt: "2099-01-01T00:00:00Z",
+      },
+      builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+      builderlabCommunities: communities(4),
+      builderlabCommunityLimit: 4,
+    },
+    { skipCommunitySeed: true },
+  );
+  await page.goto("/");
+  await page.getByTestId("community-rail-add").click();
+  await page.getByTestId("add-community-create").click();
+
+  const dialog = page.getByTestId("add-community-dialog");
+  await expect(page.getByTestId("hosted-community-create-name")).toBeDisabled();
+  await expect(
+    dialog.getByText("You’ve reached the limit of 4 hosted communities."),
+  ).toBeVisible();
+
+  await waitForAnimations(page);
+  await dialog.screenshot({ path: `${OUTDIR}/06-create-flow-gated.png` });
+});
+
+test("capture: a limit_reached transfer rejection names the recipient's limit", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    builderlabAuth: {
+      email: "owner@example.com",
+      expiresAt: "2099-01-01T00:00:00Z",
+    },
+    builderlabIdentity: { pubkey_hex: DEFAULT_MOCK_PUBKEY },
+    builderlabCommunities: communities(2),
+    builderlabCommunityLimit: 7,
+    builderlabTransferError: { code: "limit_reached", limit: 9 },
+  });
+  await openHostedCommunities(page);
+  await expect(page.getByText("2 of 7 used")).toBeVisible();
+
+  const row = page
+    .getByTestId("hosted-community-row")
+    .filter({ hasText: "Team 1" });
+  await row.getByRole("button", { name: "Transfer" }).click();
+  await page.getByLabel("Recipient npub").fill(RECIPIENT_NPUB);
+  await page.getByRole("button", { name: "Transfer ownership" }).click();
+
+  // The relay rejects a transfer on the *transferee's* quota, so the copy must
+  // be about them — not the owner who is giving the community away.
+  const rejection = page.getByText(
+    "That person already owns the limit of 9 hosted communities, so they can’t receive another.",
+  );
+  await expect(rejection).toBeVisible();
+  await expect(page.getByText(/You’ve reached the limit/)).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByLabel("Recipient npub")).toHaveCount(0);
+  await expect(page.getByText("2 of 9 used")).toBeVisible();
+
+  await capture(page, "05-transfer-rejection-names-recipient");
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -179,6 +179,16 @@ type MockBridgeOptions = {
     normalized_host?: string;
     archived_at?: string | null;
   }>;
+  /**
+   * Effective per-owner community limit the relay reports through Builderlab as
+   * `max_communities_per_owner`. Omitted = a relay (or hop) that doesn't report
+   * one, so the desktop falls back to its own default (#4160).
+   */
+  builderlabCommunityLimit?: number;
+  /** Rejection returned by hosted community creation; `limit` is the relay's reported `max_communities_per_owner`. */
+  builderlabCreateError?: { code?: string; message?: string; limit?: number };
+  /** Rejection returned by hosted community transfer; `limit` is the relay's reported `max_communities_per_owner`. */
+  builderlabTransferError?: { code?: string; message?: string; limit?: number };
   acpRuntimesCatalog?: Record<string, unknown>[];
   /** Catalog returned after a successful mocked install. */
   acpRuntimesCatalogAfterInstall?: Record<string, unknown>[];


### PR DESCRIPTION
## Intent

Resolve block/buzz#4160: the desktop hardcodes the hosted-community per-owner limit at 5, so deployments that override BUZZ_MAX_COMMUNITIES_PER_OWNER show wrong gating and copy in both directions; expose the relay's effective limit on operator responses and have the desktop resolve it with a safe fallback.

## What Changed

- **Relay** — operator list/provision responses and both `limit_reached` 409 bodies (create and transfer) now carry `max_communities_per_owner`, the effective `BUZZ_MAX_COMMUNITIES_PER_OWNER` value, as a structured field beside the unchanged `limit_reached:` message prefix that 409 routing keys off. The env var is documented in `.env.example` and the `TESTING.md` config table.
- **Desktop** — removes the hardcoded `HOSTED_COMMUNITY_LIMIT = 5` in favor of a pure resolver (`hostedCommunityLimit.ts`) plus a `useHostedCommunityLimit` hook shared by all three hosted-community surfaces (onboarding, create flow, settings card): gating and copy read the relay-reported number, a rejection's number is adopted immediately, and a response that omits the field leaves a known-good limit in place rather than resetting to the default. Limit-reached copy is centralized in one helper, and transfer rejections now name the recipient — the relay rejects those on the transferee's quota, not the requester's. Note the soft dependency: the desktop reaches the relay through Builderlab, which must forward `max_communities_per_owner`; until it does, every surface falls back to 5 and behaves exactly as before.
- **Coverage** — 22 `node:test` resolver/copy cases, a non-Postgres unit test that asserts and prints the 409/200 wire bodies under varying env values, two Postgres-gated operator handler tests (they self-skip without a database), and a 6-capture Playwright spec covering above/below-default limits, the no-limit fallback, create and transfer 409 adoption, and the gated create dialog — with mock-bridge support for the new limit and rejection payloads.

## Risk Assessment

✅ Low: The wire change is purely additive with no in-repo consumers to break, the desktop change is fully backward-compatible through a documented default fallback (worst case it behaves exactly as before), the enforced and reported limits provably come from the same source, and the refactored shared loader is byte-identical to the code it replaced — the only open item is a cosmetic dead re-export.

## Testing

Ran the change's own unit tests (22 desktop resolver/copy tests, relay provisioning and buzz-db limit tests) plus the full 4217-test desktop suite as a regression guard for the shared E2E bridge edit, then produced product-level evidence at both ends: a relay transcript showing `max_communities_per_owner` on the real 200 provision body and 409 `limit_reached` body tracking `BUZZ_MAX_COMMUNITIES_PER_OWNER` (7, 3) and falling back to 5 for `0`/`abc` with the error string unchanged, and six screenshots from a new Playwright spec showing the settings card and add-community dialog gating and wording themselves from the relay's number — ungated at "5 of 7 used", gated at "3 of 3 used", unchanged "5 of 5 used" when the field is absent, re-gated by a create 409, and a transfer 409 worded about the recipient. Existing builderlab smoke specs and the 61-test onboarding integration spec still pass. Everything passed; the only gap is the Postgres-backed operator tests, which self-skip in this environment (no Docker/Postgres).

- Evidence: Settings card: relay reports 7, owner with 5 communities is not gated (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/01-limit-above-default-ungated.png</code>)
- Evidence: Settings card: relay reports 3, owner gated with copy naming 3 (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/02-limit-below-default-gated.png</code>)
- Evidence: Settings card: response carries no limit, stock default 5 preserved (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/03-no-reported-limit-falls-back.png</code>)
- Evidence: Create 409 reporting 3: error copy names 3 and the card re-gates at 3 of 3 (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/04-create-rejection-adopts-limit.png</code>)
- Evidence: Transfer 409 reporting 9: copy names the recipient, counter adopts 9 (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/05-transfer-rejection-names-recipient.png</code>)
- Evidence: Add-community create dialog gated at the relay&#39;s limit of 4 (local file: <code>/var/folders/sr/98ws056j0msc_fv3snynykbc0000gn/T/no-mistakes-evidence/01KZ78TRBV8WKJAXR1F2JGY931/screenshots/06-create-flow-gated.png</code>)
<details>
<summary>Evidence: Relay wire contract under BUZZ_MAX_COMMUNITIES_PER_OWNER overrides</summary>

<code>BUZZ_MAX_COMMUNITIES_PER_OWNER=&lt;unset&gt; -&gt; HTTP 409 {&#34;error&#34;:&#34;limit_reached: owner already owns the maximum number of communities&#34;,&#34;max_communities_per_owner&#34;:5}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=&lt;unset&gt; -&gt; HTTP 200 {&#34;community_id&#34;:&#34;b8f7f4a0-0000-0000-0000-000000000000&#34;,&#34;host&#34;:&#34;acme.communities.buzz.xyz&#34;,&#34;status&#34;:&#34;created&#34;,&#34;max_communities_per_owner&#34;:5}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=7 -&gt; HTTP 409 {&#34;error&#34;:&#34;limit_reached: owner already owns the maximum number of communities&#34;,&#34;max_communities_per_owner&#34;:7}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=7 -&gt; HTTP 200 {&#34;community_id&#34;:&#34;b8f7f4a0-0000-0000-0000-000000000000&#34;,&#34;host&#34;:&#34;acme.communities.buzz.xyz&#34;,&#34;status&#34;:&#34;created&#34;,&#34;max_communities_per_owner&#34;:7}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=3 -&gt; HTTP 409 {&#34;error&#34;:&#34;limit_reached: owner already owns the maximum number of communities&#34;,&#34;max_communities_per_owner&#34;:3}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=3 -&gt; HTTP 200 {&#34;community_id&#34;:&#34;b8f7f4a0-0000-0000-0000-000000000000&#34;,&#34;host&#34;:&#34;acme.communities.buzz.xyz&#34;,&#34;status&#34;:&#34;created&#34;,&#34;max_communities_per_owner&#34;:3}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=0 -&gt; HTTP 409 {&#34;error&#34;:&#34;limit_reached: owner already owns the maximum number of communities&#34;,&#34;max_communities_per_owner&#34;:5}&#10;BUZZ_MAX_COMMUNITIES_PER_OWNER=abc -&gt; HTTP 200 {&#34;community_id&#34;:&#34;b8f7f4a0-0000-0000-0000-000000000000&#34;,&#34;host&#34;:&#34;acme.communities.buzz.xyz&#34;,&#34;status&#34;:&#34;created&#34;,&#34;max_communities_per_owner&#34;:5}</code>

```text
BUZZ_MAX_COMMUNITIES_PER_OWNER=<unset> -> HTTP 409 {"error":"limit_reached: owner already owns the maximum number of communities","max_communities_per_owner":5}
BUZZ_MAX_COMMUNITIES_PER_OWNER=<unset> -> HTTP 200 {"community_id":"b8f7f4a0-0000-0000-0000-000000000000","host":"acme.communities.buzz.xyz","status":"created","max_communities_per_owner":5}
BUZZ_MAX_COMMUNITIES_PER_OWNER=7 -> HTTP 409 {"error":"limit_reached: owner already owns the maximum number of communities","max_communities_per_owner":7}
BUZZ_MAX_COMMUNITIES_PER_OWNER=7 -> HTTP 200 {"community_id":"b8f7f4a0-0000-0000-0000-000000000000","host":"acme.communities.buzz.xyz","status":"created","max_communities_per_owner":7}
BUZZ_MAX_COMMUNITIES_PER_OWNER=3 -> HTTP 409 {"error":"limit_reached: owner already owns the maximum number of communities","max_communities_per_owner":3}
BUZZ_MAX_COMMUNITIES_PER_OWNER=3 -> HTTP 200 {"community_id":"b8f7f4a0-0000-0000-0000-000000000000","host":"acme.communities.buzz.xyz","status":"created","max_communities_per_owner":3}
BUZZ_MAX_COMMUNITIES_PER_OWNER=0 -> HTTP 409 {"error":"limit_reached: owner already owns the maximum number of communities","max_communities_per_owner":5}
BUZZ_MAX_COMMUNITIES_PER_OWNER=0 -> HTTP 200 {"community_id":"b8f7f4a0-0000-0000-0000-000000000000","host":"acme.communities.buzz.xyz","status":"created","max_communities_per_owner":5}
BUZZ_MAX_COMMUNITIES_PER_OWNER=abc -> HTTP 409 {"error":"limit_reached: owner already owns the maximum number of communities","max_communities_per_owner":5}
BUZZ_MAX_COMMUNITIES_PER_OWNER=abc -> HTTP 200 {"community_id":"b8f7f4a0-0000-0000-0000-000000000000","host":"acme.communities.buzz.xyz","status":"created","max_communities_per_owner":5}
```
</details>
- Outcome: ⚠️ 3 infos across 1 run (24m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `desktop/src/features/communities/hostedCommunityApi.ts:51` - The desktop reads `max_communities_per_owner` off the Builderlab response, but the desktop never talks to the relay&#39;s operator API — `list_builderlab_communities` posts to `https://app.builderlab.xyz/api/goose/v1/buzz/communities/list` (desktop/src-tauri/src/builderlab.rs:550), and Builderlab reshapes the relay payload (desktop sees `id`/`name`/`slug`/`normalized_host`; the relay emits `community_id`/`host`). Unless Builderlab (out of this repo) is updated to forward the field under this exact snake_case name, every desktop surface still resolves to the hardcoded 5 and issue #4160&#39;s repro is unchanged. Issue #4160 explicitly names this hop as the caveat it could not close; this branch neither closes nor documents it. Confirm the Builderlab-side change is landed/planned, or note the dependency in the PR.
- ⚠️ `crates/buzz-relay/src/handlers/community_provisioning.rs:82` - `limit_reached_error` appends ` (N)` to an operator-API error string that the out-of-repo Builderlab service normalizes into the `limit_reached` code the desktop maps. If that normalizer matches the message by equality rather than prefix, it stops emitting `limit_reached` and the desktop falls through to `error?.message ?? fallback` — a raw relay string instead of the friendly copy. Meanwhile no in-repo client reads the embedded number: `hostedCommunityErrorMessage` looks up `messages[error.code]` first, so `error.message` (and the `(N)`) is never rendered when the code is known. As written this is wire-visible risk with no consumer; consider carrying the number as a structured field on the 409 body instead.
- ℹ️ `desktop/src/features/communities/hostedCommunityApi.ts:66` - `HostedCommunityMutationResponse.max_communities_per_owner` is declared and documented but never read — `createHostedCommunity`/transfer callers keep the load-time `communityLimit` and pass that into the error copy, so a limit changed since page load renders the stale number. Either wire it (careful: `resolveHostedCommunityLimit` falls back to 5, so an absent field on a mutation response would clobber a valid 7 from the list call — fall back to the current state instead) or drop the field.
- ℹ️ `desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx:117` - `loadAccount` here re-implements `loadHostedCommunityAccount` (hostedCommunityApi.ts:125) — same two invokes, same error gating — so this change had to add the `resolveHostedCommunityLimit` call in two places. Having the settings card consume the shared loader (which already returns `communityLimit`) removes the duplication and the drift risk for the next field added to the account payload.
- ℹ️ `desktop/src/features/communities/hostedCommunityApi.ts:82` - The new `communityLimit` parameter defaults to `DEFAULT_HOSTED_COMMUNITY_LIMIT`, so any call site that can surface `limit_reached` and forgets the argument silently renders &#34;the limit of 5&#34; — reintroducing the exact hardcoded-default defect class #4160 is about, invisibly to review. Today&#39;s omissions are safe (availability/identity/archive paths can&#39;t return `limit_reached`), but making the parameter required turns future omissions into compile errors.

🔧 Fix: harden hosted-community limit resolution and 409 wire contract
3 infos still open:
- ℹ️ `desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx:386` - The new `hostedCommunityLimitReachedMessage` helper (hostedCommunityLimit.ts:76) exists to own the limit-reached copy, but three UI surfaces still inline their own copy of the same sentence: HostedCommunityCreateFlow.tsx:386, HostedCommunityOnboarding.tsx:367, and HostedCommunitiesSettingsCard.tsx:608. They have already drifted from the helper — the inline versions use a typographic apostrophe (`You’ve`) while the helper uses a straight one (`You&#39;ve`) — and they bypass the helper&#39;s no-number fallback entirely. Routing all three through the helper removes the drift; since every surface holds `communityLimit` as a seeded number, output is identical apart from the apostrophe glyph, so pick one glyph (the typographic one matches the current UI) and put it in the helper.
- ℹ️ `desktop/src/features/communities/hostedCommunityLimit.ts:76` - `hostedCommunityLimitReachedMessage`&#39;s doc says it &#34;names a number only when the caller resolved one from a server response&#34;, and `limit_reached_copy_omits_the_number_when_unresolved` pins that. But no product path can reach the number-less branch: every surface seeds `communityLimit` state with `DEFAULT_HOSTED_COMMUNITY_LIMIT` (HostedCommunityCreateFlow.tsx:49, HostedCommunityOnboarding.tsx:88, HostedCommunitiesSettingsCard.tsx:73) and always passes it, and the only call sites that omit the argument (identity bind/unbind, availability) cannot return `limit_reached`. So on any deployment where Builderlab does not forward the field, users are still told &#34;the limit of 5&#34; — the same fabricated number #4160 is about. That is a deliberate and reasonable back-compat tradeoff, but the &#34;never invent a number&#34; guarantee is not end-to-end; it is a tested-but-unreached branch.
- ℹ️ `desktop/src/features/communities/hostedCommunityApi.ts:166` - `loadHostedCommunityAccount` resolves with the implicit `DEFAULT_HOSTED_COMMUNITY_LIMIT` fallback, so a list response that omits `max_communities_per_owner` resets the limit to 5. That contradicts the invariant documented one file over on `HostedCommunityMutationResponse` (&#34;an omitted field never clobbers a known one&#34;) and undoes the adopt-on-rejection logic: after a 409 reports 7 and the UI adopts it, the next `loadAccount()` (fired on connect-identity, successful transfer, successful create, or sign-in) drops it back to 5 if the list payload omits the field. This only bites if Builderlab forwards the field on mutation/409 bodies but not on list — plausible given it reshapes each endpoint separately, though narrow in practice. If the sticky semantics are intended, thread the current value in (e.g. `setCommunityLimit(prev =&gt; resolveHostedCommunityLimit(resp, prev))` at the call sites); if list is meant to be authoritative, drop the &#34;never clobbers&#34; wording so the two paths do not read as contradictory.

🔧 Fix: centralize limit-reached copy and keep adopted limit sticky
2 issues (1 warning, 1 info) still open:
- ⚠️ `desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx:288` - The transfer path now threads the effective limit into a message that names the wrong party. The relay rejects a transfer with `limit_reached: transferee already owns the maximum number of communities` (operator.rs:444), but `hostedCommunityErrorMessage` maps code `limit_reached` to &#34;You’ve reached the limit of N hosted communities.&#34; — so an owner *giving away* a community is told they are at their own limit, and the adjacent settings copy then advises &#34;Transfer one to free up a slot,&#34; which is exactly what they just tried. The wrong-subject wording is pre-existing, but this change sharpens it: it now asserts the deployment&#39;s real number with confidence, and adopts that number into `communityLimit` state from a rejection that was never about this user. Because Builderlab collapses both relay details onto the single `limit_reached` code, the client cannot tell create-rejection from transfer-rejection today — distinguishing them needs a separate error code (or a transfer-specific fallback string passed at this call site, e.g. &#34;That person has reached their limit of hosted communities.&#34;). Product-copy decision, so flagging rather than changing.
- ℹ️ `desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx:319` - The same three-part limit plumbing is now copy-pasted across all three hosted-community surfaces: the `useState(DEFAULT_HOSTED_COMMUNITY_LIMIT)` seed, the `setCommunityLimit((previous) =&gt; account.communityLimit ?? previous)` line in `loadAccount`, and the `const limit = resolveHostedCommunityLimit(response, communityLimit); setCommunityLimit(limit);` adopt-on-rejection block — HostedCommunityOnboarding.tsx:90/105/319, HostedCommunityCreateFlow.tsx:51/66/249, HostedCommunitiesSettingsCard.tsx:75/90/288+370 (the settings card carries it twice). The prior rounds already centralized the copy and the account loader; this is the remaining duplicate, and it is the part that encodes the subtle `next ?? previous` stickiness invariant, so a fourth surface is the likely place it gets written as a plain `setCommunityLimit(resolveHostedCommunityLimit(response))` and silently loses stickiness. A small `useHostedCommunityLimit()` hook returning `{ communityLimit, applyFromAccount, adoptFromResponse }` collapses all four sites; it needs its own file since `hostedCommunityLimit.ts` deliberately stays value-import-free for `node:test`.

🔧 Fix: fix transfer limit copy subject and share limit hook
1 info still open:
- ℹ️ `desktop/src/features/communities/hostedCommunityApi.ts:9` - The re-export block re-exports five symbols from `./hostedCommunityLimit`, but only `hostedCommunityLimitReachedMessage` is ever consumed through this module (the three UI surfaces). `DEFAULT_HOSTED_COMMUNITY_LIMIT`, `readHostedCommunityLimit`, `resolveHostedCommunityLimit`, and `HostedCommunityLimitSubject` are imported directly from `./hostedCommunityLimit` at their only call sites (`useHostedCommunityLimit.ts:8-9`, and `hostedCommunityApi.ts` itself via the separate import on lines 3-7) — consumers pass `limitSubject: &#34;transferee&#34;` as a string literal and never name the type. Beyond dead surface, this cuts against the point of the round-3 hook: it publishes `resolveHostedCommunityLimit` on the module every hosted-community surface already imports, so a fourth surface can reach the raw resolver from `@/features/communities/hostedCommunityApi` and re-implement the `next ?? previous` stickiness by hand instead of using `useHostedCommunityLimit`. Narrow the re-export to `hostedCommunityLimitReachedMessage`.

</details>

<details>
<summary>⚠️ **Test** - 3 infos</summary>

- ℹ️ `crates/buzz-relay/src/api/operator.rs:1130` - The two Postgres-backed operator tests added by this change (`list_and_provision_responses_report_effective_owner_limit`, `limit_reached_rejections_report_effective_limit`) could not actually execute here — no Docker daemon and no local Postgres/Redis. They are not skipped loudly: `operator_test_state` returns `None` on connection failure and each test returns early, so `cargo test -- --ignored` reports them as passing after ~30s of connection attempts without asserting anything. Their end-to-end handler coverage is only real on a gate that has Postgres. I compensated with a non-Postgres unit test that asserts and prints the same 409/200 bodies under varying env values.
- ℹ️ `desktop/tests/e2e/hosted-community-limit-screenshots.spec.ts:50` - The new Playwright spec flaked twice during early runs: the app rendered a blank page and the test timed out waiting for `open-settings` (once on the 5th test, once on the 1st, in different runs). It never reproduced afterwards — 28 consecutive passes across repeat, cold-server and clean-rebuild runs — and the failures coincided with a cold Chromium install under load, so it reads as a first-load/boot race in this environment rather than a product issue. CI&#39;s `retries: 2` covers it.
- ℹ️ `desktop/tests/e2e/hosted-community-limit-screenshots.spec.ts` - new test file written by agent: desktop/tests/e2e/hosted-community-limit-screenshots.spec.ts
- <code>`node --import ./test-loader.mjs --experimental-strip-types --test &#34;src/features/communities/hostedCommunityLimit.test.mjs&#34;` — 22 resolver/copy tests added by the change</code>
- <code>`pnpm test` (desktop unit suite, 4217 tests) after modifying the shared E2E bridge</code>
- <code>`cargo test -q -p buzz-relay --lib community_provisioning` and `cargo test -q -p buzz-db --lib relay_members`</code>
- <code>`BUZZ_MAX_COMMUNITIES_PER_OWNER={unset,7,3,0,abc} cargo test -q -p buzz-relay --lib api::operator::tests::limit_reached_conflict_body_reports_the_deployment_limit -- --nocapture` — new test printing the real 409 + 200 bodies per env value</code>
- <code>`pnpm build:e2e &amp;&amp; pnpm exec playwright test --project=smoke tests/e2e/hosted-community-limit-screenshots.spec.ts` — new 6-capture spec covering limit above/below default, no-limit fallback, create-409 adoption, gated create dialog, transfer-409 recipient copy</code>
- <code>`pnpm exec playwright test --project=smoke tests/e2e/hosted-communities-settings-screenshots.spec.ts tests/e2e/add-community-screenshots.spec.ts` — regression check on existing builderlab specs after the bridge change</code>
- <code>`pnpm exec playwright test --project=integration tests/e2e/onboarding.spec.ts` — 61 tests, covers the hosted-community onboarding surfaces</code>
- <code>`cargo test -q -p buzz-relay --lib -- --ignored api::operator::tests::list_and_provision_responses_report_effective_owner_limit api::operator::tests::limit_reached_rejections_report_effective_limit` — attempted; self-skipped with no Postgres</code>
- <code>`shasum -a 256` over the captured PNGs to confirm every screenshot shows a distinct state</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `AGENTS.md:20` - The desktop only sees the relay&#39;s `max_communities_per_owner` if Builderlab (app.builderlab.xyz, an external service outside this repo) forwards the field through `/v1/buzz/communities/*`. That requirement is recorded only in a desktop code comment (desktop/src/features/communities/hostedCommunityLimit.ts:14-19); no repo-level doc states it, and AGENTS.md&#39;s Ecosystem table does not list Builderlab at all, so a Builderlab maintainer has no documented cue that the fix depends on their hop. Where to record this (AGENTS.md ecosystem table, a docs/ page, or an issue against the Builderlab repo) is a human call — I have no link or ownership info for that service, and until it forwards the field every desktop resolution silently falls back to 5.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
