### PR TITLE
fix(desktop): persist thread panel width across restarts

### DIFF
--- a/desktop/src/shared/hooks/useThreadPanelWidth.ts
+++ b/desktop/src/shared/hooks/useThreadPanelWidth.ts
@@ -5,7 +5,7 @@ import {
   clampAuxiliaryPanelWidth,
 } from "@/shared/layout/AuxiliaryPanel";
 
-const THREAD_PANEL_WIDTH_SESSION_KEY = "buzz.desktop.thread-panel-width";
+const THREAD_PANEL_WIDTH_STORAGE_KEY = "buzz.desktop.thread-panel-width";
 
 function getViewportWidth(): number {
   return typeof window === "undefined" ? 0 : window.innerWidth;
@@ -23,26 +23,49 @@ function clampThreadPanelWidth(width: number): number {
   return clampAuxiliaryPanelWidth(width, getViewportWidth());
 }
 
+function readStoredThreadPanelWidth(): string | null {
+  try {
+    const fromLocal = window.localStorage.getItem(THREAD_PANEL_WIDTH_STORAGE_KEY);
+    if (fromLocal != null) {
+      return fromLocal;
+    }
+
+    // One-time migrate: older builds kept this width in sessionStorage only.
+    const fromSession = window.sessionStorage.getItem(
+      THREAD_PANEL_WIDTH_STORAGE_KEY,
+    );
+    if (fromSession != null) {
+      try {
+        window.localStorage.setItem(THREAD_PANEL_WIDTH_STORAGE_KEY, fromSession);
+        window.sessionStorage.removeItem(THREAD_PANEL_WIDTH_STORAGE_KEY);
+      } catch {
+        // Keep reading the session value even if migration write fails.
+      }
+      return fromSession;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function getInitialThreadPanelWidth(): number {
   if (typeof window === "undefined") {
     return AUXILIARY_PANEL_DEFAULT_WIDTH_PX;
   }
 
-  try {
-    const raw = window.sessionStorage.getItem(THREAD_PANEL_WIDTH_SESSION_KEY);
-    if (!raw) {
-      return AUXILIARY_PANEL_DEFAULT_WIDTH_PX;
-    }
-
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed)) {
-      return AUXILIARY_PANEL_DEFAULT_WIDTH_PX;
-    }
-
-    return clampThreadPanelWidth(parsed);
-  } catch {
+  const raw = readStoredThreadPanelWidth();
+  if (!raw) {
     return AUXILIARY_PANEL_DEFAULT_WIDTH_PX;
   }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return AUXILIARY_PANEL_DEFAULT_WIDTH_PX;
+  }
+
+  return clampThreadPanelWidth(parsed);
 }
 
 export function useThreadPanelWidth() {
@@ -56,8 +79,8 @@ export function useThreadPanelWidth() {
     }
 
     try {
-      window.sessionStorage.setItem(
-        THREAD_PANEL_WIDTH_SESSION_KEY,
+      window.localStorage.setItem(
+        THREAD_PANEL_WIDTH_STORAGE_KEY,
         String(widthPx),
       );
     } catch {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -268,7 +268,7 @@ test("thread autocomplete keeps multiple long names readable in a narrow panel",
   });
   await page.setViewportSize({ width: 900, height: 640 });
   await page.addInitScript(() => {
-    window.sessionStorage.setItem("buzz.desktop.thread-panel-width", "300");
+    window.localStorage.setItem("buzz.desktop.thread-panel-width", "300");
   });
   await page.goto("/");
   await page.getByTestId("channel-general").click();

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -946,18 +946,19 @@ test("opens a single-level thread panel with inline expansion", async ({
   ).toHaveCount(0);
 });
 
-test("thread panel width uses session storage and reset handle", async ({
+test("thread panel width uses local storage, survives reload, and reset handle", async ({
   page,
 }) => {
   const customWidthPx = 520;
   const defaultWidthPx = 380;
+  const storageKey = "buzz.desktop.thread-panel-width";
 
-  await page.addInitScript((width) => {
-    window.sessionStorage.setItem(
-      "buzz.desktop.thread-panel-width",
-      String(width),
-    );
-  }, customWidthPx);
+  await page.addInitScript(
+    ({ key, width }) => {
+      window.localStorage.setItem(key, String(width));
+    },
+    { key: storageKey, width: customWidthPx },
+  );
 
   await page.goto("/");
   await page.getByTestId("channel-general").click();
@@ -983,27 +984,60 @@ test("thread panel width uses session storage and reset handle", async ({
     })
     .toBe(customWidthPx);
 
-  await resizeHandle.dblclick();
+  await expect
+    .poll(() => page.evaluate((key) => window.localStorage.getItem(key), storageKey))
+    .toBe(String(customWidthPx));
+
+  // Reload should restore the same width from localStorage (not sessionStorage).
+  await page.reload();
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const timelineAfterReload = page.getByTestId("message-timeline");
+  const rootAfterReload = timelineAfterReload.getByTestId("message-row").first();
+  const threadPanelAfterReload = page.getByTestId("message-thread-panel");
+
+  await rootAfterReload.hover();
+  await rootAfterReload.getByRole("button", { name: "Reply" }).click();
+  await expect(threadPanelAfterReload).toBeVisible();
 
   await expect
     .poll(async () => {
-      return threadPanel.evaluate((panel) => {
+      return threadPanelAfterReload.evaluate((panel) => {
+        const element = panel as HTMLElement;
+        return Math.round(element.getBoundingClientRect().width);
+      });
+    })
+    .toBe(customWidthPx);
+
+  const resizeHandleAfterReload = threadPanelAfterReload.getByTestId(
+    "right-auxiliary-pane-resize-handle",
+  );
+  await resizeHandleAfterReload.dblclick();
+
+  await expect
+    .poll(async () => {
+      return threadPanelAfterReload.evaluate((panel) => {
         const element = panel as HTMLElement;
         return Math.round(element.getBoundingClientRect().width);
       });
     })
     .toBe(defaultWidthPx);
 
-  await threadPanel.getByTestId("auxiliary-panel-close").click();
-  await expect(threadPanel).toBeHidden();
+  await expect
+    .poll(() => page.evaluate((key) => window.localStorage.getItem(key), storageKey))
+    .toBe(String(defaultWidthPx));
 
-  await rootMessage.hover();
-  await rootMessage.getByRole("button", { name: "Reply" }).click();
-  await expect(threadPanel).toBeVisible();
+  await threadPanelAfterReload.getByTestId("auxiliary-panel-close").click();
+  await expect(threadPanelAfterReload).toBeHidden();
+
+  await rootAfterReload.hover();
+  await rootAfterReload.getByRole("button", { name: "Reply" }).click();
+  await expect(threadPanelAfterReload).toBeVisible();
 
   await expect
     .poll(async () => {
-      return threadPanel.evaluate((panel) => {
+      return threadPanelAfterReload.evaluate((panel) => {
         const element = panel as HTMLElement;
         return Math.round(element.getBoundingClientRect().width);
       });


### PR DESCRIPTION
## Summary

Thread pane width was stored in `sessionStorage`, so it reset after restart. Switch to `localStorage` (same durability as the sidebar), migrate any leftover session value once, and update e2e coverage.

## Why

Smoked on Moonlight desktop after merge of the same change: resize → quit → reopen thread keeps width.

## Duplicates

Searched `block/buzz` issues/PRs for thread panel width / sessionStorage / splitter persistence — **none found**. Upstream `main` still uses `sessionStorage` in `useThreadPanelWidth.ts` as of this branch tip.

## Note

Opened by **Pip**, a Buzz agent acting for @naturalethic (Joshua). Human-reviewed and smoke-tested before submit.

## Test plan

- [x] Resize thread pane, quit app, reopen thread → width preserved
- [x] Double-click resize handle → default width; stays after reopen
- [x] E2E: `thread panel width uses local storage, survives reload, and reset handle`