### PR TITLE
feat(desktop): host-agent see UI from 10100 host lineage

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -207,6 +207,11 @@ pub struct RelayAgentInfo {
     pub respond_to: Option<RespondTo>,
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
+    /// Host lineage pubkey from kind:10100 content `host` (virtual mint / house
+    /// field). Optional — absent for Local-native directory entries that never
+    /// set lineage. Desktop surfaces this as an environment badge only.
+    #[serde(default)]
+    pub host: Option<String>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -964,6 +964,36 @@ mod tests {
     }
 
     #[test]
+    fn agents_preserves_host_lineage_for_directory_parse() {
+        let host = "b".repeat(64);
+        let e = ev(
+            10100,
+            &format!(r#"{{"name":"Grok","host":"{host}"}}"#),
+            vec![],
+        );
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let agents = v.get("agents").cloned().unwrap();
+        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
+            serde_json::from_value(agents).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].host.as_deref(), Some(host.as_str()));
+        assert!(parsed[0].host.as_ref().is_some_and(|h| h.len() == 64));
+    }
+
+    #[test]
+    fn agents_host_absent_defaults_to_none() {
+        let e = ev(10100, r#"{"name":"Local-shaped"}"#, vec![]);
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let agents = v.get("agents").cloned().unwrap();
+        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
+            serde_json::from_value(agents).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].host, None);
+    }
+
+    #[test]
     fn relay_members_dedupes_and_defaults_role() {
         let pk1 = "a".repeat(64);
         let pk2 = "b".repeat(64);

--- a/desktop/src/features/agents/lib/resolveHostLabel.test.mjs
+++ b/desktop/src/features/agents/lib/resolveHostLabel.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveHostLabel } from "./resolveHostLabel.ts";
+
+const HOST = "c28e6260aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa34af";
+
+test("resolveHostLabel prefers knownHosts over truncated pubkey", () => {
+  assert.equal(
+    resolveHostLabel({
+      hostPubkey: HOST,
+      knownHosts: { [HOST]: "agentbox" },
+    }),
+    "agentbox",
+  );
+});
+
+test("resolveHostLabel matches knownHosts keys case-insensitively", () => {
+  assert.equal(
+    resolveHostLabel({
+      hostPubkey: HOST.toUpperCase(),
+      knownHosts: { [HOST]: "agentbox" },
+    }),
+    "agentbox",
+  );
+});
+
+test("resolveHostLabel falls back to truncated pubkey", () => {
+  const label = resolveHostLabel({ hostPubkey: HOST });
+  assert.match(label, /^c28e6260/i);
+  assert.ok(label.includes("…") || label.includes("..."));
+});
+
+test("resolveHostLabel ignores blank known labels", () => {
+  const label = resolveHostLabel({
+    hostPubkey: HOST,
+    knownHosts: { [HOST]: "   " },
+  });
+  assert.notEqual(label, "   ");
+  assert.match(label, /^c28e6260/i);
+});

--- a/desktop/src/features/agents/lib/resolveHostLabel.ts
+++ b/desktop/src/features/agents/lib/resolveHostLabel.ts
@@ -1,0 +1,35 @@
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * Environment / machine label for a host lineage pubkey from kind:10100 `host`.
+ *
+ * Hosts are not person profiles — do not route through `resolveUserLabel` or
+ * kind:0. Prefer an explicit known-hosts map (house config later); otherwise
+ * truncate the pubkey.
+ */
+export function resolveHostLabel(input: {
+  hostPubkey: string;
+  knownHosts?: Readonly<Record<string, string>>;
+}): string {
+  const hostPubkey = normalizePubkey(input.hostPubkey);
+  if (hostPubkey.length === 0) {
+    return "host";
+  }
+
+  const known = input.knownHosts?.[hostPubkey]?.trim();
+  if (known) {
+    return known;
+  }
+
+  // knownHosts may be keyed with mixed case from callers
+  if (input.knownHosts) {
+    for (const [key, label] of Object.entries(input.knownHosts)) {
+      if (normalizePubkey(key) === hostPubkey) {
+        const trimmed = label?.trim();
+        if (trimmed) return trimmed;
+      }
+    }
+  }
+
+  return truncatePubkey(hostPubkey);
+}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -20,6 +20,7 @@ import { SecretRevealDialog } from "./SecretRevealDialog";
 import { TeamDeleteDialog } from "./TeamDeleteDialog";
 import { TeamDialog } from "./TeamDialog";
 import { TeamsSection } from "./TeamsSection";
+import { HostAgentsSection } from "./HostAgentsSection";
 import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
@@ -94,6 +95,13 @@ export function AgentsView() {
   const runningAgentCount = agents.managedAgents.filter((agent) =>
     isManagedAgentActive(agent),
   ).length;
+  const managedPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (agents.managedAgents ?? []).map((agent) => agent.pubkey.toLowerCase()),
+      ),
+    [agents.managedAgents],
+  );
   const hasSavedAgentDefaults = Boolean(
     globalConfig.preferred_runtime?.trim() ||
       globalConfig.provider?.trim() ||
@@ -268,6 +276,13 @@ export function AgentsView() {
               onDeletePersona={personas.openDelete}
               onImportSnapshotFile={(fileBytes, fileName) => {
                 void personas.handleImportSnapshotFile(fileBytes, fileName);
+              }}
+            />
+
+            <HostAgentsSection
+              managedPubkeys={managedPubkeys}
+              onOpenAgentProfile={(pubkey, options) => {
+                openProfilePanel?.(pubkey, options);
               }}
             />
 

--- a/desktop/src/features/agents/ui/HostAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/HostAgentsSection.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import type { RelayAgent } from "@/shared/api/types";
+import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
+import { Badge } from "@/shared/ui/badge";
+import { IdentityCardSkeleton } from "@/shared/ui/identity-card-skeleton";
+import { AgentIdentityCard } from "./AgentIdentityCard";
+import {
+  AGENT_CARD_GRID_COLUMNS_CLASS,
+  IDENTITY_CARD_GRID_CLASS,
+} from "./UnifiedAgentsSection";
+
+type HostAgentsSectionProps = {
+  /** Local managed agent pubkeys — excluded so we never double-list. */
+  managedPubkeys: ReadonlySet<string>;
+  onOpenAgentProfile: (
+    pubkey: string,
+    options?: ProfilePanelOpenOptions,
+  ) => void;
+};
+
+/**
+ * Read-only section for host-minted / directory agents that carry kind:10100
+ * `host` lineage and are not in the Local managed store.
+ *
+ * Reuses list_relay_agents + users-batch profile hydration (same as DMs).
+ * No Local Start — process lives on the host.
+ */
+export function HostAgentsSection({
+  managedPubkeys,
+  onOpenAgentProfile,
+}: HostAgentsSectionProps) {
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const hostAgents = React.useMemo(
+    () =>
+      (relayAgentsQuery.data ?? []).filter(
+        (agent): agent is RelayAgent & { hostPubkey: string } =>
+          typeof agent.hostPubkey === "string" &&
+          agent.hostPubkey.length === 64 &&
+          !managedPubkeys.has(agent.pubkey.toLowerCase()),
+      ),
+    [managedPubkeys, relayAgentsQuery.data],
+  );
+
+  const hostPubkeys = React.useMemo(
+    () => [...new Set(hostAgents.map((agent) => agent.hostPubkey))],
+    [hostAgents],
+  );
+  const hostProfilesQuery = useUsersBatchQuery(hostPubkeys, {
+    enabled: hostPubkeys.length > 0,
+  });
+  const hostProfiles = hostProfilesQuery.data?.profiles;
+
+  // Nothing to show and not loading → omit section (no empty chrome).
+  if (
+    !relayAgentsQuery.isLoading &&
+    !relayAgentsQuery.isError &&
+    hostAgents.length === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Host agents"
+      className="space-y-3"
+      data-testid="host-agents-section"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="min-w-0 space-y-0.5">
+          <h2 className="text-sm font-semibold tracking-tight text-foreground">
+            On host
+          </h2>
+          <p className="text-xs text-secondary-foreground/80">
+            Agents discovered from the relay with a host environment. Open a
+            profile to message them — they do not Start on this device.
+          </p>
+        </div>
+      </div>
+
+      {relayAgentsQuery.isError ? (
+        <p className="text-sm text-destructive" role="alert">
+          {relayAgentsQuery.error instanceof Error
+            ? relayAgentsQuery.error.message
+            : "Could not load relay agents."}
+        </p>
+      ) : null}
+
+      {relayAgentsQuery.isLoading ? (
+        <div className={IDENTITY_CARD_GRID_CLASS}>
+          <IdentityCardSkeleton className="w-full" />
+          <IdentityCardSkeleton className="w-full" />
+        </div>
+      ) : (
+        <div
+          className={`${AGENT_CARD_GRID_COLUMNS_CLASS} grid justify-start gap-3 [@container(max-width:40rem)]:justify-center`}
+        >
+          {hostAgents.map((agent) => {
+            const hostLabel = resolveUserLabel({
+              pubkey: agent.hostPubkey,
+              profiles: hostProfiles,
+            });
+            return (
+              <AgentIdentityCard
+                key={agent.pubkey}
+                ariaLabel={`${agent.name}, on ${hostLabel}`}
+                dataTestId={`host-agent-${agent.pubkey}`}
+                label={agent.name}
+                modelLabel={null}
+                onClick={() => {
+                  onOpenAgentProfile(agent.pubkey);
+                }}
+                statusBadge={
+                  <Badge
+                    className="pointer-events-auto max-w-full truncate font-normal"
+                    data-testid={`host-agent-badge-${agent.pubkey}`}
+                    title={`Host ${agent.hostPubkey}`}
+                    variant="secondary"
+                  >
+                    On {hostLabel}
+                  </Badge>
+                }
+              />
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/desktop/src/features/agents/ui/HostAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/HostAgentsSection.tsx
@@ -1,8 +1,15 @@
 import * as React from "react";
 
 import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { resolveHostLabel } from "@/features/agents/lib/resolveHostLabel";
+import { usePresenceQuery } from "@/features/presence/hooks";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
-import { resolveUserLabel } from "@/features/profile/lib/identity";
+import {
+  DEFAULT_HOVER_PROFILE_STATUS_GEOMETRY,
+  ProfileAvatarWithStatus,
+  scaleProfileAvatarStatusGeometry,
+} from "@/features/profile/ui/ProfileAvatarWithStatus";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import type { RelayAgent } from "@/shared/api/types";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { Badge } from "@/shared/ui/badge";
@@ -13,9 +20,22 @@ import {
   IDENTITY_CARD_GRID_CLASS,
 } from "./UnifiedAgentsSection";
 
+/** Card avatar size matches AgentIdentityCard / Local agent cards (h-24 w-24). */
+const HOST_AGENT_AVATAR_SIZE = 96;
+
+const HOST_AGENT_STATUS_GEOMETRY = scaleProfileAvatarStatusGeometry(
+  DEFAULT_HOVER_PROFILE_STATUS_GEOMETRY,
+  HOST_AGENT_AVATAR_SIZE,
+);
+
 type HostAgentsSectionProps = {
   /** Local managed agent pubkeys — excluded so we never double-list. */
   managedPubkeys: ReadonlySet<string>;
+  /**
+   * Optional hostPubkey → human environment label (e.g. agentbox).
+   * Environment names are not kind:0 person profiles.
+   */
+  knownHosts?: Readonly<Record<string, string>>;
   onOpenAgentProfile: (
     pubkey: string,
     options?: ProfilePanelOpenOptions,
@@ -26,11 +46,17 @@ type HostAgentsSectionProps = {
  * Read-only section for host-minted / directory agents that carry kind:10100
  * `host` lineage and are not in the Local managed store.
  *
- * Reuses list_relay_agents + users-batch profile hydration (same as DMs).
+ * Hydration reuses native Buzz lanes (same as DMs / profile click-through):
+ * - directory list: list_relay_agents (10100)
+ * - face + person name: users-batch (kind:0)
+ * - live online: presence (kind:20001)
+ * - environment badge: knownHosts / truncated host pubkey — not kind:0
+ *
  * No Local Start — process lives on the host.
  */
 export function HostAgentsSection({
   managedPubkeys,
+  knownHosts,
   onOpenAgentProfile,
 }: HostAgentsSectionProps) {
   const relayAgentsQuery = useRelayAgentsQuery();
@@ -45,14 +71,20 @@ export function HostAgentsSection({
     [managedPubkeys, relayAgentsQuery.data],
   );
 
-  const hostPubkeys = React.useMemo(
-    () => [...new Set(hostAgents.map((agent) => agent.hostPubkey))],
+  const agentPubkeys = React.useMemo(
+    () => hostAgents.map((agent) => agent.pubkey),
     [hostAgents],
   );
-  const hostProfilesQuery = useUsersBatchQuery(hostPubkeys, {
-    enabled: hostPubkeys.length > 0,
+
+  const agentProfilesQuery = useUsersBatchQuery(agentPubkeys, {
+    enabled: agentPubkeys.length > 0,
   });
-  const hostProfiles = hostProfilesQuery.data?.profiles;
+  const agentProfiles = agentProfilesQuery.data?.profiles;
+
+  const presenceQuery = usePresenceQuery(agentPubkeys, {
+    enabled: agentPubkeys.length > 0,
+  });
+  const presenceLookup = presenceQuery.data;
 
   // Nothing to show and not loading → omit section (no empty chrome).
   if (
@@ -99,16 +131,37 @@ export function HostAgentsSection({
           className={`${AGENT_CARD_GRID_COLUMNS_CLASS} grid justify-start gap-3 [@container(max-width:40rem)]:justify-center`}
         >
           {hostAgents.map((agent) => {
-            const hostLabel = resolveUserLabel({
-              pubkey: agent.hostPubkey,
-              profiles: hostProfiles,
+            const pubkeyLower = normalizePubkey(agent.pubkey);
+            const profile = agentProfiles?.[pubkeyLower];
+            const title =
+              profile?.displayName?.trim() || agent.name.trim() || pubkeyLower;
+            const avatarUrl = profile?.avatarUrl ?? null;
+            const presenceStatus = presenceLookup?.[pubkeyLower];
+            const hostLabel = resolveHostLabel({
+              hostPubkey: agent.hostPubkey,
+              knownHosts,
             });
+
             return (
               <AgentIdentityCard
                 key={agent.pubkey}
-                ariaLabel={`${agent.name}, on ${hostLabel}`}
+                ariaLabel={`${title}, on ${hostLabel}`}
+                avatar={
+                  <ProfileAvatarWithStatus
+                    avatarClassName="border-[3px] border-background bg-muted shadow-none"
+                    avatarUrl={avatarUrl}
+                    geometry={HOST_AGENT_STATUS_GEOMETRY}
+                    iconClassName="h-8 w-8"
+                    label={title}
+                    size={HOST_AGENT_AVATAR_SIZE}
+                    status={presenceStatus}
+                    statusTestId={`host-agent-presence-${agent.pubkey}`}
+                    testId={`host-agent-avatar-${agent.pubkey}`}
+                  />
+                }
+                avatarUrl={avatarUrl}
                 dataTestId={`host-agent-${agent.pubkey}`}
-                label={agent.name}
+                label={title}
                 modelLabel={null}
                 onClick={() => {
                   onOpenAgentProfile(agent.pubkey);

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -113,6 +113,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
               : "offline",
           respondTo: agent.respondTo,
           respondToAllowlist: agent.respondToAllowlist,
+          hostPubkey: null,
         });
       }
     }

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -117,6 +117,8 @@ type RawRelayAgent = {
   status: RelayAgent["status"];
   respond_to?: RelayAgent["respondTo"];
   respond_to_allowlist?: string[];
+  /** kind:10100 content `host` — optional host lineage pubkey. */
+  host?: string | null;
 };
 
 import type { RestartDiffEntry as RawRestartDiffEntry } from "./restartDiff";
@@ -685,7 +687,16 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
     status: agent.status,
     respondTo: agent.respond_to ?? null,
     respondToAllowlist: agent.respond_to_allowlist ?? [],
+    hostPubkey: normalizeHostPubkey(agent.host),
   };
+}
+
+/** Accept only a non-empty 64-hex host pubkey; reject junk from open 10100 content. */
+function normalizeHostPubkey(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(trimmed)) return null;
+  return trimmed;
 }
 
 export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -277,6 +277,11 @@ export type RelayAgent = {
   status: "online" | "away" | "offline";
   respondTo: RespondToMode | null;
   respondToAllowlist: string[];
+  /**
+   * Host lineage pubkey from kind:10100 `host` (64-hex). Present for
+   * host-minted agents; used for environment badge hydration — not Local Start.
+   */
+  hostPubkey: string | null;
 };
 
 export type ManagedAgentRuntimeLifecycle =

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -783,6 +783,8 @@ type RawRelayAgent = {
   status: PresenceStatus;
   respond_to?: "owner-only" | "allowlist" | "anyone";
   respond_to_allowlist?: string[];
+  /** Optional kind:10100 host lineage pubkey (64-hex). */
+  host?: string | null;
 };
 
 type RawManagedAgent = {
@@ -3570,6 +3572,7 @@ function syncMockRelayAgentsFromManagedAgents() {
             : "offline",
         respond_to: agent.respond_to,
         respond_to_allowlist: [...agent.respond_to_allowlist],
+        host: null,
       };
     },
   );


### PR DESCRIPTION
## Summary

- Plumb optional kind:10100 `host` through `list_relay_agents` into `RelayAgent.hostPubkey`.
- Add an **On host** section on the Agents page for non-managed directory agents that carry host lineage, with an environment badge hydrated via existing `useUsersBatchQuery` + `resolveUserLabel` (same progressive label model as DMs).
- No Local Start, no kind:30177 — read-only discovery surface for host-minted agents.

## Disclaimer

- This Pr only works under the premise that a remote agent is appropriately minted and expresses kind 10100.  Separate pr to follow with that.
- This Pr also only works if host on a virtual machine is created, also through a different pr.  Host creation with keypair, is a primitive function to bringing the substrate onto the relay.

## Visualization
<img width="1194" height="1089" alt="Agent cards showing with image updated" src="https://github.com/user-attachments/assets/42f999c5-1811-40a7-9696-b26e3999ff90" />


## Test plan

- [x] `cargo test --lib agents_preserves_host` / `agents_host_absent` (buzz_lib)
- [x] `biome check` on touched TS files
- [x] Desktop: Agents page shows **On host** for live agents with 10100 `host` set; badge truncates.
- [ ] Desktop: 'host' set; badge becomes name of host, from 10100
- [ ] Desktop 'host'; title of host becomes name of device from 10100
- [x] Managed Local agents still only in the main managed section (not double-listed)
- [x] No Start control on host rows
