### PR TITLE
fix(buzz-dev-mcp): configurable shell-timeout ceiling; report the clamp

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -21,8 +21,10 @@ use crate::filter::SubscriptionRule;
 /// Sized for slow turns where the agent may go silent on its outer ACP channel
 /// while running long sub-tools (e.g. a buzz-agent running another agent, or
 /// codex/claude doing multi-minute single tool calls). 900s gives 300s of
-/// breathing room above the 600s max shell timeout, so legitimate long-running
-/// tool calls don't race the idle deadline.
+/// breathing room above buzz-dev-mcp's default 600s shell-timeout ceiling, so
+/// legitimate long-running tool calls don't race the idle deadline. Operators
+/// who raise that ceiling (`BUZZ_DEV_MCP_MAX_TIMEOUT_MS`) must raise this
+/// timeout to match, or long tool calls die here instead.
 /// Override via `--idle-timeout` / `BUZZ_ACP_IDLE_TIMEOUT`.
 pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -15,6 +15,8 @@ use tokio_util::sync::CancellationToken;
 
 const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_TIMEOUT_MS: u64 = 600_000;
+/// Operator override for the shell-timeout ceiling, in milliseconds (#4638).
+const MAX_TIMEOUT_ENV: &str = "BUZZ_DEV_MCP_MAX_TIMEOUT_MS";
 const MAX_COMMAND_BYTES: usize = 1_000_000;
 const CAPTURE_CAP: usize = 10 * 1024 * 1024;
 const MAX_BYTES: usize = 50 * 1024;
@@ -28,6 +30,10 @@ pub struct SharedState {
     pub shim: Shim,
     pub session_dir: TempDir,
     pub bootstrap_instructions: String,
+    /// Ceiling for `ShellParams::timeout_ms`, resolved once at startup from
+    /// `BUZZ_DEV_MCP_MAX_TIMEOUT_MS` (default 600 000 ms). The clamp itself is
+    /// applied — and reported — per call in [`run`].
+    pub max_timeout_ms: u64,
     /// The shell resolved at construction: `Ok((path, display_name))` when a shell
     /// is available, `Err(msg)` when none was found. Stored once so both the
     /// bootstrap hint and every `run()` call read the SAME resolution — no drift.
@@ -57,6 +63,7 @@ impl SharedState {
             session_dir,
             bootstrap_instructions,
             resolved_shell,
+            max_timeout_ms: resolve_max_timeout_ms(std::env::var(MAX_TIMEOUT_ENV).ok()),
             artifacts: Mutex::new(VecDeque::with_capacity(ARTIFACT_RING_SIZE)),
             next_call_id: Mutex::new(0),
         })
@@ -69,6 +76,18 @@ impl SharedState {
         };
         *g += 1;
         *g
+    }
+}
+
+/// Resolve the effective shell-timeout ceiling from the operator override.
+///
+/// Unparseable or zero values fall back to the built-in [`MAX_TIMEOUT_MS`]
+/// rather than lowering or disabling the ceiling — a misconfigured knob must
+/// never make every command die instantly.
+fn resolve_max_timeout_ms(raw: Option<String>) -> u64 {
+    match raw.as_deref().map(|v| v.trim().parse::<u64>()) {
+        Some(Ok(v)) if v > 0 => v,
+        _ => MAX_TIMEOUT_MS,
     }
 }
 
@@ -121,7 +140,10 @@ pub struct ShellParams {
     pub command: String,
     #[serde(default)]
     pub workdir: Option<String>,
-    /// Defaults to 120000 ms (2 min) if omitted; capped at 600000 ms (10 min).
+    /// Defaults to 120000 ms (2 min) if omitted. Capped at the server's
+    /// ceiling — 600000 ms (10 min) unless the operator raised it via
+    /// BUZZ_DEV_MCP_MAX_TIMEOUT_MS; requests above the ceiling are clamped
+    /// and the clamp is reported in the result's `notes`.
     /// For long-running commands (git push with hooks, cargo build, test suites), use 300000+.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
@@ -138,10 +160,8 @@ pub async fn run(
             None,
         ));
     }
-    let timeout_ms = p
-        .timeout_ms
-        .unwrap_or(DEFAULT_TIMEOUT_MS)
-        .min(MAX_TIMEOUT_MS);
+    let requested_timeout_ms = p.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
+    let timeout_ms = requested_timeout_ms.min(state.max_timeout_ms);
     let workdir: PathBuf = p
         .workdir
         .as_deref()
@@ -215,6 +235,15 @@ pub async fn run(
 
     let timeout_dur = Duration::from_millis(timeout_ms);
     let mut notes: Vec<String> = Vec::new();
+    if requested_timeout_ms > timeout_ms {
+        // The silent version of this clamp cost real debugging time (#4638):
+        // a caller that asked for an hour and was given ten minutes could not
+        // distinguish the ceiling from a crash.
+        notes.push(format!(
+            "requested timeout_ms {requested_timeout_ms} exceeds the {timeout_ms} ms ceiling; \
+             clamped (set {MAX_TIMEOUT_ENV} to raise the ceiling)"
+        ));
+    }
     let (status, timed_out) = tokio::select! {
         biased;
         _ = ct.cancelled() => {
@@ -243,6 +272,12 @@ pub async fn run(
             (None, false)
         }
         Err(_) => {
+            // Name the effective timeout in the result: the child's own output
+            // dies with the process group, so without this note a killed job
+            // reads as a truncated stream, not as the ceiling firing (#4638).
+            notes.push(format!(
+                "process group killed at the {timeout_ms} ms timeout"
+            ));
             // Kill process group — this closes the pipes, causing reads to EOF.
             kill_group.kill_graceful().await;
             // Reap the child so it doesn't become a zombie.
@@ -1046,6 +1081,62 @@ mod tests {
         let v = body(r);
         assert_eq!(v["timed_out"], true);
         assert_eq!(v["exit_code"], 124);
+        // The kill must be attributed to the timeout in-band — a killed job's
+        // truncated output is otherwise indistinguishable from a crash.
+        assert!(
+            v["notes"].as_array().expect("notes array").iter().any(|n| n
+                .as_str()
+                .unwrap_or("")
+                .contains("killed at the 150 ms timeout")),
+            "timeout note missing from {:?}",
+            v["notes"]
+        );
+    }
+
+    #[test]
+    fn max_timeout_resolves_from_env_value() {
+        assert_eq!(resolve_max_timeout_ms(None), MAX_TIMEOUT_MS);
+        assert_eq!(resolve_max_timeout_ms(Some("3600000".into())), 3_600_000);
+        assert_eq!(resolve_max_timeout_ms(Some(" 250 ".into())), 250);
+        // Misconfiguration never lowers the ceiling to zero or garbage.
+        assert_eq!(resolve_max_timeout_ms(Some("0".into())), MAX_TIMEOUT_MS);
+        assert_eq!(resolve_max_timeout_ms(Some("-5".into())), MAX_TIMEOUT_MS);
+        assert_eq!(
+            resolve_max_timeout_ms(Some("ten minutes".into())),
+            MAX_TIMEOUT_MS
+        );
+        assert_eq!(resolve_max_timeout_ms(Some(String::new())), MAX_TIMEOUT_MS);
+    }
+
+    /// A request above the ceiling is honored at the ceiling and the clamp is
+    /// reported in-band — the silent version of this clamp is what #4638 is
+    /// about.
+    #[tokio::test(flavor = "current_thread")]
+    async fn clamped_timeout_is_reported_in_notes() {
+        let dir = tempdir().expect("tempdir");
+        let mut state = make_state(dir.path());
+        state.max_timeout_ms = 5_000;
+        let r = run(
+            &state,
+            ShellParams {
+                command: "echo capped".into(),
+                workdir: None,
+                timeout_ms: Some(60_000),
+            },
+            CancellationToken::new(),
+        )
+        .await
+        .expect("ok");
+        let v = body(r);
+        assert_eq!(v["exit_code"], 0);
+        assert!(
+            v["notes"].as_array().expect("notes array").iter().any(|n| {
+                let n = n.as_str().unwrap_or("");
+                n.contains("60000") && n.contains("5000 ms ceiling") && n.contains(MAX_TIMEOUT_ENV)
+            }),
+            "clamp note missing from {:?}",
+            v["notes"]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

`buzz-dev-mcp` capped every shell call at 600 s via an unconfigurable `.min(MAX_TIMEOUT_MS)`, and the clamp was invisible twice over: a caller asking for 3600 s was silently given 600 s (`timeout_ms` is an accepted tool parameter, so callers reasonably believe it was honored), and on expiry the process-group kill takes the child's own output buffer with it, so what the agent sees is a truncated log — not a timeout. The reporter lost four consecutive real agent runs to this, each dying at exactly 600 s with a 15-byte log, and the agent diagnosed its model backend as broken.

This implements both of the issue's asks:

1. **The ceiling is configurable**: `BUZZ_DEV_MCP_MAX_TIMEOUT_MS` (default unchanged, 600 000 ms), resolved once at `SharedState` construction. Unparseable or zero values fall back to the built-in default rather than lowering the ceiling — a misconfigured knob must never make every command die instantly (unit-tested).
2. **The clamp and the kill are reported in-band**, via the result's existing `notes: []` array (additive — no schema change, `timed_out`/`exit_code: 124` semantics untouched): a request above the ceiling gets "requested … exceeds the … ceiling; clamped (set BUZZ_DEV_MCP_MAX_TIMEOUT_MS to raise the ceiling)", and expiry adds "process group killed at the {N} ms timeout", so a killed job is attributable from inside the result.

Also updated: the `ShellParams` schema doc-comment no longer hard-codes "capped at 600000 ms", and — one comment line in `buzz-acp` — `DEFAULT_IDLE_TIMEOUT_SECS`'s doc now states the coupling this issue's scenario runs into next: the 900 s ACP idle timer is sized to the *default* shell ceiling, so operators raising the ceiling past ~900 s must raise `BUZZ_ACP_IDLE_TIMEOUT` to match (the knob already exists; past 7200 s, `BUZZ_ACP_MAX_TURN_DURATION` as well). Without that pairing the reporter's agent jobs would next die at 900 s. Related: #935 raised the idle default for exactly the adjacent reason; the issue itself draws the distinction.

### Related issue

Fixes #4638. Duplicate search at filing (2026-08-04): no open or closed PR addresses the shell-timeout ceiling (nearest match #4261 is buzz-acp `idle_timeout`, a different knob in a different crate).

### Testing

- `cargo test -p buzz-dev-mcp --lib -- --test-threads=1` — 121 passed, 0 failed (new: env-resolver cases incl. zero/garbage/empty fallbacks; clamp note asserted end-to-end with a lowered ceiling; the existing `timeout_fires` test now also asserts the kill-attribution note).
- Note on parallel runs: the suite is spawn-flaky on this Windows box *at the base commit too* (random shell-spawning tests intermittently get "failed to spawn shell" under parallel load — reproduced 1-in-3 on pristine base; single-threaded is stable). Pre-existing local-environment behavior, unrelated to this change.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — clean.
- Toolchain: Windows MSVC (as in #2638/#4214-#4216); base is 28ae6cd21 — `buzz-dev-mcp` is unchanged between that and current main.
