### PR TITLE
fix(desktop): recognize the membership gate's bodyless 404 in onboarding

### DIFF
--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -27,6 +27,7 @@ import { listPersonas } from "@/shared/api/tauriPersonas";
 import { relayClient } from "@/shared/api/relayClient";
 import type { AgentPersona } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { isRelayMembershipDeniedError } from "@/shared/lib/relayError";
 import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
 import { Button } from "@/shared/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/shared/ui/dialog";
@@ -38,16 +39,6 @@ import {
   OnboardingChrome,
 } from "./OnboardingChrome";
 import { OnboardingFooter, OnboardingFooterProvider } from "./OnboardingFooter";
-
-function isRelayMembershipDeniedError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return (
-    error.message.includes("You must be a relay member") ||
-    error.message.includes("relay_membership_required") ||
-    error.message.includes("restricted: not a relay member") ||
-    error.message.includes("invalid: you are not a relay member")
-  );
-}
 
 const STARTER_PERSONA_ANIMATIONS: Record<string, string> = {
   Fizz: "/onboarding/starter-team/fizz.png",

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -7,7 +7,10 @@ import {
 } from "@/features/profile/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { getMyRelayMembershipLookup } from "@/shared/api/relayMembers";
-import { isRelayUnreachableError } from "@/shared/lib/relayError";
+import {
+  isRelayMembershipDeniedError,
+  isRelayUnreachableError,
+} from "@/shared/lib/relayError";
 import {
   getIdentity,
   importIdentity,
@@ -35,19 +38,6 @@ import type {
   OnboardingProfileValues,
   ProfileStepState,
 } from "./types";
-
-function isRelayMembershipDeniedError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return (
-    error.message.includes("You must be a relay member") ||
-    error.message.includes("relay_membership_required") ||
-    error.message.includes("restricted: not a relay member") ||
-    error.message.includes("invalid: you are not a relay member")
-  );
-}
 
 type MembershipCheckResult = "denied" | "ok" | "unreachable" | "error";
 

--- a/desktop/src/shared/lib/relayError.test.mjs
+++ b/desktop/src/shared/lib/relayError.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isRelayUnreachableError } from "./relayError.ts";
+import {
+  isRelayMembershipDeniedError,
+  isRelayUnreachableError,
+} from "./relayError.ts";
 
 test("isRelayUnreachableError: Error with prefix returns true", () => {
   assert.equal(
@@ -52,6 +55,85 @@ test("isRelayUnreachableError: number returns false", () => {
 test("isRelayUnreachableError: plain object returns false", () => {
   assert.equal(
     isRelayUnreachableError({ message: "relay unreachable: oops" }),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: bodyless 404 returns true", () => {
+  // The exact string the membership gate produces. This is the case that
+  // stranded invitees at the profile step (block/buzz#3544).
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 404 Not Found")),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: bodyless 404 as a string returns true", () => {
+  assert.equal(
+    isRelayMembershipDeniedError("relay returned 404 Not Found"),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: surrounding whitespace still matches", () => {
+  assert.equal(
+    isRelayMembershipDeniedError("  relay returned 404 Not Found\n"),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: suffixed 404 returns false", () => {
+  // Every relay `api_error` carries {"error": "<msg>"}, which renders with a
+  // `: <detail>` suffix. Those are different failures — a host with no
+  // community bound is not a membership problem — and must not be
+  // misreported as one.
+  assert.equal(
+    isRelayMembershipDeniedError(
+      new Error(
+        "relay returned 404 Not Found: relay: no community is configured for this host",
+      ),
+    ),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: other statuses return false", () => {
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 500")),
+    false,
+  );
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 403 Forbidden")),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: message-bearing denials return true", () => {
+  for (const message of [
+    "publish failed: You must be a relay member",
+    "relay_membership_required",
+    "restricted: not a relay member",
+    "invalid: you are not a relay member",
+  ]) {
+    assert.equal(isRelayMembershipDeniedError(new Error(message)), true);
+  }
+});
+
+test("isRelayMembershipDeniedError: unreachable relay returns false", () => {
+  // A connectivity failure must route to the retry path, not to
+  // MembershipDenied — the two are handled by different screens.
+  assert.equal(
+    isRelayMembershipDeniedError("relay unreachable: connection refused"),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: non-error inputs return false", () => {
+  assert.equal(isRelayMembershipDeniedError(null), false);
+  assert.equal(isRelayMembershipDeniedError(undefined), false);
+  assert.equal(isRelayMembershipDeniedError(404), false);
+  assert.equal(
+    isRelayMembershipDeniedError({ message: "relay returned 404 Not Found" }),
     false,
   );
 });

--- a/desktop/src/shared/lib/relayError.ts
+++ b/desktop/src/shared/lib/relayError.ts
@@ -32,3 +32,61 @@ export function isRelayUnreachableError(error: unknown): boolean {
   }
   return false;
 }
+
+/**
+ * The exact message the backend produces when the relay's membership gate
+ * refuses a request.
+ *
+ * The gate (`crates/buzz-relay/src/api/mod.rs`, `mod relay_members`,
+ * `MembershipDecision::Denied`) answers with a **bodyless** 404. With no
+ * `message` or `error` field to quote, `classify_relay_error`
+ * (`desktop/src-tauri/src/relay.rs`) falls through to its status-only form,
+ * producing exactly this string with no `: <detail>` suffix.
+ *
+ * Every other relay 404 is an `api_error`, which always carries
+ * `{"error": "<msg>"}` and therefore renders with a suffix. That is what makes
+ * an exact match safe here: a suffixed 404 is a different failure (e.g. no
+ * community bound to the host) and must not be reported as a membership
+ * problem. `desktop/src/shared/api/tauri.ts` relies on the same equivalence.
+ */
+const RELAY_MEMBERSHIP_DENIED_404 = "relay returned 404 Not Found";
+
+/**
+ * Substrings emitted by relay paths that reject non-members with a message
+ * rather than the bodyless 404 above (WebSocket rejections, NIP-29 write
+ * refusals). Matched loosely because they arrive embedded in longer text.
+ */
+const RELAY_MEMBERSHIP_DENIED_SUBSTRINGS = [
+  "You must be a relay member",
+  "relay_membership_required",
+  "restricted: not a relay member",
+  "invalid: you are not a relay member",
+];
+
+/**
+ * Returns true when `error` means "you are not a member of this relay".
+ *
+ * Onboarding uses this to route to the `MembershipDenied` screen — which
+ * offers Retry, Import key, and Change community — instead of dead-ending on
+ * raw error text. Missing the bodyless-404 form is what stranded invitees at
+ * the profile step (block/buzz#3544): `update_profile` reads before it writes,
+ * so the gate rejects the read and onboarding cannot proceed.
+ *
+ * Accepts `Error` instances and raw strings so callers can pass whatever the
+ * Tauri IPC layer hands them without pre-normalizing.
+ */
+export function isRelayMembershipDeniedError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : null;
+  if (message === null) return false;
+
+  if (message.trim() === RELAY_MEMBERSHIP_DENIED_404) return true;
+
+  return RELAY_MEMBERSHIP_DENIED_SUBSTRINGS.some((substring) =>
+    message.includes(substring),
+  );
+}


### PR DESCRIPTION
## Context

A new member on a self-hosted community was blocked at **Build your profile** by a bare
`relay returned 404 Not Found` printed under the username field, with no way forward.
The only escape was quitting the app, relaunching, and clicking the invite link again.
That is the failure described in #3544, and it is actively costing us people during
onboarding.

## What was wrong

Both onboarding flows carried their own copy of `isRelayMembershipDeniedError`, and both
matched only *message-bearing* rejections:

```
"You must be a relay member"
"relay_membership_required"
"restricted: not a relay member"
"invalid: you are not a relay member"
```

The relay's membership gate emits none of those. `MembershipDecision::Denied`
(`crates/buzz-relay/src/api/mod.rs`, `mod relay_members`) answers with a **bodyless**
404. With no `message` or `error` field to quote, `classify_relay_error`
(`desktop/src-tauri/src/relay.rs`) falls through to its status-only form — exactly
`relay returned 404 Not Found`, no detail suffix.

So the predicate never fired, `saveProfile` fell through to its generic catch, and the
user got raw text instead of the `MembershipDenied` screen and its **Retry**,
**Import key**, and **Change community** affordances.

It surfaces at the profile step specifically because `update_profile`
(`desktop/src-tauri/src/commands/profile.rs`) is a read-merge-write: `query_relay` runs
*before* any write, so the gate rejects the **read**. A fix that only defers the profile
write would not have helped.

## Change

- Move the predicate to `desktop/src/shared/lib/relayError.ts`, next to
  `isRelayUnreachableError`, and teach it the bodyless-404 form.
- Delete both duplicated copies; `OnboardingFlow` and `CommunityOnboardingFlow` now
  import the shared one.
- 8 new unit tests.

The 404 match is **exact, not a prefix**. Every other relay 404 is an `api_error`
carrying `{"error": "<msg>"}` and therefore renders with a `: <detail>` suffix — e.g.
`relay returned 404 Not Found: relay: no community is configured for this host`, which
is a host-binding failure, not a membership one, and must keep routing elsewhere. A test
pins that distinction. `desktop/src/shared/api/tauri.ts` already relies on the same
equivalence for `getMyRelayMembership`.

## Scope

This restores the **recovery path**. It does not reorder onboarding, so the underlying
first-run deadlock in #3544 stays open — a user with no membership still cannot complete
a profile, they can now just see why and act on it. Reordering the profile step to sit
after join is the real fix and is worth doing separately.

## Testing

- `just desktop-ci` — green (exit 0).
- New: `desktop/src/shared/lib/relayError.test.mjs`, 17 tests total, all passing.

Unrelated flake seen on the first gate run and worth its own issue:
`relay_admission::tests::concurrent_429_extends_the_window_for_parked_waiters` failed
with `left: 300.001s` — a 300s (`MAX_HINT_SECONDS`) window leaked in from another test,
so the global gate is not isolated despite `TEST_SERIAL`. Passes 3/3 in isolation and on
a re-run; this PR is TypeScript-only and cannot affect it.

Refs #3544
