### PR TITLE
fix(mobile): add a connect timeout to the relay websocket handshake

### DIFF
--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -37,6 +37,16 @@ class RelaySocket {
   @visibleForTesting
   static Duration debugPingInterval = pingInterval;
 
+  /// Bound on the websocket handshake. Without one, a half-open TCP path —
+  /// typical after the app resumes from background across a network change —
+  /// hangs `WebSocket.connect` indefinitely: the session sits in
+  /// `reconnecting`, no error ever surfaces, and no retry is scheduled. A
+  /// bounded connect fails fast into the normal reconnect backoff instead.
+  static const connectTimeout = Duration(seconds: 10);
+
+  @visibleForTesting
+  static Duration debugConnectTimeout = connectTimeout;
+
   final String _wsUrl;
   final String? _nsec;
   final void Function(List<dynamic> message) _onMessage;
@@ -73,6 +83,7 @@ class RelaySocket {
       _channel = IOWebSocketChannel.connect(
         Uri.parse(_wsUrl),
         pingInterval: debugPingInterval,
+        connectTimeout: debugConnectTimeout,
       );
       await _channel!.ready;
     } catch (e) {

--- a/mobile/test/shared/relay/relay_socket_liveness_test.dart
+++ b/mobile/test/shared/relay/relay_socket_liveness_test.dart
@@ -108,4 +108,43 @@ void main() {
     await socket.disconnect();
     await server.close(force: true);
   });
+
+  test('bounds a handshake that never completes', () async {
+    RelaySocket.debugConnectTimeout = const Duration(milliseconds: 200);
+    addTearDown(() {
+      RelaySocket.debugConnectTimeout = RelaySocket.connectTimeout;
+    });
+
+    // Accept the TCP connection but never answer the websocket upgrade —
+    // the shape of a half-open path after a resume across a network change.
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((client) {
+      client.listen((_) {}, onError: (_) {}, onDone: () {});
+    });
+
+    final disconnected = Completer<Object?>();
+    final socket = RelaySocket(
+      wsUrl: 'ws://127.0.0.1:${server.port}',
+      nsec: null,
+      onMessage: (_) {},
+      onConnected: () {},
+      onDisconnected: (error) {
+        if (!disconnected.isCompleted) disconnected.complete(error);
+      },
+    );
+    unawaited(socket.connect());
+
+    final error = await disconnected.future.timeout(
+      const Duration(seconds: 5),
+      onTimeout: () => fail(
+        'connect never gave up: the handshake must fail once '
+        'debugConnectTimeout elapses',
+      ),
+    );
+    expect(error, isA<TimeoutException>());
+    expect(socket.state, SocketState.disconnected);
+
+    socket.dispose();
+    await server.close();
+  });
 }


### PR DESCRIPTION
Mobile's `RelaySocket` calls `IOWebSocketChannel.connect` with no `connectTimeout`, so the handshake can hang forever. The way we kept hitting it: leave the app backgrounded a while, come back on a changed network (wifi to cellular, VPN drop), and the app shows stale messages and never catches up — the session sits in `reconnecting` until you force-quit. Same experience as the Play Store review quoted in #3224.

Desktop already guards this — `native_websocket.rs` wraps `connect_async` in a 10s `CONNECT_TIMEOUT`. This PR gives mobile the same 10s bound: a hung connect now fails into the existing reconnect backoff instead of wedging the session. Normal connects are unaffected.

The production change is one constant and one parameter; the rest is the regression test. The test spins up a local server that accepts TCP but never completes the websocket upgrade, and asserts the connect fails within the bound and retries. A `debugConnectTimeout` static mirrors the existing `debugPingInterval` so tests can shrink the window.
