### PR TITLE
fix(desktop): make desktop terminal and sidecars Windows-clean

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -154,13 +154,15 @@ _ensure-sidecar-stubs:
     #!/usr/bin/env bash
     set -euo pipefail
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    EXE=""
+    [[ "$TARGET" == *windows* ]] && EXE=".exe"
     mkdir -p desktop/src-tauri/binaries
     SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz)
     if [[ "$TARGET" != *windows* ]]; then
         SIDECARS+=(buzz-backend-kubernetes)
     fi
     for bin in "${SIDECARS[@]}"; do
-        touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        touch "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
     done
 
 # Ensure Docker dev services (Postgres, Redis, etc.) are running and healthy
@@ -236,15 +238,17 @@ desktop-release-build target="aarch64-apple-darwin":
     #!/usr/bin/env bash
     set -euo pipefail
     TARGET={{target}}
+    EXE=""
+    [[ "$TARGET" == *windows* ]] && EXE=".exe"
     mkdir -p desktop/src-tauri/binaries
-    touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-acp-$TARGET$EXE"
+    touch "desktop/src-tauri/binaries/buzz-agent-$TARGET$EXE"
     if [[ "$TARGET" != *windows* ]]; then
-        touch "desktop/src-tauri/binaries/buzz-backend-kubernetes-$TARGET"
+        touch "desktop/src-tauri/binaries/buzz-backend-kubernetes-$TARGET$EXE"
     fi
-    touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
-    touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
-    touch "desktop/src-tauri/binaries/buzz-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET$EXE"
+    touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET$EXE"
+    touch "desktop/src-tauri/binaries/buzz-$TARGET$EXE"
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --features mesh-llm --target {{target}}
 
@@ -492,10 +496,12 @@ desktop-standalone *ARGS: _ensure-sidecar-stubs
     export PATH="{{justfile_directory()}}/bin:$PATH"
     cargo build -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    EXE=""
+    [[ "$TARGET" == *windows* ]] && EXE=".exe"
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
     for bin in buzz-acp buzz-agent buzz-backend-kubernetes buzz-dev-mcp git-credential-nostr buzz; do
-        cp "${TARGET_DIR}/debug/${bin}" "desktop/src-tauri/binaries/${bin}-${TARGET}"
-        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        cp "${TARGET_DIR}/debug/${bin}${EXE}" "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
+        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
     done
     cd {{desktop_dir}}
     [[ -d node_modules ]] || pnpm install
@@ -530,14 +536,16 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     # exe dir for executable buzz-backend-* files, so the non-executable stub that
     # tauri dev copies next to the exe would hide the provider from "Run on".
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    EXE=""
+    [[ "$TARGET" == *windows* ]] && EXE=".exe"
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
     STAGING_SIDECARS=(buzz)
     if [[ "$TARGET" != *windows* ]]; then
         STAGING_SIDECARS+=(buzz-backend-kubernetes)
     fi
     for bin in "${STAGING_SIDECARS[@]}"; do
-        cp "${TARGET_DIR}/release/${bin}" "desktop/src-tauri/binaries/${bin}-${TARGET}"
-        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        cp "${TARGET_DIR}/release/${bin}${EXE}" "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
+        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
     done
     cd {{desktop_dir}}
     export BUZZ_RELAY_URL="wss://sprout-oss.stage.blox.sqprod.co"
@@ -566,14 +574,16 @@ production *ARGS: bootstrap _ensure-sidecar-stubs
     # exe dir for executable buzz-backend-* files, so the non-executable stub that
     # tauri dev copies next to the exe would hide the provider from "Run on".
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    EXE=""
+    [[ "$TARGET" == *windows* ]] && EXE=".exe"
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
     PRODUCTION_SIDECARS=(buzz)
     if [[ "$TARGET" != *windows* ]]; then
         PRODUCTION_SIDECARS+=(buzz-backend-kubernetes)
     fi
     for bin in "${PRODUCTION_SIDECARS[@]}"; do
-        cp "${TARGET_DIR}/release/${bin}" "desktop/src-tauri/binaries/${bin}-${TARGET}"
-        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        cp "${TARGET_DIR}/release/${bin}${EXE}" "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
+        chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}${EXE}"
     done
     cd {{desktop_dir}}
     export BUZZ_RELAY_URL="wss://buzz.block.builderlab.xyz"

--- a/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
@@ -44,9 +44,13 @@
 //! session is the documented way to survive one's terminal, and honouring it
 //! is correct behaviour, not a gap.
 
+#[cfg(unix)]
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
+#[cfg(unix)]
 use portable_pty::Child;
 
 /// How long the group gets to honour `SIGTERM` before `SIGKILL`.
@@ -62,6 +66,7 @@ pub const TERM_GRACE: Duration = Duration::from_millis(250);
 /// Polling rather than blocking in `wait()`: a blocking wait cannot be given a
 /// deadline without a second thread, and the whole point of the grace period
 /// is that it expires.
+#[cfg(unix)]
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// How a session ended.

--- a/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
@@ -21,6 +21,7 @@
 //! on many systems. A directory or a non-executable file falls through to the
 //! next candidate instead of becoming an unspawnable child.
 
+#[cfg(unix)]
 use std::path::Path;
 
 /// Last-resort shell. POSIX guarantees `/bin/sh`; if this is not executable


### PR DESCRIPTION
## What
Makes the desktop terminal crate and sidecar handling build cleanly on Windows.

## Changes
- **Justfile**: append `.exe` to sidecar placeholder names and copied binaries for Windows targets (`_ensure-sidecar-stubs`, `desktop-release-build`, `desktop-standalone`, `staging`) so Tauri `externalBin` validation and packaging resolve the correct artifacts.
- **buzz-terminal**: gate unix-only imports (`std::io`, `Instant`, `portable_pty::Child`, `POLL_INTERVAL`) behind `#[cfg(unix)]` so the crate compiles on Windows.

## Verification
- Cherry-picked onto current `main` (`8342dfcc5`), applies cleanly.
- DCO signed; CI runs the full gate.