### PR TITLE
fix(cli): clarify broadcast flag help

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -367,7 +367,7 @@ pub enum MessagesCmd {
         /// Event ID to reply to (creates a thread)
         #[arg(long)]
         reply_to: Option<String>,
-        /// Also publish to the Nostr network
+        /// Also surface this threaded reply in the channel timeline
         #[arg(long, default_value_t = false)]
         broadcast: bool,
         /// Attach file(s) — uploads and includes as imeta tags


### PR DESCRIPTION
The messages-send `--broadcast` flag adds thread visibility in the channel timeline; it does not federate the message to the wider Nostr network.

This updates the CLI help text to describe that actual behavior.

Checks:
- `cargo fmt --all -- --check`
- `cargo test -p buzz-cli --lib` (321 passed)