### PR TITLE
fix(desktop): defer the first-run profile write until membership exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,6 +496,8 @@ reconnects preserve pending avatar verification work):
 - `resetActiveAgentTurnsStore()` — active agent turn timers
 - `resetAgentWorkingSignal()` — agent working indicator signal
 - `resetAvatarProfileSync()` — pending verified-avatar profile writes
+- `resetPendingProfileSave()` — deferred first-run profile write (the persisted
+  value is identity-scoped and deliberately survives; only the instance resets)
 - `resetAvatarPresentations()` — avatar probes, previews, and Retry toasts
 - `resetSidebarRelayConnectionCardState()` — sidebar relay card dismiss state
 - `resetMediaCaches()` — proxy port and relay origin caches

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -25,6 +25,10 @@ import { resetAgentWorkingSignal } from "@/features/agents/agentWorkingSignal";
 import { resetAgentObserverStore } from "@/features/agents/observerRelayStore";
 import { resetAvatarPresentations } from "@/features/profile/avatarPresentationStore";
 import { resetAvatarProfileSync } from "@/features/profile/avatarProfileSync";
+import {
+  flushPendingProfile,
+  resetPendingProfileSave,
+} from "@/features/profile/pendingProfileSave";
 import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useSidebarRelayConnectionCard";
 import { clearMarkdownNodeCache } from "@/shared/ui/markdown/nodeCache";
 import { resetVideoPlayerState } from "@/shared/ui/videoPlayerState";
@@ -57,6 +61,7 @@ function resetCommunityState({
     resetAvatarProfileSync();
     resetAvatarPresentations();
   }
+  resetPendingProfileSave();
   resetSidebarRelayConnectionCardState();
   resetMediaCaches();
   resetVideoPlayerState();
@@ -261,6 +266,12 @@ export function useCommunityInit(
         restoreActiveAgentTurnsForCommunity(activeCommunity.id);
         // Prime the ref so the NEXT switch saves this community's state.
         prevCommunityIdRef.current = activeCommunity.id;
+        // Replay a profile the user set up before they belonged to any relay.
+        // The write needs membership, which is exactly what this community
+        // just supplied — so this is the first moment it can succeed. No-op
+        // when nothing is parked, and it keeps waiting if membership still
+        // has not landed, so a failure here must never block readiness.
+        void flushPendingProfile().catch(() => {});
         setResult({
           isReady: true,
           needsSetup: false,

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -27,6 +27,7 @@ import { listPersonas } from "@/shared/api/tauriPersonas";
 import { relayClient } from "@/shared/api/relayClient";
 import type { AgentPersona } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { isRelayMembershipDeniedError } from "@/shared/lib/relayError";
 import { useSystemColorScheme } from "@/shared/theme/useSystemColorScheme";
 import { Button } from "@/shared/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/shared/ui/dialog";
@@ -38,16 +39,6 @@ import {
   OnboardingChrome,
 } from "./OnboardingChrome";
 import { OnboardingFooter, OnboardingFooterProvider } from "./OnboardingFooter";
-
-function isRelayMembershipDeniedError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return (
-    error.message.includes("You must be a relay member") ||
-    error.message.includes("relay_membership_required") ||
-    error.message.includes("restricted: not a relay member") ||
-    error.message.includes("invalid: you are not a relay member")
-  );
-}
 
 const STARTER_PERSONA_ANIMATIONS: Record<string, string> = {
   Fizz: "/onboarding/starter-team/fizz.png",

--- a/desktop/src/features/onboarding/ui/MembershipDenied.tsx
+++ b/desktop/src/features/onboarding/ui/MembershipDenied.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check, Copy, KeyRound, ShieldX, Ticket } from "lucide-react";
+import { Check, Clock, Copy, KeyRound, ShieldX, Ticket } from "lucide-react";
 
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
 import { nsecToNpub, pubkeyToNpub } from "@/shared/lib/nostrUtils";
@@ -16,6 +16,14 @@ type MembershipDeniedProps = {
   activeRelayUrl: string;
   onBack: () => void;
   onChangeCommunity: () => void;
+  /**
+   * Leave setup and finish the profile after joining. Only supplied by
+   * first-run onboarding, where the user has no community yet and so cannot
+   * satisfy the membership gate at all — without an exit, that is a dead end
+   * (block/buzz#3544). The invite flow omits it: a user mid-claim has a
+   * community to get into, and the actions above are the way in.
+   */
+  onContinueWithoutProfile?: () => void;
   onImportKey: (nsec: string) => Promise<void>;
   onRetry: () => void;
   pubkey: string;
@@ -25,6 +33,7 @@ export function MembershipDenied({
   activeRelayUrl,
   onBack,
   onChangeCommunity,
+  onContinueWithoutProfile,
   onImportKey,
   onRetry,
   pubkey,
@@ -289,6 +298,17 @@ export function MembershipDenied({
                 <KeyRound className="h-4 w-4" />
                 Use a different key
               </button>
+              {onContinueWithoutProfile ? (
+                <button
+                  className="flex w-full items-center justify-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  data-testid="membership-denied-continue"
+                  onClick={onContinueWithoutProfile}
+                  type="button"
+                >
+                  <Clock className="h-4 w-4" />
+                  Finish this after I join
+                </button>
+              ) : null}
             </>
           )}
         </div>

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/profile/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { getMyRelayMembershipLookup } from "@/shared/api/relayMembers";
+import { savePendingProfile } from "@/features/profile/pendingProfileSave";
 import {
   isRelayMembershipDeniedError,
   isRelayUnreachableError,
@@ -211,6 +212,41 @@ export function OnboardingFlow({
     setCurrentPage("key-import");
   }, []);
 
+  /**
+   * Route to the membership-denied screen, parking whatever the user typed so
+   * it can be written once they belong to a relay.
+   *
+   * A kind:0 write requires membership, but first-run setup runs before the
+   * user has joined anything — so this path is reachable with a perfectly
+   * valid name and avatar in hand. Discarding them (and the old dead end) is
+   * what made this a funnel-killer (block/buzz#3544).
+   */
+  const enterMembershipDenied = React.useCallback(
+    async (nextPage: OnboardingPage | "complete") => {
+      let pubkey = "";
+      try {
+        const identity = await getIdentity();
+        pubkey = identity.pubkey;
+      } catch {
+        pubkey = "";
+      }
+      setDeniedPubkey(pubkey);
+      if (pubkey) {
+        savePendingProfile({
+          pubkey,
+          displayName: profileDraft.displayName.trim(),
+          avatarUrl: profileDraft.avatarUrl.trim(),
+        });
+      }
+      setDeniedFromPage((prev) =>
+        currentPage === "membership-denied" ? prev : currentPage,
+      );
+      setMembershipRetryPage(nextPage);
+      setCurrentPage("membership-denied");
+    },
+    [currentPage, profileDraft],
+  );
+
   const saveProfileAndContinue = React.useCallback(
     async (nextPage: OnboardingPage | "complete") => {
       if (isProfileAdvancePending) {
@@ -231,17 +267,7 @@ export function OnboardingFlow({
         setMembershipError(null);
 
         if (membershipStatus === "denied") {
-          try {
-            const identity = await getIdentity();
-            setDeniedPubkey(identity.pubkey);
-          } catch {
-            setDeniedPubkey("");
-          }
-          setDeniedFromPage((prev) =>
-            currentPage === "membership-denied" ? prev : currentPage,
-          );
-          setMembershipRetryPage(nextPage);
-          setCurrentPage("membership-denied");
+          await enterMembershipDenied(nextPage);
           return;
         }
 
@@ -268,17 +294,7 @@ export function OnboardingFlow({
             await profileUpdateMutation.mutateAsync(updatePayload);
           } catch (error) {
             if (isRelayMembershipDeniedError(error)) {
-              try {
-                const identity = await getIdentity();
-                setDeniedPubkey(identity.pubkey);
-              } catch {
-                setDeniedPubkey("");
-              }
-              setDeniedFromPage((prev) =>
-                currentPage === "membership-denied" ? prev : currentPage,
-              );
-              setMembershipRetryPage(nextPage);
-              setCurrentPage("membership-denied");
+              await enterMembershipDenied(nextPage);
               return;
             }
 
@@ -297,7 +313,7 @@ export function OnboardingFlow({
       }
     },
     [
-      currentPage,
+      enterMembershipDenied,
       isProfileAdvancePending,
       profileDraft,
       profileUpdateMutation,
@@ -424,6 +440,7 @@ export function OnboardingFlow({
             setCurrentPage(deniedFromPage);
           }}
           onChangeCommunity={() => setIsCommunityChangeOpen(true)}
+          onContinueWithoutProfile={skipForNow}
           onImportKey={importExistingKey}
           onRetry={() => {
             void saveProfileAndContinue(membershipRetryPage);

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -7,7 +7,10 @@ import {
 } from "@/features/profile/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { getMyRelayMembershipLookup } from "@/shared/api/relayMembers";
-import { isRelayUnreachableError } from "@/shared/lib/relayError";
+import {
+  isRelayMembershipDeniedError,
+  isRelayUnreachableError,
+} from "@/shared/lib/relayError";
 import {
   getIdentity,
   importIdentity,
@@ -35,19 +38,6 @@ import type {
   OnboardingProfileValues,
   ProfileStepState,
 } from "./types";
-
-function isRelayMembershipDeniedError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return (
-    error.message.includes("You must be a relay member") ||
-    error.message.includes("relay_membership_required") ||
-    error.message.includes("restricted: not a relay member") ||
-    error.message.includes("invalid: you are not a relay member")
-  );
-}
 
 type MembershipCheckResult = "denied" | "ok" | "unreachable" | "error";
 

--- a/desktop/src/features/profile/pendingProfileSave.test.mjs
+++ b/desktop/src/features/profile/pendingProfileSave.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createPendingProfileSave } from "./pendingProfileSave.ts";
+
+function harness(overrides = {}) {
+  const calls = { saves: [] };
+  let stored = overrides.stored ?? null;
+  const deps = {
+    read: () => stored,
+    write: (value) => {
+      stored = value;
+    },
+    remove: () => {
+      stored = null;
+    },
+    saveProfile: async (input) => {
+      calls.saves.push(input);
+      if (overrides.saveError) throw overrides.saveError;
+      return { pubkey: "abc", displayName: input.displayName ?? null };
+    },
+    getActivePubkey: async () => {
+      if (overrides.pubkeyError) throw overrides.pubkeyError;
+      // `??` would swallow an explicitly-null activePubkey, which is a case
+      // under test — distinguish "not provided" from "provided as null".
+      return "activePubkey" in overrides ? overrides.activePubkey : "abc";
+    },
+  };
+  return {
+    calls,
+    sync: createPendingProfileSave(deps),
+    stored: () => stored,
+  };
+}
+
+const PENDING = { pubkey: "abc", displayName: "Barbee", avatarUrl: "" };
+
+test("flush with nothing pending is a no-op", async () => {
+  const h = harness();
+  assert.equal(await h.sync.flush(), "empty");
+  assert.equal(h.calls.saves.length, 0);
+});
+
+test("flush writes the parked profile and clears it", async () => {
+  const h = harness();
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "saved");
+  assert.deepEqual(h.calls.saves, [{ displayName: "Barbee" }]);
+  assert.equal(h.stored(), null);
+});
+
+test("flush keeps the value parked while membership is still denied", async () => {
+  // The case this module exists for: the user typed a name before joining.
+  const h = harness({ saveError: new Error("relay returned 404 Not Found") });
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "deferred");
+  assert.notEqual(h.stored(), null, "must survive for the next attempt");
+  assert.deepEqual(h.sync.peek(), PENDING);
+});
+
+test("flush discards a value belonging to a different identity", async () => {
+  const h = harness({ activePubkey: "def" });
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "discarded");
+  assert.equal(h.calls.saves.length, 0, "must not write under another key");
+  assert.equal(h.stored(), null);
+});
+
+test("identity comparison ignores case", async () => {
+  const h = harness({ activePubkey: "ABC" });
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "saved");
+});
+
+test("flush defers when no identity is resolvable yet", async () => {
+  const h = harness({ activePubkey: null });
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "deferred");
+  assert.notEqual(h.stored(), null);
+
+  const thrown = harness({ pubkeyError: new Error("keyring locked") });
+  thrown.sync.save(PENDING);
+  assert.equal(await thrown.sync.flush(), "deferred");
+  assert.notEqual(thrown.stored(), null);
+});
+
+test("flush discards on a non-membership save failure", async () => {
+  // Retrying forever would wedge every later boot.
+  const h = harness({ saveError: new Error("relay returned 400: malformed") });
+  h.sync.save(PENDING);
+  assert.equal(await h.sync.flush(), "discarded");
+  assert.equal(h.stored(), null);
+});
+
+test("saving an empty profile clears rather than parks", async () => {
+  const h = harness();
+  h.sync.save({ pubkey: "abc", displayName: "Barbee", avatarUrl: "" });
+  h.sync.save({ pubkey: "abc", displayName: "   ", avatarUrl: "  " });
+  assert.equal(h.stored(), null);
+  assert.equal(await h.sync.flush(), "empty");
+});
+
+test("avatar-only pending values are replayed", async () => {
+  const h = harness();
+  h.sync.save({ pubkey: "abc", displayName: "", avatarUrl: "https://x/a.png" });
+  assert.equal(await h.sync.flush(), "saved");
+  assert.deepEqual(h.calls.saves, [{ avatarUrl: "https://x/a.png" }]);
+});
+
+test("both fields are replayed together", async () => {
+  const h = harness();
+  h.sync.save({
+    pubkey: "abc",
+    displayName: " Barbee ",
+    avatarUrl: " https://x/a.png ",
+  });
+  assert.equal(await h.sync.flush(), "saved");
+  assert.deepEqual(h.calls.saves, [
+    { displayName: "Barbee", avatarUrl: "https://x/a.png" },
+  ]);
+});
+
+test("malformed or foreign storage contents are ignored", async () => {
+  for (const stored of [
+    "not json",
+    "null",
+    '{"pubkey":"abc"}',
+    '{"displayName":"x","avatarUrl":""}',
+    '{"pubkey":"","displayName":"x","avatarUrl":""}',
+    "[1,2,3]",
+  ]) {
+    const h = harness({ stored });
+    assert.equal(h.sync.peek(), null, `should reject: ${stored}`);
+    assert.equal(await h.sync.flush(), "empty");
+  }
+});
+
+test("storage failures never propagate", async () => {
+  const sync = createPendingProfileSave({
+    read: () => {
+      throw new Error("storage disabled");
+    },
+    write: () => {
+      throw new Error("quota exceeded");
+    },
+    remove: () => {
+      throw new Error("storage disabled");
+    },
+    saveProfile: async () => ({ pubkey: "abc" }),
+    getActivePubkey: async () => "abc",
+  });
+  assert.doesNotThrow(() => sync.save(PENDING));
+  assert.equal(sync.peek(), null);
+  assert.equal(await sync.flush(), "empty");
+});

--- a/desktop/src/features/profile/pendingProfileSave.ts
+++ b/desktop/src/features/profile/pendingProfileSave.ts
@@ -1,0 +1,207 @@
+import { getIdentity } from "@/shared/api/tauriIdentity";
+import { updateProfile } from "@/shared/api/tauriProfiles";
+import type { Profile } from "@/shared/api/types";
+import { isRelayMembershipDeniedError } from "@/shared/lib/relayError";
+
+/**
+ * Deferred profile save for users who set up a profile before they belong to
+ * any relay.
+ *
+ * A kind:0 write requires relay membership, but first-run setup asks for a
+ * display name and avatar before the user has joined a community. The write is
+ * refused, and historically that dead-ended onboarding (block/buzz#3544).
+ *
+ * Rather than discard what the user typed, park it here and replay it once
+ * membership exists. This mirrors `avatarProfileSync`, with one difference:
+ * the value is persisted to `localStorage`, because joining a community
+ * remounts the community-scoped React tree (and the user may quit and relaunch
+ * before joining), so in-memory state would not survive the gap.
+ */
+
+const STORAGE_KEY = "buzz.pendingProfileSave";
+
+export type PendingProfile = {
+  /** Identity the values were typed under. A different key must not inherit them. */
+  pubkey: string;
+  displayName: string;
+  avatarUrl: string;
+};
+
+type PendingProfileSaveDependencies = {
+  read: () => string | null;
+  write: (value: string) => void;
+  remove: () => void;
+  saveProfile: (input: {
+    displayName?: string;
+    avatarUrl?: string;
+  }) => Promise<Profile>;
+  getActivePubkey: () => Promise<string | null>;
+};
+
+function isPendingProfile(value: unknown): value is PendingProfile {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.pubkey === "string" &&
+    candidate.pubkey.length > 0 &&
+    typeof candidate.displayName === "string" &&
+    typeof candidate.avatarUrl === "string"
+  );
+}
+
+/**
+ * Outcome of a flush attempt.
+ *
+ * - `saved` — the write landed; the pending value is cleared.
+ * - `deferred` — still no membership, or no active identity to compare
+ *   against; the pending value is kept for the next attempt.
+ * - `discarded` — the pending value belongs to a different identity, or the
+ *   write failed for a reason retrying cannot fix; it is cleared.
+ * - `empty` — nothing was pending.
+ */
+export type FlushPendingProfileResult =
+  | "saved"
+  | "deferred"
+  | "discarded"
+  | "empty";
+
+export function createPendingProfileSave(
+  dependencies: PendingProfileSaveDependencies,
+) {
+  const read = (): PendingProfile | null => {
+    let raw: string | null;
+    try {
+      raw = dependencies.read();
+    } catch {
+      // Storage can throw (disabled, quota, private mode). Treat as empty.
+      return null;
+    }
+    if (raw === null) return null;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isPendingProfile(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const clear = (): void => {
+    try {
+      dependencies.remove();
+    } catch {
+      // Nothing actionable — a stale entry is re-validated on the next read.
+    }
+  };
+
+  const save = (pending: PendingProfile): void => {
+    // Nothing worth replaying: drop any earlier value rather than leaving a
+    // stale one to be applied later.
+    if (pending.displayName.trim() === "" && pending.avatarUrl.trim() === "") {
+      clear();
+      return;
+    }
+    try {
+      dependencies.write(JSON.stringify(pending));
+    } catch {
+      // Best-effort: losing the deferred value is strictly better than
+      // failing the onboarding step the user is trying to get past.
+    }
+  };
+
+  const flush = async (): Promise<FlushPendingProfileResult> => {
+    const pending = read();
+    if (pending === null) return "empty";
+
+    let activePubkey: string | null;
+    try {
+      activePubkey = await dependencies.getActivePubkey();
+    } catch {
+      return "deferred";
+    }
+
+    // No identity to compare against yet — keep waiting rather than writing
+    // one user's profile under whatever key happens to be active later.
+    if (activePubkey === null) return "deferred";
+    if (activePubkey.toLowerCase() !== pending.pubkey.toLowerCase()) {
+      clear();
+      return "discarded";
+    }
+
+    const payload: { displayName?: string; avatarUrl?: string } = {};
+    if (pending.displayName.trim() !== "") {
+      payload.displayName = pending.displayName.trim();
+    }
+    if (pending.avatarUrl.trim() !== "") {
+      payload.avatarUrl = pending.avatarUrl.trim();
+    }
+    if (Object.keys(payload).length === 0) {
+      clear();
+      return "discarded";
+    }
+
+    try {
+      await dependencies.saveProfile(payload);
+    } catch (error) {
+      // Still not a member — the exact case this exists for. Keep it parked.
+      if (isRelayMembershipDeniedError(error)) return "deferred";
+      // Anything else (malformed value, relay rejection) will not resolve by
+      // retrying forever; drop it so it cannot wedge every later boot.
+      clear();
+      return "discarded";
+    }
+
+    clear();
+    return "saved";
+  };
+
+  return { flush, peek: read, save, clear };
+}
+
+function browserStorage(): PendingProfileSaveDependencies {
+  return {
+    read: () => window.localStorage.getItem(STORAGE_KEY),
+    write: (value) => window.localStorage.setItem(STORAGE_KEY, value),
+    remove: () => window.localStorage.removeItem(STORAGE_KEY),
+    saveProfile: (input) => updateProfile(input),
+    getActivePubkey: async () => {
+      const identity = await getIdentity();
+      return identity.pubkey;
+    },
+  };
+}
+
+let singleton: ReturnType<typeof createPendingProfileSave> | null = null;
+
+function instance() {
+  singleton ??= createPendingProfileSave(browserStorage());
+  return singleton;
+}
+
+/** Park profile values that could not be written for lack of membership. */
+export function savePendingProfile(pending: PendingProfile): void {
+  instance().save(pending);
+}
+
+/** Read the parked profile without attempting to write it. */
+export function peekPendingProfile(): PendingProfile | null {
+  return instance().peek();
+}
+
+/**
+ * Attempt the parked write. Safe to call on every community-ready transition:
+ * it is a no-op when nothing is pending, and keeps the value parked when
+ * membership still is not established.
+ */
+export function flushPendingProfile(): Promise<FlushPendingProfileResult> {
+  return instance().flush();
+}
+
+/**
+ * Drop the in-memory instance on a relay boundary change, per the
+ * community-switching contract in CLAUDE.md. The persisted value deliberately
+ * survives — it is keyed to an identity, not to a community, and the whole
+ * point is to outlive the remount that joining causes.
+ */
+export function resetPendingProfileSave(): void {
+  singleton = null;
+}

--- a/desktop/src/shared/lib/relayError.test.mjs
+++ b/desktop/src/shared/lib/relayError.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isRelayUnreachableError } from "./relayError.ts";
+import {
+  isRelayMembershipDeniedError,
+  isRelayUnreachableError,
+} from "./relayError.ts";
 
 test("isRelayUnreachableError: Error with prefix returns true", () => {
   assert.equal(
@@ -52,6 +55,85 @@ test("isRelayUnreachableError: number returns false", () => {
 test("isRelayUnreachableError: plain object returns false", () => {
   assert.equal(
     isRelayUnreachableError({ message: "relay unreachable: oops" }),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: bodyless 404 returns true", () => {
+  // The exact string the membership gate produces. This is the case that
+  // stranded invitees at the profile step (block/buzz#3544).
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 404 Not Found")),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: bodyless 404 as a string returns true", () => {
+  assert.equal(
+    isRelayMembershipDeniedError("relay returned 404 Not Found"),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: surrounding whitespace still matches", () => {
+  assert.equal(
+    isRelayMembershipDeniedError("  relay returned 404 Not Found\n"),
+    true,
+  );
+});
+
+test("isRelayMembershipDeniedError: suffixed 404 returns false", () => {
+  // Every relay `api_error` carries {"error": "<msg>"}, which renders with a
+  // `: <detail>` suffix. Those are different failures — a host with no
+  // community bound is not a membership problem — and must not be
+  // misreported as one.
+  assert.equal(
+    isRelayMembershipDeniedError(
+      new Error(
+        "relay returned 404 Not Found: relay: no community is configured for this host",
+      ),
+    ),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: other statuses return false", () => {
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 500")),
+    false,
+  );
+  assert.equal(
+    isRelayMembershipDeniedError(new Error("relay returned 403 Forbidden")),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: message-bearing denials return true", () => {
+  for (const message of [
+    "publish failed: You must be a relay member",
+    "relay_membership_required",
+    "restricted: not a relay member",
+    "invalid: you are not a relay member",
+  ]) {
+    assert.equal(isRelayMembershipDeniedError(new Error(message)), true);
+  }
+});
+
+test("isRelayMembershipDeniedError: unreachable relay returns false", () => {
+  // A connectivity failure must route to the retry path, not to
+  // MembershipDenied — the two are handled by different screens.
+  assert.equal(
+    isRelayMembershipDeniedError("relay unreachable: connection refused"),
+    false,
+  );
+});
+
+test("isRelayMembershipDeniedError: non-error inputs return false", () => {
+  assert.equal(isRelayMembershipDeniedError(null), false);
+  assert.equal(isRelayMembershipDeniedError(undefined), false);
+  assert.equal(isRelayMembershipDeniedError(404), false);
+  assert.equal(
+    isRelayMembershipDeniedError({ message: "relay returned 404 Not Found" }),
     false,
   );
 });

--- a/desktop/src/shared/lib/relayError.ts
+++ b/desktop/src/shared/lib/relayError.ts
@@ -32,3 +32,61 @@ export function isRelayUnreachableError(error: unknown): boolean {
   }
   return false;
 }
+
+/**
+ * The exact message the backend produces when the relay's membership gate
+ * refuses a request.
+ *
+ * The gate (`crates/buzz-relay/src/api/mod.rs`, `mod relay_members`,
+ * `MembershipDecision::Denied`) answers with a **bodyless** 404. With no
+ * `message` or `error` field to quote, `classify_relay_error`
+ * (`desktop/src-tauri/src/relay.rs`) falls through to its status-only form,
+ * producing exactly this string with no `: <detail>` suffix.
+ *
+ * Every other relay 404 is an `api_error`, which always carries
+ * `{"error": "<msg>"}` and therefore renders with a suffix. That is what makes
+ * an exact match safe here: a suffixed 404 is a different failure (e.g. no
+ * community bound to the host) and must not be reported as a membership
+ * problem. `desktop/src/shared/api/tauri.ts` relies on the same equivalence.
+ */
+const RELAY_MEMBERSHIP_DENIED_404 = "relay returned 404 Not Found";
+
+/**
+ * Substrings emitted by relay paths that reject non-members with a message
+ * rather than the bodyless 404 above (WebSocket rejections, NIP-29 write
+ * refusals). Matched loosely because they arrive embedded in longer text.
+ */
+const RELAY_MEMBERSHIP_DENIED_SUBSTRINGS = [
+  "You must be a relay member",
+  "relay_membership_required",
+  "restricted: not a relay member",
+  "invalid: you are not a relay member",
+];
+
+/**
+ * Returns true when `error` means "you are not a member of this relay".
+ *
+ * Onboarding uses this to route to the `MembershipDenied` screen — which
+ * offers Retry, Import key, and Change community — instead of dead-ending on
+ * raw error text. Missing the bodyless-404 form is what stranded invitees at
+ * the profile step (block/buzz#3544): `update_profile` reads before it writes,
+ * so the gate rejects the read and onboarding cannot proceed.
+ *
+ * Accepts `Error` instances and raw strings so callers can pass whatever the
+ * Tauri IPC layer hands them without pre-normalizing.
+ */
+export function isRelayMembershipDeniedError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : null;
+  if (message === null) return false;
+
+  if (message.trim() === RELAY_MEMBERSHIP_DENIED_404) return true;
+
+  return RELAY_MEMBERSHIP_DENIED_SUBSTRINGS.some((substring) =>
+    message.includes(substring),
+  );
+}


### PR DESCRIPTION
Fixes #3544.

> **Stacked on #4821 — review that one first.** This branch is built on top of it, so the diff below includes #4821's commit (`fix(desktop): recognize the membership gate's bodyless 404 in onboarding`). The dependency is real: this imports the shared `isRelayMembershipDeniedError` that #4821 introduces. Base is `main` only because GitHub does not allow a fork branch as a cross-fork base. **Review only the second commit here**, and merge #4821 first — this rebases cleanly once it lands.

## The deadlock

First-run setup asks for a display name and avatar **before** the user has joined any community. A `kind:0` write requires relay membership, so the save is refused and setup dead-ends. Per #3544 this was the single largest drop-off on a live self-hosted community — corroborated there by four members left with no `display_name`, which is what you'd expect from people who hit the wall and gave up.

The key point: at that moment membership is **unsatisfiable**. The user has nothing to be a member of yet. Every affordance on the denied screen — retry, import a key, change community — assumes a community they are trying to get into. First-run users have none, so the refusal is terminal.

Note this is *not* fixed by deferring only the profile **write**: `update_profile` (`desktop/src-tauri/src/commands/profile.rs`) is a read-merge-write and calls `query_relay` first, so the gate rejects the **read**. #4821 covers recognizing that refusal; this PR covers surviving it.

## Approach

Stop treating the refusal as terminal — park what the user typed and replay it once membership exists.

**`features/profile/pendingProfileSave.ts`** (new) mirrors the existing `avatarProfileSync` deferred-write pattern, with one deliberate difference: it persists to `localStorage`. Joining a community remounts the community-scoped React tree, and the user may quit and relaunch before joining, so in-memory state would not survive the gap. (Relaunch-then-reclick is exactly how one user escaped this in practice.)

Safety properties, each covered by a test:

- **Identity-scoped.** A different active pubkey discards the value rather than writing one user's profile under another's key.
- **Keeps waiting** when membership still is not established, or when no identity resolves yet.
- **Drops on non-membership failure**, so a malformed value cannot wedge every later boot with a permanent retry.
- **Storage failures never propagate** — losing a deferred value beats failing the step the user is trying to get past.

**Flush point:** the community-ready transition in `useCommunityInit`, the first moment the write can succeed. Failures there can never block readiness.

**`MembershipDenied`** gains an optional `onContinueWithoutProfile` — *"Finish this after I join"* — supplied only by first-run onboarding. The invite flow omits the prop and is visually unchanged.

**`OnboardingFlow`**: both membership-denied branches now route through one `enterMembershipDenied` helper that parks the draft, replacing duplicated inline handling.

## Community-switching contract

`resetPendingProfileSave()` is registered in `resetCommunityState()` and documented in AGENTS.md, per the module-singleton rule. The *persisted* value deliberately survives the reset — it is keyed to an identity, not a community, and exists precisely to outlive the remount that joining causes. Only the in-memory instance is dropped.

## Testing

- `just desktop-ci` — green (exit 0).
- 12 new unit tests in `pendingProfileSave.test.mjs` covering flush outcomes, identity mismatch (including case-insensitive comparison), deferral, discard-on-hard-failure, malformed/foreign storage contents, and throwing storage.

Not covered: the `OnboardingFlow` / `MembershipDenied` wiring has no component test — the repo tests this layer via Playwright, and a spec for "denied → continue → join → profile appears" needs a relay-backed fixture. Worth adding; flagging rather than silently skipping.

## Follow-up, deliberately not in scope

The invite flow (`CommunityOnboardingFlow`) does not park its draft on denial. Its profile step runs *after* the community is applied, so the flush has already happened by then and parking would only pay off on a later community switch. Straightforward to add if reviewers want symmetry.
