### PR TITLE
fix(desktop): make owner-only relay agents mentionable by their owner

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -110,6 +110,73 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
   );
 });
 
+test("relayAgentIsSharedWithUser: an owner-only agent is invocable by its owner", () => {
+  const agent = {
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    channelIds: ["general"],
+  };
+  const sharedChannelIds = new Set(["general"]);
+
+  assert.equal(
+    relayAgentIsSharedWithUser(agent, sharedChannelIds, CURRENT_PUBKEY, true),
+    true,
+  );
+  // Someone else's owner-only agent stays out of reach.
+  assert.equal(
+    relayAgentIsSharedWithUser(agent, sharedChannelIds, CURRENT_PUBKEY, false),
+    false,
+  );
+  // Ownership is matched, never assumed: no viewer identity, no admission.
+  assert.equal(
+    relayAgentIsSharedWithUser(agent, sharedChannelIds, null, true),
+    false,
+  );
+});
+
+test("getMentionableAgentPubkeys: admits an owner-only relay agent for its owner", () => {
+  const relayAgents = [
+    {
+      pubkey: PUB_A,
+      respondTo: "owner-only",
+      respondToAllowlist: [],
+      channelIds: ["general"],
+    },
+    {
+      pubkey: PUB_B,
+      respondTo: "owner-only",
+      respondToAllowlist: [],
+      channelIds: ["general"],
+    },
+  ];
+  const call = (overrides) =>
+    getMentionableAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY,
+      eligibilityScope: { type: "channel", channelId: "general" },
+      managedAgentPubkeys: [],
+      relayAgents,
+      ...overrides,
+    });
+  const profiles = {
+    [PUB_A]: { ownerPubkey: CURRENT_PUBKEY.toUpperCase() },
+    [PUB_B]: { ownerPubkey: OTHER_OWNER_PUBKEY },
+  };
+
+  assert.deepEqual([...call({ profiles })], [PUB_A]);
+  // The owner still only reaches the agent in channels it actually joined.
+  assert.deepEqual(
+    [
+      ...call({
+        eligibilityScope: { type: "channel", channelId: "other" },
+        profiles,
+      }),
+    ],
+    [],
+  );
+  // No owner metadata, no admission -- unchanged from before.
+  assert.deepEqual([...call({})], []);
+});
+
 test("relayAgentCanRespondInChannel: requires exact channel membership and viewer access", () => {
   const agent = {
     respondTo: "allowlist",

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -1,3 +1,5 @@
+import { mergeOwnedAgentPubkeys } from "@/features/agents/knownAgentPubkeys";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel, RelayAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
@@ -13,10 +15,20 @@ export function relayAgentIsSharedWithUser(
   agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
   sharedChannelIds: ReadonlySet<string>,
   currentPubkey?: string | null,
+  isOwnedByViewer = false,
 ) {
   const normalizedCurrentPubkey = currentPubkey
     ? normalizePubkey(currentPubkey)
     : null;
+
+  // `owner-only` names exactly one person who may instruct the agent, so that
+  // person can invoke it. It is also the server default, so an agent created
+  // without an explicit mode used to be invocable by nobody at all. Ownership
+  // is matched, never assumed: an agent whose owner we cannot resolve stays
+  // hidden.
+  if (agent.respondTo === "owner-only") {
+    return isOwnedByViewer && normalizedCurrentPubkey !== null;
+  }
 
   if (agent.respondTo === "allowlist" && normalizedCurrentPubkey) {
     return agent.respondToAllowlist
@@ -34,10 +46,16 @@ export function relayAgentCanRespondInChannel(
   agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
   channelId: string,
   currentPubkey?: string | null,
+  isOwnedByViewer = false,
 ) {
   return (
     agent.channelIds.includes(channelId) &&
-    relayAgentIsSharedWithUser(agent, new Set([channelId]), currentPubkey)
+    relayAgentIsSharedWithUser(
+      agent,
+      new Set([channelId]),
+      currentPubkey,
+      isOwnedByViewer,
+    )
   );
 }
 
@@ -46,33 +64,57 @@ export type AgentEligibilityScope =
   | { type: "channel"; channelId: string }
   | { type: "managed-only" };
 
+const EMPTY_CHANNEL_IDS: ReadonlySet<string> = new Set();
+
 export function getMentionableAgentPubkeys({
   currentPubkey,
   eligibilityScope,
   managedAgentPubkeys,
+  profiles,
   relayAgents,
-  sharedChannelIds,
+  sharedChannelIds = EMPTY_CHANNEL_IDS,
 }: {
   currentPubkey?: string | null;
   eligibilityScope: AgentEligibilityScope;
   managedAgentPubkeys: Iterable<string>;
+  /**
+   * Profile metadata, the only place an agent's owner is published: the relay
+   * directory (`RelayAgent`) carries no owner field. Omit it and `owner-only`
+   * agents stay hidden, which is the pre-existing behaviour.
+   */
+  profiles?: UserProfileLookup;
   relayAgents: readonly RelayAgent[] | undefined;
-  sharedChannelIds: ReadonlySet<string>;
+  /** Read only by the `community` scope; the others derive their own. */
+  sharedChannelIds?: ReadonlySet<string>;
 }) {
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
+  const ownedAgentPubkeys = mergeOwnedAgentPubkeys(
+    undefined,
+    profiles,
+    currentPubkey,
+  );
 
   for (const agent of relayAgents ?? []) {
+    const isOwnedByViewer = ownedAgentPubkeys.has(
+      normalizePubkey(agent.pubkey),
+    );
     const isAllowed =
       eligibilityScope.type === "managed-only"
         ? false
         : eligibilityScope.type === "community"
-          ? relayAgentIsSharedWithUser(agent, sharedChannelIds, currentPubkey)
+          ? relayAgentIsSharedWithUser(
+              agent,
+              sharedChannelIds,
+              currentPubkey,
+              isOwnedByViewer,
+            )
           : relayAgentCanRespondInChannel(
               agent,
               eligibilityScope.channelId,
               currentPubkey,
+              isOwnedByViewer,
             );
     if (isAllowed) {
       pubkeys.add(normalizePubkey(agent.pubkey));

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -5,10 +5,7 @@ import {
   useRelayAgentsQuery,
   useTeamsQuery,
 } from "@/features/agents/hooks";
-import {
-  useChannelMembersQuery,
-  useChannelsQuery,
-} from "@/features/channels/hooks";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
 import {
@@ -16,7 +13,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
-  getSharedChannelIds,
   isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
   shouldHideAgentFromMentions,
@@ -107,7 +103,6 @@ export function useMentions(
   const isArchivedDiscovery = useIsArchivedPredicate();
   const managedAgentsQuery = useManagedAgentsQuery();
   const relayAgentsQuery = useRelayAgentsQuery();
-  const channelsQuery = useChannelsQuery();
   const personasQuery = usePersonasQuery();
   const teamsQuery = useTeamsQuery();
   const managedAgentDirectoryReady =
@@ -190,10 +185,6 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
-  const sharedChannelIds = React.useMemo(
-    () => getSharedChannelIds(channelsQuery.data),
-    [channelsQuery.data],
-  );
   const mentionChannelId = isAgentMentionChannelType(options?.channelType)
     ? channelId
     : null;
@@ -205,15 +196,15 @@ export function useMentions(
           ? { type: "channel", channelId: mentionChannelId }
           : { type: "managed-only" },
         managedAgentPubkeys,
+        profiles,
         relayAgents: relayAgentsQuery.data,
-        sharedChannelIds,
       }),
     [
       currentPubkey,
       managedAgentPubkeys,
       mentionChannelId,
+      profiles,
       relayAgentsQuery.data,
-      sharedChannelIds,
     ],
   );
   const personaNameByPubkey = React.useMemo(() => {


### PR DESCRIPTION
## What is broken

`relayAgentIsSharedWithUser` handles two response modes: `anyone` and `allowlist`. There is a third one. `RespondToMode` is `"owner-only" | "allowlist" | "anyone"`, and `owner-only` falls through to `false`. It is `false` for every viewer, including the one person the agent answers to.

This is bigger than it looks, because `owner-only` is the server default. `types.ts` says the field omitted means `"owner-only"` (server default). The agent settings label that mode "Only me (default)" and print "Only you and your agents can send instructions." So the default mode promises the owner can instruct the agent, and the mention picker then hides that agent from the owner.

The hole only opens for an agent the desktop does not manage, for example one running as a container elsewhere. Managed agents are admitted by a separate path, so nobody who starts agents from the desktop would ever see this.

## The fix

`RelayAgent` has no owner field, so the owner has to come from profile metadata. `getMentionableAgentPubkeys` now takes the profile lookup and resolves ownership with `mergeOwnedAgentPubkeys` from `features/agents/knownAgentPubkeys.ts`. That helper is already documented as "Agent identities controlled by the current user", and the inbox already uses it for the same question. This path just never asked it.

Ownership is matched, never assumed. An agent whose owner cannot be resolved stays hidden. A caller that passes no profiles gets exactly today's behaviour.

Channel exactness does not change. The mention path goes through `relayAgentCanRespondInChannel`, which still requires the agent to be in that channel, so the owner reaches the agent only where the agent actually is. DMs and unresolved composer contexts use the `managed-only` scope and stay fail-closed.

## Tests

Two new tests in `agentAutocompleteEligibility.test.mjs`. Both fail on the current helper and pass after it: `# pass 21 / # fail 2` before, `# pass 23 / # fail 0` after.

The existing `owner-only` assertion in that file is untouched and still green. It calls `relayAgentIsSharedWithUser` without a viewer pubkey and expects `false`, which is still what happens: no viewer identity, no admission.

## One removal

`useMentions` built `sharedChannelIds` and passed it in. That call site only ever asks for the `channel` or `managed-only` scope, and neither one reads that set — only `community` does. So the parameter is now optional and `useMentions` no longer builds it. `useChannelsQuery` went with it, because it fed nothing else in the hook.

## Relation to #4913

This PR opened with two commits. The first removed a managed-list gate that ran ahead of the policy check. #4913 landed that behaviour and a lot more, so that commit is dropped and the branch is rebuilt on current `main`. What is left is the `owner-only` gap, which #4913 did not close.

## Scope

Three other call sites share this helper: `MembersSidebar`, `useNewMessageRecipients` and `ProjectsAgentPromptPage`. They are unchanged. Owner data is not available at those call sites without adding a profile query, and in `ProjectsAgentPromptPage` the profile query runs after this set is computed. Because `profiles` is optional, all three keep today's behaviour.

One note on trust, since ownership now decides what the picker shows. `ownerPubkey` is not self-asserted. It comes from the NIP-OA `auth` tag on the agent's kind:0, and `profile_valid_oa_owner_pubkey` verifies that tag against the owner before `get_users_batch` returns it, so a forged or stale marker resolves to no owner at all. An agent whose owner does not verify stays hidden, and the relay still enforces the real gate on the way in.

## Validation

- `pnpm --dir desktop test` — 4389 passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check` — biome, file-size ratchet, px-text, pubkey-truncation
- `useMentions.ts` goes from 1000 lines to 991, so it stays under the ratchet

Refs #4776, #4833.
