### PR TITLE
feat(desktop): searchable channel picker in agent/team deploy dialogs

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -161,6 +161,7 @@ export default defineConfig({
         "**/persona-env-vars.spec.ts",
         "**/persona-sync.spec.ts",
         "**/team-snapshot.spec.ts",
+        "**/team-deploy-channel-picker.spec.ts",
         "**/agents-everywhere.live.spec.ts",
         "**/relay-restart.live.spec.ts",
         "**/parity-ancestor-island.spec.ts",

--- a/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
@@ -66,16 +66,6 @@ export function AddAgentToChannelDialog({
     onOpenChange(next);
   }
 
-  React.useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    if (!channelId && channels.length > 0) {
-      setChannelId(channels[0].id);
-    }
-  }, [channelId, channels, open]);
-
   const membersQuery = useChannelMembersQuery(
     channelId || null,
     open && !!channelId,

--- a/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddAgentToChannelDialog.tsx
@@ -8,6 +8,8 @@ import {
   useChannelMembersQuery,
   useChannelsQuery,
 } from "@/features/channels/hooks";
+import { sortChannelsMembersFirst } from "@/features/channels/lib/channelPickerOrdering";
+import { ChannelPickerField } from "@/features/channels/ui/ChannelPickerField";
 import type { Channel, ChannelRole, ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
@@ -42,8 +44,10 @@ export function AddAgentToChannelDialog({
   );
   const channels = React.useMemo(
     () =>
-      (channelsQuery.data ?? []).filter(
-        (channel) => channel.channelType !== "dm" && !channel.archivedAt,
+      sortChannelsMembersFirst(
+        (channelsQuery.data ?? []).filter(
+          (channel) => channel.channelType !== "dm" && !channel.archivedAt,
+        ),
       ),
     [channelsQuery.data],
   );
@@ -126,24 +130,13 @@ export function AddAgentToChannelDialog({
               <label className="text-sm font-medium" htmlFor="agent-channel-id">
                 Channel
               </label>
-              <select
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs"
-                disabled={
-                  channels.length === 0 || attachAgentMutation.isPending
-                }
-                id="agent-channel-id"
-                onChange={(event) => setChannelId(event.target.value)}
+              <ChannelPickerField
+                channels={channels}
+                disabled={attachAgentMutation.isPending}
+                inputId="agent-channel-id"
+                onChange={setChannelId}
                 value={channelId}
-              >
-                {channels.length === 0 ? (
-                  <option value="">No channels available</option>
-                ) : null}
-                {channels.map((channel) => (
-                  <option key={channel.id} value={channel.id}>
-                    {channel.name} · {channel.visibility}
-                  </option>
-                ))}
-              </select>
+              />
               <p className="text-xs text-muted-foreground">
                 Only channels accessible to the current desktop user are shown
                 here.

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -17,6 +17,8 @@ import {
   resolvePersonaRuntime,
 } from "@/features/agents/lib/resolvePersonaRuntime";
 import { useChannelsQuery } from "@/features/channels/hooks";
+import { sortChannelsMembersFirst } from "@/features/channels/lib/channelPickerOrdering";
+import { ChannelPickerField } from "@/features/channels/ui/ChannelPickerField";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import type {
   AgentPersona,
@@ -62,8 +64,10 @@ export function AddTeamToChannelDialog({
 
   const channels = React.useMemo(
     () =>
-      (channelsQuery.data ?? []).filter(
-        (channel) => channel.channelType !== "dm" && !channel.archivedAt,
+      sortChannelsMembersFirst(
+        (channelsQuery.data ?? []).filter(
+          (channel) => channel.channelType !== "dm" && !channel.archivedAt,
+        ),
       ),
     [channelsQuery.data],
   );
@@ -205,22 +209,13 @@ export function AddTeamToChannelDialog({
               <label className="text-sm font-medium" htmlFor="team-channel-id">
                 Channel
               </label>
-              <select
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs"
-                disabled={channels.length === 0 || deployMutation.isPending}
-                id="team-channel-id"
-                onChange={(event) => setChannelId(event.target.value)}
+              <ChannelPickerField
+                channels={channels}
+                disabled={deployMutation.isPending}
+                inputId="team-channel-id"
+                onChange={setChannelId}
                 value={channelId}
-              >
-                {channels.length === 0 ? (
-                  <option value="">No channels available</option>
-                ) : null}
-                {channels.map((channel) => (
-                  <option key={channel.id} value={channel.id}>
-                    {channel.name} · {channel.visibility}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
 
             <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -109,15 +109,6 @@ export function AddTeamToChannelDialog({
     onOpenChange(next);
   }
 
-  React.useEffect(() => {
-    if (!open) {
-      return;
-    }
-    if (!channelId && channels.length > 0) {
-      setChannelId(channels[0].id);
-    }
-  }, [channelId, channels, open]);
-
   const selectedChannel =
     channels.find((channel) => channel.id === channelId) ?? null;
 

--- a/desktop/src/features/channels/lib/channelPickerOrdering.test.mjs
+++ b/desktop/src/features/channels/lib/channelPickerOrdering.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterChannelsByQuery,
+  sortChannelsMembersFirst,
+} from "./channelPickerOrdering.ts";
+
+function channel(name, { isMember = false, description = "" } = {}) {
+  return { name, description, isMember };
+}
+
+test("sortChannelsMembersFirst: joined channels come first", () => {
+  const sorted = sortChannelsMembersFirst([
+    channel("zulu", { isMember: false }),
+    channel("alpha", { isMember: false }),
+    channel("yankee", { isMember: true }),
+  ]);
+  assert.deepEqual(
+    sorted.map((entry) => entry.name),
+    ["yankee", "alpha", "zulu"],
+  );
+});
+
+test("sortChannelsMembersFirst: alphabetical within each membership group", () => {
+  const sorted = sortChannelsMembersFirst([
+    channel("bravo", { isMember: true }),
+    channel("Alpha", { isMember: true }),
+    channel("delta", { isMember: false }),
+    channel("Charlie", { isMember: false }),
+  ]);
+  assert.deepEqual(
+    sorted.map((entry) => entry.name),
+    ["Alpha", "bravo", "Charlie", "delta"],
+  );
+});
+
+test("sortChannelsMembersFirst: does not mutate the input", () => {
+  const input = [channel("b"), channel("a")];
+  sortChannelsMembersFirst(input);
+  assert.deepEqual(
+    input.map((entry) => entry.name),
+    ["b", "a"],
+  );
+});
+
+test("filterChannelsByQuery: empty query returns the incoming order", () => {
+  const channels = [channel("bravo"), channel("alpha")];
+  assert.equal(filterChannelsByQuery(channels, ""), channels);
+  assert.equal(filterChannelsByQuery(channels, "   "), channels);
+});
+
+test("filterChannelsByQuery: drops non-matching channels", () => {
+  const filtered = filterChannelsByQuery(
+    [channel("release-notes"), channel("general")],
+    "rel",
+  );
+  assert.deepEqual(
+    filtered.map((entry) => entry.name),
+    ["release-notes"],
+  );
+});
+
+test("filterChannelsByQuery: better matches rank first", () => {
+  const filtered = filterChannelsByQuery(
+    [channel("team-general"), channel("general")],
+    "general",
+  );
+  assert.deepEqual(
+    filtered.map((entry) => entry.name),
+    ["general", "team-general"],
+  );
+});
+
+test("filterChannelsByQuery: equal scores keep members-first order", () => {
+  const filtered = filterChannelsByQuery(
+    sortChannelsMembersFirst([
+      channel("eng-platform", { isMember: false }),
+      channel("eng-mobile", { isMember: true }),
+    ]),
+    "eng",
+  );
+  assert.deepEqual(
+    filtered.map((entry) => entry.name),
+    ["eng-mobile", "eng-platform"],
+  );
+});
+
+test("filterChannelsByQuery: matches descriptions as a fallback", () => {
+  const filtered = filterChannelsByQuery(
+    [
+      channel("watercooler", { description: "off-topic chatter" }),
+      channel("general"),
+    ],
+    "chatter",
+  );
+  assert.deepEqual(
+    filtered.map((entry) => entry.name),
+    ["watercooler"],
+  );
+});

--- a/desktop/src/features/channels/lib/channelPickerOrdering.ts
+++ b/desktop/src/features/channels/lib/channelPickerOrdering.ts
@@ -1,0 +1,48 @@
+import {
+  type ChannelSearchable,
+  scoreChannelMatch,
+} from "./channelSearchScore";
+
+/** The subset of `Channel` the picker's ordering logic reads. */
+export type PickerChannel = ChannelSearchable & {
+  isMember: boolean;
+};
+
+/**
+ * Default ordering for the channel picker: channels the user has joined
+ * first, then alphabetical — so deploy dialogs lead with the channels a
+ * user is most likely to target.
+ */
+export function sortChannelsMembersFirst<T extends PickerChannel>(
+  channels: T[],
+): T[] {
+  return [...channels].sort(
+    (a, b) =>
+      Number(b.isMember) - Number(a.isMember) ||
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
+/**
+ * Channels matching `query`, best match first. Uses the channel browser's
+ * fuzzy scorer; ties keep the incoming (members-first) order.
+ */
+export function filterChannelsByQuery<T extends PickerChannel>(
+  channels: T[],
+  query: string,
+): T[] {
+  const lowerQuery = query.trim().toLowerCase();
+  if (lowerQuery.length === 0) {
+    return channels;
+  }
+
+  const scored: { channel: T; score: number }[] = [];
+  for (const channel of channels) {
+    const score = scoreChannelMatch(channel, lowerQuery);
+    if (score !== null) {
+      scored.push({ channel, score });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score);
+  return scored.map((entry) => entry.channel);
+}

--- a/desktop/src/features/channels/ui/ChannelPickerField.tsx
+++ b/desktop/src/features/channels/ui/ChannelPickerField.tsx
@@ -34,6 +34,7 @@ export function ChannelPickerField({
   value,
 }: ChannelPickerFieldProps) {
   const [query, setQuery] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
 
   const visibleChannels = React.useMemo(
@@ -131,6 +132,7 @@ export function ChannelPickerField({
             }
           }}
           placeholder="Search channels"
+          ref={inputRef}
           role="combobox"
           spellCheck={false}
           type="text"
@@ -165,7 +167,10 @@ export function ChannelPickerField({
                 id={optionId(channel.id)}
                 key={channel.id}
                 onClick={() => onChange(channel.id)}
-                onMouseDown={(event) => event.preventDefault()}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  inputRef.current?.focus();
+                }}
                 role="option"
                 tabIndex={-1}
                 type="button"

--- a/desktop/src/features/channels/ui/ChannelPickerField.tsx
+++ b/desktop/src/features/channels/ui/ChannelPickerField.tsx
@@ -165,6 +165,7 @@ export function ChannelPickerField({
                 id={optionId(channel.id)}
                 key={channel.id}
                 onClick={() => onChange(channel.id)}
+                onMouseDown={(event) => event.preventDefault()}
                 role="option"
                 tabIndex={-1}
                 type="button"

--- a/desktop/src/features/channels/ui/ChannelPickerField.tsx
+++ b/desktop/src/features/channels/ui/ChannelPickerField.tsx
@@ -34,13 +34,28 @@ export function ChannelPickerField({
   value,
 }: ChannelPickerFieldProps) {
   const [query, setQuery] = React.useState("");
-  const deferredQuery = React.useDeferredValue(query);
   const listRef = React.useRef<HTMLDivElement>(null);
 
   const visibleChannels = React.useMemo(
-    () => filterChannelsByQuery(channels, deferredQuery),
-    [channels, deferredQuery],
+    () => filterChannelsByQuery(channels, query),
+    [channels, query],
   );
+
+  function handleQueryChange(nextQuery: string) {
+    const nextVisibleChannels = filterChannelsByQuery(channels, nextQuery);
+    setQuery(nextQuery);
+
+    // Reconcile the parent value in the same input event. Deferring this to
+    // the effect below leaves the previous channel actionable for one render,
+    // so a no-match query could submit a hidden target before the effect runs.
+    if (nextVisibleChannels.length === 0) {
+      if (value !== "") {
+        onChange("");
+      }
+    } else if (!nextVisibleChannels.some((channel) => channel.id === value)) {
+      onChange(nextVisibleChannels[0].id);
+    }
+  }
 
   // Keep the selection visible: when the query filters out the selected
   // channel, move it to the best match — the `<select>` this replaces
@@ -105,7 +120,7 @@ export function ChannelPickerField({
           className="flex h-9 w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
           disabled={disabled}
           id={inputId}
-          onChange={(event) => setQuery(event.target.value)}
+          onChange={(event) => handleQueryChange(event.target.value)}
           onKeyDown={(event) => {
             if (event.key === "ArrowDown") {
               event.preventDefault();

--- a/desktop/src/features/channels/ui/ChannelPickerField.tsx
+++ b/desktop/src/features/channels/ui/ChannelPickerField.tsx
@@ -1,0 +1,153 @@
+import { Check, Search } from "lucide-react";
+import * as React from "react";
+
+import { filterChannelsByQuery } from "@/features/channels/lib/channelPickerOrdering";
+import type { Channel } from "@/shared/api/types";
+
+type ChannelPickerFieldProps = {
+  /** Candidate channels, in display order (see `sortChannelsMembersFirst`). */
+  channels: Channel[];
+  disabled?: boolean;
+  /** Id for the search input, so a `<label htmlFor>` can target it. */
+  inputId: string;
+  onChange: (channelId: string) => void;
+  /** Id of the currently selected channel. */
+  value: string;
+};
+
+/**
+ * Searchable channel list for dialog forms. Replaces the plain `<select>`
+ * that listed every community channel in one dropdown — communities with
+ * many channels made that unusable. Fuzzy-matches with the channel
+ * browser's scorer and keeps the caller's (members-first) ordering.
+ */
+export function ChannelPickerField({
+  channels,
+  disabled = false,
+  inputId,
+  onChange,
+  value,
+}: ChannelPickerFieldProps) {
+  const [query, setQuery] = React.useState("");
+  const deferredQuery = React.useDeferredValue(query);
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  const visibleChannels = React.useMemo(
+    () => filterChannelsByQuery(channels, deferredQuery),
+    [channels, deferredQuery],
+  );
+
+  // Keep the selection visible: when the query filters out the selected
+  // channel, move it to the best match — the `<select>` this replaces
+  // could never hold an invisible selection. Once the selection is in the
+  // list, keep its row scrolled into view for keyboard navigation.
+  React.useEffect(() => {
+    if (visibleChannels.length === 0) {
+      return;
+    }
+    if (!visibleChannels.some((channel) => channel.id === value)) {
+      onChange(visibleChannels[0].id);
+      return;
+    }
+    listRef.current
+      ?.querySelector('[aria-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [onChange, value, visibleChannels]);
+
+  function moveSelection(delta: -1 | 1) {
+    if (visibleChannels.length === 0) {
+      return;
+    }
+    const currentIndex = visibleChannels.findIndex(
+      (channel) => channel.id === value,
+    );
+    const nextIndex =
+      currentIndex === -1
+        ? delta === 1
+          ? 0
+          : visibleChannels.length - 1
+        : Math.min(
+            Math.max(currentIndex + delta, 0),
+            visibleChannels.length - 1,
+          );
+    onChange(visibleChannels[nextIndex].id);
+  }
+
+  const listId = `${inputId}-listbox`;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/55" />
+        <input
+          aria-controls={listId}
+          autoCapitalize="none"
+          autoCorrect="off"
+          className="flex h-9 w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          id={inputId}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              moveSelection(1);
+            } else if (event.key === "ArrowUp") {
+              event.preventDefault();
+              moveSelection(-1);
+            }
+          }}
+          placeholder="Search channels"
+          spellCheck={false}
+          type="text"
+          value={query}
+        />
+      </div>
+      <div
+        aria-label="Channels"
+        className="max-h-52 divide-y divide-border/40 overflow-y-auto rounded-md border border-input bg-background shadow-xs"
+        id={listId}
+        ref={listRef}
+        role="listbox"
+      >
+        {visibleChannels.length === 0 ? (
+          <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+            {channels.length === 0
+              ? "No channels available"
+              : `No channels match “${query.trim()}”`}
+          </p>
+        ) : (
+          visibleChannels.map((channel) => {
+            const isSelected = channel.id === value;
+            return (
+              <button
+                aria-selected={isSelected}
+                className={
+                  isSelected
+                    ? "flex w-full items-center gap-2 bg-muted/60 px-3 py-2 text-left transition-colors duration-150 ease-out focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    : "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                }
+                disabled={disabled}
+                key={channel.id}
+                onClick={() => onChange(channel.id)}
+                role="option"
+                type="button"
+              >
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  <span className="text-muted-foreground"># </span>
+                  <span className="font-medium">{channel.name}</span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {channel.visibility}
+                    {channel.isMember ? " · joined" : ""}
+                  </span>
+                </span>
+                {isSelected ? (
+                  <Check className="h-4 w-4 shrink-0 text-primary" />
+                ) : null}
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelPickerField.tsx
+++ b/desktop/src/features/channels/ui/ChannelPickerField.tsx
@@ -20,6 +20,11 @@ type ChannelPickerFieldProps = {
  * that listed every community channel in one dropdown — communities with
  * many channels made that unusable. Fuzzy-matches with the channel
  * browser's scorer and keeps the caller's (members-first) ordering.
+ *
+ * Selection semantics: this field owns keeping `value` consistent with the
+ * visible list. It selects the first visible channel when `value` is empty
+ * or filtered out, and clears `value` when the query matches nothing — so
+ * a hidden channel can never remain the submit target.
  */
 export function ChannelPickerField({
   channels,
@@ -39,10 +44,15 @@ export function ChannelPickerField({
 
   // Keep the selection visible: when the query filters out the selected
   // channel, move it to the best match — the `<select>` this replaces
-  // could never hold an invisible selection. Once the selection is in the
-  // list, keep its row scrolled into view for keyboard navigation.
+  // could never hold an invisible selection. When nothing matches, clear
+  // the selection so the parent form cannot submit to a hidden channel.
+  // Once the selection is in the list, keep its row scrolled into view
+  // for keyboard navigation.
   React.useEffect(() => {
     if (visibleChannels.length === 0) {
+      if (value !== "") {
+        onChange("");
+      }
       return;
     }
     if (!visibleChannels.some((channel) => channel.id === value)) {
@@ -74,13 +84,22 @@ export function ChannelPickerField({
   }
 
   const listId = `${inputId}-listbox`;
+  const optionId = (channelId: string) => `${inputId}-option-${channelId}`;
+  const selectedIsVisible = visibleChannels.some(
+    (channel) => channel.id === value,
+  );
 
   return (
     <div className="space-y-1.5">
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/55" />
         <input
+          aria-activedescendant={
+            selectedIsVisible ? optionId(value) : undefined
+          }
+          aria-autocomplete="list"
           aria-controls={listId}
+          aria-expanded={true}
           autoCapitalize="none"
           autoCorrect="off"
           className="flex h-9 w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
@@ -97,6 +116,7 @@ export function ChannelPickerField({
             }
           }}
           placeholder="Search channels"
+          role="combobox"
           spellCheck={false}
           type="text"
           value={query}
@@ -127,9 +147,11 @@ export function ChannelPickerField({
                     : "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors duration-150 ease-out hover:bg-muted/40 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                 }
                 disabled={disabled}
+                id={optionId(channel.id)}
                 key={channel.id}
                 onClick={() => onChange(channel.id)}
                 role="option"
+                tabIndex={-1}
                 type="button"
               >
                 <span className="min-w-0 flex-1 truncate text-sm">

--- a/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
+++ b/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
@@ -134,8 +134,11 @@ test("channel picker lists joined channels first and exposes the selection to AT
     firstOptionId ?? "",
   );
 
-  // Mouse selection must preserve focus on the combobox so keyboard
-  // navigation can continue without an extra click back into the input.
+  // Mouse selection must move focus to the combobox from another control so
+  // keyboard navigation continues in the channel list rather than that field.
+  const roleSelect = dialog.getByRole("combobox", { name: "Role" });
+  await roleSelect.focus();
+  await expect(roleSelect).toBeFocused();
   await options.nth(1).click();
   await expect(searchInput).toBeFocused();
   await page.keyboard.press("ArrowUp");

--- a/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
+++ b/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
@@ -134,6 +134,13 @@ test("channel picker lists joined channels first and exposes the selection to AT
     firstOptionId ?? "",
   );
 
+  // Mouse selection must preserve focus on the combobox so keyboard
+  // navigation can continue without an extra click back into the input.
+  await options.nth(1).click();
+  await expect(searchInput).toBeFocused();
+  await page.keyboard.press("ArrowUp");
+  await expect(options.first()).toHaveAttribute("aria-selected", "true");
+
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/01-picker-default.png` });
 });

--- a/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
+++ b/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
@@ -1,24 +1,33 @@
 import { expect, test } from "@playwright/test";
 
 import { waitForAnimations } from "../helpers/animations";
-import { installMockBridge } from "../helpers/bridge";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
 
 const OUTDIR = "test-results/team-deploy-channel-picker";
+const AGENT_PERSONA_ID = "custom:deploy-picker";
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page, {
     personas: [
       {
-        id: "custom:deploy-picker",
+        id: AGENT_PERSONA_ID,
         displayName: "Deploy picker agent",
         systemPrompt: "A test agent for the deploy channel picker.",
+      },
+    ],
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        name: "Deploy picker agent",
+        personaId: AGENT_PERSONA_ID,
+        status: "running",
       },
     ],
     teams: [
       {
         id: "deploy-picker-team",
         name: "Deploy picker team",
-        personaIds: ["custom:deploy-picker"],
+        personaIds: [AGENT_PERSONA_ID],
       },
     ],
   });
@@ -44,13 +53,17 @@ async function waitForInvokeBridge(page: import("@playwright/test").Page) {
   );
 }
 
-async function openDeployDialog(page: import("@playwright/test").Page) {
+async function openAgentsView(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await waitForInvokeBridge(page);
   await expect(page.getByTestId("open-agents-view")).toBeVisible({
     timeout: 10_000,
   });
   await page.getByTestId("open-agents-view").click();
+}
+
+async function openTeamDeployDialog(page: import("@playwright/test").Page) {
+  await openAgentsView(page);
   await page
     .getByRole("button", { name: "Deploy picker team team actions" })
     .click();
@@ -60,8 +73,21 @@ async function openDeployDialog(page: import("@playwright/test").Page) {
   return dialog;
 }
 
-test("channel picker lists joined channels first", async ({ page }) => {
-  const dialog = await openDeployDialog(page);
+async function openAgentAddDialog(page: import("@playwright/test").Page) {
+  await openAgentsView(page);
+  await page.getByTestId(`persona-agent-row-${AGENT_PERSONA_ID}`).click();
+  await expect(page.getByTestId("user-profile-panel")).toBeVisible();
+  await page.getByTestId("user-profile-tab-channels").click();
+  await page.getByTestId("user-profile-agent-add-channel").click();
+  const dialog = page.getByRole("dialog", { name: "Add agent to channel" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test("channel picker lists joined channels first and exposes the selection to AT", async ({
+  page,
+}) => {
+  const dialog = await openTeamDeployDialog(page);
 
   // Scope to the picker's listbox — the dialog's native role <select> also
   // exposes option elements.
@@ -83,18 +109,45 @@ test("channel picker lists joined channels first", async ({ page }) => {
   // The first (joined) channel is auto-selected.
   await expect(options.first()).toHaveAttribute("aria-selected", "true");
 
+  // Combobox semantics: the search input announces the keyboard-selected
+  // option via aria-activedescendant, and arrow keys move it. Scope by
+  // accessible name — the native Role <select> is also a combobox.
+  const searchInput = dialog.getByRole("combobox", { name: "Channel" });
+  const firstOptionId = await options.first().getAttribute("id");
+  const secondOptionId = await options.nth(1).getAttribute("id");
+  expect(firstOptionId).toBeTruthy();
+  await expect(searchInput).toHaveAttribute(
+    "aria-activedescendant",
+    firstOptionId ?? "",
+  );
+
+  await searchInput.press("ArrowDown");
+  await expect(options.nth(1)).toHaveAttribute("aria-selected", "true");
+  await expect(searchInput).toHaveAttribute(
+    "aria-activedescendant",
+    secondOptionId ?? "",
+  );
+  await searchInput.press("ArrowUp");
+  await expect(searchInput).toHaveAttribute(
+    "aria-activedescendant",
+    firstOptionId ?? "",
+  );
+
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/01-picker-default.png` });
 });
 
-test("search filters the channel list and moves the selection", async ({
+test("search filters the channel list and a no-match query blocks deploy", async ({
   page,
 }) => {
-  const dialog = await openDeployDialog(page);
+  const dialog = await openTeamDeployDialog(page);
   const searchInput = dialog.locator("#team-channel-id");
   const options = dialog
     .getByRole("listbox", { name: "Channels" })
     .getByRole("option");
+  const deployButton = dialog.getByRole("button", { name: /^Deploy \d/ });
+
+  await expect(deployButton).toBeEnabled();
 
   await searchInput.fill("eng");
 
@@ -109,9 +162,55 @@ test("search filters the channel list and moves the selection", async ({
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/02-picker-filtered.png` });
 
+  // A query with no matches clears the selection: no hidden channel stays
+  // actionable, so the submit button must disable.
   await searchInput.fill("no-such-channel");
   await expect(dialog.getByText(/No channels match/)).toBeVisible();
+  await expect(searchInput).not.toHaveAttribute("aria-activedescendant", /.+/);
+  await expect(deployButton).toBeDisabled();
 
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/03-picker-no-match.png` });
+
+  // Clearing the query restores the default (first joined) selection and
+  // re-enables deploy.
+  await searchInput.fill("");
+  await expect(options.first()).toHaveAttribute("aria-selected", "true");
+  await expect(deployButton).toBeEnabled();
+});
+
+test("agent add-to-channel dialog gets the same picker and no-match guard", async ({
+  page,
+}) => {
+  const dialog = await openAgentAddDialog(page);
+  const searchInput = dialog.locator("#agent-channel-id");
+  const options = dialog
+    .getByRole("listbox", { name: "Channels" })
+    .getByRole("option");
+  const submitButton = dialog.getByRole("button", {
+    name: /add to channel/i,
+  });
+
+  // A joined channel is auto-selected first; submit is available.
+  const names = await options.allInnerTexts();
+  const engineeringIndex = names.findIndex((name) =>
+    name.includes("engineering"),
+  );
+  const designIndex = names.findIndex((name) => name.includes("design"));
+  expect(engineeringIndex).toBeGreaterThanOrEqual(0);
+  expect(engineeringIndex).toBeLessThan(designIndex);
+  await expect(options.first()).toContainText("joined");
+  await expect(options.first()).toHaveAttribute("aria-selected", "true");
+  await expect(submitButton).toBeEnabled();
+
+  await searchInput.fill("eng");
+  await expect(options).toHaveCount(2);
+  await expect(options.first()).toContainText("engineering");
+
+  await searchInput.fill("no-such-channel");
+  await expect(dialog.getByText(/No channels match/)).toBeVisible();
+  await expect(submitButton).toBeDisabled();
+
+  await waitForAnimations(page);
+  await dialog.screenshot({ path: `${OUTDIR}/04-agent-dialog-no-match.png` });
 });

--- a/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
+++ b/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
@@ -15,6 +15,7 @@ test.beforeEach(async ({ page }) => {
         systemPrompt: "A test agent for the deploy channel picker.",
       },
     ],
+    createManagedAgentDelayMs: 1_000,
     managedAgents: [
       {
         pubkey: TEST_IDENTITIES.alice.pubkey,
@@ -162,12 +163,38 @@ test("search filters the channel list and a no-match query blocks deploy", async
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/02-picker-filtered.png` });
 
-  // A query with no matches clears the selection: no hidden channel stays
-  // actionable, so the submit button must disable.
-  await searchInput.fill("no-such-channel");
+  // Change to a no-match query and immediately attempt submission in the same
+  // browser task, without waiting for the empty-state render. The input event
+  // must synchronously clear the selected channel so the native click is a
+  // no-op rather than deploying to the previously visible target.
+  await dialog.evaluate((root) => {
+    const input = root.querySelector<HTMLInputElement>("#team-channel-id");
+    const button = Array.from(root.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.startsWith("Deploy "),
+    );
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    if (!(input instanceof HTMLInputElement) || !button || !valueSetter) {
+      throw new Error("Channel picker controls are unavailable");
+    }
+
+    valueSetter.call(input, "no-such-channel");
+    input.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        data: "no-such-channel",
+        inputType: "insertText",
+      }),
+    );
+    button.click();
+  });
+
   await expect(dialog.getByText(/No channels match/)).toBeVisible();
   await expect(searchInput).not.toHaveAttribute("aria-activedescendant", /.+/);
   await expect(deployButton).toBeDisabled();
+  await expect(deployButton).toHaveText("Deploy 1 agent");
 
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/03-picker-no-match.png` });

--- a/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
+++ b/desktop/tests/e2e/team-deploy-channel-picker.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+const OUTDIR = "test-results/team-deploy-channel-picker";
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page, {
+    personas: [
+      {
+        id: "custom:deploy-picker",
+        displayName: "Deploy picker agent",
+        systemPrompt: "A test agent for the deploy channel picker.",
+      },
+    ],
+    teams: [
+      {
+        id: "deploy-picker-team",
+        name: "Deploy picker team",
+        personaIds: ["custom:deploy-picker"],
+      },
+    ],
+  });
+});
+
+async function waitForInvokeBridge(page: import("@playwright/test").Page) {
+  await page.waitForFunction(
+    () => {
+      const tauriWindow = window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+        __TAURI_INTERNALS__?: {
+          invoke?: unknown;
+        };
+      };
+
+      return (
+        typeof tauriWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ === "function" ||
+        typeof tauriWindow.__TAURI_INTERNALS__?.invoke === "function"
+      );
+    },
+    undefined,
+    { timeout: 15_000 },
+  );
+}
+
+async function openDeployDialog(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForInvokeBridge(page);
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByTestId("open-agents-view").click();
+  await page
+    .getByRole("button", { name: "Deploy picker team team actions" })
+    .click();
+  await page.getByRole("menuitem", { name: "Deploy to channel" }).click();
+  const dialog = page.getByRole("dialog", { name: "Deploy team to channel" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test("channel picker lists joined channels first", async ({ page }) => {
+  const dialog = await openDeployDialog(page);
+
+  // Scope to the picker's listbox — the dialog's native role <select> also
+  // exposes option elements.
+  const options = dialog
+    .getByRole("listbox", { name: "Channels" })
+    .getByRole("option");
+  const names = await options.allInnerTexts();
+
+  // The mock identity is a member of `engineering` but not `design`, so
+  // members-first ordering must beat plain alphabetical order.
+  const engineeringIndex = names.findIndex((name) =>
+    name.includes("engineering"),
+  );
+  const designIndex = names.findIndex((name) => name.includes("design"));
+  expect(engineeringIndex).toBeGreaterThanOrEqual(0);
+  expect(designIndex).toBeGreaterThanOrEqual(0);
+  expect(engineeringIndex).toBeLessThan(designIndex);
+
+  // The first (joined) channel is auto-selected.
+  await expect(options.first()).toHaveAttribute("aria-selected", "true");
+
+  await waitForAnimations(page);
+  await dialog.screenshot({ path: `${OUTDIR}/01-picker-default.png` });
+});
+
+test("search filters the channel list and moves the selection", async ({
+  page,
+}) => {
+  const dialog = await openDeployDialog(page);
+  const searchInput = dialog.locator("#team-channel-id");
+  const options = dialog
+    .getByRole("listbox", { name: "Channels" })
+    .getByRole("option");
+
+  await searchInput.fill("eng");
+
+  // `engineering` matches on name (best score); `design` matches "eng" only
+  // via its description, so it ranks second. Everything else drops out.
+  await expect(options).toHaveCount(2);
+  await expect(options.first()).toContainText("engineering");
+  await expect(options.nth(1)).toContainText("design");
+  // Filtering moved the selection onto the remaining match.
+  await expect(options.first()).toHaveAttribute("aria-selected", "true");
+
+  await waitForAnimations(page);
+  await dialog.screenshot({ path: `${OUTDIR}/02-picker-filtered.png` });
+
+  await searchInput.fill("no-such-channel");
+  await expect(dialog.getByText(/No channels match/)).toBeVisible();
+
+  await waitForAnimations(page);
+  await dialog.screenshot({ path: `${OUTDIR}/03-picker-no-match.png` });
+});


### PR DESCRIPTION
## Why

The "Deploy team to channel" and "Add agent to channel" dialogs render every candidate channel as a single plain `<select>` with no search. In communities with many channels this is hard to use.

To state the premise precisely (per review): **the candidate set is intentionally unchanged.** Non-member channels are valid deployment targets — deployment adds the agent via relay-authorized membership, and the existing copy says *accessible*, not *joined*. This PR is a search/UX feature, not a scoping fix.

## What

- New shared `ChannelPickerField` component (`desktop/src/features/channels/ui/`): a combobox search input plus listbox, fuzzy-matched with the channel browser's existing scorer (`scoreChannelMatch`), with arrow-key navigation and scroll-into-view.
- New `channelPickerOrdering` lib: channels the user has joined sort first (then alphabetical); query results rank by match score with ties keeping members-first order. Unit-tested.
- Both deploy dialogs (`AddTeamToChannelDialog`, `AddAgentToChannelDialog`) swap their `<select>` for the shared picker. The picker now owns default selection, replacing the dialogs' own init effects.

### Semantic choices (flagging explicitly for product review, per feedback)

1. **Joined-first default selection** — the picker defaults to the first *joined* channel rather than the first alphabetical one. Rationale: it's the likeliest target and makes the common case one keystroke shorter; non-member channels remain fully selectable and deployable.
2. **Selection follows the filter** — when the query filters out the selected channel, selection moves to the best visible match (the `<select>` this replaces could never hold an invisible selection). When the query matches **nothing**, the selection is **cleared** so the submit button disables — a hidden channel can never remain the deploy target.

Happy to change either behavior if the team prefers different semantics (e.g. selection cleared on any filter-out, requiring an explicit pick).

## Review feedback addressed

- **No-match state is now non-actionable**: an unmatched query clears the value; both dialogs derive `selectedChannel` from it, so Deploy/Add disables. Covered by Playwright in both dialogs.
- **Combobox semantics for assistive technology**: the input is now `role="combobox"` with `aria-expanded`, `aria-autocomplete="list"`, and `aria-activedescendant` pointing at the stable id of the selected option (`tabIndex={-1}` options, matching the `NewMessageScreen` active-descendant pattern). Arrow keys move the active descendant; covered by Playwright assertions.
- **Coverage extended to both dialogs**: the spec now drives the agent profile → channels → "Add to channel" flow as well as the team deploy flow, and asserts the submit-button state in the no-match case.

The settings → local-archive card has the same unsearchable `<select>`; left out deliberately to keep this diff small — easy follow-up with the new shared component.

## Testing

- `pnpm typecheck`, biome + file-size/px-text guards clean
- Full desktop unit suite: 4294/4294 pass (includes 8 `channelPickerOrdering` tests)
- Playwright `team-deploy-channel-picker.spec.ts` (integration project): 3/3 green locally — members-first ordering + auto-selection + aria-activedescendant tracking, search filtering, no-match state disabling submit in both dialogs
- Full Playwright integration project run locally against the revised head

Closest existing PR/issue: none found.
