### PR TITLE
fix(projects): show create menu when no projects exist

### DIFF
--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -597,10 +597,6 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
-
   const projectItems =
     visibleProjects.length === 0 ? (
       <EmptyFilteredState />
@@ -859,7 +855,9 @@ export function ProjectsView() {
           </div>
           <div className="mx-auto w-full max-w-6xl">
             <div className="w-full min-w-0 pb-4 pt-4">
-              {filter === "all" ? (
+              {projects.length === 0 ? (
+                <EmptyState />
+              ) : filter === "all" ? (
                 <ProjectsOverviewPanel
                   metadata={
                     <ProjectsOverviewRail

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1174,6 +1174,8 @@ declare global {
     };
     /** Overrides the first mock repository owner for delegated-owner tests. */
     __BUZZ_E2E_PROJECT_OWNER_OVERRIDE__?: string;
+    /** Omits seeded project events for empty-state tests. */
+    __BUZZ_E2E_EMPTY_PROJECTS__?: boolean;
     /** Project history kinds rejected with CLOSED for aggregate-query tests. */
     __BUZZ_E2E_REJECT_PROJECT_QUERY_KINDS__?: number[];
     /** Captured aggregate project-history filters for request-count assertions. */
@@ -5314,6 +5316,8 @@ function writeMockProjectBranch(
 }
 
 function buildMockProjectEvents(): RelayEvent[] {
+  if (window.__BUZZ_E2E_EMPTY_PROJECTS__) return [];
+
   const events: RelayEvent[] = [];
   const daySeconds = 86_400;
   const now = Math.floor(Date.now() / 1000);

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -17,6 +17,24 @@ async function enableProjectsFeature(page: import("@playwright/test").Page) {
   });
 }
 
+test("empty projects state keeps project creation available", async ({
+  page,
+}) => {
+  await enableProjectsFeature(page);
+  await page.addInitScript(() => {
+    window.__BUZZ_E2E_EMPTY_PROJECTS__ = true;
+  });
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+
+  await expect(page.getByText("No projects yet")).toBeVisible();
+  await expect(page.getByTestId("projects-create-menu")).toBeVisible();
+  await page.getByTestId("projects-create-menu").click();
+  await page.getByRole("menuitem", { name: "Project" }).click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+});
+
 test("top-level project lists align dates and overflow actions", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

### Problem

On a relay with **zero projects**, the Projects view returned the `No projects yet` empty state before rendering the normal Projects shell. That shell contains the only project-creation affordance: the **`+` create menu**.

This created a chicken-and-egg failure: users could not create their first project from the desktop UI because the create button only appeared after at least one project already existed. Creating a project out-of-band made the button appear.

### Implementation

- Keep the normal Projects header, navigation, and `+` create menu mounted when the project list is empty.
- Render the existing `No projects yet` state inside the shell's content area instead of returning it as the entire view.
- Add an E2E-only zero-project fixture and a regression test that verifies the empty state still exposes the create menu and opens the New Project dialog.
- Leave loading, error, filtered, and non-empty rendering behavior unchanged.

No follow-up work is deferred.

### Related issue

Fixes #3504. Also addresses #2585 and #2622.

### Testing

- `pnpm --dir desktop exec playwright test tests/e2e/project-commit-detail.spec.ts --project=smoke -g "empty projects state keeps project creation available"`
  - **1 passed**
- `just ci`
  - **Passed**
- Manual/E2E verification:
  1. Start with no project events.
  2. Open **Projects** and confirm `No projects yet` is shown.
  3. Confirm the top-right `+` button is visible.
  4. Open it, select **Project**, and confirm the New Project dialog opens.

#### Before

With zero projects, only the empty state rendered. There was no Projects header, toolbar, or `+` button, so the first project could not be created from the UI.

![Before: zero-project empty state with no create button](https://raw.githubusercontent.com/mijanx/buzz/pr-assets/4842/before.png)

#### After

The standard Projects shell remains visible around the same empty state. The `+` menu is available and exposes **Project**, allowing creation of the first project.

![After: zero-project empty state with the create menu open](https://raw.githubusercontent.com/mijanx/buzz/pr-assets/4842/after.png)
