### PR TITLE
fix(compose): raise keycloak memory limit to stop OOM crash loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512m
+          memory: 2g
     labels:
       com.buzz.service: "keycloak"
       com.buzz.env: "dev"


### PR DESCRIPTION
## Summary
- buzz-keycloak was OOM-killed (137) during Keycloak 26's config build-and-exit step before the JVM even finished booting, causing an indefinite restart loop (263+ restarts observed on a long-running dev box)
- Root cause: `deploy.resources.limits.memory: 512m` is too tight for Keycloak 26 in `start-dev` mode
- Raised the limit to 2g; steady-state usage after boot is ~1.1GiB, so this leaves real headroom under load

## Test plan
- [x] Applied the change locally via `docker compose up -d keycloak`, confirmed the container starts cleanly (RestartCount=0, OOMKilled=false) and Keycloak fully initializes (master realm created, admin console listening on :8080)
- [x] Confirmed no other services in the compose file were affected

with a helping hand from Claude Code