### PR TITLE
fix(desktop): correct Grok Build setup guide URL

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -118,7 +118,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Grok Build",
         command: "grok",
         args: &["agent", "--always-approve", "stdio"],
-        install_instructions_url: "https://build.x.ai/docs",
+        install_instructions_url: "https://docs.x.ai/build/overview",
         install_hint: "Buzz talks to Grok Build through its CLI's agent stdio mode.",
         underlying_cli: None,
     },


### PR DESCRIPTION
## Problem

The **Grok Build** harness preset points its "Setup guide" link at `https://build.x.ai/docs`, which is unreachable — the hostname has no DNS record at all, so the button leads to a dead page rather than a 404.

```console
$ getent hosts build.x.ai
(no output — no record)

$ getent hosts docs.x.ai
2606:4700::6812:1350  docs.x.ai

$ curl -sS https://build.x.ai/docs
curl: (6) Could not resolve host: build.x.ai
```

This is user-facing: the link sits behind the **Setup guide** button in the harness picker, so anyone trying to connect Grok Build hits it while looking for install instructions.

## Fix

Point the preset at xAI's live Grok Build documentation.

```diff
-        install_instructions_url: "https://build.x.ai/docs",
+        install_instructions_url: "https://docs.x.ai/build/overview",
```

The preset's `command` and `args` are **unchanged and remain correct** — Grok Build ships native ACP over stdio, which `grok agent stdio` exposes:

```console
$ grok agent --help
Commands:
  stdio     Run the agent over stdio
  headless  Run the agent headlessly over the Grok WebSocket relay
  ...
```

## Testing

- `just ci` passes locally (fmt, clippy, desktop lint, Tauri clippy, unit tests, mobile tests).
- Verified `https://docs.x.ai/build/overview` resolves and returns `200`.
- Verified the harness itself still connects: installed Grok Build 0.2.118 via `irm https://x.ai/cli/install.ps1 | iex` and confirmed `grok agent stdio` matches the preset's invocation.

No UI changes — this is a string constant, so no screenshots apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
