### PR TITLE
fix(desktop): preserve PATH order for Windows command shims

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -692,18 +692,6 @@ fn resolve_command_uncached(command: &str) -> Option<PathBuf> {
         }
     }
 
-    // On Windows, also scan PATH for .cmd/.bat shims (npm globals).
-    #[cfg(windows)]
-    {
-        for basename in command_basenames(command).iter().skip(1) {
-            for candidate in path_candidates_from_env_raw(basename) {
-                if candidate.is_file() {
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-
     if let Some(path) = find_via_login_shell(command) {
         return Some(path);
     }
@@ -735,23 +723,11 @@ fn resolve_command_uncached(command: &str) -> Option<PathBuf> {
 }
 
 fn path_candidates_from_env(command: &str) -> Vec<PathBuf> {
+    let basenames = command_basenames(command);
     std::env::var_os("PATH")
         .map(|paths| {
             std::env::split_paths(&paths)
-                .map(|dir| dir.join(executable_basename(command)))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-}
-
-/// Like `path_candidates_from_env` but joins `basename` as-is (no `.exe` suffix).
-/// Used for `.cmd`/`.bat` shim resolution on Windows.
-#[cfg(windows)]
-fn path_candidates_from_env_raw(basename: &str) -> Vec<PathBuf> {
-    std::env::var_os("PATH")
-        .map(|paths| {
-            std::env::split_paths(&paths)
-                .map(|dir| dir.join(basename))
+                .flat_map(|dir| basenames.iter().map(move |basename| dir.join(basename)))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1329,6 +1329,38 @@ fn test_cmd_shim_resolves_from_path() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn test_cmd_shim_precedes_later_exe_on_path() {
+    let _guard = crate::managed_agents::lock_path_mutex();
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let npm_dir = temp.path().join("npm");
+    let windows_apps_dir = temp.path().join("WindowsApps");
+    std::fs::create_dir_all(&npm_dir).expect("create npm dir");
+    std::fs::create_dir_all(&windows_apps_dir).expect("create WindowsApps dir");
+
+    let npm_shim = npm_dir.join("test-path-order-codex.cmd");
+    let store_binary = windows_apps_dir.join("test-path-order-codex.exe");
+    std::fs::write(&npm_shim, "@echo off\r\n").expect("write npm shim");
+    std::fs::write(&store_binary, "not a real executable").expect("write store binary");
+
+    let old_path = std::env::var_os("PATH").unwrap_or_default();
+    let joined =
+        std::env::join_paths([npm_dir.as_path(), windows_apps_dir.as_path()]).expect("join PATH");
+    std::env::set_var("PATH", &joined);
+
+    let result = super::resolve_command_uncached("test-path-order-codex");
+
+    std::env::set_var("PATH", &old_path);
+
+    assert_eq!(
+        result.as_deref(),
+        Some(npm_shim.as_path()),
+        "an earlier PATH directory's .cmd shim must win over a later .exe"
+    );
+}
+
 // ── Phase A: no-shell-resolved error on Windows ────────────────────────────
 
 /// When all resolution sources are empty AND the registry is disabled,

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -100,6 +100,19 @@ pub(crate) fn classify_probe_output(stderr_bytes: &[u8], exit_success: bool) -> 
 mod tests {
     use super::{ProbeOutcome, CONFIG_PARSE_SIGNALS};
 
+    #[cfg(windows)]
+    #[test]
+    fn login_probe_executes_windows_cmd_shim() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let script_path = temp.path().join("fake-codex.cmd");
+        std::fs::write(&script_path, "@exit /b 0\r\n").expect("write cmd shim");
+
+        assert_eq!(
+            super::login_probe(&script_path, &["fake-codex", "login", "status"], None,),
+            ProbeOutcome::LoggedIn
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn login_probe_uses_augmented_path_for_env_shebang_interpreter() {


### PR DESCRIPTION
## Summary

Preserve PATH directory precedence when resolving Windows command shims.

Buzz previously searched every PATH directory for `.exe` files before searching for `.cmd` and `.bat` files. This allowed a later Windows Store `codex.exe` to override an earlier authenticated npm `codex.cmd`, causing `codex login status` to fail and managed agents to incorrectly enter setup mode.

### Related issue

N/A - no duplicate found.

### Testing

- Windows `.cmd` shim resolution regression test
- Windows login probe `.cmd` execution test
- Managed-agent discovery tests: 78 passed
- CLI probe tests: 2 passed