### PR TITLE
fix(desktop): ignore unusable local buzz-acp sidecar stubs

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -39,6 +39,89 @@ pub(crate) const FILTER_QUERY_CONCURRENCY: usize = 4;
 // the range fails the build.
 const _: () = assert!(FILTER_QUERY_CONCURRENCY >= 2 && FILTER_QUERY_CONCURRENCY <= 8);
 
+fn distinct_channels(rows: &[Option<uuid::Uuid>]) -> Vec<uuid::Uuid> {
+    let mut set: std::collections::BTreeSet<uuid::Uuid> = std::collections::BTreeSet::new();
+    for channel_id in rows.iter().flatten() {
+        set.insert(*channel_id);
+    }
+    set.into_iter().collect()
+}
+
+async fn maybe_emit_read_message_rows_with_lookup<Rows, Lookup, Fut, E>(
+    tracer: &Arc<dyn crate::conformance::Tracer>,
+    trace_state: Option<&crate::conformance::AbstractState>,
+    filter_channel: Option<uuid::Uuid>,
+    rows: Rows,
+    lookup: Lookup,
+) -> bool
+where
+    Rows: FnOnce() -> Vec<Option<uuid::Uuid>>,
+    Lookup: FnOnce(Vec<uuid::Uuid>) -> Fut,
+    Fut: std::future::Future<
+        Output = Result<std::collections::HashMap<uuid::Uuid, buzz_core::tenant::CommunityId>, E>,
+    >,
+    E: std::fmt::Display,
+{
+    let Some(state_snap) = trace_state.filter(|_| tracer.enabled()) else {
+        return false;
+    };
+
+    let row_channels = rows();
+    let distinct = distinct_channels(&row_channels);
+    let channel_communities = match lookup(distinct).await {
+        Ok(map) => map,
+        Err(e) => {
+            warn!("conformance row-community lookup failed: {e}");
+            std::collections::HashMap::new()
+        }
+    };
+    crate::conformance::record_read_message_rows(
+        tracer,
+        state_snap,
+        filter_channel,
+        &row_channels,
+        &channel_communities,
+    );
+    true
+}
+
+async fn maybe_emit_read_by_id_rows_with_lookup<Rows, Lookup, Fut, E>(
+    tracer: &Arc<dyn crate::conformance::Tracer>,
+    trace_state: Option<&crate::conformance::AbstractState>,
+    rows: Rows,
+    lookup: Lookup,
+) -> bool
+where
+    Rows: FnOnce() -> Vec<Option<uuid::Uuid>>,
+    Lookup: FnOnce(Vec<uuid::Uuid>) -> Fut,
+    Fut: std::future::Future<
+        Output = Result<std::collections::HashMap<uuid::Uuid, buzz_core::tenant::CommunityId>, E>,
+    >,
+    E: std::fmt::Display,
+{
+    let Some(state_snap) = trace_state.filter(|_| tracer.enabled()) else {
+        return false;
+    };
+
+    let row_channels = rows();
+    let distinct = distinct_channels(&row_channels);
+    let channel_communities = match lookup(distinct).await {
+        Ok(map) => map,
+        Err(e) => {
+            warn!("conformance row-community lookup failed: {e}");
+            std::collections::HashMap::new()
+        }
+    };
+    crate::conformance::record_read_by_id_rows(
+        tracer,
+        state_snap,
+        None,
+        &row_channels,
+        &channel_communities,
+    );
+    true
+}
+
 /// Handle a REQ message: register the subscription, deliver historical events, then send EOSE.
 pub async fn handle_req(
     sub_id: String,
@@ -339,35 +422,15 @@ pub async fn handle_req(
         // `channels` read whose only consumer is `record_read_message_rows`,
         // and this emit runs once PER FILTER. Gating on `trace_state` alone was
         // not enough — that is `Some` for every well-formed request.
-        if let Some(state_snap) = trace_state.as_ref().filter(|_| state.tracer.enabled()) {
-            let row_channels: Vec<Option<uuid::Uuid>> =
-                events.iter().map(|e| e.channel_id).collect();
-            let distinct: Vec<uuid::Uuid> = {
-                let mut s: std::collections::BTreeSet<uuid::Uuid> =
-                    std::collections::BTreeSet::new();
-                for c in row_channels.iter().flatten() {
-                    s.insert(*c);
-                }
-                s.into_iter().collect()
-            };
-            let channel_communities = match state.db.communities_of_channels(&distinct).await {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(
-                        conn_id = %conn_id, sub_id = %sub_id,
-                        "conformance row-community lookup failed: {e}"
-                    );
-                    std::collections::HashMap::new()
-                }
-            };
-            crate::conformance::record_read_message_rows(
-                &state.tracer,
-                state_snap,
-                per_filter_channel,
-                &row_channels,
-                &channel_communities,
-            );
-        }
+        let db = state.db.clone();
+        let _ = maybe_emit_read_message_rows_with_lookup(
+            &state.tracer,
+            trace_state.as_ref(),
+            per_filter_channel,
+            || events.iter().map(|e| e.channel_id).collect::<Vec<_>>(),
+            move |distinct| async move { db.communities_of_channels(&distinct).await },
+        )
+        .await;
 
         for stored in &events {
             // Per-filter NIP-01 matching — use the current filter only, not the
@@ -666,36 +729,14 @@ async fn handle_search_req(
                 // honestly.
                 // Same `enabled()` gate as the non-search lane: skip the
                 // trace-only `channels` lookup when nothing observes the emit.
-                if let Some(state_snap) = trace_state.filter(|_| state.tracer.enabled()) {
-                    let row_channels: Vec<Option<uuid::Uuid>> =
-                        events.iter().map(|e| e.channel_id).collect();
-                    let distinct: Vec<uuid::Uuid> = {
-                        let mut s: std::collections::BTreeSet<uuid::Uuid> =
-                            std::collections::BTreeSet::new();
-                        for c in row_channels.iter().flatten() {
-                            s.insert(*c);
-                        }
-                        s.into_iter().collect()
-                    };
-                    let channel_communities =
-                        match state.db.communities_of_channels(&distinct).await {
-                            Ok(m) => m,
-                            Err(e) => {
-                                warn!(
-                                    sub_id = %sub_id,
-                                    "conformance row-community lookup failed: {e}"
-                                );
-                                std::collections::HashMap::new()
-                            }
-                        };
-                    crate::conformance::record_read_by_id_rows(
-                        &state.tracer,
-                        state_snap,
-                        None,
-                        &row_channels,
-                        &channel_communities,
-                    );
-                }
+                let db = state.db.clone();
+                let _ = maybe_emit_read_by_id_rows_with_lookup(
+                    &state.tracer,
+                    trace_state,
+                    || events.iter().map(|e| e.channel_id).collect::<Vec<_>>(),
+                    move |distinct| async move { db.communities_of_channels(&distinct).await },
+                )
+                .await;
 
                 let event_map: std::collections::HashMap<[u8; 32], &buzz_core::StoredEvent> =
                     events
@@ -1300,6 +1341,7 @@ fn topic_for_subscription(channel_id: Option<uuid::Uuid>) -> EventTopic {
 mod tests {
     use super::*;
     use nostr::{Alphabet, Filter, SingleLetterTag};
+    use std::sync::Mutex;
 
     #[test]
     fn global_queries_push_access_scope_before_limit() {
@@ -1574,6 +1616,214 @@ mod tests {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id), Filter::new()];
         assert_eq!(extract_channel_id_from_filters(&filters), None);
+    }
+
+    #[derive(Debug, Default)]
+    struct VecTracer {
+        steps: Mutex<Vec<crate::conformance::TraceStep>>,
+    }
+
+    impl crate::conformance::Tracer for VecTracer {
+        fn record(&self, step: crate::conformance::TraceStep) {
+            self.steps.lock().expect("vec tracer mutex").push(step);
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct DisabledTracer;
+
+    impl crate::conformance::Tracer for DisabledTracer {
+        fn record(&self, _step: crate::conformance::TraceStep) {}
+        fn enabled(&self) -> bool {
+            false
+        }
+    }
+
+    fn dummy_trace_state() -> crate::conformance::AbstractState {
+        crate::conformance::AbstractState {
+            resolved_community: crate::conformance::CommunityLabel::from_uuid(
+                uuid::Uuid::from_u128(0xA),
+            ),
+            bound_host: crate::conformance::HostLabel("test.local".to_string()),
+            actor: crate::conformance::ActorLabel("0123456789abcdef".to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn historical_req_multi_filter_disabled_tracer_skips_lookup() {
+        let tracer: Arc<dyn crate::conformance::Tracer> = Arc::new(DisabledTracer);
+        assert!(
+            !tracer.enabled(),
+            "disabled tracer must report enabled()=false"
+        );
+        let state = dummy_trace_state();
+        let lookup_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rows = vec![Some(uuid::Uuid::new_v4()), Some(uuid::Uuid::new_v4())];
+
+        let called_first = maybe_emit_read_message_rows_with_lookup(
+            &tracer,
+            Some(&state),
+            Some(uuid::Uuid::new_v4()),
+            || rows.clone(),
+            {
+                let calls = Arc::clone(&lookup_calls);
+                move |_distinct| async move {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Ok::<_, std::convert::Infallible>(std::collections::HashMap::new())
+                }
+            },
+        )
+        .await;
+
+        let called_second = maybe_emit_read_message_rows_with_lookup(
+            &tracer,
+            Some(&state),
+            None,
+            || rows.clone(),
+            {
+                let calls = Arc::clone(&lookup_calls);
+                move |_distinct| async move {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Ok::<_, std::convert::Infallible>(std::collections::HashMap::new())
+                }
+            },
+        )
+        .await;
+
+        assert!(!called_first);
+        assert!(!called_second);
+        assert_eq!(
+            lookup_calls.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "disabled tracer must skip `communities_of_channels` for each historical filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_req_multi_filter_enabled_tracer_calls_lookup_and_emits() {
+        let typed = Arc::new(VecTracer::default());
+        let tracer: Arc<dyn crate::conformance::Tracer> = typed.clone();
+        let state = dummy_trace_state();
+        let lookup_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let ch1 = uuid::Uuid::new_v4();
+        let ch2 = uuid::Uuid::new_v4();
+        let rows = vec![Some(ch1), None, Some(ch2)];
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+
+        for filter_channel in [Some(ch1), None] {
+            let called = maybe_emit_read_message_rows_with_lookup(
+                &tracer,
+                Some(&state),
+                filter_channel,
+                || rows.clone(),
+                {
+                    let calls = Arc::clone(&lookup_calls);
+                    move |distinct| async move {
+                        calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let map = distinct
+                            .iter()
+                            .copied()
+                            .map(|channel_id| (channel_id, community))
+                            .collect::<std::collections::HashMap<_, _>>();
+                        Ok::<_, std::convert::Infallible>(map)
+                    }
+                },
+            )
+            .await;
+            assert!(called);
+        }
+
+        assert_eq!(
+            lookup_calls.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "enabled tracer must call `communities_of_channels` once per historical filter"
+        );
+
+        let steps = typed.steps.lock().expect("vec tracer mutex");
+        assert_eq!(steps.len(), 2, "one emit per filter expected");
+        for step in steps.iter() {
+            assert!(
+                matches!(
+                    step.action,
+                    crate::conformance::TraceAction::ReadMessageRows { .. }
+                ),
+                "expected ReadMessageRows emit, got {:?}",
+                step.action
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn search_hydration_disabled_tracer_skips_lookup() {
+        let tracer: Arc<dyn crate::conformance::Tracer> = Arc::new(DisabledTracer);
+        assert!(
+            !tracer.enabled(),
+            "disabled tracer must report enabled()=false"
+        );
+        let state = dummy_trace_state();
+        let lookup_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rows = vec![Some(uuid::Uuid::new_v4())];
+
+        let called =
+            maybe_emit_read_by_id_rows_with_lookup(&tracer, Some(&state), || rows.clone(), {
+                let calls = Arc::clone(&lookup_calls);
+                move |_distinct| async move {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Ok::<_, std::convert::Infallible>(std::collections::HashMap::new())
+                }
+            })
+            .await;
+
+        assert!(!called);
+        assert_eq!(
+            lookup_calls.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "disabled tracer must skip `communities_of_channels` on search hydration"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_hydration_enabled_tracer_calls_lookup_and_emits() {
+        let typed = Arc::new(VecTracer::default());
+        let tracer: Arc<dyn crate::conformance::Tracer> = typed.clone();
+        let state = dummy_trace_state();
+        let lookup_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let channel = uuid::Uuid::new_v4();
+        let rows = vec![Some(channel)];
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+
+        let called =
+            maybe_emit_read_by_id_rows_with_lookup(&tracer, Some(&state), || rows.clone(), {
+                let calls = Arc::clone(&lookup_calls);
+                move |distinct| async move {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let map = distinct
+                        .iter()
+                        .copied()
+                        .map(|channel_id| (channel_id, community))
+                        .collect::<std::collections::HashMap<_, _>>();
+                    Ok::<_, std::convert::Infallible>(map)
+                }
+            })
+            .await;
+
+        assert!(called);
+        assert_eq!(
+            lookup_calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "enabled tracer must call `communities_of_channels` for search hydration"
+        );
+
+        let steps = typed.steps.lock().expect("vec tracer mutex");
+        assert_eq!(steps.len(), 1);
+        assert!(
+            matches!(
+                steps[0].action,
+                crate::conformance::TraceAction::ReadByIdRows { .. }
+            ),
+            "expected ReadByIdRows emit, got {:?}",
+            steps[0].action
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agent_auth.rs
+++ b/desktop/src-tauri/src/commands/agent_auth.rs
@@ -122,7 +122,7 @@ fn run_buzz_acp_auth_command<const N: usize>(
     let acp_path = std::env::current_exe()
         .map(|path| path.with_file_name(format!("buzz-acp{}", std::env::consts::EXE_SUFFIX)))
         .ok()
-        .filter(|path| path.exists())
+        .filter(|path| is_usable_auth_helper(path))
         .or_else(|| resolve_command("buzz-acp"))
         .ok_or_else(|| "buzz-acp helper not found".to_string())?;
 
@@ -199,6 +199,23 @@ fn run_buzz_acp_auth_command_with_paths<const N: usize>(
     command
         .output()
         .map_err(|error| format!("failed to run buzz-acp auth helper: {error}"))
+}
+
+fn is_usable_auth_helper(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() || metadata.len() == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return false;
+        }
+    }
+    true
 }
 
 fn command_error(label: &str, output: &std::process::Output) -> String {
@@ -462,8 +479,8 @@ fn shell_escape(arg: &str) -> String {
 mod tests {
     use super::{
         adapter_terminal_argv, append_inherited_path, is_claude_subscription_login,
-        run_buzz_acp_auth_command_with_paths, shell_escape, shell_join, uses_terminal_auth,
-        windows_terminal_args, AcpAuthMethod,
+        is_usable_auth_helper, run_buzz_acp_auth_command_with_paths, shell_escape, shell_join,
+        uses_terminal_auth, windows_terminal_args, AcpAuthMethod,
     };
 
     /// Windows regression: the augmented PATH there holds only Buzz-managed
@@ -496,6 +513,57 @@ mod tests {
         assert_eq!(
             append_inherited_path(Some("only-augmented".into()), None),
             Some("only-augmented".into())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_helper_rejects_empty_non_executable_stub() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let stub_path = temp.path().join("buzz-acp");
+        fs::write(&stub_path, []).expect("write stub");
+        fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o644))
+            .expect("chmod non-executable stub");
+        assert!(
+            !is_usable_auth_helper(&stub_path),
+            "empty non-executable placeholder should be rejected"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_helper_accepts_non_empty_executable_binary_path() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let helper_path = temp.path().join("buzz-acp");
+        fs::write(&helper_path, b"#!/bin/sh\nexit 0\n").expect("write helper");
+        fs::set_permissions(&helper_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod executable helper");
+        assert!(
+            is_usable_auth_helper(&helper_path),
+            "non-empty executable helper should be accepted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_helper_rejects_empty_executable_stub() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let stub_path = temp.path().join("buzz-acp");
+        fs::write(&stub_path, []).expect("write empty executable stub");
+        fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod executable empty stub");
+        assert!(
+            !is_usable_auth_helper(&stub_path),
+            "empty executable placeholder should be rejected"
         );
     }
 


### PR DESCRIPTION
## What this changes

Fixes a dev-build regression where an adjacent `buzz-acp` sidecar stub (0-byte/non-executable) shadows the real helper and causes onboarding auth discovery to fail as **"Sign-in unavailable"**.

### Implementation

- In `desktop/src-tauri/src/commands/agent_auth.rs`, change helper selection from:
  - `path.exists()`
- To:
  - `is_usable_auth_helper(path)`

`is_usable_auth_helper` now requires:
- path metadata can be read
- is a regular file
- file is non-empty
- on Unix, executable bit is set

If the adjacent helper is unusable, we correctly fall back to `resolve_command("buzz-acp")`.

## Tests

Added regression tests in `agent_auth.rs`:
- rejects empty non-executable stub
- rejects empty executable stub
- accepts non-empty executable helper

## Verification run

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml auth_helper_ -- --nocapture`

## Issue

Closes #4747
