### PR TITLE
fix: adopt the native macOS app lifecycle around hide-to-tray

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -53,8 +53,8 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_22"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = { version = "0.6", default-features = false, features = ["std"] }
 objc2 = { version = "0.6.4", default-features = false }
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSEvent", "NSHapticFeedback", "NSMenu", "NSMenuItem", "NSStatusItem", "block2"] }
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSProcessInfo", "NSString"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSEvent", "NSHapticFeedback", "NSMenu", "NSMenuItem", "NSStatusItem", "block2"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSNotification", "NSOperation", "NSProcessInfo", "NSString", "block2"] }
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }
 security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 window-vibrancy = "0.6"

--- a/desktop/src-tauri/src/app_activation.rs
+++ b/desktop/src-tauri/src/app_activation.rs
@@ -1,0 +1,74 @@
+//! Restores the main window when Buzz becomes active with nothing visible.
+//!
+//! macOS surfaces Dock-icon clicks as `applicationShouldHandleReopen:` (tao
+//! forwards it as `RunEvent::Reopen`), but Cmd+Tab and other app-switcher
+//! activations only post `NSApplicationDidBecomeActiveNotification`.
+//! Without an observer for it, switching back to a hidden-to-tray Buzz
+//! brings up just the menu bar and no window, where every standard macOS
+//! app re-presents one. The observer shows the main window whenever the
+//! app becomes active with no visible webview window, gated on
+//! `initial_window::INITIAL_REVEAL_DONE` so launch-time activation cannot
+//! preempt the deliberate geometry-settled first reveal.
+
+use std::ptr::NonNull;
+use std::sync::atomic::Ordering;
+
+use crate::initial_window::INITIAL_REVEAL_DONE;
+use crate::tray_menu::show_main_window;
+
+/// Whether an app activation should re-present the main window.
+///
+/// Minimized-only counts as "nothing visible" (`NSWindow.isVisible` is
+/// false while miniaturized), matching how Cmd+Tab into a standard app
+/// with only minimized windows de-miniaturizes one.
+fn should_restore(initial_reveal_done: bool, any_window_visible: bool) -> bool {
+    initial_reveal_done && !any_window_visible
+}
+
+pub fn init<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
+    use block2::RcBlock;
+    use objc2_app_kit::NSApplicationDidBecomeActiveNotification;
+    use objc2_foundation::{NSNotification, NSNotificationCenter};
+    use tauri::Manager;
+
+    let app = app_handle.clone();
+    let block = RcBlock::new(move |_: NonNull<NSNotification>| {
+        let any_visible = app
+            .webview_windows()
+            .values()
+            .any(|window| window.is_visible().unwrap_or(false));
+        if should_restore(INITIAL_REVEAL_DONE.load(Ordering::Acquire), any_visible) {
+            show_main_window(&app);
+        }
+    });
+
+    // SAFETY: reading the notification-name static is sound — AppKit
+    // exports it for the process lifetime. For the registration: a `None`
+    // object matches any poster, a `None` queue delivers on the posting
+    // thread (the main thread for application lifecycle notifications),
+    // and the block is sendable — it captures only a cloned `AppHandle`,
+    // which is `Send + Sync`. The observer token is deliberately leaked:
+    // the observer must live for the whole app lifetime.
+    let token = unsafe {
+        NSNotificationCenter::defaultCenter().addObserverForName_object_queue_usingBlock(
+            Some(NSApplicationDidBecomeActiveNotification),
+            None,
+            None,
+            &block,
+        )
+    };
+    std::mem::forget(token);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restores_only_after_reveal_and_only_when_nothing_is_visible() {
+        assert!(should_restore(true, false));
+        assert!(!should_restore(true, true));
+        assert!(!should_restore(false, false));
+        assert!(!should_restore(false, true));
+    }
+}

--- a/desktop/src-tauri/src/app_menu.rs
+++ b/desktop/src-tauri/src/app_menu.rs
@@ -5,42 +5,111 @@
 //! `close_window` item in both the File and Window submenus, and muda gives
 //! that item a Cmd+W key equivalent bound to `performClose:`.
 //!
-//! Two consequences, both wrong for Buzz:
+//! An earlier revision of this module removed both `close_window` items,
+//! because macOS resolves a menu key equivalent before the webview receives
+//! any key event, so Buzz Term could never bind Cmd+W to "close this
+//! terminal tab" while the accelerator was claimed here. That cure traded a
+//! terminal-local conflict for an app-wide regression: Cmd+W is the standard
+//! macOS chord for "close the focused window", and with the item gone it did
+//! nothing anywhere else in the app. For a tray-resident app "close" means
+//! hide-to-tray (the `CloseRequested` interception in `lib.rs`), exactly the
+//! Cmd+W behavior of other tray-resident chat apps.
 //!
-//! 1. `CloseRequested` on the main window is intercepted in `lib.rs` and turned
-//!    into hide-to-tray, so Cmd+W never closed a window -- it hid the whole
-//!    app. That is already redundant with Cmd+H (Hide), which stays.
-//! 2. macOS resolves a menu key equivalent before the webview receives any key
-//!    event, so Buzz Term could never bind Cmd+W to "close this terminal tab"
-//!    while the accelerator was claimed here.
-//!
-//! So this module builds the standard menu minus both `close_window` items.
-//! Everything else matches `Menu::default()` deliberately: the goal is to drop
-//! one item, not to design a menu.
-//!
-//! If hide-on-Cmd+W is ever wanted back in Buzz mode, the revisit path is to
-//! restore the item and disable it while the terminal owns input (a disabled
-//! item does not consume its key equivalent) -- at the cost of an owner->Rust
-//! IPC hop this approach does not need.
+//! So the menu now restores File > Close Window as a *custom* item
+//! (predefined items cannot be toggled after creation) and Buzz Term
+//! disables it for exactly as long as it owns the keyboard, via the
+//! `set_close_window_menu_enabled` command: a disabled menu item does not
+//! consume its key equivalent, so Cmd+W falls through to the webview and the
+//! terminal's close-tab chord (`matchTabChord` in `terminalState.ts`) runs.
+//! Everything else still mirrors `Menu::default()` deliberately; the Window
+//! submenu's duplicate close item is not restored because File is the
+//! chord's canonical home.
 
 #[cfg(target_os = "macos")]
 use tauri::menu::{
-    AboutMetadata, Menu, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
+    AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
 };
 #[cfg(target_os = "macos")]
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri::{Builder, Runtime};
+
+/// Menu id for File > Close Window.
+#[cfg(target_os = "macos")]
+const CLOSE_WINDOW_ID: &str = "close-window";
+
+/// Handle to the File > Close Window item, managed so
+/// `set_close_window_menu_enabled` can toggle it after the menu is built.
+#[cfg(target_os = "macos")]
+struct CloseWindowMenuItem<R: Runtime>(MenuItem<R>);
 
 /// Installs Buzz's menu, replacing the `Menu::default()` Tauri would otherwise
 /// auto-install. A no-op off macOS, where that default is never created and
 /// the Cmd+W accelerator does not exist.
 pub fn install<R: Runtime>(builder: Builder<R>) -> Builder<R> {
     #[cfg(target_os = "macos")]
-    let builder = builder.menu(build);
+    let builder = builder.menu(build).on_menu_event(|app, event| {
+        if event.id().as_ref() == CLOSE_WINDOW_ID {
+            close_focused_window(app);
+        }
+    });
     builder
 }
 
-/// Mirrors `Menu::default()` with every `close_window` item omitted.
+/// Closes the focused window, falling back to the main window.
+///
+/// `close()` goes through `CloseRequested`, so the main window takes the
+/// hide-to-tray path in `lib.rs` and huddle windows keep their
+/// drawer-restore behavior — the same outcome as clicking the native close
+/// button.
+#[cfg(target_os = "macos")]
+fn close_focused_window<R: Runtime>(app: &AppHandle<R>) {
+    let windows = app.webview_windows();
+    let target = windows
+        .values()
+        .find(|window| window.is_focused().unwrap_or(false))
+        .or_else(|| windows.get("main"));
+    let Some(window) = target else {
+        return;
+    };
+    if let Err(error) = window.close() {
+        eprintln!("buzz-desktop: failed to close window from menu: {error}");
+    }
+}
+
+/// Enables or disables File > Close Window (Cmd+W).
+///
+/// Buzz Term claims Cmd+W to close terminal tabs while it owns the keyboard.
+/// macOS resolves menu key equivalents before the webview sees any key
+/// event, so the item must be disabled for the chord to reach the terminal
+/// at all — a disabled item does not consume its key equivalent. A no-op off
+/// macOS, where this menu is never installed.
+#[tauri::command]
+pub fn set_close_window_menu_enabled<R: Runtime>(
+    app: AppHandle<R>,
+    enabled: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let Some(item) = app.try_state::<CloseWindowMenuItem<R>>() else {
+            return Ok(());
+        };
+        let item = item.0.clone();
+        app.run_on_main_thread(move || {
+            if let Err(error) = item.set_enabled(enabled) {
+                eprintln!("buzz-desktop: failed to set Close Window enabled={enabled}: {error}");
+            }
+        })
+        .map_err(|error| error.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, enabled);
+        Ok(())
+    }
+}
+
+/// Mirrors `Menu::default()` with File > Close Window as a toggleable custom
+/// item and the Window submenu's duplicate close item omitted.
 ///
 /// The Window and Help submenus keep Tauri's well-known ids: `init_app_menu`
 /// looks them up by id to call `set_as_windows_menu_for_nsapp` and
@@ -57,6 +126,15 @@ pub fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         authors: config.bundle.publisher.clone().map(|p| vec![p]),
         ..Default::default()
     };
+
+    let close_window = MenuItem::with_id(
+        app,
+        CLOSE_WINDOW_ID,
+        "Close Window",
+        true,
+        Some("CmdOrCtrl+W"),
+    )?;
+    app.manage(CloseWindowMenuItem(close_window.clone()));
 
     Menu::with_items(
         app,
@@ -76,8 +154,10 @@ pub fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
                     &PredefinedMenuItem::quit(app, None)?,
                 ],
             )?,
-            // `Menu::default()`'s File submenu holds exactly one item on macOS
-            // -- close_window -- so dropping that item drops the submenu too.
+            // `Menu::default()`'s File submenu holds exactly one item on
+            // macOS -- close_window -- restored here as the custom item so
+            // Buzz Term can release the accelerator while it owns Cmd+W.
+            &Submenu::with_items(app, "File", true, &[&close_window])?,
             &Submenu::with_items(
                 app,
                 "Edit",

--- a/desktop/src-tauri/src/app_menu.rs
+++ b/desktop/src-tauri/src/app_menu.rs
@@ -24,18 +24,30 @@
 //! Everything else still mirrors `Menu::default()` deliberately; the Window
 //! submenu's duplicate close item is not restored because File is the
 //! chord's canonical home.
+//!
+//! The app submenu additionally carries the standard Settings… (Cmd+,) and
+//! Check for Updates… items in their HIG positions; both forward to the
+//! webview, where the settings and updater surfaces live.
 
 #[cfg(target_os = "macos")]
 use tauri::menu::{
     AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
 };
 #[cfg(target_os = "macos")]
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tauri::{Builder, Runtime};
 
 /// Menu id for File > Close Window.
 #[cfg(target_os = "macos")]
 const CLOSE_WINDOW_ID: &str = "close-window";
+
+/// Menu id for the app submenu's Settings… (Cmd+,) item.
+#[cfg(target_os = "macos")]
+const SETTINGS_ID: &str = "settings";
+
+/// Menu id for the app submenu's Check for Updates… item.
+#[cfg(target_os = "macos")]
+const CHECK_FOR_UPDATES_ID: &str = "check-for-updates";
 
 /// Handle to the File > Close Window item, managed so
 /// `set_close_window_menu_enabled` can toggle it after the menu is built.
@@ -47,12 +59,29 @@ struct CloseWindowMenuItem<R: Runtime>(MenuItem<R>);
 /// the Cmd+W accelerator does not exist.
 pub fn install<R: Runtime>(builder: Builder<R>) -> Builder<R> {
     #[cfg(target_os = "macos")]
-    let builder = builder.menu(build).on_menu_event(|app, event| {
-        if event.id().as_ref() == CLOSE_WINDOW_ID {
-            close_focused_window(app);
-        }
-    });
+    let builder = builder
+        .menu(build)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            CLOSE_WINDOW_ID => close_focused_window(app),
+            SETTINGS_ID => forward_menu_action(app, "menu-open-settings"),
+            CHECK_FOR_UPDATES_ID => forward_menu_action(app, "menu-check-for-updates"),
+            _ => {}
+        });
     builder
+}
+
+/// Shows the main window and forwards a menu action to its webview.
+///
+/// Settings-flavored items stay clickable while the window is hidden to the
+/// tray (the menu bar is reachable whenever the app is active), so the
+/// window is re-presented first — acting invisibly would look like the item
+/// did nothing.
+#[cfg(target_os = "macos")]
+fn forward_menu_action<R: Runtime>(app: &AppHandle<R>, event: &str) {
+    crate::tray_menu::show_main_window(app);
+    if let Err(error) = app.emit_to("main", event, ()) {
+        eprintln!("buzz-desktop: failed to forward menu action {event}: {error}");
+    }
 }
 
 /// Closes the focused window, falling back to the main window.
@@ -109,7 +138,8 @@ pub fn set_close_window_menu_enabled<R: Runtime>(
 }
 
 /// Mirrors `Menu::default()` with File > Close Window as a toggleable custom
-/// item and the Window submenu's duplicate close item omitted.
+/// item, the Window submenu's duplicate close item omitted, and Settings… /
+/// Check for Updates… added to the app submenu.
 ///
 /// The Window and Help submenus keep Tauri's well-known ids: `init_app_menu`
 /// looks them up by id to call `set_as_windows_menu_for_nsapp` and
@@ -145,6 +175,19 @@ pub fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
                 true,
                 &[
                     &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
+                    &PredefinedMenuItem::separator(app)?,
+                    // Standard app-submenu items macOS users expect between
+                    // About and Services; both forward to the webview (the
+                    // settings UI lives there).
+                    &MenuItem::with_id(
+                        app,
+                        CHECK_FOR_UPDATES_ID,
+                        "Check for Updates…",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &MenuItem::with_id(app, SETTINGS_ID, "Settings…", true, Some("CmdOrCtrl+,"))?,
                     &PredefinedMenuItem::separator(app)?,
                     &PredefinedMenuItem::services(app, None)?,
                     &PredefinedMenuItem::separator(app)?,

--- a/desktop/src-tauri/src/initial_window.rs
+++ b/desktop/src-tauri/src/initial_window.rs
@@ -3,11 +3,27 @@
 #[cfg(target_os = "macos")]
 pub(crate) const INITIAL_RENDER_READY_EVENT: &str = "initial-render-ready";
 
+/// Whether the main window has been deliberately shown this launch — the
+/// first-frame reveal below or an explicit show (tray, Dock reopen). Until
+/// then `app_activation` must ignore activations: the window starts hidden
+/// while saved geometry restores, and the app is already "active" during
+/// launch, so reacting early would preempt the geometry-settled reveal.
+#[cfg(target_os = "macos")]
+pub(crate) static INITIAL_REVEAL_DONE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+pub(crate) fn mark_initial_reveal_done() {
+    INITIAL_REVEAL_DONE.store(true, std::sync::atomic::Ordering::Release);
+}
+
 pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>) {
     if let Err(error) = window.show() {
         eprintln!("buzz-desktop: failed to reveal main window: {error}");
         return;
     }
+    #[cfg(target_os = "macos")]
+    mark_initial_reveal_done();
     if let Err(error) = window.set_focus() {
         eprintln!("buzz-desktop: failed to focus main window: {error}");
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -625,6 +625,7 @@ pub fn run() {
             unarchive_builderlab_community,
             transfer_builderlab_community,
             title_bar_double_click,
+            app_menu::set_close_window_menu_enabled,
             get_identity,
             get_nsec,
             generate_backup_passphrase,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "256"] // Deep Tauri command futures exceed the default layout query depth.
+#[cfg(target_os = "macos")]
+mod app_activation;
 mod app_menu;
 mod app_state;
 mod archive;
@@ -310,6 +312,8 @@ pub fn run() {
             let app_handle = app.handle().clone();
             #[cfg(target_os = "macos")]
             tray_menu::init(&app_handle)?;
+            #[cfg(target_os = "macos")]
+            app_activation::init(&app_handle);
 
             // ── Phase 2: boot-time sentinel wipe ──────────────────────────────
             // Must run before migrations and identity resolution so the wipe
@@ -926,6 +930,20 @@ pub fn run() {
             if let Some(window) = app_handle.get_webview_window("main") {
                 if let Err(error) = window.hide() {
                     eprintln!("buzz-desktop: failed to hide main window: {error}");
+                }
+            }
+            // With nothing left visible, hiding the app yields activation to
+            // the next app — the same handoff as closing the last window of
+            // a standard macOS app. Without it Buzz stays frontmost with
+            // zero windows: menu bar only, dead Cmd+Tab target. Skipped
+            // while another window (e.g. a huddle) is still up.
+            let any_visible = app_handle
+                .webview_windows()
+                .values()
+                .any(|window| window.is_visible().unwrap_or(false));
+            if !any_visible {
+                if let Err(error) = app_handle.hide() {
+                    eprintln!("buzz-desktop: failed to yield activation after close: {error}");
                 }
             }
         }

--- a/desktop/src-tauri/src/tray_menu.rs
+++ b/desktop/src-tauri/src/tray_menu.rs
@@ -232,6 +232,11 @@ pub(crate) fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
         eprintln!("buzz-desktop: failed to show main window from tray: {error}");
         return;
     }
+    // Any deliberate show counts as the initial reveal: from here on,
+    // activating the app with nothing visible may re-present the window
+    // (see `app_activation`).
+    #[cfg(target_os = "macos")]
+    crate::initial_window::mark_initial_reveal_done();
     if let Err(error) = window.set_focus() {
         eprintln!("buzz-desktop: failed to focus main window from tray: {error}");
     }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "app": {
     "windows": [
       {
-        "title": "",
+        "title": "Buzz",
         "width": 800,
         "height": 600,
         "maximized": true,

--- a/desktop/src/app/useSettingsShortcuts.ts
+++ b/desktop/src/app/useSettingsShortcuts.ts
@@ -1,10 +1,14 @@
 import * as React from "react";
+import { isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
+import { useUpdaterContext } from "@/features/settings/hooks/UpdaterProvider";
+import type { SettingsSection } from "@/features/settings/ui/SettingsPanels";
 import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
 
 type UseSettingsShortcutsOptions = {
   onClose: () => void;
-  onOpenSettings: () => void;
+  onOpenSettings: (section?: SettingsSection) => void;
   open?: boolean;
 };
 
@@ -42,4 +46,41 @@ export function useSettingsShortcuts({
       window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [onClose, onOpenSettings, open]);
+
+  // On macOS the native app menu owns these actions: its Settings… item
+  // claims the ⌘, key equivalent (resolved before the webview sees any key
+  // event, so the keydown path above never fires there), and Check for
+  // Updates… has no shortcut at all. Both arrive as Tauri events instead.
+  const { checkForUpdate } = useUpdaterContext();
+  const handleMenuOpenSettings = React.useEffectEvent(() => {
+    if (open) {
+      onClose();
+      return;
+    }
+    onOpenSettings();
+  });
+  // Land on the updates section with the check already running, mirroring
+  // the section's own button.
+  const handleMenuCheckForUpdates = React.useEffectEvent(() => {
+    onOpenSettings("updates");
+    void checkForUpdate();
+  });
+  const enabled = open !== undefined;
+  React.useEffect(() => {
+    if (!enabled || !isTauri()) {
+      return;
+    }
+
+    const unlistenSettings = listen("menu-open-settings", () => {
+      handleMenuOpenSettings();
+    });
+    const unlistenUpdates = listen("menu-check-for-updates", () => {
+      handleMenuCheckForUpdates();
+    });
+
+    return () => {
+      void unlistenSettings.then((unlisten) => unlisten());
+      void unlistenUpdates.then((unlisten) => unlisten());
+    };
+  }, [enabled]);
 }

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -3,10 +3,12 @@ import { ChevronRight, Maximize2, Minimize2, Plus, X } from "lucide-react";
 
 import { useTheme } from "@/shared/theme/ThemeProvider";
 import { cn } from "@/shared/lib/cn";
+import { setCloseWindowMenuEnabled } from "@/shared/lib/closeWindowMenu";
 import { isMacPlatform } from "@/shared/lib/platform";
 import {
   INITIAL_HANDOFF_STATE,
   accumulateScrollLines,
+  closeWindowMenuEnabledFor,
   encodePaste,
   encodeTerminalKey,
   matchTabChord,
@@ -127,6 +129,18 @@ export function TerminalSubstrate({
     [activeSessionId, frame, sessionFrames],
   );
   const [owner, setOwner] = React.useState<"buzz" | "terminal">("buzz");
+  // Release or reclaim the native ⌘W accelerator to match keyboard
+  // ownership; the unmount arm re-enables so a closed terminal never leaves
+  // File > Close Window disabled.
+  React.useEffect(() => {
+    void setCloseWindowMenuEnabled(closeWindowMenuEnabledFor(owner));
+  }, [owner]);
+  React.useEffect(
+    () => () => {
+      void setCloseWindowMenuEnabled(true);
+    },
+    [],
+  );
   const [viewport, setViewport] = React.useState({ columns: 1, rows: 1 });
   const [welcomeVisible, setWelcomeVisible] = React.useState(false);
   const [cursorPainted, setCursorPainted] = React.useState(true);

--- a/desktop/src/features/terminal/terminalState.test.mjs
+++ b/desktop/src/features/terminal/terminalState.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   INITIAL_HANDOFF_STATE,
   accumulateScrollLines,
+  closeWindowMenuEnabledFor,
   encodePaste,
   encodeTerminalKey,
   matchTabChord,
@@ -164,6 +165,11 @@ test("tab chords match the platform's primary modifier only", () => {
     matchTabChord(chord({ metaKey: true, shiftKey: true }), true),
     null,
   );
+});
+
+test("Close Window stays enabled exactly while Buzz owns the keyboard", () => {
+  assert.equal(closeWindowMenuEnabledFor("buzz"), true);
+  assert.equal(closeWindowMenuEnabledFor("terminal"), false);
 });
 
 test("tab stepping wraps and skips tabs whose select button is disabled", () => {

--- a/desktop/src/features/terminal/terminalState.ts
+++ b/desktop/src/features/terminal/terminalState.ts
@@ -109,10 +109,11 @@ export type TabChord = "close" | "new" | "next" | "previous";
  * Ctrl+Shift for exactly this reason) — see the report for why that is scoped
  * out rather than solved here.
  *
- * ⌘W is matched even though macOS currently resolves it as the File > Close
- * Window key equivalent before the webview sees any key event: the accelerator
- * has to be released natively for this arm to ever run, and matching it now
- * means the frontend needs no further change when it is.
+ * ⌘W only reaches this matcher because the File > Close Window key
+ * equivalent is released natively while the terminal owns the keyboard:
+ * macOS resolves an enabled menu accelerator before the webview sees any key
+ * event, so `TerminalSubstrate` disables the item for exactly the ownership
+ * span in which this arm may run (see `closeWindowMenuEnabledFor`).
  */
 export function matchTabChord(
   event: {
@@ -135,6 +136,18 @@ export function matchTabChord(
   if (event.code === "KeyT") return "new";
   if (event.code === "KeyW") return "close";
   return null;
+}
+
+/**
+ * Whether the native File > Close Window (⌘W) item should be enabled for the
+ * given keyboard owner.
+ *
+ * While the terminal owns input the item is disabled so the ⌘W key
+ * equivalent falls through to `matchTabChord`'s close arm instead of hiding
+ * the window; a disabled menu item does not consume its key equivalent.
+ */
+export function closeWindowMenuEnabledFor(owner: "buzz" | "terminal"): boolean {
+  return owner !== "terminal";
 }
 
 /**

--- a/desktop/src/shared/lib/closeWindowMenu.ts
+++ b/desktop/src/shared/lib/closeWindowMenu.ts
@@ -1,0 +1,26 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+/**
+ * Toggles the native File > Close Window (⌘W) menu item.
+ *
+ * Buzz Term claims ⌘W for "close this terminal tab" while it owns the
+ * keyboard. macOS resolves the menu key equivalent before the webview sees
+ * any key event, so the item must be disabled for the chord to reach the
+ * terminal at all — a disabled item does not consume its key equivalent.
+ * No-op outside Tauri; the Rust command is itself a no-op off macOS, where
+ * the menu is never installed.
+ */
+export async function setCloseWindowMenuEnabled(
+  enabled: boolean,
+): Promise<void> {
+  if (!isTauri()) {
+    return;
+  }
+
+  try {
+    await invoke("set_close_window_menu_enabled", { enabled });
+  } catch {
+    // No-op on failure; the item defaults to enabled and a stale menu state
+    // is recoverable by toggling terminal ownership again.
+  }
+}


### PR DESCRIPTION
## Why

Buzz on macOS deviated from standard app behavior in ways that compounded into "the app ignores me" moments (originally reported as Rectangle and ⌘W not working). All of them trace back to the hide-to-tray window model missing its native-lifecycle counterparts:

1. **⌘Tab into Buzz while the window is hidden showed… nothing.** Only the menu bar switched. macOS surfaces Dock-icon clicks as `applicationShouldHandleReopen:` (Tauri's `Reopen` event — already handled), but ⌘Tab and other app-switcher activations only post `NSApplicationDidBecomeActiveNotification`, which nothing observed. Every standard macOS app re-presents a window on activation.
2. **After the window hides, Buzz stayed the active app** — frontmost with zero windows: a menu bar with nothing under it, a dead ⌘Tab target, and window managers like Rectangle resolve their target from the frontmost app's focused window and find none.
3. **The main window had an empty title** (`"title": ""`), so Mission Control, the Window menu, and AX tools showed a nameless window.
4. **No Settings… (⌘,) or Check for Updates… menu items** — standard app-submenu entries users reach for.

## What

- **`app_activation.rs` (new):** observes `NSApplicationDidBecomeActiveNotification` (block2 observer, same pattern and safety posture as `mouse_nav.rs`) and re-presents the main window when the app becomes active with no visible webview window. Gated on the deliberate first reveal (`INITIAL_REVEAL_DONE`, set by the first-frame reveal and by any explicit show) so launch-time self-activation cannot preempt the geometry-settled reveal. Minimized-only counts as "nothing visible", matching how ⌘Tab de-miniaturizes in standard apps.
- **`lib.rs`:** after hide-to-tray on `CloseRequested`, if no other window is visible, `app.hide()` yields activation to the next app — the same handoff as closing the last window of any Mac app. The two changes compose: ⌘W hands focus to the next app; ⌘Tab back re-presents the window.
- **`tauri.conf.json`:** window `title: "Buzz"` (still visually hidden via `hiddenTitle` + overlay title bar).
- **App submenu** gains **Check for Updates…** and **Settings… (⌘,)** in their HIG positions. Both re-present the window and forward events to the webview: Settings toggles the settings route (mirroring the existing webview ⌘, shortcut, which keeps working on non-mac where there is no native menu), Check for Updates lands on Settings → Updates with the check already running.

## Verification on a local build

Tested against a locally built instance (`just desktop-standalone`), driving the real app pid-exactly over the Accessibility API:

- Window AX title is `Buzz` (was empty) — `windowTitles=["Buzz"]`.
- App submenu shows `Check for Updates…` and `Settings…` with cmd char `,`, in HIG positions between About and Services.
- ⌘W (posted to the pid) hides the window to tray; process stays alive; no other window visible afterward.
- The activation observer fires on `NSApplicationDidBecomeActiveNotification` with correct gate values — verified via a temporary log line in the running app: `did-become-active reveal_done=true any_visible=true` (correctly no-oping while a window is visible).
- `show_main_window` re-presents the hidden window (tray path, exercised repeatedly).
- The restore decision (`should_restore`) is unit-tested for all four gate combinations.

**Scope note on Rectangle:** during live verification, the reporter's *residual* "Rectangle can't resize the window" symptom (window visible and focused) turned out to be Rectangle's own stale Accessibility session — restarting Rectangle fixed it, and the window was AX-resizable throughout. This PR's window-manager relevance is limited to the real defect above: the frontmost-with-zero-windows state after close-to-tray, where there is no window for any WM to target.

**Verification gap, called out honestly:** the composed end-to-end gesture — a real ⌘Tab into hidden-window Buzz auto-re-presenting, and the frontmost-app switch after close — cannot be driven programmatically: macOS 14+/Tahoe refuses every synthetic activation route without real user intent (`NSRunningApplication.activate` cooperative-refused, `activateIgnoringOtherApps` a documented no-op, System Events `set frontmost` refused, HID-synthesized Dock clicks filtered). Every constituent link is verified above; the composition is three unit-tested lines. One human ⌘Tab confirms it.

Also not coverable in standalone mode (no community, so `AppShell` and its listeners never mount): the webview side of the Settings…/Check for Updates… events. That path is typechecked and mirrors the existing ⌘, handler; the native side (items present, correct accelerator) is verified above.

**Builds on the ⌘W PR** (https://github.com/block/buzz/pull/4875) — both touch `app_menu.rs`. Opened from a fork, so it targets `main` directly and includes that PR's commit until it merges; once it lands, this diff reduces to the lifecycle changes (the second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
