### PR TITLE
fix(desktop): flush automatic WebSocket Pong

### DIFF
--- a/desktop/src-tauri/src/native_websocket.rs
+++ b/desktop/src-tauri/src/native_websocket.rs
@@ -290,7 +290,23 @@ async fn run_connection<S>(
             }
             incoming = socket.next() => {
                 let message = match incoming {
-                    Some(Ok(message)) => outbound_message(message),
+                    Some(Ok(message)) => {
+                        if matches!(&message, Message::Ping(_)) {
+                            let result = tokio::time::timeout(WRITE_TIMEOUT, socket.flush())
+                                .await
+                                .map_err(|_| "WebSocket Pong flush timed out".to_string())
+                                .and_then(|result| result.map_err(|error| error.to_string()));
+                            if let Err(error) = result {
+                                if let Ok(value) =
+                                    serde_json::to_value(OutboundMessage::Error(error))
+                                {
+                                    let _ = on_message.send(value);
+                                }
+                                break;
+                            }
+                        }
+                        outbound_message(message)
+                    }
                     Some(Err(error)) => OutboundMessage::Error(error.to_string()),
                     None => OutboundMessage::Close(None),
                 };
@@ -406,6 +422,63 @@ mod tests {
             .await
             .expect("live server should observe native socket shutdown")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn idle_connection_replies_to_and_forwards_server_ping() {
+        let manager = WebSocketManager::default();
+        let (client_io, server_io) = duplex(1024);
+        let (client, mut server) = tokio::join!(
+            WebSocketStream::from_raw_socket(client_io, Role::Client, None),
+            WebSocketStream::from_raw_socket(server_io, Role::Server, None),
+        );
+        let (sender, receiver) = mpsc::channel(SEND_QUEUE_CAPACITY);
+        let (message_tx, mut message_rx) = mpsc::unbounded_channel();
+        let on_message = Channel::new(move |body| {
+            let _ = message_tx.send(body);
+            Ok(())
+        });
+        let handle = Arc::new(ConnectionHandle {
+            sender,
+            cancel: CancellationToken::new(),
+            task: Mutex::new(None),
+        });
+        manager.connections.lock().await.insert(1, handle.clone());
+        let task = tauri::async_runtime::spawn(run_connection(
+            1,
+            client,
+            receiver,
+            handle.cancel.clone(),
+            on_message,
+            manager.clone(),
+        ));
+        *handle.task.lock().await = Some(task);
+
+        let payload = b"buzz-heartbeat".to_vec();
+        server
+            .send(Message::Ping(payload.clone().into()))
+            .await
+            .unwrap();
+        let reply = tokio::time::timeout(Duration::from_secs(1), server.next())
+            .await
+            .expect("idle client should answer a relay Ping")
+            .unwrap()
+            .unwrap();
+        assert_eq!(reply, Message::Pong(payload.clone().into()));
+
+        let forwarded = tokio::time::timeout(Duration::from_secs(1), message_rx.recv())
+            .await
+            .expect("relay Ping should still reach the webview")
+            .unwrap();
+        let InvokeResponseBody::Json(json) = forwarded else {
+            panic!("relay Ping should be forwarded as JSON")
+        };
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&json).unwrap(),
+            serde_json::json!({ "type": "Ping", "data": payload })
+        );
+
+        manager.disconnect(1).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- flush `tokio-tungstenite`'s queued automatic Pong when Buzz Desktop's native Tauri socket receives a relay `Ping`
- continue forwarding the Ping to the webview so the existing inbound stall watchdog still records relay activity
- surface Pong flush failures through the existing WebSocket error channel
- add a duplex regression test proving an otherwise-idle desktop connection answers a server Ping

The relay sends a Ping every 30 seconds and closes a connection after three missed Pongs. `tokio-tungstenite` queues an automatic Pong when `read` returns a Ping, but that frame is not put on the wire until the client writes or flushes. The native Desktop loop forwarded the Ping to the webview and immediately waited for the next inbound frame, so an idle client never flushed the queued Pong and was disconnected after roughly 90 seconds.

### Related issue
Related to #4749, specifically the self-hosted Desktop clients with repeated `3 missed pongs` logs and roughly 90-second connections.

### Testing
- `just desktop-tauri-fmt-check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --no-default-features --lib native_websocket::tests -- --nocapture` (7 passed)
- isolated `tokio-tungstenite 0.29` reproduction: no Pong arrives after reading a Ping without another read, write, or flush
