### PR TITLE
fix(mobile): keep the composer alive across an IME swap

### DIFF
--- a/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
+++ b/mobile/lib/features/channels/compose_bar/compose_bar_widget.dart
@@ -122,7 +122,7 @@ class ComposeBar extends HookConsumerWidget {
 
     final appView = View.of(context);
     useEffect(() {
-      final observer = _ComposerKeyboardMetricsObserver(
+      final observer = ComposerKeyboardMetricsObserver(
         view: appView,
         onKeyboardHidden: () {
           collapseComposer();
@@ -130,7 +130,10 @@ class ComposeBar extends HookConsumerWidget {
         },
       );
       WidgetsBinding.instance.addObserver(observer);
-      return () => WidgetsBinding.instance.removeObserver(observer);
+      return () {
+        WidgetsBinding.instance.removeObserver(observer);
+        observer.dispose();
+      };
     }, [appView, focusNode]);
     final resolvedHint =
         hintText ??

--- a/mobile/lib/features/channels/compose_bar/helpers.dart
+++ b/mobile/lib/features/channels/compose_bar/helpers.dart
@@ -2,12 +2,23 @@ part of '../compose_bar.dart';
 
 const _typingThrottleMs = 3000;
 
-class _ComposerKeyboardMetricsObserver with WidgetsBindingObserver {
+/// Switching input methods — most visibly tapping the keyboard's voice-typing
+/// key, which swaps the system keyboard for the speech IME — drops the bottom
+/// inset to zero for a frame or two while the new IME attaches. Treating that
+/// dip as "keyboard hidden" collapsed the composer and unfocused it, and since
+/// the `TextField` is only mounted while expanded, the incoming IME had no
+/// input connection left to dictate into. Wait for the inset to *stay* at zero
+/// before believing it.
+const _keyboardHiddenSettleDelay = Duration(milliseconds: 300);
+
+@visibleForTesting
+class ComposerKeyboardMetricsObserver with WidgetsBindingObserver {
   final FlutterView view;
   final VoidCallback onKeyboardHidden;
   bool _wasVisible;
+  Timer? _hiddenSettleTimer;
 
-  _ComposerKeyboardMetricsObserver({
+  ComposerKeyboardMetricsObserver({
     required this.view,
     required this.onKeyboardHidden,
   }) : _wasVisible = view.viewInsets.bottom > 0;
@@ -15,8 +26,22 @@ class _ComposerKeyboardMetricsObserver with WidgetsBindingObserver {
   @override
   void didChangeMetrics() {
     final isVisible = view.viewInsets.bottom > 0;
-    if (_wasVisible && !isVisible) onKeyboardHidden();
+    if (isVisible) {
+      _hiddenSettleTimer?.cancel();
+      _hiddenSettleTimer = null;
+    } else if (_wasVisible && _hiddenSettleTimer == null) {
+      _hiddenSettleTimer = Timer(_keyboardHiddenSettleDelay, () {
+        _hiddenSettleTimer = null;
+        if (view.viewInsets.bottom > 0) return;
+        onKeyboardHidden();
+      });
+    }
     _wasVisible = isVisible;
+  }
+
+  void dispose() {
+    _hiddenSettleTimer?.cancel();
+    _hiddenSettleTimer = null;
   }
 }
 

--- a/mobile/test/features/channels/composer_keyboard_metrics_observer_test.dart
+++ b/mobile/test/features/channels/composer_keyboard_metrics_observer_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buzz/features/channels/compose_bar.dart';
+
+/// The composer only mounts its `TextField` while expanded, and it collapses
+/// when the keyboard hides. Tapping the keyboard's voice-typing key swaps the
+/// system keyboard for the speech IME, and the bottom inset briefly hits zero
+/// mid-swap — so a naive "inset == 0 means hidden" check tore the composer down
+/// before the speech IME could attach, and dictation silently did nothing.
+void main() {
+  testWidgets('ignores a transient inset drop while an IME swap is in flight', (
+    tester,
+  ) async {
+    var hiddenCount = 0;
+    final observer = ComposerKeyboardMetricsObserver(
+      view: tester.view,
+      onKeyboardHidden: () => hiddenCount++,
+    );
+    addTearDown(observer.dispose);
+    addTearDown(tester.view.resetViewInsets);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 800);
+    observer.didChangeMetrics();
+
+    // The old IME detaches: inset collapses to zero...
+    tester.view.viewInsets = FakeViewPadding.zero;
+    observer.didChangeMetrics();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(
+      hiddenCount,
+      0,
+      reason: 'must not tear the composer down before the swap settles',
+    );
+
+    // ...and the speech IME attaches before the settle delay elapses.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 800);
+    observer.didChangeMetrics();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(hiddenCount, 0);
+  });
+
+  testWidgets('still reports a keyboard that stays hidden', (tester) async {
+    var hiddenCount = 0;
+    final observer = ComposerKeyboardMetricsObserver(
+      view: tester.view,
+      onKeyboardHidden: () => hiddenCount++,
+    );
+    addTearDown(observer.dispose);
+    addTearDown(tester.view.resetViewInsets);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 800);
+    observer.didChangeMetrics();
+
+    tester.view.viewInsets = FakeViewPadding.zero;
+    observer.didChangeMetrics();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(hiddenCount, 1);
+  });
+
+  testWidgets('a disposed observer never fires', (tester) async {
+    var hiddenCount = 0;
+    final observer = ComposerKeyboardMetricsObserver(
+      view: tester.view,
+      onKeyboardHidden: () => hiddenCount++,
+    );
+    addTearDown(tester.view.resetViewInsets);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 800);
+    observer.didChangeMetrics();
+    tester.view.viewInsets = FakeViewPadding.zero;
+    observer.didChangeMetrics();
+
+    observer.dispose();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(hiddenCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary

Keyboard voice typing does nothing in the mobile channel composer: the mic key opens the speech IME, but no text is ever dictated into the message box. Typing on the same keyboard works, and voice typing works normally in other apps on the same device.

Tapping the mic key is an **input-method switch** — the system keyboard tears down and the speech IME attaches. The bottom view inset drops to zero for a frame or two in between. `ComposerKeyboardMetricsObserver` treated that dip as "keyboard hidden" and fired immediately:

```dart
final isVisible = view.viewInsets.bottom > 0;
if (_wasVisible && !isVisible) onKeyboardHidden();
```

`onKeyboardHidden` calls `collapseComposer()` and `focusNode.unfocus()`, and the `TextField` is only mounted while the composer is expanded (`compose_bar/layout.dart`) — so the speech IME came up with no input connection left to dictate into. Other apps are unaffected because their fields stay mounted through the swap.

This waits for the inset to *stay* at zero before believing the keyboard is gone. A genuine dismissal still reports after the settle delay; a transient swap no longer tears the composer down. The observer now owns a timer, so the metrics effect disposes it alongside removing it from the binding.

### Related issue

None found. Searched open/closed issues for "voice typing", "dictation", "composer keyboard", and "IME" — the closest are #2708 and #4166, both desktop voice features rather than this mobile input-connection bug.

### Testing

Three new tests in `composer_keyboard_metrics_observer_test.dart` cover a transient inset drop during an IME swap, a genuine dismissal, and disposal. They were confirmed to **fail against the pre-fix code** (`Expected: <0> Actual: <1>` on the transient-swap case) and pass with the change.

- `flutter analyze` — no issues
- `flutter test` (full mobile suite, via the pre-push hook) — all tests passed

Verified on hardware: a debug build installed side by side on a Samsung SM-S948U (Android, Samsung Keyboard + Google speech IME). Before the change, tapping the mic key collapsed the composer and closed the keyboard. After, the composer stays up and dictated speech lands in the message box and sends normally.