### PR TITLE
feat(desktop): add zcode-acp preset to the harness catalog

### DIFF
--- a/desktop/public/harness-logos/CREDITS.md
+++ b/desktop/public/harness-logos/CREDITS.md
@@ -15,6 +15,7 @@ license permits redistribution.
 | `omp.svg` | [can1357/oh-my-pi](https://github.com/can1357/oh-my-pi) | `667111575ebba136dadfd6989379e7f67e0d40d9` | MIT © 2025 Mario Zechner; © 2025–2026 Can Bölük | `assets/icon.svg` | None |
 | `kimi.png` | [MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli) | `4a550effdfcb29a25a5d325bf935296cc50cd417` | Apache-2.0; NOTICE: Kimi Code CLI © 2025 Moonshot AI | `web/public/logo.png` | None |
 | `grok.svg` | [SpaceXAI brand guidelines](https://x.ai/legal/brand-guidelines) | Retrieved 2026-07-25 | xAI Brand Guidelines: marks may be used to accurately refer to xAI or its services; logos must be used exactly as provided | `SpaceXAI_Grok_Assets.zip` → `Grok_Logomark_Dark.svg` | None |
+| `zcode-acp.svg` | Original placeholder (not derived from a third-party mark) | n/a | CC0-1.0 / public domain (attribution-free) | n/a — authored for this PR | Original monospace "ZC" wordmark on a rounded square so the entry is identifiable until an official Z.ai mark can be bundled under redistribution terms |
 
 ## Inline SVG marks (`RUNTIME_MARKS`)
 

--- a/desktop/public/harness-logos/zcode-acp.svg
+++ b/desktop/public/harness-logos/zcode-acp.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <!-- Original, attribution-free placeholder mark for the zcode-acp preset.
+       Rendered as a monospace "ZC" wordmark on a rounded square so it is
+       legible against any app theme. Replace with an official mark if/when
+       Z.ai grants redistribution. -->
+  <rect x="6" y="6" width="108" height="108" rx="22" fill="#111827" />
+  <text x="60" y="78" font-family="ui-monospace, SFMono-Regular, Menlo, monospace"
+        font-size="52" font-weight="700" text-anchor="middle" fill="#f9fafb">ZC</text>
+</svg>

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -174,6 +174,19 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "zcode-acp",
+        label: "ZCode",
+        command: "zcode-acp",
+        args: &[],
+        install_instructions_url: "https://github.com/jpalmae/zcode-acp",
+        install_hint: "Buzz talks to ZCode through the zcode-acp ACP adapter, \
+            which drives the ZCode CLI (`zcode.cjs`) over its stdio app-server. \
+            Follow the setup guide to install the adapter so the zcode-acp \
+            command is on your PATH, and run `zcode login` once to configure \
+            a model provider.",
+        underlying_cli: Some("zcode"),
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.

--- a/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
+++ b/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
@@ -25,6 +25,7 @@ export const PRESET_LOGOS: Record<string, string> = {
   amp: "/harness-logos/amp.png",
   hermes: "/harness-logos/hermes.png",
   openclaw: "/harness-logos/openclaw.svg",
+  "zcode-acp": "/harness-logos/zcode-acp.svg",
 };
 
 function isBuzzRuntime(runtime: AcpRuntimeCatalogEntry): boolean {


### PR DESCRIPTION
Following up on #3131 (closed as superseded by the harness catalog shipped in v0.5.0 / #2773), this adds `zcode-acp` as a tier-2 preset so ZCode is one-click discoverable in the Desktop runtime gallery — the data-entry PR @wpfleger96 suggested in [#3131 (comment)](https://github.com/block/buzz/pull/3131#issuecomment-).

## What

`zcode-acp` is a standalone ACP adapter (mirroring `amp-acp` / `hermes-acp`) that drives the ZCode CLI through its stdio `app-server`. It speaks ACP v1 directly, so no other Buzz-side change is needed beyond this preset entry.

- Adapter repo: https://github.com/jpalmae/zcode-acp (Apache-2.0)
- ACP parity with codex-acp: streaming text + reasoning, tool calls (`tool.updated` → `ToolCall`/`ToolCallUpdate`), `session/requestPermission` bridged bidirectionally, `authenticate`/`logout` (Z.AI OAuth init/poll + credential store compatible with `zcode login`), `UsageUpdate`.

## Changes (small data-entry, as suggested)

| File | Change |
| --- | --- |
| `desktop/src-tauri/src/managed_agents/discovery/presets.rs` | One new `PresetHarness` entry in `PRESET_HARNESSES`, shaped exactly like `amp`: `command: \"zcode-acp\"`, `args: &[]`, `underlying_cli: Some(\"zcode\")` (so Desktop reports `AdapterMissing` when the ZCode CLI is present but the adapter is not). |
| `desktop/src/features/onboarding/ui/RuntimeIcon.tsx` | Map `\"zcode-acp\"` → `/harness-logos/zcode-acp.svg` in `PRESET_LOGOS` (satisfies `presetLogos.test.mjs`). |
| `desktop/public/harness-logos/zcode-acp.svg` | **Original, CC0/public-domain placeholder** — a monospace \"ZC\" wordmark on a rounded square. Not derived from any third-party mark, so there are no trademark/redistribution concerns. Happy to swap in an official Z.ai mark under redistribution terms if/when one is provided. |
| `desktop/public/harness-logos/CREDITS.md` | Provenance row for the placeholder. |

## Why `underlying_cli: Some(\"zcode\")`

`zcode-acp` is an adapter that spawns `node zcode.cjs ...` — i.e. it wraps a separately-installed vendor bundle. Mirroring `amp` (which sets `underlying_cli: Some(\"amp\")`), this makes Desktop distinguish *“ZCode installed but the adapter missing”* from *“neither installed”*, surfacing the right install guidance.

## Verification

- `presetLogos.test.mjs` assertions replicated locally (same regex the test uses): every `PRESET_HARNESSES` id has either an inline `RUNTIME_MARKS` entry or a `PRESET_LOGOS` entry whose file exists on disk, and there are no orphan `PRESET_LOGOS` keys. ✓
- The new preset entry is byte-for-byte the same shape as the existing `amp` preset (same fields, same order, trailing comma), so it compiles under the crate's `rustfmt`/clippy gates. The full `cargo check -p buzz-desktop` requires a prebuilt `buzz-acp` binary in `build.rs` that isn't available outside the release pipeline, so I could not run it end-to-end locally — but the change is additive data-only and mirrors a sibling.

## Out of scope

- The placeholder logo is intentionally neutral. If maintainers prefer a different treatment (e.g. leave it as the generic terminal-glyph fallback by not adding a logo at all and special-casing it like `codex`), happy to adjust.
- Headless `buzz-acp` already works without this PR (per #3131 feedback); this PR is purely about Desktop discoverability.