### PR TITLE
feat(desktop): introduce .buzzteam files for sharing agent teams

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -55,7 +55,7 @@ mod qr_download;
 mod relay_members;
 mod relay_reconnect;
 mod social;
-mod team_snapshot;
+pub(crate) mod team_snapshot;
 mod teams;
 mod updater;
 mod window_chrome;

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -32,7 +32,7 @@ pub(crate) const MAX_TEAM_SNAPSHOT_PNG_BYTES: usize = 50 * 1024 * 1024;
 const PNG_MAGIC: [u8; 4] = [0x89, 0x50, 0x4e, 0x47];
 const ZIP_MAGIC_PREFIX: [u8; 2] = [0x50, 0x4b];
 const LEGACY_TEAM_ERROR: &str =
-    "Legacy team files are no longer supported. Export a buzz-team-snapshot v1 .team.json or .team.png instead.";
+    "Legacy team files are no longer supported. Export a buzz-team-snapshot v1 .buzzteam or .team.png instead.";
 
 /// Decode a canonical team snapshot, rejecting retired flat team JSON and
 /// persona-pack ZIP files with a migration-oriented error.
@@ -72,6 +72,14 @@ pub(crate) fn decode_team_snapshot_from_bytes(file_bytes: &[u8]) -> Result<TeamS
     }
 
     decode_team_snapshot_json(file_bytes)
+}
+
+fn snapshot_file_name(slug: &str, is_png: bool) -> String {
+    if is_png {
+        format!("{slug}.team.png")
+    } else {
+        format!("{slug}.buzzteam")
+    }
 }
 
 fn parse_format_is_png(format: &str) -> Result<bool, String> {
@@ -388,16 +396,16 @@ async fn materialize_team_snapshot_bytes(
                 "Team snapshot exceeds the 50 MiB size limit for .team.png files.".to_string(),
             );
         }
-        (bytes, format!("{slug}.team.png"))
+        (bytes, snapshot_file_name(&slug, true))
     } else {
         let bytes = encode_team_snapshot_json(&snapshot)
-            .map_err(|e| format!("Failed to encode .team.json: {e}"))?;
+            .map_err(|e| format!("Failed to encode .buzzteam: {e}"))?;
         if bytes.len() > MAX_TEAM_SNAPSHOT_JSON_BYTES {
             return Err(
-                "Team snapshot exceeds the 25 MiB size limit for .team.json files.".to_string(),
+                "Team snapshot exceeds the 25 MiB size limit for .buzzteam files.".to_string(),
             );
         }
-        (bytes, format!("{slug}.team.json"))
+        (bytes, snapshot_file_name(&slug, false))
     };
     Ok(EncodedTeamSnapshotPayload {
         file_bytes,
@@ -431,8 +439,8 @@ pub async fn export_team_snapshot(
         save_bytes_with_dialog(
             &app,
             &payload.file_name,
-            "Team snapshot",
-            &["json"],
+            "Buzz team",
+            &["buzzteam"],
             &payload.file_bytes,
         )
         .await

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -38,6 +38,18 @@ fn member(name: &str) -> AgentSnapshot {
     }
 }
 
+#[test]
+fn json_team_snapshot_uses_buzzteam_file_name() {
+    assert_eq!(
+        snapshot_file_name("review-team", false),
+        "review-team.buzzteam"
+    );
+    assert_eq!(
+        snapshot_file_name("review-team", true),
+        "review-team.team.png"
+    );
+}
+
 fn snapshot(members: Vec<AgentSnapshot>) -> TeamSnapshot {
     TeamSnapshot {
         format: FORMAT_DISCRIMINATOR.to_string(),

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod migration;
 #[cfg(test)]
 mod model_tests;
 mod models;
+mod native_team_snapshot;
 mod native_websocket;
 mod nostr_bind;
 pub mod nostr_convert;
@@ -70,6 +71,11 @@ use managed_agents::{
 };
 #[cfg(not(feature = "mesh-llm"))]
 use mesh_llm_stubs::*;
+use native_team_snapshot::{
+    acknowledge_pending_native_team_snapshot, enqueue_startup_buzzteam_paths, handle_opened_urls,
+    handle_single_instance_args, read_pending_native_team_snapshot,
+    take_pending_native_team_snapshot, PendingNativeTeamSnapshots,
+};
 #[cfg(all(feature = "mesh-llm", target_os = "macos"))]
 use shutdown::{hard_exit_after_mesh_shutdown, relaunch_after_mesh_shutdown};
 use shutdown::{is_restart_request, shut_down_app};
@@ -111,17 +117,11 @@ pub fn run() {
         }
     }
     let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
-            // Focus the existing window when a duplicate instance launches.
-            if let Some(w) = app.get_webview_window("main") {
-                let _ = w.set_focus();
-            }
-            // Forward any deep link URLs from the duplicate launch.
-            for arg in &argv {
-                if arg.starts_with("buzz://") {
-                    handle_deep_link_url(app, arg);
-                }
-            }
+        .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+            // Preserve upstream duplicate-launch behavior before routing
+            // deep links or opened .buzzteam files from the new instance.
+            native_team_snapshot::focus_main_window(app);
+            handle_single_instance_args(app, &argv, &cwd);
         }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())
@@ -302,12 +302,18 @@ pub fn run() {
         .manage(build_app_state())
         .manage(ClipboardState::new())
         .manage(PendingCommunityDeepLinks::default())
+        .manage(PendingNativeTeamSnapshots::default())
         .manage(BuilderlabSession::default())
         .manage(BuilderlabLogin::default())
         .manage(commands::pairing::PairingHandle::new())
         .manage(terminal_runtime::TerminalSessions::default())
         .setup(move |app| {
             let app_handle = app.handle().clone();
+            let startup_argv = std::env::args().collect::<Vec<_>>();
+            let startup_cwd = std::env::current_dir()
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            enqueue_startup_buzzteam_paths(&app_handle, &startup_argv, &startup_cwd);
             #[cfg(target_os = "macos")]
             tray_menu::init(&app_handle)?;
 
@@ -611,6 +617,9 @@ pub fn run() {
             terminal_runtime::terminal_focus,
             take_pending_community_deep_link,
             acknowledge_pending_community_deep_link,
+            take_pending_native_team_snapshot,
+            read_pending_native_team_snapshot,
+            acknowledge_pending_native_team_snapshot,
             start_builderlab_login,
             cancel_builderlab_login,
             get_builderlab_auth,
@@ -912,6 +921,8 @@ pub fn run() {
     let run_shutdown_done = Arc::clone(&shutdown_done);
     let restart_requested = Arc::new(AtomicBool::new(false));
     app.run(move |app_handle, event| match event {
+        #[cfg(target_os = "macos")]
+        RunEvent::Opened { urls } => handle_opened_urls(app_handle, urls),
         #[cfg(target_os = "macos")]
         RunEvent::Reopen { .. } => show_main_window(app_handle),
         #[cfg(target_os = "macos")]

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -5,7 +5,7 @@
 //! reuses the existing `AgentSnapshot` type from `agent_snapshot.rs`.
 //!
 //! Two encodings:
-//!   - `.team.json` — canonical; supports memory when selected.
+//!   - `.buzzteam` — canonical JSON; supports memory when selected.
 //!   - `.team.png` — 1×1 placeholder PNG with manifest in a `buzz_team_snapshot`
 //!     tEXt chunk; supports memory when selected. Since `TeamRecord` has no
 //!     team-level avatar, the image body is always the 1×1 placeholder; member
@@ -71,7 +71,7 @@ pub struct TeamSnapshotMeta {
 
 /// The top-level `buzz-team-snapshot v1` manifest.
 ///
-/// Serializes to / from JSON. Embedded in `.team.json` directly, or in the
+/// Serializes to / from JSON. Embedded in `.buzzteam` directly, or in the
 /// `buzz_team_snapshot` tEXt chunk of a `.team.png` (base64-encoded).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/desktop/src-tauri/src/native_team_snapshot.rs
+++ b/desktop/src-tauri/src/native_team_snapshot.rs
@@ -1,0 +1,336 @@
+use std::{
+    collections::VecDeque,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+use url::Url;
+
+use crate::commands::team_snapshot::MAX_TEAM_SNAPSHOT_JSON_BYTES;
+
+pub(crate) const NATIVE_TEAM_SNAPSHOT_OPENED_EVENT: &str = "native-team-snapshot-opened";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PendingNativeTeamSnapshot {
+    id: String,
+    file_name: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingNativeTeamSnapshotEntry {
+    id: String,
+    path: Option<PathBuf>,
+    file_name: String,
+    error: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct PendingNativeTeamSnapshots(Mutex<VecDeque<PendingNativeTeamSnapshotEntry>>);
+
+impl PendingNativeTeamSnapshots {
+    fn enqueue(&self, pending: PendingNativeTeamSnapshotEntry) {
+        let mut queue = self.0.lock().expect("native team snapshot queue poisoned");
+        if queue.iter().any(|entry| {
+            entry.path == pending.path
+                && entry.file_name == pending.file_name
+                && entry.error == pending.error
+        }) {
+            return;
+        }
+        queue.push_back(pending);
+    }
+
+    fn first(&self) -> Option<PendingNativeTeamSnapshot> {
+        self.0
+            .lock()
+            .expect("native team snapshot queue poisoned")
+            .front()
+            .map(|entry| PendingNativeTeamSnapshot {
+                id: entry.id.clone(),
+                file_name: entry.file_name.clone(),
+                error: entry.error.clone(),
+            })
+    }
+
+    fn read(&self, id: &str) -> Result<(String, Vec<u8>), String> {
+        let queue = self.0.lock().expect("native team snapshot queue poisoned");
+        let entry = queue
+            .front()
+            .filter(|entry| entry.id == id)
+            .ok_or_else(|| "Unknown or no-longer-pending team snapshot request.".to_string())?;
+        if let Some(error) = &entry.error {
+            return Err(error.clone());
+        }
+        let path = entry
+            .path
+            .as_deref()
+            .ok_or_else(|| "Opened team snapshot has no readable file path.".to_string())?;
+        read_buzzteam(path, &entry.file_name)
+    }
+
+    fn acknowledge(&self, id: &str) -> bool {
+        let mut queue = self.0.lock().expect("native team snapshot queue poisoned");
+        if queue.front().is_some_and(|entry| entry.id == id) {
+            queue.pop_front();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NativeTeamSnapshotBytes {
+    file_name: String,
+    file_bytes: Vec<u8>,
+}
+
+fn is_buzzteam_name(file_name: &str) -> bool {
+    file_name.to_ascii_lowercase().ends_with(".buzzteam")
+}
+
+fn read_buzzteam(path: &Path, file_name: &str) -> Result<(String, Vec<u8>), String> {
+    if !is_buzzteam_name(file_name) {
+        return Err("Opened file is not a .buzzteam snapshot.".to_string());
+    }
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| format!("Failed to inspect opened team snapshot: {error}"))?;
+    if !metadata.is_file() {
+        return Err("Opened team snapshot is not a regular file.".to_string());
+    }
+    if metadata.len() > (MAX_TEAM_SNAPSHOT_JSON_BYTES as u64) {
+        return Err("Opened team snapshot exceeds the 25 MiB limit.".to_string());
+    }
+
+    let mut file = File::open(path)
+        .map_err(|error| format!("Failed to read opened team snapshot: {error}"))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take((MAX_TEAM_SNAPSHOT_JSON_BYTES as u64) + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Failed to read opened team snapshot: {error}"))?;
+    if bytes.len() > MAX_TEAM_SNAPSHOT_JSON_BYTES {
+        return Err("Opened team snapshot exceeds the 25 MiB limit.".to_string());
+    }
+    Ok((file_name.to_owned(), bytes))
+}
+
+fn queue_opened_file(
+    app: &AppHandle,
+    path: Option<PathBuf>,
+    file_name: String,
+    error: Option<String>,
+) {
+    let pending = PendingNativeTeamSnapshotEntry {
+        id: uuid::Uuid::new_v4().to_string(),
+        path,
+        file_name,
+        error,
+    };
+    app.state::<PendingNativeTeamSnapshots>().enqueue(pending);
+    focus_main_window(app);
+    let _ = app.emit(NATIVE_TEAM_SNAPSHOT_OPENED_EVENT, ());
+}
+
+pub(crate) fn focus_main_window<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Err(error) = window.unminimize() {
+        eprintln!("buzz-desktop: failed to unminimize main window: {error}");
+    }
+    if let Err(error) = window.show() {
+        eprintln!("buzz-desktop: failed to show main window: {error}");
+    }
+    if let Err(error) = window.set_focus() {
+        eprintln!("buzz-desktop: failed to focus main window: {error}");
+    }
+}
+
+pub(crate) fn handle_native_team_snapshot_url(app: &AppHandle, url: &Url) {
+    match url.to_file_path() {
+        Ok(path) => handle_native_team_snapshot_path(app, path),
+        Err(()) => queue_opened_file(
+            app,
+            None,
+            "opened-file".to_string(),
+            Some("Opened team snapshot URL is not a local file.".to_string()),
+        ),
+    }
+}
+
+pub(crate) fn handle_native_team_snapshot_path(app: &AppHandle, path: PathBuf) {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("opened-file")
+        .to_owned();
+    if !is_buzzteam_name(&file_name) {
+        queue_opened_file(
+            app,
+            None,
+            file_name,
+            Some("Opened file is not a .buzzteam snapshot.".to_string()),
+        );
+        return;
+    }
+    queue_opened_file(app, Some(path), file_name, None);
+}
+
+fn buzzteam_path_from_arg(arg: &str, cwd: &str) -> Option<PathBuf> {
+    let path = Path::new(arg);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        Path::new(cwd).join(path)
+    };
+    let is_buzzteam = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(is_buzzteam_name);
+    is_buzzteam.then_some(path)
+}
+
+fn startup_buzzteam_paths<I, S>(argv: I, cwd: &str) -> Vec<PathBuf>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    argv.into_iter()
+        .skip(1)
+        .filter_map(|arg| buzzteam_path_from_arg(arg.as_ref(), cwd))
+        .collect()
+}
+
+pub(crate) fn enqueue_startup_buzzteam_paths(app: &AppHandle, argv: &[String], cwd: &str) {
+    for path in startup_buzzteam_paths(argv, cwd) {
+        handle_native_team_snapshot_path(app, path);
+    }
+}
+
+pub(crate) fn handle_single_instance_args(app: &AppHandle, argv: &[String], cwd: &str) {
+    for arg in argv {
+        if arg.starts_with("buzz://") {
+            crate::deep_link::handle_deep_link_url(app, arg);
+            continue;
+        }
+        if let Some(path) = buzzteam_path_from_arg(arg, cwd) {
+            handle_native_team_snapshot_path(app, path);
+        }
+    }
+}
+
+pub(crate) fn handle_opened_urls(app: &AppHandle, urls: Vec<Url>) {
+    for url in urls {
+        handle_native_team_snapshot_url(app, &url);
+    }
+}
+
+#[tauri::command]
+pub(crate) fn take_pending_native_team_snapshot(
+    pending: State<'_, PendingNativeTeamSnapshots>,
+) -> Option<PendingNativeTeamSnapshot> {
+    pending.first()
+}
+
+#[tauri::command]
+pub(crate) fn read_pending_native_team_snapshot(
+    id: String,
+    pending: State<'_, PendingNativeTeamSnapshots>,
+) -> Result<NativeTeamSnapshotBytes, String> {
+    let (file_name, file_bytes) = pending.read(&id)?;
+    Ok(NativeTeamSnapshotBytes {
+        file_name,
+        file_bytes,
+    })
+}
+
+#[tauri::command]
+pub(crate) fn acknowledge_pending_native_team_snapshot(
+    id: String,
+    pending: State<'_, PendingNativeTeamSnapshots>,
+) -> bool {
+    pending.acknowledge(&id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buzzteam_name_is_required() {
+        assert!(is_buzzteam_name("review.buzzteam"));
+        assert!(is_buzzteam_name("REVIEW.BUZZTEAM"));
+        assert!(!is_buzzteam_name("review.team.json"));
+    }
+
+    #[test]
+    fn pending_snapshots_are_fifo_and_acknowledged_in_order() {
+        let queue = PendingNativeTeamSnapshots::default();
+        queue.enqueue(PendingNativeTeamSnapshotEntry {
+            id: "one".to_owned(),
+            path: None,
+            file_name: "one.buzzteam".to_owned(),
+            error: None,
+        });
+        queue.enqueue(PendingNativeTeamSnapshotEntry {
+            id: "two".to_owned(),
+            path: None,
+            file_name: "two.buzzteam".to_owned(),
+            error: None,
+        });
+        assert_eq!(queue.first().unwrap().id, "one");
+        assert!(!queue.acknowledge("two"));
+        assert!(queue.acknowledge("one"));
+        assert_eq!(queue.first().unwrap().id, "two");
+    }
+
+    #[test]
+    fn unknown_id_does_not_read_or_acknowledge_a_pending_path() {
+        let queue = PendingNativeTeamSnapshots::default();
+        queue.enqueue(PendingNativeTeamSnapshotEntry {
+            id: "one".to_owned(),
+            path: Some(PathBuf::from("/does/not/exist.buzzteam")),
+            file_name: "one.buzzteam".to_owned(),
+            error: None,
+        });
+        assert!(queue.read("unknown").is_err());
+        assert!(!queue.acknowledge("unknown"));
+        assert_eq!(queue.first().unwrap().id, "one");
+    }
+
+    #[test]
+    fn relative_single_instance_buzzteam_path_resolves_against_callback_cwd() {
+        assert_eq!(
+            buzzteam_path_from_arg("imports/review.buzzteam", "/tmp/caller"),
+            Some(PathBuf::from("/tmp/caller/imports/review.buzzteam"))
+        );
+        assert_eq!(buzzteam_path_from_arg("--flag", "/tmp/caller"), None);
+    }
+
+    #[test]
+    fn startup_buzzteam_paths_skips_the_executable_and_uses_the_launch_cwd() {
+        assert_eq!(
+            startup_buzzteam_paths(
+                [
+                    "/Applications/Buzz.app/Contents/MacOS/buzz-desktop",
+                    "imports/review.buzzteam",
+                    "--safe-mode",
+                    "/tmp/second.BUZZTEAM",
+                ],
+                "/tmp/caller",
+            ),
+            vec![
+                PathBuf::from("/tmp/caller/imports/review.buzzteam"),
+                PathBuf::from("/tmp/second.BUZZTEAM"),
+            ],
+        );
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -67,6 +67,19 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "fileAssociations": [
+      {
+        "ext": ["buzzteam"],
+        "name": "Buzz Team",
+        "description": "Buzz team snapshot",
+        "role": "Editor",
+        "rank": "Owner",
+        "exportedType": {
+          "identifier": "xyz.block.buzz.team",
+          "conformsTo": ["public.json"]
+        }
+      }
+    ],
     "macOS": {
       "infoPlist": "Info.plist",
       "entitlements": "Entitlements.plist",

--- a/desktop/src/app/routes/root.tsx
+++ b/desktop/src/app/routes/root.tsx
@@ -1,7 +1,17 @@
 import { createRootRoute } from "@tanstack/react-router";
 
 import { AppShell } from "@/app/AppShell";
+import { NativeTeamSnapshotBridge } from "@/features/agents/NativeTeamSnapshotBridge";
 
 export const Route = createRootRoute({
-  component: AppShell,
+  component: RootRoute,
 });
+
+function RootRoute() {
+  return (
+    <>
+      <NativeTeamSnapshotBridge />
+      <AppShell />
+    </>
+  );
+}

--- a/desktop/src/features/agents/NativeTeamSnapshotBridge.tsx
+++ b/desktop/src/features/agents/NativeTeamSnapshotBridge.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useNavigate } from "@tanstack/react-router";
+
+import { createNativeTeamSnapshotAcknowledgement } from "@/features/agents/nativeTeamSnapshotAcknowledgement";
+import { requestNativeTeamSnapshotError } from "@/features/agents/nativeTeamSnapshotError";
+import { requestOpenSnapshotImport } from "@/features/agents/openSnapshotImportFromUrlEvent";
+import {
+  acknowledgePendingNativeTeamSnapshot,
+  readPendingNativeTeamSnapshot,
+  takePendingNativeTeamSnapshot,
+} from "@/shared/api/tauriTeams";
+
+/** Drains native .buzzteam opens into the route-local Agents importer. */
+export function NativeTeamSnapshotBridge() {
+  const navigate = useNavigate();
+  const drainRunningRef = React.useRef(false);
+  const drainRequestedRef = React.useRef(false);
+  const acknowledgementRef = React.useRef(
+    createNativeTeamSnapshotAcknowledgement(
+      acknowledgePendingNativeTeamSnapshot,
+    ),
+  );
+
+  const goAgents = React.useCallback(
+    () => navigate({ to: "/agents" }),
+    [navigate],
+  );
+
+  const drain = React.useEffectEvent(async () => {
+    if (!acknowledgementRef.current.requestDrain()) return;
+    if (drainRunningRef.current) {
+      drainRequestedRef.current = true;
+      return;
+    }
+    drainRunningRef.current = true;
+    try {
+      while (true) {
+        drainRequestedRef.current = false;
+        const pending = await takePendingNativeTeamSnapshot();
+        if (!pending) return;
+        if (pending.error) {
+          requestNativeTeamSnapshotError(
+            { id: pending.id, message: pending.error },
+            (id) => {
+              void acknowledgementRef.current.acknowledge(id, () => {
+                drainRequestedRef.current = true;
+                void drain();
+              });
+            },
+          );
+          void goAgents();
+          return;
+        }
+        try {
+          const snapshot = await readPendingNativeTeamSnapshot(pending.id);
+          await goAgents();
+          requestOpenSnapshotImport({
+            id: pending.id,
+            fileBytes: snapshot.fileBytes,
+            fileName: snapshot.fileName,
+            snapshotKind: "team",
+            onAccepted: () => {
+              void acknowledgementRef.current.acknowledge(pending.id, () => {
+                if (drainRequestedRef.current) void drain();
+              });
+            },
+            onRejected: (id) => {
+              void acknowledgementRef.current.acknowledge(id, () => {
+                drainRequestedRef.current = true;
+                void drain();
+              });
+            },
+            onReleased: () => {
+              drainRequestedRef.current = true;
+              void drain();
+            },
+          });
+        } catch (error) {
+          requestNativeTeamSnapshotError(
+            {
+              id: pending.id,
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to read opened team snapshot.",
+            },
+            (id) => {
+              void acknowledgementRef.current.acknowledge(id, () => {
+                drainRequestedRef.current = true;
+                void drain();
+              });
+            },
+          );
+          void goAgents();
+          return;
+        }
+        if (!drainRequestedRef.current) return;
+      }
+    } finally {
+      drainRunningRef.current = false;
+      if (drainRequestedRef.current) void drain();
+    }
+  });
+
+  React.useEffect(() => {
+    if (!isTauri()) return;
+    const unlisten = listen("native-team-snapshot-opened", () => {
+      drainRequestedRef.current = true;
+      void drain();
+    });
+    drainRequestedRef.current = true;
+    void drain();
+    return () => {
+      void unlisten.then((stop) => stop());
+    };
+  }, []);
+
+  return null;
+}

--- a/desktop/src/features/agents/nativeTeamSnapshotAcknowledgement.test.mjs
+++ b/desktop/src/features/agents/nativeTeamSnapshotAcknowledgement.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createNativeTeamSnapshotAcknowledgement } from "./nativeTeamSnapshotAcknowledgement.ts";
+
+test("native snapshot acknowledgement resumes only after its FIFO head is removed", async () => {
+  let resolveAcknowledgement;
+  const acknowledgement = new Promise((resolve) => {
+    resolveAcknowledgement = resolve;
+  });
+  const resumed = [];
+  const controller = createNativeTeamSnapshotAcknowledgement(
+    async () => acknowledgement,
+  );
+
+  const pending = controller.acknowledge("first", () => resumed.push("drain"));
+  assert.equal(controller.isAcknowledging(), true);
+  assert.equal(controller.requestDrain(), false);
+  assert.deepEqual(resumed, []);
+
+  resolveAcknowledgement(true);
+  assert.equal(await pending, true);
+  assert.equal(controller.isAcknowledging(), false);
+  assert.deepEqual(resumed, ["drain"]);
+});
+
+test("native snapshot acknowledgement retries the current FIFO head after a false response", async () => {
+  const resumed = [];
+  const controller = createNativeTeamSnapshotAcknowledgement(async () => false);
+
+  assert.equal(
+    await controller.acknowledge("first", () => resumed.push("drain")),
+    false,
+  );
+  assert.deepEqual(resumed, ["drain"]);
+});
+
+test("native snapshot acknowledgement does not replay a head after IPC failure", async () => {
+  const resumed = [];
+  const controller = createNativeTeamSnapshotAcknowledgement(async () => {
+    throw new Error("IPC unavailable");
+  });
+
+  assert.equal(
+    await controller.acknowledge("first", () => resumed.push("drain")),
+    false,
+  );
+  assert.deepEqual(resumed, []);
+});

--- a/desktop/src/features/agents/nativeTeamSnapshotAcknowledgement.ts
+++ b/desktop/src/features/agents/nativeTeamSnapshotAcknowledgement.ts
@@ -1,0 +1,28 @@
+type Acknowledge = (id: string) => Promise<boolean>;
+
+/** Serializes native FIFO removal before allowing the bridge to read again. */
+export function createNativeTeamSnapshotAcknowledgement(
+  acknowledgeNativeSnapshot: Acknowledge,
+) {
+  let acknowledging = false;
+
+  return {
+    async acknowledge(id: string, resumeDrain: () => void): Promise<boolean> {
+      acknowledging = true;
+      const acknowledged = await acknowledgeNativeSnapshot(id).catch(() => {
+        // An IPC failure leaves the native FIFO state unknown. Do not re-read
+        // it and risk duplicating a user-visible import or error.
+        return null;
+      });
+      acknowledging = false;
+      if (acknowledged === null) return false;
+
+      // `false` means this id is no longer the native FIFO head, so it is safe
+      // to check the current head without replaying this request.
+      resumeDrain();
+      return acknowledged;
+    },
+    isAcknowledging: () => acknowledging,
+    requestDrain: () => !acknowledging,
+  };
+}

--- a/desktop/src/features/agents/nativeTeamSnapshotError.test.mjs
+++ b/desktop/src/features/agents/nativeTeamSnapshotError.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  acknowledgeNativeTeamSnapshotError,
+  consumeNativeTeamSnapshotError,
+  markNativeTeamSnapshotErrorDisplayed,
+  requestNativeTeamSnapshotError,
+} from "./nativeTeamSnapshotError.ts";
+
+test("native team snapshot error remains pending until the route acknowledges display", () => {
+  consumeNativeTeamSnapshotError();
+  const acknowledgements = [];
+
+  assert.equal(
+    requestNativeTeamSnapshotError(
+      { id: "native-error", message: "Unreadable snapshot." },
+      (id) => acknowledgements.push(id),
+    ),
+    true,
+  );
+  assert.deepEqual(consumeNativeTeamSnapshotError(), {
+    id: "native-error",
+    message: "Unreadable snapshot.",
+  });
+  assert.deepEqual(acknowledgements, []);
+  assert.equal(markNativeTeamSnapshotErrorDisplayed("native-error"), true);
+  assert.deepEqual(acknowledgements, []);
+
+  assert.equal(acknowledgeNativeTeamSnapshotError("native-error"), true);
+  assert.deepEqual(acknowledgements, ["native-error"]);
+  assert.equal(consumeNativeTeamSnapshotError(), null);
+});

--- a/desktop/src/features/agents/nativeTeamSnapshotError.ts
+++ b/desktop/src/features/agents/nativeTeamSnapshotError.ts
@@ -1,0 +1,59 @@
+/**
+ * Bridges native pre-import failures into the existing Agents action-error
+ * surface. The native queue entry is acknowledged only after AgentsView has
+ * displayed the error for its matching id.
+ */
+
+export type NativeTeamSnapshotError = {
+  id: string;
+  message: string;
+};
+
+const NATIVE_TEAM_SNAPSHOT_ERROR_EVENT = "buzz:native-team-snapshot-error";
+
+let pendingError: NativeTeamSnapshotError | null = null;
+let onDisplayed: ((id: string) => void) | null = null;
+
+export function requestNativeTeamSnapshotError(
+  error: NativeTeamSnapshotError,
+  acknowledge: (id: string) => void,
+): boolean {
+  if (pendingError !== null) return false;
+  pendingError = error;
+  onDisplayed = acknowledge;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(NATIVE_TEAM_SNAPSHOT_ERROR_EVENT));
+  }
+  return true;
+}
+
+export function consumeNativeTeamSnapshotError(): NativeTeamSnapshotError | null {
+  return pendingError;
+}
+
+/** Mark the current error as rendered by the existing Agents error surface. */
+export function markNativeTeamSnapshotErrorDisplayed(id: string): boolean {
+  if (pendingError?.id !== id) return false;
+  return true;
+}
+
+export function acknowledgeNativeTeamSnapshotError(id: string): boolean {
+  if (pendingError?.id !== id) return false;
+  const acknowledge = onDisplayed;
+  pendingError = null;
+  onDisplayed = null;
+  acknowledge?.(id);
+  return true;
+}
+
+export function subscribeNativeTeamSnapshotError(
+  handler: (error: NativeTeamSnapshotError) => void,
+): () => void {
+  function handleError() {
+    if (pendingError) handler(pendingError);
+  }
+  window.addEventListener(NATIVE_TEAM_SNAPSHOT_ERROR_EVENT, handleError);
+  return () => {
+    window.removeEventListener(NATIVE_TEAM_SNAPSHOT_ERROR_EVENT, handleError);
+  };
+}

--- a/desktop/src/features/agents/openSnapshotImportFromUrlEvent.test.mjs
+++ b/desktop/src/features/agents/openSnapshotImportFromUrlEvent.test.mjs
@@ -2,41 +2,107 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  acceptPendingSnapshotImport,
+  claimPendingSnapshotImport,
   consumePendingSnapshotImport,
+  rejectPendingSnapshotImport,
+  releasePendingSnapshotImport,
   requestOpenSnapshotImport,
 } from "./openSnapshotImportFromUrlEvent.ts";
 
-test("openSnapshotImportFromUrlEvent: consume returns null with no pending import", () => {
-  // Reset state from any prior test run.
-  consumePendingSnapshotImport();
+function reset() {
+  while (true) {
+    const pending = consumePendingSnapshotImport();
+    if (!pending) return;
+    claimPendingSnapshotImport(pending.id);
+    acceptPendingSnapshotImport(pending.id);
+    assert.equal(releasePendingSnapshotImport(pending.id), true);
+  }
+}
+
+function team(id) {
+  return {
+    id,
+    fileBytes: [id.length],
+    fileName: `${id}.buzzteam`,
+    snapshotKind: "team",
+  };
+}
+
+test("openSnapshotImportFromUrlEvent: no request produces no pending import", () => {
+  reset();
   assert.equal(consumePendingSnapshotImport(), null);
 });
 
-test("openSnapshotImportFromUrlEvent: request then consume returns payload", () => {
-  consumePendingSnapshotImport(); // clear
-  requestOpenSnapshotImport({ fileBytes: [1, 2, 3], fileName: "x.agent.json" });
-  const payload = consumePendingSnapshotImport();
-  assert.ok(payload !== null);
-  assert.deepEqual(payload.fileBytes, [1, 2, 3]);
-  assert.equal(payload.fileName, "x.agent.json");
+test("openSnapshotImportFromUrlEvent: acceptance retains route ownership until state-clearing release", () => {
+  reset();
+  requestOpenSnapshotImport(team("first"));
+
+  assert.equal(consumePendingSnapshotImport()?.id, "first");
+  assert.equal(claimPendingSnapshotImport("first"), true);
+  assert.equal(acceptPendingSnapshotImport("first"), true);
+  assert.equal(
+    consumePendingSnapshotImport()?.id,
+    "first",
+    "acceptance, result, or confirm error must not release the dialog owner",
+  );
 });
 
-test("openSnapshotImportFromUrlEvent: consume is one-shot and clears pending", () => {
-  consumePendingSnapshotImport(); // clear
-  requestOpenSnapshotImport({ fileBytes: [9], fileName: "y.agent.json" });
-  const first = consumePendingSnapshotImport();
-  const second = consumePendingSnapshotImport();
-  assert.ok(first !== null, "first consume must return payload");
-  assert.equal(second, null, "second consume must return null");
+test("openSnapshotImportFromUrlEvent: serializes two distinct ids until the first dialog closes", () => {
+  reset();
+  requestOpenSnapshotImport(team("first"));
+  requestOpenSnapshotImport(team("second"));
+
+  assert.equal(consumePendingSnapshotImport()?.id, "first");
+  assert.equal(claimPendingSnapshotImport("first"), true);
+  assert.equal(acceptPendingSnapshotImport("first"), true);
+  assert.equal(
+    consumePendingSnapshotImport()?.id,
+    "first",
+    "item two must stay withheld while item one owns preview or result state",
+  );
+
+  assert.equal(releasePendingSnapshotImport("first"), true);
+  assert.equal(consumePendingSnapshotImport()?.id, "second");
+  assert.equal(claimPendingSnapshotImport("second"), true);
+  assert.equal(acceptPendingSnapshotImport("second"), true);
+  assert.equal(releasePendingSnapshotImport("second"), true);
+  assert.equal(consumePendingSnapshotImport(), null);
 });
 
-test("openSnapshotImportFromUrlEvent: double-request replaces pending payload", () => {
-  consumePendingSnapshotImport(); // clear
-  requestOpenSnapshotImport({ fileBytes: [1], fileName: "a.agent.json" });
-  requestOpenSnapshotImport({ fileBytes: [2], fileName: "b.agent.json" });
-  const payload = consumePendingSnapshotImport();
-  assert.ok(payload !== null);
-  // Only the latest request survives — prevents stacking.
-  assert.deepEqual(payload.fileBytes, [2]);
-  assert.equal(payload.fileName, "b.agent.json");
+test("openSnapshotImportFromUrlEvent: failed confirmation keeps the first request until its later dialog close", () => {
+  reset();
+  requestOpenSnapshotImport(team("first"));
+  requestOpenSnapshotImport(team("second"));
+
+  assert.equal(claimPendingSnapshotImport("first"), true);
+  assert.equal(acceptPendingSnapshotImport("first"), true);
+  // Failed confirmation and a successful retry result both leave dialog state owned.
+  assert.equal(consumePendingSnapshotImport()?.id, "first");
+  assert.equal(releasePendingSnapshotImport("first"), true);
+  assert.equal(consumePendingSnapshotImport()?.id, "second");
+});
+
+test("openSnapshotImportFromUrlEvent: preview rejection acknowledges the surfaced failure and unblocks the next request", () => {
+  reset();
+  const rejected = [];
+  requestOpenSnapshotImport({
+    ...team("first"),
+    onRejected: (id) => rejected.push(id),
+  });
+  requestOpenSnapshotImport(team("second"));
+
+  assert.equal(rejectPendingSnapshotImport("first"), true);
+  assert.deepEqual(rejected, ["first"]);
+  assert.equal(consumePendingSnapshotImport()?.id, "second");
+});
+
+test("openSnapshotImportFromUrlEvent: unknown and non-head ids cannot advance the queue", () => {
+  reset();
+  requestOpenSnapshotImport(team("first"));
+  requestOpenSnapshotImport(team("second"));
+
+  assert.equal(acceptPendingSnapshotImport("unknown"), false);
+  assert.equal(releasePendingSnapshotImport("second"), false);
+  assert.equal(consumePendingSnapshotImport()?.id, "first");
 });

--- a/desktop/src/features/agents/openSnapshotImportFromUrlEvent.ts
+++ b/desktop/src/features/agents/openSnapshotImportFromUrlEvent.ts
@@ -1,65 +1,144 @@
 /**
- * App-level event that routes a verified snapshot attachment (fetched
- * in-memory from a timeline card) to the existing AgentsView importer.
- *
- * Pattern mirrors openCreateAgentEvent.ts: a module-level pending payload
- * is set by the requester (the AgentSnapshotCard), consumed exactly once by
- * AgentsView when it mounts or is navigated to, and cleared on consumption
- * or cancel.  No localStorage, no React context — just a module-scoped
- * pending value + a window event for live navigation.
+ * App-level serialized handoff for snapshot imports. A request remains owned
+ * by AgentsView after acceptance until the corresponding dialog closes, so a
+ * later request can never replace a user-visible preview or result dialog.
  */
 
 export type PendingSnapshotImport = {
+  id: string;
   fileBytes: number[];
   fileName: string;
   snapshotKind: "agent" | "team";
 };
 
+type SnapshotImportRequest = Omit<PendingSnapshotImport, "id"> & {
+  id?: string;
+  onAccepted?: () => void;
+  onRejected?: (id: string) => void;
+  onReleased?: () => void;
+};
+
+type PendingSnapshotCallbacks = {
+  onAccepted?: () => void;
+  onRejected?: (id: string) => void;
+  onReleased?: () => void;
+};
+
 const OPEN_SNAPSHOT_IMPORT_EVENT = "buzz:open-snapshot-import";
 
-let pendingImport: PendingSnapshotImport | null = null;
+let nextSnapshotImportId = 0;
+const pendingImports: PendingSnapshotImport[] = [];
+const pendingCallbacks = new Map<string, PendingSnapshotCallbacks>();
+let deliveringId: string | null = null;
+let acceptedId: string | null = null;
 
-/**
- * Enqueue a snapshot import and dispatch the navigation event.
- * The caller must have already fetched and validated the bytes in memory.
- * Clears any prior pending import so double-clicks don't stack.
- */
-export function requestOpenSnapshotImport(payload: PendingSnapshotImport) {
-  pendingImport = {
+function currentPendingImport(): PendingSnapshotImport | null {
+  return pendingImports[0] ?? null;
+}
+
+function nextImportId(): string {
+  nextSnapshotImportId += 1;
+  return `snapshot-import-${nextSnapshotImportId}`;
+}
+
+/** Queue a verified in-memory snapshot import for eventual AgentsView delivery. */
+export function requestOpenSnapshotImport(
+  payload: SnapshotImportRequest,
+): boolean {
+  const request: PendingSnapshotImport = {
+    id: payload.id ?? nextImportId(),
     fileBytes: payload.fileBytes,
     fileName: payload.fileName,
     snapshotKind: payload.snapshotKind,
   };
+  if (pendingImports.some((pending) => pending.id === request.id)) return false;
+
+  pendingCallbacks.set(request.id, {
+    onAccepted: payload.onAccepted,
+    onRejected: payload.onRejected,
+    onReleased: payload.onReleased,
+  });
+  pendingImports.push(request);
   if (typeof window !== "undefined") {
     window.dispatchEvent(new Event(OPEN_SNAPSHOT_IMPORT_EVENT));
   }
+  return true;
 }
 
-/**
- * Consume and clear the pending import — call this in AgentsView's useEffect.
- * Returns the payload if one was waiting, null otherwise.
- */
+/** Peek at the queue head; this does not end route ownership. */
 export function consumePendingSnapshotImport(): PendingSnapshotImport | null {
-  const payload = pendingImport;
-  pendingImport = null;
-  return payload;
+  return currentPendingImport();
+}
+
+/** Claim the pending head before beginning an asynchronous route-local preview. */
+export function claimPendingSnapshotImport(id: string): boolean {
+  if (
+    deliveringId !== null ||
+    acceptedId !== null ||
+    currentPendingImport()?.id !== id
+  ) {
+    return false;
+  }
+  deliveringId = id;
+  return true;
+}
+
+/** Accept the head from exactly one matching route-local consumer. */
+export function acceptPendingSnapshotImport(id: string): boolean {
+  if (deliveringId !== id || currentPendingImport()?.id !== id) return false;
+  deliveringId = null;
+  acceptedId = id;
+  pendingCallbacks.get(id)?.onAccepted?.();
+  return true;
 }
 
 /**
- * Subscribe to the snapshot-import event — call this in AgentsView's useEffect
- * to handle navigations that happen while the view is already mounted.
+ * Remove a preview-rejected head after its route-local error is visibly
+ * surfaced. It was never accepted, so it has no dialog ownership to release.
  */
+export function rejectPendingSnapshotImport(id: string): boolean {
+  if (currentPendingImport()?.id !== id || acceptedId !== null) return false;
+  pendingImports.shift();
+  const callbacks = pendingCallbacks.get(id);
+  pendingCallbacks.delete(id);
+  deliveringId = null;
+  callbacks?.onRejected?.(id);
+  if (typeof window !== "undefined" && pendingImports.length > 0) {
+    window.dispatchEvent(new Event(OPEN_SNAPSHOT_IMPORT_EVENT));
+  }
+  return true;
+}
+
+/**
+ * Release an accepted import only after `teamSnapshotImportState` was cleared
+ * and its dialog closed. Confirmation result/error states never call this.
+ */
+export function releasePendingSnapshotImport(id: string): boolean {
+  if (acceptedId !== id || currentPendingImport()?.id !== id) return false;
+
+  pendingImports.shift();
+  const callbacks = pendingCallbacks.get(id);
+  pendingCallbacks.delete(id);
+  acceptedId = null;
+  callbacks?.onReleased?.();
+  deliveringId = null;
+  if (typeof window !== "undefined" && pendingImports.length > 0) {
+    window.dispatchEvent(new Event(OPEN_SNAPSHOT_IMPORT_EVENT));
+  }
+  return true;
+}
+
+/** Subscribe to delivery opportunities while AgentsView is mounted. */
 export function subscribeSnapshotImport(
   handler: (payload: PendingSnapshotImport) => void,
 ): () => void {
   function handleEvent() {
-    const payload = consumePendingSnapshotImport();
-    if (payload) {
+    const payload = currentPendingImport();
+    if (payload && acceptedId === null && deliveringId === null)
       handler(payload);
-    }
   }
+
   window.addEventListener(OPEN_SNAPSHOT_IMPORT_EVENT, handleEvent);
-  return () => {
+  return () =>
     window.removeEventListener(OPEN_SNAPSHOT_IMPORT_EVENT, handleEvent);
-  };
 }

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -1,9 +1,20 @@
 import * as React from "react";
 import { EllipsisVertical, OctagonX, Settings2 } from "lucide-react";
 import {
+  acceptPendingSnapshotImport,
+  claimPendingSnapshotImport,
   consumePendingSnapshotImport,
+  rejectPendingSnapshotImport,
+  releasePendingSnapshotImport,
   subscribeSnapshotImport,
+  type PendingSnapshotImport,
 } from "@/features/agents/openSnapshotImportFromUrlEvent";
+import {
+  acknowledgeNativeTeamSnapshotError,
+  consumeNativeTeamSnapshotError,
+  markNativeTeamSnapshotErrorDisplayed,
+  subscribeNativeTeamSnapshotError,
+} from "@/features/agents/nativeTeamSnapshotError";
 import { AddAgentToChannelDialog } from "./AddAgentToChannelDialog";
 import { AddTeamToChannelDialog } from "./AddTeamToChannelDialog";
 import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
@@ -102,33 +113,89 @@ export function AgentsView() {
         (value) => value.trim().length > 0,
       ),
   );
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only; personas.handleImportSnapshotFile and teamActions.handleImportTeamSnapshotFile are stable
-  React.useEffect(() => {
-    // Consume a snapshot import that was enqueued before navigation (e.g. from
-    // a timeline AgentSnapshotCard click that navigated here).
-    const pending = consumePendingSnapshotImport();
-    if (pending) {
-      if (pending.snapshotKind === "team") {
-        void teamActions.handleImportTeamSnapshotFile(
-          pending.fileBytes,
-          pending.fileName,
-        );
-      } else {
-        void personas.handleImportSnapshotFile(
-          pending.fileBytes,
-          pending.fileName,
-        );
-      }
-    }
+  const activeSnapshotImportId = React.useRef<string | null>(null);
 
-    return subscribeSnapshotImport(({ fileBytes, fileName, snapshotKind }) => {
-      if (snapshotKind === "team") {
-        void teamActions.handleImportTeamSnapshotFile(fileBytes, fileName);
-      } else {
-        void personas.handleImportSnapshotFile(fileBytes, fileName);
+  const acceptSnapshotImport = React.useCallback(
+    async ({
+      id,
+      fileBytes,
+      fileName,
+      snapshotKind,
+    }: PendingSnapshotImport) => {
+      if (!claimPendingSnapshotImport(id)) return;
+      const accepted =
+        snapshotKind === "team"
+          ? await teamActions.handleImportTeamSnapshotFile(fileBytes, fileName)
+          : await personas.handleImportSnapshotFile(fileBytes, fileName);
+      if (!accepted) {
+        rejectPendingSnapshotImport(id);
+        return;
       }
-    });
+      if (acceptPendingSnapshotImport(id)) {
+        activeSnapshotImportId.current = id;
+      }
+    },
+    [
+      personas.handleImportSnapshotFile,
+      teamActions.handleImportTeamSnapshotFile,
+    ],
+  );
+
+  // Acceptance does not release this queue head: only dialog closure ends
+  // ownership and permits the next snapshot import to be delivered.
+  React.useEffect(() => {
+    const pending = consumePendingSnapshotImport();
+    if (pending) acceptSnapshotImport(pending);
+    return subscribeSnapshotImport(acceptSnapshotImport);
+  }, [acceptSnapshotImport]);
+
+  const releaseActiveSnapshotImport = React.useCallback(() => {
+    const id = activeSnapshotImportId.current;
+    if (id && releasePendingSnapshotImport(id)) {
+      activeSnapshotImportId.current = null;
+    }
   }, []);
+
+  const displayNativeTeamSnapshotError = React.useCallback(
+    ({ id, message }: { id: string; message: string }) => {
+      agents.setActionErrorMessage(message);
+      markNativeTeamSnapshotErrorDisplayed(id);
+    },
+    [agents.setActionErrorMessage],
+  );
+
+  React.useEffect(() => {
+    const pending = consumeNativeTeamSnapshotError();
+    if (pending) displayNativeTeamSnapshotError(pending);
+    return subscribeNativeTeamSnapshotError(displayNativeTeamSnapshotError);
+  }, [displayNativeTeamSnapshotError]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: acknowledgement must run after the action-error state update has rendered
+  React.useEffect(() => {
+    const pending = consumeNativeTeamSnapshotError();
+    if (pending && markNativeTeamSnapshotErrorDisplayed(pending.id)) {
+      acknowledgeNativeTeamSnapshotError(pending.id);
+    }
+  }, [agents.actionErrorMessage]);
+
+  const hadPersonaSnapshotImport = React.useRef(false);
+  const hadTeamSnapshotImport = React.useRef(false);
+
+  React.useEffect(() => {
+    const isOpen = personas.snapshotImportState !== null;
+    if (hadPersonaSnapshotImport.current && !isOpen) {
+      releaseActiveSnapshotImport();
+    }
+    hadPersonaSnapshotImport.current = isOpen;
+  }, [personas.snapshotImportState, releaseActiveSnapshotImport]);
+
+  React.useEffect(() => {
+    const isOpen = teamActions.teamSnapshotImportState !== null;
+    if (hadTeamSnapshotImport.current && !isOpen) {
+      releaseActiveSnapshotImport();
+    }
+    hadTeamSnapshotImport.current = isOpen;
+  }, [teamActions.teamSnapshotImportState, releaseActiveSnapshotImport]);
 
   return (
     <>
@@ -645,7 +712,7 @@ export function AgentsView() {
       ) : null}
       {/* Hidden file input for team snapshot import via file picker */}
       <input
-        accept=".team.json,.team.png"
+        accept=".buzzteam,.team.json,.team.png"
         className="hidden"
         data-testid="team-snapshot-import-input"
         ref={teamImportInputRef}

--- a/desktop/src/features/agents/ui/TeamSnapshotExportDialog.tsx
+++ b/desktop/src/features/agents/ui/TeamSnapshotExportDialog.tsx
@@ -39,7 +39,7 @@ const MEMORY_LEVELS: {
 ];
 
 const FORMAT_OPTIONS: { value: SnapshotFormat; label: string }[] = [
-  { value: "json", label: "JSON" },
+  { value: "json", label: "Buzz team" },
   { value: "png", label: "PNG" },
 ];
 
@@ -57,7 +57,7 @@ export function TeamSnapshotExportDialog({
 }: TeamSnapshotExportDialogProps) {
   const [memoryLevel, setMemoryLevel] =
     React.useState<SnapshotMemoryLevel>("none");
-  const [format, setFormat] = React.useState<SnapshotFormat>("png");
+  const [format, setFormat] = React.useState<SnapshotFormat>("json");
   const shouldReduceMotion = useReducedMotion();
   const showMemoryWarning = memoryLevel !== "none";
   const modalResizeTransition = shouldReduceMotion
@@ -67,7 +67,7 @@ export function TeamSnapshotExportDialog({
   React.useEffect(() => {
     if (open) {
       setMemoryLevel("none");
-      setFormat("png");
+      setFormat("json");
     }
   }, [open]);
 

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -373,12 +373,14 @@ export function usePersonaActions() {
       setSnapshotImportState({ fileBytes, fileName, preview });
       setSnapshotImportResult(null);
       setSnapshotImportConfirmError(null);
+      return true;
     } catch (err) {
       setPersonaErrorMessage(
         err instanceof Error
           ? err.message
           : "Failed to read agent snapshot file.",
       );
+      return false;
     }
   }
 

--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -272,12 +272,14 @@ export function useTeamActions(
       setTeamSnapshotImportState({ fileBytes, fileName, preview });
       setTeamSnapshotImportResult(null);
       setTeamSnapshotImportConfirmError(null);
+      return true;
     } catch (err) {
       actions.setActionErrorMessage(
         err instanceof Error
           ? err.message
           : "Failed to read team snapshot file.",
       );
+      return false;
     }
   }
 

--- a/desktop/src/features/messages/ui/ComposerAttachments.test.mjs
+++ b/desktop/src/features/messages/ui/ComposerAttachments.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSnapshotKind } from "./ComposerAttachments.tsx";
+
+const SHA256 = "a".repeat(64);
+
+function attachment(filename) {
+  return { filename, sha256: SHA256 };
+}
+
+test("getSnapshotKind recognizes .buzzteam without regressing legacy team snapshots", () => {
+  assert.equal(getSnapshotKind(attachment("engineering.buzzteam")), "team");
+  assert.equal(getSnapshotKind(attachment("engineering.team.json")), "team");
+  assert.equal(getSnapshotKind(attachment("engineering.team.png")), "team");
+});
+
+test("getSnapshotKind rejects a .buzzteam attachment without a verified hash", () => {
+  assert.equal(
+    getSnapshotKind({ filename: "engineering.buzzteam", sha256: "short" }),
+    null,
+  );
+});

--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -86,15 +86,21 @@ function formatAttachmentSize(size: number): string {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-type SnapshotKind = "agent" | "team";
+export type SnapshotKind = "agent" | "team";
 
-function getSnapshotKind(attachment: ImetaMedia): SnapshotKind | null {
+export function getSnapshotKind(
+  attachment: Pick<ImetaMedia, "filename" | "sha256">,
+): SnapshotKind | null {
   const filename = attachment.filename?.toLowerCase();
   if (attachment.sha256.length !== 64) return null;
   if (filename?.endsWith(".agent.png") || filename?.endsWith(".agent.json")) {
     return "agent";
   }
-  if (filename?.endsWith(".team.png") || filename?.endsWith(".team.json")) {
+  if (
+    filename?.endsWith(".team.png") ||
+    filename?.endsWith(".team.json") ||
+    filename?.endsWith(".buzzteam")
+  ) {
     return "team";
   }
   return null;

--- a/desktop/src/shared/api/tauriTeams.ts
+++ b/desktop/src/shared/api/tauriTeams.ts
@@ -82,6 +82,17 @@ export type EncodedTeamSnapshotPayload = {
   fileName: string;
 };
 
+export type PendingNativeTeamSnapshot = {
+  id: string;
+  fileName: string;
+  error: string | null;
+};
+
+export type NativeTeamSnapshotBytes = {
+  fileName: string;
+  fileBytes: number[];
+};
+
 export type TeamSnapshotMemberPreview = {
   displayName: string;
   systemPrompt: string | null;
@@ -171,6 +182,29 @@ export async function encodeTeamSnapshotForSend(
       format,
     },
   );
+}
+
+export async function takePendingNativeTeamSnapshot(): Promise<PendingNativeTeamSnapshot | null> {
+  return invokeTauri<PendingNativeTeamSnapshot | null>(
+    "take_pending_native_team_snapshot",
+  );
+}
+
+export async function readPendingNativeTeamSnapshot(
+  id: string,
+): Promise<NativeTeamSnapshotBytes> {
+  return invokeTauri<NativeTeamSnapshotBytes>(
+    "read_pending_native_team_snapshot",
+    { id },
+  );
+}
+
+export async function acknowledgePendingNativeTeamSnapshot(
+  id: string,
+): Promise<boolean> {
+  return invokeTauri<boolean>("acknowledge_pending_native_team_snapshot", {
+    id,
+  });
 }
 
 export async function previewTeamSnapshotImport(

--- a/desktop/src/shared/ui/markdownFileCard.test.mjs
+++ b/desktop/src/shared/ui/markdownFileCard.test.mjs
@@ -304,6 +304,22 @@ test("resolveSnapshotCard: .team.png with image/png returns team snapshot card",
   assert.equal(card.thumb, undefined);
 });
 
+test("resolveSnapshotCard: .buzzteam with sha256 returns team snapshot card", () => {
+  const card = resolveSnapshotCard(
+    {
+      m: "application/json",
+      size: 5000,
+      filename: "my-team.buzzteam",
+      x: SHA256,
+    },
+    JSON_URL,
+    "",
+  );
+  assert.ok(card !== null);
+  assert.equal(card.snapshotKind, "team");
+  assert.equal(card.filename, "my-team.buzzteam");
+});
+
 test("resolveSnapshotCard: plain .team without suffix is not a snapshot", () => {
   const card = resolveSnapshotCard(
     { m: "application/json", filename: "team.json", x: SHA256 },

--- a/desktop/src/shared/ui/markdownFileCard.ts
+++ b/desktop/src/shared/ui/markdownFileCard.ts
@@ -90,8 +90,10 @@ export function resolveSnapshotCard(
   const isPng = lower.endsWith(".agent.png");
   const isTeamJson = lower.endsWith(".team.json");
   const isTeamPng = lower.endsWith(".team.png");
+  const isBuzzTeam = lower.endsWith(".buzzteam");
 
-  if (!isJson && !isPng && !isTeamJson && !isTeamPng) return null;
+  if (!isJson && !isPng && !isTeamJson && !isTeamPng && !isBuzzTeam)
+    return null;
 
   const isAnyPng = isPng || isTeamPng;
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11607,6 +11607,12 @@ export function maybeInstallE2eTauriMocks() {
       case "take_pending_community_deep_link":
         // Mirrors the Rust queue: peek the head; acknowledge removes it.
         return mockPendingCommunityDeepLinks[0] ?? null;
+      case "take_pending_native_team_snapshot":
+        return null;
+      case "read_pending_native_team_snapshot":
+        throw new Error("mock: no native team snapshot is pending");
+      case "acknowledge_pending_native_team_snapshot":
+        return true;
       case "acknowledge_pending_community_deep_link": {
         const { id } = payload as { id: string };
         const index = mockPendingCommunityDeepLinks.findIndex(

--- a/desktop/tests/e2e/team-snapshot.spec.ts
+++ b/desktop/tests/e2e/team-snapshot.spec.ts
@@ -532,5 +532,5 @@ test("team sharing keeps link copy and export in the shared surface", async ({
   ).toHaveText("Team only");
   await expect(
     exportDialog.getByTestId("team-snapshot-format-trigger"),
-  ).toHaveText("PNG");
+  ).toHaveText("Buzz team");
 });


### PR DESCRIPTION
## Summary

- Export canonical team snapshots as `.buzzteam` JSON, retain legacy `.team.json` / `.team.png` import compatibility, and teach attachment/card/import UI about `.buzzteam`.
- Register the owned `xyz.block.buzz.team` UTI and route native macOS open events, cold-start argv, and duplicate-launch argv through an ID-only FIFO into the existing Agents importer.
- Preserve upstream single-instance focus, Terminal/runtime behavior, and first-window reveal behavior. Native acknowledgements serialize FIFO removal before the next import is read.

## Verified evidence

At commit `e9c28c6eb0daf4960130042bcde74521cc815d8f`:

- `env -u BUZZ_AGENT_PROVIDER -u DATABRICKS_HOST -u DATABRICKS_MODEL -u GOOSE_PROVIDER -u GOOSE_MODEL just desktop-ci` passed (the unmodified environment injects `BUZZ_AGENT_PROVIDER=databricks_v2` and fails an unrelated hermetic agent-model test).
- `pnpm build:e2e` and `pnpm exec playwright test tests/e2e/team-snapshot.spec.ts --project=integration` passed: 6/6.
- Packaged arm64 `Buzz.app` plist contains UTI `xyz.block.buzz.team`, extension `buzzteam`, and document role `Editor` / rank `Owner`; bundle build completed.
- Native queue tests cover FIFO acknowledgement and cold-start argv path extraction; frontend tests cover acknowledgement serialization.

## Explicit merge/release blocker: manual Finder runtime proof

Real Finder open behavior is **not verified**. The active managed process is `/Applications/Buzz.app/Contents/MacOS/buzz-desktop` (same `xyz.block.buzz.app` bundle identity), so Finder would dispatch to installed Buzz rather than this worktree bundle. This PR must not merge or release until a disposable macOS user/session proves both:

1. Finder cold-start opening a `.buzzteam` file reaches this rebuilt app and displays the import workflow.
2. Finder opening a `.buzzteam` file while this rebuilt app is already running with a hidden/minimized window focuses it and displays the import workflow.

Windows/Linux runtime file-open behavior is also not manually verified.
