### PR TITLE
fix(desktop): recover agent definition sync

### DIFF
--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -119,7 +119,9 @@ with a TypeScript lookup table or an id comparison in a component.
     toggles await relay acceptance before the UI claims that an agent was
     published or removed. A queued update must stay visibly queued, and the
     catalog itself must render only relay-confirmed publications — never an
-    optimistic local persona.
+    optimistic local persona. Author-owned definition sync backfills on startup
+    and after reconnect, and retries failed history and live-subscription setup;
+    otherwise a device can permanently miss definitions published elsewhere.
 11. **Shared agent access names the consequence where it is selected.** The
    shared respond-to field shows a persistent warning whenever `anyone` **or**
    `allowlist` is selected — both hand the host's access to someone other than
@@ -180,6 +182,8 @@ with a TypeScript lookup table or an id comparison in a component.
 - Rust: `runtime_metadata_env_vars` tests pin spawn-time key application.
 - Rust: persona sharing/retention tests pin relay+owner scoping, durable
   enqueue errors, relay rejection/unavailability, and accepted publication.
+- `lib/usePersonaSync.test.mjs` — author-owned definition history/live sync,
+  arrival-relay scoping, transient retry, and reconnect catch-up.
 
 ## Keep this file true
 

--- a/desktop/src/features/agents/lib/usePersonaSync.test.mjs
+++ b/desktop/src/features/agents/lib/usePersonaSync.test.mjs
@@ -20,10 +20,10 @@ const EXPECTED_KINDS = [
 // Regression guard for the fresh-start backfill gap (F3): a device that comes
 // online AFTER another published gets zero history from a live-only `limit: 0`
 // subscription, because reconnect-replay's since-cursor is undefined until the
-// first live event. `startPersonaSync` MUST do a one-shot history fetch up
-// front, and both the backfill and the live sub MUST carry the deletion kind
-// so tombstones catch up too.
-test("startPersonaSync backfills history including the deletion kind", () => {
+// first live event. `startPersonaSync` MUST do an initial history fetch, and
+// both the backfill and the live sub MUST carry the deletion kind so tombstones
+// catch up too.
+test("startPersonaSync backfills history including the deletion kind", async () => {
   const fetchCalls = [];
   const liveCalls = [];
   mock.method(relayClient, "fetchEvents", (filter) => {
@@ -35,7 +35,11 @@ test("startPersonaSync backfills history including the deletion kind", () => {
     return Promise.resolve(() => Promise.resolve());
   });
 
-  startPersonaSync("owner-pubkey", "wss://relay.example", () => false);
+  const dispose = startPersonaSync(
+    "owner-pubkey",
+    "wss://relay.example",
+    () => false,
+  );
 
   assert.equal(fetchCalls.length, 1, "must do exactly one backfill fetch");
   assert.deepEqual(
@@ -56,6 +60,7 @@ test("startPersonaSync backfills history including the deletion kind", () => {
     "live sub must also carry the deletion kind",
   );
 
+  await dispose();
   mock.reset();
 });
 
@@ -86,7 +91,11 @@ test("startPersonaSync forwards its own relay as the event arrival relay", async
     Promise.resolve(() => Promise.resolve()),
   );
 
-  startPersonaSync("owner-pubkey", "wss://community-a.example", () => false);
+  const dispose = startPersonaSync(
+    "owner-pubkey",
+    "wss://community-a.example",
+    () => false,
+  );
   // Let the backfill promise chain and the reconcile invoke settle.
   await new Promise((resolve) => setImmediate(resolve));
 
@@ -105,6 +114,142 @@ test("startPersonaSync forwards its own relay as the event arrival relay", async
   );
   assert.equal(JSON.parse(reconciles[0].args.eventJson).id, "e1");
 
+  await dispose();
+  mock.reset();
+  delete globalThis.window;
+});
+
+// Regression guard for a startup fetch that fails once while the live
+// subscription remains connected. Without an independent retry, an older
+// definition never arrives because the live subscription has no history
+// cursor yet.
+test("startPersonaSync retries a failed historical backfill", async () => {
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke: () => Promise.resolve(),
+    },
+  };
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  let fetchCount = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetchCount += 1;
+    return fetchCount === 1
+      ? Promise.reject(new Error("history timed out"))
+      : Promise.resolve([]);
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+  mock.method(console, "warn", () => {});
+
+  const dispose = startPersonaSync(
+    "owner-pubkey",
+    "wss://relay.example",
+    () => false,
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(fetchCount, 1);
+
+  mock.timers.tick(1_000);
+  await Promise.resolve();
+  assert.equal(fetchCount, 2, "the failed backfill must retry");
+
+  await dispose();
+  mock.timers.reset();
+  mock.reset();
+  delete globalThis.window;
+});
+
+test("startPersonaSync retries failed live-subscription setup", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  let liveSubscribeCount = 0;
+  mock.method(relayClient, "fetchEvents", () => Promise.resolve([]));
+  mock.method(relayClient, "subscribeLive", () => {
+    liveSubscribeCount += 1;
+    return liveSubscribeCount === 1
+      ? Promise.reject(new Error("subscription setup failed"))
+      : Promise.resolve(() => Promise.resolve());
+  });
+  mock.method(console, "warn", () => {});
+
+  const dispose = startPersonaSync(
+    "owner-pubkey",
+    "wss://relay.example",
+    () => false,
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(liveSubscribeCount, 1);
+
+  mock.timers.tick(1_000);
+  await Promise.resolve();
+  assert.equal(
+    liveSubscribeCount,
+    2,
+    "failed live-subscription setup must retry",
+  );
+
+  await dispose();
+  mock.timers.reset();
+  mock.reset();
+});
+
+// A relay can answer the initial history request with an incomplete view and
+// recover later. Re-fetching after reconnect repairs the local definition
+// store even though the missing event is older than the live subscription.
+test("startPersonaSync backfills again after reconnect", async () => {
+  const invokes = [];
+  let reconnect;
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke: (cmd, args) => {
+        invokes.push({ cmd, args });
+        return Promise.resolve();
+      },
+    },
+  };
+
+  const recoveredEvent = {
+    id: "recovered-definition",
+    pubkey: "owner-pubkey",
+    kind: KIND_PERSONA,
+  };
+  let fetchCount = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetchCount += 1;
+    return Promise.resolve(fetchCount === 1 ? [] : [recoveredEvent]);
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+  mock.method(relayClient, "subscribeToReconnects", (listener) => {
+    reconnect = listener;
+    return () => {};
+  });
+
+  const dispose = startPersonaSync(
+    "owner-pubkey",
+    "wss://relay.example",
+    () => false,
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(fetchCount, 1);
+
+  reconnect();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(fetchCount, 2);
+  assert.equal(
+    invokes.filter((call) => call.cmd === "reconcile_inbound_persona_event")
+      .length,
+    1,
+    "the reconnect catch-up must reconcile the previously missing definition",
+  );
+
+  await dispose();
   mock.reset();
   delete globalThis.window;
 });

--- a/desktop/src/features/agents/lib/usePersonaSync.ts
+++ b/desktop/src/features/agents/lib/usePersonaSync.ts
@@ -20,11 +20,18 @@ const PERSONA_SYNC_KINDS = [
   KIND_DELETION,
 ];
 
+const SYNC_RETRY_BASE_MS = 1_000;
+const SYNC_RETRY_MAX_MS = 30_000;
+
+function syncRetryDelay(attempt: number): number {
+  return Math.min(SYNC_RETRY_BASE_MS * 2 ** attempt, SYNC_RETRY_MAX_MS);
+}
+
 // Start the persona/team/agent/deletion sync for `pubkey` on `relayUrl`:
-// one-shot backfill of existing heads + tombstones, then a live subscription.
-// Returns a disposer that closes the live subscription. Extracted from the hook
-// so the wiring is unit-testable without a React renderer (see
-// `usePersonaSync.test.mjs`).
+// recoverable backfill of existing heads + tombstones, then a live subscription.
+// Returns a disposer that closes the live subscription and recovery timers.
+// Extracted from the hook so the wiring is unit-testable without a React
+// renderer (see `usePersonaSync.test.mjs`).
 //
 // `relayUrl` is the community this subscription is bound to, and every reconcile
 // carries it as the event's arrival relay. Capturing it here — rather than
@@ -35,8 +42,19 @@ export function startPersonaSync(
   relayUrl: string,
   onCancelled: () => boolean,
 ): () => Promise<void> {
+  let stopped = false;
+  let backfillInFlight = false;
+  let backfillQueued = false;
+  let backfillRetryAttempt = 0;
+  let backfillRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let liveRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let liveSubscribeInFlight = false;
+  let unsub: (() => Promise<void>) | null = null;
+
+  const isCancelled = () => stopped || onCancelled();
+
   const reconcile = (event: RelayEvent) => {
-    if (event.pubkey !== pubkey) return;
+    if (isCancelled() || event.pubkey !== pubkey) return;
     void reconcileInboundPersonaEvent(JSON.stringify(event), relayUrl).catch(
       (error) => {
         console.warn("[usePersonaSync] reconcile failed:", error);
@@ -44,33 +62,84 @@ export function startPersonaSync(
     );
   };
 
-  // One-shot backfill of existing heads + tombstones (closes the fresh-start
-  // gap that live-only subscription + reconnect-replay cannot recover).
-  void relayClient
-    .fetchEvents({ kinds: PERSONA_SYNC_KINDS, authors: [pubkey], limit: 500 })
-    .then((events) => {
-      if (onCancelled()) return;
-      for (const event of events) reconcile(event);
-    })
-    .catch((error) => {
-      console.warn("[usePersonaSync] backfill failed:", error);
-    });
+  const backfill = (resetRetryAttempt = false) => {
+    if (isCancelled()) return;
+    if (resetRetryAttempt) backfillRetryAttempt = 0;
+    if (backfillRetryTimer !== null) {
+      clearTimeout(backfillRetryTimer);
+      backfillRetryTimer = null;
+    }
+    if (backfillInFlight) {
+      backfillQueued = true;
+      return;
+    }
 
-  let unsub: (() => Promise<void>) | null = null;
-  void relayClient
-    .subscribeLive(
-      { kinds: PERSONA_SYNC_KINDS, authors: [pubkey], limit: 0 },
-      reconcile,
-    )
-    .then((dispose) => {
-      if (onCancelled()) {
-        void dispose();
-      } else {
-        unsub = dispose;
-      }
-    });
+    backfillInFlight = true;
+    void relayClient
+      .fetchEvents({ kinds: PERSONA_SYNC_KINDS, authors: [pubkey], limit: 500 })
+      .then((events) => {
+        if (isCancelled()) return;
+        backfillRetryAttempt = 0;
+        for (const event of events) reconcile(event);
+      })
+      .catch((error) => {
+        if (isCancelled()) return;
+        console.warn("[usePersonaSync] backfill failed:", error);
+        const delay = syncRetryDelay(backfillRetryAttempt++);
+        backfillRetryTimer = setTimeout(() => {
+          backfillRetryTimer = null;
+          backfill();
+        }, delay);
+      })
+      .finally(() => {
+        backfillInFlight = false;
+        if (!backfillQueued || isCancelled()) return;
+        backfillQueued = false;
+        backfill(true);
+      });
+  };
+
+  const subscribeLive = (attempt = 0) => {
+    if (isCancelled() || liveSubscribeInFlight || unsub) return;
+    liveSubscribeInFlight = true;
+    void relayClient
+      .subscribeLive(
+        { kinds: PERSONA_SYNC_KINDS, authors: [pubkey], limit: 0 },
+        reconcile,
+      )
+      .then((dispose) => {
+        liveSubscribeInFlight = false;
+        if (isCancelled()) {
+          void dispose();
+        } else {
+          unsub = dispose;
+        }
+      })
+      .catch((error) => {
+        liveSubscribeInFlight = false;
+        if (isCancelled()) return;
+        console.warn("[usePersonaSync] live subscription failed:", error);
+        liveRetryTimer = setTimeout(() => {
+          liveRetryTimer = null;
+          subscribeLive(attempt + 1);
+        }, syncRetryDelay(attempt));
+      });
+  };
+
+  // A live subscription cannot recover events published before its first
+  // event cursor. Backfill immediately, retry transient failures, and repeat
+  // after every reconnect so a stale/partial startup response is self-healing.
+  const unsubscribeReconnect = relayClient.subscribeToReconnects(() => {
+    backfill(true);
+  });
+  backfill();
+  subscribeLive();
 
   return async () => {
+    stopped = true;
+    unsubscribeReconnect();
+    if (backfillRetryTimer !== null) clearTimeout(backfillRetryTimer);
+    if (liveRetryTimer !== null) clearTimeout(liveRetryTimer);
     if (unsub) await unsub();
   };
 }
@@ -85,8 +154,8 @@ export function startPersonaSync(
 // A fresh device that comes online AFTER another already published gets no
 // history from a live-only subscription: relayClient's replayLiveSubscriptions
 // only replays from a since-cursor that is undefined until the first live
-// event arrives. So `startPersonaSync` does an explicit one-shot history fetch
-// up front and feeds each event through the same reconcile path.
+// event arrives. So `startPersonaSync` does an explicit history fetch up front,
+// retries failures, and repeats the catch-up after reconnecting.
 export function usePersonaSync(
   pubkey: string | undefined,
   relayUrl: string | undefined,


### PR DESCRIPTION
## Summary
- retry failed author-owned persona/team/agent history backfills with capped exponential backoff
- repeat the historical catch-up after relay reconnects so an incomplete startup view self-heals
- retry failed live-subscription setup instead of silently abandoning cross-device sync
- document the recovery contract and add regression tests for history retry, live setup retry, reconnect catch-up, deletion coverage, and arrival-relay scoping

### Related issue
Fixes #4893

### Testing
- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/usePersonaSync.test.mjs` (5 passed)
- `pnpm test` (4,288 passed)
- `pnpm typecheck`
- `just desktop-check desktop-build`

No UI changes; screenshots are not applicable.