### PR TITLE
fix(desktop): remove join API token control

### DIFF
--- a/desktop/src/features/communities/ui/AddCommunityDialog.tsx
+++ b/desktop/src/features/communities/ui/AddCommunityDialog.tsx
@@ -55,12 +55,10 @@ export function AddCommunityDialog({
       relayUrl,
       inviteCode,
       policyReceipt,
-      token,
     }: {
       relayUrl: string;
       inviteCode?: string;
       policyReceipt?: string;
-      token?: string;
     }) => {
       const started = communityOnboarding.start({
         source: "add-community",
@@ -68,7 +66,6 @@ export function AddCommunityDialog({
         inviteCode,
         communityName: prefill?.name,
         policyReceipt,
-        token,
       });
       if (!started) {
         setJoinError(
@@ -185,9 +182,7 @@ export function AddCommunityDialog({
                 setJoinError(null);
                 setMode("choose");
               }}
-              onConnect={(relayUrl, token) =>
-                startConnection({ relayUrl, token })
-              }
+              onConnect={(relayUrl) => startConnection({ relayUrl })}
               onRedeem={(relayUrl, inviteCode, policyReceipt) =>
                 startConnection({ relayUrl, inviteCode, policyReceipt })
               }

--- a/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
+++ b/desktop/src/features/onboarding/ui/InviteRedeemForm.tsx
@@ -54,7 +54,7 @@ type InviteRedeemFormProps = {
   initialValue?: string;
   isRedeeming: boolean;
   onCancel: () => void;
-  onConnect?: (relayWsUrl: string, token?: string) => void;
+  onConnect?: (relayWsUrl: string) => void;
   onRedeem: (relayWsUrl: string, code: string, policyReceipt?: string) => void;
   placeholder?: string;
   variant?: "add-community" | "default" | "onboarding-spotlight";
@@ -76,8 +76,6 @@ export function InviteRedeemForm({
   const [bareCodeRelayUrl, setBareCodeRelayUrl] = React.useState(
     defaultRelayUrl ?? "",
   );
-  const [apiToken, setApiToken] = React.useState("");
-  const [showApiToken, setShowApiToken] = React.useState(false);
   const [joinPolicy, setJoinPolicy] = React.useState<JoinPolicy | null>(null);
   const [policyTarget, setPolicyTarget] = React.useState<{
     relayWsUrl: string;
@@ -158,7 +156,7 @@ export function InviteRedeemForm({
         try {
           const policy = await getJoinPolicy(normalizedRelayUrl, "native");
           if (!policy) {
-            onConnect?.(normalizedRelayUrl, apiToken.trim() || undefined);
+            onConnect?.(normalizedRelayUrl);
             return;
           }
 
@@ -187,7 +185,7 @@ export function InviteRedeemForm({
             return;
           }
 
-          onConnect?.(normalizedRelayUrl, apiToken.trim() || undefined);
+          onConnect?.(normalizedRelayUrl);
         } catch (policyFetchError) {
           setPolicyError(inviteErrorMessage(policyFetchError));
         } finally {
@@ -252,7 +250,6 @@ export function InviteRedeemForm({
     [
       ageConfirmed,
       agreementConfirmed,
-      apiToken,
       bareCodeRelayUrl,
       joinPolicy,
       normalizedRelayUrl,
@@ -467,55 +464,6 @@ export function InviteRedeemForm({
             value={bareCodeRelayUrl}
           />
         </div>
-      ) : null}
-
-      {isAddCommunity && normalizedRelayUrl ? (
-        showApiToken ? (
-          <div className="space-y-1.5 text-left">
-            <div className="flex items-center justify-between gap-3">
-              <label
-                className="text-sm font-medium text-foreground"
-                htmlFor="community-api-token"
-              >
-                API token
-                <span className="ml-1 text-xs font-normal text-muted-foreground">
-                  (optional)
-                </span>
-              </label>
-              <button
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-                onClick={() => {
-                  setApiToken("");
-                  setShowApiToken(false);
-                }}
-                type="button"
-              >
-                Remove
-              </button>
-            </div>
-            <Input
-              autoComplete="off"
-              className="h-10 bg-background"
-              data-testid="community-api-token"
-              disabled={isRedeeming}
-              id="community-api-token"
-              onChange={(event) => setApiToken(event.target.value)}
-              placeholder="buzz_…"
-              type="password"
-              value={apiToken}
-            />
-          </div>
-        ) : (
-          <button
-            className="w-fit text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-            data-testid="community-api-token-reveal"
-            disabled={isRedeeming}
-            onClick={() => setShowApiToken(true)}
-            type="button"
-          >
-            Use an API token
-          </button>
-        )
       ) : null}
 
       {policyError ? (

--- a/desktop/tests/e2e/add-community-screenshots.spec.ts
+++ b/desktop/tests/e2e/add-community-screenshots.spec.ts
@@ -55,7 +55,11 @@ test("capture: add-community choices", async ({ page }) => {
 test("capture: join an existing community", async ({ page }) => {
   await page.getByTestId("add-community-join").click();
   const dialog = page.getByTestId("add-community-dialog");
-  await page.getByLabel("Community URL or invite link").waitFor();
+  const communityUrl = page.getByLabel("Community URL or invite link");
+  await communityUrl.fill("community.example.com");
+  await page.getByTestId("community-api-token-reveal").waitFor({
+    state: "detached",
+  });
   await waitForAnimations(page);
   await dialog.screenshot({ path: `${OUTDIR}/02-join.png` });
 });

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -167,23 +167,18 @@ test("automatically shows community join requirements near the community URL", a
     .toContain('"relayUrl":"wss://policy.example.com"');
 });
 
-test("supports API tokens without cluttering the default join form", async ({
-  page,
-}) => {
+test("joins a community URL without an API token field", async ({ page }) => {
   await installMockBridge(page, { applyCommunityDelayMs: 1_000 });
   await page.goto("/");
 
   await openAddCommunityDialog(page);
   await page.getByTestId("add-community-join").click();
 
-  await expect(page.getByLabel("API token")).toHaveCount(0);
-  await expect(page.getByTestId("community-api-token-reveal")).toHaveCount(0);
-
   await page
     .getByLabel("Community URL or invite link")
     .fill("token.example.com");
-  await page.getByTestId("community-api-token-reveal").click();
-  await page.getByLabel("API token").fill("buzz_secret");
+  await expect(page.getByLabel("API token")).toHaveCount(0);
+  await expect(page.getByTestId("community-api-token-reveal")).toHaveCount(0);
   await page.getByTestId("invite-redeem-submit").click();
 
   await expect
@@ -191,20 +186,10 @@ test("supports API tokens without cluttering the default join form", async ({
       page.evaluate((key) => {
         const raw = window.localStorage.getItem(key);
         if (!raw) return null;
-        const transaction = JSON.parse(raw) as {
-          relayUrl?: string;
-          token?: string;
-        };
-        return {
-          relayUrl: transaction.relayUrl,
-          token: transaction.token,
-        };
+        return JSON.parse(raw) as { relayUrl?: string };
       }, COMMUNITY_ONBOARDING_STORAGE_KEY),
     )
-    .toEqual({
-      relayUrl: "wss://token.example.com",
-      token: "buzz_secret",
-    });
+    .toMatchObject({ relayUrl: "wss://token.example.com" });
 });
 
 test("hides Invites settings on open relays", async ({ page }) => {


### PR DESCRIPTION
## Summary

Remove the nonfunctional API-token option from the existing-community join flow.

## Validation

- Focused Playwright join-flow coverage
- Add-community screenshot coverage
