### PR TITLE
fix(desktop): attach Buzz MCP to Hermes sessions

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -15,7 +15,7 @@ mod runtime_metadata;
 mod windows_install;
 pub(crate) use presets::{
     canonical_harness_command, command_for_runtime_id, preset_harness_definitions,
-    preset_harness_ids,
+    preset_harness_ids, preset_mcp_command,
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use runtime_metadata::KnownAcpRuntime;

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -13,6 +13,7 @@ pub(super) struct PresetHarness {
     label: &'static str,
     command: &'static str,
     args: &'static [&'static str],
+    mcp_command: Option<&'static str>,
     install_instructions_url: &'static str,
     install_hint: &'static str,
     /// Vendor CLI the ACP command wraps, when the preset is an adapter.
@@ -63,7 +64,7 @@ pub(super) fn preset_catalog_entry(
             def.command,
             def.args.iter().map(|arg| arg.to_string()).collect(),
         ),
-        mcp_command: None,
+        mcp_command: def.mcp_command.map(str::to_string),
         model_env_var: None,
         provider_env_var: None,
         thinking_env_var: None,
@@ -91,6 +92,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Devin",
         command: "devin",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://docs.devin.ai/cli",
         install_hint: "Buzz talks to Devin through the official Devin CLI's ACP mode (devin acp).",
         underlying_cli: None,
@@ -100,6 +102,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Cursor",
         command: "cursor-agent",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://cursor.com/downloads",
         install_hint: "Buzz talks to Cursor through the cursor-agent CLI's ACP mode.",
         underlying_cli: None,
@@ -109,6 +112,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Oh My Pi",
         command: "omp",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://omp.sh/",
         install_hint: "Buzz talks to Oh My Pi through its CLI's ACP mode (omp acp).",
         underlying_cli: None,
@@ -118,6 +122,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Grok Build",
         command: "grok",
         args: &["agent", "--always-approve", "stdio"],
+        mcp_command: None,
         install_instructions_url: "https://build.x.ai/docs",
         install_hint: "Buzz talks to Grok Build through its CLI's agent stdio mode.",
         underlying_cli: None,
@@ -127,6 +132,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "OpenCode",
         command: "opencode",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://opencode.ai/docs",
         install_hint: "Buzz talks to OpenCode through its CLI's ACP mode (opencode acp).",
         underlying_cli: None,
@@ -136,6 +142,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Kimi Code",
         command: "kimi",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://kimi.ai/download",
         install_hint: "Buzz talks to Kimi Code through its CLI's ACP mode (kimi acp).",
         underlying_cli: None,
@@ -145,6 +152,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Amp",
         command: "amp-acp",
         args: &[],
+        mcp_command: None,
         install_instructions_url: "https://github.com/tao12345666333/amp-acp",
         install_hint: "Buzz talks to the Amp CLI through the amp-acp adapter. Follow the setup guide to install the adapter so the amp-acp command is on your PATH.",
         underlying_cli: Some("amp"),
@@ -154,6 +162,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Hermes Agent",
         command: "hermes-acp",
         args: &[],
+        mcp_command: Some("buzz-dev-mcp"),
         install_instructions_url: "https://hermes-agent.nousresearch.com",
         install_hint: "Buzz talks to Hermes Agent through its hermes-acp command.",
         underlying_cli: None,
@@ -163,6 +172,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "OpenClaw",
         command: "openclaw",
         args: &["acp"],
+        mcp_command: None,
         install_instructions_url: "https://docs.openclaw.ai/start/getting-started",
         install_hint: "Buzz talks to OpenClaw through its ACP mode (openclaw acp), which relies on the OpenClaw Gateway daemon. Follow the setup guide to install both.\n\n\
             ⚠️  Execution-locus note: `openclaw acp` runs tools inside the \
@@ -211,6 +221,18 @@ pub(super) fn preset_command_for_id(id: &str) -> Option<&'static str> {
         .iter()
         .find(|p| p.id == id)
         .map(|p| p.command)
+}
+
+/// Return the bundled MCP command declared by a static preset.
+pub(crate) fn preset_mcp_command(command: &str) -> Option<&'static str> {
+    let normalized = super::normalize_command_identity(command);
+    PRESET_HARNESSES
+        .iter()
+        .find(|preset| {
+            preset.id == normalized
+                || super::normalize_command_identity(preset.command) == normalized
+        })
+        .and_then(|preset| preset.mcp_command)
 }
 
 /// Return the primary harness command for a given runtime id, or `None`.
@@ -286,6 +308,7 @@ mod tests {
         label: "Amp Test",
         command: "amp-acp",
         args: &[],
+        mcp_command: None,
         install_instructions_url: "https://example.com/install",
         install_hint: "Install the amp-acp npm adapter.",
         underlying_cli: Some("amp"),
@@ -341,6 +364,19 @@ mod tests {
         assert_eq!(entry.default_args, vec!["acp"]);
         assert_eq!(entry.install_instructions_url, "https://docs.devin.ai/cli");
         assert_eq!(entry.source, HarnessSource::Preset);
+    }
+
+    #[test]
+    fn hermes_preset_exposes_bundled_buzz_mcp_in_runtime_catalog() {
+        let preset = PRESET_HARNESSES
+            .iter()
+            .find(|preset| preset.id == "hermes")
+            .expect("Hermes preset should be present");
+
+        let entry =
+            preset_catalog_entry(preset, |_| Some(PathBuf::from("/usr/local/bin/hermes-acp")));
+
+        assert_eq!(entry.mcp_command.as_deref(), Some("buzz-dev-mcp"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/mcp_command.rs
+++ b/desktop/src-tauri/src/managed_agents/mcp_command.rs
@@ -1,0 +1,16 @@
+use super::{known_acp_runtime, preset_mcp_command};
+
+/// Return the bundled MCP command declared by a builtin or static preset.
+pub(crate) fn mcp_command_for_runtime(command: &str) -> Option<&'static str> {
+    known_acp_runtime(command)
+        .and_then(|runtime| runtime.mcp_command)
+        .or_else(|| preset_mcp_command(command))
+}
+
+#[test]
+fn hermes_preset_supplies_buzz_mcp_to_managed_agent_spawns() {
+    assert_eq!(
+        mcp_command_for_runtime("/Users/example/.local/bin/hermes-acp"),
+        Some("buzz-dev-mcp")
+    );
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -15,6 +15,7 @@ mod env_vars;
 pub(crate) mod git_bash;
 pub(crate) mod global_config;
 mod managed_node_paths;
+mod mcp_command;
 mod nest;
 mod persona_avatars;
 pub(crate) mod persona_events;
@@ -58,6 +59,7 @@ pub(crate) use global_config::{
     validate_global_config, GlobalAgentConfig,
 };
 pub(crate) use managed_node_paths::*;
+pub(crate) use mcp_command::mcp_command_for_runtime;
 pub use nest::*;
 pub use personas::*;
 #[cfg(windows)]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -293,8 +293,7 @@ pub fn build_managed_agent_summary(
             env: Default::default(),
         }
     });
-    let effective_mcp_command = known_acp_runtime(&descriptor.command)
-        .and_then(|r| r.mcp_command)
+    let effective_mcp_command = crate::managed_agents::mcp_command_for_runtime(&descriptor.command)
         .unwrap_or("")
         .to_string();
 
@@ -514,9 +513,8 @@ pub fn spawn_agent_child(
         .map_err(|error| format!("failed to clone log handle: {error}"))?;
     let resolved_acp_command = resolve_command(&record.acp_command)
         .ok_or_else(|| missing_command_message(&record.acp_command, "ACP harness command"))?;
-    let effective_mcp_command = known_acp_runtime(effective_command)
-        .and_then(|r| r.mcp_command)
-        .unwrap_or("");
+    let effective_mcp_command =
+        crate::managed_agents::mcp_command_for_runtime(effective_command).unwrap_or("");
     let resolved_mcp_command: Option<std::path::PathBuf> = if effective_mcp_command.is_empty() {
         None
     } else {

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 
 use super::{
     effective_config::{resolve_effective_config, EffectiveConfigResult},
-    known_acp_runtime, normalize_agent_args,
+    mcp_command_for_runtime, normalize_agent_args,
     persona_events::preview_prospective_persona_snapshot,
     readiness::EffectiveHarnessDescriptor,
     runtime::{resolve_session_title, SESSION_TITLE_ENV_VAR},
@@ -141,8 +141,7 @@ impl SpawnConfigSnapshot {
             acp_command: record.acp_command.clone(),
             command: descriptor.command.clone(),
             args: descriptor.args.clone(),
-            mcp_command: known_acp_runtime(&descriptor.command)
-                .and_then(|runtime| runtime.mcp_command)
+            mcp_command: mcp_command_for_runtime(&descriptor.command)
                 .unwrap_or("")
                 .to_string(),
             env: descriptor.env.clone(),

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
@@ -142,6 +142,17 @@ fn materializing_runtime_keeps_snapshot_stable() {
 }
 
 #[test]
+fn hermes_spawn_snapshot_includes_bundled_buzz_mcp() {
+    let mut rec = record();
+    rec.runtime = Some("hermes".into());
+
+    assert_eq!(
+        snapshot(&rec, &[], &[], "wss://ws.example", &Default::default())["mcp_command"],
+        "buzz-dev-mcp"
+    );
+}
+
+#[test]
 fn record_env_var_edit_changes_snapshot() {
     let rec = record();
     let mut edited = record();

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -12,8 +12,11 @@ Plan of record: `Buzz/Harness-Provider-Model.md` in Morgan's Obsidian vault
 
 **Harness capability facts have exactly one source: the Rust runtime catalog.**
 `KnownAcpRuntime` (`desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs`)
-declares each harness's model/provider/effort env keys and capabilities. Spawn
-applies them; `AcpRuntimeCatalogEntry` exposes them over IPC; and
+declares each builtin harness's model/provider/effort env keys and capabilities;
+static tier-2 presets declare their limited metadata on `PresetHarness` in
+`discovery/presets.rs`. Preset MCP requirements must flow through
+`mcp_command_for_runtime` rather than the deprecated per-agent record field.
+Spawn applies the catalog facts; `AcpRuntimeCatalogEntry` exposes them over IPC; and
 `lib/agentConfigCore.ts` projects them into field descriptors. The frontend
 never maintains a rival copy of this table. Setup guidance follows the same
 rule: `requires_external_cli` is derived from `KnownAcpRuntime` and projected


### PR DESCRIPTION
## Summary

- expose bundled MCP metadata for static preset runtimes
- declare `buzz-dev-mcp` for Hermes Agent
- resolve MCP commands consistently for managed summaries, spawns, and spawn snapshots
- add regressions for the catalog, absolute-path command resolution, and spawn snapshot

## Root cause

Buzz Desktop only derived managed MCP commands from builtin `KnownAcpRuntime` metadata. Hermes is a static tier-2 preset, while preset catalog entries hard-coded `mcp_command` to `None`, so Hermes sessions started with an empty `BUZZ_ACP_MCP_COMMAND` even when the managed record contained the legacy field.

## Verification

- `just ci` at `5e3f973df402726ddc3485b466437e9421c231b1`
- 4,286 Desktop JavaScript tests passed
- 2,306 Rust tests passed, 14 ignored
- 1,163 Flutter tests passed
- focused Hermes MCP regressions: 3 passed

No deployment, merge, or production restart is included. Live Hermes MCP publication remains to be verified on a Desktop build containing this patch.

Buzz origin channel: `1e79387d-39a7-54c1-932b-b56378b01e7a`
