### PR TITLE
Fix DMG enrollment command build

### DIFF
--- a/.github/workflows/fork-unsigned-dmg.yml
+++ b/.github/workflows/fork-unsigned-dmg.yml
@@ -1,0 +1,56 @@
+name: Fork unsigned DMG
+
+on:
+  push:
+    tags:
+      - "fork-desktop-v[0-9]*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build unsigned macOS DMG
+    if: github.repository == 'atlas-maxjb/buzz'
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      VERSION: ${{ github.ref_name }}
+      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CMAKE_OSX_DEPLOYMENT_TARGET: "10.15"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+
+      - name: Set application version
+        run: |
+          VERSION="${VERSION#fork-desktop-v}"
+          cd desktop
+          node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri
+          cargo update --workspace
+
+      - name: Build sidecars
+        run: |
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh
+
+      - name: Build unsigned DMG
+        run: cd desktop && pnpm tauri build --verbose --no-sign --config src-tauri/tauri.conf.json
+
+      - name: Upload DMG to fork release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DMG=$(find desktop/src-tauri/target/release/bundle/dmg -name '*.dmg' -type f | head -1)
+          test -n "$DMG"
+          gh release upload "$GITHUB_REF_NAME" "$DMG" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   # create the release objects all four platform jobs upload into.
   setup:
     name: Setup
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -51,7 +51,7 @@ jobs:
 
   release:
     name: Release
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: macos-latest
     needs: setup
     timeout-minutes: 60
@@ -264,7 +264,7 @@ jobs:
 
   release-macos-x64:
     name: Release macOS (Intel)
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: macos-latest
     needs: setup
     timeout-minutes: 60
@@ -425,7 +425,7 @@ jobs:
 
   release-linux:
     name: Release Linux
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: ubuntu-latest
     # Digest-pinned like the SHA-pinned actions below; Renovate keeps it fresh.
     container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90

--- a/desktop/src-tauri/src/commands/agent_providers.rs
+++ b/desktop/src-tauri/src/commands/agent_providers.rs
@@ -1,4 +1,6 @@
-use crate::managed_agents::{discover_provider_candidates, invoke_provider, BackendProviderInfo};
+use crate::managed_agents::{
+    discover_provider_candidates, invoke_provider, validate_provider_info, BackendProviderInfo,
+};
 
 #[tauri::command]
 pub async fn discover_backend_providers() -> Result<Vec<BackendProviderInfo>, String> {
@@ -39,7 +41,9 @@ pub async fn probe_backend_provider(binary_path: String) -> Result<serde_json::V
         "request_id": uuid::Uuid::new_v4().to_string(),
     });
     tokio::task::spawn_blocking(move || {
-        invoke_provider(&canonical, &request, std::time::Duration::from_secs(10))
+        let info = invoke_provider(&canonical, &request, std::time::Duration::from_secs(10))?;
+        validate_provider_info(&info)?;
+        Ok(info)
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -464,7 +464,7 @@ async fn deploy_to_provider(
     config: &serde_json::Value,
     agent_json: serde_json::Value,
     cached_binary_path: Option<&str>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     // Resolve via discovered candidates only. Cached path must match BOTH
     // "is a discovered candidate" AND "belongs to this provider_id". A tampered
     // record cannot redirect deploys to a different provider's binary.
@@ -497,8 +497,9 @@ async fn deploy_to_provider(
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
 
     match deploy_result {
-        Ok(backend_agent_id) => {
-            rec.backend_agent_id = Some(backend_agent_id);
+        Ok(result) => {
+            let enrollment_command = result.enrollment_command;
+            rec.backend_agent_id = Some(result.agent_id);
             rec.last_started_at = Some(now_iso());
             rec.updated_at = now_iso();
             rec.last_error = None;
@@ -511,7 +512,7 @@ async fn deploy_to_provider(
         }
     }
     save_managed_agents(app, &records)?;
-    Ok(())
+    Ok(enrollment_command)
 }
 
 // Async so the blocking body (disk reads of agent/persona records, per-agent
@@ -999,6 +1000,7 @@ pub async fn create_managed_agent(
         .err();
 
     // ── Phase 5: provider deploy (async, outside lock) ───────────────────────
+    let mut enrollment_command = None;
     let spawn_error = if input.spawn_after_create && input.backend != BackendKind::Local {
         if let BackendKind::Provider { ref id, ref config } = input.backend {
             // Read the saved record to build the deploy payload (record has the
@@ -1016,7 +1018,10 @@ pub async fn create_managed_agent(
                 build_deploy_payload(&app, &state, rec)?
             };
             match deploy_to_provider(&app, &state, &pubkey, id, config, agent_json, None).await {
-                Ok(()) => spawn_error,
+                Ok(command) => {
+                    enrollment_command = command;
+                    spawn_error
+                }
                 Err(e) => Some(e),
             }
         } else {
@@ -1058,6 +1063,7 @@ pub async fn create_managed_agent(
         private_key_nsec,
         profile_sync_error,
         spawn_error,
+        enrollment_command,
     })
 }
 

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -510,7 +510,7 @@ async fn deploy_to_provider(
             save_managed_agents(app, &records)?;
             return Err(e.clone());
         }
-    }
+    };
     save_managed_agents(app, &records)?;
     Ok(enrollment_command)
 }

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -454,8 +454,8 @@ pub(super) async fn start_local_agent_with_preflight(
 /// again. Providers are expected to handle this as an update-in-place or no-op —
 /// the protocol does not include an explicit `undeploy` operation (deferred to v2).
 ///
-/// Returns Ok(()) on success, Err(message) on failure. Either way the record is
-/// updated and saved before returning.
+/// Returns the optional enrollment command on success, or Err(message) on
+/// failure. Either way the record is updated and saved before returning.
 async fn deploy_to_provider(
     app: &AppHandle,
     state: &AppState,
@@ -496,13 +496,13 @@ async fn deploy_to_provider(
         .find(|r| r.pubkey == pubkey)
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
 
-    match deploy_result {
+    let enrollment_command = match deploy_result {
         Ok(result) => {
-            let enrollment_command = result.enrollment_command;
             rec.backend_agent_id = Some(result.agent_id);
             rec.last_started_at = Some(now_iso());
             rec.updated_at = now_iso();
             rec.last_error = None;
+            result.enrollment_command
         }
         Err(ref e) => {
             rec.last_error = Some(e.clone());

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -10,7 +10,7 @@ const STDERR_CAP: usize = 65536;
 const STDOUT_CAP: usize = 1_048_576; // 1 MB
 const PROVIDER_PROTOCOL_VERSION: u64 = 1;
 
-fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
+pub fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
     let object = info
         .as_object()
         .ok_or_else(|| "provider info response must be a JSON object".to_string())?;
@@ -45,6 +45,38 @@ fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
         return Err("provider info response missing object config_schema".to_string());
     }
 
+    // Providers that can import an agent into an existing remote runtime may
+    // opt into the one-shot enrollment operation. Keep this capability
+    // explicit and closed-world: a provider cannot silently change the
+    // meaning of the secret-bearing deploy request.
+    if let Some(enrollment) = object.get("enrollment") {
+        let enrollment = enrollment
+            .as_object()
+            .ok_or_else(|| "provider enrollment must be an object".to_string())?;
+        if enrollment.get("operation").and_then(serde_json::Value::as_str) != Some("enroll")
+            || enrollment.get("one_time") != Some(&serde_json::Value::Bool(true))
+        {
+            return Err(
+                "provider enrollment must declare operation: enroll and one_time: true".to_string(),
+            );
+        }
+        if let Some(fields) = enrollment.get("credential_fields") {
+            let fields = fields.as_array().ok_or_else(|| {
+                "provider enrollment credential_fields must be an array".to_string()
+            })?;
+            if fields.iter().any(|field| field.as_str().is_none()) {
+                return Err(
+                    "provider enrollment credential_fields must contain strings".to_string(),
+                );
+            }
+        }
+        if enrollment.keys().any(|field| {
+            !["operation", "one_time", "credential_fields"].contains(&field.as_str())
+        }) {
+            return Err("provider enrollment contains an unknown field".to_string());
+        }
+    }
+
     const FIELDS: &[&str] = &[
         "ok",
         "name",
@@ -52,6 +84,7 @@ fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
         "protocol_version",
         "description",
         "config_schema",
+        "enrollment",
     ];
     if let Some(field) = object
         .keys()
@@ -519,12 +552,16 @@ pub fn provider_deploy(
     let info = invoke_provider(&staged, &info_request, Duration::from_secs(10))?;
     validate_provider_info(&info)?;
 
-    let request = serde_json::json!({
-        "op": "deploy",
+    let enrollment = info.get("enrollment").is_some();
+    let mut request = serde_json::json!({
+        "op": if enrollment { "enroll" } else { "deploy" },
         "request_id": uuid::Uuid::new_v4().to_string(),
         "agent": agent,
         "provider_config": provider_config,
     });
+    if enrollment {
+        request["enrollment"] = serde_json::json!({ "version": 1, "mode": "one-time" });
+    }
     let resp = invoke_provider(&staged, &request, Duration::from_secs(600))?;
     resp["agent_id"]
         .as_str()

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -539,11 +539,16 @@ fn stage_provider(
 
 /// Deploy through one immutable staged copy: negotiate protocol v1 before the
 /// secret-bearing request, then invoke deploy on those exact same bytes.
+pub struct ProviderDeployResult {
+    pub agent_id: String,
+    pub enrollment_command: Option<String>,
+}
+
 pub fn provider_deploy(
     binary: &Path,
     agent: &serde_json::Value,
     provider_config: &serde_json::Value,
-) -> Result<String, String> {
+) -> Result<ProviderDeployResult, String> {
     let (_directory, staged, _digest, _execution_guard) = stage_provider(binary)?;
     let info_request = serde_json::json!({
         "op": "info",
@@ -563,10 +568,14 @@ pub fn provider_deploy(
         request["enrollment"] = serde_json::json!({ "version": 1, "mode": "one-time" });
     }
     let resp = invoke_provider(&staged, &request, Duration::from_secs(600))?;
-    resp["agent_id"]
+    let agent_id = resp["agent_id"]
         .as_str()
         .map(String::from)
-        .ok_or_else(|| "deploy response missing agent_id".to_string())
+        .ok_or_else(|| "deploy response missing agent_id".to_string())?;
+    Ok(ProviderDeployResult {
+        agent_id,
+        enrollment_command: resp["enrollment_command"].as_str().map(String::from),
+    })
 }
 
 /// Validate provider_config: flat object, scalar values, no secret-like keys.

--- a/desktop/src-tauri/src/managed_agents/backend_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/backend_tests.rs
@@ -176,6 +176,29 @@ esac"#,
 }
 
 #[cfg(unix)]
+#[test]
+fn provider_enrollment_uses_explicit_one_time_operation() {
+    let directory = tempfile::tempdir().unwrap();
+    let provider = directory.path().join("provider");
+    let seen = directory.path().join("operation");
+    let body = format!(
+        r#"read request
+case "$request" in
+  *\"op\":\"info\"*) printf '%s\n' '{{"ok":true,"name":"openclaw","version":"1","protocol_version":1,"description":"enrollment","config_schema":{{}},"enrollment":{{"operation":"enroll","one_time":true,"credential_fields":["private_key_nsec","auth_tag","relay_url"]}}}}' ;;
+  *\"op\":\"enroll\"*) printf enroll > '{}'; printf '%s\n' '{{"ok":true,"agent_id":"openclaw-1"}}' ;;
+  *) exit 2 ;;
+esac"#,
+        seen.display()
+    );
+    write_test_provider(&provider, &body);
+
+    let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
+        .expect("staged enrollment");
+    assert_eq!(id, "openclaw-1");
+    assert_eq!(std::fs::read_to_string(seen).unwrap(), "enroll");
+}
+
+#[cfg(unix)]
 fn replacement_provider() -> &'static str {
     r#"#!/bin/sh
 set -eu

--- a/desktop/src-tauri/src/managed_agents/backend_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/backend_tests.rs
@@ -160,7 +160,7 @@ esac"#,
 
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("staged deploy");
-    assert_eq!(id, "remote-1");
+    assert_eq!(id.agent_id, "remote-1");
     let paths: Vec<_> = std::fs::read_to_string(log)
         .unwrap()
         .lines()
@@ -194,7 +194,7 @@ esac"#,
 
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("staged enrollment");
-    assert_eq!(id, "openclaw-1");
+    assert_eq!(id.agent_id, "openclaw-1");
     assert_eq!(std::fs::read_to_string(seen).unwrap(), "enroll");
 }
 
@@ -239,7 +239,7 @@ esac"#,
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("deploy from immutable staged copy");
 
-    assert_eq!(id, "original-staged-bytes");
+    assert_eq!(id.agent_id, "original-staged-bytes");
     assert_eq!(
         std::fs::metadata(&provider).unwrap().ino(),
         inode_before,
@@ -280,7 +280,7 @@ esac"#,
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("deploy from immutable staged copy");
 
-    assert_eq!(id, "original-staged-bytes");
+    assert_eq!(id.agent_id, "original-staged-bytes");
     assert_ne!(
         std::fs::metadata(&provider).unwrap().ino(),
         inode_before,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -574,6 +574,7 @@ pub struct CreateManagedAgentResponse {
     pub private_key_nsec: String,
     pub profile_sync_error: Option<String>,
     pub spawn_error: Option<String>,
+    pub enrollment_command: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/desktop/src/features/agents/ui/SecretRevealDialog.tsx
+++ b/desktop/src/features/agents/ui/SecretRevealDialog.tsx
@@ -64,6 +64,23 @@ export function SecretRevealDialog({
                   </p>
                 ) : null}
 
+                {created.enrollmentCommand ? (
+                  <div className="space-y-3 rounded-2xl border border-primary/30 bg-primary/5 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold">Enroll on OpenClaw</p>
+                        <p className="text-sm text-muted-foreground">
+                          Copy this command and run it on the private OpenClaw server. It expires in 10 minutes and can be used once.
+                        </p>
+                      </div>
+                      <CopyButton label="Copy command" value={created.enrollmentCommand} />
+                    </div>
+                    <code className="block break-all rounded-xl border border-border/70 bg-background/80 px-3 py-2 text-xs">
+                      {created.enrollmentCommand}
+                    </code>
+                  </div>
+                ) : null}
+
                 {created.spawnError ? (
                   <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                     {created.spawnError}

--- a/desktop/src/features/agents/ui/WhereToRunSection.tsx
+++ b/desktop/src/features/agents/ui/WhereToRunSection.tsx
@@ -95,7 +95,7 @@ export function WhereToRunSection({
           <option value="local">This computer</option>
           {backendProviders.map((provider) => (
             <option key={provider.id} value={provider.id}>
-              {provider.id}
+              {provider.id === "openclaw" ? "OpenClaw" : provider.id}
             </option>
           ))}
         </select>
@@ -117,6 +117,13 @@ export function WhereToRunSection({
           {probeError ? (
             <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
               Could not probe provider: {probeError}
+            </p>
+          ) : null}
+          {draft.probedProvider?.enrollment ? (
+            <p className="rounded-2xl border border-primary/30 bg-primary/5 px-4 py-3 text-sm">
+              This provider uses a one-time enrollment import. Buzz Desktop
+              hands the agent identity to the trusted provider and keeps no
+              runtime connection to the remote host.
             </p>
           ) : null}
           {draft.probedProvider?.config_schema ? (

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -171,6 +171,7 @@ type RawCreateManagedAgentResponse = {
   private_key_nsec: string;
   profile_sync_error: string | null;
   spawn_error: string | null;
+  enrollment_command: string | null;
 };
 
 type RawManagedAgentLog = {
@@ -878,6 +879,7 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
     privateKeyNsec: response.private_key_nsec,
     profileSyncError: response.profile_sync_error,
     spawnError: response.spawn_error,
+    enrollmentCommand: response.enrollment_command,
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -400,6 +400,11 @@ export type BackendProviderProbeResult = {
   version?: string;
   description?: string;
   config_schema?: Record<string, unknown>;
+  enrollment?: {
+    operation: "enroll";
+    one_time: true;
+    credential_fields?: string[];
+  };
 };
 
 export type RelayMeshConfig = {

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -455,6 +455,7 @@ export type CreateManagedAgentResponse = {
   privateKeyNsec: string;
   profileSyncError: string | null;
   spawnError: string | null;
+  enrollmentCommand: string | null;
 };
 
 export type ManagedAgentLog = {

--- a/docs/openclaw-enrollment.md
+++ b/docs/openclaw-enrollment.md
@@ -1,0 +1,94 @@
+# OpenClaw provider enrollment
+
+Buzz Desktop exposes remote run locations through discovered executables named
+`buzz-backend-<id>`. An OpenClaw integration should install
+`buzz-backend-openclaw` on the Desktop machine; it will then appear under
+**Run on** without Buzz Desktop becoming a Gateway or runtime proxy.
+
+## Provider contract
+
+The provider is a one-process-per-operation stdin/stdout JSON executable. It
+must answer `info` first, with protocol version `1`:
+
+```json
+{
+  "ok": true,
+  "name": "openclaw",
+  "version": "1.0.0",
+  "protocol_version": 1,
+  "description": "Enrolls agents with an OpenClaw host",
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "host": { "type": "string", "description": "SSH destination, e.g. openclaw@agent-host" },
+      "rooms": { "type": "string", "description": "Comma-separated Buzz room UUIDs" },
+      "port": { "type": "string", "description": "Optional SSH port" }
+    },
+    "required": ["host", "rooms"]
+  },
+  "enrollment": {
+    "operation": "enroll",
+    "one_time": true,
+    "credential_fields": ["private_key_nsec", "auth_tag", "relay_url"]
+  }
+}
+```
+
+`config_schema` is persisted in the agent record and is therefore not a place
+for credentials. Desktop rejects secret-shaped keys (`key`, `token`,
+`credential`, `password`, `secret`) and nested values in provider config.
+Host authentication belongs to the provider's normal local trust mechanism
+(for example, an existing OpenClaw CLI login or OS credential store).
+
+After `info`, Desktop invokes the same staged provider binary once with:
+
+```json
+{
+  "op": "enroll",
+  "request_id": "uuid",
+  "agent": {
+    "name": "display name",
+    "relay_url": "wss://relay.example",
+    "private_key_nsec": "nsec1...",
+    "auth_tag": "[\"auth\",\"owner\",\"\",\"signature\"]",
+    "respond_to": "owner-only",
+    "respond_to_allowlist": [],
+    "env_vars": {},
+    "launch": {
+      "command": "openclaw",
+      "args": ["acp"],
+      "env": {},
+      "policy_env": {},
+      "owner_pubkey": "hex"
+    }
+  },
+  "provider_config": {
+    "host": "openclaw@agent-host",
+    "rooms": "ROOM_UUID_1,ROOM_UUID_2",
+    "port": "22"
+  },
+  "enrollment": { "version": 1, "mode": "one-time" }
+}
+```
+
+The exact managed-agent payload is the source of truth; providers must not
+reconstruct identity from `env_vars`. The provider uses SSH only for this
+one-time handoff, running `openclaw buzz enroll --stdin` on the remote host.
+It imports the identity and room configuration into OpenClaw and returns a
+stable host-side identifier:
+
+```json
+{ "ok": true, "agent_id": "openclaw-host-agent-id" }
+```
+
+Desktop stores only that identifier and the non-secret provider config. It
+does not retain a host session, proxy messages, poll the Gateway, or provide
+remote logs/stop controls. Subsequent conversation and presence continue over
+the Buzz relay. Re-running the action must be idempotent for the same agent
+identity; the provider owns reconciliation on the OpenClaw host.
+The community relay does not need Tailscale: OpenClaw connects outbound to it
+directly.
+
+On any failure, return `{"ok":false,"error":"..."}` and exit zero. Exit
+non-zero means the response is untrusted. Provider diagnostics must never
+echo the nsec, auth tag, or environment secrets.

--- a/docs/openclaw-enrollment.md
+++ b/docs/openclaw-enrollment.md
@@ -20,11 +20,11 @@ must answer `info` first, with protocol version `1`:
   "config_schema": {
     "type": "object",
     "properties": {
-      "host": { "type": "string", "description": "SSH destination, e.g. openclaw@agent-host" },
+      "host": { "type": "string", "description": "Optional SSH destination (advanced fallback)" },
       "rooms": { "type": "string", "description": "Comma-separated Buzz room UUIDs" },
       "port": { "type": "string", "description": "Optional SSH port" }
     },
-    "required": ["host", "rooms"]
+    "required": ["rooms"]
   },
   "enrollment": {
     "operation": "enroll",
@@ -72,8 +72,16 @@ After `info`, Desktop invokes the same staged provider binary once with:
 ```
 
 The exact managed-agent payload is the source of truth; providers must not
-reconstruct identity from `env_vars`. The provider uses SSH only for this
-one-time handoff, running `openclaw buzz enroll --stdin` on the remote host.
+reconstruct identity from `env_vars`. Without `host`, the provider generates
+a signed, short-lived code and returns a copyable command for the Desktop
+operator:
+
+```bash
+openclaw buzz enroll --code 'buzz-enroll-v1....'
+```
+
+With `host`, the provider preserves the legacy SSH handoff and runs
+`openclaw buzz enroll --stdin` on the remote host.
 It imports the identity and room configuration into OpenClaw and returns a
 stable host-side identifier:
 


### PR DESCRIPTION
## Summary
- terminate the provider enrollment-command `match` expression
- preserve and return `result.enrollment_command` after saving managed-agent state

## Validation
- `git diff --check` passed
- Rust validation unavailable in this environment because `cargo`/`rustfmt` are not installed
