### PR TITLE
fix(cli): read social publish body from stdin for the `-` sentinel

### DIFF
--- a/crates/buzz-cli/src/commands/social.rs
+++ b/crates/buzz-cli/src/commands/social.rs
@@ -7,7 +7,12 @@ use serde::Deserialize;
 
 use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
-use crate::validate::{parse_event_id, validate_hex64};
+use crate::validate::{parse_event_id, read_stdin_sentinel, validate_hex64};
+
+/// Bound on stdin reads for `social publish --content -`. Matches the
+/// `notes set` guardrail: NIP-01 doesn't cap event size, so this exists to stop
+/// a runaway producer OOMing the CLI.
+pub const PUBLISH_STDIN_MAX_BYTES: usize = 1024 * 1024;
 
 /// A single contact entry (CLI-local, not from buzz-sdk).
 #[derive(Debug, Deserialize)]
@@ -23,14 +28,22 @@ pub async fn cmd_publish_note(
     client: &BuzzClient,
     content: &str,
     reply_to: Option<&str>,
+    allow_empty: bool,
 ) -> Result<(), CliError> {
     if let Some(r) = reply_to {
         validate_hex64(r)?;
     }
 
+    // `--content -` reads the note body from stdin, the same sentinel
+    // `messages send` and `notes set` accept. Without this the CLI published a
+    // literal one-character `-` note and reported success, discarding the piped
+    // body — and kind:1 notes are awkward to walk back.
+    // See https://github.com/block/buzz/issues/4905.
+    let body = read_stdin_sentinel(content, PUBLISH_STDIN_MAX_BYTES, allow_empty)?;
+
     let reply_id = reply_to.map(parse_event_id).transpose()?;
 
-    let builder = buzz_sdk::build_note(content, reply_id)
+    let builder = buzz_sdk::build_note(&body, reply_id)
         .map_err(|e| CliError::Other(format!("build error: {e}")))?;
 
     let event = client.sign_event(builder)?;
@@ -211,9 +224,11 @@ pub async fn cmd_get_list(
 pub async fn dispatch(cmd: crate::SocialCmd, client: &BuzzClient) -> Result<(), CliError> {
     use crate::SocialCmd;
     match cmd {
-        SocialCmd::PublishNote { content, reply_to } => {
-            cmd_publish_note(client, &content, reply_to.as_deref()).await
-        }
+        SocialCmd::PublishNote {
+            content,
+            reply_to,
+            allow_empty,
+        } => cmd_publish_note(client, &content, reply_to.as_deref(), allow_empty).await,
         SocialCmd::SetContactList { contacts } => cmd_set_contact_list(client, &contacts).await,
         SocialCmd::GetEvent { event } => cmd_get_event(client, &event).await,
         SocialCmd::GetUserNotes {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -963,12 +963,15 @@ pub enum SocialCmd {
     /// Publish a text note (NIP-01 kind:1)
     #[command(name = "publish")]
     PublishNote {
-        /// Text content of the note.
+        /// Text content of the note. Pass `-` to read the body from stdin.
         #[arg(long)]
         content: String,
         /// 64-char hex event ID to reply to.
         #[arg(long)]
         reply_to: Option<String>,
+        /// Allow publishing an empty body read from stdin.
+        #[arg(long)]
+        allow_empty: bool,
     },
     /// Set your contact list (NIP-02 kind:3)
     #[command(name = "set-contacts")]

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -178,6 +178,59 @@ pub fn read_or_stdin(value: &str) -> Result<String, CliError> {
     }
 }
 
+/// Resolve a `--content -` style argument, reading stdin for the `-` sentinel.
+///
+/// Unlike [`read_or_stdin`] this applies the hygiene that publish-shaped
+/// commands need, matching `notes set` and `mem set`:
+///
+/// * the read is capped at `max_bytes` so a runaway producer cannot OOM the
+///   CLI (no Nostr kind caps event size for us), and
+/// * an empty read is refused unless `allow_empty` — an empty pipe almost
+///   always means an upstream pipeline step failed, and publishing the empty
+///   result is both wrong and, for immutable kinds, awkward to undo.
+///
+/// Values other than `-` are returned verbatim, including an empty string:
+/// only stdin reads are subject to the guardrails.
+pub fn read_stdin_sentinel(
+    value: &str,
+    max_bytes: usize,
+    allow_empty: bool,
+) -> Result<String, CliError> {
+    if value != "-" {
+        return Ok(value.to_string());
+    }
+    read_sentinel_from(std::io::stdin().lock(), max_bytes, allow_empty)
+}
+
+/// The reader half of [`read_stdin_sentinel`], split out so the guardrails are
+/// testable without a process-global stdin.
+fn read_sentinel_from(
+    reader: impl std::io::Read,
+    max_bytes: usize,
+    allow_empty: bool,
+) -> Result<String, CliError> {
+    use std::io::Read;
+    let mut buf = String::new();
+    reader
+        .take(max_bytes as u64 + 1)
+        .read_to_string(&mut buf)
+        .map_err(|e| CliError::Other(format!("stdin read failed: {e}")))?;
+
+    if buf.len() > max_bytes {
+        return Err(CliError::Usage(format!(
+            "stdin body exceeds {max_bytes}-byte limit"
+        )));
+    }
+    if buf.is_empty() && !allow_empty {
+        return Err(CliError::Usage(
+            "refusing to publish an empty body from stdin (an upstream pipeline step \
+             likely failed). Pass --allow-empty to confirm."
+                .into(),
+        ));
+    }
+    Ok(buf)
+}
+
 /// Read content from a file path, or stdin if the value is "-".
 ///
 /// Unlike [`read_or_stdin`], `value` is never treated as literal content —
@@ -474,6 +527,72 @@ mod tests {
     #[test]
     fn read_or_stdin_passthrough_empty_string() {
         assert_eq!(super::read_or_stdin("").unwrap(), "");
+    }
+
+    // --- read_stdin_sentinel ---
+    //
+    // Regression coverage for issue #4905: `social publish --content -` used to
+    // publish a literal one-character `-` note and report success, discarding
+    // the piped body.
+
+    #[test]
+    fn read_stdin_sentinel_passes_literal_values_through_untouched() {
+        // Only `-` means stdin. Everything else is the body verbatim, including
+        // values that merely contain a dash.
+        assert_eq!(
+            super::read_stdin_sentinel("hello", 1024, false).unwrap(),
+            "hello"
+        );
+        assert_eq!(super::read_stdin_sentinel("-x", 1024, false).unwrap(), "-x");
+        assert_eq!(
+            super::read_stdin_sentinel("a - b", 1024, false).unwrap(),
+            "a - b"
+        );
+    }
+
+    #[test]
+    fn read_stdin_sentinel_passes_empty_literal_through_without_the_guard() {
+        // The empty-body guard exists to catch a failed upstream pipe, so it
+        // applies to stdin reads only — an explicitly passed "" is the caller's
+        // choice and is not second-guessed.
+        assert_eq!(super::read_stdin_sentinel("", 1024, false).unwrap(), "");
+    }
+
+    #[test]
+    fn read_sentinel_from_reads_the_whole_body() {
+        let body = "expected multiline note body\nsecond line";
+        assert_eq!(
+            super::read_sentinel_from(body.as_bytes(), 1024, false).unwrap(),
+            body
+        );
+    }
+
+    #[test]
+    fn read_sentinel_from_rejects_empty_unless_allowed() {
+        let err = super::read_sentinel_from(&b""[..], 1024, false).unwrap_err();
+        assert!(
+            err.to_string().contains("--allow-empty"),
+            "error should point at the opt-out: {err}"
+        );
+        assert_eq!(super::read_sentinel_from(&b""[..], 1024, true).unwrap(), "");
+    }
+
+    #[test]
+    fn read_sentinel_from_enforces_the_byte_cap() {
+        // Exactly at the cap is fine; one byte over is refused rather than
+        // silently truncated.
+        let at_cap = "a".repeat(8);
+        assert_eq!(
+            super::read_sentinel_from(at_cap.as_bytes(), 8, false).unwrap(),
+            at_cap
+        );
+
+        let over_cap = "a".repeat(9);
+        let err = super::read_sentinel_from(over_cap.as_bytes(), 8, false).unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds"),
+            "error should name the limit: {err}"
+        );
     }
 
     // --- read_file_or_stdin ---


### PR DESCRIPTION
## Summary

`buzz social publish --content -` returned `accepted:true` and published a literal one-character `-` note, discarding the piped body. `-` is the stdin sentinel that `messages send`, `notes set` and `mem set` all accept — `social publish` just never implemented it.

Fixes #4905.

## Reproduced

Before, against a local relay:

```console
$ printf '%s' 'expected multiline note body' | buzz social publish --content -
{"accepted":true,"event_id":"…"}

$ # readback
content: "-"
```

After:

```console
$ printf '%s' 'expected multiline note body\nsecond line' | buzz social publish --content -
{"accepted":true,"event_id":"960eb0e2…"}

$ select content from events where kind = 1 order by created_at desc limit 1;
expected multiline note body
second line
```

It's a silent-success failure in an awkward place: the caller is told the publish worked, the intended body is gone, and `buzz social` has no delete command to walk a kind:1 note back.

## The fix

`cmd_publish_note` passed `content` straight to `build_note`. It now resolves the sentinel — but using the hygiene the other publish-shaped commands apply, rather than the bare `read_or_stdin`:

- **capped read** (1 MiB, matching `notes set`) so a runaway producer can't OOM the CLI — no Nostr kind caps event size for us
- **empty reads refused** unless `--allow-empty`, because an empty pipe almost always means an upstream pipeline step failed, and publishing the empty result is precisely the outcome this issue is about

Values other than `-` are still returned verbatim, **including an explicit empty string** — the guard applies to stdin reads only, so it never second-guesses a body the caller passed directly.

### Where the logic lives

`notes set` and `mem set` each carry their own inline copy of this. Rather than add a third, it now lives in `validate::read_stdin_sentinel`. This PR deliberately does **not** refactor those two working call sites onto it — happy to follow up separately if that's wanted.

The reader half is split into `read_sentinel_from(impl Read, …)` so the cap and the empty-body guard are testable without a process-global stdin. That's why the existing `read_or_stdin` tests only ever covered its passthrough branch — there was no way to exercise the read.

## Not addressed

The issue also notes there's no CLI path to delete the resulting bad note (`buzz social` has no note/event delete command). That's a new command surface rather than a bug fix, so it isn't in this PR. Happy to add `social delete` as a follow-up if maintainers want it — it'd be a kind:5 `e`-tag deletion.

## Testing

Five new unit tests in `validate.rs`:

| Test | Asserts |
|---|---|
| `read_stdin_sentinel_passes_literal_values_through_untouched` | only `-` means stdin; `-x` and `a - b` are bodies |
| `read_stdin_sentinel_passes_empty_literal_through_without_the_guard` | an explicit `""` is the caller's choice |
| `read_sentinel_from_reads_the_whole_body` | multiline bodies survive intact |
| `read_sentinel_from_rejects_empty_unless_allowed` | empty refused, and the error names `--allow-empty` |
| `read_sentinel_from_enforces_the_byte_cap` | at-cap passes, one byte over is refused rather than silently truncated |

Also verified end-to-end against a local relay: piped multiline content lands intact, empty stdin is refused, `--allow-empty` opts in, and literal `--content` is unaffected.

```
cargo fmt --all -- --check                             ✅
cargo clippy --workspace --all-targets -- -D warnings   ✅
cargo test -p buzz-cli                                  ✅ 326 passed
just test                                               ✅ 11/11 suites
```

## Related

Searched open PRs for #4905 and for social/stdin work — none found.
