### PR TITLE
style(messages): increase username contrast via font weight

### DIFF
--- a/desktop/src/features/messages/ui/MessageHeader.tsx
+++ b/desktop/src/features/messages/ui/MessageHeader.tsx
@@ -39,7 +39,7 @@ export function MessageAuthorText({
   return (
     <Component
       className={cn(
-        "truncate text-sm font-semibold leading-4 tracking-tight",
+        "truncate text-sm font-bold leading-4 tracking-tight",
         hoverUnderline && "hover:underline",
         className,
       )}


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Message usernames are now bolder, making it easier to distinguish who said what at a glance.

**Problem:** Usernames and surrounding message metadata had too little visual separation, which made message headers slower to scan. **Solution:** Increase the shared message-author label from semibold to bold while preserving its existing size, spacing, and interaction behavior.

<details>
<summary>File changes</summary>

**desktop/src/features/messages/ui/MessageHeader.tsx**
Raises the shared message-author font weight so standard and system message usernames gain consistent visual contrast.

</details>

## Reproduction steps

1. Open a channel containing messages from multiple people or agents.
2. Compare each message username with its timestamp and message body.
3. Confirm the username renders in bold while the surrounding typography and layout remain unchanged.

## Screenshots

| Before | After |
| --- | --- |
| ![Message usernames before](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/4948/before-message-usernames-alice-avatar.png) | ![Message usernames after](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/4948/after-message-usernames-alice-avatar.png) |


