### PR TITLE
feat: replace OpenClaw enrollment form with room command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,7 +980,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p desktop/src-tauri/binaries
-          for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
+          for bin in buzz-acp buzz-agent buzz-backend-openclaw buzz-dev-mcp git-credential-nostr buzz; do
             touch "desktop/src-tauri/binaries/${bin}-${TARGET}.exe"
           done
       - name: Clippy (workspace)
@@ -1055,6 +1055,7 @@ jobs:
           touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-backend-kubernetes-$TARGET"
+          touch "desktop/src-tauri/binaries/buzz-backend-openclaw-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
           touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-$TARGET"

--- a/.github/workflows/fork-unsigned-dmg.yml
+++ b/.github/workflows/fork-unsigned-dmg.yml
@@ -1,0 +1,56 @@
+name: Fork unsigned DMG
+
+on:
+  push:
+    tags:
+      - "fork-desktop-v[0-9]*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build unsigned macOS DMG
+    if: github.repository == 'atlas-maxjb/buzz'
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      VERSION: ${{ github.ref_name }}
+      TAURI_BUNDLER_DMG_IGNORE_CI: "true"
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      CMAKE_OSX_DEPLOYMENT_TARGET: "10.15"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+
+      - name: Set application version
+        run: |
+          VERSION="${VERSION#fork-desktop-v}"
+          cd desktop
+          node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri
+          cargo update --workspace
+
+      - name: Build sidecars
+        run: |
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh
+
+      - name: Build unsigned DMG
+        run: cd desktop && pnpm tauri build --verbose --no-sign --config src-tauri/tauri.conf.json
+
+      - name: Upload DMG to fork release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DMG=$(find desktop/src-tauri/target/release/bundle/dmg -name '*.dmg' -type f | head -1)
+          test -n "$DMG"
+          gh release upload "$GITHUB_REF_NAME" "$DMG" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/fork-unsigned-dmg.yml
+++ b/.github/workflows/fork-unsigned-dmg.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
       - name: Build unsigned DMG

--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
       - name: Build Linux Tauri app

--- a/.github/workflows/macos-intel-canary.yml
+++ b/.github/workflows/macos-intel-canary.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build Intel sidecars
         run: |
-          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh "$TARGET"
 
       - name: Build unsigned Intel DMG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   # create the release objects all four platform jobs upload into.
   setup:
     name: Setup
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -51,7 +51,7 @@ jobs:
 
   release:
     name: Release
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: macos-latest
     needs: setup
     timeout-minutes: 60
@@ -264,7 +264,7 @@ jobs:
 
   release-macos-x64:
     name: Release macOS (Intel)
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: macos-latest
     needs: setup
     timeout-minutes: 60
@@ -425,7 +425,7 @@ jobs:
 
   release-linux:
     name: Release Linux
-    if: github.repository == 'block/buzz'
+    if: github.repository == 'block/buzz' || github.repository == 'atlas-maxjb/buzz'
     runs-on: ubuntu-latest
     # Digest-pinned like the SHA-pinned actions below; Renovate keeps it fresh.
     container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
       # Mesh rev derived from Cargo.lock (no lockstep edit on dep bump); cache key tracks it.
@@ -308,7 +308,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh "$TARGET"
 
       - name: Build unsigned Tauri app
@@ -563,7 +563,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
       - name: Generate release config

--- a/.github/workflows/signed-macos-canary.yml
+++ b/.github/workflows/signed-macos-canary.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build sidecars
         run: |
-          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
           ./scripts/bundle-sidecars.sh
 
       # Mesh rev derived from Cargo.lock (no lockstep edit on dep bump); cache key tracks it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-backend-openclaw"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
 name = "buzz-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,8 @@ dependencies = [
 name = "buzz-backend-openclaw"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "nostr",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/buzz-dev-mcp",
     "crates/buzz-voice",
     "crates/buzz-backend-kubernetes",
+    "crates/buzz-backend-openclaw",
     "examples/countdown-bot",
 ]
 exclude = ["desktop/src-tauri"]

--- a/Justfile
+++ b/Justfile
@@ -155,7 +155,7 @@ _ensure-sidecar-stubs:
     set -euo pipefail
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     mkdir -p desktop/src-tauri/binaries
-    SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz)
+    SIDECARS=(buzz-acp buzz-agent buzz-backend-openclaw buzz-dev-mcp git-credential-nostr buzz)
     if [[ "$TARGET" != *windows* ]]; then
         SIDECARS+=(buzz-backend-kubernetes)
     fi
@@ -519,7 +519,7 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     set -euo pipefail
     export PATH="{{justfile_directory()}}/bin:$PATH"
     pnpm install  # unconditional: staging must always start with a clean dep tree
-    cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
+    cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     FEATURES=()
     if [[ -n "{{mesh}}" ]]; then
         FEATURES=(--features mesh-llm)
@@ -531,7 +531,7 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
     # tauri dev copies next to the exe would hide the provider from "Run on".
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
-    STAGING_SIDECARS=(buzz)
+    STAGING_SIDECARS=(buzz buzz-backend-openclaw)
     if [[ "$TARGET" != *windows* ]]; then
         STAGING_SIDECARS+=(buzz-backend-kubernetes)
     fi
@@ -555,7 +555,7 @@ production *ARGS: bootstrap _ensure-sidecar-stubs
     set -euo pipefail
     export PATH="{{justfile_directory()}}/bin:$PATH"
     pnpm install  # unconditional: production must always start with a clean dep tree
-    cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
+    cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-openclaw -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     FEATURES=()
     if [[ -n "{{mesh}}" ]]; then
         FEATURES=(--features mesh-llm)
@@ -567,7 +567,7 @@ production *ARGS: bootstrap _ensure-sidecar-stubs
     # tauri dev copies next to the exe would hide the provider from "Run on".
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
-    PRODUCTION_SIDECARS=(buzz)
+    PRODUCTION_SIDECARS=(buzz buzz-backend-openclaw)
     if [[ "$TARGET" != *windows* ]]; then
         PRODUCTION_SIDECARS+=(buzz-backend-kubernetes)
     fi

--- a/crates/buzz-backend-openclaw/Cargo.toml
+++ b/crates/buzz-backend-openclaw/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "buzz-backend-openclaw"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "OpenClaw enrollment provider for Buzz Desktop"
+
+[[bin]]
+name = "buzz-backend-openclaw"
+path = "src/main.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/buzz-backend-openclaw/Cargo.toml
+++ b/crates/buzz-backend-openclaw/Cargo.toml
@@ -11,6 +11,8 @@ name = "buzz-backend-openclaw"
 path = "src/main.rs"
 
 [dependencies]
+base64 = { workspace = true }
+nostr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/buzz-backend-openclaw/src/main.rs
+++ b/crates/buzz-backend-openclaw/src/main.rs
@@ -5,12 +5,40 @@
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
-use serde_json::{json, Map, Value};
+use serde::Serialize;
+use serde_json::{json, Value};
 use std::io::Read;
 use uuid::Uuid;
 
 const CODE_PREFIX: &str = "buzz-enroll-v1";
 const CODE_TTL_SECONDS: u64 = 10 * 60;
+
+#[derive(Serialize)]
+struct EnrollmentPayload {
+    version: u8,
+    #[serde(rename = "relayUrl")]
+    relay_url: String,
+    #[serde(rename = "privateKey")]
+    private_key: String,
+    #[serde(rename = "authTag", skip_serializing_if = "Option::is_none")]
+    auth_tag: Option<String>,
+    rooms: Vec<Value>,
+    #[serde(rename = "accountId")]
+    account_id: String,
+    #[serde(rename = "agentId")]
+    agent_id: String,
+    #[serde(rename = "defaultTo")]
+    default_to: String,
+}
+
+#[derive(Serialize)]
+struct UnsignedCode {
+    version: u8,
+    #[serde(rename = "expiresAt")]
+    expires_at: u64,
+    nonce: String,
+    payload: EnrollmentPayload,
+}
 
 fn info() -> Value {
     json!({
@@ -65,33 +93,32 @@ fn enrollment_code(agent: &Value, rooms: &str) -> Result<(String, String), Strin
     let now = Timestamp::now().as_secs();
     let expires_at = (now + CODE_TTL_SECONDS) * 1000;
     let nonce = Uuid::new_v4().simple().to_string();
-    let mut payload = Map::new();
-    payload.insert("version".into(), json!(1));
-    payload.insert("relayUrl".into(), json!(relay_url));
-    payload.insert("privateKey".into(), json!(private_key));
-    if let Some(auth_tag) = agent.get("auth_tag").and_then(Value::as_str) {
-        if !auth_tag.is_empty() {
-            payload.insert("authTag".into(), json!(auth_tag));
-        }
-    }
-    payload.insert("rooms".into(), Value::Array(room_ids));
-    payload.insert("accountId".into(), json!(agent_id));
-    payload.insert("agentId".into(), json!(agent_id));
-    payload.insert(
-        "defaultTo".into(),
-        json!(rooms
-            .split(',')
-            .map(str::trim)
-            .find(|room| !room.is_empty())
-            .unwrap_or_default()),
-    );
-
-    let unsigned = json!({
-        "version": 1,
-        "expiresAt": expires_at,
-        "nonce": nonce,
-        "payload": Value::Object(payload),
-    });
+    let auth_tag = agent
+        .get("auth_tag")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(String::from);
+    let default_to = rooms
+        .split(',')
+        .map(str::trim)
+        .find(|room| !room.is_empty())
+        .unwrap_or_default()
+        .to_string();
+    let unsigned = UnsignedCode {
+        version: 1,
+        expires_at,
+        nonce,
+        payload: EnrollmentPayload {
+            version: 1,
+            relay_url: relay_url.to_string(),
+            private_key: private_key.to_string(),
+            auth_tag,
+            rooms: room_ids,
+            account_id: agent_id.clone(),
+            agent_id: agent_id.clone(),
+            default_to,
+        },
+    };
     let transcript = serde_json::to_string(&unsigned)
         .map_err(|_| "could not encode enrollment code".to_string())?;
     let event = EventBuilder::new(Kind::Custom(27235), transcript)
@@ -102,7 +129,8 @@ fn enrollment_code(agent: &Value, rooms: &str) -> Result<(String, String), Strin
         .custom_created_at(Timestamp::from(now))
         .sign_with_keys(&keys)
         .map_err(|_| "could not sign enrollment code".to_string())?;
-    let mut signed = unsigned;
+    let mut signed = serde_json::to_value(unsigned)
+        .map_err(|_| "could not encode enrollment code".to_string())?;
     signed["signature"] = serde_json::to_value(event)
         .map_err(|_| "could not encode enrollment signature".to_string())?;
     let encoded = URL_SAFE_NO_PAD.encode(

--- a/crates/buzz-backend-openclaw/src/main.rs
+++ b/crates/buzz-backend-openclaw/src/main.rs
@@ -1,12 +1,16 @@
 //! One-shot OpenClaw enrollment provider bundled with Buzz Desktop.
 //!
-//! The normal path uses a one-time enrollment code. An explicit host opts into
-//! the SSH fallback. OpenClaw subsequently connects directly to Buzz using the
-//! relay details in the v1 payload; this process is never a runtime proxy.
+//! The provider creates a short-lived, signed enrollment command for the
+//! operator to run on the OpenClaw server. It is never a runtime proxy.
 
-use serde_json::{json, Value};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
+use serde_json::{json, Map, Value};
 use std::io::Read;
-use std::process::{Command, Stdio};
+use uuid::Uuid;
+
+const CODE_PREFIX: &str = "buzz-enroll-v1";
+const CODE_TTL_SECONDS: u64 = 10 * 60;
 
 fn info() -> Value {
     json!({
@@ -14,16 +18,13 @@ fn info() -> Value {
         "name": "openclaw",
         "version": env!("CARGO_PKG_VERSION"),
         "protocol_version": 1,
-        "description": "Enrolls agents with OpenClaw using a one-time code",
+        "description": "Generates a one-time OpenClaw enrollment command",
         "config_schema": {
             "type": "object",
             "properties": {
-                "enrollment_code": { "type": "string", "title": "One-time enrollment code", "description": "Paste the code shown by OpenClaw" },
-                "rooms": { "type": "string", "format": "buzz-room-picker", "description": "Buzz rooms selected in Desktop" },
-                "host": { "type": "string", "title": "SSH host (advanced)", "description": "Optional SSH destination, e.g. openclaw@agent-host" },
-                "port": { "type": "string", "description": "Optional SSH port" }
+                "rooms": { "type": "string", "format": "buzz-room-picker", "description": "Buzz rooms selected in Desktop" }
             },
-            "required": ["enrollment_code", "rooms"]
+            "required": ["rooms"]
         },
         "enrollment": {
             "operation": "enroll",
@@ -37,110 +38,101 @@ fn error(message: impl Into<String>) -> Value {
     json!({"ok": false, "error": message.into()})
 }
 
+fn enrollment_code(agent: &Value, rooms: &str) -> Result<(String, String), String> {
+    let relay_url = agent
+        .get("relay_url")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "agent relay_url is required".to_string())?;
+    let private_key = agent
+        .get("private_key_nsec")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "agent private_key_nsec is required".to_string())?;
+    let keys =
+        Keys::parse(private_key).map_err(|_| "agent private_key_nsec is invalid".to_string())?;
+    let agent_id = format!("openclaw-{}", keys.public_key().to_hex()[..16].to_string());
+    let room_ids = rooms
+        .split(',')
+        .map(str::trim)
+        .filter(|room| !room.is_empty())
+        .map(|id| json!({"id": id, "enabled": true, "requireMention": false}))
+        .collect::<Vec<_>>();
+    if room_ids.is_empty() {
+        return Err("provider_config.rooms is required".to_string());
+    }
+
+    let now = Timestamp::now().as_secs();
+    let expires_at = (now + CODE_TTL_SECONDS) * 1000;
+    let nonce = Uuid::new_v4().simple().to_string();
+    let mut payload = Map::new();
+    payload.insert("version".into(), json!(1));
+    payload.insert("relayUrl".into(), json!(relay_url));
+    payload.insert("privateKey".into(), json!(private_key));
+    if let Some(auth_tag) = agent.get("auth_tag").and_then(Value::as_str) {
+        if !auth_tag.is_empty() {
+            payload.insert("authTag".into(), json!(auth_tag));
+        }
+    }
+    payload.insert("rooms".into(), Value::Array(room_ids));
+    payload.insert("accountId".into(), json!(agent_id));
+    payload.insert("agentId".into(), json!(agent_id));
+    payload.insert(
+        "defaultTo".into(),
+        json!(rooms
+            .split(',')
+            .map(str::trim)
+            .find(|room| !room.is_empty())
+            .unwrap_or_default()),
+    );
+
+    let unsigned = json!({
+        "version": 1,
+        "expiresAt": expires_at,
+        "nonce": nonce,
+        "payload": Value::Object(payload),
+    });
+    let transcript = serde_json::to_string(&unsigned)
+        .map_err(|_| "could not encode enrollment code".to_string())?;
+    let event = EventBuilder::new(Kind::Custom(27235), transcript)
+        .tags([
+            Tag::parse(["expiration", &(now + CODE_TTL_SECONDS).to_string()])
+                .map_err(|_| "could not create enrollment expiration".to_string())?,
+        ])
+        .custom_created_at(Timestamp::from(now))
+        .sign_with_keys(&keys)
+        .map_err(|_| "could not sign enrollment code".to_string())?;
+    let mut signed = unsigned;
+    signed["signature"] = serde_json::to_value(event)
+        .map_err(|_| "could not encode enrollment signature".to_string())?;
+    let encoded = URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&signed)
+            .map_err(|_| "could not encode enrollment command".to_string())?,
+    );
+    Ok((
+        agent_id,
+        format!("openclaw buzz enroll --code '{CODE_PREFIX}.{encoded}'"),
+    ))
+}
+
 fn enroll(request: &Value) -> Value {
     let config = match request.get("provider_config").and_then(Value::as_object) {
         Some(config) => config,
         None => return error("provider_config must be an object"),
     };
-    let code = match config
-        .get("enrollment_code")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-    {
-        Some(code) => code,
-        None => return error("provider_config.enrollment_code is required"),
+    let rooms = match config.get("rooms").and_then(Value::as_str) {
+        Some(rooms) => rooms,
+        None => return error("provider_config.rooms is required"),
     };
-    if config.get("rooms").and_then(Value::as_str).is_none() {
-        return error("provider_config.rooms is required");
-    }
     let agent = match request.get("agent") {
         Some(agent) if agent.is_object() => agent,
         _ => return error("agent payload is required"),
     };
-
-    let host = config
-        .get("host")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty());
-    let mut args: Vec<String> = if host.is_some() {
-        vec!["-o".into(), "BatchMode=yes".into()]
-    } else {
-        Vec::new()
-    };
-    if let Some(host) = host {
-        if let Some(port) = config
-            .get("port")
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-        {
-            args.extend(["-p".into(), port.into()]);
+    match enrollment_code(agent, rooms) {
+        Ok((agent_id, command)) => {
+            json!({"ok": true, "agent_id": agent_id, "enrollment_command": command})
         }
-        args.push(host.into());
-    }
-    args.extend([
-        "openclaw".into(),
-        "buzz".into(),
-        "enroll".into(),
-        "--code".into(),
-        code.into(),
-        "--stdin".into(),
-    ]);
-
-    // Tests may provide a fake ssh executable. Production uses the user's
-    // normal ssh trust/agent configuration for the explicit host fallback.
-    let command = if host.is_some() {
-        std::env::var_os("BUZZ_OPENCLAW_SSH").unwrap_or_else(|| "ssh".into())
-    } else {
-        "openclaw".into()
-    };
-    let mut child = match Command::new(command)
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(_) => return error("could not start OpenClaw enrollment command"),
-    };
-    let remote_payload = json!({
-        "version": 1,
-        "agent": agent,
-        "rooms": config.get("rooms").and_then(Value::as_str).unwrap_or_default(),
-    });
-    let payload = match serde_json::to_vec(&remote_payload) {
-        Ok(mut payload) => {
-            payload.push(b'\n');
-            payload
-        }
-        Err(_) => return error("could not encode enrollment payload"),
-    };
-    if let Some(mut stdin) = child.stdin.take() {
-        if std::io::Write::write_all(&mut stdin, &payload).is_err() {
-            return error("could not send enrollment payload");
-        }
-    }
-    let output = match child.wait_with_output() {
-        Ok(output) => output,
-        Err(_) => return error("OpenClaw enrollment failed"),
-    };
-    if !output.status.success() {
-        return error("OpenClaw enrollment failed");
-    }
-    let response: Value = match serde_json::from_slice(&output.stdout) {
-        Ok(response) => response,
-        Err(_) => return error("OpenClaw returned invalid enrollment response"),
-    };
-    if response.get("ok") != Some(&Value::Bool(true)) {
-        return error("OpenClaw enrollment was rejected");
-    }
-    match response
-        .get("agent_id")
-        .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())
-    {
-        Some(agent_id) => json!({"ok": true, "agent_id": agent_id}),
-        None => error("OpenClaw enrollment response missing agent_id"),
+        Err(message) => error(message),
     }
 }
 
@@ -177,17 +169,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn info_declares_one_time_v1_enrollment() {
+    fn info_declares_rooms_only_for_one_time_v1_enrollment() {
         assert_eq!(info()["protocol_version"], 1);
         assert_eq!(info()["enrollment"]["one_time"], true);
-    }
-
-    #[test]
-    fn info_prefers_code_and_marks_rooms_for_desktop_picker() {
-        assert_eq!(
-            info()["config_schema"]["required"],
-            json!(["enrollment_code", "rooms"])
-        );
+        assert_eq!(info()["config_schema"]["required"], json!(["rooms"]));
         assert_eq!(
             info()["config_schema"]["properties"]["rooms"]["format"],
             "buzz-room-picker"
@@ -195,16 +180,34 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_code_without_invoking_openclaw() {
+    fn rejects_missing_rooms_without_creating_command() {
         let response = respond(json!({
             "op": "enroll",
             "enrollment": {"version": 1},
             "agent": {}
         }));
         assert_eq!(response["ok"], false);
-        assert!(response["error"]
+        assert!(response["error"].as_str().unwrap().contains("rooms"));
+    }
+
+    #[test]
+    fn generates_copyable_command_without_ssh_or_code_config() {
+        let keys = Keys::generate();
+        let request = json!({
+            "op": "enroll",
+            "enrollment": {"version": 1, "mode": "one-time"},
+            "agent": {
+                "relay_url": "wss://relay.example",
+                "private_key_nsec": keys.secret_key().to_bech32().unwrap(),
+                "auth_tag": "[\"auth\",\"owner\",\"\",\"sig\"]"
+            },
+            "provider_config": {"rooms": "room-a,room-b"}
+        });
+        let response = respond(request);
+        assert_eq!(response["ok"], true);
+        assert!(response["enrollment_command"]
             .as_str()
             .unwrap()
-            .contains("enrollment_code"));
+            .starts_with("openclaw buzz enroll --code 'buzz-enroll-v1."));
     }
 }

--- a/crates/buzz-backend-openclaw/src/main.rs
+++ b/crates/buzz-backend-openclaw/src/main.rs
@@ -1,0 +1,210 @@
+//! One-shot OpenClaw enrollment provider bundled with Buzz Desktop.
+//!
+//! The normal path uses a one-time enrollment code. An explicit host opts into
+//! the SSH fallback. OpenClaw subsequently connects directly to Buzz using the
+//! relay details in the v1 payload; this process is never a runtime proxy.
+
+use serde_json::{json, Value};
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+fn info() -> Value {
+    json!({
+        "ok": true,
+        "name": "openclaw",
+        "version": env!("CARGO_PKG_VERSION"),
+        "protocol_version": 1,
+        "description": "Enrolls agents with OpenClaw using a one-time code",
+        "config_schema": {
+            "type": "object",
+            "properties": {
+                "enrollment_code": { "type": "string", "title": "One-time enrollment code", "description": "Paste the code shown by OpenClaw" },
+                "rooms": { "type": "string", "format": "buzz-room-picker", "description": "Buzz rooms selected in Desktop" },
+                "host": { "type": "string", "title": "SSH host (advanced)", "description": "Optional SSH destination, e.g. openclaw@agent-host" },
+                "port": { "type": "string", "description": "Optional SSH port" }
+            },
+            "required": ["enrollment_code", "rooms"]
+        },
+        "enrollment": {
+            "operation": "enroll",
+            "one_time": true,
+            "credential_fields": ["private_key_nsec", "auth_tag", "relay_url"]
+        }
+    })
+}
+
+fn error(message: impl Into<String>) -> Value {
+    json!({"ok": false, "error": message.into()})
+}
+
+fn enroll(request: &Value) -> Value {
+    let config = match request.get("provider_config").and_then(Value::as_object) {
+        Some(config) => config,
+        None => return error("provider_config must be an object"),
+    };
+    let code = match config
+        .get("enrollment_code")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        Some(code) => code,
+        None => return error("provider_config.enrollment_code is required"),
+    };
+    if config.get("rooms").and_then(Value::as_str).is_none() {
+        return error("provider_config.rooms is required");
+    }
+    let agent = match request.get("agent") {
+        Some(agent) if agent.is_object() => agent,
+        _ => return error("agent payload is required"),
+    };
+
+    let host = config
+        .get("host")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    let mut args: Vec<String> = if host.is_some() {
+        vec!["-o".into(), "BatchMode=yes".into()]
+    } else {
+        Vec::new()
+    };
+    if let Some(host) = host {
+        if let Some(port) = config
+            .get("port")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        {
+            args.extend(["-p".into(), port.into()]);
+        }
+        args.push(host.into());
+    }
+    args.extend([
+        "openclaw".into(),
+        "buzz".into(),
+        "enroll".into(),
+        "--code".into(),
+        code.into(),
+        "--stdin".into(),
+    ]);
+
+    // Tests may provide a fake ssh executable. Production uses the user's
+    // normal ssh trust/agent configuration for the explicit host fallback.
+    let command = if host.is_some() {
+        std::env::var_os("BUZZ_OPENCLAW_SSH").unwrap_or_else(|| "ssh".into())
+    } else {
+        "openclaw".into()
+    };
+    let mut child = match Command::new(command)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return error("could not start OpenClaw enrollment command"),
+    };
+    let remote_payload = json!({
+        "version": 1,
+        "agent": agent,
+        "rooms": config.get("rooms").and_then(Value::as_str).unwrap_or_default(),
+    });
+    let payload = match serde_json::to_vec(&remote_payload) {
+        Ok(mut payload) => {
+            payload.push(b'\n');
+            payload
+        }
+        Err(_) => return error("could not encode enrollment payload"),
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if std::io::Write::write_all(&mut stdin, &payload).is_err() {
+            return error("could not send enrollment payload");
+        }
+    }
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(_) => return error("OpenClaw enrollment failed"),
+    };
+    if !output.status.success() {
+        return error("OpenClaw enrollment failed");
+    }
+    let response: Value = match serde_json::from_slice(&output.stdout) {
+        Ok(response) => response,
+        Err(_) => return error("OpenClaw returned invalid enrollment response"),
+    };
+    if response.get("ok") != Some(&Value::Bool(true)) {
+        return error("OpenClaw enrollment was rejected");
+    }
+    match response
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        Some(agent_id) => json!({"ok": true, "agent_id": agent_id}),
+        None => error("OpenClaw enrollment response missing agent_id"),
+    }
+}
+
+fn respond(request: Value) -> Value {
+    match request.get("op").and_then(Value::as_str) {
+        Some("info") => info(),
+        Some("enroll")
+            if request
+                .get("enrollment")
+                .and_then(|value| value.get("version"))
+                .and_then(Value::as_u64)
+                == Some(1) =>
+        {
+            enroll(&request)
+        }
+        Some("enroll") => error("unsupported enrollment version"),
+        _ => error("unsupported operation"),
+    }
+}
+
+fn main() {
+    let mut input = String::new();
+    if std::io::stdin().read_to_string(&mut input).is_err() {
+        std::process::exit(1);
+    }
+    let response = serde_json::from_str::<Value>(&input)
+        .map(respond)
+        .unwrap_or_else(|_| error("request is not valid JSON"));
+    println!("{}", response);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_declares_one_time_v1_enrollment() {
+        assert_eq!(info()["protocol_version"], 1);
+        assert_eq!(info()["enrollment"]["one_time"], true);
+    }
+
+    #[test]
+    fn info_prefers_code_and_marks_rooms_for_desktop_picker() {
+        assert_eq!(
+            info()["config_schema"]["required"],
+            json!(["enrollment_code", "rooms"])
+        );
+        assert_eq!(
+            info()["config_schema"]["properties"]["rooms"]["format"],
+            "buzz-room-picker"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_code_without_invoking_openclaw() {
+        let response = respond(json!({
+            "op": "enroll",
+            "enrollment": {"version": 1},
+            "agent": {}
+        }));
+        assert_eq!(response["ok"], false);
+        assert!(response["error"]
+            .as_str()
+            .unwrap()
+            .contains("enrollment_code"));
+    }
+}

--- a/desktop/src-tauri/src/commands/agent_providers.rs
+++ b/desktop/src-tauri/src/commands/agent_providers.rs
@@ -1,4 +1,6 @@
-use crate::managed_agents::{discover_provider_candidates, invoke_provider, BackendProviderInfo};
+use crate::managed_agents::{
+    discover_provider_candidates, invoke_provider, validate_provider_info, BackendProviderInfo,
+};
 
 #[tauri::command]
 pub async fn discover_backend_providers() -> Result<Vec<BackendProviderInfo>, String> {
@@ -39,7 +41,9 @@ pub async fn probe_backend_provider(binary_path: String) -> Result<serde_json::V
         "request_id": uuid::Uuid::new_v4().to_string(),
     });
     tokio::task::spawn_blocking(move || {
-        invoke_provider(&canonical, &request, std::time::Duration::from_secs(10))
+        let info = invoke_provider(&canonical, &request, std::time::Duration::from_secs(10))?;
+        validate_provider_info(&info)?;
+        Ok(info)
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -464,7 +464,7 @@ async fn deploy_to_provider(
     config: &serde_json::Value,
     agent_json: serde_json::Value,
     cached_binary_path: Option<&str>,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     // Resolve via discovered candidates only. Cached path must match BOTH
     // "is a discovered candidate" AND "belongs to this provider_id". A tampered
     // record cannot redirect deploys to a different provider's binary.
@@ -497,8 +497,9 @@ async fn deploy_to_provider(
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
 
     match deploy_result {
-        Ok(backend_agent_id) => {
-            rec.backend_agent_id = Some(backend_agent_id);
+        Ok(result) => {
+            let enrollment_command = result.enrollment_command;
+            rec.backend_agent_id = Some(result.agent_id);
             rec.last_started_at = Some(now_iso());
             rec.updated_at = now_iso();
             rec.last_error = None;
@@ -511,7 +512,7 @@ async fn deploy_to_provider(
         }
     }
     save_managed_agents(app, &records)?;
-    Ok(())
+    Ok(enrollment_command)
 }
 
 // Async so the blocking body (disk reads of agent/persona records, per-agent
@@ -999,6 +1000,7 @@ pub async fn create_managed_agent(
         .err();
 
     // ── Phase 5: provider deploy (async, outside lock) ───────────────────────
+    let mut enrollment_command = None;
     let spawn_error = if input.spawn_after_create && input.backend != BackendKind::Local {
         if let BackendKind::Provider { ref id, ref config } = input.backend {
             // Read the saved record to build the deploy payload (record has the
@@ -1016,7 +1018,10 @@ pub async fn create_managed_agent(
                 build_deploy_payload(&app, &state, rec)?
             };
             match deploy_to_provider(&app, &state, &pubkey, id, config, agent_json, None).await {
-                Ok(()) => spawn_error,
+                Ok(command) => {
+                    enrollment_command = command;
+                    spawn_error
+                }
                 Err(e) => Some(e),
             }
         } else {
@@ -1058,6 +1063,7 @@ pub async fn create_managed_agent(
         private_key_nsec,
         profile_sync_error,
         spawn_error,
+        enrollment_command,
     })
 }
 

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -510,7 +510,7 @@ async fn deploy_to_provider(
             save_managed_agents(app, &records)?;
             return Err(e.clone());
         }
-    }
+    };
     save_managed_agents(app, &records)?;
     Ok(enrollment_command)
 }

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -454,8 +454,8 @@ pub(super) async fn start_local_agent_with_preflight(
 /// again. Providers are expected to handle this as an update-in-place or no-op —
 /// the protocol does not include an explicit `undeploy` operation (deferred to v2).
 ///
-/// Returns Ok(()) on success, Err(message) on failure. Either way the record is
-/// updated and saved before returning.
+/// Returns the optional enrollment command on success, or Err(message) on
+/// failure. Either way the record is updated and saved before returning.
 async fn deploy_to_provider(
     app: &AppHandle,
     state: &AppState,
@@ -496,13 +496,13 @@ async fn deploy_to_provider(
         .find(|r| r.pubkey == pubkey)
         .ok_or_else(|| format!("agent {pubkey} not found"))?;
 
-    match deploy_result {
+    let enrollment_command = match deploy_result {
         Ok(result) => {
-            let enrollment_command = result.enrollment_command;
             rec.backend_agent_id = Some(result.agent_id);
             rec.last_started_at = Some(now_iso());
             rec.updated_at = now_iso();
             rec.last_error = None;
+            result.enrollment_command
         }
         Err(ref e) => {
             rec.last_error = Some(e.clone());

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -10,7 +10,7 @@ const STDERR_CAP: usize = 65536;
 const STDOUT_CAP: usize = 1_048_576; // 1 MB
 const PROVIDER_PROTOCOL_VERSION: u64 = 1;
 
-fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
+pub fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
     let object = info
         .as_object()
         .ok_or_else(|| "provider info response must be a JSON object".to_string())?;
@@ -45,6 +45,38 @@ fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
         return Err("provider info response missing object config_schema".to_string());
     }
 
+    // Providers that can import an agent into an existing remote runtime may
+    // opt into the one-shot enrollment operation. Keep this capability
+    // explicit and closed-world: a provider cannot silently change the
+    // meaning of the secret-bearing deploy request.
+    if let Some(enrollment) = object.get("enrollment") {
+        let enrollment = enrollment
+            .as_object()
+            .ok_or_else(|| "provider enrollment must be an object".to_string())?;
+        if enrollment.get("operation").and_then(serde_json::Value::as_str) != Some("enroll")
+            || enrollment.get("one_time") != Some(&serde_json::Value::Bool(true))
+        {
+            return Err(
+                "provider enrollment must declare operation: enroll and one_time: true".to_string(),
+            );
+        }
+        if let Some(fields) = enrollment.get("credential_fields") {
+            let fields = fields.as_array().ok_or_else(|| {
+                "provider enrollment credential_fields must be an array".to_string()
+            })?;
+            if fields.iter().any(|field| field.as_str().is_none()) {
+                return Err(
+                    "provider enrollment credential_fields must contain strings".to_string(),
+                );
+            }
+        }
+        if enrollment.keys().any(|field| {
+            !["operation", "one_time", "credential_fields"].contains(&field.as_str())
+        }) {
+            return Err("provider enrollment contains an unknown field".to_string());
+        }
+    }
+
     const FIELDS: &[&str] = &[
         "ok",
         "name",
@@ -52,6 +84,7 @@ fn validate_provider_info(info: &serde_json::Value) -> Result<(), String> {
         "protocol_version",
         "description",
         "config_schema",
+        "enrollment",
     ];
     if let Some(field) = object
         .keys()
@@ -519,12 +552,16 @@ pub fn provider_deploy(
     let info = invoke_provider(&staged, &info_request, Duration::from_secs(10))?;
     validate_provider_info(&info)?;
 
-    let request = serde_json::json!({
-        "op": "deploy",
+    let enrollment = info.get("enrollment").is_some();
+    let mut request = serde_json::json!({
+        "op": if enrollment { "enroll" } else { "deploy" },
         "request_id": uuid::Uuid::new_v4().to_string(),
         "agent": agent,
         "provider_config": provider_config,
     });
+    if enrollment {
+        request["enrollment"] = serde_json::json!({ "version": 1, "mode": "one-time" });
+    }
     let resp = invoke_provider(&staged, &request, Duration::from_secs(600))?;
     resp["agent_id"]
         .as_str()

--- a/desktop/src-tauri/src/managed_agents/backend.rs
+++ b/desktop/src-tauri/src/managed_agents/backend.rs
@@ -539,11 +539,16 @@ fn stage_provider(
 
 /// Deploy through one immutable staged copy: negotiate protocol v1 before the
 /// secret-bearing request, then invoke deploy on those exact same bytes.
+pub struct ProviderDeployResult {
+    pub agent_id: String,
+    pub enrollment_command: Option<String>,
+}
+
 pub fn provider_deploy(
     binary: &Path,
     agent: &serde_json::Value,
     provider_config: &serde_json::Value,
-) -> Result<String, String> {
+) -> Result<ProviderDeployResult, String> {
     let (_directory, staged, _digest, _execution_guard) = stage_provider(binary)?;
     let info_request = serde_json::json!({
         "op": "info",
@@ -563,10 +568,14 @@ pub fn provider_deploy(
         request["enrollment"] = serde_json::json!({ "version": 1, "mode": "one-time" });
     }
     let resp = invoke_provider(&staged, &request, Duration::from_secs(600))?;
-    resp["agent_id"]
+    let agent_id = resp["agent_id"]
         .as_str()
         .map(String::from)
-        .ok_or_else(|| "deploy response missing agent_id".to_string())
+        .ok_or_else(|| "deploy response missing agent_id".to_string())?;
+    Ok(ProviderDeployResult {
+        agent_id,
+        enrollment_command: resp["enrollment_command"].as_str().map(String::from),
+    })
 }
 
 /// Validate provider_config: flat object, scalar values, no secret-like keys.

--- a/desktop/src-tauri/src/managed_agents/backend_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/backend_tests.rs
@@ -176,6 +176,29 @@ esac"#,
 }
 
 #[cfg(unix)]
+#[test]
+fn provider_enrollment_uses_explicit_one_time_operation() {
+    let directory = tempfile::tempdir().unwrap();
+    let provider = directory.path().join("provider");
+    let seen = directory.path().join("operation");
+    let body = format!(
+        r#"read request
+case "$request" in
+  *\"op\":\"info\"*) printf '%s\n' '{{"ok":true,"name":"openclaw","version":"1","protocol_version":1,"description":"enrollment","config_schema":{{}},"enrollment":{{"operation":"enroll","one_time":true,"credential_fields":["private_key_nsec","auth_tag","relay_url"]}}}}' ;;
+  *\"op\":\"enroll\"*) printf enroll > '{}'; printf '%s\n' '{{"ok":true,"agent_id":"openclaw-1"}}' ;;
+  *) exit 2 ;;
+esac"#,
+        seen.display()
+    );
+    write_test_provider(&provider, &body);
+
+    let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
+        .expect("staged enrollment");
+    assert_eq!(id, "openclaw-1");
+    assert_eq!(std::fs::read_to_string(seen).unwrap(), "enroll");
+}
+
+#[cfg(unix)]
 fn replacement_provider() -> &'static str {
     r#"#!/bin/sh
 set -eu

--- a/desktop/src-tauri/src/managed_agents/backend_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/backend_tests.rs
@@ -160,7 +160,7 @@ esac"#,
 
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("staged deploy");
-    assert_eq!(id, "remote-1");
+    assert_eq!(id.agent_id, "remote-1");
     let paths: Vec<_> = std::fs::read_to_string(log)
         .unwrap()
         .lines()
@@ -194,7 +194,7 @@ esac"#,
 
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("staged enrollment");
-    assert_eq!(id, "openclaw-1");
+    assert_eq!(id.agent_id, "openclaw-1");
     assert_eq!(std::fs::read_to_string(seen).unwrap(), "enroll");
 }
 
@@ -239,7 +239,7 @@ esac"#,
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("deploy from immutable staged copy");
 
-    assert_eq!(id, "original-staged-bytes");
+    assert_eq!(id.agent_id, "original-staged-bytes");
     assert_eq!(
         std::fs::metadata(&provider).unwrap().ino(),
         inode_before,
@@ -280,7 +280,7 @@ esac"#,
     let id = provider_deploy(&provider, &serde_json::json!({}), &serde_json::json!({}))
         .expect("deploy from immutable staged copy");
 
-    assert_eq!(id, "original-staged-bytes");
+    assert_eq!(id.agent_id, "original-staged-bytes");
     assert_ne!(
         std::fs::metadata(&provider).unwrap().ino(),
         inode_before,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -574,6 +574,7 @@ pub struct CreateManagedAgentResponse {
     pub private_key_nsec: String,
     pub profile_sync_error: Option<String>,
     pub spawn_error: Option<String>,
+    pub enrollment_command: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -56,6 +56,7 @@
       "binaries/buzz-acp",
       "binaries/buzz-agent",
       "binaries/buzz-backend-kubernetes",
+      "binaries/buzz-backend-openclaw",
       "binaries/buzz-dev-mcp",
       "binaries/git-credential-nostr",
       "binaries/buzz"

--- a/desktop/src/features/agents/ui/ProviderConfigFields.tsx
+++ b/desktop/src/features/agents/ui/ProviderConfigFields.tsx
@@ -31,20 +31,22 @@ export function ProviderConfigFields({
   schema,
   config,
   onChange,
+  excludeKeys = [],
 }: {
   schema: Record<string, unknown>;
   config: Record<string, string>;
   onChange: (config: Record<string, string>) => void;
+  excludeKeys?: string[];
 }) {
   const properties = (schema as Record<string, unknown>)?.properties ?? {};
   const required = new Set<string>(
     ((schema as Record<string, unknown>)?.required as string[]) ?? [],
   );
 
-  const entries = Object.entries(properties) as [
+  const entries = (Object.entries(properties) as [
     string,
     Record<string, unknown>,
-  ][];
+  ][]).filter(([key]) => !excludeKeys.includes(key));
 
   if (entries.length === 0) {
     return null;

--- a/desktop/src/features/agents/ui/SecretRevealDialog.tsx
+++ b/desktop/src/features/agents/ui/SecretRevealDialog.tsx
@@ -64,6 +64,23 @@ export function SecretRevealDialog({
                   </p>
                 ) : null}
 
+                {created.enrollmentCommand ? (
+                  <div className="space-y-3 rounded-2xl border border-primary/30 bg-primary/5 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold">Enroll on OpenClaw</p>
+                        <p className="text-sm text-muted-foreground">
+                          Copy this command and run it on the private OpenClaw server. It expires in 10 minutes and can be used once.
+                        </p>
+                      </div>
+                      <CopyButton label="Copy command" value={created.enrollmentCommand} />
+                    </div>
+                    <code className="block break-all rounded-xl border border-border/70 bg-background/80 px-3 py-2 text-xs">
+                      {created.enrollmentCommand}
+                    </code>
+                  </div>
+                ) : null}
+
                 {created.spawnError ? (
                   <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                     {created.spawnError}

--- a/desktop/src/features/agents/ui/WhereToRunSection.tsx
+++ b/desktop/src/features/agents/ui/WhereToRunSection.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import * as React from "react";
 
 import { useBackendProvidersQuery } from "@/features/agents/hooks";
+import { useChannelsQuery } from "@/features/channels/hooks";
 import { probeBackendProvider } from "@/shared/api/tauri";
 
 import { ProviderConfigFields } from "./ProviderConfigFields";
@@ -24,6 +25,7 @@ export function WhereToRunSection({
   const backendProviders = useBackendProvidersQuery().data ?? [];
   const [probeError, setProbeError] = React.useState<string | null>(null);
   const isProviderMode = draft.runOn !== "local";
+  const channelsQuery = useChannelsQuery({ enabled: isProviderMode });
   const selectedBackendProvider = React.useMemo(
     () =>
       backendProviders.find((provider) => provider.id === draft.runOn) ?? null,
@@ -50,6 +52,16 @@ export function WhereToRunSection({
   const selectedBinaryPath = isProviderMode
     ? (selectedBackendProvider?.binaryPath ?? null)
     : null;
+  const providerSchema = draft.probedProvider?.config_schema as
+    | Record<string, unknown>
+    | undefined;
+  const roomProperty = (providerSchema?.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined)?.rooms;
+  const hasRoomPicker = roomProperty?.format === "buzz-room-picker";
+  const discoverableRooms = (channelsQuery.data ?? []).filter(
+    (channel) => channel.channelType !== "dm" && !channel.archivedAt,
+  );
   React.useEffect(() => {
     if (!selectedBinaryPath) {
       setProbeError(null);
@@ -119,12 +131,65 @@ export function WhereToRunSection({
               Could not probe provider: {probeError}
             </p>
           ) : null}
-          {draft.probedProvider?.enrollment ? (
+          {draft.probedProvider?.enrollment && !hasRoomPicker ? (
             <p className="rounded-2xl border border-primary/30 bg-primary/5 px-4 py-3 text-sm">
               This provider uses a one-time enrollment import. Buzz Desktop
               hands the agent identity to the trusted provider and keeps no
               runtime connection to the remote host.
             </p>
+          ) : null}
+          {hasRoomPicker ? (
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                Buzz rooms <span className="text-destructive">*</span>
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Select the rooms this provider should receive.
+              </p>
+              <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border border-input p-2">
+                {discoverableRooms.length === 0 ? (
+                  <p className="p-2 text-sm text-muted-foreground">
+                    No rooms available.
+                  </p>
+                ) : (
+                  discoverableRooms.map((channel) => {
+                    const selected = (draft.providerConfig.rooms ?? "")
+                      .split(",")
+                      .filter(Boolean)
+                      .includes(channel.id);
+                    return (
+                      <label
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+                        key={channel.id}
+                      >
+                        <input
+                          checked={selected}
+                          disabled={isPending}
+                          onChange={() => {
+                            const ids = new Set(
+                              (draft.providerConfig.rooms ?? "")
+                                .split(",")
+                                .filter(Boolean),
+                            );
+                            if (selected) ids.delete(channel.id);
+                            else ids.add(channel.id);
+                            onDraftChange({
+                              ...draft,
+                              providerConfig: {
+                                ...draft.providerConfig,
+                                rooms: [...ids].join(","),
+                              },
+                            });
+                          }}
+                          type="checkbox"
+                        />
+                        <span>{channel.name}</span>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </div>
           ) : null}
           {draft.probedProvider?.config_schema ? (
             <ProviderConfigFields
@@ -133,6 +198,7 @@ export function WhereToRunSection({
                 onDraftChange({ ...draft, providerConfig })
               }
               schema={draft.probedProvider.config_schema}
+              excludeKeys={hasRoomPicker ? ["rooms"] : []}
             />
           ) : null}
         </div>

--- a/desktop/src/features/agents/ui/WhereToRunSection.tsx
+++ b/desktop/src/features/agents/ui/WhereToRunSection.tsx
@@ -95,7 +95,7 @@ export function WhereToRunSection({
           <option value="local">This computer</option>
           {backendProviders.map((provider) => (
             <option key={provider.id} value={provider.id}>
-              {provider.id}
+              {provider.id === "openclaw" ? "OpenClaw" : provider.id}
             </option>
           ))}
         </select>
@@ -117,6 +117,13 @@ export function WhereToRunSection({
           {probeError ? (
             <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
               Could not probe provider: {probeError}
+            </p>
+          ) : null}
+          {draft.probedProvider?.enrollment ? (
+            <p className="rounded-2xl border border-primary/30 bg-primary/5 px-4 py-3 text-sm">
+              This provider uses a one-time enrollment import. Buzz Desktop
+              hands the agent identity to the trusted provider and keeps no
+              runtime connection to the remote host.
             </p>
           ) : null}
           {draft.probedProvider?.config_schema ? (

--- a/desktop/src/features/agents/ui/whereToRunIntent.test.mjs
+++ b/desktop/src/features/agents/ui/whereToRunIntent.test.mjs
@@ -44,6 +44,27 @@ test("complete provider config allows submit", () => {
   assert.equal(canSubmitWhereToRun(providerDraft()), true);
 });
 
+test("OpenClaw room-picker config blocks submit until a room is selected", () => {
+  const openclaw = providerDraft({
+    runOn: "openclaw",
+    probedProvider: {
+      ok: true,
+      config_schema: {
+        properties: {
+          rooms: { type: "string", format: "buzz-room-picker" },
+        },
+        required: ["rooms"],
+      },
+    },
+    providerConfig: { rooms: "" },
+  });
+  assert.equal(canSubmitWhereToRun(openclaw), false);
+  assert.equal(
+    canSubmitWhereToRun({ ...openclaw, providerConfig: { rooms: "room-a" } }),
+    true,
+  );
+});
+
 test("local never gates submit", () => {
   assert.equal(canSubmitWhereToRun(emptyWhereToRunDraft), true);
 });

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -171,6 +171,7 @@ type RawCreateManagedAgentResponse = {
   private_key_nsec: string;
   profile_sync_error: string | null;
   spawn_error: string | null;
+  enrollment_command: string | null;
 };
 
 type RawManagedAgentLog = {
@@ -878,6 +879,7 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
     privateKeyNsec: response.private_key_nsec,
     profileSyncError: response.profile_sync_error,
     spawnError: response.spawn_error,
+    enrollmentCommand: response.enrollment_command,
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -400,6 +400,11 @@ export type BackendProviderProbeResult = {
   version?: string;
   description?: string;
   config_schema?: Record<string, unknown>;
+  enrollment?: {
+    operation: "enroll";
+    one_time: true;
+    credential_fields?: string[];
+  };
 };
 
 export type RelayMeshConfig = {

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -455,6 +455,7 @@ export type CreateManagedAgentResponse = {
   privateKeyNsec: string;
   profileSyncError: string | null;
   spawnError: string | null;
+  enrollmentCommand: string | null;
 };
 
 export type ManagedAgentLog = {

--- a/docs/openclaw-enrollment.md
+++ b/docs/openclaw-enrollment.md
@@ -20,9 +20,7 @@ must answer `info` first, with protocol version `1`:
   "config_schema": {
     "type": "object",
     "properties": {
-      "host": { "type": "string", "description": "Optional SSH destination (advanced fallback)" },
-      "rooms": { "type": "string", "description": "Comma-separated Buzz room UUIDs" },
-      "port": { "type": "string", "description": "Optional SSH port" }
+      "rooms": { "type": "string", "format": "buzz-room-picker", "description": "Buzz rooms selected in Desktop" }
     },
     "required": ["rooms"]
   },
@@ -37,8 +35,8 @@ must answer `info` first, with protocol version `1`:
 `config_schema` is persisted in the agent record and is therefore not a place
 for credentials. Desktop rejects secret-shaped keys (`key`, `token`,
 `credential`, `password`, `secret`) and nested values in provider config.
-Host authentication belongs to the provider's normal local trust mechanism
-(for example, an existing OpenClaw CLI login or OS credential store).
+The selected room IDs are the only provider configuration; the generated
+command is copied to and run by the operator on the OpenClaw server.
 
 After `info`, Desktop invokes the same staged provider binary once with:
 
@@ -62,28 +60,21 @@ After `info`, Desktop invokes the same staged provider binary once with:
       "owner_pubkey": "hex"
     }
   },
-  "provider_config": {
-    "host": "openclaw@agent-host",
-    "rooms": "ROOM_UUID_1,ROOM_UUID_2",
-    "port": "22"
-  },
+  "provider_config": { "rooms": "ROOM_UUID_1,ROOM_UUID_2" },
   "enrollment": { "version": 1, "mode": "one-time" }
 }
 ```
 
 The exact managed-agent payload is the source of truth; providers must not
-reconstruct identity from `env_vars`. Without `host`, the provider generates
-a signed, short-lived code and returns a copyable command for the Desktop
-operator:
+reconstruct identity from `env_vars`. The provider generates a signed,
+short-lived code and returns a copyable command for the Desktop operator:
 
 ```bash
 openclaw buzz enroll --code 'buzz-enroll-v1....'
 ```
 
-With `host`, the provider preserves the legacy SSH handoff and runs
-`openclaw buzz enroll --stdin` on the remote host.
-It imports the identity and room configuration into OpenClaw and returns a
-stable host-side identifier:
+The command imports the identity and room configuration into OpenClaw and
+returns a stable host-side identifier:
 
 ```json
 { "ok": true, "agent_id": "openclaw-host-agent-id" }

--- a/docs/openclaw-enrollment.md
+++ b/docs/openclaw-enrollment.md
@@ -1,0 +1,94 @@
+# OpenClaw provider enrollment
+
+Buzz Desktop exposes remote run locations through discovered executables named
+`buzz-backend-<id>`. An OpenClaw integration should install
+`buzz-backend-openclaw` on the Desktop machine; it will then appear under
+**Run on** without Buzz Desktop becoming a Gateway or runtime proxy.
+
+## Provider contract
+
+The provider is a one-process-per-operation stdin/stdout JSON executable. It
+must answer `info` first, with protocol version `1`:
+
+```json
+{
+  "ok": true,
+  "name": "openclaw",
+  "version": "1.0.0",
+  "protocol_version": 1,
+  "description": "Enrolls agents with an OpenClaw host",
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "host": { "type": "string", "description": "SSH destination, e.g. openclaw@agent-host" },
+      "rooms": { "type": "string", "description": "Comma-separated Buzz room UUIDs" },
+      "port": { "type": "string", "description": "Optional SSH port" }
+    },
+    "required": ["host", "rooms"]
+  },
+  "enrollment": {
+    "operation": "enroll",
+    "one_time": true,
+    "credential_fields": ["private_key_nsec", "auth_tag", "relay_url"]
+  }
+}
+```
+
+`config_schema` is persisted in the agent record and is therefore not a place
+for credentials. Desktop rejects secret-shaped keys (`key`, `token`,
+`credential`, `password`, `secret`) and nested values in provider config.
+Host authentication belongs to the provider's normal local trust mechanism
+(for example, an existing OpenClaw CLI login or OS credential store).
+
+After `info`, Desktop invokes the same staged provider binary once with:
+
+```json
+{
+  "op": "enroll",
+  "request_id": "uuid",
+  "agent": {
+    "name": "display name",
+    "relay_url": "wss://relay.example",
+    "private_key_nsec": "nsec1...",
+    "auth_tag": "[\"auth\",\"owner\",\"\",\"signature\"]",
+    "respond_to": "owner-only",
+    "respond_to_allowlist": [],
+    "env_vars": {},
+    "launch": {
+      "command": "openclaw",
+      "args": ["acp"],
+      "env": {},
+      "policy_env": {},
+      "owner_pubkey": "hex"
+    }
+  },
+  "provider_config": {
+    "host": "openclaw@agent-host",
+    "rooms": "ROOM_UUID_1,ROOM_UUID_2",
+    "port": "22"
+  },
+  "enrollment": { "version": 1, "mode": "one-time" }
+}
+```
+
+The exact managed-agent payload is the source of truth; providers must not
+reconstruct identity from `env_vars`. The provider uses SSH only for this
+one-time handoff, running `openclaw buzz enroll --stdin` on the remote host.
+It imports the identity and room configuration into OpenClaw and returns a
+stable host-side identifier:
+
+```json
+{ "ok": true, "agent_id": "openclaw-host-agent-id" }
+```
+
+Desktop stores only that identifier and the non-secret provider config. It
+does not retain a host session, proxy messages, poll the Gateway, or provide
+remote logs/stop controls. Subsequent conversation and presence continue over
+the Buzz relay. Re-running the action must be idempotent for the same agent
+identity; the provider owns reconciliation on the OpenClaw host.
+The community relay does not need Tailscale: OpenClaw connects outbound to it
+directly.
+
+On any failure, return `{"ok":false,"error":"..."}` and exit zero. Exit
+non-zero means the response is untrusted. Provider diagnostics must never
+echo the nsec, auth tag, or environment secrets.

--- a/docs/openclaw-enrollment.md
+++ b/docs/openclaw-enrollment.md
@@ -20,11 +20,11 @@ must answer `info` first, with protocol version `1`:
   "config_schema": {
     "type": "object",
     "properties": {
-      "host": { "type": "string", "description": "SSH destination, e.g. openclaw@agent-host" },
+      "host": { "type": "string", "description": "Optional SSH destination (advanced fallback)" },
       "rooms": { "type": "string", "description": "Comma-separated Buzz room UUIDs" },
       "port": { "type": "string", "description": "Optional SSH port" }
     },
-    "required": ["host", "rooms"]
+    "required": ["rooms"]
   },
   "enrollment": {
     "operation": "enroll",
@@ -72,8 +72,16 @@ After `info`, Desktop invokes the same staged provider binary once with:
 ```
 
 The exact managed-agent payload is the source of truth; providers must not
-reconstruct identity from `env_vars`. The provider uses SSH only for this
-one-time handoff, running `openclaw buzz enroll --stdin` on the remote host.
+reconstruct identity from `env_vars`. Without `host`, the provider generates
+a signed, short-lived code and returns a copyable command for the Desktop
+operator:
+
+```bash
+openclaw buzz enroll --code 'buzz-enroll-v1....'
+```
+
+With `host`, the provider preserves the legacy SSH handoff and runs
+`openclaw buzz enroll --stdin` on the remote host.
 It imports the identity and room configuration into OpenClaw and returns a
 stable host-side identifier:
 

--- a/scripts/bundle-sidecars.sh
+++ b/scripts/bundle-sidecars.sh
@@ -29,6 +29,13 @@ else
     EXE=""
 fi
 
+# The fork's unsigned DMG build also produces the OpenClaw backend. Keep this
+# optional so release and platform builds that do not produce it retain their
+# existing sidecar set.
+if [[ -f "$SRC_DIR/buzz-backend-openclaw${EXE}" ]]; then
+    SIDECARS+=(buzz-backend-openclaw)
+fi
+
 missing=()
 for bin in "${SIDECARS[@]}"; do
     [[ -f "$SRC_DIR/${bin}${EXE}" ]] || missing+=("${bin}${EXE}")


### PR DESCRIPTION
## Summary
- replace the deployed OpenClaw enrollment-code and optional SSH form with Desktop room selection
- generate a signed, short-lived copyable `openclaw buzz enroll --code` command from the bundled provider
- preserve the generic provider protocol and add focused room-picker coverage

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Full Rust/linking and desktop build validation runs in the fork macOS DMG workflow because the local container lacks the native C linker and desktop dependencies.