### PR TITLE
feat(desktop): add PFTerminal as a tier-2 preset harness

### DIFF
--- a/desktop/public/harness-logos/CREDITS.md
+++ b/desktop/public/harness-logos/CREDITS.md
@@ -15,6 +15,7 @@ license permits redistribution.
 | `omp.svg` | [can1357/oh-my-pi](https://github.com/can1357/oh-my-pi) | `667111575ebba136dadfd6989379e7f67e0d40d9` | MIT © 2025 Mario Zechner; © 2025–2026 Can Bölük | `assets/icon.svg` | None |
 | `kimi.png` | [MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli) | `4a550effdfcb29a25a5d325bf935296cc50cd417` | Apache-2.0; NOTICE: Kimi Code CLI © 2025 Moonshot AI | `web/public/logo.png` | None |
 | `grok.svg` | [SpaceXAI brand guidelines](https://x.ai/legal/brand-guidelines) | Retrieved 2026-07-25 | xAI Brand Guidelines: marks may be used to accurately refer to xAI or its services; logos must be used exactly as provided | `SpaceXAI_Grok_Assets.zip` → `Grok_Logomark_Dark.svg` | None |
+| `pfterminal.svg` | [agtico/PfTerminal](https://github.com/agtico/PfTerminal) | `5731f16` | Apache-2.0 | `docs/assets/images/pfterminal-logo.svg` | Extracted the square Post Fiat glyph from the wide wordmark (the full lockup is 720×220 and would letterbox to nothing in a 32px square); dropped the outer frame and both text runs, retargeted the viewBox to the glyph's own 136×136 box, and renamed the glow filter id to avoid collisions when inlined. Colours unchanged; the mark carries its own dark plate so it stays legible in both app themes |
 
 ## Inline SVG marks (`RUNTIME_MARKS`)
 

--- a/desktop/public/harness-logos/pfterminal.svg
+++ b/desktop/public/harness-logos/pfterminal.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 136 136" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="PFTerminal">
+  <defs>
+    <filter id="pft-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.50 0 0 0 0 0.93 0 0 0 0 0.39 0 0 0 0.55 0"/>
+      <feBlend in="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="136" height="136" rx="20" fill="#071007" stroke="rgba(221,255,220,.28)" stroke-width="2"/>
+  <path d="M30 30 106 106m0-76L30 106" stroke="#ddffdc" stroke-width="14" stroke-linecap="round" fill="none" filter="url(#pft-glow)"/>
+  <line x1="30" y1="106" x2="106" y2="106" stroke="#ddffdc" stroke-width="14" stroke-linecap="round" filter="url(#pft-glow)"/>
+</svg>

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -178,6 +178,15 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "pfterminal",
+        label: "PFTerminal",
+        command: "pfterminal-acp",
+        args: &[],
+        install_instructions_url: "https://github.com/agtico/PfTerminal",
+        install_hint: "Buzz talks to PFTerminal through the pfterminal-acp adapter, which ships with PFTerminal and relies on the codex-acp bridge. Install PFTerminal, then install the bridge with `npm install -g @agentclientprotocol/codex-acp`, so the pfterminal-acp command is on your PATH.",
+        underlying_cli: Some("pfterminal"),
+    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.

--- a/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
+++ b/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
@@ -25,6 +25,7 @@ export const PRESET_LOGOS: Record<string, string> = {
   amp: "/harness-logos/amp.png",
   hermes: "/harness-logos/hermes.png",
   openclaw: "/harness-logos/openclaw.svg",
+  pfterminal: "/harness-logos/pfterminal.svg",
 };
 
 function isBuzzRuntime(runtime: AcpRuntimeCatalogEntry): boolean {

--- a/desktop/src/features/settings/ui/harnessCatalogCopy.ts
+++ b/desktop/src/features/settings/ui/harnessCatalogCopy.ts
@@ -43,6 +43,10 @@ const HARNESS_DESCRIPTIONS: Record<string, string> = {
   // Sources: https://github.com/openclaw/openclaw,
   // https://docs.openclaw.ai/start/getting-started
   openclaw: "A personal AI assistant that runs on your own devices.",
+  // Source: https://github.com/agtico/PfTerminal — "an open-source,
+  // multi-provider coding terminal built on the Codex CLI".
+  pfterminal:
+    "An open-source, multi-provider coding terminal built on the Codex CLI.",
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds [PFTerminal](https://github.com/agtico/PfTerminal) as a tier-2 preset harness — an open-source, multi-provider coding terminal built on the Codex CLI.

PFTerminal exposes the Codex app-server protocol rather than ACP, so it cannot be registered as a harness directly. It reaches Buzz through `pfterminal-acp`, a launcher that ships with PFTerminal and points the maintained [`codex-acp`](https://github.com/agentclientprotocol/codex-acp) bridge at the PFTerminal binary via `CODEX_PATH`:

```
Buzz --ACP/stdio--> pfterminal-acp --CODEX_PATH--> codex-acp --app-server--> PFTerminal
```

That indirection is why `underlying_cli: Some("pfterminal")` is set — the CLI and the adapter install separately, so a user who has PFTerminal but not the bridge gets `AdapterMissing` rather than `NotInstalled`. This follows the existing `amp` / `amp-acp` precedent.

A distinct `pfterminal-acp` command is used rather than registering `codex-acp` with `CODEX_PATH` set in `env`, because Buzz's built-in Codex runtime is already defined around `codex-acp`; sharing that executable between two runtimes risks incorrect runtime identity and merged usage attribution.

Also adds the `harnessCatalogCopy.ts` entry, since every other preset carries one and its absence would leave PFTerminal as the only description-less runtime in the gallery. The description is a single vendor-sourced category sentence with provenance cited inline, per that file's stated content policy.

**Blocked on an upstream release.** `pfterminal-acp` is implemented and under review upstream in [agtico/PfTerminal#78](https://github.com/agtico/PfTerminal/pull/78), but is not yet in a published PFTerminal release. Opening as a draft so the approach can be reviewed; I'll mark it ready once that lands and ships, so the preset never points at a command users cannot install. Happy to close and re-open later if you'd rather not carry a draft.

### Related issue

#4958 — opened per CONTRIBUTING so a maintainer can acknowledge the approach before this is reviewed. The open question there is whether you want PFTerminal in the preset catalog at all; happy to close both if not.

No duplicates — searched open and closed issues and PRs for `pfterminal`, `PfTerminal`, and `codex-acp preset`.

### Testing

The transport chain was exercised end-to-end against a real PFTerminal install (0.1.20) with `codex-acp` 1.1.9, driving the compiled `pfterminal-acp` binary over stdio:

| ACP step | Result |
|---|---|
| `initialize` | OK — `protocolVersion: 1`, authMethods `[api-key, chat-gpt]` |
| `session/new` | OK — session created in a real workspace |
| model catalogue | 80 models enumerated |
| `session/prompt` | streamed text back, `stopReason: end_turn` |
| state isolation | PFTerminal used its own `~/.pfterminal`; stock Codex's `~/.codex` untouched |
| adapter missing | exits 127, diagnostic on **stderr**, stdout left clean so the ACP stream cannot be corrupted |

Repo checks on this change:

- `rustfmt --check` on `presets.rs` — clean
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec biome check` on both changed `.ts`/`.tsx` files — clean
- `pfterminal.svg` — validated as well-formed XML and rasterised at 32px (the `h-8 w-8` gallery size) and 128px to confirm the glyph stays legible

I could not run `cargo check` on `desktop/src-tauri` in my environment — the Linux Tauri system libraries (`glib-2.0` et al.) are not installed on that machine — so the Rust change is syntax- and format-verified rather than type-checked locally. It is a `PresetHarness` struct literal identical in shape to the ten existing entries, and CI will type-check it.

**UI change:** the runtime gallery gains one entry. The bundled mark is the square Post Fiat glyph extracted from PFTerminal's wordmark; the full lockup is 720×220 and would letterbox to nothing in a 32px square. It carries its own dark plate, so unlike `omp` and `grok` it needs no per-id background class in `RuntimeIcon`. Provenance, upstream commit, license (Apache-2.0), and the exact modifications are recorded in `CREDITS.md`.
