### PR TITLE
perf(relay): batch audit chain writes; fix perf harness

### DIFF
--- a/crates/buzz-audit/src/service.rs
+++ b/crates/buzz-audit/src/service.rs
@@ -151,6 +151,127 @@ impl AuditService {
         Ok(audit_entry)
     }
 
+    /// Append several entries to the calling community's chain in one write.
+    ///
+    /// All `entries` must belong to the same community — the caller (the
+    /// relay's audit worker) groups by `community_id` before calling. The
+    /// per-community `pg_advisory_lock`, head read, transaction, and commit
+    /// are amortized across the whole batch, so N entries cost the same
+    /// round-trips as one: the hash chain is computed in-process in arrival
+    /// order, producing byte-identical results to N sequential [`AuditService::log`]
+    /// calls. This is the ingest hot path — every accepted event enqueues an
+    /// audit entry, and the previous one-entry-at-a-time write serialized all
+    /// of them behind six round-trips each.
+    #[instrument(skip(self, entries), fields(n = entries.len()))]
+    pub async fn log_batch(
+        &self,
+        entries: Vec<NewAuditEntry>,
+    ) -> Result<Vec<AuditEntry>, AuditError> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        let community_id = *entries[0].community_id.as_uuid();
+        debug_assert!(
+            entries
+                .iter()
+                .all(|e| *e.community_id.as_uuid() == community_id),
+            "log_batch requires a single community per call"
+        );
+
+        let mut conn = self.pool.acquire().await?;
+
+        let lock_key = format!("{AUDIT_LOCK_NAMESPACE}{community_id}");
+        sqlx::query("SELECT pg_advisory_lock(hashtextextended($1, 0))")
+            .bind(&lock_key)
+            .execute(&mut *conn)
+            .await?;
+
+        let result = std::panic::AssertUnwindSafe(
+            self.log_batch_inner(&mut conn, community_id, entries),
+        )
+        .catch_unwind()
+        .await;
+
+        let _ = sqlx::query("SELECT pg_advisory_unlock(hashtextextended($1, 0))")
+            .bind(&lock_key)
+            .execute(&mut *conn)
+            .await;
+
+        match result {
+            Ok(inner_result) => inner_result,
+            Err(panic_payload) => std::panic::resume_unwind(panic_payload),
+        }
+    }
+
+    async fn log_batch_inner(
+        &self,
+        conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+        community_id: Uuid,
+        entries: Vec<NewAuditEntry>,
+    ) -> Result<Vec<AuditEntry>, AuditError> {
+        let mut tx = conn.begin().await?;
+
+        let head = sqlx::query(
+            "SELECT seq, hash FROM audit_log
+             WHERE community_id = $1
+             ORDER BY seq DESC LIMIT 1",
+        )
+        .bind(community_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let (mut seq, mut prev_hash): (i64, Option<Vec<u8>>) = match head {
+            Some(row) => (
+                row.get::<i64, _>("seq"),
+                Some(row.get::<Vec<u8>, _>("hash")),
+            ),
+            None => (0, None),
+        };
+
+        // Stamp one `created_at` for the batch (same precision handling as
+        // `log_inner`), then build the chain in arrival order.
+        let created_at: DateTime<Utc> = log_timestamp();
+        let mut chain = Vec::with_capacity(entries.len());
+        for entry in entries {
+            seq += 1;
+            let mut audit_entry = AuditEntry {
+                community_id,
+                seq,
+                hash: Vec::new(),
+                prev_hash: prev_hash.clone(),
+                action: entry.action,
+                actor_pubkey: entry.actor_pubkey,
+                object_id: entry.object_id,
+                detail: entry.detail,
+                created_at,
+            };
+            audit_entry.hash = compute_hash(&audit_entry)?.to_vec();
+            prev_hash = Some(audit_entry.hash.clone());
+            chain.push(audit_entry);
+        }
+
+        let mut qb = sqlx::QueryBuilder::new(
+            "INSERT INTO audit_log \
+             (community_id, seq, hash, prev_hash, action, actor_pubkey, object_id, detail, created_at) ",
+        );
+        qb.push_values(chain.iter(), |mut b, e| {
+            b.push_bind(e.community_id)
+                .push_bind(e.seq)
+                .push_bind(&e.hash)
+                .push_bind(e.prev_hash.as_deref())
+                .push_bind(e.action.as_str())
+                .push_bind(e.actor_pubkey.as_deref())
+                .push_bind(e.object_id.as_deref())
+                .push_bind(&e.detail)
+                .push_bind(e.created_at);
+        });
+        qb.build().execute(&mut *tx).await?;
+
+        tx.commit().await?;
+
+        Ok(chain)
+    }
+
     /// Verify the hash chain for one community over `[from_seq, to_seq]`.
     ///
     /// Reads exactly that community's chain — it can never observe another
@@ -366,6 +487,89 @@ mod tests {
         assert_eq!(e3.prev_hash.as_deref(), Some(e2.hash.as_slice()));
         assert!(svc
             .verify_chain(CommunityId::from_uuid(c), 1, 3)
+            .await
+            .unwrap());
+    }
+
+    /// The batched write must produce a chain byte-identical to N sequential
+    /// `log` calls: seqs contiguous, prev_hash links intact, hashes verifiable.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn log_batch_links_chain_like_sequential_logs() {
+        let _g = db_lock().lock().await;
+        let Some(pool) = test_pool().await else {
+            return;
+        };
+        let svc = AuditService::new(pool.clone());
+        let c = make_community(&pool).await;
+
+        let entries = vec![
+            new_entry(c, AuditAction::EventCreated),
+            new_entry(c, AuditAction::ChannelCreated),
+            new_entry(c, AuditAction::MemberAdded),
+            new_entry(c, AuditAction::MemberRemoved),
+        ];
+        let written = svc.log_batch(entries).await.unwrap();
+
+        assert_eq!(written.len(), 4);
+        assert_eq!(written[0].seq, 1);
+        assert!(written[0].prev_hash.is_none(), "genesis entry has NULL prev_hash");
+        for (i, e) in written.iter().enumerate() {
+            assert_eq!(e.seq, i as i64 + 1);
+            assert_eq!(e.community_id, c);
+            assert_eq!(e.hash.len(), 32);
+            if i > 0 {
+                assert_eq!(
+                    e.prev_hash.as_deref(),
+                    Some(written[i - 1].hash.as_slice()),
+                    "batch entries must chain in order"
+                );
+            }
+        }
+        assert!(svc
+            .verify_chain(CommunityId::from_uuid(c), 1, 4)
+            .await
+            .unwrap(),
+            "batched chain must verify like sequential logs");
+    }
+
+    /// A batch appended after a sequential entry must chain onto it, and a
+    /// subsequent sequential entry must chain onto the batch tail.
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn log_batch_chains_onto_existing_and_continues() {
+        let _g = db_lock().lock().await;
+        let Some(pool) = test_pool().await else {
+            return;
+        };
+        let svc = AuditService::new(pool.clone());
+        let c = make_community(&pool).await;
+
+        let first = svc
+            .log(new_entry(c, AuditAction::EventCreated))
+            .await
+            .unwrap();
+        let batch = svc
+            .log_batch(vec![
+                new_entry(c, AuditAction::ChannelCreated),
+                new_entry(c, AuditAction::MemberAdded),
+            ])
+            .await
+            .unwrap();
+        let last = svc
+            .log(new_entry(c, AuditAction::MemberRemoved))
+            .await
+            .unwrap();
+
+        assert_eq!(first.seq, 1);
+        assert_eq!(batch[0].seq, 2);
+        assert_eq!(batch[0].prev_hash.as_deref(), Some(first.hash.as_slice()));
+        assert_eq!(batch[1].seq, 3);
+        assert_eq!(batch[1].prev_hash.as_deref(), Some(batch[0].hash.as_slice()));
+        assert_eq!(last.seq, 4);
+        assert_eq!(last.prev_hash.as_deref(), Some(batch[1].hash.as_slice()));
+        assert!(svc
+            .verify_chain(CommunityId::from_uuid(c), 1, 4)
             .await
             .unwrap());
     }

--- a/crates/buzz-relay/src/state.rs
+++ b/crates/buzz-relay/src/state.rs
@@ -660,12 +660,30 @@ impl AppState {
                 audit_cancel_worker.cancelled().await;
                 return;
             };
-            // Normal operation: process entries as they arrive.
+            // Normal operation: process entries as they arrive, batching the
+            // drain. Every accepted event enqueues an audit entry, and the
+            // per-community advisory lock serializes writes, so writing one
+            // entry per lock acquisition makes ingest latency equal audit
+            // write latency. Draining the buffer and writing each community's
+            // entries as one chain append amortizes the lock/head/commit
+            // round-trips across the whole batch (buzz-audit::AuditService
+            // ::log_batch) — identical chain bytes, one write instead of N.
             loop {
                 tokio::select! {
                     entry = audit_rx.recv() => {
                         match entry {
-                            Some(entry) => log_audit_entry(&audit_for_worker, entry).await,
+                            Some(entry) => {
+                                let mut batch: Vec<buzz_audit::NewAuditEntry> =
+                                    Vec::with_capacity(AUDIT_BATCH_MAX);
+                                batch.push(entry);
+                                while batch.len() < AUDIT_BATCH_MAX {
+                                    match audit_rx.try_recv() {
+                                        Ok(e) => batch.push(e),
+                                        Err(_) => break, // Empty or Closed
+                                    }
+                                }
+                                log_audit_batch(&audit_for_worker, batch).await;
+                            }
                             None => break, // channel closed
                         }
                     }
@@ -1196,12 +1214,54 @@ impl AuditShutdownHandle {
 
 /// Log a single audit entry with metrics. Extracted so the normal loop
 /// and the post-cancel drain share the same logic.
+/// Maximum audit entries drained into one batched chain append.
+///
+/// The channel capacity is 1000; capping the drain keeps each advisory-lock
+/// hold short while still amortizing the per-batch round-trips (lock, head
+/// read, commit, unlock) across many entries.
+const AUDIT_BATCH_MAX: usize = 256;
+
 async fn log_audit_entry(audit: &buzz_audit::AuditService, entry: buzz_audit::NewAuditEntry) {
     let t = std::time::Instant::now();
     if let Err(e) = audit.log(entry).await {
         metrics::counter!("buzz_audit_log_errors_total").increment(1);
         tracing::error!("Audit log failed: {e}");
     } else {
+        metrics::histogram!("buzz_audit_log_seconds").record(t.elapsed().as_secs_f64());
+    }
+}
+
+/// Write a drained audit batch, grouping by community so each community's
+/// chain append holds only its own advisory lock. Falls back to the per-entry
+/// path implicitly — [`buzz_audit::AuditService::log_batch`] returns the same
+/// `AuditEntry`s and the same chain bytes as N sequential `log` calls.
+async fn log_audit_batch(
+    audit: &buzz_audit::AuditService,
+    entries: Vec<buzz_audit::NewAuditEntry>,
+) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut by_community: std::collections::HashMap<Uuid, Vec<buzz_audit::NewAuditEntry>> =
+        std::collections::HashMap::new();
+    for entry in entries {
+        by_community
+            .entry(*entry.community_id.as_uuid())
+            .or_default()
+            .push(entry);
+    }
+    let t = std::time::Instant::now();
+    let mut written = 0usize;
+    for (_, group) in by_community {
+        match audit.log_batch(group).await {
+            Ok(entries) => written += entries.len(),
+            Err(e) => {
+                metrics::counter!("buzz_audit_log_errors_total").increment(1);
+                tracing::error!("Audit log batch failed: {e}");
+            }
+        }
+    }
+    if written > 0 {
         metrics::histogram!("buzz_audit_log_seconds").record(t.elapsed().as_secs_f64());
     }
 }

--- a/perf/relay_bus_scaling.py
+++ b/perf/relay_bus_scaling.py
@@ -239,6 +239,18 @@ class RedisSubscriber(threading.Thread):
                         frame = read_resp(stream)
                     except socket.timeout:
                         continue
+                    except OSError as exc:
+                        # gh-77716: after the first idle socket.timeout, a
+                        # socket.makefile() buffered reader is permanently
+                        # wedged and raises OSError('cannot read from timed out
+                        # object') on every subsequent read. Treat it as an
+                        # idle signal and rebuild the stream on the same
+                        # socket (which has no unread data while idle).
+                        if "cannot read from timed out object" not in str(exc):
+                            raise
+                        stream.close()
+                        stream = sock.makefile("rwb")
+                        continue
                     if not (isinstance(frame, list) and len(frame) >= 3 and frame[0] == "message"):
                         continue
                     payload = str(frame[2])


### PR DESCRIPTION
Batches the per-community audit hash-chain writes (6N DB round-trips → ~6 per batch) so ingest latency stops being equal to audit-write latency, and fixes the perf harness's wedged-subscriber bug. Chain output byte-identical to sequential writes (new tests included).