### PR TITLE
fix(mobile): tag DM recipients

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -4,13 +4,16 @@ import '../../shared/relay/relay.dart';
 import '../channels/channel_management_provider.dart';
 import '../profile/user_cache_provider.dart';
 import '../profile/user_profile.dart';
+import 'channel.dart';
 import 'channel_messages_provider.dart';
+import 'channels_provider.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
 class SendMessage {
   final SignedEventRelay _signedEventRelay;
   final Future<List<ChannelMember>> Function(String channelId) _fetchMembers;
+  final Channel? Function(String channelId) _readChannel;
   final Map<String, UserProfile> Function() _readUserCache;
   final void Function(String channelId, NostrEvent event) _addLocalMessage;
   final void Function(String channelId, String eventId) _completeLocalMessage;
@@ -21,6 +24,7 @@ class SendMessage {
     required SignedEventRelay signedEventRelay,
     required Future<List<ChannelMember>> Function(String channelId)
     fetchMembers,
+    required Channel? Function(String channelId) readChannel,
     required Map<String, UserProfile> Function() readUserCache,
     required void Function(String channelId, NostrEvent event) addLocalMessage,
     required void Function(String channelId, String eventId)
@@ -29,6 +33,7 @@ class SendMessage {
     bool Function()? isDeliveryValid,
   }) : _signedEventRelay = signedEventRelay,
        _fetchMembers = fetchMembers,
+       _readChannel = readChannel,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
        _completeLocalMessage = completeLocalMessage,
@@ -56,14 +61,21 @@ class SendMessage {
     final resolvedMentions =
         mentionPubkeys ?? await _resolveMentions(content, channelId);
     final authorPubkey = _signedEventRelay.pubkey;
+    final channel = _readChannel(channelId);
+    final recipientPubkeys = <String>[
+      ...resolvedMentions,
+      if (channel?.isDm == true) ...channel!.participantPubkeys,
+    ];
 
-    // Normalize mentions: lowercase, deduplicate, exclude self (matching
-    // the desktop's normalizeMentionPubkeys).
+    // A DM addresses every other participant even when the composer text has
+    // no @mention. Agent harnesses and human notification subscriptions rely
+    // on those p tags, matching the desktop's messageMentionPubkeys.
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
-        if (seenMentions.add(pk.toLowerCase())) pk,
+      for (final pk in recipientPubkeys)
+        if (pk.trim().isNotEmpty && seenMentions.add(pk.trim().toLowerCase()))
+          pk.trim().toLowerCase(),
     ];
 
     final tags = <List<String>>[
@@ -182,6 +194,14 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     ),
     fetchMembers: (channelId) =>
         ref.read(channelMembersProvider(channelId).future),
+    readChannel: (channelId) {
+      final channels = ref.read(channelsProvider).value;
+      if (channels == null) return null;
+      for (final channel in channels) {
+        if (channel.id == channelId) return channel;
+      }
+      return null;
+    },
     readUserCache: () => ref.read(userCacheProvider),
     addLocalMessage: (channelId, event) => ref
         .read(channelMessagesProvider(channelId).notifier)

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
@@ -20,6 +21,7 @@ void main() {
           nsec: nostr.Keys.generate().nsec,
         ),
         fetchMembers: (_) async => const [],
+        readChannel: (_) => _streamChannel,
         readUserCache: () => const {},
         addLocalMessage: (_, event) => localMessages.add(event),
         completeLocalMessage: (_, eventId) => completedIds.add(eventId),
@@ -53,6 +55,7 @@ void main() {
         nsec: nostr.Keys.generate().nsec,
       ),
       fetchMembers: (_) async => const [],
+      readChannel: (_) => _streamChannel,
       readUserCache: () => const {},
       addLocalMessage: (_, event) => localMessages.add(event),
       completeLocalMessage: (_, eventId) => completedIds.add(eventId),
@@ -66,6 +69,75 @@ void main() {
     await expectLater(result, throwsException);
     expect(completedIds, isEmpty);
     expect(removedIds, [localMessages.single.id]);
+  });
+
+  test('adds every other DM participant as a p tag', () async {
+    final session = _PendingPublishRelaySession();
+    final keys = nostr.Keys.generate();
+    const recipient =
+        'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789';
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(session: session, nsec: keys.nsec),
+      fetchMembers: (_) async => const [],
+      readChannel: (_) => Channel(
+        id: _channelId,
+        name: 'Direct message',
+        channelType: 'dm',
+        visibility: 'private',
+        description: '',
+        createdBy: keys.public,
+        createdAt: DateTime.utc(2026),
+        memberCount: 2,
+        participantPubkeys: [recipient, keys.public, recipient],
+        isMember: true,
+      ),
+      readUserCache: () => const {},
+      addLocalMessage: (_, _) {},
+      completeLocalMessage: (_, _) {},
+      removeLocalMessage: (_, _) {},
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello without a mention',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+
+    expect(session.event.tags.where((tag) => tag.first == 'p'), [
+      ['p', recipient.toLowerCase()],
+    ]);
+
+    session.accept();
+    await result;
+  });
+
+  test('does not add channel participants to stream messages', () async {
+    final session = _PendingPublishRelaySession();
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(
+        session: session,
+        nsec: nostr.Keys.generate().nsec,
+      ),
+      fetchMembers: (_) async => const [],
+      readChannel: (_) => _streamChannel,
+      readUserCache: () => const {},
+      addLocalMessage: (_, _) {},
+      completeLocalMessage: (_, _) {},
+      removeLocalMessage: (_, _) {},
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello without a mention',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+
+    expect(session.event.tags.where((tag) => tag.first == 'p'), isEmpty);
+
+    session.accept();
+    await result;
   });
 
   test('cancels delivery after the active community changes', () async {
@@ -94,6 +166,18 @@ void main() {
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
+final _streamChannel = Channel(
+  id: _channelId,
+  name: 'General',
+  channelType: 'stream',
+  visibility: 'open',
+  description: '',
+  createdBy: 'creator',
+  createdAt: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+  memberCount: 2,
+  participantPubkeys: ['participant'],
+  isMember: true,
+);
 
 class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();


### PR DESCRIPTION
## Summary

- tag every other participant as a recipient when sending a mobile direct message
- keep channel messages and typing streams limited to explicit mentions
- add regression tests for direct-message recipients and stream events

## Root cause

Mobile sends only encoded explicit mentions as `p` tags. In a direct message that means an ordinary message can be stored without any recipient tag, so managed agents never receive it and clients cannot treat it as addressed to them.

Desktop already derives DM recipients from the channel membership. This change brings mobile in line with that behavior while excluding the sender and deduplicating recipients.

## User impact

Direct messages sent from Buzz mobile will reliably notify and wake their recipients without requiring users to type an explicit `@mention`.

## Verification

Validated after rebasing onto current `block/buzz:main` with Flutter 3.41.7 / Dart 3.11.5:

- `dart format`: 366 files, 0 changes
- `flutter analyze`: no issues
- `node scripts/check-file-sizes.mjs`: passed
- full `flutter test`: 1,231 tests passed
- `git diff --check`: passed
- remote branch tree `5cb4a66f24606afa7c6406ed8d52bc3f976d3ffb` matches the locally validated tree

Originating Buzz channel: `c3e004a6-08b4-4cd5-9c64-f84f4e599b4f`
