### PR TITLE
build(desktop): bundle supported Linux sidecars

### DIFF
--- a/desktop/src-tauri/tauri.linux.conf.json
+++ b/desktop/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,11 @@
+{
+  "bundle": {
+    "externalBin": [
+      "binaries/buzz-acp",
+      "binaries/buzz-agent",
+      "binaries/buzz-dev-mcp",
+      "binaries/git-credential-nostr",
+      "binaries/buzz"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the Linux platform-specific Tauri bundle override
- exclude the unavailable Kubernetes backend sidecar on Linux
- retain the supported Buzz CLI, ACP, agent, dev MCP, and credential-helper sidecars

## Verification
- Linux config parses and matches the existing supported Windows sidecar list
- `pnpm --dir desktop check` passes (one pre-existing CSS warning)

This makes Linux desktop packaging reproducible instead of depending on a sidecar that is not built for Linux.