### PR TITLE
feat(desktop): add per-agent working directories

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -73,6 +73,7 @@ fn agent_record() -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_args: vec![],

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -736,6 +736,11 @@ pub async fn update_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<UpdateManagedAgentResponse, String> {
+    let working_directory_update = match input.working_directory.as_ref() {
+        Some(Some(path)) => Some(Some(crate::managed_agents::normalize_agent_workdir(path)?)),
+        Some(None) => Some(None),
+        None => None,
+    };
     // Phase 1: local save (synchronous, under lock)
     let (summary, sync_params, rollback) = {
         let _store_guard = state
@@ -752,10 +757,8 @@ pub async fn update_managed_agent(
         for pubkey in &exited_pubkeys {
             state.clear_agent_session_caches(pubkey);
         }
-
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;
         let previous_record = record.clone();
-
         let mut name_changed = false;
         if let Some(name_update) = input.name {
             let trimmed = name_update.trim().to_string();
@@ -781,6 +784,9 @@ pub async fn update_managed_agent(
         // read-time. A name-only edit (relay_url == None) leaves the pin intact.
         if let Some(relay_url) = input.relay_url {
             record.relay_url = relay_url.trim().to_string();
+        }
+        if let Some(value) = working_directory_update {
+            record.working_directory = value;
         }
         if let Some(acp_command) = input.acp_command {
             record.acp_command = acp_command;
@@ -813,7 +819,6 @@ pub async fn update_managed_agent(
             crate::managed_agents::validate_user_env_keys(&env_vars)?;
             record.env_vars = env_vars;
         }
-
         // Native provider/model fields are authoritative. Keep the typed marker
         // derived for new records while retaining legacy typed records for
         // non-native providers.
@@ -828,7 +833,6 @@ pub async fn update_managed_agent(
             record.model = Some(model_ref.clone());
             record.relay_mesh = Some(crate::managed_agents::RelayMeshConfig { model_ref });
         }
-
         // Inbound author gate: merge patch onto current values, then validate
         // the merged state. This lets a single update switch to Allowlist AND
         // supply pubkeys atomically.
@@ -851,16 +855,12 @@ pub async fn update_managed_agent(
         if input.respond_to_allowlist.is_some() {
             record.respond_to_allowlist = prospective_allowlist;
         }
-
         record.updated_at = now_iso();
-
         save_managed_agents(&app, &records)?;
-
         let record = records
             .iter()
             .find(|r| r.pubkey == input.pubkey)
             .ok_or_else(|| format!("agent {} not found", input.pubkey))?;
-
         // Publish the edit to the relay. After-save, inside the lock, before
         // any .await. The retention upsert hashes the opt-IN projection, so an
         // update that touched only runtime/local fields is a no-op publish.

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -583,7 +583,11 @@ pub async fn create_managed_agent(
         }
     }
     crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
-
+    let working_directory = input
+        .working_directory
+        .as_deref()
+        .map(crate::managed_agents::normalize_agent_workdir)
+        .transpose()?;
     // Validate & normalize the respond-to allowlist BEFORE any side effects.
     // The harness has its own validator (buzz-acp/src/config.rs) but we want
     // to catch malformed input at the boundary so the agent never tries to
@@ -600,11 +604,9 @@ pub async fn create_managed_agent(
             "respond-to mode 'allowlist' requires at least one pubkey in the allowlist".to_string(),
         );
     }
-
     // Snapshot the workspace owner pubkey for the legacy-record auth_tag
     // fallback. Computed outside the records lock to keep lock ordering simple.
     let owner_hex = workspace_owner_hex(&state)?;
-
     // ── Phase 1: generate keys (sync lock) ────────────────────────────────────
     let (agent_keys, private_key_nsec, pubkey, resolved_relay_url, input) = {
         let _store_guard = state
@@ -616,7 +618,6 @@ pub async fn create_managed_agent(
             .managed_agent_processes
             .lock()
             .map_err(|error| error.to_string())?;
-
         let (sync_changed, exited_pubkeys) =
             sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
         if sync_changed {
@@ -638,7 +639,6 @@ pub async fn create_managed_agent(
             .secret_key()
             .to_bech32()
             .map_err(|error| format!("failed to encode private key: {error}"))?;
-
         // Store the relay override exactly as supplied (trimmed). An explicit
         // value pins the agent; empty stays empty and resolves to the active
         // workspace relay at read-time. Uniform for Local and Provider.
@@ -648,7 +648,6 @@ pub async fn create_managed_agent(
             .map(str::trim)
             .unwrap_or("")
             .to_string();
-
         (keys, private_key_nsec, pubkey, resolved_relay_url, input)
     };
 
@@ -838,6 +837,7 @@ pub async fn create_managed_agent(
             auth_tag: auth_tag.clone(),
             relay_url: resolved_relay_url.clone(),
             avatar_url: resolved_avatar_url.clone(),
+            working_directory: working_directory.clone(),
             acp_command: input
                 .acp_command
                 .as_deref()

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -16,6 +16,7 @@ fn bare_agent_record(
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -24,6 +24,7 @@ fn make_agent(
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "buzz-agent".to_string(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
@@ -166,6 +166,7 @@ fn local_agent() -> ManagedAgentRecord {
         auth_tag: Some("localauthtag".to_string()),
         relay_url: "wss://relay.local".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_command_override: Some("claude".to_string()),

--- a/desktop/src-tauri/src/commands/personas/snapshot/fidelity_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/fidelity_tests.rs
@@ -20,6 +20,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: String::new(),
         agent_command: String::new(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -604,6 +604,7 @@ pub async fn confirm_agent_snapshot_import(
             auth_tag: auth_tag.clone(),
             relay_url: String::new(), // resolves to workspace relay at runtime
             avatar_url: effective_avatar.clone(),
+            working_directory: None,
             // Machine-local commands: derive from the runtime catalog at
             // spawn time — never manufacture from snapshot data.
             acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -29,6 +29,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: String::new(),
         agent_command: String::new(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/commands/personas/update/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/update/name_propagation_tests.rs
@@ -12,6 +12,7 @@ fn agent(persona_id: &str, name: &str, display_name: Option<&str>) -> ManagedAge
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: String::new(),
         agent_command: String::new(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -559,6 +559,7 @@ pub async fn confirm_team_snapshot_import(
             auth_tag: auth_tag.clone(),
             relay_url: String::new(),
             avatar_url: effective_avatar_url.clone(),
+            working_directory: None,
             acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
             agent_command: String::new(),
             agent_command_override: None,

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -187,6 +187,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: crate::managed_agents::DEFAULT_ACP_COMMAND.to_string(),
         agent_command: String::new(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -165,6 +165,7 @@ mod tests {
             auth_tag: Some("authtagsecret".to_string()),
             relay_url: "wss://relay.example".to_string(),
             avatar_url: Some("https://example.com/a.png".to_string()),
+            working_directory: Some("/SENTINEL_LOCAL_WORKSPACE".to_string()),
             acp_command: "buzz-acp".to_string(),
             agent_command: "goose".to_string(),
             agent_command_override: None,
@@ -289,6 +290,8 @@ mod tests {
         assert!(!json.contains("backend_agent_id"));
         assert!(!json.contains("provider_binary_path"));
         assert!(!json.contains("relay_url"));
+        assert!(!json.contains("working_directory"));
+        assert!(!json.contains("SENTINEL_LOCAL_WORKSPACE"));
 
         // Identity fields — must appear.
         assert!(json.contains("\"name\""));

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
@@ -373,6 +373,7 @@ mod tests {
             auth_tag: None,
             relay_url: "ws://localhost:3000".to_string(),
             avatar_url: None,
+            working_directory: None,
             acp_command: "buzz-acp".to_string(),
             agent_command: "goose".to_string(),
             agent_args: vec![],

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
@@ -20,6 +20,7 @@ fn minimal_record() -> ManagedAgentRecord {
         auth_tag: Some("auth-tag-secret".to_string()),       // MUST NOT appear in snapshot
         relay_url: "wss://relay.example.com".to_string(),    // MUST NOT appear in snapshot
         avatar_url: Some("https://example.com/avatar.png".to_string()),
+        working_directory: Some("/SENTINEL_LOCAL_WORKSPACE".to_string()),
         acp_command: "/usr/local/bin/acp".to_string(), // MUST NOT appear in snapshot
         agent_command: "goose".to_string(),            // MUST NOT appear in snapshot
         agent_command_override: Some("goose-override".to_string()), // MUST NOT appear
@@ -384,7 +385,14 @@ fn snapshot_omits_removed_mcp_toolsets_config() {
 fn secret_exclusion_machine_commands_absent() {
     let record = minimal_record();
     let json = snapshot_json_string(&record);
-    // acp_command / agent_command / agent_command_override / agent_args / mcp_command
+    // working_directory / acp_command / agent_command / agent_command_override /
+    // agent_args / mcp_command
+    assert!(
+        !json.contains("workingDirectory")
+            && !json.contains("working_directory")
+            && !json.contains("SENTINEL_LOCAL_WORKSPACE"),
+        "machine-local working directory must not appear"
+    );
     assert!(
         !json.contains("/usr/local/bin/acp"),
         "acp_command path must not appear"

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -72,6 +72,7 @@ fn test_record() -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_args: vec![],

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -237,6 +237,7 @@ fn record_with(
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: String::new(),
         agent_command: String::new(),
         agent_command_override: override_cmd.map(str::to_string),
@@ -285,7 +286,6 @@ fn record_with(
         relay_mesh: None,
     }
 }
-
 #[test]
 fn record_agent_command_own_runtime_wins_over_persona() {
     // A record with its own materialized runtime never consults the

--- a/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
@@ -46,6 +46,7 @@ fn record(
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -306,6 +306,7 @@ fn bare_record() -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "goose".to_string(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -108,7 +108,129 @@ pub fn default_agent_workdir() -> Option<std::path::PathBuf> {
         .clone()
 }
 
+/// Validate and normalize a configured per-agent working directory.
+///
+/// Configured paths are machine-local guardrails, not sandbox boundaries. They
+/// must resolve to an existing absolute directory and may not resolve to a
+/// filesystem root. Canonicalizing before persistence prevents later launches
+/// from interpreting `..` components or a configured symlink differently.
+pub(crate) fn normalize_agent_workdir(path: &str) -> Result<String, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("working directory cannot be empty; clear it to use the default".to_string());
+    }
+    let candidate = std::path::Path::new(trimmed);
+    if !candidate.is_absolute() {
+        return Err("working directory must be an absolute path".to_string());
+    }
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|error| format!("working directory is not accessible: {error}"))?;
+    if !canonical.is_dir() {
+        return Err("working directory must be an existing directory".to_string());
+    }
+    if canonical.parent().is_none() {
+        return Err("working directory cannot be a filesystem root".to_string());
+    }
+    canonical
+        .into_os_string()
+        .into_string()
+        .map_err(|_| "working directory must be valid UTF-8".to_string())
+}
+
+/// Resolve the directory an agent harness will launch from.
+pub(crate) fn effective_agent_workdir(
+    record: &ManagedAgentRecord,
+) -> Result<Option<std::path::PathBuf>, String> {
+    match record.working_directory.as_deref() {
+        Some(path) => normalize_agent_workdir(path)
+            .map(std::path::PathBuf::from)
+            .map(Some),
+        None => Ok(default_agent_workdir()),
+    }
+}
+
+/// Apply the effective per-agent working directory to a child command.
+pub(crate) fn configure_agent_workdir(
+    command: &mut std::process::Command,
+    record: &ManagedAgentRecord,
+) -> Result<Option<std::path::PathBuf>, String> {
+    let working_directory = effective_agent_workdir(record)?;
+    if let Some(path) = &working_directory {
+        command.current_dir(path);
+        tracing::info!(
+            agent_pubkey = %record.pubkey,
+            working_directory = %path.display(),
+            configured = record.working_directory.is_some(),
+            "resolved managed agent working directory"
+        );
+    }
+    Ok(working_directory)
+}
+
 /// Returns `true` if `path` is a real directory (not a symlink).
 fn is_real_dir(path: &std::path::Path) -> bool {
     path.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod workdir_tests {
+    use super::{configure_agent_workdir, normalize_agent_workdir};
+
+    #[test]
+    fn configured_workdir_requires_an_absolute_existing_non_root_directory() {
+        assert!(normalize_agent_workdir("relative/path").is_err());
+        assert!(normalize_agent_workdir("").is_err());
+
+        let current = std::env::current_dir().unwrap();
+        let root = current.ancestors().last().unwrap();
+        assert!(normalize_agent_workdir(&root.to_string_lossy()).is_err());
+
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            normalize_agent_workdir(&dir.path().to_string_lossy()).unwrap(),
+            dir.path().canonicalize().unwrap().to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn configured_workdir_rejects_files_and_missing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        std::fs::write(&file, "test").unwrap();
+        assert!(normalize_agent_workdir(&file.to_string_lossy()).is_err());
+        assert!(normalize_agent_workdir(&dir.path().join("missing").to_string_lossy()).is_err());
+    }
+
+    #[test]
+    fn configured_workdir_is_applied_to_the_spawn_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut record: crate::managed_agents::ManagedAgentRecord =
+            serde_json::from_value(serde_json::json!({
+                "pubkey": "aa",
+                "name": "test",
+                "relay_url": "",
+                "working_directory": dir.path(),
+                "acp_command": "buzz-acp",
+                "agent_command": "buzz-agent",
+                "agent_args": [],
+                "mcp_command": "",
+                "turn_timeout_seconds": 0,
+                "parallelism": 1,
+                "system_prompt": null,
+                "start_on_app_launch": false,
+                "runtime_pid": null,
+                "created_at": "now",
+                "updated_at": "now"
+            }))
+            .unwrap();
+        record.working_directory = Some(dir.path().to_string_lossy().into_owned());
+
+        let mut command = std::process::Command::new("unused");
+        configure_agent_workdir(&mut command, &record).unwrap();
+        assert_eq!(
+            command.get_current_dir(),
+            Some(dir.path().canonicalize().unwrap().as_path())
+        );
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -456,6 +456,7 @@ fn make_agent(name: &str, persona_id: Option<&str>) -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: String::new(),
         avatar_url: None,
+        working_directory: None,
         acp_command: String::new(),
         agent_command: String::new(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/parallelism.rs
+++ b/desktop/src-tauri/src/managed_agents/parallelism.rs
@@ -71,6 +71,7 @@ mod tests {
             auth_tag: None,
             relay_url: String::new(),
             avatar_url: None,
+            working_directory: None,
             acp_command: String::new(),
             agent_command: String::new(),
             agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
@@ -12,6 +12,7 @@ pub(super) fn sample_record() -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".into(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".into(),
         agent_command: "goose".into(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1484,6 +1484,7 @@ mod tests {
             auth_tag: None,
             relay_url: String::new(),
             avatar_url: None,
+            working_directory: None,
             acp_command: "buzz-acp".to_string(),
             agent_command: "buzz-agent".to_string(),
             agent_command_override: None,
@@ -1531,7 +1532,6 @@ mod tests {
             definition_parallelism: None,
             relay_mesh: None,
         };
-
         let runtime = known_acp_runtime_exact("buzz-agent");
         let effective = resolve_effective_agent_env(&record, &[], runtime, &Default::default());
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -305,6 +305,7 @@ pub fn build_managed_agent_summary(
         runtime: record.runtime.clone(),
         team_id: record.team_id.clone(),
         relay_url: record.relay_url.clone(),
+        working_directory: record.working_directory.clone(),
         acp_command: record.acp_command.clone(),
         agent_command: descriptor.command,
         agent_command_override: record.agent_command_override.clone(),
@@ -557,9 +558,7 @@ pub fn spawn_agent_child(
     );
 
     let mut command = std::process::Command::new(&resolved_acp_command);
-    if let Some(home) = super::default_agent_workdir() {
-        command.current_dir(home);
-    }
+    super::configure_agent_workdir(&mut command, record)?;
     command.stdin(std::process::Stdio::null());
     command.stdout(std::process::Stdio::from(stdout));
     command.stderr(std::process::Stdio::from(stderr));

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -135,6 +135,7 @@ fn fixture(
         auth_tag,
         relay_url: "ws://localhost:3000".into(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".into(),
         agent_command: "goose".into(),
         agent_command_override: None,
@@ -183,7 +184,6 @@ fn fixture(
         relay_mesh: None,
     }
 }
-
 #[test]
 fn build_env_owner_only_sets_mode_and_removes_others() {
     let rec = fixture(RespondTo::OwnerOnly, vec![], Some("tag".into()));

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
@@ -92,6 +92,9 @@ pub(crate) struct SpawnConfigInputs<'a> {
 /// [`ManagedAgentProcess`]: super::ManagedAgentProcess
 #[derive(Clone, Serialize)]
 pub(crate) struct SpawnConfigSnapshot {
+    /// Optional machine-local launch directory. `None` preserves the shared
+    /// Buzz default used by existing records.
+    pub working_directory: Option<String>,
     /// The ACP harness binary the desktop launches (`buzz-acp`).
     pub acp_command: String,
     /// The effective agent command the harness drives.
@@ -138,6 +141,7 @@ impl SpawnConfigSnapshot {
             provider,
         } = inputs;
         Self {
+            working_directory: record.working_directory.clone(),
             acp_command: record.acp_command.clone(),
             command: descriptor.command.clone(),
             args: descriptor.args.clone(),

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
@@ -8,6 +8,7 @@ const RELAY_WITH_TOKEN: &str = "wss://relay.example/ws?token=SENTINEL";
 /// coverage guard below sees the full serialized key set.
 fn base() -> SpawnConfigSnapshot {
     SpawnConfigSnapshot {
+        working_directory: Some("/tmp/agent-workspace".into()),
         acp_command: "buzz-acp".into(),
         command: "goose".into(),
         args: vec!["--mode".into(), "acp".into()],
@@ -48,6 +49,7 @@ type Mutation = (&'static str, fn(&mut SpawnConfigSnapshot));
 
 fn mutations() -> Vec<Mutation> {
     vec![
+        ("working_directory", |s| s.working_directory = None),
         ("acp_command", |s| s.acp_command = "other-acp".into()),
         ("command", |s| s.command = "claude".into()),
         ("args", |s| s.args = vec!["--other".into()]),

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
@@ -24,6 +24,7 @@ fn record() -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".into(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".into(),
         agent_command: "goose".into(),
         agent_command_override: None,
@@ -104,6 +105,18 @@ fn snapshot_is_deterministic() {
     assert_eq!(
         snapshot(&rec, &[], &[], "wss://ws.example", &Default::default()),
         snapshot(&rec, &[], &[], "wss://ws.example", &Default::default())
+    );
+}
+
+#[test]
+fn working_directory_change_requires_restart() {
+    let first = record();
+    let mut second = first.clone();
+    second.working_directory = Some("/tmp/agent-workspace".to_string());
+
+    assert_ne!(
+        snapshot(&first, &[], &[], "wss://ws.example", &Default::default()),
+        snapshot(&second, &[], &[], "wss://ws.example", &Default::default())
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -260,6 +260,7 @@ mod tests {
             auth_tag: Some("auth-tag-secret".to_string()),       // MUST NOT appear
             relay_url: "wss://relay.example.com".to_string(),    // MUST NOT appear
             avatar_url: Some(format!("https://example.com/{name}.png")),
+            working_directory: Some("/SENTINEL_LOCAL_WORKSPACE".to_string()),
             acp_command: "/usr/local/bin/acp".to_string(), // MUST NOT appear
             agent_command: "goose".to_string(),            // MUST NOT appear
             agent_command_override: None,
@@ -483,6 +484,12 @@ mod tests {
         assert!(
             !json.contains("SENTINEL_PERSONA_ID"),
             "persona_id must not appear"
+        );
+        assert!(
+            !json.contains("SENTINEL_LOCAL_WORKSPACE")
+                && !json.contains("working_directory")
+                && !json.contains("workingDirectory"),
+            "machine-local working directory must not appear"
         );
     }
 

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -171,6 +171,7 @@ fn managed_agent(name: &str) -> ManagedAgentRecord {
         auth_tag: None,
         relay_url: "ws://localhost:3000".to_string(),
         avatar_url: None,
+        working_directory: None,
         acp_command: "buzz-acp".to_string(),
         agent_command: "buzz-agent".to_string(),
         agent_command_override: None,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -106,6 +106,7 @@ impl AgentDefinition {
             auth_tag: None,
             relay_url: String::new(),
             avatar_url: self.avatar_url,
+            working_directory: None,
             acp_command: DEFAULT_ACP_COMMAND.to_string(),
             agent_command: String::new(),
             agent_command_override: None,
@@ -156,7 +157,6 @@ impl AgentDefinition {
         }
     }
 }
-
 impl ManagedAgentRecord {
     /// Present a key-less definition record back in the legacy
     /// [`AgentDefinition`] shape — the compatibility view the persona command
@@ -192,7 +192,6 @@ impl ManagedAgentRecord {
         })
     }
 }
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelayAgentInfo {
     pub pubkey: String,
@@ -243,6 +242,9 @@ pub struct ManagedAgentRecord {
     /// `#[serde(default)]` so pre-existing records deserialize as `None`.
     #[serde(default)]
     pub avatar_url: Option<String>,
+    /// Local ACP harness CWD; excluded from portable snapshots and relay events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
     pub acp_command: String,
     pub agent_command: String,
     /// Explicit per-instance harness pin. `None` (the default) means inherit
@@ -439,7 +441,6 @@ pub struct ManagedAgentRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relay_mesh: Option<RelayMeshConfig>,
 }
-
 /// Typed relay-mesh configuration carried on a [`ManagedAgentRecord`].
 ///
 /// Feature-independent on purpose: the field is always present in the record
@@ -457,7 +458,6 @@ pub struct RelayMeshConfig {
     #[serde(alias = "modelRef")]
     pub model_ref: String,
 }
-
 #[derive(Debug)]
 pub struct ManagedAgentProcess {
     pub child: Child,
@@ -489,7 +489,6 @@ pub struct ManagedAgentProcess {
     #[cfg(windows)]
     pub job: Option<crate::managed_agents::JobHandle>,
 }
-
 #[derive(Debug, Clone, Serialize)]
 pub struct ManagedAgentSummary {
     pub pubkey: String,
@@ -501,6 +500,7 @@ pub struct ManagedAgentSummary {
     pub runtime: Option<String>,
     pub team_id: Option<String>,
     pub relay_url: String,
+    pub working_directory: Option<String>,
     pub acp_command: String,
     pub agent_command: String,
     /// Mirrors `ManagedAgentRecord.agent_command_override`: `Some` when the user

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -137,6 +137,8 @@ pub struct CreateManagedAgentRequest {
     #[serde(default)]
     pub team_id: Option<String>,
     pub relay_url: Option<String>,
+    /// Optional machine-local ACP harness working directory.
+    pub working_directory: Option<String>,
     pub acp_command: Option<String>,
     pub agent_command: Option<String>,
     /// True when `agent_command` is a runtime command the user deliberately
@@ -222,6 +224,10 @@ pub struct UpdateManagedAgentRequest {
     pub turn_timeout_seconds: Option<u64>,
     #[serde(default)]
     pub relay_url: Option<String>,
+    /// Absent = don't touch. null = restore the shared Buzz nest default.
+    /// A string sets an explicit machine-local ACP harness working directory.
+    #[serde(default, deserialize_with = "crate::util::double_option")]
+    pub working_directory: Option<Option<String>>,
     #[serde(default)]
     pub acp_command: Option<String>,
     #[serde(default)]

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -50,6 +50,7 @@ fn managed_agent_record_without_auth_tag_deserializes() {
 
     assert_eq!(record.auth_tag, None);
     assert_eq!(record.avatar_url, None);
+    assert_eq!(record.working_directory, None);
     assert_eq!(record.pubkey, "abcd1234");
 }
 
@@ -62,6 +63,7 @@ fn managed_agent_record_with_auth_tag_round_trips() {
         "private_key_nsec": "nsec1fake",
         "auth_tag": "[\"auth\",\"deadbeef\",\"\",\"cafebabe\"]",
         "relay_url": "wss://localhost:3000",
+        "working_directory": "/tmp/agent-workspace",
         "acp_command": "buzz-acp",
         "agent_command": "goose",
         "agent_args": [],
@@ -89,6 +91,10 @@ fn managed_agent_record_with_auth_tag_round_trips() {
     let record2: ManagedAgentRecord =
         serde_json::from_str(&serialized).expect("round-trip should deserialize");
     assert_eq!(record.auth_tag, record2.auth_tag);
+    assert_eq!(
+        record2.working_directory.as_deref(),
+        Some("/tmp/agent-workspace")
+    );
 }
 
 // ── Inbound author gate tests ────────────────────────────────────────
@@ -247,6 +253,21 @@ fn update_request_provider_tristate_value_means_set() {
         Some(Some("databricks_v2".to_string())),
         "provider value must deserialize to Some(Some(value)) (set)"
     );
+}
+
+#[test]
+fn update_request_working_directory_uses_nullable_patch_semantics() {
+    let absent: super::UpdateManagedAgentRequest =
+        serde_json::from_str(r#"{"pubkey":"abcd1234"}"#).unwrap();
+    assert_eq!(absent.working_directory, None);
+
+    let clear: super::UpdateManagedAgentRequest =
+        serde_json::from_str(r#"{"pubkey":"abcd1234","workingDirectory":null}"#).unwrap();
+    assert_eq!(clear.working_directory, Some(None));
+
+    let set: super::UpdateManagedAgentRequest =
+        serde_json::from_str(r#"{"pubkey":"abcd1234","workingDirectory":"/tmp/agent"}"#).unwrap();
+    assert_eq!(set.working_directory, Some(Some("/tmp/agent".to_string())));
 }
 
 use super::{CreateManagedAgentRequest, RelayMeshConfig};
@@ -707,6 +728,7 @@ fn summary_fixture(
         runtime: None,
         team_id: None,
         relay_url: String::new(),
+        working_directory: None,
         acp_command: "buzz-acp".into(),
         agent_command: "goose".into(),
         agent_command_override: None,

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -166,6 +166,8 @@ with a TypeScript lookup table or an id comparison in a component.
    expose `respond-to`, `allowlist`, Nostr, or harness jargon in primary UI
    copy.
 
+12. **Per-agent working directories stay machine-local.** The optional managed-agent `workingDirectory` is an instance launch guardrail: Rust validates and canonicalizes an absolute existing non-root directory, persists it only in the local managed-agent store, includes it in spawn drift hashing, and applies it to the `buzz-acp` parent process. Keep it out of Persona/Team snapshots and kind:30177 agent events. UI copy must not call it a sandbox or credential isolation; agents still share the desktop user's home, credentials, filesystem access, environment, and network.
+
 ## The tests that enforce this
 
 - `lib/agentConfigCore.test.mjs` — field model per harness × scope, clearing

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -117,11 +117,13 @@ export function AgentInstanceEditDialog({
   const runtimesQuery = useAcpRuntimesQuery({ enabled: open });
   const configSurfaceQuery = useAgentConfigSurface(open ? agent.pubkey : null);
   const runtimes = runtimesQuery.data ?? [];
-
   const [name, setName] = React.useState(agent.name);
   const [aiDefaultsOpen, setAiDefaultsOpen] = React.useState(false);
   const aiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [acpCommand, setAcpCommand] = React.useState(agent.acpCommand);
+  const [workingDirectory, setWorkingDirectory] = React.useState(
+    agent.workingDirectory ?? "",
+  );
   const [agentCommand, setAgentCommand] = React.useState(agent.agentCommand);
   const [originalAgentCommand, setOriginalAgentCommand] = React.useState(
     agent.agentCommand,
@@ -165,20 +167,18 @@ export function AgentInstanceEditDialog({
     React.useState(false);
   const [isAddHarnessOpen, setIsAddHarnessOpen] = React.useState(false);
   const shouldReduceMotion = useReducedMotion();
-
   // Runtime selector: defaults to "custom" until the dialog opens and the
   // catalog loads. The open-effect re-derives the correct id from the catalog.
   const [selectedRuntimeId, setSelectedRuntimeId] = React.useState("custom");
-
   // Tracks whether the user has made an in-dialog runtime selection.
   const runtimeTouched = React.useRef(false);
-
   // Reset form state only when the dialog opens or when switching to a different agent.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — including agent fields would re-fire on every 5s poll and wipe edits
   React.useEffect(() => {
     if (open) {
       setName(agent.name);
       setAcpCommand(agent.acpCommand);
+      setWorkingDirectory(agent.workingDirectory ?? "");
       setAgentCommand(agent.agentCommand);
       setOriginalAgentCommand(agent.agentCommand);
       setInheritHarness(
@@ -207,7 +207,6 @@ export function AgentInstanceEditDialog({
       updateMutation.reset();
     }
   }, [open, agent.pubkey]);
-
   // Re-derive the runtime id when the catalog loads.
   React.useEffect(() => {
     if (!open || runtimeTouched.current || runtimes.length === 0) {
@@ -220,20 +219,16 @@ export function AgentInstanceEditDialog({
       setSelectedRuntimeId(matched.id);
     }
   }, [open, runtimes, agent.agentCommand]);
-
   // Build the sorted runtime catalog for the dropdown.
   const sortedRuntimes = React.useMemo(
     () => sortPersonaRuntimes(runtimes),
     [runtimes],
   );
-
   const selectedRuntime = React.useMemo(
     () => runtimes.find((r) => r.id === selectedRuntimeId),
     [runtimes, selectedRuntimeId],
   );
-
   const runtimeDropdownValue = selectedRuntimeId || NO_RUNTIME_DROPDOWN_VALUE;
-
   const runtimeDropdownOptions: PersonaDropdownOption[] = React.useMemo(() => {
     const options: PersonaDropdownOption[] = [
       ...sortedRuntimes.map((candidate) => ({
@@ -255,7 +250,6 @@ export function AgentInstanceEditDialog({
     options.push(ADD_CUSTOM_HARNESS_OPTION);
     return options;
   }, [sortedRuntimes, selectedRuntimeId]);
-
   // Resolve the dialog-opening command as the catalog loads. Edit-state runtime
   // ids mutate during selection changes and cannot identify the original state.
   const originalRuntimeSupportsProvider = React.useMemo(() => {
@@ -660,6 +654,10 @@ export function AgentInstanceEditDialog({
         acpCommand:
           acpCommand.trim() !== agent.acpCommand
             ? acpCommand.trim()
+            : undefined,
+        workingDirectory:
+          (workingDirectory.trim() || null) !== agent.workingDirectory
+            ? workingDirectory.trim() || null
             : undefined,
         agentCommand: agentCommandUpdate,
         // A non-inheriting selection is a deliberate pin — signal it so the
@@ -1176,6 +1174,7 @@ export function AgentInstanceEditDialog({
                   >
                     <EditAgentAdvancedFields
                       acpCommand={acpCommand}
+                      workingDirectory={workingDirectory}
                       agentArgs={agentArgs}
                       autoRestartOnConfigChange={autoRestartOnConfigChange}
                       disabled={updateMutation.isPending}
@@ -1201,6 +1200,7 @@ export function AgentInstanceEditDialog({
                       selectedRuntime={prospectiveRuntime}
                       systemPrompt={systemPrompt}
                       onAcpCommandChange={setAcpCommand}
+                      onWorkingDirectoryChange={setWorkingDirectory}
                       onAgentArgsChange={setAgentArgs}
                       onAutoRestartChange={setAutoRestartOnConfigChange}
                       onEnvVarsChange={setEnvVars}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -31,6 +31,7 @@ import {
 
 export function EditAgentAdvancedFields({
   acpCommand,
+  workingDirectory,
   agentArgs,
   autoRestartOnConfigChange,
   disabled,
@@ -50,6 +51,7 @@ export function EditAgentAdvancedFields({
   selectedRuntime,
   systemPrompt,
   onAcpCommandChange,
+  onWorkingDirectoryChange,
   onAgentArgsChange,
   onEnvVarsChange,
   onInheritHarnessChange,
@@ -58,6 +60,7 @@ export function EditAgentAdvancedFields({
   onSystemPromptChange,
 }: {
   acpCommand: string;
+  workingDirectory: string;
   agentArgs: string;
   autoRestartOnConfigChange: boolean;
   disabled: boolean;
@@ -101,6 +104,7 @@ export function EditAgentAdvancedFields({
   selectedRuntime?: AcpRuntimeCatalogEntry;
   systemPrompt: string;
   onAcpCommandChange: (value: string) => void;
+  onWorkingDirectoryChange: (value: string) => void;
   onAgentArgsChange: (value: string) => void;
   onEnvVarsChange: (value: EnvVarsValue) => void;
   onInheritHarnessChange: (value: boolean) => void;
@@ -192,6 +196,42 @@ export function EditAgentAdvancedFields({
           {autoRestartOnConfigChange
             ? "Restarts this agent automatically when its configuration changes, once it is idle and connected."
             : "Configuration changes only show the restart badge; restart manually to apply them."}
+        </p>
+      </div>
+
+      {/* Machine-local working directory */}
+      <div className="space-y-1.5">
+        <label
+          className="text-sm font-medium text-foreground"
+          htmlFor="edit-agent-working-directory"
+        >
+          Working directory
+          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+        </label>
+        <div
+          className={cn(
+            "flex min-h-11 items-center px-3",
+            PERSONA_FIELD_SHELL_CLASS,
+          )}
+        >
+          <Input
+            autoCapitalize="none"
+            autoCorrect="off"
+            className={cn(
+              "h-8 px-0 py-0 leading-6",
+              PERSONA_FIELD_CONTROL_CLASS,
+            )}
+            disabled={disabled}
+            id="edit-agent-working-directory"
+            onChange={(event) => onWorkingDirectoryChange(event.target.value)}
+            placeholder="Absolute path; blank uses the Buzz default"
+            spellCheck={false}
+            value={workingDirectory}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Starts this agent in an existing local directory. This is a workspace
+          guardrail, not a sandbox or credential boundary.
         </p>
       </div>
 

--- a/desktop/src/shared/api/tauri.test.mjs
+++ b/desktop/src/shared/api/tauri.test.mjs
@@ -119,7 +119,9 @@ test("relay rate-limited: prefix check is case-sensitive (Rust always emits lowe
 // arrives as definitionEnv (camelCase), source "custom" is preserved, and the
 // env round-trips end-to-end so a save-then-edit cycle cannot erase env.
 
-const { fromRawAcpRuntimeCatalogEntry } = await import("./tauri.ts");
+const { fromRawAcpRuntimeCatalogEntry, fromRawManagedAgent } = await import(
+  "./tauri.ts"
+);
 
 test("fromRawAcpRuntimeCatalogEntry maps definition_env to definitionEnv", () => {
   const raw = {
@@ -254,6 +256,53 @@ test("fromRawAcpRuntimeCatalogEntry omits maxParallelism when max_parallelism is
     entry.maxParallelism,
     undefined,
     "uncapped harness must have maxParallelism: undefined",
+  );
+});
+
+test("fromRawManagedAgent preserves the machine-local working directory", () => {
+  const raw = {
+    pubkey: "a".repeat(64),
+    name: "Workspace Agent",
+    persona_id: null,
+    relay_url: "wss://relay.example",
+    working_directory: "/tmp/agent-workspace",
+    acp_command: "buzz-acp",
+    agent_command: "buzz-agent",
+    agent_args: [],
+    mcp_command: "",
+    turn_timeout_seconds: 0,
+    idle_timeout_seconds: null,
+    max_turn_duration_seconds: null,
+    parallelism: 1,
+    system_prompt: null,
+    model: null,
+    provider: null,
+    persona_out_of_date: false,
+    persona_orphaned: false,
+    needs_restart: false,
+    status: "stopped",
+    pid: null,
+    created_at: "2026-08-05T00:00:00Z",
+    updated_at: "2026-08-05T00:00:00Z",
+    last_started_at: null,
+    last_stopped_at: null,
+    last_exit_code: null,
+    last_error: null,
+    last_error_code: null,
+    log_path: "/tmp/agent.log",
+    start_on_app_launch: false,
+    backend: { type: "local" },
+    backend_agent_id: null,
+  };
+
+  assert.equal(
+    fromRawManagedAgent(raw).workingDirectory,
+    "/tmp/agent-workspace",
+  );
+  assert.equal(
+    fromRawManagedAgent({ ...raw, working_directory: undefined })
+      .workingDirectory,
+    null,
   );
 });
 

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -126,6 +126,7 @@ export type RawManagedAgent = {
   runtime?: string | null;
   team_id?: string | null;
   relay_url: string;
+  working_directory?: string | null;
   acp_command: string;
   agent_command: string;
   agent_command_override?: string | null;
@@ -163,19 +164,16 @@ export type RawManagedAgent = {
   respond_to?: ManagedAgent["respondTo"];
   respond_to_allowlist?: string[];
 };
-
 type RawCreateManagedAgentResponse = {
   agent: RawManagedAgent;
   private_key_nsec: string;
   profile_sync_error: string | null;
   spawn_error: string | null;
 };
-
 type RawManagedAgentLog = {
   content: string;
   log_path: string;
 };
-
 export type RawAcpRuntimeCatalogEntry = {
   id: string;
   label: string;
@@ -695,6 +693,7 @@ export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
     runtime: agent.runtime ?? null,
     teamId: agent.team_id ?? null,
     relayUrl: agent.relay_url,
+    workingDirectory: agent.working_directory ?? null,
     acpCommand: agent.acp_command,
     agentCommand: agent.agent_command,
     agentCommandOverride: agent.agent_command_override ?? null,
@@ -850,6 +849,7 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
         personaId: input.personaId,
         teamId: input.teamId,
         relayUrl: input.relayUrl,
+        workingDirectory: input.workingDirectory,
         acpCommand: input.acpCommand,
         agentCommand: input.agentCommand,
         harnessOverride: input.harnessOverride ?? false,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -318,6 +318,7 @@ export type ManagedAgent = {
   runtime: string | null;
   teamId?: string | null;
   relayUrl: string;
+  workingDirectory: string | null;
   acpCommand: string;
   /** Resolved/effective harness command (persona-wins, override-honored). */
   agentCommand: string;
@@ -385,15 +386,12 @@ export type ManagedAgent = {
    */
   respondToAllowlist: string[];
 };
-
 /** Inbound author gate mode. Mirrors buzz-acp's --respond-to CLI flag. */
 export type RespondToMode = "owner-only" | "allowlist" | "anyone";
-
 export type BackendProviderCandidate = {
   id: string;
   binaryPath: string;
 };
-
 export type BackendProviderProbeResult = {
   ok: boolean;
   name?: string;
@@ -412,6 +410,7 @@ export type CreateManagedAgentInput = {
   /** Team this instance was deployed from; controls runtime team instructions. */
   teamId?: string;
   relayUrl?: string;
+  workingDirectory?: string;
   acpCommand?: string;
   agentCommand?: string;
   /**
@@ -688,6 +687,7 @@ export type UpdateManagedAgentInput = {
   parallelism?: number;
   turnTimeoutSeconds?: number;
   relayUrl?: string;
+  workingDirectory?: string | null;
   acpCommand?: string;
   agentCommand?: string;
   /**

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -82,6 +82,7 @@ export type MockManagedAgentSeed = {
   personaId?: string | null;
   /** Harness/runtime id pin; `null` = inherit from persona (native default). */
   runtime?: string | null;
+  workingDirectory?: string | null;
   status?: RawManagedAgent["status"];
   channelNames?: string[];
   channelIds?: string[];
@@ -794,6 +795,7 @@ type RawManagedAgent = {
   /** Record-level harness/runtime pin (`null` when inheriting from the persona). */
   runtime: string | null;
   relay_url: string;
+  working_directory: string | null;
   acp_command: string;
   agent_command: string;
   agent_args: string[];
@@ -1624,6 +1626,7 @@ function cloneManagedAgent(agent: MockManagedAgent): RawManagedAgent {
     persona_id: agent.persona_id,
     runtime: agent.runtime ?? null,
     relay_url: agent.relay_url,
+    working_directory: agent.working_directory ?? null,
     acp_command: agent.acp_command,
     agent_command: agent.agent_command,
     agent_args: [...agent.agent_args],
@@ -2179,6 +2182,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     // must mirror the wire shape, not omit the key.
     runtime: seed.runtime ?? null,
     relay_url: DEFAULT_RELAY_WS_URL,
+    working_directory: seed.workingDirectory ?? null,
     acp_command: "buzz-acp",
     agent_command: agentCommand,
     agent_args: agentArgs,
@@ -8286,6 +8290,7 @@ async function handleCreateManagedAgent(
       name: string;
       personaId?: string;
       relayUrl?: string;
+      workingDirectory?: string;
       acpCommand?: string;
       agentCommand?: string;
       agentArgs?: string[];
@@ -8364,6 +8369,7 @@ async function handleCreateManagedAgent(
     // Create never pins a harness id — the record inherits from the persona.
     runtime: null,
     relay_url: args.input.relayUrl ?? DEFAULT_RELAY_WS_URL,
+    working_directory: args.input.workingDirectory ?? null,
     acp_command: args.input.acpCommand ?? "buzz-acp",
     agent_command: agentCommand,
     agent_args: agentArgs,
@@ -8636,6 +8642,7 @@ async function handleUpdateManagedAgent(args: {
     name?: string;
     model?: string | null;
     systemPrompt?: string | null;
+    workingDirectory?: string | null;
     envVars?: Record<string, string>;
     respondTo?: "owner-only" | "allowlist" | "anyone";
     respondToAllowlist?: string[];
@@ -8650,6 +8657,9 @@ async function handleUpdateManagedAgent(args: {
   }
   if (args.input.systemPrompt !== undefined) {
     agent.system_prompt = args.input.systemPrompt;
+  }
+  if (args.input.workingDirectory !== undefined) {
+    agent.working_directory = args.input.workingDirectory;
   }
   if (args.input.envVars !== undefined) {
     agent.env_vars = { ...args.input.envVars };

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -113,6 +113,42 @@ test.describe("edit agent dialog", () => {
     );
   });
 
+  test("persists a machine-local working directory from Advanced", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: AGENT_NAME,
+          status: "stopped",
+          channelNames: ["agents"],
+        },
+      ],
+    });
+
+    await openEditDialog(page);
+    await page.getByRole("button", { name: "Advanced", exact: true }).click();
+
+    const workdir = page.locator("#edit-agent-working-directory");
+    await expect(workdir).toBeVisible();
+    await expect(
+      page.getByText(
+        "This is a workspace guardrail, not a sandbox or credential boundary.",
+        { exact: false },
+      ),
+    ).toBeVisible();
+    await workdir.fill("/tmp/buzz-agent-workspace");
+    await page.getByTestId("edit-agent-dialog-submit").click();
+    await expect(page.getByTestId("edit-agent-dialog")).not.toBeVisible();
+
+    await page.getByTestId("user-profile-edit-agent").click();
+    await page.getByRole("button", { name: "Advanced", exact: true }).click();
+    await expect(page.locator("#edit-agent-working-directory")).toHaveValue(
+      "/tmp/buzz-agent-workspace",
+    );
+  });
+
   test("changes the model via custom entry and persists it", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Adds an optional machine-local working directory to each Desktop-managed agent so its `buzz-acp` process can start in an explicitly selected workspace instead of always using the shared Buzz nest.

- validates and canonicalizes configured directories through one backend path
- fails closed for missing, inaccessible, relative, root, or non-directory paths
- applies the effective directory to the managed `buzz-acp` parent process
- includes the effective directory in spawn configuration hashing so changes trigger existing restart-drift behavior
- preserves the current Buzz nest default for records without the field
- excludes machine-local paths from Persona/Team snapshots and managed-agent relay events
- adds an Advanced editor field with explicit workspace-guardrail language

This is working-directory enforcement only. It is not a sandbox, credential boundary, or filesystem isolation mechanism.

### Related issue

Addresses the optional per-agent working-directory portion of #3364. #3822 describes broader channel-scoped/runtime-portable workspace routing, which remains out of scope.

No duplicate implementation PR was found.

### Testing

After rebasing onto `main` at `06b60e6`:

- 999 managed-agent Tauri tests passed
- full Tauri run: 2,236 passed and 13 ignored; one unrelated timing-sensitive Codex version-probe test failed once and passed on immediate isolated rerun
- Tauri Clippy passed for all targets/features with warnings denied
- 4,372 frontend tests passed
- all 8 `edit-agent.spec.ts` Playwright tests passed, including working-directory save/reopen persistence
- TypeScript typecheck, Biome, Rust formatting, file-size/text/pubkey guards, E2E build, and `git diff --check` passed

Before the rebase, an isolated x86_64 macOS app bundle also built with a development-only identifier and completed a 12-second startup smoke test without fatal errors. The relevant checks were run separately rather than through one aggregate `just ci` invocation.

### UI

Advanced agent settings expose the optional machine-local path and state the security boundary explicitly.

![Per-agent working-directory field](https://raw.githubusercontent.com/iminierai-aig/buzz/08010d6ac5cad748db52ebf67e9d5a6740c371ae/pr-4977--per-agent-working-directory.png)
