### PR TITLE
fix(agent): don't acknowledge a steer that the ending turn drops

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -530,6 +530,18 @@ impl RunCtx<'_> {
                         push_hook_outputs_as_tool_results(self.history, "_Stop", &objections);
                         continue;
                     }
+                    // end_turn is accepted — the turn is ending. Close the steer
+                    // channel first so the steer handler rejects any steer that
+                    // races this decision (its `steer_tx.send` fails), instead of
+                    // acknowledging it and then silently dropping it when the turn
+                    // ends. Then fold in any steer that WAS accepted before the
+                    // close: if one arrived, run one more round to act on it
+                    // rather than losing it, so a successful steer response
+                    // guarantees the run consumes the steer.
+                    self.steer.close();
+                    if self.drain_steers() {
+                        continue;
+                    }
                 }
                 return Ok(stop);
             }
@@ -564,11 +576,14 @@ impl RunCtx<'_> {
     /// steer whose blocks all fail to render (e.g. unsupported content) is
     /// skipped rather than aborting the turn — steering is best-effort
     /// augmentation, not a hard input contract like the initial prompt.
-    fn drain_steers(&mut self) {
+    /// Returns `true` if at least one non-empty steer was folded into history.
+    fn drain_steers(&mut self) -> bool {
+        let mut folded = false;
         while let Ok(blocks) = self.steer.try_recv() {
             match prompt_to_text(blocks) {
                 Ok(text) if !text.trim().is_empty() => {
                     self.history.push(HistoryItem::User(text));
+                    folded = true;
                 }
                 Ok(_) => {
                     tracing::debug!("dropping empty steer message");
@@ -578,6 +593,7 @@ impl RunCtx<'_> {
                 }
             }
         }
+        folded
     }
 
     /// Unified tool-call execution. Three phases:

--- a/crates/buzz-agent/tests/fake_llm.rs
+++ b/crates/buzz-agent/tests/fake_llm.rs
@@ -782,6 +782,12 @@ async fn steer_folds_into_active_turn_without_cancelling() {
     let (url, captures) = spawn_capturing_fake_llm(vec![
         openai_tool_call("call_steer", "fake__noop", json!({})),
         openai_text("acknowledged the steer"),
+        // Third response is consumed only in the rare timing where the steer
+        // lands after round 2's request was already dispatched: the run folds
+        // the steer in at end_turn and runs one more round to act on it (so an
+        // accepted steer is never dropped), which needs a response. In the
+        // common timing the steer folds into round 2 and this stays unused.
+        openai_text("acknowledged the steer"),
     ])
     .await;
     let mut h = Harness::spawn(&url).await;


### PR DESCRIPTION
Fixes #4942.

## Problem

`RunCtx::run` (`crates/buzz-agent/src/agent.rs`) drains the steer queue only at each round boundary — the top of the loop. When the provider returns `end_turn`, the run returns *without a final drain*, and the outer prompt task clears `active_run_id`/`steer_tx` only afterwards.

A steer that arrives in that window — after the last `drain_steers()`, before the turn tears down — is **accepted** by the handler (`steer_tx.send` succeeds → it returns `{runId, messageId}`) and then **silently dropped**: the run has already left its loop and never drains it again. `steer_folds_into_active_turn_without_cancelling` exposes this intermittently as *"steered text never reached the provider."* The window is small, so it only fails under full-suite timing (it passes in isolation), which is exactly the flakiness reported.

## Fix

When `end_turn` is accepted, before ending:

1. `self.steer.close()` — closing the receiver makes the handler's `steer_tx.send` fail for any steer that races this decision, so it is **rejected** (the client falls back to a new turn) instead of acknowledged-and-dropped.
2. A final `self.drain_steers()` folds in anything accepted *before* the close. `drain_steers` now returns whether it folded a non-empty steer; if it did, `continue` runs one more round to actually deliver it rather than losing it.

So a successful steer response now guarantees the run consumes the steer — the invariant #4942 asks for. This only affects the end-of-turn path; mid-turn steering across rounds is unchanged (the channel stays open until `end_turn`).

The test gains a third canned response, consumed **only** in the rare timing where the steer lands after the final round's request was already dispatched and the fix runs one extra round to deliver it. In the common timing the steer folds into the existing round and the third response is unused.

## Validation — please read

I could not run the `fake_llm` integration harness locally: on this Windows box **every** `fake_llm` test (including a trivial `text_only_end_turn`) panics in `init_session` at the agent-binary spawn/handshake, and it fails identically on clean `main` with my branch stashed — so it's a pre-existing local-environment issue, not this change. What I *did* verify:

- `cargo test -p buzz-agent --no-run` — the code fix **and** the test change compile clean (0 errors/warnings).
- `cargo test -p buzz-agent --lib` — **389 pass**. The only 2 failures are `auth::tests::cache_path_includes_namespace_and_hash` and `hints::tests::discover_skills_dedup_by_name` — OS-path-sensitive tests in modules this change doesn't touch, failing on clean `main` too.
- `cargo fmt -p buzz-agent -- --check` — clean.

So the change is compile-verified and unit-test-clean; the end-to-end steer behavior is validated by CI, which runs the `fake_llm` suite on Linux. Flagging the gap plainly rather than implying a green integration run. The logic is deliberately minimal (a `bool` return + four lines on the accept path; the give-up early-return is untouched) to keep it low-risk.
