### PR TITLE
test(desktop): match attachment button label

### DIFF
--- a/desktop/tests/e2e/inbox-edit.spec.ts
+++ b/desktop/tests/e2e/inbox-edit.spec.ts
@@ -230,7 +230,7 @@ test("editing an immediate attachment reply preserves its media tags", async ({
   const detail = page.getByTestId("home-inbox-detail");
   await expect(detail).toContainText("Inbox thread root.");
 
-  await detail.getByRole("button", { name: "Attach image" }).click();
+  await detail.getByRole("button", { name: "Attach file" }).click();
   await expect(detail.getByTestId("message-composer")).toContainText(
     ATTACHMENT_FILENAME,
   );


### PR DESCRIPTION
**Category:** fix
**User Impact:** Pull requests can once again pass the Desktop smoke test suite.
**Problem:** The inbox attachment-edit smoke test still looked for the composer's former “Attach image” label after the shared action was renamed to “Attach file,” causing shard 3 and the aggregate Desktop CI job to fail on every PR.
**Solution:** Update the stale accessible-name selector to match the current composer control while preserving the test's media-tag coverage.

<details>
<summary>File changes</summary>

**desktop/tests/e2e/inbox-edit.spec.ts**
Updates the attachment button selector to use the current accessible label so the existing attachment-edit regression test reaches the behavior it is meant to verify.

</details>

## Reproduction steps

1. Build the Desktop E2E application with `pnpm -C desktop build:e2e`.
2. Run `cd desktop && pnpm exec playwright test --project=smoke tests/e2e/inbox-edit.spec.ts -g "editing an immediate attachment reply preserves its media tags"`.
3. Confirm the test locates the “Attach file” control and passes.
