### PR TITLE
fix(buzz-relay): log missing relay_member row before kind:9033 auth gate

### DIFF
--- a/crates/buzz-relay/src/handlers/relay_admin.rs
+++ b/crates/buzz-relay/src/handlers/relay_admin.rs
@@ -270,6 +270,14 @@ async fn execute_relay_admin_command(
                 .await
                 .map_err(|e| format!("database error: {e}"))?
         };
+        if sender_member.is_none() {
+            tracing::debug!(
+                pubkey = %sender_hex,
+                community = %tenant.community(),
+                kind = event.kind.as_u16(),
+                "relay_admin: no relay_member row found for sender — will be treated as no role"
+            );
+        }
         if !may_set_workspace_profile(
             sender_role,
             state.config.require_relay_membership,


### PR DESCRIPTION
## Summary

Adds a `tracing::debug!` log in `crates/buzz-relay/src/handlers/relay_admin.rs` when `get_relay_member` returns `None` for a `kind:9033` workspace profile event. The log captures the sender pubkey, community, and event kind before `may_set_workspace_profile` denies the request, making format-mismatch failures in `relay_members.pubkey` observable server-side.

Fixes block/buzz#4982.

## Test plan

- [x] `cargo fmt -p buzz-relay -- --check`
- [x] `cargo clippy -p buzz-relay`
- [x] `cargo test -p buzz-relay --lib -- relay_admin` (24 passed; Postgres-backed integration tests ignored)