### PR TITLE
fix(desktop): name the missing ACP adapter in model discovery

### DIFF
--- a/desktop/src-tauri/src/commands/agent_model_process.rs
+++ b/desktop/src-tauri/src/commands/agent_model_process.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::managed_agents::{
-    build_buzz_agent_provider_defaults, default_agent_workdir, known_acp_runtime,
-    redact_env_values_in, AgentModelsResponse,
+    adapter_missing_error, build_buzz_agent_provider_defaults, default_agent_workdir,
+    known_acp_runtime, redact_env_values_in, resolve_command, AgentModelsResponse,
 };
 
 use super::agent_models::normalize_agent_models;
@@ -14,6 +14,20 @@ pub(super) async fn run_agent_models_command(
     persisted_model: Option<String>,
     merged_env: BTreeMap<String, String>,
 ) -> Result<AgentModelsResponse, String> {
+    // Both callers reach here only after every provider-API path is exhausted,
+    // so discovery now has to spawn the runtime's ACP adapter. That adapter is
+    // installed separately from the bundled harness: when it is absent, fail
+    // with the typed sentinel carrying the runtime's install hint instead of
+    // spawning anyway and surfacing an opaque subprocess error the dialog
+    // cannot distinguish from any other discovery failure. Callers pass the
+    // resolved path when resolution succeeded, so an unresolvable command here
+    // is exactly the missing-adapter case.
+    if resolve_command(&agent_command).is_none() {
+        if let Some(error) = adapter_missing_error(&agent_command) {
+            return Err(error);
+        }
+    }
+
     // Clone the env map for redaction below — `merged_env` is moved
     // into the spawn_blocking closure and we still need the values to
     // scrub any user-supplied secrets that the child surfaces in stderr.

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -592,6 +592,75 @@ fn model_discovery_error_converts_dangling_sentinel_to_sentence() {
 }
 
 // ---------------------------------------------------------------------------
+// Missing ACP adapter
+// ---------------------------------------------------------------------------
+
+use crate::managed_agents::{adapter_missing_error, ADAPTER_MISSING_PREFIX};
+
+/// Parse the JSON payload of an `ADAPTER_MISSING:` sentinel, asserting the
+/// prefix is present.
+fn adapter_missing_payload(error: &str) -> serde_json::Value {
+    let json = error
+        .strip_prefix(ADAPTER_MISSING_PREFIX)
+        .expect("error must carry the ADAPTER_MISSING: sentinel");
+    serde_json::from_str(json).expect("sentinel payload must be valid JSON")
+}
+
+#[test]
+fn adapter_missing_error_carries_claude_install_metadata() {
+    // The reported failure: the buzz-acp harness is bundled but the npm adapter
+    // is absent. Discovery must hand the frontend the runtime's own install
+    // hint, command, and docs link instead of an opaque subprocess error.
+    let error =
+        adapter_missing_error("claude-agent-acp").expect("claude ships an installable ACP adapter");
+    let payload = adapter_missing_payload(&error);
+
+    assert_eq!(payload["runtimeId"], "claude");
+    assert_eq!(payload["runtimeLabel"], "Claude Code");
+    assert_eq!(
+        payload["commands"],
+        serde_json::json!(["npm install -g @agentclientprotocol/claude-agent-acp"])
+    );
+    assert_eq!(
+        payload["url"],
+        "https://github.com/agentclientprotocol/claude-agent-acp"
+    );
+    let hint = payload["hint"].as_str().expect("hint must be a string");
+    assert!(
+        hint.contains("npm install -g @agentclientprotocol/claude-agent-acp"),
+        "hint must name the install command, got: {hint}"
+    );
+}
+
+#[test]
+fn adapter_missing_error_reads_the_runtime_catalog() {
+    // Codex must yield codex's metadata, not claude's — proving the payload is
+    // read from the runtime catalog rather than hardcoded for one runtime.
+    let error = adapter_missing_error("codex-acp").expect("codex ships an installable ACP adapter");
+    let payload = adapter_missing_payload(&error);
+
+    assert_eq!(payload["runtimeId"], "codex");
+    assert_eq!(
+        payload["commands"],
+        serde_json::json!(["npm install -g @agentclientprotocol/codex-acp"])
+    );
+    assert!(payload["url"]
+        .as_str()
+        .expect("url must be a string")
+        .contains("codex-acp"));
+}
+
+#[test]
+fn adapter_missing_error_is_none_without_an_installable_adapter() {
+    // goose and buzz-agent have no adapter to install, and an unknown command
+    // has no catalog entry at all. All three keep the generic discovery
+    // failure — there is no install hint to offer.
+    assert!(adapter_missing_error("goose").is_none());
+    assert!(adapter_missing_error("buzz-agent").is_none());
+    assert!(adapter_missing_error("some-unknown-binary").is_none());
+}
+
+// ---------------------------------------------------------------------------
 // OpenRouter provider
 // ---------------------------------------------------------------------------
 

--- a/desktop/src-tauri/src/managed_agents/adapter_install.rs
+++ b/desktop/src-tauri/src/managed_agents/adapter_install.rs
@@ -1,0 +1,47 @@
+//! Actionable errors for a missing ACP adapter binary.
+//!
+//! A runtime's ACP adapter (e.g. `claude-agent-acp`) is installed separately
+//! from the bundled `buzz-acp` harness, so it can be absent on an otherwise
+//! healthy install. Model discovery used to spawn the harness anyway and
+//! surface the subprocess failure verbatim, which the desktop UI could not
+//! distinguish from any other discovery error — the model field fell through
+//! to "Could not load live models", with no hint about what to install.
+//!
+//! This module turns that case into a typed error carrying the runtime's own
+//! install metadata.
+
+use super::known_acp_runtime;
+
+/// Prefix of the typed missing-adapter error produced by [`adapter_missing_error`].
+///
+/// Like `DANGLING_HARNESS_PREFIX`, this sentinel is a contract with a single
+/// consumer — the desktop model-discovery status formatter
+/// (`personaModelDiscoveryStatus.ts`), which strips the prefix and renders the
+/// JSON payload as the runtime's install hint. It must never be shown raw.
+pub const ADAPTER_MISSING_PREFIX: &str = "ADAPTER_MISSING:";
+
+/// Typed error for "this runtime's ACP adapter binary is not installed".
+///
+/// Returns `None` when `command` is not a known ACP runtime, or when the
+/// runtime ships no adapter to install (goose, buzz-agent) — those cases keep
+/// the generic discovery failure they have today.
+///
+/// The payload carries the runtime's own catalog entries so the frontend
+/// renders the install hint, command, and documentation link without holding a
+/// second copy of the runtime catalog.
+pub fn adapter_missing_error(command: &str) -> Option<String> {
+    let runtime = known_acp_runtime(command)?;
+    if runtime.adapter_install_commands.is_empty() {
+        return None;
+    }
+
+    let payload = serde_json::json!({
+        "runtimeId": runtime.id,
+        "runtimeLabel": runtime.label,
+        "hint": runtime.adapter_install_hint,
+        "commands": runtime.adapter_install_commands,
+        "url": runtime.adapter_install_instructions_url,
+    });
+
+    Some(format!("{ADAPTER_MISSING_PREFIX}{payload}"))
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -1,3 +1,4 @@
+mod adapter_install;
 mod agent_env;
 pub(crate) mod agent_events;
 pub(crate) mod agent_snapshot;
@@ -47,6 +48,7 @@ pub(crate) fn lock_path_mutex() -> std::sync::MutexGuard<'static, ()> {
     PATH_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+pub use adapter_install::*;
 pub use backend::*;
 pub use discovery::*;
 pub use env_vars::*;

--- a/desktop/src/features/agents/ui/PersonaModelField.tsx
+++ b/desktop/src/features/agents/ui/PersonaModelField.tsx
@@ -108,6 +108,20 @@ export function PersonaModelField({
             data-testid="persona-model-discovery-status"
           >
             {modelDiscoveryStatus.message}
+            {modelDiscoveryStatus.link ? (
+              <>
+                {" "}
+                <a
+                  className="underline underline-offset-2"
+                  data-testid="persona-model-discovery-status-link"
+                  href={modelDiscoveryStatus.link.href}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {modelDiscoveryStatus.link.label}
+                </a>
+              </>
+            ) : null}
           </p>
         ) : null}
       </div>

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.test.mjs
@@ -111,3 +111,77 @@ test("non-auth -32000 errors do NOT get the sign-in copy", () => {
   assert.doesNotMatch(status?.message ?? "", /sign-in/i);
   assert.match(status?.message ?? "", /Using built-in model options/);
 });
+
+const CLAUDE_ADAPTER_MISSING = `ADAPTER_MISSING:${JSON.stringify({
+  runtimeId: "claude",
+  runtimeLabel: "Claude Code",
+  hint: "Buzz talks to the Claude Code CLI through an ACP adapter. Install it with: npm install -g @agentclientprotocol/claude-agent-acp.",
+  commands: ["npm install -g @agentclientprotocol/claude-agent-acp"],
+  url: "https://github.com/agentclientprotocol/claude-agent-acp",
+})}`;
+
+test("a missing ACP adapter surfaces the runtime's install hint and link", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error(CLAUDE_ADAPTER_MISSING),
+    "anthropic",
+    "Claude Code",
+  );
+
+  assert.equal(status?.tone, "warning");
+  assert.match(
+    status?.message ?? "",
+    /npm install -g @agentclientprotocol\/claude-agent-acp/,
+  );
+  assert.deepEqual(status?.link, {
+    href: "https://github.com/agentclientprotocol/claude-agent-acp",
+    label: "Installation instructions",
+  });
+  // The whole point: never the catch-all.
+  assert.doesNotMatch(status?.message ?? "", /Using built-in model options/);
+});
+
+test("the adapter hint wins over provider-specific branches", () => {
+  // A missing adapter is a local install problem whatever provider the form
+  // selected — including relay-mesh, which otherwise owns its own branch.
+  const status = formatModelDiscoveryErrorStatus(
+    new Error(CLAUDE_ADAPTER_MISSING),
+    "relay-mesh",
+  );
+
+  assert.match(status?.message ?? "", /ACP adapter/);
+  assert.doesNotMatch(status?.message ?? "", /sharing compute/);
+});
+
+test("an adapter payload without a hint synthesizes one from the command", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error(
+      `ADAPTER_MISSING:${JSON.stringify({
+        runtimeId: "codex",
+        runtimeLabel: "Codex",
+        hint: "",
+        commands: ["npm install -g @agentclientprotocol/codex-acp"],
+        url: "",
+      })}`,
+    ),
+    "openai",
+  );
+
+  assert.equal(status?.tone, "warning");
+  assert.match(status?.message ?? "", /Codex needs an ACP adapter/);
+  assert.match(
+    status?.message ?? "",
+    /npm install -g @agentclientprotocol\/codex-acp/,
+  );
+  assert.equal(status?.link, undefined);
+});
+
+test("a malformed adapter sentinel falls back to the catch-all", () => {
+  const status = formatModelDiscoveryErrorStatus(
+    new Error("ADAPTER_MISSING:{not json"),
+    "anthropic",
+  );
+
+  assert.equal(status?.tone, "warning");
+  assert.match(status?.message ?? "", /Using built-in model options/);
+  assert.equal(status?.link, undefined);
+});

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -1,7 +1,76 @@
 export type PersonaModelDiscoveryStatus = {
   message: string;
   tone: "muted" | "warning";
+  /** Optional documentation link rendered beneath the message. */
+  link?: { href: string; label: string };
 };
+
+/**
+ * Sentinel prefix emitted by the Tauri model-discovery commands when a
+ * runtime's ACP adapter binary is not installed. Mirrors
+ * `ADAPTER_MISSING_PREFIX` in `managed_agents/discovery.rs`; the JSON payload
+ * carries that runtime's install hint, commands, and documentation URL so this
+ * module renders actionable guidance without a second copy of the catalog.
+ */
+const ADAPTER_MISSING_PREFIX = "ADAPTER_MISSING:";
+
+type AdapterMissingPayload = {
+  runtimeLabel: string;
+  hint: string;
+  commands: string[];
+  url: string;
+};
+
+function parseAdapterMissingPayload(
+  message: string,
+): AdapterMissingPayload | null {
+  const index = message.indexOf(ADAPTER_MISSING_PREFIX);
+  if (index < 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message.slice(index + ADAPTER_MISSING_PREFIX.length));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+
+  const raw = parsed as Record<string, unknown>;
+  const commands = Array.isArray(raw.commands)
+    ? raw.commands.filter((value): value is string => typeof value === "string")
+    : [];
+  return {
+    runtimeLabel:
+      typeof raw.runtimeLabel === "string" ? raw.runtimeLabel : "This agent",
+    hint: typeof raw.hint === "string" ? raw.hint : "",
+    commands,
+    url: typeof raw.url === "string" ? raw.url : "",
+  };
+}
+
+function adapterMissingStatus(
+  payload: AdapterMissingPayload,
+): PersonaModelDiscoveryStatus {
+  // The catalog hint already embeds the install command verbatim, so it is used
+  // as-is. Runtimes that ship commands but no hint get a synthesized sentence.
+  const message =
+    payload.hint.trim() ||
+    (payload.commands.length > 0
+      ? `${payload.runtimeLabel} needs an ACP adapter before models can load. Install it with: ${payload.commands.join(" && ")}.`
+      : `${payload.runtimeLabel} needs an ACP adapter before models can load.`);
+
+  return {
+    message,
+    tone: "warning",
+    ...(payload.url
+      ? { link: { href: payload.url, label: "Installation instructions" } }
+      : {}),
+  };
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -47,6 +116,13 @@ export function formatModelDiscoveryErrorStatus(
   agentLabel?: string,
 ): PersonaModelDiscoveryStatus | null {
   const message = errorMessage(error);
+
+  // Checked before every provider branch: a missing adapter is a local install
+  // problem, and its remedy is the same whatever provider the form selected.
+  const adapterMissing = parseAdapterMissingPayload(message);
+  if (adapterMissing) {
+    return adapterMissingStatus(adapterMissing);
+  }
 
   if (provider.trim() === "relay-mesh") {
     if (message.includes("waiting for the current member roster")) {

--- a/docs/superpowers/specs/2026-08-03-adapter-missing-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-adapter-missing-model-discovery-design.md
@@ -1,0 +1,121 @@
+# Surface the ACP adapter install hint when model discovery fails
+
+## Problem
+
+When a user opens the Create-agent dialog and picks a runtime whose ACP adapter
+binary is not installed (e.g. `claude-agent-acp` absent because the npm package
+was never installed), the model field shows only:
+
+> Using built-in model options. Could not load live models for this provider.
+
+That is the catch-all fallback in
+`desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts`. It gives the
+user nothing actionable, even though
+`desktop/src-tauri/src/managed_agents/discovery.rs` already carries per-runtime
+`adapter_install_hint`, `adapter_install_commands`, and
+`adapter_install_instructions_url` for exactly this situation.
+
+Reported from macOS, where the `buzz-acp` harness is bundled with the app but
+the npm adapter was absent — so the existing `missing_command_message` path
+(which guards the harness command) never fired.
+
+## Root cause
+
+`discover_agent_models` resolves the *harness* command strictly:
+
+```rust
+let resolved_acp = resolve_command(acp_command)
+    .ok_or_else(|| missing_command_message(acp_command, "ACP harness command"))?;
+```
+
+but resolves the *adapter* command leniently:
+
+```rust
+let resolved_agent = resolve_command(agent_command)
+    .map(|p| p.display().to_string())
+    .unwrap_or_else(|| agent_command.to_string());
+```
+
+A missing adapter therefore falls through to the `buzz-acp models` subprocess,
+which fails, producing an opaque `buzz-acp models failed (exit N): …` string
+that the frontend cannot distinguish from any other discovery failure.
+`get_agent_models` (the saved-agent path) has the same shape.
+
+## Design
+
+### 1. A distinguishable backend error
+
+Add a pure helper in a new `managed_agents/adapter_install.rs`:
+
+```rust
+pub fn adapter_missing_error(command: &str) -> Option<String>
+```
+
+It returns `Some(sentinel)` only when the runtime declares
+`adapter_install_commands`; runtimes without an adapter (goose, buzz-agent) and
+unknown commands return `None`, preserving today's behavior exactly.
+
+The sentinel mirrors the existing `DANGLING_HARNESS_ID:` convention, with a
+JSON payload so the frontend renders hint, command, and link distinctly without
+duplicating the runtime catalog in TypeScript:
+
+```
+ADAPTER_MISSING:{"runtimeId":"claude","runtimeLabel":"Claude Code","hint":"…","commands":["npm install -g @agentclientprotocol/claude-agent-acp"],"url":"https://github.com/agentclientprotocol/claude-agent-acp"}
+```
+
+The guard lives in `run_agent_models_command` — the single spawn point both
+`discover_agent_models` and `get_agent_models` funnel into, and the first place
+the adapter is actually required. Putting it there rather than at each caller's
+command-resolution step matters for correctness as well as duplication: every
+provider-API discovery path (OpenRouter, OpenAI-compatible, Anthropic,
+Databricks, relay-mesh) runs *before* the spawn, so a setup with a missing
+adapter but a working provider key still discovers models exactly as it does
+today. Both callers already pass the resolved path when resolution succeeded,
+so an unresolvable command at the spawn point is precisely the missing-adapter
+case.
+
+It also keeps `agent_models.rs` and `discovery.rs` — both already over the
+1000-line desktop file-size ratchet — untouched.
+
+### 2. A frontend branch
+
+`formatModelDiscoveryErrorStatus` gains a first branch that detects the
+sentinel, parses the payload, and returns the runtime's own hint text. The hint
+already embeds the install command verbatim ("Buzz talks to the Claude Code CLI
+through an ACP adapter. Install it with: npm install -g …"), so it is used
+as-is — no second copy of the command to keep in sync. When the hint is empty
+the message is synthesized from `commands`. Malformed JSON after the sentinel
+falls through to the existing catch-all.
+
+### 3. Link rendering
+
+`PersonaModelDiscoveryStatus` gains an optional
+`link?: { href: string; label: string }`. `PersonaModelField.tsx` renders it as
+an anchor under the message. The two other status consumers
+(`agentConfigControls.tsx`, `AgentInstanceEditDialog.tsx`) reduce status to a
+plain string through `resolveModelFieldStatusMessage`; they show the message
+without the link and are otherwise unchanged.
+
+## Testing
+
+Rust (`agent_models_tests.rs`):
+- `adapter_missing_error` yields a sentinel carrying the claude runtime's hint,
+  command, and adapter URL.
+- The same for codex, proving the payload is read from the catalog rather than
+  hardcoded.
+- Returns `None` for goose and buzz-agent (no adapter to install).
+- Payload parses as JSON and is prefixed by the sentinel.
+
+TypeScript (`personaModelDiscoveryStatus.test.mjs`):
+- Sentinel error → warning status whose message is the runtime hint and whose
+  link points at the adapter instructions URL.
+- Sentinel with an empty hint → message synthesized from the install command.
+- Sentinel followed by malformed JSON → catch-all fallback, no crash.
+- Existing non-sentinel errors (auth required, API key required, relay-mesh)
+  keep their current output.
+
+## Non-goals
+
+- No change to `missing_command_message` or the harness-command path.
+- No auto-install trigger from the model field; Doctor already owns that flow.
+- No new copy strings — all text comes from the runtime catalog.


### PR DESCRIPTION
## Problem

A runtime's ACP adapter (e.g. `claude-agent-acp`) installs separately from the bundled `buzz-acp` harness, so it can be missing on an otherwise healthy install. When it is, the Create-agent dialog's model field shows only:

> Using built-in model options. Could not load live models for Anthropic.

That is the catch-all in `personaModelDiscoveryStatus.ts` — the user gets no idea what to install. Meanwhile `managed_agents/discovery.rs` already carries per-runtime `adapter_install_hint`, `adapter_install_commands`, and `adapter_install_instructions_url` for exactly this situation.

Reported on macOS, where the harness ships with the app but the npm adapter was absent.

**Root cause:** discovery resolves the harness command strictly but the adapter command leniently (`resolve_command(...).unwrap_or_else(|| agent_command.to_string())`), so a missing adapter falls through to the `buzz-acp models` subprocess. That fails with `buzz-acp models failed (exit N): …` — indistinguishable, from the frontend, from any other discovery failure.

## Change

**Backend.** New `managed_agents/adapter_install.rs` with `adapter_missing_error(command)`, which turns a known runtime that ships an installable adapter into a typed sentinel carrying that runtime's own catalog entries:

```
ADAPTER_MISSING:{"runtimeId":"claude","runtimeLabel":"Claude Code","hint":"…","commands":["npm install -g @agentclientprotocol/claude-agent-acp"],"url":"https://github.com/agentclientprotocol/claude-agent-acp"}
```

It mirrors the existing `DANGLING_HARNESS_ID:` convention. Runtimes with no adapter to install (goose, buzz-agent) and unknown commands return `None` and keep today's behavior exactly.

The guard sits in `run_agent_models_command` — the single spawn point both `get_agent_models` and `discover_agent_models` funnel into, and the first place the adapter is actually required. That placement matters for more than deduplication: every provider-API path (OpenRouter, OpenAI-compatible, Anthropic, Databricks, relay-mesh) runs *before* the spawn, so a missing adapter paired with a working provider key still discovers models exactly as it does now. Both callers already pass the resolved path when resolution succeeded, so an unresolvable command at the spawn point is precisely the missing-adapter case. It also keeps `agent_models.rs` and `discovery.rs` — both already over the desktop 1000-line file-size ratchet — untouched.

**Frontend.** `formatModelDiscoveryErrorStatus` gains a branch that detects the sentinel and renders the runtime's hint, checked ahead of the provider branches since a missing adapter is a local install problem whatever provider the form selected. The hint already embeds the install command verbatim, so it is used as-is — no second copy of the command to keep in sync. `PersonaModelDiscoveryStatus` gains an optional `link`, rendered by `PersonaModelField`; the two consumers that reduce status to a plain string are unchanged.

Result, in place of the catch-all:

> Buzz talks to the Claude Code CLI through an ACP adapter. Install it with: npm install -g @agentclientprotocol/claude-agent-acp. [Installation instructions]

## Tests

`agent_models_tests.rs` (3):
- claude yields a sentinel carrying its hint, install command, and adapter docs URL
- codex yields codex's metadata, proving the payload is read from the catalog rather than hardcoded for one runtime
- goose, buzz-agent, and an unknown command all yield `None`

`personaModelDiscoveryStatus.test.mjs` (4):
- sentinel renders the hint + install command and links the docs, and is *not* the catch-all
- the adapter branch wins over `relay-mesh`, which otherwise owns its own branch
- a payload with no hint synthesizes one from the install command
- a malformed sentinel falls back to the catch-all instead of throwing

## Verification

`just ci` passes end to end (exit 0), including all 7 new tests, `cargo fmt --check`, biome, `check:px-text`, and the file-size ratchet.

Not covered by automated tests: the rendered anchor in `PersonaModelField` (no existing spec covers that component) and the live subprocess path, which needs a real machine with the adapter uninstalled.
