### PR TITLE
test(buzz-agent): wait for steer response in steer_rejected_on_empty_prompt

### DIFF
--- a/crates/buzz-agent/tests/fake_llm.rs
+++ b/crates/buzz-agent/tests/fake_llm.rs
@@ -1428,7 +1428,7 @@ async fn steer_rejected_on_empty_prompt() {
     .await;
     let mut h = Harness::spawn(&url).await;
     let sid = init_session(&mut h).await;
-    let p_id = h
+    let _p_id = h
         .send(
             "session/prompt",
             json!({"sessionId": sid, "prompt": [{"type":"text","text":"go"}]}),
@@ -1441,17 +1441,8 @@ async fn steer_rejected_on_empty_prompt() {
             json!({"sessionId": sid, "expectedRunId": run_id, "prompt": []}),
         )
         .await;
-    let mut saw_reject = false;
-    for _ in 0..40 {
-        let v = h.recv().await;
-        if v["id"] == json!(s_id) {
-            assert_eq!(v["error"]["code"], -32602, "empty prompt must be rejected");
-            saw_reject = true;
-        } else if v["id"] == json!(p_id) {
-            break;
-        }
-    }
-    assert!(saw_reject, "empty steer prompt was not rejected");
+    let v = h.recv_until(|v| v["id"] == json!(s_id)).await;
+    assert_eq!(v["error"]["code"], -32602, "empty prompt must be rejected");
     h.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary

`steer_rejected_on_empty_prompt` was flaky because its receive loop stopped as soon as the `session/prompt` response arrived, even if the `session/steer` rejection had not yet been read. This made the test fail whenever the prompt response was delivered before the steer rejection.

Wait specifically for the steer response (matching the pattern already used by `steer_rejected_when_no_active_run` and `steer_rejected_on_run_id_mismatch`) so the assertion no longer depends on response ordering.

### Related issue

Fixes #4939

### Testing

- `cargo test -p buzz-agent --test fake_llm -- steer_rejected_on_empty_prompt` passed 10/10 times after the change.
- The targeted debug build also compiles with no new warnings.