### PR TITLE
fix(cli): describe broadcast as channel surfacing

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -367,7 +367,7 @@ pub enum MessagesCmd {
         /// Event ID to reply to (creates a thread)
         #[arg(long)]
         reply_to: Option<String>,
-        /// Also publish to the Nostr network
+        /// Also surface this reply in the channel timeline
         #[arg(long, default_value_t = false)]
         broadcast: bool,
         /// Attach file(s) — uploads and includes as imeta tags


### PR DESCRIPTION
The `messages send --broadcast` flag adds the exact `[`'broadcast\, '1']` tag that surfaces a depth-1 reply in the channel timeline. It does not publish the message to a separate Nostr network.\n\nThis makes the rendered CLI help describe the behavior users actually receive.\n\nVerification:\n- `cargo test -p buzz-cli` (321 passed)\n- rendered `messages send --help` says “Also surface this reply in the channel timeline”\n- `cargo fmt --check`\n\nTracks JAFairweather/waggle#56.