### PR TITLE
fix(desktop): add onboarding key copy action

### DIFF
--- a/desktop/src/features/onboarding/ui/BackupStep.tsx
+++ b/desktop/src/features/onboarding/ui/BackupStep.tsx
@@ -385,6 +385,29 @@ export function BackupStep({
                     <Eye className="h-6 w-6" aria-hidden="true" />
                   )}
                 </Button>
+                <Button
+                  aria-label={
+                    copyState === "copied"
+                      ? "Private key copied"
+                      : "Copy private key"
+                  }
+                  className="h-10 w-10 shrink-0 text-muted-foreground hover:text-foreground"
+                  data-testid="backup-key-copy"
+                  disabled={copyState === "copying"}
+                  onClick={() => void copyKeyToClipboard()}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  {copyState === "copied" ? (
+                    <Check
+                      className="h-6 w-6 text-primary"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <Copy className="h-6 w-6" aria-hidden="true" />
+                  )}
+                </Button>
               </div>
             </Card>
 

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -69,13 +69,11 @@ test("backup step appears on fresh-key path after profile submit", async ({
 });
 
 // ---------------------------------------------------------------------------
-// Key-created view: masked key with reveal toggle. Backup options open the
-// dark security view; the raw key is fetched only on explicit reveal/copy.
+// Key-created view: masked key with reveal and copy controls. Backup options
+// open the dark security view; the raw key is fetched only on explicit action.
 // ---------------------------------------------------------------------------
 
-test("key view reveals explicitly; options copy explicitly", async ({
-  page,
-}) => {
+test("key view reveals and copies explicitly", async ({ page }) => {
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
   await enterMachineBackup(page);
 
@@ -87,6 +85,17 @@ test("key view reveals explicitly; options copy explicitly", async ({
   await expect(key).toHaveClass(/blur/);
   await expect(key).not.toContainText("nsec1");
   expect(await invokedCommands(page)).not.toContain("get_nsec");
+
+  // Copy is available directly on the key card and provides confirmation.
+  const copyButton = page.getByTestId("backup-key-copy");
+  await expect(copyButton).toHaveAccessibleName("Copy private key");
+  await expect(copyButton).toHaveText("");
+  await copyButton.click();
+  await expect(copyButton).toHaveAccessibleName("Private key copied");
+  await expect
+    .poll(async () => invokedCommands(page))
+    .toContain("copy_text_to_clipboard");
+  expect(await invokedCommands(page)).toContain("get_nsec");
 
   // Reveal fetches the key; box must not reflow (same-length monospace mask).
   await page.getByTestId("backup-key-reveal-toggle").click();
@@ -100,7 +109,7 @@ test("key view reveals explicitly; options copy explicitly", async ({
   await page.getByTestId("backup-key-reveal-toggle").click();
   await expect(key).not.toContainText("nsec1");
 
-  // Copy is available only after opening the dark backup-options view.
+  // The deeper backup-options view retains its existing copy action.
   await page.getByTestId("backup-options-link").click();
   await expect(
     page.getByTestId("onboarding-page-backup-options"),


### PR DESCRIPTION
## Summary
When onboarding someone to Buzz in person, I noticed they were confused on how to copy the nsec. And since it's sensitive information, the only way to copy nsec now was to reveal it, which kinda kills the purpose of having it hidden in the first place. 

The solution is to add a copy button already using components that exist, but removing `copy` text to ensure visual consitency with the reveal button. 

### Related issue
None found

### Testing
Before this PR

https://github.com/user-attachments/assets/c46f662e-8515-46e6-b740-f46373116f27


After this PR

https://github.com/user-attachments/assets/7d57c433-944a-4ff5-91f7-fa0ad6889d2d

