### PR TITLE
docs: align buzz-acp box in README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ If you'd rather point buzz at a different bash-compatible shell, set `BUZZ_SHELL
 │  Human client         AI agent              CLI / scripts               │
 │  (Buzz desktop)       (Goose, Codex, ...)   (buzz-cli, agents)          │
 │       │               ┌──────────────┐               │                  │
-│       │               │  buzz-acp  │                 │                  │
+│       │               │   buzz-acp   │               │                  │
 │       │               │  (ACP ↔ MCP) │               │                  │
 │       │               └──────┬───────┘               │                  │
 │       │                      │                       │                  │


### PR DESCRIPTION
The `buzz-acp` box in the README architecture diagram has its right border 2 characters short of the box outline, so the box renders misaligned:

```
┌──────────────┐
│  buzz-acp  │
│  (ACP ↔ MCP) │
└──────┬───────┘
```

This pads the label line to the same interior width as the rest of the box:

```
┌──────────────┐
│   buzz-acp   │
│  (ACP ↔ MCP) │
└──────┬───────┘
```