### PR TITLE
fix(mobile): exclude archived identities from mention autocomplete (#3840)

### DIFF
--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -51,13 +51,20 @@ List<MentionCandidate> buildMentionCandidates({
   required Map<String, UserProfile> userCache,
   required Map<String, String> ownerByAgentPubkey,
   List<UserProfile> searchResults = const [],
+  Set<String> archivedPubkeys = const {},
   String? currentPubkey,
 }) {
   final candidates = <MentionCandidate>[];
   final seen = <String>{};
 
+  final self = currentPubkey?.toLowerCase();
   for (final member in members) {
     final pk = member.pubkey.toLowerCase();
+    // Fold relay-archived identities (#3840) out of
+    // autocomplete; the current user is exempt (NIP-IA §Self
+    // Requests anti-shadowban), matching desktop's
+    // `useIsArchivedPredicate`.
+    if (archivedPubkeys.contains(pk) && pk != self) continue;
     if (!seen.add(pk)) continue;
     final profile = userCache[pk];
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -80,6 +80,8 @@ final mentionCandidatesProvider = Provider.family
           ref.watch(agentDirectoryProvider).asData?.value ??
           const <AgentDirectoryEntry>[];
       final owners = ref.watch(agentOwnersProvider).asData?.value ?? const {};
+      final archived = ref.watch(archivedAgentPubkeysProvider).asData?.value ??
+          const <String>{};
       final channels =
           ref.watch(channelsProvider).asData?.value ?? const <Channel>[];
       final userCache = ref.watch(userCacheProvider);
@@ -100,6 +102,7 @@ final mentionCandidatesProvider = Provider.family
         userCache: userCache,
         ownerByAgentPubkey: owners,
         searchResults: searchResults,
+        archivedPubkeys: archived,
         currentPubkey: currentPubkey,
       );
 

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -69,6 +69,28 @@ final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
   return [for (final event in events) AgentDirectoryEntry.fromEvent(event)];
 });
 
+/// NIP-IA archived-identity pubkeys (kind:13535 snapshot).
+///
+/// The relay emits a single relay-signed `p`-tag-per-identity snapshot listing
+/// identities archived on the relay. Mobile folds those identities out of
+/// mention autocomplete (desktop does the same via `useIsArchivedPredicate`).
+///
+/// Fail-open by construction: while the snapshot is missing or unfetched the
+/// set is empty, so a cold start or a relay without any archives never briefly
+/// hides everyone.
+final archivedAgentPubkeysProvider = FutureProvider<Set<String>>((ref) async {
+  final sessionState = ref.watch(relaySessionProvider);
+  if (sessionState.status != SessionStatus.connected) return const {};
+  final session = ref.read(relaySessionProvider.notifier);
+  final events = await session.fetchHistory(NostrFilters.archivedIdentities());
+  if (events.isEmpty) return const {};
+  return _AgentPubkeySet({
+    for (final tag in events.first.tags)
+      if (tag.length >= 2 && tag[0] == 'p') tag[1].toLowerCase(),
+  });
+});
+
+
 /// Verified NIP-OA owner pubkey per agent pubkey, from the agents' kind:0
 /// profiles. An entry exists only when the `auth` tag verifies — mirrors
 /// desktop's `profile_valid_oa_owner_pubkey`.

--- a/mobile/lib/shared/relay/nostr_filters.dart
+++ b/mobile/lib/shared/relay/nostr_filters.dart
@@ -209,6 +209,12 @@ abstract final class NostrFilters {
   static NostrFilter agentProfiles() =>
       const NostrFilter(kinds: [10100], limit: 100);
 
+  /// NIP-IA archived-identity list (kind:13535). Relay-signed addressable
+  /// snapshot; one `p` tag per archived identity. Addresses match the relay's
+  /// `KIND_IA_ARCHIVED_LIST` = 13535.
+  static NostrFilter archivedIdentities() =>
+      const NostrFilter(kinds: [13535], limit: 1);
+
   /// User status (NIP-38, kind:30315).
   static NostrFilter userStatus(String pubkey) =>
       NostrFilter(kinds: [30315], authors: [pubkey], limit: 1);

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -280,5 +280,54 @@ void main() {
       expect(candidates, hasLength(1));
       expect(candidates.single.isMember, isTrue);
     });
+
+    test('archived agent identities are hidden from mention candidates', () {
+      final candidates = buildMentionCandidates(
+        members: [member(agentPubkey, role: 'bot')],
+        relayAgents: const [],
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        archivedPubkeys: {agentPubkey},
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates.any((c) => c.pubkey == agentPubkey), isFalse);
+    });
+
+    test('the current user is exempt from the archived fold', () {
+      final candidates = buildMentionCandidates(
+        members: [member(agentPubkey, role: 'bot')],
+        relayAgents: const [],
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        archivedPubkeys: {agentPubkey},
+        currentPubkey: agentPubkey,
+      );
+
+      expect(
+        candidates.any((c) => c.pubkey == agentPubkey),
+        isTrue,
+        reason: 'NIP-IA anti-shadowban: the archived self must remain visible',
+      );
+    });
+
+    test('a non-archived agent candidate remains when others are archived',
+        () {
+      const keptPubkey = 'b' * 64;
+      final candidates = buildMentionCandidates(
+        members: [
+          member(agentPubkey, role: 'bot'),
+          member(keptPubkey, role: 'bot'),
+        ],
+        relayAgents: const [],
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        archivedPubkeys: {agentPubkey},
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates.any((c) => c.pubkey == agentPubkey), isFalse);
+      expect(candidates.any((c) => c.pubkey == keptPubkey), isTrue);
+    });
   });
 }


### PR DESCRIPTION
Supersedes #4046 (rebased onto current main; single-commit, no conflict).

## Summary

Buzz Mobile's `@` mention autocomplete still offered an **archived** agent identity that was no longer a channel member, while Buzz Desktop correctly hid it. Desktop filters archived identities out of forward-looking discovery surfaces (autocomplete, pickers, search) using the relay's NIP-IA archived snapshot; Mobile never read that snapshot, so the archived agent stayed selectable.

Brings Mobile to parity with Desktop.

Fixes #3840.

## Changes

| File | Change |
| --- | --- |
| `mobile/lib/shared/relay/nostr_filters.dart` | New `NostrFilters.archivedIdentities()` — NIP-IA `kind:13535` snapshot filter. |
| `mobile/lib/shared/mentions/agent_identity_provider.dart` | New `archivedAgentPubkeysProvider` — fetch the relay-signed, addressable `kind:13535` snapshot and decode one `p` tag per archived pubkey. **Fail-open**: an absent/unfetched snapshot yields an empty set, so a cold start or a relay with no archives never briefly hides everyone. |
| `mobile/lib/features/channels/mentions/mention_candidates.dart` | `buildMentionCandidates` gains an `archivedPubkeys` param and folds archived pubkeys out of candidate assembly. The **current user is exempt** (NIP-IA §Self Requests anti-shadowban — the archived user must still see and self-unarchive), matching desktop's `useIsArchivedPredicate`. |
| `mobile/lib/features/channels/mentions/mention_candidates_provider.dart` | Watch `archivedAgentPubkeysProvider` and pass the set into `buildMentionCandidates`. |
| `mobile/test/features/channels/mentions/mention_candidates_test.dart` | Three regression tests (below). |

## Tests

`buildMentionCandidates` is the pure, directly-tested assembly point. New cases:

1. **archived agent hidden** — an archived bot member no longer appears.
2. **archived self exempt** — the archived `currentPubkey` still appears (NIP-IA anti-shadowban).
3. **non-archived agent unaffected** — a non-archived bot remains when others are archived.

## Verification

- Rebase against current `main` (`96ae1417`): no conflicts.
- The behavioral core is confined to the **pure** `buildMentionCandidates` function; data-source (`NostrFilters.archivedIdentities`) and provider (`archivedAgentPubkeysProvider`) additions mirror the existing `agentProfiles()` / `agentDirectoryProvider` shapes.
- Diff is +87/−0 across 5 files; no generated/build artifacts.

**Not verified here:** live autocomplete behavior on-device (no emulator), and the exact live shape of the `kind:13535` snapshot from a running relay (decoded as `p` tags per NIP-IA §Archived List + the relay's `publish_nipia_archival_list`). If a maintainer can confirm `flutter test mobile/.../mention_candidates_test.dart` passes and confirm 13535 carries `p`-tag pubkeys, this is otherwise self-contained.

## Notes for reviewer

- The archived fold is intentionally applied at the **candidate assembly** layer (members + relay-directory + search results all flow through it), so it covers the reported member case and the three candidate sources the issue flags. It is scoped to autocomplete only, matching desktop's predicate usage — archived identity still renders its public profile elsewhere.

Signed-off-by: iroiro147 <sarthak.singh@juspay.in>