### PR TITLE
fix(relay): tombstone kind:30620 events on workflow delete, reject resurrect (#4864)

### DIFF
--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -199,6 +199,36 @@ async fn persist_command_event(
             .await
             .map_err(|e| IngestError::Internal(format!("error: replace old event: {e}")))?;
         }
+
+        // #4864: a workflow deleted via NIP-09 must not be resurrected by
+        // re-publishing its coordinate. `workflows delete` tombstones the
+        // kind:30620 event rows (see `handle_a_tag_deletion` in side_effects);
+        // without this guard a subsequent `workflows update` would insert a
+        // fresh live row that revives a workflow the owner explicitly deleted
+        // — and re-arms its webhook trigger with a brand-new secret. Fail
+        // closed: any tombstone at the coordinate rejects the publish.
+        if kind_i32 == buzz_core::kind::KIND_WORKFLOW_DEF as i32 {
+            let tombstoned: Option<(chrono::DateTime<chrono::Utc>,)> = sqlx::query_as(
+                "SELECT deleted_at FROM events \
+                 WHERE community_id = $1 AND kind = $2 AND pubkey = $3 AND d_tag = $4 \
+                 AND deleted_at IS NOT NULL \
+                 ORDER BY deleted_at DESC LIMIT 1",
+            )
+            .bind(tenant.community().as_uuid())
+            .bind(kind_i32)
+            .bind(pubkey_bytes.as_slice())
+            .bind(d_tag)
+            .fetch_optional(tx.as_mut())
+            .await
+            .map_err(|e| {
+                IngestError::Internal(format!("error: query tombstoned coordinate: {e}"))
+            })?;
+            if tombstoned.is_some() {
+                return Err(IngestError::Rejected(format!(
+                    "not found: workflow {d_tag} was deleted and cannot be re-published"
+                )));
+            }
+        }
     }
 
     let result = sqlx::query(

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -2102,11 +2102,22 @@ async fn handle_a_tag_deletion(
             tracing::debug!(d_tag, "NIP-09 deletion ignored for push lease");
         }
         buzz_core::kind::KIND_WORKFLOW_DEF => {
-            // Try UUID first (workflow_id); fall back to name-based lookup.
-            if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
+            // Delete the scheduler/engine row AND tombstone the kind:30620
+            // event rows. The `workflows` table row is the scheduler SSOT; the
+            // event tombstone closes the visibility gap that left deleted
+            // workflows queryable via kind:30620 REQs (CLI `workflows list` /
+            // `get`, desktop Workflows screen) (#4864).
+            async fn delete_and_tombstone(
+                state: &Arc<AppState>,
+                tenant: &TenantContext,
+                wf_id: uuid::Uuid,
+                actor_bytes: &[u8],
+                pubkey_hex: &str,
+                deletion_created_at_secs: i64,
+            ) -> anyhow::Result<()> {
                 let channel_id = state
                     .db
-                    .delete_workflow_for_owner(tenant.community(), wf_id, &actor_bytes)
+                    .delete_workflow_for_owner(tenant.community(), wf_id, actor_bytes)
                     .await
                     .map_err(|e| anyhow::anyhow!("failed to delete workflow {wf_id}: {e}"))?;
                 if let Some(channel_id) = channel_id {
@@ -2114,6 +2125,36 @@ async fn handle_a_tag_deletion(
                         .workflow_engine
                         .invalidate_channel_workflows(tenant.community(), channel_id);
                 }
+                let pubkey_bytes = hex::decode(pubkey_hex).map_err(|e| {
+                    anyhow::anyhow!("invalid pubkey hex in a-tag {pubkey_hex}: {e}")
+                })?;
+                state
+                    .db
+                    .soft_delete_by_coordinate(
+                        tenant.community(),
+                        buzz_core::kind::KIND_WORKFLOW_DEF as i32,
+                        &pubkey_bytes,
+                        &wf_id.to_string(),
+                        deletion_created_at_secs,
+                    )
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("failed to tombstone workflow events {wf_id}: {e}")
+                    })?;
+                Ok(())
+            }
+
+            // Try UUID first (workflow_id); fall back to name-based lookup.
+            if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
+                delete_and_tombstone(
+                    state,
+                    tenant,
+                    wf_id,
+                    &actor_bytes,
+                    pubkey_hex,
+                    event.created_at.as_secs() as i64,
+                )
+                .await?;
                 tracing::info!(workflow_id = %wf_id, "Workflow deleted via NIP-09 a-tag (UUID)");
             } else {
                 // Name-based lookup
@@ -2123,18 +2164,15 @@ async fn handle_a_tag_deletion(
                     .await
                 {
                     Ok(Some(wf)) => {
-                        let channel_id = state
-                            .db
-                            .delete_workflow_for_owner(tenant.community(), wf.id, &actor_bytes)
-                            .await
-                            .map_err(|e| {
-                                anyhow::anyhow!("failed to delete workflow {}: {e}", wf.id)
-                            })?;
-                        if let Some(channel_id) = channel_id {
-                            state
-                                .workflow_engine
-                                .invalidate_channel_workflows(tenant.community(), channel_id);
-                        }
+                        delete_and_tombstone(
+                            state,
+                            tenant,
+                            wf.id,
+                            &actor_bytes,
+                            pubkey_hex,
+                            event.created_at.as_secs() as i64,
+                        )
+                        .await?;
                         tracing::info!(workflow_id = %wf.id, name = d_tag, "Workflow deleted via NIP-09 a-tag (name)");
                     }
                     Ok(None) => {
@@ -2151,10 +2189,10 @@ async fn handle_a_tag_deletion(
         // Generic NIP-33 (parameterized-replaceable) soft-delete by coordinate.
         //
         // Listed after the workflow branch so workflow's bespoke deletion
-        // (which doesn't soft-delete the `events` row by design — that's a
-        // separate concern) takes precedence. For every other addressable
-        // kind, including kind:30023 (NIP-23 long-form), we soft-delete the
-        // live row matching `(kind, pubkey, d_tag)` so REQs stop returning it.
+        // (row delete + event tombstone in `delete_and_tombstone` above) takes
+        // precedence. For every other addressable kind, including kind:30023
+        // (NIP-23 long-form), we soft-delete the live row matching
+        // `(kind, pubkey, d_tag)` so REQs stop returning it.
         // See https://github.com/block/sprout/issues/714.
         k if is_parameterized_replaceable(k) => {
             let pubkey_bytes = match hex::decode(pubkey_hex) {

--- a/crates/buzz-test-client/tests/e2e_workflow_delete.rs
+++ b/crates/buzz-test-client/tests/e2e_workflow_delete.rs
@@ -1,0 +1,182 @@
+//! End-to-end regression test for #4864: `buzz workflows delete` (a kind:5
+//! NIP-09 a-tag deletion) must tombstone the kind:30620 event rows so the
+//! CLI/desktop list/get paths stop returning the workflow, and re-publishing
+//! the coordinate (`workflows update`) must be rejected instead of silently
+//! resurrecting the workflow — and re-arming its webhook trigger with a brand
+//! new secret.
+//!
+//! # Running
+//!
+//! Start the relay against a test DB (dev auth, e.g.
+//! `BUZZ_REQUIRE_AUTH_TOKEN=false`), then run:
+//!
+//! ```text
+//! cargo test --test e2e_workflow_delete -- --ignored
+//! ```
+//!
+//! Override the relay URL with the `RELAY_URL` environment variable (default
+//! `ws://localhost:3000`).
+
+use nostr::{Event, EventBuilder, Keys, Kind, Tag};
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+fn relay_http_url() -> String {
+    relay_url()
+        .replace("wss://", "https://")
+        .replace("ws://", "http://")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Post an event to the HTTP bridge using the dev X-Pubkey auth path, exactly
+/// like the CLI's `submit_event`.
+async fn post_event(keys: &Keys, event: &Event) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/events", relay_http_url()))
+        .header("X-Pubkey", keys.public_key().to_hex())
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(event).unwrap())
+        .send()
+        .await
+        .expect("POST /events");
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.expect("parse event response");
+    serde_json::json!({
+        "status": status.as_u16(),
+        "accepted": body["accepted"].as_bool().unwrap_or(false),
+        "error": body["error"].as_str().unwrap_or("").to_string(),
+        "message": body["message"].as_str().unwrap_or("").to_string(),
+        "raw": body,
+    })
+}
+
+/// Query kind:30620 events in a channel via the HTTP bridge (`POST /query`),
+/// the exact path the CLI's `workflows list` and desktop use.
+async fn query_channel_workflows(keys: &Keys, channel_id: &str) -> Vec<serde_json::Value> {
+    let client = reqwest::Client::new();
+    let filter = serde_json::json!([{ "kinds": [30620], "#h": [channel_id] }]);
+    let resp = client
+        .post(format!("{}/query", relay_http_url()))
+        .header("X-Pubkey", keys.public_key().to_hex())
+        .header("Content-Type", "application/json")
+        .body(filter.to_string())
+        .send()
+        .await
+        .expect("POST /query");
+    assert!(resp.status().is_success(), "query failed: {}", resp.status());
+    resp.json().await.expect("parse query response")
+}
+
+/// Create a real channel via a signed kind:9007 event (the creator becomes an
+/// owner member), mirroring `e2e_relay.rs::create_test_channel`.
+async fn create_test_channel(keys: &Keys) -> String {
+    let channel_uuid = uuid::Uuid::new_v4().to_string();
+    let event = EventBuilder::new(Kind::Custom(9007), "")
+        .tags(vec![
+            Tag::parse(["h", &channel_uuid]).unwrap(),
+            Tag::parse(["name", &format!("wf-e2e-{channel_uuid}")]).unwrap(),
+            Tag::parse(["channel_type", "stream"]).unwrap(),
+            Tag::parse(["visibility", "open"]).unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap();
+    let resp = post_event(keys, &event).await;
+    assert!(
+        resp["accepted"].as_bool().unwrap_or(false),
+        "channel creation not accepted: {}",
+        resp["raw"]
+    );
+    channel_uuid
+}
+
+/// Build a valid kind:30620 workflow definition event (webhook trigger so the
+/// upsert would try to inject an ever-changing `webhook_secret` — the
+/// resurrection regression re-arms the webhook, which this test detects by
+/// asserting the update is rejected outright).
+fn build_workflow_def_event(keys: &Keys, channel_id: &str, workflow_id: &str) -> Event {
+    let yaml = "name: t\ntrigger:\n  on: webhook\nsteps:\n  - id: s1\n    action: send_message\n    text: hi";
+    let ch: uuid::Uuid = channel_id.parse().expect("channel uuid");
+    let wf: uuid::Uuid = workflow_id.parse().expect("workflow uuid");
+    buzz_sdk::builders::build_workflow_def(ch, wf, yaml)
+        .expect("build workflow def")
+        .sign_with_keys(keys)
+        .expect("sign workflow def")
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_workflow_delete_tombstones_event_and_blocks_resurrection() {
+    let keys = Keys::generate();
+    let pubkey_hex = keys.public_key().to_hex();
+
+    // 1. Channel (creator = owner member) + workflow definition.
+    let channel_id = create_test_channel(&keys).await;
+    let wf_id = uuid::Uuid::new_v4().to_string();
+
+    let create = build_workflow_def_event(&keys, &channel_id, &wf_id);
+    let create_resp = post_event(&keys, &create).await;
+    assert!(
+        create_resp["accepted"].as_bool().unwrap_or(false),
+        "workflow create should be accepted: {}",
+        create_resp["raw"]
+    );
+
+    // 2. List — the workflow is queryable before deletion.
+    let before = query_channel_workflows(&keys, &channel_id).await;
+    assert_eq!(before.len(), 1, "exactly one workflow before deletion");
+
+    // 3. NIP-09 a-tag deletion (what `buzz workflows delete` sends).
+    let a_coord = format!("30620:{pubkey_hex}:{wf_id}");
+    let del = EventBuilder::new(Kind::EventDeletion, "")
+        .tags(vec![Tag::parse(["a", &a_coord]).unwrap()])
+        .sign_with_keys(&keys)
+        .unwrap();
+    let del_resp = post_event(&keys, &del).await;
+    assert!(
+        del_resp["accepted"].as_bool().unwrap_or(false),
+        "deletion should be accepted: {}",
+        del_resp["raw"]
+    );
+
+    // 4. List — the workflow must be GONE (the event row is tombstoned).
+    // The side effect runs synchronously with ingest, so a single query is
+    // authoritative — no polling needed.
+    let after = query_channel_workflows(&keys, &channel_id).await;
+    assert_eq!(
+        after.len(),
+        0,
+        "deleted workflow must not appear in list/get (#4864)"
+    );
+
+    // 5. Re-publishing the coordinate (what `buzz workflows update` sends)
+    //    must be REJECTED, not silently resurrect the workflow.
+    let update = build_workflow_def_event(&keys, &channel_id, &wf_id);
+    let update_resp = post_event(&keys, &update).await;
+    assert!(
+        !update_resp["accepted"].as_bool().unwrap_or(false),
+        "update after delete must be rejected: {}",
+        update_resp["raw"]
+    );
+    let msg = update_resp["error"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("was deleted"),
+        "rejection should mention the deletion, got: {msg}"
+    );
+
+    // 6. A fresh workflow in the same channel still works — the tombstone
+    //    guard is coordinate-scoped, never channel-scoped.
+    let wf_id2 = uuid::Uuid::new_v4().to_string();
+    let create2 = build_workflow_def_event(&keys, &channel_id, &wf_id2);
+    let create2_resp = post_event(&keys, &create2).await;
+    assert!(
+        create2_resp["accepted"].as_bool().unwrap_or(false),
+        "fresh create after delete should still be accepted: {}",
+        create2_resp["raw"]
+    );
+    let after2 = query_channel_workflows(&keys, &channel_id).await;
+    assert_eq!(after2.len(), 1, "the fresh workflow is the only one left");
+}


### PR DESCRIPTION
Fixes #4864.

## Root cause

`buzz workflows delete` publishes a NIP-09 kind:5 a-tag deletion. The relay's `handle_a_tag_deletion` deleted the `workflows` **table row** (the scheduler SSOT) but never tombstoned the kind:30620 **event rows** — so every REQ-based surface (CLI `workflows list`/`get`, the desktop Workflows screen) kept returning the deleted workflow. Worse, a subsequent `workflows update` re-published the coordinate: a fresh live event row was inserted and `upsert_workflow` recreated the DB row — silently resurrecting a workflow the owner explicitly deleted, **and re-arming its webhook trigger with a brand-new secret** (confirmed by the reporter and reproduced live here).

## Fix (two parts)

1. **Tombstone the events** — `handle_a_tag_deletion`'s workflow branch now also calls `soft_delete_by_coordinate(kind=30620, pubkey, d_tag)` (same NIP-33 semantics as the generic parameterized-replaceable branch, with the at-or-before-`created_at` guard so a stale/replayed tombstone can't erase a newer head). list/get stop returning the workflow.
2. **Reject resurrection** — `persist_command_event` now rejects a kind:30620 publish when a tombstoned event exists at the coordinate: `not found: workflow … was deleted and cannot be re-published`. update-after-delete fails closed instead of reviving the workflow.

## Verification (live, against a running relay + seeded DB)

| Step | Before | After |
|---|---|---|
| create → list | 1 event | 1 event |
| NIP-09 delete | accepted, **still listed** | accepted, **list empty** |
| update same d-tag | accepted, workflow **resurrected + webhook re-armed** | **HTTP 400**, "was deleted and cannot be re-published" |
| fresh create (new uuid) | ok | ok (guard is coordinate-scoped, never channel-scoped) |

DB after fix: workflows rows 0, live 30620 events 0, tombstoned 30620 1.

## Regression test

`e2e_workflow_delete::test_workflow_delete_tombstones_event_and_blocks_resurrection` — channel create → workflow create → delete → list empty → update rejected → fresh create still works. **Verified the test FAILS on the pre-fix binary and PASSES with the fix.**

Full `buzz-relay` lib suite: 850 passed / 1 known pre-existing flake (`demo_join_forwarded_arm_round_trips_echo`, passes in isolation).
