### PR TITLE
fix(relay): backfill owners for direct NIP-OA members

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -809,13 +809,12 @@ async fn submit_event_authed(
     )
     .await
     {
-        Ok(owner) => owner.or_else(|| {
-            if !state.config.require_relay_membership {
-                super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
-            } else {
-                None
-            }
-        }),
+        // A direct member may still be a managed agent. Always verify a supplied
+        // NIP-OA attestation so older direct-member rows get their owner mapping
+        // materialized before owner-gated events (for example NIP-AM metrics)
+        // reach ingest. This cannot grant membership: that decision was already
+        // made above, and the attestation remains cryptographically verified.
+        Ok(owner) => super::relay_members::resolve_nip_oa_owner(owner, &pubkey_bytes, auth_tag),
         Err(e) => {
             return SubmitOutcome::Err {
                 status: e.0,

--- a/crates/buzz-relay/src/api/mod.rs
+++ b/crates/buzz-relay/src/api/mod.rs
@@ -146,8 +146,8 @@ pub mod relay_members {
 
     /// Extract NIP-OA owner from an auth tag without membership enforcement.
     ///
-    /// Used on open relays (`require_relay_membership = false`) to opportunistically
-    /// extract the owner pubkey for agent→owner backfill. The NIP-OA signature is
+    /// Used after membership has already been decided to opportunistically extract
+    /// the owner pubkey for agent→owner backfill. The NIP-OA signature is
     /// cryptographically self-proving, so no feature flag is needed — if the tag
     /// verifies, the owner relationship is authentic. Returns `None` if the tag
     /// is absent or invalid.
@@ -164,6 +164,20 @@ pub mod relay_members {
                 None
             }
         }
+    }
+
+    /// Preserve an owner found during delegated membership, or verify a supplied
+    /// NIP-OA tag when membership admitted the agent directly (or is disabled).
+    ///
+    /// Membership must be decided before calling this helper. It cannot grant
+    /// relay access; it only recovers the authenticated relationship needed for
+    /// first-write-wins owner-map materialization.
+    pub fn resolve_nip_oa_owner(
+        membership_owner: Option<nostr::PublicKey>,
+        pubkey_bytes: &[u8],
+        auth_tag_header: Option<&str>,
+    ) -> Option<nostr::PublicKey> {
+        membership_owner.or_else(|| extract_nip_oa_owner(pubkey_bytes, auth_tag_header))
     }
 
     /// Persist a cryptographically verified NIP-OA agent→owner relationship.
@@ -272,6 +286,40 @@ pub mod relay_members {
             let result = extract_nip_oa_owner(&agent_pubkey.to_bytes(), Some("not valid json"));
 
             assert_eq!(result, None);
+        }
+
+        /// Direct relay membership must not suppress a valid NIP-OA relationship:
+        /// owner-gated events still need the agent→owner mapping materialized.
+        #[test]
+        fn direct_member_owner_is_recovered_after_membership() {
+            let owner_keys = Keys::generate();
+            let agent_keys = Keys::generate();
+            let agent_pubkey = agent_keys.public_key();
+            let tag_json = compute_auth_tag(&owner_keys, &agent_pubkey, "")
+                .expect("compute_auth_tag must succeed");
+
+            let result = resolve_nip_oa_owner(None, &agent_pubkey.to_bytes(), Some(&tag_json));
+
+            assert_eq!(result, Some(owner_keys.public_key()));
+        }
+
+        /// A membership-gate owner remains authoritative and does not get replaced
+        /// by a second supplied relationship.
+        #[test]
+        fn delegated_membership_owner_takes_precedence() {
+            let admitted_owner = Keys::generate().public_key();
+            let other_owner = Keys::generate();
+            let agent_pubkey = Keys::generate().public_key();
+            let tag_json = compute_auth_tag(&other_owner, &agent_pubkey, "")
+                .expect("compute_auth_tag must succeed");
+
+            let result = resolve_nip_oa_owner(
+                Some(admitted_owner),
+                &agent_pubkey.to_bytes(),
+                Some(&tag_json),
+            );
+
+            assert_eq!(result, Some(admitted_owner));
         }
     }
 }

--- a/crates/buzz-relay/src/handlers/auth.rs
+++ b/crates/buzz-relay/src/handlers/auth.rs
@@ -237,20 +237,14 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                 }
             };
 
-            // Open relay NIP-OA backfill: extract owner for agent→owner DB mapping
-            // (needed for observer frame auth). Only runs on open relays — on closed
-            // relays, enforce_relay_membership already handles NIP-OA delegation.
-            // No feature flag needed: NIP-OA is cryptographically self-proving.
-            let nip_oa_owner = nip_oa_owner.or_else(|| {
-                if !state.config.require_relay_membership && auth_tag_json.is_some() {
-                    crate::api::relay_members::extract_nip_oa_owner(
-                        pubkey.as_bytes(),
-                        auth_tag_json.as_deref(),
-                    )
-                } else {
-                    None
-                }
-            });
+            // A direct member may still be a managed agent. Recover its verified
+            // NIP-OA relationship after membership succeeds so owner-gated events
+            // and observer authorization can use the first-write-wins mapping.
+            let nip_oa_owner = crate::api::relay_members::resolve_nip_oa_owner(
+                nip_oa_owner,
+                pubkey.as_bytes(),
+                auth_tag_json.as_deref(),
+            );
 
             // Stash NIP-OA owner on the auth context only after the shared
             // backfill confirms the first-write-wins relationship.


### PR DESCRIPTION
## What changed

- recover a cryptographically verified NIP-OA owner after relay membership has already succeeded
- apply the same post-membership resolution to HTTP event submission and NIP-42 WebSocket authentication
- preserve an owner already established by delegated membership
- add unit coverage for direct-member recovery and delegated-owner precedence

## Why

On a closed relay, a managed agent that was already a direct relay member passed the membership gate as `Member`. That result carried no owner, and the later owner-extraction fallback was restricted to open relays. The verified agent-to-owner relationship was therefore never materialized for these existing members.

Owner-gated event paths such as NIP-AM kind 44200 then rejected otherwise valid managed-agent events because the owner map was absent.

## Security and behavior

This does not grant membership. Both call sites resolve the owner only after the existing membership decision has succeeded, and the supplied NIP-OA tag is still cryptographically verified. Owner materialization remains first-write-wins.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- focused regression tests added for the extracted post-membership resolver

The full local `buzz-relay` test build exceeded the available host memory while compiling dependencies (`rustc` terminated with SIGKILL); no test assertion or compiler diagnostic failed. This is a draft pending CI validation.
