### PR TITLE
fix(desktop): show complete repository trees

### DIFF
--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -8,6 +8,15 @@ use crate::app_state::AppState;
 use serde::Serialize;
 use std::time::UNIX_EPOCH;
 use tauri::State;
+
+// Bound eager snapshot payloads without truncating the repository tree. Later
+// paths remain browseable without embedded content.
+const MAX_EAGER_FILE_PREVIEWS: usize = 250;
+
+#[cfg(test)]
+#[path = "project_git_tests.rs"]
+mod tests;
+
 #[derive(Clone, Serialize)]
 pub struct ProjectRepoCommitInfo {
     pub hash: String,
@@ -251,7 +260,8 @@ fn parse_worktree_files(
     output
         .split('\0')
         .filter(|path| !path.trim().is_empty())
-        .filter_map(|path| {
+        .enumerate()
+        .filter_map(|(index, path)| {
             let full_path = repo_dir.join(path);
             let metadata = std::fs::metadata(&full_path).ok()?;
             if !metadata.is_file() {
@@ -263,7 +273,9 @@ fn parse_worktree_files(
                 path: path.to_string(),
                 kind: "blob".to_string(),
                 size,
-                preview_content: read_preview_content(repo_dir, path, size),
+                preview_content: (index < MAX_EAGER_FILE_PREVIEWS)
+                    .then(|| read_preview_content(repo_dir, path, size))
+                    .flatten(),
                 last_changed_at: latest_commit
                     .as_ref()
                     .map(|commit| commit.timestamp)
@@ -271,7 +283,6 @@ fn parse_worktree_files(
                 latest_commit,
             })
         })
-        .take(250)
         .collect()
 }
 
@@ -316,14 +327,15 @@ fn parse_ls_tree(
 ) -> Vec<ProjectRepoFileInfo> {
     output
         .lines()
-        .filter_map(|line| {
+        .enumerate()
+        .filter_map(|(index, line)| {
             let (meta, path) = line.split_once('\t')?;
             let mut parts = meta.split_whitespace();
             let _mode = parts.next()?;
             let kind = parts.next()?.to_string();
             let _object = parts.next()?;
             let size = parts.next().and_then(|value| value.parse::<u64>().ok());
-            let preview_content = if kind == "blob" {
+            let preview_content = if kind == "blob" && index < MAX_EAGER_FILE_PREVIEWS {
                 read_preview_content(repo_dir, path, size)
             } else {
                 None
@@ -339,7 +351,6 @@ fn parse_ls_tree(
                 latest_commit: latest_commit_by_path.get(path).cloned(),
             })
         })
-        .take(250)
         .collect()
 }
 

--- a/desktop/src-tauri/src/commands/project_git_tests.rs
+++ b/desktop/src-tauri/src/commands/project_git_tests.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[test]
+fn parse_ls_tree_keeps_paths_after_eager_preview_limit() {
+    let hidden_entries = (0..MAX_EAGER_FILE_PREVIEWS)
+        .map(|index| {
+            format!(
+                "100644 blob {} 1\t.agents/generated-{index:03}.txt",
+                "a".repeat(40)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let output = format!(
+        "{hidden_entries}\n100644 blob {} 12\tsrc/application.rs",
+        "b".repeat(40)
+    );
+
+    let files = parse_ls_tree(
+        std::path::Path::new("/path/does/not/exist"),
+        &output,
+        &std::collections::HashMap::new(),
+    );
+
+    assert_eq!(files.len(), MAX_EAGER_FILE_PREVIEWS + 1);
+    assert_eq!(
+        files.last().map(|file| file.path.as_str()),
+        Some("src/application.rs")
+    );
+}

--- a/desktop/src/features/projects/lib/projectsViewHelpers.test.mjs
+++ b/desktop/src/features/projects/lib/projectsViewHelpers.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { relativeTime } from "./projectsViewHelpers.ts";
+import {
+  nextRepositoryEntryLimit,
+  relativeTime,
+} from "./projectsViewHelpers.ts";
 
 const DAY_SECONDS = 24 * 60 * 60;
 
@@ -42,4 +45,10 @@ test("relativeTime includes the year only across a year boundary", () => {
     relativeTime(crossYearCreatedAt, crossYearNow),
     crossYearExpected,
   );
+});
+
+test("repository entry pagination advances and clamps to the total", () => {
+  assert.equal(nextRepositoryEntryLimit(200, 450), 400);
+  assert.equal(nextRepositoryEntryLimit(400, 450), 450);
+  assert.equal(nextRepositoryEntryLimit(450, 450), 450);
 });

--- a/desktop/src/features/projects/lib/projectsViewHelpers.ts
+++ b/desktop/src/features/projects/lib/projectsViewHelpers.ts
@@ -26,6 +26,12 @@ export type ProjectsFilter =
   | "users";
 export type ProjectsSort = "updated" | "created" | "name";
 
+export const REPOSITORY_ENTRY_PAGE_SIZE = 200;
+
+export function nextRepositoryEntryLimit(current: number, total: number) {
+  return Math.min(current + REPOSITORY_ENTRY_PAGE_SIZE, total);
+}
+
 const PROJECTS_VIEW_MODE_STORAGE_KEY = "buzz.projects.viewMode";
 const PROJECTS_FILTER_STORAGE_KEY = "buzz.projects.filter";
 const PROJECTS_REPOSITORY_SCOPE_STORAGE_KEY = "buzz.projects.repositoryScope";

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -26,7 +26,11 @@ import type {
   ProjectRepoFile,
   ProjectRepoSnapshot,
 } from "@/features/projects/hooks";
-import { relativeTime } from "@/features/projects/lib/projectsViewHelpers";
+import {
+  nextRepositoryEntryLimit,
+  relativeTime,
+  REPOSITORY_ENTRY_PAGE_SIZE,
+} from "@/features/projects/lib/projectsViewHelpers";
 import { useUserSearchQuery } from "@/features/profile/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { UserSearchResult } from "@/shared/api/types";
@@ -633,11 +637,18 @@ export function RepositoryFilesPanel({
   const [currentPath, setCurrentPath] = React.useState("");
   const [selectedFile, setSelectedFile] =
     React.useState<ProjectRepoFile | null>(null);
+  const [visibleEntryCount, setVisibleEntryCount] = React.useState(
+    REPOSITORY_ENTRY_PAGE_SIZE,
+  );
+  const openPath = React.useCallback((path: string) => {
+    setCurrentPath(path);
+    setVisibleEntryCount(REPOSITORY_ENTRY_PAGE_SIZE);
+  }, []);
   const entries = React.useMemo(
     () => repositoryEntries(files, currentPath),
     [currentPath, files],
   );
-  const visibleEntries = entries.slice(0, 200);
+  const visibleEntries = entries.slice(0, visibleEntryCount);
   const latestCommit = snapshot?.latestCommit ?? null;
   const knownLatestCommitProfile = React.useMemo(
     () => profileForCommitAuthor(latestCommit, profiles),
@@ -679,6 +690,7 @@ export function RepositoryFilesPanel({
     if (!filesKey) return;
     setCurrentPath("");
     setSelectedFile(null);
+    setVisibleEntryCount(REPOSITORY_ENTRY_PAGE_SIZE);
   }, [filesKey]);
 
   // Loading/error/empty states keep the header controls visible — the
@@ -737,7 +749,7 @@ export function RepositoryFilesPanel({
         file={selectedFile}
         onOpenPath={(path) => {
           setSelectedFile(null);
-          setCurrentPath(path);
+          openPath(path);
         }}
       />
     );
@@ -766,14 +778,14 @@ export function RepositoryFilesPanel({
             />
           </>
         ) : (
-          <BreadcrumbButton onClick={() => setCurrentPath("")}>
+          <BreadcrumbButton onClick={() => openPath("")}>
             Files
           </BreadcrumbButton>
         )}
         {sourceControls && pathSegments.length > 0 ? (
           <>
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-            <BreadcrumbButton onClick={() => setCurrentPath("")}>
+            <BreadcrumbButton onClick={() => openPath("")}>
               Files
             </BreadcrumbButton>
           </>
@@ -783,7 +795,7 @@ export function RepositoryFilesPanel({
           return (
             <React.Fragment key={nextPath}>
               <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
-              <BreadcrumbButton onClick={() => setCurrentPath(nextPath)}>
+              <BreadcrumbButton onClick={() => openPath(nextPath)}>
                 {segment}
               </BreadcrumbButton>
             </React.Fragment>
@@ -855,7 +867,7 @@ export function RepositoryFilesPanel({
               const latestCommit = entry.latestCommit;
               const rowIsLast = index === visibleEntries.length - 1;
               const openEntry = () =>
-                openRepositoryEntry(entry, setCurrentPath, setSelectedFile);
+                openRepositoryEntry(entry, openPath, setSelectedFile);
 
               return (
                 <tr
@@ -904,11 +916,27 @@ export function RepositoryFilesPanel({
           </tbody>
         </table>
       </div>
-      {entries.length > 200 ? (
-        <p className="border-border/50 border-t px-4 py-3 text-2xs text-muted-foreground">
-          Showing the first 200 entries in this folder. Open a folder to narrow
-          the list.
-        </p>
+      {entries.length > visibleEntries.length ? (
+        <div className="flex items-center justify-between gap-3 border-border/50 border-t px-4 py-3 text-2xs text-muted-foreground">
+          <span>
+            Showing {visibleEntries.length} of {entries.length} entries.
+          </span>
+          <button
+            className="shrink-0 font-medium text-foreground hover:underline"
+            onClick={() =>
+              setVisibleEntryCount((current) =>
+                nextRepositoryEntryLimit(current, entries.length),
+              )
+            }
+            type="button"
+          >
+            Show next{" "}
+            {Math.min(
+              REPOSITORY_ENTRY_PAGE_SIZE,
+              entries.length - visibleEntries.length,
+            )}
+          </button>
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

Large repositories were silently limited to the first 250 lexicographically sorted paths, which could leave the Files tab showing only dot-directories. Retain all tracked paths while limiting eager content previews, and replace the Files tab hard cutoff with incremental 200-entry pagination.

### Related issue

Fixes #4960. No duplicate PR found.

### Testing

- Targeted Rust regression: `cargo test --manifest-path desktop/src-tauri/Cargo.toml parse_ls_tree_keeps_paths_after_eager_preview_limit --lib`
- Pagination helper regression: `node --import ./test-loader.mjs --experimental-strip-types --test src/features/projects/lib/projectsViewHelpers.test.mjs`
- Desktop Biome, type checking, and file-size checks pass
- All 4,393 desktop tests pass
- Repository pre-push hooks pass
- `just ci` currently stops on pre-existing Clippy warnings in `crates/buzz-acp/src/queue.rs` and `crates/buzz-agent/src/hints.rs`, outside this PR diff

Generated with Codex