### PR TITLE
ci(desktop): add sibling cargo-deny step for desktop lockfile (#4251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,6 +885,15 @@ jobs:
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
       - name: Dependency policy
         run: cargo-deny check
+      - name: Dependency policy (desktop lockfile)
+        # The root cargo-deny check ignores desktop/src-tauri/Cargo.lock (independent
+        # workspace). Lock it in so a desktop-only vuln can't silently ride along.
+        run: |
+          cargo-deny \
+            --manifest-path desktop/src-tauri/Cargo.toml \
+            --target aarch64-apple-darwin \
+            --exclude-dev \
+            check --config deny.toml advisories
 
   dead-token-guard:
     name: Dead Token Reference Guard


### PR DESCRIPTION
## Summary

Supersedes #4291 (fork-PR rebase v2).

The original PR bundled two changes: bump `nostr-relay-pool` 0.44.1 → 0.44.2 in the desktop lockfile, and add a `cargo-deny` step that audits the desktop lockfile in CI.

Since that PR was opened, `main` has bumped the desktop lockfile to `nostr-relay-pool = 0.44.3`, past the RUSTSEC-2026-0224 floor. The version bump is now redundant — only the **CI gate** remains load-bearing.

This PR carries just the CI step: a sibling `cargo-deny` invocation pointing at `desktop/src-tauri/Cargo.toml` (aarch64-apple-darwin target, `--exclude-dev`), using the repo-root `deny.toml` as config. The root `cargo-deny check` ignores `desktop/src-tauri/Cargo.lock` because the desktop workspace is independent — without this, a future desktop-only advisory could silently ride along.

Refs #4251.