### PR TITLE
fix(desktop): allow owners to remove other owners

### DIFF
--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -17,6 +17,7 @@ import {
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
 import { formatMemberName } from "@/features/channels/lib/memberUtils";
+import { canRemoveMember as canRemoveMemberPolicy } from "./canRemoveMember";
 import {
   canAddChannelMembers,
   PRIVATE_CHANNEL_ADD_DENIED_MESSAGE,
@@ -491,14 +492,8 @@ export function MembersSidebar({
     [bots, managedAgentByPubkey],
   );
   const canRemoveMember = React.useCallback(
-    (member: ChannelMember) => {
-      return (
-        (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
-        (selfMember?.role === "owner" && member.role !== "owner") ||
-        Boolean(selfMember && isMyBot(member)) ||
-        member.pubkey === currentPubkey
-      );
-    },
+    (member: ChannelMember) =>
+      canRemoveMemberPolicy(selfMember, member, currentPubkey, isMyBot),
     [currentPubkey, isMyBot, selfMember],
   );
   const removableManagedBots = React.useMemo(

--- a/desktop/src/features/channels/ui/canRemoveMember.test.mjs
+++ b/desktop/src/features/channels/ui/canRemoveMember.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { canRemoveMember } from "./canRemoveMember.ts";
+
+const SELF = "self-pubkey";
+const OTHER_OWNER = "other-owner-pubkey";
+const MEMBER = "member-pubkey";
+const BOT = "bot-pubkey";
+const noBot = () => false;
+
+test("owner can remove ANOTHER owner (the fix)", () => {
+  const self = { role: "owner" };
+  assert.equal(
+    canRemoveMember(self, { role: "owner", pubkey: OTHER_OWNER }, SELF, noBot),
+    true,
+  );
+});
+
+test("owner can remove admins and ordinary members", () => {
+  const self = { role: "owner" };
+  assert.equal(
+    canRemoveMember(self, { role: "admin", pubkey: MEMBER }, SELF, noBot),
+    true,
+  );
+  assert.equal(
+    canRemoveMember(self, { role: "member", pubkey: MEMBER }, SELF, noBot),
+    true,
+  );
+});
+
+test("self-removal preserved for every role", () => {
+  for (const role of ["owner", "admin", "member"]) {
+    assert.equal(
+      canRemoveMember({ role }, { role, pubkey: SELF }, SELF, noBot),
+      true,
+      `${role} should be able to remove self`,
+    );
+  }
+});
+
+test("admin behavior unchanged: removes any non-self, never self", () => {
+  const self = { role: "admin" };
+  assert.equal(
+    canRemoveMember(self, { role: "member", pubkey: MEMBER }, SELF, noBot),
+    true,
+  );
+  assert.equal(
+    canRemoveMember(self, { role: "owner", pubkey: OTHER_OWNER }, SELF, noBot),
+    true,
+  );
+});
+
+test("non-elevated member cannot remove other members", () => {
+  const self = { role: "member" };
+  assert.equal(
+    canRemoveMember(self, { role: "owner", pubkey: OTHER_OWNER }, SELF, noBot),
+    false,
+  );
+  assert.equal(
+    canRemoveMember(self, { role: "admin", pubkey: MEMBER }, SELF, noBot),
+    false,
+  );
+  assert.equal(
+    canRemoveMember(self, { role: "member", pubkey: MEMBER }, SELF, noBot),
+    false,
+  );
+});
+
+test("owned-bot removal unchanged (any member may remove a bot they own)", () => {
+  const self = { role: "member" };
+  const isMyBot = (m) => m.pubkey === BOT;
+  assert.equal(
+    canRemoveMember(self, { role: "bot", pubkey: BOT }, SELF, isMyBot),
+    true,
+  );
+  assert.equal(
+    canRemoveMember(self, { role: "bot", pubkey: "not-my-bot" }, SELF, isMyBot),
+    false,
+  );
+});

--- a/desktop/src/features/channels/ui/canRemoveMember.ts
+++ b/desktop/src/features/channels/ui/canRemoveMember.ts
@@ -1,0 +1,34 @@
+export interface RemovableSelf {
+  role?: string | null;
+}
+
+export interface RemovableMember {
+  role?: string | null;
+  pubkey: string;
+}
+
+/**
+ * Whether the acting member (`selfMember`) may remove `member` from the channel.
+ *
+ * Policy (must mirror the backend authorization in
+ * `crates/buzz-relay/src/handlers/side_effects.rs`):
+ * - An admin may remove any other member (not self).
+ * - An owner may remove any other member, INCLUDING another owner (not self).
+ *   The backend rejects removing the last remaining owner and the UI surfaces
+ *   that error, so the client does not need to re-check the owner count here.
+ * - Any member may remove a bot they own.
+ * - Any member may remove themselves (self-removal), regardless of role.
+ */
+export function canRemoveMember<M extends RemovableMember>(
+  selfMember: RemovableSelf | null,
+  member: M,
+  currentPubkey: string | undefined,
+  isMyBot: (member: M) => boolean,
+): boolean {
+  return (
+    (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
+    (selfMember?.role === "owner" && member.pubkey !== currentPubkey) ||
+    Boolean(selfMember && isMyBot(member)) ||
+    member.pubkey === currentPubkey
+  );
+}


### PR DESCRIPTION
The channel members menu currently hides removal for every owner target even though the backend permits an elevated member to remove another owner and independently rejects removal of the last owner. This change extracts the removal predicate, allows an owner to target another owner, preserves admin, self-removal, and owned-agent behavior, and adds focused regression tests. Validation: complete desktop test suite passed; TypeScript typecheck passed; production web build passed; touched-file Biome lint passed.