### PR TITLE
fix(desktop): discover remote channel agents

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -229,7 +229,7 @@ test("autocomplete helper extraction preserves safe filtering and labels", () =>
   );
 });
 
-test("isAgentIdentityInAllowedList: keeps people and only explicitly allowed agent identities", () => {
+test("isAgentIdentityInAllowedList: keeps people, channel members, and explicitly allowed agents", () => {
   const allowedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
@@ -252,6 +252,13 @@ test("isAgentIdentityInAllowedList: keeps people and only explicitly allowed age
       allowedAgentPubkeys,
     ),
     false,
+  );
+  assert.equal(
+    isAgentIdentityInAllowedList(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      allowedAgentPubkeys,
+    ),
+    true,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -83,11 +83,12 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInAllowedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   allowedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
+    candidate.isMember === true ||
     allowedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }


### PR DESCRIPTION
Channel members that are agents now remain eligible for mention autocomplete even when the current desktop has no local managed-agent record or relay-directory metadata for them. This lets users mention agents hosted on another desktop without copying the agent's runtime, credentials, or configuration to the desktop they are currently using.

The existing invocability guard still hides a channel-member agent when relay metadata explicitly says that the current user cannot invoke it. A regression test covers admission of remote channel members alongside the existing exclusion tests.

## Verification

- Desktop unit suite: 4,392 passed
- TypeScript typecheck: passed
- Desktop checks: passed with existing informational notices in unrelated files

🤖 Generated with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)
