### PR TITLE
fix(mobile): show owned agents in empty mentions

### DIFF
--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -114,7 +114,30 @@ List<MentionCandidate> buildMentionCandidates({
 
   for (final profile in searchResults) {
     final pk = profile.pubkey.toLowerCase();
-    if (seen.contains(pk)) continue;
+    final existingIndex = candidates.indexWhere(
+      (candidate) => candidate.pubkey == pk,
+    );
+    if (existingIndex != -1) {
+      final existing = candidates[existingIndex];
+      if (existing.isAgent && !existing.isMember) {
+        candidates[existingIndex] = MentionCandidate(
+          pubkey: pk,
+          displayName: profile.displayName?.trim().isNotEmpty == true
+              ? profile.displayName!.trim()
+              : existing.displayName,
+          secondaryLabel: profile.nip05Handle ?? existing.secondaryLabel,
+          avatarUrl: profile.avatarUrl ?? existing.avatarUrl,
+          isAgent: true,
+          isMember: false,
+          role: existing.role,
+          ownerPubkey:
+              ownerByAgentPubkey[pk] ??
+              profile.ownerPubkey ??
+              existing.ownerPubkey,
+        );
+      }
+      continue;
+    }
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile.ownerPubkey;
     final isAgent = ownerPubkey != null || directoryPubkeys.contains(pk);
     if (isAgent) {

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -87,12 +87,16 @@ List<MentionCandidate> buildMentionCandidates({
     }
   }
 
+  final currentLower = currentPubkey?.toLowerCase();
   for (final agent in relayAgents) {
     final pk = agent.pubkey;
     if (seen.contains(pk)) continue;
-    if (!sharedAgentPubkeys.contains(pk)) continue;
-    seen.add(pk);
     final profile = userCache[pk];
+    final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
+    final ownedByCurrentUser =
+        currentLower != null && ownerPubkey?.toLowerCase() == currentLower;
+    if (!ownedByCurrentUser && !sharedAgentPubkeys.contains(pk)) continue;
+    seen.add(pk);
     candidates.add(
       MentionCandidate(
         pubkey: pk,
@@ -103,12 +107,11 @@ List<MentionCandidate> buildMentionCandidates({
         avatarUrl: profile?.avatarUrl,
         isAgent: true,
         isMember: false,
-        ownerPubkey: ownerByAgentPubkey[pk] ?? profile?.ownerPubkey,
+        ownerPubkey: ownerPubkey,
       ),
     );
   }
 
-  final currentLower = currentPubkey?.toLowerCase();
   for (final profile in searchResults) {
     final pk = profile.pubkey.toLowerCase();
     if (seen.contains(pk)) continue;

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -124,20 +124,52 @@ void main() {
           AgentDirectoryEntry(
             pubkey: agentPubkey,
             displayName: 'Owned agent',
-            respondTo: 'anyone',
+            respondTo: 'owner-only',
             channelIds: const [],
           ),
         ],
         sharedChannelIds: const {},
         userCache: const {},
-        ownerByAgentPubkey: {agentPubkey: userPubkey},
+        ownerByAgentPubkey: {agentPubkey: userPubkey.toUpperCase()},
         currentPubkey: userPubkey,
       );
 
       expect(candidates.map((c) => c.pubkey), [userPubkey, agentPubkey]);
       expect(candidates.last.isAgent, isTrue);
       expect(candidates.last.isMember, isFalse);
-      expect(candidates.last.ownerPubkey, userPubkey);
+      expect(candidates.last.ownerPubkey, userPubkey.toUpperCase());
+    });
+
+    test('search metadata enriches owner-only directory agents', () {
+      final candidates = buildMentionCandidates(
+        members: const [],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: agentPubkey,
+            displayName: 'Directory name',
+            respondTo: 'owner-only',
+            channelIds: const [],
+          ),
+        ],
+        sharedChannelIds: const {},
+        userCache: const {},
+        ownerByAgentPubkey: {agentPubkey: userPubkey},
+        searchResults: [
+          UserProfile(
+            pubkey: agentPubkey,
+            displayName: 'Search result name',
+            nip05Handle: 'agent@example.com',
+            ownerPubkey: userPubkey,
+          ),
+        ],
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates, hasLength(1));
+      expect(candidates.single.displayName, 'Search result name');
+      expect(candidates.single.secondaryLabel, 'agent@example.com');
+      expect(candidates.single.isAgent, isTrue);
+      expect(candidates.single.isMember, isFalse);
     });
 
     test('owner-only directory agents stay hidden from other users', () {
@@ -147,7 +179,7 @@ void main() {
           AgentDirectoryEntry(
             pubkey: agentPubkey,
             displayName: 'Someone else agent',
-            respondTo: 'anyone',
+            respondTo: 'owner-only',
             channelIds: const [],
           ),
         ],

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -117,6 +117,49 @@ void main() {
       expect(candidates.map((c) => c.pubkey), contains(userPubkey));
     });
 
+    test('empty mentions include owner-only directory agents', () {
+      final candidates = buildMentionCandidates(
+        members: [member(userPubkey)],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: agentPubkey,
+            displayName: 'Owned agent',
+            respondTo: 'anyone',
+            channelIds: const [],
+          ),
+        ],
+        sharedChannelIds: const {},
+        userCache: const {},
+        ownerByAgentPubkey: {agentPubkey: userPubkey},
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates.map((c) => c.pubkey), [userPubkey, agentPubkey]);
+      expect(candidates.last.isAgent, isTrue);
+      expect(candidates.last.isMember, isFalse);
+      expect(candidates.last.ownerPubkey, userPubkey);
+    });
+
+    test('owner-only directory agents stay hidden from other users', () {
+      final candidates = buildMentionCandidates(
+        members: [member(userPubkey)],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: agentPubkey,
+            displayName: 'Someone else agent',
+            respondTo: 'anyone',
+            channelIds: const [],
+          ),
+        ],
+        sharedChannelIds: const {},
+        userCache: const {},
+        ownerByAgentPubkey: {agentPubkey: ownerPubkey},
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates.map((c) => c.pubkey), [userPubkey]);
+    });
+
     test('excludes non-shared agents and deduplicates member agents', () {
       final candidates = buildMentionCandidates(
         members: [member(agentPubkey, role: 'bot')],


### PR DESCRIPTION
## Summary
- include verified owner-only relay agents in the mobile mention picker before a query is typed
- preserve the existing shared-channel gate for agents owned by anyone else
- merge later search metadata into already-visible directory agents so typed lookup remains accurate
- add regression coverage for ownership, mixed-case normalization, and metadata enrichment

## Root cause
The directory pass only admitted agents already shared with the current user. Ownership was checked later only for global search results, but empty mention queries intentionally return no global results. New channels therefore showed only existing members, not the current user's managed agents.

## Verification
- reproduced red: owned agent absent from empty mention candidates
- reproduced second red: search profile metadata discarded after the directory candidate was admitted
- focused mention suite: 18/18 passed
- `flutter analyze`: passed
- full mobile test suite: 1,246/1,246 passed
- `dart format --output=none --set-exit-if-changed`: passed
- independent security/correctness review completed; no ownership-spoofing or authorization bypass found

Fixes the iPhone flow where tapping `@` in a new channel failed to surface the owner's agents for mention-and-auto-invite.