### PR TITLE
feat(desktop): add trustworthy agent observability

### DIFF
--- a/desktop/src-tauri/src/archive/causal_ledger.rs
+++ b/desktop/src-tauri/src/archive/causal_ledger.rs
@@ -1,0 +1,171 @@
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Deserialize;
+use tauri::State;
+
+use crate::app_state::AppState;
+
+use super::{identity_pubkey, now_secs, run_archive_db_task};
+
+const GENESIS_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LedgerEntryEnvelope {
+    sequence: u64,
+    previous_hash: String,
+    hash: String,
+    experiment: ExperimentIdentity,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExperimentIdentity {
+    experiment_id: String,
+}
+
+/// Return the current owner's immutable causal-ledger journal in chain order.
+#[tauri::command]
+pub async fn read_causal_ledger(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    let identity = identity_pubkey(&state)?;
+    run_archive_db_task(move |conn| read_entries(conn, &identity)).await
+}
+
+fn read_entries(conn: &Connection, identity: &str) -> Result<Vec<String>, String> {
+    let mut statement = conn
+        .prepare(
+            "SELECT entry_json FROM causal_ledger_entries
+                 WHERE identity_pubkey = ?1 ORDER BY sequence ASC",
+        )
+        .map_err(|error| format!("failed to prepare causal ledger read: {error}"))?;
+    let rows = statement
+        .query_map(params![identity], |row| row.get::<_, String>(0))
+        .map_err(|error| format!("failed to read causal ledger: {error}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to decode causal ledger row: {error}"))
+}
+
+/// Transactionally append one owner-scoped hash-linked causal-ledger entry.
+#[tauri::command]
+pub async fn append_causal_ledger_entry(
+    state: State<'_, AppState>,
+    entry_json: String,
+) -> Result<(), String> {
+    let identity = identity_pubkey(&state)?;
+    let entry: LedgerEntryEnvelope = serde_json::from_str(&entry_json)
+        .map_err(|error| format!("invalid causal ledger entry: {error}"))?;
+    if entry.sequence == 0 || entry.hash.len() != 64 || entry.previous_hash.len() != 64 {
+        return Err("invalid causal ledger chain fields".to_string());
+    }
+    let recorded_at = now_secs();
+    run_archive_db_task(move |conn| append_entry(conn, &identity, &entry_json, entry, recorded_at))
+        .await
+}
+
+fn append_entry(
+    conn: &Connection,
+    identity: &str,
+    entry_json: &str,
+    entry: LedgerEntryEnvelope,
+    recorded_at: i64,
+) -> Result<(), String> {
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .map_err(|error| format!("failed to begin causal ledger append: {error}"))?;
+    let result = (|| {
+        let tail = conn
+            .query_row(
+                "SELECT sequence, hash FROM causal_ledger_entries
+                 WHERE identity_pubkey = ?1 ORDER BY sequence DESC LIMIT 1",
+                params![identity],
+                |row| Ok((row.get::<_, u64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()
+            .map_err(|error| format!("failed to read causal ledger tail: {error}"))?;
+        let expected_sequence = tail.as_ref().map_or(1, |(sequence, _)| sequence + 1);
+        let expected_previous = tail
+            .as_ref()
+            .map_or(GENESIS_HASH, |(_, hash)| hash.as_str());
+
+        if entry.sequence != expected_sequence || entry.previous_hash != expected_previous {
+            return Err(format!(
+                "causal ledger append conflict: expected sequence {expected_sequence}"
+            ));
+        }
+        conn
+            .execute(
+                "INSERT INTO causal_ledger_entries
+                 (identity_pubkey, sequence, experiment_id, previous_hash, hash, entry_json, recorded_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    identity,
+                    entry.sequence,
+                    entry.experiment.experiment_id,
+                    entry.previous_hash,
+                    entry.hash,
+                    entry_json,
+                    recorded_at
+                ],
+            )
+            .map_err(|error| format!("failed to append causal ledger entry: {error}"))?;
+        Ok(())
+    })();
+    match result {
+        Ok(()) => conn
+            .execute_batch("COMMIT")
+            .map_err(|error| format!("failed to commit causal ledger append: {error}")),
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::store::open_archive_db;
+
+    fn envelope(sequence: u64, previous_hash: &str) -> (String, LedgerEntryEnvelope) {
+        let hash = format!("{sequence:064x}");
+        let experiment_id = format!("experiment-{sequence}");
+        let json = serde_json::json!({
+            "sequence": sequence,
+            "previousHash": previous_hash,
+            "hash": hash,
+            "experiment": { "experimentId": experiment_id }
+        })
+        .to_string();
+        let parsed = serde_json::from_str(&json).expect("test envelope should decode");
+        (json, parsed)
+    }
+
+    #[test]
+    fn persists_ten_thousand_owner_scoped_entries_on_disk_and_reopens() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let path = directory.path().join("archive.db");
+        let conn = open_archive_db(&path).expect("open archive database");
+        let mut previous = GENESIS_HASH.to_string();
+        for sequence in 1..=10_000 {
+            let (json, entry) = envelope(sequence, &previous);
+            previous = entry.hash.clone();
+            append_entry(&conn, "owner-a", &json, entry, 0).expect("append entry");
+        }
+        drop(conn);
+
+        let reopened = open_archive_db(&path).expect("reopen archive database");
+        assert_eq!(
+            read_entries(&reopened, "owner-a").expect("read").len(),
+            10_000
+        );
+        assert!(read_entries(&reopened, "owner-b").expect("read").is_empty());
+    }
+
+    #[test]
+    fn rejects_a_non_contiguous_chain_without_writing_it() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(crate::archive::store::SCHEMA)
+            .expect("initialize schema");
+        let (json, entry) = envelope(2, GENESIS_HASH);
+        assert!(append_entry(&conn, "owner", &json, entry, 0).is_err());
+        assert!(read_entries(&conn, "owner").expect("read").is_empty());
+    }
+}

--- a/desktop/src-tauri/src/archive/causal_ledger.rs
+++ b/desktop/src-tauri/src/archive/causal_ledger.rs
@@ -1,5 +1,7 @@
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tauri::State;
 
 use crate::app_state::AppState;
@@ -14,13 +16,79 @@ struct LedgerEntryEnvelope {
     sequence: u64,
     previous_hash: String,
     hash: String,
-    experiment: ExperimentIdentity,
+    experiment: Value,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ExperimentIdentity {
-    experiment_id: String,
+fn experiment_id(experiment: &Value) -> Result<&str, String> {
+    experiment
+        .get("experimentId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .ok_or_else(|| "causal ledger experimentId is required".to_string())
+}
+
+fn canonical_json(value: &Value) -> Result<String, String> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            serde_json::to_string(value)
+                .map_err(|error| format!("failed to canonicalize causal ledger value: {error}"))
+        }
+        Value::Array(values) => {
+            let values = values
+                .iter()
+                .map(canonical_json)
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(format!("[{}]", values.join(",")))
+        }
+        Value::Object(entries) => {
+            let mut entries = entries.iter().collect::<Vec<_>>();
+            entries.sort_unstable_by_key(|(key, _)| *key);
+            let entries = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    let key = serde_json::to_string(key).map_err(|error| {
+                        format!("failed to canonicalize causal ledger key: {error}")
+                    })?;
+                    Ok(format!("{key}:{}", canonical_json(value)?))
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+            Ok(format!("{{{}}}", entries.join(",")))
+        }
+    }
+}
+
+fn entry_hash(entry: &LedgerEntryEnvelope) -> Result<String, String> {
+    let hash_input = serde_json::json!({
+        "sequence": entry.sequence,
+        "previousHash": entry.previous_hash,
+        "experiment": entry.experiment,
+    });
+    Ok(hex::encode(Sha256::digest(
+        canonical_json(&hash_input)?.as_bytes(),
+    )))
+}
+
+fn validate_entry(entry: &LedgerEntryEnvelope) -> Result<(), String> {
+    experiment_id(&entry.experiment)?;
+    if entry.sequence == 0
+        || entry.hash.len() != 64
+        || entry.previous_hash.len() != 64
+        || !entry.hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || !entry
+            .previous_hash
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("invalid causal ledger chain fields".to_string());
+    }
+    let expected = entry_hash(entry)?;
+    if entry.hash != expected {
+        return Err(format!(
+            "causal ledger integrity failure at sequence {}",
+            entry.sequence
+        ));
+    }
+    Ok(())
 }
 
 /// Return the current owner's immutable causal-ledger journal in chain order.
@@ -40,8 +108,25 @@ fn read_entries(conn: &Connection, identity: &str) -> Result<Vec<String>, String
     let rows = statement
         .query_map(params![identity], |row| row.get::<_, String>(0))
         .map_err(|error| format!("failed to read causal ledger: {error}"))?;
-    rows.collect::<Result<Vec<_>, _>>()
-        .map_err(|error| format!("failed to decode causal ledger row: {error}"))
+    let entries = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to decode causal ledger row: {error}"))?;
+    let mut previous_hash = GENESIS_HASH.to_string();
+    for (index, entry_json) in entries.iter().enumerate() {
+        let entry: LedgerEntryEnvelope = serde_json::from_str(entry_json)
+            .map_err(|error| format!("invalid stored causal ledger entry: {error}"))?;
+        validate_entry(&entry)?;
+        let expected_sequence =
+            u64::try_from(index).map_err(|_| "causal ledger sequence overflow".to_string())? + 1;
+        if entry.sequence != expected_sequence || entry.previous_hash != previous_hash {
+            return Err(format!(
+                "causal ledger integrity failure at sequence {}",
+                entry.sequence
+            ));
+        }
+        previous_hash = entry.hash;
+    }
+    Ok(entries)
 }
 
 /// Transactionally append one owner-scoped hash-linked causal-ledger entry.
@@ -53,9 +138,7 @@ pub async fn append_causal_ledger_entry(
     let identity = identity_pubkey(&state)?;
     let entry: LedgerEntryEnvelope = serde_json::from_str(&entry_json)
         .map_err(|error| format!("invalid causal ledger entry: {error}"))?;
-    if entry.sequence == 0 || entry.hash.len() != 64 || entry.previous_hash.len() != 64 {
-        return Err("invalid causal ledger chain fields".to_string());
-    }
+    validate_entry(&entry)?;
     let recorded_at = now_secs();
     run_archive_db_task(move |conn| append_entry(conn, &identity, &entry_json, entry, recorded_at))
         .await
@@ -68,6 +151,7 @@ fn append_entry(
     entry: LedgerEntryEnvelope,
     recorded_at: i64,
 ) -> Result<(), String> {
+    validate_entry(&entry)?;
     conn.execute_batch("BEGIN IMMEDIATE")
         .map_err(|error| format!("failed to begin causal ledger append: {error}"))?;
     let result = (|| {
@@ -98,7 +182,7 @@ fn append_entry(
                 params![
                     identity,
                     entry.sequence,
-                    entry.experiment.experiment_id,
+                    experiment_id(&entry.experiment)?,
                     entry.previous_hash,
                     entry.hash,
                     entry_json,
@@ -125,16 +209,18 @@ mod tests {
     use crate::archive::store::open_archive_db;
 
     fn envelope(sequence: u64, previous_hash: &str) -> (String, LedgerEntryEnvelope) {
-        let hash = format!("{sequence:064x}");
         let experiment_id = format!("experiment-{sequence}");
-        let json = serde_json::json!({
+        let mut value = serde_json::json!({
             "sequence": sequence,
             "previousHash": previous_hash,
-            "hash": hash,
+            "hash": "",
             "experiment": { "experimentId": experiment_id }
-        })
-        .to_string();
-        let parsed = serde_json::from_str(&json).expect("test envelope should decode");
+        });
+        let mut parsed: LedgerEntryEnvelope =
+            serde_json::from_value(value.clone()).expect("test envelope should decode");
+        parsed.hash = entry_hash(&parsed).expect("hash test entry");
+        value["hash"] = Value::String(parsed.hash.clone());
+        let json = value.to_string();
         (json, parsed)
     }
 
@@ -167,5 +253,49 @@ mod tests {
         let (json, entry) = envelope(2, GENESIS_HASH);
         assert!(append_entry(&conn, "owner", &json, entry, 0).is_err());
         assert!(read_entries(&conn, "owner").expect("read").is_empty());
+    }
+
+    #[test]
+    fn rejects_a_forged_hash_without_writing_it() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(crate::archive::store::SCHEMA)
+            .expect("initialize schema");
+        let (json, mut entry) = envelope(1, GENESIS_HASH);
+        entry.hash = "f".repeat(64);
+        assert!(append_entry(&conn, "owner", &json, entry, 0).is_err());
+        assert!(read_entries(&conn, "owner").expect("read").is_empty());
+    }
+
+    #[test]
+    fn rejects_a_tampered_stored_experiment_on_read() {
+        let conn = Connection::open_in_memory().expect("open in-memory database");
+        conn.execute_batch(crate::archive::store::SCHEMA)
+            .expect("initialize schema");
+        let (json, entry) = envelope(1, GENESIS_HASH);
+        append_entry(&conn, "owner", &json, entry, 0).expect("append entry");
+        conn.execute(
+            "UPDATE causal_ledger_entries SET entry_json = replace(entry_json, 'experiment-1', 'experiment-x')",
+            [],
+        )
+        .expect("tamper stored entry");
+        assert!(read_entries(&conn, "owner").is_err());
+    }
+
+    #[test]
+    fn hash_matches_the_browser_canonical_json_contract() {
+        let entry = LedgerEntryEnvelope {
+            sequence: 1,
+            previous_hash: GENESIS_HASH.to_string(),
+            hash: String::new(),
+            experiment: serde_json::json!({
+                "schema": "causal-experiment/v1",
+                "experimentId": "golden",
+                "nested": { "z": true, "a": [1, "two", null] }
+            }),
+        };
+        assert_eq!(
+            entry_hash(&entry).expect("hash golden entry"),
+            "514a88ba21863a1ea56a88e91e08aa382d249f46ffaf6c1eb797c745160490d8"
+        );
     }
 }

--- a/desktop/src-tauri/src/archive/mod.rs
+++ b/desktop/src-tauri/src/archive/mod.rs
@@ -17,6 +17,7 @@
 //! validation (sig/id + kind + p-tag + agent tag + frame=telemetry + author
 //! == agent) is applied fail-closed.
 
+pub(crate) mod causal_ledger;
 mod pipeline;
 pub mod store;
 

--- a/desktop/src-tauri/src/archive/store.rs
+++ b/desktop/src-tauri/src/archive/store.rs
@@ -75,6 +75,20 @@ CREATE TABLE IF NOT EXISTS archive_migrations (
     name       TEXT PRIMARY KEY,
     applied_at INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS causal_ledger_entries (
+    identity_pubkey TEXT NOT NULL,
+    sequence        INTEGER NOT NULL,
+    experiment_id   TEXT NOT NULL,
+    previous_hash   TEXT NOT NULL,
+    hash            TEXT NOT NULL,
+    entry_json      TEXT NOT NULL,
+    recorded_at     INTEGER NOT NULL,
+    PRIMARY KEY (identity_pubkey, sequence),
+    UNIQUE (identity_pubkey, experiment_id)
+);
+CREATE INDEX IF NOT EXISTS idx_causal_ledger_experiment
+    ON causal_ledger_entries (identity_pubkey, experiment_id);
 ";
 
 // ── Open / init ─────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -85,11 +85,8 @@ use tray_menu::show_main_window;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // mesh-llm's async chains (model download, node start/join) overflow
-    // tokio's default 2 MiB worker stacks — a stack-guard SIGABRT, not a
-    // panic. Upstream mesh-llm and mesh-console both run on 8 MiB worker
-    // stacks for this reason; give Tauri's command runtime the same headroom
-    // before anything else touches tauri::async_runtime.
+    // mesh-llm's async chains overflow tokio's default 2 MiB worker stacks.
+    // Match upstream's 8 MiB stacks before anything touches tauri::async_runtime.
     #[cfg(feature = "mesh-llm")]
     match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -903,6 +900,8 @@ pub fn run() {
             archive::read_archived_observer_events_for_channel,
             archive::index_observer_channel_id,
             archive::read_unindexed_observer_rows,
+            archive::causal_ledger::read_causal_ledger,
+            archive::causal_ledger::append_causal_ledger_entry,
             is_auto_update_supported,
             set_window_vibrancy,
             #[cfg(target_os = "macos")]

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -809,10 +809,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-/// Start one runtime worker unless the owner explicitly asks for concurrency.
-///
-/// ACP adapters such as Codex launch several helper processes per worker, so a
-/// high implicit default can exhaust a desktop before the first turn begins.
+/// Use one worker by default because ACP adapters may launch helper processes.
 pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
 
 fn default_agent_parallelism() -> u32 {

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -809,7 +809,11 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 10;
+/// Start one runtime worker unless the owner explicitly asks for concurrency.
+///
+/// ACP adapters such as Codex launch several helper processes per worker, so a
+/// high implicit default can exhaust a desktop before the first turn begins.
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -468,6 +468,11 @@ fn sample_agent_record() -> ManagedAgentRecord {
     .expect("sample record")
 }
 
+#[test]
+fn records_without_parallelism_default_to_one_worker() {
+    assert_eq!(sample_agent_record().parallelism, 1);
+}
+
 // ── AgentDefinition ↔ ManagedAgentRecord fold mapping (Phase 1A) ─────────────────────
 
 fn sample_persona() -> AgentDefinition {

--- a/desktop/src/features/agents/lib/causalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/causalLedger.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CAUSAL_EXPERIMENT_SCHEMA, CausalLedger } from "./causalLedger.ts";
+
+function experiment(id, overrides = {}) {
+  return {
+    schema: CAUSAL_EXPERIMENT_SCHEMA,
+    experimentId: id,
+    recordedAt: "2026-08-05T18:44:22Z",
+    task: {
+      description: "Build the Buzz Causal Ledger",
+      sourceMessageId: "c5b7084",
+    },
+    execution: {
+      sessionId: `session-${id}`,
+      turnId: `turn-${id}`,
+      replayOf: null,
+    },
+    failureFingerprint: "host-write-without-acp-permission/v1",
+    context: {
+      codeVersion: "2330ec7",
+      policyVersion: "workspace-write/v1",
+      modelVersion: "gpt-5",
+      toolVersion: "buzz-acp/v1",
+      environmentVersion: "macos-arm64",
+    },
+    hypothesis: {
+      cause: "Host write bypassed ACP",
+      evidenceIds: [`evidence-${id}`],
+    },
+    intervention: {
+      remedyId: "route-through-acp/v1",
+      changedVariable: "execution_path",
+    },
+    result: { outcome: "validated", evidenceIds: [`result-${id}`] },
+    coverage: {
+      acp: "observed",
+      host_workspace: "observed",
+      os_sandbox: "observed",
+    },
+    relations: { supports: [], contradicts: [], invalidates: [] },
+    ...overrides,
+  };
+}
+
+test("appends immutable, hash-linked causal experiments", async () => {
+  const ledger = new CausalLedger();
+  const first = await ledger.append(experiment("one"));
+  const second = await ledger.append(experiment("two"));
+
+  assert.equal(first.sequence, 1);
+  assert.equal(second.previousHash, first.hash);
+  assert.equal(await ledger.verify(), true);
+  await assert.rejects(() => ledger.append(experiment("one")), /Duplicate/);
+  assert.throws(() => {
+    first.experiment.result.outcome = "rejected";
+  }, /read only/);
+});
+
+test("restores an append-only journal and rejects a tampered restart", async () => {
+  const ledger = new CausalLedger();
+  await ledger.append(experiment("before-crash"));
+  await ledger.append(experiment("after-restart"));
+  const journal = ledger.toJournal();
+
+  const restored = await CausalLedger.fromJournal(journal);
+  assert.equal(restored.size, 2);
+  assert.equal(await restored.verify(), true);
+
+  const tampered = journal.replace("Host write bypassed ACP", "Invented cause");
+  await assert.rejects(
+    () => CausalLedger.fromJournal(tampered),
+    /integrity failure/,
+  );
+});
+
+test("does not let unrelated or version-drifted successes strengthen a finding", async () => {
+  const ledger = new CausalLedger();
+  const target = experiment("target");
+  await ledger.append(target);
+  await ledger.append(experiment("same-context"));
+  await ledger.append(
+    experiment("unrelated", { failureFingerprint: "different-failure/v1" }),
+  );
+  await ledger.append(
+    experiment("drifted", {
+      context: { ...target.context, policyVersion: "workspace-write/v2" },
+    }),
+  );
+
+  const finding = ledger.findingFor(target);
+  assert.equal(finding.comparableExperiments, 2);
+  assert.equal(finding.validated, 2);
+  assert.equal(finding.confidence, 1);
+});
+
+test("missing coverage and contradictions lower confidence", async () => {
+  const ledger = new CausalLedger();
+  const target = experiment("target");
+  await ledger.append(target);
+  await ledger.append(
+    experiment("contradiction", {
+      result: { outcome: "rejected", evidenceIds: ["contradiction-evidence"] },
+      relations: { supports: [], contradicts: ["target"], invalidates: [] },
+    }),
+  );
+  await ledger.append(
+    experiment("live-dogfood-gap", {
+      result: { outcome: "inconclusive", evidenceIds: [] },
+      coverage: {
+        acp: "observed",
+        host_workspace: "missing",
+        os_sandbox: "missing",
+      },
+    }),
+  );
+
+  const finding = ledger.findingFor(target);
+  assert.deepEqual(
+    {
+      validated: finding.validated,
+      rejected: finding.rejected,
+      inconclusive: finding.inconclusive,
+    },
+    { validated: 1, rejected: 1, inconclusive: 1 },
+  );
+  assert.equal(finding.confidence, 1 / 3);
+});
+
+test("keeps 10,000 adversarial experiments inside their causal boundaries", async () => {
+  const ledger = new CausalLedger();
+  const target = experiment("target");
+  await ledger.append(target);
+  for (let index = 1; index < 10_000; index += 1) {
+    const poisoned = index % 5 === 0;
+    const versionDrift = index % 7 === 0;
+    await ledger.append(
+      experiment(`scale-${index}`, {
+        failureFingerprint: poisoned
+          ? "poisoned-unrelated/v1"
+          : target.failureFingerprint,
+        context: versionDrift
+          ? { ...target.context, codeVersion: `drift-${index}` }
+          : target.context,
+        result: {
+          outcome: index % 11 === 0 ? "rejected" : "validated",
+          evidenceIds: [`result-${index}`],
+        },
+      }),
+    );
+  }
+
+  const finding = ledger.findingFor(target);
+  assert.equal(ledger.size, 10_000);
+  assert.equal(await ledger.verify(), true);
+  assert.equal(
+    finding.comparableExperiments,
+    ledger
+      .entries()
+      .filter(
+        ({ experiment: item }) =>
+          item.failureFingerprint === target.failureFingerprint &&
+          item.context.codeVersion === target.context.codeVersion,
+      ).length,
+  );
+  assert.equal(finding.experimentIds.includes("scale-5"), false);
+  assert.equal(finding.experimentIds.includes("scale-7"), false);
+});

--- a/desktop/src/features/agents/lib/causalLedger.ts
+++ b/desktop/src/features/agents/lib/causalLedger.ts
@@ -30,6 +30,11 @@ export type CausalExperiment = {
     approvedAt?: string;
   };
   result: { outcome: ExperimentOutcome; evidenceIds: string[] };
+  evaluation?: {
+    evaluator: "owner-independent";
+    rationale: string;
+    evaluatedAt: string;
+  };
   coverage: Record<string, EvidenceCoverage>;
   relations: {
     supports: string[];

--- a/desktop/src/features/agents/lib/causalLedger.ts
+++ b/desktop/src/features/agents/lib/causalLedger.ts
@@ -23,7 +23,12 @@ export type CausalExperiment = {
     environmentVersion: string;
   };
   hypothesis: { cause: string; evidenceIds: string[] };
-  intervention: { remedyId: string; changedVariable: string };
+  intervention: {
+    remedyId: string;
+    changedVariable: string;
+    successCriteria?: string;
+    approvedAt?: string;
+  };
   result: { outcome: ExperimentOutcome; evidenceIds: string[] };
   coverage: Record<string, EvidenceCoverage>;
   relations: {

--- a/desktop/src/features/agents/lib/causalLedger.ts
+++ b/desktop/src/features/agents/lib/causalLedger.ts
@@ -1,0 +1,211 @@
+export const CAUSAL_EXPERIMENT_SCHEMA = "causal-experiment/v1" as const;
+
+export type ExperimentOutcome =
+  | "validated"
+  | "rejected"
+  | "inconclusive"
+  | "untested";
+
+export type EvidenceCoverage = "observed" | "missing";
+
+export type CausalExperiment = {
+  schema: typeof CAUSAL_EXPERIMENT_SCHEMA;
+  experimentId: string;
+  recordedAt: string;
+  task: { description: string; sourceMessageId: string | null };
+  execution: { sessionId: string; turnId: string; replayOf: string | null };
+  failureFingerprint: string;
+  context: {
+    codeVersion: string;
+    policyVersion: string;
+    modelVersion: string;
+    toolVersion: string;
+    environmentVersion: string;
+  };
+  hypothesis: { cause: string; evidenceIds: string[] };
+  intervention: { remedyId: string; changedVariable: string };
+  result: { outcome: ExperimentOutcome; evidenceIds: string[] };
+  coverage: Record<string, EvidenceCoverage>;
+  relations: {
+    supports: string[];
+    contradicts: string[];
+    invalidates: string[];
+  };
+};
+
+export type LedgerEntry = {
+  sequence: number;
+  previousHash: string;
+  hash: string;
+  experiment: CausalExperiment;
+};
+
+export type CausalFinding = {
+  comparableExperiments: number;
+  validated: number;
+  rejected: number;
+  inconclusive: number;
+  confidence: number;
+  experimentIds: string[];
+};
+
+const GENESIS_HASH = "0".repeat(64);
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonical(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+function sameContext(
+  left: CausalExperiment["context"],
+  right: CausalExperiment["context"],
+): boolean {
+  return canonical(left) === canonical(right);
+}
+
+function hasCompleteCoverage(experiment: CausalExperiment): boolean {
+  return Object.values(experiment.coverage).every(
+    (value) => value === "observed",
+  );
+}
+
+function immutableClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map(immutableClone)) as T;
+  }
+  if (value && typeof value === "object") {
+    const clone = Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        immutableClone(entry),
+      ]),
+    );
+    return Object.freeze(clone) as T;
+  }
+  return value;
+}
+
+export class CausalLedger {
+  readonly #entries: LedgerEntry[] = [];
+  readonly #ids = new Set<string>();
+
+  get size(): number {
+    return this.#entries.length;
+  }
+
+  entries(): readonly LedgerEntry[] {
+    return this.#entries;
+  }
+
+  toJournal(): string {
+    return this.#entries.map((entry) => canonical(entry)).join("\n");
+  }
+
+  static async fromJournal(journal: string): Promise<CausalLedger> {
+    const ledger = new CausalLedger();
+    const lines = journal.split("\n").filter((line) => line.trim());
+    for (const line of lines) {
+      const persisted = JSON.parse(line) as LedgerEntry;
+      const restored = await ledger.append(persisted.experiment);
+      if (
+        restored.sequence !== persisted.sequence ||
+        restored.previousHash !== persisted.previousHash ||
+        restored.hash !== persisted.hash
+      ) {
+        throw new Error(
+          `Causal ledger integrity failure at sequence ${persisted.sequence}`,
+        );
+      }
+    }
+    return ledger;
+  }
+
+  async append(experiment: CausalExperiment): Promise<LedgerEntry> {
+    if (experiment.schema !== CAUSAL_EXPERIMENT_SCHEMA) {
+      throw new Error(
+        `Unsupported causal experiment schema: ${experiment.schema}`,
+      );
+    }
+    if (this.#ids.has(experiment.experimentId)) {
+      throw new Error(
+        `Duplicate causal experiment: ${experiment.experimentId}`,
+      );
+    }
+    const sequence = this.#entries.length + 1;
+    const previousHash = this.#entries.at(-1)?.hash ?? GENESIS_HASH;
+    const frozenExperiment = immutableClone(experiment);
+    const hash = await sha256(
+      canonical({ sequence, previousHash, experiment: frozenExperiment }),
+    );
+    const entry = Object.freeze({
+      sequence,
+      previousHash,
+      hash,
+      experiment: frozenExperiment,
+    });
+    this.#entries.push(entry);
+    this.#ids.add(experiment.experimentId);
+    return entry;
+  }
+
+  async verify(): Promise<boolean> {
+    let previousHash = GENESIS_HASH;
+    for (const entry of this.#entries) {
+      if (entry.previousHash !== previousHash) return false;
+      const expected = await sha256(
+        canonical({
+          sequence: entry.sequence,
+          previousHash: entry.previousHash,
+          experiment: entry.experiment,
+        }),
+      );
+      if (entry.hash !== expected) return false;
+      previousHash = entry.hash;
+    }
+    return true;
+  }
+
+  findingFor(target: CausalExperiment): CausalFinding {
+    const comparable = this.#entries
+      .map((entry) => entry.experiment)
+      .filter(
+        (experiment) =>
+          experiment.failureFingerprint === target.failureFingerprint &&
+          experiment.intervention.remedyId === target.intervention.remedyId &&
+          sameContext(experiment.context, target.context),
+      );
+    const validated = comparable.filter(
+      (experiment) => experiment.result.outcome === "validated",
+    ).length;
+    const rejected = comparable.filter(
+      (experiment) => experiment.result.outcome === "rejected",
+    ).length;
+    const inconclusive = comparable.length - validated - rejected;
+    const complete = comparable.filter(hasCompleteCoverage).length;
+    const decisive = validated + rejected;
+    const evidenceFactor = comparable.length ? complete / comparable.length : 0;
+    const confidence = decisive ? (validated / decisive) * evidenceFactor : 0;
+    return {
+      comparableExperiments: comparable.length,
+      validated,
+      rejected,
+      inconclusive,
+      confidence,
+      experimentIds: comparable.map((experiment) => experiment.experimentId),
+    };
+  }
+}

--- a/desktop/src/features/agents/lib/causalReplayProposal.test.mjs
+++ b/desktop/src/features/agents/lib/causalReplayProposal.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildApprovedReplayProposal } from "./causalReplayProposal.ts";
+
+const candidate = {
+  schema: "causal-experiment/v1",
+  experimentId: "live:agent:session-1",
+  recordedAt: "2026-08-05T00:00:00Z",
+  task: { description: "Write the file", sourceMessageId: "message-1" },
+  execution: { sessionId: "session-1", turnId: "turn-1", replayOf: null },
+  failureFingerprint: "unclassified-live-candidate/v1",
+  context: {
+    codeVersion: "code-1",
+    policyVersion: "policy-1",
+    modelVersion: "model-1",
+    toolVersion: "tool-1",
+    environmentVersion: "env-1",
+  },
+  hypothesis: { cause: "unclassified", evidenceIds: [] },
+  intervention: { remedyId: "unclassified", changedVariable: "unclassified" },
+  result: { outcome: "untested", evidenceIds: ["receipt-1"] },
+  coverage: { acp_observer: "observed", os_sandbox: "missing" },
+  relations: { supports: [], contradicts: [], invalidates: [] },
+};
+
+test("builds one owner-approved controlled replay without inventing a result", () => {
+  const proposal = buildApprovedReplayProposal(
+    candidate,
+    {
+      failureFingerprint: "host-write-bypass/v1",
+      cause: "The host tool bypassed the governed path",
+      changedVariable: "execution path: host tool → ACP workspace tool",
+      successCriteria:
+        "Permission is requested before the write and the task succeeds",
+    },
+    { experimentId: "proposal-1", recordedAt: "2026-08-05T01:00:00Z" },
+  );
+
+  assert.equal(proposal.execution.replayOf, candidate.experimentId);
+  assert.equal(proposal.intervention.approvedAt, "2026-08-05T01:00:00Z");
+  assert.equal(proposal.result.outcome, "untested");
+  assert.deepEqual(proposal.result.evidenceIds, []);
+  assert.deepEqual(proposal.hypothesis.evidenceIds, ["receipt-1"]);
+});
+
+test("requires every causal and evaluation field before approval", () => {
+  assert.throws(
+    () =>
+      buildApprovedReplayProposal(
+        candidate,
+        {
+          failureFingerprint: "host-write-bypass/v1",
+          cause: "A cause",
+          changedVariable: "one variable",
+          successCriteria: " ",
+        },
+        { experimentId: "proposal-1", recordedAt: "2026-08-05T01:00:00Z" },
+      ),
+    /Success criteria is required/,
+  );
+});
+
+test("refuses to replay an already evaluated candidate", () => {
+  assert.throws(
+    () =>
+      buildApprovedReplayProposal(
+        { ...candidate, result: { outcome: "validated", evidenceIds: [] } },
+        {
+          failureFingerprint: "failure/v1",
+          cause: "A cause",
+          changedVariable: "one variable",
+          successCriteria: "A measured result",
+        },
+        { experimentId: "proposal-1", recordedAt: "2026-08-05T01:00:00Z" },
+      ),
+    /Only an untested candidate/,
+  );
+});

--- a/desktop/src/features/agents/lib/causalReplayProposal.test.mjs
+++ b/desktop/src/features/agents/lib/causalReplayProposal.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildApprovedReplayProposal } from "./causalReplayProposal.ts";
+import {
+  buildApprovedReplayProposal,
+  buildIndependentEvaluation,
+  buildReplayDispatchMessage,
+  buildReplayDispatchReceipt,
+  proposalIdFromReplayTask,
+} from "./causalReplayProposal.ts";
 
 const candidate = {
   schema: "causal-experiment/v1",
@@ -75,5 +81,82 @@ test("refuses to replay an already evaluated candidate", () => {
         { experimentId: "proposal-1", recordedAt: "2026-08-05T01:00:00Z" },
       ),
     /Only an untested candidate/,
+  );
+});
+
+test("dispatches an approved replay with a durable correlation marker", () => {
+  const proposal = buildApprovedReplayProposal(
+    candidate,
+    {
+      failureFingerprint: "failure/v1",
+      cause: "A cause",
+      changedVariable: "one variable",
+      successCriteria: "A measured result",
+    },
+    { experimentId: "proposal-1", recordedAt: "2026-08-05T01:00:00Z" },
+  );
+  const message = buildReplayDispatchMessage(proposal);
+  assert.equal(proposalIdFromReplayTask(message), "proposal-1");
+  assert.match(message, /disposable workspace/);
+  assert.match(message, /Change exactly one variable: one variable/);
+
+  const receipt = buildReplayDispatchReceipt(
+    proposal,
+    "event-1",
+    "2026-08-05T01:01:00Z",
+  );
+  assert.equal(receipt.task.sourceMessageId, "event-1");
+  assert.equal(receipt.execution.replayOf, proposal.experimentId);
+  assert.deepEqual(receipt.result.evidenceIds, ["message:event-1"]);
+});
+
+test("requires cited evidence before sealing an independent verdict", () => {
+  const replay = {
+    ...candidate,
+    experimentId: "replay-1",
+    execution: { ...candidate.execution, replayOf: "proposal-1" },
+  };
+  assert.throws(
+    () =>
+      buildIndependentEvaluation(
+        replay,
+        { outcome: "validated", evidenceIds: " ", rationale: "It worked" },
+        { experimentId: "evaluation-1", recordedAt: "2026-08-05T02:00:00Z" },
+      ),
+    /At least one evidence ID/,
+  );
+  const evaluation = buildIndependentEvaluation(
+    replay,
+    {
+      outcome: "rejected",
+      evidenceIds: "observer:1\nreceipt:2",
+      rationale: "The success criterion was not met.",
+    },
+    { experimentId: "evaluation-1", recordedAt: "2026-08-05T02:00:00Z" },
+  );
+  assert.equal(evaluation.execution.replayOf, replay.experimentId);
+  assert.equal(evaluation.result.outcome, "rejected");
+  assert.deepEqual(evaluation.relations.contradicts, [replay.experimentId]);
+  assert.equal(evaluation.evaluation.evaluator, "owner-independent");
+});
+
+test("refuses to validate a replay while an execution layer is missing", () => {
+  const replay = {
+    ...candidate,
+    experimentId: "replay-1",
+    execution: { ...candidate.execution, replayOf: "proposal-1" },
+  };
+  assert.throws(
+    () =>
+      buildIndependentEvaluation(
+        replay,
+        {
+          outcome: "validated",
+          evidenceIds: "observer:1",
+          rationale: "The observed portion worked.",
+        },
+        { experimentId: "evaluation-1", recordedAt: "2026-08-05T02:00:00Z" },
+      ),
+    /missing coverage cannot be validated/,
   );
 });

--- a/desktop/src/features/agents/lib/causalReplayProposal.ts
+++ b/desktop/src/features/agents/lib/causalReplayProposal.ts
@@ -10,6 +10,8 @@ export type ReplayProposalInput = {
   successCriteria: string;
 };
 
+const REPLAY_MARKER_PREFIX = "buzz-controlled-replay:";
+
 function required(label: string, value: string): string {
   const normalized = value.trim();
   if (!normalized) throw new Error(`${label} is required.`);
@@ -61,6 +63,106 @@ export function buildApprovedReplayProposal(
     relations: {
       supports: [],
       contradicts: [],
+      invalidates: [],
+    },
+  };
+}
+
+export function replayMarker(proposalId: string): string {
+  return `[${REPLAY_MARKER_PREFIX}${proposalId}]`;
+}
+
+export function proposalIdFromReplayTask(description: string): string | null {
+  const start = description.indexOf(`[${REPLAY_MARKER_PREFIX}`);
+  if (start < 0) return null;
+  const valueStart = start + REPLAY_MARKER_PREFIX.length + 1;
+  const end = description.indexOf("]", valueStart);
+  const value = end < 0 ? "" : description.slice(valueStart, end).trim();
+  return value || null;
+}
+
+export function buildReplayDispatchMessage(proposal: CausalExperiment): string {
+  if (
+    !proposal.intervention.approvedAt ||
+    !proposal.intervention.successCriteria
+  ) {
+    throw new Error("The replay must be approved before it can run.");
+  }
+  return [
+    replayMarker(proposal.experimentId),
+    "Run this as a controlled verification replay in a disposable workspace.",
+    `Original task: ${proposal.task.description}`,
+    `Change exactly one variable: ${proposal.intervention.changedVariable}`,
+    `Keep fixed: code, model, tools, policy, and environment versions unless that named variable explicitly changes one of them.`,
+    `Success criteria: ${proposal.intervention.successCriteria}`,
+    "Report observable evidence and do not claim the remedy is validated; an independent owner evaluation happens after this turn.",
+  ].join("\n\n");
+}
+
+export function buildReplayDispatchReceipt(
+  proposal: CausalExperiment,
+  eventId: string,
+  recordedAt: string,
+): CausalExperiment {
+  if (!proposal.intervention.approvedAt) {
+    throw new Error("The replay must be approved before it can be dispatched.");
+  }
+  return {
+    ...proposal,
+    experimentId: `dispatch:${proposal.experimentId}:${eventId}`,
+    recordedAt,
+    task: { ...proposal.task, sourceMessageId: eventId },
+    execution: {
+      sessionId: `replay-dispatch:${eventId}`,
+      turnId: "awaiting-agent-session",
+      replayOf: proposal.experimentId,
+    },
+    result: { outcome: "untested", evidenceIds: [`message:${eventId}`] },
+    relations: { supports: [], contradicts: [], invalidates: [] },
+  };
+}
+
+export function buildIndependentEvaluation(
+  replay: CausalExperiment,
+  input: {
+    outcome: Exclude<CausalExperiment["result"]["outcome"], "untested">;
+    evidenceIds: string;
+    rationale: string;
+  },
+  identity: { experimentId: string; recordedAt: string },
+): CausalExperiment {
+  if (replay.result.outcome !== "untested" || !replay.execution.replayOf) {
+    throw new Error("Only a completed, unevaluated replay can be evaluated.");
+  }
+  const evidenceIds = input.evidenceIds
+    .split(/[\n,]/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (!evidenceIds.length)
+    throw new Error("At least one evidence ID is required.");
+  if (
+    input.outcome === "validated" &&
+    Object.values(replay.coverage).some((coverage) => coverage !== "observed")
+  ) {
+    throw new Error(
+      "A replay with missing coverage cannot be validated; choose inconclusive or rejected.",
+    );
+  }
+  const rationale = required("Evaluation rationale", input.rationale);
+  return {
+    ...replay,
+    experimentId: identity.experimentId,
+    recordedAt: identity.recordedAt,
+    execution: { ...replay.execution, replayOf: replay.experimentId },
+    result: { outcome: input.outcome, evidenceIds },
+    evaluation: {
+      evaluator: "owner-independent",
+      rationale,
+      evaluatedAt: identity.recordedAt,
+    },
+    relations: {
+      supports: input.outcome === "validated" ? [replay.experimentId] : [],
+      contradicts: input.outcome === "rejected" ? [replay.experimentId] : [],
       invalidates: [],
     },
   };

--- a/desktop/src/features/agents/lib/causalReplayProposal.ts
+++ b/desktop/src/features/agents/lib/causalReplayProposal.ts
@@ -1,0 +1,67 @@
+import {
+  CAUSAL_EXPERIMENT_SCHEMA,
+  type CausalExperiment,
+} from "./causalLedger";
+
+export type ReplayProposalInput = {
+  failureFingerprint: string;
+  cause: string;
+  changedVariable: string;
+  successCriteria: string;
+};
+
+function required(label: string, value: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required.`);
+  return normalized;
+}
+
+export function buildApprovedReplayProposal(
+  candidate: CausalExperiment,
+  input: ReplayProposalInput,
+  identity: { experimentId: string; recordedAt: string },
+): CausalExperiment {
+  if (candidate.result.outcome !== "untested") {
+    throw new Error(
+      "Only an untested candidate can start a controlled replay.",
+    );
+  }
+  const failureFingerprint = required(
+    "Failure fingerprint",
+    input.failureFingerprint,
+  );
+  const cause = required("Cause hypothesis", input.cause);
+  const changedVariable = required("Changed variable", input.changedVariable);
+  const successCriteria = required("Success criteria", input.successCriteria);
+
+  return {
+    schema: CAUSAL_EXPERIMENT_SCHEMA,
+    experimentId: identity.experimentId,
+    recordedAt: identity.recordedAt,
+    task: candidate.task,
+    execution: {
+      sessionId: `replay-proposal:${candidate.execution.sessionId}`,
+      turnId: "pending-owner-approved-replay",
+      replayOf: candidate.experimentId,
+    },
+    failureFingerprint,
+    context: candidate.context,
+    hypothesis: {
+      cause,
+      evidenceIds: [...candidate.result.evidenceIds],
+    },
+    intervention: {
+      remedyId: `remedy:${identity.experimentId}`,
+      changedVariable,
+      successCriteria,
+      approvedAt: identity.recordedAt,
+    },
+    result: { outcome: "untested", evidenceIds: [] },
+    coverage: candidate.coverage,
+    relations: {
+      supports: [],
+      contradicts: [],
+      invalidates: [],
+    },
+  };
+}

--- a/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
@@ -72,3 +72,66 @@ test("restores the candidate after restart and does not duplicate terminal repla
   await restarted.ingest("agent", observer(1, "turn_completed"));
   assert.equal((await restarted.entries()).length, 1);
 });
+
+test("links a marked terminal replay to its approved proposal", async () => {
+  const storage = memoryStorage();
+  const persistence = browserLedgerPersistence("owner", storage);
+  const ledger = new LiveCausalLedger("owner", persistence);
+  const approved = {
+    schema: "causal-experiment/v1",
+    experimentId: "proposal-1",
+    recordedAt: "2026-08-05T00:00:00Z",
+    task: { description: "Write the file", sourceMessageId: "message-1" },
+    execution: {
+      sessionId: "proposal",
+      turnId: "pending",
+      replayOf: "candidate-1",
+    },
+    failureFingerprint: "host-write/v1",
+    context: {
+      codeVersion: "code-1",
+      policyVersion: "policy-1",
+      modelVersion: "model-1",
+      toolVersion: "tool-1",
+      environmentVersion: "env-1",
+    },
+    hypothesis: { cause: "Host bypass", evidenceIds: ["evidence-1"] },
+    intervention: {
+      remedyId: "remedy-1",
+      changedVariable: "tool path",
+      successCriteria: "Permission before write",
+      approvedAt: "2026-08-05T00:00:00Z",
+    },
+    result: { outcome: "untested", evidenceIds: [] },
+    coverage: { acp_observer: "observed", os_sandbox: "missing" },
+    relations: { supports: [], contradicts: [], invalidates: [] },
+  };
+  const seed = new (await import("./causalLedger.ts")).CausalLedger();
+  await persistence.appendEntry(await seed.append(approved));
+  await persistence.appendEntry(
+    await seed.append({
+      ...approved,
+      experimentId: "dispatch-1",
+      task: { ...approved.task, sourceMessageId: "dispatch-1" },
+      execution: {
+        sessionId: "replay-dispatch:dispatch-1",
+        turnId: "awaiting-agent-session",
+        replayOf: approved.experimentId,
+      },
+      result: { outcome: "untested", evidenceIds: ["message:dispatch-1"] },
+    }),
+  );
+  await ledger.ingest(
+    "agent",
+    observer(1, "task_captured", {
+      description: "[buzz-controlled-replay:proposal-1]\n\nRun it",
+      sourceMessageId: "dispatch-1",
+    }),
+  );
+  await ledger.ingest("agent", observer(2, "turn_completed"));
+  const replay = (await ledger.entries()).at(-1).experiment;
+  assert.equal(replay.execution.replayOf, "proposal-1");
+  assert.equal(replay.failureFingerprint, approved.failureFingerprint);
+  assert.equal(replay.intervention.changedVariable, "tool path");
+  assert.equal(replay.result.outcome, "untested");
+});

--- a/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
@@ -83,7 +83,8 @@ test("captures the task and OS failure from raw ACP evidence", async () => {
       params: {
         update: {
           sessionUpdate: "tool_call_update",
-          status: "failed",
+          toolCallId: "touch-library",
+          status: "in_progress",
           content: [
             {
               type: "text",
@@ -94,7 +95,21 @@ test("captures the task and OS failure from raw ACP evidence", async () => {
       },
     }),
   );
-  await ledger.ingest("agent", observer(3, "turn_completed"));
+  await ledger.ingest(
+    "agent",
+    observer(3, "acp_read", {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "touch-library",
+          status: "failed",
+          content: [],
+        },
+      },
+    }),
+  );
+  await ledger.ingest("agent", observer(4, "turn_completed"));
 
   const [entry] = await ledger.entries();
   assert.equal(

--- a/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LiveCausalLedger } from "./liveCausalLedger.ts";
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function observer(seq, kind, payload = {}) {
+  return {
+    seq,
+    timestamp: `2026-08-05T18:5${seq}:00Z`,
+    kind,
+    agentIndex: 0,
+    channelId: "2db0f46d",
+    sessionId: "live-session-1",
+    turnId: "turn-1",
+    payload,
+  };
+}
+
+test("automatically closes a live session into an owner-local candidate", async () => {
+  const storage = memoryStorage();
+  const ledger = new LiveCausalLedger("OWNER", storage);
+  await ledger.ingest(
+    "agent",
+    observer(1, "task_captured", {
+      description: "Wire this session into the causal ledger",
+      sourceMessageId: "414ccec",
+    }),
+  );
+  await ledger.ingest(
+    "agent",
+    observer(2, "permission_decision", {
+      decision: "allow_once",
+    }),
+  );
+  await ledger.ingest("agent", observer(3, "turn_completed"));
+
+  const [entry] = await ledger.entries();
+  assert.equal(entry.experiment.result.outcome, "untested");
+  assert.equal(entry.experiment.task.sourceMessageId, "414ccec");
+  assert.equal(entry.experiment.coverage.acp_permission_gate, "observed");
+  assert.equal(entry.experiment.coverage.host_workspace, "missing");
+  assert.equal(entry.experiment.coverage.os_sandbox, "missing");
+  assert.ok(storage.getItem(ledger.storageKey));
+});
+
+test("restores the candidate after restart and does not duplicate terminal replay", async () => {
+  const storage = memoryStorage();
+  const first = new LiveCausalLedger("owner", storage);
+  await first.ingest("agent", observer(1, "turn_completed"));
+
+  const restarted = new LiveCausalLedger("owner", storage);
+  await restarted.ingest("agent", observer(1, "turn_completed"));
+  assert.equal((await restarted.entries()).length, 1);
+});

--- a/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
@@ -57,6 +57,71 @@ test("automatically closes a live session into an owner-local candidate", async 
   assert.ok(storage.getItem(ledger.storageKey));
 });
 
+test("captures the task and OS failure from raw ACP evidence", async () => {
+  const ledger = new LiveCausalLedger(
+    "owner",
+    browserLedgerPersistence("owner", memoryStorage()),
+  );
+  await ledger.ingest(
+    "agent",
+    observer(1, "acp_write", {
+      method: "session/prompt",
+      params: {
+        prompt: [
+          {
+            type: "text",
+            text: `[Buzz event: @mention]\nEvent ID: ${"a".repeat(64)}\nContent: Touch the protected file once.`,
+          },
+        ],
+      },
+    }),
+  );
+  await ledger.ingest(
+    "agent",
+    observer(2, "acp_read", {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "tool_call_update",
+          status: "failed",
+          content: [
+            {
+              type: "text",
+              text: "touch: /Library/file: Permission denied",
+            },
+          ],
+        },
+      },
+    }),
+  );
+  await ledger.ingest("agent", observer(3, "turn_completed"));
+
+  const [entry] = await ledger.entries();
+  assert.equal(
+    entry.experiment.task.description,
+    "Touch the protected file once.",
+  );
+  assert.equal(entry.experiment.task.sourceMessageId, "a".repeat(64));
+  assert.equal(entry.experiment.coverage.os_sandbox, "observed");
+});
+
+test("records each turn in a reused session as its own candidate", async () => {
+  const ledger = new LiveCausalLedger(
+    "owner",
+    browserLedgerPersistence("owner", memoryStorage()),
+  );
+  await ledger.ingest("agent", observer(1, "turn_completed"));
+  await ledger.ingest("agent", {
+    ...observer(2, "turn_completed"),
+    turnId: "turn-2",
+  });
+
+  const entries = await ledger.entries();
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].experiment.execution.turnId, "turn-1");
+  assert.equal(entries[1].experiment.execution.turnId, "turn-2");
+});
+
 test("restores the candidate after restart and does not duplicate terminal replay", async () => {
   const storage = memoryStorage();
   const first = new LiveCausalLedger(

--- a/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
+++ b/desktop/src/features/agents/lib/liveCausalLedger.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { LiveCausalLedger } from "./liveCausalLedger.ts";
+import {
+  browserLedgerPersistence,
+  LiveCausalLedger,
+} from "./liveCausalLedger.ts";
 
 function memoryStorage() {
   const values = new Map();
@@ -26,7 +29,10 @@ function observer(seq, kind, payload = {}) {
 
 test("automatically closes a live session into an owner-local candidate", async () => {
   const storage = memoryStorage();
-  const ledger = new LiveCausalLedger("OWNER", storage);
+  const ledger = new LiveCausalLedger(
+    "OWNER",
+    browserLedgerPersistence("OWNER", storage),
+  );
   await ledger.ingest(
     "agent",
     observer(1, "task_captured", {
@@ -53,10 +59,16 @@ test("automatically closes a live session into an owner-local candidate", async 
 
 test("restores the candidate after restart and does not duplicate terminal replay", async () => {
   const storage = memoryStorage();
-  const first = new LiveCausalLedger("owner", storage);
+  const first = new LiveCausalLedger(
+    "owner",
+    browserLedgerPersistence("owner", storage),
+  );
   await first.ingest("agent", observer(1, "turn_completed"));
 
-  const restarted = new LiveCausalLedger("owner", storage);
+  const restarted = new LiveCausalLedger(
+    "owner",
+    browserLedgerPersistence("owner", storage),
+  );
   await restarted.ingest("agent", observer(1, "turn_completed"));
   assert.equal((await restarted.entries()).length, 1);
 });

--- a/desktop/src/features/agents/lib/liveCausalLedger.ts
+++ b/desktop/src/features/agents/lib/liveCausalLedger.ts
@@ -5,7 +5,31 @@ import {
   type CausalExperiment,
 } from "./causalLedger";
 
-type JournalStorage = Pick<Storage, "getItem" | "setItem">;
+export type CausalLedgerPersistence = {
+  loadJournal(): Promise<string>;
+  appendEntry(entry: import("./causalLedger").LedgerEntry): Promise<void>;
+};
+
+export function browserLedgerPersistence(
+  owner: string,
+  storage: Pick<Storage, "getItem" | "setItem">,
+): CausalLedgerPersistence {
+  const storageKey = `buzz-causal-ledger.v1:${owner.toLowerCase()}`;
+  return {
+    async loadJournal() {
+      return storage.getItem(storageKey) ?? "";
+    },
+    async appendEntry(entry) {
+      const existing = storage.getItem(storageKey);
+      storage.setItem(
+        storageKey,
+        existing
+          ? `${existing}\n${JSON.stringify(entry)}`
+          : JSON.stringify(entry),
+      );
+    },
+  };
+}
 
 function payload(event: ObserverEvent): Record<string, unknown> {
   return event.payload && typeof event.payload === "object"
@@ -22,16 +46,16 @@ function eventId(event: ObserverEvent): string {
 }
 
 export class LiveCausalLedger {
-  readonly #storage: JournalStorage;
+  readonly #persistence: CausalLedgerPersistence;
   readonly #owner: string;
   readonly #sessions = new Map<string, ObserverEvent[]>();
   #ledger = new CausalLedger();
   #ready: Promise<void>;
   #writes: Promise<void> = Promise.resolve();
 
-  constructor(owner: string, storage: JournalStorage) {
+  constructor(owner: string, persistence: CausalLedgerPersistence) {
     this.#owner = owner.toLowerCase();
-    this.#storage = storage;
+    this.#persistence = persistence;
     this.#ready = this.#restore();
   }
 
@@ -40,7 +64,7 @@ export class LiveCausalLedger {
   }
 
   async #restore() {
-    const journal = this.#storage.getItem(this.storageKey);
+    const journal = await this.#persistence.loadJournal();
     if (journal) this.#ledger = await CausalLedger.fromJournal(journal);
   }
 
@@ -64,10 +88,10 @@ export class LiveCausalLedger {
         this.#sessions.delete(key);
         return;
       }
-      await this.#ledger.append(
+      const entry = await this.#ledger.append(
         this.#candidate(experimentId, event.sessionId, event.turnId, session),
       );
-      this.#storage.setItem(this.storageKey, this.#ledger.toJournal());
+      await this.#persistence.appendEntry(entry);
       this.#sessions.delete(key);
     });
     return this.#writes;

--- a/desktop/src/features/agents/lib/liveCausalLedger.ts
+++ b/desktop/src/features/agents/lib/liveCausalLedger.ts
@@ -1,0 +1,136 @@
+import type { ObserverEvent } from "../ui/agentSessionTypes";
+import {
+  CAUSAL_EXPERIMENT_SCHEMA,
+  CausalLedger,
+  type CausalExperiment,
+} from "./causalLedger";
+
+type JournalStorage = Pick<Storage, "getItem" | "setItem">;
+
+function payload(event: ObserverEvent): Record<string, unknown> {
+  return event.payload && typeof event.payload === "object"
+    ? (event.payload as Record<string, unknown>)
+    : {};
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function eventId(event: ObserverEvent): string {
+  return `observer:${event.sessionId ?? "unknown"}:${event.seq}:${event.timestamp}`;
+}
+
+export class LiveCausalLedger {
+  readonly #storage: JournalStorage;
+  readonly #owner: string;
+  readonly #sessions = new Map<string, ObserverEvent[]>();
+  #ledger = new CausalLedger();
+  #ready: Promise<void>;
+  #writes: Promise<void> = Promise.resolve();
+
+  constructor(owner: string, storage: JournalStorage) {
+    this.#owner = owner.toLowerCase();
+    this.#storage = storage;
+    this.#ready = this.#restore();
+  }
+
+  get storageKey(): string {
+    return `buzz-causal-ledger.v1:${this.#owner}`;
+  }
+
+  async #restore() {
+    const journal = this.#storage.getItem(this.storageKey);
+    if (journal) this.#ledger = await CausalLedger.fromJournal(journal);
+  }
+
+  ingest(agentPubkey: string, event: ObserverEvent): Promise<void> {
+    this.#writes = this.#writes.then(async () => {
+      await this.#ready;
+      if (!event.sessionId) return;
+      const key = `${agentPubkey.toLowerCase()}:${event.sessionId}`;
+      const session = this.#sessions.get(key) ?? [];
+      session.push(event);
+      this.#sessions.set(key, session);
+      if (event.kind !== "turn_completed" && event.kind !== "turn_error")
+        return;
+
+      const experimentId = `live:${agentPubkey.toLowerCase()}:${event.sessionId}`;
+      if (
+        this.#ledger
+          .entries()
+          .some((entry) => entry.experiment.experimentId === experimentId)
+      ) {
+        this.#sessions.delete(key);
+        return;
+      }
+      await this.#ledger.append(
+        this.#candidate(experimentId, event.sessionId, event.turnId, session),
+      );
+      this.#storage.setItem(this.storageKey, this.#ledger.toJournal());
+      this.#sessions.delete(key);
+    });
+    return this.#writes;
+  }
+
+  async entries() {
+    await this.#ready;
+    await this.#writes;
+    return this.#ledger.entries();
+  }
+
+  #candidate(
+    experimentId: string,
+    sessionId: string,
+    turnId: string | null,
+    events: ObserverEvent[],
+  ): CausalExperiment {
+    const taskEvent = events.find((event) => event.kind === "task_captured");
+    const taskPayload = taskEvent ? payload(taskEvent) : {};
+    const layers = new Set(
+      events.map((event) => {
+        if (event.kind === "host_operation") return "host_workspace";
+        if (event.kind === "permission_decision") return "acp_permission_gate";
+        return "acp_observer";
+      }),
+    );
+    return {
+      schema: CAUSAL_EXPERIMENT_SCHEMA,
+      experimentId,
+      recordedAt: events.at(-1)?.timestamp ?? new Date().toISOString(),
+      task: {
+        description:
+          text(taskPayload.description) ??
+          "Task unavailable from observer evidence",
+        sourceMessageId: text(taskPayload.sourceMessageId),
+      },
+      execution: { sessionId, turnId: turnId ?? "unknown", replayOf: null },
+      failureFingerprint: "unclassified-live-candidate/v1",
+      context: {
+        codeVersion: "unknown",
+        policyVersion: "unknown",
+        modelVersion: "unknown",
+        toolVersion: "buzz-acp-observer/v1",
+        environmentVersion: "unknown",
+      },
+      hypothesis: { cause: "unclassified", evidenceIds: [] },
+      intervention: {
+        remedyId: "unclassified",
+        changedVariable: "unclassified",
+      },
+      result: {
+        outcome: "untested",
+        evidenceIds: events.map(eventId),
+      },
+      coverage: {
+        acp_observer: layers.has("acp_observer") ? "observed" : "missing",
+        acp_permission_gate: layers.has("acp_permission_gate")
+          ? "observed"
+          : "missing",
+        host_workspace: layers.has("host_workspace") ? "observed" : "missing",
+        os_sandbox: "missing",
+      },
+      relations: { supports: [], contradicts: [], invalidates: [] },
+    };
+  }
+}

--- a/desktop/src/features/agents/lib/liveCausalLedger.ts
+++ b/desktop/src/features/agents/lib/liveCausalLedger.ts
@@ -92,19 +92,23 @@ function taskFromEvents(events: readonly ObserverEvent[]): {
 }
 
 function hasOsSandboxEvidence(events: readonly ObserverEvent[]): boolean {
-  return events.some((event) => {
-    if (event.kind !== "acp_read") return false;
+  const toolOutputById = new Map<string, string>();
+  for (const event of events) {
+    if (event.kind !== "acp_read") continue;
     const eventPayload = payload(event);
-    if (asString(eventPayload.method) !== "session/update") return false;
+    if (asString(eventPayload.method) !== "session/update") continue;
     const update = asRecord(asRecord(eventPayload.params).update);
-    return (
-      asString(update.sessionUpdate) === "tool_call_update" &&
-      asString(update.status) === "failed" &&
-      /permission denied|operation not permitted/i.test(
-        extractToolResult(update),
-      )
-    );
-  });
+    if (asString(update.sessionUpdate) !== "tool_call_update") continue;
+    const toolCallId = asString(update.toolCallId);
+    const output = extractToolResult(update);
+    if (toolCallId && output) toolOutputById.set(toolCallId, output);
+    if (asString(update.status) !== "failed") continue;
+    const detail = output || (toolCallId ? toolOutputById.get(toolCallId) : "");
+    if (/permission denied|operation not permitted/i.test(detail ?? "")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export class LiveCausalLedger {

--- a/desktop/src/features/agents/lib/liveCausalLedger.ts
+++ b/desktop/src/features/agents/lib/liveCausalLedger.ts
@@ -4,6 +4,7 @@ import {
   CausalLedger,
   type CausalExperiment,
 } from "./causalLedger";
+import { proposalIdFromReplayTask } from "./causalReplayProposal";
 
 export type CausalLedgerPersistence = {
   loadJournal(): Promise<string>;
@@ -79,6 +80,14 @@ export class LiveCausalLedger {
       if (event.kind !== "turn_completed" && event.kind !== "turn_error")
         return;
 
+      // Owner actions can append approvals/evaluations while this live ingestor
+      // remains mounted. Refresh before closing the turn so correlation and the
+      // next hash are based on the same durable ledger the UI just changed.
+      const latestJournal = await this.#persistence.loadJournal();
+      this.#ledger = latestJournal
+        ? await CausalLedger.fromJournal(latestJournal)
+        : new CausalLedger();
+
       const experimentId = `live:${agentPubkey.toLowerCase()}:${event.sessionId}`;
       if (
         this.#ledger
@@ -111,6 +120,27 @@ export class LiveCausalLedger {
   ): CausalExperiment {
     const taskEvent = events.find((event) => event.kind === "task_captured");
     const taskPayload = taskEvent ? payload(taskEvent) : {};
+    const taskDescription =
+      text(taskPayload.description) ??
+      "Task unavailable from observer evidence";
+    const sourceMessageId = text(taskPayload.sourceMessageId);
+    const proposalId = proposalIdFromReplayTask(taskDescription);
+    const markedProposal = proposalId
+      ? this.#ledger
+          .entries()
+          .find((entry) => entry.experiment.experimentId === proposalId)
+          ?.experiment
+      : undefined;
+    const hasDispatchReceipt = this.#ledger
+      .entries()
+      .some(
+        (entry) =>
+          entry.experiment.execution.replayOf ===
+            markedProposal?.experimentId &&
+          entry.experiment.execution.sessionId.startsWith("replay-dispatch:") &&
+          entry.experiment.task.sourceMessageId === sourceMessageId,
+      );
+    const proposal = hasDispatchReceipt ? markedProposal : undefined;
     const layers = new Set(
       events.map((event) => {
         if (event.kind === "host_operation") return "host_workspace";
@@ -123,22 +153,28 @@ export class LiveCausalLedger {
       experimentId,
       recordedAt: events.at(-1)?.timestamp ?? new Date().toISOString(),
       task: {
-        description:
-          text(taskPayload.description) ??
-          "Task unavailable from observer evidence",
-        sourceMessageId: text(taskPayload.sourceMessageId),
+        description: proposal?.task.description ?? taskDescription,
+        sourceMessageId,
       },
-      execution: { sessionId, turnId: turnId ?? "unknown", replayOf: null },
-      failureFingerprint: "unclassified-live-candidate/v1",
-      context: {
+      execution: {
+        sessionId,
+        turnId: turnId ?? "unknown",
+        replayOf: proposal?.experimentId ?? null,
+      },
+      failureFingerprint:
+        proposal?.failureFingerprint ?? "unclassified-live-candidate/v1",
+      context: proposal?.context ?? {
         codeVersion: "unknown",
         policyVersion: "unknown",
         modelVersion: "unknown",
         toolVersion: "buzz-acp-observer/v1",
         environmentVersion: "unknown",
       },
-      hypothesis: { cause: "unclassified", evidenceIds: [] },
-      intervention: {
+      hypothesis: proposal?.hypothesis ?? {
+        cause: "unclassified",
+        evidenceIds: [],
+      },
+      intervention: proposal?.intervention ?? {
         remedyId: "unclassified",
         changedVariable: "unclassified",
       },

--- a/desktop/src/features/agents/lib/liveCausalLedger.ts
+++ b/desktop/src/features/agents/lib/liveCausalLedger.ts
@@ -1,5 +1,11 @@
 import type { ObserverEvent } from "../ui/agentSessionTypes";
 import {
+  extractPromptText,
+  extractToolResult,
+  parsePromptText,
+} from "../ui/agentSessionTranscriptHelpers";
+import { asRecord, asString } from "../ui/agentSessionUtils";
+import {
   CAUSAL_EXPERIMENT_SCHEMA,
   CausalLedger,
   type CausalExperiment,
@@ -46,6 +52,61 @@ function eventId(event: ObserverEvent): string {
   return `observer:${event.sessionId ?? "unknown"}:${event.seq}:${event.timestamp}`;
 }
 
+function taskFromEvents(events: readonly ObserverEvent[]): {
+  description: string;
+  sourceMessageId: string | null;
+} {
+  const captured = events.find((event) => event.kind === "task_captured");
+  if (captured) {
+    const capturedPayload = payload(captured);
+    return {
+      description:
+        text(capturedPayload.description) ??
+        "Task unavailable from observer evidence",
+      sourceMessageId: text(capturedPayload.sourceMessageId),
+    };
+  }
+
+  const promptEvent = events.find((event) => {
+    const eventPayload = payload(event);
+    return (
+      event.kind === "acp_write" &&
+      asString(eventPayload.method) === "session/prompt"
+    );
+  });
+  if (!promptEvent) {
+    return {
+      description: "Task unavailable from observer evidence",
+      sourceMessageId: null,
+    };
+  }
+  const prompt = extractPromptText(payload(promptEvent));
+  const parsed = parsePromptText(prompt);
+  return {
+    description:
+      parsed.userText ||
+      prompt.trim() ||
+      "Task unavailable from observer evidence",
+    sourceMessageId: parsed.userEventId,
+  };
+}
+
+function hasOsSandboxEvidence(events: readonly ObserverEvent[]): boolean {
+  return events.some((event) => {
+    if (event.kind !== "acp_read") return false;
+    const eventPayload = payload(event);
+    if (asString(eventPayload.method) !== "session/update") return false;
+    const update = asRecord(asRecord(eventPayload.params).update);
+    return (
+      asString(update.sessionUpdate) === "tool_call_update" &&
+      asString(update.status) === "failed" &&
+      /permission denied|operation not permitted/i.test(
+        extractToolResult(update),
+      )
+    );
+  });
+}
+
 export class LiveCausalLedger {
   readonly #persistence: CausalLedgerPersistence;
   readonly #owner: string;
@@ -73,7 +134,8 @@ export class LiveCausalLedger {
     this.#writes = this.#writes.then(async () => {
       await this.#ready;
       if (!event.sessionId) return;
-      const key = `${agentPubkey.toLowerCase()}:${event.sessionId}`;
+      const runId = event.turnId ?? `terminal-${event.seq}`;
+      const key = `${agentPubkey.toLowerCase()}:${event.sessionId}:${runId}`;
       const session = this.#sessions.get(key) ?? [];
       session.push(event);
       this.#sessions.set(key, session);
@@ -88,7 +150,7 @@ export class LiveCausalLedger {
         ? await CausalLedger.fromJournal(latestJournal)
         : new CausalLedger();
 
-      const experimentId = `live:${agentPubkey.toLowerCase()}:${event.sessionId}`;
+      const experimentId = `live:${agentPubkey.toLowerCase()}:${event.sessionId}:${runId}`;
       if (
         this.#ledger
           .entries()
@@ -118,12 +180,9 @@ export class LiveCausalLedger {
     turnId: string | null,
     events: ObserverEvent[],
   ): CausalExperiment {
-    const taskEvent = events.find((event) => event.kind === "task_captured");
-    const taskPayload = taskEvent ? payload(taskEvent) : {};
-    const taskDescription =
-      text(taskPayload.description) ??
-      "Task unavailable from observer evidence";
-    const sourceMessageId = text(taskPayload.sourceMessageId);
+    const task = taskFromEvents(events);
+    const taskDescription = task.description;
+    const sourceMessageId = task.sourceMessageId;
     const proposalId = proposalIdFromReplayTask(taskDescription);
     const markedProposal = proposalId
       ? this.#ledger
@@ -188,7 +247,7 @@ export class LiveCausalLedger {
           ? "observed"
           : "missing",
         host_workspace: layers.has("host_workspace") ? "observed" : "missing",
-        os_sandbox: "missing",
+        os_sandbox: hasOsSandboxEvidence(events) ? "observed" : "missing",
       },
       relations: { supports: [], contradicts: [], invalidates: [] },
     };

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -45,6 +45,9 @@ const EMPTY_EVENTS: ObserverEvent[] = [];
 const EMPTY_TRANSCRIPT: TranscriptItem[] = [];
 
 const listeners = new Set<() => void>();
+const eventListeners = new Set<
+  (agentPubkey: string, event: ObserverEvent) => void
+>();
 const eventsByAgent = new Map<string, ObserverEvent[]>();
 const transcriptByAgent = new Map<string, TranscriptState>();
 const snapshotByAgent = new Map<string, ObserverSnapshot>();
@@ -211,6 +214,9 @@ function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
     ? sorted.slice(sorted.length - MAX_OBSERVER_EVENTS)
     : sorted;
   eventsByAgent.set(key, final);
+  for (const listener of eventListeners) {
+    listener(key, event);
+  }
 
   // Determine whether the new event landed at the end of the sorted array.
   // If it did (common case), we can incrementally process just this event.
@@ -231,6 +237,16 @@ function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
   invalidateSnapshot(key);
 
   notifyListeners();
+}
+
+/** Subscribe to each newly accepted live observer event after deduplication. */
+export function subscribeObserverEvents(
+  listener: (agentPubkey: string, event: ObserverEvent) => void,
+) {
+  eventListeners.add(listener);
+  return () => {
+    eventListeners.delete(listener);
+  };
 }
 
 /**

--- a/desktop/src/features/agents/ui/CausalCandidateCard.tsx
+++ b/desktop/src/features/agents/ui/CausalCandidateCard.tsx
@@ -1,9 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Eye, GitBranch, ShieldCheck } from "lucide-react";
+import * as React from "react";
+import { toast } from "sonner";
 
-import { readCausalLedger } from "@/shared/api/tauriCausalLedger";
+import {
+  appendCausalExperiment,
+  readCausalLedger,
+} from "@/shared/api/tauriCausalLedger";
 import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Textarea } from "@/shared/ui/textarea";
 
+import { buildApprovedReplayProposal } from "../lib/causalReplayProposal";
 import { inspectCausalCandidate } from "./causalCandidateInspection";
 
 export function CausalCandidateCard({
@@ -11,6 +20,7 @@ export function CausalCandidateCard({
 }: {
   sessionId: string | null;
 }) {
+  const queryClient = useQueryClient();
   const query = useQuery({
     queryKey: ["causal-ledger", sessionId],
     queryFn: readCausalLedger,
@@ -18,6 +28,44 @@ export function CausalCandidateCard({
     refetchInterval: 5_000,
   });
   const inspection = inspectCausalCandidate(query.data ?? [], sessionId);
+  const candidate = query.data
+    ?.map((entry) => entry.experiment)
+    .find((experiment) => experiment.experimentId === inspection?.experimentId);
+  const approvedProposal = query.data
+    ?.map((entry) => entry.experiment)
+    .find(
+      (experiment) =>
+        experiment.execution.replayOf === inspection?.experimentId &&
+        experiment.intervention.approvedAt,
+    );
+  const [draft, setDraft] = React.useState({
+    failureFingerprint: "",
+    cause: "",
+    changedVariable: "",
+    successCriteria: "",
+  });
+  const approveMutation = useMutation({
+    mutationFn: async () => {
+      if (!candidate) throw new Error("The candidate is no longer available.");
+      const recordedAt = new Date().toISOString();
+      const proposal = buildApprovedReplayProposal(candidate, draft, {
+        experimentId: `proposal:${candidate.experimentId}:${crypto.randomUUID()}`,
+        recordedAt,
+      });
+      return appendCausalExperiment(proposal);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["causal-ledger"] });
+      toast.success("Controlled replay approved and sealed in the ledger.");
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not approve the replay.",
+      );
+    },
+  });
   if (!inspection) return null;
 
   return (
@@ -71,7 +119,105 @@ export function CausalCandidateCard({
           </div>
         </div>
       </div>
+
+      {approvedProposal ? (
+        <div
+          className="border-t border-border/60 p-4"
+          data-testid="approved-replay-proposal"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Owner-approved replay
+            </p>
+            <Badge variant="outline">Awaiting evaluator</Badge>
+          </div>
+          <p className="mt-2 text-sm font-medium">
+            Change only: {approvedProposal.intervention.changedVariable}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Success: {approvedProposal.intervention.successCriteria}
+          </p>
+          <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+            Approval does not prove the remedy. Buzz will keep this untested
+            until a linked replay and independent evidence produce a verdict.
+          </p>
+        </div>
+      ) : candidate?.result.outcome === "untested" ? (
+        <ReplayApprovalForm
+          draft={draft}
+          isPending={approveMutation.isPending}
+          onChange={(field, value) =>
+            setDraft((current) => ({ ...current, [field]: value }))
+          }
+          onSubmit={() => approveMutation.mutate()}
+        />
+      ) : null}
     </section>
+  );
+}
+
+function ReplayApprovalForm({
+  draft,
+  isPending,
+  onChange,
+  onSubmit,
+}: {
+  draft: {
+    failureFingerprint: string;
+    cause: string;
+    changedVariable: string;
+    successCriteria: string;
+  };
+  isPending: boolean;
+  onChange: (field: keyof typeof draft, value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <form
+      className="space-y-3 border-t border-border/60 p-4"
+      data-testid="replay-approval-form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div>
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Controlled replay proposal
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Name the cause, change exactly one variable, and define success before
+          approving anything.
+        </p>
+      </div>
+      <Input
+        aria-label="Failure fingerprint"
+        onChange={(event) => onChange("failureFingerprint", event.target.value)}
+        placeholder="Failure fingerprint, for example host-write-bypass/v1"
+        value={draft.failureFingerprint}
+      />
+      <Textarea
+        aria-label="Cause hypothesis"
+        onChange={(event) => onChange("cause", event.target.value)}
+        placeholder="Evidence-backed cause hypothesis"
+        value={draft.cause}
+      />
+      <Input
+        aria-label="One changed variable"
+        onChange={(event) => onChange("changedVariable", event.target.value)}
+        placeholder="One changed variable"
+        value={draft.changedVariable}
+      />
+      <Textarea
+        aria-label="Success criteria"
+        onChange={(event) => onChange("successCriteria", event.target.value)}
+        placeholder="Observable success criteria"
+        value={draft.successCriteria}
+      />
+      <Button disabled={isPending} size="sm" type="submit">
+        {isPending ? "Sealing approval…" : "Approve controlled replay"}
+      </Button>
+    </form>
   );
 }
 

--- a/desktop/src/features/agents/ui/CausalCandidateCard.tsx
+++ b/desktop/src/features/agents/ui/CausalCandidateCard.tsx
@@ -1,0 +1,117 @@
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Eye, GitBranch, ShieldCheck } from "lucide-react";
+
+import { readCausalLedger } from "@/shared/api/tauriCausalLedger";
+import { Badge } from "@/shared/ui/badge";
+
+import { inspectCausalCandidate } from "./causalCandidateInspection";
+
+export function CausalCandidateCard({
+  sessionId,
+}: {
+  sessionId: string | null;
+}) {
+  const query = useQuery({
+    queryKey: ["causal-ledger", sessionId],
+    queryFn: readCausalLedger,
+    enabled: Boolean(sessionId),
+    refetchInterval: 5_000,
+  });
+  const inspection = inspectCausalCandidate(query.data ?? [], sessionId);
+  if (!inspection) return null;
+
+  return (
+    <section
+      aria-label="Causal ledger candidate"
+      className="mb-3 overflow-hidden rounded-xl border border-border/70 bg-background"
+      data-testid="causal-candidate-card"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2 border-b border-border/60 p-4">
+        <div>
+          <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Durable candidate
+          </p>
+          <h3 className="mt-1 text-sm font-semibold">{inspection.task}</h3>
+        </div>
+        <Badge variant="outline" className="capitalize">
+          {inspection.status}
+        </Badge>
+      </div>
+
+      <CandidateList
+        icon={Eye}
+        items={inspection.capturedFacts}
+        label="Captured facts"
+      />
+      <CandidateList
+        empty="No causal claim has been made from this raw session."
+        icon={GitBranch}
+        items={inspection.inferredClaims}
+        label="Inferred claims"
+      />
+      <CandidateList
+        empty="No known evidence gaps."
+        icon={AlertTriangle}
+        items={inspection.missingCoverage}
+        label="Missing coverage"
+        warning
+      />
+
+      <div className="bg-primary/[0.04] p-4">
+        <div className="flex items-start gap-2">
+          <ShieldCheck
+            aria-hidden
+            className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+          />
+          <div>
+            <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Promotion gate
+            </p>
+            <p className="mt-1 text-sm font-medium">{inspection.nextGate}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CandidateList({
+  empty,
+  icon: Icon,
+  items,
+  label,
+  warning = false,
+}: {
+  empty?: string;
+  icon: typeof Eye;
+  items: readonly string[];
+  label: string;
+  warning?: boolean;
+}) {
+  return (
+    <div className="border-b border-border/60 p-4">
+      <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {items.length ? (
+        <ul className="mt-2 space-y-2">
+          {items.map((item) => (
+            <li
+              className={
+                warning
+                  ? "flex gap-2 text-xs text-amber-700 dark:text-amber-300"
+                  : "flex gap-2 text-xs"
+              }
+              key={item}
+            >
+              <Icon aria-hidden className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">{empty}</p>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/CausalCandidateCard.tsx
+++ b/desktop/src/features/agents/ui/CausalCandidateCard.tsx
@@ -7,17 +7,27 @@ import {
   appendCausalExperiment,
   readCausalLedger,
 } from "@/shared/api/tauriCausalLedger";
+import { sendChannelMessage } from "@/shared/api/tauri";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 
-import { buildApprovedReplayProposal } from "../lib/causalReplayProposal";
+import {
+  buildApprovedReplayProposal,
+  buildIndependentEvaluation,
+  buildReplayDispatchMessage,
+  buildReplayDispatchReceipt,
+} from "../lib/causalReplayProposal";
 import { inspectCausalCandidate } from "./causalCandidateInspection";
 
 export function CausalCandidateCard({
+  agentPubkey,
+  channelId,
   sessionId,
 }: {
+  agentPubkey: string;
+  channelId: string | null;
   sessionId: string | null;
 }) {
   const queryClient = useQueryClient();
@@ -28,15 +38,60 @@ export function CausalCandidateCard({
     refetchInterval: 5_000,
   });
   const inspection = inspectCausalCandidate(query.data ?? [], sessionId);
-  const candidate = query.data
-    ?.map((entry) => entry.experiment)
-    .find((experiment) => experiment.experimentId === inspection?.experimentId);
-  const approvedProposal = query.data
-    ?.map((entry) => entry.experiment)
-    .find(
+  const experiments = query.data?.map((entry) => entry.experiment) ?? [];
+  const candidate = experiments.find(
+    (experiment) => experiment.experimentId === inspection?.experimentId,
+  );
+  const activeEvaluation = candidate?.evaluation ? candidate : undefined;
+  const replayFromEvaluation = activeEvaluation
+    ? experiments.find(
+        (experiment) =>
+          experiment.experimentId === activeEvaluation.execution.replayOf,
+      )
+    : undefined;
+  const parentOfActive = candidate?.execution.replayOf
+    ? experiments.find(
+        (experiment) =>
+          experiment.experimentId === candidate.execution.replayOf,
+      )
+    : undefined;
+  const activeReplay =
+    !candidate?.evaluation &&
+    parentOfActive?.intervention.approvedAt &&
+    !candidate?.execution.sessionId.startsWith("replay-dispatch:")
+      ? candidate
+      : undefined;
+  const approvedProposal = replayFromEvaluation
+    ? experiments.find(
+        (experiment) =>
+          experiment.experimentId === replayFromEvaluation.execution.replayOf,
+      )
+    : activeReplay
+      ? parentOfActive
+      : experiments.find(
+          (experiment) =>
+            experiment.execution.replayOf === inspection?.experimentId &&
+            experiment.intervention.approvedAt,
+        );
+  const dispatchReceipt = experiments.find(
+    (experiment) =>
+      experiment.execution.replayOf === approvedProposal?.experimentId &&
+      experiment.execution.sessionId.startsWith("replay-dispatch:"),
+  );
+  const completedReplay =
+    replayFromEvaluation ??
+    activeReplay ??
+    experiments.find(
       (experiment) =>
-        experiment.execution.replayOf === inspection?.experimentId &&
-        experiment.intervention.approvedAt,
+        experiment.execution.replayOf === approvedProposal?.experimentId &&
+        !experiment.execution.sessionId.startsWith("replay-dispatch:"),
+    );
+  const evaluation =
+    activeEvaluation ??
+    experiments.find(
+      (experiment) =>
+        experiment.execution.replayOf === completedReplay?.experimentId &&
+        experiment.evaluation,
     );
   const [draft, setDraft] = React.useState({
     failureFingerprint: "",
@@ -63,6 +118,40 @@ export function CausalCandidateCard({
         error instanceof Error
           ? error.message
           : "Could not approve the replay.",
+      );
+    },
+  });
+  const dispatchMutation = useMutation({
+    mutationFn: async () => {
+      if (!approvedProposal || !channelId) {
+        throw new Error(
+          "Open this candidate inside its channel to run the replay.",
+        );
+      }
+      const result = await sendChannelMessage(
+        channelId,
+        buildReplayDispatchMessage(approvedProposal),
+        undefined,
+        undefined,
+        [agentPubkey],
+      );
+      return appendCausalExperiment(
+        buildReplayDispatchReceipt(
+          approvedProposal,
+          result.eventId,
+          new Date().toISOString(),
+        ),
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["causal-ledger"] });
+      toast.success("Controlled replay dispatched to a fresh agent turn.");
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not dispatch the replay.",
       );
     },
   });
@@ -120,7 +209,18 @@ export function CausalCandidateCard({
         </div>
       </div>
 
-      {approvedProposal ? (
+      {evaluation ? (
+        <EvaluationResult evaluation={evaluation} />
+      ) : completedReplay ? (
+        <IndependentEvaluationForm
+          replay={completedReplay}
+          onSaved={async () => {
+            await queryClient.invalidateQueries({
+              queryKey: ["causal-ledger"],
+            });
+          }}
+        />
+      ) : approvedProposal ? (
         <div
           className="border-t border-border/60 p-4"
           data-testid="approved-replay-proposal"
@@ -129,7 +229,9 @@ export function CausalCandidateCard({
             <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
               Owner-approved replay
             </p>
-            <Badge variant="outline">Awaiting evaluator</Badge>
+            <Badge variant="outline">
+              {dispatchReceipt ? "Replay running" : "Ready to run"}
+            </Badge>
           </div>
           <p className="mt-2 text-sm font-medium">
             Change only: {approvedProposal.intervention.changedVariable}
@@ -141,6 +243,23 @@ export function CausalCandidateCard({
             Approval does not prove the remedy. Buzz will keep this untested
             until a linked replay and independent evidence produce a verdict.
           </p>
+          {!dispatchReceipt ? (
+            <Button
+              className="mt-3"
+              disabled={!channelId || dispatchMutation.isPending}
+              onClick={() => dispatchMutation.mutate()}
+              size="sm"
+            >
+              {dispatchMutation.isPending
+                ? "Dispatching replay…"
+                : "Run controlled replay"}
+            </Button>
+          ) : (
+            <p className="mt-3 text-xs text-muted-foreground">
+              Buzz linked the dispatch receipt. The independent verdict unlocks
+              when the agent turn reaches a terminal event.
+            </p>
+          )}
         </div>
       ) : candidate?.result.outcome === "untested" ? (
         <ReplayApprovalForm
@@ -153,6 +272,119 @@ export function CausalCandidateCard({
         />
       ) : null}
     </section>
+  );
+}
+
+function IndependentEvaluationForm({
+  replay,
+  onSaved,
+}: {
+  replay: import("../lib/causalLedger").CausalExperiment;
+  onSaved: () => Promise<void>;
+}) {
+  const [outcome, setOutcome] = React.useState<
+    "validated" | "rejected" | "inconclusive"
+  >("inconclusive");
+  const [evidenceIds, setEvidenceIds] = React.useState(
+    replay.result.evidenceIds.join("\n"),
+  );
+  const [rationale, setRationale] = React.useState("");
+  const mutation = useMutation({
+    mutationFn: () => {
+      const recordedAt = new Date().toISOString();
+      return appendCausalExperiment(
+        buildIndependentEvaluation(
+          replay,
+          { outcome, evidenceIds, rationale },
+          {
+            experimentId: `evaluation:${replay.experimentId}:${crypto.randomUUID()}`,
+            recordedAt,
+          },
+        ),
+      );
+    },
+    onSuccess: async () => {
+      await onSaved();
+      toast.success("Independent verdict sealed in the causal ledger.");
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Could not save the verdict.",
+      );
+    },
+  });
+  return (
+    <form
+      className="space-y-3 border-t border-border/60 p-4"
+      data-testid="independent-evaluation-form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        mutation.mutate();
+      }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Independent evaluation
+        </p>
+        <Badge variant="outline">Replay complete</Badge>
+      </div>
+      <label className="block text-xs font-medium" htmlFor="causal-verdict">
+        Verdict
+      </label>
+      <select
+        className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+        id="causal-verdict"
+        onChange={(event) => setOutcome(event.target.value as typeof outcome)}
+        value={outcome}
+      >
+        <option value="validated">Validated</option>
+        <option value="rejected">Rejected</option>
+        <option value="inconclusive">Inconclusive</option>
+      </select>
+      <Textarea
+        aria-label="Evaluation evidence IDs"
+        onChange={(event) => setEvidenceIds(event.target.value)}
+        placeholder="One evidence ID per line"
+        value={evidenceIds}
+      />
+      <Textarea
+        aria-label="Evaluation rationale"
+        onChange={(event) => setRationale(event.target.value)}
+        placeholder="Why the evidence meets or fails the success criteria"
+        value={rationale}
+      />
+      <Button disabled={mutation.isPending} size="sm" type="submit">
+        {mutation.isPending ? "Sealing verdict…" : "Seal independent verdict"}
+      </Button>
+    </form>
+  );
+}
+
+function EvaluationResult({
+  evaluation,
+}: {
+  evaluation: import("../lib/causalLedger").CausalExperiment;
+}) {
+  return (
+    <div
+      className="border-t border-border/60 p-4"
+      data-testid="causal-evaluation-result"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Independent verdict
+        </p>
+        <Badge variant="outline" className="capitalize">
+          {evaluation.result.outcome}
+        </Badge>
+      </div>
+      <p className="mt-2 text-sm">{evaluation.evaluation?.rationale}</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {evaluation.result.evidenceIds.length} cited evidence receipt
+        {evaluation.result.evidenceIds.length === 1 ? "" : "s"}; sealed in the
+        owner-local ledger.
+      </p>
+    </div>
   );
 }
 

--- a/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
+++ b/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
@@ -164,6 +164,28 @@ export function CausalSessionTimeline({
         </div>
       </div>
 
+      {explanation.remediation ? (
+        <div className="border-t border-border/60 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Controlled replay
+            </p>
+            <Badge variant="outline" className="capitalize">
+              {explanation.remediation.status.replace("_", " ")}
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm font-medium">
+            {explanation.remediation.remedy}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Changed: {explanation.remediation.controlledChange}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Result: {explanation.remediation.result}
+          </p>
+        </div>
+      ) : null}
+
       <p className="border-t border-border/60 px-4 py-3 text-xs text-muted-foreground">
         Activity and raw telemetry continue below as supporting detail.
       </p>

--- a/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
+++ b/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
@@ -1,0 +1,89 @@
+import { AlertTriangle, Eye, GitBranch, ShieldCheck } from "lucide-react";
+import * as React from "react";
+
+import { Badge } from "@/shared/ui/badge";
+import { cn } from "@/shared/lib/cn";
+
+import type { ObserverEvent } from "./agentSessionTypes";
+import type { CausalFinding } from "./trustworthySessionTimeline";
+import { buildTrustworthySessionTimeline } from "./trustworthySessionTimeline";
+
+export function CausalSessionTimeline({
+  events,
+  findings,
+}: {
+  events: readonly ObserverEvent[];
+  findings: readonly CausalFinding[];
+}) {
+  const timeline = React.useMemo(
+    () => buildTrustworthySessionTimeline(events, findings),
+    [events, findings],
+  );
+  if (timeline.length === 0) return null;
+
+  const gaps = timeline.filter((event) => event.class === "gap");
+  const visible = timeline.slice(-12);
+
+  return (
+    <section
+      aria-label="Session causal timeline"
+      className="mb-3 rounded-lg border border-border/70 bg-muted/20 p-3"
+      data-testid="trustworthy-session-timeline"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold">
+            Why did this agent behave this way?
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Evidence and known visibility gaps, ordered across observing
+            systems.
+          </p>
+        </div>
+        <Badge variant={gaps.length > 0 ? "outline" : "secondary"}>
+          {gaps.length > 0
+            ? `${gaps.length} coverage gap${gaps.length === 1 ? "" : "s"}`
+            : "Complete coverage"}
+        </Badge>
+      </div>
+      <ol className="mt-3 space-y-2">
+        {visible.map((event) => {
+          const Icon =
+            event.class === "gap"
+              ? AlertTriangle
+              : event.class === "decision"
+                ? ShieldCheck
+                : event.class === "inference"
+                  ? GitBranch
+                  : Eye;
+          return (
+            <li
+              className={cn(
+                "rounded-md border px-2.5 py-2 text-xs",
+                event.class === "gap"
+                  ? "border-amber-500/40 bg-amber-500/10"
+                  : "border-border/60 bg-background/60",
+              )}
+              data-causal-event-class={event.class}
+              key={event.id}
+            >
+              <div className="flex items-start gap-2">
+                <Icon aria-hidden className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="font-medium">{event.title}</span>
+                    <Badge variant="outline">{event.sourceSystem}</Badge>
+                    <span className="text-muted-foreground">
+                      {event.observerRole}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-muted-foreground">{event.detail}</p>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
+++ b/desktop/src/features/agents/ui/CausalSessionTimeline.tsx
@@ -1,4 +1,14 @@
-import { AlertTriangle, Eye, GitBranch, ShieldCheck } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleHelp,
+  Eye,
+  GitBranch,
+  Lightbulb,
+  LoaderCircle,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
 import * as React from "react";
 
 import { Badge } from "@/shared/ui/badge";
@@ -6,7 +16,7 @@ import { cn } from "@/shared/lib/cn";
 
 import type { ObserverEvent } from "./agentSessionTypes";
 import type { CausalFinding } from "./trustworthySessionTimeline";
-import { buildTrustworthySessionTimeline } from "./trustworthySessionTimeline";
+import { explainSession } from "./trustworthySessionTimeline";
 
 export function CausalSessionTimeline({
   events,
@@ -15,75 +25,148 @@ export function CausalSessionTimeline({
   events: readonly ObserverEvent[];
   findings: readonly CausalFinding[];
 }) {
-  const timeline = React.useMemo(
-    () => buildTrustworthySessionTimeline(events, findings),
+  const explanation = React.useMemo(
+    () => explainSession(events, findings),
     [events, findings],
   );
-  if (timeline.length === 0) return null;
+  if (!explanation) return null;
 
-  const gaps = timeline.filter((event) => event.class === "gap");
-  const visible = timeline.slice(-12);
+  const OutcomeIcon =
+    explanation.outcome === "failed"
+      ? XCircle
+      : explanation.outcome === "succeeded"
+        ? CheckCircle2
+        : explanation.outcome === "in_progress"
+          ? LoaderCircle
+          : CircleHelp;
 
   return (
     <section
-      aria-label="Session causal timeline"
-      className="mb-3 rounded-lg border border-border/70 bg-muted/20 p-3"
-      data-testid="trustworthy-session-timeline"
+      aria-label="Session explanation"
+      className="mb-3 overflow-hidden rounded-xl border border-border/70 bg-background"
+      data-testid="session-explanation"
     >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <h3 className="text-sm font-semibold">
-            Why did this agent behave this way?
-          </h3>
-          <p className="text-xs text-muted-foreground">
-            Evidence and known visibility gaps, ordered across observing
-            systems.
-          </p>
-        </div>
-        <Badge variant={gaps.length > 0 ? "outline" : "secondary"}>
-          {gaps.length > 0
-            ? `${gaps.length} coverage gap${gaps.length === 1 ? "" : "s"}`
-            : "Complete coverage"}
-        </Badge>
+      <div className="border-b border-border/60 p-4">
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Task
+        </p>
+        <h3 className="mt-1 text-sm font-semibold">{explanation.task}</h3>
       </div>
-      <ol className="mt-3 space-y-2">
-        {visible.map((event) => {
-          const Icon =
-            event.class === "gap"
-              ? AlertTriangle
-              : event.class === "decision"
+
+      <div className="grid gap-0 sm:grid-cols-[8rem_1fr]">
+        <div className="border-b border-border/60 bg-muted/20 p-4 sm:border-r">
+          <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Outcome
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <OutcomeIcon
+              aria-hidden
+              className={cn(
+                "h-5 w-5",
+                explanation.outcome === "failed"
+                  ? "text-destructive"
+                  : explanation.outcome === "succeeded"
+                    ? "text-emerald-600"
+                    : "text-muted-foreground",
+              )}
+            />
+            <span className="text-sm font-semibold capitalize">
+              {explanation.outcome.replace("_", " ")}
+            </span>
+          </div>
+        </div>
+        <div className="border-b border-border/60 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Why
+            </p>
+            <Badge variant="outline" className="capitalize">
+              {explanation.confidence} confidence
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm leading-6">{explanation.why}</p>
+        </div>
+      </div>
+
+      <div className="border-b border-border/60 p-4">
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Evidence
+        </p>
+        <ol className="mt-2 space-y-2">
+          {explanation.evidence.map((event) => {
+            const Icon =
+              event.class === "decision"
                 ? ShieldCheck
                 : event.class === "inference"
                   ? GitBranch
                   : Eye;
-          return (
-            <li
-              className={cn(
-                "rounded-md border px-2.5 py-2 text-xs",
-                event.class === "gap"
-                  ? "border-amber-500/40 bg-amber-500/10"
-                  : "border-border/60 bg-background/60",
-              )}
-              data-causal-event-class={event.class}
-              key={event.id}
-            >
-              <div className="flex items-start gap-2">
-                <Icon aria-hidden className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            return (
+              <li
+                className="flex items-start gap-2 text-xs"
+                data-causal-event-class={event.class}
+                key={event.id}
+              >
+                <Icon
+                  aria-hidden
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+                />
                 <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    <span className="font-medium">{event.title}</span>
-                    <Badge variant="outline">{event.sourceSystem}</Badge>
-                    <span className="text-muted-foreground">
-                      {event.observerRole}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-muted-foreground">{event.detail}</p>
+                  <span className="font-medium">{event.title}</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    · {event.sourceSystem}
+                  </span>
                 </div>
-              </div>
-            </li>
-          );
-        })}
-      </ol>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <div className="border-b border-border/60 p-4">
+        <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Unknowns
+        </p>
+        {explanation.unknowns.length > 0 ? (
+          <ul className="mt-2 space-y-2">
+            {explanation.unknowns.map((gap) => (
+              <li
+                className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-300"
+                key={gap.id}
+              >
+                <AlertTriangle
+                  aria-hidden
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                />
+                <span>{gap.title}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No known evidence gaps.
+          </p>
+        )}
+      </div>
+
+      <div className="bg-primary/[0.04] p-4">
+        <div className="flex items-start gap-2">
+          <Lightbulb
+            aria-hidden
+            className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+          />
+          <div>
+            <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Suggested next action
+            </p>
+            <p className="mt-1 text-sm font-medium">{explanation.nextAction}</p>
+          </div>
+        </div>
+      </div>
+
+      <p className="border-t border-border/60 px-4 py-3 text-xs text-muted-foreground">
+        Activity and raw telemetry continue below as supporting detail.
+      </p>
     </section>
   );
 }

--- a/desktop/src/features/agents/ui/causalCandidateInspection.test.mjs
+++ b/desktop/src/features/agents/ui/causalCandidateInspection.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inspectCausalCandidate } from "./causalCandidateInspection.ts";
+
+function entry(sessionId, overrides = {}) {
+  return {
+    sequence: 1,
+    previousHash: "0".repeat(64),
+    hash: "1".repeat(64),
+    experiment: {
+      schema: "causal-experiment/v1",
+      experimentId: `live:agent:${sessionId}`,
+      recordedAt: "2026-08-05T00:00:00Z",
+      task: { description: "Write the file", sourceMessageId: null },
+      execution: { sessionId, turnId: "turn-1", replayOf: null },
+      failureFingerprint: "unclassified-live-candidate/v1",
+      context: {},
+      hypothesis: { cause: "unclassified", evidenceIds: [] },
+      intervention: {
+        remedyId: "unclassified",
+        changedVariable: "unclassified",
+      },
+      result: { outcome: "untested", evidenceIds: ["receipt-1"] },
+      coverage: {
+        acp_observer: "observed",
+        acp_permission_gate: "missing",
+        host_workspace: "missing",
+        os_sandbox: "missing",
+      },
+      relations: { supports: [], contradicts: [], invalidates: [] },
+      ...overrides,
+    },
+  };
+}
+
+test("keeps captured facts, claims, and missing coverage separate", () => {
+  const inspection = inspectCausalCandidate([entry("session-1")], "session-1");
+  assert.equal(inspection?.status, "untested");
+  assert.deepEqual(inspection?.inferredClaims, []);
+  assert.match(
+    inspection?.capturedFacts[1] ?? "",
+    /activity evidence was captured/,
+  );
+  assert.deepEqual(inspection?.missingCoverage, [
+    "Agent Client Protocol permission decisions",
+    "Host workspace effects",
+    "Operating-system sandbox effects",
+  ]);
+  assert.match(inspection?.nextGate ?? "", /independent evaluator/);
+});
+
+test("selects the latest ledger entry for the active session", () => {
+  const inspection = inspectCausalCandidate(
+    [
+      entry("other"),
+      entry("session-1", { result: { outcome: "validated", evidenceIds: [] } }),
+    ],
+    "session-1",
+  );
+  assert.equal(inspection?.status, "validated");
+});
+
+test("does not show a candidate from another session", () => {
+  assert.equal(inspectCausalCandidate([entry("other")], "session-1"), null);
+});

--- a/desktop/src/features/agents/ui/causalCandidateInspection.ts
+++ b/desktop/src/features/agents/ui/causalCandidateInspection.ts
@@ -1,0 +1,84 @@
+import type {
+  CausalExperiment,
+  EvidenceCoverage,
+  LedgerEntry,
+} from "../lib/causalLedger";
+
+export type CausalCandidateInspection = {
+  experimentId: string;
+  status: CausalExperiment["result"]["outcome"];
+  task: string;
+  capturedFacts: string[];
+  inferredClaims: string[];
+  missingCoverage: string[];
+  nextGate: string;
+};
+
+const COVERAGE_LABELS: Record<string, string> = {
+  acp_observer: "Agent Client Protocol activity",
+  acp_permission_gate: "Agent Client Protocol permission decisions",
+  host_workspace: "Host workspace effects",
+  os_sandbox: "Operating-system sandbox effects",
+};
+
+function coverageLabel(key: string): string {
+  return COVERAGE_LABELS[key] ?? key.replaceAll("_", " ");
+}
+
+function observedCoverage(
+  coverage: Record<string, EvidenceCoverage>,
+): string[] {
+  return Object.entries(coverage)
+    .filter(([, state]) => state === "observed")
+    .map(([key]) => coverageLabel(key));
+}
+
+function missingCoverage(coverage: Record<string, EvidenceCoverage>): string[] {
+  return Object.entries(coverage)
+    .filter(([, state]) => state === "missing")
+    .map(([key]) => coverageLabel(key));
+}
+
+export function inspectCausalCandidate(
+  entries: readonly LedgerEntry[],
+  sessionId: string | null,
+): CausalCandidateInspection | null {
+  if (!sessionId) return null;
+  const experiment = [...entries]
+    .reverse()
+    .find(
+      (entry) => entry.experiment.execution.sessionId === sessionId,
+    )?.experiment;
+  if (!experiment) return null;
+
+  const capturedFacts = [
+    `Session ${experiment.execution.sessionId} reached a terminal event.`,
+    ...observedCoverage(experiment.coverage).map(
+      (layer) => `${layer} evidence was captured.`,
+    ),
+    `${experiment.result.evidenceIds.length} evidence receipt${
+      experiment.result.evidenceIds.length === 1 ? " was" : "s were"
+    } attached.`,
+  ];
+  const inferredClaims =
+    experiment.hypothesis.cause === "unclassified"
+      ? []
+      : [`Proposed cause: ${experiment.hypothesis.cause}`];
+  const gaps = missingCoverage(experiment.coverage);
+  const nextGate =
+    experiment.result.outcome === "untested"
+      ? "Classify the failure, approve one controlled change, then require an independent evaluator before promotion."
+      : experiment.result.outcome === "inconclusive"
+        ? "Collect the missing evidence and rerun the same controlled comparison."
+        : "This result is evaluated; inspect its cited evidence before reusing the remedy.";
+
+  return {
+    experimentId: experiment.experimentId,
+    status: experiment.result.outcome,
+    task: experiment.task.description,
+    capturedFacts,
+    inferredClaims,
+    missingCoverage: gaps,
+    nextGate,
+  };
+}

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildTrustworthySessionTimeline } from "./trustworthySessionTimeline.ts";
+import {
+  buildTrustworthySessionTimeline,
+  explainSession,
+} from "./trustworthySessionTimeline.ts";
 
 const base = {
   agentIndex: 0,
@@ -65,4 +68,52 @@ test("keeps Numbat conclusions distinct from directly observed facts", () => {
 
 test("does not invent gaps before a session has any evidence", () => {
   assert.deepEqual(buildTrustworthySessionTimeline([], []), []);
+});
+
+test("explains a failed session before exposing raw telemetry", () => {
+  const explanation = explainSession(
+    [
+      {
+        ...base,
+        seq: 1,
+        timestamp: "2026-08-05T12:00:00Z",
+        kind: "turn_started",
+        payload: {},
+      },
+      {
+        ...base,
+        seq: 2,
+        timestamp: "2026-08-05T12:00:02Z",
+        kind: "turn_error",
+        payload: { error: "cargo build exited 101" },
+      },
+    ],
+    [],
+  );
+
+  assert.equal(explanation.outcome, "failed");
+  assert.equal(explanation.why, "cargo build exited 101");
+  assert.equal(explanation.confidence, "medium");
+  assert.match(explanation.nextAction, /failed event/i);
+  assert.equal(explanation.unknowns.length, 2);
+});
+
+test("does not invent a cause or fix when evidence is incomplete", () => {
+  const explanation = explainSession(
+    [
+      {
+        ...base,
+        seq: 1,
+        timestamp: "2026-08-05T12:00:00Z",
+        kind: "turn_started",
+        payload: {},
+      },
+    ],
+    [],
+  );
+
+  assert.equal(explanation.outcome, "in_progress");
+  assert.match(explanation.why, /still running/i);
+  assert.equal(explanation.confidence, "low");
+  assert.match(explanation.nextAction, /missing outcome evidence/i);
 });

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTrustworthySessionTimeline } from "./trustworthySessionTimeline.ts";
+
+const base = {
+  agentIndex: 0,
+  channelId: "channel-1",
+  sessionId: "session-1",
+  turnId: "turn-1",
+};
+
+test("projects enforcement provenance and explicit uncovered layers", () => {
+  const events = buildTrustworthySessionTimeline(
+    [
+      {
+        ...base,
+        seq: 1,
+        timestamp: "2026-08-05T12:00:00Z",
+        kind: "permission_decision",
+        payload: { mode: "lockdown", decision: "reject_once" },
+      },
+    ],
+    [],
+  );
+
+  const decision = events.find((event) => event.class === "decision");
+  assert.equal(decision.title, "Tool request denied");
+  assert.equal(decision.sourceSystem, "Buzz ACP");
+  assert.equal(decision.observerRole, "enforced");
+  assert.equal(decision.confidence, "direct");
+
+  assert.deepEqual(
+    events
+      .filter((event) => event.class === "gap")
+      .map((event) => event.sourceLayer),
+    ["host_workspace", "os_sandbox"],
+  );
+});
+
+test("keeps Numbat conclusions distinct from directly observed facts", () => {
+  const events = buildTrustworthySessionTimeline(
+    [],
+    [
+      {
+        findingId: "finding-1",
+        ruleId: "guardian.suspicious-write",
+        title: "Suspicious write",
+        severity: "high",
+        detectedAt: "2026-08-05T12:00:01Z",
+        sourceAgent: "agent-1",
+        sessionId: "session-1",
+        channelId: "channel-1",
+        turnId: "turn-1",
+        evidenceCount: 2,
+      },
+    ],
+  );
+
+  const finding = events.find((event) => event.sourceSystem === "Numbat");
+  assert.equal(finding.class, "inference");
+  assert.equal(finding.observerRole, "inferred");
+  assert.equal(finding.confidence, "correlated");
+});
+
+test("does not invent gaps before a session has any evidence", () => {
+  assert.deepEqual(buildTrustworthySessionTimeline([], []), []);
+});

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
@@ -118,6 +118,169 @@ test("does not invent a cause or fix when evidence is incomplete", () => {
   assert.match(explanation.nextAction, /missing outcome evidence/i);
 });
 
+test("explains the latest raw ACP turn instead of the whole channel history", () => {
+  const priorTurn = [
+    {
+      ...base,
+      seq: 1,
+      timestamp: "2026-08-05T12:00:00Z",
+      kind: "turn_completed",
+      payload: {},
+    },
+  ];
+  const failedTurn = [
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 2,
+      timestamp: "2026-08-05T12:01:00Z",
+      kind: "turn_started",
+      payload: {},
+    },
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 3,
+      timestamp: "2026-08-05T12:01:01Z",
+      kind: "acp_write",
+      payload: {
+        method: "session/prompt",
+        params: {
+          prompt: [
+            {
+              type: "text",
+              text: "[Buzz event: @mention]\nContent: Use /usr/bin/touch /Library/buzz-causal-test.txt once.\nEvent ID: abc123",
+            },
+          ],
+        },
+      },
+    },
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 4,
+      timestamp: "2026-08-05T12:01:02Z",
+      kind: "acp_write",
+      payload: {
+        id: 9,
+        result: {
+          outcome: { outcome: "selected", optionId: "allow_once" },
+        },
+      },
+    },
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 5,
+      timestamp: "2026-08-05T12:01:03Z",
+      kind: "acp_read",
+      payload: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call_update",
+            status: "failed",
+            content: [
+              {
+                type: "content",
+                content: {
+                  type: "text",
+                  text: "touch: /Library/buzz-causal-test.txt: Permission denied",
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 6,
+      timestamp: "2026-08-05T12:01:04Z",
+      kind: "turn_completed",
+      payload: {},
+    },
+  ];
+
+  const explanation = explainSession([...priorTurn, ...failedTurn], []);
+
+  assert.equal(
+    explanation.task,
+    "Use /usr/bin/touch /Library/buzz-causal-test.txt once.",
+  );
+  assert.equal(explanation.outcome, "failed");
+  assert.match(explanation.why, /Permission denied/);
+  assert.equal(
+    explanation.evidence.some(
+      (event) => event.title === "Tool request allowed",
+    ),
+    true,
+  );
+  assert.equal(
+    explanation.evidence.some((event) => event.title === "Tool failed"),
+    true,
+  );
+  assert.equal(
+    explanation.unknowns.some((gap) => gap.sourceLayer === "os_sandbox"),
+    false,
+  );
+});
+
+test("does not call a completed turn successful without a successful tool result", () => {
+  const explanation = explainSession(
+    [
+      {
+        ...base,
+        seq: 1,
+        timestamp: "2026-08-05T12:00:00Z",
+        kind: "turn_completed",
+        payload: {},
+      },
+    ],
+    [],
+  );
+
+  assert.equal(explanation.outcome, "unknown");
+});
+
+test("marks a completed turn successful when its tool result succeeded", () => {
+  const explanation = explainSession(
+    [
+      {
+        ...base,
+        seq: 1,
+        timestamp: "2026-08-05T12:00:00Z",
+        kind: "acp_read",
+        payload: {
+          method: "session/update",
+          params: {
+            update: {
+              sessionUpdate: "tool_call_update",
+              status: "completed",
+              content: [{ type: "text", text: "exit code 0" }],
+            },
+          },
+        },
+      },
+      {
+        ...base,
+        seq: 2,
+        timestamp: "2026-08-05T12:00:01Z",
+        kind: "turn_completed",
+        payload: {},
+      },
+    ],
+    [],
+  );
+
+  assert.equal(explanation.outcome, "succeeded");
+  assert.equal(
+    explanation.evidence.some((event) => event.title === "Tool completed"),
+    true,
+  );
+});
+
 test("models the real host-write incident and validates one controlled replay", () => {
   const failedRun = [
     {

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
@@ -179,7 +179,8 @@ test("explains the latest raw ACP turn instead of the whole channel history", ()
         params: {
           update: {
             sessionUpdate: "tool_call_update",
-            status: "failed",
+            toolCallId: "touch-library",
+            status: "in_progress",
             content: [
               {
                 type: "content",
@@ -198,6 +199,32 @@ test("explains the latest raw ACP turn instead of the whole channel history", ()
       turnId: "turn-2",
       seq: 6,
       timestamp: "2026-08-05T12:01:04Z",
+      kind: "acp_read",
+      payload: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "touch-library",
+            status: "failed",
+            content: [],
+          },
+        },
+      },
+    },
+    ...Array.from({ length: 6 }, (_, index) => ({
+      ...base,
+      turnId: "turn-2",
+      seq: 7 + index,
+      timestamp: `2026-08-05T12:01:${String(5 + index).padStart(2, "0")}Z`,
+      kind: "acp_read",
+      payload: { method: "session/update", params: { update: {} } },
+    })),
+    {
+      ...base,
+      turnId: "turn-2",
+      seq: 13,
+      timestamp: "2026-08-05T12:01:11Z",
       kind: "turn_completed",
       payload: {},
     },

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.test.mjs
@@ -117,3 +117,161 @@ test("does not invent a cause or fix when evidence is incomplete", () => {
   assert.equal(explanation.confidence, "low");
   assert.match(explanation.nextAction, /missing outcome evidence/i);
 });
+
+test("models the real host-write incident and validates one controlled replay", () => {
+  const failedRun = [
+    {
+      ...base,
+      seq: 1,
+      timestamp: "2026-08-05T12:00:00Z",
+      kind: "task_captured",
+      payload: {
+        description:
+          "Write the requested file and ask before changing the workspace",
+        sourceMessageId: "host-write-request",
+      },
+    },
+    {
+      ...base,
+      seq: 2,
+      timestamp: "2026-08-05T12:00:01Z",
+      kind: "host_operation",
+      payload: {
+        operation: "Wrote",
+        target: "workspace file",
+        executionPath: "host tool path outside ACP",
+        observedBy: "Codex host",
+      },
+    },
+    {
+      ...base,
+      seq: 3,
+      timestamp: "2026-08-05T12:00:02Z",
+      kind: "causal_hypothesis",
+      payload: {
+        title: "Host write bypassed the ACP permission gate",
+        summary:
+          "No permission appeared because the host tool performed the write outside the ACP execution path.",
+        confidence: "high",
+        evidenceIds: ["observer:session-1:2"],
+      },
+    },
+    {
+      ...base,
+      seq: 4,
+      timestamp: "2026-08-05T12:00:03Z",
+      kind: "turn_completed",
+      payload: {},
+    },
+    {
+      ...base,
+      seq: 5,
+      timestamp: "2026-08-05T12:00:04Z",
+      kind: "remediation_proposed",
+      payload: {
+        summary: "Route workspace writes through the governed ACP tool path",
+        controlledChange: "execution path: host tool → ACP workspace tool",
+      },
+    },
+  ];
+
+  const beforeReplay = explainSession(failedRun, []);
+  assert.equal(
+    beforeReplay.task,
+    "Write the requested file and ask before changing the workspace",
+  );
+  assert.match(beforeReplay.why, /outside the ACP execution path/i);
+  assert.equal(beforeReplay.remediation.status, "not_tested");
+  assert.match(beforeReplay.nextAction, /host tool → ACP workspace tool/i);
+  assert.equal(
+    beforeReplay.unknowns.some((gap) => gap.sourceLayer === "host_workspace"),
+    false,
+  );
+  assert.equal(
+    beforeReplay.unknowns.some((gap) => gap.sourceLayer === "os_sandbox"),
+    true,
+  );
+
+  const afterReplay = explainSession(
+    [
+      ...failedRun,
+      {
+        ...base,
+        sessionId: "session-replay-1",
+        turnId: "turn-replay-1",
+        seq: 6,
+        timestamp: "2026-08-05T12:01:00Z",
+        kind: "permission_decision",
+        payload: { mode: "ask", decision: "allow_once" },
+      },
+      {
+        ...base,
+        sessionId: "session-replay-1",
+        turnId: "turn-replay-1",
+        seq: 7,
+        timestamp: "2026-08-05T12:01:01Z",
+        kind: "replay_result",
+        payload: {
+          outcome: "succeeded",
+          expectedCauseObserved: true,
+          validatesRemedyId: "observer:session-1:5",
+          summary:
+            "The governed path requested permission before the write and the task succeeded.",
+        },
+      },
+    ],
+    [],
+  );
+
+  assert.equal(afterReplay.remediation.status, "validated");
+  assert.match(afterReplay.remediation.result, /requested permission/i);
+  assert.match(afterReplay.nextAction, /validated governed execution path/i);
+});
+
+test("does not validate a remedy from an unrelated or permission-free replay", () => {
+  const failedRun = [
+    {
+      ...base,
+      seq: 1,
+      kind: "remediation_proposed",
+      payload: {
+        summary: "Route writes through ACP",
+        controlledChange: "host tool → ACP workspace tool",
+      },
+    },
+  ];
+  const successfulButUnlinkedReplay = {
+    ...base,
+    sessionId: "session-replay-2",
+    turnId: "turn-replay-2",
+    seq: 2,
+    kind: "replay_result",
+    payload: {
+      outcome: "succeeded",
+      expectedCauseObserved: true,
+      validatesRemedyId: "observer:some-other-session:1",
+      summary: "An unrelated replay succeeded.",
+    },
+  };
+
+  const unlinked = explainSession(
+    [...failedRun, successfulButUnlinkedReplay],
+    [],
+  );
+  assert.equal(unlinked.remediation.status, "not_tested");
+
+  const linkedWithoutPermission = explainSession(
+    [
+      ...failedRun,
+      {
+        ...successfulButUnlinkedReplay,
+        payload: {
+          ...successfulButUnlinkedReplay.payload,
+          validatesRemedyId: "observer:session-1:1",
+        },
+      },
+    ],
+    [],
+  );
+  assert.equal(linkedWithoutPermission.remediation.status, "inconclusive");
+});

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -30,6 +30,14 @@ export type CausalTimelineEvent = {
 
 export type SessionOutcome = "succeeded" | "failed" | "in_progress" | "unknown";
 
+export type RemediationVerification = {
+  remedy: string;
+  controlledChange: string;
+  status: "validated" | "rejected" | "inconclusive" | "not_tested";
+  result: string;
+  evidenceIds: string[];
+};
+
 export type SessionExplanation = {
   task: string;
   outcome: SessionOutcome;
@@ -38,6 +46,7 @@ export type SessionExplanation = {
   evidence: CausalTimelineEvent[];
   unknowns: CausalTimelineEvent[];
   nextAction: string;
+  remediation: RemediationVerification | null;
 };
 
 const REQUIRED_SOURCE_LAYERS = [
@@ -55,6 +64,12 @@ function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function stringValues(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
 function observerEventId(event: ObserverEvent): string {
   return `observer:${event.sessionId ?? "unknown"}:${event.seq}`;
 }
@@ -62,6 +77,46 @@ function observerEventId(event: ObserverEvent): string {
 function projectObserverEvent(event: ObserverEvent): CausalTimelineEvent {
   const payload = objectPayload(event);
   const eventId = observerEventId(event);
+
+  if (event.kind === "host_operation") {
+    const operation = stringValue(payload.operation) ?? "Host operation";
+    const target = stringValue(payload.target) ?? "unknown target";
+    const path = stringValue(payload.executionPath) ?? "host runtime";
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "fact",
+      title: `${operation} ${target}`,
+      detail: `The ${path} performed this operation.`,
+      sourceSystem: stringValue(payload.observedBy) ?? "Host runtime",
+      sourceLayer: "host_workspace",
+      observerRole: "observed",
+      confidence: "direct",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: [eventId],
+    };
+  }
+
+  if (event.kind === "causal_hypothesis") {
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "inference",
+      title: stringValue(payload.title) ?? "Causal hypothesis",
+      detail:
+        stringValue(payload.summary) ??
+        "Buzz does not have a summary for this hypothesis.",
+      sourceSystem: "Buzz causal graph",
+      sourceLayer: "causal_correlation",
+      observerRole: "inferred",
+      confidence:
+        stringValue(payload.confidence) === "high" ? "correlated" : "unknown",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: stringValues(payload.evidenceIds),
+    };
+  }
 
   if (event.kind === "permission_decision") {
     const decision = stringValue(payload.decision) ?? "unknown";
@@ -204,6 +259,9 @@ export function explainSession(
       (event) =>
         event.class === "inference" && event.confidence === "correlated",
     );
+  const causalHypothesis = [...timeline]
+    .reverse()
+    .find((event) => event.sourceLayer === "causal_correlation");
   const deniedDecision = [...timeline]
     .reverse()
     .find(
@@ -220,7 +278,12 @@ export function explainSession(
       : latestStarted
         ? "in_progress"
         : "unknown";
-  const cause = strongestFinding ?? latestError ?? deniedDecision ?? null;
+  const cause =
+    causalHypothesis ??
+    strongestFinding ??
+    latestError ??
+    deniedDecision ??
+    null;
   const why = cause
     ? cause.detail === "Captured by the Buzz ACP observer."
       ? cause.title
@@ -235,19 +298,82 @@ export function explainSession(
         ? "medium"
         : "low";
 
+  const taskEvent = [...observerEvents]
+    .reverse()
+    .find((event) => event.kind === "task_captured");
+  const taskPayload = taskEvent ? objectPayload(taskEvent) : {};
+  const task =
+    stringValue(taskPayload.description) ??
+    (stringValue(taskPayload.sourceMessageId)
+      ? `Task captured from message ${stringValue(taskPayload.sourceMessageId)}`
+      : "Task description unavailable from current session evidence");
+  const remedyEvent = [...observerEvents]
+    .reverse()
+    .find((event) => event.kind === "remediation_proposed");
+  const replayEvent = [...observerEvents]
+    .reverse()
+    .find((event) => event.kind === "replay_result");
+  const remedyPayload = remedyEvent ? objectPayload(remedyEvent) : {};
+  const replayPayload = replayEvent ? objectPayload(replayEvent) : {};
+  const replayOutcome = stringValue(replayPayload.outcome);
+  const expectedCauseObserved = replayPayload.expectedCauseObserved === true;
+  const remedyEventId = remedyEvent ? observerEventId(remedyEvent) : null;
+  const replayValidatesRemedy =
+    remedyEventId !== null &&
+    stringValue(replayPayload.validatesRemedyId) === remedyEventId;
+  const replayRequestedPermission = replayEvent
+    ? observerEvents.some(
+        (event) =>
+          event.kind === "permission_decision" &&
+          event.sessionId === replayEvent.sessionId &&
+          event.turnId === replayEvent.turnId &&
+          event.timestamp <= replayEvent.timestamp,
+      )
+    : false;
+  const remediation = remedyEvent
+    ? {
+        remedy:
+          stringValue(remedyPayload.summary) ??
+          "Proposed remediation unavailable",
+        controlledChange:
+          stringValue(remedyPayload.controlledChange) ??
+          "Controlled change unavailable",
+        status:
+          replayEvent && replayValidatesRemedy
+            ? replayOutcome === "succeeded" &&
+              expectedCauseObserved &&
+              replayRequestedPermission
+              ? ("validated" as const)
+              : replayOutcome === "failed"
+                ? ("rejected" as const)
+                : ("inconclusive" as const)
+            : ("not_tested" as const),
+        result: replayEvent
+          ? (stringValue(replayPayload.summary) ?? "Replay result unavailable")
+          : "No controlled replay has tested this remedy yet.",
+        evidenceIds: replayEvent ? [observerEventId(replayEvent)] : [],
+      }
+    : null;
+
   return {
-    task: "Task description unavailable from current session evidence",
+    task,
     outcome,
     why,
     confidence,
     evidence: facts.slice(-5),
     unknowns: gaps,
-    nextAction: deniedDecision
-      ? "Review the denied tool request and grant only the access the task requires."
-      : latestError
-        ? "Open the failed event below and address its diagnostic before retrying."
-        : strongestFinding
-          ? "Review the highest-confidence finding and its linked evidence before retrying."
-          : "Collect the missing outcome evidence before choosing a fix.",
+    nextAction:
+      remediation?.status === "validated"
+        ? "Use the validated governed execution path for the next run."
+        : remediation?.status === "not_tested"
+          ? `Replay with one controlled change: ${remediation.controlledChange}`
+          : deniedDecision
+            ? "Review the denied tool request and grant only the access the task requires."
+            : latestError
+              ? "Open the failed event below and address its diagnostic before retrying."
+              : strongestFinding
+                ? "Review the highest-confidence finding and its linked evidence before retrying."
+                : "Collect the missing outcome evidence before choosing a fix.",
+    remediation,
   };
 }

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -28,6 +28,18 @@ export type CausalTimelineEvent = {
   evidenceIds: string[];
 };
 
+export type SessionOutcome = "succeeded" | "failed" | "in_progress" | "unknown";
+
+export type SessionExplanation = {
+  task: string;
+  outcome: SessionOutcome;
+  why: string;
+  confidence: "high" | "medium" | "low";
+  evidence: CausalTimelineEvent[];
+  unknowns: CausalTimelineEvent[];
+  nextAction: string;
+};
+
 const REQUIRED_SOURCE_LAYERS = [
   { layer: "host_workspace", system: "Host workspace tools" },
   { layer: "os_sandbox", system: "Operating-system sandbox" },
@@ -168,4 +180,74 @@ export function buildTrustworthySessionTimeline(
     const byTime = Date.parse(left.timestamp) - Date.parse(right.timestamp);
     return byTime || left.id.localeCompare(right.id);
   });
+}
+
+export function explainSession(
+  observerEvents: readonly ObserverEvent[],
+  findings: readonly NumbatFinding[],
+): SessionExplanation | null {
+  const timeline = buildTrustworthySessionTimeline(observerEvents, findings);
+  if (timeline.length === 0) return null;
+
+  const latestError = [...timeline]
+    .reverse()
+    .find((event) => event.title === "Turn failed");
+  const latestCompleted = [...observerEvents]
+    .reverse()
+    .find((event) => event.kind === "turn_completed");
+  const latestStarted = [...observerEvents]
+    .reverse()
+    .find((event) => event.kind === "turn_started");
+  const strongestFinding = [...timeline]
+    .reverse()
+    .find(
+      (event) =>
+        event.class === "inference" && event.confidence === "correlated",
+    );
+  const deniedDecision = [...timeline]
+    .reverse()
+    .find(
+      (event) =>
+        event.class === "decision" && event.title === "Tool request denied",
+    );
+  const gaps = timeline.filter((event) => event.class === "gap");
+  const facts = timeline.filter((event) => event.class !== "gap");
+
+  const outcome: SessionOutcome = latestError
+    ? "failed"
+    : latestCompleted
+      ? "succeeded"
+      : latestStarted
+        ? "in_progress"
+        : "unknown";
+  const cause = strongestFinding ?? latestError ?? deniedDecision ?? null;
+  const why = cause
+    ? cause.detail === "Captured by the Buzz ACP observer."
+      ? cause.title
+      : cause.detail
+    : outcome === "in_progress"
+      ? "The task is still running. Buzz does not have a final cause yet."
+      : "Buzz does not have enough evidence to explain the outcome yet.";
+  const confidence =
+    cause?.confidence === "direct" && gaps.length === 0
+      ? "high"
+      : cause && cause.confidence !== "unknown"
+        ? "medium"
+        : "low";
+
+  return {
+    task: "Task description unavailable from current session evidence",
+    outcome,
+    why,
+    confidence,
+    evidence: facts.slice(-5),
+    unknowns: gaps,
+    nextAction: deniedDecision
+      ? "Review the denied tool request and grant only the access the task requires."
+      : latestError
+        ? "Open the failed event below and address its diagnostic before retrying."
+        : strongestFinding
+          ? "Review the highest-confidence finding and its linked evidence before retrying."
+          : "Collect the missing outcome evidence before choosing a fix.",
+  };
 }

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -1,4 +1,10 @@
 import type { ObserverEvent } from "./agentSessionTypes";
+import {
+  extractPromptText,
+  extractToolResult,
+  parsePromptText,
+} from "./agentSessionTranscriptHelpers";
+import { asRecord, asString } from "./agentSessionUtils";
 
 export type CausalFinding = {
   findingId: string;
@@ -74,9 +80,140 @@ function observerEventId(event: ObserverEvent): string {
   return `observer:${event.sessionId ?? "unknown"}:${event.seq}`;
 }
 
+function latestTurnEvents(
+  observerEvents: readonly ObserverEvent[],
+): ObserverEvent[] {
+  const latestTurn = [...observerEvents]
+    .reverse()
+    .find((event) => event.turnId);
+  if (!latestTurn?.turnId) return observerEvents as ObserverEvent[];
+  return observerEvents.filter(
+    (event) =>
+      event.turnId === latestTurn.turnId &&
+      (!latestTurn.sessionId || event.sessionId === latestTurn.sessionId),
+  );
+}
+
+function acpMethod(event: ObserverEvent): string | null {
+  return asString(objectPayload(event).method);
+}
+
+function acpUpdate(event: ObserverEvent): Record<string, unknown> {
+  const payload = objectPayload(event);
+  return asRecord(asRecord(payload.params).update);
+}
+
+function permissionDecisionFromRawEvent(
+  event: ObserverEvent,
+): { decision: string; denied: boolean } | null {
+  if (event.kind !== "acp_write" || acpMethod(event)) return null;
+  const result = asRecord(asRecord(objectPayload(event).result).outcome);
+  const outcome = asString(result.outcome);
+  if (!outcome) return null;
+  const optionId = asString(result.optionId);
+  const decision = optionId ?? outcome;
+  if (outcome !== "cancelled" && !/allow|reject|deny|cancel/.test(decision)) {
+    return null;
+  }
+  return {
+    decision,
+    denied:
+      outcome === "cancelled" ||
+      decision.includes("reject") ||
+      decision.includes("deny") ||
+      decision.includes("cancel"),
+  };
+}
+
+function toolResultFromRawEvent(
+  event: ObserverEvent,
+): { detail: string; failed: boolean } | null {
+  if (event.kind !== "acp_read" || acpMethod(event) !== "session/update") {
+    return null;
+  }
+  const update = acpUpdate(event);
+  if (asString(update.sessionUpdate) !== "tool_call_update") return null;
+  const status = asString(update.status);
+  if (status !== "completed" && status !== "failed") return null;
+  const detail = extractToolResult(update) || `Tool ${status}.`;
+  return {
+    detail,
+    failed:
+      status === "failed" ||
+      /permission denied|operation not permitted/i.test(detail),
+  };
+}
+
+function taskFromEvents(events: readonly ObserverEvent[]): string | null {
+  const taskEvent = [...events]
+    .reverse()
+    .find((event) => event.kind === "task_captured");
+  if (taskEvent) {
+    const taskPayload = objectPayload(taskEvent);
+    return (
+      stringValue(taskPayload.description) ??
+      (stringValue(taskPayload.sourceMessageId)
+        ? `Task captured from message ${stringValue(taskPayload.sourceMessageId)}`
+        : null)
+    );
+  }
+
+  const promptEvent = [...events]
+    .reverse()
+    .find(
+      (event) =>
+        event.kind === "acp_write" && acpMethod(event) === "session/prompt",
+    );
+  if (!promptEvent) return null;
+  const prompt = extractPromptText(objectPayload(promptEvent));
+  if (!prompt) return null;
+  return parsePromptText(prompt).userText || prompt.trim() || null;
+}
+
 function projectObserverEvent(event: ObserverEvent): CausalTimelineEvent {
   const payload = objectPayload(event);
   const eventId = observerEventId(event);
+
+  const rawPermissionDecision = permissionDecisionFromRawEvent(event);
+  if (rawPermissionDecision) {
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "decision",
+      title: rawPermissionDecision.denied
+        ? "Tool request denied"
+        : "Tool request allowed",
+      detail: `Buzz ACP answered ${rawPermissionDecision.decision}.`,
+      sourceSystem: "Buzz ACP",
+      sourceLayer: "acp_permission_gate",
+      observerRole: "enforced",
+      confidence: "direct",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: [eventId],
+    };
+  }
+
+  const rawToolResult = toolResultFromRawEvent(event);
+  if (rawToolResult) {
+    const permissionFailure =
+      rawToolResult.failed &&
+      /permission denied|operation not permitted/i.test(rawToolResult.detail);
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "fact",
+      title: rawToolResult.failed ? "Tool failed" : "Tool completed",
+      detail: rawToolResult.detail,
+      sourceSystem: permissionFailure ? "Operating-system sandbox" : "Buzz ACP",
+      sourceLayer: permissionFailure ? "os_sandbox" : "acp_tool_result",
+      observerRole: "observed",
+      confidence: "direct",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: [eventId],
+    };
+  }
 
   if (event.kind === "host_operation") {
     const operation = stringValue(payload.operation) ?? "Host operation";
@@ -241,16 +378,26 @@ export function explainSession(
   observerEvents: readonly ObserverEvent[],
   findings: readonly NumbatFinding[],
 ): SessionExplanation | null {
-  const timeline = buildTrustworthySessionTimeline(observerEvents, findings);
+  const scopedEvents = latestTurnEvents(observerEvents);
+  const scopedTurnId = scopedEvents.find((event) => event.turnId)?.turnId;
+  const scopedFindings = scopedTurnId
+    ? findings.filter(
+        (finding) => !finding.turnId || finding.turnId === scopedTurnId,
+      )
+    : findings;
+  const timeline = buildTrustworthySessionTimeline(
+    scopedEvents,
+    scopedFindings,
+  );
   if (timeline.length === 0) return null;
 
   const latestError = [...timeline]
     .reverse()
     .find((event) => event.title === "Turn failed");
-  const latestCompleted = [...observerEvents]
+  const latestCompleted = [...scopedEvents]
     .reverse()
     .find((event) => event.kind === "turn_completed");
-  const latestStarted = [...observerEvents]
+  const latestStarted = [...scopedEvents]
     .reverse()
     .find((event) => event.kind === "turn_started");
   const strongestFinding = [...timeline]
@@ -270,18 +417,28 @@ export function explainSession(
     );
   const gaps = timeline.filter((event) => event.class === "gap");
   const facts = timeline.filter((event) => event.class !== "gap");
+  const latestToolFailure = [...timeline]
+    .reverse()
+    .find((event) => event.title === "Tool failed");
+  const latestToolSuccess = [...timeline]
+    .reverse()
+    .find((event) => event.title === "Tool completed");
 
-  const outcome: SessionOutcome = latestError
-    ? "failed"
-    : latestCompleted
-      ? "succeeded"
-      : latestStarted
-        ? "in_progress"
-        : "unknown";
+  const outcome: SessionOutcome =
+    latestError || latestToolFailure || deniedDecision
+      ? "failed"
+      : latestCompleted && latestToolSuccess
+        ? "succeeded"
+        : latestCompleted
+          ? "unknown"
+          : latestStarted
+            ? "in_progress"
+            : "unknown";
   const cause =
     causalHypothesis ??
     strongestFinding ??
     latestError ??
+    latestToolFailure ??
     deniedDecision ??
     null;
   const why = cause
@@ -298,15 +455,9 @@ export function explainSession(
         ? "medium"
         : "low";
 
-  const taskEvent = [...observerEvents]
-    .reverse()
-    .find((event) => event.kind === "task_captured");
-  const taskPayload = taskEvent ? objectPayload(taskEvent) : {};
   const task =
-    stringValue(taskPayload.description) ??
-    (stringValue(taskPayload.sourceMessageId)
-      ? `Task captured from message ${stringValue(taskPayload.sourceMessageId)}`
-      : "Task description unavailable from current session evidence");
+    taskFromEvents(scopedEvents) ??
+    "Task description unavailable from current turn evidence";
   const remedyEvent = [...observerEvents]
     .reverse()
     .find((event) => event.kind === "remediation_proposed");

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -127,6 +127,7 @@ function permissionDecisionFromRawEvent(
 
 function toolResultFromRawEvent(
   event: ObserverEvent,
+  observerEvents: readonly ObserverEvent[],
 ): { detail: string; failed: boolean } | null {
   if (event.kind !== "acp_read" || acpMethod(event) !== "session/update") {
     return null;
@@ -135,7 +136,22 @@ function toolResultFromRawEvent(
   if (asString(update.sessionUpdate) !== "tool_call_update") return null;
   const status = asString(update.status);
   if (status !== "completed" && status !== "failed") return null;
-  const detail = extractToolResult(update) || `Tool ${status}.`;
+  const toolCallId = asString(update.toolCallId);
+  const earlierUpdate = toolCallId
+    ? [...observerEvents]
+        .reverse()
+        .map((candidate) => acpUpdate(candidate))
+        .find(
+          (candidateUpdate) =>
+            asString(candidateUpdate.sessionUpdate) === "tool_call_update" &&
+            asString(candidateUpdate.toolCallId) === toolCallId &&
+            Boolean(extractToolResult(candidateUpdate)),
+        )
+    : null;
+  const detail =
+    extractToolResult(update) ||
+    (earlierUpdate ? extractToolResult(earlierUpdate) : null) ||
+    `Tool ${status}.`;
   return {
     detail,
     failed:
@@ -170,7 +186,10 @@ function taskFromEvents(events: readonly ObserverEvent[]): string | null {
   return parsePromptText(prompt).userText || prompt.trim() || null;
 }
 
-function projectObserverEvent(event: ObserverEvent): CausalTimelineEvent {
+function projectObserverEvent(
+  event: ObserverEvent,
+  observerEvents: readonly ObserverEvent[],
+): CausalTimelineEvent {
   const payload = objectPayload(event);
   const eventId = observerEventId(event);
 
@@ -194,7 +213,7 @@ function projectObserverEvent(event: ObserverEvent): CausalTimelineEvent {
     };
   }
 
-  const rawToolResult = toolResultFromRawEvent(event);
+  const rawToolResult = toolResultFromRawEvent(event, observerEvents);
   if (rawToolResult) {
     const permissionFailure =
       rawToolResult.failed &&
@@ -336,7 +355,9 @@ export function buildTrustworthySessionTimeline(
   if (observerEvents.length === 0 && findings.length === 0) return [];
 
   const projected = [
-    ...observerEvents.map(projectObserverEvent),
+    ...observerEvents.map((event) =>
+      projectObserverEvent(event, observerEvents),
+    ),
     ...findings.map(projectFinding),
   ];
   const seenLayers = new Set(projected.map((event) => event.sourceLayer));
@@ -505,13 +526,21 @@ export function explainSession(
         evidenceIds: replayEvent ? [observerEventId(replayEvent)] : [],
       }
     : null;
+  const causalEvidence = facts.filter(
+    (event) =>
+      event.class === "decision" ||
+      event.title === "Tool failed" ||
+      event.title === "Tool completed" ||
+      event.title === "Turn failed",
+  );
 
   return {
     task,
     outcome,
     why,
     confidence,
-    evidence: facts.slice(-5),
+    evidence:
+      causalEvidence.length > 0 ? causalEvidence.slice(-5) : facts.slice(-5),
     unknowns: gaps,
     nextAction:
       remediation?.status === "validated"

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -1,0 +1,171 @@
+import type { ObserverEvent } from "./agentSessionTypes";
+
+export type CausalFinding = {
+  findingId: string;
+  detectedAt: string;
+  title: string;
+  ruleId: string;
+  evidenceCount: number;
+  sessionId: string | null;
+  turnId: string | null;
+};
+
+export type CausalEventClass = "fact" | "decision" | "inference" | "gap";
+export type CausalEventConfidence = "direct" | "correlated" | "unknown";
+
+export type CausalTimelineEvent = {
+  id: string;
+  timestamp: string;
+  class: CausalEventClass;
+  title: string;
+  detail: string;
+  sourceSystem: string;
+  sourceLayer: string;
+  observerRole: "observed" | "decided" | "enforced" | "inferred" | "missing";
+  confidence: CausalEventConfidence;
+  sessionId: string | null;
+  turnId: string | null;
+  evidenceIds: string[];
+};
+
+const REQUIRED_SOURCE_LAYERS = [
+  { layer: "host_workspace", system: "Host workspace tools" },
+  { layer: "os_sandbox", system: "Operating-system sandbox" },
+] as const;
+
+function objectPayload(event: ObserverEvent): Record<string, unknown> {
+  return event.payload && typeof event.payload === "object"
+    ? (event.payload as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function observerEventId(event: ObserverEvent): string {
+  return `observer:${event.sessionId ?? "unknown"}:${event.seq}`;
+}
+
+function projectObserverEvent(event: ObserverEvent): CausalTimelineEvent {
+  const payload = objectPayload(event);
+  const eventId = observerEventId(event);
+
+  if (event.kind === "permission_decision") {
+    const decision = stringValue(payload.decision) ?? "unknown";
+    const mode = stringValue(payload.mode) ?? "unspecified policy";
+    const denied = decision.includes("reject") || decision.includes("cancel");
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "decision",
+      title: denied ? "Tool request denied" : "Tool request allowed",
+      detail: `Buzz ACP answered ${decision} under ${mode}.`,
+      sourceSystem: "Buzz ACP",
+      sourceLayer: "acp_permission_gate",
+      observerRole: "enforced",
+      confidence: "direct",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: [eventId],
+    };
+  }
+
+  if (event.kind === "turn_error") {
+    const message =
+      stringValue(payload.message) ??
+      stringValue(payload.error) ??
+      "No diagnostic was emitted.";
+    return {
+      id: eventId,
+      timestamp: event.timestamp,
+      class: "fact",
+      title: "Turn failed",
+      detail: message,
+      sourceSystem: "Buzz ACP",
+      sourceLayer: "acp_runtime",
+      observerRole: "observed",
+      confidence: "direct",
+      sessionId: event.sessionId,
+      turnId: event.turnId,
+      evidenceIds: [eventId],
+    };
+  }
+
+  return {
+    id: eventId,
+    timestamp: event.timestamp,
+    class: "fact",
+    title: event.kind.replaceAll("_", " "),
+    detail: "Captured by the Buzz ACP observer.",
+    sourceSystem: "Buzz ACP",
+    sourceLayer: "acp_observer",
+    observerRole: "observed",
+    confidence: "direct",
+    sessionId: event.sessionId,
+    turnId: event.turnId,
+    evidenceIds: [eventId],
+  };
+}
+
+function projectFinding(finding: CausalFinding): CausalTimelineEvent {
+  return {
+    id: `numbat:${finding.findingId}`,
+    timestamp: finding.detectedAt,
+    class: "inference",
+    title: finding.title,
+    detail: `${finding.ruleId} correlated ${finding.evidenceCount} evidence event${finding.evidenceCount === 1 ? "" : "s"}.`,
+    sourceSystem: "Numbat",
+    sourceLayer: "guardian_detection",
+    observerRole: "inferred",
+    confidence: finding.evidenceCount > 0 ? "correlated" : "unknown",
+    sessionId: finding.sessionId,
+    turnId: finding.turnId,
+    evidenceIds: [],
+  };
+}
+
+export function buildTrustworthySessionTimeline(
+  observerEvents: readonly ObserverEvent[],
+  findings: readonly CausalFinding[],
+): CausalTimelineEvent[] {
+  if (observerEvents.length === 0 && findings.length === 0) return [];
+
+  const projected = [
+    ...observerEvents.map(projectObserverEvent),
+    ...findings.map(projectFinding),
+  ];
+  const seenLayers = new Set(projected.map((event) => event.sourceLayer));
+  const sessionId =
+    projected.find((event) => event.sessionId)?.sessionId ?? null;
+  const turnId = projected.find((event) => event.turnId)?.turnId ?? null;
+  const gapTimestamp =
+    projected
+      .map((event) => event.timestamp)
+      .filter(Boolean)
+      .sort()[0] ?? new Date(0).toISOString();
+
+  for (const source of REQUIRED_SOURCE_LAYERS) {
+    if (seenLayers.has(source.layer)) continue;
+    projected.push({
+      id: `gap:${source.layer}:${sessionId ?? "unknown"}`,
+      timestamp: gapTimestamp,
+      class: "gap",
+      title: `${source.system} telemetry unavailable`,
+      detail:
+        "This execution layer is not connected to the Buzz session timeline. Actions may have occurred without appearing here.",
+      sourceSystem: source.system,
+      sourceLayer: source.layer,
+      observerRole: "missing",
+      confidence: "unknown",
+      sessionId,
+      turnId,
+      evidenceIds: [],
+    });
+  }
+
+  return projected.sort((left, right) => {
+    const byTime = Date.parse(left.timestamp) - Date.parse(right.timestamp);
+    return byTime || left.id.localeCompare(right.id);
+  });
+}

--- a/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
+++ b/desktop/src/features/agents/ui/trustworthySessionTimeline.ts
@@ -397,7 +397,7 @@ export function buildTrustworthySessionTimeline(
 
 export function explainSession(
   observerEvents: readonly ObserverEvent[],
-  findings: readonly NumbatFinding[],
+  findings: readonly CausalFinding[],
 ): SessionExplanation | null {
   const scopedEvents = latestTurnEvents(observerEvents);
   const scopedTurnId = scopedEvents.find((event) => event.turnId)?.turnId;

--- a/desktop/src/features/agents/useAgentObserverIngestion.ts
+++ b/desktop/src/features/agents/useAgentObserverIngestion.ts
@@ -5,7 +5,11 @@ import {
   useManagedAgentsQuery,
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
-import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import {
+  subscribeObserverEvents,
+  useManagedAgentObserverBridge,
+} from "@/features/agents/observerRelayStore";
+import { LiveCausalLedger } from "@/features/agents/lib/liveCausalLedger";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { ManagedAgent } from "@/shared/api/types";
@@ -113,4 +117,12 @@ export function useAgentObserverIngestion() {
 
   useManagedAgentObserverBridge(ingestionAgents);
   useActiveAgentTurnsBridge(ingestionAgents);
+
+  React.useEffect(() => {
+    if (!currentPubkey) return;
+    const ledger = new LiveCausalLedger(currentPubkey, window.localStorage);
+    return subscribeObserverEvents((agentPubkey, event) => {
+      void ledger.ingest(agentPubkey, event);
+    });
+  }, [currentPubkey]);
 }

--- a/desktop/src/features/agents/useAgentObserverIngestion.ts
+++ b/desktop/src/features/agents/useAgentObserverIngestion.ts
@@ -10,6 +10,7 @@ import {
   useManagedAgentObserverBridge,
 } from "@/features/agents/observerRelayStore";
 import { LiveCausalLedger } from "@/features/agents/lib/liveCausalLedger";
+import { createTauriCausalLedgerPersistence } from "@/shared/api/tauriCausalLedger";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { ManagedAgent } from "@/shared/api/types";
@@ -120,7 +121,10 @@ export function useAgentObserverIngestion() {
 
   React.useEffect(() => {
     if (!currentPubkey) return;
-    const ledger = new LiveCausalLedger(currentPubkey, window.localStorage);
+    const ledger = new LiveCausalLedger(
+      currentPubkey,
+      createTauriCausalLedgerPersistence(),
+    );
     return subscribeObserverEvents((agentPubkey, event) => {
       void ledger.ingest(agentPubkey, event);
     });

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -62,6 +62,7 @@ import { useLoadOlderOnScroll } from "@/features/messages/ui/useLoadOlderOnScrol
 import type { ChannelAgentSessionAgent } from "./useChannelAgentSessions";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { CausalSessionTimeline } from "@/features/agents/ui/CausalSessionTimeline";
+import { CausalCandidateCard } from "@/features/agents/ui/CausalCandidateCard";
 
 type AgentSessionThreadPanelProps = {
   agent: ChannelAgentSessionAgent;
@@ -128,6 +129,12 @@ export function AgentSessionThreadPanel({
   const combinedHeaderEvents = React.useMemo(
     () => mergeObserverEventWindows(scopedEvents, archivedChannelEvents),
     [scopedEvents, archivedChannelEvents],
+  );
+  const activeSessionId = React.useMemo(
+    () =>
+      combinedHeaderEvents.findLast((event) => Boolean(event.sessionId))
+        ?.sessionId ?? null,
+    [combinedHeaderEvents],
   );
   const latestActivityAt = React.useMemo(
     () => getLatestActivityTimestamp(combinedHeaderEvents),
@@ -497,6 +504,7 @@ export function AgentSessionThreadPanel({
             events={combinedHeaderEvents}
             findings={[]}
           />
+          <CausalCandidateCard sessionId={activeSessionId} />
           <ManagedAgentSessionPanel
             agent={agent}
             channelId={sessionChannelId}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -504,7 +504,11 @@ export function AgentSessionThreadPanel({
             events={combinedHeaderEvents}
             findings={[]}
           />
-          <CausalCandidateCard sessionId={activeSessionId} />
+          <CausalCandidateCard
+            agentPubkey={agent.pubkey}
+            channelId={sessionChannelId}
+            sessionId={activeSessionId}
+          />
           <ManagedAgentSessionPanel
             agent={agent}
             channelId={sessionChannelId}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -61,6 +61,7 @@ import { useLoadArchivedObserverEvents } from "@/features/agents/ui/useObserverE
 import { useLoadOlderOnScroll } from "@/features/messages/ui/useLoadOlderOnScroll";
 import type { ChannelAgentSessionAgent } from "./useChannelAgentSessions";
 import { useChannelsQuery } from "@/features/channels/hooks";
+import { CausalSessionTimeline } from "@/features/agents/ui/CausalSessionTimeline";
 
 type AgentSessionThreadPanelProps = {
   agent: ChannelAgentSessionAgent;
@@ -492,6 +493,10 @@ export function AgentSessionThreadPanel({
       >
         <div ref={topSentinelRef} aria-hidden className="h-px" />
         <div ref={contentRef}>
+          <CausalSessionTimeline
+            events={combinedHeaderEvents}
+            findings={[]}
+          />
           <ManagedAgentSessionPanel
             agent={agent}
             channelId={sessionChannelId}

--- a/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
+++ b/desktop/src/features/channels/ui/AgentSessionThreadPanel.tsx
@@ -132,7 +132,7 @@ export function AgentSessionThreadPanel({
   );
   const activeSessionId = React.useMemo(
     () =>
-      combinedHeaderEvents.findLast((event) => Boolean(event.sessionId))
+      [...combinedHeaderEvents].reverse().find((event) => event.sessionId)
         ?.sessionId ?? null,
     [combinedHeaderEvents],
   );
@@ -500,10 +500,7 @@ export function AgentSessionThreadPanel({
       >
         <div ref={topSentinelRef} aria-hidden className="h-px" />
         <div ref={contentRef}>
-          <CausalSessionTimeline
-            events={combinedHeaderEvents}
-            findings={[]}
-          />
+          <CausalSessionTimeline events={combinedHeaderEvents} findings={[]} />
           <CausalCandidateCard
             agentPubkey={agent.pubkey}
             channelId={sessionChannelId}

--- a/desktop/src/shared/api/tauriCausalLedger.ts
+++ b/desktop/src/shared/api/tauriCausalLedger.ts
@@ -1,10 +1,37 @@
-import type { LedgerEntry } from "@/features/agents/lib/causalLedger";
+import {
+  CausalLedger,
+  type CausalExperiment,
+  type LedgerEntry,
+} from "@/features/agents/lib/causalLedger";
 import type { CausalLedgerPersistence } from "@/features/agents/lib/liveCausalLedger";
 import { invokeTauri } from "./tauri";
 
 export async function readCausalLedger(): Promise<LedgerEntry[]> {
   const entries = await invokeTauri<string[]>("read_causal_ledger");
   return entries.map((entry) => JSON.parse(entry) as LedgerEntry);
+}
+
+export async function appendCausalExperiment(
+  experiment: CausalExperiment,
+): Promise<LedgerEntry> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const entries = await readCausalLedger();
+    const ledger = await CausalLedger.fromJournal(
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+    );
+    const entry = await ledger.append(experiment);
+    try {
+      await invokeTauri("append_causal_ledger_entry", {
+        entryJson: JSON.stringify(entry),
+      });
+      return entry;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (attempt === 0 && message.includes("append conflict")) continue;
+      throw error;
+    }
+  }
+  throw new Error("Could not append the causal experiment after retrying.");
 }
 
 export function createTauriCausalLedgerPersistence(): CausalLedgerPersistence {

--- a/desktop/src/shared/api/tauriCausalLedger.ts
+++ b/desktop/src/shared/api/tauriCausalLedger.ts
@@ -2,11 +2,16 @@ import type { LedgerEntry } from "@/features/agents/lib/causalLedger";
 import type { CausalLedgerPersistence } from "@/features/agents/lib/liveCausalLedger";
 import { invokeTauri } from "./tauri";
 
+export async function readCausalLedger(): Promise<LedgerEntry[]> {
+  const entries = await invokeTauri<string[]>("read_causal_ledger");
+  return entries.map((entry) => JSON.parse(entry) as LedgerEntry);
+}
+
 export function createTauriCausalLedgerPersistence(): CausalLedgerPersistence {
   return {
     async loadJournal() {
-      const entries = await invokeTauri<string[]>("read_causal_ledger");
-      return entries.join("\n");
+      const entries = await readCausalLedger();
+      return entries.map((entry) => JSON.stringify(entry)).join("\n");
     },
     async appendEntry(entry: LedgerEntry) {
       await invokeTauri("append_causal_ledger_entry", {

--- a/desktop/src/shared/api/tauriCausalLedger.ts
+++ b/desktop/src/shared/api/tauriCausalLedger.ts
@@ -1,0 +1,17 @@
+import type { LedgerEntry } from "@/features/agents/lib/causalLedger";
+import type { CausalLedgerPersistence } from "@/features/agents/lib/liveCausalLedger";
+import { invokeTauri } from "./tauri";
+
+export function createTauriCausalLedgerPersistence(): CausalLedgerPersistence {
+  return {
+    async loadJournal() {
+      const entries = await invokeTauri<string[]>("read_causal_ledger");
+      return entries.join("\n");
+    },
+    async appendEntry(entry: LedgerEntry) {
+      await invokeTauri("append_causal_ledger_entry", {
+        entryJson: JSON.stringify(entry),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add an evidence-first session timeline that separates observed actions, inferred explanations, and missing telemetry
- persist causal candidates in SQLite with integrity verification and owner inspection
- add a controlled remediation replay flow with explicit owner approval and replay results
- ingest observer evidence into the causal ledger and surface the workflow in the managed-agent session panel
- default managed agents to one runtime worker to avoid accidental local process exhaustion

## Scope

This is the clean observability-only extraction of the earlier mixed branch. It intentionally excludes Numbat/Guardian UI, Open Interpreter, and onboarding changes so each can be reviewed independently.

## Verification

- complete Desktop unit suite
- Desktop TypeScript type check
- Desktop repository checker (Biome, file-size ratchet, text-size and pubkey rules)
- Rust formatting check
- git diff whitespace check

The full Rust compile/test suite was not rerun locally because this checkout previously exhausted the available disk during a fresh Tauri build; CI is the authoritative Rust build gate.

## Review notes

The branch contains 22 files and approximately 3.5k added lines, reduced from the mixed branch's 91 files and approximately 10k changed lines.
