### PR TITLE
feat(desktop): add Settings to macOS menus

### DIFF
--- a/desktop/src-tauri/src/app_menu.rs
+++ b/desktop/src-tauri/src/app_menu.rs
@@ -36,9 +36,7 @@ use tauri::{Builder, Runtime};
 /// the Cmd+W accelerator does not exist.
 pub fn install<R: Runtime>(builder: Builder<R>) -> Builder<R> {
     #[cfg(target_os = "macos")]
-    let builder = builder
-        .menu(build)
-        .on_menu_event(|app, event| crate::tray_menu::handle_menu_event(app, event.id.as_ref()));
+    let builder = builder.menu(build);
     builder
 }
 

--- a/desktop/src-tauri/src/app_menu.rs
+++ b/desktop/src-tauri/src/app_menu.rs
@@ -25,7 +25,7 @@
 
 #[cfg(target_os = "macos")]
 use tauri::menu::{
-    AboutMetadata, Menu, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
+    AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID, WINDOW_SUBMENU_ID,
 };
 #[cfg(target_os = "macos")]
 use tauri::AppHandle;
@@ -36,7 +36,9 @@ use tauri::{Builder, Runtime};
 /// the Cmd+W accelerator does not exist.
 pub fn install<R: Runtime>(builder: Builder<R>) -> Builder<R> {
     #[cfg(target_os = "macos")]
-    let builder = builder.menu(build);
+    let builder = builder
+        .menu(build)
+        .on_menu_event(|app, event| crate::tray_menu::handle_menu_event(app, event.id.as_ref()));
     builder
 }
 
@@ -67,6 +69,13 @@ pub fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
                 true,
                 &[
                     &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
+                    &MenuItem::with_id(
+                        app,
+                        crate::tray_menu::OPEN_SETTINGS_ID,
+                        "Settings…",
+                        true,
+                        Some("CmdOrCtrl+,"),
+                    )?,
                     &PredefinedMenuItem::separator(app)?,
                     &PredefinedMenuItem::services(app, None)?,
                     &PredefinedMenuItem::separator(app)?,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -909,6 +909,8 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             tray_menu::clear_tray_agent_activity,
             #[cfg(target_os = "macos")]
+            tray_menu::set_settings_tray_actions_enabled,
+            #[cfg(target_os = "macos")]
             tray_menu::requeue_tray_actions,
             #[cfg(target_os = "macos")]
             tray_menu::take_tray_actions,

--- a/desktop/src-tauri/src/tray_menu.rs
+++ b/desktop/src-tauri/src/tray_menu.rs
@@ -28,6 +28,7 @@ use tauri::{
 const TRAY_ID: &str = "buzz-tray";
 const OPEN_BUZZ_ID: &str = "tray-open-buzz";
 const NEW_CHANNEL_ID: &str = "tray-new-channel";
+pub(crate) const OPEN_SETTINGS_ID: &str = "open-settings";
 const QUIT_ID: &str = "tray-quit";
 const OPEN_CHANNEL_PREFIX: &str = "tray-open-channel:";
 const OPEN_CHANNEL_ACTIVITY_SEPARATOR: char = '|';
@@ -212,6 +213,7 @@ struct TrayMenuState<R: Runtime> {
 #[serde(rename_all = "camelCase", tag = "kind")]
 pub enum TrayAction {
     NewChannel,
+    OpenSettings,
     OpenChannel {
         #[serde(rename = "channelId")]
         channel_id: String,
@@ -343,6 +345,13 @@ fn build_menu<R: Runtime>(
     append_separator(app, &menu)?;
     menu.append(&MenuItem::with_id(
         app,
+        OPEN_SETTINGS_ID,
+        "Settings",
+        true,
+        None::<&str>,
+    )?)?;
+    menu.append(&MenuItem::with_id(
+        app,
         QUIT_ID,
         "Quit Buzz",
         true,
@@ -444,12 +453,16 @@ fn apply_activity_presentation<R: Runtime>(
     Ok(())
 }
 
-fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) {
+pub(crate) fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) {
     match id {
         OPEN_BUZZ_ID => show_main_window(app),
         NEW_CHANNEL_ID => {
             show_main_window(app);
             queue_tray_action(app, TrayAction::NewChannel);
+        }
+        OPEN_SETTINGS_ID => {
+            show_main_window(app);
+            queue_tray_action(app, TrayAction::OpenSettings);
         }
         QUIT_ID => app.exit(0),
         _ => {
@@ -512,7 +525,7 @@ pub fn take_tray_actions<R: Runtime>(app: AppHandle<R>) -> Result<Vec<TrayAction
 
 fn requeue_actions(queue: &mut TrayActionQueue, mut actions: Vec<TrayAction>) {
     actions.retain(|action| match action {
-        TrayAction::NewChannel => true,
+        TrayAction::NewChannel | TrayAction::OpenSettings => true,
         TrayAction::OpenChannel {
             community_generation,
             ..
@@ -552,7 +565,7 @@ pub fn clear_tray_agent_activity<R: Runtime>(app: AppHandle<R>) -> Result<(), St
     queue.community_generation = queue.community_generation.wrapping_add(1);
     queue
         .pending_actions
-        .retain(|action| matches!(action, TrayAction::NewChannel));
+        .retain(|action| matches!(action, TrayAction::NewChannel | TrayAction::OpenSettings));
     drop(queue);
 
     update_tray_agent_activity(app, Vec::new(), Vec::new())
@@ -634,6 +647,14 @@ mod tests {
     }
 
     #[test]
+    fn open_settings_action_serializes_with_frontend_field_names() {
+        assert_eq!(
+            serde_json::to_value(TrayAction::OpenSettings).expect("tray action should serialize"),
+            serde_json::json!({ "kind": "openSettings" })
+        );
+    }
+
+    #[test]
     fn stale_channel_actions_are_not_requeued_after_community_change() {
         let mut queue = TrayActionQueue {
             community_generation: 2,
@@ -652,14 +673,20 @@ mod tests {
     }
 
     #[test]
-    fn new_channel_actions_survive_community_change() {
+    fn installation_global_actions_survive_community_change() {
         let mut queue = TrayActionQueue {
             community_generation: 2,
             pending_actions: Vec::new(),
         };
 
-        requeue_actions(&mut queue, vec![TrayAction::NewChannel]);
+        requeue_actions(
+            &mut queue,
+            vec![TrayAction::NewChannel, TrayAction::OpenSettings],
+        );
 
-        assert_eq!(queue.pending_actions, vec![TrayAction::NewChannel]);
+        assert_eq!(
+            queue.pending_actions,
+            vec![TrayAction::NewChannel, TrayAction::OpenSettings]
+        );
     }
 }

--- a/desktop/src-tauri/src/tray_menu.rs
+++ b/desktop/src-tauri/src/tray_menu.rs
@@ -201,6 +201,7 @@ struct TrayActivityMenuItem<R: Runtime> {
 
 struct TrayActionQueue {
     community_generation: u64,
+    settings_actions_enabled: bool,
     pending_actions: Vec<TrayAction>,
 }
 
@@ -239,12 +240,10 @@ pub(crate) fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
-fn queue_tray_action<R: Runtime>(app: &AppHandle<R>, mut action: TrayAction) {
-    let state = app.state::<TrayMenuState<R>>();
-    let Ok(mut queue) = state.action_queue.lock() else {
-        eprintln!("buzz-desktop: tray action queue is unavailable");
-        return;
-    };
+fn enqueue_action(queue: &mut TrayActionQueue, mut action: TrayAction) -> bool {
+    if matches!(action, TrayAction::OpenSettings) && !queue.settings_actions_enabled {
+        return false;
+    }
     if let TrayAction::OpenChannel {
         community_generation,
         ..
@@ -253,6 +252,18 @@ fn queue_tray_action<R: Runtime>(app: &AppHandle<R>, mut action: TrayAction) {
         *community_generation = queue.community_generation;
     }
     queue.pending_actions.push(action);
+    true
+}
+
+fn queue_tray_action<R: Runtime>(app: &AppHandle<R>, action: TrayAction) {
+    let state = app.state::<TrayMenuState<R>>();
+    let Ok(mut queue) = state.action_queue.lock() else {
+        eprintln!("buzz-desktop: tray action queue is unavailable");
+        return;
+    };
+    if !enqueue_action(&mut queue, action) {
+        return;
+    }
     drop(queue);
 
     if let Err(error) = app.emit("tray-action-available", ()) {
@@ -496,6 +507,7 @@ pub fn init<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         activity_items: Mutex::new(activity_items),
         action_queue: Mutex::new(TrayActionQueue {
             community_generation: 0,
+            settings_actions_enabled: false,
             pending_actions: Vec::new(),
         }),
     });
@@ -523,9 +535,35 @@ pub fn take_tray_actions<R: Runtime>(app: AppHandle<R>) -> Result<Vec<TrayAction
     Ok(std::mem::take(&mut queue.pending_actions))
 }
 
+fn set_settings_actions_enabled(queue: &mut TrayActionQueue, enabled: bool) {
+    queue.settings_actions_enabled = enabled;
+    if !enabled {
+        queue
+            .pending_actions
+            .retain(|action| !matches!(action, TrayAction::OpenSettings));
+    }
+}
+
+/// Controls whether native Settings menu selections can be queued. Disabling
+/// also clears Settings actions that raced with the logged-in shell unmounting.
+#[tauri::command]
+pub fn set_settings_tray_actions_enabled<R: Runtime>(
+    app: AppHandle<R>,
+    enabled: bool,
+) -> Result<(), String> {
+    let state = app.state::<TrayMenuState<R>>();
+    let mut queue = state
+        .action_queue
+        .lock()
+        .map_err(|_| "Buzz tray action queue is unavailable".to_string())?;
+    set_settings_actions_enabled(&mut queue, enabled);
+    Ok(())
+}
+
 fn requeue_actions(queue: &mut TrayActionQueue, mut actions: Vec<TrayAction>) {
     actions.retain(|action| match action {
-        TrayAction::NewChannel | TrayAction::OpenSettings => true,
+        TrayAction::NewChannel => true,
+        TrayAction::OpenSettings => queue.settings_actions_enabled,
         TrayAction::OpenChannel {
             community_generation,
             ..
@@ -627,7 +665,9 @@ pub fn update_tray_agent_activity<R: Runtime>(
 
 #[cfg(test)]
 mod tests {
-    use super::{requeue_actions, TrayAction, TrayActionQueue};
+    use super::{
+        enqueue_action, requeue_actions, set_settings_actions_enabled, TrayAction, TrayActionQueue,
+    };
 
     #[test]
     fn open_channel_action_serializes_with_frontend_field_names() {
@@ -655,9 +695,42 @@ mod tests {
     }
 
     #[test]
+    fn settings_actions_are_ignored_until_app_shell_is_ready() {
+        let mut queue = TrayActionQueue {
+            community_generation: 2,
+            settings_actions_enabled: false,
+            pending_actions: vec![TrayAction::NewChannel],
+        };
+
+        assert!(!enqueue_action(&mut queue, TrayAction::OpenSettings));
+        queue.settings_actions_enabled = true;
+        assert!(enqueue_action(&mut queue, TrayAction::OpenSettings));
+
+        assert_eq!(
+            queue.pending_actions,
+            vec![TrayAction::NewChannel, TrayAction::OpenSettings]
+        );
+    }
+
+    #[test]
+    fn disabling_settings_actions_clears_queued_and_in_flight_settings() {
+        let mut queue = TrayActionQueue {
+            community_generation: 2,
+            settings_actions_enabled: true,
+            pending_actions: vec![TrayAction::NewChannel, TrayAction::OpenSettings],
+        };
+
+        set_settings_actions_enabled(&mut queue, false);
+        requeue_actions(&mut queue, vec![TrayAction::OpenSettings]);
+
+        assert_eq!(queue.pending_actions, vec![TrayAction::NewChannel]);
+    }
+
+    #[test]
     fn stale_channel_actions_are_not_requeued_after_community_change() {
         let mut queue = TrayActionQueue {
             community_generation: 2,
+            settings_actions_enabled: true,
             pending_actions: Vec::new(),
         };
 
@@ -676,6 +749,7 @@ mod tests {
     fn installation_global_actions_survive_community_change() {
         let mut queue = TrayActionQueue {
             community_generation: 2,
+            settings_actions_enabled: true,
             pending_actions: Vec::new(),
         };
 

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { isTauri } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
@@ -245,6 +245,9 @@ function AppReady({
   isCommunitySwitch: boolean;
 }) {
   const onboarding = useAppOnboardingState(isSharedIdentity);
+  const settingsActionsReady = useSettingsTrayActionReadiness(
+    onboarding.stage === "ready",
+  );
 
   if (onboarding.stage === "reset-failed") {
     return <ResetFailedScreen />;
@@ -273,6 +276,10 @@ function AppReady({
     return isCommunitySwitch ? <CommunitySwitchGate /> : <AppLoadingGate />;
   }
 
+  if (!settingsActionsReady) {
+    return <AppLoadingGate />;
+  }
+
   return (
     <EncryptedBackupProvider
       onOpenSettings={() =>
@@ -287,6 +294,34 @@ function AppReady({
       </KnownAgentPubkeysProvider>
     </EncryptedBackupProvider>
   );
+}
+
+function useSettingsTrayActionReadiness(enabled: boolean): boolean {
+  const [ready, setReady] = useState(() => !isMacOSTauri());
+
+  useEffect(() => {
+    if (!isMacOSTauri()) return;
+
+    let disposed = false;
+    setReady(false);
+    void invoke("set_settings_tray_actions_enabled", { enabled })
+      .then(() => {
+        if (!disposed) setReady(enabled);
+      })
+      .catch((error) => {
+        console.error("Failed to update native Settings menu readiness", error);
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, [enabled]);
+
+  return !enabled || ready;
+}
+
+function isMacOSTauri(): boolean {
+  return isTauri() && navigator.userAgent.includes("Macintosh");
 }
 
 function CommunityApp({
@@ -614,6 +649,15 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     useState<MachineOnboardingPage>();
   const [postOnboardingNav, setPostOnboardingNav] =
     useState<PostOnboardingNavigation | null>(null);
+
+  useEffect(() => {
+    if (!isMacOSTauri() || machine.stage === "ready") return;
+    void invoke("set_settings_tray_actions_enabled", { enabled: false }).catch(
+      (error) => {
+        console.error("Failed to disable native Settings menu actions", error);
+      },
+    );
+  }, [machine.stage]);
 
   const reopenMachineConfig = useCallback(() => {
     setMachineInitialPage("config");

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -721,6 +721,7 @@ export function AppShell() {
           channels={channels}
           goChannel={goChannel}
           openCreateChannel={handleOpenCreateChannel}
+          openSettings={handleOpenSettings}
         />
       ) : null}
       <ChannelNavigationProvider channels={channels}>

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -703,7 +703,6 @@ export function AppShell() {
     settingsOpen,
   ]);
   useSettingsShortcuts({
-    onClose: handleCloseSettings,
     onOpenSettings: handleOpenSettings,
     open: isHuddleRoom ? undefined : settingsOpen,
   });

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -602,10 +602,11 @@ export function AppShell() {
   );
   const handleOpenSettings = React.useCallback(
     (section: SettingsSection = DEFAULT_SETTINGS_SECTION) => {
+      if (settingsOpen) return;
       setIsChannelManagementOpen(false);
       void goSettings(section);
     },
-    [goSettings],
+    [goSettings, settingsOpen],
   );
   const handleCloseSettings = React.useCallback(
     () => closeSettings(),

--- a/desktop/src/app/useAppShellTrayMenu.tsx
+++ b/desktop/src/app/useAppShellTrayMenu.tsx
@@ -8,10 +8,12 @@ export function AppShellTrayMenu({
   channels,
   goChannel,
   openCreateChannel,
+  openSettings,
 }: {
   channels: Channel[];
   goChannel: (channelId: string) => Promise<unknown>;
   openCreateChannel: () => void;
+  openSettings: () => void;
 }) {
   if (!isMacPlatform()) return null;
   return (
@@ -19,6 +21,7 @@ export function AppShellTrayMenu({
       channels={channels}
       goChannel={goChannel}
       openCreateChannel={openCreateChannel}
+      openSettings={openSettings}
     />
   );
 }
@@ -27,15 +30,18 @@ function MacAppShellTrayMenu({
   channels,
   goChannel,
   openCreateChannel,
+  openSettings,
 }: {
   channels: Channel[];
   goChannel: (channelId: string) => Promise<unknown>;
   openCreateChannel: () => void;
+  openSettings: () => void;
 }): null {
   useTrayMenu({
     channels,
     goChannel,
     openCreateChannel,
+    openSettings,
   });
   return null;
 }

--- a/desktop/src/app/useSettingsShortcuts.ts
+++ b/desktop/src/app/useSettingsShortcuts.ts
@@ -3,13 +3,11 @@ import * as React from "react";
 import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
 
 type UseSettingsShortcutsOptions = {
-  onClose: () => void;
   onOpenSettings: () => void;
   open?: boolean;
 };
 
 export function useSettingsShortcuts({
-  onClose,
   onOpenSettings,
   open,
 }: UseSettingsShortcutsOptions) {
@@ -29,11 +27,6 @@ export function useSettingsShortcuts({
 
       event.preventDefault();
       event.stopImmediatePropagation();
-      if (open) {
-        onClose();
-        return;
-      }
-
       onOpenSettings();
     }
 
@@ -41,5 +34,5 @@ export function useSettingsShortcuts({
     return () => {
       window.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [onClose, onOpenSettings, open]);
+  }, [onOpenSettings, open]);
 }

--- a/desktop/src/app/useTrayMenu.ts
+++ b/desktop/src/app/useTrayMenu.ts
@@ -25,6 +25,7 @@ type TrayAgentActivity = {
 
 type TrayAction =
   | { kind: "newChannel" }
+  | { kind: "openSettings" }
   | { kind: "openChannel"; channelId: string };
 
 const MAX_RECENT_TRAY_ACTIVITIES = 5;
@@ -37,10 +38,12 @@ export function useTrayMenu({
   channels,
   goChannel,
   openCreateChannel,
+  openSettings,
 }: {
   channels: Channel[];
   goChannel: (channelId: string) => Promise<unknown>;
   openCreateChannel: () => void;
+  openSettings: () => void;
 }): void {
   const activeTurns = useActiveAgentTurnsByChannel();
   const now = useNow(1000);
@@ -134,6 +137,8 @@ export function useTrayMenu({
       for (const action of actions) {
         if (action.kind === "newChannel") {
           openCreateChannel();
+        } else if (action.kind === "openSettings") {
+          openSettings();
         } else {
           void goChannel(action.channelId);
         }
@@ -156,5 +161,5 @@ export function useTrayMenu({
       disposed = true;
       unlisten?.();
     };
-  }, [goChannel, openCreateChannel]);
+  }, [goChannel, openCreateChannel, openSettings]);
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11133,6 +11133,7 @@ export function maybeInstallE2eTauriMocks() {
       }
       case "update_tray_agent_activity":
       case "clear_tray_agent_activity":
+      case "set_settings_tray_actions_enabled":
       case "requeue_tray_actions":
         return null;
       case "take_tray_actions":

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -1468,11 +1468,14 @@ test("opens settings with the keyboard shortcut and updates theme", async ({
     .poll(() => page.evaluate(() => localStorage.getItem("buzz-theme")))
     .toBe("dracula");
 
-  // Close settings with keyboard shortcut
+  // Repeating the shortcut keeps Settings open.
   await page.keyboard.press(
     process.platform === "darwin" ? "Meta+," : "Control+,",
   );
-  await expect(page.getByTestId("settings-view")).toHaveCount(0);
+  await expect(page.getByTestId("settings-view")).toBeVisible();
+
+  // Close explicitly.
+  await page.getByTestId("settings-back-to-app").click();
   await expectHomeView(page);
 });
 


### PR DESCRIPTION
### Background

- Buzz Settings can be opened from the app UI or keyboard shortcut, but macOS users do not have native Settings entries in either Buzz menu.

### Overview of Changes

- Add `Settings…` below About in the macOS application menu, with the standard Command-, shortcut.
- Add `Settings` above Quit Buzz in the status-item menu.
- Restore and focus the main window before opening Settings.
- Ignore Settings actions before the logged-in app shell is ready.
- Keep repeated Settings actions idempotent so Back still returns to the previous screen.

### Testing Performed

- Full `just ci` gate; reran desktop Tauri tests with the harness-injected `BUZZ_AGENT_PROVIDER` unset so the environment-isolation test exercises its intended state.
- Manually verified both native menu placements on macOS.
- Manually verified both actions are no-ops before login.
- Manually verified both actions open Settings after login.
- Manually verified repeated actions keep Settings open without adding duplicate navigation history.
