### PR TITLE
chore(hooks): run desktop typecheck in pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,11 @@ Run `just test` for integration tests if you touched `buzz-relay`,
 formatting via `stage_fixed`. Pre-commit runs fix variants in parallel (Rust
 fmt, Tauri Rust fmt, desktop biome fix, web biome fix, mobile dart format).
 Auto-fixable issues are fixed and re-staged; unfixable lint issues block the
-commit. **Pre-push hooks** run clippy (workspace + Tauri) and fast unit tests
-in parallel (Rust, desktop JS, Tauri Rust, mobile Flutter) — no overlap with
-pre-commit. Builds are CI-only. Run `just fix-all` to auto-fix all formatting
-in one shot. Run `just ci` for the full local gate. Run `just hooks` to
+commit. **Pre-push hooks** run clippy (workspace + Tauri), desktop TypeScript
+typechecking (`tsc --noEmit`), and fast unit tests in parallel (Rust, desktop
+JS, Tauri Rust, mobile Flutter) — no overlap with pre-commit. Builds are
+CI-only. Run `just fix-all` to auto-fix all formatting in one shot. Run
+`just ci` for the full local gate. Run `just hooks` to
 re-install hooks after env changes. Before agents run Git or hooks, activate the
 repo's Hermit environment (`. ./bin/activate-hermit`); do not rewrite hook
 commands to compensate for an unconfigured shell `PATH`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,9 +2,10 @@
 # .github/workflows/ci.yml — keep the two in sync. Deliberate deviations:
 # - The `.github/workflows/ci.yml` path CI adds to its `rust`/`mobile` filters
 #   is omitted; a CI-workflow-only edit doesn't need a local test run.
-# - `desktop-check`/`desktop-test` don't trigger on `rust` changes, though CI's
-#   Desktop Core job does. Those commands are pure TS (biome + node:test) with
-#   no Rust dependency, so the extra trigger would be spurious locally.
+# - `desktop-check`/`desktop-typecheck`/`desktop-test` don't trigger on `rust`
+#   changes, though CI's Desktop Core job does. Those commands are pure TS
+#   (biome + tsc + node:test) with no Rust dependency, so the extra trigger
+#   would be spurious locally.
 # - Deletion-only surface changes do not trigger local hooks: lefthook 2.1.x
 #   drops deleted paths from push-file discovery (`extractFiles` existence
 #   check, repository.go). CI's dorny/paths-filter catches deletions.
@@ -57,6 +58,10 @@ pre-push:
       glob: ["desktop/**", "pnpm-lock.yaml"]
       exclude: ["desktop/src-tauri/**"]
       run: just desktop-check
+    desktop-typecheck:
+      glob: ["desktop/**", "pnpm-lock.yaml"]
+      exclude: ["desktop/src-tauri/**"]
+      run: just desktop-typecheck
     desktop-test:
       glob: ["desktop/**", "pnpm-lock.yaml"]
       exclude: ["desktop/src-tauri/**"]


### PR DESCRIPTION
The local pre-push gate ran biome (`desktop-check`) and node:test (`desktop-test`) for desktop changes but never `tsc`, so TypeScript errors surface no earlier than CI's `desktop-core` job (`just desktop-build` = `tsc && vite build`). A branch with type errors passes every local hook today.

This adds a `desktop-typecheck` pre-push command running `just desktop-typecheck` (`tsc --noEmit`) with the same glob/exclude as `desktop-check`, and updates the hook documentation in `AGENTS.md`. CI is unchanged — it already typechecks via `desktop-build`.