### PR TITLE
fix(cli): reject JSON-escaped newlines before signing

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -12,6 +12,32 @@ use buzz_sdk::mentions::{
     extract_at_mentions_with_known, extract_nostr_uris, strip_code_regions, MENTION_CAP,
 };
 
+fn validate_multiline_encoding(content: &str) -> Result<(), CliError> {
+    // Do not rewrite arbitrary `\\n`: it is legitimate in code samples and prose.
+    // Fail closed only when escape text outside Markdown code regions appears in
+    // the structural positions produced by a JSON-escaped multiline message.
+    let prose = strip_code_regions(content);
+    let has_escaped_boundary = [r"\n\n", r"\n- ", r"\n* ", r"\n# "]
+        .iter()
+        .any(|marker| prose.contains(marker))
+        || prose.split(r"\n").skip(1).any(|line| {
+            let Some((number, rest)) = line.split_once(". ") else {
+                return false;
+            };
+            !number.is_empty()
+                && number.bytes().all(|byte| byte.is_ascii_digit())
+                && !rest.is_empty()
+        });
+
+    if has_escaped_boundary {
+        return Err(CliError::Usage(
+            "message contains literal \\n escapes at Markdown paragraph/list boundaries; stream real LF bytes with `buzz messages send ... --content -` instead"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Extract the thread root event ID from a Nostr tag array.
 ///
 /// Parses `"e"` tags with NIP-10 markers:
@@ -580,6 +606,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
+    validate_multiline_encoding(&p.content)?;
     validate_content_size(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
@@ -995,7 +1022,7 @@ mod tests {
     use super::{
         event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
         missing_members, normalize_explicit_mentions, parse_member_pubkeys,
-        resolve_names_to_pubkeys,
+        resolve_names_to_pubkeys, validate_multiline_encoding,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
@@ -1011,6 +1038,34 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    #[test]
+    fn multiline_markdown_keeps_real_lf_bytes() {
+        use nostr::{EventBuilder, Keys};
+
+        let content = "First paragraph.\n\n- first item\n- second item";
+        validate_multiline_encoding(content).unwrap();
+        let event = EventBuilder::text_note(content)
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        assert!(event.content.as_bytes().contains(&0x0a));
+        assert!(!event.content.contains(r"\n\n"));
+        assert_eq!(event.content, content);
+    }
+
+    #[test]
+    fn json_escaped_markdown_boundaries_fail_before_signing() {
+        let content = r"First paragraph.\n\n- first item\n- second item";
+        let error = validate_multiline_encoding(content).unwrap_err();
+        assert!(error.to_string().contains("stream real LF bytes"));
+    }
+
+    #[test]
+    fn intentional_backslash_n_in_code_is_preserved() {
+        let content = r"Use `printf 'first\n\n- literal'` in this code sample.";
+        validate_multiline_encoding(content).unwrap();
+        assert!(content.contains(r"\n\n"));
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {


### PR DESCRIPTION
## Summary

Messages built by shell wrappers can reach the relay carrying literal `\n` escape text instead of real LF bytes, so recipients see `\n` where paragraph and list breaks were intended. The CLI signs and publishes the mangled content without complaint, and the damage is only visible after the fact in someone else's client.

This validates content before signing and fails closed when escape text appears **outside Markdown code regions at paragraph/list boundaries** (`\n\n`, `\n- `, `\n* `, `\n# `), pointing the caller at `--content -`.

The check is deliberately narrow. Intentional `\n` inside inline and fenced code is preserved, because that is legitimate content — a message explaining `printf 'a\nb'` must still be sendable. It only rejects the structural positions that a JSON-escaped multiline message produces, which is where the mistake actually shows up.

### Why this is separate from #2121

#2121 (`fix(acp): teach agents to send real newlines`, merged July) addressed this at the prompt level in `base_prompt.md`. That reduces the mistake but cannot prevent it: any wrapper, script, or non-ACP caller building a message with single-quoted shell strings still publishes broken content, and instructions are not a mechanism.

I hit this in practice today, well after #2121 shipped, which is what prompted the change. Guidance tells the caller what to do; this makes the signing boundary refuse to do the wrong thing.

### Related issue

None found. Searched open and merged PRs and issues for newline/escape handling; the closest is #2121 above, which is complementary rather than overlapping — it changes ACP prompt text, this changes CLI validation. No open issue covers the CLI path.

## Testing

`cargo test -p buzz-cli` at `c92b5b0a`: **324 passed, 0 failed.**

Two new cases cover both directions, because a validator that only proves the failure case is half-tested:

- `multiline_markdown_keeps_real_lf_bytes` — real LF content passes untouched, including `\n` inside inline and fenced code.
- `json_escaped_markdown_boundaries_fail_before_signing` — escaped boundaries are rejected **before** signing, so nothing reaches the relay.

The second is the one that matters: the failure has to happen ahead of the signature, not after, or the event is already published by the time anyone notices.

No UI change.
