### PR TITLE
fix(relay): force monotonic created_at on the NIP-IA archive snapshot

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -3107,10 +3107,30 @@ pub async fn reconcile_channel_events(
     Ok(())
 }
 
+/// `created_at` for a replaceable snapshot that must supersede `previous`.
+///
+/// `created_at` is second-resolution, and NIP-16 breaks a same-second tie on the
+/// lowest event id — which, being a content hash, is effectively random. Two
+/// snapshots written inside one wall-clock second therefore leave an arbitrary
+/// one of them authoritative, and the loser is discarded with no error. Forcing
+/// the next snapshot strictly past the previous one keeps replacement
+/// deterministic no matter how fast the mutations arrive.
+fn monotonic_snapshot_created_at(now: u64, previous: Option<u64>) -> u64 {
+    match previous {
+        Some(previous) => now.max(previous + 1),
+        None => now,
+    }
+}
+
 /// Publish a kind:13535 archived identities list event (NIP-IA).
 ///
 /// Queries all current archived identities and emits a relay-signed,
 /// NIP-70-protected replaceable-by-convention snapshot with bare `p` tags.
+///
+/// The snapshot's `created_at` is forced strictly past the previous snapshot's,
+/// so a burst of archive requests inside one second cannot strand an
+/// intermediate list as authoritative. Same guard as
+/// `emit_addressable_discovery_event` and `publish_dm_visibility_snapshot`.
 pub async fn publish_nipia_archival_list(
     tenant: &TenantContext,
     state: &Arc<AppState>,
@@ -3128,8 +3148,26 @@ pub async fn publish_nipia_archival_list(
         );
     }
 
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let previous = state
+        .db
+        .query_events(&buzz_db::event::EventQuery {
+            kinds: Some(vec![KIND_IA_ARCHIVED_LIST as i32]),
+            pubkey: Some(state.relay_keypair.public_key().to_bytes().to_vec()),
+            limit: Some(1),
+            ..buzz_db::event::EventQuery::for_community(tenant.community())
+        })
+        .await
+        .unwrap_or_default();
+    let ts =
+        monotonic_snapshot_created_at(now, previous.first().map(|e| e.event.created_at.as_secs()));
+
     let event = EventBuilder::new(Kind::Custom(KIND_IA_ARCHIVED_LIST as u16), "")
         .tags(tags)
+        .custom_created_at(nostr::Timestamp::from(ts))
         .sign_with_keys(&state.relay_keypair)
         .map_err(|e| anyhow::anyhow!("failed to sign kind:{KIND_IA_ARCHIVED_LIST}: {e}"))?;
 
@@ -3449,5 +3487,56 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+
+    #[test]
+    fn first_snapshot_uses_wall_clock() {
+        assert_eq!(
+            monotonic_snapshot_created_at(1_700_000_000, None),
+            1_700_000_000
+        );
+    }
+
+    #[test]
+    fn snapshots_within_one_second_get_strictly_increasing_timestamps() {
+        // Six archive requests landing inside one wall-clock second: without the
+        // guard all six snapshots share `created_at`, the NIP-16 lowest-event-id
+        // tiebreak picks an arbitrary winner, and the rest are silently dropped.
+        let now = 1_700_000_000;
+        let mut previous = None;
+        let mut published = Vec::new();
+
+        for _ in 0..6 {
+            let ts = monotonic_snapshot_created_at(now, previous);
+            published.push(ts);
+            previous = Some(ts);
+        }
+
+        assert_eq!(
+            published,
+            vec![now, now + 1, now + 2, now + 3, now + 4, now + 5]
+        );
+        assert!(published.windows(2).all(|w| w[1] > w[0]));
+    }
+
+    #[test]
+    fn snapshot_follows_wall_clock_once_it_overtakes_the_previous() {
+        // A burst can push `created_at` ahead of the clock; once real time passes
+        // it, the snapshot must go back to using the wall clock rather than
+        // drifting further into the future.
+        let previous = 1_700_000_005;
+
+        assert_eq!(
+            monotonic_snapshot_created_at(1_700_000_000, Some(previous)),
+            1_700_000_006
+        );
+        assert_eq!(
+            monotonic_snapshot_created_at(1_700_000_006, Some(previous)),
+            1_700_000_006
+        );
+        assert_eq!(
+            monotonic_snapshot_created_at(1_700_000_099, Some(previous)),
+            1_700_000_099
+        );
     }
 }


### PR DESCRIPTION
Fixes #3848.

## The bug

A burst of NIP-IA archive/unarchive mutations publishes several `kind:13535` snapshots inside one wall-clock second. `created_at` is second-resolution, so NIP-16 resolves the tie on the lowest event id (`buzz-db/src/lib.rs` — *"On same-second tie, lowest event id (lexicographic) wins"*). That id is a content hash, so **which snapshot survives is effectively arbitrary** — it is not the first or the last, and an intermediate list can remain authoritative.

Every `kind:8002` delta and every `archived_identities` row is accepted. Nothing anywhere reports the mismatch.

## Why it is worse than a stale count

`useIsArchivedPredicate` (`desktop/src/features/identity-archive/hooks.ts`) filters mention autocomplete, the new-message recipient picker, search results and the add-member dialog on this snapshot — `useMentions.ts:246` drops archived pubkeys from candidates entirely.

So a lost snapshot update leaves those identities **fully selectable indefinitely**, and from the operator's side the archive looks like it silently failed: the receipt says `ok`, the table is right, the UI keeps offering the identity.

Seen twice in the field. Most recently, six archive requests ~330 ms apart grew `archived_identities` 7 → 12 while the published snapshot stayed at 7 — and stayed there for six days across relay restarts, because there is no error, no warning and no drift check in the path. It was only caught by comparing `select count(*) from archived_identities` against `buzz agents archived` by hand.

## The fix

Force the snapshot's `created_at` strictly past the previous snapshot's, exactly as `emit_addressable_discovery_event` and `publish_dm_visibility_snapshot` already do for their replaceable snapshots.

The arithmetic is extracted into a small pure helper, `monotonic_snapshot_created_at(now, previous)`, so the burst behaviour is unit-testable without a database.

**Deliberately left alone:** the two existing call sites keep their inline copies. Their semantics are identical to the helper, but migrating them is unrelated to this bug and I would rather keep the diff to what #3848 reports. Happy to fold them in if you would prefer one shared guard.

## Tests

`crates/buzz-relay/src/handlers/side_effects.rs`:

- `snapshots_within_one_second_get_strictly_increasing_timestamps` — the case from the issue: six updates at a fixed `now`, asserting `T` through `T+5` and strict monotonicity.
- `first_snapshot_uses_wall_clock` — no previous snapshot.
- `snapshot_follows_wall_clock_once_it_overtakes_the_previous` — a burst can push `created_at` ahead of the clock; once real time passes it, the snapshot returns to wall-clock rather than drifting further ahead.

```
cargo test -p buzz-relay --lib handlers::side_effects   8 passed
cargo clippy -p buzz-relay --all-targets               clean
cargo fmt --all -- --check                             clean
```

The full `cargo test -p buzz-relay --lib` run is 852 passed / 9 failed in my environment. All nine failures are `api::admin` and `api::media` tests that need Postgres (`Sqlx(PoolTimedOut)`); I confirmed the identical nine fail on unmodified `origin/main` here, so they are environmental and not from this change. Worth a second look on CI.

## Related

#4617 is the other half of this. `handlers/identity_archive.rs` early-returns on `if !changed` before reaching `publish_nipia_archival_list`, so re-archiving an already-archived identity is a no-op that never republishes — which is why an operator stuck in this state cannot repair it by simply re-archiving the missing entries. The two fixes are complementary: monotonic `created_at` prevents the loss, unconditional republish makes it recoverable.

For anyone currently stuck, the workaround is one *state-changing* cycle, since `publish_nipia_archival_list` rebuilds the full list from `list_archived()` rather than applying a delta:

```bash
buzz agents unarchive <any-already-archived-hex>
sleep 5
buzz agents archive   <same-hex> --reason bot-rebuilt
```
