### PR TITLE
fix(pairing): stop routing mobile pairing to a non-existent /pair sidecar

### DIFF
--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -666,14 +666,21 @@ fn parse_relay_event(text: &str, sub_id: &str) -> Option<nostr::Event> {
 /// Pairing route discovered from the main relay's NIP-11 document.
 #[derive(Debug, PartialEq, Eq)]
 enum PairingRelay {
+    /// Relay advertises a dedicated NIP-AB pairing relay via `pairing_relay_url`.
     Configured(String),
-    LegacyPath,
+    /// Relay enforces membership (advertises NIP-43) but advertises no
+    /// `pairing_relay_url`. An unpaired peer is rejected at NIP-42 AUTH on the
+    /// main relay (`buzz-relay` gates membership at auth time, with no
+    /// exemption for pairing events), so pairing is impossible until the
+    /// operator deploys a dedicated pairing relay.
+    MembershipWithoutPairingRelay,
+    /// Open relay: an unpaired peer can pair over the main relay itself.
     MainRelay,
 }
 
-/// Prefer the relay-advertised dedicated pairing URL. The legacy `/pair`
-/// convention remains as a compatibility fallback for NIP-43 relays that do
-/// not advertise the extension yet.
+/// Prefer the relay-advertised dedicated pairing URL. Open relays pair over the
+/// main relay directly; membership-enforcing relays (NIP-43) require the
+/// operator to advertise a dedicated pairing relay via `pairing_relay_url`.
 async fn probe_pairing_relay(relay_url: &str) -> PairingRelay {
     let http_url = if let Some(rest) = relay_url.strip_prefix("wss://") {
         format!("https://{rest}")
@@ -712,13 +719,13 @@ fn resolve_pairing_relay_url(
 ) -> Result<String, String> {
     match pairing_relay {
         PairingRelay::Configured(url) => Ok(url),
-        PairingRelay::LegacyPath => {
-            let mut url =
-                url::Url::parse(main_relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
-            let path = url.path().trim_end_matches('/').to_string();
-            url.set_path(&format!("{path}/pair"));
-            Ok(url.to_string())
-        }
+        PairingRelay::MembershipWithoutPairingRelay => Err(
+            "This relay requires membership, so an unpaired device cannot \
+             connect to it, and no device-pairing relay is configured. Ask the \
+             relay operator to deploy a pairing relay (set BUZZ_PAIRING_RELAY_URL \
+             / Helm pairingRelay.url)."
+                .to_string(),
+        ),
         PairingRelay::MainRelay => Ok(main_relay_url.to_string()),
     }
 }
@@ -740,7 +747,7 @@ fn pairing_relay_from_nip11(json: &serde_json::Value) -> PairingRelay {
         .and_then(|value| value.as_array())
         .is_some_and(|nips| nips.iter().any(|nip| nip.as_u64() == Some(43)))
     {
-        PairingRelay::LegacyPath
+        PairingRelay::MembershipWithoutPairingRelay
     } else {
         PairingRelay::MainRelay
     }

--- a/desktop/src-tauri/src/commands/pairing_relay_tests.rs
+++ b/desktop/src-tauri/src/commands/pairing_relay_tests.rs
@@ -38,7 +38,7 @@ async fn live_nip11_probe_discovers_configured_pairing_relay() {
 }
 
 #[test]
-fn configured_pairing_relay_takes_precedence_over_legacy_path() {
+fn configured_pairing_relay_takes_precedence_over_membership_gate() {
     let document = serde_json::json!({
         "pairing_relay_url": "wss://pairing.buzz.xyz",
         "supported_nips": [43]
@@ -51,7 +51,7 @@ fn configured_pairing_relay_takes_precedence_over_legacy_path() {
 }
 
 #[test]
-fn invalid_pairing_relay_url_falls_back_to_legacy_path() {
+fn membership_relay_without_pairing_url_is_not_pairable() {
     let document = serde_json::json!({
         "pairing_relay_url": "https://pairing.buzz.xyz",
         "supported_nips": [43]
@@ -59,7 +59,7 @@ fn invalid_pairing_relay_url_falls_back_to_legacy_path() {
 
     assert_eq!(
         pairing_relay_from_nip11(&document),
-        PairingRelay::LegacyPath
+        PairingRelay::MembershipWithoutPairingRelay
     );
 }
 
@@ -82,14 +82,24 @@ fn configured_pairing_relay_resolves_to_configured_url() {
 }
 
 #[test]
-fn legacy_pairing_relay_appends_pair_path() {
-    let resolved = resolve_pairing_relay_url(
+fn membership_without_pairing_relay_errors_instead_of_guessing_a_path() {
+    // Regression: a membership-enforcing relay with no advertised pairing
+    // relay must surface an actionable error, never fabricate a `/pair` URL
+    // that every current buzz-relay 404s on (the relay serves WS only at `/`).
+    let error = resolve_pairing_relay_url(
         "wss://flint.communities.buzz.xyz/community",
-        PairingRelay::LegacyPath,
+        PairingRelay::MembershipWithoutPairingRelay,
     )
-    .expect("resolve legacy pairing relay");
+    .expect_err("membership relay without a pairing relay is not pairable");
 
-    assert_eq!(resolved, "wss://flint.communities.buzz.xyz/community/pair");
+    assert!(
+        !error.contains("/pair"),
+        "must not fabricate a /pair URL: {error}"
+    );
+    assert!(
+        error.contains("pairing relay"),
+        "error should name the missing pairing relay: {error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

`probe_pairing_relay` in `desktop/src-tauri/src/commands/pairing.rs` fabricated a pairing-relay URL by appending `/pair` to the main relay's URL whenever NIP-11 advertised `supported_nips: [43]`. This replaces that fallback (`PairingRelay::LegacyPath`) with `PairingRelay::MembershipWithoutPairingRelay`, which returns an actionable error naming the operator fix instead of a URL that 404s.

## Why

Pairing a mobile device against `wss://flint.communities.buzz.xyz/community` fails with:

```
WebSocket connection failed: HTTP error: 404 Not Found
```

Two separate defects produce that 404.

**1. The fabricated URL is path-scoped; the convention is not.** The old code took the relay's existing path and appended `/pair` (`pairing.rs:715-722` on `main`), so a community relay served under `/community` produced `wss://…/community/pair`. But `/pair` is a *reverse-proxy* convention for the standalone `buzz-pair-relay` sidecar, and it is documented as root-only — "Routes only `/pair` to this sidecar" (`crates/buzz-pair-relay/src/lib.rs:11`). Nothing routes `/community/pair`. The test being replaced asserted that wrong URL verbatim (`desktop/src-tauri/src/commands/pairing_relay_tests.rs:92` on `main`).

**2. NIP-43 is the wrong signal.** NIP-43 means the relay enforces membership; it says nothing about whether a pairing sidecar is deployed. `crates/buzz-relay/src/nip11.rs:483` already carries a regression test warning about exactly this misinference.

The other route is genuinely closed on such a relay, so falling back to `PairingRelay::MainRelay` is not an option either: `crates/buzz-relay/src/handlers/event.rs:637-652` rejects any `EVENT` from an unauthenticated connection with no exemption for ephemeral kinds, and `crates/buzz-relay/src/handlers/auth.rs:217-237` runs `enforce_relay_membership` on every NIP-42 AUTH. An unpaired device cannot publish `kind:24134` over a membership relay's root socket at all.

## Behaviour change

| Relay NIP-11 | Before | After |
|---|---|---|
| `pairing_relay_url` advertised | use it as-is | unchanged |
| No NIP-43 | pair over the root socket | unchanged |
| NIP-43, no `pairing_relay_url` | `wss://host<path>/pair` → 404 | error naming the operator fix |

**This is a breaking change for one deployment shape, and I want that on the record.** A membership relay served at the *root* path, behind a proxy following the same-host convention, got a working `wss://host/pair` before and gets a hard error now. Migration is a single setting — `BUZZ_PAIRING_RELAY_URL=wss://host/pair`, or Helm `pairingRelay.url` — but it is a break, and it makes two in-tree docs stale: `deploy/charts/buzz/values.yaml:212-213` ("the legacy same-host `/pair` convention") and `crates/buzz-pair-relay/src/lib.rs:11`. I left both untouched pending the decision below.

## Verification

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml pairing_relay` — 7 tests, all in `desktop/src-tauri/src/commands/pairing_relay_tests.rs`. One of them, `live_nip11_probe_discovers_configured_pairing_relay`, binds a local socket and is not `#[ignore]`d.
- The new `membership_without_pairing_relay_errors_instead_of_guessing_a_path` asserts the error never contains `/pair` and does name the missing pairing relay, so the fabrication cannot silently return.
- The error text reaches the UI verbatim: `pairingErrorMessage` (`desktop/src/features/settings/ui/MobilePairingCard.tsx:37-50`) passes any non-timeout message straight through into the error step. That pass-through is the entire value of the change.
- **No repo CI workflow has run on this PR** — the build/test/clippy runs sit at `action_required` pending maintainer approval, and DCO/Semgrep/zizmor are the only checks that executed. There is no green build to point at.

## Scope

- Desktop client only — 2 files, +37/−20. No relay change, no new event kind, no schema or NIP-11 field.
- `desktop/src-tauri/src/commands/pairing.rs` goes 793 → 800 lines, well under the 1000-line ratchet (`desktop/scripts/check-file-sizes.mjs`).
- No mobile or web mirror needs updating: `pairing_relay_url` discovery lives only in this one desktop module. `git grep -n -i pairing_relay_url` returns 33 hits, all in `buzz-relay` config/nip11, the Helm chart, and `desktop/src-tauri/src/commands/pairing{,_relay_tests}.rs`. Mobile receives the already-resolved URL inside the QR payload and never probes NIP-11 itself.
- Docs that still describe `/pair` as a client-supported convention are deliberately left alone pending the first open question.

## Open questions for maintainers

1. **Retire `/pair` outright, or keep it for root-path relays?** This PR removes it unconditionally. Gating the fallback on `url.path() == "/"` would preserve every deployment the convention ever actually worked for, at the cost of leaving one guess in the client. If you prefer the unconditional removal, I'll fold the two doc updates into this PR.
2. **Should the relay instead exempt pairing `kind:24134` from the membership gate?** That would let a single relay serve pairing with no sidecar and remove the separate deployment entirely — but it changes the auth gate and wants a security review, so it is deliberately not attempted here.
