### PR TITLE
fix(relay): descriptive SEC-006 denial + structured skip log for workflow triggers

### DIFF
--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -885,13 +885,21 @@ async fn handle_workflow_trigger(
         .check_owner_authority(community_id, wf_channel_id, &workflow.owner_pubkey, &def)
         .await
     {
-        // Surface *why* the authority check failed so the caller can act —
-        // previously this returned a generic "not authorized" that left the
-        // caller unable to distinguish a SEC-006 elevated-role denial from a
-        // disabled workflow or a membership lapse (issue #5122).
+        // Give the caller a stable cause it can branch on (issue #5122) while
+        // keeping the underlying error server-side: `check_owner_authority`
+        // wraps store failures verbatim, so returning it would disclose
+        // internal database state on an authorization path.
+        // `owner_pubkey` is raw bytes with no Display impl; hex::encode is the
+        // convention used elsewhere in this file.
+        tracing::warn!(
+            %workflow_id,
+            owner_pubkey = %hex::encode(&workflow.owner_pubkey),
+            requires_elevated_authority = def.requires_elevated_authority(),
+            error = %e,
+            "workflow owner authority check failed"
+        );
         return Err(IngestError::Rejected(workflow_owner_authority_denial(
             def.requires_elevated_authority(),
-            &e,
         )));
     }
 
@@ -1391,44 +1399,70 @@ async fn resume_workflow_after_approval(
 /// (role missing) apart from a disabled workflow or a membership lapse (issue
 /// #5122: "workflow appears to succeed, no run record"). Naming the cause in
 /// the rejection gives the caller an actionable next step.
-fn workflow_owner_authority_denial(
-    requires_elevated_authority: bool,
-    error: &buzz_workflow::WorkflowError,
-) -> String {
+/// Caller-facing denial for a failed SEC-006 owner-authority check.
+///
+/// Carries a stable public cause and never the underlying error.
+/// `check_owner_authority` wraps store failures verbatim (`owner authority
+/// lookup failed (fail-closed): {e}`), so interpolating it here turned an
+/// authorization denial into an internal-error disclosure whenever the
+/// membership store was unavailable. The detail is logged server-side.
+fn workflow_owner_authority_denial(requires_elevated_authority: bool) -> String {
     if requires_elevated_authority {
-        format!(
-            "forbidden: SEC-006 — workflow contains exfiltration-capable \
-             actions (call_webhook) that require the owner to hold the \
-             'owner' or 'admin' role in this channel; {error}"
-        )
+        "forbidden: SEC-006 role_required — workflow contains \
+         exfiltration-capable actions (call_webhook) that require the owner \
+         to hold the 'owner' or 'admin' role in this channel"
+            .to_string()
     } else {
-        format!("forbidden: workflow owner's channel authority check failed; {error}")
+        "forbidden: SEC-006 authority_lookup_failed — workflow owner's \
+         channel authority check failed"
+            .to_string()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::workflow_owner_authority_denial;
-    use buzz_workflow::WorkflowError;
 
     #[test]
-    fn denial_for_elevated_definition_names_sec006_and_call_webhook() {
-        let err = WorkflowError::Unauthorized("not a member".into());
-        let msg = workflow_owner_authority_denial(true, &err);
+    fn denial_for_elevated_definition_names_sec006_role_required() {
+        let msg = workflow_owner_authority_denial(true);
         assert!(msg.starts_with("forbidden:"));
-        assert!(msg.contains("SEC-006"));
+        assert!(msg.contains("SEC-006 role_required"));
         assert!(msg.contains("call_webhook"));
         assert!(msg.contains("owner' or 'admin' role"));
-        assert!(msg.contains("not a member"));
     }
 
     #[test]
-    fn denial_for_ordinary_definition_has_no_sec006_hint() {
-        let err = WorkflowError::Unauthorized("unknown".into());
-        let msg = workflow_owner_authority_denial(false, &err);
+    fn denial_for_ordinary_definition_names_authority_lookup_failed() {
+        let msg = workflow_owner_authority_denial(false);
         assert!(msg.starts_with("forbidden:"));
-        assert!(!msg.contains("SEC-006"));
+        assert!(msg.contains("SEC-006 authority_lookup_failed"));
         assert!(!msg.contains("call_webhook"));
-        assert!(msg.contains("unknown"));
+    }
+
+    #[test]
+    fn denial_never_discloses_the_underlying_store_error() {
+        // Regression for the review on #5135: `check_owner_authority` wraps
+        // store failures verbatim, so interpolating the error into the
+        // caller-facing denial leaks internal database state on an
+        // authorization path.
+        const SENTINEL: &str = "connection refused to members.db at 10.0.0.7:5432";
+        for requires_elevated in [true, false] {
+            let msg = workflow_owner_authority_denial(requires_elevated);
+            assert!(!msg.contains(SENTINEL), "denial disclosed the store error: {msg}");
+            assert!(!msg.contains("members.db"));
+            assert!(!msg.contains("10.0.0.7"));
+            assert!(!msg.contains("lookup failed (fail-closed)"));
+        }
+    }
+
+    #[test]
+    fn denial_causes_are_stable_and_distinguishable() {
+        let elevated = workflow_owner_authority_denial(true);
+        let ordinary = workflow_owner_authority_denial(false);
+        assert_ne!(elevated, ordinary);
+        assert!(elevated.contains("role_required"));
+        assert!(ordinary.contains("authority_lookup_failed"));
+        assert!(!ordinary.contains("role_required"));
     }
 }

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -857,7 +857,7 @@ async fn handle_workflow_trigger(
     // member could otherwise invoke another user's webhook or message actions.
     if workflow.owner_pubkey != self_bytes {
         return Err(IngestError::Rejected(
-            "forbidden: not authorized to trigger this workflow".into(),
+            "forbidden: only the workflow owner may trigger this workflow".into(),
         ));
     }
 
@@ -866,25 +866,34 @@ async fn handle_workflow_trigger(
     // Without this, a disabled workflow — including one disabled because its
     // owner was removed from the channel — could still be fired by the owner.
     if !workflow.enabled || workflow.status != buzz_db::workflow::WorkflowStatus::Active {
-        return Err(IngestError::Rejected(
-            "forbidden: workflow is disabled or inactive".into(),
-        ));
+        return Err(IngestError::Rejected(format!(
+            "forbidden: workflow is {} (enabled={}); \
+             active runs require enabled=true and status=Active",
+            workflow.status, workflow.enabled
+        )));
     }
     let def: buzz_workflow::WorkflowDef = serde_json::from_value(workflow.definition.clone())
         .map_err(|e| IngestError::Internal(format!("error: corrupt workflow definition: {e}")))?;
     let Some(wf_channel_id) = workflow.channel_id else {
         // No channel scope means no channel authority to verify — fail closed.
         return Err(IngestError::Rejected(
-            "forbidden: workflow has no channel scope".into(),
+            "forbidden: workflow has no channel scope; cannot verify owner authority".into(),
         ));
     };
-    state
+    if let Err(e) = state
         .workflow_engine
         .check_owner_authority(community_id, wf_channel_id, &workflow.owner_pubkey, &def)
         .await
-        .map_err(|_| {
-            IngestError::Rejected("forbidden: not authorized to trigger this workflow".into())
-        })?;
+    {
+        // Surface *why* the authority check failed so the caller can act —
+        // previously this returned a generic "not authorized" that left the
+        // caller unable to distinguish a SEC-006 elevated-role denial from a
+        // disabled workflow or a membership lapse (issue #5122).
+        return Err(IngestError::Rejected(workflow_owner_authority_denial(
+            def.requires_elevated_authority(),
+            &e,
+        )));
+    }
 
     // Persist the command event under the workflow channel even though the
     // trigger event itself only carries the workflow UUID. Storing channel
@@ -1367,4 +1376,59 @@ async fn resume_workflow_after_approval(
     engine
         .finalize_run(community_id, run_id, result, existing_trace)
         .await;
+}
+
+/// Build the user-facing rejection text when a manual workflow trigger fails
+/// its SEC-006 owner-authority check.
+///
+/// Exfiltration-capable definitions (those containing a `call_webhook` step)
+/// require the owner to currently hold an elevated role (`owner` or `admin`) —
+/// plain membership is insufficient. Ordinary definitions only require channel
+/// membership.
+///
+/// Previously both branches returned the same generic "not authorized" text,
+/// which left the owner of a `call_webhook` workflow unable to tell SEC-006
+/// (role missing) apart from a disabled workflow or a membership lapse (issue
+/// #5122: "workflow appears to succeed, no run record"). Naming the cause in
+/// the rejection gives the caller an actionable next step.
+fn workflow_owner_authority_denial(
+    requires_elevated_authority: bool,
+    error: &buzz_workflow::WorkflowError,
+) -> String {
+    if requires_elevated_authority {
+        format!(
+            "forbidden: SEC-006 — workflow contains exfiltration-capable \
+             actions (call_webhook) that require the owner to hold the \
+             'owner' or 'admin' role in this channel; {error}"
+        )
+    } else {
+        format!("forbidden: workflow owner's channel authority check failed; {error}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::workflow_owner_authority_denial;
+    use buzz_workflow::WorkflowError;
+
+    #[test]
+    fn denial_for_elevated_definition_names_sec006_and_call_webhook() {
+        let err = WorkflowError::Unauthorized("not a member".into());
+        let msg = workflow_owner_authority_denial(true, &err);
+        assert!(msg.starts_with("forbidden:"));
+        assert!(msg.contains("SEC-006"));
+        assert!(msg.contains("call_webhook"));
+        assert!(msg.contains("owner' or 'admin' role"));
+        assert!(msg.contains("not a member"));
+    }
+
+    #[test]
+    fn denial_for_ordinary_definition_has_no_sec006_hint() {
+        let err = WorkflowError::Unauthorized("unknown".into());
+        let msg = workflow_owner_authority_denial(false, &err);
+        assert!(msg.starts_with("forbidden:"));
+        assert!(!msg.contains("SEC-006"));
+        assert!(!msg.contains("call_webhook"));
+        assert!(msg.contains("unknown"));
+    }
 }

--- a/crates/buzz-workflow/src/lib.rs
+++ b/crates/buzz-workflow/src/lib.rs
@@ -388,9 +388,16 @@ impl WorkflowEngine {
                 .check_owner_authority(community_id, channel_id, &workflow.owner_pubkey, &def)
                 .await
             {
+                // SEC-006 (exfiltration-capable definitions like call_webhook)
+                // denies runs without creating a run row or emitting an event —
+                // the only trace is this log. Include enough fields to diagnose
+                // "workflow appears to succeed, no run record" reports (issue
+                // #5122) from relay logs alone.
                 tracing::warn!(
                     workflow_id = %workflow.id,
-                    "Skipping workflow — owner authority check failed: {e}"
+                    owner_pubkey = %hex::encode(&workflow.owner_pubkey),
+                    requires_elevated_authority = def.requires_elevated_authority(),
+                    "Skipping workflow — SEC-006 owner authority check failed: {e}"
                 );
                 continue;
             }


### PR DESCRIPTION
Resolves #5122 (partial).

## Root cause analysis

Issue #5122 reports that `call_webhook` workflow steps never deliver HTTP requests, with no error surfaced and no run record visible. The investigation identified three distinct, interlocking causes:

1. **Silent SEC-006 denial** (actionable, fixed here): When a manual trigger's owner-authority check fails, the relay returned the same generic `"forbidden: not authorized to trigger this workflow"` for every failure mode — membership lapse, disabled workflow, SEC-006 elevated-role denial — leaving callers unable to distinguish "you lack the admin role for call_webhook" from "workflow disabled." On the event-trigger path, the skip was only a `WARN` log with the workflow_id and error, no owner_pubkey or requires_elevated flag.

2. **Run history unreadable** (known, separately filed as #2980 and #4478): `buzz workflows runs` queries Nostr kinds 46001–46003, but the relay never emits those events. Run state lives only in Postgres. This means even when `call_webhook` *does* fail (e.g. outbound HTTP blocked by infrastructure), the failure is invisible to the CLI. **Not addressed here** — it is a larger feature (event emission) tracked in its own issues.

3. **Outbound HTTP blocked by deployment** (infrastructure, not code): If the relay is hosted where egress HTTP is restricted, `call_webhook_impl` returns `Err(WorkflowError::WebhookError(...))`, the run is marked Failed in Postgres, but cause #2 hides the failure. Not fixable in-repo.

## What this PR fixes

Split the rejection text by cause in `handle_workflow_trigger` so callers can act:

- `"forbidden: only the workflow owner may trigger this workflow"` (wrong caller)
- `"forbidden: workflow is {status} (enabled={bool}); active runs require enabled=true and status=Active"` (lifecycle)
- `"forbidden: workflow has no channel scope; cannot verify owner authority"` (fail-closed)
- **SEC-006 branch**: `"forbidden: SEC-006 — workflow contains exfiltration-capable actions (call_webhook) that require the owner to hold the 'owner' or 'admin' role in this channel; {underlying_error}"` — names the cause and the fix
- Ordinary-denial fallback: `"forbidden: workflow owner's channel authority check failed; {error}"`

Also enrich the `WARN` log on the **event-trigger** path (`on_event` → `check_owner_authority`) with `owner_pubkey` and `requires_elevated_authority`, so the same silent skip is diagnosable from relay logs.

## What this PR does NOT fix

- Run history visibility (#2980, #4478) — the relay still does not emit kinds 46001–46003. That is a larger feature (event emission from `finalize_run`) tracked separately.
- `call_webhook` delivery on hosts with blocked outbound HTTP — that is an infrastructure concern; the descriptive error from this PR at least makes the SEC-006 cause visible, and once #2980 is fixed, run-history will surface the HTTP error too.

## Tests

- `cargo check -p buzz-relay -p buzz-workflow`: clean
- `cargo fmt --check -p buzz-relay -p buzz-workflow`: clean
- `cargo clippy -p buzz-relay -p buzz-workflow --all-targets -- -D warnings`: clean
- `cargo test -p buzz-relay --lib`: 854 passed, 8 pre-existing failures (api::admin / api::media, verified identical on base, unrelated)
- `cargo test -p buzz-workflow --lib`: 154 passed, 0 failed
- New unit tests: `denial_for_elevated_definition_names_sec006_and_call_webhook`, `denial_for_ordinary_definition_has_no_sec006_hint`

## Files changed

- `crates/buzz-relay/src/handlers/command_executor.rs` (+52/−7): descriptive rejections + extracted `workflow_owner_authority_denial` helper + unit tests
- `crates/buzz-workflow/src/lib.rs` (+9/−2): structured `WARN` log with `owner_pubkey` + `requires_elevated_authority`
