### PR TITLE
fix(desktop): derive remote agent liveness from presence, not backend_agent_id

### DIFF
--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentLive,
+  managedAgentPresence,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
 } from "./managedAgentControlActions.ts";
@@ -164,5 +167,98 @@ test("test_respawn_onStopped_fires_before_start_resolves", async () => {
     events,
     ["stop", "onStopped", "start"],
     "onStopped must fire after stop resolves and before start is called",
+  );
+});
+
+// ── Remote-agent liveness (I3: "Presence is the status") ─────────────────────
+// Regression coverage for #4730: a provider-backed agent that has shut down kept reading as
+// live because status is derived from backend_agent_id, which v1 never clears.
+
+const remote = (overrides = {}) =>
+  agent({
+    backend: { type: "provider", id: "mjolnir" },
+    backendAgentId: "vm-1234",
+    status: "deployed",
+    ...overrides,
+  });
+
+const presenceOf = (status, loaded = true) => ({ status, loaded });
+
+test("remote agent with no presence reads as not live once presence has loaded", () => {
+  // get_presence omits offline pubkeys, so "shut down" arrives as an absent entry.
+  assert.equal(isManagedAgentLive(remote(), presenceOf(undefined)), false);
+  assert.equal(isManagedAgentLive(remote(), presenceOf("offline")), false);
+});
+
+test("remote agent that is online or away reads as live", () => {
+  assert.equal(isManagedAgentLive(remote(), presenceOf("online")), true);
+  assert.equal(isManagedAgentLive(remote(), presenceOf("away")), true);
+});
+
+test("remote agent does not flash dead while presence is still loading", () => {
+  // Falling back to the control-plane axis here keeps I3's promise of a *bounded* wrong
+  // signal instead of trading one unbounded lie for another.
+  assert.equal(
+    isManagedAgentLive(remote(), presenceOf(undefined, false)),
+    true,
+  );
+});
+
+test("remote agent that was never deployed is not live regardless of presence", () => {
+  const undeployed = remote({ backendAgentId: null, status: "not_deployed" });
+  assert.equal(isManagedAgentLive(undeployed, presenceOf("online")), false);
+});
+
+test("local agents keep using the pid-probed status, not presence", () => {
+  const running = agent({ status: "running" });
+  // A local agent mid-start may have no presence yet; it is still running.
+  assert.equal(isManagedAgentLive(running, presenceOf(undefined)), true);
+  assert.equal(
+    isManagedAgentLive(agent({ status: "stopped" }), presenceOf("online")),
+    false,
+  );
+});
+
+test("shut-down remote agent offers Deploy, not Shutdown", () => {
+  // The bug: this returned "Shutdown" forever, making the deploy arm unreachable.
+  assert.equal(
+    getManagedAgentPrimaryActionLabel(remote(), presenceOf(undefined)),
+    "Deploy",
+  );
+  assert.equal(
+    getManagedAgentPrimaryActionLabel(remote(), presenceOf("online")),
+    "Shutdown",
+  );
+});
+
+test("local agent action labels are unchanged", () => {
+  const p = presenceOf(undefined);
+  assert.equal(
+    getManagedAgentPrimaryActionLabel(agent({ status: "running" }), p),
+    "Stop",
+  );
+  assert.equal(
+    getManagedAgentPrimaryActionLabel(agent({ status: "stopped" }), p),
+    "Restart Agent",
+  );
+  assert.equal(
+    getManagedAgentPrimaryActionLabel(agent({ status: "not_deployed" }), p),
+    "Start Agent",
+  );
+});
+
+test("managedAgentPresence distinguishes an unloaded lookup from an absent entry", () => {
+  const a = remote();
+  assert.deepEqual(managedAgentPresence(a, undefined), {
+    status: undefined,
+    loaded: false,
+  });
+  assert.deepEqual(managedAgentPresence(a, {}), {
+    status: undefined,
+    loaded: true,
+  });
+  assert.deepEqual(
+    managedAgentPresence(a, { [a.pubkey.toLowerCase()]: "online" }),
+    { status: "online", loaded: true },
   );
 });

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -3,6 +3,7 @@ import type {
   Channel,
   ManagedAgent,
   PresenceLookup,
+  PresenceStatus,
   RelayAgent,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -31,13 +32,83 @@ export type ManagedAgentActionResult = {
   noticeMessage?: string;
 };
 
+/**
+ * The **control-plane** axis: does infrastructure for this agent exist?
+ *
+ * For remote (provider) agents this is derived from `backend_agent_id` and is deliberately
+ * write-once — it stays `deployed` after `!shutdown`, because the provider may have allocated a
+ * VM or container that outlives the process. It is bookkeeping, **not liveness**.
+ *
+ * Use this only for genuinely control-plane questions ("would deleting orphan a deployment?").
+ * For "is this thing alive right now", use {@link isManagedAgentLive}.
+ */
 export function isManagedAgentActive(agent: Pick<ManagedAgent, "status">) {
   return agent.status === "running" || agent.status === "deployed";
 }
 
-export function getManagedAgentPrimaryActionLabel(agent: ManagedAgent) {
+/** Relay presence for an agent, plus whether presence has loaded at all yet. */
+export type ManagedAgentPresence = {
+  status: PresenceStatus | undefined;
+  loaded: boolean;
+};
+
+/**
+ * The **live** axis: is this agent's harness connected right now?
+ *
+ * Per invariant I3 ("Presence is the status", `docs/remote-agents.md`), a remote agent's live
+ * state is derived exclusively from relay presence self-signed by the agent key — never from the
+ * deployment axis, which never clears without a `undeploy` operation that v1 does not have.
+ *
+ * Local agents are unaffected: their status comes from a real pid probe, so the control-plane
+ * axis *is* liveness for them.
+ *
+ * While presence is still loading we fall back to the control-plane axis rather than reporting a
+ * live agent as dead — otherwise every remote agent would flash "Deploy" on app start. This keeps
+ * I3's promise of a *bounded* wrong signal rather than trading one unbounded lie for another.
+ */
+export function isManagedAgentLive(
+  agent: Pick<ManagedAgent, "status" | "backend">,
+  presence: ManagedAgentPresence,
+): boolean {
+  if (agent.backend.type !== "provider") {
+    return isManagedAgentActive(agent);
+  }
+
+  // Nothing was ever deployed — no presence can make this live.
+  if (!isManagedAgentActive(agent)) {
+    return false;
+  }
+
+  if (!presence.loaded) {
+    return true;
+  }
+
+  return presence.status === "online" || presence.status === "away";
+}
+
+/** Resolve an agent's presence out of a lookup keyed by normalized pubkey. */
+export function managedAgentPresence(
+  agent: Pick<ManagedAgent, "pubkey">,
+  presenceLookup: PresenceLookup | null | undefined,
+): ManagedAgentPresence {
+  if (!presenceLookup) {
+    return { status: undefined, loaded: false };
+  }
+  return {
+    status: presenceLookup[normalizePubkey(agent.pubkey)],
+    loaded: true,
+  };
+}
+
+export function getManagedAgentPrimaryActionLabel(
+  agent: ManagedAgent,
+  presence: ManagedAgentPresence,
+) {
   if (agent.backend.type === "provider") {
-    return isManagedAgentActive(agent) ? "Shutdown" : "Deploy";
+    // Deploy converges to at-most-one-live-instance (§Deploy State Machine), so offering
+    // "Deploy" for an agent whose deployment record still exists is safe: the provider
+    // re-adopts a live instance or recreates a reaped one.
+    return isManagedAgentLive(agent, presence) ? "Shutdown" : "Deploy";
   }
 
   if (isManagedAgentActive(agent)) {

--- a/desktop/src/features/agents/ui/AgentStatusBadge.tsx
+++ b/desktop/src/features/agents/ui/AgentStatusBadge.tsx
@@ -24,12 +24,15 @@ export function AgentStatusBadge({
     return () => clearTimeout(timer);
   }, []);
 
-  const isActive = status === "running" || status === "deployed";
+  // A deployed remote agent that is not present has shut down; the deployment record survives
+  // because v1 has no `undeploy`, so it must not keep reading as live (I3, docs/remote-agents.md).
+  const presenceSaysOffline =
+    presenceLoaded && (!presenceStatus || presenceStatus === "offline");
+  const isActive =
+    (status === "running" || status === "deployed") &&
+    !(status === "deployed" && !inGracePeriod && presenceSaysOffline);
   const isStarting =
-    !inGracePeriod &&
-    presenceLoaded &&
-    status === "running" &&
-    (!presenceStatus || presenceStatus === "offline");
+    !inGracePeriod && presenceSaysOffline && status === "running";
 
   const variant: "default" | "warning" | "secondary" = isWorking
     ? "default"

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -279,6 +279,14 @@ export function useManagedAgentActions() {
       });
       if (agent.backend.type === "local") {
         clearActiveTurnsForAgentOnStop(pubkey);
+      } else {
+        // Remote stop is a `!shutdown` message, not a mutation, so nothing invalidates on its
+        // own. Without this the roster lags up to 5 minutes and presence up to 60s, right when
+        // the user is watching for feedback. (The live transition still arrives over the kind:20001
+        // WS subscription; these refetches keep the other two axes from contradicting it.)
+        void managedPresenceQuery.refetch();
+        void relayAgentsQuery.refetch();
+        void managedAgentsQuery.refetch();
       }
       if (result.noticeMessage) {
         setActionNoticeMessage(result.noticeMessage);

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -682,6 +682,7 @@ export function MembersSidebar({
               : undefined
           }
           pairAction={pairAction}
+          presenceLoaded={memberPresenceQuery.data !== undefined}
           presenceStatus={
             memberPresenceQuery.data?.[member.pubkey.toLowerCase()] ?? null
           }

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -16,7 +16,8 @@ import {
 
 import {
   getManagedAgentPrimaryActionLabel,
-  isManagedAgentActive,
+  isManagedAgentLive,
+  type ManagedAgentPresence,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
@@ -71,6 +72,8 @@ type MembersSidebarMemberCardProps = {
   onUnban: (member: ChannelMember) => void;
   onUntimeout: (member: ChannelMember) => void;
   onViewActivity?: (pubkey: string) => void;
+  /** Whether the presence query has resolved; an absent entry is only "offline" once it has. */
+  presenceLoaded?: boolean;
   presenceStatus?: PresenceStatus | null;
   profileAvatarUrl?: string | null;
   viewerIsOwner: boolean;
@@ -139,12 +142,17 @@ export function MembersSidebarMemberCard({
   onUnban,
   onUntimeout,
   onViewActivity,
+  presenceLoaded = false,
   presenceStatus,
   profileAvatarUrl,
   viewerIsOwner,
 }: MembersSidebarMemberCardProps) {
   const roleLabel = formatRoleLabel(member, memberIsBot);
   const disabled = isActionPending || isArchived;
+  const agentPresence: ManagedAgentPresence = {
+    loaded: presenceLoaded,
+    status: presenceStatus ?? undefined,
+  };
   const canViewActivity =
     memberIsBot &&
     (viewerIsOwner || managedAgent?.backend.type === "local") &&
@@ -214,14 +222,15 @@ export function MembersSidebarMemberCard({
                 ? agentCommunityAvailability(managedAgentRuntime) === "Here"
                   ? "default"
                   : "secondary"
-                : managedAgent && isManagedAgentActive(managedAgent)
+                : managedAgent &&
+                    isManagedAgentLive(managedAgent, agentPresence)
                   ? "default"
                   : "secondary"
             }
           >
             {managedAgentRuntime
               ? agentCommunityAvailability(managedAgentRuntime)
-              : managedAgent && isManagedAgentActive(managedAgent)
+              : managedAgent && isManagedAgentLive(managedAgent, agentPresence)
                 ? "Running"
                 : "Stopped"}
           </Badge>
@@ -265,6 +274,7 @@ export function MembersSidebarMemberCard({
           canRemoveMember={canRemoveMember}
           canViewActivity={canViewActivity}
           disabled={disabled}
+          agentPresence={agentPresence}
           managedAgent={managedAgent}
           member={member}
           memberIsBot={memberIsBot}
@@ -288,6 +298,7 @@ export function MembersSidebarMemberCard({
 const PEOPLE_ROLES = ["admin", "member", "guest"] as const;
 
 function MemberActionsMenu({
+  agentPresence,
   canChangeRole,
   canModerateMember,
   canRemoveMember,
@@ -308,6 +319,7 @@ function MemberActionsMenu({
   onViewActivity,
   pairAction,
 }: {
+  agentPresence: ManagedAgentPresence;
   canChangeRole: boolean;
   canModerateMember: boolean;
   canRemoveMember: boolean;
@@ -367,10 +379,13 @@ function MemberActionsMenu({
             >
               {pairAction
                 ? getPairActionIcon(pairAction)
-                : getManagedAgentActionIcon(managedAgent)}
+                : getManagedAgentActionIcon(managedAgent, agentPresence)}
               {pairAction
                 ? MANAGED_AGENT_PAIR_ACTION_LABELS[pairAction]
-                : getManagedAgentPrimaryActionLabel(managedAgent)}
+                : getManagedAgentPrimaryActionLabel(
+                    managedAgent,
+                    agentPresence,
+                  )}
             </DropdownMenuItem>
             {onEditRespondTo ? (
               <DropdownMenuItem
@@ -501,8 +516,11 @@ function getPairActionIcon(action: ManagedAgentPairAction) {
   return <Play className="h-4 w-4" />;
 }
 
-function getManagedAgentActionIcon(agent: ManagedAgent) {
-  if (isManagedAgentActive(agent)) {
+function getManagedAgentActionIcon(
+  agent: ManagedAgent,
+  presence: ManagedAgentPresence,
+) {
+  if (isManagedAgentLive(agent, presence)) {
     return <Square className="h-4 w-4" />;
   }
 

--- a/desktop/src/features/channels/ui/useMembersSidebarActions.ts
+++ b/desktop/src/features/channels/ui/useMembersSidebarActions.ts
@@ -2,12 +2,16 @@ import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
+  managedAgentsQueryKey,
+  relayAgentsQueryKey,
   useStartManagedAgentMutation,
   useStopManagedAgentMutation,
 } from "@/features/agents/hooks";
 import {
   respawnManagedAgentWithRules,
   isManagedAgentActive,
+  isManagedAgentLive,
+  managedAgentPresence,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
@@ -16,6 +20,7 @@ import {
   useManagedAgentRuntimeAction,
 } from "@/features/agents/managedAgentRuntimeHooks";
 import { managedAgentPairAction } from "@/features/agents/managedAgentRuntimeStatus";
+import { usePresenceQuery } from "@/features/presence/hooks";
 import {
   channelsQueryKey,
   useRemoveChannelMemberMutation,
@@ -56,6 +61,10 @@ export function useMembersSidebarActions({
   relayUrl,
 }: UseMembersSidebarActionsOptions) {
   const queryClient = useQueryClient();
+  // Remote-agent liveness is relay presence, not the deployment record (I3).
+  const managedPresenceQuery = usePresenceQuery(
+    controllableManagedBots.map((agent) => agent.pubkey),
+  );
   const removeMemberMutation = useRemoveChannelMemberMutation(channelId);
   const startManagedAgentMutation = useStartManagedAgentMutation();
   const stopManagedAgentMutation = useStopManagedAgentMutation();
@@ -170,7 +179,12 @@ export function useMembersSidebarActions({
         return;
       }
 
-      if (isManagedAgentActive(agent)) {
+      if (
+        isManagedAgentLive(
+          agent,
+          managedAgentPresence(agent, managedPresenceQuery.data),
+        )
+      ) {
         await stopManagedAgentWithRules({
           agent,
           ...EMPTY_AGENT_CONTEXT,
@@ -179,6 +193,13 @@ export function useMembersSidebarActions({
         });
         if (agent.backend.type === "local") {
           clearActiveTurnsForAgentOnStop(agent.pubkey);
+        } else {
+          // `!shutdown` is a message, not a mutation — nothing invalidates on its own.
+          void queryClient.invalidateQueries({ queryKey: ["presence"] });
+          void queryClient.invalidateQueries({ queryKey: relayAgentsQueryKey });
+          void queryClient.invalidateQueries({
+            queryKey: managedAgentsQueryKey,
+          });
         }
         setActionNoticeMessage(
           agent.backend.type === "provider"

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -841,7 +841,7 @@ export function UserProfilePanel({
                   })
               : undefined
           }
-          presenceStatus={presenceStatus}
+          presence={{ loaded: presenceQuery.isSuccess, status: presenceStatus }}
           profile={profile}
           pubkey={effectivePubkey}
           relayAgent={relayAgent}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -9,7 +9,11 @@ import {
 
 import { MemorySection } from "@/features/agent-memory/ui/MemorySection";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
-import { getManagedAgentPrimaryActionLabel } from "@/features/agents/lib/managedAgentControlActions";
+import {
+  getManagedAgentPrimaryActionLabel,
+  isManagedAgentLive,
+  type ManagedAgentPresence,
+} from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
 import { ManagedAgentLogPanel } from "@/features/agents/ui/ManagedAgentLogPanel";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
@@ -101,7 +105,9 @@ export type ProfileSummaryViewProps = {
   onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
   /** Mint an agent trading card. Present only for owner-managed personas. */
   onCreateCard?: () => void;
-  presenceStatus: "online" | "away" | "offline" | undefined;
+  /** Relay presence for this profile: the status plus whether the query has resolved at all
+   * (get_presence omits offline pubkeys, so an absent entry only means "offline" once loaded). */
+  presence: ManagedAgentPresence;
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string | null;
   relayAgent: RelayAgent | undefined;
@@ -130,9 +136,11 @@ const PROFILE_HERO_PRESENCE_BADGE = {
 function resolveRuntimeTabStatus({
   diagnosticsError,
   managedAgent,
+  presence,
 }: {
   diagnosticsError: boolean;
   managedAgent: ManagedAgent | undefined;
+  presence: ManagedAgentPresence;
 }): RuntimeTabStatus | undefined {
   if (diagnosticsError || managedAgent?.lastError) {
     return "error";
@@ -142,11 +150,9 @@ function resolveRuntimeTabStatus({
     return undefined;
   }
 
-  if (managedAgent.status === "running" || managedAgent.status === "deployed") {
-    return "running";
-  }
-
-  return "stopped";
+  // I3: for remote agents the green dot must follow relay presence, not the deployment record —
+  // `deployed` never clears without an `undeploy` op, which v1 does not have.
+  return isManagedAgentLive(managedAgent, presence) ? "running" : "stopped";
 }
 
 function RuntimeTabStatusDot({ status }: { status: RuntimeTabStatus }) {
@@ -215,7 +221,7 @@ export function ProfileSummaryView({
   onTabChange,
   onOpenDm,
   onCreateCard,
-  presenceStatus,
+  presence,
   profile,
   pubkey,
   relayAgent,
@@ -268,9 +274,11 @@ export function ProfileSummaryView({
     ) : (
       "View"
     );
+  const presenceStatus = presence.status;
   const runtimeTabStatus = resolveRuntimeTabStatus({
     diagnosticsError: diagnosticsErrorField !== undefined,
     managedAgent,
+    presence,
   });
 
   const tabs = React.useMemo(() => {
@@ -359,12 +367,11 @@ export function ProfileSummaryView({
           agentActionDisabled={isAgentActionPending}
           agentActionLabel={
             isOwner === true && managedAgent
-              ? getManagedAgentPrimaryActionLabel(managedAgent)
+              ? getManagedAgentPrimaryActionLabel(managedAgent, presence)
               : undefined
           }
           agentActionLive={
-            managedAgent?.status === "running" ||
-            managedAgent?.status === "deployed"
+            managedAgent ? isManagedAgentLive(managedAgent, presence) : false
           }
           onAgentPrimaryAction={
             isOwner === true && managedAgent

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -2,12 +2,14 @@ import * as React from "react";
 import { toast } from "sonner";
 
 import {
-  isManagedAgentActive,
+  isManagedAgentLive,
+  managedAgentPresence,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
+import { usePresenceQuery } from "@/features/presence/hooks";
 import type { Channel, ManagedAgent, RelayAgent } from "@/shared/api/types";
 
 export function useAgentLifecycleActions({
@@ -23,11 +25,23 @@ export function useAgentLifecycleActions({
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
 }) {
+  // The live axis for remote agents (I3). Owned here rather than passed in, so every caller of
+  // this hook gets the presence-aware branch; react-query dedupes the subscription.
+  const presenceQuery = usePresenceQuery(
+    managedAgent ? [managedAgent.pubkey] : [],
+  );
+  const presence = managedAgent
+    ? managedAgentPresence(managedAgent, presenceQuery.data)
+    : { status: undefined, loaded: false };
+
   const handleAgentPrimaryAction = React.useCallback(async () => {
     if (!managedAgent) return;
 
     try {
-      if (isManagedAgentActive(managedAgent)) {
+      // Remote agents: a shut-down agent must fall through to the deploy arm. Keying this on
+      // the deployment record instead of presence made that arm unreachable, so a remote agent
+      // could never be brought back from this surface.
+      if (isManagedAgentLive(managedAgent, presence)) {
         const result = await stopManagedAgentWithRules({
           agent: managedAgent,
           channels: channels ?? [],
@@ -58,6 +72,7 @@ export function useAgentLifecycleActions({
   }, [
     channels,
     managedAgent,
+    presence,
     relayAgents,
     startManagedAgent,
     stopManagedAgent,


### PR DESCRIPTION
Fixes #4730.

## The problem

A provider-backed agent stays **online** with a live **Shutdown** button forever after it has shut down — and because the primary action never flips back to **Deploy**, there is no way to bring it back from that surface.

The agent is not at fault: it publishes `kind:10100` with `"status":"offline"` and `kind:20001` presence `offline`, and the relay applies both. The desktop just never looks. `build_managed_agent_summary()` derives remote status exclusively from `record.backend_agent_id.is_some()`, which is write-once — there is no `undeploy` in v1 — so `status` is pinned at `"deployed"` for the life of the record, and every liveness-shaped UI decision keys off it.

This contradicts invariant **I3** ("Presence is the status", `docs/remote-agents.md`): the deployment axis "is bookkeeping, not liveness". I3 also promises a *bounded* wrong dot (180s `PRESENCE_TTL_SECS`); today's wrong dot survives shutdown, app restart, and reboot, because it is not a presence dot at all.

## The fix

Follows suggestion **(b)** from the issue — keep the Rust summary purely control-plane and add a frontend liveness helper — so `deployed`/`not_deployed` stay honest as bookkeeping, per I3.

`isManagedAgentLive(agent, presence)` is now the "is this thing alive" predicate. `isManagedAgentActive` keeps its name and its meaning, and is reserved for genuinely control-plane questions — e.g. the orphan warning in `deleteManagedAgentWithRules`, which already read `presenceLookup` and got this right.

Routed through it:

| Surface | Was |
|---|---|
| `getManagedAgentPrimaryActionLabel` | provider + active → `"Shutdown"`, never `"Deploy"` |
| `handleAgentPrimaryAction` | branched on `isManagedAgentActive` → the `startManagedAgentWithRules` arm was unreachable |
| `agentActionLive` (profile) | inlined `status === "running" \|\| "deployed"` |
| `resolveRuntimeTabStatus` | `deployed` → `"running"` → green |
| `AgentStatusBadge` | de-escalation branch tested `status === "running"`, so it could never fire for a remote agent |
| Members sidebar badge / icon / action | same predicate |

Once the label is honest, **Deploy** reaches `startManagedAgentWithRules` → `deploy`, which is already converge-to-at-most-one-live-instance (§Deploy State Machine) and safely re-adopts or recreates. That closes the "cannot bring it back" half without needing the v2 `undeploy`.

### On the loading window

`get_presence` omits offline/unknown pubkeys (noted in `presence.ts`), so an absent entry is indistinguishable from "the query hasn't resolved". A bare `presence !== undefined` test would make every remote agent flash **Deploy** on app start.

So `ManagedAgentPresence` carries both axes — `{ status, loaded }` — and liveness falls back to the control-plane axis until presence resolves. That keeps I3's promise of a *bounded* wrong signal instead of trading one unbounded lie for another. `AgentStatusBadge`'s existing 15s grace period is reused for the same reason.

Local agents are untouched: their status comes from a real pid probe, so the control-plane axis *is* liveness for them. `isManagedAgentLive` returns `isManagedAgentActive` unchanged for `backend.type !== "provider"`.

### Secondary: nothing was refetched after `!shutdown`

`handleStop` invalidated nothing on the provider branch (unlike `handleStart`), and the same held for `useMembersSidebarActions`. With `useRelayAgentsQuery` polling at 5 minutes and `usePresenceQuery` backstopping at 60s, fixing the root cause alone would still have left a visible multi-minute lie right when the user is watching for feedback on an action they just took. Both paths now invalidate `["presence"]`, `relay-agents`, and `managed-agents`. (The live transition itself still arrives over the `kind:20001` WS subscription; these keep the other two axes from contradicting it.)

### One structural note

`useAgentLifecycleActions` now owns its presence subscription instead of taking it as a prop, so every caller gets the presence-aware branch rather than each having to remember to pass it. react-query dedupes it against the panel's existing query. This also keeps `UserProfilePanel.tsx` at its 1000-line ratchet — the two presence props on `ProfileSummaryView` were merged into one `presence` object for the same reason.

## Testing

- `pnpm test` — **4488 pass, 0 fail**, including 8 new cases in `managedAgentControlActions.test.mjs` covering: absent-vs-loaded presence, online/away, the never-deployed case, local-agent fallback, the `Deploy`/`Shutdown` label flip, and unchanged local labels.
- `npx tsc --noEmit` — clean.
- `pnpm check` — clean (biome + file-size ratchet + px-text + pubkey-truncation).

Manual: deploy a provider-backed agent, `!shutdown`, confirm the dot goes grey, the badge de-escalates, the runtime tab reads stopped, and the button becomes **Deploy** — then press it and confirm the agent comes back under the same identity.

## Related

Searched open PRs; none found addressing this. #2798 (provider config saves don't redeploy) and #4605 (no management surface on other desktops) both cite the missing `undeploy`, but are different defects. #4537 is presence for relay-discovered agents — opposite direction, different files.