### PR TITLE
fix(cli): dms list queries relay NIP-29 discovery, not phantom kind:41001

### DIFF
--- a/crates/buzz-cli/src/commands/dms.rs
+++ b/crates/buzz-cli/src/commands/dms.rs
@@ -4,19 +4,60 @@ use crate::client::{extract_d_tag, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{parse_uuid, sdk_err, validate_hex64};
 
-/// List DM conversations by querying kind:41001 (relay-confirmed DMs) filtered by our pubkey.
+/// List DM conversations by querying relay-emitted NIP-29 discovery events:
+/// kind:39002 (our channel-memberships) gives the channel IDs, then kind:39000
+/// filtered by `#t: dm` gives the metadata for those DMs. The relay emits both
+/// kinds from `emit_group_discovery_events` (called when a DM is opened, so
+/// `dms list` sees the DMs we are already a member of). A previous version of
+/// this command queried kind:41001, but no upstream event of that kind is ever
+/// published — `KIND_DM_CREATED` is an enum constant without an emitter — so the
+/// query always returned an empty list (issue #5137).
 pub async fn cmd_list_dms(client: &BuzzClient, limit: Option<u32>) -> Result<(), CliError> {
     let my_pk = client.keys().public_key().to_hex();
     let limit = limit.unwrap_or(50).min(200);
-    let filter = serde_json::json!({
-        "kinds": [41001],
+
+    // Step 1: find channel IDs where we are a member (kind:39002).
+    let member_filter = serde_json::json!({
+        "kinds": [39002],
         "#p": [my_pk],
-        "limit": limit
     });
-    let resp = client.query(&filter).await?;
-    let events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
-    let dms: Vec<serde_json::Value> = events
+    let member_events = client.query_paginated(member_filter, limit).await?;
+    let channel_ids: Vec<String> = member_events
         .iter()
+        .map(extract_d_tag)
+        .filter(|id| !id.is_empty())
+        .collect();
+    if channel_ids.is_empty() {
+        println!("[]");
+        return Ok(());
+    }
+
+    // Step 2: fetch kind:39000 metadata, keeping only DMs (`t == "dm"`).
+    let metadata_filter = serde_json::json!({
+        "kinds": [39000],
+        "#d": channel_ids,
+    });
+    let metadata_events = client.query_paginated(metadata_filter, limit).await?;
+    let dms: Vec<serde_json::Value> = metadata_events
+        .iter()
+        .filter(|e| {
+            e.get("tags")
+                .and_then(|t| t.as_array())
+                .map(|tags| {
+                    tags.iter().any(|tag| {
+                        let arr = tag.as_array();
+                        let is_t_tag = arr.and_then(|a| {
+                            if a.first().and_then(|v| v.as_str()) == Some("t") {
+                                a.get(1).and_then(|v| v.as_str())
+                            } else {
+                                None
+                            }
+                        });
+                        is_t_tag == Some("dm")
+                    })
+                })
+                .unwrap_or(false)
+        })
         .map(|e| {
             let dm_id = extract_d_tag(e);
             let participants: Vec<String> = e


### PR DESCRIPTION
## Problem
`buzz dms list` returns `[]` even for agents with active DMs. Reported in #5137: an agent's DM sat unanswered for ~20 minutes because `dms list` couldn't discover it (though `buzz feed get` showed the events).

## Root cause
`cmd_list_dms` queried `kind:41001` (`KIND_DM_CREATED`). However, **no upstream event of that kind is ever published** — the enum constant exists in `buzz-core/src/kind.rs` but no relay handler mints one. The query always returned an empty page.

The relay's actual DM discovery surface is the standard NIP-29 group-discovery emission: on `open_dm`, `emit_group_discovery_events` (crates/buzz-relay/src/handlers/side_effects.rs:1045) publishes kind:39002 (membership) and kind:39000 (channel metadata with `t: "dm"` tag).

## Fix
Rewrite `cmd_list_dms` to use the published discovery events:
1. Query kind:39002 `#p: [our_pubkey]` for our memberships → collect channel IDs.
2. Query kind:39000 `#d: [channel_ids]` → filter to `t == "dm"` → extract participants + created_at.

This matches `channels list --member` (channels.rs:33-64), keeping the CLI consistent with the relay's authority model.

## Validation
- [x] `cargo check -p buzz-cli` clean
- [x] `cargo fmt -p buzz-cli` clean
- [x] `cargo clippy -p buzz-cli --all-targets -- -D warnings` clean
- [x] `cargo test -p buzz-cli` — 321 passed, 0 failed

Closes #5137.