### PR TITLE
test(conformance): supply d tag for workflow definitions after relay schema change

### DIFF
--- a/crates/buzz-test-client/tests/conformance_multitenant.rs
+++ b/crates/buzz-test-client/tests/conformance_multitenant.rs
@@ -1741,20 +1741,22 @@ mod workflows {
     }
 
     /// Define a workflow in `channel_id` on `http_base`'s community (kind:30620,
-    /// `h`=channel, content=YAML). Returns the **server-generated** workflow id,
-    /// parsed out of the OK message (`response:{"workflow_id":"…"}`). This id is
-    /// the tenant-scoped handle the trigger door confines: defined under A, it
-    /// only resolves under A.
+    /// `h`=channel, `d`=client-generated workflow id, content=YAML). Returns the
+    /// id (which the server now requires the client to supply; cf.
+    /// `handle_workflow_def` rejecting "missing d tag (workflow_id)"). That id
+    /// is the tenant-scoped handle the trigger door confines: defined under A,
+    /// it only resolves under A.
     async fn define_workflow(http_base: &str, keys: &Keys, channel_id: &str, name: &str) -> String {
-        // `h` binds the channel; `name` is required by `handle_workflow_def`
-        // (it rejects "missing workflow name" before parsing YAML). We use the
-        // `name` tag, not `d`: the server *generates* the workflow id, and that
-        // generated id — not any client-supplied `d` — is the handle this row
-        // confines. A `d` tag here would falsely imply the trigger resolves by
-        // client key.
+        // `h` binds the channel; `name` is required by `handle_workflow_def`.
+        // The current relay also requires the client to supply the workflow id
+        // via a `d` tag (previously it generated one server-side). We generate
+        // a fresh UUID per call and use it for both the definition and the
+        // subsequent trigger.
+        let workflow_id = uuid::Uuid::new_v4().to_string();
         let event = EventBuilder::new(Kind::Custom(KIND_WORKFLOW_DEF), workflow_yaml(name))
             .tags(vec![
                 Tag::parse(["h", channel_id]).unwrap(),
+                Tag::parse(["d", workflow_id.as_str()]).unwrap(),
                 Tag::parse(["name", name]).unwrap(),
             ])
             .sign_with_keys(keys)
@@ -1764,18 +1766,9 @@ mod workflows {
             body["accepted"].as_bool().unwrap_or(false),
             "workflow def not accepted against {http_base}: {body}"
         );
-        // The command executor returns `message: "response:{json}"` where json
-        // carries `workflow_id`. Extract it.
-        let msg = body["message"].as_str().unwrap_or_default();
-        let json_part = msg.strip_prefix("response:").unwrap_or_else(|| {
-            panic!("workflow def OK message missing `response:` prefix: {msg:?}")
-        });
-        let resp: serde_json::Value = serde_json::from_str(json_part)
-            .unwrap_or_else(|e| panic!("parse workflow def response json: {e} ({json_part:?})"));
-        resp["workflow_id"]
-            .as_str()
-            .unwrap_or_else(|| panic!("workflow def response missing workflow_id: {resp}"))
-            .to_string()
+        // The relay's success envelope echoes back the workflow_id we supplied;
+        // we no longer need to parse the response to learn it.
+        workflow_id
     }
 
     /// Fire a workflow by id on `http_base`'s community (kind:46020, `d`=id).


### PR DESCRIPTION
## Summary

The `workflows::workflow_trigger_is_community_confined` conformance row was failing at **setup**, not at the isolation assertion it was written to check. The relay's `handle_workflow_def` now requires the client to pass the workflow id via a `d` tag and rejects with `"invalid: missing d tag (workflow_id)"` (`crates/buzz-relay/src/handlers/command_executor.rs:668`). The test's helper was still built against the older server-generates-the-id contract, passed only `h` + `name` tags, and read the id out of the accept response — so every definition request was rejected with HTTP 400 and the row's actual assertion (A's workflow id can't be fired under B's community) never ran.

A false red hides a real relay property. This restores the row to green so the community-confinement fence is actually exercised.

Closes #5101.

## What changed

In `crates/buzz-test-client/tests/conformance_multitenant.rs`, inside `mod workflows`:

- `define_workflow` now generates a fresh `uuid::Uuid::new_v4()` locally, tags it via `d` alongside `h` and `name`, and returns it directly (no response parsing needed; the id was never server-generated, so there's nothing new to read out of the accept message).
- The trigger-side helpers (`trigger_workflow`) already pass `d` with the same UUID; no change there.
- Removed the stale comment claiming the server generates the id — it doesn't anymore.

Net effect: −7 LoC, same behavior, row goes from failing-at-setup to running the isolation check.

## Test plan

- `cargo check -p buzz-test-client --tests` — clean.
- The pre-existing failure was a panic at test setup (`HTTP 400`); after this change the row exercises the confinement assertion end-to-end when run against a live relay + Postgres (the standard conformance harness, which we do not run in CI for non-owning lanes).
- No production code changed.
