### PR TITLE
fix(onboarding): clear the continuing-identity ref on complete

### DIFF
--- a/desktop/src/features/onboarding/machineOnboarding.ts
+++ b/desktop/src/features/onboarding/machineOnboarding.ts
@@ -176,6 +176,12 @@ export function useMachineOnboardingState({
         completionKey(MACHINE_ONBOARDING_COMPLETION_STORAGE_KEY, pubkey),
         "true",
       );
+      // Completing onboarding for this pubkey ends the "continuing" state.
+      // Without clearing it the stage below stays pinned to "onboarding"
+      // forever, so the flow can never reach "ready".
+      if (continuingPubkeyRef.current === pubkey) {
+        continuingPubkeyRef.current = null;
+      }
       setCompletedPubkey(pubkey);
     },
     [currentPubkey],


### PR DESCRIPTION
Onboarding can never reach the `ready` stage for any identity that arrived through `continueWithIdentity` or `continueWithRecoveredIdentity` — most visibly **nsec import via "Use an existing key"**.

### Cause

In `desktop/src/features/onboarding/machineOnboarding.ts`, `continuingPubkeyRef` is assigned in two places and cleared in none:

- line ~185 `continueWithIdentity`
- line ~189 `continueWithRecoveredIdentity`

The stage derivation treats a match against `currentPubkey` as "still onboarding":

```js
} else if (
    identityLost ||
    continuingPubkeyRef.current === currentPubkey ||
    !hasCompletedCurrentPubkey
) {
    stage = "onboarding";
```

So `complete()` writes `buzz-machine-onboarding-complete.v2:<pubkey>` and sets `completedPubkey`, but the condition above is permanently true and the stage stays pinned. The user finishes onboarding and the screen does not advance.

Observed directly: the completion key was present in `localStorage` while the UI remained on the onboarding step.

A relaunch clears it because the ref is per-mount, which is likely why this has survived — it presents as a transient hiccup rather than a stuck state.

### Fix

Clear the ref when it matches the pubkey being completed. Completing onboarding for an identity ends the "continuing" state by definition, so the next render settles on `ready`.

Scoped to the matching pubkey so an in-flight switch to a *different* identity is unaffected.