### PR TITLE
build(desktop): trust OS-installed CAs for websocket connections

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -210,7 +210,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2269,7 +2269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2728,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3236,7 +3236,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -5642,7 +5642,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5801,7 +5801,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6996,7 +6996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -8022,7 +8022,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8753,7 +8753,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8823,7 +8823,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9079,7 +9079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9686,7 +9686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10703,7 +10703,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10725,7 +10725,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11062,6 +11062,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -11457,7 +11458,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11558,7 +11559,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12403,7 +12404,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ infer = "0.19"
 hex = "0.4"
 ed25519-dalek = "=3.0.0-rc.0"
 tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time", "net", "io-util"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 bytes = "1"
 futures-util = "0.3"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -83,7 +83,15 @@ infer = "0.19"
 hex = "0.4"
 ed25519-dalek = "=3.0.0-rc.0"
 tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time", "net", "io-util"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+# Both root stores on purpose: native-roots alone makes an empty OS trust
+# store a hard error (tokio-tungstenite gates that check on webpki-roots
+# being absent), which would break every wss:// connection for anyone with
+# a stale SSL_CERT_FILE or a container image lacking ca-certificates.
+# The union trusts OS-installed CAs while keeping bundled roots as a floor.
+tokio-tungstenite = { version = "0.29", features = [
+  "rustls-tls-native-roots",
+  "rustls-tls-webpki-roots",
+] }
 tokio-util = { version = "0.7", features = ["rt"] }
 bytes = "1"
 futures-util = "0.3"


### PR DESCRIPTION
Self-hosted deployments that terminate TLS with a private CA (step-ca, internal PKI) cannot be trusted by the desktop app today, by any means — installing the CA in the OS trust store has no effect.

### Cause

`desktop/src-tauri/Cargo.toml` pins:

```toml
tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
```

`webpki-roots` compiles the Mozilla root set into the binary and never consults the platform store. Every call site uses bare `connect_async` with no custom `Connector` (`native_websocket.rs:132`, `commands/pairing.rs:306`, `huddle/relay_api.rs:68`), so the feature-selected default root store is what is actually used.

Since the relay URL is user-configurable and self-hosting is a supported path, this makes a private-CA relay unreachable from the app.

### Change

Enable **both** root stores:

```toml
features = ["rustls-tls-native-roots", "rustls-tls-webpki-roots"]
```

They are additive — `tls.rs` calls `add_parsable_certificates` for native roots and then `extend(webpki_roots::TLS_SERVER_ROOTS)`.

Enabling native-roots *alone* would be a regression: tokio-tungstenite gates its empty-store hard error on `rustls-tls-webpki-roots` being absent, so zero native certs would fail every `wss://` connection. That is reachable via a stale `SSL_CERT_FILE`/`SSL_CERT_DIR` (honored by `rustls-native-certs` through `openssl-probe`, and preferred over system paths) or an image without `ca-certificates`. Keeping webpki as a floor avoids trading a trust gap for an availability one.

### Cost

None in dependencies. `webpki-roots` remains in the graph via the transitive `tokio-tungstenite 0.26`, and `rustls-native-certs` is already vendored along with `openssl-probe`, `schannel` and `security-framework`. No new crates and no new license surface for `cargo-deny`. Lockfile regenerated.

### Consistency

`reqwest` already resolves with `rustls-platform-verifier`, so the HTTP path honors the OS store; the websocket path was the only holdout. `git log -S rustls-tls-webpki-roots` traces the pin to `811c8f3f0` ("Replace LiveKit with WebSocket Opus audio relay") with no stated rationale, so this does not appear to overturn a deliberate decision.

Happy to put this behind a Cargo feature instead if you would rather keep the default bundled-only.