### PR TITLE
fix(mobile): park cold-start deep link from AppLinks.getInitialLink (#5150)

### DIFF
--- a/mobile/lib/shared/deeplink/pending_deep_link_provider.dart
+++ b/mobile/lib/shared/deeplink/pending_deep_link_provider.dart
@@ -9,8 +9,14 @@ import 'deep_link.dart';
 /// Holds the most recent supported deep link that has not been
 /// dispatched yet.
 ///
-/// Listens to [AppLinks.uriLinkStream], which delivers both the cold-start
-/// link (the URL that launched the app) and links received while running.
+/// Subscribes to two sources:
+/// - [AppLinks.getInitialLink], which resolves the URI the OS delivered to
+///   the app at launch (cold start). app_links' [AppLinks.uriLinkStream] does
+///   **not** replay the cold-start URI to late subscribers, so without this
+///   call a fresh app launched from an invite link would silently drop it.
+/// - [AppLinks.uriLinkStream], which delivers URIs received while the app is
+///   already running.
+///
 /// Navigation cannot always happen the moment a link arrives — the user may
 /// not be authenticated yet, or channels may still be loading — so the parsed
 /// link is parked here and consumed by the dispatcher once the app is ready.
@@ -18,11 +24,33 @@ class PendingDeepLinkNotifier extends Notifier<BuzzDeepLink?> {
   @visibleForTesting
   static Stream<Uri>? debugUriStreamOverride;
 
+  /// Optional override used in tests to inject a cold-start URI without
+  /// going through the platform plugin.
+  @visibleForTesting
+  static Future<Uri?> Function()? debugGetInitialLinkOverride;
+
   StreamSubscription<Uri>? _subscription;
 
   @override
   BuzzDeepLink? build() {
-    final stream = debugUriStreamOverride ?? AppLinks().uriLinkStream;
+    final appLinks = AppLinks();
+    // Cold-start URI: resolved once, before any hot-link events. This must
+    // not be in a Future kept by the provider because Notifier.build is
+    // synchronous — we fire it in a microtask and park the result via
+    // handleUri so the rest of the pipeline (listen, consume, dispatch) is
+    // identical to runtime-delivered links.
+    final initialLinkFuture =
+        debugGetInitialLinkOverride?.call() ?? appLinks.getInitialLink();
+    unawaited(
+      initialLinkFuture
+          .then((uri) {
+            if (uri != null) handleUri(uri);
+          })
+          .catchError((Object error) {
+            debugPrint('deep-link: failed to read initial link: $error');
+          }),
+    );
+    final stream = debugUriStreamOverride ?? appLinks.uriLinkStream;
     _subscription = stream.listen(handleUri);
     ref.onDispose(() {
       _subscription?.cancel();

--- a/mobile/test/shared/deeplink/pending_deep_link_provider_test.dart
+++ b/mobile/test/shared/deeplink/pending_deep_link_provider_test.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+
+import 'package:buzz/shared/deeplink/deep_link.dart';
+import 'package:buzz/shared/deeplink/pending_deep_link_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  group('PendingDeepLinkNotifier cold-start (issue #5150)', () {
+    tearDown(() {
+      PendingDeepLinkNotifier.debugUriStreamOverride = null;
+      PendingDeepLinkNotifier.debugGetInitialLinkOverride = null;
+    });
+
+    test(
+      'parks the cold-start URI from AppLinks.getInitialLink() even when '
+      'uriLinkStream emits nothing',
+      () async {
+        // Regression: app_links v6 `uriLinkStream` does NOT replay the cold-
+        // start URI to late subscribers — without an explicit
+        // `getInitialLink()` call, a fresh iOS install launched from an
+        // invite link boots to a blank home with no claim POST (issue #5150).
+        PendingDeepLinkNotifier.debugGetInitialLinkOverride = () =>
+            Future.value(
+              Uri.parse(
+                'buzz://join?relay=wss%3A%2F%2Frelay.example.com&code=invite-code',
+              ),
+            );
+        PendingDeepLinkNotifier.debugUriStreamOverride =
+            const Stream<Uri>.empty();
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        // Listen synchronously so the notifier build fires.
+        container.listen(pendingDeepLinkProvider, (_, _) {});
+
+        // The initial-link future resolves on a microtask — give it time.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(pendingDeepLinkProvider),
+          const InviteDeepLink(
+            relayUrl: 'wss://relay.example.com',
+            code: 'invite-code',
+          ),
+        );
+      },
+    );
+
+    test(
+      'handles a message deep link from cold start the same way',
+      () async {
+        PendingDeepLinkNotifier.debugGetInitialLinkOverride = () =>
+            Future.value(
+              Uri.parse(
+                'buzz://message?channel=d14cd131&id=abc123&thread=root99',
+              ),
+            );
+        PendingDeepLinkNotifier.debugUriStreamOverride =
+            const Stream<Uri>.empty();
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(pendingDeepLinkProvider, (_, _) {});
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(pendingDeepLinkProvider),
+          const MessageDeepLink(
+            channelId: 'd14cd131',
+            messageId: 'abc123',
+            threadRootId: 'root99',
+          ),
+        );
+      },
+    );
+
+    test(
+      'drops a null initial link silently (no invite launch, normal boot)',
+      () async {
+        PendingDeepLinkNotifier.debugGetInitialLinkOverride = () =>
+            Future<Uri?>.value(null);
+        PendingDeepLinkNotifier.debugUriStreamOverride =
+            const Stream<Uri>.empty();
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(pendingDeepLinkProvider, (_, _) {});
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(pendingDeepLinkProvider), isNull);
+      },
+    );
+
+    test(
+      'hot stream events still dispatch after cold start is consumed',
+      () async {
+        PendingDeepLinkNotifier.debugGetInitialLinkOverride = () =>
+            Future<Uri?>.value(null);
+        final controller = StreamController<Uri>();
+        addTearDown(() => controller.close());
+        PendingDeepLinkNotifier.debugUriStreamOverride = controller.stream;
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.listen(pendingDeepLinkProvider, (_, _) {});
+
+        controller.add(
+          Uri.parse(
+            'buzz://join?relay=wss%3A%2F%2Frelay.example.com&code=hot-invite',
+          ),
+        );
+        // Flush the controller's broadcast microtask queue.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(pendingDeepLinkProvider),
+          const InviteDeepLink(
+            relayUrl: 'wss://relay.example.com',
+            code: 'hot-invite',
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #5150 — cold-start `buzz://join` invite links on a fresh iOS install were silently dropped: the app opened to a blank Home screen, no bottom sheet, no claim POST, no error visible.

## Root cause

`app_links` v6's `uriLinkStream` does **not** replay the cold-start URI to late subscribers. The previous comment in `pending_deep_link_provider.dart` claimed streams "re-emit the last link including the initial link", which was incorrect — only `getInitialLink()` / `getLatestLink()` returns it.

Concretely, on a fresh install + cold start from an invite:
1. The OS delivers the deep URI via `getInitialLink()`.
2. The late `uriLinkStream` subscription in `PendingDeepLinkNotifier.build()` receives **nothing**.
3. `pendingDeepLinkProvider` stays `null` → `DeepLinkDispatcher._maybeDispatch(null)` is a no-op → no invite sheet is ever presented.
4. The user lands on the normal unauthenticated PairingPage (or authenticated Home) with the invite silently discarded.

Note: this is separate from the also-missing iOS Associated Domains entitlement (out of scope here — the reporter's path used the `buzz://` custom-scheme redirect chain, which is exactly what `getInitialLink` returns).

## Fix

`PendingDeepLinkNotifier.build()` now subscribes to **both** sources, matching the app_links plugin guidance:

1. `getInitialLink()` — resolved once at provider construction, parked through the same `handleUri` path that hot-stream links use.
2. `uriLinkStream` — for links received while the app is already running (unchanged).

The downstream `DeepLinkDispatcher` (auth-gated mount, `prepare(link)`, `consume()`, join-sheet presentation) is untouched — the parked link flows through the identical dispatch pipeline regardless of when the URI arrived. A `@visibleForTesting` `debugGetInitialLinkOverride` hook (same pattern as the existing `debugUriStreamOverride`) lets tests inject a cold-start URI without a platform channel.

## Test

Adds `mobile/test/shared/deeplink/pending_deep_link_provider_test.dart` — 4 tests:

- cold-start `InviteDeepLink` is parked in state with an empty hot stream (distill of the #5150 repro);
- cold-start `MessageDeepLink` parked the same way;
- a `null` initial link leaves state untouched (normal-app-boot regression guard);
- hot-links still flow when a stream event arrives after a cold start (functional stream listener guard).

`flutter analyze` and `flutter test` need to run in CI (no local Flutter toolchain on the authoring host).

## Related

- #4307 (post-join community lands empty — eval if this PR fixes that next)
- #4604 (post-claim WebSocket — separate)
