### PR TITLE
feat(managed-agents): add durable ACP continuity and rapid controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ name = "buzz-acp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atomic-write-file",
  "base64 0.22.1",
  "buzz-core",
  "buzz-persona",

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { workspace = true }
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }
+atomic-write-file = "0.3"
 
 # IDs
 uuid = { workspace = true }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -5,8 +5,9 @@
 //! 1. [`AcpClient::spawn`] — launch agent binary as subprocess
 //! 2. [`AcpClient::initialize`] — protocol version negotiation
 //! 3. [`AcpClient::session_new`] — create session with MCP server config
-//! 4. [`AcpClient::session_prompt_with_idle_timeout`] — send prompt with idle/hard deadline, return stop reason
-//! 5. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
+//! 4. [`AcpClient::session_load`] — reconnect to a persisted session after process replacement
+//! 5. [`AcpClient::session_prompt_with_idle_timeout`] — send prompt with idle/hard deadline, return stop reason
+//! 6. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
 
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
@@ -642,6 +643,29 @@ impl AcpClient {
         system_prompt: Option<SystemPromptTransport<'_>>,
         session_title: Option<&str>,
     ) -> Result<SessionNewResponse, AcpError> {
+        self.session_new_full_with_timeout(
+            cwd,
+            mcp_servers,
+            system_prompt,
+            session_title,
+            Self::SESSION_SETUP_TIMEOUT,
+        )
+        .await
+    }
+
+    /// Send `session/new` with an explicit setup timeout.
+    ///
+    /// ACP adapters may do expensive one-time provider, plugin, or session
+    /// initialization while handling `session/new`. Hosts that already have a
+    /// per-agent wall-clock limit should pass a bounded value derived from it.
+    pub async fn session_new_full_with_timeout(
+        &mut self,
+        cwd: &str,
+        mcp_servers: Vec<McpServer>,
+        system_prompt: Option<SystemPromptTransport<'_>>,
+        session_title: Option<&str>,
+        setup_timeout: std::time::Duration,
+    ) -> Result<SessionNewResponse, AcpError> {
         let mut params = serde_json::json!({
             "cwd": cwd,
             "mcpServers": mcp_servers,
@@ -660,7 +684,9 @@ impl AcpClient {
             // Merge — _meta may already carry systemPrompt from ClaudeMeta above.
             params["_meta"]["sessionTitle"] = serde_json::Value::String(title.to_owned());
         }
-        let result = self.send_request("session/new", params).await?;
+        let result = self
+            .send_request_with_timeout("session/new", params, setup_timeout)
+            .await?;
         let session_id = result["sessionId"]
             .as_str()
             .ok_or_else(|| AcpError::Protocol("session/new response missing sessionId".into()))?
@@ -687,6 +713,38 @@ impl AcpClient {
             .session_new_full(cwd, mcp_servers, system_prompt, session_title)
             .await?
             .session_id)
+    }
+
+    /// Load an existing persisted ACP session and re-register its MCP servers.
+    ///
+    /// `session/load` is deliberately used instead of `session/resume`: Hermes
+    /// returns `null` when the requested session no longer exists, while resume
+    /// is allowed to silently create a replacement. The caller must make that
+    /// replacement decision explicitly so session churn is observable.
+    pub async fn session_load(
+        &mut self,
+        cwd: &str,
+        session_id: &str,
+        mcp_servers: Vec<McpServer>,
+        setup_timeout: std::time::Duration,
+    ) -> Result<bool, AcpError> {
+        let result = self
+            .send_request_with_timeout(
+                "session/load",
+                serde_json::json!({
+                    "cwd": cwd,
+                    "sessionId": session_id,
+                    "mcpServers": mcp_servers,
+                }),
+                setup_timeout,
+            )
+            .await?;
+        if result.is_null() {
+            tracing::warn!(target: "acp::session", "session/load did not find {session_id}");
+            return Ok(false);
+        }
+        tracing::info!(target: "acp::session", "session loaded: {session_id}");
+        Ok(true)
     }
 
     /// Send Goose's custom system-prompt request after `session/new`.
@@ -1061,8 +1119,14 @@ impl AcpClient {
         Ok(())
     }
 
-    /// Default timeout for non-prompt RPCs (initialize, session/new, etc.).
+    /// Default timeout for ordinary non-prompt RPCs (initialize, model changes,
+    /// authentication, etc.).
     const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+    /// Upper bound for the one-time `session/new` setup phase. The managed
+    /// runtime may lower this to its configured max-turn duration.
+    pub(crate) const SESSION_SETUP_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_secs(300);
 
     /// Send a JSON-RPC request and wait for the matching response.
     ///
@@ -1070,13 +1134,22 @@ impl AcpClient {
     /// then calls [`read_until_response`](Self::read_until_response).
     ///
     /// The write phase is bounded by `WRITE_TIMEOUT` (30s) and the read phase
-    /// by `REQUEST_TIMEOUT` (60s), so worst-case wall clock is ~90s. Non-prompt
-    /// RPCs like `initialize` and `session/new` should complete in seconds;
-    /// if they don't, the agent is likely stuck and we must not block forever.
+    /// by the selected request timeout. Ordinary RPCs use `REQUEST_TIMEOUT`
+    /// (60s); the expensive `session/new` path uses its explicit setup budget.
     async fn send_request(
         &mut self,
         method: &str,
         params: serde_json::Value,
+    ) -> Result<serde_json::Value, AcpError> {
+        self.send_request_with_timeout(method, params, Self::REQUEST_TIMEOUT)
+            .await
+    }
+
+    async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+        timeout: std::time::Duration,
     ) -> Result<serde_json::Value, AcpError> {
         let id = self.next_id;
         self.next_id += 1;
@@ -1093,7 +1166,6 @@ impl AcpClient {
         // Wrap write + read in a single timeout so a hung agent can't block forever.
         // We cannot use an async block that borrows `self` mutably across two awaits
         // inside timeout(), so we sequence them with early-return on timeout.
-        let timeout = Self::REQUEST_TIMEOUT;
         match tokio::time::timeout(timeout, self.write_ndjson(&msg)).await {
             Ok(result) => result?,
             Err(_) => return Err(AcpError::Timeout(timeout)),
@@ -3319,6 +3391,37 @@ mod tests {
             received["params"]["systemPrompt"].as_str(),
             Some("Custom system prompt"),
             "systemPrompt should be included in params when Some"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_new_full_with_timeout_uses_explicit_budget() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{}}}'
+            read -t 2 _req
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let timeout = std::time::Duration::from_millis(50);
+        let started = std::time::Instant::now();
+        let result = client
+            .session_new_full_with_timeout("/tmp", vec![], None, None, timeout)
+            .await;
+
+        assert!(
+            matches!(result, Err(AcpError::Timeout(actual)) if actual == timeout),
+            "expected explicit session setup timeout"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "explicit timeout did not fail promptly: {:?}",
+            started.elapsed()
         );
     }
 

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -10,6 +10,8 @@ When a human references work "you" are doing in another channel, that work belon
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
 
+Run Buzz CLI and workspace commands through the injected `buzz-dev-mcp` shell tool, not through a separate built-in terminal. In Hermes ACP the injected wire name is `mcp__buzz_dev_mcp__shell` and its timeout field is `timeout_ms`; its companion file tool is `mcp__buzz_dev_mcp__read_file`. Other ACP clients may display these as the `shell` and `read_file` tools sourced from `buzz-dev-mcp`. The injected shell is the environment that owns the authenticated `buzz` shim. A built-in terminal does not inherit that shim and, on Windows, may block while creating an unrelated local environment.
+
 | Group | Key commands |
 |-------|-------------|
 | `buzz agents` | `draft-create`, `draft-update` |
@@ -28,6 +30,33 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz upload` | `file` |
 
 Run `buzz --help` or `buzz <group> --help` for full usage. For multiline message content, pass real newline bytes through stdin: `printf 'first\n\nsecond\n' | buzz messages send ... --content -`. Do not write `--content 'first\n\nsecond'`: single-quoted shell strings preserve `\n` literally, so recipients will see the backslash characters. `buzz agents draft-create` and `buzz agents draft-update` require `BUZZ_AUTH_TAG`; if it is missing, explain that this managed agent cannot open owner-reviewed agent drafts from chat.
+
+## Hermes ACP tool surface
+
+The Hermes ACP session provides a coding-safe native tool surface in addition to
+the injected Buzz MCP server. Use the exact name shown by the fresh ACP catalog;
+if a required name is missing, stop and report the tool-routing blocker instead
+of substituting an unrelated tool.
+
+- **Native Hermes tools:** `delegate_task` for bounded, disjoint worker lanes;
+  `execute_code` for bounded local Python, calculations, metadata checks, and
+  loopback SearXNG JSON discovery; `todo` for the Hermes task list; `memory` and
+  `session_search` for durable/context recall; `skills_list`/`skill_view` for
+  procedures; and `web_extract`/browser tools only for an explicitly supplied
+  URL or a URL selected from SearXNG results.
+- **Research rule:** do not use generic `web_search` as a discovery fallback.
+  All research discovery must query local SearXNG at
+  `http://127.0.0.1:8888/search?format=json`. If SearXNG is unavailable, report
+  the blocker; do not silently switch to a cloud provider.
+- **Injected Buzz MCP tools:** `mcp__buzz_dev_mcp__shell` (`timeout_ms`) for
+  Buzz CLI and bounded workspace commands, `mcp__buzz_dev_mcp__read_file` for
+  targeted reads, `mcp__buzz_dev_mcp__str_replace` for atomic file replacement,
+  and `mcp__buzz_dev_mcp__view_image` for local image inspection. The injected
+  `mcp__buzz_dev_mcp__todo` is reserved for the Buzz MCP hook state; use native
+  `todo` for the Hermes task list unless the turn explicitly needs both.
+- **Authority boundary:** `delegate_task` and `execute_code` do not authorize
+  relay messages, credentials, deployments, or other external actions. Keep
+  owner-only routing and parent acceptance rules unchanged.
 
 When opening a pull request in response to channel work, always pass `--channel <current-channel-uuid>` using the UUID from `[Context]`. This preserves a link from the pull request back to its originating conversation.
 
@@ -84,6 +113,184 @@ All replies and delegations — including task assignments to other agents — g
 - Address people by the name in their own message header.
 - Use top-level channel-visible posts for milestones teammates must act on: picked up, blocked + need input, PR up, done.
 - Praise in public; correct in the work, not the person.
+
+## Response Contract — Follow This Every Turn
+
+This section is the operating contract for how you decide, work, and respond. It is
+deliberately explicit so a human can tell the difference between a completed result,
+a bounded investigation, and a blocked turn. Newer direct instructions from the
+current human message override this contract; do not invent authority that the
+current message does not grant.
+
+### 1. Intake before tools
+
+Before calling a tool, silently classify the current turn:
+
+1. **Answer** — the human wants an explanation, decision, or short piece of information.
+2. **Investigate** — the human wants current evidence from files, processes, logs, or
+   the relay.
+3. **Implement** — the human wants a working change in an existing checkout.
+4. **Research** — the human wants external or cross-channel source discovery.
+5. **Coordinate** — the human wants bounded work assigned to other agents.
+6. **External action** — the human wants a message, issue, PR, upload, workflow,
+   reaction, or other externally visible mutation.
+
+Extract five things from the message and `[Context]`: the desired outcome, the exact
+target, the authorization boundary, the evidence required to call it done, and the
+single best next action. If any one is genuinely unknowable, ask one focused question;
+otherwise act on the obvious interpretation. Do not ask the human to repeat details
+already present in `[Context]`, `AGENTS.md`, the workspace, or a previous tool result.
+
+### 2. Authority and side-effect rules
+
+- Treat the current human message as the active task. Do not resume an old task merely
+  because it appears in memory, a stale todo, or another channel.
+- A normal reply to the triggering human in the supplied channel/thread is authorized
+  by the platform routing. Other messages, mentions, channel changes, issues, PRs,
+  uploads, reactions, workflow triggers, commits, pushes, deployments, purchases, and
+  account changes are external side effects: perform them only when the human clearly
+  asks for that specific action.
+- Never expose private keys, auth tags, API keys, passwords, tokens, connection
+  strings, full environment files, private transcript text, clipboard/audio contents,
+  or unbounded channel history. Report only the minimum metadata needed: path,
+  filename, basename, boolean presence, bounded counts, timestamps, status, and
+  redacted error class.
+- Never claim that a worker, tool, message, build, deployment, smoke, or receipt
+  succeeded from an intention or dispatch acknowledgement. Require a real returned
+  result, an authoritative file/process state, or a signed/structured receipt.
+- Do not restart or kill unrelated processes. If a restart is authorized, identify
+  the exact target, capture a pre-action watermark, perform the smallest scoped action,
+  and verify the post-action state before touching anything else.
+
+### 3. Bounded execution loop
+
+Use this loop and stop as soon as its acceptance condition is met:
+
+1. **Discover narrowly.** Read the relevant tracker and repo guidance, locate the
+   symbol or record, and inspect only the needed line ranges. Do not reload a large
+   file or recursively scan a home directory when a known project path exists.
+2. **Make one concrete change or answer.** Extend the existing implementation; do not
+   create a parallel subsystem because the first seam is inconvenient.
+3. **Verify the changed behavior.** Use one focused check and one appropriate real
+   smoke at the end. Do not launch a broad test suite, GPU/model acceptance run, or
+   repeated rebuild while the change is still being discovered.
+4. **Record the receipt.** Update the canonical project Markdown tracker with the
+   decision, changed path, evidence, blocker, and next action. Do not put transient
+   progress in permanent memory.
+5. **Respond once, clearly.** Publish a useful result, blocker, question, or milestone
+   in the current channel. Do not send a progress stream that creates duplicate turns.
+
+For a direct reply-only turn that needs no discovery or artifact change, skip todos,
+tracker/file work, repository status, and environment warmup. Use
+`mcp__buzz_dev_mcp__shell` as the first and only tool to publish the requested reply
+through `buzz messages send` with the supplied `[Context]` destination, then stop.
+
+The default tool budget for one turn is: one discovery batch, one implementation
+batch, and one verification batch. If a tool returns empty, partial, or contradictory
+evidence, change the query or narrow the path once; do not repeat the same call in a
+loop. After two failures of the same class, stop and report the failure class and the
+single best next step.
+
+### 4. Critical Windows file-tool rule
+
+Use the injected `buzz-dev-mcp` tools for both shell and file work. In Hermes ACP these
+are `mcp__buzz_dev_mcp__shell` and `mcp__buzz_dev_mcp__read_file`; use shell `rg` for
+targeted content searches. Do not call Hermes built-in `terminal`, `read_file`, or
+`search_files` from a Buzz-managed turn: they use a separate per-task environment and
+can block during Windows environment creation, while only the injected shell owns the
+authenticated `buzz` shim.
+
+- Warm the current workspace with one bounded injected-shell command such as `pwd`,
+  `git status --short`, or a direct `python` metadata check only when file work is
+  actually required. A direct answer or reply does not need a preflight command.
+- On the first file access, call **one** injected MCP tool. Confirm it returns before
+  starting another file or shell operation.
+- Keep `read_file` to a symbol or line range and shell `rg` to a named repo, file glob,
+  or exact symbol. Exclude `.git`, `.hermes`, caches, models, generated
+  artifacts, and credential-bearing files unless the task explicitly requires them.
+- If an injected MCP tool has not returned within its explicit `timeout_ms`, do not
+  dispatch more tools or repeat the same call. Return a bounded blocker after one safe
+  retry: state which tool is stuck, the workspace path, the last completed operation,
+  and the one repair needed.
+- Prefer local source and workspace evidence for local-code questions. Use web tools
+  only when the task asks for external facts or local sources are insufficient; never
+  wait indefinitely on a web provider.
+
+### 5. Parent-only execution and optional delegation
+
+This managed Buzz route is parent-only by default. Use the available coding, research,
+memory, todo, `execute_code`, and injected Buzz MCP tools directly. Do not dispatch
+workers for ordinary conversation, diagnostics, implementation, research, or project
+tracking merely because delegation exists; keep the current channel session responsible
+for the final result.
+
+If `delegate_task` is absent from the live tool catalog, that is the intentional
+continuity policy and not a blocker. Only delegate when the human explicitly asks for
+workers and the tool is actually available. In that exceptional case, keep work
+bounded and disjoint, preserve all authority/secret limits, and require a verified
+handoff before the parent reports completion.
+
+### 6. How to handle tool results and interruptions
+
+- After every meaningful tool result, decide whether it closes the task, changes the
+  plan, or exposes a blocker. Do not continue calling tools merely because capacity is
+  available.
+- If a tool or worker is slow, distinguish `working`, `timed out`, `cancelled`, and
+  `respawned`; these are different states. Do not describe a cancellation as a tool
+  failure without evidence, and do not describe a respawn as recovery until the new
+  session reaches the required readiness event.
+- If the human steers the task, immediately stop the stale lane, update the todo and
+  tracker, and follow the newest instruction. Never bury a steering message below an
+  old plan.
+- After compaction or process respawn, recover from the canonical tracker, todo state,
+  current source, and fresh post-watermark logs. Do not announce lost context, repeat
+  settled fixes, or fabricate continuity.
+
+### 7. Required final response shape
+
+Lead with the result, not a preamble. Use this structure whenever the turn involved
+tools, workers, a code change, or an investigation:
+
+```markdown
+## Result
+Complete | Partial | Blocked | Needs input — one sentence answering the request.
+
+## What changed or was found
+- Exact action or finding, with `path:line` where applicable.
+
+## Evidence
+- Bounded command/log/file receipt and its real result.
+- Worker handoffs reconciled; do not list dispatches as completed work.
+
+## Remaining risk or blocker
+- Say `None` only when the acceptance condition is genuinely met.
+
+## Next action
+- One concrete parent-owned action, or `None`.
+```
+
+For a simple question, answer directly in a few sentences and omit empty headings.
+For a blocked task, name the blocker first, state what was verified, and give exactly
+one best next step. For a successful external action, include the authoritative link,
+event id, receipt, or file path—but never include credentials or private payloads. For
+an implementation, do not paste an entire file; cite changed paths and summarize the
+behavior. Never finish with only a plan, a promise, a bare acknowledgement, or “still
+working.”
+
+### 8. Acceptance gates
+
+Call a task **complete** only when every requested deliverable exists and the relevant
+verification receipt is real. Call it **partial** when useful work landed but an
+acceptance gate remains. Call it **blocked** when the next step requires unavailable
+access, a user decision, or a failing dependency. Call it **needs input** only when
+two plausible interpretations would cause different side effects.
+
+For an ACP/runtime repair, the gates are ordered: process identity → relay/channel
+readiness → ACP initialize → `session/new` return → model/tool surface → one controlled
+turn → expected response → structured receipt. Do not jump to smoke or claim repair
+from initialization alone. For a code change, the gates are: focused source check →
+changed-behavior verification → one real smoke → tracker receipt. If a gate fails,
+stop at that gate and report it instead of masking it with a later success.
 
 ## Startup Recovery
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -9,6 +9,7 @@ mod pool;
 mod pool_lifecycle;
 mod queue;
 mod relay;
+mod session_store;
 mod setup_mode;
 mod usage;
 
@@ -59,8 +60,10 @@ fn is_subcommand(name: &str) -> bool {
     std::env::args().nth(1).map(|a| a == name).unwrap_or(false)
 }
 
-/// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
-const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Timeout for helper subcommands that may trigger Hermes provider/plugin/session
+/// setup. Ordinary ACP RPCs still retain their separate 60-second fail-fast
+/// budget; this outer bound prevents slow first-run discovery from being cut off.
+const MODELS_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.
@@ -111,6 +114,14 @@ fn emit_runtime_lifecycle(
                 "error": error,
             }),
         );
+    }
+}
+
+fn initial_runtime_lifecycle(lazy_pool: bool) -> &'static str {
+    if lazy_pool {
+        "listening"
+    } else {
+        "ready"
     }
 }
 
@@ -1566,18 +1577,23 @@ async fn tokio_main() -> Result<()> {
         }
     }
 
-    if config.lazy_pool {
-        emit_runtime_lifecycle(
-            observer.as_ref(),
-            &runtime_start_nonce,
-            &pubkey_hex,
-            &config.relay_url,
-            "listening",
-            None,
-        );
-    }
+    // Runtime readiness is the pool/startup boundary. Individual channel
+    // subscription and presence-publication errors remain deliberately
+    // non-fatal above; the caller's correlated smoke is the end-to-end
+    // delivery acceptance rather than this lifecycle frame.
+    emit_runtime_lifecycle(
+        observer.as_ref(),
+        &runtime_start_nonce,
+        &pubkey_hex,
+        &config.relay_url,
+        initial_runtime_lifecycle(config.lazy_pool),
+        None,
+    );
 
     let base_prompt_content = config.base_prompt_content.take();
+    let harness_name = crate::config::normalize_agent_command_identity(&config.agent_command);
+    let session_store =
+        crate::session_store::SessionStore::open(&pubkey_hex, &config.relay_url, &harness_name);
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
         initial_message: config.initial_message.clone(),
@@ -1610,8 +1626,9 @@ async fn tokio_main() -> Result<()> {
             .as_deref()
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
         memory_enabled: config.memory_enabled,
-        harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
+        harness_name,
         relay_url: config.relay_url.clone(),
+        session_store,
     });
 
     if !config.memory_enabled {
@@ -3728,6 +3745,36 @@ mod agent_draft_prompt_tests {
     }
 
     #[test]
+    fn shared_base_prompt_routes_buzz_through_the_injected_mcp_shell() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("mcp__buzz_dev_mcp__shell"));
+        assert!(prompt.contains("its timeout field is `timeout_ms`"));
+        assert!(prompt.contains("Do not call Hermes built-in `terminal`"));
+        assert!(prompt.contains("skip todos"));
+        assert!(prompt.contains("as the first and only tool"));
+        assert!(prompt.contains("A direct answer or reply does not need a preflight command"));
+    }
+
+    #[test]
+    fn shared_base_prompt_declares_native_tools_and_local_searxng_route() {
+        let prompt = include_str!("base_prompt.md");
+        for marker in [
+            "`delegate_task`",
+            "`execute_code`",
+            "`mcp__buzz_dev_mcp__read_file`",
+            "`mcp__buzz_dev_mcp__str_replace`",
+            "`mcp__buzz_dev_mcp__view_image`",
+            "http://127.0.0.1:8888/search?format=json",
+            "do not use generic `web_search` as a discovery fallback",
+        ] {
+            assert!(
+                prompt.contains(marker),
+                "missing base-prompt marker: {marker}"
+            );
+        }
+    }
+
+    #[test]
     fn shared_base_prompt_teaches_single_command_mentions_and_preflight() {
         let prompt = include_str!("base_prompt.md");
         assert!(prompt.contains("--mention <hex-or-npub>"));
@@ -4161,11 +4208,19 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
             }
         };
 
-    // Initialize + session/new under a timeout. Client is owned above,
+    // Initialize + session/new under a bounded setup timeout. Client is owned above,
     // so shutdown() runs on all paths (success, error, timeout).
-    let protocol_result = tokio::time::timeout(MODELS_TIMEOUT, async {
+    let protocol_result = tokio::time::timeout(acp::AcpClient::SESSION_SETUP_TIMEOUT, async {
         let init = client.initialize().await?;
-        let session = client.session_new_full(&cwd, vec![], None, None).await?;
+        let session = client
+            .session_new_full_with_timeout(
+                &cwd,
+                vec![],
+                None,
+                None,
+                acp::AcpClient::SESSION_SETUP_TIMEOUT,
+            )
+            .await?;
         Ok::<_, acp::AcpError>((init, session))
     })
     .await;
@@ -6775,5 +6830,20 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod initial_runtime_lifecycle_tests {
+    use super::*;
+
+    #[test]
+    fn lazy_pool_initial_lifecycle_is_listening() {
+        assert_eq!(initial_runtime_lifecycle(true), "listening");
+    }
+
+    #[test]
+    fn eager_pool_initial_lifecycle_is_ready() {
+        assert_eq!(initial_runtime_lifecycle(false), "ready");
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -41,6 +41,7 @@ use crate::queue::{
     PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
+use crate::session_store::{SessionRecord, SessionStore};
 
 /// Window within which agent activity before a hard-cap death qualifies
 /// the turn as "recently active" (eligible for requeue instead of dead-letter).
@@ -564,6 +565,8 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Restart-durable channel/work-session affinity for this managed identity.
+    pub session_store: SessionStore,
 }
 
 impl AgentPool {
@@ -919,10 +922,14 @@ async fn create_session_and_apply_model(
         channel_type,
         ctx.session_title.as_deref(),
     );
+    // Hermes can load its provider/plugin state lazily during session/new.
+    // Give that setup phase more than the ordinary 60s RPC budget, while
+    // respecting the managed agent's configured wall-clock ceiling.
+    let session_setup_timeout = ctx.max_turn_duration.min(AcpClient::SESSION_SETUP_TIMEOUT);
 
     let resp = agent
         .acp
-        .session_new_full(
+        .session_new_full_with_timeout(
             &ctx.cwd,
             mcp_servers,
             session_new_system_prompt(
@@ -932,6 +939,7 @@ async fn create_session_and_apply_model(
                 combined_system_prompt.as_deref(),
             ),
             session_title.as_deref(),
+            session_setup_timeout,
         )
         .await?;
 
@@ -1025,6 +1033,39 @@ async fn create_session_and_apply_model(
     }
 
     Ok(resp.session_id)
+}
+
+/// Reattach a fresh ACP child to a persisted session. A transport/setup error
+/// remains an error; only a clean `false` (session not found) or method-not-found
+/// response permits the caller's single explicit replacement-session path.
+async fn load_persisted_session(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    record: &SessionRecord,
+    channel_id: Uuid,
+    channel_type: Option<&str>,
+) -> Result<bool, AcpError> {
+    let mcp_servers = mcp_servers_with_git_origin(
+        &ctx.mcp_servers,
+        Some(channel_id),
+        channel_type,
+        ctx.session_title.as_deref(),
+    );
+    let setup_timeout = ctx.max_turn_duration.min(AcpClient::SESSION_SETUP_TIMEOUT);
+    agent
+        .acp
+        .session_load(&ctx.cwd, &record.session_id, mcp_servers, setup_timeout)
+        .await
+}
+
+fn batch_thread_root(batch: Option<&FlushBatch>) -> Option<String> {
+    batch.and_then(|batch| {
+        batch
+            .events
+            .iter()
+            .rev()
+            .find_map(|event| crate::queue::parse_thread_tags(&event.event).root_event_id)
+    })
 }
 
 fn mcp_servers_with_git_origin(
@@ -1593,62 +1634,185 @@ pub async fn run_prompt_task(
         PromptSource::Heartbeat => None,
     };
 
+    let thread_root_event_id = batch_thread_root(batch.as_ref());
     let (session_id, is_new_session) = match &source {
         PromptSource::Channel(cid) => {
             if let Some(sid) = agent.state.sessions.get(cid) {
                 (sid.clone(), false)
             } else {
-                // The title is channel-qualified (`Agent · #channel`) so one
-                // agent in several channels doesn't produce identical session
-                // rows; `title_channel` comes from the single resolve above and
-                // is `None` for DM, unresolved, and unnamed channels.
-                match create_session_and_apply_model(
-                    &mut agent,
-                    &ctx,
-                    agent_core.as_deref(),
-                    agent_canvas.as_deref(),
-                    title_channel.as_deref(),
-                    Some(*cid),
-                    origin_channel_type.as_deref(),
-                )
-                .await
-                {
-                    Ok(sid) => {
-                        tracing::info!(
+                let mut continued_from = None;
+                let loaded_session = if let Some(record) = ctx.session_store.get(*cid) {
+                    let identity_matches = record.agent_pubkey
+                        == ctx.agent_keys.public_key().to_hex()
+                        && record.relay_url == ctx.relay_url
+                        && record.harness_name == ctx.harness_name;
+                    if !identity_matches {
+                        continued_from = Some(record.session_id.clone());
+                        tracing::warn!(
                             target: "pool::session",
-                            "created session {sid} for channel {cid}"
+                            channel = %cid,
+                            prior_session = %record.session_id,
+                            "persisted session identity/runtime mismatch; creating one linked replacement"
                         );
-                        agent.state.sessions.insert(*cid, sid.clone());
-                        // Commit canvas only after session creation succeeds (I3).
-                        if let Some((pending_cid, section)) = pending_canvas.take() {
-                            agent.state.canvas_sections.insert(pending_cid, section);
+                        None
+                    } else {
+                        match load_persisted_session(
+                            &mut agent,
+                            &ctx,
+                            &record,
+                            *cid,
+                            origin_channel_type.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(true) => {
+                                tracing::info!(
+                                    target: "pool::session",
+                                    channel = %cid,
+                                    session = %record.session_id,
+                                    work_key = %record.work_key,
+                                    "loaded persisted session"
+                                );
+                                agent.acp.observe(
+                                    "session_resumed",
+                                    serde_json::json!({
+                                        "sessionId": record.session_id,
+                                        "workKey": record.work_key,
+                                        "channelId": cid,
+                                        "lastCompletedTurnId": record.last_completed_turn_id,
+                                    }),
+                                );
+                                if let Err(error) = ctx.session_store.commit_session(
+                                    *cid,
+                                    thread_root_event_id.clone(),
+                                    record.session_id.clone(),
+                                    record.continued_from.clone(),
+                                ) {
+                                    tracing::error!(
+                                        target: "pool::session_store",
+                                        channel = %cid,
+                                        error = %error,
+                                        "loaded session is live but its durable metadata could not be refreshed"
+                                    );
+                                }
+                                Some(record.session_id)
+                            }
+                            Ok(false) | Err(AcpError::AgentError { code: -32601, .. }) => {
+                                continued_from = Some(record.session_id.clone());
+                                tracing::warn!(
+                                    target: "pool::session",
+                                    channel = %cid,
+                                    prior_session = %record.session_id,
+                                    "persisted session cannot be loaded; allowing one linked replacement"
+                                );
+                                None
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    target: "pool::session",
+                                    channel = %cid,
+                                    prior_session = %record.session_id,
+                                    error = %error,
+                                    "persisted session load failed; refusing silent replacement"
+                                );
+                                send_prompt_result(
+                                    &result_tx,
+                                    &turn_id,
+                                    agent,
+                                    source,
+                                    PromptOutcome::Error(error),
+                                    requeue_batch_if_queue(&ctx, batch),
+                                );
+                                return;
+                            }
                         }
-                        (sid, true)
                     }
-                    Err(AcpError::AgentExited) => {
-                        agent.state.invalidate_all();
-                        send_prompt_result(
-                            &result_tx,
-                            &turn_id,
-                            agent,
-                            source,
-                            PromptOutcome::AgentExited,
-                            requeue_batch_if_queue(&ctx, batch),
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        // Session creation failed; pending canvas was never committed,
-                        // so the next retry will re-fetch a fresh revision.
-                        send_prompt_result(
-                            &result_tx,
-                            &turn_id,
-                            agent,
-                            source,
-                            PromptOutcome::Error(e),
-                            requeue_batch_if_queue(&ctx, batch),
-                        );
-                        return;
+                } else {
+                    None
+                };
+
+                if let Some(sid) = loaded_session {
+                    agent.state.sessions.insert(*cid, sid.clone());
+                    (sid, false)
+                } else {
+                    // The title is channel-qualified (`Agent · #channel`) so one
+                    // agent in several channels doesn't produce identical session
+                    // rows; `title_channel` comes from the single resolve above and
+                    // is `None` for DM, unresolved, and unnamed channels.
+                    match create_session_and_apply_model(
+                        &mut agent,
+                        &ctx,
+                        agent_core.as_deref(),
+                        agent_canvas.as_deref(),
+                        title_channel.as_deref(),
+                        Some(*cid),
+                        origin_channel_type.as_deref(),
+                    )
+                    .await
+                    {
+                        Ok(sid) => {
+                            tracing::info!(
+                                target: "pool::session",
+                                continued_from = continued_from.as_deref().unwrap_or(""),
+                                "created session {sid} for channel {cid}"
+                            );
+                            agent.state.sessions.insert(*cid, sid.clone());
+                            if let Err(error) = ctx.session_store.commit_session(
+                                *cid,
+                                thread_root_event_id.clone(),
+                                sid.clone(),
+                                continued_from.clone(),
+                            ) {
+                                // Keep this live session in memory so a storage
+                                // fault cannot create a session/new retry loop.
+                                tracing::error!(
+                                    target: "pool::session_store",
+                                    channel = %cid,
+                                    session = %sid,
+                                    error = %error,
+                                    "new session is live but durable affinity write failed"
+                                );
+                            }
+                            agent.acp.observe(
+                                "session_affinity_committed",
+                                serde_json::json!({
+                                    "sessionId": sid,
+                                    "workKey": SessionStore::work_key(*cid),
+                                    "channelId": cid,
+                                    "continuedFrom": continued_from,
+                                }),
+                            );
+                            // Commit canvas only after session creation succeeds (I3).
+                            if let Some((pending_cid, section)) = pending_canvas.take() {
+                                agent.state.canvas_sections.insert(pending_cid, section);
+                            }
+                            (sid, true)
+                        }
+                        Err(AcpError::AgentExited) => {
+                            agent.state.invalidate_all();
+                            send_prompt_result(
+                                &result_tx,
+                                &turn_id,
+                                agent,
+                                source,
+                                PromptOutcome::AgentExited,
+                                requeue_batch_if_queue(&ctx, batch),
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            // Session creation failed; pending canvas was never committed,
+                            // so the next retry will re-fetch a fresh revision.
+                            send_prompt_result(
+                                &result_tx,
+                                &turn_id,
+                                agent,
+                                source,
+                                PromptOutcome::Error(e),
+                                requeue_batch_if_queue(&ctx, batch),
+                            );
+                            return;
+                        }
                     }
                 }
             }
@@ -2016,6 +2180,22 @@ pub async fn run_prompt_task(
                             Ok(stop_reason) => {
                                 log_stop_reason(&source, &stop_reason);
                                 agent.state.invalidate(&source);
+                                // This branch is reached only for an explicit
+                                // supervisor/control cancellation. The old
+                                // session is intentionally rotated, so remove
+                                // its durable affinity as well as in-memory
+                                // state. Crash/timeout paths below preserve
+                                // the mapping for restart continuity.
+                                if let PromptSource::Channel(cid) = &source {
+                                    if let Err(error) = ctx.session_store.remove(*cid) {
+                                        tracing::error!(
+                                            target: "pool::session_store",
+                                            channel = %cid,
+                                            error = %error,
+                                            "could not remove durable session after explicit control cancellation"
+                                        );
+                                    }
+                                }
                                 let retry_batch =
                                     requeue_cancelled_batch(&ctx, control_signal, batch);
 
@@ -2110,6 +2290,33 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        if let PromptSource::Channel(cid) = &source {
+                            if let Err(error) = ctx.session_store.mark_turn_completed(
+                                *cid,
+                                &session_id,
+                                &turn_id,
+                            ) {
+                                tracing::error!(
+                                    target: "pool::session_store",
+                                    channel = %cid,
+                                    error = %error,
+                                    "could not persist completed-turn receipt"
+                                );
+                            }
+                            if matches!(
+                                control_signal,
+                                ControlSignal::Rotate | ControlSignal::SwitchModel(_)
+                            ) {
+                                if let Err(error) = ctx.session_store.remove(*cid) {
+                                    tracing::error!(
+                                        target: "pool::session_store",
+                                        channel = %cid,
+                                        error = %error,
+                                        "could not remove explicitly rotated durable session"
+                                    );
+                                }
+                            }
+                        }
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2138,6 +2345,20 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            if let PromptSource::Channel(cid) = &source {
+                if let Err(error) =
+                    ctx.session_store
+                        .mark_turn_completed(*cid, &session_id, &turn_id)
+                {
+                    tracing::error!(
+                        target: "pool::session_store",
+                        channel = %cid,
+                        error = %error,
+                        "could not persist completed-turn receipt"
+                    );
+                }
+            }
 
             let should_rotate = matches!(
                 stop_reason,
@@ -2169,6 +2390,16 @@ pub async fn run_prompt_task(
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
                 agent.state.invalidate(&source);
+                if let PromptSource::Channel(cid) = &source {
+                    if let Err(error) = ctx.session_store.remove(*cid) {
+                        tracing::error!(
+                            target: "pool::session_store",
+                            channel = %cid,
+                            error = %error,
+                            "could not remove rotated durable session"
+                        );
+                    }
+                }
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
@@ -6542,6 +6773,11 @@ mod tests {
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            session_store: SessionStore::isolated_for_test(
+                &agent_keys.public_key().to_hex(),
+                "ws://127.0.0.1:3000",
+                "goose",
+            ),
         }
     }
 

--- a/crates/buzz-acp/src/session_store.rs
+++ b/crates/buzz-acp/src/session_store.rs
@@ -1,0 +1,303 @@
+//! Durable ACP session affinity for managed Buzz agents.
+//!
+//! The live pool keeps a fast in-memory channel -> session map. This store is
+//! the restart boundary: it survives sidecar/Desktop/ACP process replacement
+//! and lets the next child call `session/load` before considering `session/new`.
+
+use atomic_write_file::AtomicWriteFile;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+const STORE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SessionRecord {
+    pub work_key: String,
+    pub channel_id: Uuid,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_root_event_id: Option<String>,
+    pub session_id: String,
+    pub agent_pubkey: String,
+    pub relay_url: String,
+    pub harness_name: String,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_completed_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continued_from: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionStoreFile {
+    version: u32,
+    entries: HashMap<String, SessionRecord>,
+}
+
+impl Default for SessionStoreFile {
+    fn default() -> Self {
+        Self {
+            version: STORE_VERSION,
+            entries: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SessionStore {
+    path: Arc<PathBuf>,
+    agent_pubkey: Arc<String>,
+    relay_url: Arc<String>,
+    harness_name: Arc<String>,
+    state: Arc<Mutex<SessionStoreFile>>,
+}
+
+impl SessionStore {
+    pub(crate) fn open(agent_pubkey: &str, relay_url: &str, harness_name: &str) -> Self {
+        let path = session_store_path(agent_pubkey, relay_url);
+        let state = load_store(&path).unwrap_or_else(|error| {
+            tracing::warn!(
+                target: "pool::session_store",
+                path = %path.display(),
+                error = %error,
+                "could not load durable session map; preserving the unreadable file and starting with an empty in-memory map"
+            );
+            SessionStoreFile::default()
+        });
+        Self {
+            path: Arc::new(path),
+            agent_pubkey: Arc::new(agent_pubkey.to_owned()),
+            relay_url: Arc::new(relay_url.to_owned()),
+            harness_name: Arc::new(harness_name.to_owned()),
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn isolated_for_test(
+        agent_pubkey: &str,
+        relay_url: &str,
+        harness_name: &str,
+    ) -> Self {
+        Self {
+            path: Arc::new(
+                std::env::temp_dir()
+                    .join("buzz-acp-session-store-tests")
+                    .join(format!("{}.json", Uuid::new_v4())),
+            ),
+            agent_pubkey: Arc::new(agent_pubkey.to_owned()),
+            relay_url: Arc::new(relay_url.to_owned()),
+            harness_name: Arc::new(harness_name.to_owned()),
+            state: Arc::new(Mutex::new(SessionStoreFile::default())),
+        }
+    }
+
+    /// Stable per-project-channel work key. Buzz project channels are the
+    /// isolation boundary; thread roots are retained as metadata so follow-up
+    /// chats and replies continue the same session instead of fragmenting it.
+    pub(crate) fn work_key(channel_id: Uuid) -> String {
+        format!("channel:{channel_id}")
+    }
+
+    pub(crate) fn get(&self, channel_id: Uuid) -> Option<SessionRecord> {
+        let key = Self::work_key(channel_id);
+        self.state.lock().ok()?.entries.get(&key).cloned()
+    }
+
+    pub(crate) fn commit_session(
+        &self,
+        channel_id: Uuid,
+        thread_root_event_id: Option<String>,
+        session_id: String,
+        continued_from: Option<String>,
+    ) -> Result<SessionRecord, String> {
+        let work_key = Self::work_key(channel_id);
+        let mut guard = self.state.lock().map_err(|error| error.to_string())?;
+        let last_completed_turn_id = guard
+            .entries
+            .get(&work_key)
+            .and_then(|record| record.last_completed_turn_id.clone());
+        let record = SessionRecord {
+            work_key: work_key.clone(),
+            channel_id,
+            thread_root_event_id,
+            session_id,
+            agent_pubkey: (*self.agent_pubkey).clone(),
+            relay_url: (*self.relay_url).clone(),
+            harness_name: (*self.harness_name).clone(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            last_completed_turn_id,
+            continued_from,
+        };
+        guard.entries.insert(work_key, record.clone());
+        write_store(&self.path, &guard)?;
+        Ok(record)
+    }
+
+    pub(crate) fn mark_turn_completed(
+        &self,
+        channel_id: Uuid,
+        session_id: &str,
+        turn_id: &str,
+    ) -> Result<(), String> {
+        let key = Self::work_key(channel_id);
+        let mut guard = self.state.lock().map_err(|error| error.to_string())?;
+        let Some(record) = guard.entries.get_mut(&key) else {
+            return Err(format!("no durable session record for {key}"));
+        };
+        if record.session_id != session_id {
+            return Err(format!(
+                "session mismatch for {key}: stored {}, completed {session_id}",
+                record.session_id
+            ));
+        }
+        record.last_completed_turn_id = Some(turn_id.to_owned());
+        record.updated_at = chrono::Utc::now().to_rfc3339();
+        write_store(&self.path, &guard)
+    }
+
+    pub(crate) fn remove(&self, channel_id: Uuid) -> Result<bool, String> {
+        let key = Self::work_key(channel_id);
+        let mut guard = self.state.lock().map_err(|error| error.to_string())?;
+        let removed = guard.entries.remove(&key).is_some();
+        if removed {
+            write_store(&self.path, &guard)?;
+        }
+        Ok(removed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn load_store(path: &Path) -> Result<SessionStoreFile, String> {
+    if !path.exists() {
+        return Ok(SessionStoreFile::default());
+    }
+    let bytes = std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    let store: SessionStoreFile = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("parse {}: {error}", path.display()))?;
+    if store.version != STORE_VERSION {
+        return Err(format!(
+            "unsupported session-store version {} in {}",
+            store.version,
+            path.display()
+        ));
+    }
+    Ok(store)
+}
+
+fn write_store(path: &Path, store: &SessionStoreFile) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("session-store path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    let payload = serde_json::to_vec_pretty(store).map_err(|error| error.to_string())?;
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut file = AtomicWriteFile::open(&resolved)
+        .map_err(|error| format!("open {} for atomic write: {error}", resolved.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("restrict {}: {error}", resolved.display()))?;
+    }
+    file.write_all(&payload)
+        .map_err(|error| format!("write {}: {error}", resolved.display()))?;
+    file.commit()
+        .map_err(|error| format!("commit {}: {error}", resolved.display()))
+}
+
+fn session_store_path(agent_pubkey: &str, relay_url: &str) -> PathBuf {
+    let root = std::env::var_os("BUZZ_ACP_SESSION_STATE_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("APPDATA").map(|appdata| {
+                PathBuf::from(appdata)
+                    .join("xyz.block.buzz.app")
+                    .join("agents")
+                    .join("session-state")
+            })
+        })
+        .or_else(|| {
+            std::env::var_os("XDG_STATE_HOME")
+                .map(|state| PathBuf::from(state).join("buzz").join("agent-sessions"))
+        })
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| {
+                PathBuf::from(home)
+                    .join(".local")
+                    .join("state")
+                    .join("buzz")
+                    .join("agent-sessions")
+            })
+        })
+        .unwrap_or_else(|| PathBuf::from(".buzz-agent-sessions"));
+    let relay_hash = hex::encode(Sha256::digest(relay_url.as_bytes()));
+    root.join(agent_pubkey)
+        .join(format!("{}.json", &relay_hash[..16]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_key_is_stable_per_channel() {
+        let channel = Uuid::parse_str("caab4104-e53f-4d37-9d8a-d2be97f2212e").unwrap();
+        assert_eq!(
+            SessionStore::work_key(channel),
+            format!("channel:{channel}")
+        );
+    }
+
+    #[test]
+    fn commit_mark_and_remove_round_trip_to_disk() {
+        let store = SessionStore::isolated_for_test(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "wss://relay.example",
+            "hermes-acp",
+        );
+        let channel = Uuid::parse_str("f748b533-c7b1-46d4-b788-322180370310").unwrap();
+        let record = store
+            .commit_session(
+                channel,
+                Some("root-event".into()),
+                "session-1".into(),
+                Some("session-0".into()),
+            )
+            .unwrap();
+        assert_eq!(record.continued_from.as_deref(), Some("session-0"));
+        assert_eq!(store.get(channel).unwrap().session_id, "session-1");
+
+        store
+            .mark_turn_completed(channel, "session-1", "turn-1")
+            .unwrap();
+        let persisted = load_store(store.path()).unwrap();
+        let persisted_record = persisted
+            .entries
+            .get(&SessionStore::work_key(channel))
+            .unwrap();
+        assert_eq!(
+            persisted_record.last_completed_turn_id.as_deref(),
+            Some("turn-1")
+        );
+
+        assert!(store.remove(channel).unwrap());
+        assert!(store.get(channel).is_none());
+        assert!(load_store(store.path()).unwrap().entries.is_empty());
+        if let Some(parent) = store.path().parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+}

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -115,6 +115,17 @@ pub(crate) enum RequirementPayload {
     },
     /// Git for Windows is missing; open Agent runtimes for the installation guide.
     GitBash,
+    /// A custom harness command cannot be resolved on the host. The desktop
+    /// emits this for unknown `runtime` ids whose `effective_command` does
+    /// not resolve in the current PATH. Mirror of `desktop::Requirement::
+    /// MissingBinary { command }` — kept in lock-step so the consumer side
+    /// can decode any payload the producer emits across minor version skew.
+    MissingBinary {
+        /// The command name that was not found (e.g. `"my-acp-agent"` or
+        /// `""` when `agent_command` was empty and the runtime id was not
+        /// one of the known runtimes).
+        command: String,
+    },
 }
 
 impl RequirementPayload {
@@ -188,6 +199,22 @@ impl RequirementPayload {
             }
             RequirementPayload::GitBash => {
                 "install Git for Windows (open Agent runtimes in Settings to diagnose)".to_string()
+            }
+            RequirementPayload::MissingBinary { command } => {
+                // Surface the command name (if non-empty) so the user can see
+                // what was missing; if the producer emitted an empty string
+                // because `agent_command` was unset and the runtime id was
+                // unrecognized, fall back to a generic instruction that
+                // points at the Edit Agent dialog where the command lives.
+                if command.is_empty() {
+                    "set the agent command in Edit Agent (open Agent runtimes in Settings to diagnose)"
+                        .to_string()
+                } else {
+                    format!(
+                        "install `{}` or add it to PATH (open Agent runtimes in Settings to diagnose)",
+                        command
+                    )
+                }
             }
         }
     }
@@ -697,6 +724,61 @@ mod tests {
             payload.requirements.as_slice(),
             [RequirementPayload::GitBash]
         ));
+    }
+
+    #[test]
+    fn setup_payload_deserializes_missing_binary_requirement() {
+        // Mirrors the producer payload from
+        // `desktop/src-tauri/src/managed_agents/runtime.rs` — the `MissingBinary`
+        // surface carries a `command` field that names the unresolvable binary.
+        let payload: SetupPayload = serde_json::from_str(
+            r#"{"agent_name":"Buzz Agent","agent_pubkey":"test","requirements":[{"surface":"missing_binary","command":"my-acp-agent"}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            payload.requirements.as_slice(),
+            [RequirementPayload::MissingBinary { command }] if command == "my-acp-agent"
+        ));
+    }
+
+    #[test]
+    fn setup_payload_deserializes_missing_binary_with_empty_command() {
+        // The producer emits an empty `command` when the managed-agent record
+        // has `agent_command: ""` and the runtime id is not one of the known
+        // ACP runtimes. The consumer must accept that without erroring.
+        let payload: SetupPayload = serde_json::from_str(
+            r#"{"agent_name":"Buzz Agent","agent_pubkey":"test","requirements":[{"surface":"missing_binary","command":""}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            payload.requirements.as_slice(),
+            [RequirementPayload::MissingBinary { command }] if command.is_empty()
+        ));
+    }
+
+    #[test]
+    fn missing_binary_instruction_names_the_command_when_present() {
+        let r = RequirementPayload::MissingBinary {
+            command: "my-acp-agent".to_string(),
+        };
+        let s = r.instruction();
+        assert!(s.contains("my-acp-agent"), "got {s:?}");
+        assert!(
+            s.contains("Agent runtimes"),
+            "should point to Agent runtimes; got {s:?}"
+        );
+    }
+
+    #[test]
+    fn missing_binary_instruction_falls_back_when_command_is_empty() {
+        let r = RequirementPayload::MissingBinary {
+            command: String::new(),
+        };
+        let s = r.instruction();
+        assert!(
+            s.contains("Edit Agent"),
+            "empty command should point to Edit Agent; got {s:?}"
+        );
     }
 
     #[test]

--- a/crates/buzz-dev-mcp/src/agent_runtime_control.rs
+++ b/crates/buzz-dev-mcp/src/agent_runtime_control.rs
@@ -1,0 +1,189 @@
+//! Supervisor-only managed-agent lifecycle control.
+//!
+//! Requests are signed Nostr events written to Buzz Desktop's local app-data
+//! inbox. Desktop verifies the event signature and the requester's managed-agent
+//! record before invoking its existing pair-scoped start/stop functions.
+
+use nostr::{EventBuilder, JsonUtil, Kind, Tag};
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const CONTROL_KIND: u16 = 29_110;
+const SUPERVISOR_NAME: &str = "Buzz Management";
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeAction {
+    Start,
+    Stop,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeControlParams {
+    /// Start the target before assignment or stop it after its callback.
+    pub action: RuntimeAction,
+    /// Exact managed-agent public key (hex).
+    pub target_pubkey: String,
+    /// Exact Buzz community relay URL for the runtime pair.
+    pub relay_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeControlPayload<'a> {
+    action: &'a str,
+    target_pubkey: &'a str,
+    relay_url: &'a str,
+    requested_at: u64,
+    nonce: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeControlReceipt {
+    ok: bool,
+    action: String,
+    target_pubkey: String,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+pub async fn run(params: RuntimeControlParams) -> Result<CallToolResult, ErrorData> {
+    let display_name = std::env::var("BUZZ_ACP_DISPLAY_NAME").unwrap_or_default();
+    if display_name.trim() != SUPERVISOR_NAME {
+        return Ok(error_result(
+            "agent_runtime_control is restricted to the Buzz Management supervisor",
+        ));
+    }
+
+    let target_pubkey = params.target_pubkey.trim().to_ascii_lowercase();
+    if target_pubkey.len() != 64 || !target_pubkey.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Ok(error_result("target_pubkey must be a 64-character hex key"));
+    }
+    let relay_url = params.relay_url.trim();
+    if !(relay_url.starts_with("ws://") || relay_url.starts_with("wss://")) {
+        return Ok(error_result("relay_url must start with ws:// or wss://"));
+    }
+
+    let private_key = std::env::var("BUZZ_PRIVATE_KEY")
+        .map_err(|_| ErrorData::internal_error("BUZZ_PRIVATE_KEY is unavailable", None))?;
+    let keys = nostr::Keys::parse(&private_key).map_err(|error| {
+        ErrorData::internal_error(format!("invalid managed identity: {error}"), None)
+    })?;
+    let action = match params.action {
+        RuntimeAction::Start => "start",
+        RuntimeAction::Stop => "stop",
+    };
+    let requested_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let payload = RuntimeControlPayload {
+        action,
+        target_pubkey: &target_pubkey,
+        relay_url,
+        requested_at,
+        nonce: format!("{}-{}", std::process::id(), requested_at),
+    };
+    let content = serde_json::to_string(&payload)
+        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    let target_tag = Tag::parse(["p", target_pubkey.as_str()])
+        .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+    let event = EventBuilder::new(Kind::Custom(CONTROL_KIND), content)
+        .tags([target_tag])
+        .sign_with_keys(&keys)
+        .map_err(|error| {
+            ErrorData::internal_error(format!("sign control request: {error}"), None)
+        })?;
+
+    let control_root = control_root()?;
+    let inbox = control_root.join("inbox");
+    let receipts = control_root.join("receipts");
+    std::fs::create_dir_all(&inbox)
+        .and_then(|_| std::fs::create_dir_all(&receipts))
+        .map_err(|error| {
+            ErrorData::internal_error(format!("create runtime-control queue: {error}"), None)
+        })?;
+    let event_id = event.id.to_hex();
+    let request_path = inbox.join(format!("{event_id}.json"));
+    let receipt_path = receipts.join(format!("{event_id}.json"));
+    let event_json = event.as_json();
+    let mut temp = tempfile::NamedTempFile::new_in(&inbox)
+        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    use std::io::Write as _;
+    temp.write_all(event_json.as_bytes())
+        .and_then(|_| temp.flush())
+        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+    temp.persist_noclobber(&request_path).map_err(|error| {
+        ErrorData::internal_error(format!("queue runtime request: {}", error.error), None)
+    })?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        match std::fs::read(&receipt_path) {
+            Ok(bytes) => {
+                let receipt: RuntimeControlReceipt =
+                    serde_json::from_slice(&bytes).map_err(|error| {
+                        ErrorData::internal_error(format!("parse runtime receipt: {error}"), None)
+                    })?;
+                let _ = std::fs::remove_file(&receipt_path);
+                let text = if receipt.ok {
+                    format!(
+                        "{} completed for managed agent {}",
+                        receipt.action, receipt.target_pubkey
+                    )
+                } else {
+                    format!(
+                        "{} failed for managed agent {}: {}",
+                        receipt.action,
+                        receipt.target_pubkey,
+                        receipt.error.unwrap_or_else(|| "unknown error".into())
+                    )
+                };
+                return Ok(if receipt.ok {
+                    CallToolResult::success(vec![Content::text(text)])
+                } else {
+                    error_result(&text)
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(ErrorData::internal_error(
+                    format!("read runtime receipt: {error}"),
+                    None,
+                ));
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(error_result(
+                "Buzz Desktop did not acknowledge the runtime request within 20 seconds",
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn control_root() -> Result<PathBuf, ErrorData> {
+    if let Some(root) = std::env::var_os("BUZZ_RUNTIME_CONTROL_DIR") {
+        return Ok(PathBuf::from(root));
+    }
+    if let Some(appdata) = std::env::var_os("APPDATA") {
+        return Ok(PathBuf::from(appdata)
+            .join("xyz.block.buzz.app")
+            .join("agents")
+            .join("runtime-control"));
+    }
+    Err(ErrorData::internal_error(
+        "runtime-control directory is unavailable",
+        None,
+    ))
+}
+
+fn error_result(message: &str) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message.to_owned())])
+}

--- a/crates/buzz-dev-mcp/src/lib.rs
+++ b/crates/buzz-dev-mcp/src/lib.rs
@@ -10,6 +10,7 @@ use rmcp::{
 use std::path::Path;
 use std::sync::Arc;
 
+mod agent_runtime_control;
 mod paths;
 mod read_file;
 mod rg;
@@ -94,6 +95,17 @@ impl DevMcp {
             Ok(text) => todo::text_result(text),
             Err(e) => todo::error_result(format!("Error: {e}")),
         }
+    }
+
+    #[tool(
+        name = "agent_runtime_control",
+        description = "Buzz Management supervisor only. Start exactly one stopped managed worker before assigning it, or stop it after its callback. Requires the target agent's 64-character hex pubkey and exact ws(s) relay URL. Requests are signed by the supervisor identity and independently verified by Buzz Desktop."
+    )]
+    async fn agent_runtime_control(
+        &self,
+        Parameters(p): Parameters<agent_runtime_control::RuntimeControlParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        agent_runtime_control::run(p).await
     }
 
     /// Hook: called by the agent before honoring end_turn. Returns

--- a/desktop/src-tauri/src/commands/agent_logs.rs
+++ b/desktop/src-tauri/src/commands/agent_logs.rs
@@ -1,12 +1,39 @@
+use std::collections::BTreeMap;
 use tauri::{AppHandle, Manager};
 
 use crate::{
     app_state::AppState,
     managed_agents::{
-        latest_managed_agent_log_path, load_managed_agents, read_log_tail, BackendKind,
-        ManagedAgentLogResponse,
+        latest_managed_agent_log_path, load_managed_agents, read_log_tail, redact_env_values_in,
+        redact_secrets_with, BackendKind, ManagedAgentLogResponse,
     },
 };
+
+/// Scrub the bounded log tail that `get_managed_agent_log` is about to hand
+/// to the rapid-iteration UI.
+///
+/// Harnesses write diagnostics to a file that the desktop then tails at
+/// read time; spawn-time stderr scrubbing cannot see lines the ACP/MCP child
+/// writes directly, so we redo both passes here before returning any
+/// bytes to JS:
+///
+/// 1. shape-based (`redact_secrets_with([])`) catches well-known token
+///    prefixes (`nsec1`, `sprt_tok_`, `ghp_`, …) even when no env var
+///    ever carried them — e.g. an installer echoing a remote URL.
+/// 2. value-based (`redact_env_values_in`) walks every value on the
+///    resolved `ManagedAgentRecord.env_vars` and replaces literal
+///    occurrences in the tail. This is the only step that catches an
+///    API key the user actually configured for *this* agent.
+///
+/// `BTreeMap` keeps ordering deterministic for tests; we never read it
+/// back, the only thing we need is "every value, as a `&str` slice".
+pub(crate) fn redact_managed_agent_log_tail(
+    content: &str,
+    env_vars: &BTreeMap<String, String>,
+) -> String {
+    let shape = redact_secrets_with(content, &[]);
+    redact_env_values_in(&shape, env_vars)
+}
 
 #[tauri::command]
 pub async fn get_managed_agent_log(
@@ -30,11 +57,92 @@ pub async fn get_managed_agent_log(
         }
 
         let log_path = latest_managed_agent_log_path(&app, &pubkey)?;
+        let raw = read_log_tail(&log_path, line_count.unwrap_or(120) as usize)?;
+        let content = redact_managed_agent_log_tail(&raw, &record.env_vars);
+        let content = redact_secrets_with(
+            &content,
+            &[
+                record.private_key_nsec.as_str(),
+                record.auth_tag.as_deref().unwrap_or(""),
+            ],
+        );
         Ok(ManagedAgentLogResponse {
-            content: read_log_tail(&log_path, line_count.unwrap_or(120) as usize)?,
+            content,
             log_path: log_path.display().to_string(),
         })
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::redact_managed_agent_log_tail;
+
+    /// Representative-shaped text only — no real credentials. A desktop
+    /// bug that drops a literal env value, a Nostr secret, or a GitHub
+    /// token into the UI must surface as a regression here.
+    #[test]
+    fn scrubs_literal_env_values_and_preserves_neutral_lines() {
+        let mut env = BTreeMap::new();
+        env.insert(
+            "ANTHROPIC_API_KEY".to_string(),
+            "unit-test-secret-value".to_string(),
+        );
+        env.insert("EMPTY".to_string(), String::new());
+
+        let tail = "\
+[ready] harness online
+model=demo chat=local
+auth=unit-test-secret-value failed; retrying
+nonce=42 status=ok
+";
+
+        let redacted = redact_managed_agent_log_tail(tail, &env);
+
+        // The secret the user configured for this agent must be gone.
+        assert!(
+            !redacted.contains("unit-test-secret-value"),
+            "literal env value leaked through: {redacted}",
+        );
+        assert!(redacted.contains("[REDACTED]"), "{redacted}");
+        // Surrounding context — and an unrelated short token — stays.
+        assert!(redacted.contains("retrying"), "{redacted}");
+        assert!(redacted.contains("nonce=42"), "{redacted}");
+        // Empty env entries are not scrubbed (would replace empty string).
+        assert!(!redacted.contains("[REDACTED][REDACTED]"), "{redacted}");
+    }
+
+    /// Shape-based scrubbing also runs, so a token that never passed
+    /// through `ManagedAgentRecord.env_vars` (e.g. embedded in a remote
+    /// URL an installer echoes) is still removed before the tail reaches
+    /// the UI panel.
+    #[test]
+    fn scrubs_known_secret_shapes_even_when_env_map_is_empty() {
+        let env = BTreeMap::new();
+        // Representative shapes only — these are deliberately invalid
+        // (wrong length / checksum) test fixtures, not real credentials.
+        let tail = "\
+[git] cloning https://ghp_NOTAREALTOKENxxxxxxxx@github.com/owner/repo now
+[nostr] identity=nsec1NOTAREALSECRETxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+";
+
+        let redacted = redact_managed_agent_log_tail(tail, &env);
+
+        assert!(
+            !redacted.contains("ghp_NOTAREALTOKEN"),
+            "github token prefix leaked: {redacted}",
+        );
+        assert!(
+            !redacted.contains("nsec1NOTAREALSECRET"),
+            "nsec leaked: {redacted}",
+        );
+        assert!(redacted.contains("[REDACTED]"), "{redacted}");
+        // Surrounding context survives — we only narrow the secret span.
+        assert!(redacted.contains("cloning"), "{redacted}");
+        assert!(redacted.contains(" now"), "{redacted}");
+        assert!(redacted.contains("identity="), "{redacted}");
+    }
 }

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use nostr::Keys;
 use serde::Deserialize;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 
 use super::agent_model_process::run_agent_models_command;
 // The map-only lookup is reached solely from the base-URL helpers that exist for
@@ -736,8 +736,13 @@ pub async fn update_managed_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<UpdateManagedAgentResponse, String> {
-    // Phase 1: local save (synchronous, under lock)
-    let (summary, sync_params, rollback) = {
+    // Phase 1 performs blocking mutex and filesystem work. Keep it off the
+    // async runtime so concurrent runtime status/restart IPC can keep making
+    // progress while this local transaction completes.
+    let phase_one_app = app.clone();
+    let (summary, sync_params, rollback) = tokio::task::spawn_blocking(move || {
+        let app = phase_one_app;
+        let state = app.state::<AppState>();
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -902,8 +907,10 @@ pub async fn update_managed_agent(
             )?
         };
         let rollback = name_changed.then(|| AgentUpdateRollback::new(previous_record, record));
-        (summary, sync_params, rollback)
-    }; // lock dropped here
+        Ok::<_, String>((summary, sync_params, rollback))
+    })
+    .await
+    .map_err(|error| format!("spawn_blocking failed: {error}"))??;
 
     try_regenerate_nest(&app);
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -402,6 +402,14 @@ pub fn run() {
                 *guard = Some(app_handle.clone());
             }
 
+            // Signed local control requests let the persistent Buzz Management
+            // supervisor start exactly one stopped worker before assignment and
+            // stop it after callback. The watcher verifies the Nostr signature
+            // and saved supervisor identity before touching runtime ownership.
+            if !recovery_mode {
+                managed_agents::spawn_runtime_control_watcher(app_handle.clone());
+            }
+
             let (tts_settings, tts_settings_load_error) =
                 huddle::tts_settings::load_for_app(&app_handle);
             if let Ok(mut guard) = state.huddle_audio.tts.lock() {

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -178,6 +178,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
     },
+    runtime_metadata::HERMES_RUNTIME,
     KnownAcpRuntime {
         id: "buzz-agent",
         label: "Buzz Agent",
@@ -1616,7 +1617,6 @@ pub(crate) mod pre_publish_test_hook {
         }
     }
 }
-
 pub fn managed_agent_avatar_url(command: &str) -> Option<String> {
     let runtime = known_acp_runtime(command)?;
     Some(runtime.avatar_url.to_string())

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -5,8 +5,9 @@ pub(crate) struct KnownAcpRuntime {
     pub commands: &'static [&'static str],
     pub aliases: &'static [&'static str],
     pub avatar_url: &'static str,
-    /// Legacy MCP server binary field. Vestigial — all agents now use the bundled CLI
-    /// directly. Will be removed when runtime discovery is simplified.
+    /// Optional MCP server binary injected into the ACP session to provide the agent
+    /// with workspace and Buzz CLI tools without depending on the agent's own shell
+    /// environment. Empty for runtimes that do not use the bundled server.
     pub mcp_command: Option<&'static str>,
     /// Whether to enable MCP hook tools (`_Stop`, `_PostCompact`) for this agent.
     pub mcp_hooks: bool,
@@ -83,6 +84,45 @@ impl KnownAcpRuntime {
     }
 }
 
+/// Hermes Agent runtime metadata. Extracted from `discovery.rs` so the
+/// runtime catalog table stays under the 1,627-line ratchet while keeping the
+/// known-runtime descriptors self-contained in this module.
+pub(super) const HERMES_RUNTIME: KnownAcpRuntime = KnownAcpRuntime {
+    id: "hermes",
+    label: "Hermes Agent",
+    commands: &["hermes-acp"],
+    aliases: &["hermes-agent"],
+    avatar_url: "",
+    mcp_command: Some("buzz-dev-mcp"),
+    mcp_hooks: false,
+    underlying_cli: Some("hermes"),
+    cli_install_commands: &[],
+    cli_install_commands_windows: &[],
+    adapter_install_commands: &[],
+    cli_install_instructions_url: "https://hermes-agent.nousresearch.com",
+    adapter_install_instructions_url: "https://hermes-agent.nousresearch.com",
+    cli_install_hint: "Install Hermes Agent so the hermes command is available.",
+    adapter_install_hint: "Hermes Agent provides the hermes-acp command.",
+    skill_dir: None,
+    supports_acp_model_switching: false,
+    model_env_var: None,
+    provider_env_var: None,
+    provider_locked: false,
+    default_env: &[],
+    config_file_path: None,
+    config_file_format: None,
+    supports_acp_native_config: false,
+    thinking_env_var: None,
+    max_tokens_env_var: None,
+    context_limit_env_var: None,
+    max_rounds_env_var: None,
+    required_normalized_fields: &[],
+    login_hint: Some(
+        "Complete Hermes Agent provider setup if hermes-acp reports missing credentials.",
+    ),
+    auth_probe_args: None,
+};
+
 #[cfg(test)]
 mod tests {
     use super::super::known_acp_runtime_exact;
@@ -122,5 +162,9 @@ mod tests {
         );
         assert!(codex.adapter_install_instructions_url.contains("codex-acp"));
         assert!(codex.cli_install_hint.contains("Codex CLI"));
+
+        let hermes = known_acp_runtime_exact("hermes").unwrap();
+        assert_eq!(hermes.commands, &["hermes-acp"]);
+        assert_eq!(hermes.mcp_command, Some("buzz-dev-mcp"));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -88,6 +88,9 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     // ambient env var must not be able to forge setup mode (NotReady) on a
     // Ready agent or suppress it (empty/stale payload) on a NotReady one.
     "BUZZ_ACP_SETUP_PAYLOAD",
+    // Supervisor lifecycle queue: Desktop binds this path to its resolved
+    // app-data directory; an agent definition must not redirect requests.
+    "BUZZ_RUNTIME_CONTROL_DIR",
     // Desktop ownership markers: these brand every spawned harness with the
     // launching Desktop instance. A user-supplied override would let a
     // definition masquerade as a different instance or fake the nonce used

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -29,6 +29,7 @@ mod restore;
 pub mod retention;
 mod runtime;
 mod runtime_commands;
+mod runtime_control;
 mod runtime_types;
 pub(crate) mod snapshot_avatar;
 pub(crate) mod spawn_snapshot;
@@ -74,6 +75,7 @@ pub use repos::{
 pub use restore::*;
 pub use runtime::*;
 pub use runtime_commands::*;
+pub(crate) use runtime_control::spawn_runtime_control_watcher;
 pub use runtime_types::*;
 pub use storage::*;
 pub use teams::*;

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 use super::agent_env::build_buzz_agent_provider_defaults;
 
@@ -569,6 +569,12 @@ pub fn spawn_agent_child(
     command.env("RUST_LOG", child_rust_log_filter());
     command.env("BUZZ_PRIVATE_KEY", &record.private_key_nsec);
     command.env("BUZZ_RELAY_URL", &effective_relay_url);
+    if let Ok(data_dir) = app.path().app_data_dir() {
+        command.env(
+            "BUZZ_RUNTIME_CONTROL_DIR",
+            data_dir.join("agents").join("runtime-control"),
+        );
+    }
     command.env("BUZZ_ACP_LAZY_POOL", if lazy { "true" } else { "false" });
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
@@ -709,8 +715,13 @@ pub fn spawn_agent_child(
     // which is the single source of truth. The previously-emitted
     // `BUZZ_ACP_TURN_TIMEOUT` is deprecated upstream and was pinning every
     // agent to the desktop's stale default (320s), bypassing harness bumps.
+    // Desktop owns both idle bounds. Saved custom/persona env cannot override
+    // either key (BUZZ_ACP_EXIT_AFTER_INACTIVITY is reserved), and an unset
+    // record must not inherit an ambient process-level shutdown policy.
+    command.env_remove("BUZZ_ACP_EXIT_AFTER_INACTIVITY");
     if let Some(idle) = record.idle_timeout_seconds {
         command.env("BUZZ_ACP_IDLE_TIMEOUT", idle.to_string());
+        command.env("BUZZ_ACP_EXIT_AFTER_INACTIVITY", idle.to_string());
     }
 
     if let Some(max_dur) = record.max_turn_duration_seconds {

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -5,11 +5,10 @@ use tauri::{AppHandle, Emitter, Manager};
 use super::{
     agent_readiness, append_log_marker, current_instance_id, find_managed_agent_mut,
     load_global_agent_config, load_managed_agents, load_personas, managed_agent_runtime_log_path,
-    process_is_running, record_agent_command, resolve_effective_agent_env, save_managed_agents,
-    spawn_agent_child, terminate_process, terminate_untracked_pair_runtime,
-    write_agent_runtime_receipt, AgentReadiness, BackendKind, ManagedAgentPairRuntime,
-    ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle, ManagedAgentRuntimeReceipt,
-    ManagedAgentRuntimeStatus,
+    record_agent_command, resolve_effective_agent_env, save_managed_agents, spawn_agent_child,
+    terminate_process, terminate_untracked_pair_runtime, write_agent_runtime_receipt,
+    AgentReadiness, BackendKind, ManagedAgentPairRuntime, ManagedAgentRuntimeKey,
+    ManagedAgentRuntimeLifecycle, ManagedAgentRuntimeReceipt, ManagedAgentRuntimeStatus,
 };
 use crate::app_state::AppState;
 
@@ -236,6 +235,79 @@ pub fn start_managed_agent_runtime(
     start_managed_agent_runtime_pair_lazy(pubkey, relay_url, app)
 }
 
+fn wait_for_runtime_child_exit(
+    child: &mut std::process::Child,
+    timeout: std::time::Duration,
+) -> Result<Option<std::process::ExitStatus>, String> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().map_err(|error| error.to_string())? {
+            return Ok(Some(status));
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(None);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn stop_tracked_runtime_process(
+    runtime: &mut ManagedAgentPairRuntime,
+) -> Result<std::process::ExitStatus, String> {
+    #[cfg(windows)]
+    {
+        let pid = runtime.child.id();
+        if let Some(job) = runtime.process.job.take() {
+            // Closing the tracked kill-on-close Job Object is the primary tree
+            // teardown. Never follow it with an unbounded Child::wait while the
+            // runtime transition is serialized: a wedged root would otherwise
+            // stall restart and every status query indefinitely.
+            drop(job);
+            if let Some(status) =
+                wait_for_runtime_child_exit(&mut runtime.child, std::time::Duration::from_secs(2))?
+            {
+                return Ok(status);
+            }
+
+            // The job tree should already be gone. Terminate only the tracked
+            // root if it survived Job close, then keep the final reap bounded
+            // and fail closed instead of orphaning an untracked runtime. A
+            // concurrent exit makes Child::kill harmless; the final try_wait
+            // below remains authoritative.
+            let _ = runtime.child.kill();
+            return wait_for_runtime_child_exit(
+                &mut runtime.child,
+                std::time::Duration::from_secs(3),
+            )?
+            .ok_or_else(|| "managed runtime did not exit after tracked teardown".to_string());
+        }
+        if let Some(status) = runtime
+            .child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+        {
+            return Ok(status);
+        }
+        terminate_process(pid)?;
+    }
+
+    #[cfg(not(windows))]
+    if super::process_is_running(runtime.child.id()) {
+        terminate_process(runtime.child.id())?;
+    }
+
+    wait_for_runtime_child_exit(&mut runtime.child, std::time::Duration::from_secs(5))?
+        .ok_or_else(|| "managed runtime did not exit after teardown".to_string())
+}
+
+fn with_managed_agent_runtime_transition<T>(
+    transition: &std::sync::Mutex<()>,
+    operation: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let _transition = transition.lock().map_err(|e| e.to_string())?;
+    operation()
+}
+
 fn start_pair(
     pubkey: String,
     relay_url: String,
@@ -248,6 +320,17 @@ fn start_pair(
         .managed_agent_runtime_transition
         .lock()
         .map_err(|e| e.to_string())?;
+    start_pair_locked(pubkey, relay_url, lazy, expected_updated_at, app.clone())
+}
+
+fn start_pair_locked(
+    pubkey: String,
+    relay_url: String,
+    lazy: bool,
+    expected_updated_at: Option<&str>,
+    app: AppHandle,
+) -> Result<ManagedAgentRuntimeStatus, String> {
+    let state = app.state::<AppState>();
     if state.shutdown_started.load(Ordering::Acquire) {
         return Err("desktop shutdown has started".into());
     }
@@ -320,6 +403,15 @@ pub fn stop_managed_agent_runtime(
         .managed_agent_runtime_transition
         .lock()
         .map_err(|e| e.to_string())?;
+    stop_managed_agent_runtime_locked(pubkey, relay_url, app.clone())
+}
+
+fn stop_managed_agent_runtime_locked(
+    pubkey: String,
+    relay_url: String,
+    app: AppHandle,
+) -> Result<ManagedAgentRuntimeStatus, String> {
+    let state = app.state::<AppState>();
     let _store = state
         .managed_agents_store_lock
         .lock()
@@ -332,12 +424,7 @@ pub fn stop_managed_agent_runtime(
         .lock()
         .map_err(|e| e.to_string())?;
     if let Some(mut runtime) = runtimes.remove(&key) {
-        let stop_result = if process_is_running(runtime.child.id()) {
-            terminate_process(runtime.child.id())
-        } else {
-            Ok(())
-        }
-        .and_then(|()| runtime.child.wait().map_err(|e| e.to_string()));
+        let stop_result = stop_tracked_runtime_process(&mut runtime);
         match stop_result {
             Ok(status) => {
                 record.last_exit_code = status.code();
@@ -382,8 +469,18 @@ pub fn restart_managed_agent_runtime(
     relay_url: String,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
-    stop_managed_agent_runtime(pubkey.clone(), relay_url.clone(), app.clone())?;
-    start_pair(pubkey, relay_url, true, None, app)
+    // An explicit restart is an apply-and-verify boundary. Hold the transition
+    // lock across teardown and eager start so reconcile or another lazy start
+    // cannot insert a pair between the two halves of the restart.
+    let state = app.state::<AppState>();
+    let restart_app = app.clone();
+    with_managed_agent_runtime_transition(&state.managed_agent_runtime_transition, || {
+        stop_managed_agent_runtime_locked(pubkey.clone(), relay_url.clone(), restart_app.clone())?;
+        // Start eagerly so the lifecycle observer can report `ready` before
+        // an owner-authored smoke is posted; ordinary start/reconcile paths
+        // remain lazy.
+        start_pair_locked(pubkey, relay_url, false, None, restart_app)
+    })
 }
 
 /// Probe whether this agent can operate on `requested_relay_url`.
@@ -712,5 +809,21 @@ mod tests {
             Some("unexpected"),
         );
         assert!(observer_lifecycle_key(&ready_with_error.pubkey, &ready_with_error).is_err());
+    }
+
+    #[test]
+    fn restart_transition_blocks_lazy_start_between_stop_and_eager_start() {
+        let transition = std::sync::Mutex::new(());
+        let mut events = Vec::new();
+        let lazy_start_interleaved = with_managed_agent_runtime_transition(&transition, || {
+            events.push("stop");
+            let lazy_start_interleaved = transition.try_lock().is_ok();
+            events.push("eager-start");
+            Ok(lazy_start_interleaved)
+        })
+        .unwrap();
+
+        assert!(!lazy_start_interleaved);
+        assert_eq!(events, ["stop", "eager-start"]);
     }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime_control.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_control.rs
@@ -1,0 +1,237 @@
+//! Signed supervisor -> Desktop managed-runtime control queue.
+
+use atomic_write_file::AtomicWriteFile;
+use nostr::JsonUtil;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Manager};
+
+const CONTROL_KIND: u16 = 29_110;
+const SUPERVISOR_NAME: &str = "Buzz Management";
+const MAX_REQUEST_BYTES: u64 = 128 * 1024;
+const MAX_AGE_SECS: u64 = 120;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RuntimeControlPayload {
+    action: String,
+    target_pubkey: String,
+    relay_url: String,
+    requested_at: u64,
+    nonce: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeControlReceipt {
+    ok: bool,
+    action: String,
+    target_pubkey: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+pub(crate) fn spawn_runtime_control_watcher(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_millis(400));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if let Err(error) = process_pending(&app).await {
+                eprintln!("buzz-desktop: runtime-control watcher: {error}");
+            }
+        }
+    });
+}
+
+async fn process_pending(app: &AppHandle) -> Result<(), String> {
+    let root = control_root(app)?;
+    let inbox = root.join("inbox");
+    let receipts = root.join("receipts");
+    tokio::fs::create_dir_all(&inbox)
+        .await
+        .map_err(|error| format!("create {}: {error}", inbox.display()))?;
+    tokio::fs::create_dir_all(&receipts)
+        .await
+        .map_err(|error| format!("create {}: {error}", receipts.display()))?;
+    let mut entries = tokio::fs::read_dir(&inbox)
+        .await
+        .map_err(|error| format!("read {}: {error}", inbox.display()))?;
+    let mut processed = 0usize;
+    while processed < 16 {
+        let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| error.to_string())?
+        else {
+            break;
+        };
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        processed += 1;
+        let event_id = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or("invalid")
+            .to_owned();
+        let receipt_path = receipts.join(format!("{event_id}.json"));
+        let app_for_request = app.clone();
+        let request_path = path.clone();
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            process_one(&app_for_request, &request_path)
+        })
+        .await
+        .map_err(|error| format!("runtime-control worker join: {error}"))?;
+        let receipt = match result {
+            Ok(receipt) => receipt,
+            Err(error) => RuntimeControlReceipt {
+                ok: false,
+                action: "unknown".into(),
+                target_pubkey: "unknown".into(),
+                error: Some(error),
+            },
+        };
+        atomic_write_json(&receipt_path, &receipt)?;
+        if let Err(error) = tokio::fs::remove_file(&path).await {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!(
+                    "buzz-desktop: runtime-control could not remove {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn process_one(app: &AppHandle, path: &Path) -> Result<RuntimeControlReceipt, String> {
+    let metadata =
+        std::fs::metadata(path).map_err(|error| format!("inspect {}: {error}", path.display()))?;
+    if metadata.len() > MAX_REQUEST_BYTES {
+        return Err("runtime-control request exceeds size limit".into());
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("read {}: {error}", path.display()))?;
+    let event =
+        nostr::Event::from_json(raw).map_err(|error| format!("parse signed event: {error}"))?;
+    event
+        .verify()
+        .map_err(|error| format!("verify signed event: {error}"))?;
+    if event.kind.as_u16() != CONTROL_KIND {
+        return Err(format!(
+            "unexpected runtime-control kind {}",
+            event.kind.as_u16()
+        ));
+    }
+    let payload: RuntimeControlPayload = serde_json::from_str(&event.content)
+        .map_err(|error| format!("parse control payload: {error}"))?;
+    if payload.nonce.trim().is_empty() {
+        return Err("runtime-control nonce is empty".into());
+    }
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if payload.requested_at > now.saturating_add(10)
+        || now.saturating_sub(payload.requested_at) > MAX_AGE_SECS
+        || now.saturating_sub(event.created_at.as_secs()) > MAX_AGE_SECS
+    {
+        return Err("runtime-control request is stale or future-dated".into());
+    }
+    let requester_pubkey = event.pubkey.to_hex();
+    let target_pubkey = payload.target_pubkey.trim().to_ascii_lowercase();
+    if requester_pubkey == target_pubkey {
+        return Err("supervisor cannot lifecycle-control itself".into());
+    }
+    let signed_target = event.tags.iter().any(|tag| {
+        let values = tag.as_slice();
+        values.first().map(String::as_str) == Some("p")
+            && values
+                .get(1)
+                .is_some_and(|value| value.eq_ignore_ascii_case(&target_pubkey))
+    });
+    if !signed_target {
+        return Err("signed p tag does not match target_pubkey".into());
+    }
+    if !(payload.relay_url.starts_with("ws://") || payload.relay_url.starts_with("wss://")) {
+        return Err("relay_url must use ws:// or wss://".into());
+    }
+
+    let records = super::load_managed_agents(app)?;
+    let requester = records
+        .iter()
+        .find(|record| record.pubkey.eq_ignore_ascii_case(&requester_pubkey))
+        .ok_or_else(|| "requester is not a saved managed agent".to_string())?;
+    if requester.name.trim() != SUPERVISOR_NAME || requester.backend != super::BackendKind::Local {
+        return Err("requester is not the local Buzz Management supervisor".into());
+    }
+    let target = records
+        .iter()
+        .find(|record| record.pubkey.eq_ignore_ascii_case(&target_pubkey))
+        .ok_or_else(|| "target is not a saved managed agent".to_string())?;
+    if target.backend != super::BackendKind::Local {
+        return Err("target is not a local managed agent".into());
+    }
+
+    // The signed request is still bound to the active workspace relay. This
+    // prevents a valid supervisor identity from using the local queue to
+    // start/stop the same agent against an arbitrary relay pair.
+    let state = app.state::<crate::app_state::AppState>();
+    let active_relay = crate::relay::relay_ws_url_with_override(&state);
+    if normalize_relay_url(&payload.relay_url) != normalize_relay_url(&active_relay) {
+        return Err("runtime-control relay is not the active workspace relay".into());
+    }
+
+    let action = payload.action.trim().to_ascii_lowercase();
+    let outcome = match action.as_str() {
+        "start" => super::start_managed_agent_runtime(
+            target_pubkey.clone(),
+            payload.relay_url.clone(),
+            app.clone(),
+        )
+        .map(|_| ()),
+        "stop" => super::stop_managed_agent_runtime(
+            target_pubkey.clone(),
+            payload.relay_url.clone(),
+            app.clone(),
+        )
+        .map(|_| ()),
+        _ => return Err("action must be start or stop".into()),
+    };
+    Ok(RuntimeControlReceipt {
+        ok: outcome.is_ok(),
+        action,
+        target_pubkey,
+        error: outcome.err(),
+    })
+}
+
+fn normalize_relay_url(value: &str) -> String {
+    value.trim().trim_end_matches('/').to_ascii_lowercase()
+}
+
+fn control_root(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map(|path| path.join("agents").join("runtime-control"))
+        .map_err(|error| format!("resolve app-data runtime-control path: {error}"))
+}
+
+fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("receipt path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    let payload = serde_json::to_vec(value).map_err(|error| error.to_string())?;
+    let mut file =
+        AtomicWriteFile::open(path).map_err(|error| format!("open {}: {error}", path.display()))?;
+    file.write_all(&payload)
+        .map_err(|error| format!("write {}: {error}", path.display()))?;
+    file.commit()
+        .map_err(|error| format!("commit {}: {error}", path.display()))
+}

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -153,6 +153,30 @@ with a TypeScript lookup table or an id comparison in a component.
    themselves. Never synthesize a run location a surface doesn't have. Don't
    expose `respond-to`, `allowlist`, Nostr, or harness jargon in primary UI
    copy.
+12. **Rapid agent tests are explicit owner-authored round trips.** Instance Edit
+    offers separate Save, Save & restart, and Save/restart/test actions. The
+    test action is never implicit: it awaits the normal managed-agent update,
+    restarts only the active community's runtime pair through
+    `useManagedAgentRuntimeAction`, revalidates membership after readiness,
+    posts through the canonical cache-aware owner message mutation with the
+    target agent's mention tag, and opens the root
+    thread only after the relay returns the accepted event id. Eligible targets
+    are joined, non-archived channels that already contain the agent; DMs are
+    valid. Prompt previews and UI errors must never interpolate environment
+    values, credentials, relay auth, or private key material. A posted smoke is
+    not a successful agent response—the visible thread reply remains the
+    acceptance boundary. After Save and before restart, revalidate the persisted
+    effective runtime, fresh catalog/persona route, harness command, and ACP
+    sidecar against the reviewed form. Refetch the owner identity immediately
+    before posting and reject a signed event whose author differs. Abort the
+    entire rapid action on dialog, agent, owner, or active-relay change; an
+    aborted WebSocket send must never reconnect onto a replacement community.
+    The rapid flow waits for the active community pair to report `ready` before
+    posting, excludes forum channels, and is unavailable for provider-backed
+    agents; only local runtime pairs accept restart + smoke.
+    Keep any inline harness-log tail bounded and redacted at the backend read
+    seam. Distinguish “posted” from “thread opened” so a navigation failure never
+    invites a duplicate external send.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/managedAgentRuntimeHooks.test.mjs
+++ b/desktop/src/features/agents/managedAgentRuntimeHooks.test.mjs
@@ -5,12 +5,11 @@ import { restartManagedAgentPair } from "./managedAgentRuntimeHooks.ts";
 
 // ---------------------------------------------------------------------------
 // restartManagedAgentPair: discriminating regression tests for the pair
-// restart lifecycle boundary (stop → relay-scoped clear → start).
+// restart lifecycle boundary (backend-atomic restart → relay-scoped clear).
 //
 // These tests exercise the exact function called by useManagedAgentRuntimeAction's
-// mutationFn restart branch, so reverting to the old combined Rust command
-// (which cleared only in onSuccess, after the new process was already running)
-// would make tests (a) and (c) fail.
+// mutationFn restart branch, so reverting to split stop/start IPC calls makes
+// the ordering test fail.
 // ---------------------------------------------------------------------------
 
 const PUBKEY = "deadbeef".repeat(8);
@@ -26,85 +25,59 @@ function makeStatus() {
   };
 }
 
-test("test_pair_restart_stop_success_start_failure_clear_still_ran", async () => {
-  // Stop succeeds, start throws.  The clear must have fired — badge is gone
-  // regardless of the start failure.  On the old combined-command approach,
-  // a rejected command meant onSuccess never ran and the badge survived.
+test("test_pair_restart_success_clears_and_returns_runtime", async () => {
+  let clearFired = false;
+  const status = makeStatus();
+  const result = await restartManagedAgentPair(
+    PUBKEY,
+    RELAY,
+    async () => status,
+    (_pubkey, _relayUrl) => {
+      clearFired = true;
+    },
+  );
+  assert.equal(result, status);
+  assert.ok(clearFired, "clear must fire after a successful atomic restart");
+});
+
+test("test_pair_restart_failure_does_not_clear", async () => {
   let clearFired = false;
 
   await assert.rejects(
     restartManagedAgentPair(
       PUBKEY,
       RELAY,
-      async () => makeStatus(), // stop succeeds
-      (_pubkey, _relayUrl) => {
-        clearFired = true;
-      },
       async () => {
-        throw new Error("start failed");
-      },
-    ),
-    /start failed/,
-  );
-
-  assert.ok(
-    clearFired,
-    "clear must fire at stop-success boundary even when start subsequently fails",
-  );
-});
-
-test("test_pair_restart_stop_failure_neither_clear_nor_start_called", async () => {
-  // Stop throws.  Neither clear nor start should run — clearing on a failed
-  // stop would remove a badge that is still legitimately active.
-  let clearFired = false;
-  let startCalled = false;
-
-  await assert.rejects(
-    restartManagedAgentPair(
-      PUBKEY,
-      RELAY,
-      async () => {
-        throw new Error("stop failed");
+        throw new Error("restart failed");
       },
       (_pubkey, _relayUrl) => {
         clearFired = true;
       },
-      async () => {
-        startCalled = true;
-        return makeStatus();
-      },
     ),
-    /stop failed/,
+    /restart failed/,
   );
 
-  assert.ok(!clearFired, "clear must NOT fire when stop itself fails");
-  assert.ok(!startCalled, "start must NOT be called when stop fails");
+  assert.ok(!clearFired, "clear must NOT fire when atomic restart fails");
 });
 
-test("test_pair_restart_strict_stop_clear_start_ordering", async () => {
-  // Verify the operations fire in the guaranteed order: stop → clear → start.
-  // A clear that fires after start begins can tombstone genuine new turns.
+test("test_pair_restart_strict_atomic_restart_then_clear_ordering", async () => {
   const events = [];
 
   await restartManagedAgentPair(
     PUBKEY,
     RELAY,
     async () => {
-      events.push("stop");
+      events.push("atomic-restart");
       return makeStatus();
     },
     (_pubkey, _relayUrl) => {
       events.push("clear");
     },
-    async () => {
-      events.push("start");
-      return makeStatus();
-    },
   );
 
   assert.deepEqual(
     events,
-    ["stop", "clear", "start"],
-    "operations must fire in stop → clear → start order",
+    ["atomic-restart", "clear"],
+    "clear must follow the one atomic backend restart",
   );
 });

--- a/desktop/src/features/agents/managedAgentRuntimeHooks.ts
+++ b/desktop/src/features/agents/managedAgentRuntimeHooks.ts
@@ -13,6 +13,7 @@ import {
 import {
   listManagedAgentRuntimes,
   reconcileManagedAgentRuntimes,
+  restartManagedAgentRuntime,
   startManagedAgentRuntime,
   stopManagedAgentRuntime,
 } from "@/shared/api/tauriManagedAgents";
@@ -97,11 +98,15 @@ export function bootstrapManagedAgentRuntimePairs(
     });
 }
 
-export function useManagedAgentRuntimesQuery(options?: { enabled?: boolean }) {
+export function useManagedAgentRuntimesQuery(options?: {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+}) {
   return useQuery({
     enabled: options?.enabled ?? true,
     queryKey: managedAgentRuntimesQueryKey,
     queryFn: listManagedAgentRuntimes,
+    refetchInterval: options?.refetchInterval ?? false,
   });
 }
 
@@ -148,34 +153,31 @@ export function clearActiveTurnsForAgentOnStop(
 }
 
 /**
- * Execute a pair restart as stop → relay-scoped badge clear → start.
+ * Execute one backend-atomic pair restart, then clear relay-scoped badges.
  *
  * Extracted from `useManagedAgentRuntimeAction`'s `mutationFn` so the
- * three-step lifecycle boundary can be tested directly without a hook-render
- * harness.  All three operations are injected, keeping this function free of
+ * lifecycle boundary can be tested directly without a hook-render harness.
+ * Both operations are injected, keeping this function free of
  * React and Tauri imports.
  *
  * Guarantees:
- * - Clear fires only when stop succeeds.
- * - A failed start occurs after the clear — the badge is already gone.
- * - No clear can fire after start begins, so genuinely-new turns are safe.
+ * - Stop plus eager start remain one backend transition-lock boundary.
+ * - Clear fires only after that atomic restart succeeds.
+ * - Failed restarts leave the badge intact rather than clearing a potentially
+ *   still-active turn.
  */
 export async function restartManagedAgentPair(
   pubkey: string,
   relayUrl: string,
-  stop: (
+  restart: (
     pubkey: string,
     relayUrl: string,
   ) => Promise<ManagedAgentRuntimeStatus>,
   clear: (pubkey: string, relayUrl: string) => void,
-  start: (
-    pubkey: string,
-    relayUrl: string,
-  ) => Promise<ManagedAgentRuntimeStatus>,
 ): Promise<ManagedAgentRuntimeStatus> {
-  await stop(pubkey, relayUrl);
+  const runtime = await restart(pubkey, relayUrl);
   clear(pubkey, relayUrl);
-  return start(pubkey, relayUrl);
+  return runtime;
 }
 
 export function useManagedAgentRuntimeAction() {
@@ -195,9 +197,8 @@ export function useManagedAgentRuntimeAction() {
         return restartManagedAgentPair(
           pubkey,
           relayUrl,
-          stopManagedAgentRuntime,
+          restartManagedAgentRuntime,
           clearActiveTurnsForAgentOnStop,
-          startManagedAgentRuntime,
         );
       }
       return startManagedAgentRuntime(pubkey, relayUrl);

--- a/desktop/src/features/agents/rapidActionLease.ts
+++ b/desktop/src/features/agents/rapidActionLease.ts
@@ -1,0 +1,153 @@
+export type RapidActionLeaseScope = {
+  agentPubkey: string;
+  activeRelayUrl: string | null;
+  ownerIdentityPubkey: string | null;
+  route: string;
+};
+
+export type RapidActionLease = {
+  id: string;
+  controller: AbortController;
+};
+
+type LeaseEntry = RapidActionLease & {
+  agentPubkey: string;
+  scope: RapidActionLeaseScope;
+  mounts: Set<string>;
+};
+
+const leasesById = new Map<string, LeaseEntry>();
+const leaseIdByAgent = new Map<string, string>();
+const leaseIdByMount = new Map<string, string>();
+let nextLeaseId = 0;
+let nextMountId = 0;
+
+function normalizeScope(scope: RapidActionLeaseScope): RapidActionLeaseScope {
+  return {
+    agentPubkey: scope.agentPubkey.trim().toLowerCase(),
+    activeRelayUrl: scope.activeRelayUrl?.trim() || null,
+    ownerIdentityPubkey: scope.ownerIdentityPubkey?.trim().toLowerCase() || null,
+    route: scope.route,
+  };
+}
+
+function scopesMatch(
+  left: RapidActionLeaseScope,
+  right: RapidActionLeaseScope,
+): boolean {
+  return (
+    left.agentPubkey === right.agentPubkey &&
+    left.activeRelayUrl === right.activeRelayUrl &&
+    left.ownerIdentityPubkey === right.ownerIdentityPubkey &&
+    left.route === right.route
+  );
+}
+
+export function createRapidActionMountId(): string {
+  nextMountId += 1;
+  return `rapid-mount-${nextMountId}`;
+}
+
+/** Start one action lease for an agent, owned by the current dialog mount. */
+export function startRapidActionLease(
+  scope: RapidActionLeaseScope,
+  mountId: string,
+): RapidActionLease | null {
+  const normalizedScope = normalizeScope(scope);
+  if (leaseIdByAgent.has(normalizedScope.agentPubkey)) {
+    return null;
+  }
+
+  nextLeaseId += 1;
+  const lease: LeaseEntry = {
+    id: `rapid-action-${nextLeaseId}`,
+    controller: new AbortController(),
+    agentPubkey: normalizedScope.agentPubkey,
+    scope: normalizedScope,
+    mounts: new Set([mountId]),
+  };
+  leasesById.set(lease.id, lease);
+  leaseIdByAgent.set(lease.agentPubkey, lease.id);
+  leaseIdByMount.set(mountId, lease.id);
+  return lease;
+}
+
+/**
+ * Reclaim a lease only during a same-scope mount handoff. A second dialog
+ * cannot attach to an action while the original owner is still mounted.
+ */
+export function claimRapidActionLease(
+  scope: RapidActionLeaseScope,
+  mountId: string,
+): RapidActionLease | null {
+  const normalizedScope = normalizeScope(scope);
+  const leaseId = leaseIdByAgent.get(normalizedScope.agentPubkey);
+  if (!leaseId) {
+    return null;
+  }
+  const lease = leasesById.get(leaseId);
+  if (
+    !lease ||
+    lease.controller.signal.aborted ||
+    lease.mounts.size > 0 ||
+    !scopesMatch(lease.scope, normalizedScope)
+  ) {
+    return null;
+  }
+
+  lease.mounts.add(mountId);
+  leaseIdByMount.set(mountId, lease.id);
+  return lease;
+}
+
+/** Release a dialog mount; abort if no same-scope replacement claims it. */
+export function releaseRapidActionMount(mountId: string): void {
+  const leaseId = leaseIdByMount.get(mountId);
+  if (!leaseId) {
+    return;
+  }
+  leaseIdByMount.delete(mountId);
+  const lease = leasesById.get(leaseId);
+  if (!lease) {
+    return;
+  }
+  lease.mounts.delete(mountId);
+  globalThis.queueMicrotask(() => {
+    const current = leasesById.get(leaseId);
+    if (current && current.mounts.size === 0) {
+      current.controller.abort();
+    }
+  });
+}
+
+export function abortRapidActionLeaseForMount(mountId: string): void {
+  const leaseId = leaseIdByMount.get(mountId);
+  if (!leaseId) {
+    return;
+  }
+  leasesById.get(leaseId)?.controller.abort();
+}
+
+export function finishRapidActionLease(leaseId: string): void {
+  const lease = leasesById.get(leaseId);
+  if (!lease) {
+    return;
+  }
+  for (const mountId of lease.mounts) {
+    leaseIdByMount.delete(mountId);
+  }
+  if (leaseIdByAgent.get(lease.agentPubkey) === leaseId) {
+    leaseIdByAgent.delete(lease.agentPubkey);
+  }
+  leasesById.delete(leaseId);
+}
+
+/** Community switches are a hard authority boundary for all rapid actions. */
+export function resetRapidActionLeases(): void {
+  for (const lease of leasesById.values()) {
+    lease.controller.abort();
+  }
+  leasesById.clear();
+  leaseIdByAgent.clear();
+  leaseIdByMount.clear();
+}

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -7,6 +7,7 @@ import {
   useAcpRuntimesQuery,
   useAgentConfigSurface,
   useBakedBuildEnvKeysQuery,
+  useSetManagedAgentAutoRestartMutation,
   usePersonasQuery,
   useStartManagedAgentMutation,
   useUpdateManagedAgentMutation,
@@ -23,7 +24,6 @@ import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-import { setManagedAgentAutoRestart } from "@/shared/api/tauriManagedAgents";
 import { EditAgentAdvancedFields } from "./EditAgentAdvancedFields";
 import {
   ADVANCED_FIELDS_MOTION_TRANSITION,
@@ -89,6 +89,13 @@ import { resolveModelFieldStatusMessage } from "./agentConfigControls";
 import { AdvancedRequiredBadge } from "./AdvancedRequiredBadge";
 import { showAgentProfileSyncWarning } from "./agentProfileSyncWarning";
 import { AddCustomHarnessDialog } from "./AddCustomHarnessDialog";
+import { AgentRapidActionsFooter } from "./AgentRapidActionsFooter";
+import { AgentRapidTestPanel } from "./AgentRapidTestPanel";
+import {
+  revalidateRapidPostSaveRoute,
+  type RapidSaveMode,
+} from "./agentRapidTest";
+import { useAgentRapidIteration } from "./useAgentRapidIteration";
 import {
   ADD_CUSTOM_HARNESS_OPTION,
   runtimeDropdownAction,
@@ -113,7 +120,14 @@ export function AgentInstanceEditDialog({
   onUpdated?: (agent: ManagedAgent) => void;
 }) {
   const updateMutation = useUpdateManagedAgentMutation();
+  const autoRestartMutation = useSetManagedAgentAutoRestartMutation();
   const startMutation = useStartManagedAgentMutation();
+  const rapidIteration = useAgentRapidIteration({
+    agentBackend: agent.backend,
+    agentPubkey: agent.pubkey,
+    onClose: () => onOpenChange(false),
+    open,
+  });
   const runtimesQuery = useAcpRuntimesQuery({ enabled: open });
   const configSurfaceQuery = useAgentConfigSurface(open ? agent.pubkey : null);
   const runtimes = runtimesQuery.data ?? [];
@@ -205,6 +219,7 @@ export function AgentInstanceEditDialog({
         runtimes.find((r) => r.id === agent.agentCommand.trim());
       setSelectedRuntimeId(matched ? matched.id : "custom");
       updateMutation.reset();
+      autoRestartMutation.reset();
     }
   }, [open, agent.pubkey]);
 
@@ -584,7 +599,12 @@ export function AgentInstanceEditDialog({
   }
 
   function handleOpenChange(next: boolean) {
-    onOpenChange(next);
+    if (!next && rapidIteration.isPending) {
+      rapidIteration.cancel();
+      onOpenChange(false);
+      return;
+    }
+    if (next || !isSubmitPending) onOpenChange(next);
   }
 
   const providerValid = isEditAgentProviderSaveValid({
@@ -595,6 +615,10 @@ export function AgentInstanceEditDialog({
     originalRuntimeSupportsProvider,
   });
 
+  const isSubmitPending =
+    updateMutation.isPending ||
+    autoRestartMutation.isPending ||
+    rapidIteration.isPending;
   const canSubmit =
     computeEditAgentFormValidity({
       name,
@@ -609,24 +633,26 @@ export function AgentInstanceEditDialog({
       requiredEnvKeyMissing,
     }) &&
     providerValid &&
-    !updateMutation.isPending &&
+    !isSubmitPending &&
     !isAvatarUploadPending;
 
-  async function handleSubmit() {
-    try {
+  async function handleSubmit(mode: RapidSaveMode = "save") {
+    updateMutation.reset();
+    autoRestartMutation.reset();
+    const deferredUpdate: { agent: ManagedAgent | null } = { agent: null };
+    const saveAgent: Parameters<typeof rapidIteration.run>[1] = async (
+      markRecordSaved,
+      _signal,
+      assertActionAuthority,
+    ) => {
+      assertActionAuthority();
       const parsedParallelism = Number.parseInt(parallelism, 10);
       const parsedArgs = agentArgs
         .split(",")
         .map((v) => v.trim())
         .filter((v) => v.length > 0);
-      // Model to persist — from the shared inherited-submission snapshot so a
-      // provider-backed inherit-transition carries the persona model (readiness
-      // requires one) and a deliberate local model still wins.
       const normalizedModel = inheritedSubmission.model;
 
-      // Harness pin resolution — see resolveAgentCommandUpdate for the full
-      // sentinel/pin/no-op contract, including the inherit→pin transition where
-      // the prefilled command equals the original but must still be pinned.
       const agentCommandUpdate = resolveAgentCommandUpdate({
         inheritHarness,
         agentCommand,
@@ -634,38 +660,21 @@ export function AgentInstanceEditDialog({
         agentCommandOverride: agent.agentCommandOverride ?? null,
       });
 
-      // Classify the effective post-submit runtime's provider capability as a
-      // tri-state: "capable" persists the provider, "locked" clears it (only
-      // when we KNOW it's provider-locked, e.g. Claude), "unknown" OMITS it so a
-      // transient/custom state never becomes a destructive write. Resolved
-      // STATICALLY (by id) so a not-yet-loaded catalog can't misclassify a known
-      // runtime as "unknown" — see resolveRuntimeProviderCapability. The runtime
-      // id is the shared prospectiveRuntimeId, so submit and the block-save gate
-      // always agree on which runtime is being saved.
       const providerRuntimeCapability = resolveRuntimeProviderCapability(
         prospectiveRuntimeId,
         runtimeSupportsLlmProviderSelection(prospectiveRuntimeId),
       );
 
-      // Provider + env to persist — the shared inherited-submission snapshot
-      // (same values the credential gate validates), so gate ↔ record ↔ spawn
-      // all agree. See resolveInheritedRuntimeSubmission.
       const normalizedSubmitProvider = inheritedSubmission.provider;
       const submitEnvVars = inheritedSubmission.envVars;
       const input: UpdateManagedAgentInput = {
         pubkey: agent.pubkey,
         name: name.trim() !== agent.name ? name.trim() : undefined,
-        // relayUrl deliberately never submitted: the legacy per-record pin is
-        // ignored (#2122) and the stored value is preserved as-is.
         acpCommand:
           acpCommand.trim() !== agent.acpCommand
             ? acpCommand.trim()
             : undefined,
         agentCommand: agentCommandUpdate,
-        // A non-inheriting selection is a deliberate pin — signal it so the
-        // backend preserves a Custom/runtime command even when it maps to the
-        // linked persona's own runtime (otherwise it would be dropped back to
-        // inherit). Omitted (falsy) when inheriting or on a name-only edit.
         harnessOverride:
           agentCommandUpdate != null ? !inheritHarness : undefined,
         agentArgs:
@@ -676,7 +685,6 @@ export function AgentInstanceEditDialog({
           parsedParallelism > 0 && parsedParallelism !== agent.parallelism
             ? parsedParallelism
             : undefined,
-        // Linked instances defer model/provider/systemPrompt to the definition.
         systemPrompt:
           linkedPersona != null
             ? undefined
@@ -689,11 +697,7 @@ export function AgentInstanceEditDialog({
             : normalizedModel !== (agent.model ?? null)
               ? normalizedModel
               : undefined,
-        // Tri-state provider persistence keyed on providerRuntimeCapability:
-        //   "capable"  → persist: value if changed, omit if unchanged.
-        //   "locked"   → clear: send null if provider was set, else omit.
-        //   "unknown"  → omit always (never send null for a transient state).
-        // llmProviderFieldVisible is for UX visibility only; not used here.
+        // Persist, clear, or omit by the named runtime-capability tri-state.
         provider:
           linkedPersona != null
             ? undefined
@@ -710,12 +714,6 @@ export function AgentInstanceEditDialog({
           ? undefined
           : submitEnvVars,
         respondTo: respondTo !== agent.respondTo ? respondTo : undefined,
-        // The allowlist is preserved across mode toggles in local UI state
-        // (so a user can flip away from allowlist and back without losing
-        // their entries), but we only send it on the wire when (a) it
-        // actually changed, AND (b) the saved mode will need it. Sending
-        // an allowlist while switching to a non-allowlist mode would be
-        // harmless server-side, but it's noise in the persisted record.
         respondToAllowlist:
           respondTo === "allowlist" &&
           respondToAllowlist.join(",") !== agent.respondToAllowlist.join(",")
@@ -723,29 +721,58 @@ export function AgentInstanceEditDialog({
             : undefined,
       };
 
-      const result = await updateMutation.mutateAsync(input);
-      if (autoRestartOnConfigChange !== agent.autoRestartOnConfigChange) {
-        // Standalone setter (mirrors start-on-app-launch) — not part of
-        // UpdateManagedAgentInput, so the frozen update shape stays frozen.
-        await setManagedAgentAutoRestart(
-          agent.pubkey,
-          autoRestartOnConfigChange,
-        );
+      const hasAgentUpdates = Object.entries(input).some(
+        ([key, value]) => key !== "pubkey" && value !== undefined,
+      );
+      let savedAgent = agent;
+      let profileSyncError: string | null = null;
+      if (hasAgentUpdates) {
+        const result = await updateMutation.mutateAsync(input);
+        savedAgent = result.agent;
+        profileSyncError = result.profileSyncError;
       }
-      showAgentProfileSyncWarning(result.agent.name, result.profileSyncError);
-      handleOpenChange(false);
-      onUpdated?.(result.agent);
-      // The auto-restart policy deliberately never fires for a stopped or
-      // failing agent (a broken agent must not auto-loop), so an edit meant
-      // to FIX one silently waits for a manual start. Offer that start
-      // explicitly instead of relying on the user to know the policy.
-      if (!isManagedAgentActive(result.agent)) {
-        const startedName = result.agent.name;
+      markRecordSaved();
+      // Persistence is already committed. Capture it before optional
+      // follow-up work so the parent is still notified when cancellation,
+      // auto-restart, or route revalidation interrupts the rapid action.
+      deferredUpdate.agent = savedAgent;
+      assertActionAuthority();
+      if (autoRestartOnConfigChange !== agent.autoRestartOnConfigChange) {
+        savedAgent = await autoRestartMutation.mutateAsync({
+          pubkey: agent.pubkey,
+          autoRestartOnConfigChange,
+        });
+        deferredUpdate.agent = savedAgent;
+        assertActionAuthority();
+      }
+      if (mode !== "save") {
+        await revalidateRapidPostSaveRoute({
+          savedAgent,
+          expectedRuntimeId: prospectiveRuntimeId,
+          expectedAgentCommand: agentCommand,
+          expectedAcpCommand: acpCommand,
+          refetchRuntimes: runtimesQuery.refetch,
+          refetchPersonas: personasQuery.refetch,
+        });
+        assertActionAuthority();
+      }
+      showAgentProfileSyncWarning(savedAgent.name, profileSyncError);
+      if (mode === "save") {
+        onUpdated?.(savedAgent);
+        deferredUpdate.agent = null;
+      } else {
+        // Keep the dialog mounted through restart, Ready polling, smoke
+        // publication, and thread navigation. Notifying the parent here can
+        // close the dialog and abort the post-save workflow before it sends.
+        deferredUpdate.agent = savedAgent;
+      }
+      if (mode === "save" && !isManagedAgentActive(savedAgent)) {
+        const startedName = savedAgent.name;
         toast(`${startedName} saved while stopped.`, {
           action: {
             label: "Start now",
             onClick: () => {
-              startMutation.mutate(result.agent.pubkey, {
+              startMutation.mutate(savedAgent.pubkey, {
                 onSuccess: () => toast.success(`${startedName} started.`),
                 onError: (error) =>
                   toast.error(
@@ -758,8 +785,11 @@ export function AgentInstanceEditDialog({
           },
         });
       }
-    } catch {
-      // React Query stores the error; keep dialog open and render it inline.
+      return savedAgent;
+    };
+    await rapidIteration.run(mode, saveAgent);
+    if (deferredUpdate.agent) {
+      onUpdated?.(deferredUpdate.agent);
     }
   }
 
@@ -842,6 +872,10 @@ export function AgentInstanceEditDialog({
   const advancedFieldsTransition = shouldReduceMotion
     ? { duration: 0 }
     : ADVANCED_FIELDS_MOTION_TRANSITION;
+  const submitError =
+    (updateMutation.error instanceof Error
+      ? "Could not save the managed agent changes."
+      : null) ?? rapidIteration.error;
 
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
@@ -853,24 +887,17 @@ export function AgentInstanceEditDialog({
         headerClassName="pb-2"
         title={`Edit ${agent.name}`}
         footer={
-          <div className="flex w-full items-center justify-end gap-2">
-            <Button
-              disabled={updateMutation.isPending || isAvatarUploadPending}
-              onClick={() => handleOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              data-testid="edit-agent-dialog-submit"
-              disabled={!canSubmit}
-              onClick={() => void handleSubmit()}
-              type="button"
-            >
-              {updateMutation.isPending ? "Saving..." : "Save changes"}
-            </Button>
-          </div>
+          <AgentRapidActionsFooter
+            canSubmit={canSubmit}
+            canRestart={rapidIteration.canRestart}
+            canSmoke={rapidIteration.canSmoke}
+            hasRapidTestSelection={rapidIteration.selection !== null}
+            isAvatarUploadPending={isAvatarUploadPending}
+            isSubmitPending={isSubmitPending}
+            onCancel={() => handleOpenChange(false)}
+            onSubmit={(mode) => void handleSubmit(mode)}
+            rapidAction={rapidIteration.action}
+          />
         }
       >
         <div className="grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
@@ -925,7 +952,7 @@ export function AgentInstanceEditDialog({
                     "h-8 px-0 py-0 leading-6",
                     PERSONA_FIELD_CONTROL_CLASS,
                   )}
-                  disabled={updateMutation.isPending}
+                  disabled={isSubmitPending}
                   id="edit-agent-name"
                   onChange={(event) => setName(event.target.value)}
                   placeholder="Agent name"
@@ -937,7 +964,7 @@ export function AgentInstanceEditDialog({
             {/* Who can send instructions */}
             <CreateAgentRespondToField
               allowlist={respondToAllowlist}
-              disabled={updateMutation.isPending}
+              disabled={isSubmitPending}
               mode={respondTo}
               onAllowlistChange={setRespondToAllowlist}
               onModeChange={setRespondTo}
@@ -955,7 +982,7 @@ export function AgentInstanceEditDialog({
                 Provider
               </label>
               <PersonaDropdownField
-                disabled={updateMutation.isPending}
+                disabled={isSubmitPending}
                 id="edit-agent-runtime"
                 onValueChange={handleRuntimeDropdownChange}
                 options={runtimeDropdownOptions}
@@ -998,7 +1025,7 @@ export function AgentInstanceEditDialog({
                       "h-8 px-0 py-0 leading-6",
                       PERSONA_FIELD_CONTROL_CLASS,
                     )}
-                    disabled={updateMutation.isPending}
+                    disabled={isSubmitPending}
                     id="edit-agent-command"
                     onChange={(event) => setAgentCommand(event.target.value)}
                     placeholder="Full path or shell command"
@@ -1026,7 +1053,7 @@ export function AgentInstanceEditDialog({
                   )}
                 </label>
                 <PersonaDropdownField
-                  disabled={updateMutation.isPending}
+                  disabled={isSubmitPending}
                   id="edit-agent-llm-provider"
                   onValueChange={handleProviderDropdownChange}
                   options={providerDropdownOptions}
@@ -1047,7 +1074,7 @@ export function AgentInstanceEditDialog({
                         "h-8 px-0 py-0 leading-6",
                         PERSONA_FIELD_CONTROL_CLASS,
                       )}
-                      disabled={updateMutation.isPending}
+                      disabled={isSubmitPending}
                       id="edit-agent-custom-provider"
                       onChange={(event) => setProvider(event.target.value)}
                       placeholder="Custom provider ID"
@@ -1060,7 +1087,7 @@ export function AgentInstanceEditDialog({
 
             {llmProviderFieldVisible && topLevelSecretEnvVar ? (
               <PersonaProviderApiKeyField
-                disabled={updateMutation.isPending}
+                disabled={isSubmitPending}
                 envVarName={topLevelSecretEnvVar}
                 isInherited={apiKeyIsInherited}
                 inheritedLabel={apiKeyInheritedLabel}
@@ -1092,7 +1119,7 @@ export function AgentInstanceEditDialog({
                 )}
               </label>
               <PersonaDropdownField
-                disabled={updateMutation.isPending || modelDiscoveryLoading}
+                disabled={isSubmitPending || modelDiscoveryLoading}
                 id="edit-agent-model"
                 onValueChange={handleModelDropdownChange}
                 options={modelDropdownOptions}
@@ -1113,7 +1140,7 @@ export function AgentInstanceEditDialog({
                       "h-8 px-0 py-0 leading-6",
                       PERSONA_FIELD_CONTROL_CLASS,
                     )}
-                    disabled={updateMutation.isPending}
+                    disabled={isSubmitPending}
                     id="edit-agent-custom-model"
                     onChange={(event) => setModel(event.target.value)}
                     placeholder="Custom model ID"
@@ -1141,6 +1168,18 @@ export function AgentInstanceEditDialog({
               onOpenChange={setAiDefaultsOpen}
               open={aiDefaultsOpen}
               returnFocusRef={aiDefaultsTriggerRef}
+            />
+
+            <AgentRapidTestPanel
+              agent={agent}
+              disabled={isSubmitPending}
+              logContent={rapidIteration.logContent}
+              logError={rapidIteration.logError}
+              logLoading={rapidIteration.logLoading}
+              onSelectionChange={rapidIteration.setSelection}
+              open={open}
+              runtime={rapidIteration.runtime}
+              runtimeControlsAvailable={rapidIteration.canRestart}
             />
 
             {/* Advanced settings */}
@@ -1178,7 +1217,7 @@ export function AgentInstanceEditDialog({
                       acpCommand={acpCommand}
                       agentArgs={agentArgs}
                       autoRestartOnConfigChange={autoRestartOnConfigChange}
-                      disabled={updateMutation.isPending}
+                      disabled={isSubmitPending}
                       envVars={envVars}
                       fileSatisfiedEnvKeys={fileSatisfiedEnvKeys}
                       hiddenEnvKeys={
@@ -1214,10 +1253,8 @@ export function AgentInstanceEditDialog({
             </div>
 
             {/* Error */}
-            {updateMutation.error instanceof Error ? (
-              <p className="text-sm text-destructive">
-                {updateMutation.error.message}
-              </p>
+            {submitError ? (
+              <p className="text-sm text-destructive">{submitError}</p>
             ) : null}
           </div>
         </div>

--- a/desktop/src/features/agents/ui/AgentRapidActionsFooter.tsx
+++ b/desktop/src/features/agents/ui/AgentRapidActionsFooter.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/shared/ui/button";
+
+import type { RapidSaveMode } from "./agentRapidTest";
+
+export function AgentRapidActionsFooter({
+  canSubmit,
+  canRestart,
+  canSmoke,
+  hasRapidTestSelection,
+  isAvatarUploadPending,
+  isSubmitPending,
+  rapidAction,
+  onCancel,
+  onSubmit,
+}: {
+  canSubmit: boolean;
+  canRestart: boolean;
+  canSmoke: boolean;
+  hasRapidTestSelection: boolean;
+  isAvatarUploadPending: boolean;
+  isSubmitPending: boolean;
+  rapidAction: RapidSaveMode | null;
+  onCancel: () => void;
+  onSubmit: (mode: RapidSaveMode) => void;
+}) {
+  return (
+    <div
+      aria-busy={isSubmitPending}
+      className="flex w-full flex-wrap items-center justify-end gap-2"
+    >
+      <Button
+        disabled={isAvatarUploadPending}
+        onClick={onCancel}
+        type="button"
+        variant="outline"
+      >
+        Cancel
+      </Button>
+      <Button
+        data-testid="edit-agent-dialog-submit"
+        disabled={!canSubmit}
+        onClick={() => onSubmit("save")}
+        type="button"
+        variant="outline"
+      >
+        {rapidAction === "save" ? "Saving..." : "Save changes"}
+      </Button>
+      <Button
+        data-testid="edit-agent-dialog-restart"
+        disabled={!canSubmit || !canRestart}
+        onClick={() => onSubmit("restart")}
+        type="button"
+        variant="outline"
+      >
+        {rapidAction === "restart" ? "Restarting..." : "Save & restart"}
+      </Button>
+      <Button
+        data-testid="edit-agent-dialog-smoke"
+        disabled={!canSubmit || !canSmoke || !hasRapidTestSelection}
+        onClick={() => onSubmit("smoke")}
+        type="button"
+      >
+        {rapidAction === "smoke" ? "Posting test..." : "Save, restart & test"}
+      </Button>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/AgentRapidTestPanel.tsx
+++ b/desktop/src/features/agents/ui/AgentRapidTestPanel.tsx
@@ -1,0 +1,333 @@
+import * as React from "react";
+
+import { useChannelsQuery } from "@/features/channels/hooks";
+import type {
+  Channel,
+  ManagedAgent,
+  ManagedAgentRuntimeStatus,
+} from "@/shared/api/types";
+
+import { ManagedAgentLogPanel } from "./ManagedAgentLogPanel";
+import {
+  buildRapidTestPrompt,
+  createSmokeId,
+  filterEligibleRapidTestChannels,
+  pickDefaultRapidTestChannelId,
+  type RapidTestSelection,
+} from "./agentRapidTest";
+
+/**
+ * Compact, low-glare surface for the in-app rapid agent smoke test.
+ *
+ * The panel never sends the smoke message itself — submission is owned by the
+ * parent workflow (Save / restart / test), which composes the owner-authored
+ * message (via `buildRapidTestPrompt`) and posts it through the same channel
+ * send path as any other owner message. The panel only:
+ *
+ *   - Queries channels *only while open* (no idle network).
+ *   - Filters down to channels that already contain the managed agent, so the
+ *     smoke test always reaches the agent it claims to test.
+ *   - Preserves the user's last valid default across refetches, but switches
+ *     to a different eligible channel when the previous default becomes
+ *     invalid (e.g. the agent was removed from the channel).
+ *   - Exposes the selected channel id through `onChannelChange` so the parent
+ *     can wire Save/restart/test to the right target.
+ *   - Renders no-channel / loading / query-error states inline.
+ *
+ * The smoke id is minted lazily per opening and stays stable until the panel
+ * closes so the rendered prompt and the posted message stay in sync.
+ */
+
+export type AgentRapidTestPanelProps = {
+  agent: ManagedAgent | null;
+  disabled?: boolean;
+  /** Whether the panel is currently open. Channels are only queried when true. */
+  open: boolean;
+  /**
+   * Notifies the parent whenever the selected eligible channel id changes.
+   * Called with `null` when no eligible channel is available, so the parent
+   * can disable Save/restart/test accordingly.
+   */
+  onSelectionChange?: (selection: RapidTestSelection | null) => void;
+  /**
+   * Optional override for the channel list (e.g. from parent-owned cached
+   * data). When provided, the panel skips the channel query entirely while
+   * still honouring `open` as the data source toggle.
+   */
+  channels?: readonly Channel[];
+  /** Current pair status for the active community, when the agent is local. */
+  runtime?: ManagedAgentRuntimeStatus | null;
+  /** Bounded, backend-redacted log tail for the selected local agent. */
+  logContent?: string | null;
+  logError?: Error | null;
+  logLoading?: boolean;
+  /** Remote/provider-backed agents can still be edited, but not restarted here. */
+  runtimeControlsAvailable?: boolean;
+};
+
+export function AgentRapidTestPanel({
+  agent,
+  disabled = false,
+  open,
+  onSelectionChange,
+  channels: channelsOverride,
+  runtime = null,
+  logContent = null,
+  logError = null,
+  logLoading = false,
+  runtimeControlsAvailable = false,
+}: AgentRapidTestPanelProps) {
+  const channelsQuery = useChannelsQuery({
+    enabled: open && channelsOverride === undefined,
+  });
+  const channels = channelsOverride ?? channelsQuery.data ?? [];
+
+  const eligibleChannels = React.useMemo(
+    () => filterEligibleRapidTestChannels(channels, agent),
+    [channels, agent],
+  );
+
+  const [selectedChannelId, setSelectedChannelId] = React.useState<
+    string | null
+  >(null);
+
+  // The panel holds one smoke id so its rendered preview and posted prompt stay
+  // identical throughout a single open run.
+  const [smokeId, setSmokeId] = React.useState<string | null>(null);
+
+  // Reopening or switching agents starts a fresh correlated smoke run. Reset
+  // effects intentionally run before the seed effect below so an initial mount
+  // cannot clear the id after it is created in the same passive-effect batch.
+  React.useEffect(() => {
+    if (!open) {
+      setSelectedChannelId(null);
+      setSmokeId(null);
+    }
+  }, [open]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Agent identity is an intentional reset trigger.
+  React.useEffect(() => {
+    setSelectedChannelId(null);
+    setSmokeId(null);
+  }, [agent?.pubkey]);
+
+  // Seed the smoke id once on first successful eligible selection so the
+  // value the panel renders and the value the parent posts stay identical.
+  React.useEffect(() => {
+    if (smokeId) {
+      return;
+    }
+    if (!open) {
+      return;
+    }
+    if (eligibleChannels.length === 0) {
+      return;
+    }
+    setSmokeId(createSmokeId());
+  }, [smokeId, open, eligibleChannels.length]);
+
+  // Resolve the current selection, preserving the user's previous valid pick
+  // and falling back to the first eligible channel when needed.
+  const resolvedChannelId = React.useMemo(
+    () => pickDefaultRapidTestChannelId(eligibleChannels, selectedChannelId),
+    [eligibleChannels, selectedChannelId],
+  );
+
+  // Keep local state aligned with the resolved id so the next memo recomputes
+  // from a stable baseline (and so the user's pick survives a refetch).
+  React.useEffect(() => {
+    if (resolvedChannelId !== selectedChannelId) {
+      setSelectedChannelId(resolvedChannelId);
+    }
+  }, [resolvedChannelId, selectedChannelId]);
+
+  const selectedChannel = React.useMemo(
+    () =>
+      resolvedChannelId
+        ? (eligibleChannels.find((c) => c.id === resolvedChannelId) ?? null)
+        : null,
+    [eligibleChannels, resolvedChannelId],
+  );
+
+  const promptPreview = React.useMemo(
+    () => (smokeId ? buildRapidTestPrompt({ smokeId }) : null),
+    [smokeId],
+  );
+  const selection = React.useMemo<RapidTestSelection | null>(
+    () =>
+      resolvedChannelId && promptPreview && selectedChannel
+        ? {
+            channel: selectedChannel,
+            channelId: resolvedChannelId,
+            prompt: promptPreview,
+          }
+        : null,
+    [promptPreview, resolvedChannelId, selectedChannel],
+  );
+
+  React.useEffect(() => {
+    if (open) {
+      onSelectionChange?.(selection);
+    }
+  }, [onSelectionChange, open, selection]);
+
+  const handleSelectChannel = React.useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedChannelId(event.target.value || null);
+    },
+    [],
+  );
+
+  // ---- Render helpers --------------------------------------------------
+
+  let body: React.ReactNode;
+  if (!open) {
+    return null;
+  }
+
+  const runtimeLabel = runtime?.lifecycle
+    ? runtime.lifecycle[0].toUpperCase() + runtime.lifecycle.slice(1)
+    : "Not started";
+  const runtimeFailure =
+    runtime?.lifecycle === "failed"
+      ? "Runtime reported a failure. Inspect the bounded log tail below."
+      : runtime?.lifecycle === "stopped"
+        ? "Runtime is stopped. Save & restart will start only this agent pair."
+        : null;
+
+  if (channelsQuery.isLoading && !channelsOverride) {
+    body = <p className="text-xs text-muted-foreground">Loading channels…</p>;
+  } else if (channelsQuery.error instanceof Error && !channelsOverride) {
+    body = (
+      <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+        Could not load eligible channels for the active community.
+      </p>
+    );
+  } else if (eligibleChannels.length === 0) {
+    body = (
+      <p className="text-xs text-muted-foreground">
+        No eligible channels. Add this agent to a channel (DMs are allowed) and
+        try again.
+      </p>
+    );
+  } else {
+    body = (
+      <div className="space-y-1.5">
+        <label
+          className="text-sm font-medium"
+          htmlFor="agent-rapid-test-channel"
+        >
+          Channel
+        </label>
+        <select
+          className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs"
+          data-testid="agent-rapid-test-channel"
+          disabled={disabled}
+          id="agent-rapid-test-channel"
+          onChange={handleSelectChannel}
+          value={resolvedChannelId ?? ""}
+        >
+          {eligibleChannels.map((channel) => (
+            <option key={channel.id} value={channel.id}>
+              {channel.name} · {channel.channelType}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground">
+          Only channels where you are a member and the agent is already a member
+          are listed. DMs are allowed.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Rapid agent smoke test"
+      className="space-y-3 rounded-2xl border border-border/70 bg-muted/20 p-4"
+    >
+      <header className="space-y-1">
+        <p className="text-sm font-semibold tracking-tight">
+          Rapid agent smoke test
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Save updates the selected agent. Save & restart applies the change to
+          this local pair. Save, restart & test additionally posts a visible
+          message authored as the owner in the selected channel and opens its
+          thread. The{" "}
+          <code className="rounded bg-background/80 px-1 py-0.5 text-[11px]">
+            BUZZ_HERMES_OK
+          </code>{" "}
+          directive is the only token the agent must echo back; no env values or
+          secrets are embedded. Other members of that channel will see the
+          labelled test message.
+        </p>
+      </header>
+
+      <section
+        aria-label="Managed agent runtime status"
+        className="space-y-1 rounded-xl border border-border/70 bg-background/60 px-3 py-2"
+      >
+        <div className="flex items-center justify-between gap-3 text-xs">
+          <span className="font-medium">Runtime status</span>
+          <span
+            className="rounded-full bg-muted px-2 py-0.5 font-medium"
+            data-testid="agent-rapid-runtime-status"
+          >
+            {runtimeLabel}
+          </span>
+        </div>
+        {!runtimeControlsAvailable ? (
+          <p className="text-xs text-muted-foreground">
+            Restart and smoke testing are available only for local agents in the
+            active community.
+          </p>
+        ) : runtimeFailure ? (
+          <p className="text-xs text-destructive">{runtimeFailure}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Save changes, restart this pair, or post a labelled owner-authored
+            smoke prompt from the footer.
+          </p>
+        )}
+      </section>
+
+      {body}
+
+      {selectedChannel && promptPreview ? (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">
+            Smoke prompt preview
+          </p>
+          <pre className="max-h-40 overflow-auto rounded-xl border border-border/70 bg-background/80 px-3 py-2 text-[11px] leading-snug text-foreground">
+            {promptPreview.body}
+          </pre>
+          <p className="text-[11px] text-muted-foreground">
+            Smoke id:{" "}
+            <code className="rounded bg-background/80 px-1 py-0.5">
+              {promptPreview.smokeId}
+            </code>
+          </p>
+        </div>
+      ) : null}
+
+      {runtimeControlsAvailable ? (
+        <details className="rounded-xl border border-border/60 bg-background/70 p-3">
+          <summary className="cursor-pointer text-xs font-medium text-foreground">
+            Recent harness log
+          </summary>
+          <div className="mt-3 max-h-64 overflow-auto">
+            <ManagedAgentLogPanel
+              chrome="bare"
+              error={logError}
+              isLoading={logLoading}
+              logContent={logContent}
+              selectedAgent={agent}
+              variant="inline"
+            />
+          </div>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/desktop/src/features/agents/ui/agentRapidTest.test.mjs
+++ b/desktop/src/features/agents/ui/agentRapidTest.test.mjs
@@ -1,0 +1,432 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BUZZ_HERMES_OK_PREFIX,
+  RapidPostSaveRouteError,
+  assertRapidPostSaveRoute,
+  buildRapidTestPrompt,
+  createSmokeId,
+  filterEligibleRapidTestChannels,
+  pickDefaultRapidTestChannelId,
+  revalidateRapidPostSaveRoute,
+  runRapidAgentPostSaveAction,
+} from "./agentRapidTest.ts";
+
+const PUB_A = "a".repeat(64);
+const PUB_B = "b".repeat(64);
+
+function makeChannel(overrides = {}) {
+  return {
+    id: "channel-1",
+    name: "general",
+    channelType: "stream",
+    visibility: "open",
+    description: "",
+    topic: null,
+    purpose: null,
+    memberCount: 2,
+    memberPubkeys: [],
+    lastMessageAt: null,
+    archivedAt: null,
+    participants: [],
+    participantPubkeys: [],
+    isMember: true,
+    ttlSeconds: null,
+    ttlDeadline: null,
+    ...overrides,
+  };
+}
+
+test("filterEligibleRapidTestChannels keeps joined, non-archived channels that contain the agent (DMs allowed)", () => {
+  const dmChannel = makeChannel({
+    id: "dm-1",
+    name: "agent-chat",
+    channelType: "dm",
+    participantPubkeys: [PUB_A, PUB_B],
+  });
+  const streamChannel = makeChannel({
+    id: "stream-1",
+    name: "ops",
+    channelType: "stream",
+    participantPubkeys: [PUB_A, PUB_B],
+  });
+  const forumChannel = makeChannel({
+    id: "forum-1",
+    name: "announcements",
+    channelType: "forum",
+    participantPubkeys: [PUB_A, PUB_B],
+  });
+  const archivedChannel = makeChannel({
+    id: "arch-1",
+    name: "old",
+    channelType: "stream",
+    archivedAt: "2024-01-01T00:00:00Z",
+    participantPubkeys: [PUB_A, PUB_B],
+  });
+  const notJoinedChannel = makeChannel({
+    id: "leave-1",
+    name: "left",
+    channelType: "stream",
+    isMember: false,
+    participantPubkeys: [PUB_A, PUB_B],
+  });
+  const agentMissingChannel = makeChannel({
+    id: "no-agent-1",
+    name: "solo",
+    channelType: "stream",
+    participantPubkeys: [PUB_B],
+  });
+
+  const result = filterEligibleRapidTestChannels(
+    [
+      dmChannel,
+      streamChannel,
+      forumChannel,
+      archivedChannel,
+      notJoinedChannel,
+      agentMissingChannel,
+    ],
+    { pubkey: PUB_A },
+  );
+
+  assert.deepEqual(
+    result.map((c) => c.id),
+    ["dm-1", "stream-1"],
+  );
+});
+
+test("filterEligibleRapidTestChannels is case-insensitive and tolerates whitespace in pubkeys", () => {
+  const channel = makeChannel({
+    participantPubkeys: [`  ${PUB_A.toUpperCase()}  `],
+  });
+
+  const result = filterEligibleRapidTestChannels([channel], { pubkey: PUB_A });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, channel.id);
+});
+
+test("filterEligibleRapidTestChannels falls back to memberPubkeys when participantPubkeys is absent", () => {
+  const channel = makeChannel({
+    id: "legacy-1",
+    memberPubkeys: [PUB_A, PUB_B],
+    participantPubkeys: [],
+  });
+
+  const result = filterEligibleRapidTestChannels([channel], { pubkey: PUB_A });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "legacy-1");
+});
+
+test("filterEligibleRapidTestChannels returns empty when channels or agent missing", () => {
+  assert.deepEqual(
+    filterEligibleRapidTestChannels(undefined, { pubkey: PUB_A }),
+    [],
+  );
+  assert.deepEqual(filterEligibleRapidTestChannels([makeChannel()], null), []);
+  assert.deepEqual(
+    filterEligibleRapidTestChannels([makeChannel()], undefined),
+    [],
+  );
+});
+
+test("pickDefaultRapidTestChannelId returns null when nothing eligible", () => {
+  assert.equal(pickDefaultRapidTestChannelId([], "any"), null);
+  assert.equal(pickDefaultRapidTestChannelId([], null), null);
+});
+
+test("pickDefaultRapidTestChannelId preserves a still-eligible selection", () => {
+  const channels = [makeChannel({ id: "a" }), makeChannel({ id: "b" })];
+
+  assert.equal(pickDefaultRapidTestChannelId(channels, "b"), "b");
+});
+
+test("pickDefaultRapidTestChannelId falls back to first eligible when current is invalid", () => {
+  const channels = [makeChannel({ id: "a" }), makeChannel({ id: "b" })];
+
+  assert.equal(pickDefaultRapidTestChannelId(channels, "missing"), "a");
+  assert.equal(pickDefaultRapidTestChannelId(channels, null), "a");
+});
+
+test("createSmokeId is unique, short, and safe to place after the reply prefix", () => {
+  const ids = new Set();
+  for (let i = 0; i < 25; i += 1) {
+    ids.add(createSmokeId());
+  }
+  assert.equal(ids.size, 25, "smoke ids must be unique across 25 draws");
+
+  for (const id of ids) {
+    assert.match(id, /^[0-9a-z]{8}$/);
+    assert.ok(!id.includes(BUZZ_HERMES_OK_PREFIX), id);
+  }
+});
+
+test("createSmokeId accepts an injected random source for deterministic tests", () => {
+  const fake = {
+    randomValues: (buffer) => {
+      for (let i = 0; i < buffer.length; i += 1) {
+        buffer[i] = i;
+      }
+      return buffer;
+    },
+  };
+
+  const a = createSmokeId(fake);
+  const b = createSmokeId(fake);
+
+  assert.equal(a, b);
+  assert.equal(a, "01234567");
+});
+
+test("buildRapidTestPrompt is deterministic for the same inputs and labels the smoke id", () => {
+  const at = new Date("2025-01-01T00:00:00.000Z");
+  const a = buildRapidTestPrompt({ smokeId: "token_1", generatedAt: at });
+  const b = buildRapidTestPrompt({ smokeId: "token_1", generatedAt: at });
+
+  assert.equal(a.body, b.body);
+  assert.match(a.body, /\[buzz-hermes-smoke\]/);
+  assert.match(a.body, /BUZZ_HERMES_OK token_1/);
+  assert.match(a.body, /smoke id: token_1/);
+  assert.match(a.body, /generated at: 2025-01-01T00:00:00Z/);
+  assert.ok(
+    !a.body.toLowerCase().includes("nsec") &&
+      !a.body.toLowerCase().includes("api_key") &&
+      !a.body.toLowerCase().includes("password"),
+    "must not embed secret markers",
+  );
+});
+
+test("buildRapidTestPrompt falls back to 'unknown' for invalid dates", () => {
+  const prompt = buildRapidTestPrompt({
+    smokeId: "token_x",
+    generatedAt: "not-a-date",
+  });
+
+  assert.match(prompt.body, /generated at: unknown/);
+});
+
+const ROUTE_AGENT = {
+  runtime: "hermes-buzz-mcp",
+  agentCommand: "C:\\tools\\hermes-acp.exe",
+  acpCommand: "C:\\tools\\buzz-acp.exe",
+};
+
+function assertRoute(overrides = {}) {
+  return assertRapidPostSaveRoute({
+    savedAgent: ROUTE_AGENT,
+    savedRuntimeId: "hermes-buzz-mcp",
+    expectedRuntimeId: "hermes-buzz-mcp",
+    expectedAgentCommand: "C:/tools/hermes-acp.exe",
+    expectedAcpCommand: "C:/tools/buzz-acp.exe",
+    catalogRuntimeCommand: "C:/tools/hermes-acp.exe",
+    ...overrides,
+  });
+}
+
+test("assertRapidPostSaveRoute accepts the persisted selected route", () => {
+  assert.doesNotThrow(() => assertRoute());
+});
+
+test("assertRapidPostSaveRoute rejects a persisted runtime drift", () => {
+  assert.throws(
+    () => assertRoute({ savedRuntimeId: "codex" }),
+    /persisted runtime changed/,
+  );
+});
+
+test("assertRapidPostSaveRoute accepts a caller-resolved inherited runtime", () => {
+  assert.doesNotThrow(() => assertRoute({ savedRuntimeId: "hermes-buzz-mcp" }));
+});
+
+test("assertRapidPostSaveRoute accepts an explicit custom command without a catalog entry", () => {
+  assert.doesNotThrow(() =>
+    assertRoute({
+      savedRuntimeId: "custom",
+      expectedRuntimeId: "custom",
+      catalogRuntimeCommand: null,
+      catalogRequired: false,
+    }),
+  );
+});
+
+test("assertRapidPostSaveRoute throws the typed fail-closed error", () => {
+  assert.throws(
+    () => assertRoute({ savedRuntimeId: "codex" }),
+    RapidPostSaveRouteError,
+  );
+});
+
+test("revalidateRapidPostSaveRoute resolves an inherited runtime from a fresh persona", async () => {
+  await assert.doesNotReject(() =>
+    revalidateRapidPostSaveRoute({
+      savedAgent: { ...ROUTE_AGENT, runtime: null, personaId: "persona-1" },
+      expectedRuntimeId: "hermes-buzz-mcp",
+      expectedAgentCommand: "C:/tools/hermes-acp.exe",
+      expectedAcpCommand: "C:/tools/buzz-acp.exe",
+      refetchRuntimes: async () => ({
+        data: [{ id: "hermes-buzz-mcp", command: "C:/tools/hermes-acp.exe" }],
+        isError: false,
+      }),
+      refetchPersonas: async () => ({
+        data: [{ id: "persona-1", runtime: "hermes-buzz-mcp" }],
+        isError: false,
+      }),
+    }),
+  );
+});
+
+test("revalidateRapidPostSaveRoute fails closed when catalog refresh fails", async () => {
+  await assert.rejects(
+    () =>
+      revalidateRapidPostSaveRoute({
+        savedAgent: {
+          ...ROUTE_AGENT,
+          runtime: "hermes-buzz-mcp",
+          personaId: null,
+        },
+        expectedRuntimeId: "hermes-buzz-mcp",
+        expectedAgentCommand: "C:/tools/hermes-acp.exe",
+        expectedAcpCommand: "C:/tools/buzz-acp.exe",
+        refetchRuntimes: async () => ({ data: undefined, isError: true }),
+        refetchPersonas: async () => ({ data: undefined, isError: false }),
+      }),
+    RapidPostSaveRouteError,
+  );
+});
+
+test("assertRapidPostSaveRoute rejects a missing catalog route", () => {
+  assert.throws(
+    () => assertRoute({ catalogRuntimeCommand: null }),
+    /saved harness route changed/,
+  );
+});
+
+test("assertRapidPostSaveRoute rejects saved harness command drift", () => {
+  assert.throws(
+    () =>
+      assertRoute({
+        savedAgent: { ...ROUTE_AGENT, agentCommand: "codex-acp.exe" },
+      }),
+    /saved harness route changed/,
+  );
+});
+
+test("assertRapidPostSaveRoute rejects catalog harness command drift", () => {
+  assert.throws(
+    () => assertRoute({ catalogRuntimeCommand: "codex-acp.exe" }),
+    /saved harness route changed/,
+  );
+});
+
+test("assertRapidPostSaveRoute rejects ACP sidecar drift", () => {
+  assert.throws(
+    () =>
+      assertRoute({
+        savedAgent: { ...ROUTE_AGENT, acpCommand: "C:/tools/other-acp.exe" },
+      }),
+    /saved ACP sidecar changed/,
+  );
+});
+
+test("runRapidAgentPostSaveAction restarts before owner send and opens the returned root thread", async () => {
+  const calls = [];
+  const prompt = buildRapidTestPrompt({
+    smokeId: "smoke123",
+    generatedAt: "2025-01-01T00:00:00Z",
+  });
+  const channel = makeChannel({ id: "channel-1" });
+
+  const outcome = await runRapidAgentPostSaveAction({
+    mode: "smoke",
+    pubkey: PUB_A,
+    relayUrl: "wss://relay.example",
+    selection: { channel, channelId: channel.id, prompt },
+    restart: async (pubkey, relayUrl) => {
+      calls.push(["restart", pubkey, relayUrl]);
+    },
+    waitForReady: async () => {
+      calls.push(["ready"]);
+    },
+    sendOwnerMessage: async (targetChannel, content, mentionPubkeys) => {
+      calls.push(["send", targetChannel.id, content, mentionPubkeys]);
+      return { eventId: "event-1" };
+    },
+    openThread: async (channelId, eventId) => {
+      calls.push(["open", channelId, eventId]);
+    },
+  });
+
+  assert.equal(outcome.kind, "smoke-posted");
+  assert.equal(outcome.threadOpened, true);
+  assert.deepEqual(
+    calls.map(([name]) => name),
+    ["restart", "ready", "send", "open"],
+  );
+  assert.deepEqual(calls[2][3], [PUB_A]);
+  assert.match(calls[2][2], /BUZZ_HERMES_OK smoke123/);
+  assert.deepEqual(calls[3], ["open", "channel-1", "event-1"]);
+});
+
+test("runRapidAgentPostSaveAction preserves a posted event when thread navigation fails", async () => {
+  let sends = 0;
+  const channel = makeChannel({ id: "channel-1" });
+  const outcome = await runRapidAgentPostSaveAction({
+    mode: "smoke",
+    pubkey: PUB_A,
+    relayUrl: "wss://relay.example",
+    selection: {
+      channel,
+      channelId: channel.id,
+      prompt: buildRapidTestPrompt({
+        smokeId: "smoke456",
+        generatedAt: "2025-01-01T00:00:00Z",
+      }),
+    },
+    restart: async () => {},
+    sendOwnerMessage: async () => {
+      sends += 1;
+      return { eventId: "event-2" };
+    },
+    openThread: async () => {
+      throw new Error("navigation failed");
+    },
+  });
+
+  assert.equal(sends, 1);
+  assert.deepEqual(outcome, {
+    kind: "smoke-posted",
+    channelId: "channel-1",
+    eventId: "event-2",
+    threadOpened: false,
+  });
+});
+
+test("runRapidAgentPostSaveAction does not send for save or restart-only modes", async () => {
+  const calls = [];
+  const dependencies = {
+    pubkey: PUB_A,
+    relayUrl: "wss://relay.example",
+    selection: null,
+    restart: async () => calls.push("restart"),
+    sendOwnerMessage: async () => {
+      calls.push("send");
+      return { eventId: "unexpected" };
+    },
+    openThread: async () => calls.push("open"),
+  };
+
+  assert.equal(
+    await runRapidAgentPostSaveAction({ mode: "save", ...dependencies }),
+    null,
+  );
+  assert.deepEqual(calls, []);
+
+  const restarted = await runRapidAgentPostSaveAction({
+    mode: "restart",
+    ...dependencies,
+  });
+  assert.equal(restarted.kind, "restarted");
+  assert.deepEqual(calls, ["restart"]);
+});

--- a/desktop/src/features/agents/ui/agentRapidTest.ts
+++ b/desktop/src/features/agents/ui/agentRapidTest.ts
@@ -1,0 +1,424 @@
+/**
+ * Pure helpers for the in-app rapid agent smoke workflow.
+ *
+ * The rapid smoke test (Buzz Hermes) lets an owner verify that a managed agent
+ * is reachable end-to-end in a channel: Save/restart/test → owner-authored
+ * visible message in the chosen channel → agent opens/responds in its thread.
+ * This module is intentionally side-effect-free so the same helpers can run in
+ * tests, the panel, and the integration that actually posts the owner message.
+ *
+ * No env values, secrets, tokens, or relay URLs are interpolated into the
+ * generated prompt. The only token the agent needs to recognise is the smoke
+ * id, which is short, uniquely random, and self-contained.
+ */
+
+import type { Channel, ManagedAgent } from "../../../shared/api/types.ts";
+import { normalizePubkey } from "../../../shared/lib/pubkey.ts";
+
+/**
+ * Sentinel token the agent must echo back to prove the round-trip worked.
+ * The trailing `<id>` slot is filled by `createSmokeId()`.
+ */
+export const BUZZ_HERMES_OK_PREFIX = "BUZZ_HERMES_OK";
+
+/**
+ * Length of the random suffix appended to smoke prompts. Eight base36 chars
+ * give ~41 bits of entropy — enough to keep collisions vanishingly unlikely
+ * across a single device's session without making the prompt unreadable.
+ */
+const SMOKE_ID_RANDOM_SUFFIX_LENGTH = 8;
+
+/**
+ * Alphabet we draw from when minting a smoke id. Lowercase ASCII alphanumerics
+ * only, so the id is safe to embed in chat content without escaping and will
+ * not collide with whitespace/markdown tokenisation.
+ */
+const SMOKE_ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Filter a channel list down to the channels that are eligible for a rapid
+ * smoke test. A channel is eligible when:
+ *
+ *   1. The current desktop user is a member (`channel.isMember`).
+ *   2. The channel is not archived (`archivedAt` is null).
+ *   3. The channel already contains the managed agent's pubkey.
+ *      `participantPubkeys` is the canonical surface for "agent is in this
+ *      channel" (combines `memberPubkeys` + `participants` server-side); we
+ *      fall back to `memberPubkeys` for forward-compat with older relay
+ *      payloads that don't populate the merged list.
+ *   4. Direct messages are allowed — the smoke test does not require a
+ *      multi-member room, and DMs are often the cleanest place to ping a
+ *      single agent.
+ *
+ * The input is treated as readonly; ordering is preserved.
+ */
+export function filterEligibleRapidTestChannels(
+  channels: readonly Channel[] | undefined,
+  agent: Pick<ManagedAgent, "pubkey"> | null | undefined,
+): Channel[] {
+  if (!channels || channels.length === 0 || !agent?.pubkey) {
+    return [];
+  }
+
+  const targetPubkey = normalizePubkey(agent.pubkey);
+
+  return channels.filter((channel) => {
+    if (!channel.isMember) {
+      return false;
+    }
+    // Forum posts use a different composer and navigation surface. Keep the
+    // rapid workflow limited to stream/DM roots that can open the normal
+    // thread panel and be handled by the normal message mutation.
+    if (channel.channelType === "forum") {
+      return false;
+    }
+    if (channel.archivedAt) {
+      return false;
+    }
+
+    const memberPubkeys = [
+      ...(channel.participantPubkeys ?? []),
+      ...(channel.memberPubkeys ?? []),
+    ];
+    if (!Array.isArray(memberPubkeys) || memberPubkeys.length === 0) {
+      return false;
+    }
+
+    for (const candidate of memberPubkeys) {
+      if (normalizePubkey(candidate) === targetPubkey) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+/**
+ * Pick a default channel id from the eligible list, preserving the caller's
+ * existing selection when it is still valid.
+ *
+ *   - Returns `null` when nothing is eligible yet, so the caller can render
+ *     a "no channel" state instead of a misleading empty selection.
+ *   - Returns the existing id when it appears in the eligible list, so the
+ *     panel keeps the user's choice across channel-query refetches.
+ *   - Otherwise returns the first eligible channel id, which is deterministic
+ *     because `filterEligibleRapidTestChannels` preserves input order.
+ */
+export function pickDefaultRapidTestChannelId(
+  eligibleChannels: readonly Channel[],
+  currentChannelId: string | null,
+): string | null {
+  if (eligibleChannels.length === 0) {
+    return null;
+  }
+
+  if (currentChannelId) {
+    const stillEligible = eligibleChannels.some(
+      (channel) => channel.id === currentChannelId,
+    );
+    if (stillEligible) {
+      return currentChannelId;
+    }
+  }
+
+  return eligibleChannels[0].id;
+}
+
+/**
+ * Generate a short, unique smoke id suffix. The id is purely random (drawn from
+ * `crypto.getRandomValues` when available, otherwise `Math.random`) and
+ * carries no embedded metadata — agents match on the literal string, not
+ * on the encoding.
+ *
+ * The function is deterministic on shape only: callers who need the id
+ * observable across the panel and the posting path must capture the return
+ * value rather than re-rolling.
+ */
+export function createSmokeId(
+  randomSource: { randomValues?: (buffer: Uint8Array) => Uint8Array } = {},
+): string {
+  const buffer = new Uint8Array(SMOKE_ID_RANDOM_SUFFIX_LENGTH);
+  if (randomSource.randomValues) {
+    randomSource.randomValues(buffer);
+  } else if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(buffer);
+  } else {
+    for (let i = 0; i < buffer.length; i += 1) {
+      buffer[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  let suffix = "";
+  for (let i = 0; i < buffer.length; i += 1) {
+    suffix += SMOKE_ID_ALPHABET[buffer[i] % SMOKE_ID_ALPHABET.length];
+  }
+
+  return suffix;
+}
+
+export type RapidTestPrompt = {
+  /** Stable identifier for the smoke run; embedded in the prompt body. */
+  smokeId: string;
+  /** Human-readable relative timestamp suffix for log readability. */
+  generatedAt: string;
+  /** The full message body the owner should post. */
+  body: string;
+};
+
+export type RapidTestSelection = {
+  channel: Channel;
+  channelId: string;
+  prompt: RapidTestPrompt;
+};
+
+export type RapidSaveMode = "save" | "restart" | "smoke";
+
+export type RapidPostSaveOutcome =
+  | { kind: "restarted" }
+  | {
+      kind: "smoke-posted";
+      channelId: string;
+      eventId: string;
+      threadOpened: boolean;
+    };
+
+type RapidPostSaveRouteAgent = Pick<
+  ManagedAgent,
+  "agentCommand" | "acpCommand"
+>;
+
+/** Fail-closed route mismatch detected after Save and before restart/send. */
+export class RapidPostSaveRouteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RapidPostSaveRouteError";
+  }
+}
+
+function normalizeCommandIdentity(command: string): string {
+  const normalized = command.trim().replaceAll("\\", "/");
+  return /^[a-zA-Z]:\//.test(normalized)
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
+function commandsMatch(left: string, right: string): boolean {
+  return (
+    normalizeCommandIdentity(left) !== "" &&
+    normalizeCommandIdentity(left) === normalizeCommandIdentity(right)
+  );
+}
+
+/**
+ * Fail closed when Save changed the runtime route that the owner reviewed.
+ * This check runs before restart or message posting and intentionally reports
+ * only route classes, never command paths or environment values.
+ */
+export function assertRapidPostSaveRoute(input: {
+  savedAgent: RapidPostSaveRouteAgent;
+  savedRuntimeId: string | null | undefined;
+  expectedRuntimeId: string;
+  expectedAgentCommand: string;
+  expectedAcpCommand: string;
+  catalogRuntimeCommand: string | null | undefined;
+  catalogRequired?: boolean;
+}): void {
+  const expectedRuntimeId = input.expectedRuntimeId.trim();
+  if (
+    !expectedRuntimeId ||
+    input.savedRuntimeId?.trim() !== expectedRuntimeId
+  ) {
+    throw new RapidPostSaveRouteError(
+      "The persisted runtime changed after save.",
+    );
+  }
+
+  const catalogRequired = input.catalogRequired ?? true;
+  if (
+    !commandsMatch(input.savedAgent.agentCommand, input.expectedAgentCommand) ||
+    (catalogRequired &&
+      (!input.catalogRuntimeCommand ||
+        !commandsMatch(
+          input.savedAgent.agentCommand,
+          input.catalogRuntimeCommand,
+        )))
+  ) {
+    throw new RapidPostSaveRouteError(
+      "The saved harness route changed after save.",
+    );
+  }
+
+  if (!commandsMatch(input.savedAgent.acpCommand, input.expectedAcpCommand)) {
+    throw new RapidPostSaveRouteError(
+      "The saved ACP sidecar changed after save.",
+    );
+  }
+}
+
+type RapidRouteRefetchResult<T> = {
+  data: readonly T[] | undefined;
+  isError: boolean;
+};
+
+/**
+ * Re-read the persisted route after Save, then fail before restart/send if the
+ * reviewed runtime, harness command, or ACP sidecar no longer matches.
+ */
+export async function revalidateRapidPostSaveRoute(input: {
+  savedAgent: RapidPostSaveRouteAgent &
+    Pick<ManagedAgent, "runtime" | "personaId">;
+  expectedRuntimeId: string;
+  expectedAgentCommand: string;
+  expectedAcpCommand: string;
+  refetchRuntimes: () => Promise<
+    RapidRouteRefetchResult<{ id: string; command: string | null }>
+  >;
+  refetchPersonas: () => Promise<
+    RapidRouteRefetchResult<{ id: string; runtime: string | null }>
+  >;
+}): Promise<void> {
+  const catalogRequired = input.expectedRuntimeId.trim() !== "custom";
+  const personaRequired =
+    !input.savedAgent.runtime?.trim() && input.savedAgent.personaId != null;
+  const [runtimes, personas] = await Promise.all([
+    catalogRequired
+      ? input.refetchRuntimes()
+      : Promise.resolve({ data: [], isError: false }),
+    personaRequired
+      ? input.refetchPersonas()
+      : Promise.resolve({ data: [], isError: false }),
+  ]);
+  if (runtimes.isError || personas.isError) {
+    throw new RapidPostSaveRouteError(
+      "The saved runtime route could not be revalidated.",
+    );
+  }
+
+  const inheritedRuntimeId = personaRequired
+    ? personas.data?.find(
+        (persona) => persona.id === input.savedAgent.personaId,
+      )?.runtime
+    : null;
+  const savedRuntimeId =
+    input.savedAgent.runtime?.trim() ||
+    inheritedRuntimeId?.trim() ||
+    (catalogRequired ? null : "custom");
+  const savedRuntime = runtimes.data?.find(
+    (runtime) => runtime.id === savedRuntimeId,
+  );
+  assertRapidPostSaveRoute({
+    savedAgent: input.savedAgent,
+    savedRuntimeId,
+    expectedRuntimeId: input.expectedRuntimeId,
+    expectedAgentCommand: input.expectedAgentCommand,
+    expectedAcpCommand: input.expectedAcpCommand,
+    catalogRuntimeCommand: savedRuntime?.command,
+    catalogRequired,
+  });
+}
+
+/**
+ * Execute the deterministic post-save portion of the rapid workflow.
+ * Dependencies are injected so ordering is testable without React or Tauri.
+ */
+export async function runRapidAgentPostSaveAction(input: {
+  mode: RapidSaveMode;
+  pubkey: string;
+  relayUrl: string | null | undefined;
+  selection: RapidTestSelection | null;
+  restart: (pubkey: string, relayUrl: string) => Promise<unknown>;
+  waitForReady?: () => Promise<void>;
+  sendOwnerMessage: (
+    channel: Channel,
+    content: string,
+    mentionPubkeys: string[],
+  ) => Promise<{ eventId: string }>;
+  openThread: (channelId: string, eventId: string) => Promise<unknown>;
+}): Promise<RapidPostSaveOutcome | null> {
+  if (input.mode === "save") {
+    return null;
+  }
+
+  const relayUrl = input.relayUrl?.trim();
+  if (!relayUrl) {
+    throw new Error("No active community relay is available for restart.");
+  }
+
+  await input.restart(input.pubkey, relayUrl);
+  await input.waitForReady?.();
+  if (input.mode === "restart") {
+    return { kind: "restarted" };
+  }
+
+  if (!input.selection) {
+    throw new Error("Choose a channel where this agent is already a member.");
+  }
+
+  const sent = await input.sendOwnerMessage(
+    input.selection.channel,
+    input.selection.prompt.body,
+    [input.pubkey],
+  );
+  let threadOpened = true;
+  try {
+    await input.openThread(input.selection.channelId, sent.eventId);
+  } catch {
+    threadOpened = false;
+  }
+  return {
+    kind: "smoke-posted",
+    channelId: input.selection.channelId,
+    eventId: sent.eventId,
+    threadOpened,
+  };
+}
+
+/**
+ * Build the deterministic, clearly labelled prompt the owner-authored smoke
+ * message must contain. The prompt:
+ *
+ *   - Starts with a visible `[buzz-hermes-smoke]` label so anyone watching the
+ *     channel (including the agent) can recognise it as a test, not real
+ *     work.
+ *   - Echoes the full `BUZZ_HERMES_OK <smokeId>` directive on its own line so
+ *     agents can match on the literal token without parsing surrounding copy.
+ *   - Includes the smoke id and a generated-at timestamp for log correlation.
+ *   - Never embeds env values, secrets, relay URLs, or pubkey material.
+ *
+ * The function is pure: the same `smokeId` and `generatedAt` always produce
+ * the same body, and the body shape is stable enough that contract tests can
+ * assert against it.
+ */
+export function buildRapidTestPrompt(input: {
+  smokeId: string;
+  generatedAt?: Date | string;
+}): RapidTestPrompt {
+  const generatedAt = formatGeneratedAt(input.generatedAt ?? new Date());
+  const body = [
+    "[buzz-hermes-smoke] rapid agent test",
+    "",
+    `Please reply in this thread with the exact token: ${BUZZ_HERMES_OK_PREFIX} ${input.smokeId}`,
+    "",
+    `smoke id: ${input.smokeId}`,
+    `generated at: ${generatedAt}`,
+  ].join("\n");
+
+  return {
+    smokeId: input.smokeId,
+    generatedAt,
+    body,
+  };
+}
+
+/**
+ * Compact ISO-8601 (seconds, UTC) used inside the prompt body. We avoid
+ * locale formatting so the same id always renders the same timestamp —
+ * agents and humans reading logs shouldn't have to square a timezone.
+ */
+function formatGeneratedAt(value: Date | string): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(date.getTime())) {
+    return "unknown";
+  }
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}

--- a/desktop/src/features/agents/ui/useAgentRapidIteration.ts
+++ b/desktop/src/features/agents/ui/useAgentRapidIteration.ts
@@ -1,0 +1,509 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useManagedAgentLogQuery } from "@/features/agents/hooks";
+import {
+  useManagedAgentRuntimeAction,
+  useManagedAgentRuntimesQuery,
+} from "@/features/agents/managedAgentRuntimeHooks";
+import { useChannelsQuery } from "@/features/channels/hooks";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useSendMessageMutation } from "@/features/messages/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type {
+  ManagedAgent,
+  ManagedAgentRuntimeStatus,
+} from "@/shared/api/types";
+
+import {
+  filterEligibleRapidTestChannels,
+  RapidPostSaveRouteError,
+  runRapidAgentPostSaveAction,
+  type RapidSaveMode,
+  type RapidTestSelection,
+} from "./agentRapidTest";
+import { findManagedAgentRuntime } from "../managedAgentRuntimeStatus";
+import {
+  abortRapidActionLeaseForMount,
+  claimRapidActionLease,
+  createRapidActionMountId,
+  finishRapidActionLease,
+  releaseRapidActionMount,
+  startRapidActionLease,
+  type RapidActionLeaseScope,
+} from "../rapidActionLease";
+
+const RUNTIME_READY_TIMEOUT_MS = 20_000;
+const RUNTIME_READY_POLL_MS = 250;
+
+function assertRapidActionNotAborted(signal: AbortSignal) {
+  if (signal.aborted) {
+    throw new Error("Rapid agent action cancelled.");
+  }
+}
+
+function assertRapidActionRoute(route: string): void {
+  if (currentRapidActionRoute() !== route) {
+    throw new Error("Rapid agent action route changed.");
+  }
+}
+
+function currentRapidActionRoute(): string {
+  return typeof globalThis.location === "undefined"
+    ? ""
+    : globalThis.location.hash;
+}
+
+function waitForTimer(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, milliseconds);
+  });
+}
+
+export function useAgentRapidIteration({
+  agentBackend,
+  agentPubkey,
+  onClose,
+  open,
+}: {
+  agentBackend: ManagedAgent["backend"];
+  agentPubkey: string;
+  onClose: () => void;
+  open: boolean;
+}) {
+  const runtimeActionMutation = useManagedAgentRuntimeAction();
+  const { activeCommunity } = useCommunities();
+  const { goChannel } = useAppNavigation();
+  const identityQuery = useIdentityQuery();
+  const ownerIdentity = identityQuery.data;
+  const ownerIdentityPubkey = ownerIdentity?.pubkey ?? null;
+  const refetchIdentity = identityQuery.refetch;
+  const identityRefetchKeyRef = React.useRef<string | null>(null);
+  const actionAbortRef = React.useRef<AbortController | null>(null);
+  const rapidMountIdRef = React.useRef<string | null>(null);
+  const rapidMountId =
+    rapidMountIdRef.current ?? createRapidActionMountId();
+  rapidMountIdRef.current = rapidMountId;
+  const channelsQuery = useChannelsQuery({ enabled: open });
+  const sendMessageMutation = useSendMessageMutation(null, ownerIdentity);
+  const [selection, setSelection] = React.useState<RapidTestSelection | null>(
+    null,
+  );
+  const [action, setAction] = React.useState<RapidSaveMode | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const isLocalAgent = agentBackend.type === "local";
+  const activeRelayUrl = activeCommunity?.relayUrl?.trim() || null;
+  const rapidScopeRef = React.useRef<{
+    activeRelayUrl: string | null;
+    agentPubkey: string;
+    open: boolean;
+    ownerIdentityPubkey: string | null;
+  } | null>(null);
+  const runtimesQuery = useManagedAgentRuntimesQuery({
+    enabled: open && isLocalAgent,
+    refetchInterval: open && isLocalAgent && action === null ? 3_000 : false,
+  });
+  const runtime = React.useMemo<ManagedAgentRuntimeStatus | null>(() => {
+    if (!activeRelayUrl) {
+      return null;
+    }
+    return (
+      findManagedAgentRuntime(
+        runtimesQuery.data ?? [],
+        agentPubkey,
+        activeRelayUrl,
+      ) ?? null
+    );
+  }, [activeRelayUrl, agentPubkey, runtimesQuery.data]);
+  const logQuery = useManagedAgentLogQuery(
+    open && isLocalAgent ? agentPubkey : null,
+  );
+
+  const hasActiveRelay = Boolean(activeRelayUrl);
+  const canRestart = isLocalAgent && hasActiveRelay;
+  const canSmoke =
+    canRestart &&
+    ownerIdentity != null &&
+    !ownerIdentity.locked &&
+    !ownerIdentity.lost &&
+    !ownerIdentity.resetFailed;
+  const actionRelayUrl = runtime?.relayUrl ?? activeRelayUrl;
+
+  React.useEffect(() => {
+    if (!open) {
+      identityRefetchKeyRef.current = null;
+      return;
+    }
+    if (
+      identityQuery.data != null ||
+      identityRefetchKeyRef.current === agentPubkey
+    ) {
+      return;
+    }
+
+    // The identity query can fail during startup and cache the empty result.
+    // Retry a small, bounded number of times per opened agent so a now-ready
+    // identity enables the smoke action without creating an idle poll loop.
+    identityRefetchKeyRef.current = agentPubkey;
+    let cancelled = false;
+    void (async () => {
+      for (let attempt = 0; attempt < 3 && !cancelled; attempt += 1) {
+        if (attempt > 0) {
+          await new Promise((resolve) => window.setTimeout(resolve, 750));
+        }
+        const result = await identityQuery.refetch();
+        if (cancelled || result.data != null) {
+          return;
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentPubkey, identityQuery.data, identityQuery.refetch, open]);
+
+  React.useEffect(() => {
+    const previous = rapidScopeRef.current;
+    const stableOwnerIdentityPubkey =
+      ownerIdentityPubkey ?? previous?.ownerIdentityPubkey ?? null;
+    const contextChanged =
+      previous != null &&
+      (previous.activeRelayUrl !== activeRelayUrl ||
+        previous.agentPubkey !== agentPubkey ||
+        previous.open !== open ||
+        (ownerIdentityPubkey != null &&
+          previous.ownerIdentityPubkey != null &&
+          previous.ownerIdentityPubkey !== ownerIdentityPubkey));
+
+    rapidScopeRef.current = {
+      activeRelayUrl,
+      agentPubkey,
+      open,
+      ownerIdentityPubkey: stableOwnerIdentityPubkey,
+    };
+
+    if (!open || contextChanged) {
+      abortRapidActionLeaseForMount(rapidMountId);
+      actionAbortRef.current?.abort();
+      actionAbortRef.current = null;
+      setSelection(null);
+      setAction(null);
+      setError(null);
+    }
+  }, [activeRelayUrl, agentPubkey, open, ownerIdentityPubkey, rapidMountId]);
+
+  React.useEffect(() => {
+    if (open) {
+      const scope: RapidActionLeaseScope = {
+        activeRelayUrl,
+        agentPubkey,
+        ownerIdentityPubkey,
+        route: currentRapidActionRoute(),
+      };
+      claimRapidActionLease(scope, rapidMountId);
+    }
+
+    return () => {
+      releaseRapidActionMount(rapidMountId);
+    };
+  }, [activeRelayUrl, agentPubkey, open, ownerIdentityPubkey, rapidMountId]);
+
+  const waitForReady = React.useCallback(
+    async (signal: AbortSignal) => {
+      if (!canRestart || !activeRelayUrl) {
+        throw new Error("runtime unavailable");
+      }
+
+      const deadline = Date.now() + RUNTIME_READY_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        assertRapidActionNotAborted(signal);
+        const refreshed = await runtimesQuery.refetch();
+        assertRapidActionNotAborted(signal);
+        const current = findManagedAgentRuntime(
+          refreshed.data ?? [],
+          agentPubkey,
+          activeRelayUrl,
+        );
+
+        if (current?.lifecycle === "ready") {
+          return;
+        }
+        if (
+          current?.lifecycle === "failed" ||
+          current?.lifecycle === "stopped"
+        ) {
+          throw new Error("runtime failed");
+        }
+        await waitForTimer(RUNTIME_READY_POLL_MS);
+      }
+
+      throw new Error("runtime readiness timeout");
+    },
+    [activeRelayUrl, agentPubkey, canRestart, runtimesQuery],
+  );
+
+  const run = React.useCallback(
+    async (
+      mode: RapidSaveMode,
+      save: (
+        markRecordSaved: () => void,
+        signal: AbortSignal,
+        assertActionAuthority: () => void,
+      ) => Promise<ManagedAgent>,
+    ): Promise<void> => {
+      if (mode !== "save" && !canRestart) {
+        setError(
+          isLocalAgent
+            ? "Choose an active community before restarting or testing this agent."
+            : "Restart and smoke testing are available only for local agents.",
+        );
+        return;
+      }
+      if (mode === "smoke" && !canSmoke) {
+        setError("The owner identity is not available for a smoke test.");
+        return;
+      }
+      let saved = false;
+      let ownerMessageAccepted = false;
+      const actionRoute = currentRapidActionRoute();
+      const actionOwnerPubkey = ownerIdentityPubkey;
+      const actionScope: RapidActionLeaseScope = {
+        activeRelayUrl,
+        agentPubkey,
+        ownerIdentityPubkey: actionOwnerPubkey,
+        route: actionRoute,
+      };
+      const actionLease = startRapidActionLease(actionScope, rapidMountId);
+      if (!actionLease) {
+        setError("A rapid agent action is already in progress for this agent.");
+        return;
+      }
+      const { controller: abortController, id: actionLeaseId } = actionLease;
+      actionAbortRef.current = abortController;
+      const { signal } = abortController;
+      const abortOnRouteChange = () => {
+        if (
+          mode !== "save" &&
+          !ownerMessageAccepted &&
+          currentRapidActionRoute() !== actionRoute
+        ) {
+          abortController.abort();
+        }
+      };
+      window.addEventListener("hashchange", abortOnRouteChange);
+      setAction(mode);
+      setError(null);
+      runtimeActionMutation.reset();
+      try {
+        const assertActionAuthority = () => {
+          assertRapidActionNotAborted(signal);
+          if (mode !== "save") {
+            assertRapidActionRoute(actionRoute);
+          }
+        };
+        const savedAgent = await save(
+          () => {
+            saved = true;
+          },
+          signal,
+          assertActionAuthority,
+        );
+        assertActionAuthority();
+        const outcome = await runRapidAgentPostSaveAction({
+          mode,
+          pubkey: savedAgent.pubkey,
+          relayUrl: actionRelayUrl,
+          selection,
+          restart: async (pubkey, relayUrl) => {
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+            await runtimeActionMutation.mutateAsync({
+              action: "restart",
+              pubkey,
+              relayUrl,
+            });
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+          },
+          waitForReady:
+            mode === "save"
+              ? undefined
+              : async () => {
+                  await waitForReady(signal);
+                  assertRapidActionRoute(actionRoute);
+                },
+          sendOwnerMessage: async (
+            capturedChannel,
+            content,
+            mentionPubkeys,
+          ) => {
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+            const refreshedIdentity = await refetchIdentity();
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+            if (
+              refreshedIdentity.isError ||
+              !refreshedIdentity.data ||
+              refreshedIdentity.data.locked ||
+              refreshedIdentity.data.lost ||
+              refreshedIdentity.data.resetFailed ||
+              refreshedIdentity.data.pubkey !== actionOwnerPubkey
+            ) {
+              throw new Error("The owner identity changed before posting.");
+            }
+            const refreshed = await channelsQuery.refetch();
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+            const currentChannel = filterEligibleRapidTestChannels(
+              refreshed.data,
+              savedAgent,
+            ).find((channel) => channel.id === capturedChannel.id);
+            if (!currentChannel) {
+              throw new Error("The selected channel is no longer eligible.");
+            }
+            assertRapidActionRoute(actionRoute);
+            const sent = await sendMessageMutation.mutateAsync({
+              channelId: currentChannel.id,
+              content,
+              mentionPubkeys,
+              targetChannel: currentChannel,
+              abortSignal: signal,
+            });
+            if (
+              !actionOwnerPubkey ||
+              sent.pubkey.toLowerCase() !== actionOwnerPubkey.toLowerCase()
+            ) {
+              throw new Error("The owner identity changed while signing.");
+            }
+            ownerMessageAccepted = true;
+            return { eventId: sent.id };
+          },
+          openThread: async (channelId, eventId) => {
+            assertRapidActionNotAborted(signal);
+            assertRapidActionRoute(actionRoute);
+            await goChannel(channelId, {
+              messageId: eventId,
+              thread: eventId,
+              threadRootId: eventId,
+            });
+            assertRapidActionNotAborted(signal);
+            const openedRoute = decodeURIComponent(currentRapidActionRoute());
+            if (
+              !openedRoute.includes(channelId) ||
+              !openedRoute.includes(eventId)
+            ) {
+              throw new Error("The accepted smoke thread route did not open.");
+            }
+            onClose();
+          },
+        });
+        if (outcome?.kind !== "smoke-posted") {
+          assertRapidActionNotAborted(signal);
+        }
+
+        if (outcome === null) {
+          onClose();
+        }
+        if (outcome?.kind === "restarted") {
+          toast.success(`${savedAgent.name} saved and restarted.`);
+        } else if (outcome?.kind === "smoke-posted") {
+          if (outcome.threadOpened) {
+            toast.success(
+              `Smoke prompt posted for ${savedAgent.name}; watch the opened thread for its reply.`,
+            );
+          } else {
+            onClose();
+            toast.error(
+              "Smoke prompt posted, but Buzz could not open its thread. Open the selected channel manually.",
+            );
+          }
+        }
+      } catch (cause) {
+        if (signal.aborted) {
+          return;
+        }
+        if (cause instanceof RapidPostSaveRouteError) {
+          setError(
+            "Changes saved, but the runtime route changed before restart. Review the selected harness before retrying.",
+          );
+          return;
+        }
+        if (
+          cause instanceof Error &&
+          cause.message === "Rapid agent action route changed."
+        ) {
+          setError(
+            saved
+              ? "Changes saved, but navigation changed before restart or posting. Return to this agent and retry."
+              : "Navigation changed before the rapid agent action started.",
+          );
+          return;
+        }
+        setError(
+          saved
+            ? mode === "smoke"
+              ? "Changes saved, but the smoke prompt could not be posted or its thread could not be opened."
+              : "Changes saved, but the selected runtime could not be restarted."
+            : "Could not save agent changes.",
+        );
+      } finally {
+        window.removeEventListener("hashchange", abortOnRouteChange);
+        finishRapidActionLease(actionLeaseId);
+        if (actionAbortRef.current === abortController) {
+          actionAbortRef.current = null;
+          if (saved && mode !== "save") {
+            void logQuery.refetch();
+          }
+          setAction(null);
+        }
+      }
+    },
+    [
+      actionRelayUrl,
+      agentPubkey,
+      canSmoke,
+      canRestart,
+      channelsQuery,
+      goChannel,
+      isLocalAgent,
+      logQuery,
+      onClose,
+      ownerIdentityPubkey,
+      refetchIdentity,
+      runtimeActionMutation,
+      sendMessageMutation,
+      selection,
+      waitForReady,
+    ],
+  );
+
+  const cancel = React.useCallback(() => {
+    abortRapidActionLeaseForMount(rapidMountId);
+    actionAbortRef.current?.abort();
+    actionAbortRef.current = null;
+    setAction(null);
+    setError(null);
+  }, [rapidMountId]);
+
+  return {
+    action,
+    cancel,
+    canRestart,
+    canSmoke,
+    error,
+    isPending: runtimeActionMutation.isPending || action !== null,
+    logContent: logQuery.data?.content ?? null,
+    logError: logQuery.error
+      ? new Error("Could not load the managed agent log.")
+      : null,
+    logLoading: logQuery.isLoading,
+    run,
+    runtime,
+    selection,
+    setSelection,
+  };
+}

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -33,6 +33,7 @@ import { resetAvatarProfileSync } from "@/features/profile/avatarProfileSync";
 import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useSidebarRelayConnectionCard";
 import { clearMarkdownNodeCache } from "@/shared/ui/markdown/nodeCache";
 import { resetVideoPlayerState } from "@/shared/ui/videoPlayerState";
+import { resetRapidActionLeases } from "@/features/agents/rapidActionLease";
 
 import {
   initFirstCommunity,
@@ -52,6 +53,7 @@ function resetCommunityState({
 }: {
   resetAvatarState: boolean;
 }): void {
+  resetRapidActionLeases();
   relayClient.disconnect();
   resetRateLimitGate();
   clearAllDrafts();

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -76,6 +76,12 @@ type MessageQueryContext = {
   queryKey: ReturnType<typeof channelMessagesKey>;
 };
 
+function assertMessageSendNotAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new Error("Message send cancelled.");
+  }
+}
+
 const CHANNEL_TIMELINE_KINDS = new Set<number>(CHANNEL_TIMELINE_CONTENT_KINDS);
 const CHANNEL_AUX_KINDS = new Set<number>(CHANNEL_AUX_EVENT_KINDS);
 
@@ -413,6 +419,7 @@ export function useSendMessageMutation(
       mentionPubkeys?: string[];
       parentEventId?: string | null;
       mediaTags?: string[][];
+      abortSignal?: AbortSignal;
     },
     MessageQueryContext | undefined
   >({
@@ -423,7 +430,9 @@ export function useSendMessageMutation(
       mentionPubkeys,
       parentEventId,
       mediaTags,
+      abortSignal,
     }) => {
+      assertMessageSendNotAborted(abortSignal);
       // Prefer a channel captured by the caller at compose time. Otherwise,
       // resolve a captured id from the shared channel cache so navigation
       // cannot redirect the message. Legacy callers without either value use
@@ -469,6 +478,7 @@ export function useSendMessageMutation(
       // the relay's tag validation runs. The WebSocket path emits no extra
       // tags, so emoji-only messages would otherwise lose their emoji tag.
       if (parentEventId || imetaTags.length > 0 || emojiTags.length > 0) {
+        assertMessageSendNotAborted(abortSignal);
         const cachedMessages =
           queryClient.getQueryData<RelayEvent[]>(
             channelMessagesKey(effectiveChannel.id),
@@ -530,6 +540,8 @@ export function useSendMessageMutation(
         content,
         recipientPubkeys,
         mentionTags,
+        abortSignal,
+        identity.pubkey,
       );
     },
     onMutate: async ({
@@ -539,7 +551,9 @@ export function useSendMessageMutation(
       mentionPubkeys,
       parentEventId,
       mediaTags,
+      abortSignal,
     }) => {
+      assertMessageSendNotAborted(abortSignal);
       // Mirror mutationFn's target resolution so the optimistic message lands
       // in the cache for the same channel as the real send. A caller-supplied
       // channel remains valid even when a stale channel-list read omitted it.

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -199,6 +199,23 @@ export function UserProfilePanel({
     }
     return undefined;
   }, [managedAgentsQuery.data, persona, pubkey]);
+  const editAgentProfileKey = pubkey?.toLowerCase() ?? persona?.id ?? "";
+  const editAgentSnapshotRef = React.useRef<{
+    profileKey: string;
+    agent: NonNullable<typeof managedAgent>;
+  } | null>(null);
+  if (managedAgent) {
+    editAgentSnapshotRef.current = {
+      profileKey: editAgentProfileKey,
+      agent: managedAgent,
+    };
+  }
+  const editManagedAgent =
+    managedAgent ??
+    (editAgentOpen &&
+    editAgentSnapshotRef.current?.profileKey === editAgentProfileKey
+      ? editAgentSnapshotRef.current.agent
+      : undefined);
   const personaInstances = React.useMemo(() => {
     if (!managedAgent?.personaId) return managedAgent ? [managedAgent] : [];
     return (managedAgentsQuery.data ?? []).filter(
@@ -906,9 +923,9 @@ export function UserProfilePanel({
     </AuxiliaryPanelBody>
   );
   const editAgentDialog =
-    canEditAgent && managedAgent ? (
+    canEditAgent && editManagedAgent ? (
       <AgentDialog
-        agent={managedAgent}
+        agent={editManagedAgent}
         mode="instance-edit"
         initialFocus={editAgentFocus}
         onEditLinkedPersona={

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -13,6 +13,8 @@ import {
   KIND_CHANNEL_THREAD_SUMMARY,
 } from "@/shared/constants/kinds";
 import {
+  assertRelayEventAuthor,
+  assertRelaySendNotAborted,
   getTextPayload,
   type ConnectionState,
   type PendingEvent,
@@ -254,8 +256,12 @@ export class RelayClient {
     content: string,
     mentionPubkeys: string[] = [],
     extraTags: string[][] = [],
+    abortSignal?: AbortSignal,
+    expectedAuthorPubkey?: string,
   ) {
+    assertRelaySendNotAborted(abortSignal);
     await this.ensureConnected();
+    assertRelaySendNotAborted(abortSignal);
 
     const tags: string[][] = [["h", channelId]];
     for (const pubkey of mentionPubkeys) {
@@ -270,11 +276,14 @@ export class RelayClient {
       content: content.trim(),
       tags,
     });
+    assertRelaySendNotAborted(abortSignal);
+    assertRelayEventAuthor(event.pubkey, expectedAuthorPubkey);
 
     return this.publishEvent(
       event,
       "Timed out while sending the message.",
       "Failed to send the message.",
+      abortSignal,
     );
   }
 
@@ -329,9 +338,7 @@ export class RelayClient {
     channelId: string,
     onEvent: (event: RelayEvent) => void,
   ) {
-    // 39005 rides only this window-store subscription — CHANNEL_EVENT_KINDS'
-    // other consumers (unread tracking, cache merges) must never see
-    // summary overlays.
+    // Keep 39005 summary overlays isolated from other channel consumers.
     return this.subscribe(
       {
         kinds: [...CHANNEL_EVENT_KINDS, KIND_CHANNEL_THREAD_SUMMARY],
@@ -343,11 +350,7 @@ export class RelayClient {
     );
   }
 
-  /**
-   * Subscribe to huddle lifecycle events (kinds 48100–48103) for a channel,
-   * so HuddleIndicator detects active huddles without being drowned out by
-   * regular channel messages. Includes the last 10 historical events.
-   */
+  /** Subscribe to huddle lifecycle events without regular-message noise. */
   async subscribeToHuddleEvents(
     channelId: string,
     onEvent: (event: RelayEvent) => void,
@@ -428,20 +431,14 @@ export class RelayClient {
   }
 
   async preconnect() {
-    // Explicit re-engagement (reconnect card / community switch): clears the
-    // terminal latch and AUTH rejection streak, and bypasses backoff once.
+    // Explicit reconnect clears terminal/AUTH state and bypasses backoff once.
     this.terminal = false;
     this.authOkTracker.reset();
     this.keepAliveRequested = true;
     await this.connectBypassingBackoff();
   }
 
-  /**
-   * Environment-driven resume (online/focus/visibility): bypasses a pending
-   * backoff timer but preserves the terminal latch and AUTH rejection streak
-   * — only `preconnect()` clears those, so resume events during repeated
-   * AUTH rejection cannot defeat the consecutive-rejection cap.
-   */
+  /** Resume through backoff without clearing terminal/AUTH-rejection state. */
   async resumeReconnect() {
     if (this.terminal) return;
     await this.connectBypassingBackoff();
@@ -475,21 +472,14 @@ export class RelayClient {
     return this.connectionStateEmitter.get();
   }
 
-  /**
-   * Subscribe to connection-state transitions. The listener fires
-   * immediately with the current state, so callers need no separate
-   * `getConnectionState()` call to seed their UI.
-   */
+  /** Subscribe and immediately receive the current connection state. */
   subscribeToConnectionState(listener: (state: ConnectionState) => void) {
     return this.connectionStateEmitter.subscribe(listener);
   }
 
   private async ensureConnected() {
     if (shouldRefuseConnect({ terminal: this.terminal })) {
-      // Terminal (e.g. relay rejected auth): refuse until disconnect() or
-      // preconnect() clears the latch, else the reconnect-timer catch and
-      // the publish/subscribe retry wrappers would race the terminal
-      // "disconnected" state back to "reconnecting".
+      // Only disconnect/preconnect may clear a terminal session latch.
       throw new Error("Relay session is terminal; cannot reconnect.");
     }
 
@@ -506,9 +496,7 @@ export class RelayClient {
         hasPendingReconnect: this.reconnectTimeout !== null,
       })
     ) {
-      // The reconnect coordinator owns outage pacing. Query, publish, and
-      // subscription callers must wait for its scheduled attempt instead of
-      // clearing the timer and creating an immediate reconnect storm.
+      // The reconnect coordinator alone owns outage pacing.
       return this.reconnectWaiters.wait();
     }
 
@@ -709,9 +697,11 @@ export class RelayClient {
     event: RelayEvent,
     timeoutMessage: string,
     sendErrorMessage: string,
+    abortSignal?: AbortSignal,
   ) {
-    // Await the gate before sending EVENT; op timeout starts after the wait.
+    assertRelaySendNotAborted(abortSignal);
     await waitForRateLimit();
+    assertRelaySendNotAborted(abortSignal);
 
     return new Promise<RelayEvent>((resolve, reject) => {
       const timeout = window.setTimeout(() => {
@@ -729,6 +719,11 @@ export class RelayClient {
       void this.sendRaw(["EVENT", event]).catch(async (error) => {
         const pendingEvent = this.pendingEvents.get(event.id);
         this.pendingEvents.delete(event.id);
+        if (abortSignal?.aborted) {
+          window.clearTimeout(timeout);
+          reject(new Error("Message send cancelled."));
+          return;
+        }
         const normalizedError = this.recoverFromSocketFailure(
           error,
           sendErrorMessage,
@@ -736,6 +731,7 @@ export class RelayClient {
 
         try {
           await this.ensureConnected();
+          assertRelaySendNotAborted(abortSignal);
           if (!pendingEvent) {
             throw normalizedError;
           }

--- a/desktop/src/shared/api/relayClientShared.test.mjs
+++ b/desktop/src/shared/api/relayClientShared.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isRelayConnectionDegraded, sortEvents } from "./relayClientShared.ts";
+import {
+  assertRelayEventAuthor,
+  assertRelaySendNotAborted,
+  isRelayConnectionDegraded,
+  sortEvents,
+} from "./relayClientShared.ts";
 
 function event(id, createdAt) {
   return {
@@ -39,4 +44,22 @@ test("isRelayConnectionDegraded — non-healthy states are degraded", () => {
   assert.equal(isRelayConnectionDegraded("reconnecting"), true);
   assert.equal(isRelayConnectionDegraded("stalled"), true);
   assert.equal(isRelayConnectionDegraded("disconnected"), true);
+});
+
+test("relay send cancellation fails closed only after abort", () => {
+  const controller = new AbortController();
+  assert.doesNotThrow(() => assertRelaySendNotAborted(controller.signal));
+  controller.abort();
+  assert.throws(
+    () => assertRelaySendNotAborted(controller.signal),
+    /send cancelled/,
+  );
+});
+
+test("relay author guard accepts case-only differences and rejects drift", () => {
+  assert.doesNotThrow(() => assertRelayEventAuthor("ABC123", "abc123"));
+  assert.throws(
+    () => assertRelayEventAuthor("wrong", "expected"),
+    /author changed/,
+  );
 });

--- a/desktop/src/shared/api/relayClientShared.ts
+++ b/desktop/src/shared/api/relayClientShared.ts
@@ -29,6 +29,26 @@ export function isRelayConnectionDegraded(state: ConnectionState): boolean {
   );
 }
 
+/** Fail closed when a caller cancels an in-flight relay send. */
+export function assertRelaySendNotAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error("Message send cancelled.");
+  }
+}
+
+/** Fail closed when native signing returns an unexpected author. */
+export function assertRelayEventAuthor(
+  actualPubkey: string,
+  expectedPubkey?: string,
+): void {
+  if (
+    expectedPubkey &&
+    actualPubkey.toLowerCase() !== expectedPubkey.toLowerCase()
+  ) {
+    throw new Error("The message author changed before posting.");
+  }
+}
+
 export type RelaySubscriptionFilter = {
   ids?: string[];
   kinds: number[];


### PR DESCRIPTION
## Summary

- Persist managed-agent ACP session affinity per agent, relay, and channel so process replacement attempts `session/load` before creating a linked replacement session.
- Add bounded `session/new` setup timeouts and setup-payload compatibility for missing runtime binaries.
- Add signed supervisor-only managed-agent lifecycle control through the Dev MCP and Desktop runtime-control queue.
- Harden Desktop runtime teardown/restart ordering, relay/author binding, reserved environment ownership, log redaction, and Hermes runtime discovery.
- Add owner-authored rapid save/restart/smoke actions in the existing managed-agent editor, with eligible-channel selection, route revalidation, cancellation leases, readiness polling, and thread navigation.

## Verification

- `cargo check -p buzz-acp -p buzz-dev-mcp` — passed.
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --lib` — passed; warnings only, no errors.
- `cargo fmt --all -- --check` — passed.
- Focused frontend harness — 33 passed, 0 failed:
  - `src/features/agents/ui/agentRapidTest.test.mjs`
  - `src/features/agents/managedAgentRuntimeHooks.test.mjs`
  - `src/shared/api/relayClientShared.test.mjs`

## Scope notes

- Generated `target-final/**` and `target-parent-continuity/**`, local Hermes/Buzz trackers and audits, temporary wrappers, and local agent inventory were intentionally excluded.
- The branch is pushed from the contributor fork because the authenticated account cannot push directly to `block/buzz`.
- No live relay post, credential operation, or production/Desktop deployment was performed as part of this PR packaging.
