### PR TITLE
feat(desktop): style structured agent reply labels in the message renderer

### DIFF
--- a/desktop/src/shared/lib/rehypeStructuredReplyLabels.test.mjs
+++ b/desktop/src/shared/lib/rehypeStructuredReplyLabels.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import rehypeStructuredReplyLabels from "./rehypeStructuredReplyLabels.ts";
+
+const LABEL_CLASS = "text-primary font-bold";
+
+// --- tiny HAST builders (mirror what remark-rehype + remark-breaks emit) ---
+const t = (value) => ({ type: "text", value });
+const br = () => ({
+  type: "element",
+  tagName: "br",
+  properties: {},
+  children: [],
+});
+const el = (tagName, children, properties = {}) => ({
+  type: "element",
+  tagName,
+  properties,
+  children,
+});
+const root = (children) => ({ type: "root", children });
+
+/** One paragraph whose lines are separated by <br> (the remark-breaks shape). */
+function paragraphWithBreaks(lines) {
+  const kids = [];
+  lines.forEach((line, i) => {
+    if (i > 0) kids.push(br());
+    kids.push(typeof line === "string" ? t(line) : line);
+  });
+  return el("p", kids);
+}
+
+function apply(tree) {
+  rehypeStructuredReplyLabels()(tree);
+  return tree;
+}
+
+function visibleText(node) {
+  if (node.type === "text") return node.value;
+  if (Array.isArray(node.children))
+    return node.children.map(visibleText).join("");
+  return "";
+}
+
+function styledLabels(node, acc = []) {
+  if (
+    node.type === "element" &&
+    node.tagName === "span" &&
+    node.properties?.className === LABEL_CLASS
+  ) {
+    acc.push(visibleText(node));
+  }
+  for (const child of node.children ?? []) styledLabels(child, acc);
+  return acc;
+}
+
+const ENVELOPE_LINES = [
+  "STATUS: [FACT] Live",
+  "ANSWER:",
+  "What it is: Example Agent is a demo assistant.",
+  "Why it matters: It shows the reply structure.",
+  "Done when: The reply is delivered.",
+  "SOURCE: Example source v1.0",
+  "CONFIDENCE: high",
+  "NEXT ACTION:",
+  "1. Review the reply.",
+  "OWNER: Operator",
+  "BLOCKER OR ESCALATION: No blocker.",
+];
+
+const ALL_TEN = [
+  "STATUS:",
+  "ANSWER:",
+  "What it is:",
+  "Why it matters:",
+  "Done when:",
+  "SOURCE:",
+  "CONFIDENCE:",
+  "NEXT ACTION:",
+  "OWNER:",
+  "BLOCKER OR ESCALATION:",
+];
+
+test("styles all ten labels in a valid envelope (br-joined paragraph)", () => {
+  const tree = root([paragraphWithBreaks(ENVELOPE_LINES)]);
+  apply(tree);
+  assert.deepEqual(styledLabels(tree), ALL_TEN);
+});
+
+test("styles all ten labels when each line is its own block (paragraph shape)", () => {
+  const tree = root(ENVELOPE_LINES.map((line) => el("p", [t(line)])));
+  apply(tree);
+  assert.deepEqual(styledLabels(tree).sort(), [...ALL_TEN].sort());
+});
+
+test("values and body text are never styled", () => {
+  const tree = root([paragraphWithBreaks(ENVELOPE_LINES)]);
+  apply(tree);
+  for (const label of styledLabels(tree)) assert.ok(ALL_TEN.includes(label));
+  assert.equal(styledLabels(tree).length, 10);
+});
+
+test("raw visible text is unchanged (renderer-only, byte-for-byte)", () => {
+  const tree = root([paragraphWithBreaks(ENVELOPE_LINES)]);
+  const before = visibleText(tree);
+  apply(tree);
+  assert.equal(visibleText(tree), before);
+});
+
+test("numbered NEXT ACTION item is not styled (only the label)", () => {
+  const tree = root([paragraphWithBreaks(ENVELOPE_LINES)]);
+  apply(tree);
+  assert.ok(!styledLabels(tree).some((s) => s.includes("Review the reply")));
+  assert.ok(styledLabels(tree).includes("NEXT ACTION:"));
+});
+
+test("false positive: prose containing a lone 'STATUS:' is untouched", () => {
+  const tree = root([el("p", [t("STATUS: everything is on track today")])]);
+  const clone = structuredClone(tree);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+  assert.deepEqual(tree, clone);
+});
+
+test("false positive: label not at line-leading position is untouched", () => {
+  const tree = root([el("p", [t("please check the STATUS: soon")])]);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+});
+
+test("false positive: out-of-order labels are not an envelope", () => {
+  const scrambled = [
+    "STATUS: [FACT] Live",
+    "ANSWER:",
+    "What it is: x",
+    "Why it matters: y",
+    "Done when: z",
+    "OWNER: Operator", // OWNER before SOURCE/CONFIDENCE/NEXT ACTION
+    "CONFIDENCE: high",
+    "SOURCE: Example source",
+    "NEXT ACTION: none",
+    "BLOCKER OR ESCALATION: none",
+  ];
+  const tree = root([paragraphWithBreaks(scrambled)]);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+});
+
+test("false positive: partial envelope (missing labels) is untouched", () => {
+  const tree = root([
+    paragraphWithBreaks(["STATUS: Live", "ANSWER:", "OWNER: Operator"]),
+  ]);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+});
+
+test("a label inside inline code within an envelope is not styled", () => {
+  const lines = ENVELOPE_LINES.map((line) =>
+    line.startsWith("CONFIDENCE:")
+      ? [t("CONFIDENCE: "), el("code", [t("STATUS: x")])]
+      : line,
+  );
+  const kids = [];
+  lines.forEach((line, i) => {
+    if (i > 0) kids.push(br());
+    if (Array.isArray(line)) kids.push(...line);
+    else kids.push(t(line));
+  });
+  const tree = root([el("p", kids)]);
+  apply(tree);
+  const labels = styledLabels(tree);
+  assert.equal(labels.length, 10); // exactly the ten line-leading labels
+  assert.ok(labels.includes("CONFIDENCE:"));
+  assert.equal(labels.filter((l) => l === "STATUS:").length, 1);
+});
+
+test("an envelope quoted inside a blockquote is not styled", () => {
+  const tree = root([el("blockquote", [paragraphWithBreaks(ENVELOPE_LINES)])]);
+  const clone = structuredClone(tree);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+  assert.deepEqual(tree, clone);
+});
+
+test("ordinary markdown (bold, list, link) is left byte-for-byte unchanged", () => {
+  const tree = root([
+    el("p", [t("Here is "), el("strong", [t("bold")]), t(" text.")]),
+    el("ul", [el("li", [t("first")]), el("li", [t("second")])]),
+    el("p", [el("a", [t("a link")], { href: "https://example.com" })]),
+  ]);
+  const clone = structuredClone(tree);
+  apply(tree);
+  assert.equal(styledLabels(tree).length, 0);
+  assert.deepEqual(tree, clone);
+});

--- a/desktop/src/shared/lib/rehypeStructuredReplyLabels.ts
+++ b/desktop/src/shared/lib/rehypeStructuredReplyLabels.ts
@@ -1,0 +1,216 @@
+/**
+ * Rehype plugin that styles the fixed labels of a structured agent reply.
+ *
+ * Some agents answer in a fixed, labelled envelope — a status line, an answer
+ * block (broken into "what it is / why it matters / done when"), a source, a
+ * confidence, a next action, an owner, and a blocker/escalation line. This
+ * plugin gives those labels the standard accent color and bold weight so the
+ * structure reads at a glance. It is presentation only: it runs in the HAST
+ * phase of the react-markdown pipeline (the same place as rehypeSearchHighlight),
+ * so the stored message text is never altered — only wrapped for display.
+ *
+ * Safety by construction:
+ *  - It acts ONLY when the message is a valid structured envelope: the seven
+ *    top-level labels must appear as line-leading text, in the exact canonical
+ *    order. Ordinary prose, other messages, and partial/out-of-order text are
+ *    left completely untouched.
+ *  - It styles ONLY the exact labels at structural line-leading positions
+ *    (first text of a block, or the text immediately after a `<br>`). Values and
+ *    body text are never styled.
+ *  - It never descends into code, links, quotes, or pasted source
+ *    (`code`/`pre`/`a`/`blockquote`), so an incidental "STATUS:" inside those is
+ *    not styled.
+ */
+
+// Minimal HAST types — matches the pattern in rehypeSearchHighlight.ts.
+interface HastText {
+  type: "text";
+  value: string;
+}
+
+interface HastElement {
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: HastNode[];
+}
+
+type HastNode = HastElement | HastText | { type: string };
+
+interface HastRoot {
+  type: "root";
+  children: HastNode[];
+}
+
+function isElement(node: HastNode): node is HastElement {
+  return node.type === "element";
+}
+
+function isText(node: HastNode): node is HastText {
+  return node.type === "text";
+}
+
+// The canonical structured-reply envelope (order is significant — it is the gate).
+const TOP_LEVEL_LABELS = [
+  "STATUS",
+  "ANSWER",
+  "SOURCE",
+  "CONFIDENCE",
+  "NEXT ACTION",
+  "OWNER",
+  "BLOCKER OR ESCALATION",
+] as const;
+
+// The three ANSWER sub-labels, also line-leading within the envelope.
+const SUB_LABELS = ["What it is", "Why it matters", "Done when"] as const;
+
+const ALL_LABELS: readonly string[] = [...TOP_LEVEL_LABELS, ...SUB_LABELS];
+
+// Existing semantic accent (`--primary`, defined in both light and dark themes —
+// the same token links use) plus the bold weight utility. No hard-coded color.
+const LABEL_CLASS = "text-primary font-bold";
+
+// Block containers whose first child begins a visual line. `blockquote` is
+// block-level too but is handled as skip-only (see SKIP_TAGS).
+const BLOCK_TAGS = new Set([
+  "p",
+  "div",
+  "li",
+  "td",
+  "th",
+  "dd",
+  "dt",
+  "section",
+  "article",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+]);
+
+// Never style a label inside these: code, pre, links, quotes/pasted source.
+const SKIP_TAGS = new Set(["code", "pre", "a", "blockquote"]);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Longest-first alternation so multi-word labels (e.g. "BLOCKER OR ESCALATION")
+// win over any shorter prefix. Anchored at the start of a line-leading text
+// node: up to three leading spaces (CommonMark strips more), the exact label,
+// a colon, then end-of-text or whitespace so "STATUSes:" style near-misses and
+// bare "STATUS" without a colon do not match.
+const LABEL_AT_LINE_START = new RegExp(
+  `^( {0,3})(${[...ALL_LABELS]
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join("|")}):(?=$|\\s)`,
+);
+
+function matchTopLevel(value: string): string | null {
+  const m = LABEL_AT_LINE_START.exec(value);
+  return m && (TOP_LEVEL_LABELS as readonly string[]).includes(m[2])
+    ? m[2]
+    : null;
+}
+
+/** Split a line-leading text node into [leadingSpaces?, <span>label:</span>, rest?]. */
+function styleLabel(node: HastText): HastNode[] {
+  const m = LABEL_AT_LINE_START.exec(node.value);
+  if (!m) return [node];
+  const lead = m[1];
+  const label = m[2];
+  const rest = node.value.slice(m[0].length);
+  const out: HastNode[] = [];
+  if (lead) out.push({ type: "text", value: lead });
+  out.push({
+    type: "element",
+    tagName: "span",
+    properties: { className: LABEL_CLASS },
+    children: [{ type: "text", value: `${label}:` }],
+  });
+  if (rest) out.push({ type: "text", value: rest });
+  return out;
+}
+
+/**
+ * Walk a children array tracking line-leading position. Collects every
+ * line-leading text value into `leads`; when `style` is true it also rewrites
+ * line-leading label text nodes into styled spans. `startAtLineStart` is true
+ * for a block container's children and for an inline element that itself sits
+ * at a line start.
+ */
+function processChildren(
+  nodes: HastNode[],
+  inSkip: boolean,
+  style: boolean,
+  leads: string[],
+  startAtLineStart: boolean,
+): HastNode[] {
+  const result: HastNode[] = [];
+  let atLineStart = startAtLineStart;
+
+  for (const node of nodes) {
+    if (isText(node)) {
+      if (atLineStart && !inSkip) {
+        leads.push(node.value);
+        if (style) {
+          result.push(...styleLabel(node));
+          atLineStart = false;
+          continue;
+        }
+      }
+      result.push(node);
+      atLineStart = false;
+      continue;
+    }
+
+    if (isElement(node)) {
+      if (node.tagName === "br") {
+        result.push(node);
+        atLineStart = true;
+        continue;
+      }
+      const childSkip = inSkip || SKIP_TAGS.has(node.tagName);
+      const isBlock =
+        BLOCK_TAGS.has(node.tagName) || node.tagName === "blockquote";
+      const newChildren = processChildren(
+        node.children ?? [],
+        childSkip,
+        style,
+        leads,
+        isBlock ? true : atLineStart,
+      );
+      result.push(style ? { ...node, children: newChildren } : node);
+      // A block element ends the current line; content after it begins a new
+      // one. Inline content keeps the line going.
+      atLineStart = isBlock;
+      continue;
+    }
+
+    result.push(node);
+    atLineStart = false;
+  }
+
+  return result;
+}
+
+export default function rehypeStructuredReplyLabels() {
+  return (tree: HastRoot) => {
+    // Pass 1: collect line-leading text and gate on the exact envelope.
+    const leads: string[] = [];
+    processChildren(tree.children, false, false, leads, true);
+    const topLevelFound = leads
+      .map(matchTopLevel)
+      .filter((label): label is string => label !== null);
+    const isEnvelope =
+      topLevelFound.length === TOP_LEVEL_LABELS.length &&
+      topLevelFound.every((label, i) => label === TOP_LEVEL_LABELS[i]);
+    if (!isEnvelope) return;
+
+    // Pass 2: style the labels in place.
+    tree.children = processChildren(tree.children, false, true, [], true);
+  };
+}

--- a/desktop/src/shared/ui/markdown/nodeCache.ts
+++ b/desktop/src/shared/ui/markdown/nodeCache.ts
@@ -6,6 +6,7 @@ import remarkGfm from "remark-gfm";
 import remarkMessageLinks from "@/features/messages/lib/remarkMessageLinks";
 import rehypeImageGallery from "@/shared/lib/rehypeImageGallery";
 import rehypeSearchHighlight from "@/shared/lib/rehypeSearchHighlight";
+import rehypeStructuredReplyLabels from "@/shared/lib/rehypeStructuredReplyLabels";
 import remarkChannelLinks from "@/shared/lib/remarkChannelLinks";
 import remarkCustomEmoji, {
   type CustomEmoji,
@@ -83,7 +84,10 @@ function listSegment(values: readonly string[] | undefined): string {
 function buildMarkdownElement(input: MarkdownParseInputs): React.ReactElement {
   markdownParseCount += 1;
   // biome-ignore lint/suspicious/noExplicitAny: PluggableList type not directly importable
-  const rehypePlugins: any[] = [rehypeImageGallery];
+  const rehypePlugins: any[] = [
+    rehypeImageGallery,
+    rehypeStructuredReplyLabels,
+  ];
   if (input.searchQuery && input.searchQuery.trim().length >= 2) {
     rehypePlugins.push([rehypeSearchHighlight, { query: input.searchQuery }]);
   }


### PR DESCRIPTION
## Summary
Some agents reply in a fixed, labelled envelope — a status line, an answer block
(broken into "what it is / why it matters / done when"), a source, a confidence,
a next action, an owner, and a blocker/escalation line. This adds a small,
presentation-only rehype plugin (`rehypeStructuredReplyLabels`) that gives those
labels the existing `--primary` accent and `font-bold` weight so the structure
reads at a glance.

It is deliberately narrow and safe:
- Acts only when the message is a valid envelope (the seven top-level labels
  appear line-leading, in the canonical order). Ordinary prose and other
  messages are untouched.
- Styles only the exact labels at line-leading positions; values and body text
  are never styled; it never descends into `code`/`pre`/`a`/`blockquote`.
- Renderer-only: the stored message text is never altered — labels are wrapped
  for display in the HAST phase, the same place as `rehypeSearchHighlight`.
- Uses the existing semantic accent token (no hard-coded color) and is wired
  into the single markdown parse choke point (`buildMarkdownElement`).

### Related issue
none found

### Testing
- New focused unit tests (`rehypeStructuredReplyLabels.test.mjs`, 12 cases):
  all ten labels styled; values unstyled; visible text byte-for-byte unchanged;
  false positives rejected (lone/mid-line label, out-of-order, partial envelope,
  label inside inline code, envelope quoted in a blockquote); ordinary Markdown
  (bold/list/link) unchanged.
- Full desktop unit suite `pnpm test` (4492/4492), `pnpm typecheck`, and
  `biome check` all pass.
