### PR TITLE
fix(relay): return OK(accepted=false) when admission rejects an EVENT

### DIFF
--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -650,7 +650,11 @@ async fn enforce_ws_admission(
         ClientMessage::Req { sub_id, .. } => Some(sub_id.as_str()),
         _ => None,
     };
-    if !send_admission_result(conn, ws_result, sub_id) {
+    let event_id = match msg {
+        ClientMessage::Event(event) => Some(event.id.to_hex()),
+        _ => None,
+    };
+    if !send_admission_result(conn, ws_result, sub_id, event_id.as_deref()) {
         return false;
     }
 
@@ -669,7 +673,7 @@ async fn enforce_ws_admission(
             message_limit,
         )
         .await;
-        if !send_admission_result(conn, message_result, None) {
+        if !send_admission_result(conn, message_result, None, event_id.as_deref()) {
             return false;
         }
     }
@@ -681,25 +685,32 @@ fn send_admission_result(
     conn: &ConnectionState,
     result: Result<(), crate::admission::AdmissionError>,
     sub_id: Option<&str>,
+    event_id: Option<&str>,
 ) -> bool {
-    match result {
-        Ok(()) => true,
+    let rejection = match result {
+        Ok(()) => return true,
         Err(crate::admission::AdmissionError::Exceeded { reset_in_secs }) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "quota").increment(1);
-            conn.send(request_rejection_message(
-                sub_id,
-                &format!("rate-limited: quota exceeded; retry in {reset_in_secs}s"),
-            ));
-            false
+            format!("rate-limited: quota exceeded; retry in {reset_in_secs}s")
         }
         Err(crate::admission::AdmissionError::Unavailable) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "unavailable").increment(1);
-            conn.send(request_rejection_message(
-                sub_id,
-                "rate-limited: shared admission unavailable",
-            ));
-            false
+            "rate-limited: shared admission unavailable".to_string()
         }
+    };
+    conn.send(admission_rejection_frame(&rejection, sub_id, event_id));
+    false
+}
+
+/// Frame sent when admission rejects a client message. A rejected EVENT must
+/// answer with NIP-01 OK(accepted=false): publishers wait for the OK by event
+/// id, and a bare NOTICE leaves them waiting until their publish timeout even
+/// though the rejection is final.
+fn admission_rejection_frame(reason: &str, sub_id: Option<&str>, event_id: Option<&str>) -> String {
+    if let Some(event_id) = event_id {
+        RelayMessage::ok(event_id, false, reason)
+    } else {
+        request_rejection_message(sub_id, reason)
     }
 }
 
@@ -713,6 +724,23 @@ fn topic_for_subscription(channel_id: Option<Uuid>) -> EventTopic {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn admission_rejection_of_event_returns_ok_frame() {
+        let frame = admission_rejection_frame("rate-limited: quota exceeded", None, Some("ab".repeat(32).as_str()));
+        let value: serde_json::Value = serde_json::from_str(&frame).expect("valid JSON");
+        assert_eq!(value[0], "OK");
+        assert_eq!(value[2], false);
+        assert!(value[3].as_str().expect("reason").contains("rate-limited"));
+    }
+
+    #[test]
+    fn admission_rejection_of_req_keeps_closed_frame() {
+        let frame = admission_rejection_frame("rate-limited", Some("sub-1"), None);
+        let value: serde_json::Value = serde_json::from_str(&frame).expect("valid JSON");
+        assert_eq!(value[0], "CLOSED");
+        assert_eq!(value[1], "sub-1");
+    }
     use std::sync::{Arc, Mutex};
 
     #[derive(Debug, Default)]


### PR DESCRIPTION
## Problem

Admission rejection (rate limits, gates) answered an EVENT with only a NOTICE. Publishers track per-event OK frames by event id (NIP-01), so a rejected EVENT left the publisher waiting until its own ~30s timeout — presenting as the relay randomly stalling under machine publish bursts.

## Fix

Admission rejection now returns `OK(accepted=false)` naming the event id, matching the frame contract publishers already implement for other rejections (duplicates, policy).

## Testing

- Pure-function regression test for the rejection frame (`cargo test -p buzz-relay admission`: 8 passed, 1 pre-existing ignore)
- In the downstream synthetic-organization branch this fix survived a 10-package concurrent stress run (2 workers, 10/10 ready-for-pr in 484s) that previously hung on publish timeouts