### PR TITLE
feat(desktop): auto-mention replied-to author on thread reply

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -13,6 +13,7 @@ import {
   isBroadcastReply,
   normalizeMentionPubkeys,
   resolveReplyRootId,
+  resolveReplyTargetAuthorPubkey,
 } from "@/features/messages/lib/threading";
 import {
   projectChannelWindowMessages,
@@ -99,6 +100,8 @@ export function createOptimisticMessage(
         parentEventId,
         resolveReplyRootId(parentEventId, currentMessages),
         mentionPubkeys,
+        resolveReplyTargetAuthorPubkey(parentEventId, currentMessages) ??
+          undefined,
       ),
     );
   } else {
@@ -459,11 +462,34 @@ export function useSendMessageMutation(
         emojiTags,
         mentionTags,
       } = splitOutgoingTags(mediaTags);
-      const recipientPubkeys = messageMentionPubkeys(
+      const recipientPubkeysBase = messageMentionPubkeys(
         effectiveChannel,
         identity.pubkey,
         mentionPubkeys,
       );
+
+      // Replying to a message implicitly addresses its author (notably agent
+      // accounts, which wake on an explicit mentioning `p` tag) even when the
+      // composer body has no literal "@mention". Resolve the replied-to event's
+      // author from the local cache and fold it into the real recipient p-tags
+      // so the reply actually reaches them on the wire.
+      let recipientPubkeys = recipientPubkeysBase;
+      if (parentEventId) {
+        const replyParentMessages =
+          queryClient.getQueryData<RelayEvent[]>(
+            channelMessagesKey(effectiveChannel.id),
+          ) ?? [];
+        const replyTargetAuthor = resolveReplyTargetAuthorPubkey(
+          parentEventId,
+          replyParentMessages,
+        );
+        if (replyTargetAuthor) {
+          recipientPubkeys = normalizeMentionPubkeys(
+            [...recipientPubkeysBase, replyTargetAuthor],
+            identity.pubkey,
+          );
+        }
+      }
 
       // Messages carrying media OR custom-emoji tags MUST go through REST so
       // the relay's tag validation runs. The WebSocket path emits no extra
@@ -494,6 +520,8 @@ export function useSendMessageMutation(
               parentEventId,
               resolveReplyRootId(parentEventId, cachedMessages),
               recipientPubkeys,
+              resolveReplyTargetAuthorPubkey(parentEventId, cachedMessages) ??
+                undefined,
             )
           : [];
         const baseTags = parentEventId

--- a/desktop/src/features/messages/lib/threading.test.mjs
+++ b/desktop/src/features/messages/lib/threading.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReplyTags, resolveReplyTargetAuthorPubkey } from "./threading.ts";
+
+const AGENT_PK = "aa".repeat(32);
+const SELF_PK = "bb".repeat(32);
+const OTHER_PK = "cc".repeat(32);
+const PARENT_ID = "11".repeat(32);
+const ROOT_ID = "22".repeat(32);
+const CHANNEL_ID = "00000000-0000-0000-0000-000000000000";
+
+test("buildReplyTags includes the replied-to author as a p-tag by default", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p");
+  // author + replied-to author
+  assert.deepEqual(
+    pTags.map((t) => t[1].toLowerCase()).sort(),
+    [AGENT_PK, SELF_PK].sort(),
+  );
+});
+
+test("buildReplyTags folds replied-to author together with explicit mentions and dedups", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [AGENT_PK, OTHER_PK],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  // SELF_PK (author), AGENT_PK (mention + replied-to, deduped), OTHER_PK
+  assert.equal(pTags.includes(SELF_PK), true);
+  assert.equal(pTags.filter((p) => p === AGENT_PK).length, 1);
+  assert.equal(pTags.includes(OTHER_PK), true);
+});
+
+test("buildReplyTags does not re-mention the composer (self) as reply target", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [],
+    SELF_PK, // replying to own message must not add a self p-tag twice
+  );
+  const selfMentions = tags.filter(
+    (t) => t[0] === "p" && t[1].toLowerCase() === SELF_PK,
+  );
+  // Only the author p-tag, no duplicate self mention.
+  assert.equal(selfMentions.length, 1);
+});
+
+test("buildReplyTags omits replied-to author when not provided", () => {
+  const tags = buildReplyTags(CHANNEL_ID, SELF_PK, PARENT_ID, ROOT_ID, []);
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  assert.deepEqual(pTags, [SELF_PK]);
+});
+
+test("resolveReplyTargetAuthorPubkey returns the parent author from the cache", () => {
+  const events = [
+    { id: PARENT_ID, pubkey: AGENT_PK, tags: [] },
+    { id: ROOT_ID, pubkey: OTHER_PK, tags: [] },
+  ];
+  assert.equal(resolveReplyTargetAuthorPubkey(PARENT_ID, events), AGENT_PK);
+});
+
+test("resolveReplyTargetAuthorPubkey returns null when parent is not in cache", () => {
+  assert.equal(resolveReplyTargetAuthorPubkey(PARENT_ID, []), null);
+});

--- a/desktop/src/features/messages/lib/threading.ts
+++ b/desktop/src/features/messages/lib/threading.ts
@@ -104,6 +104,7 @@ export function buildReplyTags(
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] = [],
+  replyTargetAuthorPubkey?: string,
 ) {
   const tags: string[][] = [
     ["p", authorPubkey],
@@ -113,7 +114,14 @@ export function buildReplyTags(
   // Add p-tags for mentioned users so mention-filtered subscriptions
   // (e.g. ACP agent harness) receive the reply event.
   // Best-effort normalization — relay performs authoritative validation.
-  for (const pubkey of normalizeMentionPubkeys(mentionPubkeys, authorPubkey)) {
+  // The replied-to event's author is folded in too: replying to a message is
+  // itself an implicit way of addressing its author (notably agent accounts,
+  // which wake on an explicit @mention / p-tag), so include it even when the
+  // composer text contains no literal "@mention".
+  const mentionSources = replyTargetAuthorPubkey
+    ? [...mentionPubkeys, replyTargetAuthorPubkey]
+    : mentionPubkeys;
+  for (const pubkey of normalizeMentionPubkeys(mentionSources, authorPubkey)) {
     tags.push(["p", pubkey]);
   }
 
@@ -159,4 +167,21 @@ export function resolveReplyRootId(
 
   const thread = getThreadReference(parent.tags);
   return thread.rootId ?? parent.id;
+}
+
+/**
+ * Resolve the author pubkey of the event being replied to, if it is present in
+ * the local message cache.
+ *
+ * Mirrors `resolveReplyRootId`'s lookup (same event array, same `id` match) so
+ * callers can fold the replied-to author into the reply's `p` tags — replying
+ * to a message implicitly addresses its author (e.g. an agent that wakes on an
+ * explicit mentioning `p` tag), even when the composer body has no literal
+ * `@mention`. Returns `null` when the parent event isn't in the cache yet.
+ */
+export function resolveReplyTargetAuthorPubkey(
+  parentEventId: string,
+  events: RelayEvent[],
+): string | null {
+  return events.find((event) => event.id === parentEventId)?.pubkey ?? null;
 }


### PR DESCRIPTION
## Summary

- When a user replies to a message, the replied-to event's author is now automatically added as a `p`-tag mention, even when the composer body has no literal `@mention`.
- Replying to a message is itself an implicit way of addressing its author — notably **agent accounts**, which wake on an explicit mentioning `p`-tag — so the reply now actually reaches the person/agent being replied to, without requiring a manual `@`.

## Motivation

In a human + agent channel, replying to an agent's message (e.g. "Reply to Honey") did not notify that agent, because the reply event carried only `e`-thread tags and no `p`-mention of the replied-to author. The user had to add an explicit `@mention` on every reply. This makes reply-to-author automatically address the author, matching user expectation.

## Changes

- `desktop/src/features/messages/lib/threading.ts`
  - `buildReplyTags` now accepts an optional `replyTargetAuthorPubkey` and folds the replied-to author into the `p`-tags (normalized, deduped, self-filtered via the existing `normalizeMentionPubkeys`).
  - New `resolveReplyTargetAuthorPubkey(parentEventId, events)` helper mirrors `resolveReplyRootId`'s cache lookup.
- `desktop/src/features/messages/hooks.ts`
  - The real send path (`useSendMessageMutation`) resolves the replied-to author from the local message cache and folds it into `recipientPubkeys`, so the wire `p`-tags include the author of the message being replied to.
  - The optimistic UI path threads the same author into `buildReplyTags`, keeping optimistic and real tags in sync.
- `desktop/src/features/messages/lib/threading.test.mjs` — 6 unit tests.

## Test Plan

- [x] `pnpm typecheck` (tsc --noEmit) passes
- [x] `pnpm check` (biome check + file-size/px/pubkey scripts) passes
- [x] `node --experimental-strip-types --test src/features/messages/lib/threading.test.mjs` — 6/6 pass

Tests cover: default include of replied-to author, dedup with explicit mentions, self-filtering (replying to your own message doesn't double-mention), omission when not provided, and cache-hit/cache-miss resolution.

## Notes for Reviewers

- The behavior intentionally applies to **any** replied-to author (agent or human), per the requester's decision: replying addresses the author regardless of account type.
- The wire path is the authoritative one; the optimistic path mirrors it only for UI consistency.
- No changes to relay or ACP-side matching — this resolves it purely in the desktop client by emitting the right `p`-tags.
