### PR TITLE
fix(media): enforce channel ACL on bound blobs (follow-up to 769ac70)

### DIFF
--- a/crates/buzz-media/src/error.rs
+++ b/crates/buzz-media/src/error.rs
@@ -18,6 +18,8 @@ pub enum MediaError {
     InvalidImage,
     #[error("media contains metadata or a non-canonical metadata channel")]
     MetadataForbidden,
+    #[error("invalid tag value for {0}")]
+    InvalidTag(&'static str),
     #[error("invalid signature")]
     InvalidSignature,
     #[error("invalid auth event kind")]
@@ -151,6 +153,7 @@ impl IntoResponse for MediaError {
             | Self::InvalidVideo
             | Self::InvalidImage
             | Self::MetadataForbidden => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
+            Self::InvalidTag(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             Self::Io(_) | Self::StorageError(_) | Self::Internal => {
                 tracing::error!(error = %self, "media storage error");
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
@@ -177,6 +180,16 @@ mod tests {
                 StatusCode::UNSUPPORTED_MEDIA_TYPE
             );
         }
+    }
+
+    #[test]
+    fn invalid_tag_maps_to_400() {
+        // A malformed `h` (channel) tag on the Blossom auth event is a caller
+        // mistake, not an auth failure — it must surface as 400, not 401/500.
+        assert_eq!(
+            MediaError::InvalidTag("h").into_response().status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     #[test]

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -330,6 +330,67 @@ mod tests {
         );
     }
 
+    /// Sidecars written before channel binding existed have no `channel_id`
+    /// key. They must still parse, as unbound. This is what makes rolling the
+    /// channel ACL out migration-free — every already-stored sidecar in S3
+    /// predates the field.
+    #[test]
+    fn blob_meta_legacy_sidecar_without_channel_id_parses_as_unbound() {
+        let legacy = r#"{
+            "dim": "800x600",
+            "blurhash": "LEHV6nWB2yk8pyo0adR*",
+            "thumb_url": "https://media.example.com/abc.thumb.jpg",
+            "ext": "jpg",
+            "mime_type": "image/jpeg",
+            "size": 1234,
+            "uploaded_at": 1700000000
+        }"#;
+
+        let meta: BlobMeta = serde_json::from_str(legacy).expect("legacy sidecar must still parse");
+        assert_eq!(meta.channel_id, None, "legacy sidecars are unbound");
+        // The rest of the sidecar must survive untouched.
+        assert_eq!(meta.ext, "jpg");
+        assert_eq!(meta.mime_type, "image/jpeg");
+        assert_eq!(meta.size, 1234);
+        assert_eq!(meta.uploaded_at, 1700000000);
+    }
+
+    /// The other half of the back-compat contract: an unbound sidecar must
+    /// serialize *without* the key, so newly written sidecars stay readable by
+    /// any older relay still running the previous binary.
+    #[test]
+    fn blob_meta_unbound_omits_channel_id_key() {
+        let meta = BlobMeta {
+            ext: "jpg".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            size: 1234,
+            channel_id: None,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&meta).expect("serialize unbound sidecar");
+        assert!(
+            json.get("channel_id").is_none(),
+            "unbound sidecars must omit channel_id entirely, got {json}"
+        );
+    }
+
+    #[test]
+    fn blob_meta_bound_round_trips_channel_id() {
+        let channel_id = uuid::Uuid::from_u128(0x0bad_c0de);
+        let meta = BlobMeta {
+            ext: "jpg".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            size: 1234,
+            channel_id: Some(channel_id),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&meta).expect("serialize bound sidecar");
+        let parsed: BlobMeta = serde_json::from_str(&json).expect("round-trip bound sidecar");
+        assert_eq!(parsed.channel_id, Some(channel_id));
+    }
+
     #[test]
     fn partial_static_keys_are_rejected() {
         let err = match MediaStorage::new(&storage_config("buzz_dev", "")) {
@@ -422,4 +483,10 @@ pub struct BlobMeta {
     /// Video duration in seconds. `None` for non-video blobs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_secs: Option<f64>,
+    /// Optional originating channel — when `Some`, reads require channel membership
+    /// for private channels (relay membership alone is insufficient). `None` means
+    /// the blob is not bound to a channel (e.g. avatar, open-channel, legacy).
+    /// Added as follow-up to `769ac70` which noted channel binding was missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<uuid::Uuid>,
 }

--- a/crates/buzz-media/src/upload.rs
+++ b/crates/buzz-media/src/upload.rs
@@ -17,6 +17,44 @@ use crate::validation::{
     validate_video_file,
 };
 
+/// Extract an optional `h` (channel) tag from a Blossom auth event.
+///
+/// When the uploader includes `["h", "<uuid>"]` in the kind:24242 auth
+/// event, the sidecar is bound to that channel and subsequent `GET`/`HEAD`
+/// requests require channel membership for private channels. `None` means
+/// unbound (legacy / avatar / open-channel) — relay membership alone suffices.
+/// If an `h` tag is present but malformed (missing value, not a UUID, nil
+/// UUID, or multiple conflicting values), the upload fails with
+/// `InvalidTag("h")` (400) rather than silently downgrading to unbound.
+fn extract_channel_id(
+    auth_event: &nostr::Event,
+) -> Result<Option<uuid::Uuid>, crate::error::MediaError> {
+    let h_tag = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
+    let mut found: Option<uuid::Uuid> = None;
+    for tag in auth_event.tags.iter() {
+        if tag.kind() == nostr::TagKind::SingleLetter(h_tag) {
+            let val = tag
+                .content()
+                .ok_or(crate::error::MediaError::InvalidTag("h"))?;
+            let id = uuid::Uuid::parse_str(val)
+                .map_err(|_| crate::error::MediaError::InvalidTag("h"))?;
+            if id.is_nil() {
+                return Err(crate::error::MediaError::InvalidTag("h"));
+            }
+            if let Some(existing) = found {
+                if existing != id {
+                    // Multiple h tags with different UUIDs — ambiguous binding.
+                    return Err(crate::error::MediaError::InvalidTag("h"));
+                }
+                // Duplicate same UUID — idempotent, keep first.
+            } else {
+                found = Some(id);
+            }
+        }
+    }
+    Ok(found)
+}
+
 /// Shared buffered-upload pipeline for the image and generic-file paths.
 ///
 /// Both paths are identical except for two steps, which are injected:
@@ -212,6 +250,7 @@ pub async fn process_upload(
     body: Bytes,
     attribution: Option<UploadAttribution>,
 ) -> Result<BlobDescriptor, MediaError> {
+    let channel_id = extract_channel_id(auth_event)?;
     process_buffered_upload(
         BufferedUploadInput {
             storage,
@@ -226,7 +265,11 @@ pub async fn process_upload(
             let ext = mime_to_ext(&mime).to_string();
             Ok((mime, ext))
         },
-        |input| async move { prepare_image_metadata(storage, config, input).await },
+        |input| async move {
+            let mut meta = prepare_image_metadata(storage, config, input).await?;
+            meta.channel_id = channel_id;
+            Ok(meta)
+        },
     )
     .await
 }
@@ -250,6 +293,7 @@ pub async fn process_file_upload(
     body: Bytes,
     attribution: Option<UploadAttribution>,
 ) -> Result<BlobDescriptor, MediaError> {
+    let channel_id = extract_channel_id(auth_event)?;
     process_buffered_upload(
         BufferedUploadInput {
             storage,
@@ -271,6 +315,7 @@ pub async fn process_file_upload(
                 mime_type: input.mime,
                 uploaded_at: input.uploaded_at,
                 duration_secs: None,
+                channel_id,
             };
             Ok(meta)
         },
@@ -298,6 +343,7 @@ pub async fn process_video_upload(
     content_length: Option<u64>,
     attribution: Option<UploadAttribution>,
 ) -> Result<BlobDescriptor, MediaError> {
+    let channel_id = extract_channel_id(auth_event)?;
     // --- 1. Stream body to temp file, compute SHA-256 incrementally ---
     let tmp = tempfile::NamedTempFile::new().map_err(|e| MediaError::Io(e.to_string()))?;
     let tmp_path = tmp.path().to_path_buf();
@@ -476,6 +522,7 @@ pub async fn process_video_upload(
         size: file_size,
         uploaded_at,
         duration_secs: Some(video_meta.duration_secs),
+        channel_id,
     };
 
     // Record before publishing the sidecar serve gate. See the buffered path.
@@ -596,6 +643,7 @@ mod tests {
             size: 5_000_000,
             uploaded_at: 1700000000,
             duration_secs: Some(29.5),
+            channel_id: None,
         };
 
         let desc = build_descriptor(
@@ -654,6 +702,7 @@ mod tests {
             size: 100_000,
             uploaded_at: 1700000000,
             duration_secs: None,
+            channel_id: None,
         };
 
         let desc = build_descriptor(
@@ -709,6 +758,101 @@ mod tests {
 
         // Non-limit errors should remain as Other.
         assert_eq!(detect("connection reset"), std::io::ErrorKind::Other);
+    }
+
+    /// Sign a kind:24242 Blossom auth event carrying `tags`.
+    ///
+    /// `extract_channel_id` only reads tags, but it takes a real `nostr::Event`,
+    /// so the tests build and sign real events rather than a stub.
+    fn auth_event_with_tags(tags: Vec<nostr::Tag>) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        nostr::EventBuilder::new(nostr::Kind::from(24242), "Upload buzz-media")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("sign auth event")
+    }
+
+    fn h_tag(value: &str) -> nostr::Tag {
+        nostr::Tag::parse(["h", value]).expect("h tag")
+    }
+
+    #[track_caller]
+    fn assert_invalid_h_tag(result: Result<Option<uuid::Uuid>, MediaError>) {
+        match result {
+            Err(MediaError::InvalidTag(tag)) => assert_eq!(tag, "h"),
+            other => panic!("expected InvalidTag(\"h\"), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_channel_id_absent_h_tag_is_unbound() {
+        // No h tag at all: the blob is unbound (avatar / legacy / open channel).
+        let event = auth_event_with_tags(vec![
+            nostr::Tag::parse(["t", "upload"]).expect("t tag"),
+            nostr::Tag::parse(["x", &"a".repeat(64)]).expect("x tag"),
+        ]);
+        assert_eq!(extract_channel_id(&event).expect("no h tag is valid"), None);
+    }
+
+    #[test]
+    fn extract_channel_id_single_valid_h_tag_binds_channel() {
+        let channel_id = uuid::Uuid::from_u128(0x1234_5678_9abc_def0);
+        let event = auth_event_with_tags(vec![
+            nostr::Tag::parse(["t", "upload"]).expect("t tag"),
+            h_tag(&channel_id.to_string()),
+        ]);
+        assert_eq!(
+            extract_channel_id(&event).expect("valid h tag"),
+            Some(channel_id)
+        );
+    }
+
+    #[test]
+    fn extract_channel_id_rejects_non_uuid_value() {
+        let event = auth_event_with_tags(vec![h_tag("general")]);
+        assert_invalid_h_tag(extract_channel_id(&event));
+    }
+
+    #[test]
+    fn extract_channel_id_rejects_nil_uuid() {
+        // The nil UUID is a parseable-but-meaningless binding — fail closed
+        // rather than silently downgrading the blob to unbound.
+        let event = auth_event_with_tags(vec![h_tag("00000000-0000-0000-0000-000000000000")]);
+        assert_invalid_h_tag(extract_channel_id(&event));
+    }
+
+    #[test]
+    fn extract_channel_id_rejects_empty_value() {
+        let event = auth_event_with_tags(vec![h_tag("")]);
+        assert_invalid_h_tag(extract_channel_id(&event));
+    }
+
+    #[test]
+    fn extract_channel_id_rejects_valueless_h_tag() {
+        let event = auth_event_with_tags(vec![nostr::Tag::parse(["h"]).expect("valueless h tag")]);
+        assert_invalid_h_tag(extract_channel_id(&event));
+    }
+
+    #[test]
+    fn extract_channel_id_duplicate_same_uuid_is_idempotent() {
+        let channel_id = uuid::Uuid::from_u128(0xfeed_face);
+        let value = channel_id.to_string();
+        let event = auth_event_with_tags(vec![h_tag(&value), h_tag(&value)]);
+        assert_eq!(
+            extract_channel_id(&event).expect("duplicate identical h tags are idempotent"),
+            Some(channel_id)
+        );
+    }
+
+    #[test]
+    fn extract_channel_id_rejects_conflicting_h_tags() {
+        // Two different channels is an ambiguous binding — reject rather than
+        // letting tag order decide which channel's ACL guards the blob.
+        let event = auth_event_with_tags(vec![
+            h_tag(&uuid::Uuid::from_u128(1).to_string()),
+            h_tag(&uuid::Uuid::from_u128(2).to_string()),
+        ]);
+        assert_invalid_h_tag(extract_channel_id(&event));
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -223,12 +223,22 @@ async fn feedback_attachment(
         return Err(ApiError::not_found());
     }
 
-    let response = crate::api::media::serve_blob_for_tenant(&state, &tenant, &sha256, &headers)
-        .await
-        .map_err(|error| match error {
-            buzz_media::MediaError::NotFound => ApiError::not_found(),
-            _ => ApiError::internal(),
-        })?;
+    // `Operator`: this read is already admin-authorized above and pinned to the
+    // feedback row's own provenance, so the sidecar channel ACL is deliberately
+    // not applied — an admin must be able to read an attachment from a private
+    // channel they are not a member of.
+    let response = crate::api::media::serve_blob_for_tenant_with_authority(
+        &state,
+        &tenant,
+        &sha256,
+        &headers,
+        crate::api::media::BlobReadAuthority::Operator,
+    )
+    .await
+    .map_err(|error| match error {
+        buzz_media::MediaError::NotFound => ApiError::not_found(),
+        _ => ApiError::internal(),
+    })?;
     tracing::info!(
         feedback_id = %feedback.id,
         community_id = %feedback.community_id,

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -61,6 +61,9 @@ fn upload_route_mode(path: &str) -> Result<UploadRouteMode, MediaError> {
 
 struct MediaReadAuth {
     tenant: TenantContext,
+    /// Pubkey of the Blossom auth signer — used for channel ACL when the
+    /// sidecar is bound to a private channel (follow-up to 769ac70).
+    pubkey: [u8; 32],
 }
 
 const MEDIA_UPLOAD_RATE_WINDOW: Duration = Duration::from_secs(60);
@@ -507,7 +510,117 @@ async fn authenticate_media_read(
     .await
     .map_err(|_| MediaError::RelayMembershipRequired)?;
 
-    Ok(MediaReadAuth { tenant })
+    Ok(MediaReadAuth {
+        tenant,
+        pubkey: auth_event.pubkey.to_bytes(),
+    })
+}
+
+/// Who is reading a blob, for channel-ACL purposes.
+///
+/// Making the bypass a named variant rather than an absent pubkey means every
+/// call site has to *say* which one it is: skipping the channel ACL is a
+/// deliberate word in the source, not the default that falls out of passing
+/// `None`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum BlobReadAuthority<'a> {
+    /// A Blossom-authenticated end user. Private-channel membership is enforced
+    /// against this pubkey before any bytes are served.
+    User(&'a [u8; 32]),
+    /// A server-side operator path that has already performed its own
+    /// authorization and provenance checks (e.g. the admin feedback-attachment
+    /// reader). The channel ACL is intentionally **not** applied.
+    Operator,
+}
+
+impl BlobReadAuthority<'_> {
+    /// Apply the channel ACL for this authority, if it is subject to one.
+    async fn enforce_channel_acl(
+        self,
+        state: &AppState,
+        tenant: &TenantContext,
+        sidecar: &buzz_media::BlobMeta,
+    ) -> Result<(), MediaError> {
+        match self {
+            Self::User(pubkey) => enforce_media_channel_acl(state, tenant, pubkey, sidecar).await,
+            Self::Operator => Ok(()),
+        }
+    }
+}
+
+/// Enforce channel ACL when a sidecar is bound to a channel.
+///
+/// Follow-up to `769ac70` which left channel binding as `TODO`: if
+/// `sidecar.channel_id` is `Some`, and the channel is `private`, the
+/// requester must be a current member (via `is_member_cached`). Open channels
+/// and unbound blobs rely on relay membership alone. Returns `NotFound` (not
+/// `Forbidden`) so a removed member cannot probe existence of private blobs.
+async fn enforce_media_channel_acl(
+    state: &AppState,
+    tenant: &TenantContext,
+    pubkey: &[u8; 32],
+    sidecar: &buzz_media::BlobMeta,
+) -> Result<(), MediaError> {
+    let Some(channel_id) = sidecar.channel_id else {
+        return Ok(());
+    };
+    // Look up channel to determine visibility. If the channel is missing,
+    // deleted, or lookup fails, fail closed as NotFound to avoid leaking
+    // existence of a private blob. Log at debug level for expected
+    // ChannelNotFound vs warn for DB transport errors to aid incident debugging
+    // without changing the wire 404.
+    let channel = state
+        .db
+        .get_channel(tenant.community(), channel_id)
+        .await
+        .map_err(|e| {
+            // Distinguish expected missing-channel (debug, high volume if channel deleted)
+            // from transport errors (warn, needs ops attention). Matched on the
+            // typed variant, never on the rendered message — the wire response is
+            // `NotFound` either way, so this only affects operator visibility.
+            if matches!(e, buzz_db::DbError::ChannelNotFound(_)) {
+                tracing::debug!(
+                    community = %tenant.community(),
+                    channel_id = %channel_id,
+                    error = %e,
+                    "media channel ACL: get_channel failed; returning NotFound"
+                );
+            } else {
+                tracing::warn!(
+                    community = %tenant.community(),
+                    channel_id = %channel_id,
+                    error = %e,
+                    "media channel ACL: get_channel DB error; returning NotFound"
+                );
+                metrics::counter!("buzz_media_channel_acl_db_errors_total").increment(1);
+            }
+            MediaError::NotFound
+        })?;
+    if channel.visibility != "private" {
+        return Ok(());
+    }
+    let is_member = state
+        .is_member_cached(tenant.community(), channel_id, pubkey)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                community = %tenant.community(),
+                channel_id = %channel_id,
+                error = %e,
+                "media channel ACL: is_member_cached failed; returning NotFound"
+            );
+            metrics::counter!("buzz_media_channel_acl_db_errors_total").increment(1);
+            MediaError::NotFound
+        })?;
+    if !is_member {
+        tracing::debug!(
+            community = %tenant.community(),
+            channel_id = %channel_id,
+            "media channel ACL: not a member, returning NotFound"
+        );
+        return Err(MediaError::NotFound);
+    }
+    Ok(())
 }
 
 fn blob_cache_control() -> &'static str {
@@ -600,7 +713,14 @@ pub async fn get_blob(
 ) -> Result<Response, MediaError> {
     validate_media_path(&sha256_ext)?;
     let media_auth = authenticate_media_read(&state, &req_headers, &sha256_ext).await?;
-    serve_blob_for_tenant(&state, &media_auth.tenant, &sha256_ext, &req_headers).await
+    serve_blob_for_tenant_with_authority(
+        &state,
+        &media_auth.tenant,
+        &sha256_ext,
+        &req_headers,
+        BlobReadAuthority::User(&media_auth.pubkey),
+    )
+    .await
 }
 
 /// Serve a validated blob from an already-authorized tenant context.
@@ -608,44 +728,51 @@ pub async fn get_blob(
 /// This is the common byte-serving mechanism for Blossom reads and narrowly
 /// scoped internal readers. Callers must establish their own authorization
 /// before entering this function; the tenant is never derived from client input.
-pub(crate) async fn serve_blob_for_tenant(
+///
+/// `authority` decides whether the sidecar's channel ACL applies — see
+/// [`BlobReadAuthority`]. [`BlobReadAuthority::Operator`] skips it and must only
+/// be passed by paths that have already authorized the read themselves.
+pub(crate) async fn serve_blob_for_tenant_with_authority(
     state: &AppState,
     tenant: &TenantContext,
     sha256_ext: &str,
     req_headers: &HeaderMap,
+    authority: BlobReadAuthority<'_>,
 ) -> Result<Response, MediaError> {
     validate_media_path(sha256_ext)?;
     let cache_control = blob_cache_control();
 
     // Sidecar gate FIRST — reject before any blob I/O. Storage is not authoritative.
+    // When a sidecar is bound to a private channel, also enforce channel membership.
     let content_type = if sha256_ext.ends_with(".thumb.jpg") {
         let parent_hash = sha256_ext.strip_suffix(".thumb.jpg").unwrap_or(sha256_ext);
-        let _ = state
+        let sidecar = state
             .media_storage
-            .read_sidecar_mime(tenant, parent_hash)
+            .get_sidecar(tenant, parent_hash)
             .await
-            .ok_or(MediaError::NotFound)?;
+            .map_err(|_| MediaError::NotFound)?;
+        authority
+            .enforce_channel_acl(state, tenant, &sidecar)
+            .await?;
         "image/jpeg".to_string()
     } else {
         // For explicit paths (hash.ext), verify the requested extension matches
         // the sidecar's canonical extension — sidecar is authoritative.
-        let sidecar_mime = state
+        let sidecar = state
             .media_storage
-            .read_sidecar_mime(tenant, sha256_ext)
+            .get_sidecar(tenant, sha256_ext.split('.').next().unwrap_or(sha256_ext))
             .await
-            .ok_or(MediaError::NotFound)?;
+            .map_err(|_| MediaError::NotFound)?;
+        authority
+            .enforce_channel_acl(state, tenant, &sidecar)
+            .await?;
         if sha256_ext.contains('.') {
             let requested_ext = sha256_ext.rsplit('.').next().unwrap_or("");
-            let sidecar = state
-                .media_storage
-                .get_sidecar(tenant, sha256_ext.split('.').next().unwrap_or(sha256_ext))
-                .await
-                .map_err(|_| MediaError::NotFound)?;
             if requested_ext != sidecar.ext {
                 return Err(MediaError::NotFound);
             }
         }
-        sidecar_mime
+        sidecar.mime_type.clone()
     };
 
     // Images and video render inline; generic files force download. This is the
@@ -795,35 +922,38 @@ pub async fn head_blob(
     validate_media_path(&sha256_ext)?;
     let media_auth = authenticate_media_read(&state, &headers, &sha256_ext).await?;
     let tenant = media_auth.tenant;
+    let authority = BlobReadAuthority::User(&media_auth.pubkey);
     let cache_control = blob_cache_control();
 
-    // Sidecar gate FIRST — reject before any blob I/O.
+    // Sidecar gate FIRST — reject before any blob I/O. Also enforce channel ACL
+    // for private channels when sidecar is bound (follow-up to 769ac70).
     let content_type = if sha256_ext.ends_with(".thumb.jpg") {
         let parent_hash = sha256_ext.strip_suffix(".thumb.jpg").unwrap_or(&sha256_ext);
-        let _ = state
+        let sidecar = state
             .media_storage
-            .read_sidecar_mime(&tenant, parent_hash)
+            .get_sidecar(&tenant, parent_hash)
             .await
-            .ok_or(MediaError::NotFound)?;
+            .map_err(|_| MediaError::NotFound)?;
+        authority
+            .enforce_channel_acl(&state, &tenant, &sidecar)
+            .await?;
         "image/jpeg".to_string()
     } else {
-        let sidecar_mime = state
+        let sidecar = state
             .media_storage
-            .read_sidecar_mime(&tenant, &sha256_ext)
+            .get_sidecar(&tenant, sha256_ext.split('.').next().unwrap_or(&sha256_ext))
             .await
-            .ok_or(MediaError::NotFound)?;
+            .map_err(|_| MediaError::NotFound)?;
+        authority
+            .enforce_channel_acl(&state, &tenant, &sidecar)
+            .await?;
         if sha256_ext.contains('.') {
             let requested_ext = sha256_ext.rsplit('.').next().unwrap_or("");
-            let sidecar = state
-                .media_storage
-                .get_sidecar(&tenant, sha256_ext.split('.').next().unwrap_or(&sha256_ext))
-                .await
-                .map_err(|_| MediaError::NotFound)?;
             if requested_ext != sidecar.ext {
                 return Err(MediaError::NotFound);
             }
         }
-        sidecar_mime
+        sidecar.mime_type.clone()
     };
 
     let key = resolve_s3_key(&state.media_storage, &tenant, &sha256_ext).await?;


### PR DESCRIPTION
## Problem

Blossom media reads (`GET`/`HEAD /media/{sha256}`) currently require only relay membership (`769ac70`). A blob uploaded for a private channel stays readable by any relay member who knows the SHA-256, even after being removed from that channel.

The `769ac70` commit message says as much: *"It does not yet bind a blob to its originating channel, so someone removed from a private channel can still read a known blob while remaining a relay member. That channel-ACL follow-up remains required."*

## What this PR does

Adds the channel binding to the sidecar and enforces it on read.

**`buzz-media`**
- `BlobMeta.channel_id: Option<Uuid>` — serde `default` + `skip_serializing_if = "Option::is_none"`. Existing sidecars parse as unbound; new unbound sidecars omit the key entirely, so an older relay binary can still read them. No migration.
- `extract_channel_id()` reads the `h` tag off the kind:24242 Blossom auth event in `process_upload` / `process_file_upload` / `process_video_upload`. It **fails closed**: an `h` tag that is present but malformed, nil, or ambiguous (two different UUIDs) rejects the upload with `400 InvalidTag` rather than silently downgrading the blob to unbound.

**`buzz-relay`**
- `enforce_media_channel_acl()` runs inside the existing sidecar gate, before any blob I/O. When a sidecar is bound and the channel's `visibility == "private"`, the requester must be a current member (`is_member_cached`). Open channels and unbound blobs are unaffected.
- Enforced on `GET`, `HEAD`, and the `.thumb.jpg` path (which checks the parent blob's sidecar).
- Misses return **404, not 403**, so a removed member cannot probe for the existence of private blobs. Channel-lookup and membership failures also fail closed to 404, logged at `debug!` for an expected missing channel and `warn!` + `buzz_media_channel_acl_db_errors_total` for real DB/transport errors.
- `BlobReadAuthority::{User, Operator}` replaces an `Option<&[u8; 32]>` requester pubkey, so skipping the ACL is an explicit word at the call site instead of the default that falls out of passing `None`. The admin feedback-attachment reader (already admin-authorized and pinned to the feedback row's provenance) is the only `Operator` caller.

## Scope — read this before reviewing

**No first-party client emits an `h` tag on its upload auth event yet** (`desktop/src-tauri/src/commands/media.rs`, `mobile/lib/shared/relay/media_upload.dart`, `crates/buzz-cli/src/client.rs` all send only `t`/`x`/`expiration`/`server`). Official client flows therefore write unbound sidecars. However, the relay accepts valid Blossom auth events from custom clients, so server-side `h` acceptance is reachable immediately and must not be treated as inert.

This PR is deliberately the mechanism plus read-side enforcement. Two things are left as follow-ups:

1. **Clients binding uploads to their channel.** Touches three platforms and is what actually closes the leak.
2. **Binding vs. content-addressed dedupe.** `process_buffered_upload` short-circuits when the blob and sidecar both exist and does not rewrite the sidecar, so the first upload of a given hash wins the binding. Once clients emit `h`, the same bytes posted to an open channel *after* a private one would inherit the private binding and 404 for non-members. That semantic needs a decision (rebind on re-upload? widen to least-restrictive? bind per-reference instead of per-blob?) before enforcement is switched on end-to-end.

Also not addressed: the upload path does not verify that the uploader is actually a member of the channel named in the `h` tag. Combined with (2), that is a poisoning vector for custom clients as soon as server-side support is deployed.

## Design decision requested

Review feedback correctly identified that a single `(community, sha256) -> channel_id` sidecar cannot safely represent multi-channel access grants, and that the first-write-wins dedupe path can make an attacker-controlled binding authoritative. Before merging server-side `h` acceptance or enabling first-party client `h` emission, the authority model needs an explicit maintainer decision: either land only dormant read-side groundwork while rejecting upload `h` tags, or replace the sidecar authority with tenant-scoped durable grants created with accepted channel events. No client `h` emission should land until that decision is resolved.

## Testing

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p buzz-media` — 120 passed
- [x] `cargo fmt --all -- --check` — clean
- [x] Unit tests for `extract_channel_id`: absent tag, single valid UUID, non-UUID value, nil UUID, empty value, valueless `["h"]`, duplicate-identical (idempotent), conflicting UUIDs
- [x] Unit tests for the sidecar back-compat contract: legacy JSON without `channel_id` parses as unbound; unbound serializes without the key; bound round-trips
- [x] Unit test that `MediaError::InvalidTag` maps to HTTP 400
- [ ] Integration (`just test`) not run locally — needs Postgres + Redis
- No e2e for the ACL itself yet; it requires a client that emits `h`, which lands with follow-up (1).

