### PR TITLE
docs(acp): correct Codex quick-start, idle timeout, and author gate

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -74,6 +74,7 @@ npm install -g @agentclientprotocol/codex-acp
 
 # Run
 export OPENAI_API_KEY="sk-..."   # required — use an OpenAI API key, not a ChatGPT subscription
+export BUZZ_ACP_AGENT_COMMAND="codex-acp"
 
 buzz-acp
 ```
@@ -111,7 +112,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
-| `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `BUZZ_ACP_IDLE_TIMEOUT` | no | `900` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 
@@ -160,6 +161,19 @@ Use `!cancel` to stop only the current turn; it is a no-op when the channel is i
 Owner control commands must be kind:9 stream messages from the owner, must mention this agent with a `p` tag, and are consumed by the harness instead of being forwarded to the agent.
 
 > **Note:** The default mode is `owner-only`. Agents without a registered `agent_owner_pubkey` will not respond to any events until the owner is resolved. Set `--respond-to anyone` to disable the gate entirely.
+
+> **Same-owner siblings:** `owner-only` and `allowlist` also accept other agents
+> that share this agent's owner, verified from the author's NIP-OA auth tag in
+> its kind:0 profile. The allowlist adds external pubkeys on top; it never
+> revokes same-owner team bots.
+
+> **DMs are stricter than the mode suggests:** clients auto-p-tag every DM
+> participant, so any participant's message would otherwise look like a mention
+> and fire a turn — which would turn `anyone` and `allowlist` into transitive
+> access grants for whoever lands in a DM with the agent. Inside a DM only the
+> owner and verified same-owner siblings may prompt the agent; `anyone` and the
+> explicit allowlist do not apply, and `nobody` still drops everything. Channel
+> type resolves fail-closed: unknown type is treated as a DM.
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

Three statements in `crates/buzz-acp/README.md` disagree with the code they describe. Docs only, no behavior change.

**1. The Codex quick-start silently spawns goose.** The "Running with Codex" block never sets `BUZZ_ACP_AGENT_COMMAND`, which defaults to `"goose"` (`config.rs`). Following it verbatim installs `codex-acp` and then runs goose. The Claude Code section already sets the variable, so this also removes an inconsistency between the two runtime sections.

**2. `BUZZ_ACP_IDLE_TIMEOUT` is documented as `620`.** `DEFAULT_IDLE_TIMEOUT_SECS` is `900` (`config.rs`), asserted by a unit test in the same file.

**3. The author-gate section omits two behaviors that change who can prompt an agent.** The table documents four modes and notes the owner is implicitly included, but does not mention that:

- `owner-only` and `allowlist` also accept **same-owner siblings**, verified from the author's NIP-OA auth tag (`is_owner_or_sibling`);
- inside a **DM**, `anyone` and `allowlist` do not apply at all — only the owner and verified siblings may fire a turn, and unknown channel type is treated as a DM.

Both are already documented in the `author_allowed` doc comment; this surfaces them where operators configure the gate. The DM behavior in particular is a deliberate hardening against transitive access grants, and an operator reading only the README could reasonably conclude `--respond-to allowlist` is authoritative in DMs.

### Related issue

None found. Searched open issues and PRs for these specifics. The closest related PR is #5168, which also touches DM handling in this crate, but changes the mention subscription filter rather than the author gate — no overlap with these lines.

### Testing

Documentation only; no code paths changed and no tests affected. Each correction was checked against the source at the commit this branch is based on rather than inferred from the docs.