### PR TITLE
Feat/ghar buzz gitops auth

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+self-hosted-runner:
+  labels:
+    - arc-buzz-database
+    - arc-database-operations
+
+config-variables: null
+
+paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1107,3 +1107,66 @@ jobs:
           LLAMA_STAGE_BACKEND: metal
           LLAMA_STAGE_BUILD_DIR: ${{ github.workspace }}/.cache/mesh-llama/build-stage-abi-metal
           SKIPPY_LLAMA_AUTO_BUILD: "0"
+
+  keycloak-setup:
+    name: Keycloak Client Setup (buzz)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - changes
+      - rust-lint
+      - unit-tests
+      - desktop-core
+      - desktop-smoke-e2e
+      - desktop
+      - desktop-e2e-relay
+      - desktop-e2e-integration-shard
+      - desktop-e2e-integration
+      - backend-integration
+      - relay-e2e
+      - web
+      - mobile
+      - security
+      - dead-token-guard
+      - server-cross-compile
+      - windows-rust
+      - desktop-build-macos
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/keycloak-setup.yml
+    with:
+      client_id: buzz
+
+  deploy:
+    name: Deploy to Prod (apps-prod-buzz)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [
+      changes,
+      rust-lint,
+      unit-tests,
+      desktop-core,
+      desktop-smoke-e2e,
+      desktop,
+      desktop-e2e-relay,
+      desktop-e2e-integration-shard,
+      desktop-e2e-integration,
+      backend-integration,
+      relay-e2e,
+      web,
+      mobile,
+      security,
+      dead-token-guard,
+      server-cross-compile,
+      windows-rust,
+      desktop-build-macos,
+      keycloak-setup
+    ]
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      image_tag: main
+      app_name: apps-prod-buzz
+      sync_enabled: true
+      wait: true

--- a/.github/workflows/database-operations.yml
+++ b/.github/workflows/database-operations.yml
@@ -13,7 +13,7 @@ on:
           - migrate
         default: healthcheck
       migration_file:
-        description: "Ficheiro SQL versionado no repo; obrigatório para migrate"
+        description: "Ficheiro SQL em migrations/; obrigatório para migrate"
         required: false
         type: string
         default: ""
@@ -23,22 +23,78 @@ permissions:
   id-token: write
 
 jobs:
-  database:
-    uses: lolmeida/github-actions/.github/workflows/database.yml@main # NOSONAR: adoption is pinned to @main until the GHAR v1 release
-    with:
-      engine: postgres
-      operation: ${{ inputs.operation }}
-      environment: production
-      database_name: buzz
-      migration_file: ${{ inputs.migration_file }}
-      admin_ssm_connection_path: /shared/postgres
-      application_ssm_connection_path: /buzz
-      admin_host: postgres.prod-database.svc.cluster.local
-      admin_port: "5432"
-      admin_username: lolmeida
-      application_host: postgres.prod-database.svc.cluster.local
-      application_port: "5432"
-      postgres_sslmode: require
-      aws_region: eu-central-1
-      aws_role_arn: arn:aws:iam::904727092208:role/github-actions-buzz-database
-      runs_on: arc-buzz-database
+  dispatch:
+    runs-on: arc-buzz-database
+    environment: production
+    timeout-minutes: 20
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::904727092208:role/github-actions-buzz-dispatch
+          aws-region: eu-central-1
+
+      - name: Dispatch private GHAR workflow
+        env:
+          AWS_REGION: eu-central-1
+          OPERATION: ${{ inputs.operation }}
+          MIGRATION_FILE: ${{ inputs.migration_file }}
+          GHAR_REPOSITORY: lolmeida/github-actions
+          GHAR_WORKFLOW: database.yml
+          GHAR_REF: main
+        run: |
+          set -euo pipefail
+          github_token="$(aws ssm get-parameter \
+            --name /shared/github/READ_TOKEN \
+            --with-decryption \
+            --region "$AWS_REGION" \
+            --query 'Parameter.Value' \
+            --output text)"
+          [[ -n "$github_token" && "$github_token" != None ]] || { echo "::error::dispatch token unavailable"; exit 1; }
+
+          dispatch_started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          dispatch_body="$(jq -cn \
+            --arg operation "$OPERATION" \
+            --arg migration_file "$MIGRATION_FILE" \
+            '{ref:"main",inputs:{operation:$operation,migration_file:$migration_file,migration_ref:"main"}}')"
+          dispatch_status="$(curl -sS -o "$RUNNER_TEMP/ghar-dispatch-response" -w '%{http_code}' \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $github_token" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H 'Content-Type: application/json' \
+            "https://api.github.com/repos/$GHAR_REPOSITORY/actions/workflows/$GHAR_WORKFLOW/dispatches" \
+            --data "$dispatch_body")"
+          [[ "$dispatch_status" == 204 ]] || { echo "::error::GHAR dispatch failed with HTTP $dispatch_status"; cat "$RUNNER_TEMP/ghar-dispatch-response"; exit 1; }
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            runs_json="$(curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $github_token" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/$GHAR_REPOSITORY/actions/workflows/$GHAR_WORKFLOW/runs?event=workflow_dispatch&branch=$GHAR_REF&per_page=20")"
+            run_id="$(jq -r --arg since "$dispatch_started" '.workflow_runs | map(select(.created_at >= $since)) | sort_by(.created_at) | last.id // empty' <<< "$runs_json")"
+            [[ "$run_id" =~ ^[0-9]+$ ]] && break
+            sleep 2
+          done
+          [[ "$run_id" =~ ^[0-9]+$ ]] || { echo "::error::GHAR run was not created after dispatch"; exit 1; }
+
+          for _ in $(seq 1 90); do
+            run_json="$(curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $github_token" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/$GHAR_REPOSITORY/actions/runs/$run_id")"
+            status="$(jq -r '.status' <<< "$run_json")"
+            if [[ "$status" == completed ]]; then
+              conclusion="$(jq -r '.conclusion' <<< "$run_json")"
+              run_url="$(jq -r '.html_url' <<< "$run_json")"
+              [[ "$conclusion" == success ]] || { echo "::error::GHAR run failed: $run_url"; exit 1; }
+              echo "GHAR database operation completed: $run_url"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::GHAR run timed out: https://github.com/$GHAR_REPOSITORY/actions/runs/$run_id"
+          exit 1

--- a/.github/workflows/database-operations.yml
+++ b/.github/workflows/database-operations.yml
@@ -51,6 +51,12 @@ jobs:
             --query 'Parameter.Value' \
             --output text)"
           [[ -n "$github_token" && "$github_token" != None ]] || { echo "::error::dispatch token unavailable"; exit 1; }
+          github_curl_config="$RUNNER_TEMP/ghar-curl.conf"
+          umask 077
+          printf 'header = "Authorization: Bearer %s"\nheader = "Accept: application/vnd.github+json"\nheader = "X-GitHub-Api-Version: 2022-11-28"\n' \
+            "$github_token" > "$github_curl_config"
+          github_token=""
+          trap 'rm -f "$github_curl_config"' EXIT
 
           dispatch_started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           dispatch_body="$(jq -cn \
@@ -58,10 +64,8 @@ jobs:
             --arg migration_file "$MIGRATION_FILE" \
             '{ref:"main",inputs:{operation:$operation,migration_file:$migration_file,migration_ref:"main"}}')"
           dispatch_status="$(curl -sS -o "$RUNNER_TEMP/ghar-dispatch-response" -w '%{http_code}' \
+            --config "$github_curl_config" \
             -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $github_token" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
             -H 'Content-Type: application/json' \
             "https://api.github.com/repos/$GHAR_REPOSITORY/actions/workflows/$GHAR_WORKFLOW/dispatches" \
             --data "$dispatch_body")"
@@ -70,9 +74,7 @@ jobs:
           run_id=""
           for _ in $(seq 1 30); do
             runs_json="$(curl -fsS \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $github_token" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --config "$github_curl_config" \
               "https://api.github.com/repos/$GHAR_REPOSITORY/actions/workflows/$GHAR_WORKFLOW/runs?event=workflow_dispatch&branch=$GHAR_REF&per_page=20")"
             run_id="$(jq -r --arg since "$dispatch_started" '.workflow_runs | map(select(.created_at >= $since)) | sort_by(.created_at) | last.id // empty' <<< "$runs_json")"
             [[ "$run_id" =~ ^[0-9]+$ ]] && break
@@ -82,9 +84,7 @@ jobs:
 
           for _ in $(seq 1 90); do
             run_json="$(curl -fsS \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $github_token" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --config "$github_curl_config" \
               "https://api.github.com/repos/$GHAR_REPOSITORY/actions/runs/$run_id")"
             status="$(jq -r '.status' <<< "$run_json")"
             if [[ "$status" == completed ]]; then

--- a/.github/workflows/database-operations.yml
+++ b/.github/workflows/database-operations.yml
@@ -1,0 +1,44 @@
+name: Buzz Database Operations
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Operação da base de dados"
+        required: true
+        type: choice
+        options:
+          - healthcheck
+          - ensure
+          - migrate
+        default: healthcheck
+      migration_file:
+        description: "Ficheiro SQL versionado no repo; obrigatório para migrate"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  database:
+    uses: lolmeida/github-actions/.github/workflows/database.yml@main # NOSONAR: adoption is pinned to @main until the GHAR v1 release
+    with:
+      engine: postgres
+      operation: ${{ inputs.operation }}
+      environment: production
+      database_name: buzz
+      migration_file: ${{ inputs.migration_file }}
+      admin_ssm_connection_path: /shared/postgres
+      application_ssm_connection_path: /buzz
+      admin_host: postgres.prod-database.svc.cluster.local
+      admin_port: "5432"
+      admin_username: lolmeida
+      application_host: postgres.prod-database.svc.cluster.local
+      application_port: "5432"
+      postgres_sslmode: require
+      aws_region: eu-central-1
+      aws_role_arn: arn:aws:iam::904727092208:role/github-actions-buzz-database
+      runs_on: arc-buzz-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,86 @@
+name: Deploy Buzz via GitOps (GHAR)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (ex: 1.2.3 or latest)"
+        required: true
+        type: string
+      app_name:
+        description: "ArgoCD app name"
+        required: false
+        default: apps-prod-buzz
+        type: string
+      sync_enabled:
+        description: "Run ArgoCD sync after updating values"
+        required: false
+        default: true
+        type: boolean
+      wait:
+        description: "Wait for ArgoCD sync completion"
+        required: false
+        default: true
+        type: boolean
+      runs_on:
+        description: "Runner label used by GHAR"
+        required: false
+        default: ubuntu-latest
+        type: string
+      prune:
+        description: "Prune resources not in desired state"
+        required: false
+        default: false
+        type: boolean
+
+  workflow_call:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (ex: 1.2.3)"
+        required: true
+        type: string
+      app_name:
+        description: "ArgoCD app name"
+        required: false
+        default: apps-prod-buzz
+        type: string
+      sync_enabled:
+        description: "Run ArgoCD sync after updating values"
+        required: false
+        default: true
+        type: boolean
+      wait:
+        description: "Wait for ArgoCD sync completion"
+        required: false
+        default: true
+        type: boolean
+      runs_on:
+        description: "Runner label used by GHAR"
+        required: false
+        default: ubuntu-latest
+        type: string
+      prune:
+        description: "Prune resources not in desired state"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  deploy:
+    uses: lolmeida/github-actions/.github/workflows/gitops-deploy.yml@v1
+    with:
+      app_name: ${{ inputs.app_name }}
+      image_tag: ${{ inputs.image_tag }}
+      values_file: deploy/charts/buzz/values.yaml
+      sync_enabled: ${{ inputs.sync_enabled }}
+      wait: ${{ inputs.wait }}
+      prune: ${{ inputs.prune }}
+      runs_on: ${{ inputs.runs_on }}
+      aws_iam_role: arn:aws:iam::904727092208:role/github-actions-buzz-dispatch
+      aws_region: eu-central-1
+      ssm_server_path: /argocd/server
+      ssm_token_path: /argocd/auth-token

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,7 @@ env:
   # variable to override (e.g., for forks that want to push to their own
   # namespace without forking this file).
   IMAGE_NAME: ${{ vars.GHCR_IMAGE != '' && vars.GHCR_IMAGE || 'ghcr.io/block/buzz' }}
+  PUSH_GATEWAY_IMAGE: ${{ vars.GHCR_PUSH_GATEWAY_IMAGE != '' && vars.GHCR_PUSH_GATEWAY_IMAGE || 'ghcr.io/block/buzz-push-gateway' }}
 
 jobs:
   build:
@@ -387,7 +388,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
-          images: ghcr.io/block/buzz-push-gateway
+          images: ${{ env.PUSH_GATEWAY_IMAGE }}
           labels: |
             org.opencontainers.image.title=Buzz Push Gateway
             org.opencontainers.image.description=Capability-gated APNs last hop for Buzz
@@ -400,9 +401,9 @@ jobs:
           file: ./Dockerfile.push-gateway
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=ghcr.io/block/buzz-push-gateway,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: type=registry,ref=ghcr.io/block/buzz-push-gateway-buildcache:${{ matrix.arch }}
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/block/buzz-push-gateway-buildcache:{0},mode=max,compression=zstd', matrix.arch) || '' }}
+          outputs: type=image,name=${{ env.PUSH_GATEWAY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=registry,ref=${{ env.PUSH_GATEWAY_IMAGE }}-buildcache:${{ matrix.arch }}
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref={0}-buildcache:{1},mode=max,compression=zstd', env.PUSH_GATEWAY_IMAGE, matrix.arch) || '' }}
       - name: Export digest
         if: github.event_name != 'pull_request'
         env:
@@ -447,7 +448,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
-          images: ghcr.io/block/buzz-push-gateway
+          images: ${{ env.PUSH_GATEWAY_IMAGE }}
           tags: |
             type=ref,event=branch,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
             type=sha,prefix=sha-,format=short,enable=${{ github.event_name != 'workflow_dispatch' || inputs.version == '' }}
@@ -461,7 +462,7 @@ jobs:
         run: |
           set -euo pipefail
           tags=(); while IFS= read -r tag; do [ -n "$tag" ] && tags+=("-t" "$tag"); done <<< "$META_TAGS"
-          digests=(); for digest in *; do digests+=("ghcr.io/block/buzz-push-gateway@sha256:${digest}"); done
+          digests=(); for digest in *; do digests+=("${PUSH_GATEWAY_IMAGE}@sha256:${digest}"); done
           docker buildx imagetools create "${tags[@]}" "${digests[@]}"
           first_tag=$(echo "$META_TAGS" | head -n1)
           digest=$(docker buildx imagetools inspect "$first_tag" --format '{{json .Manifest}}' | jq -r '.digest')
@@ -469,7 +470,7 @@ jobs:
       - name: Attest gateway image provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/block/buzz-push-gateway
+          subject-name: ${{ env.PUSH_GATEWAY_IMAGE }}
           subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
       - name: Gateway publication summary
@@ -479,7 +480,7 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "### Published \`ghcr.io/block/buzz-push-gateway\`"
+            echo "### Published \`${PUSH_GATEWAY_IMAGE}\`"
             echo
             printf "**Digest:** \`%s\`\n" "$GATEWAY_DIGEST"
             echo
@@ -490,6 +491,6 @@ jobs:
             echo
             echo 'Verify provenance before deployment:'
             echo "\`\`\`"
-            printf 'gh attestation verify oci://ghcr.io/block/buzz-push-gateway@%s --owner block\n' "$GATEWAY_DIGEST"
+            printf 'gh attestation verify oci://%s@%s --owner lolmeida\n' "$PUSH_GATEWAY_IMAGE" "$GATEWAY_DIGEST"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/keycloak-setup.yml
+++ b/.github/workflows/keycloak-setup.yml
@@ -1,0 +1,103 @@
+name: Keycloak Client Setup (buzz)
+
+on:
+  workflow_dispatch:
+    inputs:
+      client_id:
+        description: 'Keycloak client_id (derives SSM paths + redirect URIs)'
+        required: true
+        default: buzz
+        type: string
+      public_client:
+        description: 'Public PKCE client (true for SPAs/frontends; false for oauth2-proxy/confidential)'
+        required: false
+        default: false
+        type: boolean
+      reconcile_existing_client:
+        description: 'Reconcile existing Keycloak client config (redirect URIs, web origins, PKCE, client type, secret/public mode)'
+        required: false
+        default: false
+        type: boolean
+      extra_redirect_uris:
+        description: 'JSON array of extra redirect URIs'
+        required: false
+        default: '[]'
+        type: string
+      callback_path:
+        description: 'OAuth2 callback path (default /oauth2/callback)'
+        required: false
+        default: '/oauth2/callback'
+        type: string
+      group_members:
+        description: 'Users to ensure in /<client_id>-admins'
+        required: false
+        default: '[]'
+        type: string
+      super_admin_members:
+        description: 'Users to ensure in /super-admins'
+        required: false
+        default: '[]'
+        type: string
+
+  workflow_call:
+    inputs:
+      client_id:
+        description: 'Keycloak client_id (derives SSM paths + redirect URIs)'
+        required: true
+        type: string
+      public_client:
+        description: 'Public PKCE client (true for SPAs/frontends; false for oauth2-proxy/confidential)'
+        required: false
+        type: boolean
+        default: false
+      reconcile_existing_client:
+        description: 'Reconcile existing Keycloak client config (redirect URIs, web origins, PKCE, client type, secret/public mode)'
+        required: false
+        type: boolean
+        default: false
+      extra_redirect_uris:
+        description: 'JSON array of extra redirect URIs'
+        required: false
+        type: string
+        default: '[]'
+      callback_path:
+        description: 'OAuth2 callback path (default /oauth2/callback)'
+        required: false
+        type: string
+        default: '/oauth2/callback'
+      group_members:
+        description: 'Users to ensure in /<client_id>-admins'
+        required: false
+        type: string
+        default: '[]'
+      super_admin_members:
+        description: 'Users to ensure in /super-admins'
+        required: false
+        type: string
+        default: '[]'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  keycloak-client-setup:
+    uses: lolmeida/github-actions/.github/workflows/keycloak-client-setup.yml@v1
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      client_id: ${{ inputs.client_id }}
+      keycloak_url: https://keycloak.lolmeida.com
+      realm: peah
+      domain: lolmeida.com
+      public_client: ${{ inputs.public_client }}
+      reconcile_existing_client: ${{ inputs.reconcile_existing_client }}
+      extra_redirect_uris: ${{ inputs.extra_redirect_uris }}
+      callback_path: ${{ inputs.callback_path }}
+      group_members: ${{ inputs.group_members }}
+      super_admin_members: ${{ inputs.super_admin_members }}
+      aws_region: eu-central-1
+      aws_iam_role: arn:aws:iam::904727092208:role/github-actions-buzz-dispatch
+      admin_username_ssm_path: /shared/keycloak/ADMIN_USERNAME
+      admin_password_ssm_path: /shared/keycloak/ADMIN_PASSWORD

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -23,6 +23,15 @@
 - [ ] Relay acessível por HTTPS/WSS
 - [ ] Testes funcionais concluídos
 
+## Operações da base
+
+- [x] Bootstrap ArgoCD com credencial admin `/shared/postgres/PASSWORD` e
+  credenciais de aplicação `/buzz/POSTGRES_*`
+- [x] GHAR dual-credential workflow mergeado (`lolmeida/github-actions#36`)
+- [x] Runner ARC dedicado `arc-buzz-database` declarado e acesso de rede
+  permitido
+- [ ] Workflow Buzz GHAR mergeado e healthcheck/ensure executados
+
 ## Phase 4 — Validação operacional
 
 - [ ] Backup e restore validados — CronJob declarado; restore ainda não executado
@@ -35,3 +44,4 @@
 - a validação de migrations/restore em PostgreSQL 15 ainda está pendente;
 - o digest próprio do fork ainda depende do workflow `31128599898`;
 - a validação pública de `buzz.lolmeida.com` ainda está pendente.
+- o workflow operacional do Buzz ainda está no PR #12.

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -4,7 +4,8 @@
 
 - [x] Fork e remotes configurados
 - [x] Plano e ADR documentados
-- [ ] Pipeline de imagem validado — workflow `31128541447` ainda em execução
+- [x] Pipeline de chart validado (workflow `31128437223`)
+- [ ] Pipeline de imagem própria — workflow `31128599898` ainda em execução
 - [x] PR de bootstrap aberto e mergeado (#2)
 
 ## Phase 2 — Infraestrutura GitOps
@@ -39,4 +40,5 @@
 - o Vaultwarden está inacessível pelo endpoint HTTPS;
 - o containerd do MicroK8s reporta snapshots/mounts ausentes;
 - a identidade Nostr do owner/relay ainda precisa de decisão e armazenamento no Vaultwarden;
-- a imagem multi-arch ainda precisa de digest publicado no GHCR.
+- staging já está fixado no digest público imutável do relay oficial;
+- o digest próprio do fork ainda depende do workflow `31128599898`.

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -2,29 +2,38 @@
 
 ## Phase 1 — Bootstrap
 
-- [ ] Fork e remotes configurados
-- [ ] Plano e ADR documentados
-- [ ] Pipeline de imagem validado
-- [ ] PR de bootstrap aberto
+- [x] Fork e remotes configurados
+- [x] Plano e ADR documentados
+- [ ] Pipeline de imagem validado — workflow de release ainda em execução
+- [x] PR de bootstrap aberto e mergeado (#2)
 
 ## Phase 2 — Infraestrutura GitOps
 
-- [ ] ArgoCD repository preparado
-- [ ] PostgreSQL 17 dedicado
-- [ ] Redis 7.x dedicado
-- [ ] S3/prefixo dedicado
-- [ ] ExternalSecrets configurados
+- [x] ArgoCD repository preparado (#101, #102)
+- [x] PostgreSQL 17 dedicado declarado
+- [x] Redis 7.x dedicado declarado
+- [ ] S3/prefixo dedicado — bucket ainda não provisionado
+- [x] ExternalSecret declarado
 
 ## Phase 3 — Staging
 
-- [ ] Namespace e aplicação ArgoCD
-- [ ] Ingress, DNS e TLS
+- [x] Namespace e aplicação ArgoCD declarados (sync desativado)
+- [ ] Ingress, DNS e TLS — manifests prontos; DNS e controladores estão pendentes
 - [ ] Relay acessível por HTTPS/WSS
 - [ ] Testes funcionais concluídos
 
 ## Phase 4 — Produção
 
-- [ ] Backup e restore validados
-- [ ] PR de staging aprovado/mergeado
+- [ ] Backup e restore validados — CronJob declarado; restore ainda não executado
+- [x] PRs de staging aprovados/mergeados
 - [ ] Promoção para produção
 - [ ] PR de produção aprovado/mergeado
+
+## Bloqueios operacionais
+
+- parâmetros `/buzz-staging/*` ainda não existem no AWS SSM;
+- `external-secrets`, `cert-manager` e `external-dns` estão em `CreateContainerError`;
+- `buzz-staging.lolmeida.com` ainda não resolve DNS;
+- bucket S3 `buzz-staging-media` ainda não existe;
+- a identidade Nostr do owner/relay ainda precisa de decisão e armazenamento no Vaultwarden;
+- a imagem multi-arch ainda precisa de digest publicado no GHCR.

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -11,34 +11,27 @@
 ## Phase 2 — Infraestrutura GitOps
 
 - [x] ArgoCD repository preparado (#101, #102)
-- [x] PostgreSQL 17 dedicado declarado
-- [x] Redis 7.x dedicado declarado
-- [x] Bucket S3 dedicado provisionado e endurecido; credenciais ainda pendentes
-- [x] ExternalSecret declarado
+- [x] PostgreSQL 15.18 e Redis 7 existentes verificados
+- [x] Database/role PostgreSQL e database lógico Redis dedicados definidos
+- [x] Bucket S3 direto provisionado e endurecido
+- [x] ExternalSecrets `/buzz/*` sincronizados
 
-## Phase 3 — Staging
+## Phase 3 — Deployment direto
 
-- [x] Namespace e aplicação ArgoCD declarados (sync desativado)
-- [ ] Ingress, DNS e TLS — manifests prontos; DNS e controladores estão pendentes
+- [x] Namespace `buzz` e aplicação ArgoCD declarados com auto-sync
+- [ ] Ingress, DNS e TLS — manifests prontos; validação final pendente
 - [ ] Relay acessível por HTTPS/WSS
 - [ ] Testes funcionais concluídos
 
-## Phase 4 — Produção
+## Phase 4 — Validação operacional
 
 - [ ] Backup e restore validados — CronJob declarado; restore ainda não executado
-- [x] PRs de staging aprovados/mergeados
-- [ ] Promoção para produção
-- [ ] PR de produção aprovado/mergeado
+- [ ] Migrations PostgreSQL 15 validadas
+- [ ] Teste funcional Nostr/WebSocket/media concluído
+- [ ] PR direto aprovado/mergeado
 
 ## Bloqueios operacionais
 
-- parâmetros `/buzz-staging/*` ainda não existem no AWS SSM;
-- credenciais S3 dedicadas ainda não foram criadas/armazenadas;
-- `external-secrets`, `cert-manager` e `external-dns` estão em `CreateContainerError`;
-- o ingress-nginx e o ArgoCD também estão afetados;
-- `buzz-staging.lolmeida.com` ainda não resolve DNS;
-- o Vaultwarden está inacessível pelo endpoint HTTPS;
-- o containerd do MicroK8s reporta snapshots/mounts ausentes;
-- a identidade Nostr do owner/relay ainda precisa de decisão e armazenamento no Vaultwarden;
-- staging já está fixado no digest público imutável do relay oficial;
-- o digest próprio do fork ainda depende do workflow `31128599898`.
+- a validação de migrations/restore em PostgreSQL 15 ainda está pendente;
+- o digest próprio do fork ainda depende do workflow `31128599898`;
+- a validação pública de `buzz.lolmeida.com` ainda está pendente.

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -4,7 +4,7 @@
 
 - [x] Fork e remotes configurados
 - [x] Plano e ADR documentados
-- [ ] Pipeline de imagem validado — workflow de release ainda em execução
+- [ ] Pipeline de imagem validado — workflow `31128541447` ainda em execução
 - [x] PR de bootstrap aberto e mergeado (#2)
 
 ## Phase 2 — Infraestrutura GitOps
@@ -12,7 +12,7 @@
 - [x] ArgoCD repository preparado (#101, #102)
 - [x] PostgreSQL 17 dedicado declarado
 - [x] Redis 7.x dedicado declarado
-- [ ] S3/prefixo dedicado — bucket ainda não provisionado
+- [x] Bucket S3 dedicado provisionado e endurecido; credenciais ainda pendentes
 - [x] ExternalSecret declarado
 
 ## Phase 3 — Staging
@@ -32,8 +32,11 @@
 ## Bloqueios operacionais
 
 - parâmetros `/buzz-staging/*` ainda não existem no AWS SSM;
+- credenciais S3 dedicadas ainda não foram criadas/armazenadas;
 - `external-secrets`, `cert-manager` e `external-dns` estão em `CreateContainerError`;
+- o ingress-nginx e o ArgoCD também estão afetados;
 - `buzz-staging.lolmeida.com` ainda não resolve DNS;
-- bucket S3 `buzz-staging-media` ainda não existe;
+- o Vaultwarden está inacessível pelo endpoint HTTPS;
+- o containerd do MicroK8s reporta snapshots/mounts ausentes;
 - a identidade Nostr do owner/relay ainda precisa de decisão e armazenamento no Vaultwarden;
 - a imagem multi-arch ainda precisa de digest publicado no GHCR.

--- a/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
+++ b/.specs/buzz-self-hosting/IMPLEMENTATION-STATE.md
@@ -1,0 +1,30 @@
+# Implementation State: buzz-self-hosting
+
+## Phase 1 — Bootstrap
+
+- [ ] Fork e remotes configurados
+- [ ] Plano e ADR documentados
+- [ ] Pipeline de imagem validado
+- [ ] PR de bootstrap aberto
+
+## Phase 2 — Infraestrutura GitOps
+
+- [ ] ArgoCD repository preparado
+- [ ] PostgreSQL 17 dedicado
+- [ ] Redis 7.x dedicado
+- [ ] S3/prefixo dedicado
+- [ ] ExternalSecrets configurados
+
+## Phase 3 — Staging
+
+- [ ] Namespace e aplicação ArgoCD
+- [ ] Ingress, DNS e TLS
+- [ ] Relay acessível por HTTPS/WSS
+- [ ] Testes funcionais concluídos
+
+## Phase 4 — Produção
+
+- [ ] Backup e restore validados
+- [ ] PR de staging aprovado/mergeado
+- [ ] Promoção para produção
+- [ ] PR de produção aprovado/mergeado

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -164,7 +164,7 @@ impl RelayInfo {
             supported_nips,
             supported_extensions: Some(vec!["nip-er".to_string()]),
             push: None,
-            software: "https://github.com/block/buzz".to_string(),
+            software: "https://github.com/lolmeida/buzz".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             limitation: Some(relay_limitation(max_message_length)),
             pairing_relay_url: pairing_relay_url.map(str::to_string),
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn build_advertises_buzz_repository_url() {
         let info = RelayInfo::build(None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
-        assert_eq!(info.software, "https://github.com/block/buzz");
+        assert_eq!(info.software, "https://github.com/lolmeida/buzz");
     }
 
     #[test]

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -46,7 +46,8 @@ See:
 | Key | What | When required |
 |---|---|---|
 | `relayUrl` | Public `wss://` URL clients connect to | Always |
-| `ownerPubkey` | 64-char lowercase hex Nostr pubkey of the relay operator | When `relay.requireRelayMembership=true` (default) |
+| `ownerPubkey` | 64-char lowercase hex Nostr pubkey of the relay operator | When `relay.requireRelayMembership=true` and not loaded from `secrets.existingSecret` |
+| `ownerPubkeySecretKey` | Key in `secrets.existingSecret` containing the relay owner pubkey | Alternative to inline `ownerPubkey` for ExternalSecrets/GitOps |
 | `secrets.existingSecret` | Name of pre-created Secret | Production / GitOps |
 | `externalPostgresql.url` / `externalRedis.url` / `s3.endpoint` | External service URLs | Production — when the matching bundled service is disabled (the default) |
 

--- a/deploy/charts/buzz/templates/_helpers.tpl
+++ b/deploy/charts/buzz/templates/_helpers.tpl
@@ -53,8 +53,12 @@ app.kubernetes.io/component: relay
 {{- end -}}
 
 {{- define "buzz.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/deploy/charts/buzz/templates/_validate.tpl
+++ b/deploy/charts/buzz/templates/_validate.tpl
@@ -48,8 +48,8 @@ surface at template time regardless of which manifest helm renders first.
 
 {{/* Owner pubkey required when requireRelayMembership */}}
 {{- if .Values.relay.requireRelayMembership -}}
-  {{- if not .Values.ownerPubkey -}}
-    {{- fail "ownerPubkey is required when relay.requireRelayMembership=true. Set ownerPubkey to the 64-char lowercase hex Nostr pubkey of the relay operator, or set relay.requireRelayMembership=false for an open relay." -}}
+  {{- if not (or .Values.ownerPubkey (and .Values.secrets.existingSecret .Values.ownerPubkeySecretKey)) -}}
+    {{- fail "ownerPubkey or ownerPubkeySecretKey with secrets.existingSecret is required when relay.requireRelayMembership=true." -}}
   {{- end -}}
 {{- end -}}
 

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -151,7 +151,15 @@ spec:
             {{- end }}
 
             # ── Owner ────────────────────────────────────────────────
+            {{- if .Values.ownerPubkey }}
             - { name: RELAY_OWNER_PUBKEY, value: {{ .Values.ownerPubkey | quote }} }
+            {{- else }}
+            - name: RELAY_OWNER_PUBKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "buzz.envSecretName" . }}
+                  key: {{ .Values.ownerPubkeySecretKey | quote }}
+            {{- end }}
 
             # ── Migrations ───────────────────────────────────────────
             - { name: BUZZ_AUTO_MIGRATE, value: {{ .Values.migrate.autoMigrate | quote }} }

--- a/deploy/charts/buzz/tests/render_test.yaml
+++ b/deploy/charts/buzz/tests/render_test.yaml
@@ -8,6 +8,26 @@ templates:
   - templates/service.yaml
   - templates/pvc-git.yaml
 tests:
+  - it: reads the relay owner pubkey from the existing secret
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkeySecretKey: RELAY_OWNER_PUBKEY
+      secrets.existingSecret: buzz-secrets
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "RELAY_OWNER_PUBKEY")].valueFrom.secretKeyRef.name
+          value: buzz-secrets
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "RELAY_OWNER_PUBKEY")].valueFrom.secretKeyRef.key
+          value: RELAY_OWNER_PUBKEY
+        template: templates/deployment.yaml
+
   - it: renders an immutable image digest when configured
     set:
       relayUrl: wss://buzz.example.com

--- a/deploy/charts/buzz/tests/render_test.yaml
+++ b/deploy/charts/buzz/tests/render_test.yaml
@@ -8,6 +8,24 @@ templates:
   - templates/service.yaml
   - templates/pvc-git.yaml
 tests:
+  - it: renders an immutable image digest when configured
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      image.repository: ghcr.io/lolmeida/buzz
+      image.tag: relay-test
+      image.digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/lolmeida/buzz@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        template: templates/deployment.yaml
+
   - it: renders cleanly in production profile (external pg/redis)
     set:
       relayUrl: wss://buzz.example.com

--- a/deploy/charts/buzz/tests/validation_test.yaml
+++ b/deploy/charts/buzz/tests/validation_test.yaml
@@ -18,7 +18,7 @@ tests:
       externalPostgresql.url: postgres://u:p@h:5432/d
     asserts:
       - failedTemplate:
-          errorPattern: "ownerPubkey is required when relay.requireRelayMembership=true"
+          errorPattern: "ownerPubkey or ownerPubkeySecretKey with secrets.existingSecret is required when relay.requireRelayMembership=true"
 
   - it: fails when ownerPubkey is not 64 lowercase hex (schema-level)
     set:

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -43,6 +43,10 @@
       "pattern": "^([0-9a-f]{64})?$",
       "description": "64-char lowercase hex Nostr pubkey of the relay operator. Required when relay.requireRelayMembership=true."
     },
+    "ownerPubkeySecretKey": {
+      "type": "string",
+      "description": "Key in secrets.existingSecret containing the relay owner pubkey."
+    },
     "secrets": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -15,6 +15,7 @@
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
         "tag": { "type": "string" },
+        "digest": { "type": "string", "pattern": "^(|sha256:[a-f0-9]{64})$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
         "pullSecrets": {
           "type": "array",

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -25,6 +25,7 @@ quickstart: false
 image:
   repository: ghcr.io/block/buzz
   tag: ""                        # empty → .Chart.AppVersion
+  digest: ""                     # optional immutable sha256 digest; overrides tag
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -80,6 +80,9 @@ mediaBaseUrl: ""
 # 64-char lowercase hex Nostr pubkey of the relay operator. Required when
 # relay.requireRelayMembership=true (the production default).
 ownerPubkey: ""
+# Optional key in secrets.existingSecret containing the relay owner pubkey.
+# Use this when the operator identity is managed by ExternalSecrets.
+ownerPubkeySecretKey: ""
 
 # ── Chart-managed secrets ────────────────────────────────────────────────────
 # Production / GitOps path: create a Secret out-of-band with these keys and

--- a/docs/decisoes/ADR-0001-buzz-self-hosting.md
+++ b/docs/decisoes/ADR-0001-buzz-self-hosting.md
@@ -1,0 +1,32 @@
+# ADR-0001 — Self-hosting do Buzz na VPS
+
+- Estado: aceito
+- Data: 2026-08-06
+- Issue: https://github.com/lolmeida/buzz/issues/1
+
+## Contexto
+
+O Buzz será executado no MicroK8s da VPS e exposto por um subdomínio de
+`lolmeida.com`. A VPS já possui PostgreSQL e Redis associados a outros serviços,
+mas esses serviços não devem ser usados como dependências compartilhadas sem
+isolamento explícito.
+
+## Decisão
+
+Usar deployment GitOps via ArgoCD, com uma instalação single-community inicial,
+uma réplica, PostgreSQL 17 dedicado, Redis 7.x dedicado e S3-compatible com
+bucket ou prefixo exclusivo. A aplicação será publicada inicialmente em staging
+antes da promoção para produção.
+
+Secrets serão entregues por Vaultwarden → AWS SSM → ExternalSecrets. O relay,
+PostgreSQL, Redis e storage não serão expostos diretamente à Internet; apenas o
+Ingress HTTPS/WSS será público.
+
+## Consequências
+
+- A operação ganha isolamento entre o Buzz e os serviços existentes.
+- A VPS single-node continua sendo um ponto único de falha.
+- PostgreSQL e Redis dedicados aumentam consumo e responsabilidade de backup.
+- A primeira instalação será limitada até serem validados agentes, workflows,
+  webhooks, huddles e migrations.
+- GitHub Issue #1 substitui temporariamente o Jira como tracker operacional.

--- a/docs/decisoes/ADR-0001-buzz-self-hosting.md
+++ b/docs/decisoes/ADR-0001-buzz-self-hosting.md
@@ -22,6 +22,11 @@ Secrets serão entregues por Vaultwarden → AWS SSM → ExternalSecrets. O rela
 PostgreSQL, Redis e storage não serão expostos diretamente à Internet; apenas o
 Ingress HTTPS/WSS será público.
 
+O bucket `buzz-staging-media` usa bloqueio integral de acesso público,
+`BucketOwnerEnforced`, SSE-S3, versionamento e expiração de versões não atuais
+após 30 dias. Credenciais S3 dedicadas serão criadas apenas depois de o
+Vaultwarden estar disponível e sincronizadas pelo fluxo Vaultwarden → SSM.
+
 ## Consequências
 
 - A operação ganha isolamento entre o Buzz e os serviços existentes.
@@ -29,4 +34,6 @@ Ingress HTTPS/WSS será público.
 - PostgreSQL e Redis dedicados aumentam consumo e responsabilidade de backup.
 - A primeira instalação será limitada até serem validados agentes, workflows,
   webhooks, huddles e migrations.
+- O versionamento do bucket permite recuperação operacional, mas exige política
+  de retenção para limitar custo de versões antigas.
 - GitHub Issue #1 substitui temporariamente o Jira como tracker operacional.

--- a/docs/decisoes/ADR-0001-buzz-self-hosting.md
+++ b/docs/decisoes/ADR-0001-buzz-self-hosting.md
@@ -3,6 +3,7 @@
 - Estado: aceito
 - Data: 2026-08-06
 - Issue: https://github.com/lolmeida/buzz/issues/1
+- Supersedido em deployment por: [ADR-0002](ADR-0002-buzz-direct-shared-services.md)
 
 ## Contexto
 

--- a/docs/decisoes/ADR-0002-buzz-direct-shared-services.md
+++ b/docs/decisoes/ADR-0002-buzz-direct-shared-services.md
@@ -1,0 +1,38 @@
+# ADR-0002 — Deployment direto com serviços partilhados isolados
+
+- Estado: aceito
+- Data: 2026-08-06
+- Issue: https://github.com/lolmeida/buzz/issues/1
+
+## Contexto
+
+A VPS tem um único nó de 4 vCPU. O PostgreSQL 17 e o Redis dedicados do
+deployment intermédio não conseguem ser agendados com os requests dos
+workloads existentes. O PostgreSQL 15.18 e o Redis 7 existentes em
+`prod-database` estão operacionais.
+
+## Decisão
+
+Publicar diretamente em `buzz.lolmeida.com`, no namespace `buzz`, sem uma fase
+de staging. Reutilizar os serviços de `prod-database` com isolamento lógico:
+
+- database e role PostgreSQL exclusivos do Buzz;
+- database lógico Redis exclusivo (`7`);
+- NetworkPolicies explícitas entre o namespace `buzz` e os serviços partilhados;
+- bucket S3 e credenciais IAM exclusivos;
+- ExternalSecrets separados sob `/buzz/*`.
+
+O bootstrap PostgreSQL é idempotente e executado pelo ArgoCD. O relay continua
+sem dependência de serviços expostos à Internet; apenas HTTPS/WSS fica público.
+
+## Consequências
+
+- Reduz consumo de CPU/memória e elimina PVCs de PostgreSQL/Redis do Buzz.
+- PostgreSQL e Redis passam a partilhar disponibilidade e manutenção com a
+  infraestrutura existente, mitigado por database/role, database lógico,
+  NetworkPolicy e backup separado.
+- PostgreSQL 15 requer validação das migrations e do restore antes de tratar a
+  instalação como operacional.
+- O bucket anterior `buzz-staging-media` deixa de ser usado; o bucket direto
+  tem bloqueio público, `BucketOwnerEnforced`, SSE-S3, versionamento e retenção
+  de versões não atuais.

--- a/docs/decisoes/ADR-0002-buzz-direct-shared-services.md
+++ b/docs/decisoes/ADR-0002-buzz-direct-shared-services.md
@@ -22,8 +22,17 @@ de staging. Reutilizar os serviços de `prod-database` com isolamento lógico:
 - bucket S3 e credenciais IAM exclusivos;
 - ExternalSecrets separados sob `/buzz/*`.
 
-O bootstrap PostgreSQL é idempotente e executado pelo ArgoCD. O relay continua
-sem dependência de serviços expostos à Internet; apenas HTTPS/WSS fica público.
+O bootstrap PostgreSQL é idempotente e executado pelo ArgoCD, que continua a
+ser a fonte de verdade para Job, RBAC, NetworkPolicy, ExternalSecrets e
+workloads. Operações controladas da base — healthcheck, ensure e migrations SQL
+explicitamente escolhidas — são expostas pelo GHAR através de um runner ARC
+dedicado com acesso à rede do cluster.
+
+O bootstrap usa `/shared/postgres/PASSWORD` apenas para a administração e
+`/buzz/POSTGRES_USER`, `/buzz/POSTGRES_PASSWORD` e `/buzz/POSTGRES_DB` para a
+aplicação. O relay usa exclusivamente as credenciais da aplicação. O relay
+continua sem dependência de serviços expostos à Internet; apenas HTTPS/WSS fica
+público.
 
 ## Consequências
 
@@ -33,6 +42,11 @@ sem dependência de serviços expostos à Internet; apenas HTTPS/WSS fica públi
   NetworkPolicy e backup separado.
 - PostgreSQL 15 requer validação das migrations e do restore antes de tratar a
   instalação como operacional.
+- O runner GitHub-hosted não alcança `*.svc.cluster.local`; o workflow GHAR
+  requer o scale set `arc-buzz-database` e OIDC restrito ao Environment
+  `production`.
+- A referência `@main` no consumidor é temporária para adopção imediata; deve
+  voltar a `@v1` após a próxima release compatível do GHAR.
 - O bucket anterior `buzz-staging-media` deixa de ser usado; o bucket direto
   tem bloqueio público, `BucketOwnerEnforced`, SSE-S3, versionamento e retenção
   de versões não atuais.

--- a/docs/implementation/buzz-self-hosting-plan.md
+++ b/docs/implementation/buzz-self-hosting-plan.md
@@ -1,0 +1,62 @@
+# Buzz self-hosting na VPS
+
+## Rastreadibilidade
+
+- Tracker: GitHub Issue [#1](https://github.com/lolmeida/buzz/issues/1).
+- Jira está temporariamente indisponível; esta issue é a fonte operacional de rastreabilidade.
+- Upstream: `block/buzz`.
+- Fork: `lolmeida/buzz`.
+- Deployment: `lolmeida/argo-cd`.
+
+## Objetivo
+
+Publicar o Buzz primeiro em `buzz-staging.lolmeida.com` e depois em
+`buzz.lolmeida.com`, usando MicroK8s, ArgoCD, PostgreSQL, Redis e S3-compatible
+isolados.
+
+## Decisões
+
+- Single-community e uma réplica no primeiro release.
+- PostgreSQL 17 é o baseline de produção.
+- PostgreSQL 16 só pode ser aceite após testes completos de migrations e restore.
+- Não reutilizar databases, roles ou Redis de outros serviços.
+- Não expor PostgreSQL, Redis, MinIO, Adminer ou métricas à Internet.
+- Secrets: Vaultwarden → AWS SSM → ExternalSecrets → Kubernetes Secret.
+- Imagem fixada por digest; nunca `main` ou `latest` em produção.
+- Agentes privilegiados, workflows, webhooks e huddles ficam desativados inicialmente.
+
+## Fases
+
+1. Fork, branch, pipeline de imagem e documentação.
+2. PostgreSQL 17, Redis 7.x, S3/prefixo e secrets dedicados.
+3. ArgoCD, Ingress, TLS, DNS e staging.
+4. Testes de migrations, runtime, segurança, backup e restore.
+5. Promoção controlada para produção.
+6. Ativação gradual de agentes, workflows, webhooks e HA.
+
+## Critérios de aceitação
+
+- ArgoCD `Synced` e `Healthy`.
+- HTTPS e WSS funcionais.
+- Membership fechado validado.
+- Mensagens, pesquisa, media e Git funcionais.
+- PostgreSQL e Redis não acessíveis externamente.
+- Nenhum secret no Git, manifests renderizados ou logs.
+- Backup e restore demonstrados.
+- Imagem e chart fixados em versões imutáveis.
+- Rollback para o digest anterior validado.
+
+## Rollback
+
+- Reverter o commit GitOps e aguardar reconciliação do ArgoCD.
+- Reverter imagem para digest anterior.
+- Não remover PVCs, buckets ou secrets automaticamente.
+- Migration incompatível exige restore validado e correção no Git.
+
+## Riscos conhecidos
+
+- VPS single-node não fornece HA real.
+- O relay é parte da fronteira de confiança das DMs.
+- Approval gates e algumas ações de workflow estão incompletos upstream.
+- Redis é necessário para fanout e coordenação distribuída.
+- A especificação de multi-tenancy upstream ainda é draft.

--- a/docs/implementation/buzz-self-hosting-plan.md
+++ b/docs/implementation/buzz-self-hosting-plan.md
@@ -10,16 +10,16 @@
 
 ## Objetivo
 
-Publicar o Buzz primeiro em `buzz-staging.lolmeida.com` e depois em
-`buzz.lolmeida.com`, usando MicroK8s, ArgoCD, PostgreSQL, Redis e S3-compatible
-isolados.
+Publicar diretamente o Buzz em `buzz.lolmeida.com`, usando MicroK8s, ArgoCD,
+PostgreSQL/Redis partilhados com database/role e database lógico exclusivos, e
+S3-compatible exclusivo.
 
 ## Decisões
 
 - Single-community e uma réplica no primeiro release.
-- PostgreSQL 17 é o baseline de produção.
-- PostgreSQL 16 só pode ser aceite após testes completos de migrations e restore.
-- Não reutilizar databases, roles ou Redis de outros serviços.
+- PostgreSQL 15.18 e Redis 7 existentes são reutilizados somente com isolamento
+  lógico explícito; migrations e restore têm de ser validados.
+- O namespace `buzz` é a única instalação pública; não há promoção staging → produção.
 - Não expor PostgreSQL, Redis, MinIO, Adminer ou métricas à Internet.
 - Secrets: Vaultwarden → AWS SSM → ExternalSecrets → Kubernetes Secret.
 - Imagem fixada por digest; nunca `main` ou `latest` em produção.
@@ -28,11 +28,10 @@ isolados.
 ## Fases
 
 1. Fork, branch, pipeline de imagem e documentação.
-2. PostgreSQL 17, Redis 7.x, S3/prefixo e secrets dedicados.
-3. ArgoCD, Ingress, TLS, DNS e staging.
+2. S3, database/role PostgreSQL, database lógico Redis e secrets dedicados.
+3. ArgoCD, Ingress, TLS e DNS diretos.
 4. Testes de migrations, runtime, segurança, backup e restore.
-5. Promoção controlada para produção.
-6. Ativação gradual de agentes, workflows, webhooks e HA.
+5. Ativação gradual de agentes, workflows, webhooks e HA.
 
 ## Critérios de aceitação
 

--- a/docs/implementation/buzz-self-hosting-plan.md
+++ b/docs/implementation/buzz-self-hosting-plan.md
@@ -23,6 +23,11 @@ S3-compatible exclusivo.
 - Não expor PostgreSQL, Redis, MinIO, Adminer ou métricas à Internet.
 - Secrets: Vaultwarden → AWS SSM → ExternalSecrets → Kubernetes Secret.
 - Imagem fixada por digest; nunca `main` ou `latest` em produção.
+- Bootstrap admin/app: ArgoCD lê `/shared/postgres/PASSWORD` para o role
+  administrativo e `/buzz/POSTGRES_*` para o role da aplicação; o runtime usa
+  somente a credencial da aplicação.
+- Operações manuais da base: workflow GHAR através do runner ARC
+  `arc-buzz-database`, com OIDC/SSM e sem criação de recursos Kubernetes.
 - Agentes privilegiados, workflows, webhooks e huddles ficam desativados inicialmente.
 
 ## Fases
@@ -30,8 +35,10 @@ S3-compatible exclusivo.
 1. Fork, branch, pipeline de imagem e documentação.
 2. S3, database/role PostgreSQL, database lógico Redis e secrets dedicados.
 3. ArgoCD, Ingress, TLS e DNS diretos.
-4. Testes de migrations, runtime, segurança, backup e restore.
-5. Ativação gradual de agentes, workflows, webhooks e HA.
+4. Bootstrap PostgreSQL via ArgoCD com credenciais admin/app separadas e
+   operações controladas via GHAR/runner ARC.
+5. Testes de migrations, runtime, segurança, backup e restore.
+6. Ativação gradual de agentes, workflows, webhooks e HA.
 
 ## Critérios de aceitação
 
@@ -44,6 +51,7 @@ S3-compatible exclusivo.
 - Backup e restore demonstrados.
 - Imagem e chart fixados em versões imutáveis.
 - Rollback para o digest anterior validado.
+- GHAR verifica a conectividade com `sslmode=require` e não oferece DROP/reset.
 
 ## Rollback
 
@@ -59,3 +67,6 @@ S3-compatible exclusivo.
 - Approval gates e algumas ações de workflow estão incompletos upstream.
 - Redis é necessário para fanout e coordenação distribuída.
 - A especificação de multi-tenancy upstream ainda é draft.
+- A migração GHAR executa apenas o ficheiro SQL explicitamente selecionado; a
+  migração automática embutida do relay continua a ser a fonte de migrações
+  SQLx completas.


### PR DESCRIPTION
## Summary

- Encadear CI de produção no Buzz para chamar, por ordem, Keycloak bootstrap + deploy GitOps, usando apenas `main`.
- Criado thin-caller local `keycloak-setup` para manter a separação de responsabilidades (Auth como passo dedicado e não dentro do sync do ArgoCD).
- Reutiliza GHAR `@v1` via `keycloak-client-setup` com OIDC + SSM (sem segredos em YAML).
- Mantém `deploy` como thin-caller de `gitops-deploy` com `app_name: apps-prod-buzz`, `sync_enabled: true`, `wait: true`.

## Files changed

- `.github/workflows/ci.yml`
  - add: job `keycloak-setup` (`workflow_call` para `./.github/workflows/keycloak-setup.yml`)
  - add: job `deploy` (`./.github/workflows/deploy.yml`)
  - ambos com `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` e `needs` completos da pipeline de validação
- `.github/workflows/keycloak-setup.yml`
  - novo thin-caller com `workflow_dispatch` + `workflow_call`
  - delegação para `lolmeida/github-actions/.github/workflows/keycloak-client-setup.yml@v1`
  - input principal `client_id` + parâmetros padrão de Keycloak

## Validation

- `python` YAML parse dos arquivos `ci.yml`, `deploy.yml`, `keycloak-setup.yml`: OK
- `actionlint` local: sem erros para estes workflows
- Commit da mudança já enviado na branch `feat/ghar-buzz-gitops-auth` (`4e5652faa`)
