### PR TITLE
Harden thread reply roleplay E2E

### DIFF
--- a/desktop/tests/e2e/thread-reply-anchor-roleplay.spec.ts
+++ b/desktop/tests/e2e/thread-reply-anchor-roleplay.spec.ts
@@ -129,9 +129,25 @@ async function setupRoleplayChannel(page: import("@playwright/test").Page) {
   await waitForMockLiveSubscription(page, CHANNEL);
 }
 
-async function openThread(page: import("@playwright/test").Page) {
-  const summary = page.getByTestId("message-thread-summary").first();
+async function openThread(
+  page: import("@playwright/test").Page,
+  threadHeadId: string,
+) {
+  const viewport = page.viewportSize();
+  if (!viewport) throw new Error("Missing viewport size");
+  await page.mouse.move(viewport.width - 1, 1);
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId(`channel-activity-popover-${CHANNEL}`),
+  ).toBeHidden();
+
+  const summary = page.locator(
+    `[data-testid="message-thread-summary"][data-thread-head-id="${threadHeadId}"]`,
+  );
   await expect(summary).toBeVisible();
+  await summary.evaluate((element) =>
+    element.scrollIntoView({ block: "center", inline: "nearest" }),
+  );
   await summary.click();
   await expect(page.getByTestId("message-thread-panel")).toBeVisible();
 }
@@ -200,7 +216,7 @@ test.describe("thread reply anchor A/B roleplay screenshots", () => {
       },
     );
 
-    await openThread(page);
+    await openThread(page, root.id);
     await expandReply(page, humanReply.id);
     await expect(page.getByText("Nora: adding context")).toBeVisible();
     await expect(page.getByText("Pinky: Got it")).toBeVisible();
@@ -252,7 +268,14 @@ test.describe("thread reply anchor A/B roleplay screenshots", () => {
       },
     );
 
-    await openThread(page);
+    // Reproduce the CI timing where the pointer remains over #general long
+    // enough for its newly available activity preview to cover the timeline.
+    await page.getByTestId("channel-general").hover();
+    await expect(
+      page.getByTestId("channel-activity-popover-general"),
+    ).toBeVisible();
+
+    await openThread(page, root.id);
     await expect(page.getByText("Nora: adding context")).toBeVisible();
     await expect(page.getByText("Pinky: Got it")).toBeVisible();
     await expect(
@@ -291,7 +314,7 @@ test.describe("thread reply anchor A/B roleplay screenshots", () => {
       },
     );
 
-    await openThread(page);
+    await openThread(page, humanRoot.id);
     await expect(page.getByText("Pinky: Starting the audit")).toBeVisible();
     await expect(
       page.getByTestId("message-thread-replies").getByTestId("message-row"),
@@ -337,7 +360,7 @@ test.describe("thread reply anchor A/B roleplay screenshots", () => {
       },
     );
 
-    await openThread(page);
+    await openThread(page, root.id);
     await expandReply(page, brainReply.id);
     await expect(page.getByText("Brain: Check the anchor")).toBeVisible();
     await expect(page.getByText("Pinky: Good catch")).toBeVisible();


### PR DESCRIPTION
## Why
The desktop smoke suite intermittently times out while opening a seeded thread. On slower runs, the pointer can remain over `#general` long enough for the channel activity popover to cover the thread summary; the composer can also overlap a summary near the bottom of the timeline. The roleplay test is meant to validate reply anchoring, so transient pointer placement and viewport position should not determine whether it reaches that assertion.

## What
- Reproduce the activity-popover overlap in the formerly failing scenario
- Select each seeded thread by its exact head event ID instead of the first summary in the timeline
- Dismiss transient activity UI and center the target summary before clicking it

## Risk Assessment
Low — this changes only Playwright test interaction logic. Production code and behavior are unchanged.

## Validation
- `just ci`
- `pnpm build:e2e`
- Thread reply roleplay smoke spec repeated five times: 20/20 passed

## References
- Original failing job: https://github.com/block/buzz/actions/runs/31185005369/job/92895359582
- Reproduced the same pointer-interception timeout locally before applying the fix

Generated with Codex