### PR TITLE
fix(desktop): keep Create controls on empty Projects view

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
         "**/project-inbox.spec.ts",
         "**/project-issue-comments.spec.ts",
         "**/project-pr-review.spec.ts",
+        "**/projects-empty-create.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",
         "**/drafts-screenshots.spec.ts",
         "**/drafts-all-fix-screenshots.spec.ts",

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -4,6 +4,7 @@ import {
   Folders,
   GitCommit,
   GitPullRequest,
+  Plus,
   TerminalSquare,
   Trash2,
 } from "lucide-react";
@@ -313,9 +314,16 @@ function RepositoryUnavailableIndicator({
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateProject,
+}: {
+  onCreateProject?: () => void;
+} = {}) {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center"
+      data-testid="projects-empty-state"
+    >
       <Folders className="h-10 w-10 text-muted-foreground/40" />
       <div className="space-y-1">
         <p className="text-sm font-medium text-foreground">No projects yet</p>
@@ -323,6 +331,18 @@ export function EmptyState() {
           Projects published to this relay will appear here.
         </p>
       </div>
+      {onCreateProject ? (
+        <Button
+          data-testid="projects-empty-create-project"
+          onClick={onCreateProject}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Create your first project
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -597,10 +597,6 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
-
   const projectItems =
     visibleProjects.length === 0 ? (
       <EmptyFilteredState />
@@ -859,7 +855,11 @@ export function ProjectsView() {
           </div>
           <div className="mx-auto w-full max-w-6xl">
             <div className="w-full min-w-0 pb-4 pt-4">
-              {filter === "all" ? (
+              {projects.length === 0 ? (
+                <EmptyState
+                  onCreateProject={() => setCreateProjectOpen(true)}
+                />
+              ) : filter === "all" ? (
                 <ProjectsOverviewPanel
                   metadata={
                     <ProjectsOverviewRail

--- a/desktop/tests/e2e/projects-empty-create.spec.ts
+++ b/desktop/tests/e2e/projects-empty-create.spec.ts
@@ -59,7 +59,7 @@ test("empty Projects keeps Create controls and offers an empty-state CTA", async
   await page.getByRole("menuitem", { name: "Project" }).click();
   await expect(page.getByTestId("create-project-dialog")).toBeVisible();
   await page.keyboard.press("Escape");
-  await expect(page.getByTestId("create-project-dialog")).not.toBeVisible();
+  await expect(page.getByTestId("create-project-dialog")).toBeHidden();
 
   // Entry point 2: the empty-state CTA.
   await page.getByTestId("projects-empty-create-project").click();

--- a/desktop/tests/e2e/projects-empty-create.spec.ts
+++ b/desktop/tests/e2e/projects-empty-create.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import { FEATURE_OVERRIDES_STORAGE_KEY } from "../helpers/features";
+
+const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
+
+// The projects surface is a preview feature — opt in before the app mounts.
+// Must run before installMockBridge so React reads the override on mount.
+async function enableProjectsFeature(page: import("@playwright/test").Page) {
+  await page.addInitScript(
+    ({ key }) => {
+      window.localStorage.setItem(key, JSON.stringify({ projects: true }));
+    },
+    { key: FEATURE_OVERRIDES_STORAGE_KEY },
+  );
+}
+
+/**
+ * Hide every seeded mock project so Projects renders the true empty state.
+ *
+ * Addresses must match MOCK_PROJECT_SEEDS (and the kind:30621 "buzz" project
+ * announcement) in `desktop/src/testing/e2eBridge.ts`. If a seed is added or
+ * renamed there without updating this list, the list stays populated and the
+ * `projects-empty-state` assertion below fails.
+ */
+async function hideAllMockProjects(page: import("@playwright/test").Page) {
+  const hiddenCards = [
+    `30621:${DEFAULT_MOCK_PUBKEY}:buzz`,
+    `30617:${DEFAULT_MOCK_PUBKEY}:buzz`,
+    `30617:${TEST_IDENTITIES.alice.pubkey}:relay-tools`,
+    `30617:${TEST_IDENTITIES.bob.pubkey}:design-system`,
+  ];
+  await page.addInitScript((cards) => {
+    window.localStorage.setItem(
+      "buzz.projects.hidden-cards.v1",
+      JSON.stringify(cards),
+    );
+  }, hiddenCards);
+}
+
+test("empty Projects keeps Create controls and offers an empty-state CTA", async ({
+  page,
+}) => {
+  await enableProjectsFeature(page);
+  await hideAllMockProjects(page);
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+
+  // The chrome (header + toolbar + create menu) must mount with zero projects.
+  await expect(page.getByTestId("projects-empty-state")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("projects-create-menu")).toBeVisible();
+
+  // Entry point 1: the toolbar "+" create menu.
+  await page.getByTestId("projects-create-menu").hover();
+  await page.getByRole("menuitem", { name: "Project" }).click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("create-project-dialog")).not.toBeVisible();
+
+  // Entry point 2: the empty-state CTA.
+  await page.getByTestId("projects-empty-create-project").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await expect(page.getByTestId("create-project-name")).toBeVisible();
+});


### PR DESCRIPTION
## Summary

When a relay has zero projects, `ProjectsView` early-returned a bare `<EmptyState />` before the header, toolbar, and `ProjectsCreateMenu` (`+`) mounted — so the first project could only be created from the CLI. Chicken-and-egg: the create button only appeared once a project already existed.

- Remove the early return; render `EmptyState` inside the normal layout so the Projects chrome (header, filter toolbar, `+` create menu) always mounts.
- Add a "Create your first project" CTA to the empty state (same pattern as the Workflows empty state), wired to the existing `CreateProjectDialog`.
- Add a Playwright smoke spec covering both entry points against a true zero-project state (all mock seeds hidden).

Ported from closed PR #3620 (closed in favor of tracking as issue #4009) onto current `main`, adapted for the multi-repo changes from #4671 and the current create-menu item names.

Fixes #2585, fixes #2622, fixes #3470, fixes #3504, fixes #4009

## Testing

- `pnpm exec tsc --noEmit`, biome clean on touched files
- `pnpm exec playwright test --project=smoke tests/e2e/projects-empty-create.spec.ts` — new spec green
- All 36 existing project smoke specs (`project-commit-detail`, `project-inbox`, `project-pr-review`, `project-issue-comments`) pass
- `just ci`
