### PR TITLE
fix(release): pin desktop PR operations to block/buzz

### DIFF
--- a/scripts/prepare-desktop-release.sh
+++ b/scripts/prepare-desktop-release.sh
@@ -75,9 +75,9 @@ This PR may be **squash merged** after the Desktop Release Candidate check and a
 
 The checked-in changelog accounts for every non-merge commit in the release range. The Desktop tag points to the reviewed candidate commit, not the later squash commit. Publication remains bound to that immutable candidate tag.
 EOF
-if existing="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')" && [[ -n "$existing" ]]; then
-  gh pr edit "$existing" --title "chore(release): release Buzz Desktop version $version" --body-file "$body"
+if existing="$(gh pr list --repo block/buzz --head "$branch" --state open --json number --jq '.[0].number')" && [[ -n "$existing" ]]; then
+  gh pr edit --repo block/buzz "$existing" --title "chore(release): release Buzz Desktop version $version" --body-file "$body"
 else
-  gh pr create --base main --head "$branch" \
+  gh pr create --repo block/buzz --base main --head "$branch" \
     --title "chore(release): release Buzz Desktop version $version" --body-file "$body"
 fi

--- a/scripts/test-release-ref-contract.sh
+++ b/scripts/test-release-ref-contract.sh
@@ -76,6 +76,9 @@ grep -Fq 'GH_TOKEN: ${{ github.token }}' "$candidate_workflow" || {
   exit 1
 }
 grep -Fq 'reviewed candidate' "$repo_root/scripts/prepare-desktop-release.sh"
+grep -Fq 'gh pr list --repo block/buzz' "$repo_root/scripts/prepare-desktop-release.sh"
+grep -Fq 'gh pr edit --repo block/buzz' "$repo_root/scripts/prepare-desktop-release.sh"
+grep -Fq 'gh pr create --repo block/buzz' "$repo_root/scripts/prepare-desktop-release.sh"
 if grep -Fq 'current `main`' "$repo_root/scripts/prepare-desktop-release.sh"; then
   echo "desktop release PR body contains executable command substitution" >&2
   exit 1


### PR DESCRIPTION
## Summary

Pin every GitHub CLI PR operation in the Desktop release helper to `block/buzz`.

Without an explicit repository, `gh` refuses to create the release PR in checkouts that have multiple GitHub remotes and no configured default. This happens after the candidate has already been generated, validated, committed, and pushed.

Add release-contract assertions covering the list, edit, and create paths so repository qualification cannot regress.

## Validation

- `bash -n scripts/prepare-desktop-release.sh scripts/test-release-ref-contract.sh`
- `scripts/test-release-ref-contract.sh`
- pre-push `branch-skew`
