### PR TITLE
Add semantic desktop foundation roles

### DIFF
--- a/desktop/src/shared/lib/cn.test.mjs
+++ b/desktop/src/shared/lib/cn.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { cn } from "./cn.ts";
+
+test("semantic type roles merge as font sizes rather than colors", () => {
+  assert.equal(cn("text-sm", "text-body-medium"), "text-body-medium");
+  assert.equal(cn("text-body-medium", "text-sm"), "text-sm");
+  assert.equal(
+    cn("text-content-subtle", "text-body-medium"),
+    "text-content-subtle text-body-medium",
+  );
+});

--- a/desktop/src/shared/lib/cn.ts
+++ b/desktop/src/shared/lib/cn.ts
@@ -1,5 +1,24 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// tailwind-merge cannot infer whether a custom `text-*` token is a font size
+// or a color. Register the semantic type ramp so role classes compose exactly
+// like Tailwind's stock `text-sm` / `text-base` utilities.
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: [
+        "display-page-title",
+        "display-section-title",
+        "body-medium",
+        "label-medium",
+        "body-small",
+        "label-small",
+        "caption",
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/desktop/src/shared/styles/globals/foundations.test.mjs
+++ b/desktop/src/shared/styles/globals/foundations.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import tailwindConfig from "../../../../tailwind.config.js";
+
+const themeCss = readFileSync(new URL("./theme.css", import.meta.url), "utf8");
+const { borderRadius, colors, fontSize } = tailwindConfig.theme.extend;
+
+test("semantic type roles preserve Buzz's current shared type ramp", () => {
+  assert.deepEqual(fontSize["display-page-title"], [
+    "1.5rem",
+    {
+      lineHeight: "2rem",
+      fontWeight: "600",
+      letterSpacing: "-0.025em",
+    },
+  ]);
+  assert.deepEqual(fontSize["display-section-title"], [
+    "1.125rem",
+    {
+      lineHeight: "1.75rem",
+      fontWeight: "600",
+      letterSpacing: "-0.025em",
+    },
+  ]);
+  assert.deepEqual(fontSize["body-medium"], [
+    "1rem",
+    { lineHeight: "1.5rem", fontWeight: "400" },
+  ]);
+  assert.deepEqual(fontSize["label-medium"], [
+    "1rem",
+    { lineHeight: "1.5rem", fontWeight: "600" },
+  ]);
+  assert.deepEqual(fontSize["body-small"], [
+    "0.875rem",
+    { lineHeight: "1.25rem", fontWeight: "400" },
+  ]);
+  assert.deepEqual(fontSize.caption, [
+    "0.75rem",
+    { lineHeight: "1rem", fontWeight: "400" },
+  ]);
+});
+
+test("semantic color families expose the BlockUI role vocabulary", () => {
+  assert.deepEqual(Object.keys(colors.content), [
+    "standard",
+    "subtle",
+    "muted",
+    "disabled",
+    "inverse",
+  ]);
+  assert.deepEqual(Object.keys(colors.icon), [
+    "standard",
+    "subtle",
+    "muted",
+    "disabled",
+    "inverse",
+  ]);
+  assert.deepEqual(Object.keys(colors.surface), [
+    "app",
+    "subtle",
+    "standard",
+    "prominent",
+    "inverse",
+    "card",
+    "popover",
+  ]);
+  assert.deepEqual(Object.keys(colors.border).slice(1), [
+    "subtle",
+    "standard",
+    "prominent",
+    "focus",
+  ]);
+  assert.deepEqual(Object.keys(colors.status).slice(3), [
+    "error",
+    "warning",
+    "success",
+    "info",
+    "notification",
+  ]);
+});
+
+test("semantic color aliases preserve the current theme mappings", () => {
+  const expectedAliases = {
+    "content-standard": "hsl(var(--foreground))",
+    "content-subtle": "hsl(var(--muted-foreground))",
+    "content-muted": "hsl(var(--muted-foreground))",
+    "content-disabled": "hsl(var(--muted-foreground))",
+    "surface-app": "hsl(var(--background))",
+    "surface-card": "hsl(var(--card))",
+    "surface-popover": "hsl(var(--popover))",
+    "border-subtle": "hsl(var(--border))",
+    "border-standard": "hsl(var(--border))",
+    "border-focus": "hsl(var(--ring))",
+    "status-error": "hsl(var(--destructive))",
+    "status-warning": "var(--ui-warning)",
+    "status-success": "var(--status-added)",
+  };
+
+  for (const [alias, currentValue] of Object.entries(expectedAliases)) {
+    assert.match(
+      themeCss,
+      new RegExp(`--${alias}:\\s*${currentValue.replace(/[()*-]/g, "\\$&")};`),
+      `${alias} should continue to resolve to ${currentValue}`,
+    );
+  }
+});
+
+test("semantic shape roles preserve Buzz's current radius steps", () => {
+  assert.deepEqual(
+    {
+      control: borderRadius["shape-control"],
+      notice: borderRadius["shape-notice"],
+      menu: borderRadius["shape-menu"],
+      container: borderRadius["shape-container"],
+      overlay: borderRadius["shape-overlay"],
+      sheet: borderRadius["shape-sheet"],
+      pill: borderRadius["shape-pill"],
+      circular: borderRadius["shape-circular"],
+    },
+    {
+      control: "var(--shape-control)",
+      notice: "var(--shape-notice)",
+      menu: "var(--shape-menu)",
+      container: "var(--shape-container)",
+      overlay: "var(--shape-overlay)",
+      sheet: "var(--shape-sheet)",
+      pill: "var(--shape-pill)",
+      circular: "var(--shape-circular)",
+    },
+  );
+
+  for (const [role, value] of [
+    ["control", "calc(var(--radius) - 2px)"],
+    ["notice", "var(--radius)"],
+    ["menu", "1rem"],
+    ["container", "1.5rem"],
+    ["overlay", "2rem"],
+    ["sheet", "2.5rem"],
+    ["pill", "9999px"],
+    ["circular", "9999px"],
+  ]) {
+    assert.match(
+      themeCss,
+      new RegExp(`--shape-${role}:\\s*${value.replace(/[()*-]/g, "\\$&")};`),
+    );
+  }
+});

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -47,6 +47,50 @@
     --sidebar-accent-foreground: 234 16.02% 35.49%;
     --sidebar-border: 225 13.56% 76.86%;
     --sidebar-ring: 225 13.56% 76.86%;
+
+    /*
+     * BlockUI-aligned semantic foundation contract.
+     *
+     * These aliases deliberately resolve to Buzz's existing substrate tokens,
+     * so introducing the contract has no intended visual effect. Several roles
+     * currently converge on one value (for example subtle/muted/disabled);
+     * later migrations can split those values here without renaming consumers.
+     */
+    --content-standard: hsl(var(--foreground));
+    --content-subtle: hsl(var(--muted-foreground));
+    --content-muted: hsl(var(--muted-foreground));
+    --content-disabled: hsl(var(--muted-foreground));
+    --content-inverse: hsl(var(--primary-foreground));
+    --icon-standard: var(--content-standard);
+    --icon-subtle: var(--content-subtle);
+    --icon-muted: var(--content-muted);
+    --icon-disabled: var(--content-disabled);
+    --icon-inverse: var(--content-inverse);
+    --surface-app: hsl(var(--background));
+    --surface-subtle: hsl(var(--muted));
+    --surface-standard: hsl(var(--secondary));
+    --surface-prominent: hsl(var(--accent));
+    --surface-inverse: hsl(var(--foreground));
+    --surface-card: hsl(var(--card));
+    --surface-popover: hsl(var(--popover));
+    --border-subtle: hsl(var(--border));
+    --border-standard: hsl(var(--border));
+    --border-prominent: hsl(var(--ring));
+    --border-focus: hsl(var(--ring));
+    --status-error: hsl(var(--destructive));
+    --status-warning: var(--ui-warning);
+    --status-success: var(--status-added);
+    --status-info: hsl(var(--primary));
+    --status-notification: hsl(var(--primary));
+    --shape-control: calc(var(--radius) - 2px);
+    --shape-notice: var(--radius);
+    --shape-menu: 1rem;
+    --shape-container: 1.5rem;
+    --shape-overlay: 2rem;
+    --shape-sheet: 2.5rem;
+    --shape-pill: 9999px;
+    --shape-circular: 9999px;
+
     /* Exact Buzz palette tokens; components consume these semantically. */
     --buzz-gradient-light-top: #e6e6b6;
     --buzz-gradient-light-bottom: #c4d0da;

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -15,6 +15,38 @@ export default {
         title: ["2.5rem", { lineHeight: "1.15", letterSpacing: "-0.02em" }],
         // 36px — the backup-step private key, shown large in monospace
         "nsec-key": ["2.25rem", { lineHeight: "1.3" }],
+
+        // BlockUI-aligned semantic type roles. These intentionally resolve to
+        // Buzz's current shared-header and body styles; adopting BlockUI's
+        // target scale is a separate, visual migration. Keeping the role name
+        // stable lets that happen without another feature-level rename.
+        "display-page-title": [
+          "1.5rem",
+          {
+            lineHeight: "2rem",
+            fontWeight: "600",
+            letterSpacing: "-0.025em",
+          },
+        ],
+        "display-section-title": [
+          "1.125rem",
+          {
+            lineHeight: "1.75rem",
+            fontWeight: "600",
+            letterSpacing: "-0.025em",
+          },
+        ],
+        "body-medium": ["1rem", { lineHeight: "1.5rem", fontWeight: "400" }],
+        "label-medium": ["1rem", { lineHeight: "1.5rem", fontWeight: "600" }],
+        "body-small": [
+          "0.875rem",
+          { lineHeight: "1.25rem", fontWeight: "400" },
+        ],
+        "label-small": [
+          "0.875rem",
+          { lineHeight: "1.25rem", fontWeight: "600" },
+        ],
+        caption: ["0.75rem", { lineHeight: "1rem", fontWeight: "400" }],
       },
       boxShadow: {
         "content-edge": "-1px -1px 0 0 hsl(var(--sidebar-border) / 0.45)",
@@ -33,6 +65,16 @@ export default {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        // Semantic aliases resolve to radius steps Buzz already uses. The
+        // aliases are intentionally non-visual until primitives opt into them.
+        "shape-control": "var(--shape-control)",
+        "shape-notice": "var(--shape-notice)",
+        "shape-menu": "var(--shape-menu)",
+        "shape-container": "var(--shape-container)",
+        "shape-overlay": "var(--shape-overlay)",
+        "shape-sheet": "var(--shape-sheet)",
+        "shape-pill": "var(--shape-pill)",
+        "shape-circular": "var(--shape-circular)",
       },
       spacing: {
         4.5: "1.125rem",
@@ -49,6 +91,29 @@ export default {
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        content: {
+          standard: "var(--content-standard)",
+          subtle: "var(--content-subtle)",
+          muted: "var(--content-muted)",
+          disabled: "var(--content-disabled)",
+          inverse: "var(--content-inverse)",
+        },
+        icon: {
+          standard: "var(--icon-standard)",
+          subtle: "var(--icon-subtle)",
+          muted: "var(--icon-muted)",
+          disabled: "var(--icon-disabled)",
+          inverse: "var(--icon-inverse)",
+        },
+        surface: {
+          app: "var(--surface-app)",
+          subtle: "var(--surface-subtle)",
+          standard: "var(--surface-standard)",
+          prominent: "var(--surface-prominent)",
+          inverse: "var(--surface-inverse)",
+          card: "var(--surface-card)",
+          popover: "var(--surface-popover)",
+        },
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
@@ -77,7 +142,13 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
-        border: "hsl(var(--border))",
+        border: {
+          DEFAULT: "hsl(var(--border))",
+          subtle: "var(--border-subtle)",
+          standard: "var(--border-standard)",
+          prominent: "var(--border-prominent)",
+          focus: "var(--border-focus)",
+        },
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         sidebar: {
@@ -96,6 +167,11 @@ export default {
           added: "var(--status-added)",
           deleted: "var(--status-deleted)",
           modified: "var(--status-modified)",
+          error: "var(--status-error)",
+          warning: "var(--status-warning)",
+          success: "var(--status-success)",
+          info: "var(--status-info)",
+          notification: "var(--status-notification)",
         },
         warning: {
           DEFAULT: "var(--ui-warning)",


### PR DESCRIPTION
## Summary

- add semantic aliases for BlockUI-aligned type, content, icon, surface, border, status, and shape roles
- map every new role to Buzz’s existing values so this contract has zero intended visual change
- teach the shared class merger to distinguish semantic type roles from semantic color roles
- add regression coverage for the complete foundation vocabulary and current mappings

This is roadmap item 1 from the BlockUI foundations audit and unlocks the small, targeted migration PRs that follow. Agentation is not included in this branch.

### Related issue

None found.

### Testing

- full pre-push desktop check, TypeScript typecheck, and 4,000+ unit test suite
- focused foundation and class-merging tests
- production build

Screenshots are not included because all semantic aliases intentionally resolve to the pre-existing values in this PR.

Generated with Codex