### PR TITLE
perf(ci): cancel superseded main runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
   pull_request:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Keep only the newest run for each PR and for main. Release runs are never
+  # cancelled: a newer release push must not evict an older release gate.
+  group: ci-${{ github.workflow }}-${{ (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- cancel superseded CI runs on `main`, matching the existing pull-request behavior
- keep release runs SHA-scoped and non-cancellable so a newer release push cannot evict an older release gate

## Why

Recent run data does **not** show runner contention as the primary latency source: across 34 runs, median and p90 startup delay were both 0 seconds. There are occasional queue outliers, however, and obsolete `main` runs currently continue consuming runners after a newer commit lands.

This is deliberately a small resource-waste/contention improvement. It does not address the dominant isolated Rust PR bottleneck: the roughly 21–22 minute cold artifact build.

## Validation

- `actionlint .github/workflows/ci.yml`
- `bash scripts/ci/test-release-build-contract.sh`
- `bash scripts/ci/test-release-e2e-contract.sh`
- independent review by Princess Donut and Mongo
