### PR TITLE
feat(buzz-acp): add bounded local event sink

### DIFF
--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 
 # IDs
 uuid = { workspace = true }

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -114,10 +114,18 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `BUZZ_ACP_EVENT_SINK_SOCKET` | no | — | Absolute Unix socket path for the optional local accepted-event sink. Unset disables it. |
+| `BUZZ_ACP_EVENT_SINK_TIMEOUT_MS` | no | `250` | Shared connect/write/ack deadline for the local event sink. Must be 1–5000ms. |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+The local event sink emits a versioned, length-prefixed frame containing only
+the relay origin, channel UUID, and exact signed Nostr event JSON. It is invoked
+after the inbound author gate and waits for one acknowledgement byte. Failures
+are bounded and logged without changing ordinary agent dispatch. Private keys,
+API tokens, owner attestations, and other credentials are never included.
 
 ### Parallel Agents & Heartbeat
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -468,6 +468,14 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_RELAY_OBSERVER", default_value_t = false)]
     pub relay_observer: bool,
 
+    /// Optional absolute Unix socket receiving accepted inbound signed events.
+    #[arg(long, env = "BUZZ_ACP_EVENT_SINK_SOCKET")]
+    pub event_sink_socket: Option<PathBuf>,
+
+    /// Shared connection/write/ack deadline for the local event sink.
+    #[arg(long, env = "BUZZ_ACP_EVENT_SINK_TIMEOUT_MS", default_value_t = 250)]
+    pub event_sink_timeout_ms: u64,
+
     /// Exit after this many seconds with no dispatched events and no turn in flight.
     /// 0 disables inactivity self-termination.
     #[arg(long, env = "BUZZ_ACP_EXIT_AFTER_INACTIVITY", default_value_t = 0)]
@@ -549,6 +557,10 @@ pub struct Config {
     pub has_generated_codex_config: bool,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
+    /// Optional absolute local event-sink socket. None keeps the feature off.
+    pub event_sink_socket: Option<PathBuf>,
+    /// Shared connection/write/ack deadline for the local event sink.
+    pub event_sink_timeout_ms: u64,
     /// Seconds without dispatched events before an idle harness exits. 0 = disabled.
     pub exit_after_inactivity_secs: u64,
     /// Whether ACP/LLM subprocess initialization is deferred until accepted work arrives.
@@ -1099,6 +1111,8 @@ impl Config {
             persona_env_vars,
             has_generated_codex_config,
             relay_observer: args.relay_observer,
+            event_sink_socket: args.event_sink_socket,
+            event_sink_timeout_ms: args.event_sink_timeout_ms,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
@@ -1470,6 +1484,8 @@ mod tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            event_sink_socket: None,
+            event_sink_timeout_ms: 250,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             agent_owner: None,
@@ -2198,6 +2214,29 @@ channels = "ALL"
         let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool=true"]);
         assert!(args.is_err(), "bool flags do not take an explicit value");
         assert!(CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool"]).lazy_pool);
+    }
+
+    #[test]
+    fn local_event_sink_defaults_off_and_accepts_explicit_bounded_config() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert_eq!(default.event_sink_socket, None);
+        assert_eq!(default.event_sink_timeout_ms, 250);
+
+        let configured = CliArgs::parse_from([
+            "buzz-acp",
+            "--private-key",
+            &key,
+            "--event-sink-socket",
+            "/run/buzz/matos.sock",
+            "--event-sink-timeout-ms",
+            "750",
+        ]);
+        assert_eq!(
+            configured.event_sink_socket,
+            Some(PathBuf::from("/run/buzz/matos.sock"))
+        );
+        assert_eq!(configured.event_sink_timeout_ms, 750);
     }
 
     #[test]

--- a/crates/buzz-acp/src/event_sink.rs
+++ b/crates/buzz-acp/src/event_sink.rs
@@ -1,0 +1,267 @@
+//! Optional local sink for accepted inbound Buzz events.
+//!
+//! The sink is disabled unless an absolute Unix socket path is configured. It
+//! carries only public event/provenance data and never receives relay or agent
+//! credentials.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use base64::Engine;
+use serde::Serialize;
+use thiserror::Error;
+use uuid::Uuid;
+
+const FRAME_VERSION: u8 = 1;
+const ACK: u8 = 0x06;
+const MAX_FRAME_BYTES: usize = 512 * 1024;
+
+#[derive(Debug, Error)]
+pub enum EventSinkError {
+    #[error("event sink socket path must be absolute")]
+    RelativePath,
+    #[error("event sink socket path exceeds the platform bound")]
+    PathTooLong,
+    #[cfg(not(unix))]
+    #[error("event sink is unsupported on this platform")]
+    UnsupportedPlatform,
+    #[error("event sink frame exceeds the bounded size")]
+    FrameTooLarge,
+    #[error("event sink timeout must be between 1ms and 5000ms")]
+    InvalidTimeout,
+    #[error("event sink timed out")]
+    Timeout,
+    #[error("event sink I/O failed")]
+    Io,
+    #[error("event sink refused the frame")]
+    Refused,
+    #[error("event sink frame serialization failed")]
+    Serialization,
+}
+
+#[derive(Clone, Debug)]
+pub struct EventSink {
+    socket_path: PathBuf,
+    relay_origin: String,
+    timeout: Duration,
+}
+
+#[derive(Serialize)]
+struct EventSinkFrame<'a> {
+    version: u8,
+    relay_origin: &'a str,
+    channel_id: Uuid,
+    event_b64: String,
+}
+
+impl EventSink {
+    /// Build a local event sink. The path must be absolute so the destination
+    /// cannot drift with the harness working directory.
+    pub fn new(
+        socket_path: PathBuf,
+        relay_origin: String,
+        timeout: Duration,
+    ) -> Result<Self, EventSinkError> {
+        if !socket_path.is_absolute() {
+            return Err(EventSinkError::RelativePath);
+        }
+        if socket_path.as_os_str().as_encoded_bytes().len() > 100 {
+            return Err(EventSinkError::PathTooLong);
+        }
+        if timeout.is_zero() || timeout > Duration::from_secs(5) {
+            return Err(EventSinkError::InvalidTimeout);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (socket_path, relay_origin, timeout);
+            return Err(EventSinkError::UnsupportedPlatform);
+        }
+        #[cfg(unix)]
+        Ok(Self {
+            socket_path,
+            relay_origin,
+            timeout,
+        })
+    }
+
+    /// Deliver one event and wait for a one-byte acknowledgement. Every phase
+    /// shares the same deadline, bounding connection, write, and response time.
+    #[cfg(unix)]
+    pub async fn deliver(
+        &self,
+        channel_id: Uuid,
+        raw_event_json: &[u8],
+    ) -> Result<(), EventSinkError> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::UnixStream;
+
+        let frame = EventSinkFrame {
+            version: FRAME_VERSION,
+            relay_origin: &self.relay_origin,
+            channel_id,
+            event_b64: base64::engine::general_purpose::STANDARD.encode(raw_event_json),
+        };
+        let payload = serde_json::to_vec(&frame).map_err(|_| EventSinkError::Serialization)?;
+        if payload.len() > MAX_FRAME_BYTES || payload.len() > u32::MAX as usize {
+            return Err(EventSinkError::FrameTooLarge);
+        }
+        let socket_path = self.socket_path.clone();
+        let timeout = self.timeout;
+        tokio::time::timeout(timeout, async move {
+            let mut stream = UnixStream::connect(socket_path)
+                .await
+                .map_err(|_| EventSinkError::Io)?;
+            stream
+                .write_all(&(payload.len() as u32).to_be_bytes())
+                .await
+                .map_err(|_| EventSinkError::Io)?;
+            stream
+                .write_all(&payload)
+                .await
+                .map_err(|_| EventSinkError::Io)?;
+            stream.flush().await.map_err(|_| EventSinkError::Io)?;
+            let mut ack = [0u8; 1];
+            stream
+                .read_exact(&mut ack)
+                .await
+                .map_err(|_| EventSinkError::Io)?;
+            if ack[0] != ACK {
+                return Err(EventSinkError::Refused);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|_| EventSinkError::Timeout)?
+    }
+
+    /// Expose the configured socket path for diagnostics without exposing any
+    /// credentials (none are retained by this type).
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+
+    fn socket_path(label: &str) -> PathBuf {
+        let suffix = Uuid::new_v4().simple().to_string();
+        PathBuf::from(format!("/tmp/bz-{label}-{}.sock", &suffix[..8]))
+    }
+
+    #[test]
+    fn relative_socket_path_refuses() {
+        let result = EventSink::new(
+            PathBuf::from("relative.sock"),
+            "wss://relay.example.test".into(),
+            Duration::from_millis(50),
+        );
+        assert!(matches!(result, Err(EventSinkError::RelativePath)));
+    }
+
+    #[test]
+    fn zero_and_excessive_timeouts_refuse() {
+        for timeout in [Duration::ZERO, Duration::from_millis(5_001)] {
+            let result = EventSink::new(
+                PathBuf::from("/tmp/bz-timeout.sock"),
+                "wss://relay.example.test".into(),
+                timeout,
+            );
+            assert!(matches!(result, Err(EventSinkError::InvalidTimeout)));
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_event_bytes_and_public_provenance_are_delivered() {
+        let path = socket_path("exact");
+        let listener = UnixListener::bind(&path).expect("bind test socket");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept test connection");
+            let mut size = [0u8; 4];
+            stream.read_exact(&mut size).await.expect("read size");
+            let mut payload = vec![0u8; u32::from_be_bytes(size) as usize];
+            stream.read_exact(&mut payload).await.expect("read payload");
+            stream.write_all(&[ACK]).await.expect("write ack");
+            payload
+        });
+        let sink = EventSink::new(
+            path.clone(),
+            "wss://relay.example.test".into(),
+            Duration::from_secs(1),
+        )
+        .expect("valid sink");
+        let raw = br#"{ "content" : "exact bytes" }"#;
+        let channel_id = Uuid::new_v4();
+        sink.deliver(channel_id, raw).await.expect("deliver frame");
+        let payload = server.await.expect("server task");
+        let frame: serde_json::Value = serde_json::from_slice(&payload).expect("parse frame");
+        let keys = frame
+            .as_object()
+            .expect("frame object")
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            keys,
+            ["channel_id", "event_b64", "relay_origin", "version"]
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(frame["version"], FRAME_VERSION);
+        assert_eq!(frame["relay_origin"], "wss://relay.example.test");
+        assert_eq!(frame["channel_id"], channel_id.to_string());
+        let restored = base64::engine::general_purpose::STANDARD
+            .decode(frame["event_b64"].as_str().expect("event bytes"))
+            .expect("decode event");
+        assert_eq!(restored, raw);
+        assert!(!payload.windows(11).any(|w| w == b"private_key"));
+        std::fs::remove_file(path).expect("remove socket");
+    }
+
+    #[tokio::test]
+    async fn backpressure_without_acknowledgement_is_bounded() {
+        let path = socket_path("timeout");
+        let listener = UnixListener::bind(&path).expect("bind test socket");
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.expect("accept test connection");
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+        let sink = EventSink::new(
+            path.clone(),
+            "wss://relay.example.test".into(),
+            Duration::from_millis(25),
+        )
+        .expect("valid sink");
+        let result = sink.deliver(Uuid::new_v4(), b"{}").await;
+        assert!(matches!(result, Err(EventSinkError::Timeout)));
+        server.abort();
+        std::fs::remove_file(path).expect("remove socket");
+    }
+
+    #[tokio::test]
+    async fn wrong_ack_refuses() {
+        let path = socket_path("refuse");
+        let listener = UnixListener::bind(&path).expect("bind test socket");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept test connection");
+            let mut size = [0u8; 4];
+            stream.read_exact(&mut size).await.expect("read size");
+            let mut payload = vec![0u8; u32::from_be_bytes(size) as usize];
+            stream.read_exact(&mut payload).await.expect("read payload");
+            stream.write_all(&[0x15]).await.expect("write refusal");
+        });
+        let sink = EventSink::new(
+            path.clone(),
+            "wss://relay.example.test".into(),
+            Duration::from_secs(1),
+        )
+        .expect("valid sink");
+        let result = sink.deliver(Uuid::new_v4(), b"{}").await;
+        assert!(matches!(result, Err(EventSinkError::Refused)));
+        server.await.expect("server task");
+        std::fs::remove_file(path).expect("remove socket");
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3,6 +3,7 @@
 mod acp;
 mod config;
 mod engram_fetch;
+mod event_sink;
 mod filter;
 mod observer;
 mod pool;
@@ -1563,6 +1564,14 @@ async fn tokio_main() -> Result<()> {
         .init();
 
     let mut config = Config::from_cli().map_err(|e| anyhow::anyhow!("configuration error: {e}"))?;
+    let event_sink = match config.event_sink_socket.clone() {
+        Some(path) => Some(event_sink::EventSink::new(
+            path,
+            config.relay_url.clone(),
+            Duration::from_millis(config.event_sink_timeout_ms),
+        )?),
+        None => None,
+    };
 
     // ── Setup-mode early branch ───────────────────────────────────────────────
     //
@@ -2470,6 +2479,22 @@ async fn tokio_main() -> Result<()> {
                                         "inbound author gate — dropping event"
                                     );
                                     continue;
+                                }
+                            }
+
+                            if let Some(sink) = &event_sink {
+                                if let Err(error) = sink
+                                    .deliver(
+                                        buzz_event.channel_id,
+                                        buzz_event.raw_event_json.as_bytes(),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        channel_id = %buzz_event.channel_id,
+                                        socket = %sink.socket_path().display(),
+                                        "local event sink delivery failed: {error}"
+                                    );
                                 }
                             }
 
@@ -6206,6 +6231,8 @@ mod build_mcp_servers_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            event_sink_socket: None,
+            event_sink_timeout_ms: 250,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             agent_owner: None,
@@ -6428,6 +6455,8 @@ mod error_outcome_emission_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            event_sink_socket: None,
+            event_sink_timeout_ms: 250,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
             agent_owner: None,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -446,6 +446,8 @@ pub struct BuzzEvent {
     pub channel_id: Uuid,
     /// The underlying Nostr event.
     pub event: Event,
+    /// Exact JSON bytes of the event object as received inside the NIP-01 frame.
+    pub raw_event_json: Box<str>,
 }
 
 /// Errors from relay operations.
@@ -488,6 +490,7 @@ enum RelayMessage {
     Event {
         subscription_id: String,
         event: Box<Event>,
+        raw_event_json: Box<str>,
     },
     Ok {
         event_id: String,
@@ -2081,6 +2084,7 @@ async fn handle_ws_message(
                 RelayMessage::Event {
                     subscription_id,
                     event,
+                    raw_event_json,
                 } => {
                     if subscription_id == OBSERVER_CONTROL_SUB_ID {
                         match observer_control_tx.try_send(*event) {
@@ -2118,6 +2122,7 @@ async fn handle_ws_message(
                         let buzz_event = BuzzEvent {
                             channel_id: channel_uuid,
                             event: *event,
+                            raw_event_json,
                         };
                         let cap = event_tx.max_capacity();
                         let used = cap - event_tx.capacity();
@@ -2159,6 +2164,7 @@ async fn handle_ws_message(
                             let buzz_event = BuzzEvent {
                                 channel_id,
                                 event: *event,
+                                raw_event_json,
                             };
                             // Warn at 80% capacity.
                             let cap = event_tx.max_capacity();
@@ -2428,8 +2434,11 @@ async fn process_handshake_buffer(
         let text = match &relay_msg {
             RelayMessage::Event {
                 subscription_id,
-                event,
-            } => serde_json::to_string(&json!(["EVENT", subscription_id, event])).ok(),
+                event: _,
+                raw_event_json,
+            } => serde_json::to_string(subscription_id)
+                .ok()
+                .map(|subscription| format!("[\"EVENT\",{subscription},{raw_event_json}]")),
             RelayMessage::Eose { subscription_id } => {
                 serde_json::to_string(&json!(["EOSE", subscription_id])).ok()
             }
@@ -3561,14 +3570,18 @@ pub(crate) fn parse_relay_message(text: &str) -> Result<RelayMessage, RelayError
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| RelayError::UnexpectedMessage(text.to_string()))?
                 .to_string();
-            let event: Event = serde_json::from_value(
-                arr.get(2)
-                    .cloned()
-                    .ok_or_else(|| RelayError::UnexpectedMessage(text.to_string()))?,
-            )?;
+            let raw_arr: Vec<Box<serde_json::value::RawValue>> = serde_json::from_str(text)?;
+            let raw_event_json = raw_arr
+                .get(2)
+                .ok_or_else(|| RelayError::UnexpectedMessage(text.to_string()))?
+                .get()
+                .to_string()
+                .into_boxed_str();
+            let event: Event = serde_json::from_str(&raw_event_json)?;
             Ok(RelayMessage::Event {
                 subscription_id: sub_id,
                 event: Box::new(event),
+                raw_event_json,
             })
         }
         "OK" => {
@@ -4178,6 +4191,31 @@ mod tests {
                 assert_eq!(message, "");
             }
             _ => panic!("expected Ok"),
+        }
+    }
+
+    #[test]
+    fn parse_event_preserves_exact_event_object_json() {
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "exact bytes")
+            .tags([])
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign event");
+        let raw = serde_json::to_string(&event)
+            .expect("serialize event")
+            .replace(',', ", ");
+        let text = format!(r#"["EVENT","ch-test",{raw}]"#);
+        let message = parse_relay_message(&text).expect("parse event frame");
+        match message {
+            RelayMessage::Event {
+                subscription_id,
+                event: parsed,
+                raw_event_json,
+            } => {
+                assert_eq!(subscription_id, "ch-test");
+                assert_eq!(parsed.id, event.id);
+                assert_eq!(&*raw_event_json, raw);
+            }
+            _ => panic!("expected event"),
         }
     }
 


### PR DESCRIPTION
## Status
Repository-only, default-off local event sink for the CHANNEL-CONTINUITY-01 integration. No deployment, service restart, credential, runtime flag, live data, or unrelated behavior change.

## What I did
- Preserve the exact inbound Nostr event-object JSON from relay parsing, including handshake replay.
- Add an optional Unix-socket sink after the inbound author gate.
- Send one bounded length-prefixed frame containing only version, relay origin, channel UUID, and base64 exact event bytes.
- Require a one-byte acknowledgement under a shared connect/write/read deadline; failures are sanitized and do not alter ordinary agent dispatch.
- Keep the sink disabled unless `BUZZ_ACP_EVENT_SINK_SOCKET` is explicitly configured.

## Base and commit
- Reviewed base: `742e8d11974498a6ed71c70dd87dc6c25fcbf2b7`
- Candidate: `6ea717970ac1ba0388dc08571133e644aae81a3f`

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo test -p buzz-acp --no-fail-fast`: 696 unit tests and 9 lifecycle tests pass
- `just ci`: pass, including full workspace checks, web, desktop, and 1,260 mobile tests

## Security and rollback
The frame has an exact four-key schema and no private key, API token, auth tag, or other credential source. Paths and deadlines are bounded. Reverting this commit removes the optional sink without affecting relay state or data.