### PR TITLE
fix(desktop): play notification sounds via Web Audio (stop macOS media-key hijack)

### DIFF
--- a/desktop/src/features/notifications/lib/sound.test.mjs
+++ b/desktop/src/features/notifications/lib/sound.test.mjs
@@ -16,3 +16,132 @@ test("silences notifications from Huddle backing channels", () => {
   );
   assert.equal(shouldPlayNotificationSound(null, silentChannelIds), true);
 });
+
+// Regression: notification sounds must play through the Web Audio API, not an
+// HTMLAudioElement. A playing HTMLMediaElement is adopted by the browser's
+// Media Session, which binds the OS media keys (macOS Play/Pause) to it — the
+// bug where pressing Play kept replaying the preview ping. Web Audio buffer
+// sources are never captured by media keys.
+test("playNotificationSound uses Web Audio and never an HTMLAudioElement when available", async () => {
+  const started = [];
+  let audioConstructed = 0;
+
+  class FakeBufferSource {
+    constructor() {
+      this.buffer = null;
+      this._ended = null;
+    }
+    connect() {}
+    addEventListener(type, cb) {
+      if (type === "ended") this._ended = cb;
+    }
+    start() {
+      started.push(this);
+    }
+    stop() {
+      this._ended?.();
+    }
+  }
+
+  class FakeAudioContext {
+    constructor() {
+      this.state = "running";
+      this.destination = {};
+    }
+    createBufferSource() {
+      return new FakeBufferSource();
+    }
+    async decodeAudioData() {
+      return { duration: 0.2 };
+    }
+    async resume() {
+      this.state = "running";
+    }
+  }
+
+  const priorAudioContext = globalThis.AudioContext;
+  const priorFetch = globalThis.fetch;
+  const priorAudio = globalThis.Audio;
+
+  globalThis.AudioContext = FakeAudioContext;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => new ArrayBuffer(8),
+  });
+  globalThis.Audio = class {
+    constructor() {
+      audioConstructed += 1;
+    }
+    play() {
+      return Promise.resolve();
+    }
+    pause() {}
+    addEventListener() {}
+  };
+
+  try {
+    // Fresh module instance so the module-level AudioContext/buffer caches
+    // pick up the mocks installed above.
+    const mod = await import(`./sound.ts?webaudio=${Date.now()}`);
+
+    // Warm the decoded-buffer cache, then play.
+    mod.preloadNotificationSound("ping");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const playback = mod.playNotificationSound("ping");
+    assert.equal(started.length, 1, "expected a Web Audio buffer source start");
+    assert.equal(
+      audioConstructed,
+      0,
+      "must not construct an HTMLAudioElement on the Web Audio path",
+    );
+
+    let ended = false;
+    playback.onEnded(() => {
+      ended = true;
+    });
+    playback.stop();
+    assert.equal(ended, true, "stop() must fire the onEnded callback");
+  } finally {
+    globalThis.AudioContext = priorAudioContext;
+    globalThis.fetch = priorFetch;
+    globalThis.Audio = priorAudio;
+  }
+});
+
+test("playNotificationSound falls back to HTMLAudioElement without Web Audio", async () => {
+  let audioConstructed = 0;
+
+  const priorAudioContext = globalThis.AudioContext;
+  const priorAudio = globalThis.Audio;
+
+  // No AudioContext available -> fallback path.
+  globalThis.AudioContext = undefined;
+  globalThis.Audio = class {
+    constructor() {
+      audioConstructed += 1;
+      this.currentTime = 0;
+    }
+    play() {
+      return Promise.resolve();
+    }
+    pause() {}
+    addEventListener() {}
+  };
+
+  try {
+    const mod = await import(`./sound.ts?fallback=${Date.now()}`);
+    const playback = mod.playNotificationSound("ping");
+    assert.equal(
+      audioConstructed,
+      1,
+      "fallback must construct exactly one HTMLAudioElement",
+    );
+    assert.equal(typeof playback.stop, "function");
+    assert.equal(typeof playback.onEnded, "function");
+  } finally {
+    globalThis.AudioContext = priorAudioContext;
+    globalThis.Audio = priorAudio;
+  }
+});

--- a/desktop/src/features/notifications/lib/sound.ts
+++ b/desktop/src/features/notifications/lib/sound.ts
@@ -135,29 +135,178 @@ export function shouldPlayNotificationSound(
   return !channelId || !silentChannelIds?.has(channelId);
 }
 
-const cache = new Map<SoundName, HTMLAudioElement>();
+/**
+ * A cancellable handle for an in-flight notification sound.
+ *
+ * `stop()` halts playback; `onEnded()` registers a callback fired once when
+ * playback finishes naturally or is stopped (used by the settings preview
+ * button to reset its play/pause state).
+ */
+export type SoundPlayback = {
+  stop: () => void;
+  onEnded: (callback: () => void) => void;
+};
 
-function getAudio(name: SoundName): HTMLAudioElement {
-  let audio = cache.get(name);
-  if (!audio) {
-    audio = new Audio(`/sounds/${name}.mp3`);
-    cache.set(name, audio);
-  }
-  return audio;
+function soundUrl(name: SoundName): string {
+  return `/sounds/${name}.mp3`;
 }
 
-export function playNotificationSound(
-  name: SoundName,
-): HTMLAudioElement | null {
+// Notification sounds play through the Web Audio API rather than an
+// <audio>/HTMLAudioElement. A playing HTMLMediaElement is automatically
+// adopted by the browser's Media Session, which binds the OS hardware
+// media keys (macOS Play/Pause) to it — so previewing a sound left the
+// Play key replaying the ping indefinitely. Web Audio buffer sources are
+// not media-session participants and are never captured by media keys.
+// (This mirrors the click-poof sound in PoofBurstProvider.tsx.)
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext | null {
   try {
-    const audio = getAudio(name);
-    audio.currentTime = 0;
-    audio.play().catch(() => {
-      // Best-effort — user may not have interacted with the page yet.
-    });
-    return audio;
+    audioContext ??= new AudioContext({ latencyHint: "interactive" });
+    return audioContext;
   } catch {
-    // Best-effort only.
     return null;
   }
+}
+
+const bufferCache = new Map<SoundName, AudioBuffer>();
+const bufferPromises = new Map<SoundName, Promise<AudioBuffer | null>>();
+
+function loadBuffer(name: SoundName): Promise<AudioBuffer | null> {
+  const cached = bufferCache.get(name);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+  const pending = bufferPromises.get(name);
+  if (pending) {
+    return pending;
+  }
+
+  const context = getAudioContext();
+  if (!context) {
+    return Promise.resolve(null);
+  }
+
+  const promise = fetch(soundUrl(name))
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load sound ${name}: ${response.status}`);
+      }
+      return response.arrayBuffer();
+    })
+    .then((arrayBuffer) => context.decodeAudioData(arrayBuffer))
+    .then((buffer) => {
+      bufferCache.set(name, buffer);
+      return buffer;
+    })
+    .catch(() => null)
+    .finally(() => {
+      bufferPromises.delete(name);
+    });
+
+  bufferPromises.set(name, promise);
+  return promise;
+}
+
+/** Warm the decoded-buffer cache so the first play has no fetch/decode lag. */
+export function preloadNotificationSound(name: SoundName): void {
+  void loadBuffer(name);
+}
+
+function noopPlayback(): SoundPlayback {
+  return { stop: () => {}, onEnded: (callback) => callback() };
+}
+
+// Fallback for environments without a usable AudioContext (or a buffer that
+// failed to decode). Uses a one-shot HTMLAudioElement; this path can still be
+// captured by media keys, but it only runs when Web Audio is unavailable.
+function playViaAudioElement(name: SoundName): SoundPlayback {
+  try {
+    const audio = new Audio(soundUrl(name));
+    audio.currentTime = 0;
+    audio.play().catch(() => {
+      // Best-effort — the user may not have interacted with the page yet.
+    });
+    return {
+      stop: () => {
+        audio.pause();
+      },
+      onEnded: (callback) => {
+        const handler = () => callback();
+        audio.addEventListener("ended", handler, { once: true });
+        audio.addEventListener("pause", handler, { once: true });
+      },
+    };
+  } catch {
+    return noopPlayback();
+  }
+}
+
+function playViaWebAudio(
+  context: AudioContext,
+  buffer: AudioBuffer,
+): SoundPlayback {
+  const endedCallbacks: Array<() => void> = [];
+  let ended = false;
+  const finish = () => {
+    if (ended) return;
+    ended = true;
+    for (const callback of endedCallbacks) {
+      callback();
+    }
+  };
+
+  const source = context.createBufferSource();
+  source.buffer = buffer;
+  source.connect(context.destination);
+  source.addEventListener("ended", finish, { once: true });
+
+  const start = () => {
+    try {
+      source.start();
+    } catch {
+      finish();
+    }
+  };
+  if (context.state === "suspended") {
+    void context.resume().then(start, finish);
+  } else {
+    start();
+  }
+
+  return {
+    stop: () => {
+      try {
+        source.stop();
+      } catch {
+        // Already stopped/ended.
+      }
+      finish();
+    },
+    onEnded: (callback) => {
+      if (ended) {
+        callback();
+      } else {
+        endedCallbacks.push(callback);
+      }
+    },
+  };
+}
+
+export function playNotificationSound(name: SoundName): SoundPlayback {
+  const context = getAudioContext();
+  const buffer = bufferCache.get(name);
+
+  if (context && buffer) {
+    try {
+      return playViaWebAudio(context, buffer);
+    } catch {
+      return playViaAudioElement(name);
+    }
+  }
+
+  // Buffer not ready yet: warm the cache for next time and fall back to an
+  // HTMLAudioElement for this play so the sound is not silently dropped.
+  void loadBuffer(name);
+  return playViaAudioElement(name);
 }

--- a/desktop/src/features/settings/ui/SoundPicker.tsx
+++ b/desktop/src/features/settings/ui/SoundPicker.tsx
@@ -1,10 +1,12 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, Pause, Play } from "lucide-react";
 
 import {
   playNotificationSound,
+  preloadNotificationSound,
   SOUND_NAMES,
   type SoundName,
+  type SoundPlayback,
 } from "@/features/notifications/lib/sound";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -64,21 +66,25 @@ export function SoundPicker({
 }) {
   const items = sortedSounds(recommended);
   const [isPlaying, setIsPlaying] = useState(false);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const playbackRef = useRef<SoundPlayback | null>(null);
+
+  // Warm the Web Audio buffer for the selected sound so the first preview
+  // plays through Web Audio (not the HTMLAudioElement fallback, which the OS
+  // media keys can capture).
+  useEffect(() => {
+    preloadNotificationSound(value);
+  }, [value]);
 
   function togglePreview() {
     if (isPlaying) {
-      audioRef.current?.pause();
+      playbackRef.current?.stop();
       setIsPlaying(false);
       return;
     }
-    const audio = playNotificationSound(value);
-    if (!audio) return;
-    audioRef.current = audio;
+    const playback = playNotificationSound(value);
+    playbackRef.current = playback;
     setIsPlaying(true);
-    const stop = () => setIsPlaying(false);
-    audio.addEventListener("ended", stop, { once: true });
-    audio.addEventListener("pause", stop, { once: true });
+    playback.onEnded(() => setIsPlaying(false));
   }
 
   return (


### PR DESCRIPTION
## Problem

Previewing a notification sound (Settings > Notifications: change a sound, press Play) binds the macOS hardware **Play/Pause media key** to that ping. Afterwards, pressing the keyboard **Play button** replays the sound — seemingly indefinitely.

Reported by Kevin Chung in the Buzz "Welcome" channel.

## Root cause

Notification sounds played through a plain `HTMLAudioElement` (`new Audio(...)`) in `desktop/src/features/notifications/lib/sound.ts`. Any playing `HTMLMediaElement` is automatically adopted by the browser's **Media Session**, which binds the OS hardware media keys to it. The app never touched `navigator.mediaSession`, so nothing told the OS these were throwaway UI blips rather than real media.

## Fix

Play notification sounds through the **Web Audio API** (`AudioContext` + `AudioBufferSourceNode`) instead. Web Audio buffer sources are **not** Media Session participants and are never captured by media keys.

This mirrors the existing **click-poof** sound in `PoofBurstProvider.tsx`, which already uses Web Audio for exactly this reason (with an `HTMLAudioElement` only as a fallback).

- `playNotificationSound` now returns a small `SoundPlayback` handle (`stop()` + `onEnded()`), so the Settings preview button keeps its play/pause and "playing" state. The three fire-and-forget notification callers are unaffected (they ignore the return value).
- Decoded buffers are cached; `preloadNotificationSound` warms the cache, and `SoundPicker` preloads the selected sound so the **first** preview uses Web Audio rather than the fallback.
- An `HTMLAudioElement` fallback remains only for environments without a usable `AudioContext`.

## Tests

- Added regression coverage in `sound.test.mjs`:
  - the Web Audio path **never constructs an HTMLAudioElement** (the media-key-capture source) and its `stop()`/`onEnded()` handle works;
  - the fallback path still plays and returns a usable handle when no `AudioContext` is available.

## Validation

- `pnpm typecheck` — clean
- `biome check` (changed files) — clean
- `pnpm test` — **4537 passed / 0 failed**
- `pnpm build:e2e` — builds clean

## Manual verification note

The media-key binding is a browser/OS behavior that can't be exercised in headless CI. The fix is verified by unit tests asserting the Web Audio path (no `HTMLAudioElement`) plus the established poof-sound precedent. Worth a quick manual sanity check on macOS: preview a sound, then press the keyboard Play key — it should no longer replay the ping.
