### PR TITLE
feat(desktop): surface externally managed agents

### DIFF
--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -25,8 +25,6 @@ import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
 import { useBakedBuildEnvQuery, useRelayAgentsQuery } from "@/features/agents/hooks";
-import { useUsersBatchQuery } from "@/features/profile/hooks";
-import { useIdentityQuery } from "@/shared/api/hooks";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
@@ -42,40 +40,19 @@ import { getInheritedAgentDefaults } from "./bakedEnvHelpers";
 
 export function AgentsView() {
   const { openPersonaProfilePanel, openProfilePanel } = useProfilePanel();
-  const identityQuery = useIdentityQuery();
   const relayAgentsQuery = useRelayAgentsQuery();
   const { globalConfig } = useGlobalAgentConfig();
   const { data: bakedEnv } = useBakedBuildEnvQuery({ enabled: true });
   const inheritedDefaults = getInheritedAgentDefaults(globalConfig, bakedEnv);
   const agents = useManagedAgentActions();
-  const relayAgentPubkeys = React.useMemo(
-    () => (relayAgentsQuery.data ?? []).map((agent) => agent.pubkey),
-    [relayAgentsQuery.data],
-  );
-  const relayProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
-    enabled: relayAgentPubkeys.length > 0,
-  });
   const externalAgents = React.useMemo(() => {
-    const ownerPubkey = identityQuery.data?.pubkey;
-    if (!ownerPubkey) return [];
     const localPubkeys = new Set(
       agents.managedAgents.map((agent) => normalizePubkey(agent.pubkey)),
     );
-    return (relayAgentsQuery.data ?? []).filter((agent) => {
-      const pubkey = normalizePubkey(agent.pubkey);
-      const profile = relayProfilesQuery.data?.profiles[pubkey];
-      return (
-        !localPubkeys.has(pubkey) &&
-        profile?.ownerPubkey &&
-        normalizePubkey(profile.ownerPubkey) === normalizePubkey(ownerPubkey)
-      );
-    });
-  }, [
-    agents.managedAgents,
-    identityQuery.data?.pubkey,
-    relayAgentsQuery.data,
-    relayProfilesQuery.data,
-  ]);
+    return (relayAgentsQuery.data ?? []).filter(
+      (agent) => !localPubkeys.has(normalizePubkey(agent.pubkey)),
+    );
+  }, [agents.managedAgents, relayAgentsQuery.data]);
   const personas = usePersonaActions();
   const teamImportInputRef = React.useRef<HTMLInputElement | null>(null);
   const aiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -24,7 +24,10 @@ import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
-import { useBakedBuildEnvQuery } from "@/features/agents/hooks";
+import { useBakedBuildEnvQuery, useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { Button } from "@/shared/ui/button";
@@ -39,10 +42,40 @@ import { getInheritedAgentDefaults } from "./bakedEnvHelpers";
 
 export function AgentsView() {
   const { openPersonaProfilePanel, openProfilePanel } = useProfilePanel();
+  const identityQuery = useIdentityQuery();
+  const relayAgentsQuery = useRelayAgentsQuery();
   const { globalConfig } = useGlobalAgentConfig();
   const { data: bakedEnv } = useBakedBuildEnvQuery({ enabled: true });
   const inheritedDefaults = getInheritedAgentDefaults(globalConfig, bakedEnv);
   const agents = useManagedAgentActions();
+  const relayAgentPubkeys = React.useMemo(
+    () => (relayAgentsQuery.data ?? []).map((agent) => agent.pubkey),
+    [relayAgentsQuery.data],
+  );
+  const relayProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
+    enabled: relayAgentPubkeys.length > 0,
+  });
+  const externalAgents = React.useMemo(() => {
+    const ownerPubkey = identityQuery.data?.pubkey;
+    if (!ownerPubkey) return [];
+    const localPubkeys = new Set(
+      agents.managedAgents.map((agent) => normalizePubkey(agent.pubkey)),
+    );
+    return (relayAgentsQuery.data ?? []).filter((agent) => {
+      const pubkey = normalizePubkey(agent.pubkey);
+      const profile = relayProfilesQuery.data?.profiles[pubkey];
+      return (
+        !localPubkeys.has(pubkey) &&
+        profile?.ownerPubkey &&
+        normalizePubkey(profile.ownerPubkey) === normalizePubkey(ownerPubkey)
+      );
+    });
+  }, [
+    agents.managedAgents,
+    identityQuery.data?.pubkey,
+    relayAgentsQuery.data,
+    relayProfilesQuery.data,
+  ]);
   const personas = usePersonaActions();
   const teamImportInputRef = React.useRef<HTMLInputElement | null>(null);
   const aiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);
@@ -273,6 +306,40 @@ export function AgentsView() {
                 void personas.handleImportSnapshotFile(fileBytes, fileName);
               }}
             />
+
+            {externalAgents.length > 0 ? (
+              <section className="space-y-3" data-testid="external-agents-section">
+                <div>
+                  <h2 className="text-sm font-semibold">External agents</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Running outside this Desktop. Their deployment owns their keys and lifecycle.
+                  </p>
+                </div>
+                <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,240px))] justify-start gap-3 [@container(max-width:40rem)]:justify-center">
+                  {externalAgents.map((agent) => (
+                    <button
+                      className="rounded-2xl border bg-card p-4 text-left transition-colors hover:bg-accent"
+                      key={agent.pubkey}
+                      onClick={() => openProfilePanel?.(agent.pubkey)}
+                      type="button"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="truncate font-medium">{agent.name}</span>
+                        <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+                          External
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {agent.agentType || "Agent"} · {agent.status}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        View identity and runtime details
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ) : null}
 
             <TeamsSection
               error={

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -214,6 +214,31 @@ async function countCommandInvocations(
   );
 }
 
+test("shows relay agents outside Desktop even when their owner profile is unavailable", async ({
+  page,
+}) => {
+  const externalPubkey = "ab".repeat(32);
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        agentType: "omp",
+        name: "Cluster GLM",
+        pubkey: externalPubkey,
+        status: "online",
+      },
+    ],
+  });
+
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+
+  const section = page.getByTestId("external-agents-section");
+  await expect(section).toBeVisible();
+  await expect(section).toContainText("Cluster GLM");
+  await expect(section).toContainText("External");
+  await expect(section).toContainText("omp · online");
+});
+
 test("catalog hides built-ins and shows the shared-agent empty state", async ({
   page,
 }) => {


### PR DESCRIPTION
## What changed

Adds an **External agents** section to the Desktop Agents page. It discovers relay-registered agents whose NIP-OA owner is the current Desktop identity and excludes locally managed agents.

## Why

Kubernetes/external agent identities are operationally real but were invisible in the Agents panel, making the desktop list misleading.

## Safety

External cards are read-only: they open the existing profile/runtime details and deliberately do not expose local start/stop, lifecycle, or private-key controls.

## Validation

- `pnpm --dir desktop exec tsc --noEmit` passed.
- `git diff --check` passed.
- Biome could not run because the repository currently rejects its nested `desktop/biome.json` configuration before processing the target file.