### PR TITLE
fix(desktop): let channel-member agents through the allowed-list mention gate

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -82,6 +82,18 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+/**
+ * Gate for *non-member* agent identities in autocomplete / add-member search.
+ *
+ * Returns true when the candidate should stay in the pipeline:
+ * - humans always pass
+ * - agents pass only if they are in the caller's allowed/mentionable set
+ *
+ * Channel *members* that are agents are handled separately by the caller
+ * (see `useMentions`): they bypass this gate so `shouldHideAgentFromMentions`
+ * can apply Option B invocability (member bots with unknown/allowed
+ * invocability remain mentionable — required for self-hosted ACP agents).
+ */
 export function isAgentIdentityInAllowedList(
   candidate: { isAgent?: boolean; pubkey: string },
   allowedAgentPubkeys: ReadonlySet<string>,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -255,7 +255,15 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
+      // Allowed-list gate applies to *non-member* agent identities (global
+      // search / directory noise). Channel members still pass through so
+      // `shouldHideAgentFromMentions` can decide invocability (Option B:
+      // member bots with unknown/allowed invocability stay mentionable —
+      // e.g. self-hosted ACP agents added as role=bot).
+      if (
+        !isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys) &&
+        candidate.isMember !== true
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

- Channel **member** agents now bypass the allowed-list gate in `@` autocomplete.
- `shouldHideAgentFromMentions` still decides invocability (Option B): member bots with unknown/allowed invocability stay mentionable.
- Non-member directory noise remains filtered by the allowed-list check.

## Why

Self-hosted ACP agents added as channel members (`role=bot`) were dropped from autocomplete by the allowed-list gate before Option B could run. Stock Desktop could not mention them even though they were channel members.

Ported onto current main after the rename from `isAgentIdentityInManagedList` / managed-list to `isAgentIdentityInAllowedList` / `mentionableAgentPubkeys`.

## Test plan

- [ ] `cd desktop && node --test src/features/agents/lib/agentAutocompleteEligibility.test.mjs src/features/messages/lib/useMentions.test.mjs` (or the project's equivalent)
- [ ] Add a non-managed agent as a channel member and confirm it appears in `@` autocomplete
- [ ] Confirm non-member directory agents still require being on the allowed/mentionable set