### PR TITLE
chore(deploy): ignore every deploy/compose/.env* variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,15 @@ identity.key
 
 # Helm dependency tarballs — regenerable from Chart.lock via `helm dependency build`
 deploy/charts/*/charts/*.tgz
+
+# Local self-host secrets (minipc). `.env*` (not just `.env`) so ad-hoc copies
+# like `.env.bak-before-tailscale` can never reach a `git add -A` — they carry
+# the same secrets as .env.
+deploy/compose/OWNER_KEY.txt
+deploy/compose/.env*
+!deploy/compose/.env.example
+
+# HQ agent system — its own PRIVATE repo (manuarraya/proximotrabajo-agents),
+# with agent private keys and DB passwords under deploy/agents/keys/. This repo
+# is PUBLIC, so a stray `git add -A` here must not be able to reach them.
+deploy/agents/


### PR DESCRIPTION
## Summary

- Ignore the whole `.env*` family under deploy compose paths (keeping `.env.example`).
- Prevents ad-hoc copies like `.env.bak-before-tailscale` from being addable next to the ignored `.env` in a public repo.

## Test plan

- [ ] Confirm `.env.example` is still tracked / not ignored
- [ ] Confirm a local `.env.bak` under `deploy/compose` is ignored by `git status`