### PR TITLE
fix: derive community name past service subdomain labels

### DIFF
--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   clearCommunityStorage,
+  deriveCommunityName,
   initFirstCommunity,
   loadCommunities,
   loadCommunityDiscoveryAfterLeave,
@@ -131,4 +132,27 @@ test("clearCommunityStorage preserves completed final-leave discovery", () => {
 
   assert.equal(storage.length, 1);
   assert.equal(loadCommunityDiscoveryAfterLeave(storage), true);
+});
+
+test("deriveCommunityName skips service labels ahead of the org label", () => {
+  assert.equal(deriveCommunityName("wss://buzz.nilor.cool"), "nilor");
+  assert.equal(deriveCommunityName("wss://relay.example.com"), "example");
+  assert.equal(deriveCommunityName("wss://buzz.relay.example.com"), "example");
+});
+
+test("deriveCommunityName keeps the registrable domain label", () => {
+  // The service label IS the org when nothing follows it but the TLD.
+  assert.equal(deriveCommunityName("wss://buzz.com"), "buzz");
+  assert.equal(deriveCommunityName("wss://nilor.cool"), "nilor");
+  // Non-service subdomains still win over the domain.
+  assert.equal(deriveCommunityName("wss://acme.example.com"), "acme");
+});
+
+test("deriveCommunityName preserves local and staging special cases", () => {
+  assert.equal(deriveCommunityName("ws://localhost:3000"), "Local Dev");
+  assert.equal(
+    deriveCommunityName("wss://buzz-oss.stage.blox.sqprod.co"),
+    "Buzz (staging)",
+  );
+  assert.equal(deriveCommunityName("not a url"), "Community");
 });

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -185,6 +185,10 @@ export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
   }
 }
 
+// Hostname labels that identify the Buzz service rather than the organization
+// hosting it (e.g. buzz.nilor.cool → "nilor").
+const SERVICE_HOST_LABELS = new Set(["buzz", "relay"]);
+
 export function deriveCommunityName(relayUrl: string): string {
   try {
     const url = new URL(
@@ -199,9 +203,14 @@ export function deriveCommunityName(relayUrl: string): string {
     if (parts.some((p) => p === "stage" || p === "staging")) {
       return "Buzz (staging)";
     }
-    // Use the first subdomain segment or the domain itself
     if (parts.length >= 2) {
-      return parts[0] === "relay" ? parts[1] : parts[0];
+      // Skip leading service labels, but never walk past the registrable
+      // domain label (for buzz.example.com the org is "example").
+      let i = 0;
+      while (i < parts.length - 2 && SERVICE_HOST_LABELS.has(parts[i])) {
+        i++;
+      }
+      return parts[i];
     }
     return host;
   } catch {

--- a/mobile/lib/shared/community/community.dart
+++ b/mobile/lib/shared/community/community.dart
@@ -70,13 +70,25 @@ class Community {
     addedAt: DateTime.parse(json['addedAt'] as String),
   );
 
+  /// Hostname labels that identify the Buzz service rather than the
+  /// organization hosting it (e.g. `buzz.nilor.cool` → "nilor").
+  static const _serviceLabels = {'buzz', 'relay'};
+
   /// Derive a human-friendly community name from a relay URL.
   static String nameFromUrl(String url) {
     try {
       final host = Uri.parse(url).host;
       if (host.contains('localhost') || host == '127.0.0.1') return 'Local Dev';
       final parts = host.split('.');
-      if (parts.length > 2) return parts.first;
+      if (parts.length > 2) {
+        // Skip leading service labels, but never walk past the registrable
+        // domain label (for `buzz.example.com` the org is "example").
+        var i = 0;
+        while (i < parts.length - 2 && _serviceLabels.contains(parts[i])) {
+          i++;
+        }
+        return parts[i];
+      }
       return host;
     } catch (_) {
       return 'Community';

--- a/mobile/test/shared/community/community_test.dart
+++ b/mobile/test/shared/community/community_test.dart
@@ -1,0 +1,25 @@
+import 'package:buzz/shared/community/community.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Community.nameFromUrl', () {
+    test('skips service labels ahead of the org label', () {
+      expect(Community.nameFromUrl('wss://buzz.nilor.cool'), 'nilor');
+      expect(Community.nameFromUrl('wss://relay.example.com'), 'example');
+      expect(Community.nameFromUrl('wss://buzz.relay.example.com'), 'example');
+    });
+
+    test('keeps the registrable domain label', () {
+      // The service label IS the org when nothing follows it but the TLD.
+      expect(Community.nameFromUrl('wss://buzz.example.com'), 'example');
+      expect(Community.nameFromUrl('wss://acme.example.com'), 'acme');
+      // Two-label hosts keep the full host, matching existing behavior.
+      expect(Community.nameFromUrl('wss://nilor.cool'), 'nilor.cool');
+    });
+
+    test('preserves local and fallback special cases', () {
+      expect(Community.nameFromUrl('ws://localhost:3000'), 'Local Dev');
+      expect(Community.nameFromUrl('ws://127.0.0.1:3000'), 'Local Dev');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Adding a community on mobile from a relay hosted at `buzz.nilor.cool` shows the community as **"buzz"** instead of **"nilor"**. Both clients derive the display name from the relay hostname and take the *first* label, which is the service name, not the organization.

## Fix

Generalize the existing desktop special case for the `relay` label into a shared service-label set (`buzz`, `relay`) on both platforms: skip leading service labels, but never walk past the registrable domain label.

| Host | Before (mobile) | After |
|------|-----------------|-------|
| `buzz.nilor.cool` | buzz | **nilor** |
| `relay.example.com` | relay (mobile) / example (desktop) | example |
| `buzz.relay.example.com` | buzz | example |
| `buzz.com` | buzz | buzz |
| `localhost` | Local Dev | Local Dev |

Desktop's staging detection and mobile's two-label-host behavior are unchanged.

## Testing

- New unit tests: `deriveCommunityName` cases in `desktop/src/features/communities/communityStorage.test.mjs`, new `mobile/test/shared/community/community_test.dart`.
- Full desktop unit suite: 4538 pass. Full mobile suite: 1264 pass. `flutter analyze` and biome clean.

This is the stopgap companion to a follow-up PR that adds an authoritative server-set workspace name served via NIP-11 (clients will prefer it over this heuristic).
