### PR TITLE
fix(auth): match bracketed ::1 host in NIP-42 relay url check

### DIFF
--- a/crates/buzz-auth/src/nip42.rs
+++ b/crates/buzz-auth/src/nip42.rs
@@ -22,8 +22,11 @@ fn normalize_relay_url(raw: &str) -> String {
         Err(_) => return raw.to_string(),
     };
     // Treat localhost variants as equivalent by normalizing to 127.0.0.1.
+    // `Url::host_str` returns IPv6 literals wrapped in brackets, so the loopback
+    // address arrives as `[::1]`, not `::1`. Match the bracketed form or the
+    // branch never fires and a valid `[::1]` client is rejected as a mismatch.
     if let Some(host) = parsed.host_str() {
-        if host == "localhost" || host == "::1" {
+        if host == "localhost" || host == "[::1]" {
             let _ = parsed.set_host(Some("127.0.0.1"));
         }
     }
@@ -170,6 +173,13 @@ mod tests {
     #[test]
     fn localhost_and_127_are_equivalent() {
         let a = normalize_relay_url("ws://localhost:3030");
+        let b = normalize_relay_url("ws://127.0.0.1:3030");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn ipv6_loopback_and_127_are_equivalent() {
+        let a = normalize_relay_url("ws://[::1]:3030");
         let b = normalize_relay_url("ws://127.0.0.1:3030");
         assert_eq!(a, b);
     }


### PR DESCRIPTION
normalize_relay_url is supposed to treat localhost, ::1 and 127.0.0.1 as the same relay when verifying a NIP-42 AUTH event, but the ::1 branch never runs. url::Url::host_str() returns IPv6 literals wrapped in brackets, so the host comes back as `[::1]` and the `host == "::1"` check is always false.

The effect is a client that signs its AUTH event against ws://[::1]:3030 while the relay is configured as localhost or 127.0.0.1 gets rejected with RelayUrlMismatch. It mostly bites local and dev setups running on IPv6 loopback.

Matched the bracketed form and added a test next to the existing localhost/127 one. cargo test -p buzz-auth passes.
