### PR TITLE
fix(relay): let DM participants rename their own DM (#4739)

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -593,6 +593,18 @@ pub async fn validate_admin_event(
                 k == "name" || k == "about" || k == "archived" || k == "visibility" || k == "ttl"
             });
             if has_privileged_tag {
+                // A DM rename is gated on participation, not on a role no DM
+                // participant can hold. See `is_dm_rename_only`.
+                if is_dm_rename_only(&channel.channel_type, event) {
+                    return if state
+                        .is_member_cached(tenant.community(), channel_id, &actor_bytes)
+                        .await?
+                    {
+                        Ok(())
+                    } else {
+                        Err(anyhow::anyhow!("actor is not a participant of this DM"))
+                    };
+                }
                 let members = state.db.get_members(tenant.community(), channel_id).await?;
                 let actor_member = members.iter().find(|m| m.pubkey == actor_bytes);
                 match actor_member {
@@ -2466,6 +2478,24 @@ fn actor_is_channel_owner_or_admin(members: &[MemberRecord], actor: &[u8]) -> bo
         .any(|m| m.pubkey == actor && (m.role == "owner" || m.role == "admin"))
 }
 
+/// Whether a kind:9002 event is a DM rename and nothing else.
+///
+/// A DM's privileged-metadata gate is unsatisfiable by construction:
+/// `buzz_db::dm` enrols every participant with a hardcoded `member` role
+/// ("always `member` for DMs"), and a DM never carries an owner-role agent, so
+/// neither the `owner`/`admin` branch nor the NIP-OA agent-owner fallback can
+/// admit anyone — not even the community owner. Renaming is the one privileged
+/// tag that is meaningful for a DM, so it joins `topic`/`purpose` on the
+/// any-active-participant tier. Every other privileged tag stays locked, which
+/// is why this returns false as soon as one of them is present.
+fn is_dm_rename_only(channel_type: &str, event: &Event) -> bool {
+    channel_type == "dm"
+        && extract_tag_value(event, "name").is_some()
+        && !["about", "archived", "visibility", "ttl"]
+            .iter()
+            .any(|tag| extract_tag_value(event, tag).is_some())
+}
+
 #[cfg(test)]
 fn delete_tombstone_content(
     actor_hex: String,
@@ -3449,5 +3479,43 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+
+    fn metadata_event(tags: &[&[&str]]) -> Event {
+        let keys = nostr::Keys::generate();
+        let nostr_tags: Vec<Tag> = tags
+            .iter()
+            .map(|parts| Tag::parse(parts.to_vec()).expect("valid tag"))
+            .collect();
+        EventBuilder::new(Kind::from(9002_u16), "")
+            .tags(nostr_tags)
+            .sign_with_keys(&keys)
+            .expect("signing failed")
+    }
+
+    #[test]
+    fn non_dm_name_edit_stays_role_gated() {
+        let ev = metadata_event(&[&["h", "chan"], &["name", "general"]]);
+        assert!(!is_dm_rename_only("stream", &ev));
+        assert!(!is_dm_rename_only("forum", &ev));
+    }
+
+    #[test]
+    fn dm_edit_touching_another_privileged_tag_stays_role_gated() {
+        // A rename must  not become a way to smuggle `visibility` or `archived`
+        // past the owner/admin gate.
+        for extra in ["about", "archived", "visibility", "ttl"] {
+            let ev = metadata_event(&[&["h", "chan"], &["name", "Founders"], &[extra, "x"]]);
+            assert!(
+                !is_dm_rename_only("dm", &ev),
+                "`{extra}` alongside `name` must keep the owner/admin gate"
+            );
+        }
+    }
+
+    #[test]
+    fn dm_edit_with_a_name_tag_is_not_a_rename() {
+        let ev = metadata_event(&[&["h", "chan"], &["archived", "true"]]);
+        assert!(!is_dm_rename_only("dm", &ev));
     }
 }


### PR DESCRIPTION
Fixes #4739.

## Summary

Renaming a group DM is impossible for everyone, community owner included. The
kind:9002 privileged-tag gate (`side_effects.rs:595`) requires `owner` or `admin`,
but `buzz-db/src/dm.rs` enrols every DM participant with a hardcoded role —
`VALUES ($1, $2, $3, 'member', $4)`, commented as an invariant ("always `member`
for DMs") — and a DM never carries an owner-role agent for the NIP-OA fallback
either. So this isn't a policy against renaming; it's an authorization predicate
no principal can satisfy.

## Change

The handler already has the tier this needs, documented two lines above the check:
"topic/purpose allow any member", implemented with `state.is_member_cached`. `name`
now rides that tier for `channel_type == "dm"` only, behind `is_dm_rename_only`.
Every other privileged tag stays locked — a rename carrying
`about`/`archived`/`visibility`/`ttl` falls back to the owner/admin gate.

No new query: `validate_admin_event` already loads the channel record for the
archived-channel check, so `channel.channel_type` was in scope.

## Why the rename actually lands

The gate is only half the path, so I traced the rest rather than assuming it:

- **membership** — `is_member` filters on `removed_at IS NULL` only, no role
  predicate (`buzz-db/src/channel.rs:654`), so a plain `member` passes;
- **apply** — `handle_edit_metadata`'s `name` arm calls
  `update_channel(name: Some(..))` with no channel-type condition
  (`side_effects.rs:1445`);
- **propagate** — `emit_group_discovery_events` pushes `["name", &channel.name]`
  unconditionally (`side_effects.rs:1057`); the DM branch only *adds* `hidden` and
  `p` tags (`:1073`). It runs at the end of `handle_edit_metadata` (`:1649`).

## Tests

Four unit tests on the predicate, no infrastructure needed. The one that matters
for review is `dm_edit_touching_another_privileged_tag_stays_role_gated`: it
asserts a rename cannot smuggle `visibility` or `archived` past the gate, for each
of the four locked tags.

`cargo fmt --check`, `cargo clippy -p buzz-relay --all-targets -- -D warnings`,
`just test-unit` and `just desktop-tauri-test` are clean.

## Not included

Desktop excludes DMs from channel management entirely
(`ChannelManagementSheet.tsx:142`), so the UI unlock is a separate PR — happy to
follow up once the relay side lands.

The rule is isolated in one small pure predicate, so if you'd rather scope it
differently — creator-only, or a community-owner bypass — that's a one-function
change rather than a rework.