### PR TITLE
fix(cli): query NIP-29 group metadata instead of non-existent kind:41001 for DM list

### DIFF
--- a/crates/buzz-cli/src/commands/dms.rs
+++ b/crates/buzz-cli/src/commands/dms.rs
@@ -4,19 +4,62 @@ use crate::client::{extract_d_tag, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{parse_uuid, sdk_err, validate_hex64};
 
-/// List DM conversations by querying kind:41001 (relay-confirmed DMs) filtered by our pubkey.
+/// List DM conversations by querying NIP-29 group metadata (kind:39000) for
+/// channels we are a member of, then filtering for DM channels.
+///
+/// The relay emits kind:39000 with a `["t", "dm"]` tag and `["hidden"]` tag for
+/// DM channels. We discover our memberships via kind:39002 (group members)
+/// filtered by our pubkey, then fetch the metadata for those channel IDs.
 pub async fn cmd_list_dms(client: &BuzzClient, limit: Option<u32>) -> Result<(), CliError> {
     let my_pk = client.keys().public_key().to_hex();
-    let limit = limit.unwrap_or(50).min(200);
-    let filter = serde_json::json!({
-        "kinds": [41001],
+    let effective_limit = limit.unwrap_or(50).min(200);
+
+    // Step 1: find channel IDs where we're a member (kind:39002).
+    let member_filter = serde_json::json!({
+        "kinds": [39002],
         "#p": [my_pk],
-        "limit": limit
     });
-    let resp = client.query(&filter).await?;
-    let events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
+    let member_events = client
+        .query_paginated(member_filter, effective_limit)
+        .await?;
+    let channel_ids: Vec<String> = member_events
+        .iter()
+        .map(extract_d_tag)
+        .filter(|id| !id.is_empty())
+        .collect();
+    if channel_ids.is_empty() {
+        println!("[]");
+        return Ok(());
+    }
+
+    // Step 2: fetch kind:39000 metadata for those channels.
+    let metadata_filter = serde_json::json!({
+        "kinds": [39000],
+        "#d": channel_ids,
+    });
+    let events = client
+        .query_paginated(metadata_filter, effective_limit)
+        .await?;
+
+    // Step 3: filter for DM channels (tagged ["t", "dm"] and ["hidden"]).
     let dms: Vec<serde_json::Value> = events
         .iter()
+        .filter(|e| {
+            e.get("tags")
+                .and_then(|t| t.as_array())
+                .map(|tags| {
+                    tags.iter().any(|tag| {
+                        tag.as_array()
+                            .map(|a| {
+                                a.len() >= 2
+                                    && a.first().and_then(|v| v.as_str()) == Some("t")
+                                    && a.get(1).and_then(|v| v.as_str()) == Some("dm")
+                            })
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        })
         .map(|e| {
             let dm_id = extract_d_tag(e);
             let participants: Vec<String> = e


### PR DESCRIPTION
## What was wrong

`buzz dms list` always returned an empty array, even for active DM conversations with messages. Agents relying on this command to discover DMs would silently miss messages sent directly to them.

The command queried kind:41001 (`KIND_DM_CREATED`) filtered by the caller's `#p` tag. However, the relay never emits kind:41001 events. When a DM is opened via `handle_dm_open`, the relay creates the channel in the database and emits NIP-29 group discovery events (kind:39000/39001/39002), not kind:41001. The query had zero matching events to return.

## Why it happened

PR #510 (`fix(cli): normalize output and fix wrong Nostr kinds across all commands`) corrected the previous wrong kind (41010) to 41001, based on the `KIND_DM_CREATED` constant. But the relay doesn't actually emit that kind — it only defines it. The relay's DM creation path (`handle_dm_open` → `emit_group_discovery_events`) emits kind:39000 (group metadata) with a `["t", "dm"]` tag and `["hidden"]` tag, plus kind:39002 (group members) with `p` tags for each participant. There is no code path that emits kind:41001.

## What changed

Switched `cmd_list_dms` to the same two-step pattern already used by `cmd_list_channels --member`:

1. Query kind:39002 (group members) filtered by `#p` with our pubkey to find channel IDs where we're a member.
2. Fetch kind:39000 (group metadata) for those channel IDs.
3. Filter for DM channels by checking for the `["t", "dm"]` tag.

The output format (`dm_id`, `participants`, `created_at`) is unchanged, so callers that already parse the output need no changes.

## Verification

```text
cargo check -p buzz-cli
cargo test -p buzz-cli --lib
cargo fmt -p buzz-cli -- --check
cargo clippy -p buzz-cli --all-targets -- -D warnings
```

All 341 `buzz-cli` tests passed, formatting is clean, and Clippy reports no warnings.

Closes #5137.
