### PR TITLE
fix(desktop): read syntax scopes from tokenColors

### DIFF
--- a/desktop/src/shared/theme/theme-loader.ts
+++ b/desktop/src/shared/theme/theme-loader.ts
@@ -398,14 +398,18 @@ export function extractThemeInfo(
   const gitColors = extractGitColors(
     theme.colors as Record<string, string> | undefined,
   );
+  // Shiki's bundled themes carry their scope rules on `tokenColors`; `settings`
+  // is the raw TextMate spelling and stays supported for hand-written themes.
+  // Reading only `settings` silently returned the fallback for every bundled
+  // theme, which collapsed --muted-foreground onto --foreground.
+  const tokenSettings = (theme.tokenColors ?? theme.settings) as
+    | ReadonlyArray<ThemeSetting>
+    | undefined;
   return {
     name: themeName,
     bg,
     fg,
-    comment: extractCommentColor(
-      theme.settings as ReadonlyArray<ThemeSetting> | undefined,
-      fg,
-    ),
+    comment: extractCommentColor(tokenSettings, fg),
     ...gitColors,
     terminalPalette: extractTerminalPalette(theme),
   };

--- a/desktop/src/shared/theme/themeTokenColors.test.mjs
+++ b/desktop/src/shared/theme/themeTokenColors.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SYNTAX_THEMES,
+  extractThemeInfo,
+  loadThemeData,
+} from "./theme-loader.ts";
+
+test("comment color comes from the theme's own scope rules", async () => {
+  const info = extractThemeInfo(
+    "github-light",
+    await loadThemeData("github-light"),
+  );
+
+  // GitHub Light styles comments grey and body text near-black. Reading scope
+  // rules from the wrong field silently returned the foreground for both.
+  assert.equal(info.comment.toLowerCase(), "#6a737d");
+  assert.notEqual(info.comment.toLowerCase(), info.fg.toLowerCase());
+});
+
+test("bundled themes keep muted text distinct from body text", async () => {
+  const collapsed = [];
+
+  for (const name of SYNTAX_THEMES) {
+    const info = extractThemeInfo(name, await loadThemeData(name));
+    if (info.comment.toLowerCase() === info.fg.toLowerCase()) {
+      collapsed.push(name);
+    }
+  }
+
+  // A few minimal themes genuinely paint comments in the body text color; the
+  // regression this guards against collapsed every single theme.
+  assert.ok(
+    collapsed.length <= 8,
+    `muted text collapsed onto body text in ${collapsed.length} themes: ${collapsed.join(", ")}`,
+  );
+});


### PR DESCRIPTION
## Summary

`extractThemeInfo` looks for scope rules on `theme.settings`, but Shiki's bundled themes carry them on `tokenColors` — `settings` is the raw TextMate spelling. The lookup never matches for a bundled theme, so `extractCommentColor` always returns its fallback: the editor foreground.

The result is that `--muted-foreground` comes out byte-identical to `--foreground` in **all 62 bundled themes**, so secondary text (timestamps, join notices, hints, placeholders) renders in the body text color instead of the theme's muted tone.

Measured on current `main`:

```text
github-light   comment=#24292e  fg=#24292e   --muted-foreground === --foreground
github-dark    comment=#e1e4e8  fg=#e1e4e8   --muted-foreground === --foreground
dracula        comment=#F8F8F2  fg=#F8F8F2   --muted-foreground === --foreground
```

GitHub Light's actual comment color is `#6a737d`, so the intended separation between muted and body text exists in the theme — it just never reaches the CSS variables.

This change reads `tokenColors` first and keeps `settings` as the fallback, so hand-written TextMate themes keep working.

### Related issue

None found — searched open issues and PRs for `tokenColors`, `muted foreground` and `inline code`.

A follow-up (#5256) builds on this to give inline `code` spans a theme-derived color; it is only correct once scope extraction works, so this should land first.

### Testing

New `themeTokenColors.test.mjs`:

- GitHub Light's comment color resolves to the theme's own grey rather than the foreground.
- Walks every bundled theme and fails if more than 8 collapse muted text onto body text. Before this change that number was 62; after it is 5, and those five genuinely paint comments in the body color.

`just ci` passes locally under the repo's Hermit toolchain — the full gate: `check`, Rust unit tests, desktop typecheck and test suite (4540/4540), desktop build, Tauri check and tests, web build, and the mobile Flutter suite (1261/1261).

Screenshots captured with `just desktop-screenshot` (same message fixture, `general` channel). Sampling the darkest pixel of the "alice joined the channel" line in the captured PNGs: `rgb(101, 105, 108)` before → `rgb(150, 157, 164)` after, i.e. muted text stops impersonating body text.

**Before (main)**

![pr-5255--before-main](https://raw.githubusercontent.com/TolgaCinisli/buzz/fe32115e42e47521fb1d7a813fe8e07fa9dbf7c6/pr-5255--before-main.png)

**After (this PR)**

![pr-5255--after-fix](https://raw.githubusercontent.com/TolgaCinisli/buzz/fe32115e42e47521fb1d7a813fe8e07fa9dbf7c6/pr-5255--after-fix.png)
