### PR TITLE
feat(desktop): color inline code from the theme's keyword accent

### DIFF
--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -156,7 +156,7 @@
   font-size: var(--inline-code-font-size);
   font-family: ui-monospace, monospace;
   background: hsl(var(--muted));
-  color: inherit;
+  color: hsl(var(--code-foreground));
 }
 
 /* Code block content — higher specificity than the inline chips above; kept

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -14,6 +14,7 @@
     --secondary-foreground: 234 16.02% 35.49%;
     --muted: 223 15.91% 82.75%;
     --muted-foreground: 233 12.8% 41.37%;
+    --code-foreground: 266.07 61.18% 46.47%;
     --huddle-drawer-surface: 0 0% 0%;
     --huddle-control-surface: 0 0% 20%;
     --huddle-control-hover-surface: 0 0% 24%;
@@ -80,6 +81,7 @@
     --secondary-foreground: 227 68.25% 87.65%;
     --muted: 230 18.8% 26.08%;
     --muted-foreground: 228 39.22% 80%;
+    --code-foreground: 266.51 82.69% 79.61%;
     --huddle-drawer-surface: 230 18.8% 26.08%;
     --huddle-control-surface: 231 15.61% 33.92%;
     --huddle-control-hover-surface: 231 15.61% 38%;

--- a/desktop/src/shared/theme/ThemeProvider.tsx
+++ b/desktop/src/shared/theme/ThemeProvider.tsx
@@ -445,11 +445,17 @@ async function applyTheme(name: SyntaxThemeName): Promise<{
   if (requestToken !== themeApplyRequest) return null;
 
   const info = extractThemeInfo(name, themeData);
-  const { isDark, vars } = createThemeVars(info.bg, info.fg, info.comment, {
-    added: info.added,
-    deleted: info.deleted,
-    modified: info.modified,
-  });
+  const { isDark, vars } = createThemeVars(
+    info.bg,
+    info.fg,
+    info.comment,
+    {
+      added: info.added,
+      deleted: info.deleted,
+      modified: info.modified,
+    },
+    info.keyword,
+  );
 
   const root = document.documentElement;
   for (const [key, value] of Object.entries(vars)) {

--- a/desktop/src/shared/theme/adaptive-theme.ts
+++ b/desktop/src/shared/theme/adaptive-theme.ts
@@ -76,6 +76,40 @@ function overlay(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+/** WCAG 2.1 contrast ratio between two opaque colors. */
+function contrastRatio(hex1: string, hex2: string): number {
+  const [lighter, darker] = [luminance(hex1), luminance(hex2)].sort(
+    (a, b) => b - a,
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** WCAG AA minimum for normal-size text. */
+const AA_CONTRAST = 4.5;
+
+/**
+ * Push `color` toward white (dark themes) or black (light themes) in 5% steps
+ * until it clears `target` contrast against `bg`, preserving hue.
+ *
+ * Syntax themes tune their accents against the editor background, not against
+ * the slightly elevated surface an inline chip sits on, so a handful of themes
+ * land just under AA when their accent is reused verbatim. Nudging beats
+ * substituting: the color stays recognizably the theme's own.
+ */
+function ensureContrast(
+  color: string,
+  bg: string,
+  target: number,
+  isDark: boolean,
+): string {
+  const pole = isDark ? "#ffffff" : "#000000";
+  for (let step = 0; step <= 20; step++) {
+    const candidate = step === 0 ? color : mix(color, pole, step * 0.05);
+    if (contrastRatio(candidate, bg) >= target) return candidate;
+  }
+  return pole;
+}
+
 // =============================================================================
 // Chrome Color Calculation
 // =============================================================================
@@ -193,6 +227,7 @@ export function createThemeVars(
   syntaxFg: string,
   syntaxComment: string,
   gitColors?: ThemeGitColors,
+  syntaxKeyword?: string,
 ): ThemeResult {
   const isDark = luminance(syntaxBg) < 0.5;
 
@@ -214,6 +249,15 @@ export function createThemeVars(
   // Derived colors
   const borderColor = mix(primaryBg, syntaxFg, isDark ? 0.15 : 0.12);
   const hoverBg = elevate(0.06);
+  // Inline `code` chips sit on --muted (hoverBg) and, until now, inherited body
+  // text color — the one piece of message markdown with no tie to the syntax
+  // theme. Borrow the keyword accent instead, held to AA against that chip.
+  const codeFg = ensureContrast(
+    syntaxKeyword ?? syntaxFg,
+    hoverBg,
+    AA_CONTRAST,
+    isDark,
+  );
   const huddleControlBg = isDark ? mix(hoverBg, syntaxFg, 0.14) : "#333333";
   const huddleControlHoverBg = isDark
     ? mix(huddleControlBg, syntaxFg, 0.08)
@@ -257,6 +301,7 @@ export function createThemeVars(
       "--card-foreground": textFg,
       "--popover-foreground": textFg,
       "--muted-foreground": hexToHsl(syntaxComment),
+      "--code-foreground": hexToHsl(codeFg),
       "--accent-foreground": textFg,
       "--secondary-foreground": textFg,
 

--- a/desktop/src/shared/theme/inlineCodeColor.test.mjs
+++ b/desktop/src/shared/theme/inlineCodeColor.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createThemeVars } from "./adaptive-theme.ts";
+import {
+  SYNTAX_THEMES,
+  extractThemeInfo,
+  loadThemeData,
+} from "./theme-loader.ts";
+
+const HSL_TRIPLE = /^-?[\d.]+ [\d.]+% [\d.]+%$/;
+/** WCAG AA minimum for normal-size text. */
+const AA_CONTRAST = 4.5;
+
+function hslToRgb(triple) {
+  const [h, s, l] = triple
+    .split(" ")
+    .map((part) => Number.parseFloat(part.replace("%", "")));
+  const sat = s / 100;
+  const light = l / 100;
+  const k = (n) => (n + h / 30) % 12;
+  const a = sat * Math.min(light, 1 - light);
+  const f = (n) => light - a * Math.max(-1, Math.min(k(n) - 3, 9 - k(n), 1));
+  return [f(0), f(8), f(4)];
+}
+
+function relativeLuminance([r, g, b]) {
+  const [rs, gs, bs] = [r, g, b].map((channel) =>
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+function contrastRatio(a, b) {
+  const [lighter, darker] = [relativeLuminance(a), relativeLuminance(b)].sort(
+    (x, y) => y - x,
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+async function themeVars(name) {
+  const info = extractThemeInfo(name, await loadThemeData(name));
+  const { vars } = createThemeVars(
+    info.bg,
+    info.fg,
+    info.comment,
+    { added: info.added, deleted: info.deleted, modified: info.modified },
+    info.keyword,
+  );
+  return { info, vars };
+}
+
+test("every bundled theme yields an inline code color that clears AA on the chip", async () => {
+  assert.ok(
+    SYNTAX_THEMES.length > 0,
+    "the bundled theme audit cannot be empty",
+  );
+
+  for (const name of SYNTAX_THEMES) {
+    const { vars } = await themeVars(name);
+    const code = vars["--code-foreground"];
+
+    assert.match(
+      code,
+      HSL_TRIPLE,
+      `${name}: --code-foreground must be an HSL triple, got "${code}"`,
+    );
+
+    // Inline code chips paint their background with --muted, so that — not the
+    // page background — is the surface the text has to stay legible against.
+    const ratio = contrastRatio(hslToRgb(code), hslToRgb(vars["--muted"]));
+    assert.ok(
+      ratio >= AA_CONTRAST,
+      `${name}: inline code contrast ${ratio.toFixed(2)} is below AA (${AA_CONTRAST})`,
+    );
+  }
+});
+
+test("inline code borrows the theme's keyword accent, not the body text color", async () => {
+  const { info, vars } = await themeVars("github-light");
+
+  // GitHub Light styles keywords crimson; that is the accent inline code should
+  // pick up rather than falling back to the near-black editor foreground.
+  assert.equal(info.keyword.toLowerCase(), "#d73a49");
+  assert.notEqual(vars["--code-foreground"], vars["--foreground"]);
+});
+
+test("a theme whose keyword accent already clears AA is used verbatim", async () => {
+  const { info, vars } = await themeVars("slack-ochin");
+
+  assert.equal(info.keyword.toLowerCase(), "#7b30d0");
+  // Already 5.8:1 on the chip — no nudging needed, so the hue survives intact.
+  assert.equal(vars["--code-foreground"], "268.1 62.99% 50.2%");
+});

--- a/desktop/src/shared/theme/theme-loader.ts
+++ b/desktop/src/shared/theme/theme-loader.ts
@@ -398,14 +398,18 @@ export function extractThemeInfo(
   const gitColors = extractGitColors(
     theme.colors as Record<string, string> | undefined,
   );
+  // Shiki's bundled themes carry their scope rules on `tokenColors`; `settings`
+  // is the raw TextMate spelling and stays supported for hand-written themes.
+  // Reading only `settings` silently returned the fallback for every bundled
+  // theme, which collapsed --muted-foreground onto --foreground.
+  const tokenSettings = (theme.tokenColors ?? theme.settings) as
+    | ReadonlyArray<ThemeSetting>
+    | undefined;
   return {
     name: themeName,
     bg,
     fg,
-    comment: extractCommentColor(
-      theme.settings as ReadonlyArray<ThemeSetting> | undefined,
-      fg,
-    ),
+    comment: extractCommentColor(tokenSettings, fg),
     ...gitColors,
     terminalPalette: extractTerminalPalette(theme),
   };

--- a/desktop/src/shared/theme/theme-loader.ts
+++ b/desktop/src/shared/theme/theme-loader.ts
@@ -330,6 +330,52 @@ function extractCommentColor(
   return fallback;
 }
 
+/**
+ * Scopes searched, in priority order, for the color inline code borrows.
+ *
+ * Keywords carry a theme's most recognizable accent — GitHub Light's crimson
+ * `#d73a49`, Dracula's pink `#ff79c6` — which is exactly the signal a `code`
+ * span should pick up. The trailing entries cover the few themes that never
+ * style a bare `keyword` scope.
+ */
+const INLINE_CODE_SCOPES = [
+  "keyword",
+  "storage",
+  "keyword.control",
+  "storage.type",
+] as const;
+
+/**
+ * First foreground color whose scope matches one of `scopePriority`, matching
+ * either the scope itself or a dotted child of it (`keyword.operator` matches
+ * `keyword`). Priority is by wanted scope, not by position in the theme, so a
+ * theme that styles `storage` before `keyword` still yields its keyword color.
+ */
+function extractScopeColor(
+  settings: ReadonlyArray<ThemeSetting> | undefined,
+  scopePriority: readonly string[],
+  fallback: string,
+): string {
+  if (!settings) return fallback;
+
+  for (const wanted of scopePriority) {
+    for (const setting of settings) {
+      if (!setting.scope || !setting.settings?.foreground) continue;
+      const scopes = Array.isArray(setting.scope)
+        ? setting.scope
+        : [setting.scope];
+      for (const scope of scopes) {
+        const name = scope.trim();
+        if (name === wanted || name.startsWith(`${wanted}.`)) {
+          return setting.settings.foreground;
+        }
+      }
+    }
+  }
+
+  return fallback;
+}
+
 function stripAlpha(color: string): string {
   if (color.length === 9 && color.startsWith("#")) {
     return color.slice(0, 7);
@@ -381,6 +427,8 @@ export interface ThemeInfo {
   bg: string;
   fg: string;
   comment: string;
+  /** Keyword accent, used as the source color for inline code. */
+  keyword: string;
   added: string | null;
   deleted: string | null;
   modified: string | null;
@@ -410,6 +458,7 @@ export function extractThemeInfo(
     bg,
     fg,
     comment: extractCommentColor(tokenSettings, fg),
+    keyword: extractScopeColor(tokenSettings, INLINE_CODE_SCOPES, fg),
     ...gitColors,
     terminalPalette: extractTerminalPalette(theme),
   };

--- a/desktop/src/shared/theme/themeTokenColors.test.mjs
+++ b/desktop/src/shared/theme/themeTokenColors.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SYNTAX_THEMES,
+  extractThemeInfo,
+  loadThemeData,
+} from "./theme-loader.ts";
+
+test("comment color comes from the theme's own scope rules", async () => {
+  const info = extractThemeInfo(
+    "github-light",
+    await loadThemeData("github-light"),
+  );
+
+  // GitHub Light styles comments grey and body text near-black. Reading scope
+  // rules from the wrong field silently returned the foreground for both.
+  assert.equal(info.comment.toLowerCase(), "#6a737d");
+  assert.notEqual(info.comment.toLowerCase(), info.fg.toLowerCase());
+});
+
+test("bundled themes keep muted text distinct from body text", async () => {
+  const collapsed = [];
+
+  for (const name of SYNTAX_THEMES) {
+    const info = extractThemeInfo(name, await loadThemeData(name));
+    if (info.comment.toLowerCase() === info.fg.toLowerCase()) {
+      collapsed.push(name);
+    }
+  }
+
+  // A few minimal themes genuinely paint comments in the body text color; the
+  // regression this guards against collapsed every single theme.
+  assert.ok(
+    collapsed.length <= 8,
+    `muted text collapsed onto body text in ${collapsed.length} themes: ${collapsed.join(", ")}`,
+  );
+});

--- a/desktop/src/shared/theme/useThemePreviewVars.ts
+++ b/desktop/src/shared/theme/useThemePreviewVars.ts
@@ -25,11 +25,17 @@ let themePreviewVarsPromise: Promise<ThemePreviewVarsByTheme> | null = null;
 async function loadThemePreviewVars(name: SyntaxThemeName) {
   const themeData = await loadThemeData(name);
   const info = extractThemeInfo(name, themeData);
-  const { vars } = createThemeVars(info.bg, info.fg, info.comment, {
-    added: info.added,
-    deleted: info.deleted,
-    modified: info.modified,
-  });
+  const { vars } = createThemeVars(
+    info.bg,
+    info.fg,
+    info.comment,
+    {
+      added: info.added,
+      deleted: info.deleted,
+      modified: info.modified,
+    },
+    info.keyword,
+  );
   return [name, vars] as const;
 }
 


### PR DESCRIPTION
## Summary

Inline `code` spans are the one piece of message markdown with no tie to the active theme. The chip background comes from `--muted`, but the text is `color: inherit`:

```css
.message-markdown .inline-code-chip,
.message-markdown :not(pre) > code {
  background: hsl(var(--muted));
  color: inherit;
}
```

So `code` reads as ordinary body text in a slightly darker box, in every theme, while a fenced block two lines below gets full Shiki highlighting. Every other semantic color in the app is derived from the syntax theme — `--muted-foreground` comes from the theme's comment color — so this one should be too.

This adds a `--code-foreground` token derived from the theme's **keyword** scope. Keywords carry a theme's most recognizable accent (GitHub Light's crimson `#d73a49`, Dracula's `#bd93f9`), which is exactly the signal a code span should pick up, and it means the color follows the user's chosen theme rather than being a hard-coded brand color.

The naive version fails accessibility, which is worth spelling out. Syntax themes tune their accents against the *editor background*, but an inline chip sits on `--muted`, a slightly elevated surface. Reusing the accent verbatim puts **27 of the 62 bundled themes** under WCAG AA — GitHub Light lands at 4.01:1. So the token runs the accent through a contrast pass: nudge toward white (dark themes) or black (light themes) in 5% steps until it clears 4.5:1, preserving hue. Nudging beats substituting — the color stays recognizably the theme's own.

| Theme | Keyword accent | Raw ratio | Shipped ratio |
|---|---|---|---|
| Buzz / GitHub Light | `#d73a49` | 4.01 | 4.77 |
| GitHub Dark | `#f97583` | 4.59 | 4.59 (verbatim) |
| Slack Ochin | `#7b30d0` | 5.80 | 5.80 (verbatim) |
| Dracula | `#bd93f9` | 4.91 | 4.91 (verbatim) |

Across all 62 themes: 27 nudged, 35 verbatim, lowest resulting ratio 4.51 (Rose Pine Moon). Static fallbacks are added to `:root` and `.dark` in `theme.css` so the token is defined before the theme engine runs.

### Related issue

Stacks on #5255 — the first commit here is that PR, and this change is only correct once scope extraction reads `tokenColors`. Please review and merge #5255 first; this branch then rebases down to the single commit.

Related: #5257 tracks the mobile half — `message_content.dart` overrides `codeBuilder` but never `highlightBuilder`, so mobile renders inline code with `gpt_markdown`'s default (bold body text with a translucent `Paint` wash) and diverges from desktop. That needs the same keyword extraction on the Dart side plus a Flutter toolchain to verify, so it is filed rather than shipped untested here.

Otherwise none found — searched open issues and PRs for `inline code`, `tokenColors` and `muted foreground`.

### Testing

New `inlineCodeColor.test.mjs`:

- walks every bundled theme, asserts `--code-foreground` is a valid HSL triple and clears 4.5:1 against that theme's own `--muted`
- asserts GitHub Light borrows the keyword crimson rather than the body foreground
- asserts a theme with headroom (Slack Ochin) is used verbatim, so the contrast pass cannot silently start rewriting every color

`just ci` passes locally under the repo's Hermit toolchain — the full gate: `check`, Rust unit tests, desktop typecheck and test suite (4540/4540), desktop build, Tauri check and tests, web build, and the mobile Flutter suite (1261/1261).

Screenshots captured with `just desktop-screenshot`, both from this PR's base (#5255) and this PR's head, same message fixture. Sampling the darkest pixel of the `markdown.css` chip in the captured PNGs: `rgb(36, 41, 46)` — the editor foreground — before, `rgb(194, 52, 66)` after, which is the `#c23442` the token computes for GitHub Light.

**Before (this PR's base)**

![pr-5256--before-base](https://raw.githubusercontent.com/TolgaCinisli/buzz/fe32115e42e47521fb1d7a813fe8e07fa9dbf7c6/pr-5256--before-base.png)

**After (this PR)**

![pr-5256--after-feature](https://raw.githubusercontent.com/TolgaCinisli/buzz/fe32115e42e47521fb1d7a813fe8e07fa9dbf7c6/pr-5256--after-feature.png)
