### PR TITLE
fix(buzz-relay): write conformance probe phase 1 packs under probe/ prefix

### DIFF
--- a/crates/buzz-relay/src/api/git/store.rs
+++ b/crates/buzz-relay/src/api/git/store.rs
@@ -596,7 +596,9 @@ impl GitStore {
         // -- Phase 1: sequential --------------------------------------------------
         for round in 0..cfg.race_rounds {
             let body = format!("probe-sequential-{nonce}-{round}").into_bytes();
-            let key = self.put_pack(&body).await?;
+            let key = self
+                .put_immutable("probe/pack", &body, "application/x-git-pack")
+                .await?;
             let got = self
                 .get_verified(&key, &Self::digest_hex(&body))
                 .await


### PR DESCRIPTION
## Summary
Phase 1 of `run_conformance_probe` was calling `put_pack`, which writes to the production `packs/` prefix. This left probe objects in the production prefix and made the bucket retention-policy comment untrue for phase 1.

Use `put_immutable("probe/pack", ...)` for phase 1 probe bodies so all probe artifacts use the `probe/` prefix and the retention policy applies consistently.

### Related issue
Fixes https://github.com/block/buzz/issues/5241

### Testing
- `cargo fmt --all -- --check` passed
- `cargo clippy -p buzz-relay --all-targets --all-features -- -D warnings` passed
- `cargo test -p buzz-relay git` passed (139 tests, including `api::git::store::probe::*`)
- Full `cargo test -p buzz-relay` was run; it produced 858 passes and 9 failures, all in media/admin/mesh-demo paths that require a running Postgres/MinIO/mesh infrastructure. Those failures are unrelated to the git store change.
