### PR TITLE
fix(acp): notice when a @mention turn Ok's with no channel reply

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,12 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Set to true to process the agent's own messages (default: ignore self).
 # BUZZ_ACP_NO_IGNORE_SELF=false
 
+# Seconds to wait after an Ok mention turn before posting a "couldn't publish"
+# notice, so a late ws echo (including post-reconnect replay) can clear it.
+# Default 8 covers ≈6s relay resubscribe bursts; set higher for many-channel
+# harnesses. (#2459)
+# BUZZ_SILENT_REPLY_GRACE_SECS=8
+
 # ── Context ──────────────────────────────────────────────────────────────────
 # Max context messages fetched for thread replies and DMs (0–100). 0 = disabled.
 # BUZZ_ACP_CONTEXT_MESSAGE_LIMIT=12

--- a/.env.example
+++ b/.env.example
@@ -226,7 +226,8 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Seconds to wait after an Ok mention turn before posting a "couldn't publish"
 # notice, so a late ws echo (including post-reconnect replay) can clear it.
 # Default 8 covers ≈6s relay resubscribe bursts; set higher for many-channel
-# harnesses. (#2459)
+# harnesses. Values ≤0 or unparsable fall back to 8 (grace cannot be disabled).
+# (#2459)
 # BUZZ_SILENT_REPLY_GRACE_SECS=8
 
 # ── Context ──────────────────────────────────────────────────────────────────

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,7 @@ mod pool_lifecycle;
 mod queue;
 mod relay;
 mod setup_mode;
+mod silent_reply;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -2327,6 +2328,9 @@ async fn tokio_main() -> Result<()> {
                             }
 
                             if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
+                                if silent_reply::is_agent_reply_kind(kind_u32) {
+                                    queue.note_self_publish(buzz_event.channel_id);
+                                }
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
                                 continue;
                             }
@@ -3421,7 +3425,20 @@ fn handle_prompt_result(
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
         if !removed_channels.contains(&batch.channel_id) {
-            if matches!(
+            if matches!(result.outcome, PromptOutcome::Ok(_)) {
+                // Ok turns keep the batch only for silent-reply detection —
+                // never requeue a successful turn (#2459).
+                let publishes = queue.take_self_publishes(batch.channel_id);
+                if let Some(content) =
+                    silent_reply::silent_reply_loss_notice(&result.outcome, Some(&batch), publishes)
+                {
+                    tracing::warn!(
+                        channel_id = %batch.channel_id,
+                        "mention turn completed Ok with no agent channel publish — posting failure notice"
+                    );
+                    spawn_failure_notice(rest_client, &batch, content);
+                }
+            } else if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
             ) {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -13,8 +13,27 @@ mod setup_mode;
 mod silent_reply;
 mod usage;
 
-/// Grace window before posting a silent-reply notice so a late ws echo can land (#2459).
-const SILENT_REPLY_GRACE: Duration = Duration::from_secs(3);
+/// Default grace before posting a silent-reply notice so a late ws echo can
+/// land (#2459). Relay resubscribe bursts can spread ≈6s under REQ pacing, so
+/// the default sits above that; override with `BUZZ_SILENT_REPLY_GRACE_SECS`.
+const DEFAULT_SILENT_REPLY_GRACE_SECS: u64 = 8;
+
+fn silent_reply_grace() -> Duration {
+    std::env::var("BUZZ_SILENT_REPLY_GRACE_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|&secs| secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DEFAULT_SILENT_REPLY_GRACE_SECS))
+}
+
+/// Deferred silent-reply check payload: batch plus the watch generation armed
+/// when the Ok turn completed.
+#[derive(Clone)]
+struct SilentReplyCheck {
+    batch: FlushBatch,
+    generation: u64,
+}
 
 pub use usage::TurnUsage;
 
@@ -1931,7 +1950,7 @@ async fn tokio_main() -> Result<()> {
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
     // Deferred silent-reply checks: Ok mention turns wait a grace window so a
     // late ws echo can clear the "couldn't publish" notice (#2459).
-    let (silent_reply_tx, mut silent_reply_rx) = mpsc::unbounded_channel::<FlushBatch>();
+    let (silent_reply_tx, mut silent_reply_rx) = mpsc::unbounded_channel::<SilentReplyCheck>();
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -2006,7 +2025,7 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
-        SilentReplyDue(FlushBatch),
+        SilentReplyDue(SilentReplyCheck),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2154,8 +2173,8 @@ async fn tokio_main() -> Result<()> {
                 Some(ack_event) = steer_ack_rx.recv() => {
                     Some(PoolEvent::SteerAck(ack_event))
                 }
-                Some(batch) = silent_reply_rx.recv() => {
-                    Some(PoolEvent::SilentReplyDue(batch))
+                Some(check) = silent_reply_rx.recv() => {
+                    Some(PoolEvent::SilentReplyDue(check))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -2904,22 +2923,24 @@ async fn tokio_main() -> Result<()> {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
-            Some(PoolEvent::SilentReplyDue(batch)) => {
-                let Some(publishes) = queue.take_silent_reply_watch(batch.channel_id) else {
-                    // Already consumed (e.g. a later Ok on the same channel
-                    // re-armed / raced); nothing to do.
+            Some(PoolEvent::SilentReplyDue(check)) => {
+                let Some(publishes) =
+                    queue.take_silent_reply_watch(check.batch.channel_id, check.generation)
+                else {
+                    // Already consumed or superseded by a later Ok on the same
+                    // channel; nothing to do.
                     continue;
                 };
                 if let Some(content) = silent_reply::silent_reply_loss_notice(
                     &PromptOutcome::Ok(StopReason::EndTurn),
-                    Some(&batch),
+                    Some(&check.batch),
                     publishes,
                 ) {
                     tracing::warn!(
-                        channel_id = %batch.channel_id,
+                        channel_id = %check.batch.channel_id,
                         "mention turn completed Ok with no agent channel publish — posting failure notice"
                     );
-                    spawn_failure_notice(Some(&ctx.rest_client), &batch, content);
+                    spawn_failure_notice(Some(&ctx.rest_client), &check.batch, content);
                 }
             }
             Some(PoolEvent::Wake(attempt, result)) => {
@@ -3434,7 +3455,7 @@ fn handle_prompt_result(
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
     rest_client: Option<&relay::RestClient>,
-    silent_reply_tx: Option<&mpsc::UnboundedSender<FlushBatch>>,
+    silent_reply_tx: Option<&mpsc::UnboundedSender<SilentReplyCheck>>,
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
@@ -3468,18 +3489,23 @@ fn handle_prompt_result(
                     // and is not ordered vs pool completion. Arm a watch so
                     // counts survive mark_complete, then re-check after a
                     // short grace window.
-                    queue.arm_silent_reply_watch(batch.channel_id);
+                    let generation = queue.arm_silent_reply_watch(batch.channel_id);
                     if let Some(tx) = silent_reply_tx {
                         let tx = tx.clone();
-                        let batch_for_check = batch.clone();
+                        let check = SilentReplyCheck {
+                            batch: batch.clone(),
+                            generation,
+                        };
+                        let grace = silent_reply_grace();
                         tokio::spawn(async move {
-                            tokio::time::sleep(SILENT_REPLY_GRACE).await;
-                            let _ = tx.send(batch_for_check);
+                            tokio::time::sleep(grace).await;
+                            let _ = tx.send(check);
                         });
                     } else {
                         // Tests / callers without a deferred channel: decide now.
-                        let publishes =
-                            queue.take_silent_reply_watch(batch.channel_id).unwrap_or(0);
+                        let publishes = queue
+                            .take_silent_reply_watch(batch.channel_id, generation)
+                            .unwrap_or(0);
                         if let Some(content) = silent_reply::silent_reply_loss_notice(
                             &result.outcome,
                             Some(&batch),

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -13,13 +13,16 @@ mod setup_mode;
 mod silent_reply;
 mod usage;
 
+/// Grace window before posting a silent-reply notice so a late ws echo can land (#2459).
+const SILENT_REPLY_GRACE: Duration = Duration::from_secs(3);
+
 pub use usage::TurnUsage;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
-use acp::{AcpClient, EnvVar, McpServer};
+use acp::{AcpClient, EnvVar, McpServer, StopReason};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
@@ -1926,6 +1929,9 @@ async fn tokio_main() -> Result<()> {
     //      withheld event in `EventQueue::withheld_native_steer` until
     //      `IN_FLIGHT_DEADLINE_SECS` expires.
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
+    // Deferred silent-reply checks: Ok mention turns wait a grace window so a
+    // late ws echo can clear the "couldn't publish" notice (#2459).
+    let (silent_reply_tx, mut silent_reply_rx) = mpsc::unbounded_channel::<FlushBatch>();
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -2000,6 +2006,7 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
+        SilentReplyDue(FlushBatch),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2146,6 +2153,9 @@ async fn tokio_main() -> Result<()> {
                 // locked semantics (Eva + Max + Perci).
                 Some(ack_event) = steer_ack_rx.recv() => {
                     Some(PoolEvent::SteerAck(ack_event))
+                }
+                Some(batch) = silent_reply_rx.recv() => {
+                    Some(PoolEvent::SilentReplyDue(batch))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -2327,10 +2337,15 @@ async fn tokio_main() -> Result<()> {
                                 continue;
                             }
 
+                            // Count self-authored stream replies for silent-reply
+                            // detection regardless of ignore_self (#2459): under
+                            // --no-ignore-self the counter must still increment.
+                            if buzz_event.event.pubkey.to_hex() == pubkey_hex
+                                && silent_reply::is_agent_reply_kind(kind_u32)
+                            {
+                                queue.note_self_publish(buzz_event.channel_id);
+                            }
                             if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
-                                if silent_reply::is_agent_reply_kind(kind_u32) {
-                                    queue.note_self_publish(buzz_event.channel_id);
-                                }
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
                                 continue;
                             }
@@ -2694,6 +2709,7 @@ async fn tokio_main() -> Result<()> {
                     &mut respawn_tasks,
                     observer.clone(),
                     Some(&ctx.rest_client),
+                    Some(&silent_reply_tx),
                 ) == LoopAction::Exit
                 {
                     break;
@@ -2886,6 +2902,24 @@ async fn tokio_main() -> Result<()> {
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
+                }
+            }
+            Some(PoolEvent::SilentReplyDue(batch)) => {
+                let Some(publishes) = queue.take_silent_reply_watch(batch.channel_id) else {
+                    // Already consumed (e.g. a later Ok on the same channel
+                    // re-armed / raced); nothing to do.
+                    continue;
+                };
+                if let Some(content) = silent_reply::silent_reply_loss_notice(
+                    &PromptOutcome::Ok(StopReason::EndTurn),
+                    Some(&batch),
+                    publishes,
+                ) {
+                    tracing::warn!(
+                        channel_id = %batch.channel_id,
+                        "mention turn completed Ok with no agent channel publish — posting failure notice"
+                    );
+                    spawn_failure_notice(Some(&ctx.rest_client), &batch, content);
                 }
             }
             Some(PoolEvent::Wake(attempt, result)) => {
@@ -3400,6 +3434,7 @@ fn handle_prompt_result(
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
     rest_client: Option<&relay::RestClient>,
+    silent_reply_tx: Option<&mpsc::UnboundedSender<FlushBatch>>,
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
@@ -3428,15 +3463,37 @@ fn handle_prompt_result(
             if matches!(result.outcome, PromptOutcome::Ok(_)) {
                 // Ok turns keep the batch only for silent-reply detection —
                 // never requeue a successful turn (#2459).
-                let publishes = queue.take_self_publishes(batch.channel_id);
-                if let Some(content) =
-                    silent_reply::silent_reply_loss_notice(&result.outcome, Some(&batch), publishes)
-                {
-                    tracing::warn!(
-                        channel_id = %batch.channel_id,
-                        "mention turn completed Ok with no agent channel publish — posting failure notice"
-                    );
-                    spawn_failure_notice(rest_client, &batch, content);
+                if silent_reply::batch_expects_channel_reply(&batch) {
+                    // Defer the notice: the reply echo arrives on the ws path
+                    // and is not ordered vs pool completion. Arm a watch so
+                    // counts survive mark_complete, then re-check after a
+                    // short grace window.
+                    queue.arm_silent_reply_watch(batch.channel_id);
+                    if let Some(tx) = silent_reply_tx {
+                        let tx = tx.clone();
+                        let batch_for_check = batch.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(SILENT_REPLY_GRACE).await;
+                            let _ = tx.send(batch_for_check);
+                        });
+                    } else {
+                        // Tests / callers without a deferred channel: decide now.
+                        let publishes =
+                            queue.take_silent_reply_watch(batch.channel_id).unwrap_or(0);
+                        if let Some(content) = silent_reply::silent_reply_loss_notice(
+                            &result.outcome,
+                            Some(&batch),
+                            publishes,
+                        ) {
+                            tracing::warn!(
+                                channel_id = %batch.channel_id,
+                                "mention turn completed Ok with no agent channel publish — posting failure notice"
+                            );
+                            spawn_failure_notice(rest_client, &batch, content);
+                        }
+                    }
+                } else {
+                    let _ = queue.take_self_publishes(batch.channel_id);
                 }
             } else if matches!(
                 result.outcome,
@@ -6546,6 +6603,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
+            None,
         );
 
         let turn_errors: Vec<_> = observer
@@ -6711,6 +6769,7 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 Some(observer.clone()),
                 None,
+                None,
             );
             let events = observer.snapshot();
             let turn_error = events.iter().find(|e| e.kind == "turn_error").unwrap();
@@ -6799,6 +6858,7 @@ mod error_outcome_emission_tests {
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
+                None,
                 None,
                 None,
             );
@@ -6906,6 +6966,7 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 None,
                 None,
+                None,
             );
             (
                 queue.pending_channels(),
@@ -6996,6 +7057,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -7089,6 +7151,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -7204,6 +7267,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -7336,6 +7400,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -7610,6 +7610,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             None,
             None,
+            None,
         );
 
         // The batch must not be requeued: pending_channels returns 0.
@@ -7693,6 +7694,7 @@ mod error_outcome_emission_tests {
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
+            None,
             None,
             None,
         );

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2126,7 +2126,8 @@ pub async fn run_prompt_task(
                             agent,
                             source,
                             PromptOutcome::Ok(StopReason::EndTurn),
-                            None, // turn succeeded — batch was processed, no requeue
+                            // Keep batch for silent-reply detection; Ok must not requeue.
+                            batch,
                         );
                         return;
                     }
@@ -2189,7 +2190,8 @@ pub async fn run_prompt_task(
                 agent,
                 source,
                 PromptOutcome::Ok(stop_reason),
-                None,
+                // Keep batch for silent-reply detection; Ok must not requeue.
+                batch,
             );
         }
         Err(AcpError::AgentExited) => {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -146,10 +146,13 @@ pub struct EventQueue {
     /// Used to detect silent reply loss when ACP reports Ok but
     /// `buzz messages send` never landed (#2459).
     in_flight_self_publishes: HashMap<Uuid, u64>,
-    /// Channels whose Ok turn is waiting on a deferred silent-reply check.
-    /// Counts in [`in_flight_self_publishes`] survive [`mark_complete`] while
-    /// a watch is armed so a late ws echo can still clear the notice.
-    silent_reply_watches: HashSet<Uuid>,
+    /// Channels whose Ok turn is waiting on a deferred silent-reply check,
+    /// keyed by a per-channel generation. Counts in
+    /// [`in_flight_self_publishes`] survive [`mark_complete`] while a watch is
+    /// armed so a late ws echo can still clear the notice. Generation IDs stop
+    /// a stale grace timer from consuming a newer turn's watch on the same
+    /// channel (#2459).
+    silent_reply_watches: HashMap<Uuid, u64>,
     retry_after: HashMap<Uuid, Instant>,
     /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
     retry_counts: HashMap<Uuid, u32>,
@@ -192,7 +195,7 @@ impl EventQueue {
             in_flight_deadlines: HashMap::new(),
             in_flight_batch_sizes: HashMap::new(),
             in_flight_self_publishes: HashMap::new(),
-            silent_reply_watches: HashSet::new(),
+            silent_reply_watches: HashMap::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
             dedup_mode,
@@ -407,7 +410,7 @@ impl EventQueue {
         self.in_flight_batch_sizes.remove(&channel_id);
         // Keep publish counts while a silent-reply grace watch is armed so a
         // late echo can still arrive after turn completion (#2459).
-        if !self.silent_reply_watches.contains(&channel_id) {
+        if !self.silent_reply_watches.contains_key(&channel_id) {
             self.in_flight_self_publishes.remove(&channel_id);
         }
         let now = Instant::now();
@@ -673,7 +676,7 @@ impl EventQueue {
     /// channel turn, or during a deferred silent-reply grace watch.
     pub fn note_self_publish(&mut self, channel_id: Uuid) {
         if self.in_flight_channels.contains(&channel_id)
-            || self.silent_reply_watches.contains(&channel_id)
+            || self.silent_reply_watches.contains_key(&channel_id)
         {
             *self.in_flight_self_publishes.entry(channel_id).or_insert(0) += 1;
         }
@@ -688,17 +691,33 @@ impl EventQueue {
 
     /// Arm a post-Ok silent-reply watch so publish counts survive
     /// [`mark_complete`] until [`take_silent_reply_watch`].
-    pub fn arm_silent_reply_watch(&mut self, channel_id: Uuid) {
-        self.silent_reply_watches.insert(channel_id);
+    ///
+    /// Returns the watch generation. Callers must pass that generation back to
+    /// [`take_silent_reply_watch`] so a stale grace timer cannot consume a
+    /// newer turn's watch on the same channel.
+    pub fn arm_silent_reply_watch(&mut self, channel_id: Uuid) -> u64 {
+        let next = self
+            .silent_reply_watches
+            .get(&channel_id)
+            .copied()
+            .unwrap_or(0)
+            .wrapping_add(1);
+        self.silent_reply_watches.insert(channel_id, next);
+        next
     }
 
     /// End a silent-reply watch and take the accumulated publish count.
-    /// Returns `None` if no watch was armed (already consumed / never armed).
-    pub fn take_silent_reply_watch(&mut self, channel_id: Uuid) -> Option<u64> {
-        if !self.silent_reply_watches.remove(&channel_id) {
-            return None;
+    ///
+    /// Returns `None` if no matching generation is armed (already consumed,
+    /// never armed, or superseded by a later Ok on the same channel).
+    pub fn take_silent_reply_watch(&mut self, channel_id: Uuid, generation: u64) -> Option<u64> {
+        match self.silent_reply_watches.get(&channel_id).copied() {
+            Some(current) if current == generation => {
+                self.silent_reply_watches.remove(&channel_id);
+                Some(self.take_self_publishes(channel_id))
+            }
+            _ => None,
         }
-        Some(self.take_self_publishes(channel_id))
     }
 
     // ── Goose-native steer withhold (side table) ──────────────────────────
@@ -4823,17 +4842,39 @@ mod tests {
         // Re-note during in-flight, arm watch, then complete — count must survive.
         q.in_flight_channels.insert(ch);
         q.note_self_publish(ch);
-        q.arm_silent_reply_watch(ch);
+        let gen = q.arm_silent_reply_watch(ch);
         q.mark_complete(ch);
         assert!(!q.is_channel_in_flight(ch));
         // Late echo after completion still counts.
         q.note_self_publish(ch);
-        assert_eq!(q.take_silent_reply_watch(ch), Some(2));
+        assert_eq!(q.take_silent_reply_watch(ch, gen), Some(2));
         // Second take is a no-op.
-        assert_eq!(q.take_silent_reply_watch(ch), None);
+        assert_eq!(q.take_silent_reply_watch(ch, gen), None);
         // Without a watch, post-complete echoes are ignored.
         q.note_self_publish(ch);
         assert_eq!(q.take_self_publishes(ch), 0);
+    }
+
+    #[test]
+    fn silent_reply_watch_generation_ignores_stale_timer() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.in_flight_channels.insert(ch);
+        q.note_self_publish(ch);
+        let first = q.arm_silent_reply_watch(ch);
+        q.mark_complete(ch);
+
+        // A second Ok on the same channel re-arms with a new generation.
+        q.in_flight_channels.insert(ch);
+        let second = q.arm_silent_reply_watch(ch);
+        assert_ne!(first, second);
+        q.mark_complete(ch);
+        q.note_self_publish(ch);
+
+        // Stale first timer must not consume the newer watch (count still
+        // includes the earlier turn's publish — generations only gate take).
+        assert_eq!(q.take_silent_reply_watch(ch, first), None);
+        assert_eq!(q.take_silent_reply_watch(ch, second), Some(2));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -142,10 +142,14 @@ pub struct EventQueue {
     /// Number of events in each in-flight batch (for expiry logging).
     in_flight_batch_sizes: HashMap<Uuid, usize>,
     /// Agent-authored stream messages observed on the wire while a channel
-    /// turn is in flight (counted at the `ignore_self` drop site). Used to
-    /// detect silent reply loss when ACP reports Ok but `buzz messages send`
-    /// never landed (#2459).
+    /// turn is in flight (or during a post-Ok silent-reply grace watch).
+    /// Used to detect silent reply loss when ACP reports Ok but
+    /// `buzz messages send` never landed (#2459).
     in_flight_self_publishes: HashMap<Uuid, u64>,
+    /// Channels whose Ok turn is waiting on a deferred silent-reply check.
+    /// Counts in [`in_flight_self_publishes`] survive [`mark_complete`] while
+    /// a watch is armed so a late ws echo can still clear the notice.
+    silent_reply_watches: HashSet<Uuid>,
     retry_after: HashMap<Uuid, Instant>,
     /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
     retry_counts: HashMap<Uuid, u32>,
@@ -188,6 +192,7 @@ impl EventQueue {
             in_flight_deadlines: HashMap::new(),
             in_flight_batch_sizes: HashMap::new(),
             in_flight_self_publishes: HashMap::new(),
+            silent_reply_watches: HashSet::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
             dedup_mode,
@@ -400,7 +405,11 @@ impl EventQueue {
         self.in_flight_channels.remove(&channel_id);
         self.in_flight_deadlines.remove(&channel_id);
         self.in_flight_batch_sizes.remove(&channel_id);
-        self.in_flight_self_publishes.remove(&channel_id);
+        // Keep publish counts while a silent-reply grace watch is armed so a
+        // late echo can still arrive after turn completion (#2459).
+        if !self.silent_reply_watches.contains(&channel_id) {
+            self.in_flight_self_publishes.remove(&channel_id);
+        }
         let now = Instant::now();
         match self.retry_after.get(&channel_id) {
             // Active throttle → channel was requeued; keep retry_counts intact.
@@ -661,9 +670,11 @@ impl EventQueue {
     }
 
     /// Record a self-authored stream message seen on the wire for an in-flight
-    /// channel turn. No-op when the channel is not in flight.
+    /// channel turn, or during a deferred silent-reply grace watch.
     pub fn note_self_publish(&mut self, channel_id: Uuid) {
-        if self.in_flight_channels.contains(&channel_id) {
+        if self.in_flight_channels.contains(&channel_id)
+            || self.silent_reply_watches.contains(&channel_id)
+        {
             *self.in_flight_self_publishes.entry(channel_id).or_insert(0) += 1;
         }
     }
@@ -673,6 +684,21 @@ impl EventQueue {
         self.in_flight_self_publishes
             .remove(&channel_id)
             .unwrap_or(0)
+    }
+
+    /// Arm a post-Ok silent-reply watch so publish counts survive
+    /// [`mark_complete`] until [`take_silent_reply_watch`].
+    pub fn arm_silent_reply_watch(&mut self, channel_id: Uuid) {
+        self.silent_reply_watches.insert(channel_id);
+    }
+
+    /// End a silent-reply watch and take the accumulated publish count.
+    /// Returns `None` if no watch was armed (already consumed / never armed).
+    pub fn take_silent_reply_watch(&mut self, channel_id: Uuid) -> Option<u64> {
+        if !self.silent_reply_watches.remove(&channel_id) {
+            return None;
+        }
+        Some(self.take_self_publishes(channel_id))
     }
 
     // ── Goose-native steer withhold (side table) ──────────────────────────
@@ -4784,5 +4810,39 @@ mod tests {
             after_second >= after_first,
             "second extend must not move deadline backward (monotonic)"
         );
+    }
+
+    #[test]
+    fn silent_reply_watch_survives_mark_complete_and_counts_late_echo() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.in_flight_channels.insert(ch);
+        q.note_self_publish(ch);
+        assert_eq!(q.take_self_publishes(ch), 1);
+
+        // Re-note during in-flight, arm watch, then complete — count must survive.
+        q.in_flight_channels.insert(ch);
+        q.note_self_publish(ch);
+        q.arm_silent_reply_watch(ch);
+        q.mark_complete(ch);
+        assert!(!q.is_channel_in_flight(ch));
+        // Late echo after completion still counts.
+        q.note_self_publish(ch);
+        assert_eq!(q.take_silent_reply_watch(ch), Some(2));
+        // Second take is a no-op.
+        assert_eq!(q.take_silent_reply_watch(ch), None);
+        // Without a watch, post-complete echoes are ignored.
+        q.note_self_publish(ch);
+        assert_eq!(q.take_self_publishes(ch), 0);
+    }
+
+    #[test]
+    fn mark_complete_clears_publishes_without_silent_reply_watch() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.in_flight_channels.insert(ch);
+        q.note_self_publish(ch);
+        q.mark_complete(ch);
+        assert_eq!(q.take_self_publishes(ch), 0);
     }
 }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -141,6 +141,11 @@ pub struct EventQueue {
     in_flight_deadlines: HashMap<Uuid, Instant>,
     /// Number of events in each in-flight batch (for expiry logging).
     in_flight_batch_sizes: HashMap<Uuid, usize>,
+    /// Agent-authored stream messages observed on the wire while a channel
+    /// turn is in flight (counted at the `ignore_self` drop site). Used to
+    /// detect silent reply loss when ACP reports Ok but `buzz messages send`
+    /// never landed (#2459).
+    in_flight_self_publishes: HashMap<Uuid, u64>,
     retry_after: HashMap<Uuid, Instant>,
     /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
     retry_counts: HashMap<Uuid, u32>,
@@ -182,6 +187,7 @@ impl EventQueue {
             in_flight_channels: HashSet::new(),
             in_flight_deadlines: HashMap::new(),
             in_flight_batch_sizes: HashMap::new(),
+            in_flight_self_publishes: HashMap::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
             dedup_mode,
@@ -278,6 +284,7 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
+            self.in_flight_self_publishes.remove(&id);
             // Recover any withheld goose-native steer events for the expired
             // channel back to the queue front so normal dispatch delivers
             // them. Unlike the in-flight batch above (already delivered to a
@@ -393,6 +400,7 @@ impl EventQueue {
         self.in_flight_channels.remove(&channel_id);
         self.in_flight_deadlines.remove(&channel_id);
         self.in_flight_batch_sizes.remove(&channel_id);
+        self.in_flight_self_publishes.remove(&channel_id);
         let now = Instant::now();
         match self.retry_after.get(&channel_id) {
             // Active throttle → channel was requeued; keep retry_counts intact.
@@ -574,6 +582,7 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
+            self.in_flight_self_publishes.remove(&id);
             // Symmetric with the flush_next expiry block: recover withheld
             // goose-native steer events for the expired channel so they are
             // not permanently orphaned in the side table.
@@ -649,6 +658,21 @@ impl EventQueue {
     /// Whether any channel currently has a turn in flight.
     pub fn has_in_flight(&self) -> bool {
         !self.in_flight_channels.is_empty()
+    }
+
+    /// Record a self-authored stream message seen on the wire for an in-flight
+    /// channel turn. No-op when the channel is not in flight.
+    pub fn note_self_publish(&mut self, channel_id: Uuid) {
+        if self.in_flight_channels.contains(&channel_id) {
+            *self.in_flight_self_publishes.entry(channel_id).or_insert(0) += 1;
+        }
+    }
+
+    /// Take and clear the self-publish count for `channel_id` (0 if none).
+    pub fn take_self_publishes(&mut self, channel_id: Uuid) -> u64 {
+        self.in_flight_self_publishes
+            .remove(&channel_id)
+            .unwrap_or(0)
     }
 
     // ── Goose-native steer withhold (side table) ──────────────────────────

--- a/crates/buzz-acp/src/silent_reply.rs
+++ b/crates/buzz-acp/src/silent_reply.rs
@@ -13,6 +13,10 @@ use crate::queue::FlushBatch;
 
 /// True when this batch was admitted as an `@mention` of a stream message —
 /// the path that is expected to produce a visible channel reply.
+///
+/// `SubscribeMode::All` batches use `prompt_tag: "all"` and intentionally get
+/// no protection here: every event fires a turn in that mode, so a zero-publish
+/// outcome is not anomalous the way a missed mention reply is.
 pub(crate) fn batch_expects_channel_reply(batch: &FlushBatch) -> bool {
     batch.events.iter().any(|be| {
         be.prompt_tag == "@mention"

--- a/crates/buzz-acp/src/silent_reply.rs
+++ b/crates/buzz-acp/src/silent_reply.rs
@@ -1,0 +1,131 @@
+//! Detect turns that finished `Ok` without publishing a channel reply (#2459).
+//!
+//! Agents reply out-of-band via `buzz messages send`. When that write fails,
+//! ACP still reports `end_turn` / `Ok` and the human sees silence. The harness
+//! counts agent-authored stream messages observed on the wire during the turn
+//! (self-events that `ignore_self` would otherwise drop) and posts a failure
+//! notice when a mention-triggered turn ends with zero publishes.
+
+use buzz_core::kind::{KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_V2};
+
+use crate::pool::PromptOutcome;
+use crate::queue::FlushBatch;
+
+/// True when this batch was admitted as an `@mention` of a stream message —
+/// the path that is expected to produce a visible channel reply.
+pub(crate) fn batch_expects_channel_reply(batch: &FlushBatch) -> bool {
+    batch.events.iter().any(|be| {
+        be.prompt_tag == "@mention"
+            && matches!(
+                be.event.kind.as_u16() as u32,
+                KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_V2
+            )
+    })
+}
+
+/// Kind filter used when counting self-authored publishes during a turn.
+pub(crate) fn is_agent_reply_kind(kind: u32) -> bool {
+    matches!(kind, KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_V2)
+}
+
+/// Return a user-visible notice when an Ok turn looks like a silently lost reply.
+pub(crate) fn silent_reply_loss_notice(
+    outcome: &PromptOutcome,
+    batch: Option<&FlushBatch>,
+    agent_message_publishes: u64,
+) -> Option<String> {
+    if !matches!(outcome, PromptOutcome::Ok(_)) {
+        return None;
+    }
+    let batch = batch?;
+    if !batch_expects_channel_reply(batch) {
+        return None;
+    }
+    if agent_message_publishes > 0 {
+        return None;
+    }
+    Some(
+        "⚠️ I finished the turn but couldn't publish a reply to the channel. Please re-send if it's still needed."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::{AcpError, StopReason};
+    use crate::queue::BatchEvent;
+    use nostr::{EventBuilder, Keys, Kind};
+    use std::time::Instant;
+    use uuid::Uuid;
+
+    fn mention_batch() -> FlushBatch {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "hi @agent")
+            .tag(nostr::Tag::parse(["h", &Uuid::new_v4().to_string()]).unwrap())
+            .sign_with_keys(&keys)
+            .unwrap();
+        FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    fn all_mode_batch() -> FlushBatch {
+        let mut batch = mention_batch();
+        batch.events[0].prompt_tag = "all".into();
+        batch
+    }
+
+    #[test]
+    fn notice_fires_for_mention_ok_with_zero_publishes() {
+        let batch = mention_batch();
+        let notice =
+            silent_reply_loss_notice(&PromptOutcome::Ok(StopReason::EndTurn), Some(&batch), 0);
+        assert!(notice.unwrap().contains("couldn't publish"));
+    }
+
+    #[test]
+    fn notice_skips_when_agent_published() {
+        let batch = mention_batch();
+        assert!(
+            silent_reply_loss_notice(&PromptOutcome::Ok(StopReason::EndTurn), Some(&batch), 1,)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn notice_skips_non_mention_batches() {
+        let batch = all_mode_batch();
+        assert!(
+            silent_reply_loss_notice(&PromptOutcome::Ok(StopReason::EndTurn), Some(&batch), 0,)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn notice_skips_errors_and_missing_batch() {
+        assert!(silent_reply_loss_notice(
+            &PromptOutcome::Error(AcpError::Protocol("x".into())),
+            Some(&mention_batch()),
+            0,
+        )
+        .is_none());
+        assert!(
+            silent_reply_loss_notice(&PromptOutcome::Ok(StopReason::EndTurn), None, 0,).is_none()
+        );
+    }
+
+    #[test]
+    fn reply_kind_filter_excludes_reactions() {
+        assert!(is_agent_reply_kind(KIND_STREAM_MESSAGE));
+        assert!(is_agent_reply_kind(KIND_STREAM_MESSAGE_V2));
+        assert!(!is_agent_reply_kind(7));
+    }
+}


### PR DESCRIPTION
## Summary
- When an agent's mention turn returns `Ok` but it never publishes a channel reply, buzz-acp now surfaces a "couldn't publish" notice instead of hanging silently. New `silent_reply.rs` watches the turn's reply channel.
- Count the agent's own kind-9 / kind-45001 publishes even under `--no-ignore-self`, and defer the notice by a grace window so a ws echo arriving just after turn completion can clear a false positive.
- Default grace is 8s (override with `BUZZ_SILENT_REPLY_GRACE_SECS`); watches are keyed by generation so a stale timer can't steal a later Ok turn's check. `≤0` falls back to 8.

## Test plan
- [x] `cargo test -p buzz-acp`
- [ ] Mention an agent whose provider errors silently → user sees the couldn't-publish notice
- [ ] Normal reply within grace → no false notice
- [ ] `BUZZ_SILENT_REPLY_GRACE_SECS=2` shortens the window as expected