### PR TITLE
fix(desktop): reject unsupported snapshot fields

### DIFF
--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -295,6 +295,23 @@ fn import_unsupported_version_fails_closed() {
     );
 }
 
+/// The production import decoder must not accept a v1 manifest while silently
+/// discarding portable capabilities added by another exporter.
+#[test]
+fn import_unknown_portable_capability_fails_closed() {
+    let snapshot = make_snapshot(MemoryLevel::None, vec![]);
+    let mut value = serde_json::to_value(snapshot).unwrap();
+    value["definition"]["skills"] = serde_json::json!([{
+        "name": "analytics",
+        "description": "Analyze product performance"
+    }]);
+
+    let result = decode_snapshot_from_bytes(&serde_json::to_vec(&value).unwrap());
+    let error = result.expect_err("unknown portable capability must fail closed");
+    assert!(error.contains("contains fields this version of Buzz does not support"));
+    assert!(error.contains("skills"));
+}
+
 /// Completely empty input fails closed.
 #[test]
 fn import_empty_bytes_fail_closed() {

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests_locked.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests_locked.rs
@@ -8,9 +8,11 @@ use super::*;
 use crate::commands::personas::snapshot::import::{
     decode_snapshot_for_import, parse_snapshot_payload_from_bytes,
 };
+use crate::managed_agents::agent_snapshot::{make_png_with_text, PNG_CHUNK_KEYWORD};
 use crate::managed_agents::agent_snapshot_envelope::{
     encode_locked_snapshot_png, encrypt_snapshot_envelope, ChunkPayload, LOCKED_CARD_REFUSAL,
 };
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 /// Build a keyed instance record holding real key material, so the
 /// agent-endpoint unlock path resolves exactly as production does.
@@ -126,4 +128,46 @@ fn plain_decoder_refuses_locked_cards() {
     let (_snapshot, png) = locked_png(&owner, &agent);
     let err = decode_snapshot_from_bytes(&png).unwrap_err();
     assert_eq!(err, LOCKED_CARD_REFUSAL);
+}
+
+#[test]
+fn locked_import_rejects_unknown_envelope_fields_from_json_and_png() {
+    let (owner, agent) = (nostr::Keys::generate(), nostr::Keys::generate());
+    let snapshot = make_snapshot(MemoryLevel::None, vec![]);
+    let envelope = encrypt_snapshot_envelope(&snapshot, &owner, &agent.public_key()).unwrap();
+
+    for (field, nested) in [("keyDerivation", false), ("transport", true)] {
+        let mut value = serde_json::to_value(&envelope).unwrap();
+        if nested {
+            value["encryption"][field] = serde_json::json!("future");
+        } else {
+            value[field] = serde_json::json!("future");
+        }
+        let json = serde_json::to_vec(&value).unwrap();
+        let png = make_png_with_text(PNG_CHUNK_KEYWORD, &STANDARD.encode(&json)).unwrap();
+
+        for bytes in [json.as_slice(), png.as_slice()] {
+            let error = parse_snapshot_payload_from_bytes(bytes).unwrap_err();
+            assert!(error.contains("contains fields this version of Buzz does not support"));
+            assert!(error.contains(field));
+        }
+    }
+}
+
+#[test]
+fn newer_locked_envelope_version_precedes_unknown_fields_for_json_and_png() {
+    let (owner, agent) = (nostr::Keys::generate(), nostr::Keys::generate());
+    let snapshot = make_snapshot(MemoryLevel::None, vec![]);
+    let envelope = encrypt_snapshot_envelope(&snapshot, &owner, &agent.public_key()).unwrap();
+    let mut value = serde_json::to_value(envelope).unwrap();
+    value["version"] = serde_json::json!(2);
+    value["keyDerivation"] = serde_json::json!("future");
+    let json = serde_json::to_vec(&value).unwrap();
+    let png = make_png_with_text(PNG_CHUNK_KEYWORD, &STANDARD.encode(&json)).unwrap();
+
+    for bytes in [json.as_slice(), png.as_slice()] {
+        let error = parse_snapshot_payload_from_bytes(bytes).unwrap_err();
+        assert!(error.contains("Unsupported locked card envelope version 2"));
+        assert!(error.contains("Update Buzz"));
+    }
 }

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -1,11 +1,12 @@
 use super::*;
 use crate::managed_agents::{
     agent_snapshot::{
-        AgentSnapshotDefinition, AgentSnapshotMemory, AgentSnapshotMemoryEntry,
+        make_png_with_text, AgentSnapshotDefinition, AgentSnapshotMemory, AgentSnapshotMemoryEntry,
         AgentSnapshotProfile,
     },
-    team_snapshot::{TeamSnapshotMeta, FORMAT_DISCRIMINATOR, FORMAT_VERSION},
+    team_snapshot::{TeamSnapshotMeta, FORMAT_DISCRIMINATOR, FORMAT_VERSION, PNG_CHUNK_KEYWORD},
 };
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 fn member(name: &str) -> AgentSnapshot {
     AgentSnapshot {
@@ -359,6 +360,54 @@ fn canonical_team_json_is_accepted_without_extension_case_policy() {
     // Preview/confirm intentionally decode content rather than file names, so
     // canonical lowercase and uppercase extensions reach this same safe path.
     assert!(decode_team_snapshot_from_bytes(&bytes).is_ok());
+}
+
+#[test]
+fn team_import_rejects_unknown_portable_fields_from_json_and_png() {
+    let mut value = serde_json::to_value(snapshot(vec![member("Alice")])).unwrap();
+    value["team"]["toolRequirements"] = serde_json::json!([{"capability": "analytics.read"}]);
+    let json = serde_json::to_vec(&value).unwrap();
+    let png = make_png_with_text(PNG_CHUNK_KEYWORD, &STANDARD.encode(&json)).unwrap();
+
+    for bytes in [&json, &png] {
+        let error = decode_team_snapshot_from_bytes(bytes).unwrap_err();
+        assert!(error.contains("contains fields this version of Buzz does not support"));
+        assert!(error.contains("toolRequirements"));
+    }
+}
+
+#[test]
+fn team_import_reports_newer_member_version_before_unknown_fields() {
+    let mut value = serde_json::to_value(snapshot(vec![member("Alice")])).unwrap();
+    value["members"][0]["version"] = serde_json::json!(2);
+    value["members"][0]["definition"]["skills"] = serde_json::json!([{"name": "analysis"}]);
+    let json = serde_json::to_vec(&value).unwrap();
+    let png = make_png_with_text(PNG_CHUNK_KEYWORD, &STANDARD.encode(&json)).unwrap();
+
+    for bytes in [json.as_slice(), png.as_slice()] {
+        let error = decode_team_snapshot_from_bytes(bytes).unwrap_err();
+        assert!(error.contains("Team member 0 is invalid"));
+        assert!(error.contains("Unsupported snapshot version 2"));
+        assert!(error.contains("Update Buzz"));
+    }
+}
+
+#[test]
+fn newer_team_version_precedes_a_changed_member_container() {
+    let value = serde_json::json!({
+        "format": FORMAT_DISCRIMINATOR,
+        "version": 2,
+        "team": {"name": "Future Team"},
+        "agents": [{"format": "future-agent"}]
+    });
+    let json = serde_json::to_vec(&value).unwrap();
+    let png = make_png_with_text(PNG_CHUNK_KEYWORD, &STANDARD.encode(&json)).unwrap();
+
+    for bytes in [json.as_slice(), png.as_slice()] {
+        let error = decode_team_snapshot_from_bytes(bytes).unwrap_err();
+        assert!(error.contains("Unsupported team snapshot version 2"));
+        assert!(error.contains("Update Buzz"));
+    }
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
@@ -88,7 +88,7 @@ pub enum MemoryLevel {
 /// meaningful across environments is included; machine-local / secret fields
 /// are deliberately absent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentSnapshotDefinition {
     pub name: String,
     /// Portable source classification for import-preview metadata. Imported
@@ -121,7 +121,7 @@ pub struct AgentSnapshotDefinition {
 
 /// kind:0 presentation fields.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentSnapshotProfile {
     pub display_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -138,7 +138,7 @@ pub struct AgentSnapshotProfile {
 
 /// A single decrypted memory entry.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentSnapshotMemoryEntry {
     pub slug: String,
     pub body: String,
@@ -146,7 +146,7 @@ pub struct AgentSnapshotMemoryEntry {
 
 /// Memory section of the manifest.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentSnapshotMemory {
     /// Indicates what was included at export time.
     pub level: MemoryLevel,
@@ -162,7 +162,7 @@ pub struct AgentSnapshotMemory {
 /// Serializes to / from JSON. Embedded in `.agent.json` directly, or in the
 /// `buzz_agent_snapshot` tEXt chunk of a `.agent.png` (base64-encoded).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentSnapshot {
     /// Fixed discriminator for format sniffing.
     pub format: String,
@@ -285,8 +285,29 @@ pub fn encode_snapshot_json(snapshot: &AgentSnapshot) -> Result<Vec<u8>, String>
 
 /// Decode a manifest from JSON bytes.
 pub fn decode_snapshot_json(bytes: &[u8]) -> Result<AgentSnapshot, String> {
-    let snapshot: AgentSnapshot =
+    #[derive(Deserialize)]
+    struct SnapshotHeader {
+        format: String,
+        version: u32,
+    }
+
+    // Read the discriminator first so a snapshot from a newer Buzz release
+    // receives the useful version error even when that version adds fields v1
+    // does not understand.
+    let header: SnapshotHeader =
         serde_json::from_slice(bytes).map_err(|e| format!("Invalid snapshot JSON: {e}"))?;
+    validate_snapshot_format(&header.format, header.version)?;
+
+    let snapshot: AgentSnapshot =
+        serde_json::from_slice(bytes).map_err(|e| {
+            if e.to_string().starts_with("unknown field") {
+                format!(
+                    "This agent snapshot contains fields this version of Buzz does not support. Update Buzz or export a compatible snapshot. Details: {e}"
+                )
+            } else {
+                format!("Invalid snapshot JSON: {e}")
+            }
+        })?;
     validate_snapshot(&snapshot)?;
     Ok(snapshot)
 }
@@ -385,23 +406,31 @@ pub fn decode_snapshot_png(png_bytes: &[u8]) -> Result<AgentSnapshot, String> {
 /// Validate that the manifest has the correct format/version and required
 /// fields. Returns an error string on failure.
 pub(crate) fn validate_snapshot(snapshot: &AgentSnapshot) -> Result<(), String> {
-    if snapshot.format != FORMAT_DISCRIMINATOR {
-        return Err(format!(
-            "Unsupported snapshot format: {:?} (expected {:?})",
-            snapshot.format, FORMAT_DISCRIMINATOR
-        ));
-    }
-    if snapshot.version != 1 {
-        return Err(format!(
-            "Unsupported snapshot version: {} (expected 1)",
-            snapshot.version
-        ));
-    }
+    validate_snapshot_format(&snapshot.format, snapshot.version)?;
     if snapshot.definition.name.trim().is_empty() {
         return Err("Snapshot definition.name is empty".to_string());
     }
     if snapshot.profile.display_name.trim().is_empty() {
         return Err("Snapshot profile.displayName is empty".to_string());
+    }
+    Ok(())
+}
+
+/// Validate only the portable snapshot discriminator and schema version.
+///
+/// Team snapshots use this before strict member deserialization so a newer
+/// member version receives upgrade guidance before any new fields are parsed.
+pub(crate) fn validate_snapshot_format(format: &str, version: u32) -> Result<(), String> {
+    if format != FORMAT_DISCRIMINATOR {
+        return Err(format!(
+            "Unsupported snapshot format: {:?} (expected {:?})",
+            format, FORMAT_DISCRIMINATOR
+        ));
+    }
+    if version != FORMAT_VERSION {
+        return Err(format!(
+            "Unsupported snapshot version {version}. This version of Buzz supports version {FORMAT_VERSION}. Update Buzz or export a compatible snapshot."
+        ));
     }
     Ok(())
 }

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
@@ -58,7 +58,7 @@ pub const LOCKED_CARD_REFUSAL: &str =
 /// Typed outer envelope stored (base64 JSON) in the `buzz_agent_snapshot`
 /// chunk of a locked card.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LockedSnapshotEnvelope {
     /// Always [`LOCKED_FORMAT`].
     pub format: String,
@@ -68,7 +68,7 @@ pub struct LockedSnapshotEnvelope {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct LockedEncryption {
     /// Always [`LOCKED_SCHEME`].
     pub scheme: String,
@@ -130,24 +130,14 @@ pub(crate) fn parse_canonical_pubkey(field: &str, value: &str) -> Result<PublicK
 pub fn validate_envelope(
     envelope: &LockedSnapshotEnvelope,
 ) -> Result<(PublicKey, PublicKey), String> {
-    if envelope.format != LOCKED_FORMAT {
-        return Err(format!(
-            "Unsupported locked card format: {:?} (expected {LOCKED_FORMAT:?})",
-            envelope.format
-        ));
-    }
-    if envelope.version != LOCKED_VERSION {
-        return Err(format!(
-            "Unsupported locked card envelope version: {} (expected {LOCKED_VERSION})",
-            envelope.version
-        ));
-    }
+    validate_locked_envelope_format(&envelope.format, envelope.version)?;
     if envelope.encryption.scheme != LOCKED_SCHEME {
         return Err(format!(
             "Unsupported locked card encryption scheme: {:?} (expected {LOCKED_SCHEME:?})",
             envelope.encryption.scheme
         ));
     }
+
     let owner = parse_canonical_pubkey("ownerPubkey", &envelope.encryption.owner_pubkey)?;
     let agent = parse_canonical_pubkey("agentPubkey", &envelope.encryption.agent_pubkey)?;
     if owner == agent {
@@ -160,6 +150,20 @@ pub fn validate_envelope(
         return Err("Locked card ciphertext is empty.".to_string());
     }
     Ok((owner, agent))
+}
+
+fn validate_locked_envelope_format(format: &str, version: u32) -> Result<(), String> {
+    if format != LOCKED_FORMAT {
+        return Err(format!(
+            "Unsupported locked card format: {format:?} (expected {LOCKED_FORMAT:?})"
+        ));
+    }
+    if version != LOCKED_VERSION {
+        return Err(format!(
+            "Unsupported locked card envelope version {version}. This version of Buzz supports version {LOCKED_VERSION}. Update Buzz or export a compatible snapshot."
+        ));
+    }
+    Ok(())
 }
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────
@@ -185,8 +189,27 @@ pub fn parse_chunk_payload(json_bytes: &[u8]) -> Result<ChunkPayload, String> {
             if json_bytes.len() > MAX_LOCKED_ENVELOPE_JSON_BYTES {
                 return Err("Locked card envelope exceeds the maximum size.".to_string());
             }
-            let envelope: LockedSnapshotEnvelope = serde_json::from_slice(json_bytes)
+            #[derive(Deserialize)]
+            struct LockedEnvelopeHeader {
+                format: String,
+                version: u32,
+            }
+
+            let header: LockedEnvelopeHeader = serde_json::from_slice(json_bytes)
                 .map_err(|e| format!("Invalid locked card envelope: {e}"))?;
+            validate_locked_envelope_format(&header.format, header.version)?;
+
+            let envelope: LockedSnapshotEnvelope = serde_json::from_slice(json_bytes).map_err(
+                |e| {
+                    if e.to_string().starts_with("unknown field") {
+                        format!(
+                            "This locked agent snapshot contains fields this version of Buzz does not support. Update Buzz or export a compatible snapshot. Details: {e}"
+                        )
+                    } else {
+                        format!("Invalid locked card envelope: {e}")
+                    }
+                },
+            )?;
             validate_envelope(&envelope)?;
             Ok(ChunkPayload::Locked(envelope))
         }

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
@@ -597,3 +597,28 @@ fn unsupported_version_is_rejected() {
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("Unsupported snapshot version"));
 }
+
+#[test]
+fn newer_version_reports_version_before_unknown_fields() {
+    let snapshot = build_snapshot(&minimal_record(), MemoryLevel::None, vec![], None);
+    let mut value = serde_json::to_value(snapshot).unwrap();
+    value["version"] = serde_json::json!(2);
+    value["definition"]["skills"] = serde_json::json!([{"name": "analysis"}]);
+
+    let error = decode_snapshot_json(&serde_json::to_vec(&value).unwrap()).unwrap_err();
+    assert!(error.contains("Unsupported snapshot version 2"));
+    assert!(error.contains("Update Buzz"));
+}
+
+#[test]
+fn v1_rejects_unknown_portable_capabilities_instead_of_dropping_them() {
+    for field in ["skills", "toolRequirements"] {
+        let snapshot = build_snapshot(&minimal_record(), MemoryLevel::None, vec![], None);
+        let mut value = serde_json::to_value(snapshot).unwrap();
+        value["definition"][field] = serde_json::json!([{"name": "analytics"}]);
+
+        let error = decode_snapshot_json(&serde_json::to_vec(&value).unwrap()).unwrap_err();
+        assert!(error.contains("contains fields this version of Buzz does not support"));
+        assert!(error.contains(field));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -39,7 +39,9 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
 use crate::managed_agents::{
-    agent_snapshot::{make_png_with_text, validate_snapshot, AgentSnapshot, MemoryLevel},
+    agent_snapshot::{
+        make_png_with_text, validate_snapshot, validate_snapshot_format, AgentSnapshot, MemoryLevel,
+    },
     TeamRecord,
 };
 
@@ -58,7 +60,7 @@ pub const FORMAT_VERSION: u32 = 1;
 
 /// Team-level metadata carried in the snapshot header.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TeamSnapshotMeta {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74,7 +76,7 @@ pub struct TeamSnapshotMeta {
 /// Serializes to / from JSON. Embedded in `.team.json` directly, or in the
 /// `buzz_team_snapshot` tEXt chunk of a `.team.png` (base64-encoded).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TeamSnapshot {
     /// Fixed discriminator for format sniffing.
     pub format: String,
@@ -116,8 +118,46 @@ pub fn encode_team_snapshot_json(snapshot: &TeamSnapshot) -> Result<Vec<u8>, Str
 
 /// Decode a manifest from JSON bytes.
 pub fn decode_team_snapshot_json(bytes: &[u8]) -> Result<TeamSnapshot, String> {
-    let snapshot: TeamSnapshot =
+    #[derive(Deserialize)]
+    struct TeamSnapshotHeader {
+        format: String,
+        version: u32,
+    }
+
+    #[derive(Deserialize)]
+    struct TeamMemberHeaders {
+        members: Vec<AgentSnapshotHeader>,
+    }
+
+    #[derive(Deserialize)]
+    struct AgentSnapshotHeader {
+        format: String,
+        version: u32,
+    }
+
+    // Check the envelope before decoding strict v1 fields. This keeps the
+    // upgrade path useful when a newer team format adds fields v1 cannot read.
+    let header: TeamSnapshotHeader =
         serde_json::from_slice(bytes).map_err(|e| format!("Invalid team snapshot JSON: {e}"))?;
+    validate_team_snapshot_format(&header.format, header.version)?;
+
+    let member_headers: TeamMemberHeaders =
+        serde_json::from_slice(bytes).map_err(|e| format!("Invalid team snapshot JSON: {e}"))?;
+    for (index, member) in member_headers.members.iter().enumerate() {
+        validate_snapshot_format(&member.format, member.version)
+            .map_err(|e| format!("Team member {index} is invalid: {e}"))?;
+    }
+
+    let snapshot: TeamSnapshot =
+        serde_json::from_slice(bytes).map_err(|e| {
+            if e.to_string().starts_with("unknown field") {
+                format!(
+                    "This team snapshot contains fields this version of Buzz does not support. Update Buzz or export a compatible snapshot. Details: {e}"
+                )
+            } else {
+                format!("Invalid team snapshot JSON: {e}")
+            }
+        })?;
     validate_team_snapshot(&snapshot)?;
     Ok(snapshot)
 }
@@ -194,18 +234,7 @@ fn validate_member_memory_consistency(idx: usize, member: &AgentSnapshot) -> Res
 /// Also checks the memory-consistency invariant per member via
 /// `validate_member_memory_consistency`.
 pub(crate) fn validate_team_snapshot(snapshot: &TeamSnapshot) -> Result<(), String> {
-    if snapshot.format != FORMAT_DISCRIMINATOR {
-        return Err(format!(
-            "Unsupported team snapshot format: {:?} (expected {:?})",
-            snapshot.format, FORMAT_DISCRIMINATOR
-        ));
-    }
-    if snapshot.version != 1 {
-        return Err(format!(
-            "Unsupported team snapshot version: {} (expected 1)",
-            snapshot.version
-        ));
-    }
+    validate_team_snapshot_format(&snapshot.format, snapshot.version)?;
     if snapshot.team.name.trim().is_empty() {
         return Err("Team snapshot team.name is empty".to_string());
     }
@@ -216,6 +245,21 @@ pub(crate) fn validate_team_snapshot(snapshot: &TeamSnapshot) -> Result<(), Stri
         validate_snapshot(member).map_err(|e| format!("Team member {i} is invalid: {e}"))?;
         validate_member_memory_consistency(i, member)
             .map_err(|e| format!("Team member {i} memory is malformed: {e}"))?;
+    }
+    Ok(())
+}
+
+fn validate_team_snapshot_format(format: &str, version: u32) -> Result<(), String> {
+    if format != FORMAT_DISCRIMINATOR {
+        return Err(format!(
+            "Unsupported team snapshot format: {:?} (expected {:?})",
+            format, FORMAT_DISCRIMINATOR
+        ));
+    }
+    if version != FORMAT_VERSION {
+        return Err(format!(
+            "Unsupported team snapshot version {version}. This version of Buzz supports version {FORMAT_VERSION}. Update Buzz or export a compatible snapshot."
+        ));
     }
     Ok(())
 }
@@ -414,6 +458,36 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("Unsupported team snapshot version"));
+    }
+
+    #[test]
+    fn newer_version_reports_version_before_unknown_member_fields() {
+        let mut value = serde_json::to_value(two_member_team()).unwrap();
+        value["version"] = serde_json::json!(2);
+        value["members"][0]["definition"]["skills"] = serde_json::json!([{"name": "analysis"}]);
+
+        let error = decode_team_snapshot_json(&serde_json::to_vec(&value).unwrap()).unwrap_err();
+        assert!(error.contains("Unsupported team snapshot version 2"));
+        assert!(error.contains("Update Buzz"));
+    }
+
+    #[test]
+    fn v1_rejects_unknown_team_fields_instead_of_dropping_them() {
+        for path in ["top-level", "team metadata"] {
+            let mut value = serde_json::to_value(two_member_team()).unwrap();
+            if path == "top-level" {
+                value["coordinationPolicy"] = serde_json::json!({"mode": "review"});
+            } else {
+                value["team"]["sharedContext"] = serde_json::json!("current priorities");
+            }
+
+            let error =
+                decode_team_snapshot_json(&serde_json::to_vec(&value).unwrap()).unwrap_err();
+            assert!(
+                error.contains("contains fields this version of Buzz does not support"),
+                "{path} should fail with compatibility guidance: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Agent snapshots currently import successfully when they contain fields this Buzz version does not understand. Serde drops those fields, so a future snapshot with Skills or tool requirements can appear to import while losing part of the agent.

This makes v1 strict for agents and teams. Newer versions still get the version-specific upgrade message before strict field validation. JSON, PNG, and the production import paths now prove unknown portable fields are rejected rather than discarded.

This is the compatibility guard for #5267. It does not add v2 fields or activate imported capabilities.

Tests:
- `just desktop-tauri-test`
- `just desktop-tauri-clippy`
- `just desktop-tauri-fmt-check`