### PR TITLE
fix(desktop): flush pending events for every community, not only the active one

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -590,7 +590,10 @@ pub fn run() {
                     use tauri::Manager;
                     loop {
                         let state = flush_handle.state::<AppState>();
-                        if let Err(e) = managed_agents::persona_events::flush_active_pending_events(
+                        // Every scope, not just the active community's: a row
+                        // queued while another community was open is otherwise
+                        // never retried again. See `flush_all_pending_events`.
+                        if let Err(e) = managed_agents::persona_events::flush_all_pending_events(
                             &flush_handle,
                             &state,
                         )

--- a/desktop/src-tauri/src/managed_agents/persona_events.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events.rs
@@ -239,12 +239,78 @@ pub async fn flush_pending_events(
 /// The scope snapshots its relay, owner keys, and database path together
 /// before network work starts. Switching communities during the flush cannot
 /// redirect rows from the old scope into the new relay.
+///
+/// Prefer [`flush_all_pending_events`]: draining only the active scope is what
+/// stranded definitions queued in a community the user has since left. Kept for
+/// the tests that pin single-scope behaviour, and so a caller that genuinely
+/// wants one scope has a name for it.
+#[cfg(test)]
 pub async fn flush_active_pending_events(
     app: &tauri::AppHandle,
     state: &AppState,
 ) -> Result<u32, String> {
     let scope = crate::managed_agents::retention::active_retention_scope(app, state)?;
     flush_pending_events_at(&scope.db_path, state, &scope.relay_url, &scope.owner_keys).await
+}
+
+/// Flush EVERY retention scope, each to its own relay.
+///
+/// The bug this closes: a definition is retained with `pending_sync = 1` in the
+/// scope that was active when it was authored, and the flush loop only ever
+/// drained the ACTIVE scope. Switch or leave that community and the row is
+/// never retried again — not on restart, not ever. The agent then exists only
+/// on the device that created it, and every other client renders it as
+/// "Unknown" with a "Configuration missing" badge. No amount of retrying from
+/// the new community could fix it, because the rows were never in the new
+/// community's database.
+///
+/// Each scope publishes to ITS OWN relay, never the active one: republishing
+/// community A's definitions onto community B's relay is the leak the per-scope
+/// split exists to prevent.
+///
+/// A scope whose relay is unknown (a database written before scopes were
+/// stamped) is counted and reported rather than guessed at. One log line per
+/// sweep, only when such rows exist — silence here is what let the original bug
+/// hide for so long.
+///
+/// Best-effort per scope: one unreachable relay leaves its rows pending and
+/// does not stop the others. Returns the total events accepted across scopes.
+pub async fn flush_all_pending_events(
+    app: &tauri::AppHandle,
+    state: &AppState,
+) -> Result<u32, String> {
+    use crate::managed_agents::retention::{get_pending_sync, open_retention_db};
+
+    let owner_keys = state.signing_keys()?;
+    let scopes = crate::managed_agents::retention::all_retention_scopes(app, state)?;
+
+    let mut flushed = 0u32;
+    let mut stranded = 0usize;
+    for scope in scopes {
+        let Some(relay_url) = scope.relay_url else {
+            // Count what is stuck so the operator can see it, but never guess a
+            // destination for it.
+            if let Ok(conn) = open_retention_db(&scope.db_path) {
+                stranded += get_pending_sync(&conn).map(|rows| rows.len()).unwrap_or(0);
+            }
+            continue;
+        };
+        match flush_pending_events_at(&scope.db_path, state, &relay_url, &owner_keys).await {
+            Ok(count) => flushed += count,
+            Err(error) => {
+                eprintln!("buzz-desktop: event-flush scope {relay_url}: {error}");
+            }
+        }
+    }
+
+    if stranded > 0 {
+        eprintln!(
+            "buzz-desktop: event-flush: {stranded} pending event(s) in retention \
+             scope(s) with no recorded relay — they cannot be published until \
+             their community is opened again"
+        );
+    }
+    Ok(flushed)
 }
 
 async fn flush_pending_events_at(
@@ -269,6 +335,11 @@ async fn flush_pending_events_at(
     let mut flushed = 0u32;
     let mut failed_tombstones: std::collections::HashSet<(String, String)> =
         std::collections::HashSet::new();
+    // A rejected row used to vanish here without a single log line, so a
+    // definition the relay keeps refusing retried every 30s forever and the
+    // operator never learned. Collected and reported as ONE line per sweep:
+    // enough to see it, bounded when the relay is simply unreachable.
+    let mut refused: Vec<String> = Vec::new();
     for row in pending {
         if row.pubkey != owner_pubkey {
             continue;
@@ -306,15 +377,18 @@ async fn flush_pending_events_at(
             event
         };
 
-        if crate::relay::submit_signed_event_at_with_keys(
+        if let Err(error) = crate::relay::submit_signed_event_at_with_keys(
             &event,
             state,
             &relay_api_base,
             owner_keys,
         )
         .await
-        .is_err()
         {
+            refused.push(format!(
+                "kind:{} '{}' ({error})",
+                current.kind, current.d_tag
+            ));
             if current.kind == 5 {
                 failed_tombstones.insert((current.pubkey.clone(), current.d_tag.clone()));
             }
@@ -331,6 +405,14 @@ async fn flush_pending_events_at(
             &current.content,
         )?;
         flushed += 1;
+    }
+
+    if !refused.is_empty() {
+        eprintln!(
+            "buzz-desktop: event-flush: {} event(s) still pending after this sweep at {relay_url}: {}",
+            refused.len(),
+            refused.join("; ")
+        );
     }
 
     Ok(flushed)

--- a/desktop/src-tauri/src/managed_agents/retention.rs
+++ b/desktop/src-tauri/src/managed_agents/retention.rs
@@ -140,11 +140,121 @@ pub fn open_retention_db(path: &Path) -> Result<Connection, String> {
             raw_event TEXT NOT NULL,
             pending_sync INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (kind, pubkey, d_tag)
+        );
+        CREATE TABLE IF NOT EXISTS scope_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
         );",
     )
     .map_err(|e| format!("failed to create retention table: {e}"))?;
 
     Ok(conn)
+}
+
+/// `scope_meta` key holding the relay URL this database's rows belong to.
+const SCOPE_META_RELAY_URL: &str = "relay_url";
+
+/// Stamp this database with the relay its rows publish to.
+///
+/// [`scoped_retention_db_path`] hashes `(owner, relay)` into the filename, and
+/// a hash cannot be reversed — so without this stamp there is no way to look at
+/// a retention database on disk and know where its pending rows should go. That
+/// is precisely why the flush loop could only ever drain the ACTIVE community:
+/// it was the only scope whose relay was known. Recording the relay at scope
+/// resolution makes every scope self-describing, so
+/// [`all_retention_scopes`] can hand the flush loop a relay per database.
+///
+/// Idempotent, and best-effort by design: a write failure here must never break
+/// resolving a scope, since every read and write path depends on it.
+pub fn record_scope_relay(conn: &Connection, relay_url: &str) {
+    let normalized = normalized_relay_scope(relay_url);
+    if normalized.is_empty() {
+        return;
+    }
+    if let Err(error) = conn.execute(
+        "INSERT INTO scope_meta (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![SCOPE_META_RELAY_URL, normalized],
+    ) {
+        eprintln!("buzz-desktop: retention-scope-stamp: {error}");
+    }
+}
+
+/// The relay this database's rows belong to, if it has been stamped.
+///
+/// `None` for a database written before the stamp existed, or by a build that
+/// does not write it. Callers must treat that as "unknown", never as the active
+/// relay — publishing community A's events to community B's relay is the exact
+/// failure the per-scope split exists to prevent.
+pub fn read_scope_relay(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM scope_meta WHERE key = ?1",
+        params![SCOPE_META_RELAY_URL],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .filter(|value| !value.trim().is_empty())
+}
+
+/// One retention database on disk, with the relay it belongs to if known.
+pub struct DiscoveredScope {
+    pub db_path: PathBuf,
+    /// `None` when the database predates the relay stamp; its pending rows
+    /// cannot be published because their destination is unknowable.
+    pub relay_url: Option<String>,
+}
+
+/// Every retention database for this owner, not just the active community's.
+///
+/// The active scope is resolved first (and stamped in passing), so it is always
+/// present and always has a known relay even on a first run. Remaining
+/// databases are read from disk and identified by their own stamp.
+///
+/// Databases belonging to a DIFFERENT owner are indistinguishable from this
+/// owner's here — the filename hash covers both — so a scope is only ever
+/// flushed for rows whose `pubkey` matches the signing key, which
+/// `flush_pending_events_at` already enforces per row.
+pub fn all_retention_scopes(
+    app: &AppHandle,
+    state: &AppState,
+) -> Result<Vec<DiscoveredScope>, String> {
+    let active = active_retention_scope(app, state)?;
+    if let Ok(conn) = open_retention_db(&active.db_path) {
+        record_scope_relay(&conn, &active.relay_url);
+    }
+
+    let mut scopes = vec![DiscoveredScope {
+        db_path: active.db_path.clone(),
+        relay_url: Some(active.relay_url.clone()),
+    }];
+
+    let dir = match active.db_path.parent() {
+        Some(dir) => dir,
+        None => return Ok(scopes),
+    };
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // A missing directory is not an error: it just means no other scope
+        // has ever been written.
+        Err(_) => return Ok(scopes),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == active.db_path || path.extension().is_none_or(|ext| ext != "db") {
+            continue;
+        }
+        let relay_url = open_retention_db(&path)
+            .ok()
+            .and_then(|conn| read_scope_relay(&conn));
+        scopes.push(DiscoveredScope {
+            db_path: path,
+            relay_url,
+        });
+    }
+    Ok(scopes)
 }
 
 fn set_wal_mode(conn: &Connection) -> Result<(), String> {
@@ -930,5 +1040,137 @@ mod tests {
             "other-persona",
             &failed
         ));
+    }
+
+    /// A retention database is stamped with the relay it belongs to, so a later
+    /// sweep can publish its rows without knowing which community was active
+    /// when they were written.
+    #[test]
+    fn a_scope_records_and_reports_the_relay_it_belongs_to() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = scoped_retention_db_path(dir.path(), "wss://a.example", "ownerpubkey");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = open_retention_db(&db_path).unwrap();
+
+        assert_eq!(
+            read_scope_relay(&conn),
+            None,
+            "an unstamped database must report unknown, never a guess"
+        );
+
+        record_scope_relay(&conn, "wss://a.example");
+        assert_eq!(read_scope_relay(&conn), Some("wss://a.example".to_string()));
+    }
+
+    /// The stamp normalizes exactly like the path hash does, so a trailing
+    /// slash cannot make one scope look like two.
+    #[test]
+    fn the_recorded_relay_is_normalized_like_the_scope_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = scoped_retention_db_path(dir.path(), "wss://a.example", "ownerpubkey");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = open_retention_db(&db_path).unwrap();
+
+        record_scope_relay(&conn, "  wss://a.example/  ");
+
+        assert_eq!(read_scope_relay(&conn), Some("wss://a.example".to_string()));
+        assert_eq!(
+            scoped_retention_db_path(dir.path(), "wss://a.example/", "ownerpubkey"),
+            db_path,
+            "path hashing and the stamp must agree on what one scope is"
+        );
+    }
+
+    /// Re-stamping is idempotent: a scope opened on every sweep must not
+    /// accumulate rows or change its answer.
+    #[test]
+    fn re_recording_the_same_relay_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = scoped_retention_db_path(dir.path(), "wss://a.example", "ownerpubkey");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = open_retention_db(&db_path).unwrap();
+
+        record_scope_relay(&conn, "wss://a.example");
+        record_scope_relay(&conn, "wss://a.example");
+
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scope_meta", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 1);
+        assert_eq!(read_scope_relay(&conn), Some("wss://a.example".to_string()));
+    }
+
+    /// An empty relay is not a relay. Stamping one would be worse than leaving
+    /// the scope unknown, because the flush loop would then try to publish to
+    /// nowhere instead of reporting the rows as stranded.
+    #[test]
+    fn an_empty_relay_is_never_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = scoped_retention_db_path(dir.path(), "wss://a.example", "ownerpubkey");
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = open_retention_db(&db_path).unwrap();
+
+        record_scope_relay(&conn, "   ");
+
+        assert_eq!(read_scope_relay(&conn), None);
+    }
+
+    /// THE REGRESSION THIS FIX EXISTS FOR.
+    ///
+    /// A definition authored in community A is retained pending in A's
+    /// database. The user switches to community B. Before this fix the flush
+    /// loop resolved only B's scope, so A's row was never retried again — not
+    /// on the next sweep, not on restart, ever — and the agent showed up as
+    /// "Unknown / Configuration missing" in every other client.
+    ///
+    /// Scope discovery is the part that was missing: A's database must still be
+    /// found from B, and must still name A's relay rather than B's.
+    #[test]
+    fn a_scope_left_behind_is_still_discoverable_and_still_names_its_own_relay() {
+        let dir = tempfile::tempdir().unwrap();
+        let owner = "ownerpubkey";
+        let community_a = scoped_retention_db_path(dir.path(), "wss://a.example", owner);
+        let community_b = scoped_retention_db_path(dir.path(), "wss://b.example", owner);
+        std::fs::create_dir_all(community_a.parent().unwrap()).unwrap();
+
+        for (path, relay) in [
+            (&community_a, "wss://a.example"),
+            (&community_b, "wss://b.example"),
+        ] {
+            let conn = open_retention_db(path).unwrap();
+            record_scope_relay(&conn, relay);
+        }
+
+        // Community B is active; walk the directory the way `all_retention_scopes`
+        // does and confirm A is found, carrying A's relay.
+        let mut discovered: Vec<(std::path::PathBuf, Option<String>)> =
+            std::fs::read_dir(community_b.parent().unwrap())
+                .unwrap()
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().is_some_and(|ext| ext == "db"))
+                .map(|path| {
+                    let relay = open_retention_db(&path)
+                        .ok()
+                        .and_then(|conn| read_scope_relay(&conn));
+                    (path, relay)
+                })
+                .collect();
+        discovered.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(discovered.len(), 2, "both scopes must be visible from either");
+        let relay_for = |target: &std::path::Path| {
+            discovered
+                .iter()
+                .find(|(path, _)| path == target)
+                .and_then(|(_, relay)| relay.clone())
+        };
+        assert_eq!(relay_for(&community_a), Some("wss://a.example".to_string()));
+        assert_eq!(relay_for(&community_b), Some("wss://b.example".to_string()));
+        assert_ne!(
+            relay_for(&community_a),
+            relay_for(&community_b),
+            "a left-behind scope must never inherit the active community's relay"
+        );
     }
 }


### PR DESCRIPTION
Duplicate search: no open PR or issue found covering the per-scope flush loop.

## The problem

Agent definitions, teams and personas are retained locally with `pending_sync = 1` and published by the background flush loop in `lib.rs`. That loop calls `flush_active_pending_events`, which resolves `active_retention_scope` and drains **that scope alone** — but retention databases are per `(relay, owner)` by design.

So a definition authored in one community and not yet published is never retried once the workspace switches away. Not on the next 30s sweep, not on restart, not ever.

What the user sees: the agent exists only on the device that created it. Every other client asks the relay for that definition id, gets nothing, and renders the agent under **"Unknown agents"** with a **"Configuration missing"** badge. The only thing that republishes it is switching back to the original community — and nothing tells the user that.

I hit this with four agents across two communities. Three were queued in a community I had left, and showed as Unknown on every other client indefinitely.

## Why it wasn't simply "flush every scope"

`scoped_retention_db_path` hashes `(owner, relay)` into the filename, and a hash does not reverse. Nothing on disk said where a given database's rows should be published, so the active scope was the only one whose destination was knowable — which is exactly why it was the only one flushed.

## The change

1. **`scope_meta` table** recording the relay each retention database belongs to, written whenever a scope is resolved. Normalized identically to `scoped_retention_db_path`, so a trailing slash cannot split one scope into two.
2. **`all_retention_scopes`** enumerates the retention directory and yields a relay per database.
3. **`flush_all_pending_events`** publishes each scope to **its own** relay — never the active one. Republishing community A's definitions onto community B's relay is the leak the per-scope split exists to prevent.

A database written before this change carries no stamp, so its destination is genuinely unknowable. Those rows are **counted and reported in one log line per sweep** rather than guessed at, and they publish normally once that community is opened again, which stamps it.

Best-effort per scope: one unreachable relay leaves its own rows pending without affecting the others.

## What is unchanged

Per-row safety is untouched — rows whose pubkey doesn't match the signing key are still skipped, the pre-publish re-read still guards against superseded edits, and `mark_synced` still compares the original `created_at`/`content`. `flush_active_pending_events` is retained for the single-scope tests.

## Tests

Five new cases in `managed_agents::retention`, including the regression: **a definition queued in community A is still discovered from community B and still names A's relay, never B's.** Also covers stamp round-trip, normalization matching the path hash, idempotent re-stamping, and refusing to record an empty relay.

`cargo test --lib managed_agents::retention` — 32 passed, 0 failed.

## Manual verification

Reproduced on Windows against a real relay: three definitions sitting at `pending_sync = 1` in a departed community's store, rendering as "Unknown / Configuration missing" in a second client. After the change the flush loop picks up that scope and publishes to its own relay.

## Not in this PR

No UI changes. The "Configuration missing" badge is correct behaviour — it accurately reports that a definition cannot be resolved — so it is deliberately left alone. This fixes the cause, not the symptom.