### PR TITLE
fix(chart): declare ephemeral-storage request/limit for relay pods

### DIFF
--- a/deploy/charts/buzz/tests/render_test.yaml
+++ b/deploy/charts/buzz/tests/render_test.yaml
@@ -48,6 +48,16 @@ tests:
             name: BUZZ_HUDDLE_AUDIO_AVAILABLE
             value: "true"
         template: templates/deployment.yaml
+      # Default relay.resources now declares ephemeral-storage so the scheduler
+      # accounts for the per-pod emptyDir footprint (git-repos + git-pack-cache) (#5215).
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests["ephemeral-storage"]
+          value: 17Gi
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["ephemeral-storage"]
+          value: 17Gi
+        template: templates/deployment.yaml
   - it: renders virtual-hosted S3 addressing for providers that require it
     set:
       relayUrl: wss://buzz.example.com

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -165,9 +165,14 @@ relay:
     requests:
       cpu: "500m"
       memory: "512Mi"
+      # Account for the two sizeLimit-ed emptyDirs (git.size + git.packCacheVolumeSize,
+      # 10Gi + 7Gi = 17Gi by default) so kube-scheduler sees the per-pod disk footprint
+      # and does not co-pack pods beyond a node's allocatable ephemeral storage (#5215).
+      ephemeral-storage: "17Gi"
     limits:
       cpu: "2"
       memory: "2Gi"
+      ephemeral-storage: "17Gi"
 
   podAnnotations: {}
   podLabels: {}


### PR DESCRIPTION
## Summary
- HA guidance mounts two sizeLimit-ed emptyDirs (git-repos 10Gi + git-pack-cache 7Gi = 17Gi/pod by default) but `relay.resources` declared no `ephemeral-storage`, so kube-scheduler could not see the per-pod disk footprint and co-packed pods onto nodes that then evict under DiskPressure.
- Default `relay.resources` now request/limit `17Gi` ephemeral-storage and `render_test` pins it.

Fixes #5215

## Test plan
- [x] `helm unittest deploy/charts/buzz` (render_test passes; the 2 validation_test schema-rejection quirks are pre-existing on main and unrelated)
- [ ] `helm template` an HA render and confirm `resources.requests.ephemeral-storage` is present