### PR TITLE
fix(relay): namespace the conformance probe's sequential writes under probe/

### DIFF
--- a/crates/buzz-relay/src/api/git/store.rs
+++ b/crates/buzz-relay/src/api/git/store.rs
@@ -594,9 +594,17 @@ impl GitStore {
         let mut transport_drops = 0usize;
 
         // -- Phase 1: sequential --------------------------------------------------
+        // Phase 1 writes through the same immutable create-only path as real packs
+        // (`put_immutable`), but under the `probe/` namespace rather than `packs/`
+        // so the probe litter is collectable by a `probe/`-scoped retention rule.
+        // Going through `put_pack` instead hardcoded these probe bodies to `packs/`,
+        // where they could not be told apart from real (content-addressed) pack
+        // data and could not be cleaned without risking real packs (#5241).
         for round in 0..cfg.race_rounds {
             let body = format!("probe-sequential-{nonce}-{round}").into_bytes();
-            let key = self.put_pack(&body).await?;
+            let key = self
+                .put_immutable("probe/pack", &body, "application/x-git-pack")
+                .await?;
             let got = self
                 .get_verified(&key, &Self::digest_hex(&body))
                 .await


### PR DESCRIPTION
## Summary
- Phase 1 of `run_conformance_probe` wrote its probe bodies through `put_pack`, which hardcodes the production `packs/` prefix. Those `probe-sequential-{nonce}-{round}` objects are not valid packs and accumulate on every startup (3 by default), with no key-level way to tell them from real content-addressed pack data — so a retention rule broad enough to catch the litter is broad enough to delete real packs.
- Route phase 1 through `put_immutable("probe/pack", ...)` instead. It still exercises the same immutable create-only path (`If-None-Match *`) and the same content-addressed key shape, but under `probe/`, where phases 2 and 3 already live and a `probe/`-scoped retention rule can clean all probe litter safely.

Fixes #5241

## Test plan
- [x] `cargo check -p buzz-relay` compiles
- [ ] `cargo test -p buzz-relay --lib git::store` (the `probe_conformance` end-to-end test needs a live MinIO via `probe_enabled()`, same as on main)

Made with [Cursor](https://cursor.com)