### PR TITLE
fix(acp): deliver forum mentions

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -222,7 +222,16 @@ Start with **N=2** for most deployments. Increase if queue depth grows under loa
 
 ## Forum Channels
 
-By default, the ACP harness subscribes to stream message kinds (9, 46010, 40007). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
+The default `subscribe=mentions` mode receives tagged forum posts and comments alongside stream messages, workflow approvals, and reminders. Forum events still need a `p` tag for the agent; unmentioned activity remains filtered out. Votes stay excluded because they are not agent-directed messages.
+
+Default mention kinds:
+- **9** — Stream message
+- **40007** — Stream reminder
+- **45001** — Forum post (thread root)
+- **45003** — Comment reply on a forum post
+- **46010** — Workflow approval request
+
+To receive unmentioned forum activity, explicitly widen the filter:
 
 **CLI flags:**
 ```bash
@@ -234,9 +243,11 @@ buzz-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
 buzz-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
 ```
 
-**Per-channel config:**
+**Per-channel config (`--subscribe config`):**
 ```toml
-[channel.CHANNEL_UUID]
+[[rules]]
+name = "forum-all"
+channels = ["CHANNEL_UUID"]
 kinds = [9, 46010, 40007, 45001, 45002, 45003]
 require_mention = false
 ```
@@ -246,13 +257,13 @@ Forum event kinds:
 - **45002** — Vote on a post or comment
 - **45003** — Comment reply on a forum post
 
-> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
+> **Note:** `--kinds` replaces the default kind list rather than extending it, so repeat any defaults you still want to receive.
 
 ## How It Works
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
+3. **Event loop** — Listens for supported @mention events (including stream messages and forum posts/comments with the agent's pubkey in a `#p` tag). Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -35,6 +35,15 @@ pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
 /// deadline (`max_turn_duration + IN_FLIGHT_DEADLINE_BUFFER_SECS`).
 pub(crate) const MAX_TURN_DURATION_CEILING_SECS: u64 = 604_800;
 
+/// Event kinds delivered by the default `mentions` subscription.
+pub(crate) const DEFAULT_MENTION_KINDS: [u32; 5] = [
+    buzz_core::kind::KIND_STREAM_MESSAGE,
+    buzz_core::kind::KIND_FORUM_POST,
+    buzz_core::kind::KIND_FORUM_COMMENT,
+    buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED,
+    buzz_core::kind::KIND_STREAM_REMINDER,
+];
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to parse nostr keys: {0}")]
@@ -1237,10 +1246,6 @@ pub fn resolve_channel_filters(
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
         overrides
             .iter()
@@ -1255,13 +1260,10 @@ pub fn resolve_channel_filters(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => {
-            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            });
+            let kinds = config
+                .kinds_override
+                .clone()
+                .unwrap_or_else(|| DEFAULT_MENTION_KINDS.to_vec());
             let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
@@ -1339,10 +1341,6 @@ pub fn resolve_dynamic_channel_filter(
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     // In Mentions/All mode, if the operator explicitly constrained channels
     // with --channels, only allow dynamic subscription to channels in that
     // allowlist. Config mode ignores --channels (per CLI contract) and uses
@@ -1360,13 +1358,12 @@ pub fn resolve_dynamic_channel_filter(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => Some(ChannelFilter {
-            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            })),
+            kinds: Some(
+                config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_MENTION_KINDS.to_vec()),
+            ),
             require_mention: !config.no_mention_filter,
         }),
         SubscribeMode::All => Some(ChannelFilter {
@@ -1512,7 +1509,24 @@ mod tests {
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
             assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
+            assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_POST));
+            assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_COMMENT));
         }
+    }
+
+    #[test]
+    fn test_dynamic_mentions_mode_default_kinds() {
+        let config = test_config(SubscribeMode::Mentions);
+        let filter = resolve_dynamic_channel_filter(&config, Uuid::new_v4(), &[])
+            .expect("channel should be present");
+
+        assert!(filter.require_mention, "mentions mode requires mention");
+        let kinds = filter.kinds.as_ref().expect("should have kinds");
+        assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
+        assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
+        assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
+        assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_POST));
+        assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_COMMENT));
     }
 
     #[test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -664,6 +664,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_default_mentions_match_tagged_forum_events() {
+        let agent_pubkey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let channel_id = any_channel();
+        let rules = vec![make_rule(
+            "mentions",
+            ChannelScope::All("all".into()),
+            crate::config::DEFAULT_MENTION_KINDS.to_vec(),
+            true,
+            None,
+            Some("@mention"),
+        )];
+
+        for kind in [
+            buzz_core::kind::KIND_FORUM_POST,
+            buzz_core::kind::KIND_FORUM_COMMENT,
+        ] {
+            let event = make_event_with_p_tag(kind, "hello", agent_pubkey);
+            let matched = match_event(&event, channel_id, &rules, agent_pubkey)
+                .await
+                .expect("tagged forum event should match");
+            assert_eq!(matched.prompt_tag, "@mention");
+
+            let unmentioned = make_event(kind, "hello");
+            assert!(
+                match_event(&unmentioned, channel_id, &rules, agent_pubkey)
+                    .await
+                    .is_none(),
+                "unmentioned forum event should not match"
+            );
+        }
+
+        let vote = make_event_with_p_tag(buzz_core::kind::KIND_FORUM_VOTE, "vote", agent_pubkey);
+        assert!(
+            match_event(&vote, channel_id, &rules, agent_pubkey)
+                .await
+                .is_none(),
+            "forum votes should remain outside mentions mode"
+        );
+    }
+
+    #[tokio::test]
     async fn test_match_event_no_match() {
         let event = make_event(1, "hello");
         let channel_id = any_channel();

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,7 +22,6 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1723,13 +1722,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(|| config::DEFAULT_MENTION_KINDS.to_vec()),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -36,10 +36,17 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use nostr::EventId;
+
+const SETUP_NUDGE_KINDS: [u32; 4] = [
+    KIND_STREAM_MESSAGE,
+    KIND_FORUM_POST,
+    KIND_FORUM_COMMENT,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
+];
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -409,8 +416,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             continue;
         }
 
-        // Ignore non-message kinds (relay housekeeping, etc.).
-        if kind_u32 != KIND_STREAM_MESSAGE && kind_u32 != KIND_WORKFLOW_APPROVAL_REQUESTED {
+        // Ignore non-message kinds (relay housekeeping, reminders, votes, etc.).
+        if !SETUP_NUDGE_KINDS.contains(&kind_u32) {
             continue;
         }
 
@@ -524,7 +531,7 @@ fn build_setup_subscription_rules(config: &Config) -> Vec<filter::SubscriptionRu
     let kinds = config
         .kinds_override
         .clone()
-        .unwrap_or_else(|| vec![KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED]);
+        .unwrap_or_else(|| crate::config::DEFAULT_MENTION_KINDS.to_vec());
 
     match &config.subscribe_mode {
         // Config mode: load the actual rules, but they will be filtered by
@@ -650,6 +657,16 @@ async fn publish_setup_nudge(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn setup_nudge_kinds_include_forum_messages_but_not_votes_or_reminders() {
+        assert!(SETUP_NUDGE_KINDS.contains(&KIND_STREAM_MESSAGE));
+        assert!(SETUP_NUDGE_KINDS.contains(&KIND_FORUM_POST));
+        assert!(SETUP_NUDGE_KINDS.contains(&KIND_FORUM_COMMENT));
+        assert!(SETUP_NUDGE_KINDS.contains(&KIND_WORKFLOW_APPROVAL_REQUESTED));
+        assert!(!SETUP_NUDGE_KINDS.contains(&buzz_core::kind::KIND_FORUM_VOTE));
+        assert!(!SETUP_NUDGE_KINDS.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
+    }
 
     #[test]
     fn setup_payload_from_raw_returns_none_when_absent() {


### PR DESCRIPTION
## Summary
- add forum post and comment kinds to the shared ACP mention defaults used by static, dynamic, runtime, and setup-mode paths
- preserve `p`-tag mention enforcement and exclude forum votes from the default kind set
- add regression coverage for tagged and untagged forum events plus override semantics
- document the default forum behavior and a valid `[[rules]]` opt-in for unmentioned forum activity

### Related issue
Fixes #5249.

No duplicate open PR found. #5268 is the closest related report and is already closed as a duplicate of #5249.

### Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- static acceptance audit covering static/dynamic subscriptions, runtime dispatch, setup mode, relay serialization/reconnect, and README TOML parsing
- Honest caveat: I could not run `just ci` locally — my sandboxed macOS environment kills native cargo processes (Gatekeeper), and I chose not to weaken that boundary. Hosted CI is the verification path for this PR; requesting first-time-contributor workflow approval.

### How to test manually
1. Configure an ACP agent without an explicit `--kinds` override (default mention subscription).
2. Post a forum post and a forum comment that `p`-tag the agent's pubkey → both should now be delivered to the agent.
3. Post an untagged forum post/comment → not delivered (mention enforcement unchanged).
4. Cast a forum vote tagging the agent → not delivered (votes stay excluded by default).
5. Run an agent with an explicit `--kinds` list → the explicit list still fully replaces the defaults.

No UI change.
