### PR TITLE
fix(desktop): use the OS trust store for relay WebSockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ moka    = { version = "0.12", features = ["sync"] }
 futures-util = "0.3"
 
 # WebSocket client (test client)
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 url = "2"
 
 # Property-based testing (dev-only)

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ infer = "0.19"
 hex = "0.4"
 ed25519-dalek = "=3.0.0-rc.0"
 tokio = { version = "1", features = ["fs", "sync", "rt", "macros", "time", "net", "io-util"] }
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 bytes = "1"
 futures-util = "0.3"


### PR DESCRIPTION
The desktop client opens its relay WebSocket with tokio-tungstenite's
connect_async(url) and no custom Connector, so the compiled-in TLS feature
decides the trust store. It was pinned to rustls-tls-webpki-roots, which only
trusts a fixed list of public CAs and cannot read the OS trust store. A
self-hosted relay whose TLS certificate chains to a private/internal CA —
even one installed in the OS trust store — never establishes a WebSocket:
the webview's HTTP requests still use system trust and succeed, so the app
looks functional while the connection banner stays 'Can't reach the relay'
and live push never starts.

Switch the tokio-tungstenite feature to rustls-tls-native-roots so the
Connector trusts the operating system's root store, matching the webview's
HTTP path and letting internal CAs work without patching and rebuilding.

Closes #5197