### PR TITLE
fix(relay): republish the NIP-IA snapshot on idempotent archive retries

### DIFF
--- a/crates/buzz-relay/src/handlers/identity_archive.rs
+++ b/crates/buzz-relay/src/handlers/identity_archive.rs
@@ -97,39 +97,44 @@ pub async fn handle_identity_archive_event(
         "identity archive request processed"
     );
 
-    if !changed {
-        return Ok(());
-    }
+    // Only emit a delta when the DB state actually transitioned — an idempotent
+    // retry (changed == false) has no state change to describe. The snapshot,
+    // however, is a pure function of the archived_identities table, so
+    // republish it on every request — including idempotent retries — so a
+    // snapshot publish that failed transiently self-heals without a destructive
+    // unarchive/archive cycle. Previously the early return gated both behind
+    // `changed`, making a lost snapshot permanently unrepairable.
+    if changed {
+        let publish_delta = if kind == KIND_IA_ARCHIVE_REQUEST {
+            publish_nipia_archived(
+                tenant,
+                state,
+                &target_hex,
+                consent_path.as_str(),
+                &actor_hex,
+                &request_event_id,
+                &event.content,
+                reason.as_deref(),
+                replaced_by.as_deref(),
+            )
+            .await
+        } else {
+            publish_nipia_unarchived(
+                tenant,
+                state,
+                &target_hex,
+                consent_path.as_str(),
+                &actor_hex,
+                &request_event_id,
+                &event.content,
+                reason.as_deref(),
+            )
+            .await
+        };
 
-    let publish_delta = if kind == KIND_IA_ARCHIVE_REQUEST {
-        publish_nipia_archived(
-            tenant,
-            state,
-            &target_hex,
-            consent_path.as_str(),
-            &actor_hex,
-            &request_event_id,
-            &event.content,
-            reason.as_deref(),
-            replaced_by.as_deref(),
-        )
-        .await
-    } else {
-        publish_nipia_unarchived(
-            tenant,
-            state,
-            &target_hex,
-            consent_path.as_str(),
-            &actor_hex,
-            &request_event_id,
-            &event.content,
-            reason.as_deref(),
-        )
-        .await
-    };
-
-    if let Err(e) = publish_delta {
-        warn!(error = %e, "failed to publish NIP-IA delta");
+        if let Err(e) = publish_delta {
+            warn!(error = %e, "failed to publish NIP-IA delta");
+        }
     }
     if let Err(e) = publish_nipia_archival_list(tenant, state).await {
         warn!(error = %e, "failed to publish NIP-IA archival list");


### PR DESCRIPTION
If the relay-signed kind:13535 archived-identities snapshot failed to publish
during a NIP-IA archive request, the snapshot was permanently stale: db.archive
returns changed=false on every subsequent request for the same identity, and
the early return gated both the delta and publish_nipia_archival_list behind
changed. Retrying the request was an idempotent no-op — the DB row existed, the
snapshot stayed wrong, and the client saw OK every time. The only repair was a
full unarchive/archive cycle.

Gate only the delta on changed (an idempotent retry has no state transition to
describe) and always republish the snapshot, which is a pure function of the
archived_identities table — so retrying the request becomes an actual repair
path.

Closes #4617