### PR TITLE
fix(desktop): sign NIP-42 AUTH against the bare relay origin, not /pair

### DIFF
--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -607,21 +607,8 @@ where
         Err(_) => return Ok(()),
     };
 
-    // The relay's NIP-42 AUTH expects the bare WS origin (scheme://host[:port]),
-    // not the full connection URL. The legacy /pair fallback connects to
-    // wss://<host>/pair but must sign the AUTH event against wss://<host>, or
-    // the relay rejects it with "relay url mismatch" and closes the
-    // connection within its 5s auth window. Strip the path before signing;
-    // for path-less URLs (the modern pairing_relay_url path) this is a no-op.
-    let parsed =
-        url::Url::parse(relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
-    let bare_origin = match (parsed.host_str(), parsed.port()) {
-        (Some(host), Some(port)) => format!("{}://{}:{}", parsed.scheme(), host, port),
-        (Some(host), None) => format!("{}://{}", parsed.scheme(), host),
-        _ => relay_url.to_string(),
-    };
-    let relay_url_parsed =
-        nostr::RelayUrl::parse(&bare_origin).map_err(|e| format!("invalid relay URL: {e}"))?;
+    let relay_url_parsed = nostr::RelayUrl::parse(&nip42_auth_origin(relay_url)?)
+        .map_err(|e| format!("invalid relay URL: {e}"))?;
     let auth_json = {
         let guard = session.lock().await;
         let s = guard.as_ref().ok_or("session gone during auth")?;
@@ -795,6 +782,32 @@ where
     })
     .await
     .map_err(|_| "timeout waiting for EOSE".to_string())?
+}
+
+/// The bare WS origin a NIP-42 AUTH event must be signed against.
+///
+/// The relay derives its expected value as the bare WS origin
+/// (`scheme://host[:port]`) of the tenant host, not the full connection URL.
+/// The legacy fallback connects to `wss://<host>/pair` when NIP-11 carries no
+/// `pairing_relay_url`, so signing the connection URL verbatim produced a
+/// "relay url mismatch" and the relay closed the socket inside its 5s auth
+/// window — every legacy-path pairing failed. Strip the path before signing;
+/// for the modern origin-only `pairing_relay_url` this is a no-op.
+///
+/// The origin is serialized by the `url` crate rather than reassembled from
+/// `host_str()`, which drops the brackets an IPv6 literal needs — `ws://[::1]:7777/pair`
+/// would otherwise become `ws://::1:7777` and fail to parse. Leaving it to the
+/// serializer also handles default-port elision and host normalization.
+fn nip42_auth_origin(relay_url: &str) -> Result<String, String> {
+    let parsed = url::Url::parse(relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
+    let origin = parsed.origin();
+    if origin.is_tuple() {
+        Ok(origin.ascii_serialization())
+    } else {
+        // Opaque origin (a scheme the URL spec does not treat as special).
+        // Nothing meaningful to strip; leave it for RelayUrl to reject.
+        Ok(relay_url.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -607,8 +607,21 @@ where
         Err(_) => return Ok(()),
     };
 
+    // The relay's NIP-42 AUTH expects the bare WS origin (scheme://host[:port]),
+    // not the full connection URL. The legacy /pair fallback connects to
+    // wss://<host>/pair but must sign the AUTH event against wss://<host>, or
+    // the relay rejects it with "relay url mismatch" and closes the
+    // connection within its 5s auth window. Strip the path before signing;
+    // for path-less URLs (the modern pairing_relay_url path) this is a no-op.
+    let parsed =
+        url::Url::parse(relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
+    let bare_origin = match (parsed.host_str(), parsed.port()) {
+        (Some(host), Some(port)) => format!("{}://{}:{}", parsed.scheme(), host, port),
+        (Some(host), None) => format!("{}://{}", parsed.scheme(), host),
+        _ => relay_url.to_string(),
+    };
     let relay_url_parsed =
-        nostr::RelayUrl::parse(relay_url).map_err(|e| format!("invalid relay URL: {e}"))?;
+        nostr::RelayUrl::parse(&bare_origin).map_err(|e| format!("invalid relay URL: {e}"))?;
     let auth_json = {
         let guard = session.lock().await;
         let s = guard.as_ref().ok_or("session gone during auth")?;

--- a/desktop/src-tauri/src/commands/pairing_relay_tests.rs
+++ b/desktop/src-tauri/src/commands/pairing_relay_tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    pairing_relay_from_nip11, probe_pairing_relay, resolve_pairing_relay_url, PairingRelay,
+    nip42_auth_origin, pairing_relay_from_nip11, probe_pairing_relay, resolve_pairing_relay_url,
+    PairingRelay,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -101,4 +102,48 @@ fn main_relay_pairing_uses_main_relay_url() {
     .expect("resolve main pairing relay");
 
     assert_eq!(resolved, "wss://sprout-oss.stage.blox.sqprod.co");
+}
+
+/// The relay expects the bare origin, so the legacy `/pair` path must not
+/// reach the signed AUTH event.
+#[test]
+fn nip42_auth_url_strips_the_legacy_pair_path() {
+    assert_eq!(
+        nip42_auth_origin("wss://relay.example/pair").expect("hostname pair URL"),
+        "wss://relay.example"
+    );
+}
+
+/// Reassembling the origin from `host_str()` drops the brackets an IPv6
+/// literal needs, which made `RelayUrl::parse` fail before the AUTH event was
+/// ever signed.
+#[test]
+fn nip42_auth_url_keeps_ipv6_brackets() {
+    assert_eq!(
+        nip42_auth_origin("ws://[::1]:7777/pair").expect("IPv6 pair URL"),
+        "ws://[::1]:7777"
+    );
+}
+
+#[test]
+fn nip42_auth_url_preserves_a_non_default_port() {
+    assert_eq!(
+        nip42_auth_origin("ws://127.0.0.1:5000/pair").expect("ported pair URL"),
+        "ws://127.0.0.1:5000"
+    );
+}
+
+/// The modern `pairing_relay_url` path is already origin-only; the helper must
+/// leave it alone.
+#[test]
+fn nip42_auth_url_is_a_no_op_for_an_origin_only_url() {
+    assert_eq!(
+        nip42_auth_origin("wss://relay.example").expect("origin-only URL"),
+        "wss://relay.example"
+    );
+}
+
+#[test]
+fn nip42_auth_url_rejects_a_malformed_url() {
+    assert!(nip42_auth_origin("not a url").is_err());
 }


### PR DESCRIPTION
On relays whose NIP-11 lacks pairing_relay_url (the tagged relay-v0.1.1 and
relay-v0.2.0 releases), device pairing falls back to the legacy wss://<host>/pair
convention. handle_nip42_auth signed the AUTH event with that full URL including
the path, but the relay's nip42_expected_relay_url derives the expected value
from the tenant host as the bare origin (wss://<host>). normalize_relay_url only
trims a trailing slash, so wss://<host>/pair vs wss://<host> never matched and
every legacy-path pairing failed NIP-42 within the 5s window.

Strip the path before signing so the AUTH event carries the bare origin. For
the modern pairing_relay_url path (already origin-only) this is a no-op.

Closes #4932