### PR TITLE
fix(auth): don't leak the relay's internal address in the NIP-98 mismatch error

### DIFF
--- a/crates/buzz-auth/src/nip98.rs
+++ b/crates/buzz-auth/src/nip98.rs
@@ -95,9 +95,18 @@ pub fn verify_nip98_event(
         .ok_or_else(|| AuthError::Nip98Invalid("missing `u` tag".to_string()))?;
 
     if normalize_url(u_tag) != normalize_url(expected_url) {
-        return Err(AuthError::Nip98Invalid(format!(
-            "URL mismatch: event has `{u_tag}`, expected `{expected_url}`"
-        )));
+        // Log the detail (both URLs) server-side for diagnosis, but return
+        // only a generic "URL mismatch" to the client. The expected URL is
+        // derived from the relay's configured bind address, which is often an
+        // internal/private address fronted by a reverse proxy; echoing it back
+        // to an unauthenticated caller discloses internal topology (and, for
+        // routable origins, the origin address itself, undermining the proxy).
+        tracing::warn!(
+            u_tag = %u_tag,
+            expected_url = %expected_url,
+            "NIP-98 auth URL mismatch"
+        );
+        return Err(AuthError::Nip98Invalid("URL mismatch".to_string()));
     }
 
     // 6. Verify `method` tag matches expected_method (case-insensitive).


### PR DESCRIPTION
The NIP-98 URL-mismatch error embedded the expected URL in the message
returned to the caller:

    NIP-98 HTTP Auth verification failed: URL mismatch:
      event has `https://public.example.com/query`,
      expected `http://10.0.0.1:3001/query`

That error fires during verification, so it reaches unauthenticated callers
too. When the relay is fronted by a reverse proxy on a public hostname, the
expected URL is the relay's configured internal bind address — so anyone who
can reach the public endpoint learns the internal address and port (and, for
routable origins, the origin address itself, undermining the proxy).

Log both URLs server-side at WARN for diagnosis, but return only a generic
"URL mismatch" to the client. Existing tests assert on `contains("URL
mismatch")`, which the generic message still satisfies.

Closes #4954