### PR TITLE
fix(desktop): preserve managed-agent git delegation

### DIFF
--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -48,7 +48,15 @@ pub(crate) struct GitAuthConfig {
     git_path: std::path::PathBuf,
     credential_helper: Option<std::path::PathBuf>,
     nsec: String,
+    auth_tag: Option<String>,
     allow_file_transport: bool,
+}
+
+#[cfg(test)]
+impl GitAuthConfig {
+    pub(crate) fn auth_tag(&self) -> Option<&str> {
+        self.auth_tag.as_deref()
+    }
 }
 
 fn read_pipe_lossy(pipe: Option<impl Read>) -> String {
@@ -139,6 +147,8 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
         "GIT_ALTERNATE_OBJECT_DIRECTORIES",
         "GIT_SSH_COMMAND",
         "GIT_EXTERNAL_DIFF",
+        "NOSTR_PRIVATE_KEY",
+        "BUZZ_AUTH_TAG",
     ] {
         command.env_remove(key);
     }
@@ -173,6 +183,9 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
             return apply_git_config(command, &entries);
         };
         command.env("NOSTR_PRIVATE_KEY", &auth.nsec);
+        if let Some(auth_tag) = &auth.auth_tag {
+            command.env("BUZZ_AUTH_TAG", auth_tag);
+        }
         entries.push((
             "credential.helper",
             credential_helper_config_value(cred_helper),
@@ -200,7 +213,7 @@ fn apply_git_config(command: &mut Command, entries: &[(&str, String)]) {
 
 pub(crate) fn build_git_auth_config(state: &AppState) -> Result<GitAuthConfig, String> {
     let keys = state.signing_keys()?;
-    build_git_auth_config_for_keys(&keys)
+    build_git_auth_config_for_keys(&keys, None)
 }
 
 pub(crate) fn build_git_clone_auth_config(
@@ -213,13 +226,17 @@ pub(crate) fn build_git_clone_auth_config(
                 .ok_or_else(|| "git was not found on PATH".to_string())?,
             credential_helper: None,
             nsec: String::new(),
+            auth_tag: None,
             allow_file_transport: false,
         });
     }
     build_git_auth_config(state)
 }
 
-pub(crate) fn build_git_auth_config_for_keys(keys: &Keys) -> Result<GitAuthConfig, String> {
+pub(crate) fn build_git_auth_config_for_keys(
+    keys: &Keys,
+    auth_tag: Option<&str>,
+) -> Result<GitAuthConfig, String> {
     let git_path = resolve_command("git").ok_or_else(|| "git was not found on PATH".to_string())?;
     let credential_helper = resolve_command("git-credential-nostr");
     let nsec = keys
@@ -230,13 +247,14 @@ pub(crate) fn build_git_auth_config_for_keys(keys: &Keys) -> Result<GitAuthConfi
         git_path,
         credential_helper,
         nsec,
+        auth_tag: auth_tag.map(ToString::to_string),
         allow_file_transport: false,
     })
 }
 
 #[cfg(test)]
 pub(crate) fn build_test_git_auth_config() -> Result<GitAuthConfig, String> {
-    let mut auth = build_git_auth_config_for_keys(&Keys::generate())?;
+    let mut auth = build_git_auth_config_for_keys(&Keys::generate(), None)?;
     auth.allow_file_transport = true;
     Ok(auth)
 }
@@ -393,10 +411,77 @@ fn validate_clone_url_against_relay(clone_url: &str, relay_base: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        clean_branch, clean_target_ref, credential_helper_config_value, git_needs_credentials,
-        git_subcommand, validate_clone_url, validate_clone_url_against_relay,
-        validate_local_clone_url,
+        clean_branch, clean_target_ref, configure_git_auth, credential_helper_config_value,
+        git_needs_credentials, git_subcommand, validate_clone_url,
+        validate_clone_url_against_relay, validate_local_clone_url, GitAuthConfig,
     };
+
+    fn command_env(command: &std::process::Command, key: &str) -> Option<String> {
+        command
+            .get_envs()
+            .find(|(name, _)| *name == key)
+            .and_then(|(_, value)| value)
+            .map(|value| value.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn remote_git_auth_includes_managed_agent_owner_attestation() {
+        let auth = GitAuthConfig {
+            git_path: "git".into(),
+            credential_helper: Some("git-credential-nostr".into()),
+            nsec: "nsec1agent".into(),
+            auth_tag: Some("[\"auth\",\"owner\",\"\",\"signature\"]".into()),
+            allow_file_transport: false,
+        };
+        let mut command = std::process::Command::new("git");
+
+        configure_git_auth(&mut command, &auth, true);
+
+        assert_eq!(
+            command_env(&command, "BUZZ_AUTH_TAG").as_deref(),
+            Some("[\"auth\",\"owner\",\"\",\"signature\"]")
+        );
+    }
+
+    #[test]
+    fn git_auth_clears_inherited_credentials_when_not_needed() {
+        let auth = GitAuthConfig {
+            git_path: "git".into(),
+            credential_helper: Some("git-credential-nostr".into()),
+            nsec: "nsec1agent".into(),
+            auth_tag: Some("[\"auth\",\"owner\",\"\",\"signature\"]".into()),
+            allow_file_transport: false,
+        };
+        let mut command = std::process::Command::new("git");
+        command.env("NOSTR_PRIVATE_KEY", "inherited-key");
+        command.env("BUZZ_AUTH_TAG", "inherited-tag");
+
+        configure_git_auth(&mut command, &auth, false);
+
+        assert_eq!(command_env(&command, "NOSTR_PRIVATE_KEY"), None);
+        assert_eq!(command_env(&command, "BUZZ_AUTH_TAG"), None);
+    }
+
+    #[test]
+    fn direct_member_remote_git_clears_inherited_owner_attestation() {
+        let auth = GitAuthConfig {
+            git_path: "git".into(),
+            credential_helper: Some("git-credential-nostr".into()),
+            nsec: "nsec1member".into(),
+            auth_tag: None,
+            allow_file_transport: false,
+        };
+        let mut command = std::process::Command::new("git");
+        command.env("BUZZ_AUTH_TAG", "inherited-tag");
+
+        configure_git_auth(&mut command, &auth, true);
+
+        assert_eq!(command_env(&command, "BUZZ_AUTH_TAG"), None);
+        assert_eq!(
+            command_env(&command, "NOSTR_PRIVATE_KEY").as_deref(),
+            Some("nsec1member")
+        );
+    }
 
     #[test]
     fn credential_helper_config_value_uses_forward_slashes() {

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -104,6 +104,12 @@ struct ProjectOwnerIdentity {
     auth_tag: Option<String>,
 }
 
+impl ProjectOwnerIdentity {
+    fn git_auth_config(&self) -> Result<GitAuthConfig, String> {
+        build_git_auth_config_for_keys(&self.keys, self.auth_tag.as_deref())
+    }
+}
+
 fn project_owner_identity(
     app: &AppHandle,
     state: &AppState,
@@ -548,7 +554,7 @@ pub async fn merge_project_pull_request(
         &pull_request_id,
         &pull_request_author,
     )?;
-    let auth = build_git_auth_config_for_keys(&owner_identity.keys)?;
+    let auth = owner_identity.git_auth_config()?;
 
     let git_result = tauri::async_runtime::spawn_blocking(
         move || -> Result<ProjectRepoMergeGitResult, ProjectPullRequestMergeError> {
@@ -684,10 +690,25 @@ mod tests {
     use super::{
         align_unborn_head_branch, build_merged_status_event, build_pull_request_status_event,
         build_review_request_event, normalize_commit, same_repository,
-        validate_merge_status_metadata,
+        validate_merge_status_metadata, ProjectOwnerIdentity,
     };
     use crate::commands::project_git_exec::{build_test_git_auth_config, run_git};
     use nostr::{Event, JsonUtil, Keys, Timestamp};
+
+    #[test]
+    fn managed_agent_owner_attestation_reaches_merge_git_auth() {
+        let identity = ProjectOwnerIdentity {
+            keys: Keys::generate(),
+            auth_tag: Some("[\"auth\",\"owner\",\"\",\"signature\"]".into()),
+        };
+
+        let auth = identity.git_auth_config().expect("build owner git auth");
+
+        assert_eq!(
+            auth.auth_tag(),
+            Some("[\"auth\",\"owner\",\"\",\"signature\"]")
+        );
+    }
 
     #[test]
     fn empty_clone_uses_requested_default_branch() {


### PR DESCRIPTION
## Summary
- carry the managed-agent owner's NIP-OA auth tag into Git credential-helper subprocesses used by PR merge
- clear inherited Nostr key and delegation environment variables before configuring each Git command
- add regression coverage for workflow propagation and stale credential isolation

## Root cause
The merge workflow resolved both the managed-agent key and its owner attestation, but built `GitAuthConfig` from the key alone. `git-credential-nostr` therefore signed clone/fetch/push requests without `BUZZ_AUTH_TAG`, and membership-restricted relays rejected the managed-agent identity with `403 restricted: not a relay member`.

The credential helper and relay already support NIP-OA owner delegation; this change preserves that existing contract at the Desktop Git subprocess boundary.

## Testing
- `just desktop-tauri-test` (2,274 passed, 14 ignored)
- `cargo test -p git-credential-nostr` (8 passed)
- `just desktop-tauri-clippy`
- `git diff --check`

Related to #2316.