### PR TITLE
fix(desktop): wrap markdown table cells in narrow thread panel

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1652,12 +1652,12 @@ function createMarkdownComponents(
     ),
     table: ({ children }) => <MarkdownTable>{children}</MarkdownTable>,
     td: ({ children }) => (
-      <td className="border-t border-border/70 px-3 py-2 align-top">
+      <td className="border-t border-border/70 px-3 py-2 align-top break-words">
         {children}
       </td>
     ),
     th: ({ children }) => (
-      <th className="bg-muted/60 px-3 py-2 font-semibold text-foreground">
+      <th className="bg-muted/60 px-3 py-2 font-semibold text-foreground break-words">
         {children}
       </th>
     ),

--- a/desktop/src/shared/ui/markdown/MarkdownTable.tsx
+++ b/desktop/src/shared/ui/markdown/MarkdownTable.tsx
@@ -12,7 +12,7 @@ export function MarkdownTable({ children }: { children?: React.ReactNode }) {
       className="overflow-x-auto rounded-2xl border border-border/70"
       data-table-block=""
     >
-      <table className="w-max min-w-full border-collapse text-left text-sm">
+      <table className="w-full table-fixed border-collapse text-left text-sm">
         {children}
       </table>
     </div>


### PR DESCRIPTION
## Summary
In the desktop thread panel, markdown tables with a long second column were clipped at the panel edge because the table used `w-max` and the cells had no wrapping rule. This change switches the table to `w-full table-fixed` and adds `break-words` to `td`/`th` so long cell content wraps within the available width.

### Related issue
Fixes #5313

### Testing
- `cd desktop && pnpm typecheck` — passed
- `cd desktop && pnpm check` — passed (no new lint/file-size/px-text/pubkey issues)
- `pnpm build:e2e` succeeded
- Captured Playwright screenshots in the mock thread panel:

**Before — text clipped at the panel edge:**
![before](https://raw.githubusercontent.com/block/buzz/1f282ce009bc8d1759833e85084047b9a33da5ed/pr-5315--01-before.png)

**After — long cell text wraps within the thread panel:**
![after](https://raw.githubusercontent.com/block/buzz/1f282ce009bc8d1759833e85084047b9a33da5ed/pr-5315--02-after.png)