### PR TITLE
feat(runtime-config): add unified MCP config model with Hermes and Kimi Code adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,6 +1270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-runtime-config"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "buzz-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/buzz-pairing-cli",
     "crates/buzz-sdk",
     "crates/buzz-persona",
+    "crates/buzz-runtime-config",
     "crates/git-credential-nostr",
     "crates/git-sign-nostr",
     "crates/buzz-pair-relay",

--- a/crates/buzz-runtime-config/Cargo.toml
+++ b/crates/buzz-runtime-config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "buzz-runtime-config"
+version = "0.1.0"
+edition = "2021"
+description = "Runtime-agnostic MCP/Skill configuration model with read-only adapters for external agent frameworks (Hermes, Kimi Code)"
+license = "Apache-2.0"
+repository = "https://github.com/block/sprout"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/buzz-runtime-config/examples/mcp_launch_mapper.rs
+++ b/crates/buzz-runtime-config/examples/mcp_launch_mapper.rs
@@ -17,6 +17,14 @@ use buzz_runtime_config::McpServerConfig;
 fn redacted_json(doc: &McpLaunchConfigDocument) -> serde_json::Value {
     let mut value = serde_json::to_value(doc).expect("doc serializes");
     for server in value["servers"].as_array_mut().expect("servers array") {
+        // Arguments may carry secrets too (e.g. an API key passed as a CLI
+        // flag), so redact both args and environment values before emitting
+        // a shareable sample.
+        if let Some(args) = server["args"].as_array_mut() {
+            for arg in args.iter_mut() {
+                *arg = serde_json::Value::String("***".to_string());
+            }
+        }
         if let Some(env) = server["env"].as_object_mut() {
             for val in env.values_mut() {
                 *val = serde_json::Value::String("***".to_string());
@@ -46,9 +54,9 @@ fn main() {
             path.display()
         )
     });
-    let doc = McpLaunchConfigDocument::from_runtime_config(&native);
-    doc.validate()
-        .unwrap_or_else(|err| panic!("mapped document is invalid: {err}"));
+    let doc = McpLaunchConfigDocument::from_runtime_config(&native).unwrap_or_else(|err| {
+        panic!("mapped document is invalid (no launch document can be built): {err}")
+    });
 
     let total = native.servers.len();
     let enabled = native

--- a/crates/buzz-runtime-config/examples/mcp_launch_mapper.rs
+++ b/crates/buzz-runtime-config/examples/mcp_launch_mapper.rs
@@ -1,0 +1,76 @@
+//! Map a native Hermes MCP config into the versioned stdio MCP launch
+//! document (buzz-core `mcp_config` v1).
+//!
+//! Usage:
+//!   cargo run -p buzz-runtime-config --example mcp_launch_mapper [PATH]
+//!
+//! `PATH` defaults to `~/.hermes/config.yaml`. The output is the versioned
+//! launch document (JSON) with environment values redacted so it is safe to
+//! paste into a PR comment or log. Pass `--no-redact` to emit full env values
+//! (only if you are launching an agent locally and trust the output channel).
+use std::path::PathBuf;
+
+use buzz_runtime_config::hermes;
+use buzz_runtime_config::launch::{to_launch_json, McpLaunchConfigDocument};
+use buzz_runtime_config::McpServerConfig;
+
+fn redacted_json(doc: &McpLaunchConfigDocument) -> serde_json::Value {
+    let mut value = serde_json::to_value(doc).expect("doc serializes");
+    for server in value["servers"].as_array_mut().expect("servers array") {
+        if let Some(env) = server["env"].as_object_mut() {
+            for val in env.values_mut() {
+                *val = serde_json::Value::String("***".to_string());
+            }
+        }
+    }
+    value
+}
+
+fn main() {
+    let mut redact = true;
+    let mut path: PathBuf = std::env::home_dir()
+        .expect("home dir")
+        .join(".hermes")
+        .join("config.yaml");
+    for arg in std::env::args().skip(1) {
+        if arg == "--no-redact" {
+            redact = false;
+        } else {
+            path = PathBuf::from(arg);
+        }
+    }
+
+    let native = hermes::read_mcp_config(&path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read native Hermes config {}: {err}",
+            path.display()
+        )
+    });
+    let doc = McpLaunchConfigDocument::from_runtime_config(&native);
+    doc.validate()
+        .unwrap_or_else(|err| panic!("mapped document is invalid: {err}"));
+
+    let total = native.servers.len();
+    let enabled = native
+        .servers
+        .iter()
+        .filter(|s: &&McpServerConfig| s.is_enabled())
+        .count();
+    let json = if redact {
+        redacted_json(&doc)
+    } else {
+        // Also verify the raw launch bytes encode cleanly (validates env fully).
+        let bytes = to_launch_json(&native).expect("launch document encodes");
+        serde_json::from_slice(&bytes).expect("parses")
+    };
+
+    println!("// source: {}", path.display());
+    println!(
+        "// runtime shortlist: {enabled}/{total} native servers enabled -> {} launch entries",
+        doc.servers().len()
+    );
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json).expect("pretty json")
+    );
+}

--- a/crates/buzz-runtime-config/src/error.rs
+++ b/crates/buzz-runtime-config/src/error.rs
@@ -12,6 +12,12 @@ pub enum ConfigError {
     #[error("failed to parse JSON: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("config file exceeds the {limit} byte limit")]
+    TooLarge {
+        /// Maximum config size accepted by the adapter.
+        limit: u64,
+    },
+
     #[error("invalid configuration: {0}")]
     Validation(String),
 }

--- a/crates/buzz-runtime-config/src/error.rs
+++ b/crates/buzz-runtime-config/src/error.rs
@@ -1,0 +1,17 @@
+//! Error types for runtime config adapters.
+
+/// Errors returned when reading or validating a runtime's MCP configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to parse YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    #[error("failed to parse JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("invalid configuration: {0}")]
+    Validation(String),
+}

--- a/crates/buzz-runtime-config/src/hermes.rs
+++ b/crates/buzz-runtime-config/src/hermes.rs
@@ -1,0 +1,187 @@
+//! Read-only adapter for Hermes MCP configuration.
+//!
+//! Hermes keeps its configuration in `~/.hermes/config.yaml`. MCP servers
+//! live under the top-level `mcp_servers` map:
+//!
+//! ```yaml
+//! mcp_servers:
+//!   sciverse:
+//!     command: npx
+//!     args: ["-y", "@sciverse/mcp"]
+//!     env:
+//!       SCIVERSE_API_TOKEN: "..."
+//!     enabled: true
+//! ```
+//!
+//! Only `mcp_servers` is read; every other top-level key in the file is
+//! ignored, so unrelated Hermes settings never fail parsing here.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::ConfigError;
+use crate::model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig};
+
+/// Default location of the Hermes config file (`~/.hermes/config.yaml`).
+/// Returns `None` when the home directory cannot be determined.
+pub fn default_config_path() -> Option<PathBuf> {
+    std::env::home_dir().map(|h| h.join(".hermes").join("config.yaml"))
+}
+
+/// Read and validate MCP servers from a Hermes `config.yaml`.
+pub fn read_mcp_config(path: &Path) -> Result<RuntimeMcpConfig, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    parse_mcp_config(&content)
+}
+
+/// Parse and validate MCP servers from Hermes `config.yaml` content.
+pub fn parse_mcp_config(content: &str) -> Result<RuntimeMcpConfig, ConfigError> {
+    let raw: RawHermesConfig = serde_yaml::from_str(content)?;
+    let mut servers: Vec<McpServerConfig> = raw
+        .mcp_servers
+        .into_iter()
+        .map(|(name, srv)| McpServerConfig {
+            name,
+            command: srv.command,
+            args: srv.args,
+            env: srv.env,
+            enabled: srv.enabled,
+        })
+        .collect();
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
+    RuntimeMcpConfig {
+        runtime: RuntimeKind::Hermes,
+        servers,
+    }
+    .validated()
+}
+
+/// Intentionally permissive view of `config.yaml`: only `mcp_servers` is
+/// modeled. The real file carries many unrelated sections (teams, model
+/// aliases, ...); unknown keys are silently ignored.
+#[derive(Debug, Deserialize)]
+struct RawHermesConfig {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, RawHermesServer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawHermesServer {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_config_ignores_unrelated_sections() {
+        let yaml = r#"
+teams:
+  google_chat: {}
+mcp_servers:
+  sciverse:
+    command: npx
+    args:
+      - "-y"
+      - "@sciverse/mcp"
+    env:
+      SCIVERSE_API_TOKEN: "token-value"
+    enabled: true
+  local-tool:
+    command: uv
+    args: ["run", "tool"]
+    enabled: false
+model_aliases:
+  kimi-k3:
+    model: kimi-k3
+"#;
+        let cfg = parse_mcp_config(yaml).unwrap();
+        assert_eq!(cfg.runtime, RuntimeKind::Hermes);
+        assert_eq!(cfg.servers.len(), 2);
+
+        let local = &cfg.servers[0];
+        assert_eq!(local.name, "local-tool");
+        assert_eq!(local.command, "uv");
+        assert_eq!(local.args, vec!["run", "tool"]);
+        assert_eq!(local.enabled, Some(false));
+        assert!(!local.is_enabled());
+
+        let sci = &cfg.servers[1];
+        assert_eq!(sci.name, "sciverse");
+        assert_eq!(sci.command, "npx");
+        assert_eq!(sci.args, vec!["-y", "@sciverse/mcp"]);
+        assert_eq!(
+            sci.env.get("SCIVERSE_API_TOKEN").map(String::as_str),
+            Some("token-value")
+        );
+        assert_eq!(sci.enabled, Some(true));
+    }
+
+    #[test]
+    fn missing_mcp_servers_yields_empty_config() {
+        let cfg = parse_mcp_config("teams: {}\n").unwrap();
+        assert!(cfg.servers.is_empty());
+    }
+
+    #[test]
+    fn missing_optional_fields_default() {
+        let yaml = r#"
+mcp_servers:
+  minimal:
+    command: npx
+"#;
+        let cfg = parse_mcp_config(yaml).unwrap();
+        let s = &cfg.servers[0];
+        assert!(s.args.is_empty());
+        assert!(s.env.is_empty());
+        assert_eq!(s.enabled, None);
+        assert!(s.is_enabled());
+    }
+
+    #[test]
+    fn empty_command_is_a_validation_error() {
+        let yaml = r#"
+mcp_servers:
+  broken:
+    command: ""
+"#;
+        let err = parse_mcp_config(yaml).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(err.to_string().contains("broken"));
+    }
+
+    #[test]
+    fn malformed_yaml_errors() {
+        let err = parse_mcp_config("mcp_servers: [not, a, map").unwrap_err();
+        assert!(matches!(err, ConfigError::Yaml(_)));
+    }
+
+    #[test]
+    fn read_missing_file_errors() {
+        let err = read_mcp_config(Path::new("/nonexistent/config.yaml")).unwrap_err();
+        assert!(matches!(err, ConfigError::Io(_)));
+    }
+
+    #[test]
+    fn read_from_disk_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "mcp_servers:\n  t:\n    command: npx\n    enabled: true\n",
+        )
+        .unwrap();
+        let cfg = read_mcp_config(&path).unwrap();
+        assert_eq!(cfg.servers.len(), 1);
+        assert_eq!(cfg.servers[0].name, "t");
+    }
+}

--- a/crates/buzz-runtime-config/src/hermes.rs
+++ b/crates/buzz-runtime-config/src/hermes.rs
@@ -32,12 +32,13 @@ pub fn default_config_path() -> Option<PathBuf> {
 
 /// Read and validate MCP servers from a Hermes `config.yaml`.
 pub fn read_mcp_config(path: &Path) -> Result<RuntimeMcpConfig, ConfigError> {
-    let content = std::fs::read_to_string(path)?;
+    let content = crate::read_config(path)?;
     parse_mcp_config(&content)
 }
 
 /// Parse and validate MCP servers from Hermes `config.yaml` content.
 pub fn parse_mcp_config(content: &str) -> Result<RuntimeMcpConfig, ConfigError> {
+    crate::validate_config_size(content.len())?;
     let raw: RawHermesConfig = serde_yaml::from_str(content)?;
     let mut servers: Vec<McpServerConfig> = raw
         .mcp_servers
@@ -183,5 +184,26 @@ mcp_servers:
         let cfg = read_mcp_config(&path).unwrap();
         assert_eq!(cfg.servers.len(), 1);
         assert_eq!(cfg.servers[0].name, "t");
+    }
+
+    #[test]
+    fn oversized_config_is_rejected_before_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            vec![b'x'; crate::RUNTIME_CONFIG_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let err = read_mcp_config(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn oversized_in_memory_config_is_rejected_before_parsing() {
+        let content = "x".repeat(crate::RUNTIME_CONFIG_MAX_BYTES as usize + 1);
+        let err = parse_mcp_config(&content).unwrap_err();
+        assert!(matches!(err, ConfigError::TooLarge { .. }));
     }
 }

--- a/crates/buzz-runtime-config/src/kimi.rs
+++ b/crates/buzz-runtime-config/src/kimi.rs
@@ -48,12 +48,13 @@ pub fn default_config_path() -> Option<PathBuf> {
 
 /// Read and validate MCP servers from a Kimi Code `mcp.json`.
 pub fn read_mcp_config(path: &Path) -> Result<RuntimeMcpConfig, ConfigError> {
-    let content = std::fs::read_to_string(path)?;
+    let content = crate::read_config(path)?;
     parse_mcp_config(&content)
 }
 
 /// Parse and validate MCP servers from Kimi Code `mcp.json` content.
 pub fn parse_mcp_config(content: &str) -> Result<RuntimeMcpConfig, ConfigError> {
+    crate::validate_config_size(content.len())?;
     let raw: RawKimiConfig = serde_json::from_str(content)?;
     let mut servers: Vec<McpServerConfig> = raw
         .mcp_servers
@@ -202,5 +203,26 @@ mod tests {
         assert_eq!(cfg.servers.len(), 1);
         assert_eq!(cfg.servers[0].name, "t");
         assert_eq!(cfg.servers[0].enabled, Some(true));
+    }
+
+    #[test]
+    fn oversized_config_is_rejected_before_parsing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            vec![b'x'; crate::RUNTIME_CONFIG_MAX_BYTES as usize + 1],
+        )
+        .unwrap();
+
+        let err = read_mcp_config(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn oversized_in_memory_config_is_rejected_before_parsing() {
+        let content = "x".repeat(crate::RUNTIME_CONFIG_MAX_BYTES as usize + 1);
+        let err = parse_mcp_config(&content).unwrap_err();
+        assert!(matches!(err, ConfigError::TooLarge { .. }));
     }
 }

--- a/crates/buzz-runtime-config/src/kimi.rs
+++ b/crates/buzz-runtime-config/src/kimi.rs
@@ -1,0 +1,206 @@
+//! Read-only adapter for Kimi Code MCP configuration.
+//!
+//! Kimi Code keeps its MCP configuration in `~/.kimi-code/mcp.json`
+//! (or `$KIMI_CODE_HOME/mcp.json`). MCP servers live under the top-level
+//! `mcpServers` map:
+//!
+//! ```json
+//! {
+//!   "mcpServers": {
+//!     "sciverse": {
+//!       "command": "npx",
+//!       "args": ["-y", "sciverse-mcp-server"],
+//!       "env": { "SCIVERSE_API_TOKEN": "..." }
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! Only `mcpServers` is read; every other top-level key in the file is
+//! ignored, so unrelated settings never fail parsing here.
+//!
+//! Limitations (PR-0 scope): the unified model currently covers stdio
+//! servers only. Kimi Code also supports HTTP/SSE servers declared with a
+//! `url` field instead of `command` (plus `headers`, `bearerTokenEnvVar`,
+//! `transport: "sse"`); such entries surface here as a validation error
+//! naming the server rather than being silently dropped. Timeouts and tool
+//! allow/block lists (`startupTimeoutMs`, `toolTimeoutMs`, `enabledTools`,
+//! `disabledTools`) are likewise not modeled yet.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::ConfigError;
+use crate::model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig};
+
+/// Default location of the Kimi Code MCP config file
+/// (`$KIMI_CODE_HOME/mcp.json`, else `~/.kimi-code/mcp.json`).
+/// Returns `None` when neither is set and the home directory cannot be
+/// determined.
+pub fn default_config_path() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("KIMI_CODE_HOME") {
+        return Some(PathBuf::from(home).join("mcp.json"));
+    }
+    std::env::home_dir().map(|h| h.join(".kimi-code").join("mcp.json"))
+}
+
+/// Read and validate MCP servers from a Kimi Code `mcp.json`.
+pub fn read_mcp_config(path: &Path) -> Result<RuntimeMcpConfig, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    parse_mcp_config(&content)
+}
+
+/// Parse and validate MCP servers from Kimi Code `mcp.json` content.
+pub fn parse_mcp_config(content: &str) -> Result<RuntimeMcpConfig, ConfigError> {
+    let raw: RawKimiConfig = serde_json::from_str(content)?;
+    let mut servers: Vec<McpServerConfig> = raw
+        .mcp_servers
+        .into_iter()
+        .map(|(name, srv)| McpServerConfig {
+            name,
+            command: srv.command,
+            args: srv.args,
+            env: srv.env,
+            enabled: srv.enabled,
+        })
+        .collect();
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
+    RuntimeMcpConfig {
+        runtime: RuntimeKind::KimiCode,
+        servers,
+    }
+    .validated()
+}
+
+/// Intentionally permissive view of `mcp.json`: only `mcpServers` is
+/// modeled. Unknown keys are silently ignored.
+#[derive(Debug, Deserialize)]
+struct RawKimiConfig {
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, RawKimiServer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawKimiServer {
+    /// Empty for HTTP/SSE (`url`-based) servers, which the unified model
+    /// does not represent yet; validation rejects them loudly.
+    #[serde(default)]
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    /// Kimi Code supports `enabled` (default: enabled). Absent maps to
+    /// `None`, which [`McpServerConfig::is_enabled`] treats as enabled.
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_config_ignores_unrelated_keys() {
+        let json = r#"{
+            "someOtherSetting": true,
+            "mcpServers": {
+                "sciverse": {
+                    "command": "npx",
+                    "args": ["-y", "sciverse-mcp-server"],
+                    "env": {"SCIVERSE_API_TOKEN": "token-value"}
+                },
+                "local-tool": {
+                    "command": "uv",
+                    "args": ["run", "tool"],
+                    "enabled": false
+                }
+            }
+        }"#;
+        let cfg = parse_mcp_config(json).unwrap();
+        assert_eq!(cfg.runtime, RuntimeKind::KimiCode);
+        assert_eq!(cfg.servers.len(), 2);
+
+        let local = &cfg.servers[0];
+        assert_eq!(local.name, "local-tool");
+        assert_eq!(local.command, "uv");
+        assert_eq!(local.args, vec!["run", "tool"]);
+        assert_eq!(local.enabled, Some(false));
+        assert!(!local.is_enabled());
+
+        let sci = &cfg.servers[1];
+        assert_eq!(sci.name, "sciverse");
+        assert_eq!(sci.command, "npx");
+        assert_eq!(sci.args, vec!["-y", "sciverse-mcp-server"]);
+        assert_eq!(
+            sci.env.get("SCIVERSE_API_TOKEN").map(String::as_str),
+            Some("token-value")
+        );
+        assert_eq!(sci.enabled, None);
+        assert!(sci.is_enabled());
+    }
+
+    #[test]
+    fn missing_mcp_servers_yields_empty_config() {
+        let cfg = parse_mcp_config("{}").unwrap();
+        assert!(cfg.servers.is_empty());
+    }
+
+    #[test]
+    fn missing_optional_fields_default() {
+        let json = r#"{"mcpServers": {"minimal": {"command": "npx"}}}"#;
+        let cfg = parse_mcp_config(json).unwrap();
+        let s = &cfg.servers[0];
+        assert!(s.args.is_empty());
+        assert!(s.env.is_empty());
+        assert_eq!(s.enabled, None);
+        assert!(s.is_enabled());
+    }
+
+    #[test]
+    fn empty_command_is_a_validation_error() {
+        // Also how `url`-based (HTTP/SSE) servers surface until the unified
+        // model grows a transport field: loud error, never silently dropped.
+        let json = r#"{"mcpServers": {"broken": {"command": ""}}}"#;
+        let err = parse_mcp_config(json).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(err.to_string().contains("broken"));
+    }
+
+    #[test]
+    fn url_based_server_is_rejected_loudly() {
+        let json = r#"{"mcpServers": {"remote": {"url": "https://mcp.example.com/mcp"}}}"#;
+        let err = parse_mcp_config(json).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(err.to_string().contains("remote"));
+    }
+
+    #[test]
+    fn malformed_json_errors() {
+        let err = parse_mcp_config("{\"mcpServers\": [not, a, map").unwrap_err();
+        assert!(matches!(err, ConfigError::Json(_)));
+    }
+
+    #[test]
+    fn read_missing_file_errors() {
+        let err = read_mcp_config(Path::new("/nonexistent/mcp.json")).unwrap_err();
+        assert!(matches!(err, ConfigError::Io(_)));
+    }
+
+    #[test]
+    fn read_from_disk_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers": {"t": {"command": "npx", "enabled": true}}}"#,
+        )
+        .unwrap();
+        let cfg = read_mcp_config(&path).unwrap();
+        assert_eq!(cfg.servers.len(), 1);
+        assert_eq!(cfg.servers[0].name, "t");
+        assert_eq!(cfg.servers[0].enabled, Some(true));
+    }
+}

--- a/crates/buzz-runtime-config/src/launch.rs
+++ b/crates/buzz-runtime-config/src/launch.rs
@@ -250,6 +250,24 @@ impl McpLaunchConfigDocument {
                 }
             }
         }
+
+        // Enforce the 64 KiB *encoded* size too, not just the raw string byte
+        // sum above. Raw bytes are a necessary but not sufficient bound: JSON
+        // escaping (e.g. a newline -> `\n`, a quote -> `\"`) only ever expands
+        // a document, so a doc whose raw strings are under the limit can still
+        // encode to more than the wire bound. Because construction (and this
+        // `validate`) is the only gate a `McpLaunchConfigDocument` can pass
+        // through, checking the encoded size here closes the `Serialize` path
+        // where a caller could otherwise `serde_json::to_vec` a constructible
+        // document straight out, bypassing `to_json`'s size check.
+        let encoded =
+            serde_json::to_vec(self).map_err(|err| LaunchMapError::Encode(err.to_string()))?;
+        if encoded.len() as u64 > MCP_CONFIG_MAX_BYTES {
+            return Err(LaunchMapError::Invalid(format!(
+                "MCP config exceeds the {MCP_CONFIG_MAX_BYTES} byte limit after JSON encoding"
+            )));
+        }
+
         Ok(())
     }
 }
@@ -472,6 +490,25 @@ mod tests {
         // 64 KiB in-memory bound is enforced inline rather than after encode.
         let mut server = native("one", "npx", None);
         server.args = vec!["x".repeat(MCP_CONFIG_MAX_BYTES as usize + 1)];
+        let cfg = config(vec![server]);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("byte limit"));
+    }
+
+    #[test]
+    fn rejects_escape_expansion_past_encoded_limit() {
+        // Regression for the serialization bypass wolfyy970 flagged: raw string
+        // bytes are bounded at construction, but JSON escaping only ever expands
+        // a document. A raw value below the 64 KiB raw limit (e.g. a long string
+        // of newline characters) encodes to more than the wire bound because each
+        // newline becomes the two bytes `\n`. Construction must reject it — not
+        // just `to_json()` — so a caller cannot `serde_json::to_vec` a
+        // constructible-but-over-limit document directly.
+        let mut server = native("one", "npx", None);
+        // 40_000 raw newline bytes: comfortably under 64 KiB raw, but JSON
+        // escaping turns each into `\n` (2 bytes), pushing the encoded
+        // document past the 64 KiB limit.
+        server.args = vec!["\n".repeat(40_000)];
         let cfg = config(vec![server]);
         let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("byte limit"));

--- a/crates/buzz-runtime-config/src/launch.rs
+++ b/crates/buzz-runtime-config/src/launch.rs
@@ -1,0 +1,341 @@
+//! Mapper from the unified native model to the versioned stdio MCP launch
+//! document consumed by agent launchers.
+//!
+//! [`RuntimeMcpConfig`] is the runtime-agnostic view read from an external
+//! framework's native config (Hermes YAML / Kimi Code JSON). The launcher-side
+//! contract — the wire document that #5349 browser_harness consumes — is a
+//! separate, stricter, versioned shape. This module translates the former into
+//! the latter.
+//!
+//! The target schema mirrors buzz-core's `mcp_config` v1 launch document
+//! (`transport: "stdio"`), and mirrors its validation so a mapping that cannot
+//! be represented as a valid launch document is rejected loudly — an enabled
+//! native server whose name or environment fails the stricter launch-schema
+//! rules surfaces as an error naming the server, never silently dropped.
+use std::collections::{BTreeMap, HashSet};
+
+use serde::Serialize;
+
+use crate::model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig};
+
+/// Wire-schema version of the launch document we emit (buzz-core v1).
+pub const MCP_LAUNCH_DOC_VERSION: u32 = 1;
+/// Transport tag of the emitted launch entries (v1 supports stdio only).
+pub const STDIO_TRANSPORT: &str = "stdio";
+
+/// Harness identity/authorization variables the launch schema forbids a server
+/// from configuring. Kept in sync with buzz-core's `PROTECTED_MCP_ENV_NAMES`.
+pub const PROTECTED_MCP_ENV_NAMES: [&str; 6] = [
+    "BUZZ_PRIVATE_KEY",
+    "NOSTR_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_PRIVATE_KEY",
+    "BUZZ_ACP_API_TOKEN",
+];
+
+/// One native server mapped into launch-document form.
+///
+/// Field order and `serde` tagging match the versioned stdio MCP launch
+/// document so the emitted JSON is directly consumable by a parse.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LaunchStdioServer {
+    /// `transport` tag from the launch schema (always `"stdio"`).
+    #[serde(rename = "transport")]
+    transport: &'static str,
+    /// Stable server name.
+    name: String,
+    /// Executable invoked directly without shell parsing.
+    command: String,
+    /// Arguments passed to `command` in configured order.
+    args: Vec<String>,
+    /// Server-specific environment in deterministic key order.
+    env: BTreeMap<String, String>,
+}
+
+/// A versioned collection of stdio MCP servers ready for agent launch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct McpLaunchConfigDocument {
+    /// Wire-schema version.
+    version: u32,
+    /// Ordered stdio servers in launch order.
+    servers: Vec<LaunchStdioServer>,
+}
+
+impl McpLaunchConfigDocument {
+    /// Return the mapped launch entries in launch order.
+    pub fn servers(&self) -> &[LaunchStdioServer] {
+        &self.servers
+    }
+
+    /// Map every *enabled* native server into a versioned stdio launch
+    /// document.
+    ///
+    /// Disabled servers (`enabled: Some(false)`) are excluded. Servers whose
+    /// native entry does not specify `enabled` (treat as enabled) are included.
+    /// Field values map 1:1 from the native entry into the launch entry.
+    pub fn from_runtime_config(config: &RuntimeMcpConfig) -> Self {
+        let servers = config
+            .servers
+            .iter()
+            .filter(|server| server.is_enabled())
+            .map(native_to_launch)
+            .collect();
+        Self {
+            version: MCP_LAUNCH_DOC_VERSION,
+            servers,
+        }
+    }
+
+    /// Encode this document as JSON after validating it against the launch
+    /// schema (mirrors `buzz-core::mcp_config::McpLaunchConfigDocument`).
+    pub fn to_json(&self) -> Result<Vec<u8>, LaunchMapError> {
+        self.validate()?;
+        serde_json::to_vec(self).map_err(|err| LaunchMapError::Encode(err.to_string()))
+    }
+
+    /// Validate the mapped document against the launch-schema rules. Returns
+    /// an error naming the first offending server; a document that validates
+    /// here is guaranteed to be accepted by the launch-schema parser.
+    pub fn validate(&self) -> Result<(), LaunchMapError> {
+        if self.version != MCP_LAUNCH_DOC_VERSION {
+            return Err(LaunchMapError::Invalid(format!(
+                "unsupported MCP config version {} (expected {MCP_LAUNCH_DOC_VERSION})",
+                self.version
+            )));
+        }
+        let mut names = HashSet::with_capacity(self.servers.len());
+        for server in &self.servers {
+            if !valid_server_name(&server.name) {
+                return Err(LaunchMapError::Invalid(format!(
+                    "MCP server '{}' has invalid name: use 1..=128 ASCII letters, digits, underscores, or hyphens, without '__'",
+                    server.name
+                )));
+            }
+            if !names.insert(server.name.as_str()) {
+                return Err(LaunchMapError::Invalid(format!(
+                    "duplicate MCP server name '{}'",
+                    server.name
+                )));
+            }
+            if server.command.trim().is_empty() || server.command.contains('\0') {
+                return Err(LaunchMapError::Invalid(format!(
+                    "MCP server '{}' command must not be blank and must contain no NUL bytes",
+                    server.name
+                )));
+            }
+            if server.args.iter().any(|argument| argument.contains('\0')) {
+                return Err(LaunchMapError::Invalid(format!(
+                    "MCP server '{}' arguments must contain no NUL bytes",
+                    server.name
+                )));
+            }
+            let mut env_names = HashSet::with_capacity(server.env.len());
+            for (key, value) in &server.env {
+                if !valid_env_name(key) {
+                    return Err(LaunchMapError::Invalid(format!(
+                        "MCP server '{}' environment key '{key}' is invalid (must start with an ASCII letter or '_' and contain only letters, digits, '_')",
+                        server.name
+                    )));
+                }
+                if !env_names.insert(key.to_ascii_uppercase()) {
+                    return Err(LaunchMapError::Invalid(format!(
+                        "MCP server '{}' has environment keys that differ only by ASCII case",
+                        server.name
+                    )));
+                }
+                if PROTECTED_MCP_ENV_NAMES
+                    .iter()
+                    .any(|protected| key.eq_ignore_ascii_case(protected))
+                {
+                    return Err(LaunchMapError::Invalid(format!(
+                        "MCP server '{}' may not configure a protected environment key",
+                        server.name
+                    )));
+                }
+                if value.contains('\0') {
+                    return Err(LaunchMapError::Invalid(format!(
+                        "MCP server '{}' environment entry '{key}' contains a NUL byte",
+                        server.name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Map one native server into launch-document form. Field values are copied
+/// verbatim — this mapper performs a structural translation, not a value
+/// rewrite.
+fn native_to_launch(server: &McpServerConfig) -> LaunchStdioServer {
+    LaunchStdioServer {
+        transport: STDIO_TRANSPORT,
+        name: server.name.clone(),
+        command: server.command.clone(),
+        args: server.args.clone(),
+        env: server.env.clone(),
+    }
+}
+
+/// Mirror of the launch-schema's `valid_mcp_server_name`.
+fn valid_server_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && !name.contains("__")
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+/// Mirror of the launch-schema's `valid_mcp_env_name`.
+fn valid_env_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(byte) if byte.is_ascii_alphabetic() || byte == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+/// A mapping-time failure: either the document cannot be encoded or a mapped
+/// server would not be accepted by the launch schema.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LaunchMapError {
+    /// The document violates the launch schema.
+    #[error("{0}")]
+    Invalid(String),
+    /// The document is valid but failed to serialize.
+    #[error("failed to encode MCP launch document: {0}")]
+    Encode(String),
+}
+
+/// Convenience: map a native runtime config straight to encoded launch JSON.
+///
+/// Returns the encoded document bytes on success. On failure, names the
+/// offending server.
+pub fn to_launch_json(config: &RuntimeMcpConfig) -> Result<Vec<u8>, LaunchMapError> {
+    let document = McpLaunchConfigDocument::from_runtime_config(config);
+    document.to_json()
+}
+
+/// Human-readable runtime label for diagnostics.
+pub fn runtime_label(runtime: RuntimeKind) -> &'static str {
+    match runtime {
+        RuntimeKind::Hermes => "Hermes",
+        RuntimeKind::KimiCode => "Kimi Code",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn native(name: &str, command: &str, enabled: Option<bool>) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: vec![],
+            env: BTreeMap::new(),
+            enabled,
+        }
+    }
+
+    fn config(servers: Vec<McpServerConfig>) -> RuntimeMcpConfig {
+        RuntimeMcpConfig {
+            runtime: RuntimeKind::Hermes,
+            servers,
+        }
+    }
+
+    #[test]
+    fn maps_enabled_servers_and_skips_disabled() {
+        let cfg = config(vec![
+            native("on", "npx", Some(true)),
+            native("off", "npx", Some(false)),
+            native("unset", "uv", None),
+        ]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
+        let names: Vec<_> = doc.servers.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["on", "unset"]);
+        assert_eq!(doc.version, MCP_LAUNCH_DOC_VERSION);
+    }
+
+    #[test]
+    fn wire_carries_stdio_transport_tag() {
+        let cfg = config(vec![native("sciverse", "npx", None)]);
+        let json =
+            serde_json::to_value(McpLaunchConfigDocument::from_runtime_config(&cfg)).unwrap();
+        assert_eq!(json["version"], 1);
+        assert_eq!(json["servers"][0]["transport"], "stdio");
+        assert_eq!(json["servers"][0]["name"], "sciverse");
+        assert_eq!(json["servers"][0]["command"], "npx");
+    }
+
+    #[test]
+    fn maps_env_verbatim() {
+        let mut server = native("sciverse", "npx", None);
+        server
+            .args
+            .extend(["-y".to_string(), "sciverse-mcp-server".to_string()]);
+        server
+            .env
+            .insert("SCIVERSE_API_TOKEN".to_string(), "token-value".to_string());
+        let cfg = config(vec![server]);
+        let json =
+            serde_json::to_value(McpLaunchConfigDocument::from_runtime_config(&cfg)).unwrap();
+        assert_eq!(json["servers"][0]["args"][0], "-y");
+        assert_eq!(
+            json["servers"][0]["env"]["SCIVERSE_API_TOKEN"],
+            "token-value"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_names() {
+        let cfg = config(vec![native("dup", "npx", None), native("dup", "uv", None)]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
+        let err = doc.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate MCP server name"));
+    }
+
+    #[test]
+    fn rejects_protected_env_key() {
+        let mut server = native("one", "npx", None);
+        server
+            .env
+            .insert("BUZZ_PRIVATE_KEY".to_string(), "secret".to_string());
+        let cfg = config(vec![server]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
+        let err = doc.validate().unwrap_err();
+        assert!(err.to_string().contains("protected environment key"));
+    }
+
+    #[test]
+    fn rejects_env_keys_differing_only_by_case() {
+        let mut server = native("one", "npx", None);
+        server.env.insert("Token".to_string(), "a".to_string());
+        server.env.insert("TOKEN".to_string(), "b".to_string());
+        let cfg = config(vec![server]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
+        let err = doc.validate().unwrap_err();
+        assert!(err.to_string().contains("differ only by ASCII case"));
+    }
+
+    #[test]
+    fn roundtrip_real_sciverse_entry_validates() {
+        // The real Hermes `sciverse` entry (redacted token) must map cleanly.
+        let mut server = native("sciverse", "npx", Some(true));
+        server
+            .args
+            .extend(["-y".to_string(), "sciverse-mcp-server".to_string()]);
+        server
+            .env
+            .insert("SCIVERSE_API_TOKEN".to_string(), "sci_redacted".to_string());
+        let cfg = config(vec![server]);
+        let bytes = to_launch_json(&cfg).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed["servers"][0]["name"], "sciverse");
+        assert_eq!(
+            parsed["servers"][0]["env"]["SCIVERSE_API_TOKEN"],
+            "sci_redacted"
+        );
+    }
+}

--- a/crates/buzz-runtime-config/src/launch.rs
+++ b/crates/buzz-runtime-config/src/launch.rs
@@ -8,10 +8,14 @@
 //! the latter.
 //!
 //! The target schema mirrors buzz-core's `mcp_config` v1 launch document
-//! (`transport: "stdio"`), and mirrors its validation so a mapping that cannot
-//! be represented as a valid launch document is rejected loudly — an enabled
-//! native server whose name or environment fails the stricter launch-schema
-//! rules surfaces as an error naming the server, never silently dropped.
+//! (`transport: "stdio"`), and mirrors its validation — including every one of
+//! #5349's hard limits — so a mapping that cannot be represented as a valid
+//! launch document is rejected loudly. Validation runs at **construction**
+//! ([`McpLaunchConfigDocument::from_runtime_config`]) rather than only at
+//! encode time, so an invalid document cannot even be instantiated, let alone
+//! serialized out through any `Serialize` path. An enabled native server whose
+//! name or environment fails the stricter launch-schema rules surfaces as an
+//! error naming the server, never silently dropped.
 use std::collections::{BTreeMap, HashSet};
 
 use serde::Serialize;
@@ -22,6 +26,19 @@ use crate::model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig};
 pub const MCP_LAUNCH_DOC_VERSION: u32 = 1;
 /// Transport tag of the emitted launch entries (v1 supports stdio only).
 pub const STDIO_TRANSPORT: &str = "stdio";
+
+// --- Limits mirrored from buzz-core `mcp_config` v1 (#5349) -----------------
+// These are kept in sync with the wire schema so that any document this crate
+// can build is, by construction, accepted by the launcher-side parser.
+
+/// Maximum number of MCP servers in one launch document.
+pub const MCP_SERVER_MAX_COUNT: usize = 16;
+/// Maximum number of arguments for one stdio MCP server.
+pub const MCP_SERVER_MAX_ARGS: usize = 128;
+/// Maximum number of environment entries for one stdio MCP server.
+pub const MCP_SERVER_MAX_ENV: usize = 128;
+/// Maximum encoded size accepted for one structured MCP configuration.
+pub const MCP_CONFIG_MAX_BYTES: u64 = 64 * 1024;
 
 /// Harness identity/authorization variables the launch schema forbids a server
 /// from configuring. Kept in sync with buzz-core's `PROTECTED_MCP_ENV_NAMES`.
@@ -38,7 +55,11 @@ pub const PROTECTED_MCP_ENV_NAMES: [&str; 6] = [
 ///
 /// Field order and `serde` tagging match the versioned stdio MCP launch
 /// document so the emitted JSON is directly consumable by a parse.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+///
+/// Note the manual [`Debug`] impl: it prints only the server name and the
+/// argument / environment *counts*. Arguments and environment values may
+/// contain secrets, so they are never echoed in debug output.
+#[derive(Clone, PartialEq, Eq, Serialize)]
 pub struct LaunchStdioServer {
     /// `transport` tag from the launch schema (always `"stdio"`).
     #[serde(rename = "transport")]
@@ -53,7 +74,22 @@ pub struct LaunchStdioServer {
     env: BTreeMap<String, String>,
 }
 
+impl std::fmt::Debug for LaunchStdioServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LaunchStdioServer")
+            .field("name", &self.name)
+            .field("arg_count", &self.args.len())
+            .field("env_count", &self.env.len())
+            .finish()
+    }
+}
+
 /// A versioned collection of stdio MCP servers ready for agent launch.
+///
+/// Validation runs at construction (`from_runtime_config`), so a valid
+/// [`McpLaunchConfigDocument`] is guaranteed to satisfy every launch-schema
+/// limit and to encode without leaking secrets through `Debug`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct McpLaunchConfigDocument {
     /// Wire-schema version.
@@ -69,34 +105,54 @@ impl McpLaunchConfigDocument {
     }
 
     /// Map every *enabled* native server into a versioned stdio launch
-    /// document.
+    /// document, validating each against the launch schema.
     ///
     /// Disabled servers (`enabled: Some(false)`) are excluded. Servers whose
     /// native entry does not specify `enabled` (treat as enabled) are included.
     /// Field values map 1:1 from the native entry into the launch entry.
-    pub fn from_runtime_config(config: &RuntimeMcpConfig) -> Self {
+    ///
+    /// Returns `Err` — rather than building a document — the moment any
+    /// mapped server would violate a launch-schema rule or one of #5349's hard
+    /// limits (server count, argument count, environment count, or the 64 KiB
+    /// wire-size bound). This makes an invalid document un-constructible, so it
+    /// cannot be serialized out through any `Serialize` path.
+    pub fn from_runtime_config(config: &RuntimeMcpConfig) -> Result<Self, LaunchMapError> {
         let servers = config
             .servers
             .iter()
             .filter(|server| server.is_enabled())
             .map(native_to_launch)
             .collect();
-        Self {
+        let document = Self {
             version: MCP_LAUNCH_DOC_VERSION,
             servers,
-        }
+        };
+        document.validate()?;
+        Ok(document)
     }
 
     /// Encode this document as JSON after validating it against the launch
     /// schema (mirrors `buzz-core::mcp_config::McpLaunchConfigDocument`).
     pub fn to_json(&self) -> Result<Vec<u8>, LaunchMapError> {
         self.validate()?;
-        serde_json::to_vec(self).map_err(|err| LaunchMapError::Encode(err.to_string()))
+        let encoded =
+            serde_json::to_vec(self).map_err(|err| LaunchMapError::Encode(err.to_string()))?;
+        if encoded.len() as u64 > MCP_CONFIG_MAX_BYTES {
+            return Err(LaunchMapError::Invalid(format!(
+                "MCP config exceeds the {MCP_CONFIG_MAX_BYTES} byte limit"
+            )));
+        }
+        Ok(encoded)
     }
 
     /// Validate the mapped document against the launch-schema rules. Returns
     /// an error naming the first offending server; a document that validates
     /// here is guaranteed to be accepted by the launch-schema parser.
+    ///
+    /// This mirrors `buzz-core::mcp_config` v1 validation exactly, including
+    /// its hard limits. Called from `from_runtime_config` so construction is
+    /// the gate; kept as a public method so `to_json` (and callers that have
+    /// not gone through `from_runtime_config`) get the same guarantees.
     pub fn validate(&self) -> Result<(), LaunchMapError> {
         if self.version != MCP_LAUNCH_DOC_VERSION {
             return Err(LaunchMapError::Invalid(format!(
@@ -104,8 +160,18 @@ impl McpLaunchConfigDocument {
                 self.version
             )));
         }
+        if self.servers.len() > MCP_SERVER_MAX_COUNT {
+            return Err(LaunchMapError::Invalid(format!(
+                "too many MCP servers ({} configured, max {MCP_SERVER_MAX_COUNT})",
+                self.servers.len()
+            )));
+        }
+        let mut raw_string_bytes = 0_u64;
         let mut names = HashSet::with_capacity(self.servers.len());
         for server in &self.servers {
+            add_string_bytes(&mut raw_string_bytes, &server.name)?;
+            add_string_bytes(&mut raw_string_bytes, &server.command)?;
+
             if !valid_server_name(&server.name) {
                 return Err(LaunchMapError::Invalid(format!(
                     "MCP server '{}' has invalid name: use 1..=128 ASCII letters, digits, underscores, or hyphens, without '__'",
@@ -124,18 +190,40 @@ impl McpLaunchConfigDocument {
                     server.name
                 )));
             }
+            if server.args.len() > MCP_SERVER_MAX_ARGS {
+                return Err(LaunchMapError::Invalid(format!(
+                    "MCP server '{}' has too many arguments ({}, max {MCP_SERVER_MAX_ARGS})",
+                    server.name,
+                    server.args.len()
+                )));
+            }
             if server.args.iter().any(|argument| argument.contains('\0')) {
                 return Err(LaunchMapError::Invalid(format!(
                     "MCP server '{}' arguments must contain no NUL bytes",
                     server.name
                 )));
             }
+            for argument in &server.args {
+                add_string_bytes(&mut raw_string_bytes, argument)?;
+            }
+            if server.env.len() > MCP_SERVER_MAX_ENV {
+                return Err(LaunchMapError::Invalid(format!(
+                    "MCP server '{}' has too many environment entries ({}, max {MCP_SERVER_MAX_ENV})",
+                    server.name,
+                    server.env.len()
+                )));
+            }
             let mut env_names = HashSet::with_capacity(server.env.len());
-            for (key, value) in &server.env {
+            // Report env issues by 1-based index, never by echoing the key or
+            // value — untrusted names and values may themselves be secrets.
+            for (env_index, (key, value)) in server.env.iter().enumerate() {
+                add_string_bytes(&mut raw_string_bytes, key)?;
+                add_string_bytes(&mut raw_string_bytes, value)?;
                 if !valid_env_name(key) {
                     return Err(LaunchMapError::Invalid(format!(
-                        "MCP server '{}' environment key '{key}' is invalid (must start with an ASCII letter or '_' and contain only letters, digits, '_')",
-                        server.name
+                        "MCP server '{}' environment entry {} has an invalid key (must start with an ASCII letter or '_' and contain only letters, digits, '_')",
+                        server.name,
+                        env_index + 1
                     )));
                 }
                 if !env_names.insert(key.to_ascii_uppercase()) {
@@ -155,8 +243,9 @@ impl McpLaunchConfigDocument {
                 }
                 if value.contains('\0') {
                     return Err(LaunchMapError::Invalid(format!(
-                        "MCP server '{}' environment entry '{key}' contains a NUL byte",
-                        server.name
+                        "MCP server '{}' environment entry {} contains a NUL byte",
+                        server.name,
+                        env_index + 1
                     )));
                 }
             }
@@ -195,6 +284,24 @@ fn valid_env_name(name: &str) -> bool {
         && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
+/// Accumulate `value`'s byte length toward the 64 KiB in-memory bound, failing
+/// as soon as the running total exceeds it. Mirrors buzz-core's
+/// `add_string_bytes`, bounding documents *before* encoding so an oversized
+/// document can never be built.
+fn add_string_bytes(total: &mut u64, value: &str) -> Result<(), LaunchMapError> {
+    let length = u64::try_from(value.len())
+        .map_err(|_| LaunchMapError::Invalid("MCP config is too large".to_string()))?;
+    *total = total
+        .checked_add(length)
+        .ok_or_else(|| LaunchMapError::Invalid("MCP config is too large".to_string()))?;
+    if *total > MCP_CONFIG_MAX_BYTES {
+        return Err(LaunchMapError::Invalid(format!(
+            "MCP config exceeds the {MCP_CONFIG_MAX_BYTES} byte limit"
+        )));
+    }
+    Ok(())
+}
+
 /// A mapping-time failure: either the document cannot be encoded or a mapped
 /// server would not be accepted by the launch schema.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -212,7 +319,7 @@ pub enum LaunchMapError {
 /// Returns the encoded document bytes on success. On failure, names the
 /// offending server.
 pub fn to_launch_json(config: &RuntimeMcpConfig) -> Result<Vec<u8>, LaunchMapError> {
-    let document = McpLaunchConfigDocument::from_runtime_config(config);
+    let document = McpLaunchConfigDocument::from_runtime_config(config)?;
     document.to_json()
 }
 
@@ -252,7 +359,7 @@ mod tests {
             native("off", "npx", Some(false)),
             native("unset", "uv", None),
         ]);
-        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap();
         let names: Vec<_> = doc.servers.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["on", "unset"]);
         assert_eq!(doc.version, MCP_LAUNCH_DOC_VERSION);
@@ -261,8 +368,8 @@ mod tests {
     #[test]
     fn wire_carries_stdio_transport_tag() {
         let cfg = config(vec![native("sciverse", "npx", None)]);
-        let json =
-            serde_json::to_value(McpLaunchConfigDocument::from_runtime_config(&cfg)).unwrap();
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap();
+        let json = serde_json::to_value(doc).unwrap();
         assert_eq!(json["version"], 1);
         assert_eq!(json["servers"][0]["transport"], "stdio");
         assert_eq!(json["servers"][0]["name"], "sciverse");
@@ -279,8 +386,8 @@ mod tests {
             .env
             .insert("SCIVERSE_API_TOKEN".to_string(), "token-value".to_string());
         let cfg = config(vec![server]);
-        let json =
-            serde_json::to_value(McpLaunchConfigDocument::from_runtime_config(&cfg)).unwrap();
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap();
+        let json = serde_json::to_value(doc).unwrap();
         assert_eq!(json["servers"][0]["args"][0], "-y");
         assert_eq!(
             json["servers"][0]["env"]["SCIVERSE_API_TOKEN"],
@@ -291,8 +398,7 @@ mod tests {
     #[test]
     fn rejects_duplicate_names() {
         let cfg = config(vec![native("dup", "npx", None), native("dup", "uv", None)]);
-        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
-        let err = doc.validate().unwrap_err();
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("duplicate MCP server name"));
     }
 
@@ -303,8 +409,7 @@ mod tests {
             .env
             .insert("BUZZ_PRIVATE_KEY".to_string(), "secret".to_string());
         let cfg = config(vec![server]);
-        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
-        let err = doc.validate().unwrap_err();
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("protected environment key"));
     }
 
@@ -314,9 +419,100 @@ mod tests {
         server.env.insert("Token".to_string(), "a".to_string());
         server.env.insert("TOKEN".to_string(), "b".to_string());
         let cfg = config(vec![server]);
-        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg);
-        let err = doc.validate().unwrap_err();
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
         assert!(err.to_string().contains("differ only by ASCII case"));
+    }
+
+    #[test]
+    fn rejects_invalid_env_key_without_echoing_it() {
+        let mut server = native("one", "npx", None);
+        let pasted_secret = "pasted-secret-that-must-not-appear";
+        let bad_key = format!("BAD-KEY-{pasted_secret}");
+        server.env.insert(bad_key.clone(), "value".to_string());
+        let cfg = config(vec![server]);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(!err.to_string().contains(&bad_key));
+        assert!(!err.to_string().contains(pasted_secret));
+        assert!(err.to_string().contains("invalid key"));
+    }
+
+    #[test]
+    fn rejects_too_many_servers() {
+        let servers = (0..=MCP_SERVER_MAX_COUNT)
+            .map(|i| native(&format!("srv{i:02}"), "npx", None))
+            .collect();
+        let cfg = config(servers);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("too many MCP servers"));
+    }
+
+    #[test]
+    fn rejects_too_many_args() {
+        let mut server = native("one", "npx", None);
+        server.args = vec!["arg".to_string(); MCP_SERVER_MAX_ARGS + 1];
+        let cfg = config(vec![server]);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("too many arguments"));
+    }
+
+    #[test]
+    fn rejects_too_many_env_entries() {
+        let mut server = native("one", "npx", None);
+        for i in 0..=MCP_SERVER_MAX_ENV {
+            server.env.insert(format!("KEY_{i}"), format!("v{i}"));
+        }
+        let cfg = config(vec![server]);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("too many environment entries"));
+    }
+
+    #[test]
+    fn rejects_oversized_document_before_encoding() {
+        // A single oversized argument must fail construction, proving the
+        // 64 KiB in-memory bound is enforced inline rather than after encode.
+        let mut server = native("one", "npx", None);
+        server.args = vec!["x".repeat(MCP_CONFIG_MAX_BYTES as usize + 1)];
+        let cfg = config(vec![server]);
+        let err = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("byte limit"));
+    }
+
+    #[test]
+    fn accepts_large_valid_document() {
+        // A large but legitimate document — many arguments within the 128-count
+        // bound, totalling well under the 64 KiB wire-size limit — must build
+        // and encode cleanly (no false rejections).
+        let mut server = native("srv00", "npx", None);
+        server.args = vec!["a".repeat(300); MCP_SERVER_MAX_ARGS];
+        let cfg = config(vec![server]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap();
+        assert!(doc.to_json().is_ok());
+    }
+
+    #[test]
+    fn debug_output_redacts_args_and_env() {
+        let mut server = native("one", "npx", None);
+        server.args = vec![
+            "--api-key".to_string(),
+            "hunter2-secret-arg-9999".to_string(),
+        ];
+        server.env.insert(
+            "SCIVERSE_API_TOKEN".to_string(),
+            "env-token-654321".to_string(),
+        );
+        let cfg = config(vec![server]);
+        let doc = McpLaunchConfigDocument::from_runtime_config(&cfg).unwrap();
+
+        let output = format!("{doc:?}");
+        assert!(output.contains("one"));
+        assert!(output.contains("arg_count: 2"));
+        assert!(output.contains("env_count: 1"));
+        // Neither the secret value in args nor the secret value in env may
+        // leak through debug output.
+        assert!(!output.contains("hunter2-secret-arg-9999"));
+        assert!(!output.contains("env-token-654321"));
+        assert!(!output.contains("--api-key"));
+        assert!(!output.contains("SCIVERSE_API_TOKEN"));
     }
 
     #[test]

--- a/crates/buzz-runtime-config/src/lib.rs
+++ b/crates/buzz-runtime-config/src/lib.rs
@@ -11,10 +11,36 @@
 //! file, and secret values (API tokens in `env`) are never logged or
 //! persisted by this crate — see [`McpServerConfig::redacted`] for display.
 
+use std::{fs::File, io::Read as _, path::Path};
+
 pub mod error;
 pub mod hermes;
 pub mod kimi;
 pub mod model;
 
 pub use error::ConfigError;
-pub use model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig, ValidationIssue};
+pub use model::{
+    McpServerConfig, McpServerInventoryEntry, RuntimeKind, RuntimeMcpConfig, RuntimeMcpInventory,
+    ValidationIssue,
+};
+
+/// Maximum native runtime configuration size accepted by an adapter.
+pub const RUNTIME_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
+
+fn read_config(path: &Path) -> Result<String, ConfigError> {
+    let file = File::open(path)?;
+    let mut content = String::new();
+    file.take(RUNTIME_CONFIG_MAX_BYTES + 1)
+        .read_to_string(&mut content)?;
+    validate_config_size(content.len())?;
+    Ok(content)
+}
+
+fn validate_config_size(size: usize) -> Result<(), ConfigError> {
+    if size as u64 > RUNTIME_CONFIG_MAX_BYTES {
+        return Err(ConfigError::TooLarge {
+            limit: RUNTIME_CONFIG_MAX_BYTES,
+        });
+    }
+    Ok(())
+}

--- a/crates/buzz-runtime-config/src/lib.rs
+++ b/crates/buzz-runtime-config/src/lib.rs
@@ -1,0 +1,20 @@
+//! Runtime-agnostic MCP/Skill configuration model.
+//!
+//! Buzz users run agents on multiple external frameworks ("runtimes") — e.g.
+//! Hermes (`~/.hermes/config.yaml`) and Kimi Code (`~/.kimi-code/mcp.json`).
+//! Each runtime keeps its own MCP server configuration in its own format.
+//! This crate defines a unified, runtime-agnostic model for that
+//! configuration plus read-only adapters that load and validate each
+//! runtime's native config file.
+//!
+//! Read + validate only: adapters never write back to the runtime's config
+//! file, and secret values (API tokens in `env`) are never logged or
+//! persisted by this crate — see [`McpServerConfig::redacted`] for display.
+
+pub mod error;
+pub mod hermes;
+pub mod kimi;
+pub mod model;
+
+pub use error::ConfigError;
+pub use model::{McpServerConfig, RuntimeKind, RuntimeMcpConfig, ValidationIssue};

--- a/crates/buzz-runtime-config/src/lib.rs
+++ b/crates/buzz-runtime-config/src/lib.rs
@@ -16,9 +16,11 @@ use std::{fs::File, io::Read as _, path::Path};
 pub mod error;
 pub mod hermes;
 pub mod kimi;
+pub mod launch;
 pub mod model;
 
 pub use error::ConfigError;
+pub use launch::{to_launch_json, LaunchMapError, McpLaunchConfigDocument};
 pub use model::{
     McpServerConfig, McpServerInventoryEntry, RuntimeKind, RuntimeMcpConfig, RuntimeMcpInventory,
     ValidationIssue,

--- a/crates/buzz-runtime-config/src/model.rs
+++ b/crates/buzz-runtime-config/src/model.rs
@@ -1,0 +1,233 @@
+//! Unified, runtime-agnostic MCP configuration model.
+//!
+//! The model captures the common denominator of external agent runtimes'
+//! MCP server configuration. Runtime-specific concepts are represented
+//! explicitly as optional fields:
+//!
+//! - `enabled`: both Hermes and Kimi Code support a per-server `enabled`
+//!   flag (Kimi Code defaults to enabled when the key is absent). Adapters
+//!   leave it `None` when the native config does not specify it, which
+//!   callers must treat as enabled.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+
+/// An external agent framework whose MCP configuration Buzz can read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeKind {
+    /// Hermes — `~/.hermes/config.yaml`, `mcp_servers` map (YAML).
+    Hermes,
+    /// Kimi Code — `~/.kimi-code/mcp.json`, `mcpServers` map (JSON).
+    KimiCode,
+}
+
+/// A single MCP server entry in the unified model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerConfig {
+    /// Server name (the map key in the runtime's native config).
+    pub name: String,
+
+    /// Executable used to launch the server (e.g. `npx`, `uv`).
+    pub command: String,
+
+    /// Arguments passed to `command`.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Environment variables passed to the server process. May contain
+    /// secrets — never log or persist values directly; use [`Self::redacted`]
+    /// for display.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+
+    /// Whether the server is enabled. `None` means the native config did
+    /// not specify it (treat as enabled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+impl McpServerConfig {
+    /// Whether this server is active. Servers whose native config does not
+    /// specify `enabled` (`None`) are active by default.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+
+    /// A copy with every `env` value replaced by a mask, safe to display or
+    /// log. Keys are preserved so operators can still see which variables a
+    /// server expects.
+    pub fn redacted(&self) -> Self {
+        Self {
+            env: self
+                .env
+                .keys()
+                .map(|k| (k.clone(), "<redacted>".to_string()))
+                .collect(),
+            ..self.clone()
+        }
+    }
+}
+
+/// The MCP configuration of one runtime, in unified form.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeMcpConfig {
+    /// Which runtime this configuration was read from.
+    pub runtime: RuntimeKind,
+
+    /// MCP servers, ordered by name for stable comparisons and output.
+    pub servers: Vec<McpServerConfig>,
+}
+
+impl RuntimeMcpConfig {
+    /// Servers that are currently active (see [`McpServerConfig::is_enabled`]).
+    pub fn enabled_servers(&self) -> impl Iterator<Item = &McpServerConfig> {
+        self.servers.iter().filter(|s| s.is_enabled())
+    }
+
+    /// Validate the configuration, returning all issues found.
+    ///
+    /// Validation is structural only: it checks that entries are well-formed
+    /// (non-empty name and command), not that the referenced executables
+    /// exist.
+    pub fn validate(&self) -> Vec<ValidationIssue> {
+        let mut issues = Vec::new();
+        let mut seen = std::collections::BTreeSet::new();
+        for server in &self.servers {
+            if server.name.trim().is_empty() {
+                issues.push(ValidationIssue::EmptyServerName);
+            } else if !seen.insert(server.name.clone()) {
+                issues.push(ValidationIssue::DuplicateServerName(server.name.clone()));
+            }
+            if server.command.trim().is_empty() {
+                issues.push(ValidationIssue::EmptyCommand(server.name.clone()));
+            }
+        }
+        issues
+    }
+
+    /// Validate, returning `Err` summarizing the issues if any exist.
+    pub fn validated(self) -> Result<Self, ConfigError> {
+        let issues = self.validate();
+        if issues.is_empty() {
+            return Ok(self);
+        }
+        let summary = issues
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        Err(ConfigError::Validation(summary))
+    }
+}
+
+/// A single structural problem found by [`RuntimeMcpConfig::validate`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ValidationIssue {
+    #[error("server entry with an empty name")]
+    EmptyServerName,
+
+    #[error("duplicate server name: {0}")]
+    DuplicateServerName(String),
+
+    #[error("server {0:?} has an empty command")]
+    EmptyCommand(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server(name: &str, command: &str, enabled: Option<bool>) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: vec![],
+            env: BTreeMap::new(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn none_enabled_means_active() {
+        assert!(server("a", "npx", None).is_enabled());
+        assert!(server("a", "npx", Some(true)).is_enabled());
+        assert!(!server("a", "npx", Some(false)).is_enabled());
+    }
+
+    #[test]
+    fn redacted_masks_env_values_but_keeps_keys() {
+        let mut s = server("a", "npx", None);
+        s.env
+            .insert("API_TOKEN".to_string(), "secret-value".to_string());
+        let r = s.redacted();
+        assert_eq!(
+            r.env.get("API_TOKEN").map(String::as_str),
+            Some("<redacted>")
+        );
+        // Original is untouched.
+        assert_eq!(
+            s.env.get("API_TOKEN").map(String::as_str),
+            Some("secret-value")
+        );
+    }
+
+    #[test]
+    fn enabled_servers_filters_disabled() {
+        let cfg = RuntimeMcpConfig {
+            runtime: RuntimeKind::Hermes,
+            servers: vec![
+                server("on", "npx", Some(true)),
+                server("off", "npx", Some(false)),
+                server("kimi-style", "uv", None),
+            ],
+        };
+        let names: Vec<&str> = cfg.enabled_servers().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["on", "kimi-style"]);
+    }
+
+    #[test]
+    fn validate_clean_config_has_no_issues() {
+        let cfg = RuntimeMcpConfig {
+            runtime: RuntimeKind::KimiCode,
+            servers: vec![server("a", "npx", None), server("b", "uv", None)],
+        };
+        assert!(cfg.validate().is_empty());
+    }
+
+    #[test]
+    fn validate_catches_empty_command_and_duplicates() {
+        let cfg = RuntimeMcpConfig {
+            runtime: RuntimeKind::Hermes,
+            servers: vec![
+                server("a", "", None),
+                server("a", "npx", None),
+                server("b", "uv", None),
+            ],
+        };
+        let issues = cfg.validate();
+        assert!(issues.contains(&ValidationIssue::EmptyCommand("a".into())));
+        assert!(issues.contains(&ValidationIssue::DuplicateServerName("a".into())));
+        assert_eq!(issues.len(), 2);
+    }
+
+    #[test]
+    fn validated_err_summarizes_issues() {
+        let cfg = RuntimeMcpConfig {
+            runtime: RuntimeKind::Hermes,
+            servers: vec![server("a", "", None)],
+        };
+        let err = cfg.validated().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(err.to_string().contains("empty command"));
+    }
+
+    #[test]
+    fn runtime_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&RuntimeKind::KimiCode).unwrap();
+        assert_eq!(json, "\"kimi_code\"");
+    }
+}

--- a/crates/buzz-runtime-config/src/model.rs
+++ b/crates/buzz-runtime-config/src/model.rs
@@ -26,7 +26,7 @@ pub enum RuntimeKind {
 }
 
 /// A single MCP server entry in the unified model.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct McpServerConfig {
     /// Server name (the map key in the runtime's native config).
     pub name: String,
@@ -35,19 +35,44 @@ pub struct McpServerConfig {
     pub command: String,
 
     /// Arguments passed to `command`.
-    #[serde(default)]
     pub args: Vec<String>,
 
     /// Environment variables passed to the server process. May contain
     /// secrets — never log or persist values directly; use [`Self::redacted`]
     /// for display.
-    #[serde(default)]
     pub env: BTreeMap<String, String>,
 
     /// Whether the server is enabled. `None` means the native config did
     /// not specify it (treat as enabled).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+}
+
+impl std::fmt::Debug for McpServerConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServerConfig")
+            .field("name", &self.name)
+            .field("command", &self.command)
+            .field("arg_count", &self.args.len())
+            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .field("enabled", &self.enabled)
+            .finish()
+    }
+}
+
+/// Secret-free view of one native MCP server for inventory and display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct McpServerInventoryEntry {
+    /// Server name from the native runtime configuration.
+    pub name: String,
+    /// Executable configured for the server.
+    pub command: String,
+    /// Number of configured arguments. Argument values may contain secrets and are omitted.
+    pub arg_count: usize,
+    /// Environment variable names expected by the server. Values are omitted.
+    pub env_names: Vec<String>,
+    /// Whether the native runtime enables this server.
+    pub enabled: bool,
 }
 
 impl McpServerConfig {
@@ -57,23 +82,20 @@ impl McpServerConfig {
         self.enabled.unwrap_or(true)
     }
 
-    /// A copy with every `env` value replaced by a mask, safe to display or
-    /// log. Keys are preserved so operators can still see which variables a
-    /// server expects.
-    pub fn redacted(&self) -> Self {
-        Self {
-            env: self
-                .env
-                .keys()
-                .map(|k| (k.clone(), "<redacted>".to_string()))
-                .collect(),
-            ..self.clone()
+    /// Return a secret-free inventory view safe to display or serialize.
+    pub fn redacted(&self) -> McpServerInventoryEntry {
+        McpServerInventoryEntry {
+            name: self.name.clone(),
+            command: self.command.clone(),
+            arg_count: self.args.len(),
+            env_names: self.env.keys().cloned().collect(),
+            enabled: self.is_enabled(),
         }
     }
 }
 
 /// The MCP configuration of one runtime, in unified form.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeMcpConfig {
     /// Which runtime this configuration was read from.
     pub runtime: RuntimeKind,
@@ -82,10 +104,27 @@ pub struct RuntimeMcpConfig {
     pub servers: Vec<McpServerConfig>,
 }
 
+/// Secret-free native MCP inventory for one runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeMcpInventory {
+    /// Runtime that supplied this inventory.
+    pub runtime: RuntimeKind,
+    /// Native MCP servers with arguments and environment values omitted.
+    pub servers: Vec<McpServerInventoryEntry>,
+}
+
 impl RuntimeMcpConfig {
     /// Servers that are currently active (see [`McpServerConfig::is_enabled`]).
     pub fn enabled_servers(&self) -> impl Iterator<Item = &McpServerConfig> {
         self.servers.iter().filter(|s| s.is_enabled())
+    }
+
+    /// Return a secret-free inventory view safe to display or serialize.
+    pub fn redacted(&self) -> RuntimeMcpInventory {
+        RuntimeMcpInventory {
+            runtime: self.runtime,
+            servers: self.servers.iter().map(McpServerConfig::redacted).collect(),
+        }
     }
 
     /// Validate the configuration, returning all issues found.
@@ -159,20 +198,31 @@ mod tests {
     }
 
     #[test]
-    fn redacted_masks_env_values_but_keeps_keys() {
+    fn redacted_inventory_omits_argument_and_env_values() {
         let mut s = server("a", "npx", None);
+        s.args.push("argument-secret".to_string());
         s.env
             .insert("API_TOKEN".to_string(), "secret-value".to_string());
         let r = s.redacted();
-        assert_eq!(
-            r.env.get("API_TOKEN").map(String::as_str),
-            Some("<redacted>")
-        );
-        // Original is untouched.
-        assert_eq!(
-            s.env.get("API_TOKEN").map(String::as_str),
-            Some("secret-value")
-        );
+        assert_eq!(r.arg_count, 1);
+        assert_eq!(r.env_names, vec!["API_TOKEN"]);
+        let serialized = serde_json::to_string(&r).unwrap();
+        assert!(!serialized.contains("argument-secret"));
+        assert!(!serialized.contains("secret-value"));
+        assert!(serialized.contains("API_TOKEN"));
+    }
+
+    #[test]
+    fn debug_output_omits_argument_and_env_values() {
+        let mut s = server("a", "npx", None);
+        s.args.push("argument-secret".to_string());
+        s.env
+            .insert("API_TOKEN".to_string(), "secret-value".to_string());
+
+        let debug = format!("{s:?}");
+        assert!(!debug.contains("argument-secret"));
+        assert!(!debug.contains("secret-value"));
+        assert!(debug.contains("API_TOKEN"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a new lightweight crate `buzz-runtime-config`: a **runtime-agnostic, read-only** model of external agent frameworks' MCP server configuration, with adapters for Hermes (`~/.hermes/config.yaml`, `mcp_servers`) and Kimi Code (`~/.kimi-code/mcp.json`, `mcpServers`).

This is a pathfinding slice (**PR-0**) toward the larger goal of letting Buzz manage Skills / MCP for different agent frameworks from one place — and it dovetails directly with the direction of #4164 (*buzz-acp: add structured MCP server configuration*). It is deliberately backend-only: pure structs + `serde`, no write paths, no desktop changes.

## What's in it

- `src/model.rs` — unified model: `RuntimeKind` (Hermes / KimiCode), `McpServerConfig` (`enabled: Option<bool>`, `None` = native config did not specify → treated as enabled), `RuntimeMcpConfig` with structural `validate()` (empty name / empty command / duplicate names) and `redacted()` (masks env values so secrets never reach logs or display).
- `src/hermes.rs` — read-only adapter for YAML `~/.hermes/config.yaml`. Unknown top-level keys ignored.
- `src/kimi.rs` — read-only adapter for JSON `~/.kimi-code/mcp.json`, with `$KIMI_CODE_HOME` fallback. Unknown top-level keys ignored.
- `src/error.rs` — `ConfigError` (Io / Yaml / Json / Validation).

## Scope notes / intentional limits

- **stdio servers only for now.** Kimi Code also supports HTTP/SSE servers declared with `url` instead of `command`; those surface as a loud validation error naming the server rather than being silently dropped. A follow-up PR extends the model with a transport field.
- Kimi timeout / tool-list fields (`startupTimeoutMs`, `toolTimeoutMs`, `enabledTools`, `disabledTools`) are not modeled yet.
- Adapters are strictly read-only; secret values are never logged (`redacted()` for display).

## Testing

- 22 unit tests across model/hermes/kimi (parse, defaults, validation, redaction, disk roundtrip).
- `just ci` green locally (fmt + clippy + unit tests + build).
