### PR TITLE
fix(desktop): prevent horizontal clipping in Prompt Context modal

### DIFF
--- a/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
+++ b/desktop/src/features/agents/ui/AgentSessionTranscriptList.tsx
@@ -747,7 +747,7 @@ function PromptContextDialog({
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-xl overflow-hidden p-0">
-        <div className="flex max-h-[85vh] flex-col">
+        <div className="flex min-w-0 max-h-[85vh] flex-col">
           <DialogHeader className="px-6 pb-3 pt-5 pr-14">
             <DialogTitle>Prompt context</DialogTitle>
             {setupText ? (

--- a/desktop/src/features/agents/ui/PromptSectionAccordion.tsx
+++ b/desktop/src/features/agents/ui/PromptSectionAccordion.tsx
@@ -47,7 +47,7 @@ export function PromptSectionAccordion({
             <div
               className={cn(
                 "text-sm font-semibold text-foreground",
-                !open && "line-clamp-2 wrap-break-word",
+                !open && "line-clamp-2 wrap-anywhere",
               )}
             >
               {section.title}
@@ -56,8 +56,8 @@ export function PromptSectionAccordion({
               className={cn(
                 "mt-1 text-xs leading-5 text-foreground/70",
                 open
-                  ? "whitespace-pre-wrap wrap-break-word"
-                  : "line-clamp-2 wrap-break-word",
+                  ? "whitespace-pre-wrap wrap-anywhere"
+                  : "line-clamp-2 wrap-anywhere",
               )}
             >
               {body.length > 0 ? (


### PR DESCRIPTION
The Prompt Context modal (observer feed → check icon under sent messages) was clipping all content and card right-padding at the dialog edge.

**Root cause**: `PromptContextDialog` renders inside `DialogContent`, which is a CSS grid. The child flex wrapper had default `min-width: auto`, so the widest unbreakable token in the content (64-char hex event IDs, `Tags: [[...]]` JSON) set the grid track width, blowing it past `max-w-xl`. `overflow-hidden` then clipped everything at the dialog edge — including the section cards' right padding.

**Fix**:
- `AgentSessionTranscriptList.tsx`: add `min-w-0` to the `flex max-h-[85vh] flex-col` wrapper so the grid item can shrink below its max-content width.
- `PromptSectionAccordion.tsx`: replace `wrap-break-word` with `wrap-anywhere` on the body text (open and collapsed states) and the title. `overflow-wrap: anywhere` reduces min-content width, which `break-word` does not, letting long tokens wrap inside the cards rather than inflating the track.

The `line-clamp-2` collapsed preview is preserved unchanged.