### PR TITLE
fix(cli): install rustls crypto provider explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "futures-util",
  "hex",
  "nostr",
+ "rustls",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/buzz-cli/src/main.rs
+++ b/crates/buzz-cli/src/main.rs
@@ -1,4 +1,16 @@
 #[tokio::main]
 async fn main() {
+    // Select the rustls crypto provider explicitly.
+    //
+    // The workspace ends up with BOTH providers compiled in: crates pin
+    // `rustls` to `ring`, while `reqwest` -> `hyper-rustls` /
+    // `rustls-platform-verifier` enable `aws-lc-rs`. With two providers
+    // available rustls cannot pick one at runtime and panics on the first TLS
+    // handshake ("Could not automatically determine the process-level
+    // CryptoProvider from Rustls crate features"). A crate-level feature pin
+    // cannot fix this because Cargo unifies features across the graph, so the
+    // choice has to be made here. Ignore the error: a provider may already be
+    // installed by an embedding caller, which is not a failure.
+    let _ = rustls::crypto::ring::default_provider().install_default();
     std::process::exit(buzz_cli::run_from_args(std::env::args()).await);
 }

--- a/crates/buzz-pairing-cli/Cargo.toml
+++ b/crates/buzz-pairing-cli/Cargo.toml
@@ -23,3 +23,4 @@ hex = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }

--- a/crates/buzz-pairing-cli/src/main.rs
+++ b/crates/buzz-pairing-cli/src/main.rs
@@ -96,6 +96,19 @@ enum CliError {
 
 #[tokio::main]
 async fn main() {
+    // Select the rustls crypto provider explicitly.
+    //
+    // The workspace ends up with BOTH providers compiled in: crates pin
+    // `rustls` to `ring`, while `reqwest` -> `hyper-rustls` /
+    // `rustls-platform-verifier` enable `aws-lc-rs`. With two providers
+    // available rustls cannot pick one at runtime and panics on the first TLS
+    // handshake ("Could not automatically determine the process-level
+    // CryptoProvider from Rustls crate features"). A crate-level feature pin
+    // cannot fix this because Cargo unifies features across the graph, so the
+    // choice has to be made here. Ignore the error: a provider may already be
+    // installed by an embedding caller, which is not a failure.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = Cli::parse();
     if let Err(e) = run(cli.command).await {
         eprintln!("error: {e}");


### PR DESCRIPTION
## Problem

`buzz` and `buzz-pair` panic on their first TLS handshake:

```
thread 'main' panicked at rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

Reported in #2666, and independently in #2552, #2457, #2308 and #2329.

## Why a feature pin doesn't fix it

Six crates already pin the provider:

```toml
rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
```

That isn't enough, because `reqwest` brings the *other* provider in transitively:

```
aws-lc-rs v1.17.0
└── rustls v0.23.42
    ├── hyper-rustls v0.27.9 → reqwest v0.13.4 → buzz-cli
    ├── rustls-platform-verifier v0.7.0 → reqwest v0.13.4
    └── tokio-rustls v0.26.4 → tokio-tungstenite v0.29.0 → buzz-ws-client → buzz-cli
```

Cargo unifies features across the graph, so `buzz-cli` ends up with **both** `ring` and `aws-lc-rs` compiled in. rustls then cannot choose and panics. A crate-level pin can never win this, which is why the failure looks intermittent — and why building more binaries in one invocation makes it *worse* rather than better, by turning "no provider" into "two providers".

`buzz-pairing-cli` was hitting the other half of the same problem: it declared no `rustls` dependency at all, so a standalone `cargo build -p buzz-pairing-cli` produced a binary with **zero** providers. That one is particularly unpleasant, because the tool prints the pairing QR URI *before* it connects — so it emitted a valid-looking `nostrpair://` code and then died, making a client crash look like a relay fault.

## Change

Select the provider explicitly at startup in both binaries, and give `buzz-pairing-cli` the same dependency pin the other crates use.

```rust
let _ = rustls::crypto::ring::default_provider().install_default();
```

`ring` matches what the rest of the workspace already pins. The `Result` is deliberately discarded: a provider may already have been installed by an embedding caller, which is not an error.

## Verification

Built `--release` on `aarch64-unknown-linux-gnu` against a self-hosted relay (docker compose, public HTTPS via a tunnel).

**`buzz agents draft-create` — the exact path reported in #2666**

Before: panic. After — a normal response, reaching application logic:

```json
{"error":"auth_error","message":"auth error: agent draft requests require BUZZ_AUTH_TAG","retryable":false}
```

**`buzz-pair source`**

Before: printed the QR URI, then panicked ~2s later. After — prints the URI and holds the pairing session open (exit 124 = still alive when the 25s test timeout killed it), 0 panic matches in the log:

```
QR URI (contains session secret — do not share beyond the target device):
nostrpair://9a6199de…&v=1
Waiting for target to scan QR code...
```

A full source ↔ target NIP-AB handshake (SAS confirmation plus encrypted payload transfer) also completes end to end with this build.

## Notes

Happy to switch to `aws-lc-rs` instead if that's the preferred direction — the important part is that the choice is made explicitly somewhere, since feature unification means it cannot be made in a crate manifest. I picked `ring` only because it's what the existing pins use.

Fixes #2666
