### PR TITLE
feat(desktop): make reply auto-mention configurable per account

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -28,6 +28,7 @@ import {
 export { mergeMessages, mergeTimelineCacheMessages };
 import { splitOutgoingTags } from "@/features/messages/lib/imetaMediaMarkdown";
 import { messageMentionPubkeys } from "@/features/messages/lib/messageMentionPubkeys";
+import { readStoredReplyMentionSettings } from "@/features/messages/lib/replyMentionSettings";
 import {
   clearTimeoutState,
   recordTimeoutFromRejection,
@@ -93,15 +94,22 @@ export function createOptimisticMessage(
   const tags: string[][] = [];
 
   if (parentEventId) {
+    // Honor the per-account reply-mention settings so the optimistic event's
+    // p-tags match what the send path actually puts on the wire.
+    const replyMentionSettings = readStoredReplyMentionSettings(
+      identity.pubkey,
+    );
     tags.push(
       ...buildReplyTags(
         channelId,
         identity.pubkey,
         parentEventId,
         resolveReplyRootId(parentEventId, currentMessages),
-        mentionPubkeys,
-        resolveReplyTargetAuthorPubkey(parentEventId, currentMessages) ??
-          undefined,
+        [...mentionPubkeys, ...replyMentionSettings.mentionPrefixPubkeys],
+        replyMentionSettings.autoMentionRepliedTo
+          ? (resolveReplyTargetAuthorPubkey(parentEventId, currentMessages) ??
+              undefined)
+          : undefined,
       ),
     );
   } else {
@@ -472,23 +480,34 @@ export function useSendMessageMutation(
       // accounts, which wake on an explicit mentioning `p` tag) even when the
       // composer body has no literal "@mention". Resolve the replied-to event's
       // author from the local cache and fold it into the real recipient p-tags
-      // so the reply actually reaches them on the wire.
+      // so the reply actually reaches them on the wire. Both behaviors are
+      // user-configurable per account (see lib/replyMentionSettings.ts): the
+      // implicit author fold can be toggled off, and extra "prefix" pubkeys
+      // can be folded into every reply.
       let recipientPubkeys = recipientPubkeysBase;
+      let replyTargetAuthor: string | null = null;
       if (parentEventId) {
+        const replyMentionSettings = readStoredReplyMentionSettings(
+          identity.pubkey,
+        );
         const replyParentMessages =
           queryClient.getQueryData<RelayEvent[]>(
             channelMessagesKey(effectiveChannel.id),
           ) ?? [];
-        const replyTargetAuthor = resolveReplyTargetAuthorPubkey(
-          parentEventId,
-          replyParentMessages,
-        );
-        if (replyTargetAuthor) {
-          recipientPubkeys = normalizeMentionPubkeys(
-            [...recipientPubkeysBase, replyTargetAuthor],
-            identity.pubkey,
+        if (replyMentionSettings.autoMentionRepliedTo) {
+          replyTargetAuthor = resolveReplyTargetAuthorPubkey(
+            parentEventId,
+            replyParentMessages,
           );
         }
+        recipientPubkeys = normalizeMentionPubkeys(
+          [
+            ...recipientPubkeysBase,
+            ...replyMentionSettings.mentionPrefixPubkeys,
+            ...(replyTargetAuthor ? [replyTargetAuthor] : []),
+          ],
+          identity.pubkey,
+        );
       }
 
       // Messages carrying media OR custom-emoji tags MUST go through REST so
@@ -520,8 +539,8 @@ export function useSendMessageMutation(
               parentEventId,
               resolveReplyRootId(parentEventId, cachedMessages),
               recipientPubkeys,
-              resolveReplyTargetAuthorPubkey(parentEventId, cachedMessages) ??
-                undefined,
+              // Settings-aware: null when autoMentionRepliedTo is toggled off.
+              replyTargetAuthor ?? undefined,
             )
           : [];
         const baseTags = parentEventId

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -13,6 +13,7 @@ import {
   isBroadcastReply,
   normalizeMentionPubkeys,
   resolveReplyRootId,
+  resolveReplyTargetAuthorPubkey,
 } from "@/features/messages/lib/threading";
 import {
   projectChannelWindowMessages,
@@ -99,6 +100,8 @@ export function createOptimisticMessage(
         parentEventId,
         resolveReplyRootId(parentEventId, currentMessages),
         mentionPubkeys,
+        resolveReplyTargetAuthorPubkey(parentEventId, currentMessages) ??
+          undefined,
       ),
     );
   } else {
@@ -459,11 +462,34 @@ export function useSendMessageMutation(
         emojiTags,
         mentionTags,
       } = splitOutgoingTags(mediaTags);
-      const recipientPubkeys = messageMentionPubkeys(
+      const recipientPubkeysBase = messageMentionPubkeys(
         effectiveChannel,
         identity.pubkey,
         mentionPubkeys,
       );
+
+      // Replying to a message implicitly addresses its author (notably agent
+      // accounts, which wake on an explicit mentioning `p` tag) even when the
+      // composer body has no literal "@mention". Resolve the replied-to event's
+      // author from the local cache and fold it into the real recipient p-tags
+      // so the reply actually reaches them on the wire.
+      let recipientPubkeys = recipientPubkeysBase;
+      if (parentEventId) {
+        const replyParentMessages =
+          queryClient.getQueryData<RelayEvent[]>(
+            channelMessagesKey(effectiveChannel.id),
+          ) ?? [];
+        const replyTargetAuthor = resolveReplyTargetAuthorPubkey(
+          parentEventId,
+          replyParentMessages,
+        );
+        if (replyTargetAuthor) {
+          recipientPubkeys = normalizeMentionPubkeys(
+            [...recipientPubkeysBase, replyTargetAuthor],
+            identity.pubkey,
+          );
+        }
+      }
 
       // Messages carrying media OR custom-emoji tags MUST go through REST so
       // the relay's tag validation runs. The WebSocket path emits no extra
@@ -494,6 +520,8 @@ export function useSendMessageMutation(
               parentEventId,
               resolveReplyRootId(parentEventId, cachedMessages),
               recipientPubkeys,
+              resolveReplyTargetAuthorPubkey(parentEventId, cachedMessages) ??
+                undefined,
             )
           : [];
         const baseTags = parentEventId

--- a/desktop/src/features/messages/lib/replyMentionSettings.test.mjs
+++ b/desktop/src/features/messages/lib/replyMentionSettings.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_REPLY_MENTION_SETTINGS,
+  readStoredReplyMentionSettings,
+  sanitizeReplyMentionSettings,
+} from "./replyMentionSettings.ts";
+
+const PK_A = "aa".repeat(32);
+const PK_B = "bb".repeat(32);
+
+test("sanitizeReplyMentionSettings returns defaults for non-objects", () => {
+  for (const value of [null, undefined, 42, "nope", []]) {
+    assert.deepEqual(sanitizeReplyMentionSettings(value), {
+      autoMentionRepliedTo: true,
+      mentionPrefixPubkeys: [],
+    });
+  }
+});
+
+test("sanitizeReplyMentionSettings defaults autoMentionRepliedTo when not a boolean", () => {
+  const result = sanitizeReplyMentionSettings({
+    autoMentionRepliedTo: "yes",
+    mentionPrefixPubkeys: [],
+  });
+  assert.equal(result.autoMentionRepliedTo, true);
+});
+
+test("sanitizeReplyMentionSettings preserves an explicit false toggle", () => {
+  const result = sanitizeReplyMentionSettings({
+    autoMentionRepliedTo: false,
+    mentionPrefixPubkeys: [],
+  });
+  assert.equal(result.autoMentionRepliedTo, false);
+});
+
+test("sanitizeReplyMentionSettings filters, lowercases, and dedupes prefix pubkeys", () => {
+  const result = sanitizeReplyMentionSettings({
+    autoMentionRepliedTo: true,
+    mentionPrefixPubkeys: [
+      PK_A.toUpperCase(),
+      ` ${PK_A} `, // whitespace + duplicate of the first entry
+      PK_B,
+      "not-a-pubkey",
+      123,
+      null,
+    ],
+  });
+  assert.deepEqual(result.mentionPrefixPubkeys, [PK_A, PK_B]);
+});
+
+test("sanitizeReplyMentionSettings drops malformed prefix pubkeys", () => {
+  const result = sanitizeReplyMentionSettings({
+    autoMentionRepliedTo: true,
+    mentionPrefixPubkeys: ["zz".repeat(32), "short", PK_A.slice(0, 63)],
+  });
+  assert.deepEqual(result.mentionPrefixPubkeys, []);
+});
+
+test("readStoredReplyMentionSettings falls back to defaults outside the browser", () => {
+  // node:test has no window.localStorage — the reader must not throw and must
+  // return the defaults.
+  assert.deepEqual(
+    readStoredReplyMentionSettings(PK_A),
+    DEFAULT_REPLY_MENTION_SETTINGS,
+  );
+});

--- a/desktop/src/features/messages/lib/replyMentionSettings.ts
+++ b/desktop/src/features/messages/lib/replyMentionSettings.ts
@@ -1,0 +1,113 @@
+/**
+ * User-configurable reply mention settings ("reply auto-mention").
+ *
+ * The desktop composer folds the replied-to author into a reply's `p` tags so
+ * they get woken even without a literal "@mention" in the body. This module is
+ * the per-account persisted model that makes that behavior configurable:
+ *
+ * - `autoMentionRepliedTo` — toggle the implicit replied-to author `p` tag.
+ * - `mentionPrefixPubkeys` — extra pubkeys always folded into a reply's
+ *   `p` tags (a user-defined "reply prefix", e.g. a teammate or agent group
+ *   that should be woken on every reply the user sends).
+ *
+ * Storage follows the notifications pattern: one localStorage key per account
+ * (`<key>:<pubkey>`), sanitized on read so a corrupt hand-edit can never wedge
+ * the composer. Kept React-free so the send paths (`hooks.ts`) and unit tests
+ * can use it directly; the `useReplyMentionSettings` hook lives in
+ * `../useReplyMentionSettings.ts`.
+ */
+
+export type ReplyMentionSettings = {
+  /** When true (default), replying p-tags the replied-to event's author. */
+  autoMentionRepliedTo: boolean;
+  /** Extra pubkeys folded into every reply's p-tags. May be empty. */
+  mentionPrefixPubkeys: string[];
+};
+
+export const DEFAULT_REPLY_MENTION_SETTINGS: ReplyMentionSettings = {
+  autoMentionRepliedTo: true,
+  mentionPrefixPubkeys: [],
+};
+
+const REPLY_MENTION_SETTINGS_STORAGE_KEY = "buzz-reply-mention-settings.v1";
+
+const PUBKEY_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+function sanitizeMentionPrefixPubkeys(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") {
+      continue;
+    }
+    const lower = item.trim().toLowerCase();
+    if (!PUBKEY_HEX_PATTERN.test(lower) || seen.has(lower)) {
+      continue;
+    }
+    seen.add(lower);
+    result.push(lower);
+  }
+  return result;
+}
+
+export function sanitizeReplyMentionSettings(
+  value: unknown,
+): ReplyMentionSettings {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_REPLY_MENTION_SETTINGS;
+  }
+
+  const candidate = value as Partial<ReplyMentionSettings>;
+  return {
+    autoMentionRepliedTo:
+      typeof candidate.autoMentionRepliedTo === "boolean"
+        ? candidate.autoMentionRepliedTo
+        : DEFAULT_REPLY_MENTION_SETTINGS.autoMentionRepliedTo,
+    mentionPrefixPubkeys: sanitizeMentionPrefixPubkeys(
+      candidate.mentionPrefixPubkeys,
+    ),
+  };
+}
+
+function replyMentionSettingsStorageKey(pubkey: string) {
+  return `${REPLY_MENTION_SETTINGS_STORAGE_KEY}:${pubkey}`;
+}
+
+export function readStoredReplyMentionSettings(
+  pubkey: string,
+): ReplyMentionSettings {
+  if (typeof window === "undefined" || pubkey.length === 0) {
+    return DEFAULT_REPLY_MENTION_SETTINGS;
+  }
+
+  const rawValue = window.localStorage.getItem(
+    replyMentionSettingsStorageKey(pubkey),
+  );
+  if (!rawValue) {
+    return DEFAULT_REPLY_MENTION_SETTINGS;
+  }
+
+  try {
+    return sanitizeReplyMentionSettings(JSON.parse(rawValue));
+  } catch {
+    return DEFAULT_REPLY_MENTION_SETTINGS;
+  }
+}
+
+export function writeStoredReplyMentionSettings(
+  pubkey: string,
+  settings: ReplyMentionSettings,
+) {
+  if (typeof window === "undefined" || pubkey.length === 0) {
+    return;
+  }
+
+  window.localStorage.setItem(
+    replyMentionSettingsStorageKey(pubkey),
+    JSON.stringify(settings),
+  );
+}

--- a/desktop/src/features/messages/lib/threading.test.mjs
+++ b/desktop/src/features/messages/lib/threading.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReplyTags, resolveReplyTargetAuthorPubkey } from "./threading.ts";
+
+const AGENT_PK = "aa".repeat(32);
+const SELF_PK = "bb".repeat(32);
+const OTHER_PK = "cc".repeat(32);
+const PARENT_ID = "11".repeat(32);
+const ROOT_ID = "22".repeat(32);
+const CHANNEL_ID = "00000000-0000-0000-0000-000000000000";
+
+test("buildReplyTags includes the replied-to author as a p-tag by default", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p");
+  // author + replied-to author
+  assert.deepEqual(
+    pTags.map((t) => t[1].toLowerCase()).sort(),
+    [AGENT_PK, SELF_PK].sort(),
+  );
+});
+
+test("buildReplyTags folds replied-to author together with explicit mentions and dedups", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [AGENT_PK, OTHER_PK],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  // SELF_PK (author), AGENT_PK (mention + replied-to, deduped), OTHER_PK
+  assert.equal(pTags.includes(SELF_PK), true);
+  assert.equal(pTags.filter((p) => p === AGENT_PK).length, 1);
+  assert.equal(pTags.includes(OTHER_PK), true);
+});
+
+test("buildReplyTags does not re-mention the composer (self) as reply target", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [],
+    SELF_PK, // replying to own message must not add a self p-tag twice
+  );
+  const selfMentions = tags.filter(
+    (t) => t[0] === "p" && t[1].toLowerCase() === SELF_PK,
+  );
+  // Only the author p-tag, no duplicate self mention.
+  assert.equal(selfMentions.length, 1);
+});
+
+test("buildReplyTags omits replied-to author when not provided", () => {
+  const tags = buildReplyTags(CHANNEL_ID, SELF_PK, PARENT_ID, ROOT_ID, []);
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  assert.deepEqual(pTags, [SELF_PK]);
+});
+
+test("resolveReplyTargetAuthorPubkey returns the parent author from the cache", () => {
+  const events = [
+    { id: PARENT_ID, pubkey: AGENT_PK, tags: [] },
+    { id: ROOT_ID, pubkey: OTHER_PK, tags: [] },
+  ];
+  assert.equal(resolveReplyTargetAuthorPubkey(PARENT_ID, events), AGENT_PK);
+});
+
+test("resolveReplyTargetAuthorPubkey returns null when parent is not in cache", () => {
+  assert.equal(resolveReplyTargetAuthorPubkey(PARENT_ID, []), null);
+});

--- a/desktop/src/features/messages/lib/threading.test.mjs
+++ b/desktop/src/features/messages/lib/threading.test.mjs
@@ -76,3 +76,56 @@ test("resolveReplyTargetAuthorPubkey returns the parent author from the cache", 
 test("resolveReplyTargetAuthorPubkey returns null when parent is not in cache", () => {
   assert.equal(resolveReplyTargetAuthorPubkey(PARENT_ID, []), null);
 });
+
+// The send path (hooks.ts) implements the configurable reply-mention settings
+// by (a) withholding replyTargetAuthorPubkey when autoMentionRepliedTo is off
+// and (b) pre-folding mentionPrefixPubkeys into mentionPubkeys. These tests
+// pin the buildReplyTags contract that wiring relies on.
+
+test("buildReplyTags with auto-mention off (no reply target) keeps only explicit mentions", () => {
+  // Mirrors the wiring when autoMentionRepliedTo=false: the replied-to author
+  // is never passed in, so no implicit p-tag is emitted for them.
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [OTHER_PK],
+    undefined,
+  );
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  assert.deepEqual(pTags.sort(), [OTHER_PK, SELF_PK].sort());
+});
+
+test("buildReplyTags folds configured prefix pubkeys into reply p-tags", () => {
+  // Mirrors the wiring pre-folding mentionPrefixPubkeys into mentionPubkeys.
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    [OTHER_PK, AGENT_PK],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  assert.equal(pTags.includes(OTHER_PK), true);
+  // Prefix pubkey identical to the replied-to author stays deduped.
+  assert.equal(pTags.filter((p) => p === AGENT_PK).length, 1);
+});
+
+test("buildReplyTags prefix dedupes case-insensitively and excludes self", () => {
+  const tags = buildReplyTags(
+    CHANNEL_ID,
+    SELF_PK,
+    PARENT_ID,
+    ROOT_ID,
+    // Prefix set containing a case-variant duplicate and the composer itself.
+    [OTHER_PK.toUpperCase(), OTHER_PK, SELF_PK],
+    AGENT_PK,
+  );
+  const pTags = tags.filter((t) => t[0] === "p").map((t) => t[1].toLowerCase());
+  assert.equal(pTags.filter((p) => p === OTHER_PK).length, 1);
+  // Self appears exactly once (the author p-tag), never as a mention.
+  assert.equal(pTags.filter((p) => p === SELF_PK).length, 1);
+  assert.equal(pTags.includes(AGENT_PK), true);
+});

--- a/desktop/src/features/messages/lib/threading.ts
+++ b/desktop/src/features/messages/lib/threading.ts
@@ -104,6 +104,7 @@ export function buildReplyTags(
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] = [],
+  replyTargetAuthorPubkey?: string,
 ) {
   const tags: string[][] = [
     ["p", authorPubkey],
@@ -113,7 +114,14 @@ export function buildReplyTags(
   // Add p-tags for mentioned users so mention-filtered subscriptions
   // (e.g. ACP agent harness) receive the reply event.
   // Best-effort normalization — relay performs authoritative validation.
-  for (const pubkey of normalizeMentionPubkeys(mentionPubkeys, authorPubkey)) {
+  // The replied-to event's author is folded in too: replying to a message is
+  // itself an implicit way of addressing its author (notably agent accounts,
+  // which wake on an explicit @mention / p-tag), so include it even when the
+  // composer text contains no literal "@mention".
+  const mentionSources = replyTargetAuthorPubkey
+    ? [...mentionPubkeys, replyTargetAuthorPubkey]
+    : mentionPubkeys;
+  for (const pubkey of normalizeMentionPubkeys(mentionSources, authorPubkey)) {
     tags.push(["p", pubkey]);
   }
 
@@ -159,4 +167,21 @@ export function resolveReplyRootId(
 
   const thread = getThreadReference(parent.tags);
   return thread.rootId ?? parent.id;
+}
+
+/**
+ * Resolve the author pubkey of the event being replied to, if it is present in
+ * the local message cache.
+ *
+ * Mirrors `resolveReplyRootId`'s lookup (same event array, same `id` match) so
+ * callers can fold the replied-to author into the reply's `p` tags — replying
+ * to a message implicitly addresses its author (e.g. an agent that wakes on an
+ * explicit mentioning `p` tag), even when the composer body has no literal
+ * `@mention`. Returns `null` when the parent event isn't in the cache yet.
+ */
+export function resolveReplyTargetAuthorPubkey(
+  parentEventId: string,
+  events: RelayEvent[],
+): string | null {
+  return events.find((event) => event.id === parentEventId)?.pubkey ?? null;
 }

--- a/desktop/src/features/messages/useReplyMentionSettings.ts
+++ b/desktop/src/features/messages/useReplyMentionSettings.ts
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import {
+  DEFAULT_REPLY_MENTION_SETTINGS,
+  readStoredReplyMentionSettings,
+  type ReplyMentionSettings,
+  writeStoredReplyMentionSettings,
+} from "@/features/messages/lib/replyMentionSettings";
+
+/**
+ * React binding over the per-account reply-mention settings stored in
+ * localStorage (see `lib/replyMentionSettings.ts`). Settings screens consume
+ * this hook; the message send paths read the same storage directly via
+ * `readStoredReplyMentionSettings` so a fresh value is picked up at send time.
+ */
+export function useReplyMentionSettings(pubkey?: string) {
+  const normalizedPubkey = pubkey?.trim().toLowerCase() ?? "";
+  const [settings, setSettings] = React.useState<ReplyMentionSettings>(() =>
+    readStoredReplyMentionSettings(normalizedPubkey),
+  );
+
+  React.useEffect(() => {
+    setSettings(readStoredReplyMentionSettings(normalizedPubkey));
+  }, [normalizedPubkey]);
+
+  React.useEffect(() => {
+    writeStoredReplyMentionSettings(normalizedPubkey, settings);
+  }, [normalizedPubkey, settings]);
+
+  const setAutoMentionRepliedTo = React.useCallback((enabled: boolean) => {
+    setSettings((current) => ({
+      ...current,
+      autoMentionRepliedTo: enabled,
+    }));
+  }, []);
+
+  const setMentionPrefixPubkeys = React.useCallback((pubkeys: string[]) => {
+    setSettings((current) => ({
+      ...current,
+      mentionPrefixPubkeys: pubkeys,
+    }));
+  }, []);
+
+  const resetReplyMentionSettings = React.useCallback(() => {
+    setSettings(DEFAULT_REPLY_MENTION_SETTINGS);
+  }, []);
+
+  return {
+    settings,
+    setAutoMentionRepliedTo,
+    setMentionPrefixPubkeys,
+    resetReplyMentionSettings,
+  };
+}

--- a/desktop/src/features/settings/ui/ReplyMentionSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ReplyMentionSettingsCard.tsx
@@ -1,0 +1,156 @@
+import { X } from "lucide-react";
+import { useState } from "react";
+
+import { useReplyMentionSettings } from "@/features/messages/useReplyMentionSettings";
+import { parsePubkeyInput } from "@/shared/lib/nostrUtils";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { PubKey } from "@/shared/ui/PubKey";
+import { Switch } from "@/shared/ui/switch";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import { SettingsSectionHeader } from "./SettingsSectionHeader";
+
+/**
+ * Per-account "reply auto-mention" preferences, backed by
+ * `useReplyMentionSettings` (localStorage; see
+ * features/messages/lib/replyMentionSettings.ts). The message send path reads
+ * the same storage at send time, so changes here apply to the next reply.
+ */
+export function ReplyMentionSettingsCard({
+  currentPubkey,
+}: {
+  currentPubkey?: string;
+}) {
+  const { settings, setAutoMentionRepliedTo, setMentionPrefixPubkeys } =
+    useReplyMentionSettings(currentPubkey);
+  const [prefixInput, setPrefixInput] = useState("");
+
+  const parsedPrefix = parsePubkeyInput(prefixInput);
+  const alreadyAdded =
+    parsedPrefix != null &&
+    settings.mentionPrefixPubkeys.includes(parsedPrefix);
+  const showInvalidInput =
+    prefixInput.trim().length > 0 && parsedPrefix == null;
+
+  const addPrefix = () => {
+    if (!parsedPrefix || alreadyAdded) {
+      return;
+    }
+    setMentionPrefixPubkeys([...settings.mentionPrefixPubkeys, parsedPrefix]);
+    setPrefixInput("");
+  };
+
+  const removePrefix = (pubkey: string) => {
+    setMentionPrefixPubkeys(
+      settings.mentionPrefixPubkeys.filter((entry) => entry !== pubkey),
+    );
+  };
+
+  return (
+    <section className="min-w-0" data-testid="settings-reply-mentions">
+      <SettingsSectionHeader
+        title="Reply mentions"
+        description="Control who gets woken when you reply in a thread."
+      />
+
+      <div className="flex flex-col gap-4">
+        <SettingsOptionGroup>
+          <SettingsOptionRow>
+            <div className="min-w-0">
+              <label
+                className="text-sm font-medium"
+                htmlFor="reply-auto-mention-switch"
+              >
+                Mention the author you reply to
+              </label>
+              <p className="text-sm font-normal text-muted-foreground">
+                Replying folds the replied-to author into the reply's mentions
+                so they get notified, even without a literal @mention. Turn off
+                to reply without waking them.
+              </p>
+            </div>
+            <Switch
+              checked={settings.autoMentionRepliedTo}
+              data-testid="reply-auto-mention-toggle"
+              id="reply-auto-mention-switch"
+              onCheckedChange={(checked) => {
+                setAutoMentionRepliedTo(checked);
+              }}
+            />
+          </SettingsOptionRow>
+        </SettingsOptionGroup>
+
+        <SettingsOptionGroup>
+          <SettingsOptionRow className="items-start">
+            <div className="min-w-0">
+              <span className="text-sm font-medium">Always mention</span>
+              <p className="text-sm font-normal text-muted-foreground">
+                These accounts are folded into every reply you send — e.g. a
+                teammate or agent group that should wake on each reply.
+              </p>
+            </div>
+          </SettingsOptionRow>
+
+          {settings.mentionPrefixPubkeys.map((pubkey) => (
+            <SettingsOptionRow key={pubkey} className="min-h-12 py-2">
+              <PubKey
+                className="text-sm"
+                pubkey={pubkey}
+                testId={`reply-mention-prefix-${pubkey.slice(0, 8)}`}
+              />
+              <Button
+                aria-label="Remove always-mention entry"
+                data-testid={`reply-mention-prefix-remove-${pubkey.slice(0, 8)}`}
+                onClick={() => removePrefix(pubkey)}
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              >
+                <X />
+              </Button>
+            </SettingsOptionRow>
+          ))}
+
+          <SettingsOptionRow className="items-start">
+            <div className="flex w-full flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Input
+                  aria-label="Add always-mention pubkey"
+                  data-testid="reply-mention-prefix-input"
+                  onChange={(event) => setPrefixInput(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      addPrefix();
+                    }
+                  }}
+                  placeholder="hex pubkey or npub1…"
+                  value={prefixInput}
+                />
+                <Button
+                  data-testid="reply-mention-prefix-add"
+                  disabled={!parsedPrefix || alreadyAdded}
+                  onClick={addPrefix}
+                  size="sm"
+                  type="button"
+                  variant="secondary"
+                >
+                  Add
+                </Button>
+              </div>
+              {showInvalidInput ? (
+                <p className="text-sm text-destructive">
+                  Enter a 64-character hex pubkey or an npub1… address.
+                </p>
+              ) : alreadyAdded ? (
+                <p className="text-sm text-muted-foreground">
+                  Already in the list.
+                </p>
+              ) : null}
+            </div>
+          </SettingsOptionRow>
+        </SettingsOptionGroup>
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/features/settings/ui/ReplyMentionSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ReplyMentionSettingsCard.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { useReplyMentionSettings } from "@/features/messages/useReplyMentionSettings";
 import { parsePubkeyInput } from "@/shared/lib/nostrUtils";
+import { truncatePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { PubKey } from "@/shared/ui/PubKey";
@@ -96,11 +97,11 @@ export function ReplyMentionSettingsCard({
               <PubKey
                 className="text-sm"
                 pubkey={pubkey}
-                testId={`reply-mention-prefix-${pubkey.slice(0, 8)}`}
+                testId={`reply-mention-prefix-${truncatePubkey(pubkey)}`}
               />
               <Button
                 aria-label="Remove always-mention entry"
-                data-testid={`reply-mention-prefix-remove-${pubkey.slice(0, 8)}`}
+                data-testid={`reply-mention-prefix-remove-${truncatePubkey(pubkey)}`}
                 onClick={() => removePrefix(pubkey)}
                 size="icon-xs"
                 type="button"

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -82,6 +82,7 @@ import { MobilePairingCard } from "./MobilePairingCard";
 import { ModerationQueueCard } from "./ModerationQueueCard";
 import { NotificationSettingsCard } from "./NotificationSettingsCard";
 import { PreventSleepSettingsCard } from "./PreventSleepSettingsCard";
+import { ReplyMentionSettingsCard } from "./ReplyMentionSettingsCard";
 import { AgentDefaultsSettingsCard } from "./AgentDefaultsSettingsCard";
 import { HostedCommunitiesSettingsCard } from "./HostedCommunitiesSettingsCard";
 import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
@@ -853,20 +854,25 @@ export function renderSettingsSection(
       );
     case "notifications":
       return (
-        <NotificationSettingsCard
-          isUpdatingDesktopNotifications={props.isUpdatingDesktopNotifications}
-          notificationErrorMessage={props.notificationErrorMessage}
-          notificationPermission={props.notificationPermission}
-          notificationSettings={props.notificationSettings}
-          onSetDesktopNotificationsEnabled={
-            props.onSetDesktopNotificationsEnabled
-          }
-          onSetHomeBadgeEnabled={props.onSetHomeBadgeEnabled}
-          onSetSlotAlertsEnabled={props.onSetSlotAlertsEnabled}
-          onSetNotifyWhileViewing={props.onSetNotifyWhileViewing}
-          onSetAllSlotAlertsEnabled={props.onSetAllSlotAlertsEnabled}
-          onSetSoundForSlot={props.onSetSoundForSlot}
-        />
+        <div className="space-y-12">
+          <NotificationSettingsCard
+            isUpdatingDesktopNotifications={
+              props.isUpdatingDesktopNotifications
+            }
+            notificationErrorMessage={props.notificationErrorMessage}
+            notificationPermission={props.notificationPermission}
+            notificationSettings={props.notificationSettings}
+            onSetDesktopNotificationsEnabled={
+              props.onSetDesktopNotificationsEnabled
+            }
+            onSetHomeBadgeEnabled={props.onSetHomeBadgeEnabled}
+            onSetSlotAlertsEnabled={props.onSetSlotAlertsEnabled}
+            onSetNotifyWhileViewing={props.onSetNotifyWhileViewing}
+            onSetAllSlotAlertsEnabled={props.onSetAllSlotAlertsEnabled}
+            onSetSoundForSlot={props.onSetSoundForSlot}
+          />
+          <ReplyMentionSettingsCard currentPubkey={props.currentPubkey} />
+        </div>
       );
     case "voice":
       return <VoiceSettingsCard />;


### PR DESCRIPTION
## Summary

Makes the desktop composer's reply auto-mention behavior (shipped in `2c97683`) user-configurable per account:

- **Toggle**: users can turn off the implicit `p`-tag fold of the replied-to event's author (`autoMentionRepliedTo`, default `true` — current behavior preserved).
- **Reply prefix**: users can configure extra pubkeys (`mentionPrefixPubkeys`) that are folded into every reply's `p`-tags — e.g. a teammate or agent group that should be woken on every reply.

## Changes

- `desktop/src/features/messages/lib/replyMentionSettings.ts` — per-account persisted settings model (localStorage, per-pubkey key, sanitize-on-read so a corrupt hand-edit can never wedge the composer). React-free so send paths and tests consume it directly.
- `desktop/src/features/messages/useReplyMentionSettings.ts` — React binding for settings screens.
- `desktop/src/features/messages/hooks.ts` — all three send-path touch points now read the stored settings at send time: the `mutationFn` recipient resolution, the returned event's `buildReplyTags` call, and the optimistic message builder. Toggle off ⇒ replied-to author is no longer folded; prefix pubkeys are folded with `normalizeMentionPubkeys` (dedup + self-exclusion).
- `desktop/src/features/settings/ui/ReplyMentionSettingsCard.tsx` — settings card ("Mention the author you reply to" toggle + "Always mention" prefix list with hex/npub validation, dedup hints, per-entry removal), wired into the notifications section of `SettingsPanels.tsx`.

## Testing

- `threading.test.mjs` (+3 cases): pins the `buildReplyTags` contract the send path depends on — toggle off leaves only explicit mentions, prefix fold works, case-insensitive dedup + self-exclusion.
- `replyMentionSettings.test.mjs` (new, 6 cases): sanitize defaults / non-object / boolean preserved / case+whitespace dedup / malformed filtered / non-browser fallback.
- `just ci` full gate green on branch HEAD `5883bce` (fmt + clippy + desktop lint/typecheck/tests + web + mobile 1249 tests).
