### PR TITLE
feat(mobile): add voice-enabled Huddles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,6 +885,30 @@ jobs:
       - name: Build Android debug APK
         run: just mobile-build-android
 
+  mobile-ios:
+    name: Mobile iOS
+    runs-on: macos-15
+    timeout-minutes: 35
+    needs: [changes]
+    if: github.event_name == 'push' || needs.changes.outputs.mobile == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+      - name: Prime Flutter SDK
+        run: flutter --version
+      - name: Install dependencies
+        run: cd mobile && flutter pub get
+      - name: Analyze
+        run: cd mobile && flutter analyze
+      - name: Test
+        run: cd mobile && flutter test
+      - name: Build unsigned iOS app
+        run: cd mobile && flutter build ios --debug --no-codesign
+
   security:
     name: Security
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,6 +867,10 @@ jobs:
           restore-keys: pub-${{ runner.os }}-
       - name: Install dependencies
         run: cd mobile && flutter pub get
+      - name: Install native Opus test library
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libopus0
       - name: Save pub cache
         if: always() && steps.pub-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,7 +887,8 @@ jobs:
 
   mobile-ios:
     name: Mobile iOS
-    runs-on: macos-15
+    # connectivity_plus 7.1.x uses the Xcode 26 Network framework API.
+    runs-on: macos-26
     timeout-minutes: 35
     needs: [changes]
     if: github.event_name == 'push' || needs.changes.outputs.mobile == 'true'

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32"
@@ -63,6 +68,12 @@
 
          In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -45,6 +45,10 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Buzz needs camera access so you can take photos to attach to messages and scan QR codes for device pairing.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Buzz needs microphone access so you can speak in Huddles.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Buzz uses speech recognition to turn your Huddle questions into messages for participating bots.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Buzz needs photo library access so you can attach images to messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -53,6 +53,7 @@ import '../../shared/read_state/read_state_time.dart';
 import 'reaction_row.dart';
 import 'send_message_provider.dart';
 import '../profile/user_profile_sheet.dart';
+import '../huddles/huddle_controls.dart';
 import 'small_avatar.dart';
 import 'thread_detail_page.dart';
 import 'timeline_message.dart';
@@ -338,6 +339,7 @@ class ChannelDetailPage extends HookConsumerWidget {
                 ],
               ),
         actions: [
+          HuddleButton(channelId: resolvedChannel.id),
           _MembersButton(
             channelId: resolvedChannel.id,
             channel: resolvedChannel,

--- a/mobile/lib/features/huddles/huddle_audio.dart
+++ b/mobile/lib/features/huddles/huddle_audio.dart
@@ -1,0 +1,326 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:audio_session/audio_session.dart';
+import 'package:flutter_pcm_sound/flutter_pcm_sound.dart';
+import 'package:opus_codec/opus_codec.dart' as opus_codec;
+import 'package:opus_codec_dart/opus_codec_dart.dart';
+import 'package:opus_codec_dart/wrappers/opus_defines.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:record/record.dart' hide IosAudioCategory;
+
+import 'huddle_wire.dart';
+
+enum HuddleOutputRoute { system, speaker, earpiece, wired, bluetooth }
+
+class HuddleAudioCapabilityException implements Exception {
+  const HuddleAudioCapabilityException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+abstract interface class HuddleAudioEngine {
+  Stream<Int16List> get microphonePcm;
+  Stream<void> get interruptions;
+  Future<void> start();
+  Future<void> pauseMicrophone();
+  Future<void> resumeMicrophone();
+  Future<void> setOutputRoute(HuddleOutputRoute route);
+  Future<Uint8List> encode(Int16List pcm);
+  Future<Int16List> decode(int peerIndex, Uint8List opus, {bool plc = false});
+  void removePeer(int peerIndex);
+  Future<void> play(Int16List mixedPcm);
+  Future<void> stop();
+}
+
+/// Native, full-duplex Huddle audio for Android and iOS.
+///
+/// Codec and plugin objects remain behind [HuddleAudioEngine], so controller
+/// tests never need a microphone, platform channel, or native libopus binary.
+class MobileHuddleAudioEngine implements HuddleAudioEngine {
+  final AudioRecorder _recorder = AudioRecorder();
+  final _microphone = StreamController<Int16List>.broadcast();
+  final _interruptions = StreamController<void>.broadcast();
+  final Map<int, SimpleOpusDecoder> _decoders = {};
+  BufferedOpusEncoder? _encoder;
+  AudioSession? _session;
+  StreamSubscription<Uint8List>? _recordingSubscription;
+  StreamSubscription<AudioInterruptionEvent>? _interruptionSubscription;
+  Future<void> _playbackQueue = Future<void>.value();
+  int? _pendingPcmByte;
+  bool _started = false;
+  bool _stopped = false;
+  bool _microphonePaused = false;
+  HuddleOutputRoute _outputRoute = HuddleOutputRoute.system;
+
+  @override
+  Stream<Int16List> get microphonePcm => _microphone.stream;
+
+  @override
+  Stream<void> get interruptions => _interruptions.stream;
+
+  @override
+  Future<void> start() async {
+    if (_started) return;
+    if (_stopped) throw StateError('Huddle audio engine cannot be restarted');
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      throw const HuddleAudioCapabilityException(
+        'Huddle audio requires an Android or iOS device.',
+      );
+    }
+    if (!await _recorder.hasPermission()) {
+      throw const HuddleAudioCapabilityException(
+        'Microphone permission is required to join a Huddle.',
+      );
+    }
+
+    try {
+      initOpus(await opus_codec.load());
+      final encoder = BufferedOpusEncoder(
+        sampleRate: huddleSampleRate,
+        channels: 1,
+        application: Application.voip,
+        maxInputBufferSizeBytes: huddleFrameSamples * 2,
+        maxOutputBufferSizeBytes: 400,
+      );
+      encoder
+        ..encoderCtl(request: OPUS_SET_BITRATE_REQUEST, value: 32000)
+        ..encoderCtl(request: OPUS_SET_INBAND_FEC_REQUEST, value: 1)
+        ..encoderCtl(request: OPUS_SET_PACKET_LOSS_PERC_REQUEST, value: 10)
+        ..encoderCtl(request: OPUS_SET_DTX_REQUEST, value: 1);
+      _encoder = encoder;
+
+      await FlutterPcmSound.setLogLevel(LogLevel.none);
+      await FlutterPcmSound.setup(
+        sampleRate: huddleSampleRate,
+        channelCount: 1,
+        iosAudioCategory: IosAudioCategory.playAndRecord,
+      );
+      await FlutterPcmSound.setFeedThreshold(huddleFrameSamples * 2);
+      FlutterPcmSound.setFeedCallback((_) {});
+
+      // Configure after every audio plugin is loaded. AVAudioSession is global
+      // and plugins may otherwise replace voice-chat mode with their defaults.
+      final session = await AudioSession.instance;
+      await session.configure(_voiceSessionConfiguration());
+      if (!await session.setActive(true)) {
+        throw const HuddleAudioCapabilityException(
+          'Another app currently owns the speech audio session.',
+        );
+      }
+      _session = session;
+      await setOutputRoute(HuddleOutputRoute.system);
+      _interruptionSubscription = session.interruptionEventStream.listen((
+        event,
+      ) {
+        if (event.begin) _interruptions.add(null);
+      });
+      FlutterPcmSound.start();
+
+      await _startMicrophoneStream();
+      _started = true;
+    } catch (error) {
+      await stop();
+      if (error is HuddleAudioCapabilityException) rethrow;
+      throw HuddleAudioCapabilityException(
+        'Could not initialize Huddle audio: $error',
+      );
+    }
+  }
+
+  AudioSessionConfiguration _voiceSessionConfiguration() =>
+      AudioSessionConfiguration(
+        avAudioSessionCategory: AVAudioSessionCategory.playAndRecord,
+        avAudioSessionCategoryOptions:
+            AVAudioSessionCategoryOptions.allowBluetooth |
+            AVAudioSessionCategoryOptions.allowBluetoothA2dp,
+        avAudioSessionMode: AVAudioSessionMode.voiceChat,
+        androidAudioAttributes: const AndroidAudioAttributes(
+          contentType: AndroidAudioContentType.speech,
+          usage: AndroidAudioUsage.voiceCommunication,
+        ),
+        androidAudioFocusGainType: AndroidAudioFocusGainType.gain,
+        androidWillPauseWhenDucked: true,
+      );
+
+  Future<void> _startMicrophoneStream() async {
+    await _recorder.ios?.manageAudioSession(false);
+    final bytes = await _recorder.startStream(
+      const RecordConfig(
+        encoder: AudioEncoder.pcm16bits,
+        sampleRate: huddleSampleRate,
+        numChannels: 1,
+        autoGain: true,
+        echoCancel: true,
+        noiseSuppress: true,
+        streamBufferSize: huddleFrameSamples * 4,
+        androidConfig: AndroidRecordConfig(
+          audioSource: AndroidAudioSource.voiceCommunication,
+          audioManagerMode: AudioManagerMode.modeInCommunication,
+        ),
+      ),
+    );
+    _pendingPcmByte = null;
+    _recordingSubscription = bytes.listen((chunk) {
+      final normalized = _withPendingPcmByte(chunk);
+      if (normalized.isEmpty) return;
+      final data = ByteData.sublistView(normalized);
+      final pcm = Int16List(normalized.length ~/ 2);
+      for (var i = 0; i < pcm.length; i++) {
+        pcm[i] = data.getInt16(i * 2, Endian.little);
+      }
+      _microphone.add(pcm);
+    }, onError: _microphone.addError);
+    _microphonePaused = false;
+  }
+
+  @override
+  Future<void> pauseMicrophone() async {
+    if (!_started || _stopped || _microphonePaused) return;
+    await _recordingSubscription?.cancel();
+    _recordingSubscription = null;
+    await _recorder.stop();
+    _pendingPcmByte = null;
+    _microphonePaused = true;
+  }
+
+  @override
+  Future<void> resumeMicrophone() async {
+    if (!_started || _stopped || !_microphonePaused) return;
+    final session = _session;
+    if (session == null) return;
+    await session.configure(_voiceSessionConfiguration());
+    if (!await session.setActive(true)) {
+      throw const HuddleAudioCapabilityException(
+        'Could not restore the Huddle audio session after speech recognition.',
+      );
+    }
+    await setOutputRoute(_outputRoute);
+    await _startMicrophoneStream();
+  }
+
+  @override
+  Future<Uint8List> encode(Int16List pcm) async {
+    if (pcm.length != huddleFrameSamples || _encoder == null) {
+      throw const HuddleAudioCapabilityException(
+        'Huddle encoder is not ready.',
+      );
+    }
+    final encoder = _encoder!;
+    final input = ByteData.sublistView(encoder.inputBuffer);
+    for (var i = 0; i < pcm.length; i++) {
+      input.setInt16(i * 2, pcm[i], Endian.little);
+    }
+    encoder.inputBufferIndex = pcm.length * 2;
+    return encoder.encode();
+  }
+
+  @override
+  Future<Int16List> decode(
+    int peerIndex,
+    Uint8List opus, {
+    bool plc = false,
+  }) async {
+    final decoder = _decoders.putIfAbsent(
+      peerIndex,
+      () => SimpleOpusDecoder(sampleRate: huddleSampleRate, channels: 1),
+    );
+    return decoder.decode(input: plc ? null : opus, loss: plc ? 20 : null);
+  }
+
+  @override
+  void removePeer(int peerIndex) => _decoders.remove(peerIndex)?.destroy();
+
+  @override
+  Future<void> play(Int16List mixedPcm) {
+    if (_stopped || mixedPcm.isEmpty) return Future<void>.value();
+    _playbackQueue = _playbackQueue.then((_) async {
+      if (!_stopped) {
+        await FlutterPcmSound.feed(PcmArrayInt16.fromList(mixedPcm));
+      }
+    });
+    return _playbackQueue;
+  }
+
+  @override
+  Future<void> setOutputRoute(HuddleOutputRoute route) async {
+    if (Platform.isIOS) {
+      final av = AVAudioSession();
+      await av.overrideOutputAudioPort(
+        route == HuddleOutputRoute.speaker
+            ? AVAudioSessionPortOverride.speaker
+            : AVAudioSessionPortOverride.none,
+      );
+      _outputRoute = route;
+      return;
+    }
+    if (Platform.isAndroid) {
+      final manager = AndroidAudioManager();
+      await manager.setMode(AndroidAudioHardwareMode.inCommunication);
+      await manager.setSpeakerphoneOn(route == HuddleOutputRoute.speaker);
+      if (route == HuddleOutputRoute.bluetooth) {
+        final permission = await Permission.bluetoothConnect.request();
+        if (!permission.isGranted) {
+          throw const HuddleAudioCapabilityException(
+            'Nearby devices permission is required to use Bluetooth audio.',
+          );
+        }
+        await manager.startBluetoothSco();
+        await manager.setBluetoothScoOn(true);
+      } else {
+        await manager.setBluetoothScoOn(false);
+        await manager.stopBluetoothSco();
+      }
+      _outputRoute = route;
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
+    _started = false;
+    await _recordingSubscription?.cancel();
+    _recordingSubscription = null;
+    try {
+      await _recorder.stop();
+    } catch (_) {}
+    await _recorder.dispose();
+    await _interruptionSubscription?.cancel();
+    _interruptionSubscription = null;
+    try {
+      await _playbackQueue;
+    } catch (_) {}
+    FlutterPcmSound.setFeedCallback(null);
+    try {
+      await FlutterPcmSound.release();
+    } catch (_) {}
+    _encoder?.destroy();
+    _encoder = null;
+    for (final decoder in _decoders.values) {
+      decoder.destroy();
+    }
+    _decoders.clear();
+    try {
+      await _session?.setActive(false);
+    } catch (_) {}
+    _session = null;
+    await _microphone.close();
+    await _interruptions.close();
+  }
+
+  Uint8List _withPendingPcmByte(Uint8List chunk) {
+    final pending = _pendingPcmByte;
+    final combined = pending == null
+        ? Uint8List.fromList(chunk)
+        : Uint8List.fromList([pending, ...chunk]);
+    if (combined.length.isOdd) {
+      _pendingPcmByte = combined.last;
+      return Uint8List.sublistView(combined, 0, combined.length - 1);
+    }
+    _pendingPcmByte = null;
+    return combined;
+  }
+}

--- a/mobile/lib/features/huddles/huddle_bot_voice.dart
+++ b/mobile/lib/features/huddles/huddle_bot_voice.dart
@@ -1,0 +1,168 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:speech_to_text/speech_recognition_error.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
+
+class HuddleBotVoiceException implements Exception {
+  const HuddleBotVoiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+abstract interface class HuddleBotVoiceEngine {
+  Future<String?> transcribe();
+  Future<void> stopTranscribing();
+  Future<void> speak(String text);
+  Future<void> stopSpeaking();
+  Future<void> dispose();
+}
+
+/// Short-utterance speech recognition and system TTS for mobile bot turns.
+///
+/// Human-to-human audio continues over the Huddle Opus transport. The recorder
+/// is paused by [HuddleController] while this engine owns the microphone.
+class MobileHuddleBotVoiceEngine implements HuddleBotVoiceEngine {
+  final SpeechToText _speech = SpeechToText();
+  final FlutterTts _tts = FlutterTts();
+
+  Completer<String?>? _transcription;
+  String _recognizedWords = '';
+  bool _speechReady = false;
+  bool _disposed = false;
+
+  @override
+  Future<String?> transcribe() async {
+    if (_disposed) throw StateError('Bot voice engine has been disposed');
+    if (_transcription != null) {
+      throw const HuddleBotVoiceException(
+        'Speech recognition is already listening.',
+      );
+    }
+
+    final completer = Completer<String?>();
+    _transcription = completer;
+    _recognizedWords = '';
+    try {
+      if (!_speechReady) {
+        _speechReady = await _speech.initialize(
+          onError: _onSpeechError,
+          onStatus: _onSpeechStatus,
+          options: [
+            if (Platform.isAndroid) SpeechToText.androidNoBluetooth,
+            if (Platform.isIOS) SpeechToText.iosNoBluetooth,
+          ],
+        );
+      }
+      if (!_speechReady) {
+        throw const HuddleBotVoiceException(
+          'Speech recognition is not available on this device.',
+        );
+      }
+
+      await _speech.listen(
+        onResult: _onSpeechResult,
+        listenOptions: SpeechListenOptions(
+          listenMode: ListenMode.confirmation,
+          cancelOnError: true,
+          partialResults: true,
+          autoPunctuation: true,
+          enableHapticFeedback: true,
+          listenFor: Duration(seconds: 30),
+          pauseFor: Duration(seconds: 2),
+        ),
+      );
+      return await completer.future.timeout(
+        const Duration(seconds: 35),
+        onTimeout: () async {
+          await _speech.stop();
+          return _normalizedWords();
+        },
+      );
+    } catch (error) {
+      if (!completer.isCompleted) completer.completeError(error);
+      rethrow;
+    } finally {
+      if (identical(_transcription, completer)) _transcription = null;
+    }
+  }
+
+  void _onSpeechResult(SpeechRecognitionResult result) {
+    _recognizedWords = result.recognizedWords;
+    if (result.finalResult) _completeTranscription();
+  }
+
+  void _onSpeechStatus(String status) {
+    if (status == SpeechToText.doneStatus ||
+        status == SpeechToText.notListeningStatus) {
+      _completeTranscription();
+    }
+  }
+
+  void _onSpeechError(SpeechRecognitionError error) {
+    final completer = _transcription;
+    if (completer == null || completer.isCompleted) return;
+    completer.completeError(
+      HuddleBotVoiceException('Speech recognition failed: ${error.errorMsg}'),
+    );
+  }
+
+  void _completeTranscription() {
+    final completer = _transcription;
+    if (completer == null || completer.isCompleted) return;
+    completer.complete(_normalizedWords());
+  }
+
+  String? _normalizedWords() {
+    final words = _recognizedWords.trim();
+    return words.isEmpty ? null : words;
+  }
+
+  @override
+  Future<void> stopTranscribing() async {
+    if (_speech.isListening) await _speech.stop();
+    _completeTranscription();
+  }
+
+  @override
+  Future<void> speak(String text) async {
+    final normalized = text.trim();
+    if (_disposed || normalized.isEmpty) return;
+    await _tts.awaitSpeakCompletion(true);
+    if (Platform.isIOS) {
+      await _tts.setIosAudioCategory(
+        IosTextToSpeechAudioCategory.playAndRecord,
+        [
+          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
+          IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP,
+          IosTextToSpeechAudioCategoryOptions.defaultToSpeaker,
+        ],
+        IosTextToSpeechAudioMode.voicePrompt,
+      );
+    }
+    final result = await _tts.speak(normalized);
+    if (result != 1) {
+      throw const HuddleBotVoiceException(
+        'The device text-to-speech engine could not play the bot reply.',
+      );
+    }
+  }
+
+  @override
+  Future<void> stopSpeaking() async {
+    await _tts.stop();
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await stopTranscribing();
+    await stopSpeaking();
+  }
+}

--- a/mobile/lib/features/huddles/huddle_controller.dart
+++ b/mobile/lib/features/huddles/huddle_controller.dart
@@ -1,0 +1,654 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../shared/relay/relay.dart';
+import '../channels/channel_management_provider.dart';
+import '../channels/send_message_provider.dart';
+import 'huddle_audio.dart';
+import 'huddle_bot_voice.dart';
+import 'huddle_transport.dart';
+import 'huddle_wire.dart';
+
+enum HuddlePhase { idle, creating, connecting, connected, reconnecting, failed }
+
+class HuddleState {
+  const HuddleState({
+    this.phase = HuddlePhase.idle,
+    this.parentChannelId,
+    this.channelId,
+    this.isCreator = false,
+    this.isMuted = false,
+    this.botPubkeys = const {},
+    this.isTranscribing = false,
+    this.isBotSpeaking = false,
+    this.lastTranscript,
+    this.outputRoute = HuddleOutputRoute.system,
+    this.peers = const {},
+    this.error,
+  });
+
+  final HuddlePhase phase;
+  final String? parentChannelId;
+  final String? channelId;
+  final bool isCreator;
+  final bool isMuted;
+  final Set<String> botPubkeys;
+  final bool isTranscribing;
+  final bool isBotSpeaking;
+  final String? lastTranscript;
+  final HuddleOutputRoute outputRoute;
+  final Map<int, HuddlePeer> peers;
+  final String? error;
+
+  bool get isActive => phase != HuddlePhase.idle && phase != HuddlePhase.failed;
+
+  HuddleState copyWith({
+    HuddlePhase? phase,
+    String? parentChannelId,
+    String? channelId,
+    bool? isCreator,
+    bool? isMuted,
+    Set<String>? botPubkeys,
+    bool? isTranscribing,
+    bool? isBotSpeaking,
+    String? lastTranscript,
+    HuddleOutputRoute? outputRoute,
+    Map<int, HuddlePeer>? peers,
+    String? error,
+    bool clearError = false,
+  }) => HuddleState(
+    phase: phase ?? this.phase,
+    parentChannelId: parentChannelId ?? this.parentChannelId,
+    channelId: channelId ?? this.channelId,
+    isCreator: isCreator ?? this.isCreator,
+    isMuted: isMuted ?? this.isMuted,
+    botPubkeys: botPubkeys ?? this.botPubkeys,
+    isTranscribing: isTranscribing ?? this.isTranscribing,
+    isBotSpeaking: isBotSpeaking ?? this.isBotSpeaking,
+    lastTranscript: lastTranscript ?? this.lastTranscript,
+    outputRoute: outputRoute ?? this.outputRoute,
+    peers: peers ?? this.peers,
+    error: clearError ? null : error ?? this.error,
+  );
+}
+
+typedef HuddleTransportFactory = HuddleTransport Function();
+typedef HuddleAudioFactory = HuddleAudioEngine Function();
+typedef HuddleBotVoiceFactory = HuddleBotVoiceEngine Function();
+typedef HuddleBotPubkeysLoader = Future<Set<String>> Function(String channelId);
+typedef HuddleMessageSubscriber =
+    Future<void Function()> Function(
+      String channelId,
+      void Function(NostrEvent event) onEvent,
+    );
+typedef HuddleTranscriptSender =
+    Future<void> Function(
+      String channelId,
+      String content,
+      List<String> mentionPubkeys,
+    );
+
+class HuddleController extends Notifier<HuddleState> {
+  HuddleController({
+    HuddleTransportFactory? transportFactory,
+    HuddleAudioFactory? audioFactory,
+    HuddleBotVoiceFactory? botVoiceFactory,
+    HuddleBotPubkeysLoader? botPubkeysLoader,
+    HuddleMessageSubscriber? messageSubscriber,
+    HuddleTranscriptSender? transcriptSender,
+  }) : _transportFactory = transportFactory ?? WebSocketHuddleTransport.new,
+       _audioFactory = audioFactory ?? MobileHuddleAudioEngine.new,
+       _botVoiceFactory = botVoiceFactory ?? MobileHuddleBotVoiceEngine.new,
+       _botPubkeysLoader = botPubkeysLoader,
+       _messageSubscriber = messageSubscriber,
+       _transcriptSender = transcriptSender;
+
+  final HuddleTransportFactory _transportFactory;
+  final HuddleAudioFactory _audioFactory;
+  final HuddleBotVoiceFactory _botVoiceFactory;
+  final HuddleBotPubkeysLoader? _botPubkeysLoader;
+  final HuddleMessageSubscriber? _messageSubscriber;
+  final HuddleTranscriptSender? _transcriptSender;
+  HuddleTransport? _transport;
+  HuddleAudioEngine? _audio;
+  HuddleBotVoiceEngine? _botVoice;
+  StreamSubscription<HuddleTransportEvent>? _transportSub;
+  StreamSubscription<Int16List>? _microphoneSub;
+  StreamSubscription<void>? _interruptionSub;
+  void Function()? _messageUnsubscribe;
+  Timer? _reconnectTimer;
+  Timer? _playoutTimer;
+  int _generation = 0;
+  int _reconnectAttempt = 0;
+  Future<void> _encodeQueue = Future<void>.value();
+  Future<void> _decodeQueue = Future<void>.value();
+  Future<void> _speechQueue = Future<void>.value();
+  final Set<String> _spokenMessageIds = {};
+  final Map<int, ListQueue<Int16List>> _playoutQueues = {};
+  final Map<int, int> _lastPeerSequence = {};
+  final _chunker = PcmFrameChunker();
+  final _sequence = HuddleSequence();
+
+  @override
+  HuddleState build() {
+    ref.listen(appLifecycleProvider, (_, next) {
+      if (next == AppLifecycleState.paused ||
+          next == AppLifecycleState.detached) {
+        unawaited(leave());
+      }
+    });
+    ref.onDispose(() => unawaited(_teardown(sendLeave: true)));
+    return const HuddleState();
+  }
+
+  Future<void> start(String parentChannelId) async {
+    if (state.isActive) throw StateError('Only one Huddle may be active');
+    final generation = ++_generation;
+    const uuid = Uuid();
+    final channelId = uuid.v4();
+    state = HuddleState(
+      phase: HuddlePhase.creating,
+      parentChannelId: parentChannelId,
+      channelId: channelId,
+      isCreator: true,
+    );
+    var created = false;
+    var announced = false;
+    try {
+      final botPubkeys = await _parentBotPubkeys(parentChannelId);
+      if (generation != _generation) {
+        throw StateError('Huddle start cancelled');
+      }
+      final relay = _signedRelay();
+      await relay.submit(
+        kind: 9007,
+        content: '',
+        tags: buildCreateChannelTags(
+          channelId: channelId,
+          name: 'Huddle',
+          channelType: 'stream',
+          visibility: 'private',
+          ttlSeconds: 3600,
+        ),
+      );
+      created = true;
+      if (generation != _generation) {
+        throw StateError('Huddle start cancelled');
+      }
+      await relay.submit(
+        kind: EventKind.huddleGuidelines,
+        content: _voiceModeGuidelines(parentChannelId),
+        tags: [
+          ['h', channelId],
+        ],
+      );
+      if (generation != _generation) {
+        throw StateError('Huddle start cancelled');
+      }
+      if (botPubkeys.isNotEmpty) {
+        await ref
+            .read(channelActionsProvider)
+            .addMembers(
+              channelId: channelId,
+              pubkeys: botPubkeys.toList(),
+              role: 'bot',
+            );
+      }
+      if (generation != _generation) {
+        throw StateError('Huddle start cancelled');
+      }
+      state = state.copyWith(botPubkeys: botPubkeys);
+      await relay.submit(
+        kind: EventKind.huddleStarted,
+        content: jsonEncode({'ephemeral_channel_id': channelId}),
+        tags: [
+          ['h', parentChannelId],
+          ['channel', channelId],
+        ],
+      );
+      announced = true;
+      if (generation != _generation) {
+        throw StateError('Huddle start cancelled');
+      }
+      await _connect(generation);
+    } catch (error) {
+      if (created) {
+        try {
+          if (announced) {
+            await _signedRelay().submit(
+              kind: EventKind.huddleEnded,
+              content: jsonEncode({'ephemeral_channel_id': channelId}),
+              tags: [
+                ['h', parentChannelId],
+                ['channel', channelId],
+              ],
+            );
+          }
+          await _signedRelay().submit(
+            kind: 9002,
+            content: '',
+            tags: buildSetChannelArchivedTags(channelId, archived: true),
+          );
+        } catch (_) {}
+      }
+      await _fail(generation, error);
+      rethrow;
+    }
+  }
+
+  Future<Set<String>> _parentBotPubkeys(String parentChannelId) async {
+    final loader = _botPubkeysLoader;
+    if (loader != null) return loader(parentChannelId);
+    final members = await ref.read(
+      channelMembersProvider(parentChannelId).future,
+    );
+    return members
+        .where((member) => member.isBot)
+        .take(20)
+        .map((member) => member.pubkey.toLowerCase())
+        .toSet();
+  }
+
+  String _voiceModeGuidelines(String parentChannelId) =>
+      '''
+You are in a live voice huddle attached to channel $parentChannelId.
+Your text is read aloud via TTS, message by message, in the order sent.
+
+Latency matters most: send your first sentence immediately, then each following sentence as a separate message.
+- If not addressed or relevant: do nothing.
+- Keep the whole reply short and start with the answer.
+- Use natural speech: no markdown, code blocks, lists, or structured data.
+- If a new human message arrives mid-reply, drop unsent sentences and answer the new message.
+- Use your Buzz tools proactively when asked.
+''';
+
+  Future<void> join({
+    required String parentChannelId,
+    required String channelId,
+  }) async {
+    if (state.isActive) throw StateError('Only one Huddle may be active');
+    final generation = ++_generation;
+    state = HuddleState(
+      phase: HuddlePhase.connecting,
+      parentChannelId: parentChannelId,
+      channelId: channelId,
+    );
+    try {
+      await _connect(generation);
+    } catch (error) {
+      await _fail(generation, error);
+      rethrow;
+    }
+  }
+
+  SignedEventRelay _signedRelay() {
+    final config = ref.read(relayConfigProvider);
+    return SignedEventRelay(
+      session: ref.read(relaySessionProvider.notifier),
+      nsec: config.nsec,
+    );
+  }
+
+  Future<void> _connect(int generation) async {
+    if (generation != _generation) return;
+    state = state.copyWith(phase: HuddlePhase.connecting, clearError: true);
+    final config = ref.read(relayConfigProvider);
+    final nsec = config.nsec;
+    if (nsec == null || nsec.isEmpty) {
+      throw StateError('Huddle requires a signing key');
+    }
+    final audio = _audioFactory();
+    await audio.start();
+    if (generation != _generation) {
+      await audio.stop();
+      return;
+    }
+    final transport = _transportFactory();
+    _audio = audio;
+    _transport = transport;
+    _transportSub = transport.events.listen(
+      (event) => _onTransportEvent(generation, event),
+      onError: (Object error, StackTrace stack) =>
+          _onDisconnected(generation, error),
+    );
+    await transport.connect(
+      relayWebSocket: Uri.parse(config.wsUrl),
+      channelId: state.channelId!,
+      parentChannelId: state.parentChannelId,
+      nsec: nsec,
+    );
+    if (generation != _generation) {
+      await transport.close(sendLeave: true);
+      await audio.stop();
+      return;
+    }
+    final botPubkeys = {
+      ...state.botPubkeys,
+      ...await _parentBotPubkeys(state.channelId!),
+    };
+    if (generation != _generation) return;
+    state = state.copyWith(botPubkeys: botPubkeys);
+    if (botPubkeys.isNotEmpty) {
+      _botVoice ??= _botVoiceFactory();
+      final subscriber = _messageSubscriber;
+      final unsubscribe = subscriber != null
+          ? await subscriber(
+              state.channelId!,
+              (event) => _onBotMessage(generation, event),
+            )
+          : await ref
+                .read(relaySessionProvider.notifier)
+                .subscribe(
+                  NostrFilter(
+                    kinds: const [
+                      EventKind.streamMessage,
+                      EventKind.streamMessageV2,
+                    ],
+                    tags: {
+                      '#h': [state.channelId!],
+                    },
+                    since: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                    limit: 200,
+                  ),
+                  (event) => _onBotMessage(generation, event),
+                );
+      if (generation != _generation) {
+        unsubscribe();
+        return;
+      }
+      _messageUnsubscribe = unsubscribe;
+    }
+    _microphoneSub = audio.microphonePcm.listen(
+      (chunk) {
+        _encodeQueue = _encodeQueue
+            .then((_) => _onMicrophone(generation, chunk))
+            .catchError((Object error) => _onDisconnected(generation, error));
+      },
+      onError: (Object error, StackTrace stack) =>
+          _onDisconnected(generation, error),
+    );
+    _interruptionSub = audio.interruptions.listen((_) {
+      if (generation == _generation) {
+        unawaited(leave());
+      }
+    });
+    _reconnectAttempt = 0;
+    state = state.copyWith(phase: HuddlePhase.connected, clearError: true);
+  }
+
+  Future<void> _onMicrophone(int generation, Int16List chunk) async {
+    if (generation != _generation ||
+        state.isMuted ||
+        state.isTranscribing ||
+        state.isBotSpeaking) {
+      return;
+    }
+    for (final pcm in _chunker.add(chunk)) {
+      final opus = await _audio!.encode(pcm);
+      if (generation != _generation) return;
+      final header = _sequence.next(
+        levelDbov: audioLevelDbov(pcm),
+        isDtx: opus.length <= 2,
+      );
+      _transport?.sendAudio(Uint8List.fromList([...header.encode(), ...opus]));
+    }
+  }
+
+  void _onBotMessage(int generation, NostrEvent event) {
+    if (generation != _generation ||
+        !state.botPubkeys.contains(event.pubkey.toLowerCase()) ||
+        !_spokenMessageIds.add(event.id) ||
+        event.content.trim().isEmpty) {
+      return;
+    }
+    _speechQueue = _speechQueue
+        .then((_) => _speakBotMessage(generation, event.content))
+        .catchError((Object error) {
+          if (generation == _generation) {
+            state = state.copyWith(
+              isBotSpeaking: false,
+              error: error.toString(),
+            );
+          }
+        });
+  }
+
+  Future<void> _speakBotMessage(int generation, String text) async {
+    if (generation != _generation || _botVoice == null) return;
+    state = state.copyWith(isBotSpeaking: true, clearError: true);
+    try {
+      await _botVoice!.speak(text);
+    } finally {
+      if (generation == _generation) {
+        state = state.copyWith(isBotSpeaking: false);
+      }
+    }
+  }
+
+  Future<void> talkToBots() async {
+    if (state.phase != HuddlePhase.connected || state.botPubkeys.isEmpty) {
+      throw const HuddleBotVoiceException(
+        'Add a bot to this channel before starting a voice turn.',
+      );
+    }
+    if (state.isTranscribing) {
+      await _botVoice?.stopTranscribing();
+      return;
+    }
+    final generation = _generation;
+    state = state.copyWith(isTranscribing: true, clearError: true);
+    try {
+      await _botVoice?.stopSpeaking();
+      await _audio?.pauseMicrophone();
+      final transcript = await _botVoice!.transcribe();
+      if (generation != _generation || transcript == null) return;
+      state = state.copyWith(lastTranscript: transcript);
+      final sender = _transcriptSender;
+      if (sender != null) {
+        await sender(state.channelId!, transcript, state.botPubkeys.toList());
+      } else {
+        await ref.read(sendMessageProvider)(
+          channelId: state.channelId!,
+          content: transcript,
+          mentionPubkeys: state.botPubkeys.toList(),
+        );
+      }
+    } catch (error) {
+      if (generation == _generation) {
+        state = state.copyWith(error: error.toString());
+      }
+      rethrow;
+    } finally {
+      if (generation == _generation) {
+        try {
+          await _audio?.resumeMicrophone();
+        } catch (error) {
+          state = state.copyWith(error: error.toString());
+        }
+        state = state.copyWith(isTranscribing: false);
+      }
+    }
+  }
+
+  void _onTransportEvent(int generation, HuddleTransportEvent event) {
+    if (generation != _generation) return;
+    switch (event) {
+      case HuddleRosterEvent(:final peers):
+        state = state.copyWith(
+          peers: {for (final peer in peers) peer.peerIndex: peer},
+        );
+      case HuddlePeerJoinedEvent(:final peer):
+        state = state.copyWith(peers: {...state.peers, peer.peerIndex: peer});
+      case HuddlePeerLeftEvent(:final peerIndex):
+        state = state.copyWith(peers: {...state.peers}..remove(peerIndex));
+        _playoutQueues.remove(peerIndex);
+        _lastPeerSequence.remove(peerIndex);
+        _audio?.removePeer(peerIndex);
+      case HuddleAudioFrameEvent(:final peerIndex, :final bytes):
+        _decodeQueue = _decodeQueue
+            .then((_) => _queueFrame(generation, peerIndex, bytes))
+            .catchError((Object error) => _onDisconnected(generation, error));
+    }
+  }
+
+  Future<void> _queueFrame(
+    int generation,
+    int peerIndex,
+    Uint8List bytes,
+  ) async {
+    final parsed = HuddleFrameHeader.parse(bytes);
+    if (parsed == null || parsed.payload.isEmpty) return;
+    final previous = _lastPeerSequence[peerIndex];
+    if (previous != null) {
+      final delta = (parsed.header.sequence - previous) & 0xffff;
+      if (delta == 0 || delta > 0x8000) return;
+      if (delta <= 4) {
+        for (var missing = 1; missing < delta; missing++) {
+          final plc = await _audio?.decode(peerIndex, Uint8List(0), plc: true);
+          if (plc != null) _enqueuePlayout(peerIndex, plc);
+        }
+      }
+    }
+    _lastPeerSequence[peerIndex] = parsed.header.sequence;
+    final pcm = await _audio?.decode(peerIndex, parsed.payload);
+    if (pcm == null || generation != _generation) return;
+    _enqueuePlayout(peerIndex, pcm);
+    _playoutTimer ??= Timer.periodic(
+      const Duration(milliseconds: 20),
+      (_) => unawaited(_drainPlayout(generation)),
+    );
+  }
+
+  void _enqueuePlayout(int peerIndex, Int16List pcm) {
+    final queue = _playoutQueues.putIfAbsent(peerIndex, ListQueue.new);
+    if (queue.length >= 10) queue.removeFirst();
+    queue.addLast(pcm);
+  }
+
+  Future<void> _drainPlayout(int generation) async {
+    if (generation != _generation) return;
+    final frames = <Int16List>[];
+    for (final queue in _playoutQueues.values) {
+      if (queue.isNotEmpty) frames.add(queue.removeFirst());
+    }
+    _playoutQueues.removeWhere((_, queue) => queue.isEmpty);
+    if (frames.isEmpty) {
+      _playoutTimer?.cancel();
+      _playoutTimer = null;
+      return;
+    }
+    await _audio?.play(mixPcmFrames(frames));
+  }
+
+  void _onDisconnected(int generation, Object error) {
+    if (generation != _generation || !state.isActive) return;
+    if (_reconnectTimer != null) return;
+    if (ref.read(appLifecycleProvider) != AppLifecycleState.resumed) {
+      unawaited(leave());
+      return;
+    }
+    if (_reconnectAttempt >= 5) {
+      unawaited(_fail(generation, error));
+      return;
+    }
+    state = state.copyWith(
+      phase: HuddlePhase.reconnecting,
+      error: error.toString(),
+    );
+    final delay = Duration(milliseconds: 250 * (1 << _reconnectAttempt));
+    _reconnectAttempt++;
+    _reconnectTimer = Timer(delay, () async {
+      _reconnectTimer = null;
+      await _teardown(sendLeave: false, invalidate: false);
+      try {
+        await _connect(generation);
+      } catch (nextError) {
+        _onDisconnected(generation, nextError);
+      }
+    });
+  }
+
+  void toggleMute() => state = state.copyWith(isMuted: !state.isMuted);
+
+  Future<void> setOutputRoute(HuddleOutputRoute route) async {
+    try {
+      await _audio?.setOutputRoute(route);
+      state = state.copyWith(outputRoute: route, clearError: true);
+    } catch (error) {
+      state = state.copyWith(error: error.toString());
+    }
+  }
+
+  Future<void> leave() async {
+    if (state.isCreator &&
+        state.parentChannelId != null &&
+        state.channelId != null) {
+      try {
+        final relay = _signedRelay();
+        await relay.submit(
+          kind: EventKind.huddleEnded,
+          content: jsonEncode({'ephemeral_channel_id': state.channelId}),
+          tags: [
+            ['h', state.parentChannelId!],
+            ['channel', state.channelId!],
+          ],
+        );
+        await relay.submit(
+          kind: 9002,
+          content: '',
+          tags: buildSetChannelArchivedTags(state.channelId!, archived: true),
+        );
+      } catch (_) {
+        // Leaving must always release the microphone and audio session. The
+        // ephemeral channel also has a relay-enforced TTL as a final fallback.
+      }
+    }
+    ++_generation;
+    await _teardown(sendLeave: true);
+    state = const HuddleState();
+  }
+
+  Future<void> _fail(int generation, Object error) async {
+    if (generation != _generation) return;
+    await _teardown(sendLeave: false, invalidate: false);
+    state = state.copyWith(phase: HuddlePhase.failed, error: error.toString());
+  }
+
+  Future<void> _teardown({
+    required bool sendLeave,
+    bool invalidate = true,
+  }) async {
+    if (invalidate) ++_generation;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _playoutTimer?.cancel();
+    _playoutTimer = null;
+    await _microphoneSub?.cancel();
+    _microphoneSub = null;
+    await _interruptionSub?.cancel();
+    _interruptionSub = null;
+    _messageUnsubscribe?.call();
+    _messageUnsubscribe = null;
+    await _transportSub?.cancel();
+    _transportSub = null;
+    await _transport?.close(sendLeave: sendLeave);
+    _transport = null;
+    await _audio?.stop();
+    _audio = null;
+    await _botVoice?.dispose();
+    _botVoice = null;
+    _chunker.clear();
+    _playoutQueues.clear();
+    _lastPeerSequence.clear();
+    _spokenMessageIds.clear();
+  }
+}
+
+final huddleControllerProvider =
+    NotifierProvider<HuddleController, HuddleState>(HuddleController.new);

--- a/mobile/lib/features/huddles/huddle_controls.dart
+++ b/mobile/lib/features/huddles/huddle_controls.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/relay/relay.dart';
+import '../../shared/theme/theme.dart';
+import '../channels/channel_messages_provider.dart';
+import 'huddle_audio.dart';
+import 'huddle_controller.dart';
+
+String? activeHuddleChannelId(Iterable<NostrEvent> events) {
+  final sorted =
+      events
+          .where(
+            (event) =>
+                event.kind >= EventKind.huddleStarted &&
+                event.kind <= EventKind.huddleEnded,
+          )
+          .toList()
+        ..sort((a, b) {
+          final created = a.createdAt.compareTo(b.createdAt);
+          if (created != 0) return created;
+          final kind = a.kind.compareTo(b.kind);
+          return kind != 0 ? kind : a.id.compareTo(b.id);
+        });
+  final active = <String, NostrEvent>{};
+  for (final event in sorted) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(event.content);
+    } catch (_) {
+      continue;
+    }
+    if (decoded is! Map<String, dynamic>) continue;
+    final channelId = decoded['ephemeral_channel_id'];
+    if (channelId is! String || channelId.isEmpty) continue;
+    switch (event.kind) {
+      case EventKind.huddleStarted:
+        active[channelId] = event;
+        break;
+      case EventKind.huddleParticipantJoined:
+      case EventKind.huddleParticipantLeft:
+        break;
+      case EventKind.huddleEnded:
+        active.remove(channelId);
+        break;
+    }
+  }
+  if (active.isEmpty) return null;
+  final rooms = active.entries.toList()
+    ..sort((a, b) {
+      final created = a.value.createdAt.compareTo(b.value.createdAt);
+      return created != 0 ? created : a.value.id.compareTo(b.value.id);
+    });
+  return rooms.last.key;
+}
+
+class HuddleButton extends ConsumerWidget {
+  const HuddleButton({required this.channelId, super.key});
+  final String channelId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(huddleControllerProvider);
+    final messages =
+        ref.watch(channelMessagesProvider(channelId)).value ?? const [];
+    final joinableChannelId = activeHuddleChannelId(messages);
+    final activeHere = state.parentChannelId == channelId && state.isActive;
+    final canJoin = !state.isActive && joinableChannelId != null;
+    return IconButton(
+      tooltip: activeHere
+          ? 'Huddle controls'
+          : canJoin
+          ? 'Join Huddle'
+          : 'Start Huddle',
+      color: activeHere || canJoin
+          ? context.appColors.success
+          : context.colors.primary,
+      icon: Icon(
+        activeHere || canJoin ? LucideIcons.audioLines : LucideIcons.phone,
+        size: 22,
+      ),
+      onPressed: () {
+        if (!state.isActive) {
+          final controller = ref.read(huddleControllerProvider.notifier);
+          if (joinableChannelId != null) {
+            controller
+                .join(parentChannelId: channelId, channelId: joinableChannelId)
+                .catchError((Object _) {});
+          } else {
+            controller.start(channelId).catchError((Object _) {});
+          }
+        }
+        showModalBottomSheet<void>(
+          context: context,
+          showDragHandle: true,
+          builder: (_) => const HuddleControlsSheet(),
+        );
+      },
+    );
+  }
+}
+
+class HuddleControlsSheet extends ConsumerWidget {
+  const HuddleControlsSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(huddleControllerProvider);
+    final controller = ref.read(huddleControllerProvider.notifier);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(Grid.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Huddle', style: context.textTheme.titleLarge),
+            const SizedBox(height: Grid.sm),
+            Text(_status(state), textAlign: TextAlign.center),
+            if (state.error != null) ...[
+              const SizedBox(height: Grid.sm),
+              Text(
+                state.error!,
+                style: TextStyle(color: context.colors.error),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            if (state.peers.isNotEmpty) ...[
+              const SizedBox(height: Grid.sm),
+              Text(
+                '${state.peers.length} participant${state.peers.length == 1 ? '' : 's'}',
+              ),
+            ],
+            if (state.botPubkeys.isNotEmpty) ...[
+              const SizedBox(height: Grid.sm),
+              Text(
+                state.isTranscribing
+                    ? 'Listening for your bot question…'
+                    : state.isBotSpeaking
+                    ? 'Bot is speaking…'
+                    : '${state.botPubkeys.length} bot${state.botPubkeys.length == 1 ? '' : 's'} ready',
+                textAlign: TextAlign.center,
+              ),
+              if (state.lastTranscript != null)
+                Text(
+                  'You: ${state.lastTranscript}',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: context.textTheme.bodySmall,
+                ),
+            ],
+            const SizedBox(height: Grid.md),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                IconButton.filledTonal(
+                  tooltip: state.isMuted ? 'Unmute' : 'Mute',
+                  onPressed: state.isActive ? controller.toggleMute : null,
+                  icon: Icon(
+                    state.isMuted ? LucideIcons.micOff : LucideIcons.mic,
+                  ),
+                ),
+                PopupMenuButton<HuddleOutputRoute>(
+                  tooltip: 'Audio output',
+                  initialValue: state.outputRoute,
+                  enabled: state.isActive,
+                  onSelected: (route) => controller.setOutputRoute(route),
+                  itemBuilder: (_) => HuddleOutputRoute.values
+                      .map(
+                        (route) => PopupMenuItem(
+                          value: route,
+                          child: Text(route.name),
+                        ),
+                      )
+                      .toList(),
+                  icon: const Icon(LucideIcons.volume2),
+                ),
+                IconButton.filledTonal(
+                  tooltip: state.isTranscribing
+                      ? 'Finish bot voice turn'
+                      : 'Talk to bots',
+                  onPressed:
+                      state.phase == HuddlePhase.connected &&
+                          state.botPubkeys.isNotEmpty
+                      ? () => controller.talkToBots().catchError((Object _) {})
+                      : null,
+                  icon: Icon(
+                    state.isTranscribing
+                        ? LucideIcons.square
+                        : LucideIcons.messageCircleMore,
+                  ),
+                ),
+                IconButton.filled(
+                  tooltip: 'Leave Huddle',
+                  style: IconButton.styleFrom(
+                    backgroundColor: context.colors.error,
+                  ),
+                  onPressed: state.isActive
+                      ? () async {
+                          await controller.leave();
+                          if (context.mounted) Navigator.of(context).pop();
+                        }
+                      : null,
+                  icon: const Icon(LucideIcons.phoneOff),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _status(HuddleState state) => switch (state.phase) {
+    HuddlePhase.idle => 'Not connected',
+    HuddlePhase.creating => 'Starting…',
+    HuddlePhase.connecting => 'Connecting…',
+    HuddlePhase.connected => state.isMuted ? 'Connected · muted' : 'Connected',
+    HuddlePhase.reconnecting => 'Network lost · reconnecting…',
+    HuddlePhase.failed => 'Could not connect',
+  };
+}

--- a/mobile/lib/features/huddles/huddle_transport.dart
+++ b/mobile/lib/features/huddles/huddle_transport.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'huddle_wire.dart';
+
+class HuddlePeer {
+  const HuddlePeer({required this.pubkey, required this.peerIndex});
+  final String pubkey;
+  final int peerIndex;
+}
+
+sealed class HuddleTransportEvent {
+  const HuddleTransportEvent();
+}
+
+class HuddleRosterEvent extends HuddleTransportEvent {
+  const HuddleRosterEvent(this.peers);
+  final List<HuddlePeer> peers;
+}
+
+class HuddlePeerJoinedEvent extends HuddleTransportEvent {
+  const HuddlePeerJoinedEvent(this.peer);
+  final HuddlePeer peer;
+}
+
+class HuddlePeerLeftEvent extends HuddleTransportEvent {
+  const HuddlePeerLeftEvent(this.peerIndex);
+  final int peerIndex;
+}
+
+class HuddleAudioFrameEvent extends HuddleTransportEvent {
+  const HuddleAudioFrameEvent({required this.peerIndex, required this.bytes});
+  final int peerIndex;
+  final Uint8List bytes;
+}
+
+class HuddleTransportException implements Exception {
+  const HuddleTransportException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+abstract interface class HuddleTransport {
+  Stream<HuddleTransportEvent> get events;
+  Future<void> connect({
+    required Uri relayWebSocket,
+    required String channelId,
+    required String? parentChannelId,
+    required String nsec,
+  });
+  void sendAudio(Uint8List bytes);
+  Future<void> close({bool sendLeave = true});
+}
+
+class WebSocketHuddleTransport implements HuddleTransport {
+  final _events = StreamController<HuddleTransportEvent>.broadcast();
+  WebSocketChannel? _socket;
+  StreamSubscription<Object?>? _subscription;
+  Completer<void>? _joined;
+  bool _closing = false;
+
+  @override
+  Stream<HuddleTransportEvent> get events => _events.stream;
+
+  @override
+  Future<void> connect({
+    required Uri relayWebSocket,
+    required String channelId,
+    required String? parentChannelId,
+    required String nsec,
+  }) async {
+    await close(sendLeave: false);
+    _closing = false;
+    final uri = relayWebSocket.replace(
+      path:
+          '${relayWebSocket.path.replaceFirst(RegExp(r'/$'), '')}/huddle/$channelId/audio',
+    );
+    final socket = WebSocketChannel.connect(uri);
+    _socket = socket;
+    _joined = Completer<void>();
+    _subscription = socket.stream.listen(
+      (message) => _onMessage(message, relayWebSocket, parentChannelId, nsec),
+      onError: (Object error, StackTrace stack) {
+        if (!(_joined?.isCompleted ?? true)) {
+          _joined?.completeError(error, stack);
+        }
+        _events.addError(error, stack);
+      },
+      onDone: () {
+        if (_closing) return;
+        final error = const HuddleTransportException(
+          'Huddle connection closed',
+        );
+        if (!(_joined?.isCompleted ?? true)) _joined?.completeError(error);
+        _events.addError(error);
+      },
+    );
+    await socket.ready.timeout(const Duration(seconds: 5));
+    await _joined!.future.timeout(const Duration(seconds: 5));
+  }
+
+  void _onMessage(
+    Object? message,
+    Uri relayWebSocket,
+    String? parentChannelId,
+    String nsec,
+  ) {
+    if (message is List<int>) {
+      final bytes = Uint8List.fromList(message);
+      if (bytes.length < huddleHeaderLength + 2 ||
+          bytes.length > huddleMaxFrameBytes + 1) {
+        return;
+      }
+      _events.add(
+        HuddleAudioFrameEvent(
+          peerIndex: bytes.first,
+          bytes: Uint8List.sublistView(bytes, 1),
+        ),
+      );
+      return;
+    }
+    if (message is! String || message.length > 8192) return;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(message);
+    } catch (_) {
+      _events.addError(
+        const HuddleTransportException('Malformed Huddle control message'),
+      );
+      return;
+    }
+    if (decoded is! Map<String, dynamic>) return;
+    switch (decoded['type']) {
+      case 'challenge':
+        final challenge = decoded['challenge'];
+        if (challenge is! String || challenge.isEmpty) {
+          _events.addError(
+            const HuddleTransportException('Missing Huddle challenge'),
+          );
+          return;
+        }
+        _socket?.sink.add(
+          buildHuddleAuthMessage(
+            relayWebSocket: relayWebSocket,
+            challenge: challenge,
+            parentChannelId: parentChannelId,
+            nsec: nsec,
+          ),
+        );
+      case 'joined':
+        final peers = _parsePeers(decoded['peers']);
+        if (!(_joined?.isCompleted ?? true)) _joined?.complete();
+        _events.add(HuddleRosterEvent(peers));
+      case 'left':
+        final index = decoded['peer_index'];
+        if (index is int) _events.add(HuddlePeerLeftEvent(index));
+      case 'error':
+        final error = HuddleTransportException(
+          decoded['message']?.toString() ?? 'Huddle relay error',
+        );
+        if (!(_joined?.isCompleted ?? true)) _joined?.completeError(error);
+        _events.addError(error);
+    }
+  }
+
+  List<HuddlePeer> _parsePeers(Object? raw) {
+    if (raw is! List) return const [];
+    return raw
+        .take(256)
+        .whereType<Map>()
+        .map((peer) {
+          final pubkey = peer['pubkey'];
+          final index = peer['peer_index'];
+          if (pubkey is! String ||
+              pubkey.length != 64 ||
+              !RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(pubkey) ||
+              index is! int ||
+              index < 0 ||
+              index > 255) {
+            return null;
+          }
+          return HuddlePeer(pubkey: pubkey, peerIndex: index);
+        })
+        .whereType<HuddlePeer>()
+        .toList();
+  }
+
+  @override
+  void sendAudio(Uint8List bytes) {
+    if (bytes.length > huddleHeaderLength &&
+        bytes.length <= huddleMaxFrameBytes) {
+      _socket?.sink.add(bytes);
+    }
+  }
+
+  @override
+  Future<void> close({bool sendLeave = true}) async {
+    _closing = true;
+    final socket = _socket;
+    _socket = null;
+    if (socket != null) {
+      if (sendLeave) socket.sink.add(jsonEncode({'type': 'leave'}));
+      await socket.sink.close();
+    }
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}
+
+String buildHuddleAuthMessage({
+  required Uri relayWebSocket,
+  required String challenge,
+  required String? parentChannelId,
+  required String nsec,
+}) {
+  final privateKey = nostr.Nip19.decode(payload: nsec).data;
+  final event = nostr.Event.from(
+    kind: 22242,
+    content: '',
+    tags: [
+      ['relay', relayWebSocket.toString()],
+      ['challenge', challenge],
+    ],
+    secretKey: privateKey,
+    verify: false,
+  );
+  return jsonEncode({
+    'type': 'auth',
+    'event': event.toMap(),
+    'parent_channel_id': parentChannelId,
+    'protocol_version': huddleProtocolVersion,
+  });
+}

--- a/mobile/lib/features/huddles/huddle_wire.dart
+++ b/mobile/lib/features/huddles/huddle_wire.dart
@@ -1,0 +1,111 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+const huddleProtocolVersion = 2;
+const huddleHeaderLength = 8;
+const huddleFrameSamples = 960;
+const huddleSampleRate = 48000;
+const huddleDtxFlag = 0x01;
+const huddleMaxFrameBytes = 4096;
+
+class HuddleFrameHeader {
+  const HuddleFrameHeader({
+    required this.sequence,
+    required this.timestamp48k,
+    required this.levelDbov,
+    required this.flags,
+  });
+
+  final int sequence;
+  final int timestamp48k;
+  final int levelDbov;
+  final int flags;
+
+  bool get isDtx => flags & huddleDtxFlag != 0;
+
+  Uint8List encode() {
+    final data = ByteData(huddleHeaderLength)
+      ..setUint16(0, sequence & 0xffff)
+      ..setUint32(2, timestamp48k & 0xffffffff)
+      ..setInt8(6, levelDbov.clamp(-127, 0))
+      ..setUint8(7, flags & 0xff);
+    return data.buffer.asUint8List();
+  }
+
+  static ({HuddleFrameHeader header, Uint8List payload})? parse(
+    Uint8List bytes,
+  ) {
+    if (bytes.length < huddleHeaderLength) return null;
+    final data = ByteData.sublistView(bytes);
+    final rawLevel = data.getInt8(6);
+    return (
+      header: HuddleFrameHeader(
+        sequence: data.getUint16(0),
+        timestamp48k: data.getUint32(2),
+        levelDbov: rawLevel >= -127 && rawLevel <= 0 ? rawLevel : -127,
+        flags: data.getUint8(7),
+      ),
+      payload: Uint8List.sublistView(bytes, huddleHeaderLength),
+    );
+  }
+}
+
+class HuddleSequence {
+  int sequence = 0;
+  int timestamp48k = 0;
+
+  HuddleFrameHeader next({required int levelDbov, required bool isDtx}) {
+    final header = HuddleFrameHeader(
+      sequence: sequence,
+      timestamp48k: timestamp48k,
+      levelDbov: levelDbov,
+      flags: isDtx ? huddleDtxFlag : 0,
+    );
+    sequence = (sequence + 1) & 0xffff;
+    timestamp48k = (timestamp48k + huddleFrameSamples) & 0xffffffff;
+    return header;
+  }
+}
+
+int audioLevelDbov(Int16List pcm) {
+  if (pcm.isEmpty) return -127;
+  var sum = 0.0;
+  for (final sample in pcm) {
+    final normalized = sample / 32768.0;
+    sum += normalized * normalized;
+  }
+  final rms = math.sqrt(sum / pcm.length);
+  if (rms <= 0 || !rms.isFinite) return -127;
+  return (20 * math.log(rms) / math.ln10).round().clamp(-127, 0);
+}
+
+class PcmFrameChunker {
+  final List<int> _pending = [];
+
+  List<Int16List> add(Int16List samples) {
+    _pending.addAll(samples);
+    final frames = <Int16List>[];
+    while (_pending.length >= huddleFrameSamples) {
+      frames.add(Int16List.fromList(_pending.sublist(0, huddleFrameSamples)));
+      _pending.removeRange(0, huddleFrameSamples);
+    }
+    return frames;
+  }
+
+  void clear() => _pending.clear();
+}
+
+Int16List mixPcmFrames(Iterable<Int16List> frames) {
+  final sources = frames.toList(growable: false);
+  if (sources.isEmpty) return Int16List(0);
+  final sampleCount = sources.map((frame) => frame.length).reduce(math.min);
+  final mixed = Int16List(sampleCount);
+  for (var sample = 0; sample < sampleCount; sample++) {
+    var sum = 0;
+    for (final source in sources) {
+      sum += source[sample];
+    }
+    mixed[sample] = sum.clamp(-32768, 32767);
+  }
+  return mixed;
+}

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -39,6 +39,7 @@ abstract final class EventKind {
   static const huddleParticipantJoined = 48101;
   static const huddleParticipantLeft = 48102;
   static const huddleEnded = 48103;
+  static const huddleGuidelines = 48106;
 
   /// Event kinds that represent user-visible channel messages.
   static const channelMessageEventKinds = [
@@ -86,6 +87,7 @@ abstract final class EventKind {
     jobCancel,
     jobError,
     huddleStarted,
+    huddleEnded,
   ];
 }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  audio_session:
+    dependency: "direct main"
+    description:
+      name: audio_session
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
   bech32:
     dependency: transitive
     description:
@@ -470,6 +478,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  flutter_pcm_sound:
+    dependency: "direct main"
+    description:
+      name: flutter_pcm_sound
+      sha256: "15c6894da8195122001375084d51449bd77849579c93fca2800c00b615699dc0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -547,6 +563,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_tts:
+    dependency: "direct main"
+    description:
+      name: flutter_tts
+      sha256: ce5eb209b40e95f2f4a1397116c87ab2fcdff32257d04ed7a764e75894c03775
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -904,6 +928,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.7.0"
+  opus_codec:
+    dependency: "direct main"
+    description:
+      name: opus_codec
+      sha256: d8ad96b7242e78025122bc2b3821788310ddfb4700f03da7c67da83339099287
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_android:
+    dependency: transitive
+    description:
+      name: opus_codec_android
+      sha256: "347f61ac7fe53cb684ec4777b49688a8336077e025a3e04e3f61294da5d89c68"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_dart:
+    dependency: "direct main"
+    description:
+      name: opus_codec_dart
+      sha256: a5570ca76ff4d973415991e09507cc05f11d640c2d635aee101152457fecf88f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_ios:
+    dependency: transitive
+    description:
+      name: opus_codec_ios
+      sha256: fdca5606410eaf14b9d1f1179f0b00b7994b6dbc64f0399e2955618b16ef9353
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_linux:
+    dependency: transitive
+    description:
+      name: opus_codec_linux
+      sha256: "69762fa3c8e87e38e6279124544deeebad48b5c3d8b8950de2ce7ef9c63f80f6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_macos:
+    dependency: transitive
+    description:
+      name: opus_codec_macos
+      sha256: ff8012e5eb692a81151404bc5b43385794be0e7b779e60f7f9d7405bba69d693
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_platform_interface:
+    dependency: transitive
+    description:
+      name: opus_codec_platform_interface
+      sha256: "76c6b64097fd1eed334e7be6fc161567058ba26e61f792be9416552fcf48e83b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_web:
+    dependency: transitive
+    description:
+      name: opus_codec_web
+      sha256: c23af0111c986d62ab14c92a25a5e73939034f5d8cd3ef2aca76d904a5994f29
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  opus_codec_windows:
+    dependency: transitive
+    description:
+      name: opus_codec_windows
+      sha256: "85fff458e90d1cca8ae0ea2527fa408db3c7dd4d48d98e407e2eac4f4c3a3426"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
   package_config:
     dependency: transitive
     description:
@@ -992,6 +1088,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "06149cba29bc46206f8b54b56065fe74b07602d2454a281287685ae66b5ab7b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d7676c6fcf2f0b92537ec41476a6ead45a00b0d8bbb852395a6f9f33f49d6242
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.5.0"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4+1"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   petitparser:
     dependency: transitive
     description:
@@ -1064,6 +1208,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "223258060a1d25c62bae18282c16783f28581ec19401d17e56b5205b9f039d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   riverpod:
     dependency: transitive
     description:
@@ -1245,6 +1453,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: "75587f7400f485fdf166beacd471549d98fe5d58e634f708916bb65dec05d6a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.4.0"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: a7e16e02853853ed7534ac2bde9a1c4f39c8879970a7974ac6ff832d4bdaa4b0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  speech_to_text_windows:
+    dependency: transitive
+    description:
+      name: speech_to_text_windows
+      sha256: "2d1d10565b23262386b453b33656299608dc7a66784453735d6c1318f13f44d7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1485,6 +1717,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  wasm_ffi:
+    dependency: transitive
+    description:
+      name: wasm_ffi
+      sha256: "950238f09e2d18b85c5c4356833a06319b049c1d19f936db32c3f0d8194e30b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   watcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -42,6 +42,14 @@ dependencies:
   open_filex: ^4.7.0
   path_provider: ^2.1.6
   share_plus: ^13.3.0
+  audio_session: 0.2.4
+  flutter_pcm_sound: 3.3.3
+  opus_codec: 3.0.5
+  opus_codec_dart: 3.0.5
+  record: 6.2.1
+  permission_handler: ^13.0.0
+  speech_to_text: ^7.4.0
+  flutter_tts: ^4.2.5
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/features/huddles/huddle_codec_test.dart
+++ b/mobile/test/features/huddles/huddle_codec_test.dart
@@ -1,0 +1,43 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:buzz/features/huddles/huddle_wire.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:opus_codec_dart/opus_codec_dart.dart';
+
+void main() {
+  test('libopus encodes and decodes a 20 ms mono frame', () {
+    initOpus(DynamicLibrary.open('libopus.so.0'));
+    final encoder = SimpleOpusEncoder(
+      application: Application.voip,
+      sampleRate: huddleSampleRate,
+      channels: 1,
+    );
+    final decoder = SimpleOpusDecoder(
+      sampleRate: huddleSampleRate,
+      channels: 1,
+    );
+    addTearDown(() {
+      encoder.destroy();
+      decoder.destroy();
+    });
+
+    final input = Int16List.fromList(
+      List.generate(
+        huddleFrameSamples,
+        (sample) =>
+            (math.sin(2 * math.pi * 440 * sample / huddleSampleRate) * 12000)
+                .round(),
+      ),
+    );
+    final encoded = encoder.encode(input: input);
+    final decoded = decoder.decode(input: encoded);
+
+    expect(encoded, isNotEmpty);
+    expect(encoded.length, lessThan(huddleMaxFrameBytes - huddleHeaderLength));
+    expect(decoded, hasLength(huddleFrameSamples));
+    expect(decoded.any((sample) => sample != 0), isTrue);
+  }, skip: !Platform.isLinux);
+}

--- a/mobile/test/features/huddles/huddle_controller_test.dart
+++ b/mobile/test/features/huddles/huddle_controller_test.dart
@@ -1,0 +1,368 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:buzz/features/huddles/huddle_audio.dart';
+import 'package:buzz/features/huddles/huddle_bot_voice.dart';
+import 'package:buzz/features/huddles/huddle_controller.dart';
+import 'package:buzz/features/huddles/huddle_transport.dart';
+import 'package:buzz/features/huddles/huddle_wire.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('join, mute, downlink, route, and leave preserve boundaries', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio();
+    final container = _container(transport: transport, audio: audio);
+    addTearDown(container.dispose);
+    final controller = container.read(huddleControllerProvider.notifier);
+
+    await controller.join(parentChannelId: 'parent', channelId: 'huddle');
+    expect(
+      container.read(huddleControllerProvider).phase,
+      HuddlePhase.connected,
+    );
+    expect(transport.channelId, 'huddle');
+    expect(transport.parentChannelId, 'parent');
+
+    controller.toggleMute();
+    audio.microphone.add(Int16List(960));
+    await Future<void>.delayed(Duration.zero);
+    expect(transport.sentAudio, isEmpty);
+
+    transport.eventsController.add(
+      HuddleAudioFrameEvent(
+        peerIndex: 7,
+        bytes: Uint8List.fromList([
+          ...const HuddleFrameHeader(
+            sequence: 1,
+            timestamp48k: 960,
+            levelDbov: -20,
+            flags: 0,
+          ).encode(),
+          9,
+        ]),
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    expect(audio.decodedPeers, [7]);
+    expect(audio.played, hasLength(1));
+
+    transport.eventsController.add(
+      HuddleAudioFrameEvent(
+        peerIndex: 7,
+        bytes: Uint8List.fromList([
+          ...const HuddleFrameHeader(
+            sequence: 3,
+            timestamp48k: 2880,
+            levelDbov: -20,
+            flags: 0,
+          ).encode(),
+          10,
+        ]),
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(audio.plcCalls, 1);
+    expect(audio.played, hasLength(3));
+
+    await controller.setOutputRoute(HuddleOutputRoute.speaker);
+    expect(audio.route, HuddleOutputRoute.speaker);
+    await controller.leave();
+    expect(container.read(huddleControllerProvider).phase, HuddlePhase.idle);
+    expect(transport.sentLeave, isTrue);
+    expect(audio.stopped, isTrue);
+  });
+
+  test('capability failure is visible and tears down', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio(
+      startError: const HuddleAudioCapabilityException('denied'),
+    );
+    final container = _container(transport: transport, audio: audio);
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(huddleControllerProvider.notifier)
+          .join(parentChannelId: 'parent', channelId: 'huddle'),
+      throwsA(isA<HuddleAudioCapabilityException>()),
+    );
+    final state = container.read(huddleControllerProvider);
+    expect(state.phase, HuddlePhase.failed);
+    expect(state.error, contains('denied'));
+  });
+
+  test('audio interruption leaves without creating a second session', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio();
+    final container = _container(transport: transport, audio: audio);
+    addTearDown(container.dispose);
+    await container
+        .read(huddleControllerProvider.notifier)
+        .join(parentChannelId: 'parent', channelId: 'huddle');
+    audio.interrupted.add(null);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(huddleControllerProvider).phase, HuddlePhase.idle);
+    expect(audio.starts, 1);
+  });
+
+  test('route permission failure is visible and preserves the route', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio(routeError: StateError('permission denied'));
+    final container = _container(transport: transport, audio: audio);
+    addTearDown(container.dispose);
+    final controller = container.read(huddleControllerProvider.notifier);
+    await controller.join(parentChannelId: 'parent', channelId: 'huddle');
+
+    await controller.setOutputRoute(HuddleOutputRoute.bluetooth);
+
+    final state = container.read(huddleControllerProvider);
+    expect(state.outputRoute, HuddleOutputRoute.system);
+    expect(state.error, contains('permission denied'));
+  });
+
+  test('bot voice turn pauses audio, mentions bots, and resumes', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio();
+    final botVoice = _FakeBotVoice(transcript: 'What should we build?');
+    String? sentChannel;
+    String? sentContent;
+    List<String>? sentMentions;
+    final container = _container(
+      transport: transport,
+      audio: audio,
+      botVoice: botVoice,
+      botPubkeys: const {'bot-pubkey'},
+      transcriptSender: (channelId, content, mentions) async {
+        sentChannel = channelId;
+        sentContent = content;
+        sentMentions = mentions;
+      },
+    );
+    addTearDown(container.dispose);
+    final controller = container.read(huddleControllerProvider.notifier);
+    await controller.join(parentChannelId: 'parent', channelId: 'huddle');
+
+    await controller.talkToBots();
+
+    expect(audio.pauses, 1);
+    expect(audio.resumes, 1);
+    expect(sentChannel, 'huddle');
+    expect(sentContent, 'What should we build?');
+    expect(sentMentions, ['bot-pubkey']);
+    expect(
+      container.read(huddleControllerProvider).lastTranscript,
+      sentContent,
+    );
+  });
+
+  test(
+    'leave during bot discovery cannot reactivate a joined Huddle',
+    () async {
+      final transport = _FakeTransport();
+      final audio = _FakeAudio();
+      final discoveryStarted = Completer<void>();
+      final releaseDiscovery = Completer<Set<String>>();
+      final container = _container(
+        transport: transport,
+        audio: audio,
+        botPubkeysLoader: (_) {
+          discoveryStarted.complete();
+          return releaseDiscovery.future;
+        },
+      );
+      addTearDown(container.dispose);
+      final controller = container.read(huddleControllerProvider.notifier);
+
+      final joining = controller.join(
+        parentChannelId: 'parent',
+        channelId: 'huddle',
+      );
+      await discoveryStarted.future;
+      await controller.leave();
+      releaseDiscovery.complete(const {'bot-pubkey'});
+      await joining;
+
+      expect(container.read(huddleControllerProvider).phase, HuddlePhase.idle);
+      expect(audio.stopped, isTrue);
+    },
+  );
+
+  test('leave during bot subscription immediately unsubscribes', () async {
+    final transport = _FakeTransport();
+    final audio = _FakeAudio();
+    final subscriptionStarted = Completer<void>();
+    final releaseSubscription = Completer<void>();
+    var unsubscribes = 0;
+    final container = _container(
+      transport: transport,
+      audio: audio,
+      botPubkeys: const {'bot-pubkey'},
+      messageSubscriber: (_, _) async {
+        subscriptionStarted.complete();
+        await releaseSubscription.future;
+        return () => unsubscribes++;
+      },
+    );
+    addTearDown(container.dispose);
+    final controller = container.read(huddleControllerProvider.notifier);
+
+    final joining = controller.join(
+      parentChannelId: 'parent',
+      channelId: 'huddle',
+    );
+    await subscriptionStarted.future;
+    await controller.leave();
+    releaseSubscription.complete();
+    await joining;
+
+    expect(container.read(huddleControllerProvider).phase, HuddlePhase.idle);
+    expect(unsubscribes, 1);
+  });
+}
+
+ProviderContainer _container({
+  required _FakeTransport transport,
+  required _FakeAudio audio,
+  _FakeBotVoice? botVoice,
+  Set<String> botPubkeys = const {},
+  HuddleBotPubkeysLoader? botPubkeysLoader,
+  HuddleMessageSubscriber? messageSubscriber,
+  HuddleTranscriptSender? transcriptSender,
+}) {
+  return ProviderContainer(
+    overrides: [
+      relayConfigProvider.overrideWith(() => _RelayConfig()),
+      huddleControllerProvider.overrideWith(
+        () => HuddleController(
+          transportFactory: () => transport,
+          audioFactory: () => audio,
+          botVoiceFactory: () => botVoice ?? _FakeBotVoice(),
+          botPubkeysLoader: botPubkeysLoader ?? (_) async => botPubkeys,
+          messageSubscriber: messageSubscriber ?? (_, _) async => () {},
+          transcriptSender: transcriptSender,
+        ),
+      ),
+    ],
+  );
+}
+
+class _RelayConfig extends RelayConfigNotifier {
+  @override
+  RelayConfig build() => const RelayConfig(
+    baseUrl: 'wss://relay.example',
+    nsec:
+        'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc824v',
+  );
+}
+
+class _FakeTransport implements HuddleTransport {
+  final eventsController = StreamController<HuddleTransportEvent>.broadcast();
+  final sentAudio = <Uint8List>[];
+  String? channelId;
+  String? parentChannelId;
+  bool sentLeave = false;
+
+  @override
+  Stream<HuddleTransportEvent> get events => eventsController.stream;
+  @override
+  Future<void> connect({
+    required Uri relayWebSocket,
+    required String channelId,
+    required String? parentChannelId,
+    required String nsec,
+  }) async {
+    this.channelId = channelId;
+    this.parentChannelId = parentChannelId;
+  }
+
+  @override
+  void sendAudio(Uint8List bytes) => sentAudio.add(bytes);
+  @override
+  Future<void> close({bool sendLeave = true}) async => sentLeave = sendLeave;
+}
+
+class _FakeAudio implements HuddleAudioEngine {
+  _FakeAudio({this.startError, this.routeError});
+  final Object? startError;
+  final Object? routeError;
+  final microphone = StreamController<Int16List>.broadcast();
+  final interrupted = StreamController<void>.broadcast();
+  final decodedPeers = <int>[];
+  final played = <Int16List>[];
+  int starts = 0;
+  int pauses = 0;
+  int resumes = 0;
+  int plcCalls = 0;
+  bool stopped = false;
+  HuddleOutputRoute? route;
+
+  @override
+  Stream<void> get interruptions => interrupted.stream;
+  @override
+  Stream<Int16List> get microphonePcm => microphone.stream;
+  @override
+  Future<void> start() async {
+    starts++;
+    if (startError != null) throw startError!;
+  }
+
+  @override
+  Future<void> pauseMicrophone() async => pauses++;
+
+  @override
+  Future<void> resumeMicrophone() async => resumes++;
+
+  @override
+  Future<Uint8List> encode(Int16List pcm) async =>
+      Uint8List.fromList([1, 2, 3]);
+  @override
+  Future<Int16List> decode(
+    int peerIndex,
+    Uint8List opus, {
+    bool plc = false,
+  }) async {
+    decodedPeers.add(peerIndex);
+    if (plc) plcCalls++;
+    return Int16List(960);
+  }
+
+  @override
+  void removePeer(int peerIndex) {}
+
+  @override
+  Future<void> play(Int16List mixedPcm) async => played.add(mixedPcm);
+  @override
+  Future<void> setOutputRoute(HuddleOutputRoute route) async {
+    if (routeError != null) throw routeError!;
+    this.route = route;
+  }
+
+  @override
+  Future<void> stop() async => stopped = true;
+}
+
+class _FakeBotVoice implements HuddleBotVoiceEngine {
+  _FakeBotVoice({this.transcript});
+
+  final String? transcript;
+  final spoken = <String>[];
+
+  @override
+  Future<String?> transcribe() async => transcript;
+
+  @override
+  Future<void> stopTranscribing() async {}
+
+  @override
+  Future<void> speak(String text) async => spoken.add(text);
+
+  @override
+  Future<void> stopSpeaking() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/mobile/test/features/huddles/huddle_controls_test.dart
+++ b/mobile/test/features/huddles/huddle_controls_test.dart
@@ -1,0 +1,106 @@
+import 'package:buzz/features/huddles/huddle_controller.dart';
+import 'package:buzz/features/huddles/huddle_controls.dart';
+import 'package:buzz/features/huddles/huddle_transport.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('active Huddle lifecycle selects live room and honors end', () {
+    final events = [
+      _event(EventKind.huddleStarted, 1, 'room-a'),
+      _event(EventKind.huddleEnded, 2, 'room-a'),
+      _event(EventKind.huddleStarted, 3, 'room-b'),
+    ];
+
+    expect(activeHuddleChannelId(events), 'room-b');
+    expect(
+      activeHuddleChannelId([
+        ...events,
+        _event(EventKind.huddleEnded, 4, 'room-b'),
+      ]),
+      isNull,
+    );
+    expect(
+      activeHuddleChannelId([
+        _event(EventKind.huddleStarted, 1, 'room-a'),
+        _event(EventKind.huddleStarted, 2, 'room-b'),
+        _event(EventKind.huddleEnded, 3, 'room-b'),
+      ]),
+      'room-a',
+    );
+  });
+
+  testWidgets(
+    'controls expose connected, mute, route, roster, and leave actions',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            huddleControllerProvider.overrideWith(_ConnectedController.new),
+          ],
+          child: const MaterialApp(home: Scaffold(body: HuddleControlsSheet())),
+        ),
+      );
+
+      expect(find.text('Connected'), findsOneWidget);
+      expect(find.text('2 participants'), findsOneWidget);
+      expect(find.byTooltip('Mute'), findsOneWidget);
+      expect(find.byTooltip('Audio output'), findsOneWidget);
+      expect(find.byTooltip('Talk to bots'), findsOneWidget);
+      expect(find.byTooltip('Leave Huddle'), findsOneWidget);
+    },
+  );
+
+  testWidgets('controls show capability errors and disable active actions', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          huddleControllerProvider.overrideWith(_FailedController.new),
+        ],
+        child: const MaterialApp(home: Scaffold(body: HuddleControlsSheet())),
+      ),
+    );
+    expect(find.text('Could not connect'), findsOneWidget);
+    expect(find.text('Microphone permission is required'), findsOneWidget);
+    expect(
+      tester.widget<IconButton>(find.byType(IconButton).first).onPressed,
+      isNull,
+    );
+  });
+}
+
+NostrEvent _event(int kind, int createdAt, String channelId) => NostrEvent(
+  id: '$kind-$createdAt',
+  pubkey: 'pubkey',
+  createdAt: createdAt,
+  kind: kind,
+  tags: const [],
+  content: '{"ephemeral_channel_id":"$channelId"}',
+  sig: 'sig',
+);
+
+class _ConnectedController extends HuddleController {
+  @override
+  HuddleState build() => const HuddleState(
+    phase: HuddlePhase.connected,
+    parentChannelId: 'parent',
+    channelId: 'huddle',
+    botPubkeys: {'bot'},
+    peers: {
+      1: HuddlePeer(pubkey: 'a', peerIndex: 1),
+      2: HuddlePeer(pubkey: 'b', peerIndex: 2),
+    },
+  );
+}
+
+class _FailedController extends HuddleController {
+  @override
+  HuddleState build() => const HuddleState(
+    phase: HuddlePhase.failed,
+    error: 'Microphone permission is required',
+  );
+}

--- a/mobile/test/features/huddles/huddle_transport_test.dart
+++ b/mobile/test/features/huddles/huddle_transport_test.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:buzz/features/huddles/huddle_transport.dart';
+import 'package:buzz/features/huddles/huddle_wire.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+void main() {
+  test('auth signs the exact relay challenge and negotiates v2', () {
+    final keys = nostr.Keys.generate();
+    final message =
+        jsonDecode(
+              buildHuddleAuthMessage(
+                relayWebSocket: Uri.parse('wss://relay.example'),
+                challenge: 'challenge-123',
+                parentChannelId: '00000000-0000-0000-0000-000000000001',
+                nsec: keys.nsec,
+              ),
+            )
+            as Map<String, dynamic>;
+    expect(message['type'], 'auth');
+    expect(message['protocol_version'], huddleProtocolVersion);
+    expect(
+      message['parent_channel_id'],
+      '00000000-0000-0000-0000-000000000001',
+    );
+    final event = message['event'] as Map<String, dynamic>;
+    expect(event['kind'], 22242);
+    expect(event['tags'], contains(equals(['relay', 'wss://relay.example'])));
+    expect(event['tags'], contains(equals(['challenge', 'challenge-123'])));
+  });
+}

--- a/mobile/test/features/huddles/huddle_wire_test.dart
+++ b/mobile/test/features/huddles/huddle_wire_test.dart
@@ -1,0 +1,67 @@
+import 'dart:typed_data';
+
+import 'package:buzz/features/huddles/huddle_wire.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('v2 header is big endian and round trips metadata and payload', () {
+    final bytes = Uint8List.fromList([
+      ...const HuddleFrameHeader(
+        sequence: 0xabcd,
+        timestamp48k: 0x12345678,
+        levelDbov: -40,
+        flags: huddleDtxFlag,
+      ).encode(),
+      1,
+      2,
+    ]);
+    expect(bytes.take(8), [0xab, 0xcd, 0x12, 0x34, 0x56, 0x78, 0xd8, 1]);
+    final parsed = HuddleFrameHeader.parse(bytes)!;
+    expect(parsed.header.sequence, 0xabcd);
+    expect(parsed.header.timestamp48k, 0x12345678);
+    expect(parsed.header.levelDbov, -40);
+    expect(parsed.header.isDtx, isTrue);
+    expect(parsed.payload, [1, 2]);
+  });
+
+  test('rejects short headers and clamps invalid dBov telemetry', () {
+    expect(HuddleFrameHeader.parse(Uint8List(7)), isNull);
+    final bytes = Uint8List.fromList([0, 0, 0, 0, 0, 0, 1, 0]);
+    expect(HuddleFrameHeader.parse(bytes)!.header.levelDbov, -127);
+  });
+
+  test('sequence and timestamp wrap deterministically', () {
+    final sequence = HuddleSequence()
+      ..sequence = 0xffff
+      ..timestamp48k = 0xfffffc40;
+    final first = sequence.next(levelDbov: -1, isDtx: false);
+    final second = sequence.next(levelDbov: -127, isDtx: true);
+    expect(first.sequence, 0xffff);
+    expect(first.timestamp48k, 0xfffffc40);
+    expect(second.sequence, 0);
+    expect(second.timestamp48k, 0);
+    expect(second.isDtx, isTrue);
+  });
+
+  test('PCM chunker emits exact 20 ms frames and retains remainder', () {
+    final chunker = PcmFrameChunker();
+    expect(chunker.add(Int16List(959)), isEmpty);
+    final frames = chunker.add(Int16List(962));
+    expect(frames, hasLength(2));
+    expect(frames.every((frame) => frame.length == 960), isTrue);
+    expect(chunker.add(Int16List(99)), isEmpty);
+  });
+
+  test('audio level uses canonical silence and full-scale bounds', () {
+    expect(audioLevelDbov(Int16List(960)), -127);
+    expect(audioLevelDbov(Int16List.fromList(List.filled(960, 32767))), 0);
+  });
+
+  test('PCM mixer combines peers and clamps overflow', () {
+    final mixed = mixPcmFrames([
+      Int16List.fromList([1000, 30000, -30000]),
+      Int16List.fromList([2000, 10000, -10000]),
+    ]);
+    expect(mixed, [3000, 32767, -32768]);
+  });
+}


### PR DESCRIPTION
## Summary
- add protocol-v2 mobile Huddle audio with 48 kHz mono PCM/Opus capture, transport, mixing, routing, and reconnect lifecycle
- add mobile-native bot voice turns using platform STT, Huddle channel transcripts, authorized bot reply observation, and platform TTS
- add active Huddle discovery/join/end lifecycle and Android/iOS native configuration
- add Ubuntu Android plus macOS unsigned-iOS CI coverage

## Verification
- mobile file-size ratchet passed
- dart format check passed
- flutter analyze passed
- flutter test: 1,279 passed
- real libopus 20 ms frame round-trip passed
- mobile release/worktree contract tests passed

## Device validation
Android and unsigned iOS compilation are intentionally delegated to this PR's GitHub Actions lanes; real-device microphone, recognition, Bluetooth, and TTS validation remains required before release.