### PR TITLE
fix(desktop): retain welcome dismissal across channels

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -678,7 +678,9 @@ export const ChannelPane = React.memo(function ChannelPane({
                   hasComposerBottomActivity && "composer-dock--with-activity",
                 )}
               >
-                {isActiveWelcomeChannel && !timeoutState.active ? (
+                {isActiveWelcomeChannel &&
+                welcomeComposerBannerState !== "hidden" &&
+                !timeoutState.active ? (
                   <WelcomeComposerGuidanceLayer
                     onDismiss={handleDismissWelcomeBanner}
                     settingUp={welcomeKickoffSettingUp}

--- a/desktop/src/features/channels/ui/useWelcomeComposerBanner.ts
+++ b/desktop/src/features/channels/ui/useWelcomeComposerBanner.ts
@@ -8,11 +8,17 @@ import {
   type WelcomeComposerBannerState,
 } from "@/features/channels/ui/WelcomeComposerBanner";
 
+let welcomeComposerBannerCompleted = false;
+
+export function resetWelcomeComposerBannerState(): void {
+  welcomeComposerBannerCompleted = false;
+}
+
 /**
  * Manages the Welcome-channel composer hint banner's state machine.
  *
- * Tracks which channels have been completed within the session so the banner
- * stays hidden on re-entry. Exposes three transitions:
+ * Tracks completion for the active community session so the single Welcome
+ * banner stays hidden on re-entry. Exposes three transitions:
  * - `completeBanner`: agent-mention path — plays the "Nice work." success
  *   animation before auto-dismissing.
  * - `dismissBanner`: manual X-button path — immediately begins the slide-down
@@ -26,7 +32,6 @@ export function useWelcomeComposerBanner(
   completeBanner: () => void;
   dismissBanner: () => void;
 } {
-  const completedChannelIdsRef = React.useRef(new Set<string>());
   const dismissTimerRef = React.useRef<number | null>(null);
   const hideTimerRef = React.useRef<number | null>(null);
   const [bannerState, setBannerState] =
@@ -50,7 +55,7 @@ export function useWelcomeComposerBanner(
     if (
       activeChannelId &&
       isActiveWelcomeChannel &&
-      completedChannelIdsRef.current.has(activeChannelId)
+      welcomeComposerBannerCompleted
     ) {
       setBannerState("hidden");
       return;
@@ -75,7 +80,7 @@ export function useWelcomeComposerBanner(
     }
 
     clearTimers();
-    completedChannelIdsRef.current.add(activeChannelId);
+    welcomeComposerBannerCompleted = true;
     setBannerState("complete");
     dismissTimerRef.current = window.setTimeout(() => {
       setBannerState("dismissing");
@@ -90,7 +95,7 @@ export function useWelcomeComposerBanner(
     }
 
     clearTimers();
-    completedChannelIdsRef.current.add(activeChannelId);
+    welcomeComposerBannerCompleted = true;
     setBannerState("dismissing");
     scheduleHide();
   }, [activeChannelId, clearTimers, isActiveWelcomeChannel, scheduleHide]);

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -33,6 +33,7 @@ import { resetAvatarProfileSync } from "@/features/profile/avatarProfileSync";
 import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useSidebarRelayConnectionCard";
 import { clearMarkdownNodeCache } from "@/shared/ui/markdown/nodeCache";
 import { resetVideoPlayerState } from "@/shared/ui/videoPlayerState";
+import { resetWelcomeComposerBannerState } from "@/features/channels/ui/useWelcomeComposerBanner";
 
 import {
   initFirstCommunity,
@@ -71,6 +72,7 @@ function resetCommunityState({
   resetVideoPlayerState();
   resetRenderScopedReactionHydration();
   resetBackgroundMediaUploads();
+  resetWelcomeComposerBannerState();
   clearSearchHitEventCache();
   clearMarkdownNodeCache();
 }

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -3218,7 +3218,9 @@ test("welcome-everywhere banner: dismiss persists after channel re-entry", async
 
   // Return — banner must stay hidden.
   await page.getByTestId("channel-welcome-everyone").click();
-  await expect(page.getByTestId("chat-title")).toContainText("Welcome");
+  await expect(page.getByTestId("chat-title")).toContainText(
+    "welcome-everyone",
+  );
   await expect(banner).toHaveCount(0);
 });
 


### PR DESCRIPTION
## Summary
- retain welcome-flow dismissal for the active community session instead of tying it to one channel id
- reset that state when the active community changes
- unmount the hidden welcome layer so it cannot intercept clicks after dismissal
- update the desktop end-to-end expectation to prove channel navigation does not reopen the prompt

## Why
The prior channel-scoped state could reopen the welcome composer after navigating away and back, leaving a visually hidden layer that intercepted clicks. The state is session-local and deliberately resets at the community boundary.

## Validation
- full Kiingo fork CI, including both desktop integration shards and all four desktop smoke shards
- focused onboarding E2E regression passed in that CI

This PR contains only the generic upstream-compatible fix; no Kiingo provider or service code is included.