### PR TITLE
feat(cli): manage NIP-43 relay membership

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -48,6 +48,11 @@ buzz channels create --name "my-channel" --type stream --visibility open
 buzz channels join --channel <uuid>
 buzz channels topic --channel <uuid> --topic "New topic"
 
+# Relay membership (NIP-43; add/remove require relay admin or owner)
+buzz relay list-members
+buzz relay add-member --pubkey npub1...
+buzz relay remove-member --pubkey <hex>
+
 # Reactions
 buzz reactions add --event <event-id> --emoji "👍"
 buzz reactions get --event <event-id>
@@ -124,6 +129,9 @@ stored rules in `validation_error` so an owner can remove and repair them.
 | | `members` | List channel members |
 | | `add-member` | Add a member |
 | | `remove-member` | Remove a member |
+| `relay` | `list-members` | List the relay-signed NIP-43 membership roster |
+| | `add-member` | Add a relay member (admin/owner only) |
+| | `remove-member` | Remove a relay member (admin/owner only) |
 | `canvas` | `get` | Get channel canvas |
 | | `set` | Set channel canvas |
 | `reactions` | `add` | React to a message |

--- a/crates/buzz-cli/src/commands/mod.rs
+++ b/crates/buzz-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod patches;
 pub mod pr;
 pub mod projects;
 pub mod reactions;
+pub mod relay;
 pub mod repos;
 pub mod social;
 pub mod upload;

--- a/crates/buzz-cli/src/commands/relay.rs
+++ b/crates/buzz-cli/src/commands/relay.rs
@@ -1,0 +1,160 @@
+//! `buzz relay` — NIP-43 community membership administration.
+//!
+//! Mutations are signed kinds 9030/9031 submitted through the generic event
+//! bridge. The relay host identifies the community; there is no channel scope.
+
+use buzz_core::kind::KIND_NIP43_MEMBERSHIP_LIST;
+use nostr::PublicKey;
+
+use crate::client::BuzzClient;
+use crate::commands::parse_write_response;
+use crate::error::CliError;
+use crate::{OutputFormat, RelayCmd, RelayMemberRole};
+
+fn resolve_pubkey(value: &str) -> Result<String, CliError> {
+    let value = value.trim();
+    PublicKey::parse(value)
+        .map(|pubkey| pubkey.to_hex())
+        .map_err(|error| {
+            if value.to_ascii_lowercase().starts_with("npub1") {
+                CliError::Usage(format!("invalid npub (check its Bech32 checksum): {error}"))
+            } else {
+                CliError::Usage(format!(
+                    "invalid pubkey: pass a 64-character hex pubkey or a valid npub: {error}"
+                ))
+            }
+        })
+}
+
+/// Return a relay-admin write response only when the relay accepted it.
+///
+/// NIP-43 commands are security-sensitive mutations; a `200` bridge response
+/// with `accepted: false` must remain a non-zero CLI result.
+fn accepted_write_response(response: &str) -> Result<String, CliError> {
+    parse_write_response(response, "relay membership command was not accepted")
+}
+
+async fn cmd_add_member(
+    client: &BuzzClient,
+    pubkey: &str,
+    role: RelayMemberRole,
+) -> Result<(), CliError> {
+    let pubkey = resolve_pubkey(pubkey)?;
+    let builder = buzz_sdk::build_relay_add_member(&pubkey, role.as_wire())
+        .map_err(crate::validate::sdk_err)?;
+    let event = client.sign_event(builder)?;
+    let response = client.submit_event(event).await?;
+    println!("{}", accepted_write_response(&response)?);
+    Ok(())
+}
+
+async fn cmd_remove_member(client: &BuzzClient, pubkey: &str) -> Result<(), CliError> {
+    let pubkey = resolve_pubkey(pubkey)?;
+    let builder = buzz_sdk::build_relay_remove_member(&pubkey).map_err(crate::validate::sdk_err)?;
+    let event = client.sign_event(builder)?;
+    let response = client.submit_event(event).await?;
+    println!("{}", accepted_write_response(&response)?);
+    Ok(())
+}
+
+async fn cmd_list_members(client: &BuzzClient, format: &OutputFormat) -> Result<(), CliError> {
+    let filter = serde_json::json!({
+        "kinds": [KIND_NIP43_MEMBERSHIP_LIST],
+        "limit": 1,
+    });
+    let raw = client.query(&filter).await?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
+        .map_err(|error| CliError::Other(format!("invalid relay membership response: {error}")))?;
+    let event = events.first().ok_or_else(|| {
+        CliError::Other("relay has not published a membership snapshot yet".into())
+    })?;
+    let members = event
+        .get("tags")
+        .and_then(serde_json::Value::as_array)
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|tag| {
+                    let tag = tag.as_array()?;
+                    let [kind, pubkey, role, ..] = tag.as_slice() else {
+                        return None;
+                    };
+                    (kind.as_str() == Some("member"))
+                        .then(|| Some((pubkey.as_str()?, role.as_str()?)))
+                        .flatten()
+                        .map(|(pubkey, role)| serde_json::json!({"pubkey": pubkey, "role": role}))
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    match format {
+        OutputFormat::Json => println!(
+            "{}",
+            serde_json::to_string(&members)
+                .map_err(|error| CliError::Other(format!("serialize relay members: {error}")))?
+        ),
+        OutputFormat::Compact => {
+            for member in members {
+                let pubkey = member
+                    .get("pubkey")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let role = member
+                    .get("role")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                println!("{pubkey}\t{role}");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn dispatch(
+    command: RelayCmd,
+    client: &BuzzClient,
+    format: &OutputFormat,
+) -> Result<(), CliError> {
+    match command {
+        RelayCmd::AddMember { pubkey, role } => cmd_add_member(client, &pubkey, role).await,
+        RelayCmd::RemoveMember { pubkey } => cmd_remove_member(client, &pubkey).await,
+        RelayCmd::ListMembers => cmd_list_members(client, format).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{accepted_write_response, resolve_pubkey};
+    use nostr::ToBech32;
+
+    const PUBKEY: &str = "7f2a7d4223a977bbca6403fcf9d7c6393eb2730d03a2cc2b504143f1fb5b9670";
+
+    #[test]
+    fn resolves_hex_and_npub_to_lowercase_hex() {
+        assert_eq!(resolve_pubkey(PUBKEY).unwrap(), PUBKEY);
+        let npub = nostr::PublicKey::from_hex(PUBKEY)
+            .unwrap()
+            .to_bech32()
+            .unwrap();
+        assert_eq!(resolve_pubkey(&npub).unwrap(), PUBKEY);
+    }
+
+    #[test]
+    fn rejects_a_corrupted_npub_with_checksum_guidance() {
+        let error =
+            resolve_pubkey("npub10u486s3r49mmhjnyq070n47xxyltyucdqw3v8x6sg9plr0m6jecr5yaqqqqqq")
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("invalid npub"));
+        assert!(error.contains("checksum"));
+    }
+
+    #[test]
+    fn rejects_a_relay_admin_response_that_was_not_accepted() {
+        let error =
+            accepted_write_response(r#"{"accepted":false,"message":"actor not authorized"}"#)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("relay rejected event"));
+        assert!(error.contains("actor not authorized"));
+    }
+}

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -240,6 +240,9 @@ enum Cmd {
     /// Community moderation — reports queue, bans, timeouts, audit trail
     #[command(subcommand)]
     Moderation(ModerationCmd),
+    /// Manage the relay-wide member roster (NIP-43)
+    #[command(subcommand)]
+    Relay(RelayCmd),
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -1907,6 +1910,53 @@ pub enum ModerationCmd {
     },
 }
 
+/// NIP-43 relay membership commands.
+///
+/// The relay URL identifies the community. Add/remove commands are authorized
+/// by the relay (admin or owner); the roster is read from relay-signed kind
+/// 13534 membership snapshots.
+#[derive(Subcommand)]
+pub enum RelayCmd {
+    /// Add a relay member (kind 9030)
+    #[command(
+        name = "add-member",
+        after_help = "Examples:\n  buzz relay add-member --pubkey npub1...\n  buzz relay add-member --pubkey <HEX> --role admin"
+    )]
+    AddMember {
+        /// Member pubkey (64-character hex or checksum-valid npub)
+        #[arg(long)]
+        pubkey: String,
+        /// Role to grant (only relay owners may grant admin)
+        #[arg(long, value_enum, default_value_t = RelayMemberRole::Member)]
+        role: RelayMemberRole,
+    },
+    /// Remove a relay member (kind 9031)
+    #[command(name = "remove-member")]
+    RemoveMember {
+        /// Member pubkey (64-character hex or checksum-valid npub)
+        #[arg(long)]
+        pubkey: String,
+    },
+    /// List the relay-signed NIP-43 membership roster
+    #[command(name = "list-members")]
+    ListMembers,
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+pub enum RelayMemberRole {
+    Member,
+    Admin,
+}
+
+impl RelayMemberRole {
+    fn as_wire(self) -> &'static str {
+        match self {
+            Self::Member => "member",
+            Self::Admin => "admin",
+        }
+    }
+}
+
 /// Normalize hand-authored `BUZZ_AUTH_TAG` input to strict JSON.
 ///
 /// `.env` files and shell exports sometimes carry the tag in the unquoted
@@ -2012,6 +2062,7 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Cmd::Upload(sub) => commands::upload::dispatch(sub, &client).await,
         Cmd::Mem(sub) => commands::mem::dispatch(sub, &client).await,
         Cmd::Moderation(sub) => commands::moderation::dispatch(sub, &client, &cli.format).await,
+        Cmd::Relay(sub) => commands::relay::dispatch(sub, &client, &cli.format).await,
         Cmd::Pack(_) => unreachable!("handled above"),
     }
 }
@@ -2116,6 +2167,7 @@ mod tests {
             "pr",
             "projects",
             "reactions",
+            "relay",
             "repos",
             "social",
             "upload",
@@ -2207,6 +2259,10 @@ mod tests {
             ]
         );
         assert_eq!(names(&cmd, "canvas"), vec!["get", "set"]);
+        assert_eq!(
+            names(&cmd, "relay"),
+            vec!["add-member", "list-members", "remove-member"]
+        );
         assert_eq!(names(&cmd, "reactions"), vec!["add", "get", "remove"]);
         assert_eq!(
             names(&cmd, "emoji"),

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -12,7 +12,8 @@ use buzz_core::{
         KIND_GIT_STATUS_OPEN, KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST,
         KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
         KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_PRESENCE_UPDATE, KIND_PROJECT,
-        KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
+        KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER, RELAY_ADMIN_ADD_MEMBER,
+        RELAY_ADMIN_REMOVE_MEMBER,
     },
     observer::{
         content_looks_like_nip44, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
@@ -1568,6 +1569,42 @@ pub fn build_dm_add_member(channel_id: Uuid, pubkey: &str) -> Result<EventBuilde
     Ok(EventBuilder::new(Kind::Custom(KIND_DM_ADD_MEMBER as u16), "").tags(tags))
 }
 
+/// Build a NIP-43 relay-member enrollment command (kind 9030).
+///
+/// The relay community is selected by the connection host, so this command
+/// carries no channel (`h`) tag. `role` must be `member` or `admin`; the relay
+/// separately enforces that only an owner may grant the latter.
+pub fn build_relay_add_member(pubkey: &str, role: &str) -> Result<EventBuilder, SdkError> {
+    let pubkey = check_pubkey_hex(pubkey, "pubkey")?;
+    if !matches!(role, "member" | "admin") {
+        return Err(SdkError::InvalidInput(
+            "relay member role must be member or admin".into(),
+        ));
+    }
+    let tags = vec![tag(&["p", &pubkey])?, tag(&["role", role])?];
+    // A relay admin may intentionally target its own pubkey. Preserve that p
+    // tag so the relay can apply its own self-membership rules.
+    Ok(
+        EventBuilder::new(Kind::Custom(RELAY_ADMIN_ADD_MEMBER as u16), "")
+            .tags(tags)
+            .allow_self_tagging(),
+    )
+}
+
+/// Build a NIP-43 relay-member removal command (kind 9031).
+///
+/// The relay rejects attempts to remove the signing identity, but preserving a
+/// self-targeting p tag lets it return that authoritative error to the caller.
+pub fn build_relay_remove_member(pubkey: &str) -> Result<EventBuilder, SdkError> {
+    let pubkey = check_pubkey_hex(pubkey, "pubkey")?;
+    let tags = vec![tag(&["p", &pubkey])?];
+    Ok(
+        EventBuilder::new(Kind::Custom(RELAY_ADMIN_REMOVE_MEMBER as u16), "")
+            .tags(tags)
+            .allow_self_tagging(),
+    )
+}
+
 /// Build a presence update event (kind 20001).
 ///
 /// `status` must be one of: `"online"`, `"away"`, `"offline"`.
@@ -2831,6 +2868,32 @@ mod tests {
         let ev = sign(build_remove_member(cid, pubkey).unwrap());
         assert_eq!(ev.kind.as_u16(), 9001);
         assert!(has_tag(&ev, "p", pubkey));
+    }
+
+    #[test]
+    fn relay_member_commands_are_nip43_and_preserve_self_targets() {
+        let signer = keys();
+        let pubkey = signer.public_key().to_hex();
+        let add = build_relay_add_member(&pubkey, "member")
+            .unwrap()
+            .sign_with_keys(&signer)
+            .unwrap();
+        assert_eq!(add.kind.as_u16(), RELAY_ADMIN_ADD_MEMBER as u16);
+        assert!(has_tag(&add, "p", &pubkey));
+        assert!(has_tag(&add, "role", "member"));
+
+        let remove = build_relay_remove_member(&pubkey)
+            .unwrap()
+            .sign_with_keys(&signer)
+            .unwrap();
+        assert_eq!(remove.kind.as_u16(), RELAY_ADMIN_REMOVE_MEMBER as u16);
+        assert!(has_tag(&remove, "p", &pubkey));
+    }
+
+    #[test]
+    fn relay_add_member_rejects_invalid_role() {
+        let pubkey = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
+        assert!(build_relay_add_member(pubkey, "owner").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add generic relay membership list, add, and remove commands to `buzz`
- accept hex or checksummed `npub` public keys and give a clear checksum error
- propagate rejected relay writes as nonzero CLI failures, with regression coverage

Refs #3326
Refs https://github.com/happyvertical/happyvertical.com/issues/162

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fe35f-b2d2-7fb1-849f-7bd333162041","issue":"block/buzz#3326","policy_revision":"1.0.0","validation":["cargo fmt --check","cargo test -p buzz-cli","cargo test -p buzz-sdk","review-cycle: approved"],"status":"review"}