### PR TITLE
fix(desktop): re-sign stale retention events at flush

### DIFF
--- a/desktop/src-tauri/src/managed_agents/persona_events.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events.rs
@@ -307,15 +307,15 @@ pub(crate) async fn flush_pending_events_at(
         let event = nostr::Event::from_json(&current.raw_event)
             .map_err(|e| format!("failed to parse retained event '{}': {e}", current.d_tag))?;
 
-        // NIP-IA requests are freshness-checked by the relay (±120s on
-        // `created_at`), so a request retained while the relay was
-        // unreachable would be permanently stale. Re-sign with a fresh
-        // timestamp at publish time; kind, tags, and content are preserved,
-        // and `mark_synced` below still compares against the retained row's
-        // original `created_at`/`content`, which are untouched.
-        let is_archive_request =
-            buzz_core_pkg::kind::is_identity_archive_request_kind(current.kind);
-        let event = if is_archive_request {
+        // Relay ingest rejects events outside ±900s of server time
+        // (`MAX_TIMESTAMP_DRIFT_SECS`). Retention may hold a row longer than
+        // that while the relay is down or after a failed sweep, so replaying
+        // the retained pre-signed `raw_event` would be rejected forever.
+        // Re-sign at publish with a fresh `created_at`; kind, tags, and
+        // content are preserved. `mark_synced` below still keys off the
+        // retained row's original `created_at`+`content` (untouched by
+        // re-sign).
+        let event = if needs_fresh_timestamp_at_publish(current.kind) {
             resign_with_fresh_timestamp(&event, state)?
         } else {
             event
@@ -351,12 +351,27 @@ pub(crate) async fn flush_pending_events_at(
     Ok(flushed)
 }
 
+/// Whether a retained event must be re-signed with a fresh `created_at` at
+/// flush time (see `flush_pending_events_at`).
+///
+/// Covers identity-archive requests, NIP-33 parameterized replaceables
+/// (30175/30176/30177/30178 and siblings), and NIP-09 tombstones (kind:5) —
+/// all gated by the relay's ±900s timestamp window.
+fn needs_fresh_timestamp_at_publish(kind: u32) -> bool {
+    use buzz_core_pkg::kind::{
+        is_identity_archive_request_kind, is_parameterized_replaceable, KIND_DELETION,
+    };
+    is_identity_archive_request_kind(kind)
+        || is_parameterized_replaceable(kind)
+        || kind == KIND_DELETION
+}
+
 /// Re-sign a retained event with the current owner keys and a fresh
 /// `created_at`, preserving kind, tags, and content.
 ///
-/// Used for relay-freshness-checked kinds (NIP-IA 9035/9036) that would
-/// otherwise go permanently stale sitting in the retention store while the
-/// relay is unreachable. `.allow_self_tagging()` mirrors
+/// Used for kinds that would otherwise go permanently stale sitting in the
+/// retention store past the relay's ±900s ingest window (see
+/// [`needs_fresh_timestamp_at_publish`]). `.allow_self_tagging()` mirrors
 /// `events::build_archive_identity_request` — nostr strips `p` tags matching
 /// the signer by default, which would corrupt a self-targeted request.
 ///

--- a/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
@@ -867,6 +867,100 @@ mod flush_barrier {
         assert_ne!(fresh.as_json(), stale.as_json());
     }
 
+    #[test]
+    fn managed_agent_resign_refreshes_timestamp_and_preserves_payload() {
+        use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+        use nostr::JsonUtil;
+
+        let keys = nostr::Keys::generate();
+        let content = r#"{"name":"agent","display_name":"Agent"}"#;
+        let stale = EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content)
+            .tags([Tag::parse(["d", "agent-slug"]).unwrap()])
+            .custom_created_at(nostr::Timestamp::from(1))
+            .sign_with_keys(&keys)
+            .unwrap();
+        let state = build_app_state();
+        *state.keys.lock().unwrap() = keys;
+
+        let fresh = resign_with_fresh_timestamp(&stale, &state).unwrap();
+
+        assert!(fresh.created_at.as_secs() > stale.created_at.as_secs());
+        assert_eq!(fresh.kind, Kind::Custom(KIND_MANAGED_AGENT as u16));
+        assert_eq!(fresh.content, content);
+        assert_eq!(fresh.tags, stale.tags);
+        assert!(fresh.verify_id());
+        assert!(fresh.verify_signature());
+        assert_ne!(fresh.as_json(), stale.as_json());
+    }
+
+    #[test]
+    fn needs_fresh_timestamp_covers_replaceables_tombstones_and_archive() {
+        use buzz_core_pkg::kind::{
+            KIND_DELETION, KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST, KIND_MANAGED_AGENT,
+            KIND_PERSONA, KIND_REACTION, KIND_TEAM, KIND_TEAM_CATALOG, KIND_TEXT_NOTE,
+        };
+
+        assert!(needs_fresh_timestamp_at_publish(KIND_DELETION));
+        assert!(needs_fresh_timestamp_at_publish(KIND_PERSONA));
+        assert!(needs_fresh_timestamp_at_publish(KIND_TEAM));
+        assert!(needs_fresh_timestamp_at_publish(KIND_MANAGED_AGENT));
+        assert!(needs_fresh_timestamp_at_publish(KIND_TEAM_CATALOG));
+        assert!(needs_fresh_timestamp_at_publish(KIND_IA_ARCHIVE_REQUEST));
+        assert!(needs_fresh_timestamp_at_publish(KIND_IA_UNARCHIVE_REQUEST));
+        assert!(!needs_fresh_timestamp_at_publish(KIND_TEXT_NOTE));
+        assert!(!needs_fresh_timestamp_at_publish(KIND_REACTION));
+    }
+
+    /// Stale retained parameterized-replaceable events must still flush: the
+    /// publish path re-signs with a fresh timestamp so the relay's ±900s
+    /// window does not permanently reject them.
+    #[tokio::test]
+    async fn stale_managed_agent_event_flushes_after_resign() {
+        use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+
+        let keys = nostr::Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("retention.db");
+
+        {
+            let conn = open_retention_db(&db_path).expect("open db");
+            let content = r#"{"name":"stale-agent"}"#;
+            let stale = EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content)
+                .tags([Tag::parse(["d", "stale-agent"]).unwrap()])
+                .custom_created_at(nostr::Timestamp::from(1))
+                .sign_with_keys(&keys)
+                .expect("sign stale managed-agent");
+            retain_event(
+                &conn,
+                &RetainedEvent {
+                    kind: KIND_MANAGED_AGENT,
+                    pubkey: pubkey.clone(),
+                    d_tag: "stale-agent".to_string(),
+                    content: stale.content.to_string(),
+                    created_at: 1,
+                    raw_event: stale.as_json(),
+                    pending_sync: true,
+                },
+            )
+            .expect("retain stale managed-agent");
+        }
+
+        let state = build_app_state();
+        *state.keys.lock().unwrap() = keys;
+        *state.relay_url_override.lock().unwrap() = Some(spawn_stub_relay().await);
+
+        let flushed = flush_pending_events(&db_path, &state).await.expect("flush");
+        assert_eq!(flushed, 1, "stale managed-agent row publishes after re-sign");
+
+        let conn = open_retention_db(&db_path).expect("reopen db");
+        let row = get_retained_event(&conn, KIND_MANAGED_AGENT, &pubkey, "stale-agent")
+            .unwrap()
+            .unwrap();
+        assert!(!row.pending_sync, "flushed row marked synced");
+        assert_eq!(row.created_at, 1, "retention created_at unchanged by re-sign");
+    }
+
     /// The mid-sweep barrier: a tombstone the relay rejects must defer its
     /// own replacement to the next sweep (still pending, not counted as
     /// flushed) while unrelated rows in the same sweep publish normally.


### PR DESCRIPTION
## Problem

Managed-agent retention can leave parameterized replaceables (kinds 30175–30178) and kind:5 tombstones stuck with `pending_sync = 1` forever. Desktop re-publishes the retained pre-signed `raw_event` every ~30s; once `created_at` falls outside the relay ingest skew window the relay rejects every attempt and nothing ever clears.

## Root cause

`flush_pending_events_at` in `desktop/src-tauri/src/managed_agents/persona_events.rs` replayed retained pre-signed events for most kinds.

Relay ingest enforces `MAX_TIMESTAMP_DRIFT_SECS = 900`. After that window:

- publish → `invalid: event timestamp too far from server time`
- row stays `pending_sync = 1`
- next flush repeats forever (reject storm)

NIP-IA identity-archive requests already re-signed with a fresh timestamp at publish; parameterized replaceables and tombstones did not.

## Fix

At flush/publish time, re-sign events that need a fresh timestamp via the same path as archive requests (`resign_with_fresh_timestamp`):

- parameterized replaceables 30175–30178 (`is_parameterized_replaceable`)
- kind:5 tombstones
- existing archive-request path unchanged

Preserves kind, tags, and content. `mark_synced` still keys off the retained original `created_at` + content so local retention rows clear correctly after a successful publish.

Helper: `needs_fresh_timestamp_at_publish`.

## Why it matters

Without this, managed-agent persona/retention traffic can permanently hammer the relay with undeliverable events and never converge — a reliability bug for every desktop that retains those kinds across the ±15m window (sleep, offline, long-lived agents). Independent confirmations on #4967 (`unclesvf`, `bokiko`).

## Test plan

```bash
. ./bin/activate-hermit
just _ensure-sidecar-stubs
cd desktop/src-tauri && cargo test --lib flush_barrier -- --nocapture
```

- [x] `flush_barrier` unit tests: **5/5** @ head `915a977` (rebased on current `main`)
- [x] DCO / Semgrep OSS / zizmor green on prior heads; re-run expected after rebase push
- [ ] Full monorepo `just ci` not run on this change (desktop Tauri lib filter only)
- [ ] Optional soak: age a retained replaceable past 15m, confirm next 30s flush accepts and `pending_sync` clears

## Risk / blast radius

- **In scope:** desktop managed-agent retention flush publisher only
- **Not changed:** relay ingest rules, non-retained publish paths, replaceable semantics beyond fresh `created_at` at send
- **Sync keying:** intentionally still original `created_at`+content so we do not orphan retention rows after re-sign

## Closest existing work

none found for this root cause (issue #4967 open; this is the only linked fix PR)

Fixes #4967

Retested after rebase onto current main @ `915a977d2`.

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `73c511bea`: cargo test --lib flush_barrier — 5/5.

## Mini retest (2026-08-24 acceptance)
- Head `db2be20fb1` · cargo test --lib flush_barrier → 5 passed
- Rebased onto current upstream `main` (force-with-lease, pre-review)
