### PR TITLE
fix(mobile): hide archived identities from discovery

### DIFF
--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../shared/auth/auth.dart';
 import '../../shared/custom_emoji/custom_emoji.dart';
 import '../../shared/custom_emoji/custom_emoji_provider.dart';
+import '../../shared/identity_archive/archived_identities_provider.dart';
 import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../profile/profile_provider.dart';
@@ -277,13 +278,24 @@ final relayDirectoryUsersProvider =
       ref.watch(relayConfigProvider);
       final session = ref.watch(relaySessionProvider.notifier);
       final currentPubkey = ref.watch(currentPubkeyProvider)?.toLowerCase();
+      final archivedPubkeys = await ref.watch(
+        archivedIdentitiesProvider.future,
+      );
       final directoryEvents = await session.queryRelay([
         const NostrFilter(kinds: [0], limit: 50, extensions: {'page': 1}),
       ]);
       var users = directoryUsersFromProfileEvents(directoryEvents);
       if (users.isNotEmpty) {
         return users
-            .where((user) => user.pubkey.toLowerCase() != currentPubkey)
+            .where(
+              (user) =>
+                  user.pubkey.toLowerCase() != currentPubkey &&
+                  !isArchivedForDiscovery(
+                    pubkey: user.pubkey,
+                    archivedPubkeys: archivedPubkeys,
+                    currentPubkey: currentPubkey,
+                  ),
+            )
             .toList();
       }
 
@@ -324,7 +336,15 @@ final relayDirectoryUsersProvider =
                 ? labelComparison
                 : a.pubkey.compareTo(b.pubkey);
           });
-      return users;
+      return users
+          .where(
+            (user) => !isArchivedForDiscovery(
+              pubkey: user.pubkey,
+              archivedPubkeys: archivedPubkeys,
+              currentPubkey: currentPubkey,
+            ),
+          )
+          .toList();
     });
 
 /// Prefix-searches the active relay's kind:0 people directory.
@@ -354,12 +374,23 @@ final relayDirectorySearchProvider = FutureProvider.autoDispose
       ref.watch(relayConfigProvider);
       final session = ref.watch(relaySessionProvider.notifier);
       final currentPubkey = ref.watch(currentPubkeyProvider)?.toLowerCase();
+      final archivedPubkeys = await ref.watch(
+        archivedIdentitiesProvider.future,
+      );
       final events = await session.queryRelay([
         NostrFilters.searchUsers(trimmed, limit: 50),
       ]);
-      return directoryUsersFromProfileEvents(
-        events,
-      ).where((user) => user.pubkey.toLowerCase() != currentPubkey).toList();
+      return directoryUsersFromProfileEvents(events)
+          .where(
+            (user) =>
+                user.pubkey.toLowerCase() != currentPubkey &&
+                !isArchivedForDiscovery(
+                  pubkey: user.pubkey,
+                  archivedPubkeys: archivedPubkeys,
+                  currentPubkey: currentPubkey,
+                ),
+          )
+          .toList();
     });
 
 /// Build [ChannelDetails] from a kind:39000 metadata event.

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -1,3 +1,4 @@
+import '../../../shared/identity_archive/archived_identities_provider.dart';
 import '../../../shared/mentions/agent_identity_provider.dart';
 import '../../profile/user_profile.dart';
 import '../channel_management_provider.dart';
@@ -52,13 +53,21 @@ List<MentionCandidate> buildMentionCandidates({
   required Map<String, String> ownerByAgentPubkey,
   List<UserProfile> searchResults = const [],
   String? currentPubkey,
+  Set<String> archivedPubkeys = const {},
 }) {
   final candidates = <MentionCandidate>[];
   final seen = <String>{};
 
+  bool isArchived(String pubkey) => isArchivedForDiscovery(
+    pubkey: pubkey,
+    archivedPubkeys: archivedPubkeys,
+    currentPubkey: currentPubkey,
+  );
+
   for (final member in members) {
     final pk = member.pubkey.toLowerCase();
     if (!seen.add(pk)) continue;
+    if (isArchived(pk)) continue;
     final profile = userCache[pk];
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
     final isAgent = member.isBot || ownerPubkey != null;
@@ -90,6 +99,7 @@ List<MentionCandidate> buildMentionCandidates({
   for (final agent in relayAgents) {
     final pk = agent.pubkey;
     if (seen.contains(pk)) continue;
+    if (isArchived(pk)) continue;
     if (!sharedAgentPubkeys.contains(pk)) continue;
     seen.add(pk);
     final profile = userCache[pk];
@@ -112,6 +122,7 @@ List<MentionCandidate> buildMentionCandidates({
   for (final profile in searchResults) {
     final pk = profile.pubkey.toLowerCase();
     if (seen.contains(pk)) continue;
+    if (isArchived(pk)) continue;
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile.ownerPubkey;
     final isAgent = ownerPubkey != null || directoryPubkeys.contains(pk);
     if (isAgent) {

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../shared/crypto/nip_oa.dart';
+import '../../../shared/identity_archive/archived_identities_provider.dart';
 import '../../../shared/mentions/agent_identity_provider.dart';
 import '../../../shared/relay/relay.dart';
 import '../../profile/user_cache_provider.dart';
@@ -87,6 +88,8 @@ final mentionCandidatesProvider = Provider.family
       final searchResults =
           ref.watch(mentionUserSearchProvider(args.query)).asData?.value ??
           const <UserProfile>[];
+      final archivedPubkeys =
+          ref.watch(archivedIdentitiesProvider).asData?.value ?? const {};
 
       final sharedChannelIds = {
         for (final channel in channels)
@@ -101,6 +104,7 @@ final mentionCandidatesProvider = Provider.family
         ownerByAgentPubkey: owners,
         searchResults: searchResults,
         currentPubkey: currentPubkey,
+        archivedPubkeys: archivedPubkeys,
       );
 
       return rankMentionCandidates(candidates, args.query);

--- a/mobile/lib/shared/identity_archive/archived_identities_provider.dart
+++ b/mobile/lib/shared/identity_archive/archived_identities_provider.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../relay/relay.dart';
+
+/// NIP-IA archived identity snapshot (`kind:13535`). Mirrors desktop's
+/// `list_archived_identities` — only relay-signed snapshots from NIP-11 `self`
+/// affect discovery filtering.
+final archivedIdentitiesProvider = FutureProvider<Set<String>>((ref) async {
+  final config = ref.watch(relayConfigProvider);
+  final relaySelf = await _fetchRelaySelf(config.baseUrl);
+  if (relaySelf == null) return const {};
+
+  final events = await ref.read(relaySessionProvider.notifier).queryRelay([
+    NostrFilters.archivedIdentities(relaySelf),
+  ]);
+
+  if (events.isEmpty) return const {};
+  final snapshot = events.first;
+  if (snapshot.pubkey.toLowerCase() != relaySelf) return const {};
+
+  return _archivedPubkeysFromSnapshot(snapshot);
+});
+
+/// Fail-open archived predicate for identity discovery. Returns `false` while
+/// the snapshot loads so a cold start cannot briefly hide everyone. The current
+/// user is never filtered, matching desktop's `useIsArchivedPredicate`.
+bool isArchivedForDiscovery({
+  required String pubkey,
+  required Set<String> archivedPubkeys,
+  String? currentPubkey,
+}) {
+  final lower = pubkey.toLowerCase();
+  final self = currentPubkey?.toLowerCase();
+  if (self != null && lower == self) return false;
+  return archivedPubkeys.contains(lower);
+}
+
+Future<String?> _fetchRelaySelf(String relayUrl) async {
+  final uri = _relayInfoUri(relayUrl);
+  if (uri == null) return null;
+
+  try {
+    final response = await http
+        .get(uri, headers: const {'Accept': 'application/nostr+json'})
+        .timeout(const Duration(seconds: 5));
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      return null;
+    }
+
+    final document = jsonDecode(response.body);
+    if (document is! Map<String, dynamic>) return null;
+
+    final relaySelf = document['self'];
+    if (relaySelf is! String) return null;
+    final normalized = relaySelf.trim().toLowerCase();
+    if (normalized.length != 64 ||
+        !RegExp(r'^[0-9a-f]+$').hasMatch(normalized)) {
+      return null;
+    }
+    return normalized;
+  } catch (_) {
+    return null;
+  }
+}
+
+Uri? _relayInfoUri(String relayUrl) {
+  try {
+    final uri = Uri.parse(relayUrl.trim());
+    final scheme = switch (uri.scheme) {
+      'wss' => 'https',
+      'ws' => 'http',
+      'https' || 'http' => uri.scheme,
+      _ => null,
+    };
+    return scheme == null ? null : uri.replace(scheme: scheme);
+  } on FormatException {
+    return null;
+  }
+}
+
+Set<String> _archivedPubkeysFromSnapshot(NostrEvent snapshot) {
+  final archived = <String>{};
+  for (final tag in snapshot.tags) {
+    if (tag.isEmpty || tag.first != 'p' || tag.length < 2) continue;
+    final pk = tag[1].toLowerCase();
+    if (pk.length == 64 && RegExp(r'^[0-9a-f]+$').hasMatch(pk)) {
+      archived.add(pk);
+    }
+  }
+  return archived;
+}

--- a/mobile/lib/shared/relay/nostr_filters.dart
+++ b/mobile/lib/shared/relay/nostr_filters.dart
@@ -205,6 +205,13 @@ abstract final class NostrFilters {
   static NostrFilter relayMembers() =>
       const NostrFilter(kinds: [13534], limit: 1);
 
+  /// NIP-IA archived identities snapshot (kind:13535) signed by the relay.
+  static NostrFilter archivedIdentities(String relaySelfPubkey) => NostrFilter(
+    kinds: [EventKind.archivedIdentitiesList],
+    authors: [relaySelfPubkey],
+    limit: 1,
+  );
+
   /// Agent profiles (kind:10100).
   static NostrFilter agentProfiles() =>
       const NostrFilter(kinds: [10100], limit: 100);

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -40,6 +40,9 @@ abstract final class EventKind {
   static const huddleParticipantLeft = 48102;
   static const huddleEnded = 48103;
 
+  /// NIP-IA relay archive snapshot (`kind:13535`).
+  static const archivedIdentitiesList = 13535;
+
   /// Event kinds that represent user-visible channel messages.
   static const channelMessageEventKinds = [
     streamMessage, // 9

--- a/mobile/test/features/channels/channel_management_provider_test.dart
+++ b/mobile/test/features/channels/channel_management_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/shared/identity_archive/archived_identities_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 /// Tests for [channelDetailsFromEvent].
@@ -233,15 +234,59 @@ void main() {
       sig: 'sig',
     );
 
-    ProviderContainer buildContainer(_DirectoryFakeRelaySession session) {
+    ProviderContainer buildContainer(
+      _DirectoryFakeRelaySession session, {
+      Set<String> archivedPubkeys = const {},
+    }) {
       return ProviderContainer(
         retry: (_, _) => null,
         overrides: [
           relaySessionProvider.overrideWith(() => session),
           myPubkeyProvider.overrideWithValue('me'),
+          archivedIdentitiesProvider.overrideWith(
+            (ref) async => archivedPubkeys,
+          ),
         ],
       );
     }
+
+    test('browse directory excludes archived identities', () async {
+      final session = _DirectoryFakeRelaySession(
+        profileEvents: [
+          profile('active-agent', 'Active Agent'),
+          profile('archived-agent', 'Archived Agent'),
+        ],
+      );
+      final container = buildContainer(
+        session,
+        archivedPubkeys: const {'archived-agent'},
+      );
+      addTearDown(container.dispose);
+
+      final users = await container.read(relayDirectoryUsersProvider.future);
+
+      expect(users.map((user) => user.pubkey), ['active-agent']);
+    });
+
+    test('search directory excludes archived identities', () async {
+      final session = _DirectoryFakeRelaySession(
+        profileEvents: [
+          profile('active-agent', 'Active Agent'),
+          profile('archived-agent', 'Archived Agent'),
+        ],
+      );
+      final container = buildContainer(
+        session,
+        archivedPubkeys: const {'archived-agent'},
+      );
+      addTearDown(container.dispose);
+
+      final users = await container.read(
+        relayDirectorySearchProvider('agent').future,
+      );
+
+      expect(users.map((user) => user.pubkey), ['active-agent']);
+    });
 
     test('browse directory refetches when the relay config changes', () async {
       final session = _DirectoryFakeRelaySession(

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/mentions/mention_candidates.dart';
 import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/shared/identity_archive/archived_identities_provider.dart';
 import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 
 final userPubkey = 'a' * 64;
@@ -279,6 +280,71 @@ void main() {
 
       expect(candidates, hasLength(1));
       expect(candidates.single.isMember, isTrue);
+    });
+
+    test('archived identities are excluded from every candidate source', () {
+      final archivedAgent = '9' * 64;
+      final candidates = buildMentionCandidates(
+        members: [
+          member(memberPubkey),
+          member(archivedAgent, role: 'bot'),
+        ],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: agentPubkey,
+            respondTo: 'anyone',
+            channelIds: const ['chan-1'],
+          ),
+        ],
+        sharedChannelIds: {'chan-1'},
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        searchResults: [
+          UserProfile(pubkey: archivedAgent, displayName: 'Old Bot'),
+        ],
+        currentPubkey: userPubkey,
+        archivedPubkeys: {archivedAgent},
+      );
+
+      expect(candidates.map((c) => c.pubkey), [memberPubkey, agentPubkey]);
+    });
+
+    test('current user stays mentionable even when archived on the relay', () {
+      final candidates = buildMentionCandidates(
+        members: [member(userPubkey)],
+        relayAgents: const [],
+        sharedChannelIds: const {},
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        currentPubkey: userPubkey,
+        archivedPubkeys: {userPubkey},
+      );
+
+      expect(candidates.map((c) => c.pubkey), contains(userPubkey));
+    });
+  });
+
+  group('isArchivedForDiscovery', () {
+    test('returns false while archived set is empty', () {
+      expect(
+        isArchivedForDiscovery(
+          pubkey: agentPubkey,
+          archivedPubkeys: const {},
+          currentPubkey: userPubkey,
+        ),
+        isFalse,
+      );
+    });
+
+    test('never archives the current user', () {
+      expect(
+        isArchivedForDiscovery(
+          pubkey: userPubkey,
+          archivedPubkeys: {userPubkey},
+          currentPubkey: userPubkey,
+        ),
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Load the relay-signed NIP-IA archived identity snapshot on mobile.
- Hide archived identities from mention autocomplete and New DM browse/search.
- Keep the current user's identity visible as a recovery safeguard.

## Root cause

Mobile's New DM directory queried kind:0 profiles and deduplicated only by pubkey. After an admin archived a duplicate managed-agent identity, that identity therefore remained selectable in mobile discovery.

## Scope

This fixes discovery after duplicate identities are archived. It intentionally does not deduplicate mutable display names, move agent keys between devices, or implement runtime lease/fencing; those identity-portability concerns remain tracked in #2648.

This rebases and extends Taksh's #3887; the original work is credited in the commit trailers.

## Verification

- `just ci` passed at commit `83289dde8089b16d5890a45b8e840fd23d6de13c`.
- `flutter analyze` reported no issues.
- The full Flutter suite passed: 1,267 tests.

Related: #2648, #3840, #3887
