### PR TITLE
fix(desktop): restore remote agent mention tags

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -17,7 +17,6 @@ import {
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
@@ -255,9 +254,9 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
-        return;
-      }
+      // Keep this as the single agent admission gate. It deliberately admits
+      // channel members whose relay-directory policy is missing, while an
+      // explicit directory entry can still exclude an unauthorized viewer.
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -848,7 +848,7 @@ test("other-owned agents without a shared channel are hidden from mentions", asy
   await expect(input.locator(".mention-chip")).toHaveCount(0);
 });
 
-test("stale channel-member agents absent from managed and relay directories stay hidden", async ({
+test("channel-member agents absent from the relay directory still emit an outbound mention tag", async ({
   page,
 }) => {
   await installMockBridge(page, { userSearchDelayMs: 1_000 });
@@ -859,7 +859,18 @@ test("stale channel-member agents absent from managed and relay directories stay
   const input = page.getByTestId("message-input");
   await input.fill("@mira");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const miraRow = autocomplete(page).locator("button", { hasText: "mira" });
+  await expect(miraRow).toBeVisible();
+  await miraRow.click();
+  await page.keyboard.type(" please reply");
+
+  const content = "@mira  please reply";
+  await expect(input).toHaveText(content);
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(PROFILE_ONLY_AGENT_PUBKEY);
 });
 
 test("managed relay agents are visible in channel mentions regardless of relay policy", async ({


### PR DESCRIPTION
## Summary

- make `shouldHideAgentFromMentions` the composer's single agent admission gate
- allow a visible channel-member agent to remain mentionable when its relay-directory entry is missing
- preserve explicit directory-policy exclusions and non-member filtering
- verify that selecting the agent adds its exact Nostr `p` tag to the outbound event

## Root cause

`useMentions.addCandidate` rejected any non-local agent absent from `mentionableAgentPubkeys` before calling `shouldHideAgentFromMentions`. That made the downstream helper's intentional "member with unknown invocability => show" branch unreachable.

This reproduces when two collaborators share a channel and one user's managed agent has a valid kind:0 profile and `bot` membership but no kind:10100 relay-directory row. The collaborator sees or types the agent name, but Desktop publishes plain `@Name` text without the agent's `p` tag, so `buzz-acp` cannot receive the invocation.

The receiving harness remains authoritative for `respond_to` enforcement. Agents with an explicit relay-directory policy excluding the viewer remain hidden.

Closes #2508.

## Validation

- `pnpm --dir desktop test` — 4,535 passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `pnpm --dir desktop build:e2e`
- focused Playwright signed-mention regression — 1 passed
