### PR TITLE
fix(mobile): open threads at the newest reply, with a shared jump-to-latest pill

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math' show min;
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
@@ -42,6 +41,7 @@ import 'date_formatters.dart';
 import 'day_divider.dart';
 import 'dm_channel_labels.dart';
 import 'ephemeral_channel_display.dart';
+import 'jump_to_latest_button.dart';
 import 'members_sheet.dart';
 import 'message_actions.dart';
 import 'message_long_press_region.dart';

--- a/mobile/lib/features/channels/channel_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_list.dart
@@ -550,74 +550,14 @@ class _MessageList extends HookConsumerWidget {
             right: 0,
             bottom: composerBottomInset + Grid.xs,
             child: Center(
-              child: _JumpToLatestButton(
+              child: JumpToLatestButton(
                 key: const ValueKey('channel-jump-to-latest'),
+                surfaceKey: const ValueKey('channel-jump-to-latest-surface'),
                 onPressed: scrollToLatest,
               ),
             ),
           ),
       ],
-    );
-  }
-}
-
-class _JumpToLatestButton extends StatelessWidget {
-  final VoidCallback onPressed;
-
-  const _JumpToLatestButton({required this.onPressed, super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final borderRadius = BorderRadius.circular(Radii.full);
-    return Semantics(
-      button: true,
-      child: ClipRRect(
-        borderRadius: borderRadius,
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            key: const ValueKey('channel-jump-to-latest-surface'),
-            decoration: BoxDecoration(
-              color: context.colors.surface.withValues(alpha: 0.5),
-              borderRadius: borderRadius,
-              border: Border.all(
-                color: Colors.black.withValues(alpha: 0.04),
-                width: 1,
-              ),
-            ),
-            child: Material(
-              type: MaterialType.transparency,
-              child: InkWell(
-                onTap: onPressed,
-                borderRadius: borderRadius,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: Grid.gutter,
-                    vertical: Grid.xxs,
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        LucideIcons.arrowDown,
-                        size: 16,
-                        color: context.colors.onSurface,
-                      ),
-                      const SizedBox(width: Grid.half),
-                      Text(
-                        'Latest',
-                        style: context.textTheme.labelLarge?.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/features/channels/jump_to_latest_button.dart
+++ b/mobile/lib/features/channels/jump_to_latest_button.dart
@@ -1,0 +1,80 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/theme/theme.dart';
+
+/// Frosted pill that jumps a message timeline back to its newest entry.
+///
+/// Shared by the channel timeline and the thread detail page. Callers show
+/// it only while the newest message is scrolled out of view and hide it once
+/// the tail is visible again.
+class JumpToLatestButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  /// Optional key for the frosted surface container, kept separate from the
+  /// widget [key] so tests can target the surface decoration directly.
+  final Key? surfaceKey;
+
+  const JumpToLatestButton({
+    required this.onPressed,
+    this.surfaceKey,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(Radii.full);
+    return Semantics(
+      button: true,
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            key: surfaceKey,
+            decoration: BoxDecoration(
+              color: context.colors.surface.withValues(alpha: 0.5),
+              borderRadius: borderRadius,
+              border: Border.all(
+                color: Colors.black.withValues(alpha: 0.04),
+                width: 1,
+              ),
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: onPressed,
+                borderRadius: borderRadius,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Grid.gutter,
+                    vertical: Grid.xxs,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        LucideIcons.arrowDown,
+                        size: 16,
+                        color: context.colors.onSurface,
+                      ),
+                      const SizedBox(width: Grid.half),
+                      Text(
+                        'Latest',
+                        style: context.textTheme.labelLarge?.copyWith(
+                          color: context.colors.onSurface,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -153,16 +153,32 @@ class ThreadDetailPage extends HookConsumerWidget {
       );
     }, [itemPositionsListener, replies.length]);
 
+    // The composer is painted over the bottom of the list viewport, so the
+    // usable trailing edge sits above the dock rather than at the physical
+    // bottom (1.0). Matches `latestAlignment()` in the channel timeline.
+    double usableTrailingEdge() {
+      final viewportHeight = context.size?.height ?? 0;
+      if (viewportHeight <= 0) return 1.0;
+      final reserved = composerDockHeight.value + Grid.xs;
+      return (1.0 - reserved / viewportHeight).clamp(0.0, 1.0).toDouble();
+    }
+
     // Second pass of a tail jump: once the tail item has rendered and its
-    // extent is measurable, align its trailing edge with the viewport bottom.
-    void alignTailWithViewportBottom(int lastIndex) {
+    // extent is measurable, rest its trailing edge on that usable boundary.
+    // Aligning against 1.0 instead only cleared the composer when the list's
+    // bottom padding happened to cap the scroll — the animated pill path
+    // scrolls that padding offscreen and buried the newest reply.
+    void alignTailAboveComposer(int lastIndex) {
       final lastPosition = itemPositionsListener.itemPositions.value
           .where((position) => position.index == lastIndex)
           .firstOrNull;
       if (lastPosition == null) return;
-      final targetAlignment =
-          1.0 - (lastPosition.itemTrailingEdge - lastPosition.itemLeadingEdge);
-      itemScrollController.jumpTo(index: lastIndex, alignment: targetAlignment);
+      final extent =
+          lastPosition.itemTrailingEdge - lastPosition.itemLeadingEdge;
+      itemScrollController.jumpTo(
+        index: lastIndex,
+        alignment: usableTrailingEdge() - extent,
+      );
     }
 
     useEffect(() {
@@ -214,7 +230,7 @@ class ThreadDetailPage extends HookConsumerWidget {
         itemScrollController.jumpTo(index: lastIndex);
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!context.mounted || !itemScrollController.isAttached) return;
-          alignTailWithViewportBottom(lastIndex);
+          alignTailAboveComposer(lastIndex);
         });
       });
       return null;
@@ -234,7 +250,7 @@ class ThreadDetailPage extends HookConsumerWidget {
       );
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted || !itemScrollController.isAttached) return;
-        alignTailWithViewportBottom(lastIndex);
+        alignTailAboveComposer(lastIndex);
       });
     }
 

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -117,6 +117,7 @@ class ThreadDetailPage extends HookConsumerWidget {
     final itemScrollController = useMemoized(ItemScrollController.new);
     final itemPositionsListener = useMemoized(ItemPositionsListener.create);
     final didJumpToInitialMessage = useRef(false);
+    final didJumpToThreadTail = useRef(false);
     final followsThreadTail = useRef(false);
     final pendingTailAlignment = useRef<double?>(null);
     final tailRealignmentQueued = useRef(false);
@@ -172,6 +173,44 @@ class ThreadDetailPage extends HookConsumerWidget {
       });
       return null;
     }, [initialMessageId, fetchedReplies, replies.length]);
+
+    // Without a deep-link target, opening a thread lands on the newest reply
+    // (matching desktop's thread panel) instead of the head. Wait for the
+    // authoritative thread query so the jump measures the full reply list,
+    // and leave short threads alone when the tail is already on screen.
+    useEffect(() {
+      if (initialMessageId != null ||
+          fetchedReplies == null ||
+          didJumpToThreadTail.value) {
+        return null;
+      }
+      didJumpToThreadTail.value = true;
+      if (replies.isEmpty) return null;
+      final lastIndex = indexForReply(replies.length - 1);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted || !itemScrollController.isAttached) return;
+        followsThreadTail.value = true;
+        if (threadTailIsVisible()) return;
+        // Render the tail first, then align its trailing edge with the
+        // viewport bottom once its extent is measurable.
+        itemScrollController.jumpTo(index: lastIndex);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!context.mounted || !itemScrollController.isAttached) return;
+          final lastPosition = itemPositionsListener.itemPositions.value
+              .where((position) => position.index == lastIndex)
+              .firstOrNull;
+          if (lastPosition == null) return;
+          final targetAlignment =
+              1.0 -
+              (lastPosition.itemTrailingEdge - lastPosition.itemLeadingEdge);
+          itemScrollController.jumpTo(
+            index: lastIndex,
+            alignment: targetAlignment,
+          );
+        });
+      });
+      return null;
+    }, [initialMessageId, fetchedReplies == null, replies.length]);
 
     // A top-anchored list doesn't stick to the newest item the way the old
     // reversed one did, so follow the tail explicitly: when a reply arrives

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -17,6 +17,7 @@ import 'channel_link_navigation.dart';
 import 'channel_messages_provider.dart';
 import 'channel_typing_provider.dart';
 import 'channel_typing_indicator.dart';
+import 'jump_to_latest_button.dart';
 import 'thread_replies_provider.dart';
 import 'channels_provider.dart';
 import 'compose_bar.dart';
@@ -33,6 +34,8 @@ import '../../shared/read_state/read_state_provider.dart';
 import 'send_message_provider.dart';
 import 'small_avatar.dart';
 import 'timeline_message.dart';
+
+part 'thread_detail_page/thread_message.dart';
 
 /// Full-screen thread detail page.
 ///
@@ -116,6 +119,7 @@ class ThreadDetailPage extends HookConsumerWidget {
     final replies = childrenByParent[threadHead.id] ?? const [];
     final itemScrollController = useMemoized(ItemScrollController.new);
     final itemPositionsListener = useMemoized(ItemPositionsListener.create);
+    final isAtTail = useState(true);
     final didJumpToInitialMessage = useRef(false);
     final didJumpToThreadTail = useRef(false);
     final followsThreadTail = useRef(false);
@@ -138,7 +142,9 @@ class ThreadDetailPage extends HookConsumerWidget {
 
     useEffect(() {
       void onPositionsChanged() {
-        if (threadTailIsVisible()) followsThreadTail.value = true;
+        final atTail = threadTailIsVisible();
+        if (atTail) followsThreadTail.value = true;
+        if (isAtTail.value != atTail) isAtTail.value = atTail;
       }
 
       itemPositionsListener.itemPositions.addListener(onPositionsChanged);
@@ -146,6 +152,18 @@ class ThreadDetailPage extends HookConsumerWidget {
         onPositionsChanged,
       );
     }, [itemPositionsListener, replies.length]);
+
+    // Second pass of a tail jump: once the tail item has rendered and its
+    // extent is measurable, align its trailing edge with the viewport bottom.
+    void alignTailWithViewportBottom(int lastIndex) {
+      final lastPosition = itemPositionsListener.itemPositions.value
+          .where((position) => position.index == lastIndex)
+          .firstOrNull;
+      if (lastPosition == null) return;
+      final targetAlignment =
+          1.0 - (lastPosition.itemTrailingEdge - lastPosition.itemLeadingEdge);
+      itemScrollController.jumpTo(index: lastIndex, alignment: targetAlignment);
+    }
 
     useEffect(() {
       final messageId = initialMessageId;
@@ -196,21 +214,29 @@ class ThreadDetailPage extends HookConsumerWidget {
         itemScrollController.jumpTo(index: lastIndex);
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!context.mounted || !itemScrollController.isAttached) return;
-          final lastPosition = itemPositionsListener.itemPositions.value
-              .where((position) => position.index == lastIndex)
-              .firstOrNull;
-          if (lastPosition == null) return;
-          final targetAlignment =
-              1.0 -
-              (lastPosition.itemTrailingEdge - lastPosition.itemLeadingEdge);
-          itemScrollController.jumpTo(
-            index: lastIndex,
-            alignment: targetAlignment,
-          );
+          alignTailWithViewportBottom(lastIndex);
         });
       });
       return null;
     }, [initialMessageId, fetchedReplies == null, replies.length]);
+
+    // Animated return to the newest reply, used by the jump-to-latest pill.
+    Future<void> scrollToTail() async {
+      if (!itemScrollController.isAttached) return;
+      followsThreadTail.value = true;
+      final lastIndex = replies.isEmpty
+          ? headIndex
+          : indexForReply(replies.length - 1);
+      await itemScrollController.scrollTo(
+        index: lastIndex,
+        duration: const Duration(milliseconds: 220),
+        curve: Curves.easeOutCubic,
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted || !itemScrollController.isAttached) return;
+        alignTailWithViewportBottom(lastIndex);
+      });
+    }
 
     // A top-anchored list doesn't stick to the newest item the way the old
     // reversed one did, so follow the tail explicitly: when a reply arrives
@@ -587,6 +613,18 @@ class ThreadDetailPage extends HookConsumerWidget {
                 ),
               ),
             ),
+          if (!isAtTail.value)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: composerDockHeight.value + Grid.xs,
+              child: Center(
+                child: JumpToLatestButton(
+                  key: const ValueKey('thread-jump-to-latest'),
+                  onPressed: scrollToTail,
+                ),
+              ),
+            ),
         ],
       ),
     );
@@ -748,287 +786,4 @@ class _ThreadTailMetricsObserver with WidgetsBindingObserver {
 
   @override
   void didChangeMetrics() => onMetricsChanged();
-}
-
-class _ThreadMessage extends ConsumerWidget {
-  final TimelineMessage message;
-  final Map<String, String> channelNames;
-  final String channelId;
-  final String? currentPubkey;
-  final bool showAuthor;
-  final bool isHighlighted;
-  final List<TimelineMessage>? allMessages;
-  final bool isMember;
-  final bool isArchived;
-
-  /// Whether this is the message the thread hangs off, which keeps a standing
-  /// "+" where replies only get one once they carry a reaction.
-  final bool isThreadHead;
-
-  const _ThreadMessage({
-    required this.message,
-    required this.channelNames,
-    required this.channelId,
-    required this.currentPubkey,
-    required this.showAuthor,
-    this.isHighlighted = false,
-    this.allMessages,
-    this.isMember = false,
-    this.isArchived = false,
-    this.isThreadHead = false,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final pk = message.pubkey.toLowerCase();
-    final profile =
-        ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
-        ref.read(userCacheProvider.notifier).get(pk);
-    final displayName = profile?.label ?? shortPubkey(message.pubkey);
-    final canManageMessage =
-        currentPubkey?.toLowerCase() == pk ||
-        (profile?.ownerPubkey != null &&
-            profile?.ownerPubkey == currentPubkey?.toLowerCase());
-
-    final userCache = ref.watch(userCacheProvider);
-    final knownAgentPubkeys = agentPubkeysWithProfileOwners(
-      knownAgentPubkeys: ref.watch(agentMentionPubkeysProvider(channelId)),
-      profileOwnedAgentPubkeys: [
-        for (final profile in userCache.values)
-          if (profile.ownerPubkey != null) profile.pubkey,
-      ],
-    );
-    final mentionNames = <String, String>{};
-    final agentMentionPubkeys = <String>{};
-    for (final mpk in message.mentionPubkeys) {
-      final normalizedPubkey = mpk.toLowerCase();
-      final p = userCache[normalizedPubkey];
-      if (p?.displayName != null) {
-        mentionNames[normalizedPubkey] = p!.displayName!;
-      }
-      if (knownAgentPubkeys.contains(normalizedPubkey)) {
-        agentMentionPubkeys.add(normalizedPubkey);
-      }
-    }
-    final resolvedMentionNames = mentionNamesWithDirectoryLabels(
-      mentionPubkeys: message.mentionPubkeys,
-      profileMentionNames: mentionNames,
-      directoryDisplayNames: ref.watch(agentDirectoryDisplayNamesProvider),
-      agentMentionPubkeys: agentMentionPubkeys,
-    );
-
-    void openMessageActions(Rect anchorRect) {
-      showMessageActions(
-        context: context,
-        ref: ref,
-        message: message,
-        channelId: channelId,
-        canManageMessage: canManageMessage,
-        allMessages: allMessages,
-        currentPubkey: currentPubkey,
-        isMember: isMember,
-        isArchived: isArchived,
-        anchorRect: anchorRect,
-      );
-    }
-
-    return Padding(
-      padding: EdgeInsets.only(top: showAuthor ? Grid.xs : 0),
-      child: DecoratedBox(
-        key: ValueKey('thread-message-${message.id}'),
-        decoration: BoxDecoration(
-          color: isHighlighted
-              ? context.colors.primary.withValues(alpha: 0.12)
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(Radii.md),
-        ),
-        child: Material(
-          color: Colors.transparent,
-          borderRadius: BorderRadius.circular(Radii.md),
-          // The media carousel intentionally continues through the list's
-          // trailing gutter. InkWell still clips its ink to [borderRadius],
-          // while leaving overflowing message content visible.
-          clipBehavior: Clip.none,
-          child: MessageLongPressInkWell(
-            key: ValueKey('thread-message-row-${message.id}'),
-            onLongPress: openMessageActions,
-            borderRadius: BorderRadius.circular(Radii.md),
-            highlightColor: context.colors.primary.withValues(alpha: 0.1),
-            child: Padding(
-              padding: EdgeInsets.only(
-                top: showAuthor ? 0 : Grid.xxs,
-                bottom: showAuthor ? 0 : Grid.xxs,
-              ),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (showAuthor)
-                    GestureDetector(
-                      onTap: () =>
-                          showUserProfileSheet(context, message.pubkey),
-                      child: _Avatar(profile: profile, pubkey: message.pubkey),
-                    )
-                  else
-                    const SizedBox(width: messageAvatarSize),
-                  const SizedBox(width: messageAvatarContentGap),
-                  Expanded(
-                    child: Padding(
-                      padding: EdgeInsets.only(top: showAuthor ? Grid.half : 0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          if (showAuthor)
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                bottom: Grid.quarter,
-                              ),
-                              child: Row(
-                                children: [
-                                  Expanded(
-                                    child: MessageAuthorMeta(
-                                      displayName: displayName,
-                                      username: messageUsernameLabel(profile),
-                                      timestamp: formatMessageTime(
-                                        message.createdAt,
-                                      ),
-                                      nameColor: context.colors.onSurface,
-                                      metadataColor:
-                                          context.colors.onSurfaceVariant,
-                                      onAuthorTap: () => showUserProfileSheet(
-                                        context,
-                                        message.pubkey,
-                                      ),
-                                      displayNameKey: ValueKey(
-                                        'thread-message-author-${message.id}',
-                                      ),
-                                      usernameKey: ValueKey(
-                                        'thread-message-username-${message.id}',
-                                      ),
-                                      timestampKey: ValueKey(
-                                        'thread-message-timestamp-${message.id}',
-                                      ),
-                                    ),
-                                  ),
-                                  if (message.edited) ...[
-                                    const SizedBox(width: Grid.half),
-                                    Text(
-                                      '(edited)',
-                                      style: context.textTheme.labelSmall
-                                          ?.copyWith(
-                                            color:
-                                                context.colors.onSurfaceVariant,
-                                            fontStyle: FontStyle.italic,
-                                          ),
-                                    ),
-                                  ],
-                                ],
-                              ),
-                            ),
-                          MessageContent(
-                            content: message.content,
-                            mentionNames: resolvedMentionNames,
-                            agentMentionPubkeys: agentMentionPubkeys,
-                            channelNames: channelNames,
-                            tags: message.tags,
-                            baseStyle: messageBodyTextStyle.copyWith(
-                              color: context.colors.onSurface,
-                            ),
-                            scaleEmojiOnly: true,
-                            mediaCarouselTrailingOverflow: Grid.gutter,
-                            onMediaReply: allMessages == null
-                                ? null
-                                : () {
-                                    if (!context.mounted) return;
-                                    Navigator.of(context).push(
-                                      MaterialPageRoute<void>(
-                                        builder: (_) => ThreadDetailPage(
-                                          threadHead: message,
-                                          allMessages: allMessages!,
-                                          channelId: channelId,
-                                          currentPubkey: currentPubkey,
-                                          isMember: isMember,
-                                          isArchived: isArchived,
-                                        ),
-                                      ),
-                                    );
-                                  },
-                            onMediaMore: (viewerContext, imageUrl) =>
-                                showImageActions(
-                                  context: viewerContext,
-                                  ref: ref,
-                                  message: message,
-                                  channelId: channelId,
-                                  imageUrl: imageUrl,
-                                  canManageMessage: canManageMessage,
-                                  onDeleted: () {
-                                    if (viewerContext.mounted) {
-                                      Navigator.of(viewerContext).maybePop();
-                                    }
-                                  },
-                                ),
-                            onChannelTap: (targetChannelId) {
-                              openChannelLink(
-                                context: context,
-                                ref: ref,
-                                channelId: targetChannelId,
-                                currentChannelId: channelId,
-                              );
-                            },
-                            onMentionTap: (pubkey) =>
-                                showUserProfileSheet(context, pubkey),
-                          ),
-                          ReactionRow(
-                            messageId: message.id,
-                            reactions: message.reactions,
-                            onToggle: (emoji) =>
-                                toggleReaction(ref, message, emoji),
-                            showAddButton:
-                                isMember &&
-                                !isArchived &&
-                                (isThreadHead || message.reactions.isNotEmpty),
-                            onAddReaction: () => showAddReactionPicker(
-                              context: context,
-                              ref: ref,
-                              message: message,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _Avatar extends StatelessWidget {
-  final UserProfile? profile;
-  final String pubkey;
-
-  const _Avatar({required this.profile, required this.pubkey});
-
-  @override
-  Widget build(BuildContext context) {
-    final initial =
-        profile?.initial ?? (pubkey.isNotEmpty ? pubkey[0].toUpperCase() : '?');
-    final avatarUrl = profile?.avatarUrl;
-
-    return AvatarImage(
-      imageUrl: avatarUrl,
-      radius: messageAvatarSize / 2,
-      backgroundColor: context.colors.primaryContainer,
-      fallback: Text(
-        initial,
-        style: context.textTheme.labelMedium?.copyWith(
-          color: context.colors.onPrimaryContainer,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
 }

--- a/mobile/lib/features/channels/thread_detail_page/thread_message.dart
+++ b/mobile/lib/features/channels/thread_detail_page/thread_message.dart
@@ -1,0 +1,284 @@
+part of '../thread_detail_page.dart';
+
+class _ThreadMessage extends ConsumerWidget {
+  final TimelineMessage message;
+  final Map<String, String> channelNames;
+  final String channelId;
+  final String? currentPubkey;
+  final bool showAuthor;
+  final bool isHighlighted;
+  final List<TimelineMessage>? allMessages;
+  final bool isMember;
+  final bool isArchived;
+
+  /// Whether this is the message the thread hangs off, which keeps a standing
+  /// "+" where replies only get one once they carry a reaction.
+  final bool isThreadHead;
+
+  const _ThreadMessage({
+    required this.message,
+    required this.channelNames,
+    required this.channelId,
+    required this.currentPubkey,
+    required this.showAuthor,
+    this.isHighlighted = false,
+    this.allMessages,
+    this.isMember = false,
+    this.isArchived = false,
+    this.isThreadHead = false,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pk = message.pubkey.toLowerCase();
+    final profile =
+        ref.watch(userCacheProvider.select((cache) => cache[pk])) ??
+        ref.read(userCacheProvider.notifier).get(pk);
+    final displayName = profile?.label ?? shortPubkey(message.pubkey);
+    final canManageMessage =
+        currentPubkey?.toLowerCase() == pk ||
+        (profile?.ownerPubkey != null &&
+            profile?.ownerPubkey == currentPubkey?.toLowerCase());
+
+    final userCache = ref.watch(userCacheProvider);
+    final knownAgentPubkeys = agentPubkeysWithProfileOwners(
+      knownAgentPubkeys: ref.watch(agentMentionPubkeysProvider(channelId)),
+      profileOwnedAgentPubkeys: [
+        for (final profile in userCache.values)
+          if (profile.ownerPubkey != null) profile.pubkey,
+      ],
+    );
+    final mentionNames = <String, String>{};
+    final agentMentionPubkeys = <String>{};
+    for (final mpk in message.mentionPubkeys) {
+      final normalizedPubkey = mpk.toLowerCase();
+      final p = userCache[normalizedPubkey];
+      if (p?.displayName != null) {
+        mentionNames[normalizedPubkey] = p!.displayName!;
+      }
+      if (knownAgentPubkeys.contains(normalizedPubkey)) {
+        agentMentionPubkeys.add(normalizedPubkey);
+      }
+    }
+    final resolvedMentionNames = mentionNamesWithDirectoryLabels(
+      mentionPubkeys: message.mentionPubkeys,
+      profileMentionNames: mentionNames,
+      directoryDisplayNames: ref.watch(agentDirectoryDisplayNamesProvider),
+      agentMentionPubkeys: agentMentionPubkeys,
+    );
+
+    void openMessageActions(Rect anchorRect) {
+      showMessageActions(
+        context: context,
+        ref: ref,
+        message: message,
+        channelId: channelId,
+        canManageMessage: canManageMessage,
+        allMessages: allMessages,
+        currentPubkey: currentPubkey,
+        isMember: isMember,
+        isArchived: isArchived,
+        anchorRect: anchorRect,
+      );
+    }
+
+    return Padding(
+      padding: EdgeInsets.only(top: showAuthor ? Grid.xs : 0),
+      child: DecoratedBox(
+        key: ValueKey('thread-message-${message.id}'),
+        decoration: BoxDecoration(
+          color: isHighlighted
+              ? context.colors.primary.withValues(alpha: 0.12)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(Radii.md),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(Radii.md),
+          // The media carousel intentionally continues through the list's
+          // trailing gutter. InkWell still clips its ink to [borderRadius],
+          // while leaving overflowing message content visible.
+          clipBehavior: Clip.none,
+          child: MessageLongPressInkWell(
+            key: ValueKey('thread-message-row-${message.id}'),
+            onLongPress: openMessageActions,
+            borderRadius: BorderRadius.circular(Radii.md),
+            highlightColor: context.colors.primary.withValues(alpha: 0.1),
+            child: Padding(
+              padding: EdgeInsets.only(
+                top: showAuthor ? 0 : Grid.xxs,
+                bottom: showAuthor ? 0 : Grid.xxs,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (showAuthor)
+                    GestureDetector(
+                      onTap: () =>
+                          showUserProfileSheet(context, message.pubkey),
+                      child: _Avatar(profile: profile, pubkey: message.pubkey),
+                    )
+                  else
+                    const SizedBox(width: messageAvatarSize),
+                  const SizedBox(width: messageAvatarContentGap),
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.only(top: showAuthor ? Grid.half : 0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (showAuthor)
+                            Padding(
+                              padding: const EdgeInsets.only(
+                                bottom: Grid.quarter,
+                              ),
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: MessageAuthorMeta(
+                                      displayName: displayName,
+                                      username: messageUsernameLabel(profile),
+                                      timestamp: formatMessageTime(
+                                        message.createdAt,
+                                      ),
+                                      nameColor: context.colors.onSurface,
+                                      metadataColor:
+                                          context.colors.onSurfaceVariant,
+                                      onAuthorTap: () => showUserProfileSheet(
+                                        context,
+                                        message.pubkey,
+                                      ),
+                                      displayNameKey: ValueKey(
+                                        'thread-message-author-${message.id}',
+                                      ),
+                                      usernameKey: ValueKey(
+                                        'thread-message-username-${message.id}',
+                                      ),
+                                      timestampKey: ValueKey(
+                                        'thread-message-timestamp-${message.id}',
+                                      ),
+                                    ),
+                                  ),
+                                  if (message.edited) ...[
+                                    const SizedBox(width: Grid.half),
+                                    Text(
+                                      '(edited)',
+                                      style: context.textTheme.labelSmall
+                                          ?.copyWith(
+                                            color:
+                                                context.colors.onSurfaceVariant,
+                                            fontStyle: FontStyle.italic,
+                                          ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
+                          MessageContent(
+                            content: message.content,
+                            mentionNames: resolvedMentionNames,
+                            agentMentionPubkeys: agentMentionPubkeys,
+                            channelNames: channelNames,
+                            tags: message.tags,
+                            baseStyle: messageBodyTextStyle.copyWith(
+                              color: context.colors.onSurface,
+                            ),
+                            scaleEmojiOnly: true,
+                            mediaCarouselTrailingOverflow: Grid.gutter,
+                            onMediaReply: allMessages == null
+                                ? null
+                                : () {
+                                    if (!context.mounted) return;
+                                    Navigator.of(context).push(
+                                      MaterialPageRoute<void>(
+                                        builder: (_) => ThreadDetailPage(
+                                          threadHead: message,
+                                          allMessages: allMessages!,
+                                          channelId: channelId,
+                                          currentPubkey: currentPubkey,
+                                          isMember: isMember,
+                                          isArchived: isArchived,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                            onMediaMore: (viewerContext, imageUrl) =>
+                                showImageActions(
+                                  context: viewerContext,
+                                  ref: ref,
+                                  message: message,
+                                  channelId: channelId,
+                                  imageUrl: imageUrl,
+                                  canManageMessage: canManageMessage,
+                                  onDeleted: () {
+                                    if (viewerContext.mounted) {
+                                      Navigator.of(viewerContext).maybePop();
+                                    }
+                                  },
+                                ),
+                            onChannelTap: (targetChannelId) {
+                              openChannelLink(
+                                context: context,
+                                ref: ref,
+                                channelId: targetChannelId,
+                                currentChannelId: channelId,
+                              );
+                            },
+                            onMentionTap: (pubkey) =>
+                                showUserProfileSheet(context, pubkey),
+                          ),
+                          ReactionRow(
+                            messageId: message.id,
+                            reactions: message.reactions,
+                            onToggle: (emoji) =>
+                                toggleReaction(ref, message, emoji),
+                            showAddButton:
+                                isMember &&
+                                !isArchived &&
+                                (isThreadHead || message.reactions.isNotEmpty),
+                            onAddReaction: () => showAddReactionPicker(
+                              context: context,
+                              ref: ref,
+                              message: message,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  final UserProfile? profile;
+  final String pubkey;
+
+  const _Avatar({required this.profile, required this.pubkey});
+
+  @override
+  Widget build(BuildContext context) {
+    final initial =
+        profile?.initial ?? (pubkey.isNotEmpty ? pubkey[0].toUpperCase() : '?');
+    final avatarUrl = profile?.avatarUrl;
+
+    return AvatarImage(
+      imageUrl: avatarUrl,
+      radius: messageAvatarSize / 2,
+      backgroundColor: context.colors.primaryContainer,
+      fallback: Text(
+        initial,
+        style: context.textTheme.labelMedium?.copyWith(
+          color: context.colors.onPrimaryContainer,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -4053,6 +4053,81 @@ void main() {
       expect(find.text('Reply number 0'), findsNothing);
     });
 
+    testWidgets('thread shows a Latest pill when scrolled up that jumps back '
+        'to the newest reply', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 40; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply number $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // At the tail after opening: no pill.
+      expect(find.byKey(const ValueKey('thread-jump-to-latest')), findsNothing);
+
+      // Scroll up to read older replies: the pill appears.
+      await tester.drag(
+        find.byKey(const ValueKey('thread-message-list')),
+        const Offset(0, 600),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('thread-jump-to-latest')),
+        findsOneWidget,
+      );
+      expect(find.text('Reply number 39'), findsNothing);
+
+      // Tapping the pill returns to the newest reply and hides the pill.
+      await tester.tap(find.byKey(const ValueKey('thread-jump-to-latest')));
+      await tester.pumpAndSettle();
+      expect(find.text('Reply number 39'), findsOneWidget);
+      expect(find.byKey(const ValueKey('thread-jump-to-latest')), findsNothing);
+    });
+
     testWidgets('thread deep link still lands on the linked reply', (
       tester,
     ) async {
@@ -4203,73 +4278,72 @@ void main() {
       );
     });
 
-    testWidgets(
-      'initial thread hydration lands on the newest reply',
-      (tester) async {
-        final rootEvent = _textMsg(
-          id: 'thread-root',
-          pubkey: 'alice',
-          content: 'Thread root',
-          createdAt: 1000,
-        );
-        final replies = [
-          for (var i = 0; i < 30; i++)
-            _textMsg(
-              id: 'reply-$i',
-              pubkey: 'bob',
-              content: 'Reply $i',
-              createdAt: 1100 + i,
-              extraTags: const [
-                ['e', 'thread-root', '', 'reply'],
-              ],
-            ),
-        ];
-        final completer = Completer<List<NostrEvent>>();
-
-        await tester.pumpWidget(
-          _buildTestable(
-            messages: [rootEvent],
-            pendingThreadReplies: {'thread-root': completer.future},
-            users: const {
-              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
-              'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
-            },
+    testWidgets('initial thread hydration lands on the newest reply', (
+      tester,
+    ) async {
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 30; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
           ),
-        );
-        await tester.pumpAndSettle();
+      ];
+      final completer = Completer<List<NostrEvent>>();
 
-        final threadHead = formatTimeline([rootEvent]).single;
-        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
-          MaterialPageRoute<void>(
-            builder: (_) => ThreadDetailPage(
-              threadHead: threadHead,
-              allMessages: [threadHead],
-              channelId: _channelId,
-              currentPubkey: 'self',
-              isMember: true,
-              isArchived: false,
-            ),
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          pendingThreadReplies: {'thread-root': completer.future},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
           ),
-        );
-        await tester.pumpAndSettle();
-        expect(
-          find.byKey(const ValueKey('thread-message-group-thread-root')),
-          findsOneWidget,
-        );
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('thread-message-group-thread-root')),
+        findsOneWidget,
+      );
 
-        completer.complete(replies);
-        await tester.pumpAndSettle();
+      completer.complete(replies);
+      await tester.pumpAndSettle();
 
-        expect(
-          find.byKey(const ValueKey('thread-message-group-reply-29')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey('thread-message-group-thread-root')),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-29')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('thread-message-group-thread-root')),
+        findsNothing,
+      );
+    });
 
     testWidgets(
       'deep-linking an older reply does not resume tail following on keyboard resize',

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -3995,6 +3995,124 @@ void main() {
       expect(oldestReplyY, lessThan(newestReplyY));
     });
 
+    testWidgets('thread opens scrolled to the newest reply', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 40; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply number $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The newest reply is on screen; the head and oldest replies are not.
+      expect(find.text('Reply number 39'), findsOneWidget);
+      expect(find.text('Thread root'), findsNothing);
+      expect(find.text('Reply number 0'), findsNothing);
+    });
+
+    testWidgets('thread deep link still lands on the linked reply', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 40; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply number $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+            initialMessageId: 'reply-2',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The deep-link target wins over the tail jump.
+      expect(find.text('Reply number 2'), findsOneWidget);
+      expect(find.text('Reply number 39'), findsNothing);
+    });
+
     testWidgets('thread keeps its tail above a growing composer dock', (
       tester,
     ) async {
@@ -4086,7 +4204,7 @@ void main() {
     });
 
     testWidgets(
-      'initial thread hydration keeps the head visible instead of following the tail',
+      'initial thread hydration lands on the newest reply',
       (tester) async {
         final rootEvent = _textMsg(
           id: 'thread-root',
@@ -4143,11 +4261,11 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.byKey(const ValueKey('thread-message-group-thread-root')),
+          find.byKey(const ValueKey('thread-message-group-reply-29')),
           findsOneWidget,
         );
         expect(
-          find.byKey(const ValueKey('thread-message-group-reply-29')),
+          find.byKey(const ValueKey('thread-message-group-thread-root')),
           findsNothing,
         );
       },

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -4346,6 +4346,154 @@ void main() {
     });
 
     testWidgets(
+      'hydrated thread settles its tail above the overlaid composer',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final rootEvent = _textMsg(
+          id: 'thread-root',
+          pubkey: 'alice',
+          content: 'Thread root',
+          createdAt: 1000,
+        );
+        final replies = [
+          for (var i = 0; i < 30; i++)
+            _textMsg(
+              id: 'reply-$i',
+              pubkey: 'bob',
+              content: 'Reply $i',
+              createdAt: 1100 + i,
+              extraTags: const [
+                ['e', 'thread-root', '', 'reply'],
+              ],
+            ),
+        ];
+        // Hydrate after the first layout pass so the composer dock is already
+        // measured when the tail settle runs — the dock-height callback cannot
+        // correct the alignment on that path.
+        final completer = Completer<List<NostrEvent>>();
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [rootEvent],
+            pendingThreadReplies: {'thread-root': completer.future},
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+              'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final threadHead = formatTimeline([rootEvent]).single;
+        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: threadHead,
+              allMessages: [threadHead],
+              channelId: _channelId,
+              currentPubkey: 'self',
+              isMember: true,
+              isArchived: false,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        completer.complete(replies);
+        await tester.pumpAndSettle();
+
+        // The newest reply must clear the composer painted over the list, not
+        // merely sit inside the list viewport.
+        final latestReply = find.byKey(
+          const ValueKey('thread-message-group-reply-29'),
+        );
+        final composerSurface = find.byKey(const ValueKey('composer-surface'));
+        expect(latestReply, findsOneWidget);
+        expect(
+          tester.getBottomLeft(latestReply).dy,
+          lessThanOrEqualTo(tester.getTopLeft(composerSurface).dy),
+        );
+      },
+    );
+
+    testWidgets('thread Latest pill returns the tail above the composer', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 30; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(
+        find.byKey(const ValueKey('thread-message-list')),
+        const Offset(0, 600),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('thread-jump-to-latest')));
+      await tester.pumpAndSettle();
+
+      final latestReply = find.byKey(
+        const ValueKey('thread-message-group-reply-29'),
+      );
+      final composerSurface = find.byKey(const ValueKey('composer-surface'));
+      expect(latestReply, findsOneWidget);
+      expect(
+        tester.getBottomLeft(latestReply).dy,
+        lessThanOrEqualTo(tester.getTopLeft(composerSurface).dy),
+      );
+    });
+
+    testWidgets(
       'deep-linking an older reply does not resume tail following on keyboard resize',
       (tester) async {
         tester.view.physicalSize = const Size(400, 800);


### PR DESCRIPTION
## Summary

Opening a thread on mobile lands on the thread head. In agent-heavy channels where threads routinely reach 300+ replies, reaching the newest message takes dozens of scroll gestures. Desktop's thread panel already opens at the bottom.

Two commits:

1. **`fix`: open threads scrolled to the newest reply.** Once the authoritative thread query hydrates, jump to the last reply, then align its trailing edge with the viewport bottom in a second pass (the tail must render before its extent is measurable). Guard rails:
   - **Deep links win**: `initialMessageId` keeps its existing jump and takes precedence over the tail jump.
   - **Short threads keep their top anchoring**: when the tail is already on screen, no scroll happens at all.
2. **`feat`: jump-to-latest pill in threads.** The channel timeline's frosted "Latest" pill now also appears in threads when the newest reply scrolls out of view; tapping it animates back to the tail. The pill is extracted into a shared, documented `JumpToLatestButton` used by both surfaces (net deduplication). `_ThreadMessage`/`_Avatar` move to a `part` file to keep `thread_detail_page.dart` under the 1000-line guard.
3. **`fix`: rest the tail above the overlaid composer** (review follow-up). The alignment targeted the physical viewport bottom, so clearing the composer depended on the list's bottom padding capping the scroll rather than on the alignment itself. That held on the hydration path but not on the animated pill path, which scrolls the padding offscreen and left 62px of the newest reply behind the composer. The usable trailing edge is now derived from the dock height and gutter, mirroring `latestAlignment()` in the channel timeline, and both paths share it.

### Related issue

Fixes #4354.

Closest existing PRs (searched before opening):
- #4702 settles hydrated threads on the latest reply (review in progress). This PR covers the same defect and additionally keeps short threads top-anchored, measures the tail's real extent before aligning it, and adds the jump-back affordance for the scroll-up case.
- #4355 pins threads to the newest reply (no activity since Aug 2).

No intent to race either one — happy to rebase on top if maintainers prefer to land one of those first, or to fold this PR's tests and pill onto it.

### Testing

TDD: each behavior landed with a widget test written first and observed failing. New/updated tests in `channel_detail_page_test.dart`:

- `thread opens scrolled to the newest reply` — 40-reply thread opens with the tail visible, head unbuilt
- `initial thread hydration lands on the newest reply` — same, with delayed (Completer-driven) hydration
- `thread deep link still lands on the linked reply` — deep-link precedence over the tail jump
- `thread shows a Latest pill when scrolled up that jumps back to the newest reply` — pill appears on scroll-up, returns to the tail on tap, hides at the tail

Review follow-up added two more, one per settle path, asserting the newest reply's bottom sits at or above the composer's top (not merely inside the list viewport):

- `hydrated thread settles its tail above the overlaid composer` — replies arrive through a `Completer` so the composer is already measured when the settle runs
- `thread Latest pill returns the tail above the composer`

Full mobile suite: **1266/1266 green**; `just mobile-check` clean (analyze, format, file-size guard). All commits are DCO signed.

On device: validated on a Galaxy S23 Ultra debug build against a production relay — long agent threads (300+ replies) open on the newest reply, the pill appears on scroll-up and returns to the tail, deep links and short threads behave as before. Re-validated after the composer fix: the end of the thread is now fully visible on both paths, where a sliver previously sat behind the translucent composer. Screenshot in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

