### PR TITLE
fix(huddle): make agent voice assignment stable across huddles

### DIFF
--- a/desktop/src-tauri/src/huddle/agent_voice.rs
+++ b/desktop/src-tauri/src/huddle/agent_voice.rs
@@ -54,9 +54,9 @@ fn catalog(app: &AppHandle, state: &AppState) -> Result<AgentVoiceCatalog, Strin
     })
 }
 
-fn stable_voice_index(agent_pubkey: &str, huddle_generation: u64, len: usize) -> usize {
+fn stable_voice_index(agent_pubkey: &str, len: usize) -> usize {
     let hash = agent_pubkey.bytes().fold(
-        0xcbf2_9ce4_8422_2325_u64 ^ huddle_generation,
+        0xcbf2_9ce4_8422_2325_u64,
         |hash, byte| hash.wrapping_mul(0x0000_0100_0000_01b3) ^ u64::from(byte),
     );
     (hash as usize) % len
@@ -107,10 +107,8 @@ pub(crate) fn sync_agent_voice_assignments(
             } else {
                 &unused_alternates
             };
-            (!candidates.is_empty()).then(|| {
-                candidates[stable_voice_index(pubkey, huddle.huddle_generation, candidates.len())]
-                    .clone()
-            })
+            (!candidates.is_empty())
+                .then(|| candidates[stable_voice_index(pubkey, candidates.len())].clone())
         };
         if let Some(voice_key) = preferred {
             used.insert(voice_key.clone());


### PR DESCRIPTION
## Problem

`stable_voice_index` seeds its hash with `huddle_generation`, so an agent is assigned a different voice in every huddle:

```rust
fn stable_voice_index(agent_pubkey: &str, huddle_generation: u64, len: usize) -> usize {
    let hash = agent_pubkey.bytes().fold(
        0xcbf2_9ce4_8422_2325_u64 ^ huddle_generation,
        ...
```

The function is named `stable_voice_index`, but it is only stable *within* a single huddle.

## Why it matters

In a voice huddle the user often isn't looking at the screen, so voice is the only cue to which agent is speaking. If an agent sounds different every session, that cue never becomes learnable and the per-agent voice feature loses most of its value.

## Change

Drop `huddle_generation` from the seed, so assignment is stable per agent pubkey. There was exactly one call site, so the parameter is removed cleanly rather than left as `_huddle_generation`.

Collision avoidance is unchanged: agents still get distinct voices within a huddle, because the candidate list already excludes voices taken by earlier agents in the same session.

## Was the old behaviour deliberate?

I don't think so, but you'd know better. No test asserts variation across generations — the only test touching this file (`first_agent_uses_default_and_additional_agents_are_distinct`) sets `huddle_generation: 9` purely to populate a required `HuddleState` field, and never compares assignments across two generations. It reads like an artifact of the seed rather than an intended feature.

**If it was intentional**, the same goal is better served by seeding from a stable per-user salt: still varied between users, still constant for one user over time.

## Testing

```
cd desktop/src-tauri && cargo test huddle::agent_voice
```
```
test huddle::agent_voice::tests::explicit_session_choices_survive_roster_resync ... ok
test huddle::agent_voice::tests::first_agent_uses_default_and_additional_agents_are_distinct ... ok
```
2 passed, 0 failed.
