### PR TITLE
fix(desktop): notify reply authors

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -473,6 +473,7 @@ async fn resolve_thread_ref(
     Ok(events::ThreadRef {
         root_event_id: root_eid,
         parent_event_id: parent_eid,
+        parent_author_pubkey: parent.pubkey.to_hex(),
     })
 }
 

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -11,12 +11,16 @@
 use buzz_core_pkg::kind::{KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST};
 use nostr::{EventBuilder, EventId, Kind, Tag};
 use uuid::Uuid;
+
+mod reply_recipients;
+pub use reply_recipients::ThreadRef;
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
 const MAX_CONTENT_BYTES: usize = 64 * 1024;
 
-/// Maximum mention count — matches buzz-sdk.
+/// Maximum caller-supplied mention count — matches buzz-sdk. Replies may add
+/// one automatic parent-author recipient after this limit is enforced.
 const MAX_MENTIONS: usize = 50;
 
 /// Maximum emoji length in characters — matches buzz-sdk.
@@ -39,12 +43,6 @@ fn check_content(content: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// NIP-10 thread reference.
-pub struct ThreadRef {
-    pub root_event_id: EventId,
-    pub parent_event_id: EventId,
-}
-
 fn thread_tags(tr: &ThreadRef) -> Result<Vec<Tag>, String> {
     let root = tr.root_event_id.to_hex();
     let parent = tr.parent_event_id.to_hex();
@@ -60,7 +58,7 @@ fn thread_tags(tr: &ThreadRef) -> Result<Vec<Tag>, String> {
 
 fn mention_tags(mentions: &[&str]) -> Result<Vec<Tag>, String> {
     if mentions.len() > MAX_MENTIONS {
-        return Err(format!("too many mentions (max {MAX_MENTIONS})"));
+        return Err(format!("too many explicit mentions (max {MAX_MENTIONS})"));
     }
     let mut seen = std::collections::HashSet::new();
     let mut tags = Vec::new();
@@ -341,7 +339,7 @@ pub fn build_message_with_client_tags(
     if let Some(tr) = thread_ref {
         tags.extend(thread_tags(tr)?);
     }
-    tags.extend(mention_tags(mentions)?);
+    tags.extend(reply_recipients::tags(thread_ref, mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     emoji_tags(custom_emoji_tags, &mut tags)?;
     mention_reference_tags(mention_ref_tags, &mut tags)?;
@@ -395,7 +393,7 @@ pub fn build_forum_comment(
     check_content(content)?;
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     tags.extend(thread_tags(thread_ref)?);
-    tags.extend(mention_tags(mentions)?);
+    tags.extend(reply_recipients::tags(Some(thread_ref), mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     mention_reference_tags(mention_ref_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(45003), content).tags(tags))
@@ -855,6 +853,7 @@ mod tests {
         assert!(build_create_channel(channel_id, "###", "open", "stream", None, None).is_err());
         assert!(build_update_channel(channel_id, Some("###"), None, None, None).is_err());
     }
+
     /// Builder layout regression for the NIP-IA owner-of-agent archive flow.
     /// Compares against `docs/nips/NIP-IA.md` §Vector 1.
     #[test]

--- a/desktop/src-tauri/src/events/reply_recipients.rs
+++ b/desktop/src-tauri/src/events/reply_recipients.rs
@@ -1,0 +1,129 @@
+use super::mention_tags;
+use nostr::{EventId, Tag};
+
+/// NIP-10 thread reference plus the immediate parent author who must be notified.
+pub struct ThreadRef {
+    pub root_event_id: EventId,
+    pub parent_event_id: EventId,
+    pub parent_author_pubkey: String,
+}
+
+pub(super) fn tags(thread_ref: Option<&ThreadRef>, mentions: &[&str]) -> Result<Vec<Tag>, String> {
+    let mut tags = mention_tags(mentions)?;
+    if let Some(thread_ref) = thread_ref {
+        let parent_author = thread_ref.parent_author_pubkey.as_str();
+        if !tags
+            .iter()
+            .filter_map(|tag| tag.as_slice().get(1))
+            .any(|pubkey| pubkey.eq_ignore_ascii_case(parent_author))
+        {
+            tags.extend(mention_tags(&[parent_author])?);
+        }
+    }
+    Ok(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{build_forum_comment, build_message};
+    use super::*;
+    use nostr::{EventId, Keys};
+    use uuid::Uuid;
+
+    fn thread_ref(parent_author_pubkey: String) -> ThreadRef {
+        ThreadRef {
+            root_event_id: EventId::from_hex(
+                "1111111111111111111111111111111111111111111111111111111111111111",
+            )
+            .unwrap(),
+            parent_event_id: EventId::from_hex(
+                "2222222222222222222222222222222222222222222222222222222222222222",
+            )
+            .unwrap(),
+            parent_author_pubkey,
+        }
+    }
+
+    fn p_tag_value(tag: &Tag) -> Option<String> {
+        let parts = tag.as_slice();
+        (parts.first().map(String::as_str) == Some("p"))
+            .then(|| parts.get(1).cloned())
+            .flatten()
+    }
+
+    #[test]
+    fn stream_reply_mentions_parent_author_without_explicit_mentions() {
+        let parent_author = Keys::generate().public_key().to_hex();
+        let thread_ref = thread_ref(parent_author.clone());
+        let event = build_message(
+            Uuid::new_v4(),
+            "reply",
+            Some(&thread_ref),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            "http://localhost:3000",
+        )
+        .unwrap()
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+
+        assert_eq!(
+            event
+                .tags
+                .iter()
+                .filter_map(p_tag_value)
+                .collect::<Vec<_>>(),
+            vec![parent_author]
+        );
+    }
+
+    #[test]
+    fn parent_author_deduplicates_case_insensitively() {
+        let parent_author = Keys::generate().public_key().to_hex();
+        let duplicate_uppercase = parent_author.to_ascii_uppercase();
+        let thread_ref = thread_ref(parent_author.clone());
+        let tags = tags(Some(&thread_ref), &[&duplicate_uppercase]).unwrap();
+
+        assert_eq!(
+            tags.iter().filter_map(p_tag_value).collect::<Vec<_>>(),
+            vec![parent_author]
+        );
+    }
+
+    #[test]
+    fn automatic_parent_does_not_reduce_explicit_mention_cap() {
+        let parent_author = Keys::generate().public_key().to_hex();
+        let thread_ref = thread_ref(parent_author.clone());
+        let mentions: Vec<String> = (0..50)
+            .map(|_| Keys::generate().public_key().to_hex())
+            .collect();
+        let mention_refs: Vec<&str> = mentions.iter().map(String::as_str).collect();
+        let tags = tags(Some(&thread_ref), &mention_refs).unwrap();
+        let recipients: Vec<String> = tags.iter().filter_map(p_tag_value).collect();
+
+        assert_eq!(recipients.len(), 51);
+        assert_eq!(recipients.last(), Some(&parent_author));
+    }
+
+    #[test]
+    fn forum_reply_mentions_parent_author_without_explicit_mentions() {
+        let parent_author = Keys::generate().public_key().to_hex();
+        let thread_ref = thread_ref(parent_author.clone());
+        let event = build_forum_comment(Uuid::new_v4(), "reply", &thread_ref, &[], &[], &[])
+            .unwrap()
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        assert_eq!(
+            event
+                .tags
+                .iter()
+                .filter_map(p_tag_value)
+                .collect::<Vec<_>>(),
+            vec![parent_author]
+        );
+    }
+}

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -1,5 +1,10 @@
 import { useEffect, useEffectEvent } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import {
@@ -12,7 +17,7 @@ import {
   getThreadReference,
   isBroadcastReply,
   normalizeMentionPubkeys,
-  resolveReplyRootId,
+  resolveReplyContext,
 } from "@/features/messages/lib/threading";
 import {
   projectChannelWindowMessages,
@@ -79,6 +84,25 @@ type MessageQueryContext = {
 const CHANNEL_TIMELINE_KINDS = new Set<number>(CHANNEL_TIMELINE_CONTENT_KINDS);
 const CHANNEL_AUX_KINDS = new Set<number>(CHANNEL_AUX_EVENT_KINDS);
 
+type ReplyContextQueryClient = Pick<
+  QueryClient,
+  "getQueryData" | "getQueriesData"
+>;
+
+export function getCachedReplyContextEvents(
+  queryClient: ReplyContextQueryClient,
+  channelId: string,
+): RelayEvent[] {
+  const timeline =
+    queryClient.getQueryData<RelayEvent[]>(channelMessagesKey(channelId)) ?? [];
+  const threadReplies = queryClient
+    .getQueriesData<RelayEvent[]>({
+      queryKey: ["thread-replies", channelId],
+    })
+    .flatMap(([, events]) => events ?? []);
+  return [...threadReplies, ...timeline];
+}
+
 export function createOptimisticMessage(
   channelId: string,
   content: string,
@@ -92,12 +116,14 @@ export function createOptimisticMessage(
   const tags: string[][] = [];
 
   if (parentEventId) {
+    const replyContext = resolveReplyContext(parentEventId, currentMessages);
     tags.push(
       ...buildReplyTags(
         channelId,
         identity.pubkey,
+        replyContext.parentAuthorPubkey,
         parentEventId,
-        resolveReplyRootId(parentEventId, currentMessages),
+        replyContext.rootEventId,
         mentionPubkeys,
       ),
     );
@@ -475,10 +501,12 @@ export function useSendMessageMutation(
         emojiTags.length > 0 ||
         linkPreviewTags.length > 0
       ) {
-        const cachedMessages =
-          queryClient.getQueryData<RelayEvent[]>(
-            channelMessagesKey(effectiveChannel.id),
-          ) ?? [];
+        const replyContext = parentEventId
+          ? resolveReplyContext(
+              parentEventId,
+              getCachedReplyContextEvents(queryClient, effectiveChannel.id),
+            )
+          : null;
         const result = await sendChannelMessage(
           effectiveChannel.id,
           content,
@@ -491,20 +519,21 @@ export function useSendMessageMutation(
           linkPreviewTags,
         );
 
-        // Build tags matching relay-emitted shape: h, author p, mention ps, reply es, imeta, emoji.
-        // For replies, buildReplyTags already includes ["p", author] and ["h", channel].
+        // Build tags matching the relay-emitted reply shape, including the
+        // immediate parent author as an automatic recipient.
         // For non-replies (media-only), we add them ourselves.
         const replyTags = parentEventId
           ? buildReplyTags(
               effectiveChannel.id,
               identity.pubkey,
+              replyContext?.parentAuthorPubkey ?? null,
               parentEventId,
-              resolveReplyRootId(parentEventId, cachedMessages),
+              replyContext?.rootEventId ?? parentEventId,
               recipientPubkeys,
             )
           : [];
         const baseTags = parentEventId
-          ? replyTags // buildReplyTags includes h + author p + mention ps
+          ? replyTags // buildReplyTags includes h + thread refs + recipient ps
           : [
               ["h", effectiveChannel.id],
               ["p", identity.pubkey],
@@ -578,7 +607,7 @@ export function useSendMessageMutation(
         effectiveChannel.id,
         content.trim(),
         identity,
-        previousMessages,
+        getCachedReplyContextEvents(queryClient, effectiveChannel.id),
         mentionPubkeys ?? [],
         parentEventId ?? null,
         mediaTags ?? [],

--- a/desktop/src/features/messages/lib/sendChannelBinding.test.mjs
+++ b/desktop/src/features/messages/lib/sendChannelBinding.test.mjs
@@ -24,10 +24,12 @@ import test from "node:test";
 
 import {
   createOptimisticMessage,
+  getCachedReplyContextEvents,
   resolveEffectiveChannel,
   resolveSendChannel,
   resolveThreadReplyTarget,
 } from "../hooks.ts";
+import { buildReplyTags } from "./threading.ts";
 
 // ---------------------------------------------------------------------------
 // Minimal stubs
@@ -35,6 +37,11 @@ import {
 const IDENTITY = {
   pubkey: "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222",
 };
+const PARENT_IDENTITY = {
+  pubkey: "bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222cccc3333",
+};
+const MENTION_PUBKEY =
+  "cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222cccc3333dddd4444";
 
 function makeChannel(id) {
   return {
@@ -113,7 +120,7 @@ test("createOptimisticMessage_withReply_hTagStillCarriesSuppliedChannelId", () =
   const parentEvent = createOptimisticMessage(
     "channel-A",
     "parent",
-    IDENTITY,
+    PARENT_IDENTITY,
     [],
     [],
     null,
@@ -135,6 +142,94 @@ test("createOptimisticMessage_withReply_hTagStillCarriesSuppliedChannelId", () =
     hTag[1],
     composeChannelId,
     "reply h-tag must match the compose-time channelId",
+  );
+  assert.deepEqual(
+    replyMsg.tags.filter(([name]) => name === "p"),
+    [["p", PARENT_IDENTITY.pubkey]],
+    "reply must notify the immediate parent author",
+  );
+});
+
+test("nested reply resolves its immediate parent from the thread cache", () => {
+  const root = createOptimisticMessage(
+    "channel-A",
+    "root",
+    IDENTITY,
+    [],
+    [],
+    null,
+    [],
+  );
+  const immediateParent = createOptimisticMessage(
+    "channel-A",
+    "nested parent",
+    PARENT_IDENTITY,
+    [root],
+    [],
+    root.id,
+    [],
+  );
+  const queryClient = {
+    getQueryData: () => [root],
+    getQueriesData: () => [
+      [["thread-replies", "channel-A", root.id], [immediateParent]],
+    ],
+  };
+  const replyContextEvents = getCachedReplyContextEvents(
+    queryClient,
+    "channel-A",
+  );
+  const reply = createOptimisticMessage(
+    "channel-A",
+    "nested reply",
+    IDENTITY,
+    replyContextEvents,
+    [],
+    immediateParent.id,
+    [],
+  );
+
+  assert.deepEqual(
+    reply.tags.filter(([name]) => name === "p"),
+    [["p", PARENT_IDENTITY.pubkey]],
+  );
+  assert.deepEqual(
+    reply.tags.filter(([name]) => name === "e"),
+    [
+      ["e", root.id, "", "root"],
+      ["e", immediateParent.id, "", "reply"],
+    ],
+  );
+});
+
+test("buildReplyTags deduplicates parent and explicit recipients", () => {
+  const tags = buildReplyTags(
+    "channel-A",
+    IDENTITY.pubkey,
+    PARENT_IDENTITY.pubkey,
+    "parent-id",
+    "root-id",
+    [
+      PARENT_IDENTITY.pubkey.toUpperCase(),
+      MENTION_PUBKEY,
+      PARENT_IDENTITY.pubkey,
+      IDENTITY.pubkey,
+    ],
+  );
+
+  assert.deepEqual(
+    tags.filter(([name]) => name === "p"),
+    [
+      ["p", PARENT_IDENTITY.pubkey],
+      ["p", MENTION_PUBKEY],
+    ],
+  );
+  assert.deepEqual(
+    tags.filter(([name]) => name === "e"),
+    [
+      ["e", "root-id", "", "root"],
+      ["e", "parent-id", "", "reply"],
+    ],
   );
 });
 

--- a/desktop/src/features/messages/lib/threading.ts
+++ b/desktop/src/features/messages/lib/threading.ts
@@ -101,29 +101,29 @@ export function diffAddedMentionPubkeys(
 export function buildReplyTags(
   channelId: string,
   authorPubkey: string,
+  parentAuthorPubkey: string | null,
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] = [],
 ) {
-  const tags: string[][] = [
-    ["p", authorPubkey],
-    ["h", channelId],
-  ];
-
-  // Add p-tags for mentioned users so mention-filtered subscriptions
-  // (e.g. ACP agent harness) receive the reply event.
-  // Best-effort normalization — relay performs authoritative validation.
-  for (const pubkey of normalizeMentionPubkeys(mentionPubkeys, authorPubkey)) {
-    tags.push(["p", pubkey]);
-  }
+  const tags: string[][] = [["h", channelId]];
 
   if (parentEventId === rootEventId) {
     tags.push(["e", rootEventId, "", "reply"]);
-    return tags;
+  } else {
+    tags.push(["e", rootEventId, "", "root"]);
+    tags.push(["e", parentEventId, "", "reply"]);
   }
 
-  tags.push(["e", rootEventId, "", "root"]);
-  tags.push(["e", parentEventId, "", "reply"]);
+  // Notify the immediate parent author as well as explicit mentions so
+  // mention-filtered subscriptions (e.g. ACP agent harness) receive replies.
+  // Best-effort normalization — relay performs authoritative validation.
+  const recipients = parentAuthorPubkey
+    ? [parentAuthorPubkey, ...mentionPubkeys]
+    : mentionPubkeys;
+  for (const pubkey of normalizeMentionPubkeys(recipients, authorPubkey)) {
+    tags.push(["p", pubkey]);
+  }
   return tags;
 }
 
@@ -152,11 +152,24 @@ export function resolveReplyRootId(
   parentEventId: string,
   events: RelayEvent[],
 ) {
+  return resolveReplyContext(parentEventId, events).rootEventId;
+}
+
+export function resolveReplyContext(
+  parentEventId: string,
+  events: RelayEvent[],
+) {
   const parent = events.find((event) => event.id === parentEventId);
   if (!parent) {
-    return parentEventId;
+    return {
+      parentAuthorPubkey: null,
+      rootEventId: parentEventId,
+    };
   }
 
   const thread = getThreadReference(parent.tags);
-  return thread.rootId ?? parent.id;
+  return {
+    parentAuthorPubkey: parent.pubkey,
+    rootEventId: thread.rootId ?? parent.id,
+  };
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -3900,25 +3900,26 @@ function buildTopLevelMessageTags(
 function buildReplyMessageTags(
   channelId: string,
   authorPubkey: string,
+  parentAuthorPubkey: string | null,
   parentEventId: string,
   rootEventId: string,
   mentionPubkeys: string[] | undefined,
 ) {
-  // Preserve the reply tag ordering that the desktop message hooks already
-  // expect locally: author p, h, mention ps, then thread e-tags.
-  const tags: string[][] = [
-    ["p", authorPubkey],
-    ["h", channelId],
-  ];
-  appendMentionTags(tags, mentionPubkeys, authorPubkey);
+  const tags: string[][] = [["h", channelId]];
 
   if (parentEventId === rootEventId) {
     tags.push(["e", rootEventId, "", "reply"]);
-    return tags;
+  } else {
+    tags.push(["e", rootEventId, "", "root"]);
+    tags.push(["e", parentEventId, "", "reply"]);
   }
-
-  tags.push(["e", rootEventId, "", "root"]);
-  tags.push(["e", parentEventId, "", "reply"]);
+  appendMentionTags(
+    tags,
+    parentAuthorPubkey
+      ? [parentAuthorPubkey, ...(mentionPubkeys ?? [])]
+      : mentionPubkeys,
+    authorPubkey,
+  );
   return tags;
 }
 
@@ -4010,6 +4011,7 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
               tags: buildReplyMessageTags(
                 channelId,
                 ALICE_PUBKEY,
+                "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
                 "mock-forum-release-thread",
                 "mock-forum-release-thread",
                 undefined,
@@ -4032,6 +4034,7 @@ function getMockMessageStore(channelId: string): RelayEvent[] {
               tags: buildReplyMessageTags(
                 channelId,
                 ALICE_PUBKEY,
+                "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
                 "mock-forum-release-thread",
                 "mock-forum-release-thread",
                 undefined,
@@ -4417,6 +4420,7 @@ function emitMockChannelMessage(
   const tags = buildReplyMessageTags(
     channelId,
     authorPubkey,
+    parentEvent?.pubkey ?? null,
     parentEventId,
     rootEventId,
     mentionPubkeys,
@@ -9110,6 +9114,7 @@ async function handleSendChannelMessage(
         ...buildReplyMessageTags(
           args.channelId,
           mockPubkey,
+          parentEvent?.pubkey ?? null,
           args.parentEventId,
           rootEventId,
           args.mentionPubkeys,
@@ -9133,12 +9138,16 @@ async function handleSendChannelMessage(
   }
 
   const relayIdentity = getRelayIdentity(config);
+  const relayReplyContext = args.parentEventId
+    ? await resolveRelayReplyContext(config, args.parentEventId)
+    : null;
   const tags = args.parentEventId
     ? buildReplyMessageTags(
         args.channelId,
         relayIdentity.pubkey,
+        relayReplyContext?.parentAuthorPubkey ?? null,
         args.parentEventId,
-        args.parentEventId,
+        relayReplyContext?.rootEventId ?? args.parentEventId,
         args.mentionPubkeys,
       )
     : buildTopLevelMessageTags(
@@ -9156,9 +9165,29 @@ async function handleSendChannelMessage(
   return {
     event_id: result.event_id,
     parent_event_id: args.parentEventId ?? null,
-    root_event_id: args.parentEventId ?? null,
-    depth: args.parentEventId ? 1 : 0,
+    root_event_id: relayReplyContext?.rootEventId ?? null,
+    depth: relayReplyContext?.depth ?? 0,
     created_at: Math.floor(Date.now() / 1000),
+  };
+}
+
+async function resolveRelayReplyContext(
+  config: E2eConfig | undefined,
+  parentEventId: string,
+) {
+  const [parentEvent] = await relayQuery(config, [
+    { ids: [parentEventId], limit: 1 },
+  ]);
+  if (!parentEvent) {
+    throw new Error(`Event not found: ${parentEventId}`);
+  }
+
+  const parentThread = getThreadReferenceFromTags(parentEvent.tags);
+  const rootEventId = parentThread.rootEventId ?? parentEventId;
+  return {
+    parentAuthorPubkey: parentEvent.pubkey,
+    rootEventId,
+    depth: rootEventId === parentEventId ? 1 : 2,
   };
 }
 
@@ -9195,10 +9224,16 @@ async function handleSendManagedAgentChannelMessage(
   }
 
   const createdAt = Math.floor(Date.now() / 1000);
+  const parentAuthor = args.parentEventId
+    ? (getMockMessageStore(args.channelId).find(
+        (event) => event.id === args.parentEventId,
+      )?.pubkey ?? null)
+    : null;
   const tags = args.parentEventId
     ? buildReplyMessageTags(
         args.channelId,
         agent.pubkey,
+        parentAuthor,
         args.parentEventId,
         args.parentEventId,
         args.mentionPubkeys ?? undefined,
@@ -9480,6 +9515,7 @@ async function resolveGetEvent(
         tags: buildReplyMessageTags(
           "a27e1ee9-76a6-5bdf-a5d5-1d85610dad11",
           ALICE_PUBKEY,
+          "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
           "mock-forum-release-thread",
           "mock-forum-release-thread",
           undefined,

--- a/desktop/tests/e2e/stream.spec.ts
+++ b/desktop/tests/e2e/stream.spec.ts
@@ -105,10 +105,12 @@ async function sendChannelMessage(
     channelName,
     content,
     mentionPubkeys,
+    parentEventId,
   }: {
     channelName: string;
     content: string;
     mentionPubkeys?: string[];
+    parentEventId?: string;
   },
 ) {
   await page.waitForFunction(
@@ -123,8 +125,13 @@ async function sendChannelMessage(
     { timeout: 5_000 },
   );
 
-  await page.evaluate(
-    async ({ channelName: targetChannelName, content, mentionPubkeys }) => {
+  return page.evaluate(
+    async ({
+      channelName: targetChannelName,
+      content,
+      mentionPubkeys,
+      parentEventId,
+    }) => {
       const tauriWindow = window as Window & {
         __TAURI_INTERNALS__?: {
           invoke: (
@@ -148,16 +155,21 @@ async function sendChannelMessage(
         throw new Error(`Channel not found: ${targetChannelName}`);
       }
 
-      await invoke("send_channel_message", {
+      return (await invoke("send_channel_message", {
         channelId: channel.id,
         content,
         kind: null,
         mediaTags: null,
         mentionPubkeys: mentionPubkeys ?? null,
-        parentEventId: null,
-      });
+        parentEventId: parentEventId ?? null,
+      })) as {
+        event_id: string;
+        parent_event_id: string | null;
+        root_event_id: string | null;
+        depth: number;
+      };
     },
-    { channelName, content, mentionPubkeys },
+    { channelName, content, mentionPubkeys, parentEventId },
   );
 }
 
@@ -292,6 +304,72 @@ test("sends a message through the real relay", async ({ page }) => {
   await page.getByTestId("send-message").click();
 
   await expectTimelineToContain(page, message);
+});
+
+test("relay-backed nested replies tag the immediate parent and preserve the root", async ({
+  browser,
+}) => {
+  const rootContext = await browser.newContext();
+  const parentContext = await browser.newContext();
+  const replyContext = await browser.newContext();
+  const rootPage = await rootContext.newPage();
+  const parentPage = await parentContext.newPage();
+  const replyPage = await replyContext.newPage();
+
+  try {
+    await installRelayBridge(rootPage, "alice");
+    await installRelayBridge(parentPage, "bob");
+    await installRelayBridge(replyPage, "tyler");
+    await rootPage.goto("/");
+    await parentPage.goto("/");
+    await replyPage.goto("/");
+
+    const root = await sendChannelMessage(rootPage, {
+      channelName: "general",
+      content: `Reply recipient root ${Date.now()}`,
+    });
+    const parent = await sendChannelMessage(parentPage, {
+      channelName: "general",
+      content: `Reply recipient parent ${Date.now()}`,
+      parentEventId: root.event_id,
+    });
+    const reply = await sendChannelMessage(replyPage, {
+      channelName: "general",
+      content: `Reply recipient nested reply ${Date.now()}`,
+      parentEventId: parent.event_id,
+    });
+
+    const rawEvent = await replyPage.evaluate(async (eventId) => {
+      const tauriWindow = window as Window & {
+        __TAURI_INTERNALS__?: {
+          invoke: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+      };
+      return tauriWindow.__TAURI_INTERNALS__?.invoke("get_event", { eventId });
+    }, reply.event_id);
+    const event = JSON.parse(String(rawEvent)) as {
+      tags: string[][];
+    };
+
+    expect(reply.root_event_id).toBe(root.event_id);
+    expect(reply.depth).toBe(2);
+    expect(
+      event.tags.filter((tag) => tag[0] === "p").map((tag) => tag[1]),
+    ).toEqual([TEST_IDENTITIES.bob.pubkey]);
+    expect(event.tags).toEqual(
+      expect.arrayContaining([
+        ["e", root.event_id, "", "root"],
+        ["e", parent.event_id, "", "reply"],
+      ]),
+    );
+  } finally {
+    await rootContext.close();
+    await parentContext.close();
+    await replyContext.close();
+  }
 });
 
 test("delivers a message to a second browser context in real time", async ({


### PR DESCRIPTION
## Summary

- automatically add the immediate parent author's `p` tag to desktop replies, so reply-filtered agent subscriptions receive the event without requiring an explicit mention
- resolve nested reply context from both the channel timeline and cached thread replies while preserving the root and immediate-parent references
- deduplicate explicit and automatic recipients, keep the 50-recipient cap scoped to explicit mentions, and mirror the behavior in the Tauri event builder
- add frontend, Rust, and relay-backed nested-reply coverage

### Related issue

No duplicate found. Adjacent: #3971 tracks remotely hosted agents missing from mention autocomplete; this change does not alter picker eligibility.

### Testing

Passed locally at the exact head:

- `just ci`
- `pnpm -C desktop test` (4,537 passed)
- `pnpm -C desktop typecheck`
- 18 focused reply/context-cache tests
- 4 focused Rust reply-recipient tests

The added relay-backed Playwright case is not included in `just ci`; it remains gated on the required upstream Desktop Smoke E2E and Desktop E2E Integration workflows. Those fork workflows currently require maintainer approval before they can run.

No screenshot: this changes signed-event recipient metadata and delivery behavior, not rendered UI.
