### PR TITLE
fix(desktop): merge live events only into the active channel's timeline cache

### DIFF
--- a/desktop/src/features/channels/useLiveChannelUpdates.ts
+++ b/desktop/src/features/channels/useLiveChannelUpdates.ts
@@ -314,20 +314,30 @@ export function useLiveChannelUpdates(
       }
     }
 
-    // Merge into the timeline cache for the active channel.
+    // Merge into the timeline cache for the active channel only.
     // useChannelSubscription also writes to this cache, but there's a
     // race window where it hasn't connected yet. Writes are idempotent
     // (mergeTimelineCacheMessages deduplicates by event ID).
-    queryClient.setQueryData<RelayEvent[]>(
-      channelMessagesKey(channelId),
-      (current) => {
-        if (!current) {
-          return current;
-        }
+    //
+    // Inactive channels are skipped on purpose: their cached timelines
+    // are not on screen, and merging every live event into every
+    // visited channel's cache costs a full dedupe + sort per event per
+    // channel (O(channels × events)) and keeps those caches growing
+    // until gcTime evicts them. When an inactive channel is opened
+    // again, its stale query refetches and useChannelSubscription
+    // reconciles the newest window, so no messages are lost.
+    if (channelId === activeChannelId) {
+      queryClient.setQueryData<RelayEvent[]>(
+        channelMessagesKey(channelId),
+        (current) => {
+          if (!current) {
+            return current;
+          }
 
-        return mergeTimelineCacheMessages(current, event);
-      },
-    );
+          return mergeTimelineCacheMessages(current, event);
+        },
+      );
+    }
   });
 
   const handleMentionEvent = React.useEffectEvent((event: RelayEvent) => {


### PR DESCRIPTION
## Problem

On installs with many channels, the single WebKit WebContent process sits at 15–40% CPU while the app is idle, and its RSS climbs steadily (observed +150 MB within minutes). The UI gets noticeably laggier the more channels have been opened.

Root cause: `useLiveChannelUpdates` subscribes to live events for **every** channel (needed for unread badges/notifications), but its `handleIncomingMessage` also merges each incoming event into that channel's React Query timeline cache:

- each merge is a full dedupe + filter + concat + sort over the cached event array (`mergeTimelineCacheMessages`), so total cost scales **O(channels × events)**;
- these caches have `gcTime: 1h` and are continuously written even for channels the user isn't viewing, so they keep growing and stay "fresh" — exactly matching the observed CPU churn and memory climb.

Notably, the existing code comment already said *"Merge into the timeline cache for the **active** channel"* — the code just didn't match the comment.

## Fix

Guard the `setQueryData` merge with `channelId === activeChannelId`. This is the entire behavioral change; unread tracking, DM/mention notifications, and channel-list invalidation are untouched (they run earlier in the same handler).

Inactive channels lose nothing: their message queries are stale when reopened, so they refetch, and `useChannelSubscription` reconciles the newest window on connect — the same path that already covers the app-restart case where no cache exists at all.

## Testing

- `tsc --noEmit` clean
- `biome check` clean on the changed file
- `src/features/channels/*.test.mjs`: 111/111 pass
- `src/features/messages/**/*.test.mjs`: 811/811 pass

Duplicate search: closest existing PRs (#1802, #1105) fix adjacent live-event merge bugs but don't touch this inactive-channel write path — none found covering this.

## Follow-ups (not in this PR)

- Bound `liveOverlay`/`liveAux` growth in `channelWindowStore.ts` for long-lived sessions
- Reconsider `gcTime: 60min` on `useChannelMessagesQuery` (vs. the 5min global default)
- Merge the per-channel live + mention subscriptions (2N → N relay subs)