### PR TITLE
fix shared agent mention eligibility

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.test.mjs
+++ b/desktop/src/features/messages/lib/useMentions.test.mjs
@@ -1,7 +1,23 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { getMentionOffset, hasMention } from "./hasMention.ts";
+
+const useMentionsSource = await readFile(
+  new URL("./useMentions.ts", import.meta.url),
+  "utf8",
+);
+
+test("channel bot members reach the unknown-directory visibility fallback", () => {
+  const addCandidateSource = useMentionsSource.slice(
+    useMentionsSource.indexOf("const addCandidate ="),
+    useMentionsSource.indexOf("const current = candidatesByPubkey"),
+  );
+
+  assert.match(addCandidateSource, /shouldHideAgentFromMentions/);
+  assert.doesNotMatch(addCandidateSource, /isAgentIdentityInAllowedList/);
+});
 
 // ── Plain @mention ────────────────────────────────────────────────────
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -17,7 +17,6 @@ import {
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
@@ -253,9 +252,6 @@ export function useMentions(
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## What changed

- Removed the legacy hard allow-list prefilter from channel mention candidates.
- Kept the existing unified visibility decision that distinguishes explicit directory exclusion from unknown directory state.
- Added a regression contract ensuring channel bot members reach that fallback.

## Why

Shared agents that were valid channel members but had no kind-10100 directory event were removed before the intended member fallback ran. Their names therefore never appeared in autocomplete, so users could only send plain-text `@Name` strings without the structured mention tag required to invoke the agent.

After this change, channel-member agents with unknown directory state remain selectable. Agents with an explicit non-invocable directory record remain hidden, and non-member agents still fail closed.

## Validation

- Full Desktop unit suite
- Desktop TypeScript typecheck
- Desktop Biome check
- Desktop file-size, px-text, and pubkey-truncation checks

All checks passed at commit `2d403b3028220eb5f2588a8fbaf669fcbb526aac`.
