### PR TITLE
feat(cli): add idempotent message delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,6 +710,14 @@ jobs:
             --run-ignored ignored-only
         env:
           DATABASE_URL: postgres://buzz:${{ env.BUZZ_TEST_POSTGRES_PASSWORD }}@localhost:5432/buzz
+      - name: Idempotent message database contract
+        run: |
+          cargo nextest run \
+            --archive-file target/ci/backend-integration-tests.tar.zst \
+            -E 'package(buzz-db) and test(/idempotency_receipt_is_atomic_under_concurrency_and_replays_canonical_event|idempotent_message_insert_populates_mentions/)' \
+            --run-ignored ignored-only
+        env:
+          DATABASE_URL: postgres://buzz:${{ env.BUZZ_TEST_POSTGRES_PASSWORD }}@localhost:5432/buzz
       - name: Workspace profile (kind:9033) gate tests
         # Call-site integration for the 9033 authorization gate: open relay
         # rosterless/steward transitions and the closed-relay admin/owner rule,

--- a/.github/workflows/sprig-image.yml
+++ b/.github/workflows/sprig-image.yml
@@ -77,6 +77,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Verify immutable tagged source
+        if: startsWith(github.ref, 'refs/tags/sprig-v')
+        run: |
+          set -euo pipefail
+          scripts/verify-release-ref.sh sprig-v "${GITHUB_REF#refs/tags/sprig-v}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
         with:

--- a/.github/workflows/sprig.yml
+++ b/.github/workflows/sprig.yml
@@ -74,6 +74,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved version=$VERSION channel=$CHANNEL"
 
+      - name: Verify immutable tagged source
+        if: steps.ver.outputs.channel == 'tag'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: scripts/verify-release-ref.sh sprig-v "$VERSION"
+
       - name: Build & package Sprig
         id: pkg
         env:
@@ -94,6 +100,19 @@ jobs:
           test -f "$ARCHIVE"
           echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
           echo "archive_name=${ARCHIVE_BASENAME}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-check packaged Buzz CLI
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        env:
+          ARCHIVE: ${{ steps.pkg.outputs.archive }}
+        run: |
+          set -euo pipefail
+          sha256sum -c "${ARCHIVE}.sha256"
+          tar -tzf "$ARCHIVE" | grep -Eq '(^|/)buzz$'
+          smoke_dir=$(mktemp -d)
+          trap 'rm -rf "$smoke_dir"' EXIT
+          tar -xzf "$ARCHIVE" -C "$smoke_dir"
+          "$smoke_dir/buzz" --help >/dev/null
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,6 +7,7 @@ Mobile uses immutable release-candidate tags cut directly from remote `main`:
 |------|-------------|----------|
 | Desktop | `just release-desktop <version>` | Packaged desktop app (signed/notarized macOS, unsigned Windows, and Linux) |
 | Relay | `just release-relay` | `ghcr.io/block/buzz` container image |
+| Sprig | protected `sprig-v*` tag | Static Linux agent bundle and `ghcr.io/block/buzz-sprig` |
 | Mobile | `scripts/mobile-release.sh candidate X.Y.Z` | Exact `mobile-vX.Y.Z-rc.N` source identity |
 
 The lanes version independently. Desktop reads its manifests, relay reads its
@@ -88,6 +89,18 @@ prior release's recorded squash commit; tag ancestry is deliberately irrelevant.
 
 Every push to `main` continues to publish the rolling relay `:main` and
 `:sha-<7>` tags, plus matching `:debug-main` and `:debug-sha-<7>` variants.
+
+### Sprig (headless Buzz CLI)
+
+Sprig is the supported headless Linux distribution for `buzz-cli`: its static
+tarball includes the `buzz` command, a SHA-256 sidecar, and a source/binary
+manifest. A protected `sprig-v<version>` tag publishes immutable versioned
+assets and a multi-architecture `ghcr.io/block/buzz-sprig:<version>` image
+with provenance. Consumers pin the OCI manifest digest or the versioned
+tarball plus its SHA-256; never use `sprig-latest` or `:main` as a production
+boundary. Tagged workflows verify the checked-out source is exactly the tag
+before packaging or publishing. The image's default entrypoint remains
+`buzz-acp`; invoke the CLI with `--entrypoint buzz`.
 
 ### Mobile
 

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -1,5 +1,6 @@
 use buzz_sdk::{DeleteMessageOptions, DiffMeta, ThreadRef, VoteDirection};
-use nostr::PublicKey;
+use nostr::{PublicKey, Tag};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::client::{normalize_events, normalize_write_response, BuzzClient};
@@ -569,6 +570,18 @@ pub struct SendMessageParams {
     pub broadcast: bool,
     pub files: Vec<String>,
     pub mentions: Vec<String>,
+    pub idempotency_key: Option<String>,
+}
+
+/// Convert a caller's opaque retry key to the fixed-width value stored in the
+/// event receipt tag. The raw key never leaves the CLI process.
+fn idempotency_key_digest(key: &str) -> Result<String, CliError> {
+    if key.is_empty() || key.len() > 256 || key.chars().any(char::is_control) {
+        return Err(CliError::Usage(
+            "--idempotency-key must be 1–256 non-control UTF-8 bytes".into(),
+        ));
+    }
+    Ok(hex::encode(Sha256::digest(key.as_bytes())))
 }
 
 pub async fn cmd_send_message(
@@ -677,9 +690,23 @@ pub async fn cmd_send_message(
         }
     };
 
+    let idempotency_enabled = p.idempotency_key.is_some();
+    let builder = if let Some(key) = p.idempotency_key.as_deref() {
+        let key_digest = idempotency_key_digest(key)?;
+        let tag = Tag::parse(["buzz-idempotency", key_digest.as_str()])
+            .map_err(|e| CliError::Other(format!("build idempotency tag failed: {e}")))?;
+        builder.tag(tag)
+    } else {
+        builder
+    };
     let event = client.sign_event(builder)?;
     let emitted_mentions = event_mention_pubkeys(&event);
-    let resp = client.submit_event(event).await?;
+    let resp = match client.submit_event(event).await {
+        Err(CliError::Relay { status: 409, body }) if idempotency_enabled => {
+            return Err(CliError::Conflict(body));
+        }
+        other => other?,
+    };
     let mut output: serde_json::Value = serde_json::from_str(&normalize_write_response(&resp))
         .unwrap_or_else(|_| serde_json::json!({ "response": resp }));
     if let Some(object) = output.as_object_mut() {
@@ -687,6 +714,14 @@ pub async fn cmd_send_message(
             "mention_pubkeys".into(),
             serde_json::json!(emitted_mentions),
         );
+        if idempotency_enabled {
+            let replayed = object.get("message").and_then(serde_json::Value::as_str)
+                == Some("idempotency-replay");
+            object.insert(
+                "idempotency".into(),
+                serde_json::json!({ "replayed": replayed }),
+            );
+        }
     }
     println!("{output}");
     Ok(())
@@ -880,6 +915,7 @@ pub async fn dispatch(
             broadcast,
             files,
             mentions,
+            idempotency_key,
         } => {
             cmd_send_message(
                 client,
@@ -891,6 +927,7 @@ pub async fn dispatch(
                     broadcast,
                     files,
                     mentions,
+                    idempotency_key,
                 },
             )
             .await
@@ -993,14 +1030,23 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        event_mention_pubkeys, find_root_from_tags, idempotency_key_digest, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
     use serde_json::json;
+
+    #[test]
+    fn idempotency_key_digest_is_stable_and_rejects_empty_keys() {
+        assert_eq!(
+            idempotency_key_digest("outbox-event-1").expect("digest"),
+            idempotency_key_digest("outbox-event-1").expect("same digest")
+        );
+        assert!(idempotency_key_digest("").is_err());
+    }
 
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const ID_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -371,7 +371,7 @@ buzz agents archived"
 pub enum MessagesCmd {
     /// Send a message to a channel
     #[command(
-        after_help = "Examples:\n  buzz messages send --channel <UUID> --content \"hello\"\n  buzz messages send --channel <UUID> --content \"@alice check this\"\n  echo \"hello from stdin\" | buzz messages send --channel <UUID> --content -"
+        after_help = "Examples:\n  buzz messages send --channel <UUID> --content \"hello\"\n  buzz messages send --channel <UUID> --content \"@alice check this\"\n  buzz messages send --channel <UUID> --content \"retry-safe\" --idempotency-key work-outbox-123\n  echo \"hello from stdin\" | buzz messages send --channel <UUID> --content -"
     )]
     Send {
         /// Channel UUID (from 'buzz channels list')
@@ -395,6 +395,9 @@ pub enum MessagesCmd {
         /// Pubkey to mention (hex or npub; repeatable). Supplying any explicit identity permits unresolved or ambiguous @Name text as presentation-only; uniquely resolved member names still notify.
         #[arg(long = "mention")]
         mentions: Vec<String>,
+        /// Stable caller key for durable retry safety. Reusing it with different message content conflicts.
+        #[arg(long)]
+        idempotency_key: Option<String>,
     },
     /// Send a code diff / patch to a channel
     SendDiff {

--- a/crates/buzz-db/src/event.rs
+++ b/crates/buzz-db/src/event.rs
@@ -1111,6 +1111,40 @@ pub struct ThreadMetadataParams<'a> {
     pub broadcast: bool,
 }
 
+/// Caller idempotency material for a channel message.
+///
+/// The key is already a fixed-length opaque digest; never persist a caller's
+/// raw idempotency token in an event or database row.
+#[derive(Debug)]
+pub struct MessageIdempotencyParams<'a> {
+    /// Authenticated message author (32-byte Nostr pubkey).
+    pub author_pubkey: &'a [u8],
+    /// Opaque, caller-derived idempotency key digest (32 bytes).
+    pub key: &'a [u8],
+    /// Digest of the request's semantic message payload (32 bytes).
+    pub semantic_digest: &'a [u8],
+}
+
+/// Result of an atomic idempotent message write.
+#[derive(Debug)]
+pub enum IdempotentMessageInsertOutcome {
+    /// A receipt was created for this request. The event may already have been
+    /// stored only when an identical signed event won a separate exact-ID race.
+    Created {
+        /// Stored message event.
+        stored_event: Box<StoredEvent>,
+        /// Whether this call inserted the event row.
+        event_was_inserted: bool,
+    },
+    /// The receipt already exists with the same semantic digest.
+    Replay {
+        /// Canonical event ID recorded by the original successful write.
+        event_id: Vec<u8>,
+    },
+    /// The caller reused a key for a different semantic payload.
+    Conflict,
+}
+
 pub(crate) async fn insert_event_with_thread_metadata_tx(
     tx: &mut Transaction<'_, Postgres>,
     community_id: CommunityId,
@@ -1300,6 +1334,76 @@ pub async fn insert_event_with_thread_metadata(
             .await?;
     tx.commit().await?;
     Ok(result)
+}
+
+/// Atomically establish a caller-idempotency receipt and persist its message.
+///
+/// The unique receipt key serializes concurrent callers. If the winning
+/// transaction commits, a waiter observes either its canonical event ID (same
+/// digest) or a conflict (different digest); if it rolls back, the waiter can
+/// become the winner. Consequently a committed receipt never points to an
+/// absent event.
+pub async fn insert_idempotent_message_with_thread_metadata(
+    pool: &PgPool,
+    community_id: CommunityId,
+    event: &Event,
+    channel_id: Uuid,
+    thread_meta: Option<ThreadMetadataParams<'_>>,
+    idempotency: MessageIdempotencyParams<'_>,
+) -> Result<IdempotentMessageInsertOutcome> {
+    let mut tx = pool.begin().await?;
+    let inserted_receipt: Option<(Vec<u8>,)> = sqlx::query_as(
+        r#"
+        INSERT INTO message_idempotency_receipts
+            (community_id, author_pubkey, channel_id, idempotency_key, semantic_digest, event_id)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT DO NOTHING
+        RETURNING event_id
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(idempotency.author_pubkey)
+    .bind(channel_id)
+    .bind(idempotency.key)
+    .bind(idempotency.semantic_digest)
+    .bind(event.id.as_bytes().as_slice())
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if inserted_receipt.is_none() {
+        let (existing_digest, event_id): (Vec<u8>, Vec<u8>) = sqlx::query_as(
+            r#"
+            SELECT semantic_digest, event_id
+            FROM message_idempotency_receipts
+            WHERE community_id = $1 AND author_pubkey = $2 AND channel_id = $3
+              AND idempotency_key = $4
+            "#,
+        )
+        .bind(community_id.as_uuid())
+        .bind(idempotency.author_pubkey)
+        .bind(channel_id)
+        .bind(idempotency.key)
+        .fetch_one(&mut *tx)
+        .await?;
+        if existing_digest == idempotency.semantic_digest {
+            return Ok(IdempotentMessageInsertOutcome::Replay { event_id });
+        }
+        return Ok(IdempotentMessageInsertOutcome::Conflict);
+    }
+
+    let (stored_event, event_was_inserted) = insert_event_with_thread_metadata_tx(
+        &mut tx,
+        community_id,
+        event,
+        Some(channel_id),
+        thread_meta,
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(IdempotentMessageInsertOutcome::Created {
+        stored_event: Box::new(stored_event),
+        event_was_inserted,
+    })
 }
 
 /// Atomically insert a kind:7 reaction event and its reaction row.
@@ -1563,6 +1667,145 @@ mod tests {
             .await
             .expect("insert test community");
         id
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn idempotency_receipt_is_atomic_under_concurrency_and_replays_canonical_event() {
+        let pool = setup_pool().await;
+        let community_uuid = make_test_community(&pool).await;
+        let community = CommunityId::from_uuid(community_uuid);
+        let channel = make_test_channel(&pool, community_uuid, None).await;
+        let author = Keys::generate();
+        let event_a = EventBuilder::new(Kind::Custom(9), "retry-safe message")
+            .sign_with_keys(&author)
+            .expect("sign first event");
+        let event_b = EventBuilder::new(Kind::Custom(9), "retry-safe message")
+            .custom_created_at(nostr::Timestamp::from(event_a.created_at.as_secs() + 1))
+            .sign_with_keys(&author)
+            .expect("sign competing event");
+        let author_bytes = author.public_key().to_bytes();
+        let key = [7u8; 32];
+        let digest = [9u8; 32];
+
+        let first = insert_idempotent_message_with_thread_metadata(
+            &pool,
+            community,
+            &event_a,
+            channel,
+            None,
+            MessageIdempotencyParams {
+                author_pubkey: &author_bytes,
+                key: &key,
+                semantic_digest: &digest,
+            },
+        );
+        let second = insert_idempotent_message_with_thread_metadata(
+            &pool,
+            community,
+            &event_b,
+            channel,
+            None,
+            MessageIdempotencyParams {
+                author_pubkey: &author_bytes,
+                key: &key,
+                semantic_digest: &digest,
+            },
+        );
+        let (first, second) = tokio::join!(first, second);
+        let (first, second) = (first.expect("first write"), second.expect("second write"));
+        let canonical = match (&first, &second) {
+            (
+                IdempotentMessageInsertOutcome::Created { stored_event, .. },
+                IdempotentMessageInsertOutcome::Replay { event_id },
+            )
+            | (
+                IdempotentMessageInsertOutcome::Replay { event_id },
+                IdempotentMessageInsertOutcome::Created { stored_event, .. },
+            ) => {
+                assert_eq!(
+                    event_id.as_slice(),
+                    stored_event.event.id.as_bytes().as_slice()
+                );
+                stored_event.event.id.to_hex()
+            }
+            other => panic!("one caller must create and one replay, got {other:?}"),
+        };
+        let stored: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM events WHERE community_id = $1 AND channel_id = $2",
+        )
+        .bind(community_uuid)
+        .bind(channel)
+        .fetch_one(&pool)
+        .await
+        .expect("count stored events");
+        assert_eq!(
+            stored, 1,
+            "concurrent retries must create one visible event"
+        );
+
+        let conflicting = EventBuilder::new(Kind::Custom(9), "different payload")
+            .sign_with_keys(&author)
+            .expect("sign conflicting event");
+        assert!(matches!(
+            insert_idempotent_message_with_thread_metadata(
+                &pool,
+                community,
+                &conflicting,
+                channel,
+                None,
+                MessageIdempotencyParams {
+                    author_pubkey: &author_bytes,
+                    key: &key,
+                    semantic_digest: &[3u8; 32],
+                },
+            )
+            .await
+            .expect("conflict result"),
+            IdempotentMessageInsertOutcome::Conflict
+        ));
+
+        // A rejected event must roll the freshly-inserted receipt back too;
+        // otherwise an ambiguous failed delivery would permanently consume a
+        // caller key without producing a canonical event to replay.
+        let rollback_key = [8u8; 32];
+        let rejected = EventBuilder::new(Kind::Custom(KIND_AUTH as u16), "not stored")
+            .sign_with_keys(&author)
+            .expect("sign rejected event");
+        assert!(matches!(
+            insert_idempotent_message_with_thread_metadata(
+                &pool,
+                community,
+                &rejected,
+                channel,
+                None,
+                MessageIdempotencyParams {
+                    author_pubkey: &author_bytes,
+                    key: &rollback_key,
+                    semantic_digest: &digest,
+                },
+            )
+            .await,
+            Err(DbError::AuthEventRejected)
+        ));
+        assert!(matches!(
+            insert_idempotent_message_with_thread_metadata(
+                &pool,
+                community,
+                &event_a,
+                channel,
+                None,
+                MessageIdempotencyParams {
+                    author_pubkey: &author_bytes,
+                    key: &rollback_key,
+                    semantic_digest: &digest,
+                },
+            )
+            .await
+            .expect("retry after rollback"),
+            IdempotentMessageInsertOutcome::Created { .. }
+        ));
+        assert_eq!(canonical.len(), 64, "canonical id stays a Nostr hex id");
     }
 
     async fn make_test_channel(

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -2255,7 +2255,7 @@ impl Db {
         thread_meta: Option<event::ThreadMetadataParams<'_>>,
         idempotency: event::MessageIdempotencyParams<'_>,
     ) -> Result<event::IdempotentMessageInsertOutcome> {
-        event::insert_idempotent_message_with_thread_metadata(
+        let outcome = event::insert_idempotent_message_with_thread_metadata(
             &self.pool,
             community_id,
             event,
@@ -2263,7 +2263,18 @@ impl Db {
             thread_meta,
             idempotency,
         )
-        .await
+        .await?;
+        if let event::IdempotentMessageInsertOutcome::Created {
+            event_was_inserted: true,
+            ..
+        } = &outcome
+        {
+            if let Err(e) = insert_mentions(&self.pool, community_id, event, Some(channel_id)).await
+            {
+                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+            }
+        }
+        Ok(outcome)
     }
 
     /// Atomically insert a kind:7 reaction event and its reaction row.
@@ -6566,6 +6577,80 @@ mod tests {
         .execute(pool)
         .await
         .expect("insert channel");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn idempotent_message_insert_populates_mentions() {
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+
+        let admin = PgPool::connect(&admin_url().await)
+            .await
+            .expect("connect admin");
+        let (pool, db_name) = create_scratch_db(&admin, "idem_mention").await;
+        let cleanup_pool = pool.clone();
+        let test_result = tokio::spawn(async move {
+            let db = Db::from_pool(pool);
+            let community_uuid = make_community(&db.pool).await;
+            let community = CommunityId::from_uuid(community_uuid);
+            let channel = Uuid::new_v4();
+            insert_channel(&db.pool, community_uuid, channel).await;
+
+            let author = Keys::generate();
+            let mentioned = Keys::generate();
+            let mentioned_hex = mentioned.public_key().to_hex();
+            let event = EventBuilder::new(Kind::Custom(9), "retry-safe mention")
+                .tags([Tag::parse(["p", mentioned_hex.as_str()]).expect("p tag")])
+                .sign_with_keys(&author)
+                .expect("sign event");
+            let author_bytes = author.public_key().to_bytes();
+
+            let outcome = db
+                .insert_idempotent_message_with_thread_metadata(
+                    community,
+                    &event,
+                    channel,
+                    None,
+                    event::MessageIdempotencyParams {
+                        author_pubkey: &author_bytes,
+                        key: &[7u8; 32],
+                        semantic_digest: &[9u8; 32],
+                    },
+                )
+                .await
+                .expect("insert idempotent message");
+            assert!(matches!(
+                outcome,
+                event::IdempotentMessageInsertOutcome::Created {
+                    event_was_inserted: true,
+                    ..
+                }
+            ));
+
+            let mention_rows: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM event_mentions \
+                 WHERE community_id = $1 AND event_id = $2 \
+                   AND pubkey_hex = $3 AND channel_id = $4",
+            )
+            .bind(community_uuid)
+            .bind(event.id.as_bytes().as_slice())
+            .bind(mentioned_hex)
+            .bind(channel)
+            .fetch_one(&db.pool)
+            .await
+            .expect("count mention rows");
+            assert_eq!(mention_rows, 1);
+        })
+        .await;
+
+        cleanup_pool.close().await;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DROP DATABASE {db_name} WITH (FORCE)"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop idempotent mention scratch DB");
+        test_result.expect("idempotent mention test task");
     }
 
     #[tokio::test]

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -57,7 +57,10 @@ pub mod user;
 pub mod workflow;
 
 pub use error::{DbError, Result};
-pub use event::{EventQuery, ReactionEventInsertOutcome, DEFAULT_MAX_PAGE_LIMIT};
+pub use event::{
+    EventQuery, IdempotentMessageInsertOutcome, MessageIdempotencyParams,
+    ReactionEventInsertOutcome, DEFAULT_MAX_PAGE_LIMIT,
+};
 
 use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
@@ -2241,6 +2244,26 @@ impl Db {
             }
         }
         Ok(result)
+    }
+
+    /// Atomically persist a channel message and its caller-idempotency receipt.
+    pub async fn insert_idempotent_message_with_thread_metadata(
+        &self,
+        community_id: CommunityId,
+        event: &nostr::Event,
+        channel_id: Uuid,
+        thread_meta: Option<event::ThreadMetadataParams<'_>>,
+        idempotency: event::MessageIdempotencyParams<'_>,
+    ) -> Result<event::IdempotentMessageInsertOutcome> {
+        event::insert_idempotent_message_with_thread_metadata(
+            &self.pool,
+            community_id,
+            event,
+            channel_id,
+            thread_meta,
+            idempotency,
+        )
+        .await
     }
 
     /// Atomically insert a kind:7 reaction event and its reaction row.

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -625,7 +625,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 30);
+        assert_eq!(migrations.len(), 31);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -1036,6 +1036,14 @@ mod tests {
         assert_eq!(migrations[29].version, 30);
         let deletion_recovery = migrations[29].sql.as_str();
         assert!(deletion_recovery.contains("SET LOCAL lock_timeout = '5s'"));
+
+        // Idempotency receipts are additive and follow main's deletion migrations.
+        assert_eq!(migrations[30].version, 31);
+        let idempotency = migrations[30].sql.as_str();
+        assert!(idempotency.contains("CREATE TABLE message_idempotency_receipts"));
+        assert!(idempotency.contains("community_id UUID NOT NULL"));
+        assert!(idempotency
+            .contains("PRIMARY KEY (community_id, author_pubkey, channel_id, idempotency_key)"));
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -862,6 +862,14 @@ async fn submit_event_authed(
                 response: api_error(StatusCode::BAD_REQUEST, &msg),
             }
         }
+        Err(IngestError::Conflict(msg)) => {
+            crate::handlers::ingest::reject_with_transport("http", "invalid");
+            let e = api_error(StatusCode::CONFLICT, &msg);
+            SubmitOutcome::Err {
+                status: e.0,
+                response: e,
+            }
+        }
         Err(IngestError::AuthFailed(msg)) => {
             crate::handlers::ingest::reject_with_transport("http", "auth");
             let e = api_error(StatusCode::FORBIDDEN, &msg);

--- a/crates/buzz-relay/src/conformance/mod.rs
+++ b/crates/buzz-relay/src/conformance/mod.rs
@@ -432,7 +432,7 @@ impl Drop for EmitGuard {
 pub fn sanitized_reason_for(err: &crate::handlers::ingest::IngestError) -> SanitizedReason {
     use crate::handlers::ingest::IngestError as E;
     match err {
-        E::Rejected(_) => SanitizedReason::Invalid,
+        E::Rejected(_) | E::Conflict(_) => SanitizedReason::Invalid,
         E::AuthFailed(_) => SanitizedReason::Restricted,
         E::Internal(_) => SanitizedReason::ServerError,
     }

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -781,7 +781,7 @@ pub async fn handle_event(event: Event, conn: Arc<ConnectionState>, state: Arc<A
         Err(e) => {
             // Sanitize internal errors — don't leak DB/system details over WS.
             let (msg, reason) = match &e {
-                IngestError::Rejected(m) => (m.clone(), "invalid"),
+                IngestError::Rejected(m) | IngestError::Conflict(m) => (m.clone(), "invalid"),
                 IngestError::AuthFailed(m) => (m.clone(), "auth"),
                 IngestError::Internal(_) => ("error: internal server error".to_string(), "error"),
             };

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use sha2::{Digest, Sha256};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -295,6 +296,8 @@ pub enum IngestError {
     Rejected(String),
     /// Auth/scope error — WS: OK false, HTTP: 401/403.
     AuthFailed(String),
+    /// A caller reused an idempotency key for a different message payload.
+    Conflict(String),
     /// Server error — WS: OK false, HTTP: 500.
     Internal(String),
 }
@@ -315,6 +318,86 @@ fn map_serving_fence_state(active: Result<bool, buzz_db::DbError>) -> Result<(),
             "error: checking community write fence: {error}"
         ))),
     }
+}
+
+const MESSAGE_IDEMPOTENCY_TAG: &str = "buzz-idempotency";
+
+#[derive(Debug, Clone)]
+struct MessageIdempotency {
+    key: [u8; 32],
+    semantic_digest: [u8; 32],
+}
+
+/// Read Buzz's message idempotency tag and derive the payload digest used by
+/// the durable receipt. The tag carries a SHA-256 digest of the caller's raw
+/// key, so the key itself is never persisted in the public Nostr event.
+fn message_idempotency(
+    event: &Event,
+    channel_id: Uuid,
+) -> Result<Option<MessageIdempotency>, IngestError> {
+    let tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.kind().to_string() == MESSAGE_IDEMPOTENCY_TAG)
+        .collect();
+    if tags.is_empty() {
+        return Ok(None);
+    }
+    if !matches!(
+        event_kind_u32(event),
+        KIND_STREAM_MESSAGE | KIND_FORUM_POST | KIND_FORUM_COMMENT
+    ) {
+        return Err(IngestError::Rejected(format!(
+            "invalid: {MESSAGE_IDEMPOTENCY_TAG} is only supported for channel messages"
+        )));
+    }
+    if tags.len() != 1 {
+        return Err(IngestError::Rejected(format!(
+            "invalid: exactly one {MESSAGE_IDEMPOTENCY_TAG} tag is allowed"
+        )));
+    }
+    let parts = tags[0].as_slice();
+    let Some(key_hex) = parts.get(1) else {
+        return Err(IngestError::Rejected(format!(
+            "invalid: {MESSAGE_IDEMPOTENCY_TAG} tag requires a key digest"
+        )));
+    };
+    if parts.len() != 2 || key_hex.len() != 64 || !key_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(IngestError::Rejected(format!(
+            "invalid: {MESSAGE_IDEMPOTENCY_TAG} key digest must be 64 hexadecimal characters"
+        )));
+    }
+    let key: [u8; 32] = hex::decode(key_hex)
+        .map_err(|_| IngestError::Rejected("invalid: malformed idempotency key digest".into()))?
+        .try_into()
+        .map_err(|_| IngestError::Rejected("invalid: malformed idempotency key digest".into()))?;
+
+    // `created_at`, event ID, signature, idempotency tag, and NIP-OA auth are
+    // transport/authentication details. Excluding them lets a caller safely
+    // re-sign the same user-visible message after an ambiguous response.
+    let semantic_tags: Vec<Vec<String>> = event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let parts = tag.as_slice();
+            match parts.first().map(String::as_str) {
+                Some(MESSAGE_IDEMPOTENCY_TAG | "auth") => None,
+                _ => Some(parts.to_vec()),
+            }
+        })
+        .collect();
+    let semantic = serde_json::json!({
+        "channel_id": channel_id,
+        "content": event.content,
+        "kind": event_kind_u32(event),
+        "tags": semantic_tags,
+    });
+    let semantic_bytes = serde_json::to_vec(&semantic)
+        .map_err(|e| IngestError::Internal(format!("error: serialize idempotency payload: {e}")))?;
+    Ok(Some(MessageIdempotency {
+        key,
+        semantic_digest: Sha256::digest(semantic_bytes).into(),
+    }))
 }
 
 fn map_relay_admin_error(error: super::relay_admin::RelayAdminError) -> IngestError {
@@ -2909,7 +2992,65 @@ async fn ingest_event_inner(
         });
     }
 
-    let (stored_event, was_inserted) = if buzz_core::kind::is_replaceable(kind_u32) {
+    let message_idempotency = if let Some(ch_id) = channel_id {
+        message_idempotency(&event, ch_id)?
+    } else {
+        None
+    };
+    let is_idempotent_message = message_idempotency.is_some();
+
+    let (stored_event, was_inserted) = if let Some(idempotency) = message_idempotency.as_ref() {
+        let ch_id = channel_id.expect("idempotent messages have a channel");
+        let thread_params = thread_meta.as_ref().map(|m| m.as_params());
+        match state
+            .db
+            .insert_idempotent_message_with_thread_metadata(
+                tenant.community(),
+                &event,
+                ch_id,
+                thread_params,
+                buzz_db::MessageIdempotencyParams {
+                    author_pubkey: auth.pubkey().as_bytes(),
+                    key: &idempotency.key,
+                    semantic_digest: &idempotency.semantic_digest,
+                },
+            )
+            .await
+            .map_err(|e| IngestError::Internal(format!("error: database error: {e}")))?
+        {
+            buzz_db::IdempotentMessageInsertOutcome::Created {
+                stored_event,
+                event_was_inserted,
+            } => (*stored_event, event_was_inserted),
+            buzz_db::IdempotentMessageInsertOutcome::Replay { event_id } => {
+                if event_id.len() != 32 {
+                    return Err(IngestError::Internal(
+                        "error: idempotency receipt contains an invalid event id".into(),
+                    ));
+                }
+                let canonical_event_id = hex::encode(event_id);
+                emit(
+                    tracer,
+                    TraceAction::WriteDuplicate {
+                        msg_id: msg_id_label(event.id.as_bytes()),
+                        channel: channel_label(ch_id),
+                        claimed_community: claimed_community_from_event(&event),
+                    },
+                    state_for_request(tenant, auth.pubkey()),
+                );
+                return Ok(IngestResult {
+                    event_id: canonical_event_id,
+                    accepted: true,
+                    message: "idempotency-replay".into(),
+                });
+            }
+            buzz_db::IdempotentMessageInsertOutcome::Conflict => {
+                return Err(IngestError::Conflict(
+                    "idempotency key was already used for a different message payload".into(),
+                ));
+            }
+        }
+    } else if buzz_core::kind::is_replaceable(kind_u32) {
         // NIP-16 replaceable event — atomic replace with stale-write protection.
         // channel_id is None for global kinds (0, 1, 3) due to step 5b above.
         state
@@ -3049,7 +3190,11 @@ async fn ingest_event_inner(
     Ok(IngestResult {
         event_id: event_id_hex,
         accepted: true,
-        message: String::new(),
+        message: if is_idempotent_message {
+            "idempotency-created".into()
+        } else {
+            String::new()
+        },
     })
 }
 
@@ -3065,6 +3210,49 @@ mod tests {
         KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
     };
     use nostr::{EventBuilder, Kind};
+
+    #[test]
+    fn message_idempotency_digest_ignores_retry_and_auth_envelope_fields() {
+        let key_digest = "a".repeat(64);
+        let channel = Uuid::new_v4();
+        let tags = [
+            nostr::Tag::parse(["h", &channel.to_string()]).expect("channel tag"),
+            nostr::Tag::parse([MESSAGE_IDEMPOTENCY_TAG, &key_digest]).expect("idempotency tag"),
+        ];
+        let first = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "same message")
+            .tags(tags.clone())
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign first");
+        let retry = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "same message")
+            .tags([
+                tags[0].clone(),
+                tags[1].clone(),
+                nostr::Tag::parse(["auth", "rotated-auth", "conditions", "signature"])
+                    .expect("auth tag"),
+            ])
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign retry");
+        let changed = EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            "different message",
+        )
+        .tags(tags)
+        .sign_with_keys(&nostr::Keys::generate())
+        .expect("sign changed");
+
+        let first = message_idempotency(&first, channel)
+            .expect("first digest")
+            .expect("first tag");
+        let retry = message_idempotency(&retry, channel)
+            .expect("retry digest")
+            .expect("retry tag");
+        let changed = message_idempotency(&changed, channel)
+            .expect("changed digest")
+            .expect("changed tag");
+        assert_eq!(first.key, retry.key);
+        assert_eq!(first.semantic_digest, retry.semantic_digest);
+        assert_ne!(first.semantic_digest, changed.semantic_digest);
+    }
 
     #[test]
     fn reaction_validation_accepts_wrapped_max_shortcode() {

--- a/migrations/0031_message_idempotency_receipts.sql
+++ b/migrations/0031_message_idempotency_receipts.sql
@@ -1,0 +1,12 @@
+-- Durable caller idempotency for channel messages. The receipt and the event
+-- are written in one transaction so a retry can always return a canonical ID.
+CREATE TABLE message_idempotency_receipts (
+    community_id UUID NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
+    author_pubkey BYTEA NOT NULL CHECK (octet_length(author_pubkey) = 32),
+    channel_id UUID NOT NULL,
+    idempotency_key BYTEA NOT NULL CHECK (octet_length(idempotency_key) = 32),
+    semantic_digest BYTEA NOT NULL CHECK (octet_length(semantic_digest) = 32),
+    event_id BYTEA NOT NULL CHECK (octet_length(event_id) = 32),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (community_id, author_pubkey, channel_id, idempotency_key)
+);

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -278,6 +278,20 @@ CREATE INDEX idx_events_not_before ON events (community_id, not_before)
 -- EXPLAIN before its work lands (Quinn option A; Max's index-spelling caveat).
 CREATE INDEX idx_events_search_tsv ON events USING GIN (search_tsv);
 
+-- ── Message idempotency receipts ────────────────────────────────────────────
+-- A caller key is scoped to its authenticated author and channel. The relay
+-- inserts this receipt and its canonical event in one transaction.
+CREATE TABLE message_idempotency_receipts (
+    community_id UUID NOT NULL REFERENCES communities(id) ON DELETE CASCADE,
+    author_pubkey BYTEA NOT NULL CHECK (octet_length(author_pubkey) = 32),
+    channel_id UUID NOT NULL,
+    idempotency_key BYTEA NOT NULL CHECK (octet_length(idempotency_key) = 32),
+    semantic_digest BYTEA NOT NULL CHECK (octet_length(semantic_digest) = 32),
+    event_id BYTEA NOT NULL CHECK (octet_length(event_id) = 32),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (community_id, author_pubkey, channel_id, idempotency_key)
+);
+
 -- ── Event mentions ────────────────────────────────────────────────────────────
 -- Conformance: "Channel-less global events and DMs" (#p fan-out). The join to
 -- events MUST carry the community tuple (e.community_id = m.community_id AND

--- a/scripts/build-sprig.sh
+++ b/scripts/build-sprig.sh
@@ -59,7 +59,7 @@ else
 fi
 
 BUNDLE_BIN="sprig"
-COMMANDS=(buzz-acp buzz-agent buzz-dev-mcp)
+COMMANDS=(buzz buzz-acp buzz-agent buzz-dev-mcp)
 
 echo "==> Building Sprig v${VERSION} for ${TARGET}"
 echo "    git_sha=${GIT_SHA}"

--- a/scripts/test-release-ref-contract.sh
+++ b/scripts/test-release-ref-contract.sh
@@ -43,6 +43,12 @@ git -C "$tmp" tag -m "relay release" relay-v2.0.0
   GITHUB_REF=refs/tags/relay-v2.0.0 "$verify" relay-v 2.0.0
 )
 
+git -C "$tmp" tag -m "sprig release" sprig-v3.0.0
+(
+  cd "$tmp"
+  GITHUB_REF=refs/tags/sprig-v3.0.0 "$verify" sprig-v 3.0.0
+)
+
 if grep -q 'inputs\.ref' \
   "$repo_root/.github/workflows/release.yml" \
   "$repo_root/.github/workflows/docker.yml"; then
@@ -52,6 +58,9 @@ fi
 
 grep -q 'verify-release-ref\.sh' "$repo_root/.github/workflows/release.yml"
 grep -q 'verify-release-ref\.sh' "$repo_root/.github/workflows/docker.yml"
+grep -Fq 'scripts/verify-release-ref.sh sprig-v' "$repo_root/.github/workflows/sprig.yml"
+grep -Fq 'scripts/verify-release-ref.sh sprig-v' "$repo_root/.github/workflows/sprig-image.yml"
+grep -Fq 'COMMANDS=(buzz buzz-acp buzz-agent buzz-dev-mcp)' "$repo_root/scripts/build-sprig.sh"
 grep -q 'test-release-ref-contract\.sh' "$repo_root/.github/workflows/ci.yml"
 "$repo_root/scripts/test-signed-canary-contract.sh"
 "$repo_root/scripts/test-desktop-release-cache-key.sh"


### PR DESCRIPTION
## Summary
- persist atomic channel-message idempotency receipts keyed by community, authenticated author, channel, and caller key digest
- make CLI retries return the original canonical event ID; expose `--idempotency-key`, replay JSON, and a 409 conflict exit
- preserve mention indexing on newly created idempotent messages and gate the Postgres regression in backend CI
- make Sprig’s existing headless `buzz` CLI release tag-bound and checksum/digest-pinnable

## Validation
- `PATH="$PWD/bin:$PATH" just ci`
- isolated disposable Postgres proof: concurrent replay, changed-payload conflict, failed-write rollback/retry, and exact mention indexing
- targeted clippy, CLI/relay/migration tests, release-ref contract, formatting, and diff checks

Refs happyvertical/happyvertical.com#190, happyvertical/happyvertical.com#172, happyvertical/happyvertical.com#158

No release tag, OCI image, or artifact was published.

<!-- hv-agent-run:v1 -->
```json
{"runtime":"codex","session":"codex-190-buzz-delivery-review-019fe85b","issue":"happyvertical/happyvertical.com#190","policy_revision":"1.0.0","head":"706437da8f6a3522c8f8a0ff7dfa098fda12fe40","validation":["PATH=\"$PWD/bin:$PATH\" just ci","cargo clippy -p buzz-db --all-targets -- -D warnings","disposable Postgres idempotency and mention-index contracts"]}
```