### PR TITLE
feat(cli): schedule message delivery with --scheduled-at

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -3,7 +3,8 @@ use nostr::PublicKey;
 use uuid::Uuid;
 
 use crate::client::{normalize_events, normalize_write_response, BuzzClient};
-use crate::error::CliError;
+use crate::error::{is_retryable_error, CliError};
+use crate::schedule::{self, ScheduledMessage};
 use crate::validate::{
     infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
     validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
@@ -569,6 +570,48 @@ pub struct SendMessageParams {
     pub broadcast: bool,
     pub files: Vec<String>,
     pub mentions: Vec<String>,
+    /// ISO8601 delivery time — when set, enqueue instead of sending now.
+    pub scheduled_at: Option<String>,
+}
+
+/// Enqueue a `--scheduled-at` delivery and print the queue receipt.
+///
+/// Validates the timestamp, channel UUID, and content up front so a bad
+/// scheduling request fails before anything is persisted. File attachments are
+/// not schedulable in the first cut — they would need the upload to be
+/// replayed at delivery time.
+fn cmd_enqueue_scheduled_message(p: &SendMessageParams, when: &str) -> Result<(), CliError> {
+    let scheduled_at = schedule::parse_scheduled_at(when)?;
+    parse_uuid(&p.channel_id)?;
+    if !p.files.is_empty() {
+        return Err(CliError::Usage(
+            "--scheduled-at cannot be combined with --file; schedule a text-only message instead"
+                .into(),
+        ));
+    }
+
+    let path = schedule::resolve_queue_path(None)?;
+    let msg = ScheduledMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        channel_id: p.channel_id.clone(),
+        content: p.content.clone(),
+        kind: p.kind,
+        reply_to: p.reply_to.clone(),
+        broadcast: Some(p.broadcast),
+        mentions: p.mentions.clone(),
+        scheduled_at,
+        created_at: chrono::Utc::now().timestamp(),
+    };
+    schedule::enqueue(&path, msg.clone())?;
+    let output = serde_json::json!({
+        "scheduled": true,
+        "id": msg.id,
+        "channel_id": msg.channel_id,
+        "scheduled_at": msg.scheduled_at,
+        "message": format!("scheduled for delivery at {when} (deliver with `buzz messages scheduled run`)"),
+    });
+    println!("{output}");
+    Ok(())
 }
 
 pub async fn cmd_send_message(
@@ -581,6 +624,9 @@ pub async fn cmd_send_message(
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
+    if let Some(ref when) = p.scheduled_at {
+        return cmd_enqueue_scheduled_message(&p, when);
+    }
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -865,6 +911,106 @@ pub async fn cmd_vote_on_post(
     Ok(())
 }
 
+/// List pending scheduled messages from the local queue.
+///
+/// `--queue-file` overrides the store path (useful for tests and debugging).
+/// Output is the raw queue as a JSON array, newest-first by creation.
+pub fn cmd_scheduled_list(queue_file: Option<&str>) -> Result<(), CliError> {
+    let path = schedule::resolve_queue_path(queue_file)?;
+    let mut queue = schedule::load_queue(&path)?;
+    queue.sort_by_key(|m| std::cmp::Reverse(m.created_at));
+    let output = serde_json::json!(queue);
+    println!("{output}");
+    Ok(())
+}
+
+/// Cancel a pending scheduled message by id.
+///
+/// Removes the entry from the queue and prints a receipt. Cancelling a
+/// message that is already delivered (or was never scheduled) is a `Usage`
+/// error so callers can distinguish a real cancellation from a no-op.
+pub fn cmd_scheduled_cancel(queue_file: Option<&str>, id: &str) -> Result<(), CliError> {
+    let path = schedule::resolve_queue_path(queue_file)?;
+    let removed = schedule::cancel_by_id(&path, id)?;
+    match removed {
+        Some(msg) => {
+            let output = serde_json::json!({
+                "cancelled": true,
+                "id": msg.id,
+                "channel_id": msg.channel_id,
+                "scheduled_at": msg.scheduled_at,
+                "message": "scheduled delivery cancelled",
+            });
+            println!("{output}");
+            Ok(())
+        }
+        None => Err(CliError::Usage(format!(
+            "no pending scheduled message with id '{id}' (run `buzz messages scheduled list` to see pending deliveries)"
+        ))),
+    }
+}
+
+/// Deliver every scheduled message that is due.
+///
+/// Each due entry is sent through the normal `cmd_send_message` path (mentions
+/// are re-resolved and thread refs rebuilt at delivery time). Permanent
+/// failures drop the entry and are reported; transient failures (network /
+/// relay overload) are re-enqueued so a later sweep retries them. With
+/// `--watch`, keeps polling and delivers messages as they come due.
+pub async fn cmd_scheduled_run(
+    client: &BuzzClient,
+    watch: bool,
+    queue_file: Option<&str>,
+) -> Result<(), CliError> {
+    let path = schedule::resolve_queue_path(queue_file)?;
+    loop {
+        let due = schedule::take_due(&path, chrono::Utc::now().timestamp())?;
+        for msg in due {
+            let result = cmd_send_message(
+                client,
+                SendMessageParams {
+                    channel_id: msg.channel_id.clone(),
+                    content: msg.content.clone(),
+                    kind: msg.kind,
+                    reply_to: msg.reply_to.clone(),
+                    broadcast: msg.broadcast.unwrap_or(false),
+                    files: Vec::new(),
+                    mentions: msg.mentions.clone(),
+                    scheduled_at: None,
+                },
+            )
+            .await;
+            match result {
+                Ok(()) => {}
+                Err(e) if is_retryable_error(&e) => {
+                    crate::error::print_error(&e);
+                    // Put it back for a later sweep instead of dropping it.
+                    schedule::enqueue(&path, msg)?;
+                }
+                Err(e) => {
+                    crate::error::print_error(&e);
+                    eprintln!(
+                        "dropping scheduled message {}: permanent failure (re-enqueue manually)",
+                        msg.id
+                    );
+                }
+            }
+        }
+        if !watch {
+            return Ok(());
+        }
+        // Sleep until the next due timestamp (capped so newly scheduled
+        // messages are picked up promptly), or poll at a fixed cadence when
+        // the queue is empty.
+        let next = schedule::next_due(&path)?;
+        let seconds = match next {
+            Some(t) => (t - chrono::Utc::now().timestamp()).clamp(1, 30),
+            None => 30,
+        };
+        tokio::time::sleep(std::time::Duration::from_secs(seconds as u64)).await;
+    }
+}
+
 pub async fn dispatch(
     cmd: crate::MessagesCmd,
     client: &BuzzClient,
@@ -877,6 +1023,7 @@ pub async fn dispatch(
             content,
             kind,
             reply_to,
+            scheduled_at,
             broadcast,
             files,
             mentions,
@@ -891,6 +1038,7 @@ pub async fn dispatch(
                     broadcast,
                     files,
                     mentions,
+                    scheduled_at,
                 },
             )
             .await
@@ -987,6 +1135,17 @@ pub async fn dispatch(
         MessagesCmd::Vote { event, direction } => {
             cmd_vote_on_post(client, &event, &direction).await
         }
+        MessagesCmd::Scheduled(command) => match command {
+            crate::MessagesScheduledCmd::List { queue_file } => {
+                cmd_scheduled_list(queue_file.as_deref())
+            }
+            crate::MessagesScheduledCmd::Cancel { id, queue_file } => {
+                cmd_scheduled_cancel(queue_file.as_deref(), &id)
+            }
+            crate::MessagesScheduledCmd::Run { watch, queue_file } => {
+                cmd_scheduled_run(client, watch, queue_file.as_deref()).await
+            }
+        },
     }
 }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -3,6 +3,7 @@ mod client;
 mod commands;
 mod error;
 mod links;
+mod schedule;
 mod validate;
 
 use clap::{Parser, Subcommand};
@@ -386,6 +387,11 @@ pub enum MessagesCmd {
         /// Event ID to reply to (creates a thread)
         #[arg(long)]
         reply_to: Option<String>,
+        /// ISO8601 / RFC 3339 timestamp (e.g. 2026-08-09T09:00:00Z) for future
+        /// delivery. Enqueues a durable scheduled delivery instead of sending
+        /// now; deliver with `buzz messages scheduled run`.
+        #[arg(long)]
+        scheduled_at: Option<String>,
         /// Also publish to the Nostr network
         #[arg(long, default_value_t = false)]
         broadcast: bool,
@@ -521,6 +527,43 @@ pub enum MessagesCmd {
         /// Vote direction: "up" or "down"
         #[arg(long)]
         direction: String,
+    },
+    /// Manage scheduled (deliver-later) messages
+    #[command(subcommand)]
+    Scheduled(MessagesScheduledCmd),
+}
+
+/// Commands for inspecting and delivering the local scheduled-message queue.
+#[derive(Subcommand)]
+pub enum MessagesScheduledCmd {
+    /// List pending scheduled messages
+    #[command(after_help = "Examples:\n  buzz messages scheduled list")]
+    List {
+        /// Override the scheduled-messages store path (testing/debugging)
+        #[arg(long)]
+        queue_file: Option<String>,
+    },
+    /// Cancel a pending scheduled message before delivery
+    #[command(after_help = "Examples:\n  buzz messages scheduled cancel --id <scheduled-id>")]
+    Cancel {
+        /// Scheduled message ID (from 'buzz messages scheduled list')
+        #[arg(long)]
+        id: String,
+        /// Override the scheduled-messages store path (testing/debugging)
+        #[arg(long)]
+        queue_file: Option<String>,
+    },
+    /// Deliver scheduled messages that are due now, then exit
+    #[command(
+        after_help = "Examples:\n  buzz messages scheduled run\n  buzz messages scheduled run --watch"
+    )]
+    Run {
+        /// Keep running and deliver messages as they come due
+        #[arg(long, default_value_t = false)]
+        watch: bool,
+        /// Override the scheduled-messages store path (testing/debugging)
+        #[arg(long)]
+        queue_file: Option<String>,
     },
 }
 
@@ -2178,6 +2221,7 @@ mod tests {
                 "delete",
                 "edit",
                 "get",
+                "scheduled",
                 "search",
                 "send",
                 "send-diff",
@@ -2315,7 +2359,7 @@ mod tests {
             ("feed", 1),
             ("issues", 4),
             ("media", 1),
-            ("messages", 8),
+            ("messages", 9),
             ("pack", 2),
             ("patches", 4),
             ("pr", 5),

--- a/crates/buzz-cli/src/schedule.rs
+++ b/crates/buzz-cli/src/schedule.rs
@@ -1,0 +1,314 @@
+//! Durable scheduled-message queue for the Buzz CLI.
+//!
+//! `buzz messages send --scheduled-at <ISO8601>` writes a pending delivery to a
+//! JSON store instead of publishing immediately. `buzz messages scheduled run`
+//! (optionally `--watch`) delivers due entries by re-running the normal send
+//! path; `buzz messages scheduled list` / `cancel` inspect and mutate the
+//! pending queue.
+//!
+//! The store lives at `<platform-data-dir>/xyz.block.buzz.app/scheduled/
+//! scheduled-messages.json` — the same app-data root the desktop app uses (see
+//! `channel_templates.rs`), so a future desktop "Schedule for later" composer
+//! can share the queue. Writes are atomic (temp file + rename) and the store is
+//! read/written in full, which keeps the shape simple for a single-user local
+//! queue.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::CliError;
+
+/// Tauri bundle identifier for the production desktop app. `dirs::data_dir()`
+/// joined with this segment matches `app.path().app_data_dir()` exactly
+/// (Tauri resolves app-data as the platform data dir plus the identifier).
+const PROD_BUNDLE_IDENTIFIER: &str = "xyz.block.buzz.app";
+
+/// A pending (not-yet-delivered) message in the local scheduling queue.
+///
+/// Field-for-field this mirrors the flags accepted by
+/// `buzz messages send`, minus file attachments (scheduling uploads is not
+/// supported in the first cut). Delivered entries are removed from the store;
+/// `scheduled_at` is a Unix timestamp in seconds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduledMessage {
+    /// Stable local id (UUID) used to list and cancel the delivery.
+    pub id: String,
+    /// Channel UUID the message will be delivered to.
+    pub channel_id: String,
+    /// Message content (markdown, @mentions) exactly as passed to `send`.
+    pub content: String,
+    /// Nostr event kind (defaults to the channel default on delivery).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<u16>,
+    /// Parent event id to reply to (threads the delivered message).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    /// Whether to also publish to the Nostr network on delivery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub broadcast: Option<bool>,
+    /// Explicit mention pubkeys (hex or npub) to tag on delivery.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mentions: Vec<String>,
+    /// Unix timestamp (seconds) at which the message becomes deliverable.
+    pub scheduled_at: i64,
+    /// Unix timestamp (seconds) when the delivery was scheduled.
+    pub created_at: i64,
+}
+
+/// Parse an ISO8601 / RFC 3339 timestamp into Unix seconds.
+///
+/// Rejects anything that is not parseable or is already in the past, so a
+/// mistyped `--scheduled-at` fails at enqueue time instead of silently
+/// delivering the message immediately.
+pub fn parse_scheduled_at(input: &str) -> Result<i64, CliError> {
+    let dt = chrono::DateTime::parse_from_rfc3339(input).map_err(|e| {
+        CliError::Usage(format!(
+            "--scheduled-at must be an ISO8601 / RFC 3339 timestamp (e.g. 2026-08-09T09:00:00Z): {e}"
+        ))
+    })?;
+    let ts = dt.timestamp();
+    if ts <= chrono::Utc::now().timestamp() {
+        return Err(CliError::Usage(format!(
+            "--scheduled-at must be in the future (got {input})"
+        )));
+    }
+    Ok(ts)
+}
+
+/// Resolve the scheduled-messages store path.
+///
+/// `override_path` (from `--queue-file`) always wins — useful for tests and
+/// ad-hoc debugging. Otherwise defaults to the prod bundle's app-data dir:
+/// `<platform-data-dir>/xyz.block.buzz.app/scheduled/scheduled-messages.json`.
+pub fn resolve_queue_path(override_path: Option<&str>) -> Result<PathBuf, CliError> {
+    if let Some(p) = override_path {
+        return Ok(PathBuf::from(p));
+    }
+    let data_dir = dirs::data_dir().ok_or_else(|| {
+        CliError::Other("could not resolve platform app-data directory".to_string())
+    })?;
+    Ok(data_dir
+        .join(PROD_BUNDLE_IDENTIFIER)
+        .join("scheduled")
+        .join("scheduled-messages.json"))
+}
+
+/// Load the pending queue from `path`. A missing or empty store is an empty
+/// queue (an interrupted atomic write can leave a zero-byte file behind).
+pub fn load_queue(path: &Path) -> Result<Vec<ScheduledMessage>, CliError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|e| CliError::Other(format!("failed to read {}: {e}", path.display())))?;
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str(&content)
+        .map_err(|e| CliError::Other(format!("failed to parse {}: {e}", path.display())))
+}
+
+/// Persist `queue` to `path` atomically (temp file + rename).
+///
+/// Creates the parent directory when missing. Corrupt or unreadable existing
+/// stores are surfaced as errors rather than silently overwritten.
+fn save_queue(path: &Path, queue: &[ScheduledMessage]) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| CliError::Other(format!("failed to create {}: {e}", parent.display())))?;
+    }
+    let json = serde_json::to_string_pretty(queue)
+        .map_err(|e| CliError::Other(format!("failed to serialize queue: {e}")))?;
+    let tmp = path.with_extension("json.tmp");
+    let mut f = fs::File::create(&tmp)
+        .map_err(|e| CliError::Other(format!("failed to write {}: {e}", tmp.display())))?;
+    f.write_all(json.as_bytes())
+        .map_err(|e| CliError::Other(format!("failed to write {}: {e}", tmp.display())))?;
+    f.sync_all()
+        .map_err(|e| CliError::Other(format!("failed to sync {}: {e}", tmp.display())))?;
+    fs::rename(&tmp, path)
+        .map_err(|e| CliError::Other(format!("failed to replace {}: {e}", path.display())))?;
+    Ok(())
+}
+
+/// Append `msg` to the queue at `path`.
+pub fn enqueue(path: &Path, msg: ScheduledMessage) -> Result<(), CliError> {
+    let mut queue = load_queue(path)?;
+    queue.push(msg);
+    save_queue(path, &queue)
+}
+
+/// Remove the entry with `id` from the queue, returning it if present.
+pub fn cancel_by_id(path: &Path, id: &str) -> Result<Option<ScheduledMessage>, CliError> {
+    let mut queue = load_queue(path)?;
+    let mut removed = None;
+    queue.retain(|m| {
+        if m.id == id {
+            removed = Some(m.clone());
+            false
+        } else {
+            true
+        }
+    });
+    save_queue(path, &queue)?;
+    Ok(removed)
+}
+
+/// Split the queue into (due, pending) at `now` and persist the pending half.
+///
+/// Due entries are removed from the store and returned so the caller can
+/// attempt delivery without racing the watcher on the same record. Failed
+/// deliveries may be re-enqueued by the caller.
+pub fn take_due(path: &Path, now: i64) -> Result<Vec<ScheduledMessage>, CliError> {
+    let queue = load_queue(path)?;
+    let mut due = Vec::new();
+    let mut pending = Vec::new();
+    for msg in queue {
+        if msg.scheduled_at <= now {
+            due.push(msg);
+        } else {
+            pending.push(msg);
+        }
+    }
+    save_queue(path, &pending)?;
+    Ok(due)
+}
+
+/// Earliest scheduled timestamp still pending, if any.
+pub fn next_due(path: &Path) -> Result<Option<i64>, CliError> {
+    Ok(load_queue(path)?.into_iter().map(|m| m.scheduled_at).min())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn sample(id: &str, scheduled_at: i64) -> ScheduledMessage {
+        ScheduledMessage {
+            id: id.to_string(),
+            channel_id: "3f4c2d10-1b9e-4e1a-9f6e-6c6f3f0b0f0f".to_string(),
+            content: "hello".to_string(),
+            kind: None,
+            reply_to: None,
+            broadcast: Some(false),
+            mentions: Vec::new(),
+            scheduled_at,
+            created_at: 1000,
+        }
+    }
+
+    fn write_store(json: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        f.write_all(json.as_bytes()).expect("write");
+        f
+    }
+
+    #[test]
+    fn resolve_queue_path_honors_override() {
+        let path = resolve_queue_path(Some("/tmp/custom.json")).unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/custom.json"));
+    }
+
+    #[test]
+    fn resolve_queue_path_defaults_to_prod_bundle() {
+        let path = resolve_queue_path(None).unwrap();
+        assert!(path.ends_with("xyz.block.buzz.app/scheduled/scheduled-messages.json"));
+    }
+
+    #[test]
+    fn parse_scheduled_at_accepts_rfc3339_future() {
+        let future = (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339();
+        let ts = parse_scheduled_at(&future).expect("future timestamp parses");
+        assert!(ts > chrono::Utc::now().timestamp());
+    }
+
+    #[test]
+    fn parse_scheduled_at_rejects_past() {
+        let past = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        let err = parse_scheduled_at(&past).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+        assert!(err.to_string().contains("future"));
+    }
+
+    #[test]
+    fn parse_scheduled_at_rejects_garbage() {
+        let err = parse_scheduled_at("not-a-timestamp").unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn load_queue_missing_store_is_empty() {
+        let queue = load_queue(Path::new("/nonexistent/scheduled-messages.json")).unwrap();
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn enqueue_and_cancel_round_trip() {
+        let f = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = f.path();
+        enqueue(path, sample("id-1", 2000)).expect("enqueue");
+        enqueue(path, sample("id-2", 3000)).expect("enqueue");
+        let queue = load_queue(path).expect("load");
+        assert_eq!(queue.len(), 2);
+
+        let removed = cancel_by_id(path, "id-1").expect("cancel");
+        assert_eq!(removed.map(|m| m.id).as_deref(), Some("id-1"));
+        let queue = load_queue(path).expect("load");
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue[0].id, "id-2");
+    }
+
+    #[test]
+    fn cancel_unknown_id_is_none() {
+        let f = tempfile::NamedTempFile::new().expect("tempfile");
+        enqueue(f.path(), sample("id-1", 2000)).expect("enqueue");
+        let removed = cancel_by_id(f.path(), "missing").expect("cancel");
+        assert!(removed.is_none());
+        assert_eq!(load_queue(f.path()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn take_due_removes_due_and_keeps_pending() {
+        let f = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = f.path();
+        enqueue(path, sample("due-1", 1000)).expect("enqueue");
+        enqueue(path, sample("due-2", 1000)).expect("enqueue");
+        enqueue(path, sample("future", 9999)).expect("enqueue");
+
+        let due = take_due(path, 1000).expect("take_due");
+        assert_eq!(due.len(), 2);
+        assert!(due.iter().all(|m| m.id.starts_with("due-")));
+        let remaining = load_queue(path).expect("load");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "future");
+    }
+
+    #[test]
+    fn next_due_reports_earliest_pending() {
+        let f = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = f.path();
+        enqueue(path, sample("late", 5000)).expect("enqueue");
+        enqueue(path, sample("early", 2000)).expect("enqueue");
+        assert_eq!(next_due(path).unwrap(), Some(2000));
+        assert_eq!(next_due(Path::new("/nonexistent/q.json")).unwrap(), None);
+    }
+
+    #[test]
+    fn corrupted_store_surfaces_as_error() {
+        let f = write_store("not json");
+        let err = load_queue(f.path()).unwrap_err();
+        assert!(err.to_string().contains("failed to parse"));
+    }
+
+    #[test]
+    fn save_queue_creates_missing_parent_dirs() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("a/b/c/scheduled-messages.json");
+        enqueue(&path, sample("id-1", 2000)).expect("enqueue");
+        assert_eq!(load_queue(&path).unwrap().len(), 1);
+    }
+}


### PR DESCRIPTION
Closes #5356 (agent + queue/delivery slice)

## Summary

Adds **"Schedule for Later"** message delivery to the Buzz CLI — the agent-facing
half of the requested feature. Agents can now compose a message now and have it
delivered at a specified time, with the queue persisting durably across agent
restarts.

```bash
# Enqueue a delivery for later (instead of sending now)
buzz messages send --channel <uuid> --content "standup reminder" --scheduled-at 2026-08-09T09:00:00Z

# Inspect / manage the pending queue
buzz messages scheduled list
buzz messages scheduled cancel --id <scheduled-id>

# Deliver due messages (once, or keep watching)
buzz messages scheduled run
buzz messages scheduled run --watch
```

## What's implemented

1. **Agent support** — `--scheduled-at <ISO8601>` on `buzz messages send`. The
   timestamp is validated up front (RFC 3339, must be in the future) and any
   invalid request fails before anything is persisted.
2. **Durable queue** — pending deliveries are stored atomically (temp file +
   rename) at `<app-data>/xyz.block.buzz.app/scheduled/scheduled-messages.json`
   — the same app-data root the desktop app owns (`channel-templates.json` uses
   it), so a future desktop composer integration can share the queue.
3. **Delivery** — `buzz messages scheduled run` replays the normal send path
   (mentions re-resolved, thread refs rebuilt at delivery time) for every due
   entry. Transient failures (network / relay overload) are re-enqueued for a
   later sweep; permanent failures are reported and dropped. `--watch` keeps
   polling and delivers messages as they come due.
4. **List / cancel** — `buzz messages scheduled list` and `... cancel --id`
   give agents a Scheduled view and cancellation before delivery.

## Scope notes (intentional first cut)

- **Text-only**: `--scheduled-at` rejects `--file` (uploads would need to be
  replayed at delivery time).
- **CLI/agent surface only**: the composer UI, timezone-aware delivery
  windows, and recurring schedules from the issue are follow-ups and are
  explicitly not part of this PR.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p buzz-cli --all-targets -- -D warnings` — clean
- `cargo test -p buzz-cli` — 353 passed, 0 failed (13 new tests for the queue
  store: parse/validate, atomic persistence, enqueue/cancel round-trip,
  take-due partitioning, corrupt-store handling)
- Manually exercised `send --scheduled-at` validation, `list`, `cancel`
  (found + missing), and `run` (failed delivery re-enqueued for retry)
