### PR TITLE
feat(desktop): open workspace files from `buzz://file` deep links

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -63,6 +63,7 @@ mod window_chrome;
 mod window_vibrancy;
 mod workflows;
 mod workspace;
+mod workspace_file;
 
 pub use agent_access::*;
 pub use agent_auth::*;
@@ -116,3 +117,4 @@ pub use window_chrome::*;
 pub use window_vibrancy::*;
 pub use workflows::*;
 pub use workspace::*;
+pub use workspace_file::*;

--- a/desktop/src-tauri/src/commands/workspace_file.rs
+++ b/desktop/src-tauri/src/commands/workspace_file.rs
@@ -1,0 +1,230 @@
+//! Open an artifact referenced by a `buzz://file` deep link.
+//!
+//! The frontend parses those links in `shared/lib/fileLink.ts`, but that parse
+//! is a convenience filter, not the security boundary — anything that can reach
+//! the IPC layer bypasses it. The containment check therefore lives here, and
+//! this module must be safe to call with fully attacker-controlled arguments.
+
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+use tauri::AppHandle;
+use tauri_plugin_opener::OpenerExt;
+
+use crate::managed_agents::nest_dir;
+
+/// Directory name of the nest entry that points at the active workspace's
+/// repos directory. It is a symlink whenever the user has pointed the repos
+/// directory outside the nest, which is exactly why `Repos` is a distinct root
+/// rather than a path under `Nest`: a nest-rooted path traversing this entry
+/// canonicalizes outside the nest and is (correctly) rejected.
+const REPOS_ENTRY: &str = "REPOS";
+
+/// The roots a `buzz://file` link may address. Mirrors `FileLinkRoot` in
+/// `desktop/src/shared/lib/fileLink.ts`.
+///
+/// Deliberately closed: there is no variant for an arbitrary absolute path.
+/// Adding one would make any chat message a filesystem opener.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileLinkRoot {
+    /// The nest root — `~/.buzz`, or `~/.buzz-dev` on dev builds.
+    Nest,
+    /// The active workspace's repos directory.
+    Repos,
+}
+
+/// Reject a link path that is empty, absolute, or able to escape its root, and
+/// return it rebuilt from its plain components.
+///
+/// Uses [`Path::components`], so this catches `..` however it is spelled —
+/// including the forms a naive `split('/')` check misses on Windows. Callers
+/// still canonicalize afterwards; this is the cheap pre-filter that keeps a
+/// hostile path from ever being joined.
+///
+/// `.` components are dropped rather than rejected. They are pure no-ops once
+/// resolved, `components()` already elides the interior ones (`a/./b` yields
+/// exactly `a` then `b`), and rejecting only the leading `./` would put this
+/// out of step with `fileLink.ts`, which accepts both. A link the frontend
+/// renders as a pill must not fail on click.
+fn validate_relative_path(path: &str) -> Result<PathBuf, String> {
+    if path.contains('\0') {
+        return Err("file link path contains a null byte".into());
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => return Err("file link path contains '..'".into()),
+            Component::RootDir | Component::Prefix(_) => {
+                return Err("file link path must be relative".into());
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err("file link path is empty".into());
+    }
+    Ok(normalized)
+}
+
+/// Resolve `root` to an existing directory on disk.
+fn resolve_root(root: FileLinkRoot) -> Result<PathBuf, String> {
+    let nest = nest_dir().ok_or("cannot resolve home directory for nest")?;
+    let dir = match root {
+        FileLinkRoot::Nest => nest,
+        FileLinkRoot::Repos => nest.join(REPOS_ENTRY),
+    };
+    dir.canonicalize()
+        .map_err(|e| format!("cannot resolve {} root: {e}", root_label(root)))
+}
+
+fn root_label(root: FileLinkRoot) -> &'static str {
+    match root {
+        FileLinkRoot::Nest => "nest",
+        FileLinkRoot::Repos => "repos",
+    }
+}
+
+/// Resolve a link path against its root, or explain why it is not openable.
+///
+/// The returned path is canonical, exists, and is inside the canonicalized
+/// root. Canonicalizing *both* sides is what makes a planted symlink useless:
+/// agents can write anywhere in the nest, so a symlink pointing at a credential
+/// directory elsewhere in `$HOME` is a realistic way to turn a chat message
+/// into an exfiltration primitive. Resolving before comparing closes it.
+fn resolve_link_target(root: FileLinkRoot, path: &str) -> Result<PathBuf, String> {
+    let relative = validate_relative_path(path)?;
+    let root_dir = resolve_root(root)?;
+    let target = root_dir
+        .join(&relative)
+        .canonicalize()
+        .map_err(|_| format!("{path} does not exist in the {} root", root_label(root)))?;
+
+    if !target.starts_with(&root_dir) {
+        return Err(format!(
+            "{path} resolves outside the {} root",
+            root_label(root)
+        ));
+    }
+    Ok(target)
+}
+
+/// Open — or reveal in the file manager — an artifact addressed by a
+/// `buzz://file` link.
+///
+/// Returns `Err` with a human-readable reason the caller surfaces as a toast.
+/// A missing file is an ordinary outcome, not a bug: artifacts get regenerated
+/// and deleted, and a dead link must say so rather than silently do nothing.
+#[tauri::command]
+pub async fn open_workspace_file(
+    app: AppHandle,
+    path: String,
+    root: FileLinkRoot,
+    reveal: bool,
+) -> Result<(), String> {
+    let target = tokio::task::spawn_blocking(move || resolve_link_target(root, &path))
+        .await
+        .map_err(|e| format!("spawn_blocking failed: {e}"))??;
+
+    let opener = app.opener();
+    if reveal {
+        opener
+            .reveal_item_in_dir(&target)
+            .map_err(|e| format!("failed to reveal file: {e}"))
+    } else {
+        opener
+            .open_path(target.to_string_lossy(), None::<&str>)
+            .map_err(|e| format!("failed to open file: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_plain_nested_path() {
+        assert_eq!(
+            validate_relative_path("docs/guides/NOTES.md").unwrap(),
+            PathBuf::from("docs/guides/NOTES.md")
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_and_traversing_paths() {
+        for bad in ["", "/etc/passwd", "../outside", "a/../../b", ".", "./"] {
+            assert!(
+                validate_relative_path(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    /// `.` components are no-ops, so they are dropped rather than rejected —
+    /// and `fileLink.ts` accepts them too. Pinned because the two layers
+    /// disagreeing would mean a pill that renders but fails on click.
+    #[test]
+    fn drops_no_op_current_dir_components() {
+        assert_eq!(
+            validate_relative_path("./docs/./P.md").unwrap(),
+            PathBuf::from("docs/P.md")
+        );
+    }
+
+    #[test]
+    fn rejects_null_bytes() {
+        assert!(validate_relative_path("a/\0/b").is_err());
+    }
+
+    #[test]
+    fn resolves_a_file_inside_the_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("docs/NOTES.md"), b"hi").unwrap();
+
+        let relative = validate_relative_path("docs/NOTES.md").unwrap();
+        let target = root.join(&relative).canonicalize().unwrap();
+        assert!(target.starts_with(&root));
+    }
+
+    /// The case that motivates canonicalizing both sides: a symlink planted
+    /// inside the root pointing at a file outside it. A textual `..` check
+    /// passes this path; the prefix check on canonicalized paths does not.
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_symlink_that_escapes_the_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret"), b"s3cret").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("escape")).unwrap();
+
+        let root = root.canonicalize().unwrap();
+        let relative = validate_relative_path("escape/secret").unwrap();
+        let target = root.join(&relative).canonicalize().unwrap();
+
+        assert!(
+            !target.starts_with(&root),
+            "symlink escape should not be contained by the root"
+        );
+    }
+
+    #[test]
+    fn root_deserializes_from_the_frontend_spelling() {
+        assert_eq!(
+            serde_json::from_str::<FileLinkRoot>("\"nest\"").unwrap(),
+            FileLinkRoot::Nest
+        );
+        assert_eq!(
+            serde_json::from_str::<FileLinkRoot>("\"repos\"").unwrap(),
+            FileLinkRoot::Repos
+        );
+        assert!(serde_json::from_str::<FileLinkRoot>("\"home\"").is_err());
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -885,6 +885,7 @@ pub fn run() {
             apply_workspace,
             validate_repos_dir,
             get_active_workspace,
+            open_workspace_file,
             fetch_workspace_icon,
             fetch_join_policy,
             set_prevent_sleep_active,

--- a/desktop/src/features/messages/lib/openPopoverLink.ts
+++ b/desktop/src/features/messages/lib/openPopoverLink.ts
@@ -1,23 +1,34 @@
 import { isMessageLink, parseMessageLink } from "./messageLink";
 import type { ParsedMessageLink } from "./messageLink";
+import { isFileLink, parseFileLink } from "@/shared/lib/fileLink";
+import type { ParsedFileLink } from "@/shared/lib/fileLink";
 
 /**
  * Open a link the same way the rendered-message link path does:
- * `buzz://message?…` deep-links navigate in-app, everything else (http(s),
- * other buzz:// URLs) goes to the OS opener. Mirrors `markdown.tsx`'s `a`
- * renderer so the composer popover and the rendered link behave identically.
+ * `buzz://message?…` deep-links navigate in-app, `buzz://file?…` links open the
+ * artifact on disk, and everything else (http(s), other buzz:// URLs) goes to
+ * the OS opener. Mirrors `markdown.tsx`'s `a` renderer so the composer popover
+ * and the rendered link behave identically.
  */
 export function openPopoverLink(
   url: string,
   handlers: {
     openExternal: (url: string) => void;
     openMessageLink: (link: ParsedMessageLink) => void;
+    openFileLink?: (link: ParsedFileLink) => void;
   },
 ): void {
   if (isMessageLink(url)) {
     const parsed = parseMessageLink(url);
     if (parsed.ok) {
       handlers.openMessageLink(parsed.value);
+      return;
+    }
+  }
+  if (isFileLink(url) && handlers.openFileLink) {
+    const parsed = parseFileLink(url);
+    if (parsed.ok) {
+      handlers.openFileLink(parsed.value);
       return;
     }
   }

--- a/desktop/src/features/messages/lib/useLinkEditor.tsx
+++ b/desktop/src/features/messages/lib/useLinkEditor.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Pencil, Unlink } from "lucide-react";
+import { toast } from "sonner";
 
+import { invokeTauri } from "@/shared/api/tauri";
 import {
   Dialog,
   DialogContent,
@@ -244,7 +246,8 @@ export function useLinkEditor(richText: UseRichTextEditorResult) {
     closeCard();
   }, [cardState, openDialogFromInfo, closeCard]);
 
-  // Card URL click: route `buzz://message?…` deep-links in-app (matching the
+  // Card URL click: route `buzz://message?…` deep-links in-app and
+  // `buzz://file?…` links to the artifact on disk (matching the
   // rendered-message link path), everything else to the OS opener.
   const openCardUrl = React.useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -258,6 +261,17 @@ export function useLinkEditor(richText: UseRichTextEditorResult) {
             messageId: link.messageId,
             threadRootId: link.threadRootId,
           }),
+        openFileLink: (link) => {
+          void invokeTauri("open_workspace_file", {
+            path: link.path,
+            root: link.root,
+            reveal: link.reveal,
+          }).catch((err: unknown) => {
+            toast.error(
+              err instanceof Error ? err.message : "Cannot open file",
+            );
+          });
+        },
       });
     },
     [cardState, goChannel],

--- a/desktop/src/shared/lib/fileLink.test.mjs
+++ b/desktop/src/shared/lib/fileLink.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildFileLink,
+  fileLinkBasename,
+  isFileLink,
+  parseFileLink,
+} from "./fileLink.ts";
+
+const PATH = "docs/guides/DEPLOY_RUNBOOK.md";
+
+test("builder emits the canonical link format", () => {
+  assert.equal(
+    buildFileLink({ path: PATH }),
+    `buzz://file?path=${encodeURIComponent(PATH)}`,
+  );
+  assert.equal(
+    buildFileLink({ path: PATH, reveal: true }),
+    `buzz://file?path=${encodeURIComponent(PATH)}&reveal=1`,
+  );
+  assert.equal(
+    buildFileLink({ path: "buzz/README.md", root: "repos" }),
+    "buzz://file?path=buzz%2FREADME.md&root=repos",
+  );
+});
+
+test("builder omits root=nest so the format has one spelling", () => {
+  assert.equal(
+    buildFileLink({ path: PATH, root: "nest" }),
+    buildFileLink({ path: PATH }),
+  );
+});
+
+test("builder rejects paths that leave the root", () => {
+  for (const bad of [
+    "",
+    "/etc/passwd",
+    "../outside",
+    "a/../../b",
+    "C:/Windows",
+    "a\\..\\b",
+    "a//b",
+    "a/\0/b",
+  ]) {
+    assert.throws(() => buildFileLink({ path: bad }), /fileLink/, bad);
+  }
+});
+
+test("build → parse round-trips, including a path with spaces", () => {
+  const spaced = "docs/design notes v2.pdf";
+  const parsed = parseFileLink(buildFileLink({ path: spaced, reveal: true }));
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.value, {
+    path: spaced,
+    root: "nest",
+    reveal: true,
+  });
+});
+
+test("parse defaults root to nest and reveal to false", () => {
+  const parsed = parseFileLink(`buzz://file?path=${PATH}`);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.value, { path: PATH, root: "nest", reveal: false });
+});
+
+test("parse accepts the repos root", () => {
+  const parsed = parseFileLink("buzz://file?path=buzz/README.md&root=repos");
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.value.root, "repos");
+});
+
+test("parse rejects paths that escape the root", () => {
+  // Percent-encoded traversal must be caught after decoding, not before.
+  const encodedDotDot = parseFileLink("buzz://file?path=%2E%2E%2Fsecrets");
+  assert.equal(encodedDotDot.ok, false);
+  assert.equal(encodedDotDot.reason, "bad-path");
+
+  for (const bad of [
+    "buzz://file?path=/etc/passwd",
+    "buzz://file?path=../../.ssh/id_rsa",
+    "buzz://file?path=a/../../b",
+  ]) {
+    assert.equal(parseFileLink(bad).ok, false, bad);
+  }
+});
+
+test("parse rejects malformed links rather than guessing", () => {
+  const cases = [
+    ["buzz://file", "missing-path"],
+    ["buzz://file?path=", "bad-path"],
+    ["buzz://message?channel=a&id=b", "wrong-host"],
+    ["https://example.com/file?path=a", "wrong-scheme"],
+    ["buzz://file/extra?path=a", "unexpected-path"],
+    ["buzz://file?path=a#frag", "unexpected-fragment"],
+    ["buzz://file?path=a&nope=1", "unknown-param"],
+    ["buzz://file?path=a&path=b", "duplicate-param"],
+    ["buzz://file?path=a&root=home", "unknown-root"],
+    ["buzz://file?path=a&reveal=yes", "bad-reveal"],
+    ["not a url", "invalid-url"],
+  ];
+  for (const [url, reason] of cases) {
+    const result = parseFileLink(url);
+    assert.equal(result.ok, false, url);
+    assert.equal(result.reason, reason, url);
+  }
+});
+
+test("isFileLink is a cheap prefix check that excludes other buzz links", () => {
+  assert.equal(isFileLink(buildFileLink({ path: PATH })), true);
+  assert.equal(isFileLink("buzz://message?channel=a&id=b"), false);
+  assert.equal(isFileLink("buzz://pr?id=a&owner=b&d=c"), false);
+  // No query string — cannot carry a path, so it is not a file link.
+  assert.equal(isFileLink("buzz://file"), false);
+  assert.equal(isFileLink(undefined), false);
+  assert.equal(isFileLink(null), false);
+});
+
+test("basename is the display label", () => {
+  assert.equal(
+    fileLinkBasename({ path: PATH, root: "nest", reveal: false }),
+    "DEPLOY_RUNBOOK.md",
+  );
+  assert.equal(
+    fileLinkBasename({ path: "README.md", root: "nest", reveal: false }),
+    "README.md",
+  );
+});

--- a/desktop/src/shared/lib/fileLink.ts
+++ b/desktop/src/shared/lib/fileLink.ts
@@ -1,0 +1,178 @@
+/**
+ * `buzz://file` deep links for artifacts inside the Buzz nest, mirroring
+ * `entityLink.ts` for `buzz://pr|issue|repo`.
+ *
+ * Format:
+ *   buzz://file?path=<root-relative-path>[&root=nest|repos][&reveal=1]
+ *
+ * `path` is always relative to a *named* root — never absolute, and never
+ * containing a `..` segment. `root` selects which one:
+ *
+ * - `nest` (the default) — the nest root, `~/.buzz` (`~/.buzz-dev` on dev
+ *   builds).
+ * - `repos` — the active workspace's repos directory, which the user may point
+ *   outside the nest. It needs its own alias precisely because the nest's
+ *   `REPOS` entry can be a symlink: a `nest`-rooted path that traverses it
+ *   canonicalizes outside the nest and is rejected, by design.
+ *
+ * Only these two roots exist, and both are directories the app already manages.
+ * The scheme deliberately cannot address an arbitrary absolute path; widening
+ * it would turn any chat message into a filesystem opener.
+ *
+ * `reveal=1` selects "show in the file manager" over "open in the default
+ * application".
+ *
+ * Agents write these links so a human can click an artifact in chat and land on
+ * the live file rather than a copy pinned at upload time. The complementary
+ * mechanism is `buzz messages send --file`, which uploads to Blossom and
+ * renders a downloadable `FileCard`; the two are meant to be used together, so
+ * a message stays useful on a device that does not have the nest.
+ *
+ * The validation here is a *convenience* filter, not the security boundary. The
+ * real containment check lives in the `open_workspace_file` Tauri command,
+ * which canonicalizes the joined path and requires the canonicalized root as a
+ * prefix. Anything that can reach the IPC layer bypasses this module
+ * entirely, so this file must never be the only thing standing between a link
+ * and the filesystem.
+ */
+
+const FILE_LINK_SCHEME = "buzz:";
+
+/** The named roots a file link may address. Must match `FileLinkRoot` in Rust. */
+export const FILE_LINK_ROOTS = ["nest", "repos"] as const;
+
+export type FileLinkRoot = (typeof FILE_LINK_ROOTS)[number];
+
+export type ParsedFileLink = {
+  path: string;
+  root: FileLinkRoot;
+  reveal: boolean;
+};
+
+export type FileLinkParseResult =
+  | { ok: true; value: ParsedFileLink }
+  | { ok: false; reason: string };
+
+/** Upper bound on `path`, well clear of any real artifact path. */
+const MAX_PATH_LENGTH = 1024;
+
+function isFileLinkRoot(value: string): value is FileLinkRoot {
+  return (FILE_LINK_ROOTS as readonly string[]).includes(value);
+}
+
+/**
+ * Reject paths that are absolute, escape upward, or carry characters that have
+ * no business in a root-relative artifact path.
+ *
+ * Backslashes are rejected rather than normalized: on Windows `a\..\b` would be
+ * an escaping path that a POSIX-style `..` segment check does not catch, and
+ * Buzz has no artifact paths that legitimately contain one.
+ */
+function isValidRootRelativePath(path: string): boolean {
+  if (path.length === 0 || path.length > MAX_PATH_LENGTH) return false;
+  if (path.includes("\0") || path.includes("\\")) return false;
+  // Absolute POSIX path, or a Windows drive/UNC path.
+  if (path.startsWith("/") || /^[a-zA-Z]:/.test(path)) return false;
+  const segments = path.split("/");
+  return segments.every((segment) => segment !== "" && segment !== "..");
+}
+
+/**
+ * Build a `buzz://file` link for a root-relative artifact path.
+ *
+ * `root` is omitted from the emitted URL when it is the `nest` default, so the
+ * common case stays short and the golden format has exactly one spelling.
+ *
+ * @throws if `path` is not a valid root-relative path.
+ */
+export function buildFileLink(input: {
+  path: string;
+  root?: FileLinkRoot;
+  reveal?: boolean;
+}): string {
+  if (!isValidRootRelativePath(input.path)) {
+    throw new Error(
+      "fileLink: path must be a relative path inside a known root",
+    );
+  }
+  const params = [`path=${encodeURIComponent(input.path)}`];
+  if (input.root && input.root !== "nest") params.push(`root=${input.root}`);
+  if (input.reveal) params.push("reveal=1");
+  return `buzz://file?${params.join("&")}`;
+}
+
+/**
+ * Cheap pre-check used by the markdown renderer and the URL transform before
+ * parsing, matching `isEntityLink`'s role for git entities.
+ */
+export function isFileLink(href: string | undefined | null): boolean {
+  if (!href) return false;
+  return href.startsWith("buzz://file?");
+}
+
+/**
+ * Parse a `buzz://file?…` URL. Returns a discriminated result so callers can
+ * fall back to plain-link rendering without throwing.
+ *
+ * Strict canonical form, matching `parseEntityLink`, so that old clients
+ * decline rather than silently misinterpret a future extension:
+ * - Empty or root path only (no `/extra/segments`)
+ * - No fragment
+ * - `path` exactly once; `root` and `reveal` at most once each
+ * - `root` must name a known root; `reveal` must be exactly `1`
+ * - Unknown query parameters rejected
+ */
+export function parseFileLink(url: string): FileLinkParseResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: "invalid-url" };
+  }
+
+  if (parsed.protocol !== FILE_LINK_SCHEME) {
+    return { ok: false, reason: "wrong-scheme" };
+  }
+  if (parsed.hostname !== "file") {
+    return { ok: false, reason: "wrong-host" };
+  }
+  if (parsed.pathname !== "" && parsed.pathname !== "/") {
+    return { ok: false, reason: "unexpected-path" };
+  }
+  if (parsed.hash) {
+    return { ok: false, reason: "unexpected-fragment" };
+  }
+
+  const KNOWN_PARAMS = new Set(["path", "root", "reveal"]);
+  for (const key of parsed.searchParams.keys()) {
+    if (!KNOWN_PARAMS.has(key)) {
+      return { ok: false, reason: "unknown-param" };
+    }
+    if (parsed.searchParams.getAll(key).length !== 1) {
+      return { ok: false, reason: "duplicate-param" };
+    }
+  }
+
+  const path = parsed.searchParams.get("path");
+  if (path === null) return { ok: false, reason: "missing-path" };
+  if (!isValidRootRelativePath(path)) return { ok: false, reason: "bad-path" };
+
+  const rawRoot = parsed.searchParams.get("root");
+  if (rawRoot !== null && !isFileLinkRoot(rawRoot)) {
+    return { ok: false, reason: "unknown-root" };
+  }
+  const root: FileLinkRoot = rawRoot ?? "nest";
+
+  const reveal = parsed.searchParams.get("reveal");
+  if (reveal !== null && reveal !== "1") {
+    return { ok: false, reason: "bad-reveal" };
+  }
+
+  return { ok: true, value: { path, root, reveal: reveal === "1" } };
+}
+
+/** Display label for a file link — the basename of its path. */
+export function fileLinkBasename(link: ParsedFileLink): string {
+  const segments = link.path.split("/");
+  return segments[segments.length - 1] ?? link.path;
+}

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -527,28 +527,25 @@ test("rehypeImageGallery: leaves a single trailing image in the text flow", () =
 // deep links and delegates everything else to `defaultUrlTransform`.
 //
 // This test renders real `<ReactMarkdown>` with the production transform
-// and asserts the link href survives to the rendered DOM. Mirrors the
-// `markdown.tsx` source — keep in sync if either changes.
+// and asserts the link href survives to the rendered DOM.
+//
+// It imports the REAL `buzzDeepLinkUrlTransform` rather than re-declaring it.
+// An inlined copy lived here previously and silently drifted: it had no
+// `buzz://file` branch, so every file-link case passed against a transform the
+// app does not ship. Importing the real one is what makes these assertions mean
+// anything.
 
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import ReactMarkdown from "react-markdown";
 
-import { isMessageLink } from "../../features/messages/lib/messageLink.ts";
-import { parseEntityLink } from "../lib/entityLink.ts";
 import remarkSpoilers from "../lib/remarkSpoilers.ts";
+import { buzzDeepLinkUrlTransform } from "./markdown/utils.ts";
 
 const OWNER_HEX =
   "71d67180ba17e749ee825fc8819c9c6ee7003617e1c126504f9b658070ab9224";
 const EVENT_HEX =
   "c3b589fa5713ba25bad6dc095e2de00a4ac8f50050fdea00fc6444e603be1dd1";
-
-function buzzDeepLinkUrlTransform(value, key) {
-  if (key !== "href") return defaultUrlTransform(value);
-  if (isMessageLink(value)) return value;
-  if (parseEntityLink(value).ok) return value;
-  return defaultUrlTransform(value);
-}
 
 function renderMarkdown(content) {
   return renderToStaticMarkup(
@@ -643,6 +640,30 @@ test("buzzDeepLinkUrlTransform: strips malformed buzz://pr (unknown param)", () 
   const html = renderMarkdown(
     `[link](buzz://pr?id=${EVENT_HEX}&owner=${OWNER_HEX}&d=buzz-world&extra=ignored)`,
   );
+  assert.match(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: preserves buzz://file href", () => {
+  const html = renderMarkdown("[runbook](buzz://file?path=docs%2FP.md)");
+  assert.match(html, /href="buzz:\/\/file\?path=docs%2FP\.md"/);
+  assert.doesNotMatch(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: preserves buzz://file autolink href", () => {
+  const html = renderMarkdown("<buzz://file?path=workspace%2FP.md&root=repos>");
+  assert.match(html, /href="buzz:\/\/file\?/);
+  assert.doesNotMatch(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: strips buzz://file that escapes its root", () => {
+  // The transform is the last line of defense in the renderer: a link the
+  // strict parser rejects must never reach the `a` override with a live href.
+  const html = renderMarkdown("[oops](buzz://file?path=..%2F..%2Fsecrets)");
+  assert.match(html, /href=""/);
+});
+
+test("buzzDeepLinkUrlTransform: strips buzz://file with an unknown root", () => {
+  const html = renderMarkdown("[oops](buzz://file?path=a.md&root=home)");
   assert.match(html, /href=""/);
 });
 

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -22,6 +22,7 @@ import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { invokeTauri } from "@/shared/api/tauri";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
+import { isFileLink, parseFileLink } from "@/shared/lib/fileLink";
 import {
   extractSupportedLinkPreviews,
   parseSupportedLinkPreview,
@@ -65,6 +66,7 @@ import {
 } from "./markdown/entityLinks";
 import { ExternalLinkAnchor } from "./markdown/ExternalLinkAnchor";
 import { FileCard } from "./markdown/FileCard";
+import { FileLinkPill } from "./markdown/FileLinkPill";
 import { InlineEmojiPopover } from "./markdown/InlineEmojiPopover";
 import { MarkdownInput } from "./markdown/MarkdownInput";
 import {
@@ -1390,6 +1392,15 @@ function createMarkdownComponents(
       }
       // Malformed message deep link — fall through to the default
       // anchor (renders as a normal external link).
+    }
+
+    // `buzz://file?…` links open an artifact on disk; malformed ones fall
+    // through to the default anchor.
+    if (isFileLink(href)) {
+      const fileLink = parseFileLink(href ?? "");
+      if (fileLink.ok) {
+        return <FileLinkPill interactive={interactive} link={fileLink.value} />;
+      }
     }
 
     // `buzz://pr|issue|repo?…` entity links navigate in-app; malformed ones

--- a/desktop/src/shared/ui/markdown/FileLinkPill.tsx
+++ b/desktop/src/shared/ui/markdown/FileLinkPill.tsx
@@ -1,0 +1,75 @@
+import { FileText } from "lucide-react";
+import { toast } from "sonner";
+
+import { invokeTauri } from "@/shared/api/tauri";
+import { cn } from "@/shared/lib/cn";
+import { fileLinkBasename, type ParsedFileLink } from "@/shared/lib/fileLink";
+import {
+  MENTION_CHIP_BASE_CLASSES,
+  MENTION_CHIP_HOVER_CLASSES,
+} from "@/shared/ui/mentionChip";
+
+/**
+ * Inline pill for a `buzz://file` deep link — click to open the live artifact
+ * on disk, unlike a `FileCard`, which downloads the copy pinned at upload time.
+ *
+ * The open goes through the `open_workspace_file` command rather than the
+ * frontend opener API so the containment check runs in Rust, where a caller
+ * cannot skip it. A failure (deleted artifact, path outside its root) surfaces
+ * as a toast: artifacts get regenerated, and a dead link must say so rather
+ * than silently do nothing.
+ */
+export function FileLinkPill({
+  interactive,
+  link,
+}: {
+  interactive: boolean;
+  link: ParsedFileLink;
+}) {
+  const label = fileLinkBasename(link);
+
+  const content = (
+    <>
+      <FileText aria-hidden className="size-3.5 shrink-0" />
+      {label}
+    </>
+  );
+
+  // Non-interactive surfaces (the channel canvas) render every anchor inert.
+  if (!interactive) {
+    return (
+      <span className="inline-flex items-center gap-1" data-file-link="">
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      data-file-link=""
+      aria-label={
+        link.reveal ? `Show ${label} in the file manager` : `Open ${label}`
+      }
+      title={link.path}
+      className={cn(
+        "inline-flex cursor-pointer items-center gap-1",
+        MENTION_CHIP_BASE_CLASSES,
+        MENTION_CHIP_HOVER_CLASSES,
+      )}
+      onClick={() => {
+        void invokeTauri("open_workspace_file", {
+          path: link.path,
+          root: link.root,
+          reveal: link.reveal,
+        }).catch((err: unknown) => {
+          toast.error(
+            err instanceof Error ? err.message : `Cannot open ${label}`,
+          );
+        });
+      }}
+    >
+      {content}
+    </button>
+  );
+}

--- a/desktop/src/shared/ui/markdown/utils.ts
+++ b/desktop/src/shared/ui/markdown/utils.ts
@@ -3,6 +3,7 @@ import { defaultUrlTransform } from "react-markdown";
 
 import { isMessageLink } from "@/features/messages/lib/messageLink";
 import { parseEntityLink } from "@/shared/lib/entityLink";
+import { parseFileLink } from "@/shared/lib/fileLink";
 
 export function useStableArray<T>(arr: T[]): T[] {
   const ref = React.useRef(arr);
@@ -178,12 +179,15 @@ export function isInsideHiddenSpoiler(element: Element): boolean {
  *   message-link pill renderer).
  * - `buzz://pr|issue|repo` hrefs — preserved only when `parseEntityLink`
  *   succeeds, keeping the sanitizer active against arbitrary `buzz://` URIs.
+ * - `buzz://file` hrefs — preserved only when `parseFileLink` succeeds, on the
+ *   same terms.
  * - Everything else delegates to `defaultUrlTransform`.
  */
 export function buzzDeepLinkUrlTransform(value: string, key: string): string {
   if (key !== "href") return defaultUrlTransform(value);
   if (isMessageLink(value)) return value;
   if (parseEntityLink(value).ok) return value;
+  if (parseFileLink(value).ok) return value;
   return defaultUrlTransform(value);
 }
 


### PR DESCRIPTION
## Summary

Chat messages routinely reference artifacts on disk, but there is no way to open one from a message. `file:///` is not in react-markdown's safe-protocol allowlist, so `[open](file:///…)` renders an anchor with an empty `href`, and a bare `file:///path` is not autolinked at all. A `FileCard` attachment is the closest thing today, but it downloads a copy pinned at upload time — for any artifact a build script regenerates, that copy is stale as soon as it reruns.

This adds a `buzz://file` deep link that opens the live file:

```
buzz://file?path=<root-relative>[&root=nest|repos][&reveal=1]
```

It follows the same parse → `urlTransform` → render path as the existing `buzz://pr|issue|repo` entity links, so nothing new is introduced structurally.

## The security boundary is in Rust, not the webview

`fileLink.ts` validates paths, but that is a convenience filter — anything that can reach the IPC layer bypasses it. The real check is in `open_workspace_file`: join onto a named root, `canonicalize()`, and require the canonicalized root as a prefix.

Canonicalizing **both** sides is the point. Agents can write anywhere in the nest, so a planted symlink resolving to a credential directory elsewhere in `$HOME` is a realistic way to turn a chat message into an exfiltration primitive. Resolving before comparing closes it, and there is a test that asserts exactly this case.

## Roots are a closed set

Only two, both directories the app already manages:

| Alias | Resolves to |
|---|---|
| `nest` (default) | `~/.buzz` (`~/.buzz-dev` on dev builds) |
| `repos` | the nest's `REPOS` entry |

There is deliberately no variant for an arbitrary absolute path — that would make any chat message a filesystem opener. `repos` needs its own alias rather than being a path under `nest` because `REPOS` is a symlink whenever the user points the repos directory outside the nest, so a nest-rooted path traversing it canonicalizes outside and is correctly rejected.

## Cross-layer agreement on `.` and `..`

Both layers drop `.` components and reject `..`. This is not cosmetic: `Path::components()` elides interior `.` (`a/./b` yields `a` then `b`), so an earlier revision that rejected `.` in Rust while `fileLink.ts` accepted it would have rendered a clickable pill that silently failed on click. A test pins the agreement.

## Incidental fix: `markdown.test.mjs` was testing a copy of the code

The URL-transform block declared its own `buzzDeepLinkUrlTransform` under a "keep in sync" comment rather than importing the real one. It had already drifted — the copy had no `buzz://file` branch — so every assertion in that block was validating a function the app does not ship. It now imports the real implementation, which is how the new cases failed on first wiring instead of passing vacuously.

This may be worth a look independent of the feature.

## Testing

- `desktop` JS unit suite: 4401 passed, 0 failed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`: full crate green, including 7 new tests in `commands::workspace_file`
- `cargo clippy --all-targets -- -D warnings`: exit 0
- `cargo fmt --check`, `biome check`, `tsc --noEmit`: clean

New coverage includes root-escape rejection, percent-encoded traversal, symlink escape, unknown root/param rejection, and build→parse round-trips.

## Notes / follow-ups

- Desktop-only by construction. The Flutter mobile client has its own renderer and will not recognize the scheme, which is the correct degradation.
- On any released build predating this, `buzz://file` links are stripped to an empty `href` by the sanitizer, so they should not be emitted until this ships.
- `crates/buzz-cli/src/links.rs` has `repo_link`/`pull_request_link`/`issue_link` but no `file_link`, so callers percent-encode by hand. Left out to keep this change narrow; happy to add it with the usual golden-format cross-language test if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
