### PR TITLE
feat(acp): negotiate persistent system prompts

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -132,6 +132,13 @@ fn build_initialize_params() -> serde_json::Value {
     })
 }
 
+fn read_persistent_system_prompt_capability(result: &serde_json::Value) -> bool {
+    result
+        .pointer("/_meta/capabilities/persistentSystemPrompt")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
 /// ACP client that owns an agent subprocess and communicates over its stdio.
 ///
 /// One `AcpClient` per agent process. Multiple sessions can be created on the
@@ -198,6 +205,9 @@ pub struct AcpClient {
     /// a JSON-RPC *success*, not `-32601` — which the main loop would read as
     /// a delivered steer and drop the user's message from the queue.
     steering_supported: bool,
+    /// Whether the agent accepts a persistent string-valued `_meta.systemPrompt`
+    /// on session creation.
+    persistent_system_prompt_supported: bool,
     /// Per-turn channel for receiving goose-native non-cancelling steer
     /// requests from the main loop. Installed by
     /// [`install_steer_rx`](Self::install_steer_rx) at dispatch and
@@ -548,6 +558,7 @@ impl AcpClient {
             observer_context: ObserverContext::default(),
             active_run_id: None,
             steering_supported: false,
+            persistent_system_prompt_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
         })
@@ -604,6 +615,7 @@ impl AcpClient {
             .pointer("/_meta/steering/supported")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        self.persistent_system_prompt_supported = read_persistent_system_prompt_capability(&result);
         tracing::debug!(target: "acp::init", "initialize response: {result}");
         Ok(result)
     }
@@ -625,6 +637,8 @@ impl AcpClient {
     /// - `None` — no system-prompt field in the request (legacy framing).
     /// - `Some(SystemPromptTransport::Field(text))` — bare `systemPrompt` field
     ///   (ACP protocol v2, buzz-agent, goose unused).
+    /// - `Some(SystemPromptTransport::PersistentMeta(text))` — string-valued
+    ///   `_meta.systemPrompt` for agents that explicitly advertise the extension.
     /// - `Some(SystemPromptTransport::ClaudeMeta(text))` — `_meta.systemPrompt`
     ///   as `{"append": text}`, keeping claude-agent-acp's native preset intact.
     ///
@@ -642,24 +656,7 @@ impl AcpClient {
         system_prompt: Option<SystemPromptTransport<'_>>,
         session_title: Option<&str>,
     ) -> Result<SessionNewResponse, AcpError> {
-        let mut params = serde_json::json!({
-            "cwd": cwd,
-            "mcpServers": mcp_servers,
-        });
-        match system_prompt {
-            Some(SystemPromptTransport::Field(sp)) => {
-                params["systemPrompt"] = serde_json::Value::String(sp.to_owned());
-            }
-            Some(SystemPromptTransport::ClaudeMeta(sp)) => {
-                // Merge into _meta so sessionTitle (set below) is not clobbered.
-                params["_meta"]["systemPrompt"] = serde_json::json!({ "append": sp });
-            }
-            None => {}
-        }
-        if let Some(title) = session_title {
-            // Merge — _meta may already carry systemPrompt from ClaudeMeta above.
-            params["_meta"]["sessionTitle"] = serde_json::Value::String(title.to_owned());
-        }
+        let params = build_session_new_params(cwd, mcp_servers, system_prompt, session_title);
         let result = self.send_request("session/new", params).await?;
         let session_id = result["sessionId"]
             .as_str()
@@ -865,6 +862,12 @@ impl AcpClient {
     /// for the supervisor's post-initialize log line.
     pub fn steering_supported(&self) -> bool {
         self.steering_supported
+    }
+
+    /// Whether `initialize` advertised string-valued persistent system-prompt
+    /// metadata for session creation.
+    pub fn persistent_system_prompt_supported(&self) -> bool {
+        self.persistent_system_prompt_supported
     }
 
     /// Consume and return the per-turn usage record computed from the most
@@ -2057,9 +2060,11 @@ pub struct SessionNewResponse {
 
 /// How to deliver a system prompt on `session/new`.
 ///
-/// The two variants match the two mechanisms supported by current adapters:
+/// The variants match the mechanisms supported by current adapters:
 ///
 /// - **`Field`** — bare `systemPrompt` field (ACP protocol v2, buzz-agent).
+/// - **`PersistentMeta`** — string-valued `_meta.systemPrompt`, gated by the
+///   agent's explicit `_meta.capabilities.persistentSystemPrompt` advertisement.
 /// - **`ClaudeMeta`** — `_meta.systemPrompt: {"append": text}`, used by
 ///   `claude-agent-acp` to append to the adapter's own native system prompt
 ///   while keeping its tool-use preset intact.
@@ -2067,8 +2072,38 @@ pub struct SessionNewResponse {
 pub enum SystemPromptTransport<'a> {
     /// Deliver as a bare top-level `systemPrompt` field.
     Field(&'a str),
+    /// Deliver as a string-valued `_meta.systemPrompt` extension.
+    PersistentMeta(&'a str),
     /// Deliver as `_meta.systemPrompt: {"append": text}`.
     ClaudeMeta(&'a str),
+}
+
+fn build_session_new_params(
+    cwd: &str,
+    mcp_servers: Vec<McpServer>,
+    system_prompt: Option<SystemPromptTransport<'_>>,
+    session_title: Option<&str>,
+) -> serde_json::Value {
+    let mut params = serde_json::json!({
+        "cwd": cwd,
+        "mcpServers": mcp_servers,
+    });
+    match system_prompt {
+        Some(SystemPromptTransport::Field(sp)) => {
+            params["systemPrompt"] = serde_json::Value::String(sp.to_owned());
+        }
+        Some(SystemPromptTransport::PersistentMeta(sp)) => {
+            params["_meta"]["systemPrompt"] = serde_json::Value::String(sp.to_owned());
+        }
+        Some(SystemPromptTransport::ClaudeMeta(sp)) => {
+            params["_meta"]["systemPrompt"] = serde_json::json!({ "append": sp });
+        }
+        None => {}
+    }
+    if let Some(title) = session_title {
+        params["_meta"]["sessionTitle"] = serde_json::Value::String(title.to_owned());
+    }
+    params
 }
 
 /// How to switch to a particular model on a session.
@@ -2258,13 +2293,15 @@ mod tests {
 
     #[test]
     fn persistent_system_prompt_capability_requires_explicit_true() {
-        assert!(read_persistent_system_prompt_capability(&serde_json::json!({
-            "_meta": {
-                "capabilities": {
-                    "persistentSystemPrompt": true
+        assert!(read_persistent_system_prompt_capability(
+            &serde_json::json!({
+                "_meta": {
+                    "capabilities": {
+                        "persistentSystemPrompt": true
+                    }
                 }
-            }
-        })));
+            })
+        ));
         for result in [
             serde_json::json!({}),
             serde_json::json!({"_meta": {"capabilities": {}}}),
@@ -2273,6 +2310,48 @@ mod tests {
         ] {
             assert!(!read_persistent_system_prompt_capability(&result));
         }
+    }
+
+    #[test]
+    fn session_new_params_keep_persistent_claude_and_protocol_transports_distinct() {
+        let persistent = build_session_new_params(
+            "/workspace",
+            vec![],
+            Some(SystemPromptTransport::PersistentMeta("persistent")),
+            Some("Agent · Channel"),
+        );
+        assert_eq!(
+            persistent.pointer("/_meta/systemPrompt"),
+            Some(&serde_json::json!("persistent"))
+        );
+        assert_eq!(
+            persistent.pointer("/_meta/sessionTitle"),
+            Some(&serde_json::json!("Agent · Channel"))
+        );
+        assert!(persistent.get("systemPrompt").is_none());
+
+        let claude = build_session_new_params(
+            "/workspace",
+            vec![],
+            Some(SystemPromptTransport::ClaudeMeta("append")),
+            None,
+        );
+        assert_eq!(
+            claude.pointer("/_meta/systemPrompt"),
+            Some(&serde_json::json!({"append": "append"}))
+        );
+
+        let protocol = build_session_new_params(
+            "/workspace",
+            vec![],
+            Some(SystemPromptTransport::Field("protocol")),
+            None,
+        );
+        assert_eq!(
+            protocol.get("systemPrompt"),
+            Some(&serde_json::json!("protocol"))
+        );
+        assert!(protocol.get("_meta").is_none());
     }
 
     #[test]
@@ -4012,6 +4091,38 @@ mod tests {
             !supported,
             "_meta.steering.supported: false must leave steering_supported false"
         );
+    }
+
+    async fn persistent_system_prompt_supported_after_initialize(init_result: &str) -> bool {
+        let script = format!(
+            "read -r _init; printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{result}}}'; \
+             sleep 5",
+            result = init_result,
+        );
+        let mut client = spawn_script(&script).await;
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        client.persistent_system_prompt_supported()
+    }
+
+    #[tokio::test]
+    async fn initialize_records_persistent_system_prompt_capability() {
+        let supported = persistent_system_prompt_supported_after_initialize(
+            r#"{"protocolVersion":1,"agentCapabilities":{},"_meta":{"capabilities":{"persistentSystemPrompt":true}}}"#,
+        )
+        .await;
+        assert!(supported);
+    }
+
+    #[tokio::test]
+    async fn initialize_leaves_persistent_system_prompt_unsupported_when_absent() {
+        let supported = persistent_system_prompt_supported_after_initialize(
+            r#"{"protocolVersion":1,"agentCapabilities":{}}"#,
+        )
+        .await;
+        assert!(!supported);
     }
 
     /// Test 2: no `active_run_id` + capability advertised → the bytes on the

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2257,6 +2257,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn persistent_system_prompt_capability_requires_explicit_true() {
+        assert!(read_persistent_system_prompt_capability(&serde_json::json!({
+            "_meta": {
+                "capabilities": {
+                    "persistentSystemPrompt": true
+                }
+            }
+        })));
+        for result in [
+            serde_json::json!({}),
+            serde_json::json!({"_meta": {"capabilities": {}}}),
+            serde_json::json!({"_meta": {"capabilities": {"persistentSystemPrompt": false}}}),
+            serde_json::json!({"_meta": {"capabilities": {"persistentSystemPrompt": "true"}}}),
+        ] {
+            assert!(!read_persistent_system_prompt_capability(&result));
+        }
+    }
+
+    #[test]
     fn stop_reason_parses_all_known_values() {
         assert_eq!(StopReason::from_str("end_turn"), Some(StopReason::EndTurn));
         assert_eq!(

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -4183,6 +4183,226 @@ mod tests {
         );
     }
 
+    async fn capture_system_prompt_lifecycle(
+        initialize_result: serde_json::Value,
+    ) -> (serde_json::Value, serde_json::Value, bool) {
+        let capture_path =
+            std::env::temp_dir().join(format!("buzz-acp-persistent-{}.jsonl", Uuid::new_v4()));
+        let capture = capture_path.to_string_lossy();
+        let initialize_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": initialize_result,
+        })
+        .to_string();
+        let session_new_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"sessionId": "session-1"},
+        })
+        .to_string();
+        let session_prompt_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"stopReason": "end_turn"},
+        })
+        .to_string();
+        let script = format!(
+            r#"read -r _initialize
+printf '%s\n' '{initialize_response}'
+read -r session_new
+printf '%s\n' "$session_new" > '{capture}'
+printf '%s\n' '{session_new_response}'
+read -r session_prompt
+printf '%s\n' "$session_prompt" >> '{capture}'
+printf '%s\n' '{session_prompt_response}'
+sleep 1"#
+        );
+        let mut acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
+            .await
+            .expect("spawn lifecycle test agent");
+        acp.initialize()
+            .await
+            .expect("initialize lifecycle test agent");
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "codex-acp".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.base_prompt = Some("BASE-CONTENT");
+        ctx.system_prompt = Some("SYSTEM-CONTENT".into());
+        ctx.team_instructions = Some("TEAM-CONTENT".into());
+        ctx.session_title = Some("Codex".into());
+        let core = "[Agent Memory — core]\nCORE-CONTENT";
+        let canvas = "[Channel Canvas]\nCANVAS-CONTENT";
+        let session_id = create_session_and_apply_model(
+            &mut agent,
+            &ctx,
+            Some(core),
+            Some(canvas),
+            Some("test"),
+            None,
+            None,
+        )
+        .await
+        .expect("create lifecycle test session");
+
+        let has_system_prompt_support = agent.has_system_prompt_support();
+        let batch = one_event_batch(Uuid::new_v4());
+        let prompt_blocks = crate::queue::format_prompt(
+            &batch,
+            &crate::queue::FormatPromptArgs {
+                has_system_prompt_support,
+                base_prompt: ctx.base_prompt,
+                system_prompt: ctx.system_prompt.as_deref(),
+                team_instructions: ctx.team_instructions.as_deref(),
+                agent_core: Some(core),
+                agent_canvas: Some(canvas),
+                ..Default::default()
+            },
+        );
+        let prompt_refs: Vec<&str> = prompt_blocks.iter().map(String::as_str).collect();
+        let stop_reason = agent
+            .acp
+            .session_prompt_blocks_with_idle_timeout(
+                &session_id,
+                &prompt_refs,
+                Duration::from_secs(5),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("send lifecycle test prompt");
+        assert_eq!(stop_reason, StopReason::EndTurn);
+
+        let captured = std::fs::read_to_string(&capture_path).expect("read lifecycle capture");
+        let _ = std::fs::remove_file(&capture_path);
+        let requests: Vec<serde_json::Value> = captured
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("captured request must be JSON"))
+            .collect();
+        assert_eq!(requests.len(), 2, "capture session/new then session/prompt");
+        (
+            requests[0].clone(),
+            requests[1].clone(),
+            has_system_prompt_support,
+        )
+    }
+
+    fn captured_prompt_text(request: &serde_json::Value) -> String {
+        request
+            .pointer("/params/prompt")
+            .and_then(serde_json::Value::as_array)
+            .expect("session/prompt must contain prompt blocks")
+            .iter()
+            .filter_map(|block| block.get("text").and_then(serde_json::Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[tokio::test]
+    async fn persistent_capability_sends_static_prompt_once_and_omits_it_from_user_turn() {
+        let (session_new, session_prompt, supported) = capture_system_prompt_lifecycle(json!({
+            "protocolVersion": 1,
+            "agentInfo": {"name": "codex-acp"},
+            "_meta": {"capabilities": {"persistentSystemPrompt": true}},
+        }))
+        .await;
+        assert!(supported);
+        assert_eq!(
+            session_new.pointer("/params/_meta/systemPrompt"),
+            Some(&json!(
+                "[Base]\nBASE-CONTENT\n\n[System]\nSYSTEM-CONTENT\n\n[Team Instructions]\nTEAM-CONTENT\n\n[Agent Memory — core]\nCORE-CONTENT\n\n[Channel Canvas]\nCANVAS-CONTENT"
+            ))
+        );
+        assert!(session_new.pointer("/params/systemPrompt").is_none());
+        assert!(session_new.pointer("/params/_meta/sessionTitle").is_some());
+
+        let user_prompt = captured_prompt_text(&session_prompt);
+        for repeated_section in [
+            "[Base]",
+            "[System]",
+            "[Team Instructions]",
+            "[Agent Memory — core]",
+            "[Channel Canvas]",
+        ] {
+            assert!(
+                !user_prompt.contains(repeated_section),
+                "capable agent user prompt repeated {repeated_section}: {user_prompt}"
+            );
+        }
+        assert!(user_prompt.contains("test"), "event content must remain");
+    }
+
+    #[tokio::test]
+    async fn unsupported_capabilities_omit_persistent_metadata_and_preserve_legacy_sections() {
+        let cases = [
+            (
+                "absent",
+                json!({
+                    "protocolVersion": 1,
+                    "agentInfo": {"name": "codex-acp"},
+                }),
+            ),
+            (
+                "false",
+                json!({
+                    "protocolVersion": 1,
+                    "agentInfo": {"name": "codex-acp"},
+                    "_meta": {"capabilities": {"persistentSystemPrompt": false}},
+                }),
+            ),
+            (
+                "malformed",
+                json!({
+                    "protocolVersion": 1,
+                    "agentInfo": {"name": "codex-acp"},
+                    "_meta": {"capabilities": {"persistentSystemPrompt": "true"}},
+                }),
+            ),
+            (
+                "unknown-only",
+                json!({
+                    "protocolVersion": 1,
+                    "agentInfo": {"name": "codex-acp"},
+                    "_meta": {"capabilities": {"futureCapability": true}},
+                }),
+            ),
+        ];
+
+        for (label, initialize_result) in cases {
+            let (session_new, session_prompt, supported) =
+                capture_system_prompt_lifecycle(initialize_result).await;
+            assert!(!supported, "{label} metadata must fail closed");
+            assert!(
+                session_new.pointer("/params/_meta/systemPrompt").is_none(),
+                "{label} metadata must not emit persistent metadata"
+            );
+            assert!(session_new.pointer("/params/systemPrompt").is_none());
+
+            let user_prompt = captured_prompt_text(&session_prompt);
+            for legacy_section in [
+                "[Base]\nBASE-CONTENT",
+                "[System]\nSYSTEM-CONTENT",
+                "[Team Instructions]\nTEAM-CONTENT",
+                "[Agent Memory — core]\nCORE-CONTENT",
+                "[Channel Canvas]\nCANVAS-CONTENT",
+            ] {
+                assert!(
+                    user_prompt.contains(legacy_section),
+                    "{label} legacy prompt omitted {legacy_section}: {user_prompt}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn old_zed_adapter_name_falls_through_to_protocol_version_gate() {
         // The renamed @zed-industries package predates the _meta.systemPrompt support,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -4185,7 +4185,7 @@ mod tests {
 
     async fn capture_system_prompt_lifecycle(
         initialize_result: serde_json::Value,
-    ) -> (serde_json::Value, serde_json::Value, bool) {
+    ) -> (serde_json::Value, serde_json::Value, bool, Vec<String>) {
         let capture_path =
             std::env::temp_dir().join(format!("buzz-acp-persistent-{}.jsonl", Uuid::new_v4()));
         let capture = capture_path.to_string_lossy();
@@ -4293,49 +4293,74 @@ sleep 1"#
             requests[0].clone(),
             requests[1].clone(),
             has_system_prompt_support,
+            prompt_blocks,
         )
-    }
-
-    fn captured_prompt_text(request: &serde_json::Value) -> String {
-        request
-            .pointer("/params/prompt")
-            .and_then(serde_json::Value::as_array)
-            .expect("session/prompt must contain prompt blocks")
-            .iter()
-            .filter_map(|block| block.get("text").and_then(serde_json::Value::as_str))
-            .collect::<Vec<_>>()
-            .join("\n")
     }
 
     #[tokio::test]
     async fn persistent_capability_sends_static_prompt_once_and_omits_it_from_user_turn() {
-        let (session_new, session_prompt, supported) = capture_system_prompt_lifecycle(json!({
+        let (session_new, session_prompt, supported, prompt_blocks) =
+            capture_system_prompt_lifecycle(json!({
             "protocolVersion": 1,
             "agentInfo": {"name": "codex-acp"},
             "_meta": {"capabilities": {"persistentSystemPrompt": true}},
-        }))
-        .await;
+            }))
+            .await;
         assert!(supported);
+        let combined = "[Base]\nBASE-CONTENT\n\n[System]\nSYSTEM-CONTENT\n\n[Team Instructions]\nTEAM-CONTENT\n\n[Agent Memory — core]\nCORE-CONTENT\n\n[Channel Canvas]\nCANVAS-CONTENT";
         assert_eq!(
-            session_new.pointer("/params/_meta/systemPrompt"),
-            Some(&json!(
-                "[Base]\nBASE-CONTENT\n\n[System]\nSYSTEM-CONTENT\n\n[Team Instructions]\nTEAM-CONTENT\n\n[Agent Memory — core]\nCORE-CONTENT\n\n[Channel Canvas]\nCANVAS-CONTENT"
-            ))
+            session_new,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {
+                    "cwd": ".",
+                    "mcpServers": [],
+                    "_meta": {
+                        "systemPrompt": combined,
+                        "sessionTitle": "Codex · #test",
+                    },
+                },
+            })
         );
-        assert!(session_new.pointer("/params/systemPrompt").is_none());
-        assert!(session_new.pointer("/params/_meta/sessionTitle").is_some());
-
-        let user_prompt = captured_prompt_text(&session_prompt);
-        for repeated_section in [
+        assert_eq!(
+            prompt_blocks.len(),
+            2,
+            "capable turn has context + event only"
+        );
+        let expected_prompt_blocks: Vec<serde_json::Value> = prompt_blocks
+            .iter()
+            .map(|text| json!({"type": "text", "text": text}))
+            .collect();
+        assert_eq!(
+            session_prompt,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": "session-1",
+                    "prompt": expected_prompt_blocks,
+                },
+            })
+        );
+        let user_prompt = prompt_blocks.join("\n");
+        for repeated_static_content in [
             "[Base]",
+            "BASE-CONTENT",
             "[System]",
+            "SYSTEM-CONTENT",
             "[Team Instructions]",
+            "TEAM-CONTENT",
             "[Agent Memory — core]",
+            "CORE-CONTENT",
             "[Channel Canvas]",
+            "CANVAS-CONTENT",
         ] {
             assert!(
-                !user_prompt.contains(repeated_section),
-                "capable agent user prompt repeated {repeated_section}: {user_prompt}"
+                !user_prompt.contains(repeated_static_content),
+                "capable user prompt repeated {repeated_static_content}: {user_prompt}"
             );
         }
         assert!(user_prompt.contains("test"), "event content must remain");
@@ -4378,28 +4403,56 @@ sleep 1"#
         ];
 
         for (label, initialize_result) in cases {
-            let (session_new, session_prompt, supported) =
+            let (session_new, session_prompt, supported, prompt_blocks) =
                 capture_system_prompt_lifecycle(initialize_result).await;
             assert!(!supported, "{label} metadata must fail closed");
-            assert!(
-                session_new.pointer("/params/_meta/systemPrompt").is_none(),
-                "{label} metadata must not emit persistent metadata"
+            assert_eq!(
+                session_new,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "session/new",
+                    "params": {
+                        "cwd": ".",
+                        "mcpServers": [],
+                        "_meta": {"sessionTitle": "Codex · #test"},
+                    },
+                }),
+                "{label} metadata changed the legacy session/new envelope"
             );
-            assert!(session_new.pointer("/params/systemPrompt").is_none());
-
-            let user_prompt = captured_prompt_text(&session_prompt);
-            for legacy_section in [
-                "[Base]\nBASE-CONTENT",
-                "[System]\nSYSTEM-CONTENT",
-                "[Team Instructions]\nTEAM-CONTENT",
-                "[Agent Memory — core]\nCORE-CONTENT",
-                "[Channel Canvas]\nCANVAS-CONTENT",
-            ] {
-                assert!(
-                    user_prompt.contains(legacy_section),
-                    "{label} legacy prompt omitted {legacy_section}: {user_prompt}"
-                );
-            }
+            assert_eq!(
+                prompt_blocks.len(),
+                7,
+                "legacy turn has five static + context + event blocks"
+            );
+            assert_eq!(
+                &prompt_blocks[..5],
+                [
+                    "[Base]\nBASE-CONTENT",
+                    "[System]\nSYSTEM-CONTENT",
+                    "[Team Instructions]\nTEAM-CONTENT",
+                    "[Agent Memory — core]\nCORE-CONTENT",
+                    "[Channel Canvas]\nCANVAS-CONTENT",
+                ],
+                "{label} legacy static block order changed"
+            );
+            let expected_prompt_blocks: Vec<serde_json::Value> = prompt_blocks
+                .iter()
+                .map(|text| json!({"type": "text", "text": text}))
+                .collect();
+            assert_eq!(
+                session_prompt,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "session/prompt",
+                    "params": {
+                        "sessionId": "session-1",
+                        "prompt": expected_prompt_blocks,
+                    },
+                }),
+                "{label} legacy session/prompt envelope changed"
+            );
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -4138,6 +4138,32 @@ mod tests {
     }
 
     #[test]
+    fn explicit_persistent_system_prompt_capability_enables_protocol_v1_agent() {
+        assert!(has_system_prompt_support(1, "codex-acp", None, true));
+        assert_eq!(
+            session_new_system_prompt(false, 1, "codex-acp", true, Some("instructions")),
+            Some(SystemPromptTransport::PersistentMeta("instructions"))
+        );
+    }
+
+    #[test]
+    fn absent_persistent_system_prompt_capability_preserves_legacy_fallback() {
+        assert!(!has_system_prompt_support(1, "codex-acp", None, false));
+        assert_eq!(
+            session_new_system_prompt(false, 1, "codex-acp", false, Some("instructions")),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_persistent_capability_prefers_meta_over_protocol_v2_field() {
+        assert_eq!(
+            session_new_system_prompt(false, 2, "future-agent", true, Some("instructions")),
+            Some(SystemPromptTransport::PersistentMeta("instructions"))
+        );
+    }
+
+    #[test]
     fn old_zed_adapter_name_falls_through_to_protocol_version_gate() {
         // The renamed @zed-industries package predates the _meta.systemPrompt support,
         // so it must not be treated as capable and stays on legacy user-message framing.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -183,13 +183,14 @@ fn has_system_prompt_support(
     protocol_version: u32,
     agent_name: &str,
     goose_system_prompt_supported: Option<bool>,
+    persistent_system_prompt_supported: bool,
 ) -> bool {
     if agent_name == "goose" {
         goose_system_prompt_supported == Some(true)
     } else if agent_name == CLAUDE_AGENT_ACP_NAME {
         true
     } else {
-        protocol_version >= 2
+        persistent_system_prompt_supported || protocol_version >= 2
     }
 }
 
@@ -197,12 +198,17 @@ fn session_new_system_prompt<'a>(
     is_goose: bool,
     protocol_version: u32,
     agent_name: &str,
+    persistent_system_prompt_supported: bool,
     prompt: Option<&'a str>,
 ) -> Option<SystemPromptTransport<'a>> {
-    if is_goose || (protocol_version < 2 && agent_name != CLAUDE_AGENT_ACP_NAME) {
+    if is_goose {
         None
     } else if agent_name == CLAUDE_AGENT_ACP_NAME {
         prompt.map(SystemPromptTransport::ClaudeMeta)
+    } else if persistent_system_prompt_supported {
+        prompt.map(SystemPromptTransport::PersistentMeta)
+    } else if protocol_version < 2 {
+        None
     } else {
         prompt.map(SystemPromptTransport::Field)
     }
@@ -214,6 +220,7 @@ impl OwnedAgent {
             self.protocol_version,
             &self.agent_name,
             self.goose_system_prompt_supported,
+            self.acp.persistent_system_prompt_supported(),
         )
     }
 }
@@ -892,8 +899,8 @@ async fn create_session_and_apply_model(
     channel_type: Option<&str>,
 ) -> Result<String, AcpError> {
     // Build base_prompt + system_prompt + agent core + canvas metadata into a
-    // single prompt. Standard protocol-v2 agents receive it in `session/new`;
-    // Goose receives it through the custom request below. Legacy agents receive
+    // single prompt. Protocol-v2 or explicitly capable agents receive it in
+    // `session/new`; Goose receives it through the custom request below. Legacy agents receive
     // the same content as user-message sections via `format_prompt`. Core carries
     // its own `[Agent Memory — core]` header, and canvas carries its own
     // `[Channel Canvas]` header; both are appended with a blank-line separator.
@@ -920,17 +927,20 @@ async fn create_session_and_apply_model(
         ctx.session_title.as_deref(),
     );
 
+    let persistent_system_prompt_supported = agent.acp.persistent_system_prompt_supported();
+    let system_prompt_transport = session_new_system_prompt(
+        is_goose,
+        agent.protocol_version,
+        &agent.agent_name,
+        persistent_system_prompt_supported,
+        combined_system_prompt.as_deref(),
+    );
     let resp = agent
         .acp
         .session_new_full(
             &ctx.cwd,
             mcp_servers,
-            session_new_system_prompt(
-                is_goose,
-                agent.protocol_version,
-                &agent.agent_name,
-                combined_system_prompt.as_deref(),
-            ),
+            system_prompt_transport,
             session_title.as_deref(),
         )
         .await?;
@@ -4097,33 +4107,33 @@ mod tests {
 
     #[test]
     fn goose_uses_system_prompt_only_after_custom_method_succeeds() {
-        assert!(!has_system_prompt_support(2, "goose", None));
-        assert!(!has_system_prompt_support(2, "goose", Some(false)));
-        assert!(has_system_prompt_support(2, "goose", Some(true)));
-        assert!(has_system_prompt_support(1, "goose", Some(true)));
-        assert!(has_system_prompt_support(2, "buzz-agent", None));
+        assert!(!has_system_prompt_support(2, "goose", None, false));
+        assert!(!has_system_prompt_support(2, "goose", Some(false), false));
+        assert!(has_system_prompt_support(2, "goose", Some(true), false));
+        assert!(has_system_prompt_support(1, "goose", Some(true), false));
+        assert!(has_system_prompt_support(2, "buzz-agent", None, false));
         // Goose never receives system prompt via session/new (uses post-hoc method).
         assert_eq!(
-            session_new_system_prompt(true, 2, "goose", Some("instructions")),
+            session_new_system_prompt(true, 2, "goose", false, Some("instructions")),
             None
         );
         // Protocol-v2 non-goose gets Field transport.
         assert_eq!(
-            session_new_system_prompt(false, 2, "buzz-agent", Some("instructions")),
+            session_new_system_prompt(false, 2, "buzz-agent", false, Some("instructions")),
             Some(SystemPromptTransport::Field("instructions"))
         );
         // Protocol-v1 non-goose, non-claude gets None (legacy user-message framing).
         assert_eq!(
-            session_new_system_prompt(false, 1, "codex", Some("instructions")),
+            session_new_system_prompt(false, 1, "codex", false, Some("instructions")),
             None
         );
         // claude-agent-acp gets ClaudeMeta transport regardless of protocol version.
         assert_eq!(
-            session_new_system_prompt(false, 1, CLAUDE_AGENT_ACP_NAME, Some("instructions")),
+            session_new_system_prompt(false, 1, CLAUDE_AGENT_ACP_NAME, false, Some("instructions")),
             Some(SystemPromptTransport::ClaudeMeta("instructions"))
         );
         assert_eq!(
-            session_new_system_prompt(true, 1, CLAUDE_AGENT_ACP_NAME, Some("instructions")),
+            session_new_system_prompt(true, 1, CLAUDE_AGENT_ACP_NAME, false, Some("instructions")),
             None,
             "goose path must never produce a transport even when agent_name matches"
         );
@@ -4133,8 +4143,18 @@ mod tests {
     fn claude_agent_acp_has_system_prompt_support_regardless_of_protocol_version() {
         // claude-agent-acp declares protocolVersion:1 but supports _meta.systemPrompt;
         // has_system_prompt_support must return true so user-message framing is suppressed.
-        assert!(has_system_prompt_support(1, CLAUDE_AGENT_ACP_NAME, None));
-        assert!(has_system_prompt_support(2, CLAUDE_AGENT_ACP_NAME, None));
+        assert!(has_system_prompt_support(
+            1,
+            CLAUDE_AGENT_ACP_NAME,
+            None,
+            false
+        ));
+        assert!(has_system_prompt_support(
+            2,
+            CLAUDE_AGENT_ACP_NAME,
+            None,
+            false
+        ));
     }
 
     #[test]
@@ -4168,8 +4188,8 @@ mod tests {
         // The renamed @zed-industries package predates the _meta.systemPrompt support,
         // so it must not be treated as capable and stays on legacy user-message framing.
         let old_name = "@zed-industries/claude-code-acp";
-        assert!(!has_system_prompt_support(1, old_name, None));
-        assert!(has_system_prompt_support(2, old_name, None));
+        assert!(!has_system_prompt_support(1, old_name, None, false));
+        assert!(has_system_prompt_support(2, old_name, None, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Buzz-managed agents receive a sizeable block of static instructions: the managed-agent base prompt plus configured system, team/core, and channel-canvas context. For ACP adapters without a recognized persistent prompt transport, Buzz currently includes that static material in ordinary user prompts. This consumes context repeatedly and makes downstream conversation records harder to read and reason about.

This PR adds capability-negotiated persistent system prompts to `buzz-acp`:

- read `_meta.capabilities.persistentSystemPrompt` from the adapter's `initialize` response;
- when advertised, send the assembled static prompt once in `session/new` as `_meta.systemPrompt`;
- omit that static material from ordinary prompts after session creation;
- preserve the existing Claude-specific `_meta.systemPrompt.append`, Goose, and protocol-v2 transports;
- retain the legacy repeated-prompt fallback for adapters that advertise no persistent transport;
- pin the exact wire requests and prompt lifecycle in regression tests.

The resulting path is:

```text
Buzz static context
  -> ACP session/new _meta.systemPrompt
  -> adapter-owned persistent instructions

ordinary channel turns
  -> only dynamic user/channel content
```

### Companion work

**Hard dependency for the accepted Codex path:** the companion `codex-acp` contribution advertises the capability and persists `_meta.systemPrompt` as Codex developer instructions:

https://github.com/agentclientprotocol/codex-acp/compare/main...Peakhunter:codex-acp:fix/buzz-persistent-developer-instructions?expand=1

The companion branch was live-tested at exact head `1cf677dbe2801c4dbab678fc9e479a4a7fd87aa6`.

Current Claude support remains on its existing provider-specific transport; this PR does not require a Claude adapter change.

### Scope

This change owns prompt transport and repetition only. It does not add durable channel-to-ACP-session persistence across a Buzz Desktop restart, change Codex thread visibility in ChatGPT, alter lazy-pool sizing, or change outbound relay delivery/network policy.

### Related work

- **Addresses part of #3242:** this PR removes repeated Buzz-owned static Base/System/team/core/canvas material for adapters that explicitly advertise persistent prompt support. It does not deduplicate dynamic thread context, so it should not close the broader issue by itself.
- **Related but not fixed — #5342:** supervised restart acceptance confirmed that Buzz loses its process-local channel-to-session mapping and creates a new ACP/Codex session after Desktop restart. The new session still receives static instructions exactly once, but durable restart continuity remains separate work.
- **Complementary implementation — #4183:** that PR sends standing context once through the legacy user-message path for adapters without a persistent system-prompt transport. This PR instead negotiates adapter-owned system/developer instructions, preserving their authority and retaining the legacy fallback for unsupported adapters. The two approaches are semantically complementary, although both touch `pool.rs` and may require mechanical reconciliation depending on merge order.

No duplicate issue or pull request was found for the capability-negotiated transport introduced here.

### Testing

Automated `buzz-acp` verification:

- library tests: **695 passed**;
- integration tests: **9 passed**;
- combined: **704 passed, 0 failed**.

Supervised macOS acceptance used the coordinated frozen Buzz and `codex-acp` candidates:

- rebuilt `buzz-acp` SHA-256: `b5a2cb7113a9ddadd76d93679ca6df7eb1a4e0eca6a0e5a8ec6577f53c415be9`;
- every adapter initialization advertised `persistentSystemPrompt: true`;
- two ordinary turns continued the same main Codex session;
- static Buzz instructions appeared once in initial developer instructions;
- static Buzz instructions appeared zero times in either ordinary user-prompt record;
- after an application restart, the new session again received static instructions once and its ordinary prompt contained no repeated static material.

The live-tested source head was `282988ea71869e82f05131d88307c4fce3750e49`. The publication head is `1db51a13a60e09f0876c41e163fc082453c45456`; it differs only by required DCO trailers. Both heads have the identical Git tree `ae3312d03bc5bf757ccdb26c35b819194c378ba8`, so the tested source and artifact are unchanged.

There is no visual UI change. Acceptance relied on UI continuity plus protocol/downstream structural evidence rather than treating visible replies alone as proof.