### PR TITLE
fix(desktop): set the configured app icon as the macOS dock icon

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ webkit2gtk = { version = "=2.0.2", features = ["v2_22"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = { version = "0.6", default-features = false, features = ["std"] }
 objc2 = { version = "0.6.4", default-features = false }
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSEvent", "NSHapticFeedback", "NSMenu", "NSMenuItem", "NSStatusItem", "block2"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSEvent", "NSHapticFeedback", "NSImage", "NSMenu", "NSMenuItem", "NSResponder", "NSStatusItem", "block2"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSDictionary", "NSError", "NSBundle", "NSObject", "NSProcessInfo", "NSString"] }
 objc2-user-notifications = { version = "0.3.2", default-features = false, features = ["block2", "UNNotification", "UNNotificationContent", "UNNotificationRequest", "UNNotificationResponse", "UNNotificationSettings", "UNNotificationTrigger", "UNUserNotificationCenter"] }
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -83,6 +83,36 @@ use tauri::{Emitter, Manager, RunEvent, WindowEvent};
 use tauri_plugin_window_state::StateFlags;
 #[cfg(target_os = "macos")]
 use tray_menu::show_main_window;
+
+#[cfg(target_os = "macos")]
+fn set_configured_dock_icon<R: tauri::Runtime>(app: &tauri::App<R>) {
+    use objc2::{AllocAnyThread, MainThreadMarker};
+    use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::NSString;
+    use std::path::Path;
+
+    let Some(icon_path) = app
+        .config()
+        .bundle
+        .icon
+        .iter()
+        .find(|path| Path::new(path).exists())
+    else {
+        return;
+    };
+    let Some(main_thread) = MainThreadMarker::new() else {
+        return;
+    };
+    let icon_path = NSString::from_str(icon_path);
+    let Some(image) = NSImage::initWithContentsOfFile(NSImage::alloc(), &icon_path) else {
+        return;
+    };
+
+    unsafe {
+        NSApplication::sharedApplication(main_thread).setApplicationIconImage(Some(&image));
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // mesh-llm's async chains (model download, node start/join) overflow
@@ -312,6 +342,7 @@ pub fn run() {
             let app_handle = app.handle().clone();
             #[cfg(target_os = "macos")]
             {
+                set_configured_dock_icon(app);
                 tray_menu::init(&app_handle)?;
                 macos_notifications::init(&app_handle)?;
             }

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -82,9 +82,15 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
 
         ICON_DIR="$WORKTREE_ROOT/desktop/src-tauri/target/dev-icons"
         mkdir -p "$ICON_DIR"
-        DEV_ICON="$ICON_DIR/icon.icns"
         GENERATE_DEV_ICON="$WORKTREE_ROOT/scripts/generate-dev-icon.swift"
         BASE_ICON="$WORKTREE_ROOT/desktop/src-tauri/icons/icon.icns"
+        # Version the generated dev-icon filename by the base icon's size+mtime so a
+        # changed base icon writes to a NEW path. macOS caches rendered dock tiles by
+        # icon path and does not reliably refresh when a file's contents change under
+        # the same name, which strands the old icon. A fresh path sidesteps that.
+        ICON_VER=$(stat -f "%z-%m" "$BASE_ICON" 2>/dev/null | /sbin/md5 2>/dev/null | tr -cd '0-9a-f' | cut -c1-10)
+        [ -n "$ICON_VER" ] || ICON_VER="v"
+        DEV_ICON="$ICON_DIR/icon-${ICON_VER}.icns"
 
         if swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${BUZZ_WORKTREE_LABEL}"


### PR DESCRIPTION
## Problem

`tauri dev` runs the desktop app as a bare Mach-O executable rather than a `.app` bundle. On macOS a bundle-less binary has no dock icon, so during development the Dock shows a generic executable tile instead of the app's icon.

## Fix

Set the dock icon at runtime from the app's resolved bundle icon:

- Add a macOS-only `set_configured_dock_icon` that takes the first existing `bundle.icon` path, loads it as an `NSImage`, and calls `NSApplication.setApplicationIconImage`. It's called from the `setup` hook and silently no-ops when the icon is missing or can't be loaded — so bundled release builds (which already get their dock icon from the app bundle) are unaffected.
- Enable the `objc2-app-kit` `NSApplication`, `NSImage`, and `NSResponder` features required by the above.
- `scripts/instance-env.sh`: version the generated dev-icon filename by the base icon's size+mtime so changing the icon writes to a fresh path. macOS caches rendered dock tiles by icon path and doesn't reliably refresh when a file's contents change under the same name, which otherwise strands the old tile.

## Notes

- macOS-only; no behavior change on other platforms, and a no-op in bundled release builds.

## Testing

- `cargo build` (desktop/src-tauri) passes.
- Verified in `tauri dev` on macOS: the Dock now shows the configured app icon instead of the generic executable tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
