### PR TITLE
Harden NIP-29 discovery and local compose defaults

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -74,6 +74,20 @@ impl StopReason {
     }
 }
 
+/// Per-turn observations about whether the agent produced private ACP text and
+/// whether it attempted a public Buzz room send.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct TurnOutputObservations {
+    pub agent_message_chunk: bool,
+    pub public_send_tool_call: bool,
+}
+
+impl TurnOutputObservations {
+    pub(crate) fn text_without_public_send(self) -> bool {
+        self.agent_message_chunk && !self.public_send_tool_call
+    }
+}
+
 /// Errors that can occur in the ACP client.
 #[derive(Debug, thiserror::Error)]
 pub enum AcpError {
@@ -211,6 +225,9 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Best-effort per-turn observations used to detect private ACP text that
+    /// never became a public Buzz room reply.
+    turn_output_observations: TurnOutputObservations,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +567,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            turn_output_observations: TurnOutputObservations::default(),
         })
     }
 
@@ -754,6 +772,7 @@ impl AcpClient {
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
+        self.reset_turn_output_observations();
 
         // Mark the usage tracker as in-flight for this turn BEFORE sending the
         // prompt so that any setup notifications recorded earlier are not
@@ -862,6 +881,14 @@ impl AcpClient {
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
         self.goose_usage.take()
+    }
+
+    pub(crate) fn reset_turn_output_observations(&mut self) {
+        self.turn_output_observations = TurnOutputObservations::default();
+    }
+
+    pub(crate) fn take_turn_output_observations(&mut self) -> TurnOutputObservations {
+        std::mem::take(&mut self.turn_output_observations)
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1713,6 +1740,7 @@ impl AcpClient {
 
         match update_type {
             "agent_message_chunk" => {
+                self.turn_output_observations.agent_message_chunk = true;
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
                 }
@@ -1727,6 +1755,9 @@ impl AcpClient {
                     .get("kind")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
+                if is_public_send_tool_call(title, kind) {
+                    self.turn_output_observations.public_send_tool_call = true;
+                }
                 tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
                 true
             }
@@ -2161,6 +2192,16 @@ pub fn model_in_catalog(
                 .iter()
                 .any(|model| model.get("modelId").and_then(|v| v.as_str()) == Some(desired_model))
         })
+}
+
+fn is_public_send_tool_call(title: &str, kind: &str) -> bool {
+    [title, kind].iter().any(|value| {
+        let lower = value.to_ascii_lowercase();
+        lower == "send_message"
+            || lower.ends_with(".send_message")
+            || lower.ends_with("::send_message")
+            || lower.ends_with("__send_message")
+    })
 }
 
 // ─── Drop: kill child process ─────────────────────────────────────────────────
@@ -3252,6 +3293,64 @@ mod tests {
             matches!(result, Err(AcpError::IdleTimeout(_))),
             "expected IdleTimeout after silence, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn no_public_send_observation_records_agent_text_without_send_tool() {
+        let mut client = spawn_inert_client().await;
+        client.reset_turn_output_observations();
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"text": "draft reply visible only on ACP stdout"}
+                }
+            }
+        });
+
+        let _ = client.handle_session_update(&msg);
+
+        let observations = client.take_turn_output_observations();
+        assert!(observations.agent_message_chunk);
+        assert!(!observations.public_send_tool_call);
+        assert!(observations.text_without_public_send());
+    }
+
+    #[tokio::test]
+    async fn no_public_send_observation_is_suppressed_by_send_message_tool_call() {
+        let mut client = spawn_inert_client().await;
+        client.reset_turn_output_observations();
+        let stream_msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"text": "I will reply publicly."}
+                }
+            }
+        });
+        let tool_msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "title": "send_message",
+                    "kind": "mcp"
+                }
+            }
+        });
+
+        let _ = client.handle_session_update(&stream_msg);
+        let _ = client.handle_session_update(&tool_msg);
+
+        let observations = client.take_turn_output_observations();
+        assert!(observations.agent_message_chunk);
+        assert!(observations.public_send_tool_call);
+        assert!(!observations.text_without_public_send());
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2829,28 +2829,18 @@ fn try_native_steer(
     prompt_tag: String,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
-    // Build the steer body: framing strings come from
-    // `queue::native_steer_framing()` (Eva's drift-proof requirement —
-    // native and cancel+merge fallback share these so the agent gets the
-    // same orientation regardless of transport). The single event block
-    // is rendered by `queue::format_event_block`, the same function
-    // `queue::format_prompt` uses internally for `[Buzz event: …]`
-    // sections, so the rendering also cannot drift.
+    // Build the steer body through queue's native-steer formatter. It shares
+    // steer framing, event rendering, and human-facing reply anchoring with
+    // the normal cancel+merge fallback so non-cancelling delivery cannot
+    // become a private ACP-text-only path.
     //
     // Passing `None` for `channel_info` / `profile_lookup` is intentional:
     // native steer is a *delta* into a live turn — the agent already saw
     // channel context and the actor's profile in the original prompt,
     // duplicating it here would defeat the point of non-cancelling
     // steering (which is to inject only what's new).
-    let (header, closing) = queue::native_steer_framing();
     let event_id_hex = event.id.to_hex();
-    let be = queue::BatchEvent {
-        event,
-        prompt_tag: prompt_tag.clone(),
-        received_at: std::time::Instant::now(),
-    };
-    let event_block = queue::format_event_block(channel_id, None, &be, None);
-    let body = format!("{header}\n\n[Buzz event: {prompt_tag}]\n{event_block}\n\n{closing}");
+    let body = queue::format_native_steer_prompt(channel_id, event, prompt_tag, None, None);
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -32,6 +32,7 @@ use uuid::Uuid;
 use crate::acp::{
     extract_model_config_options, extract_model_state, model_in_catalog,
     resolve_model_switch_method, AcpClient, AcpError, McpServer, ModelSwitchMethod, StopReason,
+    TurnOutputObservations,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
@@ -290,7 +291,7 @@ pub enum ControlSignal {
 /// The read loop owns the `AcpClient`'s reader/writer for the duration of the
 /// turn, so we cannot drive a steer write from the main thread directly. The
 /// main loop carries the steer prompt body (already framed by
-/// `queue::native_steer_framing()` + `queue::format_event_block`); the read
+/// `queue::format_native_steer_prompt`); the read
 /// loop completes `sessionId` (lexical) and `expectedRunId`
 /// (`AcpClient::active_run_id` at write time) when it actually emits the
 /// JSON-RPC request. The main loop awaits a `SteerAck` on the `ack_tx`
@@ -323,7 +324,7 @@ pub enum ControlSignal {
 pub struct SteerRequest {
     /// Prompt body text blocks. Each entry becomes one `text` content
     /// block in `params.prompt`. Built by the main loop via
-    /// `queue::native_steer_framing()` + `queue::format_event_block` so
+    /// `queue::format_native_steer_prompt` so
     /// the wording cannot drift from the cancel+merge fallback path.
     pub prompt_blocks: Vec<String>,
     /// Oneshot for the read loop to report the outcome.
@@ -2055,6 +2056,15 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        let output_observations = agent.acp.take_turn_output_observations();
+                        log_no_public_send_observation(
+                            &source,
+                            &StopReason::EndTurn,
+                            &output_observations,
+                            observer_channel_id,
+                            &session_id,
+                            &turn_id,
+                        );
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2117,6 +2127,15 @@ pub async fn run_prompt_task(
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
+            let output_observations = agent.acp.take_turn_output_observations();
+            log_no_public_send_observation(
+                &source,
+                &stop_reason,
+                &output_observations,
+                observer_channel_id,
+                &session_id,
+                &turn_id,
+            );
             let usage = agent.acp.take_turn_usage();
             publish_agent_turn_metric(
                 &ctx,
@@ -3360,6 +3379,35 @@ fn log_stop_reason(source: &PromptSource, stop_reason: &StopReason) {
     }
 }
 
+fn should_warn_no_public_send_observation(
+    source: &PromptSource,
+    stop_reason: &StopReason,
+    output: &TurnOutputObservations,
+) -> bool {
+    matches!(source, PromptSource::Channel(_))
+        && matches!(stop_reason, StopReason::EndTurn)
+        && output.text_without_public_send()
+}
+
+fn log_no_public_send_observation(
+    source: &PromptSource,
+    stop_reason: &StopReason,
+    output: &TurnOutputObservations,
+    channel_id: Option<Uuid>,
+    session_id: &str,
+    turn_id: &str,
+) {
+    if should_warn_no_public_send_observation(source, stop_reason, output) {
+        tracing::warn!(
+            target: "pool::prompt",
+            ?channel_id,
+            %session_id,
+            %turn_id,
+            "human-facing turn streamed ACP text but did not call send_message; no public Buzz reply was published"
+        );
+    }
+}
+
 //
 // Two-phase lifecycle visible to users:
 //   👀  "seen"    — event was queued and an agent will handle it
@@ -3994,6 +4042,45 @@ mod tests {
         // message is left untouched even when a base_prompt is present.
         let composed = prepend_base_for_legacy(2, Some("you are a helpful agent"), "hello channel");
         assert_eq!(composed, "hello channel");
+    }
+
+    #[test]
+    fn no_public_send_observation_warns_for_channel_end_turn_text_only() {
+        let source = PromptSource::Channel(Uuid::new_v4());
+        let observations = TurnOutputObservations {
+            agent_message_chunk: true,
+            public_send_tool_call: false,
+        };
+
+        assert!(should_warn_no_public_send_observation(
+            &source,
+            &StopReason::EndTurn,
+            &observations
+        ));
+    }
+
+    #[test]
+    fn no_public_send_observation_ignores_heartbeat_and_send_tool_turns() {
+        let text_only = TurnOutputObservations {
+            agent_message_chunk: true,
+            public_send_tool_call: false,
+        };
+        let sent_publicly = TurnOutputObservations {
+            agent_message_chunk: true,
+            public_send_tool_call: true,
+        };
+        let channel = PromptSource::Channel(Uuid::new_v4());
+
+        assert!(!should_warn_no_public_send_observation(
+            &PromptSource::Heartbeat,
+            &StopReason::EndTurn,
+            &text_only
+        ));
+        assert!(!should_warn_no_public_send_observation(
+            &channel,
+            &StopReason::EndTurn,
+            &sent_publicly
+        ));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1625,6 +1625,64 @@ pub(crate) fn native_steer_framing() -> (&'static str, &'static str) {
     (framing.new_header_single, framing.closing_note)
 }
 
+/// Format the single-event body delivered by the goose-native steer path.
+///
+/// Native steer is still a delta into an in-flight turn, but it must preserve
+/// the normal human-facing reply contract: if the steered event is a human
+/// mention or room message, the agent is reminded to publish an ordinary Buzz
+/// reply anchored to the triggering event/thread instead of only streaming
+/// private ACP text.
+pub(crate) fn format_native_steer_prompt(
+    channel_id: Uuid,
+    event: Event,
+    prompt_tag: String,
+    channel_info: Option<&PromptChannelInfo>,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> String {
+    let thread_tags = parse_thread_tags(&event);
+    let is_dm = channel_info
+        .map(|ci| ci.channel_type == "dm")
+        .unwrap_or(false);
+    let sender_pubkey = event.pubkey.to_hex();
+    let triggering_event_id = event.id.to_hex();
+    let reply_anchor = if is_dm {
+        thread_tags
+            .root_event_id
+            .is_some()
+            .then(|| triggering_event_id.clone())
+    } else {
+        resolve_reply_anchor(
+            &sender_pubkey,
+            &thread_tags,
+            &triggering_event_id,
+            profile_lookup,
+        )
+    };
+
+    let be = BatchEvent {
+        event,
+        prompt_tag: prompt_tag.clone(),
+        received_at: Instant::now(),
+    };
+    let (header, closing) = native_steer_framing();
+    [
+        format_context_hints(
+            channel_id,
+            channel_info,
+            &thread_tags,
+            is_dm,
+            false,
+            reply_anchor.as_deref(),
+        ),
+        format!(
+            "{header}\n\n[Buzz event: {prompt_tag}]\n{}",
+            format_event_block(channel_id, channel_info, &be, profile_lookup)
+        ),
+        closing.to_string(),
+    ]
+    .join("\n\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1934,6 +1992,62 @@ mod tests {
         // Both the original and new content must survive the merge.
         assert!(prompt.contains("the original task"));
         assert!(prompt.contains("the new message"));
+    }
+
+    #[test]
+    fn test_native_steer_framing_includes_top_level_human_reply_instruction() {
+        let ch = Uuid::new_v4();
+        let event = make_event("@agent can you see this?");
+        let event_id = event.id.to_hex();
+
+        let prompt = format_native_steer_prompt(ch, event, "@mention".into(), None, None);
+
+        assert!(
+            prompt.contains("[Context]"),
+            "native steer should keep the normal context section"
+        );
+        assert!(
+            prompt.contains("arrived while you were working"),
+            "native steer should keep steer merge framing"
+        );
+        assert!(
+            prompt.contains(&format!("--reply-to {event_id}")),
+            "top-level human steer should tell the agent to publish a public reply anchored to the triggering event"
+        );
+        assert!(
+            prompt.contains("new top-level message"),
+            "top-level native steer should use the new-thread reply instruction"
+        );
+    }
+
+    #[test]
+    fn test_native_steer_framing_anchors_thread_reply_to_root() {
+        let ch = Uuid::new_v4();
+        let root_id = "a".repeat(64);
+        let parent_id = "b".repeat(64);
+        let event = make_event_with_tags(
+            "@agent please answer in this thread",
+            vec![
+                vec!["e".into(), root_id.clone(), "".into(), "root".into()],
+                vec!["e".into(), parent_id.clone(), "".into(), "reply".into()],
+            ],
+        );
+        let event_id = event.id.to_hex();
+
+        let prompt = format_native_steer_prompt(ch, event, "@mention".into(), None, None);
+
+        assert!(
+            prompt.contains(&format!("--reply-to {root_id}")),
+            "threaded human steer should anchor the public reply to the root"
+        );
+        assert!(
+            !prompt.contains(&format!("--reply-to {parent_id}")),
+            "threaded native steer should not deepen the reply chain"
+        );
+        assert!(
+            !prompt.contains(&format!("--reply-to {event_id}")),
+            "threaded native steer should not anchor to the triggering nested event"
+        );
     }
 
     #[test]

--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -20,15 +20,17 @@
 //! newest timestamp and collide on the bumped second. run.sh serialization is
 //! the guard against parallel adds (e.g. `xargs -P`).
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use anyhow::Result;
 use buzz_core::kind::KIND_NIP43_MEMBERSHIP_LIST;
 use buzz_core::tenant::{relay_url_authority, TenantContext};
+use buzz_core::StoredEvent;
 use buzz_db::{Db, DbConfig};
 use buzz_pubsub::{EventTopic, PubSubManager};
 use clap::{Parser, Subcommand};
-use nostr::{EventBuilder, Keys, Kind, Tag};
+use nostr::{Event, EventBuilder, Keys, Kind, Tag};
 use tracing::warn;
 
 #[derive(Parser)]
@@ -81,7 +83,7 @@ enum Command {
         #[command(subcommand)]
         command: ProductFeedbackCommand,
     },
-    /// Emit kind:39000/39002 events for channels missing them.
+    /// Emit kind:39000/39001/39002 events for channels missing them.
     ///
     /// Channels created via direct SQL (seed scripts, pre-migration data) won't
     /// have Nostr discovery events. This command creates them so pure-nostr
@@ -459,7 +461,9 @@ async fn resolve_admin_tenant(db: &Db) -> Result<TenantContext> {
 }
 
 async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
-    use buzz_core::kind::KIND_NIP29_GROUP_ADMINS;
+    use buzz_core::kind::{
+        KIND_NIP29_GROUP_ADMINS, KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA,
+    };
     use buzz_db::event::EventQuery;
 
     let db = connect_db().await?;
@@ -494,23 +498,43 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
     for channel in &channels {
         let channel_id_str = channel.id.to_string();
 
-        // Check if kind:39000 already exists
-        let existing = db
+        let discovery_events = db
             .query_events(&EventQuery {
-                kinds: Some(vec![39000]),
+                kinds: Some(vec![
+                    KIND_NIP29_GROUP_METADATA as i32,
+                    KIND_NIP29_GROUP_ADMINS as i32,
+                    KIND_NIP29_GROUP_MEMBERS as i32,
+                ]),
                 d_tag: Some(channel_id_str.clone()),
-                limit: Some(1),
+                limit: Some(100),
                 ..EventQuery::for_community(tenant.community())
             })
             .await
             .unwrap_or_default();
 
-        if !existing.is_empty() {
+        let members = db.get_members(tenant.community(), channel.id).await?;
+        let (admin_roles, member_roles) = discovery_role_maps(
+            members
+                .iter()
+                .map(|member| (hex::encode(&member.pubkey), member.role.clone())),
+            hex::encode(&channel.created_by),
+        );
+        if std::env::var("BUZZ_ADMIN_RECONCILE_DEBUG").as_deref() == Ok("1") {
+            eprintln!(
+                "reconcile-debug channel={} creator={} admins={:?} members={:?}",
+                channel.name,
+                short_hex(&channel.created_by),
+                prefixed_roles(&admin_roles),
+                prefixed_roles(&member_roles)
+            );
+        }
+        let admin_pubkeys: BTreeSet<String> = admin_roles.keys().cloned().collect();
+        let member_pubkeys: BTreeSet<String> = member_roles.keys().cloned().collect();
+
+        if discovery_events_are_complete(&discovery_events, &admin_pubkeys, &member_pubkeys) {
             skipped += 1;
             continue;
         }
-
-        let members = db.get_members(tenant.community(), channel.id).await?;
 
         // kind:39000 — channel metadata
         {
@@ -532,7 +556,8 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
             tags.push(Tag::parse(["closed"])?);
             tags.push(Tag::parse(["t", &channel.channel_type])?);
 
-            let event = EventBuilder::new(Kind::Custom(39000), "")
+            let event = EventBuilder::new(Kind::Custom(KIND_NIP29_GROUP_METADATA as u16), "")
+                .allow_self_tagging()
                 .tags(tags)
                 .sign_with_keys(&relay_keys)
                 .map_err(|e| anyhow::anyhow!("sign kind:39000: {e}"))?;
@@ -543,14 +568,11 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
         // kind:39001 — admins
         {
             let mut tags: Vec<Tag> = vec![Tag::parse(["d", &channel_id_str])?];
-            for m in members
-                .iter()
-                .filter(|m| m.role == "owner" || m.role == "admin")
-            {
-                let pk = hex::encode(&m.pubkey);
-                tags.push(Tag::parse(["p", &pk, &m.role])?);
+            for (pk, role) in &admin_roles {
+                tags.push(Tag::parse(["p", pk, role])?);
             }
             let event = EventBuilder::new(Kind::Custom(KIND_NIP29_GROUP_ADMINS as u16), "")
+                .allow_self_tagging()
                 .tags(tags)
                 .sign_with_keys(&relay_keys)
                 .map_err(|e| anyhow::anyhow!("sign kind:39001: {e}"))?;
@@ -561,11 +583,11 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
         // kind:39002 — members
         {
             let mut tags: Vec<Tag> = vec![Tag::parse(["d", &channel_id_str])?];
-            for m in &members {
-                let pk = hex::encode(&m.pubkey);
-                tags.push(Tag::parse(["p", &pk, "", &m.role])?);
+            for (pk, role) in &member_roles {
+                tags.push(Tag::parse(["p", pk, "", role])?);
             }
-            let event = EventBuilder::new(Kind::Custom(39002), "")
+            let event = EventBuilder::new(Kind::Custom(KIND_NIP29_GROUP_MEMBERS as u16), "")
+                .allow_self_tagging()
                 .tags(tags)
                 .sign_with_keys(&relay_keys)
                 .map_err(|e| anyhow::anyhow!("sign kind:39002: {e}"))?;
@@ -581,4 +603,259 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
         channels.len()
     );
     Ok(())
+}
+
+fn discovery_role_maps<I>(
+    members: I,
+    channel_creator_pubkey: String,
+) -> (BTreeMap<String, String>, BTreeMap<String, String>)
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut admin_roles = BTreeMap::new();
+    let mut member_roles = BTreeMap::new();
+
+    for (pubkey, role) in members {
+        let pubkey = pubkey.to_ascii_lowercase();
+        if role == "owner" || role == "admin" {
+            admin_roles.insert(pubkey.clone(), role.clone());
+        }
+        member_roles.insert(pubkey, role);
+    }
+
+    if admin_roles.is_empty() && !channel_creator_pubkey.is_empty() {
+        let pubkey = channel_creator_pubkey.to_ascii_lowercase();
+        admin_roles.insert(pubkey.clone(), "owner".to_string());
+        member_roles
+            .entry(pubkey)
+            .or_insert_with(|| "owner".to_string());
+    }
+
+    (admin_roles, member_roles)
+}
+
+fn short_hex(bytes: &[u8]) -> String {
+    hex::encode(bytes).chars().take(8).collect()
+}
+
+fn prefixed_roles(roles: &BTreeMap<String, String>) -> Vec<String> {
+    roles
+        .iter()
+        .map(|(pubkey, role)| format!("{}:{role}", pubkey.chars().take(8).collect::<String>()))
+        .collect()
+}
+
+fn p_tag_pubkeys(event: &Event) -> BTreeSet<String> {
+    event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let parts = tag.as_slice();
+            if parts.len() >= 2 && parts[0] == "p" {
+                Some(parts[1].to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn discovery_event_for_kind(events: &[StoredEvent], kind: u32) -> Option<&Event> {
+    // EventQuery returns newest first, so the first matching addressable head is
+    // the one clients will resolve. If that head is malformed, reconcile.
+    events
+        .iter()
+        .find(|event| event.event.kind.as_u16() as u32 == kind)
+        .map(|event| &event.event)
+}
+
+fn discovery_event_has_exact_p_tags(event: Option<&Event>, expected: &BTreeSet<String>) -> bool {
+    event.is_some_and(|event| p_tag_pubkeys(event) == *expected)
+}
+
+fn discovery_events_are_complete(
+    events: &[StoredEvent],
+    admin_pubkeys: &BTreeSet<String>,
+    member_pubkeys: &BTreeSet<String>,
+) -> bool {
+    discovery_event_for_kind(events, buzz_core::kind::KIND_NIP29_GROUP_METADATA).is_some()
+        && discovery_event_has_exact_p_tags(
+            discovery_event_for_kind(events, buzz_core::kind::KIND_NIP29_GROUP_ADMINS),
+            admin_pubkeys,
+        )
+        && discovery_event_has_exact_p_tags(
+            discovery_event_for_kind(events, buzz_core::kind::KIND_NIP29_GROUP_MEMBERS),
+            member_pubkeys,
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use buzz_core::kind::{
+        KIND_NIP29_GROUP_ADMINS, KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA,
+    };
+
+    fn signed_stored_event(kind: u32, tags: Vec<Tag>) -> StoredEvent {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(kind as u16), "")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("sign event");
+        StoredEvent::new(event, None)
+    }
+
+    fn p_tag(pubkey: &str, role: &str) -> Tag {
+        Tag::parse(["p", pubkey, "", role]).expect("p tag")
+    }
+
+    fn d_tag(channel_id: &str) -> Tag {
+        Tag::parse(["d", channel_id]).expect("d tag")
+    }
+
+    #[test]
+    fn discovery_role_maps_preserve_explicit_owner_and_members() {
+        let owner = "a".repeat(64);
+        let member = "b".repeat(64);
+
+        let (admin_roles, member_roles) = discovery_role_maps(
+            vec![
+                (owner.clone(), "owner".to_string()),
+                (member.clone(), "member".to_string()),
+            ],
+            "c".repeat(64),
+        );
+
+        assert_eq!(admin_roles.get(&owner).map(String::as_str), Some("owner"));
+        assert_eq!(member_roles.get(&owner).map(String::as_str), Some("owner"));
+        assert_eq!(
+            member_roles.get(&member).map(String::as_str),
+            Some("member")
+        );
+        assert_eq!(admin_roles.len(), 1);
+    }
+
+    #[test]
+    fn discovery_role_maps_fall_back_to_creator_when_no_admin_role_exists() {
+        let creator = "a".repeat(64);
+        let member = "b".repeat(64);
+
+        let (admin_roles, member_roles) = discovery_role_maps(
+            vec![(member.clone(), "member".to_string())],
+            creator.clone(),
+        );
+
+        assert_eq!(admin_roles.get(&creator).map(String::as_str), Some("owner"));
+        assert_eq!(
+            member_roles.get(&creator).map(String::as_str),
+            Some("owner")
+        );
+        assert_eq!(
+            member_roles.get(&member).map(String::as_str),
+            Some("member")
+        );
+    }
+
+    #[test]
+    fn discovery_complete_requires_exact_admin_and_member_p_tags() {
+        let owner = "a".repeat(64);
+        let member = "b".repeat(64);
+        let channel_id = "channel-1";
+
+        let events = vec![
+            signed_stored_event(KIND_NIP29_GROUP_METADATA, vec![d_tag(channel_id)]),
+            signed_stored_event(
+                KIND_NIP29_GROUP_ADMINS,
+                vec![d_tag(channel_id), p_tag(&owner, "owner")],
+            ),
+            signed_stored_event(
+                KIND_NIP29_GROUP_MEMBERS,
+                vec![
+                    d_tag(channel_id),
+                    p_tag(&owner, "owner"),
+                    p_tag(&member, "member"),
+                ],
+            ),
+        ];
+
+        let admin_pubkeys = BTreeSet::from([owner.clone()]);
+        let member_pubkeys = BTreeSet::from([owner, member]);
+
+        assert!(discovery_events_are_complete(
+            &events,
+            &admin_pubkeys,
+            &member_pubkeys
+        ));
+    }
+
+    #[test]
+    fn discovery_incomplete_when_owner_p_tag_is_missing() {
+        let owner = "a".repeat(64);
+        let member = "b".repeat(64);
+        let channel_id = "channel-1";
+
+        let events = vec![
+            signed_stored_event(KIND_NIP29_GROUP_METADATA, vec![d_tag(channel_id)]),
+            signed_stored_event(KIND_NIP29_GROUP_ADMINS, vec![d_tag(channel_id)]),
+            signed_stored_event(
+                KIND_NIP29_GROUP_MEMBERS,
+                vec![d_tag(channel_id), p_tag(&member, "member")],
+            ),
+        ];
+
+        let admin_pubkeys = BTreeSet::from([owner.clone()]);
+        let member_pubkeys = BTreeSet::from([owner, member]);
+
+        assert!(!discovery_events_are_complete(
+            &events,
+            &admin_pubkeys,
+            &member_pubkeys
+        ));
+    }
+
+    #[test]
+    fn discovery_incomplete_when_newest_head_is_malformed() {
+        let owner = "a".repeat(64);
+        let member = "b".repeat(64);
+        let channel_id = "channel-1";
+
+        let events = vec![
+            signed_stored_event(KIND_NIP29_GROUP_METADATA, vec![d_tag(channel_id)]),
+            signed_stored_event(KIND_NIP29_GROUP_ADMINS, vec![d_tag(channel_id)]),
+            signed_stored_event(
+                KIND_NIP29_GROUP_ADMINS,
+                vec![d_tag(channel_id), p_tag(&owner, "owner")],
+            ),
+            signed_stored_event(
+                KIND_NIP29_GROUP_MEMBERS,
+                vec![
+                    d_tag(channel_id),
+                    p_tag(&owner, "owner"),
+                    p_tag(&member, "member"),
+                ],
+            ),
+        ];
+
+        let admin_pubkeys = BTreeSet::from([owner.clone()]);
+        let member_pubkeys = BTreeSet::from([owner, member]);
+
+        assert!(!discovery_events_are_complete(
+            &events,
+            &admin_pubkeys,
+            &member_pubkeys
+        ));
+    }
+
+    #[test]
+    fn discovery_p_tags_preserve_signer_self_reference() {
+        let keys = Keys::generate();
+        let owner = keys.public_key().to_hex();
+        let event = EventBuilder::new(Kind::Custom(KIND_NIP29_GROUP_MEMBERS as u16), "")
+            .allow_self_tagging()
+            .tags(vec![d_tag("channel-1"), p_tag(&owner, "owner")])
+            .sign_with_keys(&keys)
+            .expect("sign event");
+
+        assert_eq!(p_tag_pubkeys(&event), BTreeSet::from([owner]));
+    }
 }

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1019,6 +1019,7 @@ async fn emit_addressable_discovery_event(
     let ts = now.max(min_ts);
 
     let event = EventBuilder::new(Kind::Custom(kind as u16), "")
+        .allow_self_tagging()
         .tags(tags)
         .custom_created_at(nostr::Timestamp::from(ts))
         .sign_with_keys(&state.relay_keypair)

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -1,5 +1,6 @@
 //! NIP-29 and NIP-25 side-effect handlers.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use nostr::{Event, EventBuilder, Kind, Tag};
@@ -3043,14 +3044,56 @@ pub async fn publish_nip43_member_removed(
     publish_nip43_delta(tenant, state, 8001, target_pubkey_hex, "member-removed").await
 }
 
-/// Reconcile channels that exist in the DB but don't have kind:39000 events.
+fn p_tag_pubkeys(event: &Event) -> BTreeSet<String> {
+    event
+        .tags
+        .iter()
+        .filter_map(|tag| {
+            let parts = tag.as_slice();
+            if parts.len() >= 2 && parts[0] == "p" {
+                Some(parts[1].to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn discovery_event_for_kind(events: &[StoredEvent], kind: u32) -> Option<&Event> {
+    events
+        .iter()
+        .find(|event| event_kind_u32(&event.event) == kind)
+        .map(|event| &event.event)
+}
+
+fn discovery_event_has_exact_p_tags(event: Option<&Event>, expected: &BTreeSet<String>) -> bool {
+    event.is_some_and(|event| p_tag_pubkeys(event) == *expected)
+}
+
+fn discovery_events_are_complete(
+    events: &[StoredEvent],
+    admin_pubkeys: &BTreeSet<String>,
+    member_pubkeys: &BTreeSet<String>,
+) -> bool {
+    discovery_event_for_kind(events, KIND_NIP29_GROUP_METADATA).is_some()
+        && discovery_event_has_exact_p_tags(
+            discovery_event_for_kind(events, KIND_NIP29_GROUP_ADMINS),
+            admin_pubkeys,
+        )
+        && discovery_event_has_exact_p_tags(
+            discovery_event_for_kind(events, KIND_NIP29_GROUP_MEMBERS),
+            member_pubkeys,
+        )
+}
+
+/// Reconcile channels that exist in the DB but don't have complete discovery events.
 ///
 /// This handles the case where channels were created via direct SQL inserts
-/// (e.g. test seed scripts) rather than through the Nostr event pipeline.
-/// Emits kind:39000 (metadata) and kind:39002 (members) for each channel
-/// that is missing its discovery events.
+/// (e.g. test seed scripts) rather than through the Nostr event pipeline, and
+/// repairs partial historical discovery heads whose 39001/39002 events are
+/// missing canonical member `p` tags.
 ///
-/// Idempotent: checks for existing kind:39000 events before emitting.
+/// Idempotent: checks the current 39000/39001/39002 heads before emitting.
 pub async fn reconcile_channel_events(
     tenant: &TenantContext,
     state: &Arc<AppState>,
@@ -3064,14 +3107,17 @@ pub async fn reconcile_channel_events(
 
     let mut reconciled = 0u32;
     for channel in &channels {
-        // Check if kind:39000 event already exists for this channel.
         let channel_id_str = channel.id.to_string();
-        let existing = match state
+        let discovery_events = match state
             .db
             .query_events(&EventQuery {
-                kinds: Some(vec![39000]),
+                kinds: Some(vec![
+                    KIND_NIP29_GROUP_METADATA as i32,
+                    KIND_NIP29_GROUP_ADMINS as i32,
+                    KIND_NIP29_GROUP_MEMBERS as i32,
+                ]),
                 d_tag: Some(channel_id_str.clone()),
-                limit: Some(1),
+                limit: Some(10),
                 ..EventQuery::for_community(tenant.community())
             })
             .await
@@ -3087,8 +3133,28 @@ pub async fn reconcile_channel_events(
             }
         };
 
-        if existing.is_empty() {
-            // No discovery event — emit one.
+        let members = match state.db.get_members(tenant.community(), channel.id).await {
+            Ok(members) => members,
+            Err(e) => {
+                tracing::warn!(
+                    channel_id = %channel.id,
+                    error = %e,
+                    "reconcile: failed to query channel members"
+                );
+                continue;
+            }
+        };
+        let admin_pubkeys: BTreeSet<String> = members
+            .iter()
+            .filter(|member| member.role == "owner" || member.role == "admin")
+            .map(|member| hex::encode(&member.pubkey))
+            .collect();
+        let member_pubkeys: BTreeSet<String> = members
+            .iter()
+            .map(|member| hex::encode(&member.pubkey))
+            .collect();
+
+        if !discovery_events_are_complete(&discovery_events, &admin_pubkeys, &member_pubkeys) {
             if let Err(e) = emit_group_discovery_events(tenant, state, channel.id).await {
                 tracing::warn!(
                     channel_id = %channel.id,
@@ -3372,6 +3438,106 @@ fn topic_for_subscription(channel_id: Option<Uuid>) -> EventTopic {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn stored_discovery_event(kind: u32, tags: Vec<Tag>) -> StoredEvent {
+        let event = EventBuilder::new(Kind::Custom(kind as u16), "")
+            .tags(tags)
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign discovery test event");
+        StoredEvent::with_received_at(event, chrono::Utc::now(), Some(Uuid::new_v4()), true)
+    }
+
+    #[test]
+    fn discovery_completeness_requires_owner_self_p_tags() {
+        let channel_id = Uuid::new_v4().to_string();
+        let owner = "a".repeat(64);
+        let metadata = stored_discovery_event(
+            KIND_NIP29_GROUP_METADATA,
+            vec![Tag::parse(["d", &channel_id]).expect("d tag")],
+        );
+        let admins = stored_discovery_event(
+            KIND_NIP29_GROUP_ADMINS,
+            vec![
+                Tag::parse(["d", &channel_id]).expect("d tag"),
+                Tag::parse(["p", &owner, "owner"]).expect("owner p tag"),
+            ],
+        );
+        let members = stored_discovery_event(
+            KIND_NIP29_GROUP_MEMBERS,
+            vec![
+                Tag::parse(["d", &channel_id]).expect("d tag"),
+                Tag::parse(["p", &owner, "", "owner"]).expect("member p tag"),
+            ],
+        );
+
+        let expected = BTreeSet::from([owner]);
+        assert!(discovery_events_are_complete(
+            &[metadata, admins, members],
+            &expected,
+            &expected
+        ));
+    }
+
+    #[test]
+    fn discovery_completeness_rejects_missing_member_p_tags() {
+        let channel_id = Uuid::new_v4().to_string();
+        let owner = "b".repeat(64);
+        let metadata = stored_discovery_event(
+            KIND_NIP29_GROUP_METADATA,
+            vec![Tag::parse(["d", &channel_id]).expect("d tag")],
+        );
+        let admins = stored_discovery_event(
+            KIND_NIP29_GROUP_ADMINS,
+            vec![
+                Tag::parse(["d", &channel_id]).expect("d tag"),
+                Tag::parse(["p", &owner, "owner"]).expect("owner p tag"),
+            ],
+        );
+        let members_without_p = stored_discovery_event(
+            KIND_NIP29_GROUP_MEMBERS,
+            vec![Tag::parse(["d", &channel_id]).expect("d tag")],
+        );
+
+        let expected = BTreeSet::from([owner]);
+        assert!(!discovery_events_are_complete(
+            &[metadata, admins, members_without_p],
+            &expected,
+            &expected
+        ));
+    }
+
+    #[test]
+    fn discovery_completeness_rejects_stale_extra_member_p_tags() {
+        let channel_id = Uuid::new_v4().to_string();
+        let owner = "c".repeat(64);
+        let removed = "d".repeat(64);
+        let metadata = stored_discovery_event(
+            KIND_NIP29_GROUP_METADATA,
+            vec![Tag::parse(["d", &channel_id]).expect("d tag")],
+        );
+        let admins = stored_discovery_event(
+            KIND_NIP29_GROUP_ADMINS,
+            vec![
+                Tag::parse(["d", &channel_id]).expect("d tag"),
+                Tag::parse(["p", &owner, "owner"]).expect("owner p tag"),
+            ],
+        );
+        let members = stored_discovery_event(
+            KIND_NIP29_GROUP_MEMBERS,
+            vec![
+                Tag::parse(["d", &channel_id]).expect("d tag"),
+                Tag::parse(["p", &owner, "", "owner"]).expect("owner p tag"),
+                Tag::parse(["p", &removed, "", "member"]).expect("removed p tag"),
+            ],
+        );
+
+        let expected = BTreeSet::from([owner]);
+        assert!(!discovery_events_are_complete(
+            &[metadata, admins, members],
+            &expected,
+            &expected
+        ));
+    }
 
     #[test]
     fn delete_tombstone_omits_absent_moderation_metadata() {

--- a/deploy/compose/compose.dev.yml
+++ b/deploy/compose/compose.dev.yml
@@ -1,19 +1,19 @@
 services:
   postgres:
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_HOST:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
 
   redis:
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_HOST:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
 
   minio:
     ports:
-      - "${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+      - "${MINIO_HOST:-127.0.0.1}:${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_HOST:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9001}:9001"
 
   adminer:
-    image: adminer:latest
+    image: adminer:5.5.0
     container_name: buzz-adminer
     depends_on:
       postgres:
@@ -21,19 +21,19 @@ services:
     environment:
       ADMINER_DEFAULT_SERVER: postgres
     ports:
-      - "${ADMINER_PORT:-8082}:8080"
+      - "${ADMINER_HOST:-127.0.0.1}:${ADMINER_PORT:-18082}:8080"
     restart: unless-stopped
     networks:
       - buzz-net
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.2
     container_name: buzz-prometheus
     volumes:
       - ../../prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - buzz-prometheus-data:/prometheus
     ports:
-      - "${PROMETHEUS_PORT:-9090}:9090"
+      - "${PROMETHEUS_HOST:-127.0.0.1}:${PROMETHEUS_PORT:-9090}:9090"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -21,7 +21,7 @@ services:
       BUZZ_AUTO_MIGRATE: ${BUZZ_AUTO_MIGRATE:-false}
       BUZZ_GIT_CONFORMANCE_PROBE: ${BUZZ_GIT_CONFORMANCE_PROBE:-true}
     ports:
-      - "${BUZZ_HTTP_PORT:-3000}:3000"
+      - "${BUZZ_HTTP_PORT:-127.0.0.1:3000}:3000"
     volumes:
       - buzz-git-data:/data/git
     depends_on:
@@ -49,7 +49,7 @@ services:
       - buzz-net
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.10-alpine
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-buzz}
       POSTGRES_USER: ${POSTGRES_USER:-buzz}
@@ -68,7 +68,7 @@ services:
       - buzz-net
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.10-alpine
     command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD}"]
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:?set REDIS_PASSWORD}

--- a/desktop/src/features/messages/lib/messageMentionPubkeys.test.mjs
+++ b/desktop/src/features/messages/lib/messageMentionPubkeys.test.mjs
@@ -46,3 +46,17 @@ test("stream messages preserve explicit-mention semantics", () => {
     [],
   );
 });
+
+test("stream messages p-tag selected agent mentions", () => {
+  const agentPubkey =
+    "e3066c9a6081fcd4d0945c8f14f52bbc71a87c74b34a6594fe540f73e41acf09";
+
+  assert.deepEqual(
+    messageMentionPubkeys(
+      channel({ channelType: "stream", memberPubkeys: ["owner", agentPubkey] }),
+      "owner",
+      [agentPubkey.toUpperCase()],
+    ),
+    [agentPubkey],
+  );
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: buzz
 
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17.10-alpine
     container_name: buzz-postgres
     environment:
       POSTGRES_USER: buzz
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: buzz
       PGDATA: /var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
@@ -31,10 +31,10 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.10-alpine
     container_name: buzz-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     networks:
       - buzz-net
     healthcheck:
@@ -53,10 +53,10 @@ services:
     restart: unless-stopped
 
   adminer:
-    image: adminer:latest
+    image: adminer:5.5.0
     container_name: buzz-adminer
     ports:
-      - "8082:8080"
+      - "127.0.0.1:18082:8080"
     networks:
       - buzz-net
     depends_on:
@@ -74,19 +74,20 @@ services:
     restart: unless-stopped
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: quay.io/keycloak/keycloak:26.0.8
     container_name: buzz-keycloak
     command: start-dev --http-port=8080
     environment:
       KC_DB: dev-mem
+      KC_HEALTH_ENABLED: "true"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
-      - "8180:8080"
+      - "127.0.0.1:8180:8080"
     networks:
       - buzz-net
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200 OK'"]
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/9000; printf \"GET /health/ready HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q \"200 OK\" <&3'"]
       interval: 10s
       timeout: 5s
       retries: 15
@@ -101,15 +102,15 @@ services:
     restart: unless-stopped
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: buzz-minio
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: buzz_dev
       MINIO_ROOT_PASSWORD: buzz_dev_secret
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     volumes:
       - minio-data:/data
     networks:
@@ -130,7 +131,7 @@ services:
     restart: unless-stopped
 
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: buzz-minio-init
     depends_on:
       minio:
@@ -149,10 +150,10 @@ services:
     restart: "no"
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.2
     container_name: buzz-prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus


### PR DESCRIPTION
Summary:
- Makes channel reconcile require complete NIP-29 discovery heads before skipping: metadata, admins, and members.
- Preserves relay self p-tags with allow_self_tagging for discovery event emission.
- Pins local compose helper images and binds development surfaces to loopback by default.

Verification:
- git status -sb
- git status --porcelain
- git diff --check
- ./bin/cargo fmt --check
- ./bin/cargo test -p buzz-admin discovery_
- ./bin/cargo test -p buzz-relay discovery_completeness
- ./bin/cargo check -p buzz-admin
- ./bin/cargo check -p buzz-relay
- docker compose -f deploy/compose/compose.yml -f deploy/compose/compose.dev.yml config --quiet

Boundaries:
- Draft PR only; no merge or release.
- No Docker recreate, volume deletion, room mutation, public expose, LAN bind expansion, signed installer, or secret material in receipts.