### PR TITLE
ci(security): allow retired relay pool advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,10 @@ ignore = [
     # remove these when upstream catches up.
     { id = "RUSTSEC-2026-0194", reason = "transitive via rust-s3 and mesh-llm→plist; trusted-input XML only; no upstream fix available yet" },
     { id = "RUSTSEC-2026-0195", reason = "transitive via rust-s3 and mesh-llm→plist; trusted-input XML only; no upstream fix available yet" },
+    # nostr-relay-pool 0.44.3 — informational/unmaintained, not a vulnerability.
+    # Transitive via mesh-llm 0.74 → nostr-sdk 0.44.1. Remove after mesh-llm
+    # migrates to nostr-sdk >= 0.45, which absorbed the standalone relay pool.
+    { id = "RUSTSEC-2026-0243", reason = "transitive via mesh-llm; upstream nostr-sdk 0.45 migration requires API changes" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- temporarily allow the informational `RUSTSEC-2026-0243` advisory for the retired `nostr-relay-pool` crate
- document the exact MeshLLM → `nostr-sdk 0.44.1` transitive path and removal condition
- keep every other advisory and the global dependency policy enforced

## Why an exception

RustSec provides no patched `nostr-relay-pool` release because the standalone crate was absorbed into `nostr-sdk >= 0.45`. Buzz inherits it through pinned MeshLLM v0.74. A direct test bump to `nostr-sdk 0.45.1` removed the retired crate but produced 13 MeshLLM API compilation errors, so the durable fix requires an upstream source migration rather than a lockfile update.

This narrow exception restores the required Security check while that migration is completed. It must be removed once MeshLLM adopts `nostr-sdk >= 0.45`.

## Validation

- `bin/cargo-deny --locked check --config deny.toml advisories`
- `bin/cargo-deny --locked check`
- `git diff --check origin/main...HEAD`
- mandatory pre-push Rust and desktop/Tauri checks

## Scope

One four-line `deny.toml` addition. No Rust source, lockfile, runtime, or release behavior changes.
