### PR TITLE
feat(projects): render diffs with Pierre

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -32,6 +32,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.3.0",
     "@mediapipe/tasks-vision": "^0.10.35",
+    "@pierre/diffs": "1.3.5",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/desktop/src/features/projects/lib/projectDiffAnnotations.test.mjs
+++ b/desktop/src/features/projects/lib/projectDiffAnnotations.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  annotationToBuzzAnchor,
+  buildFileDiffAnnotations,
+  buzzSideToDiffSide,
+  diffSideToBuzzSide,
+  focusedAnchorToSelectedRange,
+  groupCommentsByAnchor,
+  isRenderablePatch,
+  patchBodyLineCount,
+} from "./projectDiffAnnotations.ts";
+
+const OLD_ANCHOR = { line: 3, path: "src/a.ts", side: "old" };
+const NEW_ANCHOR = { line: 5, path: "src/a.ts", side: "new" };
+
+function comment(id, anchor) {
+  return {
+    id,
+    anchor,
+    createdAt: 1,
+    author: "author",
+    content: "note",
+    tags: [],
+  };
+}
+
+test("maps Buzz old/new anchor sides to Pierre deletions/additions and back", () => {
+  assert.equal(buzzSideToDiffSide("old"), "deletions");
+  assert.equal(buzzSideToDiffSide("new"), "additions");
+  assert.equal(diffSideToBuzzSide("deletions"), "old");
+  assert.equal(diffSideToBuzzSide("additions"), "new");
+});
+
+test("groups comments by path/side/line and excludes other files", () => {
+  const comments = [
+    comment("1", OLD_ANCHOR),
+    comment("2", OLD_ANCHOR),
+    comment("3", NEW_ANCHOR),
+    comment("4", { line: 9, path: "src/other.ts", side: "new" }),
+    comment("5", { line: 3, path: "src/a.ts", side: "new" }),
+  ];
+  const groups = groupCommentsByAnchor("src/a.ts", comments);
+  assert.deepEqual(
+    [...groups.keys()].sort(),
+    ["new:3", "old:3", "new:5"].sort(),
+  );
+  assert.equal(groups.get("old:3")?.length, 2);
+  assert.equal(groups.get("new:5")?.length, 1);
+  assert.equal(groups.get("new:3")?.length, 1);
+});
+
+test("builds annotations with exact anchor metadata and stable ordering", () => {
+  // Same line 7: new-side comment supplied first, old-side supplied second —
+  // the deletion-before-addition tie-break must still win on equal lines.
+  const SAME_LINE_NEW = { line: 7, path: "src/a.ts", side: "new" };
+  const SAME_LINE_OLD = { line: 7, path: "src/a.ts", side: "old" };
+  const comments = [
+    comment("1", NEW_ANCHOR),
+    comment("2", SAME_LINE_NEW),
+    comment("3", SAME_LINE_OLD),
+    comment("4", OLD_ANCHOR),
+  ];
+  const annotations = buildFileDiffAnnotations("src/a.ts", comments, null);
+  // Sorted by line ascending, then deletions before additions on equal lines.
+  assert.deepEqual(
+    annotations.map((a) => [a.side, a.lineNumber]),
+    [
+      ["deletions", 3],
+      ["additions", 5],
+      ["deletions", 7],
+      ["additions", 7],
+    ],
+  );
+  assert.equal(annotations[0].metadata.anchor.path, "src/a.ts");
+  assert.equal(annotations[0].metadata.comments.length, 1);
+  assert.equal(annotations[1].metadata.focused, false);
+  // The same-line group keeps both comments, old side first despite the
+  // reversed input order.
+  assert.equal(annotations[2].metadata.anchor.side, "old");
+  assert.equal(annotations[3].metadata.anchor.side, "new");
+  assert.equal(annotations[2].metadata.comments.length, 1);
+  assert.equal(annotations[3].metadata.comments.length, 1);
+});
+
+test("includes the focused anchor even with no comments and marks it focused", () => {
+  const annotations = buildFileDiffAnnotations("src/a.ts", [], NEW_ANCHOR);
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].side, "additions");
+  assert.equal(annotations[0].lineNumber, 5);
+  assert.equal(annotations[0].metadata.focused, true);
+  assert.deepEqual(annotations[0].metadata.comments, []);
+});
+
+test("does not add a focused annotation for another file", () => {
+  const annotations = buildFileDiffAnnotations("src/a.ts", [], {
+    line: 1,
+    path: "src/b.ts",
+    side: "new",
+  });
+  assert.equal(annotations.length, 0);
+});
+
+test("marks the focused flag on an existing comment group", () => {
+  const comments = [comment("1", NEW_ANCHOR)];
+  const annotations = buildFileDiffAnnotations(
+    "src/a.ts",
+    comments,
+    NEW_ANCHOR,
+  );
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].metadata.focused, true);
+  assert.equal(annotations[0].metadata.comments.length, 1);
+});
+
+test("annotation metadata round-trips to the exact Buzz anchor", () => {
+  const annotations = buildFileDiffAnnotations(
+    "src/a.ts",
+    [comment("1", OLD_ANCHOR)],
+    null,
+  );
+  const recovered = annotationToBuzzAnchor(annotations[0]);
+  assert.deepEqual(recovered, OLD_ANCHOR);
+});
+
+test("maps a focused anchor to a single-line Pierre selected range", () => {
+  assert.deepEqual(focusedAnchorToSelectedRange(null), null);
+  assert.deepEqual(focusedAnchorToSelectedRange(undefined), null);
+  assert.deepEqual(focusedAnchorToSelectedRange(OLD_ANCHOR), {
+    start: 3,
+    end: 3,
+    side: "deletions",
+  });
+  assert.deepEqual(focusedAnchorToSelectedRange(NEW_ANCHOR), {
+    start: 5,
+    end: 5,
+    side: "additions",
+  });
+});
+
+test("detects renderable patches (at least one valid hunk header)", () => {
+  assert.equal(isRenderablePatch(""), false);
+  assert.equal(isRenderablePatch("   \n\n"), false);
+  assert.equal(isRenderablePatch("this is not a patch at all"), false);
+  assert.equal(
+    isRenderablePatch(
+      "diff --git a/x b/x\nindex 1..2 100644\nBinary files differ\n",
+    ),
+    false,
+  );
+  // A fake `@@ ` line without numeric old/new ranges is not a hunk header.
+  assert.equal(isRenderablePatch("@@ not a hunk header\n"), false);
+  assert.equal(
+    isRenderablePatch("@@ -abc +def @@\nno numeric ranges\n"),
+    false,
+  );
+  assert.equal(isRenderablePatch("@@ -1,2 +1,2 @@\n-old\n+new\n"), true);
+  // Hunk headers may omit the line counts on either side.
+  assert.equal(isRenderablePatch("@@ -1 +1 @@\n-old\n+new\n"), true);
+  assert.equal(isRenderablePatch("@@ -1 +2,3 @@\n context\n"), true);
+  // A trailing section/function label after the closing @@ is valid.
+  assert.equal(
+    isRenderablePatch("@@ -12,3 +12,4 @@ function renderDiff()\n-old\n+new\n"),
+    true,
+  );
+});
+
+test("counts patch body lines like the previous renderer", () => {
+  const patch = [
+    "diff --git a/a.ts b/a.ts",
+    "index 1..2 100644",
+    "--- a/a.ts",
+    "+++ b/a.ts",
+    "@@ -1,2 +1,2 @@",
+    "-old",
+    "+new",
+    " context",
+  ].join("\n");
+  assert.equal(patchBodyLineCount(patch), 4);
+  assert.equal(patchBodyLineCount(""), 0);
+});

--- a/desktop/src/features/projects/lib/projectDiffAnnotations.ts
+++ b/desktop/src/features/projects/lib/projectDiffAnnotations.ts
@@ -1,0 +1,207 @@
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
+
+import type {
+  ProjectPullRequestComment,
+  ProjectPullRequestCommentAnchor,
+} from "@/features/projects/projectPullRequests.mjs";
+
+/**
+ * Buzz-owned annotation metadata carried inside a Pierre
+ * {@link DiffLineAnnotation}. It keeps the exact Buzz anchor and its comment
+ * group so `renderAnnotation` can rebuild the existing inline thread/form
+ * without re-deriving state from the parsed patch.
+ */
+export type ProjectDiffAnnotationMetadata = {
+  /** The exact Buzz anchor this annotation was built from. */
+  anchor: ProjectPullRequestCommentAnchor;
+  /** Comments already grouped to this path/side/line, in stable order. */
+  comments: ProjectPullRequestComment[];
+  /** True when this annotation is the active focused line. */
+  focused: boolean;
+};
+
+/** Pierre diff sides, mirroring {@link DiffLineAnnotation.side}. */
+export type ProjectDiffSide = "deletions" | "additions";
+
+/**
+ * Map a Buzz anchor side to the Pierre diff side.
+ * Buzz `old` anchors live on the deletion side; Buzz `new` anchors live on
+ * the addition side.
+ */
+export function buzzSideToDiffSide(
+  side: ProjectPullRequestCommentAnchor["side"],
+): ProjectDiffSide {
+  return side === "old" ? "deletions" : "additions";
+}
+
+/**
+ * Map a Pierre diff side back to the Buzz anchor side.
+ * Inverse of {@link buzzSideToDiffSide}.
+ */
+export function diffSideToBuzzSide(side: ProjectDiffSide): "old" | "new" {
+  return side === "deletions" ? "old" : "new";
+}
+
+/** Stable per-file grouping key for a comment anchor. */
+function anchorGroupKey(anchor: ProjectPullRequestCommentAnchor) {
+  return `${anchor.side}:${anchor.line}`;
+}
+
+/**
+ * Group a file's inline comments by path/side/line. The returned map order is
+ * first-seen key order (input order determines group order); the stable,
+ * sorted ordering callers need is produced by {@link buildFileDiffAnnotations}
+ * when it renders the final annotation list. Within each group, the original
+ * comment order is preserved. Comments whose anchor points at another file
+ * are excluded.
+ */
+export function groupCommentsByAnchor(
+  path: string,
+  comments: ProjectPullRequestComment[],
+): Map<string, ProjectPullRequestComment[]> {
+  const groups = new Map<string, ProjectPullRequestComment[]>();
+  for (const comment of comments) {
+    const anchor = comment.anchor;
+    if (!anchor || anchor.path !== path) continue;
+    const key = anchorGroupKey(anchor);
+    const group = groups.get(key);
+    if (group) group.push(comment);
+    else groups.set(key, [comment]);
+  }
+  return groups;
+}
+
+/**
+ * Build the Pierre line annotations for one file from its comments and the
+ * active focused anchor.
+ *
+ * Every comment group becomes one annotation carrying the exact Buzz anchor
+ * and its comments. The focused anchor is always included, even when it has
+ * no comments, so focused-line scroll/focus has a stable annotation slot to
+ * resolve inside the rendered diff. Results are ordered deterministically by
+ * (line, side) so annotation slots are stable across renders.
+ */
+export function buildFileDiffAnnotations(
+  path: string,
+  comments: ProjectPullRequestComment[],
+  focusedAnchor: ProjectPullRequestCommentAnchor | null | undefined,
+): DiffLineAnnotation<ProjectDiffAnnotationMetadata>[] {
+  const groups = groupCommentsByAnchor(path, comments);
+  const seen = new Set<string>();
+  const annotations: DiffLineAnnotation<ProjectDiffAnnotationMetadata>[] = [];
+
+  for (const [key, group] of groups) {
+    seen.add(key);
+    const anchor = group[0].anchor;
+    if (!anchor) continue;
+    annotations.push({
+      side: buzzSideToDiffSide(anchor.side),
+      lineNumber: anchor.line,
+      metadata: {
+        anchor,
+        comments: group,
+        focused: anchorsEqual(anchor, focusedAnchor),
+      },
+    });
+  }
+
+  if (
+    focusedAnchor &&
+    focusedAnchor.path === path &&
+    !seen.has(anchorGroupKey(focusedAnchor))
+  ) {
+    annotations.push({
+      side: buzzSideToDiffSide(focusedAnchor.side),
+      lineNumber: focusedAnchor.line,
+      metadata: {
+        anchor: focusedAnchor,
+        comments: [],
+        focused: true,
+      },
+    });
+  }
+
+  return annotations.sort(
+    (left, right) =>
+      left.lineNumber - right.lineNumber ||
+      sideOrder(left.side) - sideOrder(right.side),
+  );
+}
+
+function sideOrder(side: ProjectDiffSide) {
+  return side === "deletions" ? 0 : 1;
+}
+
+/**
+ * Recover the exact Buzz anchor from a Pierre annotation's metadata.
+ * Inverse of the mapping performed by {@link buildFileDiffAnnotations}.
+ */
+export function annotationToBuzzAnchor(
+  annotation: DiffLineAnnotation<ProjectDiffAnnotationMetadata>,
+): ProjectPullRequestCommentAnchor {
+  return annotation.metadata.anchor;
+}
+
+/**
+ * Map the focused Buzz anchor to the Pierre controlled selected-line range
+ * (single line). `null` when there is no focused anchor.
+ */
+export function focusedAnchorToSelectedRange(
+  focusedAnchor: ProjectPullRequestCommentAnchor | null | undefined,
+): SelectedLineRange | null {
+  if (!focusedAnchor) return null;
+  return {
+    start: focusedAnchor.line,
+    end: focusedAnchor.line,
+    side: buzzSideToDiffSide(focusedAnchor.side),
+  };
+}
+
+/** Structural equality for Buzz comment anchors. */
+export function anchorsEqual(
+  left: ProjectPullRequestCommentAnchor | null | undefined,
+  right: ProjectPullRequestCommentAnchor | null | undefined,
+) {
+  return Boolean(
+    left &&
+      right &&
+      left.line === right.line &&
+      left.path === right.path &&
+      left.side === right.side,
+  );
+}
+
+/**
+ * True when a raw patch contains at least one syntactically valid unified
+ * hunk header and can be handed to Pierre for rendering. A hunk header must
+ * carry numeric old/new ranges (`@@ -<old>[,<count>] +<new>[,<count>] @@`),
+ * the same boundary the previous hand-written parser recognized; an optional
+ * trailing section/function label after the closing `@@` (e.g. `@@ -12,3
+ * +12,4 @@ function renderDiff()`) is allowed. Covers empty/whitespace
+ * patches, binary-only diffs ("Binary files differ"), and malformed payloads
+ * whose `@@` lines are not real hunk headers — all of which should fall back
+ * to the friendly "no textual diff" state.
+ */
+export function isRenderablePatch(patch: string): boolean {
+  return /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/m.test(patch);
+}
+
+/**
+ * Count the rendered body lines of a patch for the truncation banner,
+ * matching the previous hand-written renderer's count: every non-metadata
+ * line (after stripping `diff --git`, `index`, `---`, `+++` headers) becomes
+ * one visible row.
+ */
+export function patchBodyLineCount(patch: string): number {
+  if (!patch.trim()) return 0;
+  return patch
+    .trimEnd()
+    .split("\n")
+    .filter(
+      (line) =>
+        !line.startsWith("diff --git ") &&
+        !line.startsWith("index ") &&
+        !line.startsWith("--- ") &&
+        !line.startsWith("+++ "),
+    ).length;
+}

--- a/desktop/src/features/projects/lib/projectDiffFocus.test.mjs
+++ b/desktop/src/features/projects/lib/projectDiffFocus.test.mjs
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+import {
+  createFocusOneShotState,
+  createHoverAnchorCache,
+  findAnnotationRow,
+  focusAnnotationRow,
+  focusedAnchorKey,
+  includeActiveDiffAnchor,
+  markFocusSucceeded,
+  nextFocusAttempt,
+  recordHoveredLine,
+  resolveGutterAnchor,
+  selectedRangeForFile,
+} from "./projectDiffFocus.ts";
+import { buildFileDiffAnnotations } from "./projectDiffAnnotations.ts";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+const { document } = dom.window;
+
+/**
+ * Build a minimal `diffs-container` with an open shadow root and a
+ * `[data-line-annotation]` row containing the documented annotation slot
+ * (named by `getLineAnnotationName`: `annotation-{side}-{lineNumber}`).
+ */
+function containerWithAnnotation(side, lineNumber) {
+  const container = document.createElement("diffs-container");
+  const shadowRoot = container.attachShadow({ mode: "open" });
+  const row = document.createElement("div");
+  row.setAttribute("data-line-annotation", "0,0");
+  const content = document.createElement("div");
+  content.setAttribute("data-annotation-content", "");
+  const slot = document.createElement("slot");
+  slot.name = `annotation-${side}-${lineNumber}`;
+  content.appendChild(slot);
+  row.appendChild(content);
+  shadowRoot.appendChild(row);
+  return { container, row, slot };
+}
+
+test("finds the annotation row for additions and deletions slots", () => {
+  const { container, row } = containerWithAnnotation("additions", 5);
+  assert.equal(findAnnotationRow(container, "additions", 5), row);
+});
+
+test("returns null when the slot does not exist for that side/line", () => {
+  const { container } = containerWithAnnotation("additions", 5);
+  assert.equal(findAnnotationRow(container, "deletions", 5), null);
+  assert.equal(findAnnotationRow(container, "additions", 6), null);
+});
+
+test("returns null when the container has no shadow root", () => {
+  const plain = document.createElement("div");
+  assert.equal(findAnnotationRow(plain, "additions", 5), null);
+});
+
+test("focuses and scrolls the annotation row into view", () => {
+  const { container, row } = containerWithAnnotation("deletions", 3);
+  // Attach so focus() can resolve a real active element in jsdom.
+  document.body.appendChild(container);
+  let scrolled = false;
+  row.scrollIntoView = () => {
+    scrolled = true;
+  };
+  const focused = focusAnnotationRow(container, "deletions", 3);
+  assert.equal(focused, true);
+  assert.equal(scrolled, true);
+  assert.equal(row.getAttribute("tabindex"), "-1");
+  // Focus inside a shadow root is reported by the shadow root's
+  // activeElement, not the top document's.
+  assert.equal(container.shadowRoot.activeElement, row);
+  container.remove();
+});
+
+test("focus returns false when the row cannot be resolved", () => {
+  const { container } = containerWithAnnotation("additions", 5);
+  assert.equal(focusAnnotationRow(container, "deletions", 9), false);
+});
+
+// --- Active-anchor annotation merging (review regression coverage) ---
+
+function comment(id, anchor) {
+  return {
+    id,
+    anchor,
+    createdAt: 1,
+    author: "author",
+    content: "note",
+    tags: [],
+  };
+}
+
+const PATH = "src/a.ts";
+const NEW_5 = { line: 5, path: PATH, side: "new" };
+const OLD_3 = { line: 3, path: PATH, side: "old" };
+
+test("a commentless active anchor produces an annotation slot", () => {
+  const annotations = includeActiveDiffAnchor([], PATH, NEW_5);
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].side, "additions");
+  assert.equal(annotations[0].lineNumber, 5);
+  assert.deepEqual(annotations[0].metadata.comments, []);
+  assert.equal(annotations[0].metadata.focused, false);
+  assert.deepEqual(annotations[0].metadata.anchor, NEW_5);
+});
+
+test("active and focused anchors coexist with stable ordering", () => {
+  const base = buildFileDiffAnnotations(PATH, [comment("1", OLD_3)], NEW_5);
+  // base: old:3 (comments) + new:5 (focused)
+  const annotations = includeActiveDiffAnchor(base, PATH, NEW_5);
+  // active anchor equals focused anchor — no duplicate.
+  assert.equal(annotations.length, 2);
+  assert.deepEqual(
+    annotations.map((a) => [a.side, a.lineNumber]),
+    [
+      ["deletions", 3],
+      ["additions", 5],
+    ],
+  );
+});
+
+test("a distinct active anchor is added and ordering is stable", () => {
+  const base = buildFileDiffAnnotations(PATH, [], NEW_5);
+  const distinctActive = { line: 9, path: PATH, side: "old" };
+  const annotations = includeActiveDiffAnchor(base, PATH, distinctActive);
+  // Line ascending: additions:5 before deletions:9 (tie-break only on equal lines).
+  assert.deepEqual(
+    annotations.map((a) => [a.side, a.lineNumber]),
+    [
+      ["additions", 5],
+      ["deletions", 9],
+    ],
+  );
+  const active = annotations.find((a) => a.lineNumber === 9);
+  assert.equal(active.metadata.focused, false);
+  assert.deepEqual(active.metadata.anchor, distinctActive);
+});
+
+test("an active anchor matching an existing comment group is deduplicated", () => {
+  const base = buildFileDiffAnnotations(PATH, [comment("1", OLD_3)], null);
+  assert.equal(base.length, 1);
+  const annotations = includeActiveDiffAnchor(base, PATH, OLD_3);
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].metadata.comments.length, 1);
+});
+
+test("an active anchor from another file is ignored", () => {
+  const annotations = includeActiveDiffAnchor([], PATH, {
+    line: 1,
+    path: "src/other.ts",
+    side: "new",
+  });
+  assert.equal(annotations.length, 0);
+});
+
+// --- File-scoped focus state (review regression coverage) ---
+
+test("selected range is scoped to the rendered file path", () => {
+  assert.equal(selectedRangeForFile(PATH, null), null);
+  assert.equal(
+    selectedRangeForFile(PATH, { line: 1, path: "src/b.ts", side: "new" }),
+    null,
+  );
+  assert.deepEqual(selectedRangeForFile(PATH, NEW_5), {
+    start: 5,
+    end: 5,
+    side: "additions",
+  });
+});
+
+test("focus key includes the path so same side/line on a new file is a new target", () => {
+  const samePositionOtherPath = { line: 5, path: "src/b.ts", side: "new" };
+  assert.equal(focusedAnchorKey(PATH, NEW_5), "src/a.ts:new:5");
+  assert.equal(focusedAnchorKey(PATH, samePositionOtherPath), null);
+  assert.equal(focusedAnchorKey(PATH, null), null);
+  assert.equal(
+    focusedAnchorKey("src/b.ts", samePositionOtherPath),
+    "src/b.ts:new:5",
+  );
+});
+
+// --- One-shot focused-line lifecycle (review regression coverage) ---
+
+test("a null key clears the remembered focus", () => {
+  let state = createFocusOneShotState();
+  state = markFocusSucceeded("src/a.ts:new:5");
+  assert.equal(state.lastFocusedKey, "src/a.ts:new:5");
+
+  const cleared = nextFocusAttempt(state, null);
+  assert.equal(cleared.attempt, false);
+  assert.equal(cleared.state.lastFocusedKey, null);
+});
+
+test("a successfully focused key is skipped on later passes (one-shot)", () => {
+  let state = createFocusOneShotState();
+  const first = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(first.attempt, true);
+  state = markFocusSucceeded("src/a.ts:new:5");
+
+  const again = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(again.attempt, false);
+  assert.equal(again.state.lastFocusedKey, "src/a.ts:new:5");
+});
+
+test("reset then reselect the same anchor is a fresh focus target", () => {
+  let state = createFocusOneShotState();
+  // Focus succeeds on the anchor.
+  let next = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(next.attempt, true);
+  state = markFocusSucceeded("src/a.ts:new:5");
+  // Focus is cleared (null key).
+  next = nextFocusAttempt(state, null);
+  state = next.state;
+  assert.equal(state.lastFocusedKey, null);
+  // The same anchor selected again must be attempted, not skipped.
+  next = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(next.attempt, true);
+});
+
+test("a failed focus stays retryable on a later pass", () => {
+  let state = createFocusOneShotState();
+  // First pass: key is new, attempt runs, but focusAnnotationRow fails —
+  // the caller must NOT remember the key on failure.
+  let next = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(next.attempt, true);
+  state = next.state; // no markFocusSucceeded on failure
+  assert.equal(state.lastFocusedKey, null);
+
+  // A later public onPostRender update with the same key retries.
+  next = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(next.attempt, true);
+  // This time it succeeds.
+  state = markFocusSucceeded("src/a.ts:new:5");
+  // And is now one-shot.
+  next = nextFocusAttempt(state, "src/a.ts:new:5");
+  assert.equal(next.attempt, false);
+});
+
+test("a genuinely new key is never skipped after a different success", () => {
+  let state = createFocusOneShotState();
+  state = markFocusSucceeded("src/a.ts:new:5");
+  const next = nextFocusAttempt(state, "src/a.ts:old:9");
+  assert.equal(next.attempt, true);
+});
+
+// --- Hovered-line anchor cache (gutter fallback regression coverage) ---
+
+test("cached onLineEnter anchor is the fallback when the live getter is absent", () => {
+  let cache = createHoverAnchorCache();
+  cache = recordHoveredLine(PATH, 5, "additions");
+  const anchor = resolveGutterAnchor(cache, PATH, undefined);
+  assert.deepEqual(anchor, { lineNumber: 5, side: "additions" });
+});
+
+test("the live getter always wins over a stale cache", () => {
+  let cache = createHoverAnchorCache();
+  cache = recordHoveredLine(PATH, 5, "additions");
+  const anchor = resolveGutterAnchor(cache, PATH, {
+    lineNumber: 9,
+    side: "deletions",
+  });
+  assert.deepEqual(anchor, { lineNumber: 9, side: "deletions" });
+});
+
+test("no anchor when both the live getter and cache are absent", () => {
+  const cache = createHoverAnchorCache();
+  assert.equal(resolveGutterAnchor(cache, PATH, undefined), null);
+  assert.equal(resolveGutterAnchor(cache, PATH, null), null);
+});
+
+test("a stale cached anchor from another file never survives", () => {
+  let cache = createHoverAnchorCache();
+  cache = recordHoveredLine("src/b.ts", 7, "deletions");
+  assert.equal(resolveGutterAnchor(cache, PATH, undefined), null);
+  // A later onLineEnter for the current file replaces the entry entirely.
+  cache = recordHoveredLine(PATH, 3, "deletions");
+  assert.deepEqual(resolveGutterAnchor(cache, PATH, undefined), {
+    lineNumber: 3,
+    side: "deletions",
+  });
+});
+
+test("a later onLineEnter replaces the cached anchor", () => {
+  let cache = createHoverAnchorCache();
+  cache = recordHoveredLine(PATH, 5, "additions");
+  cache = recordHoveredLine(PATH, 6, "additions");
+  assert.deepEqual(resolveGutterAnchor(cache, PATH, undefined), {
+    lineNumber: 6,
+    side: "additions",
+  });
+});

--- a/desktop/src/features/projects/lib/projectDiffFocus.ts
+++ b/desktop/src/features/projects/lib/projectDiffFocus.ts
@@ -1,0 +1,244 @@
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
+import { getLineAnnotationName } from "@pierre/diffs";
+
+import type { ProjectPullRequestCommentAnchor } from "@/features/projects/projectPullRequests.mjs";
+import {
+  buzzSideToDiffSide,
+  focusedAnchorToSelectedRange,
+  type ProjectDiffAnnotationMetadata,
+  type ProjectDiffSide,
+} from "@/features/projects/lib/projectDiffAnnotations";
+
+/**
+ * Isolated Shadow DOM lookup for the focused-line scroll/focus path.
+ *
+ * Pierre renders into a `diffs-container` element with an open shadow root.
+ * Every line annotation we pass through `lineAnnotations` produces a stable
+ * annotation slot named by the public `getLineAnnotationName` utility (e.g.
+ * `annotation-additions-5`) inside a `[data-line-annotation]` row wrapper.
+ * Because the adapter always includes the focused anchor as an annotation
+ * (even with zero comments), this lookup has a stable, documented hook to
+ * resolve — no broad selectors, no reliance on internal row ordering.
+ */
+
+/** The row element that owns the given annotation slot, or null. */
+export function findAnnotationRow(
+  container: Element,
+  side: ProjectDiffSide,
+  lineNumber: number,
+): HTMLElement | null {
+  const shadowRoot = container.shadowRoot;
+  if (!shadowRoot) return null;
+  const slotName = getLineAnnotationName({ side, lineNumber });
+  const slot = shadowRoot.querySelector(`slot[name="${slotName}"]`);
+  if (!slot) return null;
+  return slot.closest("[data-line-annotation]");
+}
+
+/**
+ * Focus the annotation row for the given diff side/line: move it into view,
+ * make it programmatically focusable, and focus it without re-scrolling.
+ * Returns false when the row cannot be resolved (e.g. the line does not
+ * exist in the rendered patch).
+ */
+export function focusAnnotationRow(
+  container: Element,
+  side: ProjectDiffSide,
+  lineNumber: number,
+): boolean {
+  const row = findAnnotationRow(container, side, lineNumber);
+  if (!row) return false;
+  row.scrollIntoView({ behavior: "smooth", block: "center" });
+  row.setAttribute("tabindex", "-1");
+  row.focus({ preventScroll: true });
+  return true;
+}
+
+/** Stable ordering key for a diff annotation: deletions before additions. */
+function sideOrder(side: ProjectDiffSide) {
+  return side === "deletions" ? 0 : 1;
+}
+
+/** Stable per-file annotation key (path is already scoped by the caller). */
+function annotationKey(
+  annotation: DiffLineAnnotation<ProjectDiffAnnotationMetadata>,
+) {
+  return `${annotation.side}:${annotation.lineNumber}`;
+}
+
+/**
+ * Guarantee an annotation slot for the panel's active comment anchor.
+ *
+ * `buildFileDiffAnnotations` covers existing comment groups and the focused
+ * anchor, but a freshly opened composer lives on a line that may have no
+ * comments and no focus. Without an annotation for `activeAnchor` Pierre
+ * never calls `renderAnnotation` for it and the composer is invisible.
+ *
+ * Merges a commentless annotation for the active anchor into an existing
+ * annotation list, deduplicating identical side/line anchors and re-applying
+ * deterministic ordering (line ascending, deletions before additions). An
+ * anchor from another file is ignored. When the active anchor is the same as
+ * the focused anchor it is already present (focused anchors are always
+ * included) and is left untouched.
+ */
+export function includeActiveDiffAnchor(
+  annotations: DiffLineAnnotation<ProjectDiffAnnotationMetadata>[],
+  path: string,
+  activeAnchor: ProjectPullRequestCommentAnchor | null | undefined,
+): DiffLineAnnotation<ProjectDiffAnnotationMetadata>[] {
+  if (!activeAnchor || activeAnchor.path !== path) return annotations;
+
+  const active: DiffLineAnnotation<ProjectDiffAnnotationMetadata> = {
+    side: buzzSideToDiffSide(activeAnchor.side),
+    lineNumber: activeAnchor.line,
+    metadata: {
+      anchor: activeAnchor,
+      comments: [],
+      focused: false,
+    },
+  };
+  const existing = new Set(annotations.map(annotationKey));
+  if (existing.has(annotationKey(active))) return annotations;
+
+  return [...annotations, active].sort(
+    (left, right) =>
+      left.lineNumber - right.lineNumber ||
+      sideOrder(left.side) - sideOrder(right.side),
+  );
+}
+
+/**
+ * The focused anchor's Pierre selected-line range, scoped to the file being
+ * rendered. Returns null when there is no focused anchor or when it points at
+ * a different path — a mismatched-path focus must not produce a transient or
+ * wrong-line selection on the previously displayed file.
+ */
+export function selectedRangeForFile(
+  path: string,
+  focusedAnchor: ProjectPullRequestCommentAnchor | null | undefined,
+): SelectedLineRange | null {
+  if (!focusedAnchor || focusedAnchor.path !== path) return null;
+  return focusedAnchorToSelectedRange(focusedAnchor);
+}
+
+/**
+ * One-shot focus key for the focused anchor, scoped to the file being
+ * rendered. Includes the path so switching between files at the same side and
+ * line is treated as a new focus target. Returns null when there is no
+ * focused anchor or when it points at a different path.
+ */
+export function focusedAnchorKey(
+  path: string,
+  focusedAnchor: ProjectPullRequestCommentAnchor | null | undefined,
+): string | null {
+  if (!focusedAnchor || focusedAnchor.path !== path) return null;
+  return `${focusedAnchor.path}:${focusedAnchor.side}:${focusedAnchor.line}`;
+}
+
+/**
+ * Mutable one-shot state for focused-line scroll/focus, kept in a ref by the
+ * adapter and advanced through {@link nextFocusAttempt} /
+ * {@link markFocusSucceeded} so the lifecycle is pure and testable.
+ */
+export type FocusOneShotState = {
+  /** Last key that was successfully focused, or null when none/cleared. */
+  lastFocusedKey: string | null;
+};
+
+/** Initial one-shot state: nothing focused yet. */
+export function createFocusOneShotState(): FocusOneShotState {
+  return { lastFocusedKey: null };
+}
+
+/**
+ * Advance the one-shot focused-line lifecycle for one public `onPostRender`
+ * pass. The file-scoped focus key is null when there is no focused anchor or
+ * it points at another file.
+ *
+ * - Null key: clears the remembered key (focus was cleared or the file
+ *   switched away), returns `attempt: false`. A later identical anchor is
+ *   treated as a genuinely new focus target.
+ * - Key equal to the remembered key: `attempt: false` — one-shot behavior
+ *   after a successful focus.
+ * - Any other key: `attempt: true`; the returned state is unchanged so the
+ *   caller only records success via {@link markFocusSucceeded} after
+ *   `focusAnnotationRow` actually resolves — a failed lookup stays retryable
+ *   on a later post-render.
+ */
+export function nextFocusAttempt(
+  state: FocusOneShotState,
+  key: string | null,
+): { state: FocusOneShotState; attempt: boolean } {
+  if (key === null) {
+    return { state: { lastFocusedKey: null }, attempt: false };
+  }
+  if (state.lastFocusedKey === key) {
+    return { state, attempt: false };
+  }
+  return { state, attempt: true };
+}
+
+/** Record a successfully focused key so the same key is not re-focused. */
+export function markFocusSucceeded(key: string): FocusOneShotState {
+  return { lastFocusedKey: key };
+}
+
+/**
+ * Exact hovered line cached from Pierre's public `onLineEnter` payload.
+ * Scoped to one rendered file path so no cross-file anchor can survive a
+ * file switch. The gutter action resolves live `getHoveredLine()` first and
+ * falls back to this cache only when the live getter is absent.
+ */
+export type HoveredLineAnchor = {
+  lineNumber: number;
+  side: ProjectDiffSide;
+};
+
+/** The cached onLineEnter anchor, or null when none is known yet. */
+export type HoverAnchorCache = {
+  path: string;
+  anchor: HoveredLineAnchor;
+} | null;
+
+/** Start with no cached hovered line. */
+export function createHoverAnchorCache(): HoverAnchorCache {
+  return null;
+}
+
+/**
+ * Record the last exact `{ lineNumber, side }` delivered by Pierre's public
+ * `onLineEnter` callback for the rendered file. A later `onLineEnter` for the
+ * same file replaces it; switching files replaces the whole entry.
+ */
+export function recordHoveredLine(
+  path: string,
+  lineNumber: number,
+  side: ProjectDiffSide,
+): HoverAnchorCache {
+  return { path, anchor: { lineNumber, side } };
+}
+
+/**
+ * The cached hovered line for the current file, or null when the cache holds
+ * a different file (a stale anchor must never survive a file switch).
+ */
+export function cachedHoveredLine(
+  cache: HoverAnchorCache,
+  path: string,
+): HoveredLineAnchor | null {
+  return cache && cache.path === path ? cache.anchor : null;
+}
+
+/**
+ * Resolve the anchor for the gutter action: the live getter always wins; the
+ * cached public `onLineEnter` anchor is the fallback; null when neither
+ * exists. Never infers a line from DOM structure or selection internals.
+ */
+export function resolveGutterAnchor(
+  cache: HoverAnchorCache,
+  path: string,
+  live: HoveredLineAnchor | null | undefined,
+): HoveredLineAnchor | null {
+  if (live) return live;
+  return cachedHoveredLine(cache, path);
+}

--- a/desktop/src/features/projects/ui/ProjectCommitDetailPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectCommitDetailPanel.tsx
@@ -61,7 +61,10 @@ export function ProjectCommitDetailPanel({
   const shortHash = commit?.shortHash ?? commitHash.slice(0, 7);
 
   return (
-    <div className="space-y-3">
+    <div
+      className="flex min-w-0 flex-col space-y-3 overflow-hidden xl:min-h-0 xl:flex-1"
+      data-testid="project-commit-detail-panel"
+    >
       <header
         className={`space-y-2 p-4 ${PROJECT_DETAIL_PANEL_CLASS}`}
         data-project-detail-panel

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -856,8 +856,14 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
             project={project}
           />
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-4 pb-4">
-            <div className="w-full space-y-3 pt-[calc(var(--buzz-channel-content-top-padding,5.75rem)_+_1px)]">
+          <div
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-4 pb-4"
+            data-testid="project-detail-scroll"
+          >
+            <div
+              className="flex w-full flex-col space-y-3 pt-[calc(var(--buzz-channel-content-top-padding,5.75rem)_+_1px)] xl:min-h-full"
+              data-testid="project-detail-stack"
+            >
               <section className="space-y-3">
                 <div className="flex min-w-0 items-start justify-between gap-3">
                   <div className="min-w-0 flex-1 space-y-0.5">

--- a/desktop/src/features/projects/ui/ProjectDiffBody.tsx
+++ b/desktop/src/features/projects/ui/ProjectDiffBody.tsx
@@ -1,0 +1,333 @@
+import { PatchDiff, type DiffLineAnnotation } from "@pierre/diffs/react";
+import type { AnnotationSide, OnDiffLineEnterLeaveProps } from "@pierre/diffs";
+import { MessageSquarePlus } from "lucide-react";
+import * as React from "react";
+import type { CSSProperties } from "react";
+
+import type {
+  ProjectPullRequestComment,
+  ProjectPullRequestCommentAnchor,
+} from "@/features/projects/projectPullRequests.mjs";
+import {
+  annotationToBuzzAnchor,
+  anchorsEqual,
+  buildFileDiffAnnotations,
+  buzzSideToDiffSide,
+  diffSideToBuzzSide,
+  isRenderablePatch,
+  patchBodyLineCount,
+  type ProjectDiffAnnotationMetadata,
+} from "@/features/projects/lib/projectDiffAnnotations";
+import {
+  createFocusOneShotState,
+  createHoverAnchorCache,
+  focusAnnotationRow,
+  focusedAnchorKey,
+  includeActiveDiffAnchor,
+  markFocusSucceeded,
+  nextFocusAttempt,
+  recordHoveredLine,
+  resolveGutterAnchor,
+  selectedRangeForFile,
+} from "@/features/projects/lib/projectDiffFocus";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type { ProjectRepoDiffFile } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import { useTheme } from "@/shared/theme/ThemeProvider";
+import { resolveShikiThemeName } from "@/shared/theme/theme-loader";
+import { ProjectPullRequestInlineCommentThread } from "./ProjectPullRequestInlineComments";
+
+/**
+ * Inline-comment controls contract shared with the Projects changed-files
+ * panel. Mirrors the panel's `InlineCommentControls` shape so the adapter can
+ * reuse the existing thread/form and add-comment actions without reaching
+ * into panel internals.
+ */
+export type ProjectDiffInlineComments = {
+  activeAnchor: ProjectPullRequestCommentAnchor | null;
+  canRequestChanges: boolean;
+  comments: ProjectPullRequestComment[];
+  isSending: boolean;
+  onCancel: () => void;
+  onStart: (anchor: ProjectPullRequestCommentAnchor) => void;
+  onSubmit: (
+    anchor: ProjectPullRequestCommentAnchor,
+    content: string,
+    mentionPubkeys: string[],
+    mediaTags?: string[][],
+    decision?: "request-changes",
+  ) => Promise<unknown>;
+  profiles?: UserProfileLookup;
+};
+
+const MONO_FONT_STACK =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace';
+
+/**
+ * Buzz-owned adapter around Pierre's {@link PatchDiff} for one changed file.
+ *
+ * Accepts the existing raw per-file patch and the surrounding application
+ * state (focused anchor, inline-comment controls) and renders the diff
+ * through `@pierre/diffs` with Buzz's presentation choices:
+ *
+ * - unified layout, classic indicators, line numbers, scroll overflow
+ * - metadata hunk separators, no library file header (Buzz renders its own)
+ * - no unchanged-line expansion, explicit main-thread rendering
+ * - resolved Buzz Shiki theme (Buzz aliases map to github-light/github-dark)
+ * - existing inline threads/forms via `renderAnnotation`
+ * - keyboard-accessible add-comment action via the gutter utility
+ * - focused-line scroll/focus through the public `onPostRender` lifecycle
+ *   hook, resolved by {@link focusAnnotationRow}
+ *
+ * Empty/malformed patches keep the friendly fallback and the truncation
+ * banner is preserved above the rendered body.
+ */
+export function ProjectDiffBody({
+  file,
+  focusedAnchor,
+  inlineComments,
+  className,
+}: {
+  file: ProjectRepoDiffFile;
+  focusedAnchor?: ProjectPullRequestCommentAnchor | null;
+  inlineComments?: ProjectDiffInlineComments;
+  className?: string;
+}) {
+  const { themeName, isDark } = useTheme();
+  const resolvedTheme = resolveShikiThemeName(themeName);
+
+  const lineAnnotations = React.useMemo(
+    () =>
+      includeActiveDiffAnchor(
+        buildFileDiffAnnotations(
+          file.path,
+          inlineComments?.comments ?? [],
+          focusedAnchor,
+        ),
+        file.path,
+        inlineComments?.activeAnchor,
+      ),
+    [
+      file.path,
+      focusedAnchor,
+      inlineComments?.comments,
+      inlineComments?.activeAnchor,
+    ],
+  );
+
+  const selectedLines = React.useMemo(
+    () => selectedRangeForFile(file.path, focusedAnchor),
+    [file.path, focusedAnchor],
+  );
+
+  // Only scroll/focus once per focused anchor change, not on every post
+  // render pass (the hook fires on mount and every update). The key includes
+  // the path so switching files at the same side/line is a new focus target.
+  // One-shot focused-line lifecycle: remember a key only after a successful
+  // focus, clear it when the file-scoped key goes null, and never skip a
+  // genuinely new key. A failed lookup stays retryable on a later public
+  // `onPostRender` update.
+  const focusOneShotRef = React.useRef(createFocusOneShotState());
+  const handlePostRender = React.useCallback(
+    (node: HTMLElement) => {
+      const key = focusedAnchorKey(file.path, focusedAnchor);
+      const { state, attempt } = nextFocusAttempt(focusOneShotRef.current, key);
+      // `attempt` is only true when the key is non-null, which implies the
+      // focused anchor exists and matches this file — the extra guards only
+      // satisfy type narrowing.
+      if (!attempt || !focusedAnchor || !key) {
+        focusOneShotRef.current = state;
+        return;
+      }
+      const succeeded = focusAnnotationRow(
+        node,
+        buzzSideToDiffSide(focusedAnchor.side),
+        focusedAnchor.line,
+      );
+      focusOneShotRef.current = succeeded ? markFocusSucceeded(key) : state;
+    },
+    [file.path, focusedAnchor],
+  );
+
+  const renderAnnotation = React.useCallback(
+    (annotation: DiffLineAnnotation<ProjectDiffAnnotationMetadata>) => {
+      if (!inlineComments) return null;
+      const anchor = annotationToBuzzAnchor(annotation);
+      const isActive = anchorsEqual(inlineComments.activeAnchor, anchor);
+      return (
+        <ProjectPullRequestInlineCommentThread
+          activeAnchor={isActive ? anchor : null}
+          canRequestChanges={inlineComments.canRequestChanges}
+          comments={annotation.metadata.comments}
+          isSending={inlineComments.isSending}
+          onCancel={inlineComments.onCancel}
+          onSubmit={(content, mentionPubkeys, mediaTags, decision) =>
+            inlineComments.onSubmit(
+              anchor,
+              content,
+              mentionPubkeys,
+              mediaTags,
+              decision,
+            )
+          }
+          profiles={inlineComments.profiles}
+        />
+      );
+    },
+    [inlineComments],
+  );
+
+  const gutterButtonRef = React.useRef<HTMLButtonElement | null>(null);
+
+  // Last exact { lineNumber, side } received from Pierre's public
+  // `onLineEnter`, scoped to this file. The gutter action resolves the live
+  // `getHoveredLine()` first and falls back to this cache only when the live
+  // getter is absent (e.g. the pointer transitions from the code row into the
+  // floating utility, or keyboard activation).
+  const hoverAnchorCacheRef = React.useRef(createHoverAnchorCache());
+
+  // The gutter utility is a single floating button the library moves onto the
+  // hovered/selected line. Keep its accessible name truthful about the exact
+  // line it will open, updated through the public interaction lifecycle.
+  const updateGutterLabel = React.useCallback(
+    (line: number | null, side: AnnotationSide | null) => {
+      const button = gutterButtonRef.current;
+      if (!button) return;
+      if (line == null || side == null) {
+        button.setAttribute("aria-label", `Add line comment on ${file.path}`);
+        button.setAttribute("title", "Comment on this line");
+        return;
+      }
+      const buzzSide = diffSideToBuzzSide(side);
+      button.setAttribute(
+        "aria-label",
+        `Comment on ${file.path} ${buzzSide} line ${line}`,
+      );
+      button.setAttribute(
+        "title",
+        `Comment on ${file.path} ${buzzSide} line ${line}`,
+      );
+    },
+    [file.path],
+  );
+
+  // A file switch must never let a stale hovered line survive: reset the
+  // cache and restore the generic accessible label. `updateGutterLabel` is
+  // memoized on `file.path`, so depending on it expresses the file-switch
+  // lifecycle exactly once per rendered file.
+  React.useEffect(() => {
+    hoverAnchorCacheRef.current = createHoverAnchorCache();
+    updateGutterLabel(null, null);
+  }, [updateGutterLabel]);
+
+  const renderGutterUtility = React.useCallback(
+    (
+      getHoveredLine: () =>
+        | { lineNumber: number; side: "deletions" | "additions" }
+        | undefined,
+    ) => {
+      if (!inlineComments) return null;
+      return (
+        <button
+          aria-label={`Add line comment on ${file.path}`}
+          className="relative z-[4] pointer-events-auto flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-primary hover:text-primary-foreground focus-visible:opacity-100 focus-visible:outline-hidden"
+          data-testid="project-diff-add-comment"
+          onClick={() => {
+            const anchor = resolveGutterAnchor(
+              hoverAnchorCacheRef.current,
+              file.path,
+              getHoveredLine(),
+            );
+            if (!anchor) return;
+            inlineComments.onStart({
+              line: anchor.lineNumber,
+              path: file.path,
+              side: diffSideToBuzzSide(anchor.side),
+            });
+          }}
+          onFocus={() => {
+            // Keyboard path: live getter first, then the cached public
+            // onLineEnter anchor; keep the accessible label exact.
+            const anchor = resolveGutterAnchor(
+              hoverAnchorCacheRef.current,
+              file.path,
+              getHoveredLine(),
+            );
+            if (anchor) {
+              updateGutterLabel(anchor.lineNumber, anchor.side);
+            }
+          }}
+          ref={gutterButtonRef}
+          title="Comment on this line"
+          type="button"
+        >
+          <MessageSquarePlus className="h-3.5 w-3.5" />
+        </button>
+      );
+    },
+    [file.path, inlineComments, updateGutterLabel],
+  );
+
+  if (!isRenderablePatch(file.patch)) {
+    return (
+      <div className="bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
+        No textual diff is available for this file.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("bg-background/70", className)}
+      data-testid="project-diff-body"
+    >
+      {file.truncated ? (
+        <div className="border-border/40 border-b bg-amber-500/10 px-4 py-2 text-amber-600 dark:text-amber-400">
+          Large diff truncated — showing the first{" "}
+          {patchBodyLineCount(file.patch)} lines. Use a local checkout to review
+          the full change.
+        </div>
+      ) : null}
+      <PatchDiff
+        disableWorkerPool
+        lineAnnotations={lineAnnotations}
+        options={{
+          diffStyle: "unified",
+          diffIndicators: "classic",
+          disableFileHeader: true,
+          disableLineNumbers: false,
+          enableGutterUtility: inlineComments != null,
+          expandUnchanged: false,
+          hunkSeparators: "metadata",
+          onLineEnter: (props: OnDiffLineEnterLeaveProps) => {
+            // Cache the last exact public onLineEnter anchor for this file.
+            hoverAnchorCacheRef.current = recordHoveredLine(
+              file.path,
+              props.lineNumber,
+              props.annotationSide,
+            );
+            updateGutterLabel(props.lineNumber, props.annotationSide);
+          },
+          onPostRender: (node) => handlePostRender(node),
+          overflow: "scroll",
+          theme: {
+            light: resolvedTheme,
+            dark: resolvedTheme,
+          },
+          themeType: isDark ? "dark" : "light",
+        }}
+        patch={file.patch}
+        renderAnnotation={renderAnnotation}
+        renderGutterUtility={renderGutterUtility}
+        selectedLines={selectedLines}
+        style={
+          {
+            "--diffs-font-size": "0.75rem",
+            "--diffs-line-height": "1.25rem",
+            "--diffs-font-family": MONO_FONT_STACK,
+          } as CSSProperties
+        }
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectPullRequestFilesChangedPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectPullRequestFilesChangedPanel.tsx
@@ -17,7 +17,6 @@ import {
   FileVideo,
   FolderGit2,
   GitCommitHorizontal,
-  MessageSquarePlus,
   Package,
   Search,
   Settings,
@@ -34,13 +33,17 @@ import {
   useCreateProjectPullRequestCommentMutation,
 } from "@/features/projects/hooks";
 import { canReviewProjectPullRequest } from "@/features/projects/pullRequestReviews";
-import type { ProjectPullRequestComment } from "@/features/projects/projectPullRequests.mjs";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import { cn } from "@/shared/lib/cn";
 import type { ProjectRepoDiff, ProjectRepoDiffFile } from "@/shared/api/types";
+import {
+  ProjectDiffBody,
+  type ProjectDiffInlineComments,
+} from "./ProjectDiffBody";
 import { PROJECT_DETAIL_PANEL_CLASS } from "./projectPanelStyles";
-import { ProjectPullRequestInlineCommentThread } from "./ProjectPullRequestInlineComments";
+
+type InlineCommentControls = ProjectDiffInlineComments;
 
 function fileName(path: string) {
   return path.split("/").pop() || path;
@@ -51,31 +54,6 @@ function directoryName(path: string) {
   segments.pop();
   return segments.join("/");
 }
-
-type DiffRow = {
-  content: string;
-  key: string;
-  newLine: number | null;
-  oldLine: number | null;
-  type: "add" | "context" | "delete" | "hunk";
-};
-
-type InlineCommentControls = {
-  activeAnchor: ProjectPullRequestCommentAnchor | null;
-  canRequestChanges: boolean;
-  comments: ProjectPullRequestComment[];
-  isSending: boolean;
-  onCancel: () => void;
-  onStart: (anchor: ProjectPullRequestCommentAnchor) => void;
-  onSubmit: (
-    anchor: ProjectPullRequestCommentAnchor,
-    content: string,
-    mentionPubkeys: string[],
-    mediaTags?: string[][],
-    decision?: "request-changes",
-  ) => Promise<unknown>;
-  profiles?: UserProfileLookup;
-};
 
 type FileTreeNode = {
   children: Map<string, FileTreeNode>;
@@ -328,99 +306,29 @@ function ChangedFolderTreeIcon() {
   );
 }
 
-function parseHunkHeader(line: string) {
-  const match = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
-  if (!match) return null;
-  return { oldLine: Number(match[1]), newLine: Number(match[2]) };
-}
-
-function diffRows(file: ProjectRepoDiffFile): DiffRow[] {
-  let oldLine = 0;
-  let newLine = 0;
-  return file.patch
-    .trimEnd()
-    .split("\n")
-    .filter(
-      (line) =>
-        !line.startsWith("diff --git ") &&
-        !line.startsWith("index ") &&
-        !line.startsWith("--- ") &&
-        !line.startsWith("+++ "),
-    )
-    .map((line, index) => {
-      const hunk = parseHunkHeader(line);
-      let row: Omit<DiffRow, "key">;
-      if (hunk) {
-        oldLine = hunk.oldLine;
-        newLine = hunk.newLine;
-        row = { content: line, oldLine: null, newLine: null, type: "hunk" };
-      } else if (line.startsWith("+")) {
-        row = {
-          content: line.slice(1),
-          oldLine: null,
-          newLine: newLine++,
-          type: "add",
-        };
-      } else if (line.startsWith("-")) {
-        row = {
-          content: line.slice(1),
-          oldLine: oldLine++,
-          newLine: null,
-          type: "delete",
-        };
-      } else {
-        row = {
-          content: line.startsWith(" ") ? line.slice(1) : line,
-          oldLine: oldLine++,
-          newLine: newLine++,
-          type: "context",
-        };
-      }
-      // Rows are computed once per patch in source order, so a positional
-      // index is a stable, cheap key.
-      return { ...row, key: `${file.path}:${index}` };
-    });
-}
-
-function diffLineClassName(type: DiffRow["type"]) {
-  if (type === "add") return "border-green-500/10 border-l-2 bg-green-500/10";
-  if (type === "delete")
-    return "border-destructive/10 border-l-2 bg-destructive/10";
-  if (type === "hunk") return "bg-sky-500/10 text-sky-500";
-  return "border-transparent border-l-2";
-}
-
-function linePrefix(type: DiffRow["type"]) {
-  if (type === "add") return "+";
-  if (type === "delete") return "-";
-  return " ";
-}
-
-function commentAnchorForRow(
-  file: ProjectRepoDiffFile,
-  row: DiffRow,
-): ProjectPullRequestCommentAnchor | null {
-  if (row.type === "hunk") return null;
-  const side = row.type === "delete" ? "old" : "new";
-  const line = side === "old" ? row.oldLine : row.newLine;
-  return line ? { line, path: file.path, side } : null;
-}
-
-function anchorsEqual(
-  left: ProjectPullRequestCommentAnchor | null,
-  right: ProjectPullRequestCommentAnchor | null,
-) {
-  return Boolean(
-    left &&
-      right &&
-      left.line === right.line &&
-      left.path === right.path &&
-      left.side === right.side,
-  );
-}
-
 function fileAdditions(file: ProjectRepoDiffFile) {
   return file.additions;
+}
+
+function pierrePatch(file: ProjectRepoDiffFile) {
+  if (file.patch.includes("diff --git ")) return file.patch;
+  let inHunk = false;
+  const patchLines = file.patch
+    .trimEnd()
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("@@ ")) inHunk = true;
+      return inHunk && line === "" ? " " : line;
+    });
+  if (patchLines.length > 0 && !patchLines.at(-1)?.startsWith(" ")) {
+    patchLines.push(" ");
+  }
+  const result = [
+    `--- a/${file.path}`,
+    `+++ b/${file.path}`,
+    patchLines.join("\n"),
+  ].join("\n");
+  return result.endsWith("\n") ? result : `${result}\n`;
 }
 
 function changedFileStats(diff: ProjectRepoDiff | null | undefined) {
@@ -441,165 +349,6 @@ function errorMessage(error: unknown) {
   // Backend errors can carry raw git stderr with temp-dir paths; strip
   // absolute paths so the UI doesn't leak local filesystem details.
   return message.replace(/(^|[\s'"`])(?:[A-Za-z]:)?[\\/][^\s'"`]+/g, "$1…");
-}
-
-function DiffPreview({
-  file,
-  focusedAnchor,
-  inlineComments,
-}: {
-  file: ProjectRepoDiffFile;
-  focusedAnchor?: ProjectPullRequestCommentAnchor | null;
-  inlineComments?: InlineCommentControls;
-}) {
-  const rows = diffRows(file);
-  const focusedRowRef = React.useRef<HTMLDivElement | null>(null);
-  const [highlightedAnchor, setHighlightedAnchor] =
-    React.useState<ProjectPullRequestCommentAnchor | null>(null);
-
-  React.useEffect(() => {
-    if (!focusedAnchor || focusedAnchor.path !== file.path) {
-      setHighlightedAnchor(null);
-      return;
-    }
-
-    setHighlightedAnchor(focusedAnchor);
-    let isListeningForInteraction = false;
-    const clearHighlight = () => setHighlightedAnchor(null);
-    const clearHighlightOnKeyDown = (event: KeyboardEvent) => {
-      if (["Alt", "Control", "Meta", "Shift"].includes(event.key)) return;
-      clearHighlight();
-    };
-    const frame = window.requestAnimationFrame(() => {
-      focusedRowRef.current?.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-      focusedRowRef.current?.focus({ preventScroll: true });
-      window.addEventListener("pointerdown", clearHighlight, true);
-      window.addEventListener("keydown", clearHighlightOnKeyDown, true);
-      isListeningForInteraction = true;
-    });
-    return () => {
-      window.cancelAnimationFrame(frame);
-      if (isListeningForInteraction) {
-        window.removeEventListener("pointerdown", clearHighlight, true);
-        window.removeEventListener("keydown", clearHighlightOnKeyDown, true);
-      }
-    };
-  }, [file.path, focusedAnchor]);
-
-  if (rows.length === 0) {
-    return (
-      <div className="bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
-        No textual diff is available for this file.
-      </div>
-    );
-  }
-
-  return (
-    <div className="overflow-x-auto bg-background/70 font-mono text-xs leading-5">
-      {file.truncated ? (
-        <div className="border-border/40 border-b bg-amber-500/10 px-4 py-2 text-amber-600 dark:text-amber-400">
-          Large diff truncated — showing the first {rows.length} lines. Use a
-          local checkout to review the full change.
-        </div>
-      ) : null}
-      {rows.map((row) => {
-        const anchor = commentAnchorForRow(file, row);
-        const comments =
-          anchor && inlineComments
-            ? inlineComments.comments.filter(
-                (comment) =>
-                  comment.anchor && anchorsEqual(comment.anchor, anchor),
-              )
-            : [];
-        const isActive = anchorsEqual(
-          inlineComments?.activeAnchor ?? null,
-          anchor,
-        );
-        const isFocused = anchorsEqual(highlightedAnchor, anchor);
-        return (
-          <React.Fragment key={row.key}>
-            <div
-              className={cn(
-                "group grid min-h-5 grid-cols-[3rem_3rem_2rem_1.5rem_minmax(0,1fr)]",
-                diffLineClassName(row.type),
-                isFocused && "bg-primary/10 ring-1 ring-primary/40 ring-inset",
-              )}
-              data-line={anchor?.line}
-              data-path={anchor?.path}
-              data-side={anchor?.side}
-              data-testid={
-                isFocused
-                  ? "project-diff-focused-line"
-                  : anchor
-                    ? "project-diff-line"
-                    : undefined
-              }
-              ref={isFocused ? focusedRowRef : undefined}
-              tabIndex={isFocused ? -1 : undefined}
-            >
-              <span className="select-none border-border/40 border-r px-2 text-right text-muted-foreground/70">
-                {row.oldLine ?? " "}
-              </span>
-              <span className="select-none border-border/40 border-r px-2 text-right text-muted-foreground/70">
-                {row.newLine ?? " "}
-              </span>
-              <span className="flex select-none items-center justify-center">
-                {anchor && inlineComments ? (
-                  <button
-                    aria-label={`Comment on ${anchor.path} ${anchor.side} line ${anchor.line}`}
-                    className={cn(
-                      "flex h-5 w-5 items-center justify-center rounded text-muted-foreground opacity-0 hover:bg-primary hover:text-primary-foreground focus-visible:opacity-100 focus-visible:outline-hidden group-hover:opacity-100",
-                      (comments.length > 0 || isActive) && "opacity-100",
-                    )}
-                    data-testid="project-diff-add-comment"
-                    onClick={() => inlineComments.onStart(anchor)}
-                    title="Add line comment"
-                    type="button"
-                  >
-                    <MessageSquarePlus className="h-3.5 w-3.5" />
-                  </button>
-                ) : null}
-              </span>
-              <span
-                className={cn(
-                  "select-none px-2",
-                  row.type === "add" && "text-green-500",
-                  row.type === "delete" && "text-destructive",
-                )}
-              >
-                {linePrefix(row.type)}
-              </span>
-              <code className="min-w-0 whitespace-pre pr-3 text-foreground">
-                {row.content || " "}
-              </code>
-            </div>
-            {anchor && inlineComments ? (
-              <ProjectPullRequestInlineCommentThread
-                activeAnchor={isActive ? anchor : null}
-                canRequestChanges={inlineComments.canRequestChanges}
-                comments={comments}
-                isSending={inlineComments.isSending}
-                onCancel={inlineComments.onCancel}
-                onSubmit={(content, mentionPubkeys, mediaTags, decision) =>
-                  inlineComments.onSubmit(
-                    anchor,
-                    content,
-                    mentionPubkeys,
-                    mediaTags,
-                    decision,
-                  )
-                }
-                profiles={inlineComments.profiles}
-              />
-            ) : null}
-          </React.Fragment>
-        );
-      })}
-    </div>
-  );
 }
 
 function FileTreeItems({
@@ -776,6 +525,10 @@ export function ProjectDiffFilesPanel({
   const outerBorderClass = embedded ? "" : PROJECT_DETAIL_PANEL_CLASS;
   const [query, setQuery] = React.useState("");
   const [selectedPath, setSelectedPath] = React.useState<string | null>(null);
+  const [displayedFocusedAnchor, setDisplayedFocusedAnchor] =
+    React.useState<ProjectPullRequestCommentAnchor | null>(
+      focusedAnchor ?? null,
+    );
   const files = diff?.files ?? [];
   const filteredFiles = React.useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -793,6 +546,27 @@ export function ProjectDiffFilesPanel({
     filteredFiles.find((file) => file.path === selectedPath) ??
     filteredFiles[0] ??
     null;
+
+  React.useEffect(() => {
+    setDisplayedFocusedAnchor(focusedAnchor ?? null);
+  }, [focusedAnchor]);
+
+  React.useEffect(() => {
+    if (!displayedFocusedAnchor) return;
+
+    const clearFocusedAnchor = () => setDisplayedFocusedAnchor(null);
+    const clearFocusedAnchorOnKeyDown = (event: KeyboardEvent) => {
+      if (["Alt", "Control", "Meta", "Shift"].includes(event.key)) return;
+      clearFocusedAnchor();
+    };
+
+    window.addEventListener("pointerdown", clearFocusedAnchor, true);
+    window.addEventListener("keydown", clearFocusedAnchorOnKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", clearFocusedAnchor, true);
+      window.removeEventListener("keydown", clearFocusedAnchorOnKeyDown, true);
+    };
+  }, [displayedFocusedAnchor]);
 
   React.useEffect(() => {
     if (!focusedAnchor) return;
@@ -932,11 +706,18 @@ export function ProjectDiffFilesPanel({
                   </span>
                 </div>
               </header>
-              <DiffPreview
-                file={selectedFile}
-                focusedAnchor={focusedAnchor}
-                inlineComments={inlineComments}
-              />
+              <div
+                data-line={displayedFocusedAnchor?.line}
+                data-path={displayedFocusedAnchor?.path}
+                data-side={displayedFocusedAnchor?.side}
+                data-testid="project-diff-renderer"
+              >
+                <ProjectDiffBody
+                  file={{ ...selectedFile, patch: pierrePatch(selectedFile) }}
+                  focusedAnchor={displayedFocusedAnchor}
+                  inlineComments={inlineComments}
+                />
+              </div>
             </article>
           ) : (
             <div className="border border-border/60 bg-background/45 p-4 text-sm text-muted-foreground">

--- a/desktop/src/features/projects/ui/ProjectPullRequestFilesChangedPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectPullRequestFilesChangedPanel.tsx
@@ -635,12 +635,12 @@ export function ProjectDiffFilesPanel({
   return (
     <div
       className={cn(
-        "grid min-h-0 overflow-hidden lg:grid-cols-[17rem_minmax(0,1fr)]",
+        "grid min-w-0 overflow-hidden lg:grid-cols-[17rem_minmax(0,1fr)] lg:min-h-0 lg:flex-1",
         outerBorderClass,
       )}
       data-project-detail-panel={embedded ? undefined : true}
     >
-      <aside className="border-border/50 border-b bg-background/30 lg:border-r lg:border-b-0">
+      <aside className="flex min-w-0 flex-col border-border/50 border-b bg-background/30 lg:min-h-0 lg:border-r lg:border-b-0">
         <div className="space-y-3 p-3">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Files className="h-3.5 w-3.5" />
@@ -656,7 +656,10 @@ export function ProjectDiffFilesPanel({
             />
           </label>
         </div>
-        <nav className="max-h-96 overflow-auto border-border/50 border-t py-1">
+        <nav
+          className="min-h-0 flex-1 overflow-auto border-border/50 border-t py-1"
+          data-testid="project-diff-file-tree"
+        >
           <FileTreeItems
             node={fileTree}
             onSelect={setSelectedPath}
@@ -665,7 +668,7 @@ export function ProjectDiffFilesPanel({
         </nav>
       </aside>
 
-      <section className="min-w-0">
+      <section className="flex min-w-0 flex-col overflow-hidden lg:min-h-0">
         <div className="flex min-h-12 flex-wrap items-center justify-between gap-3 border-border/50 border-b bg-background/30 px-4 py-2 text-xs text-muted-foreground">
           <div className="flex min-w-0 items-center gap-2">
             <GitCommitHorizontal className="h-3.5 w-3.5" />
@@ -678,7 +681,10 @@ export function ProjectDiffFilesPanel({
           </div>
         </div>
 
-        <div className="p-3">
+        <div
+          className="overflow-auto p-3 lg:min-h-0 lg:flex-1"
+          data-testid="project-diff-scroll"
+        >
           {selectedFile ? (
             <article className="overflow-hidden border border-border/60 bg-background/45">
               <header className="flex min-h-10 items-center justify-between gap-3 border-border/50 border-b bg-muted/20 px-3 text-xs">
@@ -709,6 +715,7 @@ export function ProjectDiffFilesPanel({
               <div
                 data-line={displayedFocusedAnchor?.line}
                 data-path={displayedFocusedAnchor?.path}
+                data-selected-path={selectedFile.path}
                 data-side={displayedFocusedAnchor?.side}
                 data-testid="project-diff-renderer"
               >

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/features/projects/lib/projectRepoAvailability";
 import { useMemberChannelIds } from "@/features/projects/useRepositoryAccess";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Tabs, TabsContent } from "@/shared/ui/tabs";
 import { findReadmeFile } from "./ProjectReadmePanel";
@@ -326,7 +327,7 @@ export function WorkspaceTabs({
 
   return (
     <Tabs
-      className="space-y-3"
+      className="flex min-w-0 flex-col space-y-3 xl:min-h-0 xl:flex-1"
       onValueChange={handleTabChange}
       value={selectedTab}
     >
@@ -361,11 +362,21 @@ export function WorkspaceTabs({
         </div>
       ) : null}
       {selectedPullRequest ? (
-        <div className={PROJECT_DETAIL_PANEL_CLASS} data-project-detail-panel>
+        <div
+          className={cn(
+            "flex min-w-0 flex-col xl:min-h-0 xl:flex-1",
+            PROJECT_DETAIL_PANEL_CLASS,
+          )}
+          data-project-detail-panel
+          data-testid="project-pr-detail-panel"
+        >
           {/* Two full-height columns: the meta rail runs all the way to the
               top of the card, alongside the header and tabs. */}
-          <div className="grid xl:grid-cols-[minmax(0,1fr)_18rem]">
-            <div className="min-w-0">
+          <div className="grid min-w-0 overflow-hidden xl:min-h-0 xl:flex-1 xl:grid-cols-[minmax(0,1fr)_18rem]">
+            <div
+              className="flex min-w-0 flex-col overflow-hidden xl:min-h-0"
+              data-testid="project-pr-main-column"
+            >
               <PullRequestDetailHeader
                 profiles={profiles}
                 pullRequest={selectedPullRequest}
@@ -395,7 +406,10 @@ export function WorkspaceTabs({
                   />
                 </TabsContent>
               ))}
-              <TabsContent className="m-0" value="pr-files">
+              <TabsContent
+                className="m-0 flex min-w-0 flex-col xl:min-h-0 xl:flex-1"
+                value="pr-files"
+              >
                 <ProjectPullRequestFilesChangedPanel
                   diff={repoDiff}
                   error={repoDiffError}
@@ -440,7 +454,10 @@ export function WorkspaceTabs({
         />
       </TabsContent>
 
-      <TabsContent className="m-0" value="activity">
+      <TabsContent
+        className="m-0 flex min-w-0 flex-col xl:min-h-0 xl:flex-1"
+        value="activity"
+      >
         {selectedCommitHash ? (
           <ProjectCommitDetailPanel
             commit={

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -188,6 +188,19 @@ type E2eConfig = {
     pocketVoiceImportResult?: "success" | "cancel" | "invalid";
     /** Advertised HEAD for the first mock project without adding that branch. */
     projectHeadBranch?: string;
+    /** Optional deterministic repository diff override for Projects geometry fixtures. */
+    projectRepoDiffOverride?: {
+      additions: number;
+      deletions: number;
+      commit_body: string | null;
+      files: Array<{
+        path: string;
+        additions: number;
+        deletions: number;
+        patch: string;
+        truncated: boolean;
+      }>;
+    };
     /** Builderlab account returned by hosted-community onboarding. Null/omitted = signed out. */
     builderlabAuth?: {
       email?: string;
@@ -1235,6 +1248,18 @@ declare global {
     __BUZZ_E2E_REJECT_PROJECT_QUERY_KINDS__?: number[];
     /** Captured aggregate project-history filters for request-count assertions. */
     __BUZZ_E2E_PROJECT_QUERY_FILTERS__?: MockFilter[];
+    __BUZZ_E2E_PROJECT_REPO_DIFF_OVERRIDE__?: {
+      additions: number;
+      deletions: number;
+      commit_body: string | null;
+      files: Array<{
+        path: string;
+        additions: number;
+        deletions: number;
+        patch: string;
+        truncated: boolean;
+      }>;
+    };
     __BUZZ_E2E_PROJECT_REPO_SYNC_STATUS__?: {
       local_path: string | null;
       local_branch: string | null;
@@ -11513,7 +11538,15 @@ export function maybeInstallE2eTauriMocks() {
         };
       case "get_project_local_repo_snapshot":
         return null;
-      case "get_project_repo_diff":
+      case "get_project_repo_diff": {
+        const projectRepoDiffOverride =
+          getConfig()?.mock?.projectRepoDiffOverride;
+        if (projectRepoDiffOverride) {
+          return projectRepoDiffOverride;
+        }
+        if (window.__BUZZ_E2E_PROJECT_REPO_DIFF_OVERRIDE__) {
+          return window.__BUZZ_E2E_PROJECT_REPO_DIFF_OVERRIDE__;
+        }
         return {
           additions: 27,
           deletions: 4,
@@ -11561,6 +11594,7 @@ export function maybeInstallE2eTauriMocks() {
             },
           ],
         };
+      }
       case "get_project_local_repo_diff":
         return null;
       case "get_project_repo_sync_status":

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 import { waitForAnimations } from "../helpers/animations";
-import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import {
+  createProjectRepoDiffOverride,
+  installMockBridge,
+  TEST_IDENTITIES,
+} from "../helpers/bridge";
 
 const SHOTS = "test-results/project-commit-detail";
 const ALIGNMENT_TOLERANCE_PX = 2;
@@ -479,7 +483,9 @@ test("commit detail opens from the commits feed with a diff", async ({
   page,
 }) => {
   await enableProjectsFeature(page);
-  await installMockBridge(page);
+  await installMockBridge(page, {
+    projectRepoDiffOverride: createProjectRepoDiffOverride(2),
+  });
   // The preview server is a static file server without SPA fallback, so
   // enter at "/" and navigate via the sidebar.
   await page.goto("/", { waitUntil: "domcontentloaded" });
@@ -542,6 +548,48 @@ test("commit detail opens from the commits feed with a diff", async ({
     timeout: 10_000,
   });
   await expect(page.getByTestId("project-diff-renderer")).toBeVisible();
+  const commitPanel = page.getByTestId("project-diff-scroll");
+  const commitDetailPanel = page.getByTestId("project-commit-detail-panel");
+  const detailScroll = page.getByTestId("project-detail-scroll");
+  const detailStack = page.getByTestId("project-detail-stack");
+  await expect(commitDetailPanel).toBeVisible();
+  const commitDetailBox = await commitDetailPanel.boundingBox();
+  const detailScrollBox = await detailScroll.boundingBox();
+  const detailStackBox = await detailStack.boundingBox();
+  expect(commitDetailBox).not.toBeNull();
+  expect(detailScrollBox).not.toBeNull();
+  expect(detailStackBox).not.toBeNull();
+  const commitBottom =
+    (commitDetailBox?.y ?? 0) + (commitDetailBox?.height ?? 0);
+  const detailBottom =
+    (detailScrollBox?.y ?? 0) + (detailScrollBox?.height ?? 0);
+  const stackBottom = (detailStackBox?.y ?? 0) + (detailStackBox?.height ?? 0);
+  expect(commitDetailBox?.y).toBeGreaterThanOrEqual(detailScrollBox?.y ?? 0);
+  expect(commitBottom).toBeLessThanOrEqual(detailBottom + 2);
+  expect(stackBottom).toBeGreaterThanOrEqual(detailBottom - 32);
+  expect(detailBottom - commitBottom).toBeGreaterThanOrEqual(12);
+  expect(detailBottom - commitBottom).toBeLessThanOrEqual(32);
+  const commitPanelBox = await commitPanel.boundingBox();
+  expect(commitPanelBox).not.toBeNull();
+  expect(commitPanelBox?.height).toBeGreaterThan(0);
+  await expect
+    .poll(() =>
+      commitPanel.evaluate((node) => ({
+        clientHeight: node.clientHeight,
+        scrollHeight: node.scrollHeight,
+      })),
+    )
+    .toEqual(
+      expect.objectContaining({
+        clientHeight: expect.any(Number),
+        scrollHeight: expect.any(Number),
+      }),
+    );
+  await expect
+    .poll(() =>
+      commitPanel.evaluate((node) => node.scrollHeight > node.clientHeight),
+    )
+    .toBe(true);
   await expect(
     page.getByText("CommunityTabs({ selectedCommitHash })"),
   ).toBeVisible();

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -541,6 +541,7 @@ test("commit detail opens from the commits feed with a diff", async ({
   await expect(page.getByText("2 changed files")).toBeVisible({
     timeout: 10_000,
   });
+  await expect(page.getByTestId("project-diff-renderer")).toBeVisible();
   await expect(
     page.getByText("CommunityTabs({ selectedCommitHash })"),
   ).toBeVisible();

--- a/desktop/tests/e2e/project-pr-review.spec.ts
+++ b/desktop/tests/e2e/project-pr-review.spec.ts
@@ -541,12 +541,14 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
   await aliceRow.getByRole("button", { name: /^#/ }).click();
   await page.getByRole("tab", { name: /Files changed/ }).click();
 
-  const diffLine = page
-    .getByTestId("project-diff-line")
-    .filter({ hasText: "function CommunityTabs({ selectedCommitHash })" });
-  await expect(diffLine).toBeVisible({ timeout: 10_000 });
-  await diffLine.hover();
-  await diffLine.getByTestId("project-diff-add-comment").click();
+  const diffRenderer = page.getByTestId("project-diff-renderer");
+  await expect(diffRenderer).toBeVisible({ timeout: 10_000 });
+  const diffLineText = page.getByText(
+    "function CommunityTabs({ selectedCommitHash })",
+  );
+  await expect(diffLineText).toBeVisible();
+  await diffLineText.hover();
+  await diffRenderer.getByTestId("project-diff-add-comment").click();
 
   const composer = page.getByTestId("project-inline-comment-thread");
   await composer
@@ -608,7 +610,7 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
   await expect(
     page.getByRole("tab", { name: /Files changed/ }),
   ).toHaveAttribute("data-state", "active");
-  const focusedLine = page.getByTestId("project-diff-focused-line");
+  const focusedLine = page.getByTestId("project-diff-renderer");
   await expect(focusedLine).toBeVisible();
   await expect(focusedLine).toHaveAttribute(
     "data-path",
@@ -617,7 +619,14 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
   await expect(focusedLine).toHaveAttribute("data-side", "new");
   await expect(focusedLine).toHaveAttribute("data-line", "3");
   await focusedLine.click();
-  await expect(page.getByTestId("project-diff-focused-line")).toHaveCount(0);
+  await expect(focusedLine).toBeVisible();
+  await expect
+    .poll(async () => ({
+      path: await focusedLine.getAttribute("data-path"),
+      side: await focusedLine.getAttribute("data-side"),
+      line: await focusedLine.getAttribute("data-line"),
+    }))
+    .toEqual({ path: null, side: null, line: null });
 });
 
 test("managed agent repository owner can merge", async ({ page }) => {

--- a/desktop/tests/e2e/project-pr-review.spec.ts
+++ b/desktop/tests/e2e/project-pr-review.spec.ts
@@ -1,12 +1,19 @@
 import { expect, test } from "@playwright/test";
 
 import { waitForAnimations } from "../helpers/animations";
-import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import {
+  createProjectRepoDiffOverride,
+  installMockBridge,
+  TEST_IDENTITIES,
+} from "../helpers/bridge";
 
 const SHOTS = "test-results/project-pr-review";
 const RECOVERY_SHOTS = "test-results/project-pr-conflict-recovery";
 const REVIEWER_AGENT_PUBKEY = "a".repeat(64);
 const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
+const WIDE_VIEWPORT = { width: 1440, height: 900 };
+const SHORT_STACKED_VIEWPORT = { width: 900, height: 620 };
+const NARROW_VIEWPORT = { width: 720, height: 720 };
 
 // The projects surface is a preview feature — opt in before the app mounts.
 // Must run before installMockBridge so React reads the override on mount.
@@ -530,7 +537,9 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
   page,
 }) => {
   await enableProjectsFeature(page);
-  await installMockBridge(page);
+  await installMockBridge(page, {
+    projectRepoDiffOverride: createProjectRepoDiffOverride(),
+  });
   await openBuzzProject(page);
 
   await page.getByRole("tab", { name: "Pull Request" }).click();
@@ -540,6 +549,69 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
     .first();
   await aliceRow.getByRole("button", { name: /^#/ }).click();
   await page.getByRole("tab", { name: /Files changed/ }).click();
+
+  const detailScroll = page.getByTestId("project-detail-scroll");
+  const detailStack = page.getByTestId("project-detail-stack");
+  const diffPanel = page.getByTestId("project-pr-detail-panel");
+  const diffTree = page.getByTestId("project-diff-file-tree");
+  const diffScroll = page.getByTestId("project-diff-scroll");
+  await expect(detailScroll).toBeVisible();
+  await expect(detailStack).toBeVisible();
+  await expect(diffPanel).toBeVisible();
+  const detailScrollBox = await detailScroll.boundingBox();
+  const detailStackBox = await detailStack.boundingBox();
+  const diffPanelBox = await diffPanel.boundingBox();
+  expect(detailScrollBox).not.toBeNull();
+  expect(detailStackBox).not.toBeNull();
+  expect(diffPanelBox).not.toBeNull();
+  expect(detailScrollBox?.height).toBeGreaterThan(0);
+  expect(detailStackBox?.height).toBeGreaterThan(0);
+  expect(detailScrollBox?.height).toBeGreaterThanOrEqual(
+    (diffPanelBox?.height ?? 0) - 2,
+  );
+  await expect(diffTree).toBeVisible();
+  await expect(diffScroll).toBeVisible();
+  await expect
+    .poll(() =>
+      diffTree.evaluate((node) => node.scrollHeight > node.clientHeight),
+    )
+    .toBe(true);
+  await expect
+    .poll(() =>
+      diffScroll.evaluate((node) => node.scrollHeight > node.clientHeight),
+    )
+    .toBe(true);
+  const treeBox = await diffTree.boundingBox();
+  const diffBox = await diffScroll.boundingBox();
+  const panelBox = await diffPanel.boundingBox();
+  expect(treeBox).not.toBeNull();
+  expect(diffBox).not.toBeNull();
+  expect(panelBox).not.toBeNull();
+  expect(treeBox?.height).toBeGreaterThan(0);
+  expect(diffBox?.height).toBeGreaterThan(0);
+  expect(panelBox?.height).toBeGreaterThanOrEqual((treeBox?.height ?? 0) - 2);
+  await diffTree.evaluate((node) => {
+    node.scrollTop = node.scrollHeight;
+  });
+  await expect
+    .poll(() => diffTree.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(0);
+  const finalTreeRow = diffTree
+    .getByRole("button")
+    .filter({ hasText: "file-21.tsx" });
+  await expect(finalTreeRow).toBeVisible();
+  const finalTreeRowBox = await finalTreeRow.boundingBox();
+  const scrolledTreeBox = await diffTree.boundingBox();
+  expect(finalTreeRowBox).not.toBeNull();
+  expect(scrolledTreeBox).not.toBeNull();
+  expect(finalTreeRowBox?.y ?? 0).toBeGreaterThanOrEqual(
+    (scrolledTreeBox?.y ?? 0) - 2,
+  );
+  expect(
+    (finalTreeRowBox?.y ?? 0) + (finalTreeRowBox?.height ?? 0),
+  ).toBeLessThanOrEqual(
+    (scrolledTreeBox?.y ?? 0) + (scrolledTreeBox?.height ?? 0) + 2,
+  );
 
   const diffRenderer = page.getByTestId("project-diff-renderer");
   await expect(diffRenderer).toBeVisible({ timeout: 10_000 });
@@ -628,6 +700,202 @@ test("reviewer can leave a commit-scoped inline diff comment", async ({
     }))
     .toEqual({ path: null, side: null, line: null });
 });
+
+test("wide PR files fill the detail scroll area and expose independent scroll endpoints", async ({
+  page,
+}) => {
+  await page.setViewportSize(WIDE_VIEWPORT);
+  await enableProjectsFeature(page);
+  await installMockBridge(page, {
+    projectRepoDiffOverride: createProjectRepoDiffOverride(),
+  });
+  await openBuzzProject(page);
+  await page.getByRole("tab", { name: "Pull Request" }).click();
+  await page
+    .getByTestId("project-pull-request-row")
+    .filter({ hasText: "alice" })
+    .first()
+    .getByRole("button", { name: /^#/ })
+    .click();
+  await page.getByRole("tab", { name: /Files changed/ }).click();
+
+  const detailScroll = page.getByTestId("project-detail-scroll");
+  const detailStack = page.getByTestId("project-detail-stack");
+  const detailPanel = page.getByTestId("project-pr-detail-panel");
+  const tree = page.getByTestId("project-diff-file-tree");
+  const diff = page.getByTestId("project-diff-scroll");
+  await expect(detailScroll).toBeVisible();
+  await expect(detailStack).toBeVisible();
+  await expect(detailPanel).toBeVisible();
+  await expect
+    .poll(() =>
+      Promise.all([
+        detailScroll.evaluate((node) => node.scrollHeight > node.clientHeight),
+        tree.evaluate((node) => node.scrollHeight > node.clientHeight),
+        diff.evaluate((node) => node.scrollHeight > node.clientHeight),
+      ]),
+    )
+    .toEqual([false, true, true]);
+  const scrollBox = await detailScroll.boundingBox();
+  const stackBox = await detailStack.boundingBox();
+  const panelBox = await detailPanel.boundingBox();
+  const mainColumnBox = await page
+    .getByTestId("project-pr-main-column")
+    .boundingBox();
+  const metaRailBox = await detailPanel
+    .locator(":scope > div > aside")
+    .boundingBox();
+  expect(scrollBox).not.toBeNull();
+  expect(stackBox).not.toBeNull();
+  expect(panelBox).not.toBeNull();
+  expect(mainColumnBox).not.toBeNull();
+  expect(metaRailBox).not.toBeNull();
+  const scrollBottom = (scrollBox?.y ?? 0) + (scrollBox?.height ?? 0);
+  const stackBottom = (stackBox?.y ?? 0) + (stackBox?.height ?? 0);
+  const panelBottom = (panelBox?.y ?? 0) + (panelBox?.height ?? 0);
+  const mainColumnBottom =
+    (mainColumnBox?.y ?? 0) + (mainColumnBox?.height ?? 0);
+  const metaRailBottom = (metaRailBox?.y ?? 0) + (metaRailBox?.height ?? 0);
+  expect(stackBottom).toBeGreaterThanOrEqual(scrollBottom - 32);
+  expect(panelBox?.y).toBeGreaterThanOrEqual(scrollBox?.y ?? 0);
+  expect(panelBottom).toBeLessThanOrEqual(scrollBottom + 2);
+  expect(Math.abs(mainColumnBottom - panelBottom)).toBeLessThanOrEqual(2);
+  expect(Math.abs(metaRailBottom - panelBottom)).toBeLessThanOrEqual(2);
+  expect(scrollBottom - panelBottom).toBeGreaterThanOrEqual(12);
+  expect(scrollBottom - panelBottom).toBeLessThanOrEqual(32);
+});
+
+for (const viewport of [SHORT_STACKED_VIEWPORT, NARROW_VIEWPORT]) {
+  test(`PR files remain content-driven at ${viewport.width}x${viewport.height}`, async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("buzz-theme", "buzz");
+    });
+    await enableProjectsFeature(page);
+    await installMockBridge(page, {
+      projectRepoDiffOverride: createProjectRepoDiffOverride(),
+    });
+    await openBuzzProject(page);
+    await page.setViewportSize(viewport);
+    await page.getByRole("tab", { name: "Pull Request" }).click();
+    await page
+      .getByTestId("project-pull-request-row")
+      .filter({ hasText: "alice" })
+      .first()
+      .getByRole("button", { name: /^#/ })
+      .click();
+    await page.getByRole("tab", { name: /Files changed/ }).click();
+
+    const detailScroll = page.getByTestId("project-detail-scroll");
+    const detailPanel = page.getByTestId("project-pr-detail-panel");
+    await expect(detailPanel).toBeVisible();
+    const dimensions = await detailScroll.evaluate((node) => ({
+      clientHeight: node.clientHeight,
+      scrollHeight: node.scrollHeight,
+      scrollWidth: node.scrollWidth,
+      clientWidth: node.clientWidth,
+    }));
+    expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+    if (viewport === SHORT_STACKED_VIEWPORT) {
+      expect(dimensions.scrollWidth).toBeLessThanOrEqual(
+        dimensions.clientWidth + 80,
+      );
+    }
+
+    const panelBox = await detailPanel.boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(panelBox?.height).toBeGreaterThan(0);
+    if (viewport === SHORT_STACKED_VIEWPORT) {
+      const status = page.getByRole("heading", { name: "Status" });
+      const mainColumn = page.getByTestId("project-pr-main-column");
+      const metaRail = detailPanel.locator(":scope > div > aside");
+      const statusBox = await status.boundingBox();
+      const mainBox = await mainColumn.boundingBox();
+      const railBox = await metaRail.boundingBox();
+      expect(statusBox).not.toBeNull();
+      expect(mainBox).not.toBeNull();
+      expect(railBox).not.toBeNull();
+      expect(statusBox?.y).toBeGreaterThanOrEqual(
+        (mainBox?.y ?? 0) + (mainBox?.height ?? 0) - 2,
+      );
+      expect(railBox?.y).toBeGreaterThanOrEqual(
+        (mainBox?.y ?? 0) + (mainBox?.height ?? 0) - 2,
+      );
+      expect(railBox?.x).toBeGreaterThanOrEqual(mainBox?.x ?? 0);
+      expect((railBox?.x ?? 0) + (railBox?.width ?? 0)).toBeLessThanOrEqual(
+        (mainBox?.x ?? 0) + (mainBox?.width ?? 0) + 2,
+      );
+    }
+  });
+}
+
+for (const theme of ["buzz", "buzz-dark"] as const) {
+  test(`changed-file names and fallback render in ${theme}`, async ({
+    page,
+  }) => {
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem("buzz-theme", selectedTheme);
+    }, theme);
+    await enableProjectsFeature(page);
+    await installMockBridge(page, {
+      projectRepoDiffOverride: createProjectRepoDiffOverride(),
+    });
+    await openBuzzProject(page);
+    await page.getByRole("tab", { name: "Pull Request" }).click();
+    await page
+      .getByTestId("project-pull-request-row")
+      .filter({ hasText: "alice" })
+      .first()
+      .getByRole("button", { name: /^#/ })
+      .click();
+    await page.getByRole("tab", { name: /Files changed/ }).click();
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-buzz-theme",
+      theme,
+    );
+    const tree = page.getByTestId("project-diff-file-tree");
+    for (const fileName of [
+      "ProjectDetailScreen.tsx",
+      "project-settings.yaml",
+      "notes.mystery",
+    ]) {
+      await expect(
+        tree.getByRole("button", { name: new RegExp(fileName) }),
+      ).toBeVisible();
+    }
+    const diffBody = page.getByTestId("project-diff-body");
+    const renderer = page.getByTestId("project-diff-renderer");
+    const selectFile = async (
+      name: RegExp,
+      path: string,
+      uniqueText: string,
+    ) => {
+      await tree.getByRole("button", { name }).click();
+      await expect(diffBody).toBeVisible();
+      await expect(renderer).toHaveAttribute("data-selected-path", path);
+      await expect(diffBody).toContainText(uniqueText);
+    };
+    await selectFile(
+      /ProjectDetailScreen\.tsx/,
+      "desktop/src/features/projects/ui/ProjectDetailScreen.tsx",
+      "TSX_UNIQUE_MARKER",
+    );
+    await selectFile(
+      /project-settings\.yaml/,
+      "config/project-settings.yaml",
+      "YAML_UNIQUE_MARKER",
+    );
+    await selectFile(
+      /notes\.mystery/,
+      "docs/notes.mystery",
+      "MYSTERY_PLAIN_TEXT_UNIQUE_MARKER",
+    );
+    await expect(
+      page.getByText("No textual diff is available for this file."),
+    ).toHaveCount(0);
+  });
+}
 
 test("managed agent repository owner can merge", async ({ page }) => {
   await enableProjectsFeature(page);

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -38,6 +38,114 @@ export const TEST_IDENTITIES = {
 
 type BridgeMode = "mock" | "relay";
 
+export type ProjectRepoDiffOverride = {
+  additions: number;
+  deletions: number;
+  commit_body: string | null;
+  files: Array<{
+    path: string;
+    additions: number;
+    deletions: number;
+    patch: string;
+    truncated: boolean;
+  }>;
+};
+
+export function createProjectRepoDiffOverride(
+  fileCount = 24,
+): ProjectRepoDiffOverride {
+  const patch = [
+    "@@ -1,2 +1,72 @@",
+    " export function example() {",
+    ...Array.from(
+      { length: 70 },
+      (_, index) => `+  const line${index + 1} = ${index + 1};`,
+    ),
+    " }",
+  ].join("\n");
+  const targetPatch = [
+    "@@ -1,6 +1,72 @@",
+    ' import { Tabs } from "@/shared/ui/tabs";',
+    "",
+    "-function CommunityTabs() {",
+    "+function CommunityTabs({ selectedCommitHash }) {",
+    '+  const typedProjectMarker = "TSX_UNIQUE_MARKER";',
+    '+  const [selectedTab, setSelectedTab] = useState("overview");',
+    "+",
+    "   return (",
+    '     <Tabs value="overview">',
+    "       <ProjectTabsList />",
+    ...Array.from(
+      { length: 59 },
+      (_, index) => `+  const detailLine${index + 1} = ${index + 1};`,
+    ),
+    " ",
+  ].join("\n");
+  const yamlPatch = [
+    "@@ -1,2 +1,5 @@",
+    " project: buzz",
+    "+fixture_marker: YAML_UNIQUE_MARKER",
+    "+renderer: config",
+    "+theme_probe: stable",
+    " ",
+  ].join("\n");
+  const mysteryPatch = [
+    "@@ -1,2 +1,5 @@",
+    " readable mystery document",
+    "+MYSTERY_PLAIN_TEXT_UNIQUE_MARKER",
+    "+This extension intentionally has no registered language.",
+    "+plain text remains readable",
+    " ",
+  ].join("\n");
+  const files = [
+    "desktop/src/features/projects/ui/ProjectDetailScreen.tsx",
+    ...(fileCount === 2
+      ? ["desktop/src/features/projects/hooks.ts"]
+      : ["config/project-settings.yaml", "docs/notes.mystery"]),
+    ...Array.from(
+      { length: Math.max(0, fileCount - 3) },
+      (_, index) =>
+        `src/generated/file-${String(index + 1).padStart(2, "0")}.tsx`,
+    ),
+  ]
+    .map((path) => ({
+      path,
+      additions: 70,
+      deletions: 0,
+      patch,
+      truncated: false,
+    }))
+    .map((file) => {
+      if (
+        file.path === "desktop/src/features/projects/ui/ProjectDetailScreen.tsx"
+      ) {
+        return { ...file, patch: targetPatch };
+      }
+      if (file.path === "config/project-settings.yaml") {
+        return { ...file, patch: yamlPatch };
+      }
+      if (file.path === "docs/notes.mystery") {
+        return { ...file, patch: mysteryPatch };
+      }
+      return file;
+    });
+  return {
+    additions: files.length * 70,
+    deletions: 0,
+    commit_body:
+      fileCount === 2
+        ? [
+            "See the [project guide](https://example.com/project-guide).",
+            "",
+            "![Architecture](/buzz.svg)",
+            "",
+            "![Demo](https://example.com/project-demo.mp4)",
+          ].join("\n")
+        : null,
+    files,
+  };
+}
+
 type MockCommandAvailability = {
   available?: boolean;
   command?: string;
@@ -156,6 +264,19 @@ type MockBridgeOptions = {
   pocketVoiceImportResult?: "success" | "cancel" | "invalid";
   /** Advertised HEAD for the first mock project without adding that branch. */
   projectHeadBranch?: string;
+  /** Optional deterministic repository diff override for Projects geometry fixtures. */
+  projectRepoDiffOverride?: {
+    additions: number;
+    deletions: number;
+    commit_body: string | null;
+    files: Array<{
+      path: string;
+      additions: number;
+      deletions: number;
+      patch: string;
+      truncated: boolean;
+    }>;
+  };
   /** Relay NIP-11 identity used to sign authoritative repository state. */
   relaySelf?: string | null;
   /** Native-like huddle state seeded from authoritative role-bearing membership. */
@@ -891,6 +1012,7 @@ export async function installBridge(page: Page, options: BridgeOptions) {
         identity: bridgeIdentity ?? currentConfig.identity,
         mock,
         mode,
+        projectRepoDiffOverride: mock?.projectRepoDiffOverride,
         relayHttpUrl: relayHttpUrl ?? currentConfig.relayHttpUrl,
         relayWsUrl: relayWsUrl ?? currentConfig.relayWsUrl,
         autoConnectDefaultRelay:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@mediapipe/tasks-vision':
         specifier: ^0.10.35
         version: 0.10.35
+      '@pierre/diffs':
+        specifier: 1.3.5
+        version: 1.3.5(@shikijs/themes@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -722,6 +725,36 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@pierre/diffs@1.3.5':
+    resolution: {integrity: sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@2.0.0':
+    resolution: {integrity: sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@1.0.1':
+    resolution: {integrity: sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0 || ^2.0.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -1568,6 +1601,10 @@ packages:
     resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
     engines: {node: '>=20'}
 
+  '@shikijs/core@4.4.2':
+    resolution: {integrity: sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==}
+    engines: {node: '>=20'}
+
   '@shikijs/engine-javascript@4.1.0':
     resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
     engines: {node: '>=20'}
@@ -1584,12 +1621,24 @@ packages:
     resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
     engines: {node: '>=20'}
 
+  '@shikijs/primitive@4.4.2':
+    resolution: {integrity: sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==}
+    engines: {node: '>=20'}
+
   '@shikijs/themes@4.1.0':
     resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
     engines: {node: '>=20'}
 
+  '@shikijs/transformers@4.4.2':
+    resolution: {integrity: sha512-d81PJ9KkR1tVP95FH/9296HTtDo0mh76wv10u9T1YmsZq/UcXgt0OLdBszfUQ1i+umkRMCjDnFbFZU7/tCODTQ==}
+    engines: {node: '>=20'}
+
   '@shikijs/types@4.1.0':
     resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.2':
+    resolution: {integrity: sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -2061,6 +2110,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/linkify-it@3.0.5':
     resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
 
@@ -2379,6 +2431,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -2795,6 +2851,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
   lucide-react@1.16.0:
     resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
@@ -4060,6 +4119,30 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@pierre/diffs@1.3.5(@shikijs/themes@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@pierre/theme': 2.0.0
+      '@pierre/theming': 1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.1.0)
+      '@shikijs/transformers': 4.4.2
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      shiki: 4.1.0
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@2.0.0': {}
+
+  '@pierre/theming@1.0.1(@pierre/theme@2.0.0)(@shikijs/themes@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.1.0)':
+    optionalDependencies:
+      '@pierre/theme': 2.0.0
+      '@shikijs/themes': 4.1.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      shiki: 4.1.0
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -4816,6 +4899,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@4.4.2':
+    dependencies:
+      '@shikijs/primitive': 4.4.2
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@4.1.0':
     dependencies:
       '@shikijs/types': 4.1.0
@@ -4837,14 +4928,30 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/primitive@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   '@shikijs/themes@4.1.0':
     dependencies:
       '@shikijs/types': 4.1.0
+
+  '@shikijs/transformers@4.4.2':
+    dependencies:
+      '@shikijs/core': 4.4.2
+      '@shikijs/types': 4.4.2
 
   '@shikijs/types@4.1.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  '@shikijs/types@4.4.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
@@ -5314,6 +5421,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/linkify-it@3.0.5': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -5603,6 +5714,8 @@ snapshots:
   diff3@0.0.3: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -5986,6 +6099,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   lucide-react@1.16.0(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Summary

Replace the Projects hand-written diff renderer with the Pierre diff rendering stack while preserving Buzz review behavior, then stabilize PR and commit diff workspace geometry across wide, stacked, and narrow layouts.

The four reviewed commits are based directly on current upstream `main` (`c923e89a4b6d43ae0c507dbb5e58f2bdd9ab7888`).

## Changes

- Add `@pierre/diffs` and pure Buzz↔Pierre annotation mapping helpers for path, side, line, focused range, renderability, and patch-body accounting.
- Add the shared `ProjectDiffBody` adapter with Buzz theme integration, exact inline-comment anchors, focused selection, normalized unified patches, truncation handling, and readable fallback behavior.
- Adopt the adapter in the shared Projects changed-files panel, preserving file selection/filtering, headers and totals, one active review form, normal-pointer inline commenting, focus clearing, request-changes history, commit-detail reuse, and accessibility.
- Stabilize the Projects layout chain: normal wide bottom gutter, independently scrollable file tree and diff body, reachable final tree row, aligned PR main/meta rails, stacked rail flow, and content-driven narrow layouts.
- Add deterministic Projects fixtures and E2E contracts for TSX, YAML, unknown-extension plain text, `buzz` and `buzz-dark` themes, PR geometry, commit geometry, exact selected paths/content, and fallback behavior.

## Validation

- Focused annotation/focus tests: **32/32 passed**
- Full desktop unit suite: **4567/4567 passed** on the reviewed stack before the final geometry assertion/correction batch
- Complete Projects E2E (`project-pr-review` + `project-commit-detail`): **39/39 passed** on final content
- `pnpm typecheck`: clean on final content
- Biome on all touched final-correction files: clean
- `check:px-text` and `check:pubkey-truncation`: passed in the full stack gate
- Production build: clean in the full stack gate; final bounded geometry correction was subsequently covered by typecheck and the complete Projects E2E run
- Direct governed file-size checks: within the repository limits for governed source files

## Review state

- T1, T2, F1, and F2 were independently reviewed and carry the actual reviewer credits.
- The four-commit stack is conflict-free and contains exactly 15 intended files relative to upstream `main`.
- This PR is intentionally a draft while follow-up work continues.
