### PR TITLE
feat(desktop): read-only shared fleet view for relay-hosted agents

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
         "**/signout-confirmation.spec.ts",
         "**/agent-provider-dropdowns.spec.ts",
         "**/agent-lifecycle-feedback.spec.ts",
+        "**/shared-fleet.spec.ts",
         "**/agent-access-warning.spec.ts",
         "**/edit-agent-run-on.spec.ts",
         "**/inbox-live-update.spec.ts",

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -197,6 +197,8 @@ impl ManagedAgentRecord {
 pub struct RelayAgentInfo {
     pub pubkey: String,
     pub name: String,
+    #[serde(default)]
+    pub model: Option<String>,
     pub agent_type: String,
     pub channels: Vec<String>,
     #[serde(default)]

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -65,6 +65,10 @@ import {
   updatePersona,
 } from "@/shared/api/tauriPersonas";
 import { teamsQueryKey } from "@/features/agents/teamHooks";
+import {
+  relayAgentsQueryKey,
+  useRelayAgentsQueryScope,
+} from "@/features/agents/relayAgentsQueryScope";
 import type {
   AcpRuntime,
   AgentPersona,
@@ -87,6 +91,11 @@ import type {
 } from "@/features/agents/channelAgents";
 export { findReusableAgent } from "@/features/agents/agentReuse";
 export {
+  relayAgentsQueryKey,
+  relayAgentsQueryKeyForScope,
+  useRelayAgentsQueryScope,
+} from "@/features/agents/relayAgentsQueryScope";
+export {
   teamsQueryKey,
   useCreateTeamMutation,
   useDeleteTeamMutation,
@@ -105,7 +114,6 @@ export type {
   ProvisionChannelManagedAgentResult,
 } from "@/features/agents/channelAgents";
 
-export const relayAgentsQueryKey = ["relay-agents"] as const;
 export const managedAgentsQueryKey = ["managed-agents"] as const;
 export const personasQueryKey = ["personas"] as const;
 export const acpRuntimesQueryKey = ["acp-runtimes"] as const;
@@ -322,8 +330,10 @@ export function useManagedAgentPrereqsQuery(
 }
 
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
+  const scope = useRelayAgentsQueryScope();
+
   return useQuery({
-    queryKey: relayAgentsQueryKey,
+    queryKey: scope.queryKey,
     queryFn: listRelayAgents,
     staleTime: 30_000,
     // Relay agent profiles (kind:10100) are near-static and the backing
@@ -336,7 +346,7 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
     // keep polling but at a relaxed cadence and pause it while backgrounded.
     refetchInterval: 5 * 60_000,
     refetchIntervalInBackground: false,
-    enabled: options?.enabled,
+    enabled: (options?.enabled ?? true) && scope.enabled,
   });
 }
 

--- a/desktop/src/features/agents/lib/sharedFleetModel.test.mjs
+++ b/desktop/src/features/agents/lib/sharedFleetModel.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  activeSharedFleetRows,
+  buildSharedFleetRows,
+} from "./sharedFleetModel.ts";
+
+const PUB_A = "a".repeat(64);
+const PUB_B = "b".repeat(64);
+
+function agent(overrides = {}) {
+  return {
+    pubkey: PUB_A,
+    name: "Remote Scout",
+    model: null,
+    agentType: "agent",
+    channels: ["Agent Testing", "Agent Testing", "x-articles-ozark"],
+    channelIds: ["a", "b"],
+    capabilities: [],
+    status: "offline",
+    respondTo: "anyone",
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+test("current presence overrides directory status and deduplicates channels", () => {
+  const rows = buildSharedFleetRows([agent({ model: "Model Alpha" })], {
+    [PUB_A]: "online",
+  });
+  assert.deepEqual(rows, [
+    {
+      pubkey: PUB_A,
+      name: "Remote Scout",
+      modelLabel: "Model Alpha",
+      status: "online",
+      channels: ["Agent Testing", "x-articles-ozark"],
+      mentionHint: "Mention only in its 2 assigned channels",
+    },
+  ]);
+});
+
+test("offline and directory-only records are excluded from active fleet", () => {
+  const rows = buildSharedFleetRows(
+    [
+      agent(),
+      agent({ pubkey: PUB_B, name: "Offline Remote", status: "online" }),
+    ],
+    { [PUB_A]: "away", [PUB_B]: "offline" },
+  );
+  assert.deepEqual(
+    activeSharedFleetRows(rows).map((row) => row.name),
+    ["Remote Scout"],
+  );
+
+  const directoryOnly = buildSharedFleetRows(
+    [agent({ status: "online" })],
+    undefined,
+  );
+  assert.deepEqual(activeSharedFleetRows(directoryOnly), []);
+});
+
+test("unknown presence cannot make a worker live", () => {
+  const rows = buildSharedFleetRows([agent()], { [PUB_A]: "transitioning" });
+  assert.deepEqual(activeSharedFleetRows(rows), []);
+});

--- a/desktop/src/features/agents/lib/sharedFleetModel.ts
+++ b/desktop/src/features/agents/lib/sharedFleetModel.ts
@@ -1,0 +1,74 @@
+import type {
+  PresenceLookup,
+  PresenceStatus,
+  RelayAgent,
+} from "@/shared/api/types";
+import { isSafeDisplayText } from "@/shared/lib/safeDisplayText";
+
+export type SharedFleetRow = {
+  pubkey: string;
+  name: string;
+  modelLabel?: string;
+  status: PresenceStatus;
+  channels: string[];
+  /** Informational only; mentioning remains channel-scoped elsewhere. */
+  mentionHint: string;
+};
+
+function safeDisplayLabel(value: string, maximum = 256): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || !isSafeDisplayText(trimmed, maximum)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function uniqueChannelNames(channels: readonly string[]): string[] {
+  const names = new Set<string>();
+  for (const channel of channels) {
+    const normalized = safeDisplayLabel(channel);
+    if (normalized) names.add(normalized);
+  }
+  return [...names].sort((left, right) => left.localeCompare(right));
+}
+
+function mentionHint(channelCount: number): string {
+  if (channelCount === 0) return "No assigned channels";
+  return `Mention only in its ${channelCount} assigned channel${
+    channelCount === 1 ? "" : "s"
+  }`;
+}
+
+/** Build a presentation-only projection. It has no remote lifecycle actions. */
+export function buildSharedFleetRows(
+  agents: readonly RelayAgent[],
+  presence: PresenceLookup | undefined,
+): SharedFleetRow[] {
+  return agents
+    .map((agent) => {
+      // Directory status is durable metadata, not current liveness. Never use
+      // it as a fallback when the separate presence read has no entry.
+      const status = presence?.[agent.pubkey.toLowerCase()];
+      if (status === undefined) return null;
+      const channels = uniqueChannelNames(agent.channels);
+      const name = safeDisplayLabel(agent.name) ?? "Unnamed remote worker";
+      const modelLabel = agent.model ? safeDisplayLabel(agent.model) : null;
+      return {
+        pubkey: agent.pubkey,
+        name,
+        status,
+        channels,
+        mentionHint: mentionHint(channels.length),
+        ...(modelLabel ? { modelLabel } : {}),
+      };
+    })
+    .filter((row): row is SharedFleetRow => row !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** Only a recognized current presence may render as a live remote worker. */
+export function activeSharedFleetRows(
+  rows: readonly SharedFleetRow[],
+): SharedFleetRow[] {
+  return rows.filter((row) => row.status === "online" || row.status === "away");
+}

--- a/desktop/src/features/agents/lib/teamCatalogRelay.test.mjs
+++ b/desktop/src/features/agents/lib/teamCatalogRelay.test.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test, { mock } from "node:test";
+
+import { relayClient } from "@/shared/api/relayClient";
+import {
+  fetchTeamCatalogPublications,
+  teamCatalogPublicationsFromEvents,
+  teamEventIsShared,
+} from "./teamCatalogRelay.ts";
+
+const OWNER = "a".repeat(64);
+
+function eventId(label) {
+  return createHash("sha256").update(label).digest("hex");
+}
+
+function teamEvent({
+  id = "team",
+  createdAt = 1,
+  owner = OWNER,
+  dTag = "review-team",
+  shared = true,
+  sharedTag,
+  content,
+  kind = 30178,
+} = {}) {
+  return {
+    id: eventId(id),
+    pubkey: owner,
+    created_at: createdAt,
+    kind,
+    tags: [
+      ["d", dTag],
+      ...(shared
+        ? [sharedTag ?? ["shared", "true"]]
+        : sharedTag
+          ? [sharedTag]
+          : []),
+    ],
+    content:
+      content ??
+      JSON.stringify({
+        v: 1,
+        name: "Review Team",
+        members: [
+          {
+            member_key: "persona-1",
+            display_name: "Reviewer",
+            system_prompt: "private prompt must not escape the projection",
+            provider: "private-provider",
+          },
+        ],
+      }),
+    sig: "f".repeat(128),
+  };
+}
+
+test("strict shared v1 parsing returns only safe team projection fields", () => {
+  const [publication] = teamCatalogPublicationsFromEvents([teamEvent({})]);
+  assert.equal(publication.name, "Review Team");
+  assert.equal(publication.memberCount, 1);
+  assert.deepEqual(publication.memberKeys, ["persona-1"]);
+  assert.equal("systemPrompt" in publication, false);
+  assert.equal("provider" in publication, false);
+});
+
+test("malformed tags, wrong kind, and wrong schema are rejected", () => {
+  const exact = teamEvent({ id: "exact" });
+  assert.equal(teamEventIsShared(exact), true);
+
+  for (const [index, sharedTag] of [
+    ["shared"],
+    ["shared", "false"],
+    ["shared", "true", "extra"],
+  ].entries()) {
+    const malformed = teamEvent({
+      id: `shared-${index}`,
+      shared: false,
+      sharedTag,
+    });
+    assert.equal(teamEventIsShared(malformed), false);
+    assert.deepEqual(teamCatalogPublicationsFromEvents([malformed]), []);
+  }
+
+  const duplicateD = teamEvent({ id: "duplicate-d" });
+  duplicateD.tags.push(["d", "another"]);
+  assert.deepEqual(teamCatalogPublicationsFromEvents([duplicateD]), []);
+
+  const duplicateShared = teamEvent({ id: "duplicate-shared" });
+  duplicateShared.tags.push(["shared", "true"]);
+  assert.deepEqual(teamCatalogPublicationsFromEvents([duplicateShared]), []);
+
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      teamEvent({ id: "wrong-kind", kind: 30176 }),
+      teamEvent({
+        id: "wrong-version",
+        content: '{"v":2,"name":"Future","members":[]}',
+      }),
+    ]),
+    [],
+  );
+});
+
+test("duplicate member projections are rejected", () => {
+  const content = JSON.stringify({
+    v: 1,
+    name: "Unsafe Team",
+    members: [
+      { member_key: "same", display_name: "One" },
+      { member_key: "same", display_name: "Again" },
+    ],
+  });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([teamEvent({ content })]),
+    [],
+  );
+});
+
+test("bounded names, member keys, and content are enforced", () => {
+  const oversizedName = JSON.stringify({
+    v: 1,
+    name: "x".repeat(257),
+    members: [],
+  });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      teamEvent({ id: "oversized-name", content: oversizedName }),
+    ]),
+    [],
+  );
+
+  const oversizedMemberKey = JSON.stringify({
+    v: 1,
+    name: "Bounded Team",
+    members: [{ member_key: "x".repeat(129), display_name: "Worker" }],
+  });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      teamEvent({ id: "oversized-member-key", content: oversizedMemberKey }),
+    ]),
+    [],
+  );
+
+  const oversizedContent = JSON.stringify({
+    v: 1,
+    name: "Bounded Team",
+    description: "x".repeat(4_097),
+    members: [],
+  });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      teamEvent({ id: "oversized-content-field", content: oversizedContent }),
+    ]),
+    [],
+  );
+});
+
+test("display text rejects control and bidi characters", () => {
+  const content = JSON.stringify({
+    v: 1,
+    name: "Safe\u202eTeam",
+    members: [],
+  });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      teamEvent({ id: "bidi-name", content }),
+    ]),
+    [],
+  );
+});
+
+test("one owner's large heads cannot exhaust validation for another owner", () => {
+  const largeContent = JSON.stringify({
+    v: 1,
+    name: "Large Team",
+    members: [],
+    padding: "x".repeat(190_000),
+  });
+  const noisyOwner = "b".repeat(64);
+  const noisyHeads = Array.from({ length: 24 }, (_, index) =>
+    teamEvent({
+      id: `large-${index}`,
+      owner: noisyOwner,
+      dTag: `large-${index}`,
+      createdAt: 10_000 - index,
+      content: largeContent,
+    }),
+  );
+  const otherOwnerHead = teamEvent({
+    id: "other-owner",
+    owner: "c".repeat(64),
+    dTag: "other-owner-team",
+    createdAt: 1,
+  });
+
+  assert.equal(
+    teamCatalogPublicationsFromEvents([...noisyHeads, otherOwnerHead]).some(
+      (publication) => publication.ownerPubkey === "c".repeat(64),
+    ),
+    true,
+  );
+});
+
+test("newer invalid or unshared head hides older shared head", () => {
+  const older = teamEvent({ id: "older", createdAt: 1 });
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      older,
+      teamEvent({ id: "unshared", createdAt: 2, shared: false }),
+    ]),
+    [],
+  );
+  assert.deepEqual(
+    teamCatalogPublicationsFromEvents([
+      older,
+      teamEvent({ id: "invalid", createdAt: 2, content: "{}" }),
+    ]),
+    [],
+  );
+});
+
+test("full catalog pages are read past the relay limit and event ids are deduped", async (t) => {
+  t.after(() => mock.restoreAll());
+  const first = Array.from({ length: 500 }, (_, index) =>
+    teamEvent({
+      id: `page-${index}`,
+      createdAt: 1_000 - index,
+      dTag: `team-${index}`,
+    }),
+  );
+  const second = [
+    first.at(-1),
+    teamEvent({ id: "older", createdAt: 1, dTag: "older-team" }),
+  ];
+  const filters = [];
+  mock.method(relayClient, "fetchEvents", (filter) => {
+    filters.push(filter);
+    return Promise.resolve(filters.length === 1 ? first : second);
+  });
+
+  const publications = await fetchTeamCatalogPublications();
+  assert.equal(publications.length, 501);
+  assert.deepEqual(filters, [
+    { kinds: [30178], limit: 500 },
+    { kinds: [30178], limit: 500, until: 501 },
+  ]);
+});

--- a/desktop/src/features/agents/lib/teamCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/teamCatalogRelay.ts
@@ -1,0 +1,479 @@
+import { relayClient } from "@/shared/api/relayClient";
+import type { RelayEvent } from "@/shared/api/types";
+import { KIND_TEAM_CATALOG } from "@/shared/constants/kinds";
+import { isSafeDisplayText } from "@/shared/lib/safeDisplayText";
+
+const TEAM_CATALOG_SCHEMA_VERSION = 1;
+const CATALOG_PAGE_SIZE = 500;
+const MAX_CATALOG_PAGES = 40;
+const MAX_CATALOG_EVENTS = CATALOG_PAGE_SIZE * MAX_CATALOG_PAGES;
+const MAX_CATALOG_VALIDATION_BYTES = 4 * 1024 * 1024;
+const MAX_OWNER_VALIDATION_BYTES = 512 * 1024;
+const MAX_EVENT_CONTENT_BYTES = 192 * 1024;
+const MAX_MEMBERS = 64;
+const MAX_NAME_BYTES = 256;
+const MAX_MEMBER_KEY_BYTES = 128;
+const MAX_TEXT_BYTES = 4 * 1024;
+const MAX_SYSTEM_PROMPT_BYTES = 16 * 1024;
+const MAX_IDENTIFIER_BYTES = 256;
+const MAX_NAME_POOL_ENTRIES = 64;
+const MAX_EVENT_TAGS = 128;
+const MAX_EVENT_TAG_FIELDS = 8;
+const MAX_EVENT_TAG_FIELD_BYTES = 256;
+const NOSTR_HEX = /^[0-9a-f]{64}$/u;
+
+export type TeamCatalogPublication = {
+  eventId: string;
+  ownerPubkey: string;
+  teamDTag: string;
+  name: string;
+  memberCount: number;
+  /** Opaque member keys used only for relay-aware team resolution. */
+  memberKeys: string[];
+};
+
+type JsonObject = Record<string, unknown>;
+type CatalogMember = JsonObject & {
+  member_key: string;
+  display_name: string;
+};
+type SafeCatalogEvent = {
+  id: string;
+  ownerPubkey: string;
+  teamDTag: string;
+  createdAt: number;
+  content: string;
+  shared: boolean;
+  coordinate: string;
+};
+type CatalogHead = {
+  createdAt: number;
+  eventId: string;
+  publication: TeamCatalogPublication | null;
+};
+type CatalogAccumulator = {
+  heads: Map<string, CatalogHead>;
+  validationBytes: number;
+  validationBytesByOwner: Map<string, number>;
+};
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function withinBytes(value: string, maximum: number): boolean {
+  return utf8ByteLength(value) <= maximum;
+}
+
+function safeDisplayText(value: string, maximum: number): boolean {
+  return isSafeDisplayText(value, maximum);
+}
+
+function scanContent(value: string, maximum: number) {
+  const bytes = utf8ByteLength(value);
+  return bytes <= maximum ? bytes : null;
+}
+
+function validDTag(value: string): boolean {
+  return (
+    value.trim().length > 0 &&
+    Array.from(value).length <= 64 &&
+    !/[\s\p{C}]/u.test(value)
+  );
+}
+
+function readCatalogTags(value: unknown): {
+  teamDTag: string;
+  shared: boolean;
+} | null {
+  if (!Array.isArray(value) || value.length > MAX_EVENT_TAGS) return null;
+
+  let dTagCount = 0;
+  let teamDTag: string | null = null;
+  let sharedTagCount = 0;
+  let exactSharedTag = false;
+
+  for (const tag of value) {
+    if (
+      !Array.isArray(tag) ||
+      tag.length === 0 ||
+      tag.length > MAX_EVENT_TAG_FIELDS ||
+      tag.some(
+        (field) =>
+          typeof field !== "string" ||
+          !withinBytes(field, MAX_EVENT_TAG_FIELD_BYTES),
+      )
+    ) {
+      return null;
+    }
+
+    if (tag[0] === "d") {
+      dTagCount += 1;
+      if (tag.length === 2 && typeof tag[1] === "string") {
+        teamDTag = tag[1];
+      }
+    }
+    if (tag[0] === "shared") {
+      sharedTagCount += 1;
+      exactSharedTag = tag.length === 2 && tag[1] === "true";
+    }
+  }
+
+  if (
+    dTagCount !== 1 ||
+    teamDTag === null ||
+    !withinBytes(teamDTag, MAX_EVENT_TAG_FIELD_BYTES) ||
+    !validDTag(teamDTag)
+  ) {
+    return null;
+  }
+
+  return {
+    teamDTag,
+    shared: sharedTagCount === 1 && exactSharedTag,
+  };
+}
+
+function assessCatalogEvent(value: unknown): {
+  event: SafeCatalogEvent | null;
+  unsafeCandidate: boolean;
+} {
+  try {
+    if (!isObject(value) || value.kind !== KIND_TEAM_CATALOG) {
+      return { event: null, unsafeCandidate: false };
+    }
+
+    if (
+      typeof value.id !== "string" ||
+      !NOSTR_HEX.test(value.id) ||
+      typeof value.pubkey !== "string" ||
+      !NOSTR_HEX.test(value.pubkey) ||
+      typeof value.created_at !== "number" ||
+      !Number.isSafeInteger(value.created_at) ||
+      value.created_at < 0 ||
+      typeof value.content !== "string"
+    ) {
+      return { event: null, unsafeCandidate: true };
+    }
+
+    const tags = readCatalogTags(value.tags);
+    if (!tags) return { event: null, unsafeCandidate: true };
+
+    return {
+      event: {
+        id: value.id,
+        ownerPubkey: value.pubkey,
+        teamDTag: tags.teamDTag,
+        createdAt: value.created_at,
+        content: value.content,
+        shared: tags.shared,
+        coordinate: `${value.pubkey}:${tags.teamDTag}`,
+      },
+      unsafeCandidate: false,
+    };
+  } catch {
+    return { event: null, unsafeCandidate: true };
+  }
+}
+
+function optionalBoundedString(value: unknown, maximum: number): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && withinBytes(value, maximum))
+  );
+}
+
+function validCatalogMember(value: unknown): value is CatalogMember {
+  if (!isObject(value)) return false;
+  if (
+    typeof value.member_key !== "string" ||
+    value.member_key.trim().length === 0 ||
+    !withinBytes(value.member_key, MAX_MEMBER_KEY_BYTES) ||
+    typeof value.display_name !== "string" ||
+    value.display_name.trim().length === 0 ||
+    !safeDisplayText(value.display_name, MAX_NAME_BYTES)
+  ) {
+    return false;
+  }
+  if (
+    !optionalBoundedString(value.system_prompt, MAX_SYSTEM_PROMPT_BYTES) ||
+    !optionalBoundedString(value.avatar_url, MAX_TEXT_BYTES * 8)
+  ) {
+    return false;
+  }
+  for (const field of ["runtime", "model", "provider"] as const) {
+    const candidate = value[field];
+    if (
+      candidate !== undefined &&
+      candidate !== null &&
+      (typeof candidate !== "string" ||
+        candidate.trim().length === 0 ||
+        !withinBytes(candidate, MAX_IDENTIFIER_BYTES))
+    ) {
+      return false;
+    }
+  }
+  if (value.name_pool !== undefined) {
+    if (
+      !Array.isArray(value.name_pool) ||
+      value.name_pool.length > MAX_NAME_POOL_ENTRIES ||
+      value.name_pool.some(
+        (name) =>
+          typeof name !== "string" ||
+          name.trim().length === 0 ||
+          !withinBytes(name, MAX_NAME_BYTES),
+      )
+    ) {
+      return false;
+    }
+  }
+  if (
+    value.respond_to !== undefined &&
+    value.respond_to !== null &&
+    value.respond_to !== "owner-only" &&
+    value.respond_to !== "allowlist" &&
+    value.respond_to !== "anyone"
+  ) {
+    return false;
+  }
+  return (
+    value.parallelism === undefined ||
+    value.parallelism === null ||
+    (typeof value.parallelism === "number" &&
+      Number.isInteger(value.parallelism) &&
+      value.parallelism >= 1 &&
+      value.parallelism <= 32)
+  );
+}
+
+function parseCatalogContent(
+  content: string,
+  contentBytes: number,
+): { name: string; memberKeys: string[] } | null {
+  if (contentBytes > MAX_EVENT_CONTENT_BYTES) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (
+    !isObject(parsed) ||
+    parsed.v !== TEAM_CATALOG_SCHEMA_VERSION ||
+    typeof parsed.name !== "string" ||
+    parsed.name.trim().length === 0 ||
+    !safeDisplayText(parsed.name, MAX_NAME_BYTES) ||
+    !Array.isArray(parsed.members) ||
+    parsed.members.length > MAX_MEMBERS ||
+    !optionalBoundedString(parsed.description, MAX_TEXT_BYTES) ||
+    !optionalBoundedString(parsed.instructions, MAX_TEXT_BYTES)
+  ) {
+    return null;
+  }
+
+  const memberKeys = new Set<string>();
+  for (const member of parsed.members) {
+    if (!validCatalogMember(member) || memberKeys.has(member.member_key)) {
+      return null;
+    }
+    memberKeys.add(member.member_key);
+  }
+
+  return { name: parsed.name, memberKeys: [...memberKeys] };
+}
+
+function newerThan(event: SafeCatalogEvent, head: CatalogHead): boolean {
+  return (
+    event.createdAt > head.createdAt ||
+    (event.createdAt === head.createdAt &&
+      event.id.localeCompare(head.eventId) < 0)
+  );
+}
+
+function considerEvent(
+  accumulator: CatalogAccumulator,
+  event: SafeCatalogEvent,
+): void {
+  const previous = accumulator.heads.get(event.coordinate);
+  if (previous && !newerThan(event, previous)) return;
+
+  let publication: TeamCatalogPublication | null = null;
+  if (event.shared) {
+    const ownerValidationBytes =
+      accumulator.validationBytesByOwner.get(event.ownerPubkey) ?? 0;
+    const remaining = Math.min(
+      MAX_CATALOG_VALIDATION_BYTES - accumulator.validationBytes,
+      MAX_OWNER_VALIDATION_BYTES - ownerValidationBytes,
+    );
+    if (remaining > 0) {
+      const contentBytes = scanContent(
+        event.content,
+        Math.min(MAX_EVENT_CONTENT_BYTES, remaining),
+      );
+      accumulator.validationBytes += contentBytes ?? remaining;
+      accumulator.validationBytesByOwner.set(
+        event.ownerPubkey,
+        ownerValidationBytes + (contentBytes ?? remaining),
+      );
+      if (contentBytes !== null) {
+        const content = parseCatalogContent(event.content, contentBytes);
+        if (content) {
+          publication = {
+            eventId: event.id,
+            ownerPubkey: event.ownerPubkey,
+            teamDTag: event.teamDTag,
+            name: content.name,
+            memberCount: content.memberKeys.length,
+            memberKeys: content.memberKeys,
+          };
+        }
+      }
+    }
+  }
+
+  // Claim the coordinate even when the current head is unshared or malformed.
+  accumulator.heads.set(event.coordinate, {
+    createdAt: event.createdAt,
+    eventId: event.id,
+    publication,
+  });
+}
+
+function sortedEvents(events: SafeCatalogEvent[]): SafeCatalogEvent[] {
+  return events.sort(
+    (left, right) =>
+      right.createdAt - left.createdAt || left.id.localeCompare(right.id),
+  );
+}
+
+function safeEvents(values: Iterable<unknown>, maximum: number) {
+  const events: SafeCatalogEvent[] = [];
+  const seenIds = new Set<string>();
+  let inspected = 0;
+  for (const value of values) {
+    if (inspected >= maximum) {
+      return { events, truncated: true, unsafeCandidate: false };
+    }
+    inspected += 1;
+    const assessment = assessCatalogEvent(value);
+    if (assessment.unsafeCandidate) {
+      return { events, truncated: false, unsafeCandidate: true };
+    }
+    if (assessment.event && !seenIds.has(assessment.event.id)) {
+      seenIds.add(assessment.event.id);
+      events.push(assessment.event);
+    }
+  }
+  return { events, truncated: false, unsafeCandidate: false };
+}
+
+function publicationsFromHeads(
+  heads: ReadonlyMap<string, CatalogHead>,
+): TeamCatalogPublication[] {
+  return [...heads.values()]
+    .flatMap((head) => (head.publication ? [head.publication] : []))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function suppressAll(accumulator: CatalogAccumulator): void {
+  for (const [coordinate, head] of accumulator.heads) {
+    accumulator.heads.set(coordinate, { ...head, publication: null });
+  }
+}
+
+function suppressAtTimestamp(
+  accumulator: CatalogAccumulator,
+  timestamp: number,
+): void {
+  for (const [coordinate, head] of accumulator.heads) {
+    if (head.createdAt === timestamp) {
+      accumulator.heads.set(coordinate, { ...head, publication: null });
+    }
+  }
+}
+
+/** Only an exact `['shared', 'true']` declaration opts a head into discovery. */
+export function teamEventIsShared(event: RelayEvent): boolean {
+  return assessCatalogEvent(event).event?.shared ?? false;
+}
+
+/** Resolve complete, safe public projections using replaceable-head semantics. */
+export function teamCatalogPublicationsFromEvents(
+  events: readonly RelayEvent[],
+): TeamCatalogPublication[] {
+  const accumulator: CatalogAccumulator = {
+    heads: new Map(),
+    validationBytes: 0,
+    validationBytesByOwner: new Map(),
+  };
+  const safe = safeEvents(events, MAX_CATALOG_EVENTS);
+  for (const event of sortedEvents(safe.events)) {
+    considerEvent(accumulator, event);
+  }
+  if (safe.truncated || safe.unsafeCandidate) suppressAll(accumulator);
+  return publicationsFromHeads(accumulator.heads);
+}
+
+function catalogPage(value: unknown) {
+  if (!Array.isArray(value)) {
+    return { events: [], full: false, unsafeCandidate: true };
+  }
+  const rawEvents = value.slice(0, CATALOG_PAGE_SIZE);
+  const safe = safeEvents(rawEvents, CATALOG_PAGE_SIZE);
+  return {
+    events: sortedEvents(safe.events),
+    full: rawEvents.length === CATALOG_PAGE_SIZE,
+    unsafeCandidate: value.length > CATALOG_PAGE_SIZE || safe.unsafeCandidate,
+  };
+}
+
+/** Read all bounded catalog pages and deduplicate inclusive cursor repeats. */
+export async function fetchTeamCatalogPublications(): Promise<
+  TeamCatalogPublication[]
+> {
+  const accumulator: CatalogAccumulator = {
+    heads: new Map(),
+    validationBytes: 0,
+    validationBytesByOwner: new Map(),
+  };
+  const seenEventIds = new Set<string>();
+  let until: number | undefined;
+
+  for (let page = 0; page < MAX_CATALOG_PAGES; page += 1) {
+    const response = await relayClient.fetchEvents({
+      kinds: [KIND_TEAM_CATALOG],
+      limit: CATALOG_PAGE_SIZE,
+      ...(until === undefined ? {} : { until }),
+    });
+    const catalog = catalogPage(response);
+    if (catalog.unsafeCandidate) return [];
+
+    const sizeBefore = seenEventIds.size;
+    let oldestCreatedAt = Number.POSITIVE_INFINITY;
+    for (const event of catalog.events) {
+      oldestCreatedAt = Math.min(oldestCreatedAt, event.createdAt);
+      if (seenEventIds.has(event.id)) continue;
+      seenEventIds.add(event.id);
+      considerEvent(accumulator, event);
+    }
+
+    if (!catalog.full) break;
+    if (!Number.isFinite(oldestCreatedAt)) {
+      suppressAll(accumulator);
+      break;
+    }
+    if (seenEventIds.size === sizeBefore || page === MAX_CATALOG_PAGES - 1) {
+      suppressAtTimestamp(accumulator, oldestCreatedAt);
+      break;
+    }
+    until = oldestCreatedAt;
+  }
+
+  return publicationsFromHeads(accumulator.heads);
+}

--- a/desktop/src/features/agents/lib/teamPersonas.test.mjs
+++ b/desktop/src/features/agents/lib/teamPersonas.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   emptyResolvedTeamPersonas,
   getUsableTeams,
+  resolveTeamMembers,
   resolveTeamPersonas,
 } from "./teamPersonas.ts";
 
@@ -91,4 +92,104 @@ test("getUsableTeams keeps only fully-resolved teams with at least one persona",
     getUsableTeams(teams, personas).map((team) => team.id),
     ["team-ready"],
   );
+});
+
+test("resolveTeamMembers keeps local personas deployable", () => {
+  const personas = [createPersona("persona-1", "Local")];
+  const resolution = resolveTeamMembers(
+    createTeam("team-local", ["persona-1"]),
+    personas,
+    [],
+    [],
+  );
+
+  assert.equal(resolution.isComplete, true);
+  assert.equal(resolution.isUsable, true);
+  assert.equal(resolution.hasRemoteMembers, false);
+  assert.deepEqual(resolution.resolvedPersonaIds, ["persona-1"]);
+});
+
+test("resolveTeamMembers marks relay-only matches resolved but not usable", () => {
+  const relayPubkey = "a".repeat(64);
+  const catalogKey = "catalog-member";
+  const resolution = resolveTeamMembers(
+    createTeam("team-remote", [relayPubkey, catalogKey]),
+    [],
+    [{ pubkey: relayPubkey }],
+    [
+      {
+        ownerPubkey: "owner-pubkey",
+        teamDTag: "team-remote",
+        memberKeys: [catalogKey],
+      },
+    ],
+    "owner-pubkey",
+  );
+
+  assert.equal(resolution.hasMissingPersonas, false);
+  assert.equal(resolution.isComplete, true);
+  assert.equal(resolution.isUsable, false);
+  assert.equal(resolution.remoteMemberCount, 2);
+  assert.deepEqual(resolution.resolvedRemoteMemberIds, [
+    relayPubkey,
+    catalogKey,
+  ]);
+  assert.deepEqual(resolution.resolvedPersonas, []);
+});
+
+test("resolveTeamMembers distinguishes local, relay, and missing members", () => {
+  const relayPubkey = "b".repeat(64);
+  const resolution = resolveTeamMembers(
+    createTeam("team-mixed", ["persona-1", relayPubkey, "missing"]),
+    [createPersona("persona-1", "Local")],
+    [{ pubkey: relayPubkey.toUpperCase() }],
+    [],
+  );
+
+  assert.equal(resolution.hasMissingPersonas, true);
+  assert.equal(resolution.isComplete, false);
+  assert.equal(resolution.isUsable, false);
+  assert.equal(resolution.missingPersonaCount, 1);
+  assert.deepEqual(resolution.missingPersonaIds, ["missing"]);
+  assert.deepEqual(resolution.resolvedPersonaIds, ["persona-1"]);
+  assert.deepEqual(resolution.resolvedRemoteMemberIds, [relayPubkey]);
+});
+
+test("resolveTeamMembers ignores catalog members from another team", () => {
+  const resolution = resolveTeamMembers(
+    createTeam("team-local", ["foreign-member"]),
+    [],
+    [],
+    [
+      {
+        ownerPubkey: "owner-pubkey",
+        teamDTag: "team-other",
+        memberKeys: ["foreign-member"],
+      },
+    ],
+    "owner-pubkey",
+  );
+
+  assert.equal(resolution.hasMissingPersonas, true);
+  assert.deepEqual(resolution.missingPersonaIds, ["foreign-member"]);
+  assert.equal(resolution.hasRemoteMembers, false);
+});
+
+test("resolveTeamMembers ignores a matching team from another catalog owner", () => {
+  const resolution = resolveTeamMembers(
+    createTeam("team-local", ["foreign-member"]),
+    [],
+    [],
+    [
+      {
+        ownerPubkey: "other-owner",
+        teamDTag: "team-local",
+        memberKeys: ["foreign-member"],
+      },
+    ],
+    "owner-pubkey",
+  );
+
+  assert.equal(resolution.hasMissingPersonas, true);
+  assert.deepEqual(resolution.missingPersonaIds, ["foreign-member"]);
 });

--- a/desktop/src/features/agents/lib/teamPersonas.ts
+++ b/desktop/src/features/agents/lib/teamPersonas.ts
@@ -1,4 +1,6 @@
 import type { AgentPersona, AgentTeam } from "@/shared/api/types";
+import type { RelayAgent } from "@/shared/api/types";
+import type { TeamCatalogPublication } from "./teamCatalogRelay";
 
 export type ResolvedTeamPersonas = {
   hasMissingPersonas: boolean;
@@ -8,6 +10,12 @@ export type ResolvedTeamPersonas = {
   missingPersonaIds: string[];
   resolvedPersonaIds: string[];
   resolvedPersonas: AgentPersona[];
+};
+
+export type ResolvedTeamMembers = ResolvedTeamPersonas & {
+  hasRemoteMembers: boolean;
+  remoteMemberCount: number;
+  resolvedRemoteMemberIds: string[];
 };
 
 export function emptyResolvedTeamPersonas(): ResolvedTeamPersonas {
@@ -70,5 +78,88 @@ export function resolveTeamPersonas(
     missingPersonaIds,
     resolvedPersonaIds,
     resolvedPersonas,
+  };
+}
+
+function relayIdentityKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Resolve team membership across local definitions and relay-only identities.
+ * Remote matches stay outside `resolvedPersonas`, so local deployment gates
+ * remain conservative while the UI can explain why a member is not missing.
+ */
+export function resolveTeamMembers(
+  team: Pick<AgentTeam, "id" | "personaIds">,
+  personas: readonly AgentPersona[],
+  relayAgents: readonly Pick<RelayAgent, "pubkey">[] = [],
+  sharedCatalogTeams: readonly Pick<
+    TeamCatalogPublication,
+    "memberKeys" | "teamDTag" | "ownerPubkey"
+  >[] = [],
+  catalogOwnerPubkey = "",
+): ResolvedTeamMembers {
+  const localById = new Map(personas.map((persona) => [persona.id, persona]));
+  const relayIdentityIds = new Set<string>();
+  for (const agent of relayAgents) {
+    const key = relayIdentityKey(agent.pubkey);
+    if (key.length > 0) relayIdentityIds.add(key);
+  }
+  const catalogMemberIds = new Set<string>();
+  const normalizedCatalogOwner = relayIdentityKey(catalogOwnerPubkey);
+  for (const catalogTeam of sharedCatalogTeams) {
+    // The 30178 d-tag is the stable team id, and the active account owns this
+    // local team. Require both coordinates before using opaque member keys.
+    if (
+      catalogTeam.teamDTag !== team.id ||
+      relayIdentityKey(catalogTeam.ownerPubkey) !== normalizedCatalogOwner ||
+      normalizedCatalogOwner.length === 0
+    ) {
+      continue;
+    }
+    for (const memberKey of catalogTeam.memberKeys) {
+      const trimmed = memberKey.trim();
+      if (trimmed.length > 0) catalogMemberIds.add(trimmed);
+    }
+  }
+
+  const resolvedPersonas: AgentPersona[] = [];
+  const resolvedPersonaIds: string[] = [];
+  const resolvedRemoteMemberIds: string[] = [];
+  const missingPersonaIds: string[] = [];
+
+  for (const personaId of team.personaIds) {
+    const persona = localById.get(personaId);
+    if (persona) {
+      resolvedPersonas.push(persona);
+      resolvedPersonaIds.push(persona.id);
+      continue;
+    }
+
+    const isRemote =
+      relayIdentityIds.has(relayIdentityKey(personaId)) ||
+      catalogMemberIds.has(personaId);
+    if (isRemote) {
+      resolvedRemoteMemberIds.push(personaId);
+    } else {
+      missingPersonaIds.push(personaId);
+    }
+  }
+
+  return {
+    hasMissingPersonas: missingPersonaIds.length > 0,
+    isComplete: missingPersonaIds.length === 0,
+    isUsable:
+      missingPersonaIds.length === 0 &&
+      resolvedRemoteMemberIds.length === 0 &&
+      resolvedPersonaIds.length > 0,
+    missingPersonaCount: missingPersonaIds.length,
+    missingPersonaIds,
+    resolvedPersonaIds,
+    resolvedPersonas,
+    hasRemoteMembers: resolvedRemoteMemberIds.length > 0,
+    remoteMemberCount: resolvedRemoteMemberIds.length,
+    resolvedRemoteMemberIds,
   };
 }

--- a/desktop/src/features/agents/relayAgentsQueryKey.test.mjs
+++ b/desktop/src/features/agents/relayAgentsQueryKey.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { relayAgentsQueryKeyForScope } from "./relayAgentsQueryScope.ts";
+
+test("relay agent cache keys differ for relay URLs", () => {
+  const first = relayAgentsQueryKeyForScope(
+    "wss://first.example.test",
+    "community-a",
+    "a".repeat(64),
+  );
+  const second = relayAgentsQueryKeyForScope(
+    "wss://second.example.test",
+    "community-b",
+    "a".repeat(64),
+  );
+
+  assert.notDeepEqual(first, second);
+  assert.equal(first[1], "wss://first.example.test");
+  assert.equal(second[1], "wss://second.example.test");
+  assert.equal(
+    relayAgentsQueryKeyForScope(" WSS://FIRST.EXAMPLE.TEST/// ")[1],
+    "wss://first.example.test",
+  );
+});

--- a/desktop/src/features/agents/relayAgentsQueryScope.ts
+++ b/desktop/src/features/agents/relayAgentsQueryScope.ts
@@ -1,0 +1,39 @@
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
+
+export const relayAgentsQueryKey = ["relay-agents"] as const;
+
+export function relayAgentsQueryKeyForScope(
+  relayUrl: string,
+  communityId = "",
+  accountPubkey = "",
+) {
+  return [
+    relayAgentsQueryKey[0],
+    normalizeRelayUrl(relayUrl),
+    communityId,
+    accountPubkey,
+  ] as const;
+}
+
+/**
+ * Tenant scope for relay-directory queries. Cache keys include the active
+ * canonical relay URL plus the community and account identity so a
+ * relay/community switch can never briefly serve another tenant's records
+ * out of the persisted query cache.
+ */
+export function useRelayAgentsQueryScope() {
+  const { activeCommunity } = useCommunities();
+  const identityQuery = useIdentityQuery();
+  const relayUrl = normalizeRelayUrl(activeCommunity?.relayUrl ?? "");
+  const communityId = activeCommunity?.id ?? "";
+  const accountPubkey = identityQuery.data?.pubkey?.toLowerCase() ?? "";
+
+  return {
+    accountPubkey,
+    communityId,
+    enabled: relayUrl.length > 0 && accountPubkey.length > 0,
+    queryKey: relayAgentsQueryKeyForScope(relayUrl, communityId, accountPubkey),
+  } as const;
+}

--- a/desktop/src/features/agents/teamCatalogHooks.test.mjs
+++ b/desktop/src/features/agents/teamCatalogHooks.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { teamCatalogQueryKey } from "./teamCatalogHooks.ts";
+
+test("shared catalog cache keys differ for relay URLs", () => {
+  const first = teamCatalogQueryKey("wss://first.example.test");
+  const second = teamCatalogQueryKey("wss://second.example.test");
+
+  assert.deepEqual(first, ["shared-team-catalog", "wss://first.example.test"]);
+  assert.notDeepEqual(first, second);
+  assert.deepEqual(teamCatalogQueryKey(" WSS://FIRST.EXAMPLE.TEST/// "), first);
+});

--- a/desktop/src/features/agents/teamCatalogHooks.ts
+++ b/desktop/src/features/agents/teamCatalogHooks.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchTeamCatalogPublications } from "@/features/agents/lib/teamCatalogRelay";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
+
+export function teamCatalogQueryKey(relayUrl: string) {
+  return ["shared-team-catalog", normalizeRelayUrl(relayUrl)] as const;
+}
+
+/** Read relay-confirmed shared team heads without exposing mutations. */
+export function useTeamCatalogQuery(options?: { enabled?: boolean }) {
+  const { activeCommunity } = useCommunities();
+  const relayUrl = normalizeRelayUrl(activeCommunity?.relayUrl ?? "");
+
+  return useQuery({
+    queryKey: teamCatalogQueryKey(relayUrl),
+    queryFn: fetchTeamCatalogPublications,
+    staleTime: 30_000,
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
+    enabled: (options?.enabled ?? true) && relayUrl.length > 0,
+  });
+}

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -9,8 +9,9 @@ import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import type { CreateChannelManagedAgentsResult } from "@/features/agents/channelAgents";
 import {
   emptyResolvedTeamPersonas,
-  resolveTeamPersonas,
+  resolveTeamMembers,
 } from "@/features/agents/lib/teamPersonas";
+import type { TeamCatalogPublication } from "@/features/agents/lib/teamCatalogRelay";
 import {
   collectRuntimeWarnings,
   getDefaultPersonaRuntime,
@@ -23,6 +24,7 @@ import type {
   AgentTeam,
   Channel,
   ChannelRole,
+  RelayAgent,
 } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
 import {
@@ -36,6 +38,9 @@ import {
 type AddTeamToChannelDialogProps = {
   team: AgentTeam | null;
   personas: AgentPersona[];
+  relayAgents: RelayAgent[];
+  sharedCatalogTeams: TeamCatalogPublication[];
+  catalogOwnerPubkey: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDeployed: (
@@ -47,6 +52,9 @@ type AddTeamToChannelDialogProps = {
 export function AddTeamToChannelDialog({
   team,
   personas,
+  relayAgents,
+  sharedCatalogTeams,
+  catalogOwnerPubkey,
   open,
   onOpenChange,
   onDeployed,
@@ -78,11 +86,25 @@ export function AddTeamToChannelDialog({
 
   const teamPersonaResolution = React.useMemo(
     () =>
-      team ? resolveTeamPersonas(team, personas) : emptyResolvedTeamPersonas(),
-    [team, personas],
+      team
+        ? resolveTeamMembers(
+            team,
+            personas,
+            relayAgents,
+            sharedCatalogTeams,
+            catalogOwnerPubkey,
+          )
+        : {
+            ...emptyResolvedTeamPersonas(),
+            hasRemoteMembers: false,
+            remoteMemberCount: 0,
+            resolvedRemoteMemberIds: [],
+          },
+    [team, personas, relayAgents, sharedCatalogTeams, catalogOwnerPubkey],
   );
   const resolved = teamPersonaResolution.resolvedPersonas;
   const missingPersonaCount = teamPersonaResolution.missingPersonaCount;
+  const remoteMemberCount = teamPersonaResolution.remoteMemberCount;
 
   // Surface warnings when a persona's preferred runtime is unavailable.
   // This dialog has no runtime selector, so the fallback is always
@@ -118,7 +140,12 @@ export function AddTeamToChannelDialog({
     channels.find((channel) => channel.id === channelId) ?? null;
 
   async function handleDeploy() {
-    if (!team || !selectedChannel || !defaultProvider) {
+    if (
+      !team ||
+      !selectedChannel ||
+      !defaultProvider ||
+      !teamPersonaResolution.isUsable
+    ) {
       return;
     }
 
@@ -250,8 +277,15 @@ export function AddTeamToChannelDialog({
               <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                 This team references {missingPersonaCount} agent
                 {missingPersonaCount === 1 ? "" : "s"} that{" "}
-                {missingPersonaCount === 1 ? "is" : "are"} no longer in My
-                Agents. Add them back or edit the team before deploying.
+                {missingPersonaCount === 1 ? "is" : "are"} missing locally. Add
+                them back or edit the team before deploying.
+              </p>
+            ) : null}
+            {remoteMemberCount > 0 ? (
+              <p className="rounded-2xl border border-warning/30 bg-warning-bg px-4 py-3 text-sm text-warning">
+                {remoteMemberCount} team member
+                {remoteMemberCount === 1 ? " is" : "s are"} resolved via the
+                relay. Remote members cannot be deployed from this device.
               </p>
             ) : null}
 
@@ -303,6 +337,7 @@ export function AddTeamToChannelDialog({
                 !defaultProvider ||
                 resolved.length === 0 ||
                 missingPersonaCount > 0 ||
+                remoteMemberCount > 0 ||
                 channelsQuery.isLoading ||
                 providersQuery.isLoading ||
                 deployMutation.isPending

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -19,12 +19,18 @@ import { TeamShareDialog } from "./TeamShareDialog";
 import { TeamDeleteDialog } from "./TeamDeleteDialog";
 import { TeamDialog } from "./TeamDialog";
 import { TeamsSection } from "./TeamsSection";
+import { SharedFleetSection } from "./SharedFleetSection";
 import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
 import { useProfilePanel } from "@/shared/context/ProfilePanelContext";
-import { useBakedBuildEnvQuery } from "@/features/agents/hooks";
+import {
+  useRelayAgentsQuery,
+  useBakedBuildEnvQuery,
+} from "@/features/agents/hooks";
+import { useTeamCatalogQuery } from "@/features/agents/teamCatalogHooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { Button } from "@/shared/ui/button";
@@ -44,6 +50,10 @@ export function AgentsView() {
   const inheritedDefaults = getInheritedAgentDefaults(globalConfig, bakedEnv);
   const agents = useManagedAgentActions();
   const personas = usePersonaActions();
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const teamCatalogQuery = useTeamCatalogQuery();
+  const identityQuery = useIdentityQuery();
+  const catalogOwnerPubkey = identityQuery.data?.pubkey ?? "";
   const teamImportInputRef = React.useRef<HTMLInputElement | null>(null);
   const aiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);
   const fullAiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);
@@ -274,6 +284,8 @@ export function AgentsView() {
               }}
             />
 
+            <SharedFleetSection />
+
             <TeamsSection
               error={
                 teamActions.teamsQuery.error instanceof Error
@@ -296,6 +308,9 @@ export function AgentsView() {
                 teamImportInputRef.current?.click();
               }}
               personas={personas.libraryPersonas}
+              relayAgents={relayAgentsQuery.data ?? []}
+              sharedCatalogTeams={teamCatalogQuery.data ?? []}
+              catalogOwnerPubkey={catalogOwnerPubkey}
               teams={teamActions.teams}
             />
           </div>
@@ -564,6 +579,9 @@ export function AgentsView() {
           }}
           open={teamActions.teamToAddToChannel !== null}
           personas={personas.libraryPersonas}
+          relayAgents={relayAgentsQuery.data ?? []}
+          sharedCatalogTeams={teamCatalogQuery.data ?? []}
+          catalogOwnerPubkey={catalogOwnerPubkey}
           team={teamActions.teamToAddToChannel}
         />
       ) : null}

--- a/desktop/src/features/agents/ui/SharedFleetSection.test.mjs
+++ b/desktop/src/features/agents/ui/SharedFleetSection.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  currentSharedFleetRows,
+  currentSharedTeamCatalog,
+  SharedFleetContent,
+} from "./SharedFleetSection.tsx";
+
+const PUBKEY = "a".repeat(64);
+
+function render(overrides = {}) {
+  return renderToStaticMarkup(
+    React.createElement(SharedFleetContent, {
+      fleetError: null,
+      isFleetLoading: false,
+      isTeamsLoading: false,
+      rows: [
+        {
+          pubkey: PUBKEY,
+          name: "Clyde",
+          modelLabel: "Model Alpha",
+          status: "online",
+          channels: ["Agent Testing", "x-articles-ozark"],
+          mentionHint: "Mention only in its 2 assigned channels",
+        },
+      ],
+      teamError: null,
+      teams: [
+        {
+          eventId: "c".repeat(64),
+          ownerPubkey: "b".repeat(64),
+          teamDTag: "deepseek-crew",
+          name: "DeepSeek Crew",
+          memberCount: 5,
+          memberKeys: [],
+        },
+      ],
+      ...overrides,
+    }),
+  );
+}
+
+test("renders live remote worker and safe shared team fields", () => {
+  const html = render();
+  assert.match(html, /Shared fleet/);
+  assert.match(html, /Remote worker/);
+  assert.match(html, /Clyde/);
+  assert.match(html, /Model Alpha/);
+  assert.match(html, /Agent Testing/);
+  assert.match(html, /DeepSeek Crew/);
+  assert.match(html, /5 members/);
+  assert.doesNotMatch(html, />#x-articles</);
+  assert.doesNotMatch(html, /c{64}|memberKeys|provider|filesystem/);
+});
+
+test("renders no lifecycle, deployment, or global mention controls", () => {
+  const html = render();
+  assert.doesNotMatch(
+    html,
+    /\b(Start|Stop|Restart|Deploy|Delete|Edit|Create|Add to channel)\b/,
+  );
+  assert.doesNotMatch(html, /Mention all|Mention everywhere/);
+  assert.doesNotMatch(html, /system_prompt|provider|filesystem|credential/);
+});
+
+test("failed current reads do not retain stale fleet or catalog rows", () => {
+  const staleRows = currentSharedFleetRows(
+    [
+      {
+        pubkey: PUBKEY,
+        name: "Clyde",
+        model: null,
+        agentType: "agent",
+        channels: [],
+        channelIds: [],
+        capabilities: [],
+        status: "online",
+        respondTo: null,
+        respondToAllowlist: [],
+      },
+    ],
+    { [PUBKEY]: "online" },
+    { relayAgentsAreCurrent: false, presenceIsCurrent: true },
+  );
+  const staleTeams = currentSharedTeamCatalog(
+    [
+      {
+        eventId: "d".repeat(64),
+        ownerPubkey: "b".repeat(64),
+        teamDTag: "stale",
+        name: "Stale Team",
+        memberCount: 1,
+        memberKeys: [],
+      },
+    ],
+    false,
+  );
+  assert.deepEqual(staleRows, []);
+  assert.deepEqual(staleTeams, []);
+});

--- a/desktop/src/features/agents/ui/SharedFleetSection.tsx
+++ b/desktop/src/features/agents/ui/SharedFleetSection.tsx
@@ -1,0 +1,242 @@
+import * as React from "react";
+
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useTeamCatalogQuery } from "@/features/agents/teamCatalogHooks";
+import {
+  activeSharedFleetRows,
+  buildSharedFleetRows,
+  type SharedFleetRow,
+} from "@/features/agents/lib/sharedFleetModel";
+import type { TeamCatalogPublication } from "@/features/agents/lib/teamCatalogRelay";
+import { getPresenceLabel } from "@/features/presence/lib/presence";
+import { usePresenceQuery } from "@/features/presence/hooks";
+import type { PresenceLookup, RelayAgent } from "@/shared/api/types";
+import { Badge } from "@/shared/ui/badge";
+import { SectionHeader } from "@/shared/ui/PageHeader";
+
+type SharedFleetContentProps = {
+  fleetError: Error | null;
+  isFleetLoading: boolean;
+  isTeamsLoading: boolean;
+  rows: readonly SharedFleetRow[];
+  teamError: Error | null;
+  teams: readonly TeamCatalogPublication[];
+};
+
+function statusVariant(
+  status: SharedFleetRow["status"],
+): "success" | "warning" | "secondary" {
+  if (status === "online") return "success";
+  if (status === "away") return "warning";
+  return "secondary";
+}
+
+function memberLabel(memberCount: number): string {
+  return `${memberCount} member${memberCount === 1 ? "" : "s"}`;
+}
+
+export function currentSharedFleetRows(
+  relayAgents: readonly RelayAgent[],
+  presence: PresenceLookup | undefined,
+  {
+    relayAgentsAreCurrent,
+    presenceIsCurrent,
+  }: {
+    relayAgentsAreCurrent: boolean;
+    presenceIsCurrent: boolean;
+  },
+): SharedFleetRow[] {
+  if (
+    !relayAgentsAreCurrent ||
+    (relayAgents.length > 0 && !presenceIsCurrent)
+  ) {
+    return [];
+  }
+  return activeSharedFleetRows(buildSharedFleetRows(relayAgents, presence));
+}
+
+export function currentSharedTeamCatalog(
+  teams: readonly TeamCatalogPublication[],
+  teamCatalogIsCurrent: boolean,
+): readonly TeamCatalogPublication[] {
+  return teamCatalogIsCurrent ? teams : [];
+}
+
+/** Read-only rendering of relay-confirmed workers and public team heads. */
+export function SharedFleetContent({
+  fleetError,
+  isFleetLoading,
+  isTeamsLoading,
+  rows,
+  teamError,
+  teams,
+}: SharedFleetContentProps) {
+  return (
+    <div className="flex flex-col gap-8" data-testid="shared-fleet-section">
+      <section className="space-y-4" data-testid="shared-fleet">
+        <SectionHeader
+          description="Relay-confirmed remote workers. Read-only: execution stays on the worker host."
+          title="Shared fleet"
+        />
+        {isFleetLoading ? (
+          <p className="text-sm text-muted-foreground">
+            Loading live worker presence…
+          </p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No live shared workers are currently reported.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {rows.map((row) => (
+              <article
+                className="min-w-0 rounded-xl border border-border bg-card p-4 shadow-sm"
+                data-testid={`shared-fleet-worker-${row.pubkey}`}
+                key={row.pubkey}
+              >
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-base font-semibold tracking-tight">
+                      {row.name}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      Remote worker
+                    </p>
+                    {row.modelLabel ? (
+                      <p className="mt-1 truncate text-xs text-muted-foreground">
+                        {row.modelLabel}
+                      </p>
+                    ) : null}
+                  </div>
+                  <Badge variant={statusVariant(row.status)}>
+                    {getPresenceLabel(row.status)}
+                  </Badge>
+                </div>
+                <div className="mt-4 space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Assigned channels
+                  </p>
+                  {row.channels.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No assigned channels
+                    </p>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                      {row.channels.map((channel) => (
+                        <Badge
+                          key={`${row.pubkey}:${channel}`}
+                          variant="outline"
+                        >
+                          {channel}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                  <p className="pt-1 text-xs text-muted-foreground">
+                    {row.mentionHint}
+                  </p>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+        {fleetError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {fleetError.message}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-4" data-testid="shared-team-catalog">
+        <SectionHeader
+          description="Relay-confirmed shared teams. Membership and lifecycle stay with the team owner."
+          title="Shared agent teams"
+        />
+        {isTeamsLoading ? (
+          <p className="text-sm text-muted-foreground">Loading shared teams…</p>
+        ) : teams.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No shared teams are currently published.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {teams.map((team, index) => (
+              <article
+                className="min-w-0 rounded-xl border border-border bg-card p-4 shadow-sm"
+                data-testid={`shared-team-card-${index}`}
+                key={`${team.ownerPubkey}:${team.teamDTag}`}
+              >
+                <p className="truncate text-base font-semibold tracking-tight">
+                  {team.name}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {memberLabel(team.memberCount)}
+                </p>
+              </article>
+            ))}
+          </div>
+        )}
+        {teamError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {teamError.message}
+          </p>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+export function SharedFleetSection() {
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const teamCatalogQuery = useTeamCatalogQuery();
+  const relayAgents = relayAgentsQuery.data ?? [];
+  const pubkeys = React.useMemo(
+    () => relayAgents.map((agent) => agent.pubkey),
+    [relayAgents],
+  );
+  const presenceQuery = usePresenceQuery(pubkeys, {
+    enabled: relayAgentsQuery.isSuccess && pubkeys.length > 0,
+  });
+  const rows = React.useMemo(
+    () =>
+      currentSharedFleetRows(relayAgents, presenceQuery.data, {
+        relayAgentsAreCurrent:
+          relayAgentsQuery.isSuccess && !relayAgentsQuery.isError,
+        presenceIsCurrent: presenceQuery.isSuccess && !presenceQuery.isError,
+      }),
+    [
+      presenceQuery.data,
+      presenceQuery.isError,
+      presenceQuery.isSuccess,
+      relayAgents,
+      relayAgentsQuery.isError,
+      relayAgentsQuery.isSuccess,
+    ],
+  );
+  const teams = currentSharedTeamCatalog(
+    teamCatalogQuery.data ?? [],
+    teamCatalogQuery.isSuccess && !teamCatalogQuery.isError,
+  );
+  const fleetError =
+    relayAgentsQuery.error instanceof Error
+      ? relayAgentsQuery.error
+      : presenceQuery.error instanceof Error
+        ? presenceQuery.error
+        : null;
+  const teamError =
+    teamCatalogQuery.error instanceof Error ? teamCatalogQuery.error : null;
+
+  return (
+    <SharedFleetContent
+      fleetError={fleetError}
+      isFleetLoading={
+        relayAgentsQuery.isLoading ||
+        (relayAgents.length > 0 && presenceQuery.isLoading)
+      }
+      isTeamsLoading={teamCatalogQuery.isLoading}
+      rows={rows}
+      teamError={teamError}
+      teams={teams}
+    />
+  );
+}

--- a/desktop/src/features/agents/ui/TeamsSection.tsx
+++ b/desktop/src/features/agents/ui/TeamsSection.tsx
@@ -7,8 +7,9 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { resolveTeamPersonas } from "@/features/agents/lib/teamPersonas";
-import type { AgentPersona, AgentTeam } from "@/shared/api/types";
+import { resolveTeamMembers } from "@/features/agents/lib/teamPersonas";
+import type { TeamCatalogPublication } from "@/features/agents/lib/teamCatalogRelay";
+import type { AgentPersona, AgentTeam, RelayAgent } from "@/shared/api/types";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +28,9 @@ const TEAM_CARD_COLUMN_CLASS = "w-full";
 type TeamsSectionProps = {
   teams: AgentTeam[];
   personas: AgentPersona[];
+  relayAgents: RelayAgent[];
+  sharedCatalogTeams: TeamCatalogPublication[];
+  catalogOwnerPubkey: string;
   error: Error | null;
   isLoading: boolean;
   isPending: boolean;
@@ -42,6 +46,9 @@ type TeamsSectionProps = {
 export function TeamsSection({
   teams,
   personas,
+  relayAgents,
+  sharedCatalogTeams,
+  catalogOwnerPubkey,
   error,
   isLoading,
   isPending,
@@ -85,7 +92,13 @@ export function TeamsSection({
       {!isLoading ? (
         <div className={IDENTITY_CARD_GRID_CLASS}>
           {teams.map((team) => {
-            const resolution = resolveTeamPersonas(team, personas);
+            const resolution = resolveTeamMembers(
+              team,
+              personas,
+              relayAgents,
+              sharedCatalogTeams,
+              catalogOwnerPubkey,
+            );
             const missingPersonaCount = resolution.missingPersonaCount;
             const hasMissingPersonas = resolution.hasMissingPersonas;
 
@@ -107,7 +120,7 @@ export function TeamsSection({
                       onCloseAutoFocus={(event) => event.preventDefault()}
                     >
                       <DropdownMenuItem
-                        disabled={isPending || hasMissingPersonas}
+                        disabled={isPending || !resolution.isUsable}
                         onClick={() => onAddToChannel(team)}
                       >
                         <Rocket className="h-4 w-4" />
@@ -162,8 +175,16 @@ export function TeamsSection({
                   <p className="border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
                     {missingPersonaCount} agent
                     {missingPersonaCount === 1 ? "" : "s"} in this team{" "}
-                    {missingPersonaCount === 1 ? "is" : "are"} no longer in your
-                    agents. Edit the team to fix it before deploying or sharing.
+                    {missingPersonaCount === 1 ? "is" : "are"} missing locally.
+                    Edit the team to fix it before deploying or sharing.
+                  </p>
+                ) : null}
+                {resolution.hasRemoteMembers ? (
+                  <p className="border-t border-warning/20 bg-warning-bg px-3 py-2 text-xs text-warning">
+                    {resolution.remoteMemberCount} agent
+                    {resolution.remoteMemberCount === 1 ? "" : "s"} resolved via
+                    the relay. Remote members cannot be deployed from this
+                    device.
                   </p>
                 ) : null}
               </TeamIdentityCard>

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -6,7 +6,9 @@ import { isRateLimited } from "@/shared/api/relayRateLimitGate";
 import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { getOsIdleSeconds } from "@/shared/api/osIdle";
 import { getPresence } from "@/shared/api/tauri";
+import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { useCommunities } from "@/features/communities/useCommunities";
 import {
   mergePresenceUpdate,
   parseLivePresenceEvent,
@@ -29,8 +31,22 @@ function normalizePubkeys(pubkeys: string[]) {
     .sort();
 }
 
-function presenceQueryKey(pubkeys: string[]) {
-  return ["presence", ...normalizePubkeys(pubkeys)] as const;
+function presenceQueryKey(
+  relayUrl: string,
+  normalizedPubkeys: readonly string[],
+) {
+  return [
+    "presence",
+    normalizeRelayUrl(relayUrl),
+    ...normalizedPubkeys,
+  ] as const;
+}
+
+export function presenceQueryKeyForScope(
+  relayUrl: string,
+  pubkeys: readonly string[],
+) {
+  return presenceQueryKey(relayUrl, normalizePubkeys([...pubkeys]));
 }
 
 function presencePreferenceStorageKey(pubkey: string) {
@@ -80,13 +96,18 @@ export function usePresenceQuery(
   },
 ) {
   const normalizedPubkeys = normalizePubkeys(pubkeys);
-  const enabled = (options?.enabled ?? true) && normalizedPubkeys.length > 0;
+  const { activeCommunity } = useCommunities();
+  const relayUrl = normalizeRelayUrl(activeCommunity?.relayUrl ?? "");
+  const enabled =
+    (options?.enabled ?? true) &&
+    relayUrl.length > 0 &&
+    normalizedPubkeys.length > 0;
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
 
   return useQuery<PresenceLookup>({
     enabled,
-    queryKey: presenceQueryKey(normalizedPubkeys),
+    queryKey: presenceQueryKey(relayUrl, normalizedPubkeys),
     queryFn: () => getPresence(normalizedPubkeys),
     staleTime: 30_000,
     // Backstop poll: catches REST-only writers (ACP agents) and TTL expiry

--- a/desktop/src/features/presence/lib/presence.ts
+++ b/desktop/src/features/presence/lib/presence.ts
@@ -15,7 +15,7 @@ export function parseLivePresenceEvent(event: {
   return { pubkey: event.pubkey.toLowerCase(), status };
 }
 
-// Presence query keys are ["presence", ...normalizedSortedPubkeys]; a query
+// Presence query keys are ["presence", relayUrl, ...normalizedSortedPubkeys]; a query
 // "wants" an update only for a pubkey it actually requested.
 export function presenceQueryWantsPubkey(
   queryKey: readonly unknown[],

--- a/desktop/src/features/presence/presenceQueryKey.test.mjs
+++ b/desktop/src/features/presence/presenceQueryKey.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { presenceQueryKeyForScope } from "./hooks.ts";
+
+test("presence cache keys differ for relay URLs", () => {
+  const pubkey = "a".repeat(64);
+  const first = presenceQueryKeyForScope("wss://first.example.test", [pubkey]);
+  const second = presenceQueryKeyForScope("wss://second.example.test", [
+    pubkey,
+  ]);
+
+  assert.notDeepEqual(first, second);
+  assert.equal(first[1], "wss://first.example.test");
+  assert.equal(second[1], "wss://second.example.test");
+  assert.deepEqual(
+    presenceQueryKeyForScope(" WSS://FIRST.EXAMPLE.TEST/// ", [pubkey]),
+    first,
+  );
+});

--- a/desktop/src/shared/api/relayAgent.ts
+++ b/desktop/src/shared/api/relayAgent.ts
@@ -1,0 +1,44 @@
+import type { RespondToMode } from "./types";
+
+export type RelayAgent = {
+  pubkey: string;
+  name: string;
+  /** Optional model label carried by newer kind:10100 directory records. */
+  model?: string | null;
+  agentType: string;
+  channels: string[];
+  channelIds: string[];
+  capabilities: string[];
+  status: "online" | "away" | "offline";
+  respondTo: RespondToMode | null;
+  respondToAllowlist: string[];
+};
+
+export type RawRelayAgent = {
+  pubkey: string;
+  name: string;
+  model?: string | null;
+  model_label?: string | null;
+  agent_type: string;
+  channels: string[];
+  channel_ids: string[];
+  capabilities: string[];
+  status: RelayAgent["status"];
+  respond_to?: RelayAgent["respondTo"];
+  respond_to_allowlist?: string[];
+};
+
+export function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
+  return {
+    pubkey: agent.pubkey,
+    name: agent.name,
+    model: agent.model ?? agent.model_label ?? null,
+    agentType: agent.agent_type,
+    channels: agent.channels,
+    channelIds: agent.channel_ids ?? [],
+    capabilities: agent.capabilities,
+    status: agent.status,
+    respondTo: agent.respond_to ?? null,
+    respondToAllowlist: agent.respond_to_allowlist ?? [],
+  };
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -105,18 +105,7 @@ type RawSendChannelMessageResult = {
   created_at: number;
 };
 
-type RawRelayAgent = {
-  pubkey: string;
-  name: string;
-  agent_type: string;
-  channels: string[];
-  channel_ids: string[];
-  capabilities: string[];
-  status: RelayAgent["status"];
-  respond_to?: RelayAgent["respondTo"];
-  respond_to_allowlist?: string[];
-};
-
+import { fromRawRelayAgent, type RawRelayAgent } from "./relayAgent";
 import type { RestartDiffEntry as RawRestartDiffEntry } from "./restartDiff";
 export type RawManagedAgent = {
   pubkey: string;
@@ -657,20 +646,6 @@ export async function createAuthEvent(input: {
 }): Promise<RelayEvent> {
   const eventJson = await invokeTauri<string>("create_auth_event", input);
   return JSON.parse(eventJson) as RelayEvent;
-}
-
-function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
-  return {
-    pubkey: agent.pubkey,
-    name: agent.name,
-    agentType: agent.agent_type,
-    channels: agent.channels,
-    channelIds: agent.channel_ids ?? [],
-    capabilities: agent.capabilities,
-    status: agent.status,
-    respondTo: agent.respond_to ?? null,
-    respondToAllowlist: agent.respond_to_allowlist ?? [],
-  };
 }
 
 export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -267,17 +267,7 @@ export type RelayMember = {
   createdAt: string;
 };
 
-export type RelayAgent = {
-  pubkey: string;
-  name: string;
-  agentType: string;
-  channels: string[];
-  channelIds: string[];
-  capabilities: string[];
-  status: "online" | "away" | "offline";
-  respondTo: RespondToMode | null;
-  respondToAllowlist: string[];
-};
+export type { RelayAgent } from "./relayAgent";
 
 export type ManagedAgentRuntimeLifecycle =
   | "starting"

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -22,6 +22,10 @@ export const KIND_CHANNEL_WINDOW_BOUNDS = 39006;
 export const KIND_STREAM_MESSAGE_DIFF = 40008;
 export const KIND_REMINDER = 40007;
 export const KIND_SYSTEM_MESSAGE = 40099;
+// Agent directory profiles published by remote worker hosts.
+export const KIND_AGENT_DIRECTORY = 10100;
+// Ephemeral presence updates. Directory status is not current liveness.
+export const KIND_PRESENCE_UPDATE = 20001;
 export const KIND_JOB_REQUEST = 43001;
 export const KIND_JOB_ACCEPTED = 43002;
 export const KIND_JOB_PROGRESS = 43003;
@@ -53,6 +57,8 @@ export const KIND_COMMUNITY_THEME = 30078;
 export const KIND_PERSONA = 30175;
 export const KIND_TEAM = 30176;
 export const KIND_MANAGED_AGENT = 30177;
+// Read-only shared team-catalog heads with bounded public projections.
+export const KIND_TEAM_CATALOG = 30178;
 export const KIND_USER_STATUS = 30315;
 export const KIND_AGENT_OBSERVER_FRAME = 24200;
 export const KIND_AGENT_TURN_METRIC = 44200;

--- a/desktop/src/shared/lib/safeDisplayText.ts
+++ b/desktop/src/shared/lib/safeDisplayText.ts
@@ -1,0 +1,21 @@
+/** Return false for oversized text or Unicode controls that can spoof labels. */
+export function isSafeDisplayText(value: string, maximum: number): boolean {
+  if (new TextEncoder().encode(value).length > maximum) return false;
+
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (
+      codePoint <= 0x1f ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      (codePoint >= 0x200b && codePoint <= 0x200f) ||
+      (codePoint >= 0x202a && codePoint <= 0x202e) ||
+      (codePoint >= 0x2060 && codePoint <= 0x2064) ||
+      (codePoint >= 0x2066 && codePoint <= 0x206f) ||
+      codePoint === 0xfeff
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -44,6 +44,7 @@ import {
   KIND_MEMBER_ADDED_NOTIFICATION,
   KIND_MEMBER_REMOVED_NOTIFICATION,
   KIND_PERSONA,
+  KIND_TEAM_CATALOG,
   KIND_PROJECT_ANNOUNCEMENT,
   KIND_REPO_ANNOUNCEMENT,
   KIND_REPO_STATE,
@@ -110,6 +111,7 @@ type MockManagedAgentRuntimeSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  model?: string | null;
   agentType?: string;
   capabilities?: string[];
   respondTo?: RawRelayAgent["respond_to"];
@@ -285,10 +287,14 @@ type E2eConfig = {
     personas?: MockPersonaSeed[];
     /** Community catalog replaceable-event heads returned by relay queries. */
     personaCatalogEvents?: RelayEvent[];
+    /** Shared Team Catalog heads returned by relay queries. */
+    teamCatalogEvents?: RelayEvent[];
     /** Outcomes for successive explicit persona share publications. */
     personaSharePublicationStatuses?: Array<"published" | "queued">;
     teams?: MockTeamSeed[];
     relayAgents?: MockRelayAgentSeed[];
+    /** Independent current presence values for relay-agent fixtures. */
+    presenceStatuses?: Record<string, PresenceStatus>;
     /** Native-like huddle state seeded from authoritative role-bearing membership. */
     huddle?: MockHuddleSeed;
     agentListDelayMs?: number;
@@ -810,6 +816,7 @@ type RawSendChannelMessageResponse = {
 type RawRelayAgent = {
   pubkey: string;
   name: string;
+  model?: string | null;
   agent_type: string;
   channels: string[];
   channel_ids: string[];
@@ -2261,17 +2268,24 @@ function resetMockRelayAgents(config?: E2eConfig) {
   }));
 
   for (const seed of config?.mock?.relayAgents ?? []) {
+    const seededChannelNames = seed.channelNames ?? [];
     const channels = mockChannels.filter((channel) => {
       return (
         seed.channelIds?.includes(channel.id) ||
-        seed.channelNames?.includes(channel.name)
+        seededChannelNames.includes(channel.name)
       );
     });
     mockRelayAgents.push({
       pubkey: seed.pubkey,
       name: seed.name,
+      model: seed.model ?? null,
       agent_type: seed.agentType ?? "goose",
-      channels: channels.map((channel) => channel.name),
+      channels: [
+        ...new Set([
+          ...channels.map((channel) => channel.name),
+          ...seededChannelNames,
+        ]),
+      ],
       channel_ids: channels.map((channel) => channel.id),
       capabilities: seed.capabilities ?? ["messages", "channels", "mcp"],
       status: seed.status ?? "online",
@@ -2996,6 +3010,7 @@ const deferredSendMessageLiveEchoes: Array<{
 const mockUserStatuses: RelayEvent[] = [];
 const mockReminderEvents: RelayEvent[] = [];
 const mockPersonaEvents: RelayEvent[] = [];
+const mockTeamCatalogEvents: RelayEvent[] = [];
 let mockRelayMembers: RawRelayMember[] = [];
 const mockSockets = new Map<number, MockSocket>();
 const mockAuthResponses: Array<{ success: boolean; message: string }> = [];
@@ -3037,6 +3052,24 @@ function resetMockPersonaCatalogEvents(config: E2eConfig | undefined) {
       ...event,
       tags: event.tags.map((tag) => [...tag]),
     });
+  }
+}
+
+function resetMockTeamCatalogEvents(config: E2eConfig | undefined) {
+  mockTeamCatalogEvents.length = 0;
+  for (const event of config?.mock?.teamCatalogEvents ?? []) {
+    mockTeamCatalogEvents.push({
+      ...event,
+      tags: event.tags.map((tag) => [...tag]),
+    });
+  }
+}
+
+function resetMockPresence(config: E2eConfig | undefined) {
+  for (const [pubkey, status] of Object.entries(
+    config?.mock?.presenceStatuses ?? {},
+  )) {
+    setMockPresenceStatus(pubkey, status);
   }
 }
 
@@ -9755,6 +9788,36 @@ function sendToMockSocket(args: {
       return;
     }
 
+    if (filter.kinds?.includes(KIND_TEAM_CATALOG)) {
+      const authors = filter.authors?.map((author) => author.toLowerCase());
+      const sourceIds = filter["#d"];
+      const candidates = mockTeamCatalogEvents
+        .filter((event) => {
+          if (authors && !authors.includes(event.pubkey.toLowerCase())) {
+            return false;
+          }
+          if (filter.until !== undefined && event.created_at > filter.until) {
+            return false;
+          }
+          const sourceId = event.tags.find((tag) => tag[0] === "d")?.[1];
+          return (
+            !sourceIds ||
+            (sourceId !== undefined && sourceIds.includes(sourceId))
+          );
+        })
+        .sort(
+          (left, right) =>
+            right.created_at - left.created_at ||
+            left.id.localeCompare(right.id),
+        )
+        .slice(0, filter.limit ?? mockTeamCatalogEvents.length);
+      for (const event of candidates) {
+        sendWsText(socket.handler, ["EVENT", subId, event]);
+      }
+      sendWsText(socket.handler, ["EOSE", subId]);
+      return;
+    }
+
     // Project queries: NIP-34 kinds, or kind:1 comments scoped by repo `a`
     // tag (PR/issue discussions, approvals, review requests).
     if (
@@ -10050,6 +10113,7 @@ export function maybeInstallE2eTauriMocks() {
     : null;
   resetMockRelayMembers(config);
   resetMockRelayAgents(config);
+  resetMockPresence(config);
   resetMockManagedAgents(config);
   resetMockPersonas(config);
   resetMockTeams(config);
@@ -10058,6 +10122,7 @@ export function maybeInstallE2eTauriMocks() {
   resetMockMesh();
   resetMockUserStatuses();
   resetMockPersonaCatalogEvents(config);
+  resetMockTeamCatalogEvents(config);
   resetMockSaveSubscriptions(config);
   resetMockPendingCommunityDeepLinks(config);
   initializeMockHuddle(config.mock?.huddle, config);

--- a/desktop/tests/e2e/shared-fleet.spec.ts
+++ b/desktop/tests/e2e/shared-fleet.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+import type { RelayEvent } from "@/shared/api/types";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const LIVE_PUBKEY = "f".repeat(64);
+const STALE_PUBKEY = "e".repeat(64);
+
+function teamCatalogEvent(input: {
+  dTag: string;
+  eventId: string;
+  memberCount: number;
+  name: string;
+}): RelayEvent {
+  return {
+    id: input.eventId,
+    pubkey: TEST_IDENTITIES.alice.pubkey,
+    created_at: 1_721_750_400,
+    kind: 30178,
+    tags: [
+      ["d", input.dTag],
+      ["shared", "true"],
+    ],
+    content: JSON.stringify({
+      v: 1,
+      name: input.name,
+      members: Array.from({ length: input.memberCount }, (_, index) => ({
+        member_key: `member-${index + 1}`,
+        display_name: `Member ${index + 1}`,
+      })),
+    }),
+    sig: "f".repeat(128),
+  };
+}
+
+test("Agents shows an independently confirmed read-only shared fleet", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: LIVE_PUBKEY,
+        name: "Clyde",
+        model: "Model Alpha",
+        channelNames: ["Agent Testing", "x-articles-ozark", "Agent Testing"],
+        // Directory status is deliberately stale. Presence below is current.
+        status: "offline",
+      },
+      {
+        pubkey: STALE_PUBKEY,
+        name: "Stale directory profile",
+        channelNames: ["general"],
+        status: "online",
+      },
+    ],
+    presenceStatuses: {
+      [LIVE_PUBKEY]: "online",
+      [STALE_PUBKEY]: "offline",
+    },
+    teamCatalogEvents: [
+      teamCatalogEvent({
+        dTag: "deepseek-crew",
+        eventId: "1".repeat(64),
+        memberCount: 5,
+        name: "DeepSeek Crew",
+      }),
+      teamCatalogEvent({
+        dTag: "hermes-canary-team",
+        eventId: "2".repeat(64),
+        memberCount: 13,
+        name: "Hermes Canaries",
+      }),
+    ],
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByTestId("open-agents-view").click();
+
+  const fleet = page.getByTestId("shared-fleet");
+  const liveWorker = fleet.getByTestId(`shared-fleet-worker-${LIVE_PUBKEY}`);
+  await expect(liveWorker).toBeVisible();
+  await expect(liveWorker).toContainText("Clyde");
+  await expect(liveWorker).toContainText("Remote worker");
+  await expect(liveWorker).toContainText("Model Alpha");
+  await expect(liveWorker).toContainText("Online");
+  await expect(liveWorker).toContainText("Agent Testing");
+  await expect(liveWorker).toContainText("x-articles-ozark");
+  await expect(liveWorker).toContainText(
+    "Mention only in its 2 assigned channels",
+  );
+  await expect(
+    fleet.getByTestId(`shared-fleet-worker-${STALE_PUBKEY}`),
+  ).toHaveCount(0);
+  await expect(fleet.getByRole("button")).toHaveCount(0);
+
+  const teams = page.getByTestId("shared-team-catalog");
+  await expect(teams).toContainText("DeepSeek Crew");
+  await expect(teams).toContainText("5 members");
+  await expect(teams).toContainText("Hermes Canaries");
+  await expect(teams).toContainText("13 members");
+  await expect(teams.getByRole("button")).toHaveCount(0);
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -57,6 +57,7 @@ type MockSearchProfileSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  model?: string | null;
   agentType?: string;
   capabilities?: string[];
   respondTo?: "owner-only" | "allowlist" | "anyone";
@@ -246,10 +247,14 @@ type MockBridgeOptions = {
   personas?: MockPersonaSeed[];
   /** Community catalog replaceable-event heads returned by relay queries. */
   personaCatalogEvents?: RelayEvent[];
+  /** Shared Team Catalog heads returned by relay queries. */
+  teamCatalogEvents?: RelayEvent[];
   /** Outcomes for successive explicit persona share publications. */
   personaSharePublicationStatuses?: Array<"published" | "queued">;
   teams?: MockTeamSeed[];
   relayAgents?: MockRelayAgentSeed[];
+  /** Independent current presence values for relay-agent fixtures. */
+  presenceStatuses?: Record<string, "online" | "away" | "offline">;
   /** Delay both managed and relay agent directory reads. */
   agentListDelayMs?: number;
   createManagedAgentDelayMs?: number;


### PR DESCRIPTION
## What

Adds a read-only **Shared fleet** section to the desktop Agents page and makes team cards relay-aware, so a Buzz Desktop acting as a *controller* against a self-hosted relay can see the agents that actually live there.

- **Shared fleet (read-only):** lists remote workers from current kind:10100 agent-directory records (name, optional model label, presence, deduplicated assigned channels). Liveness comes from an independent presence read — a stale directory-only record never renders as an active worker. The surface exposes zero lifecycle/membership/global-mention controls; execution stays on the worker host.
- **Shared team catalog (kind:30178):** strict reader — exact `["shared","true"]` opt-in, exactly one `d` tag, schema-versioned, replaceable-head semantics (a newer malformed/unshared head hides older shared heads rather than falling back), bounded paging with event-id dedupe. Only safe fields (display name, member count) are projected; prompts/provider config/paths are never exposed.
- **Team cards:** membership now resolves against local personas **and** the relay directory **and** the owner-scoped 30178 catalog. Relay-hosted members show as "resolved via the relay" instead of the false "no longer in your agents" warning; deploy gating stays conservative (remote-only members still block a local deploy that would fail).
- **Cache isolation:** relay-agent, presence, and catalog query keys are scoped by the active canonical relay URL (+ account identity), so switching communities can never briefly serve another tenant's records from the query cache.

## Why

Self-hosted multi-device use case: agents run as `buzz-acp` workers on a home server, and other devices (Windows desktop, mobile) connect to the same relay as controllers. Today the Agents page renders only locally managed agents, so a healthy relay-registered fleet is invisible and teams referencing relay members are flagged as broken. This is the same ecosystem gap discussed around #4128 (remote/managed-agent visibility), but a separate, additive feature: inspection only, no remote lifecycle control.

## Testing

- `pnpm check` (biome + file-size/px/pubkey guards) — clean
- `pnpm typecheck` — clean
- `pnpm test` — 4557 pass
- `pnpm build:e2e && playwright test tests/e2e/shared-fleet.spec.ts` — 1 pass (bridge seeded with independent fixtures for directory, presence, and 30178 catalog; asserts a live worker renders with channels, a stale directory-only record does not, shared teams render with member counts, and the surface contains no action buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYzfZG6xwRGefUB9EAsh8q
