### PR TITLE
fix(desktop): make the Windows terminal spawn, close, and inherit PATH (#4930)

### DIFF
--- a/desktop/src-tauri/crates/buzz-terminal/src/env_fence.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/env_fence.rs
@@ -53,19 +53,38 @@ pub const UNIX_INHERIT_ALLOWLIST: &[&str] = &[
 /// plumbing that every process on the machine can read. The keys the fence
 /// exists to withhold (`BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, ...) stay
 /// unlisted, exactly as on Unix.
+/// The list is longer than the Unix one for a structural reason rather than a
+/// permissive one: a Unix shell reads rc files and a Windows shell does not,
+/// so anything omitted here is omitted for the whole session with no mechanism
+/// to restore it. Every entry is machine or user *layout* — paths and counts
+/// any process on the box can read — and the keys the fence exists to withhold
+/// stay unlisted, exactly as on Unix.
 pub const WINDOWS_INHERIT_ALLOWLIST: &[&str] = &[
-    "ComSpec",      // default-program resolution (see above)
-    "SystemRoot",   // required by much of Win32; DLL and WMI resolution
-    "windir",       // legacy alias of SystemRoot; old scripts read it
-    "PATHEXT",      // which extensions the shell treats as executable
-    "USERPROFILE",  // ~ equivalent; portable-pty's cwd fallback (see above)
-    "HOMEDRIVE",    // POSIX-ish home components used by ports and MSYS tools
-    "HOMEPATH",     // companion to HOMEDRIVE
-    "APPDATA",      // roaming config; PowerShell profiles, npm, git
-    "LOCALAPPDATA", // local config and caches
-    "TEMP",         // temp dir; absence breaks cmd internals and most tools
-    "TMP",          // companion to TEMP
-    "USERNAME",     // prompt expansion, `whoami`-adjacent tooling
+    "ComSpec",                // default-program resolution (see above)
+    "SystemRoot",             // required by much of Win32; DLL and WMI resolution
+    "SystemDrive",            // `%SystemDrive%` in scripts and installers
+    "windir",                 // legacy alias of SystemRoot; old scripts read it
+    "PATHEXT",                // which extensions the shell treats as executable
+    "USERPROFILE",            // ~ equivalent; portable-pty's cwd fallback (see above)
+    "HOMEDRIVE",              // POSIX-ish home components used by ports and MSYS tools
+    "HOMEPATH",               // companion to HOMEDRIVE
+    "APPDATA",                // roaming config; PowerShell profiles, npm, git
+    "LOCALAPPDATA",           // local config and caches
+    "ProgramData",            // machine-wide app data; chocolatey, docker, certs
+    "ALLUSERSPROFILE",        // legacy alias of ProgramData
+    "ProgramFiles",           // install root many tool scripts resolve through
+    "ProgramFiles(x86)",      // 32-bit install root on 64-bit Windows
+    "ProgramW6432",           // 64-bit install root as seen from a 32-bit process
+    "PUBLIC",                 // shared user profile; some installers write here
+    "PSModulePath",           // how `powershell` finds its modules at all
+    "TEMP",                   // temp dir; absence breaks cmd internals and most tools
+    "TMP",                    // companion to TEMP
+    "USERNAME",               // prompt expansion, `whoami`-adjacent tooling
+    "USERDOMAIN",             // companion to USERNAME on domain-joined machines
+    "COMPUTERNAME",           // prompt expansion; build scripts label output with it
+    "NUMBER_OF_PROCESSORS",   // parallelism default for cargo, make, ninja
+    "PROCESSOR_ARCHITECTURE", // which binaries a script picks to run
+    "OS",                     // `%OS%`, still branched on by older scripts
 ];
 
 #[cfg(unix)]

--- a/desktop/src-tauri/crates/buzz-terminal/src/env_fence.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/env_fence.rs
@@ -19,13 +19,13 @@
 
 use portable_pty::CommandBuilder;
 
-/// Keys the child is allowed to inherit from Buzz's own environment.
+/// Keys the child is allowed to inherit from Buzz's own environment, on Unix.
 ///
 /// Deliberately minimal: each entry is something a shell genuinely cannot
 /// function without, or that visibly degrades the session by its absence.
 /// Anything not listed here does not reach the child, including keys that do
 /// not exist yet — which is the property a denylist cannot offer.
-const INHERIT_ALLOWLIST: &[&str] = &[
+pub const UNIX_INHERIT_ALLOWLIST: &[&str] = &[
     "HOME",     // shell startup files, ~ expansion
     "USER",     // prompt expansion, `whoami`-adjacent tooling
     "LOGNAME",  // POSIX companion to USER
@@ -35,6 +35,43 @@ const INHERIT_ALLOWLIST: &[&str] = &[
     "TZ",       // timestamps in prompts and logs
     "TMPDIR",   // per-user temp dir; absence breaks many tools on macOS
 ];
+
+/// The Windows counterpart. Same rule — allowlist, never denylist — but the
+/// set a shell cannot function without is different, and two entries are
+/// load-bearing for the spawn itself, not just the session:
+///
+/// - `ComSpec`: `portable-pty` resolves a default program by reading `ComSpec`
+///   from the **builder's** env map (`cmdbuilder.rs:671-675`), not the process
+///   environment, and hands it to `CreateProcessW` as `lpApplicationName` —
+///   which performs no path search. Fencing it away turned every spawn into
+///   `CreateProcessW "cmd.exe" ... (os error 2)`.
+/// - `USERPROFILE`: same story for the working directory — `portable-pty`
+///   falls back to the builder-env `USERPROFILE` (`cmdbuilder.rs:609-611`);
+///   without it the child starts with `cwd None`.
+///
+/// None of these carry secrets: they are machine/user layout paths and shell
+/// plumbing that every process on the machine can read. The keys the fence
+/// exists to withhold (`BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, ...) stay
+/// unlisted, exactly as on Unix.
+pub const WINDOWS_INHERIT_ALLOWLIST: &[&str] = &[
+    "ComSpec",      // default-program resolution (see above)
+    "SystemRoot",   // required by much of Win32; DLL and WMI resolution
+    "windir",       // legacy alias of SystemRoot; old scripts read it
+    "PATHEXT",      // which extensions the shell treats as executable
+    "USERPROFILE",  // ~ equivalent; portable-pty's cwd fallback (see above)
+    "HOMEDRIVE",    // POSIX-ish home components used by ports and MSYS tools
+    "HOMEPATH",     // companion to HOMEDRIVE
+    "APPDATA",      // roaming config; PowerShell profiles, npm, git
+    "LOCALAPPDATA", // local config and caches
+    "TEMP",         // temp dir; absence breaks cmd internals and most tools
+    "TMP",          // companion to TEMP
+    "USERNAME",     // prompt expansion, `whoami`-adjacent tooling
+];
+
+#[cfg(unix)]
+const INHERIT_ALLOWLIST: &[&str] = UNIX_INHERIT_ALLOWLIST;
+#[cfg(windows)]
+const INHERIT_ALLOWLIST: &[&str] = WINDOWS_INHERIT_ALLOWLIST;
 
 /// Values Buzz sets on the child unconditionally, overriding any inherited
 /// value. `TERM` in particular must describe *our* emulator, not whatever
@@ -81,5 +118,16 @@ pub fn fence_env(cmd: &mut CommandBuilder, path: &str, shell: &str) {
     // 5. The resolved shell, last. `CommandBuilder::as_command` writes its own
     //    `SHELL` before applying this map (`cmdbuilder.rs:528-536`), so our
     //    explicit entry is the one the child sees.
+    #[cfg(not(windows))]
     cmd.env("SHELL", shell);
+
+    // 5. (Windows) The contract key is `ComSpec`, not `SHELL`, and it is
+    //    doubly load-bearing: besides telling the child what its shell is, it
+    //    is what `portable-pty` spawns for a default program — read from this
+    //    builder's env map and passed to `CreateProcessW` as
+    //    `lpApplicationName`, which does no path search. It must be the
+    //    validated absolute path from `resolve_shell`, overriding whatever
+    //    value step 2 inherited.
+    #[cfg(windows)]
+    cmd.env("ComSpec", shell);
 }

--- a/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
@@ -4,9 +4,11 @@
 //! assertion against the `CommandBuilder` alone would be weaker: it would not
 //! prove that what the builder holds is what the kernel hands the child.
 
-use crate::env_fence::fence_env;
+use crate::env_fence::{fence_env, WINDOWS_INHERIT_ALLOWLIST};
 use crate::path::user_shell_path;
-use crate::shell::{is_executable_file, login_argv0, resolve_shell, FALLBACK_SHELL};
+use crate::shell::{
+    is_executable_file, login_argv0, pick_windows_shell, resolve_shell, FALLBACK_SHELL,
+};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
 
@@ -323,6 +325,105 @@ fn child_shell_is_the_resolved_shell_not_the_inherited_one() {
     assert!(
         !out.contains("/definitely/not/a/real/shell"),
         "the inherited SHELL reached the child:\n{out}"
+    );
+}
+
+/// The Windows allowlist obeys the same law as the Unix one: no secrets, ever.
+/// Windows environment names are case-insensitive, so the comparison here is
+/// too — an allowlist entry of `comspec` and one of `BUZZ_PRIVATE_KEY` differ
+/// only in how obviously wrong they are.
+#[test]
+fn windows_allowlist_admits_no_secrets() {
+    for entry in WINDOWS_INHERIT_ALLOWLIST {
+        let upper = entry.to_ascii_uppercase();
+        assert!(
+            !SECRET_KEYS
+                .iter()
+                .any(|secret| secret.eq_ignore_ascii_case(entry)),
+            "{entry} is a reserved secret and must not be allowlisted"
+        );
+        assert!(
+            !upper.starts_with("BUZZ") && !upper.starts_with("NOSTR"),
+            "{entry}: Buzz/Nostr-namespaced keys are exactly what the fence \
+             exists to withhold"
+        );
+    }
+}
+
+/// The keys the spawn itself depends on must be present: `ComSpec` and
+/// `USERPROFILE` feed `portable-pty`'s default-program and cwd resolution
+/// (`cmdbuilder.rs:671-675`, `:609-611`), and their absence is the confirmed
+/// `CreateProcessW "cmd.exe" in cwd None ... (os error 2)` failure. This
+/// pins them so a future trim of the list cannot silently reintroduce it.
+#[test]
+fn windows_allowlist_covers_the_spawn_contract() {
+    for key in ["ComSpec", "SystemRoot", "PATHEXT", "USERPROFILE"] {
+        assert!(
+            WINDOWS_INHERIT_ALLOWLIST.contains(&key),
+            "{key} is load-bearing for the Windows spawn and must stay \
+             allowlisted"
+        );
+    }
+}
+
+/// A rooted `ComSpec` naming a real file is the user's choice; honour it
+/// verbatim, including the `C:/` forward-slash and `\\server` UNC spellings
+/// Windows itself accepts.
+#[test]
+fn windows_shell_honours_a_valid_comspec() {
+    for candidate in [
+        r"C:\Windows\System32\cmd.exe",
+        r"D:\shells\nu.exe",
+        "C:/Windows/System32/cmd.exe",
+        r"\\server\share\cmd.exe",
+    ] {
+        assert_eq!(
+            pick_windows_shell(Some(candidate), Some(r"C:\Windows"), |path| path
+                == candidate),
+            candidate,
+            "a rooted, existing ComSpec must be used verbatim"
+        );
+    }
+}
+
+/// A `ComSpec` naming a file that does not exist falls through to the
+/// `SystemRoot`-derived absolute fallback — the case that used to become
+/// `CreateProcessW`'s os error 2, because `lpApplicationName` is never
+/// path-searched.
+#[test]
+fn windows_shell_falls_back_when_comspec_is_missing() {
+    let picked = pick_windows_shell(
+        Some(r"C:\definitely\not\real\cmd.exe"),
+        Some(r"D:\CustomRoot"),
+        |_| false,
+    );
+    assert_eq!(picked, r"D:\CustomRoot\System32\cmd.exe");
+}
+
+/// The hijack guard: a relative `ComSpec=cmd.exe` is rejected even when a file
+/// by that name exists, because `lpApplicationName` would execute whatever
+/// `cmd.exe` sits in Buzz's current directory. `is_file` answering `true` is
+/// exactly the attack scenario, so this arm discriminates the rootedness
+/// check from the existence check.
+#[test]
+fn windows_shell_rejects_a_relative_comspec_even_if_the_file_exists() {
+    for candidate in ["cmd.exe", r"tools\cmd.exe", r"\cmd.exe", "C:cmd.exe"] {
+        assert_eq!(
+            pick_windows_shell(Some(candidate), Some(r"C:\Windows"), |_| true),
+            r"C:\Windows\System32\cmd.exe",
+            "{candidate}: a ComSpec not anchored to a drive or UNC share must \
+             not be spawned"
+        );
+    }
+}
+
+/// With no `ComSpec` and no `SystemRoot` at all — a hand-stripped environment
+/// — the resolver still produces an absolute path rather than a bare name.
+#[test]
+fn windows_shell_survives_an_empty_environment() {
+    assert_eq!(
+        pick_windows_shell(None, None, |_| false),
+        r"C:\Windows\System32\cmd.exe"
     );
 }
 

--- a/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
@@ -427,6 +427,20 @@ fn windows_shell_survives_an_empty_environment() {
     );
 }
 
+/// `SystemRoot` comes from the mutable process environment, so presence alone
+/// does not make the fallback absolute. A relative or empty value must not
+/// recreate the same current-directory hijack rejected for `ComSpec`.
+#[test]
+fn windows_shell_rejects_an_unrooted_system_root() {
+    for system_root in ["", "Windows", r"\Windows", "C:Windows"] {
+        assert_eq!(
+            pick_windows_shell(None, Some(system_root), |_| false),
+            r"C:\Windows\System32\cmd.exe",
+            "{system_root:?}: an unrooted SystemRoot must use the absolute fallback"
+        );
+    }
+}
+
 /// The user's own entries survive, in their own order, ahead of the system
 /// directories we guarantee. This is the regression that stripped `ssh`,
 /// `git`, and every other installed tool from the Windows terminal.
@@ -496,6 +510,22 @@ fn windows_path_survives_an_empty_environment() {
             path,
             r"C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0",
             "an empty inherited PATH falls back to the system directories alone"
+        );
+    }
+}
+
+/// The system directories appended to PATH obey the same rootedness rule as
+/// the shell fallback; otherwise an invalid `SystemRoot` would still add
+/// current-directory-relative command lookup locations.
+#[test]
+fn windows_path_rejects_an_unrooted_system_root() {
+    let expected = r"C:\tools;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0";
+
+    for system_root in ["", "Windows", r"\Windows", "C:Windows"] {
+        assert_eq!(
+            windows_shell_path(Some(r"C:\tools"), Some(system_root)),
+            expected,
+            "{system_root:?}: PATH must append only rooted system directories"
         );
     }
 }

--- a/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/env_fence_tests.rs
@@ -5,7 +5,7 @@
 //! prove that what the builder holds is what the kernel hands the child.
 
 use crate::env_fence::{fence_env, WINDOWS_INHERIT_ALLOWLIST};
-use crate::path::user_shell_path;
+use crate::path::{user_shell_path, windows_shell_path};
 use crate::shell::{
     is_executable_file, login_argv0, pick_windows_shell, resolve_shell, FALLBACK_SHELL,
 };
@@ -425,6 +425,79 @@ fn windows_shell_survives_an_empty_environment() {
         pick_windows_shell(None, None, |_| false),
         r"C:\Windows\System32\cmd.exe"
     );
+}
+
+/// The user's own entries survive, in their own order, ahead of the system
+/// directories we guarantee. This is the regression that stripped `ssh`,
+/// `git`, and every other installed tool from the Windows terminal.
+#[test]
+fn windows_path_keeps_what_the_user_installed() {
+    let inherited = r"C:\Users\dev\.cargo\bin;C:\Program Files\Git\cmd;C:\Windows\System32\OpenSSH";
+    let path = windows_shell_path(Some(inherited), Some(r"C:\Windows"));
+    let entries: Vec<&str> = path.split(';').collect();
+
+    assert_eq!(
+        &entries[..3],
+        &[
+            r"C:\Users\dev\.cargo\bin",
+            r"C:\Program Files\Git\cmd",
+            r"C:\Windows\System32\OpenSSH",
+        ],
+        "inherited entries must keep their order and their precedence"
+    );
+    for required in [
+        r"C:\Windows\System32",
+        r"C:\Windows",
+        r"C:\Windows\System32\Wbem",
+        r"C:\Windows\System32\WindowsPowerShell\v1.0",
+    ] {
+        assert!(
+            entries.contains(&required),
+            "{required} must be reachable however sparse the inherited PATH"
+        );
+    }
+}
+
+/// A `PATH` that already names a system directory must not gain a second copy
+/// of it, whatever case or trailing separator it was written with.
+#[test]
+fn windows_path_does_not_duplicate_system_directories() {
+    let path = windows_shell_path(
+        Some(r"c:\windows\system32\;C:\tools;C:\WINDOWS\System32\Wbem"),
+        Some(r"C:\Windows"),
+    );
+    let entries: Vec<&str> = path.split(';').collect();
+
+    let system32 = entries
+        .iter()
+        .filter(|entry| {
+            entry
+                .trim_end_matches('\\')
+                .eq_ignore_ascii_case(r"C:\Windows\System32")
+        })
+        .count();
+    assert_eq!(
+        system32, 1,
+        "System32 appears once, in the form the user wrote: {path}"
+    );
+    assert!(
+        entries.contains(&r"C:\tools"),
+        "de-duplication must not drop unrelated entries: {path}"
+    );
+}
+
+/// An absent or empty inherited `PATH` still yields a usable shell rather than
+/// an empty string.
+#[test]
+fn windows_path_survives_an_empty_environment() {
+    for inherited in [None, Some(""), Some(";;")] {
+        let path = windows_shell_path(inherited, None);
+        assert_eq!(
+            path,
+            r"C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0",
+            "an empty inherited PATH falls back to the system directories alone"
+        );
+    }
 }
 
 /// Guards the duplication of `RESERVED_ENV_KEYS` above. If the desktop crate

--- a/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
@@ -265,3 +265,53 @@ pub fn shutdown_draining(
     reader.join();
     outcome
 }
+
+/// Ends a session on a platform whose PTY is a ConPTY pseudo console, closing
+/// the console as part of the teardown rather than leaving it to `Drop`.
+///
+/// ConPTY inverts the EOF contract the Unix path is written against. There, the
+/// slave closing when the child dies is what EOFs the master, so the reader
+/// ends on its own and [`DrainingReader::stop`] is only a safety net. Here the
+/// output pipe does **not** EOF when the child dies — it EOFs when
+/// `ClosePseudoConsole` runs, which `portable-pty` performs in the master's
+/// `Drop` (`win/psuedocon.rs:73-75`). A reader parked in `read()` therefore
+/// never observes the stop flag, and joining it while the master is still alive
+/// blocks forever. For a synchronous Tauri command that block lands on the
+/// app's main thread: the whole window stops responding with no panic and no
+/// stack, which is the `AppHangB1` reported as #4930.
+///
+/// So the master is taken **by value** and dropped here, before the join. The
+/// ordering is also what ConPTY itself requires: `ClosePseudoConsole` blocks
+/// until pending output has been consumed, so the reader must still be draining
+/// when it runs, and only then does the reader see EOF and finish.
+///
+/// The child is killed rather than signalled politely because Windows has no
+/// process-group equivalent of the Unix escalation: `portable-pty`'s `kill` is
+/// `TerminateProcess` and its `wait` is `WaitForSingleObject`, both prompt and
+/// both pid-scoped. [`Shutdown::Terminated`] is therefore never returned from
+/// this path — a session either was already gone or was killed.
+#[cfg(not(unix))]
+pub fn shutdown_closing_console(
+    child: &mut Box<dyn Child + Send + Sync>,
+    reader: Box<dyn DrainingReader>,
+    master: Option<Box<dyn portable_pty::MasterPty + Send>>,
+) -> io::Result<Shutdown> {
+    reader.begin_closing();
+
+    let already_exited = child.try_wait()?.is_some();
+    if !already_exited {
+        let _ = child.kill();
+    }
+    child.wait()?;
+
+    // ClosePseudoConsole: the only thing that can EOF the reader.
+    drop(master);
+    reader.stop();
+    reader.join();
+
+    Ok(if already_exited {
+        Shutdown::AlreadyExited
+    } else {
+        Shutdown::Killed
+    })
+}

--- a/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
@@ -45,7 +45,9 @@
 //! is correct behaviour, not a gap.
 
 use std::io;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use portable_pty::Child;
 
@@ -62,6 +64,7 @@ pub const TERM_GRACE: Duration = Duration::from_millis(250);
 /// Polling rather than blocking in `wait()`: a blocking wait cannot be given a
 /// deadline without a second thread, and the whole point of the grace period
 /// is that it expires.
+#[cfg(unix)]
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// How a session ended.

--- a/desktop/src-tauri/crates/buzz-terminal/src/path.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/path.rs
@@ -18,9 +18,28 @@
 //! removed. A subtractive fence depends on evidence of what to subtract, and
 //! that evidence is exactly what the preceding cleanup destroys.
 //!
-//! So `PATH` is *constructed*, not filtered. The child gets the platform's
-//! standard user path, which is what a login shell would have produced had
-//! Buzz never been in the picture.
+//! So on Unix `PATH` is *constructed*, not filtered. The child gets the
+//! platform's standard user path, which is what a login shell would have
+//! produced had Buzz never been in the picture.
+//!
+//! **Windows constructs nothing, and the difference is not a shortcut.** The
+//! Unix design leans on a mechanism Windows does not have: the login shell
+//! reads rc files that *rebuild* `PATH`, so a minimal starting point is a
+//! starting point rather than a ceiling. `cmd.exe` has no rc file. A Windows
+//! user's `PATH` lives in the registry (`HKCU\Environment` +
+//! `HKLM\...\Session Manager\Environment`) and is composed into the process
+//! environment at launch; nothing inside the session ever puts back what we
+//! leave out. Handing the child `System32;Windows;Wbem` therefore does not
+//! give it a clean path — it deletes `ssh`, `git`, `node`, `python`, and every
+//! other tool the user installed, permanently, for that session. Field-
+//! verified on 0.5.9-fork.3: `ssh` reported "not recognized as an internal or
+//! external command" in the Buzz terminal on a machine where it resolves
+//! everywhere else.
+//!
+//! Nor does the reason for constructing apply there: Hermit activation is a
+//! POSIX shell script (`. ./bin/activate-hermit`) and is never in effect in a
+//! Windows process, so there is no build toolchain to fence out of the
+//! inherited value.
 
 /// The default user `PATH` for a spawned shell.
 ///
@@ -37,10 +56,82 @@ pub fn user_shell_path() -> String {
     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string()
 }
 
+/// The user `PATH` for a spawned shell on Windows: the inherited value, plus
+/// the system directories it must contain.
+///
+/// See the module header for why this inherits where Unix constructs.
 #[cfg(windows)]
 pub fn user_shell_path() -> String {
-    // On Windows the system directories are derived from the environment
-    // rather than fixed, and `cmd.exe`/PowerShell resolution depends on them.
-    let root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
-    format!(r"{root}\system32;{root};{root}\system32\Wbem")
+    windows_shell_path(
+        std::env::var("PATH").ok().as_deref(),
+        std::env::var("SystemRoot").ok().as_deref(),
+    )
+}
+
+/// System directories the child must be able to reach whatever the inherited
+/// `PATH` says. They are appended, not prepended: an entry the user put ahead
+/// of `System32` is a deliberate override, and reordering it would make Buzz's
+/// terminal disagree with every other terminal on the machine.
+///
+/// `Wbem` carries `wmic` and is on the stock path; `WindowsPowerShell\v1.0` is
+/// how `powershell` resolves at all. `System32\OpenSSH` is deliberately *not*
+/// listed: it is present only when the OpenSSH client feature is installed,
+/// and when it is installed the installer puts it on the machine `PATH`, so
+/// inheritance already covers it. Guessing at optional components is how a
+/// "safe default" becomes a list of dead entries.
+#[cfg(any(windows, test))]
+fn windows_system_directories(system_root: &str) -> [String; 4] {
+    [
+        format!(r"{system_root}\System32"),
+        system_root.to_string(),
+        format!(r"{system_root}\System32\Wbem"),
+        format!(r"{system_root}\System32\WindowsPowerShell\v1.0"),
+    ]
+}
+
+/// The pure half of the Windows [`user_shell_path`], compiled on every
+/// platform so the Unix CI this repo actually runs can exercise it.
+///
+/// Order is preserved and entries are de-duplicated case-insensitively —
+/// Windows path comparison is case-insensitive, and a `PATH` that names the
+/// same directory twice is how a "we appended the system dirs" fix announces
+/// itself in every `echo %PATH%` from then on.
+#[cfg(any(windows, test))]
+pub fn windows_shell_path(inherited: Option<&str>, system_root: Option<&str>) -> String {
+    // `SystemRoot` is set by the OS for every process; the literal default
+    // only covers a hand-stripped environment, where `C:\Windows` is the
+    // least-wrong guess. Same fallback as the shell resolver, deliberately.
+    let root = system_root.unwrap_or(r"C:\Windows");
+    let mut entries: Vec<String> = Vec::new();
+    for entry in inherited
+        .unwrap_or_default()
+        .split(';')
+        .map(str::to_owned)
+        .chain(windows_system_directories(root))
+    {
+        push_unique(&mut entries, entry);
+    }
+    entries.join(";")
+}
+
+/// Appends `entry` unless it is empty or already present.
+///
+/// Comparison ignores case and a trailing separator, because `C:\Windows\`
+/// and `c:\windows` are the same directory to Windows and differ only in how
+/// they were typed.
+#[cfg(any(windows, test))]
+fn push_unique(entries: &mut Vec<String>, entry: String) {
+    let key = |value: &str| {
+        value
+            .trim_end_matches(['\\', '/'])
+            .to_ascii_lowercase()
+            .to_owned()
+    };
+    if entry.trim().is_empty() {
+        return;
+    }
+    if entries.iter().any(|existing| key(existing) == key(&entry)) {
+        return;
+    }
+    entries.push(entry);
 }

--- a/desktop/src-tauri/crates/buzz-terminal/src/path.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/path.rs
@@ -41,6 +41,9 @@
 //! Windows process, so there is no build toolchain to fence out of the
 //! inherited value.
 
+#[cfg(any(windows, test))]
+use crate::shell::validated_windows_system_root;
+
 /// The default user `PATH` for a spawned shell.
 ///
 /// This intentionally does not consult Buzz's own `PATH`. A login shell reads
@@ -98,10 +101,9 @@ fn windows_system_directories(system_root: &str) -> [String; 4] {
 /// itself in every `echo %PATH%` from then on.
 #[cfg(any(windows, test))]
 pub fn windows_shell_path(inherited: Option<&str>, system_root: Option<&str>) -> String {
-    // `SystemRoot` is set by the OS for every process; the literal default
-    // only covers a hand-stripped environment, where `C:\Windows` is the
-    // least-wrong guess. Same fallback as the shell resolver, deliberately.
-    let root = system_root.unwrap_or(r"C:\Windows");
+    // Use the shell resolver's validation so a relative process-environment
+    // value cannot add current-directory-relative entries to the child PATH.
+    let root = validated_windows_system_root(system_root);
     let mut entries: Vec<String> = Vec::new();
     for entry in inherited
         .unwrap_or_default()

--- a/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
@@ -177,11 +177,22 @@ pub fn pick_windows_shell(
             return candidate.to_owned();
         }
     }
-    // Last-resort shell, absolute by construction. `SystemRoot` is set by the
-    // OS for every process; the literal default only covers a hand-stripped
-    // environment, where `C:\Windows` is the least-wrong guess.
-    let root = system_root.unwrap_or(r"C:\Windows");
+    // Last-resort shell, absolute by construction. The process environment is
+    // mutable, so merely having a `SystemRoot` value does not make it rooted:
+    // a relative value would recreate the current-directory hijack rejected
+    // above for `ComSpec`. Fall back to the stock root in that case as well as
+    // when the variable is absent.
+    let root = validated_windows_system_root(system_root);
     format!(r"{root}\System32\cmd.exe")
+}
+
+/// Returns a rooted Windows system directory, rejecting environment values
+/// that `CreateProcessW` or `PATH` lookup would resolve against the current
+/// drive or directory.
+pub(crate) fn validated_windows_system_root(system_root: Option<&str>) -> &str {
+    system_root
+        .filter(|candidate| has_windows_root(candidate))
+        .unwrap_or(r"C:\Windows")
 }
 
 /// True if `candidate` is anchored to a drive (`C:\...`, `C:/...`) or a UNC

--- a/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
@@ -131,8 +131,65 @@ pub fn login_argv0(shell: &str) -> String {
     format!("-{basename}")
 }
 
-/// Resolve the command shell on Windows from `ComSpec`, falling back to cmd.
+/// Resolve the command shell on Windows from `ComSpec`, falling back to the
+/// absolute `%SystemRoot%\System32\cmd.exe`.
+///
+/// The result ends up as `CreateProcessW`'s `lpApplicationName` (via the
+/// builder-env `ComSpec` that [`crate::env_fence::fence_env`] sets), and
+/// `lpApplicationName` performs **no path search**: a bare `cmd.exe` fails
+/// with os error 2 no matter what `PATH` says. So the same discipline as the
+/// Unix resolver applies — validate each candidate, and make the last resort
+/// an absolute path.
 #[cfg(windows)]
 pub fn resolve_shell(shell_env: Option<&str>) -> String {
-    shell_env.unwrap_or("cmd.exe").to_owned()
+    pick_windows_shell(
+        shell_env,
+        std::env::var("SystemRoot").ok().as_deref(),
+        |candidate| {
+            std::fs::metadata(candidate)
+                .map(|meta| meta.is_file())
+                .unwrap_or(false)
+        },
+    )
+}
+
+/// The pure candidate-selection half of the Windows [`resolve_shell`],
+/// compiled on every platform so its behaviour is testable from the Unix CI
+/// this repo actually runs. `is_file` is injected for the same reason
+/// `shell_env` is: no process-global state in the decision.
+///
+/// A candidate must be rooted ([`has_windows_root`]) *and* an existing file.
+/// The rootedness check is not redundant with the file check: a relative
+/// `ComSpec=cmd.exe` could name a real file in whatever directory Buzz
+/// happens to run from, and `lpApplicationName` would execute exactly that
+/// file — planting `cmd.exe` next to a program is a classic hijack.
+pub fn pick_windows_shell(
+    shell_env: Option<&str>,
+    system_root: Option<&str>,
+    is_file: impl Fn(&str) -> bool,
+) -> String {
+    if let Some(candidate) = shell_env {
+        if has_windows_root(candidate) && is_file(candidate) {
+            return candidate.to_owned();
+        }
+    }
+    // Last-resort shell, absolute by construction. `SystemRoot` is set by the
+    // OS for every process; the literal default only covers a hand-stripped
+    // environment, where `C:\Windows` is the least-wrong guess.
+    let root = system_root.unwrap_or(r"C:\Windows");
+    format!(r"{root}\System32\cmd.exe")
+}
+
+/// True if `candidate` is anchored to a drive (`C:\...`, `C:/...`) or a UNC
+/// share (`\\server\...`) — i.e. not resolved relative to the current
+/// directory. A byte-level check rather than `Path::is_absolute` because this
+/// function also compiles on Unix (for tests), where `Path` applies Unix
+/// path semantics to Windows strings.
+fn has_windows_root(candidate: &str) -> bool {
+    let bytes = candidate.as_bytes();
+    let drive_rooted = bytes.len() > 2
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/');
+    drive_rooted || candidate.starts_with(r"\\")
 }

--- a/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shell.rs
@@ -21,6 +21,10 @@
 //! on many systems. A directory or a non-executable file falls through to the
 //! next candidate instead of becoming an unspawnable child.
 
+// Every user of `Path` in this module is part of the Unix executability check;
+// the Windows resolver below works on the string form, because what it has to
+// reject (a relative `ComSpec`) is a question about the text, not the file.
+#[cfg(unix)]
 use std::path::Path;
 
 /// Last-resort shell. POSIX guarantees `/bin/sh`; if this is not executable

--- a/desktop/src-tauri/src/terminal_runtime.rs
+++ b/desktop/src-tauri/src/terminal_runtime.rs
@@ -297,6 +297,17 @@ impl Session {
                 reader.begin_closing();
                 let _ = self.child.kill();
                 let _ = self.child.wait();
+                // ConPTY inverts the Unix EOF contract this teardown was
+                // written against: the output pipe does not EOF when the child
+                // dies — only when the pseudo console itself is closed. The
+                // reader is blocked in read(), so stop()'s flag alone can
+                // never wake it; joining here deadlocks the closing thread
+                // (the app's main thread for a sync command) — the
+                // AppHangB1 behind #4930. Dropping the master runs
+                // ClosePseudoConsole while the reader is still draining,
+                // which is also the order ConPTY requires: the close blocks
+                // until pending output is consumed, then EOFs the reader.
+                drop(self.master.take());
                 reader.stop();
                 reader.join();
             }

--- a/desktop/src-tauri/src/terminal_runtime.rs
+++ b/desktop/src-tauri/src/terminal_runtime.rs
@@ -289,28 +289,15 @@ impl Session {
         }
         if let Some(reader) = self.reader.take() {
             #[cfg(unix)]
-            {
-                let _ = buzz_terminal::lifecycle::shutdown_draining(&mut self.child, reader);
-            }
+            let _ = buzz_terminal::lifecycle::shutdown_draining(&mut self.child, reader);
+            // Windows must also close the pseudo console, and only the helper
+            // knows when: see `lifecycle::shutdown_closing_console`.
             #[cfg(not(unix))]
-            {
-                reader.begin_closing();
-                let _ = self.child.kill();
-                let _ = self.child.wait();
-                // ConPTY inverts the Unix EOF contract this teardown was
-                // written against: the output pipe does not EOF when the child
-                // dies — only when the pseudo console itself is closed. The
-                // reader is blocked in read(), so stop()'s flag alone can
-                // never wake it; joining here deadlocks the closing thread
-                // (the app's main thread for a sync command) — the
-                // AppHangB1 behind #4930. Dropping the master runs
-                // ClosePseudoConsole while the reader is still draining,
-                // which is also the order ConPTY requires: the close blocks
-                // until pending output is consumed, then EOFs the reader.
-                drop(self.master.take());
-                reader.stop();
-                reader.join();
-            }
+            let _ = buzz_terminal::lifecycle::shutdown_closing_console(
+                &mut self.child,
+                reader,
+                self.master.take(),
+            );
         }
         if let Ok(mut channel) = self.channel.lock() {
             *channel = None;


### PR DESCRIPTION
## Summary

Buzz Term never worked on Windows, and the failure mode was an app-wide hang rather than an error. Investigating #4930 turned up **three separate defects**, each one hiding the next, and all three with the same origin: this subsystem was written against Unix and the Windows arms were written as mirrors of it. Two of the three mirrors are invalid, because the platform contract they mirror is inverted on Windows.

Fixing only the first gets you a terminal that hangs the app. Fixing the first two gets you a shell with no `ssh`, `git`, or `node`. So they are here together.

### 1. The spawn never happened — `CreateProcessW "cmd.exe" in cwd None failed (os error 2)`

`env_fence::fence_env` calls `env_clear()` and rebuilds from an allowlist. That allowlist was Unix-only (`HOME`, `USER`, `LANG`, …), so on Windows it cleared **`ComSpec`** and **`USERPROFILE`** and put back neither.

Those two are not cosmetic on Windows. `portable-pty` 0.9.0 reads `ComSpec` **out of the builder's own env map** (`cmdbuilder.rs`, `cmdline()`) and hands the result to `CreateProcessW` as `lpApplicationName` — which performs **no path search**. With `ComSpec` gone the builder falls back to the bare string `"cmd.exe"`, `CreateProcessW` refuses to search for it, and you get `os error 2`. `current_directory()` reads `USERPROFILE` from that same map and filters it through `is_dir()`, which is where `cwd None` comes from.

`shell::resolve_shell` was also `#[cfg(unix)]` only, so there was no Windows shell resolution at all. This PR adds one, and it validates: a `ComSpec` candidate must be rooted (drive-qualified or UNC) *and* an existing file, otherwise it falls back to `%SystemRoot%\System32\cmd.exe`. The rootedness check is not decoration — a relative `ComSpec` would let a `cmd.exe` dropped in the working directory be launched instead.

@BoydVC's hypothesis in the issue was close: the resolution chain really does have no valid candidate on a stock Windows install. The reason is one layer deeper than `$SHELL` — the fence had already deleted the variable Windows uses in its place.

### 2. The hang itself — ConPTY inverts the EOF contract

This is the `AppHangB1`, and it is not the spawn failure. It only becomes reachable *after* #1 is fixed, which is why the issue reports a hang rather than the error above.

On Unix, the pty slave closing when the child dies is what EOFs the master, so a reader blocked in `read()` ends on its own. **ConPTY does not do this.** The conout pipe stays open after the child exits and EOFs only when `ClosePseudoConsole` runs — which `portable-pty` performs in the master's `Drop` (`win/psuedocon.rs:73-75`).

`Session::shutdown`'s non-unix arm joined the reader while still holding the master. The reader was parked in `read()`, so it could never observe the stop flag, and `join()` blocked forever. `terminal_close` is a **synchronous Tauri command**, so that block landed on the app's main thread: the whole window stopped responding, with no panic and no stack — exactly the "Application Hang rather than a crash/panic … blocks the main thread" in the report.

The fix drops the master **before** the join. That is also the order ConPTY itself requires: `ClosePseudoConsole` blocks until pending output is consumed, so the reader has to still be draining when it runs.

This now lives in `buzz-terminal::lifecycle::shutdown_closing_console`, beside the Unix `shutdown_draining` whose ordering law it is an exception to — a reader comparing the two orders shouldn't have to look in two crates. It takes the master **by value** for the same reason `shutdown_draining` takes the reader by value: the ordering becomes a property of the signature instead of a comment. A caller cannot close the console early, because passing it in is the only way to close it at all.

### 3. `PATH` was constructed instead of inherited, which deletes the user's toolchain

`path::user_shell_path` builds a minimal `PATH` rather than inheriting Buzz's, deliberately: Buzz runs under Hermit activation, and inheriting it would hand the user Buzz's pinned `cargo`/`node` instead of their own. The Windows arm mirrored that with a constructed `System32;Windows;Wbem` stub.

**That mirror is invalid.** On Unix a minimal `PATH` is a *starting point*, because the login shell reads rc files that rebuild it — that is precisely what lets Hermit be fenced out without collateral. `cmd.exe` reads no rc file. The user's `PATH` lives in the registry (`HKCU\Environment` plus the machine `Session Manager\Environment`) and is composed into the process environment at launch, so anything omitted at spawn is omitted for the entire session with no mechanism to restore it. In practice that deleted `ssh`, `git`, `node`, and `python` from the Term.

Windows now inherits `PATH` and appends the guaranteed system directories, preserving inherited order (so user overrides stay ahead) and de-duplicating case-insensitively. The Hermit rationale simply does not apply: `bin/activate-hermit` is a POSIX shell script and is never active on Windows. The Unix arm is untouched.

### The security invariant is unchanged

`env_fence` exists to keep `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, and relay credentials out of spawned children, and it is an **allowlist, never a denylist**. That is preserved exactly. The Windows list is longer than the Unix one for a structural reason rather than a permissive one — no rc file means no second chance — and every entry on it is machine or user *layout*: paths, counts, architecture, things any process on the box can already read. No key, token, or credential is listed, and `windows_allowlist_admits_no_secrets` asserts that case-insensitively, since Windows environment names are case-insensitive and a case-only bypass would otherwise be invisible.

## Related issue

Fixes #4930.

### Overlap with #4829 — please read before merging either

@weiox's #4829 (open since Aug 5) touches the same two files, and the two changes **interact**. I found it while checking for duplicates and I'd rather flag it than have it discovered at merge time.

- **Same intent, same lines:** #4829 already gates `POLL_INTERVAL`, `Instant`, and `Path` behind `#[cfg(unix)]`. My two smallest commits do exactly that. If #4829 lands first, I'll drop them and rebase — they exist here only so this branch compiles for `x86_64-pc-windows-msvc` on its own.
- **One genuine conflict:** #4829 also gates `use std::io;` and `use portable_pty::Child;` to unix. This PR's `shutdown_closing_console` is `#[cfg(not(unix))]` and uses **both**, so those two imports must stay ungated. Merging #4829 as-is on top of this PR breaks the Windows build with unresolved `io` and `Child`.

Nothing in #4829's `Justfile` half overlaps with this PR. Happy to rebase onto it, fold this into it, or split the gating out entirely — whichever the maintainers prefer; I don't want to step on an older PR.

Otherwise: no other open PR touches `env_fence.rs`, `path.rs`, `terminal_runtime.rs`, or `desktop/src/features/term`, and #4930 has no linked PR.

The report's fourth symptom — *"the Term panel renders permanently blank"* after relaunch — is a separate surface (a failed attach renders nothing rather than an error) and is **not** addressed here. With this PR the attach succeeds, so the blank panel should not be reachable by this path, but the missing empty/error state is its own defect and deserves its own change.

## Testing

**Field-verified on the reported platform.** Reproduced and fixed on Windows 11 build 26200 across six unsigned canary builds, one defect per cycle:

| Build | Result |
|---|---|
| fork.1 / fork.3 | `CreateProcessW "cmd.exe" in cwd None failed … (os error 2)` |
| fork.3 + spawn fix | Terminal opens — then `AppHangB1`, twice, no panic and no stack in WER |
| fork.4 + teardown fix | No more hang; `'ssh' is not recognized as an internal or external command` |
| fork.5 / fork.6 + PATH fix | `ssh`, `git`, `node` resolve; open / close / switch channels / quit all healthy |

**Automated.** 36 unit tests in `buzz-terminal`, of which the Windows-specific logic is 9. Those tests run on the Unix CI: the Windows behaviour is factored into pure functions with injected effects (`pick_windows_shell`, `windows_shell_path`), compiled on all platforms and driven directly, with thin `#[cfg(windows)]` wrappers supplying `std::env::var` / `std::fs::metadata` in production. Windows logic that only compiles on Windows is Windows logic nobody runs until a user finds it.

They cover: the no-secrets property; the full spawn contract (`ComSpec`, `USERPROFILE`, `SystemRoot`, `PATHEXT`); a valid `ComSpec` honoured; a missing one falling back; a **relative** `ComSpec` rejected even when the file exists; inherited `PATH` keeping its order and precedence; system directories not duplicated across case and trailing-separator differences; and an entirely empty environment still yielding a usable shell and `PATH`.

**Cross-target.** `cargo clippy -p buzz-terminal --target x86_64-pc-windows-msvc -- -D warnings` is clean. Reaching that also required cfg-gating three pre-existing unix-only items (`POLL_INTERVAL`, and the `Instant` and `Path` imports) that were dead code on every non-unix build — harmless under a plain build, an error the moment the crate is linted with `-D warnings`. Those are the two smallest commits here, and the ones #4829 already covers (see above).

**Full CI.** Verified green on a branch simulating this merged into `main`: `Windows Rust (x86_64-pc-windows-msvc)`, `Rust Lint`, `Desktop Core`, all smoke and integration E2E shards, macOS build, `Unit Tests`, `Web`, `Mobile`, and both cross-compile targets. The only red was `Security`, which fails identically on `main` itself (`nostr-relay-pool` unmaintained advisory) and is unrelated to this change.

No screenshots: the change is a shell that spawns instead of an app that hangs, and the terminal contents are the user's own machine.
