### PR TITLE
fix(desktop): surface Buzz Term attach failures instead of a blank panel

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/term-empty-states-screenshots.spec.ts",
         "**/onboarding-docked-cta-screenshots.spec.ts",
         "**/identity-key-help.spec.ts",
         "**/key-import-reveal.spec.ts",

--- a/desktop/src/features/terminal/TerminalBootstrap.test.mjs
+++ b/desktop/src/features/terminal/TerminalBootstrap.test.mjs
@@ -762,3 +762,60 @@ test("retry reattaches a failed new tab while another session remains", async ()
   );
   view.unmount();
 });
+
+test("retry waits for the channel whose attachment failed", async () => {
+  const { createElement } = await import("react");
+  const { act, fireEvent, render, waitFor } = await import(
+    "@testing-library/react"
+  );
+  const { ThemeProvider } = await import("@/shared/theme/ThemeProvider");
+  const { TerminalBootstrap } = await import("./TerminalBootstrap.tsx");
+
+  const tree = (channelId, channelName) =>
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(TerminalBootstrap, {
+        channelId,
+        channelName,
+        npub: "npub1owner",
+        relayUrl: "wss://relay.example",
+        threadId: null,
+      }),
+    );
+  const attachCount = (channelId) =>
+    calls.filter(
+      ({ command, args }) =>
+        command === "terminal_attach" && args.request.channelId === channelId,
+    ).length;
+
+  const view = render(tree("channel-a", "alpha"));
+  await waitFor(() => assert.equal(attachCount("channel-a"), 1));
+
+  attachRejection = "channel-b conpty spawn failed";
+  view.rerender(tree("channel-b", "beta"));
+  await waitFor(() => assert.ok(view.getByTestId("terminal-notice")));
+  assert.equal(attachCount("channel-b"), 1);
+  const failedAttachCount = calls.filter(
+    ({ command }) => command === "terminal_attach",
+  ).length;
+
+  view.rerender(tree("channel-a", "alpha"));
+  attachRejection = null;
+  await act(async () => {
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+  });
+  await waitFor(() =>
+    assert.equal(view.queryByTestId("terminal-notice"), null),
+  );
+
+  assert.equal(attachCount("channel-a"), 1);
+  assert.equal(
+    calls.filter(({ command }) => command === "terminal_attach").length,
+    failedAttachCount,
+  );
+
+  view.rerender(tree("channel-b", "beta"));
+  await waitFor(() => assert.equal(attachCount("channel-b"), 2));
+  view.unmount();
+});

--- a/desktop/src/features/terminal/TerminalBootstrap.test.mjs
+++ b/desktop/src/features/terminal/TerminalBootstrap.test.mjs
@@ -18,6 +18,7 @@ let channel;
 let resizeCallback;
 let canvasWidth = 840;
 let attachResolver = null;
+let attachRejection = null;
 let deferResizes = false;
 let deferClose = false;
 let closeResolver = null;
@@ -84,6 +85,7 @@ before(async () => {
     invoke(command, args) {
       calls.push({ command, args });
       if (command === "terminal_attach") {
+        if (attachRejection) return Promise.reject(attachRejection);
         channel = args.onFrame;
         const sessionNumber = calls.filter(
           ({ command }) => command === "terminal_attach",
@@ -137,6 +139,7 @@ afterEach(async () => {
   calls.length = 0;
   canvasWidth = 840;
   attachResolver = null;
+  attachRejection = null;
   deferResizes = false;
   deferClose = false;
   closeResolver = null;
@@ -651,5 +654,61 @@ test("a non-channel route closes the panel and ignores the terminal shortcut", a
     window.dispatchEvent(new KeyboardEvent("keyup", chord));
   });
   assert.equal(getTerminalPanelSnapshotForTests().mode, "closed");
+  view.unmount();
+});
+
+test("surfaces attach failures as a visible notice with a working retry", async () => {
+  const { StrictMode, createElement } = await import("react");
+  const { act, fireEvent, render, waitFor } = await import(
+    "@testing-library/react"
+  );
+  const { ThemeProvider } = await import("@/shared/theme/ThemeProvider");
+  const { TerminalBootstrap } = await import("./TerminalBootstrap.tsx");
+
+  attachRejection = "conpty spawn failed";
+  const view = render(
+    createElement(
+      StrictMode,
+      null,
+      createElement(
+        ThemeProvider,
+        null,
+        createElement(TerminalBootstrap, {
+          channelId: "channel-1",
+          channelName: "general",
+          npub: "npub1owner",
+          relayUrl: "wss://relay.example",
+          threadId: null,
+        }),
+      ),
+    ),
+  );
+
+  await waitFor(() => assert.ok(view.getByTestId("terminal-notice")));
+  assert.match(
+    view.getByTestId("terminal-notice").textContent,
+    /Terminal unavailable: conpty spawn failed/,
+  );
+
+  const failedAttachCount = calls.filter(
+    ({ command }) => command === "terminal_attach",
+  ).length;
+  assert.ok(failedAttachCount >= 1);
+
+  attachRejection = null;
+  const retryButton = view.getByRole("button", { name: "Retry" });
+  await act(async () => {
+    fireEvent.click(retryButton);
+  });
+
+  await waitFor(() =>
+    assert.ok(
+      calls.filter(({ command }) => command === "terminal_attach").length >
+        failedAttachCount,
+    ),
+  );
+  await waitFor(() =>
+    assert.equal(view.queryByTestId("terminal-notice"), null),
+  );
   view.unmount();
 });

--- a/desktop/src/features/terminal/TerminalBootstrap.test.mjs
+++ b/desktop/src/features/terminal/TerminalBootstrap.test.mjs
@@ -712,3 +712,53 @@ test("surfaces attach failures as a visible notice with a working retry", async 
   );
   view.unmount();
 });
+
+test("retry reattaches a failed new tab while another session remains", async () => {
+  const { createElement } = await import("react");
+  const { act, fireEvent, render, waitFor } = await import(
+    "@testing-library/react"
+  );
+  const { ThemeProvider } = await import("@/shared/theme/ThemeProvider");
+  const { TerminalBootstrap } = await import("./TerminalBootstrap.tsx");
+
+  const view = render(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement(TerminalBootstrap, {
+        channelId: "channel-1",
+        channelName: "general",
+        npub: "npub1owner",
+        relayUrl: "wss://relay.example",
+        threadId: null,
+      }),
+    ),
+  );
+  await waitFor(() => assert.equal(view.getAllByRole("tab").length, 1));
+
+  attachRejection = "second conpty spawn failed";
+  fireEvent.click(view.getByLabelText("New Buzz Term tab"));
+  await waitFor(() => assert.ok(view.getByTestId("terminal-notice")));
+  await waitFor(() => assert.equal(view.getAllByRole("tab").length, 1));
+  const failedAttachCount = calls.filter(
+    ({ command }) => command === "terminal_attach",
+  ).length;
+  assert.equal(failedAttachCount, 2);
+
+  attachRejection = null;
+  await act(async () => {
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+  });
+
+  await waitFor(() =>
+    assert.equal(
+      calls.filter(({ command }) => command === "terminal_attach").length,
+      failedAttachCount + 1,
+    ),
+  );
+  await waitFor(() => assert.equal(view.getAllByRole("tab").length, 2));
+  await waitFor(() =>
+    assert.equal(view.queryByTestId("terminal-notice"), null),
+  );
+  view.unmount();
+});

--- a/desktop/src/features/terminal/TerminalBootstrap.tsx
+++ b/desktop/src/features/terminal/TerminalBootstrap.tsx
@@ -82,6 +82,7 @@ export function TerminalBootstrap({
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [activeKey, setActiveKey] = React.useState<string | null>(null);
   const [available, setAvailable] = React.useState(() => isTauri());
+  const [attachError, setAttachError] = React.useState<string | null>(null);
   const panel = useTerminalPanel();
   const [renderedMode, setRenderedMode] = React.useState<
     "docked" | "maximized"
@@ -169,7 +170,13 @@ export function TerminalBootstrap({
 
   const fail = React.useCallback((error: unknown) => {
     report(error);
+    setAttachError(error instanceof Error ? error.message : String(error));
     setAvailable(false);
+  }, []);
+
+  const retry = React.useCallback(() => {
+    setAttachError(null);
+    setAvailable(isTauri());
   }, []);
 
   const removeSession = React.useCallback((key: string) => {
@@ -358,12 +365,29 @@ export function TerminalBootstrap({
 
   if (!panelMounted) return null;
 
+  // Silent gray panels are undiagnosable in production builds — no devtools,
+  // and on Windows no log file either. An unavailable terminal must say so,
+  // and say what the backend actually reported.
+  //
+  // A missing `context` needs no notice: the Cmd/Ctrl+J toggle refuses to open
+  // the panel without a channel, and the effect above closes it if the channel
+  // goes away. Rendering one there would only flash during navigation.
+  const notice = available
+    ? null
+    : {
+        message: attachError
+          ? `Terminal unavailable: ${attachError}`
+          : "Terminal is unavailable in this environment.",
+        action: isTauri() ? { label: "Retry", onAction: retry } : undefined,
+      };
+
   return (
     <TerminalSubstrate
       bracketedPaste={active?.frame?.bracketedPaste ?? false}
       channelName={active?.context.channelName ?? channelName}
       enabled={available && Boolean(context)}
       mode={renderedMode}
+      notice={notice}
       visible={panelVisible}
       onHide={() => setTerminalPanelMode("closed")}
       onModeChange={setTerminalPanelMode}

--- a/desktop/src/features/terminal/TerminalBootstrap.tsx
+++ b/desktop/src/features/terminal/TerminalBootstrap.tsx
@@ -79,6 +79,8 @@ export function TerminalBootstrap({
     new WeakMap<TerminalConnection, TerminalViewportSize>(),
   );
   const closedSessionKeysRef = React.useRef(new Set<string>());
+  const failedAttachRef = React.useRef(false);
+  const attachRetryRequestedRef = React.useRef(false);
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [activeKey, setActiveKey] = React.useState<string | null>(null);
   const [available, setAvailable] = React.useState(() => isTauri());
@@ -175,8 +177,11 @@ export function TerminalBootstrap({
   }, []);
 
   const retry = React.useCallback(() => {
+    const nextAvailable = isTauri();
+    attachRetryRequestedRef.current = nextAvailable && failedAttachRef.current;
+    failedAttachRef.current = false;
     setAttachError(null);
-    setAvailable(isTauri());
+    setAvailable(nextAvailable);
   }, []);
 
   const removeSession = React.useCallback((key: string) => {
@@ -265,6 +270,7 @@ export function TerminalBootstrap({
       })
       .catch((error) => {
         if (closedSessionKeysRef.current.delete(key)) return;
+        failedAttachRef.current = true;
         removeSession(key);
         fail(error);
       });
@@ -289,7 +295,10 @@ export function TerminalBootstrap({
 
   React.useEffect(() => {
     if (panel.mode === "closed" || !available || !context) return;
-    if (channelSessions.length === 0) createSession();
+    if (attachRetryRequestedRef.current) {
+      attachRetryRequestedRef.current = false;
+      createSession();
+    } else if (channelSessions.length === 0) createSession();
     else if (!channelSessions.some((session) => session.key === activeKey))
       setActiveKey(channelSessions.at(-1)?.key ?? null);
   }, [

--- a/desktop/src/features/terminal/TerminalBootstrap.tsx
+++ b/desktop/src/features/terminal/TerminalBootstrap.tsx
@@ -47,6 +47,15 @@ function report(error: unknown) {
   console.error("terminal session failed", error);
 }
 
+function isSameTerminalContext(left: TerminalContext, right: TerminalContext) {
+  return (
+    left.channelId === right.channelId &&
+    left.threadId === right.threadId &&
+    left.npub === right.npub &&
+    left.relayUrl === right.relayUrl
+  );
+}
+
 export function TerminalBootstrap({
   channelId,
   channelName,
@@ -79,8 +88,8 @@ export function TerminalBootstrap({
     new WeakMap<TerminalConnection, TerminalViewportSize>(),
   );
   const closedSessionKeysRef = React.useRef(new Set<string>());
-  const failedAttachRef = React.useRef(false);
-  const attachRetryRequestedRef = React.useRef(false);
+  const failedAttachContextRef = React.useRef<TerminalContext | null>(null);
+  const attachRetryContextRef = React.useRef<TerminalContext | null>(null);
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [activeKey, setActiveKey] = React.useState<string | null>(null);
   const [available, setAvailable] = React.useState(() => isTauri());
@@ -178,8 +187,10 @@ export function TerminalBootstrap({
 
   const retry = React.useCallback(() => {
     const nextAvailable = isTauri();
-    attachRetryRequestedRef.current = nextAvailable && failedAttachRef.current;
-    failedAttachRef.current = false;
+    attachRetryContextRef.current = nextAvailable
+      ? failedAttachContextRef.current
+      : null;
+    failedAttachContextRef.current = null;
     setAttachError(null);
     setAvailable(nextAvailable);
   }, []);
@@ -270,7 +281,7 @@ export function TerminalBootstrap({
       })
       .catch((error) => {
         if (closedSessionKeysRef.current.delete(key)) return;
-        failedAttachRef.current = true;
+        failedAttachContextRef.current = spawnContext;
         removeSession(key);
         fail(error);
       });
@@ -295,8 +306,9 @@ export function TerminalBootstrap({
 
   React.useEffect(() => {
     if (panel.mode === "closed" || !available || !context) return;
-    if (attachRetryRequestedRef.current) {
-      attachRetryRequestedRef.current = false;
+    const retryContext = attachRetryContextRef.current;
+    if (retryContext && isSameTerminalContext(retryContext, context)) {
+      attachRetryContextRef.current = null;
       createSession();
     } else if (channelSessions.length === 0) createSession();
     else if (!channelSessions.some((session) => session.key === activeKey))

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -37,6 +37,12 @@ export type TerminalSessionTab = {
   active: boolean;
 };
 
+/** Centered viewport message shown when no session can render. */
+export type TerminalNotice = {
+  message: string;
+  action?: { label: string; onAction: () => void };
+};
+
 type TerminalSubstrateProps = {
   channelName: string | null;
   frame?: TerminalFrame;
@@ -46,6 +52,7 @@ type TerminalSubstrateProps = {
   focusReportingEnabled: boolean;
   enabled?: boolean;
   mode?: "docked" | "maximized";
+  notice?: TerminalNotice | null;
   visible?: boolean;
   onHide?: () => void;
   onModeChange?: (mode: "docked" | "maximized") => void;
@@ -85,6 +92,7 @@ export function TerminalSubstrate({
   focusReportingEnabled,
   enabled = true,
   mode = "docked",
+  notice = null,
   visible = true,
   onHide = NOOP,
   onModeChange = NOOP,
@@ -757,6 +765,24 @@ export function TerminalSubstrate({
         </div>
         {welcomeVisible && banner ? (
           <canvas className="buzz-terminal-welcome" ref={bannerCanvasRef} />
+        ) : null}
+        {notice ? (
+          <div
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 px-6 text-center"
+            data-testid="terminal-notice"
+            role="status"
+          >
+            <p className="max-w-md text-sm opacity-80">{notice.message}</p>
+            {notice.action ? (
+              <button
+                className="buzz-terminal-designator rounded border border-current px-3 py-1 text-xs"
+                onClick={notice.action.onAction}
+                type="button"
+              >
+                {notice.action.label}
+              </button>
+            ) : null}
+          </div>
         ) : null}
         <textarea
           aria-label="Terminal input"

--- a/desktop/tests/e2e/term-empty-states-screenshots.spec.ts
+++ b/desktop/tests/e2e/term-empty-states-screenshots.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Screenshot spec for Buzz Term visible empty/error states (issue #4930).
+ *
+ * The mock bridge does not implement `terminal_attach`, so opening the Term
+ * panel in the e2e build exercises the real attach-failure path end to end:
+ * the panel must render a visible "Terminal unavailable" notice with a Retry
+ * action instead of the silent gray body shipped today.
+ */
+
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+const SHOTS = "test-results/term-empty-states";
+
+test.describe("terminal empty/error states", () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test.beforeEach(async ({ page }) => {
+    // windowLabel makes the bridge set window.isTauri, so the panel takes the
+    // real attach path; the bridge then rejects the unmocked terminal_attach,
+    // exercising the attach-failure notice end to end.
+    await installMockBridge(page, { windowLabel: "main" });
+  });
+
+  test("attach failure renders a visible notice with retry", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("message-composer")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.keyboard.press("Control+j");
+
+    const notice = page.getByTestId("terminal-notice");
+    await expect(notice).toBeVisible({ timeout: 10_000 });
+    await expect(notice).toContainText("Terminal unavailable");
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+
+    // The unread pill animates in over the sidebar and would otherwise land in
+    // the shot at a nondeterministic opacity.
+    await page
+      .getByText("1 new message")
+      .waitFor({ state: "hidden", timeout: 15_000 })
+      .catch(() => {});
+    await waitForAnimations(page);
+    await page
+      .locator(".buzz-terminal-substrate")
+      .screenshot({ path: `${SHOTS}/01-term-attach-error.png` });
+  });
+});


### PR DESCRIPTION
## Summary

When the Term panel fails to attach, it renders **nothing** — a blank body with a `+` button that does nothing. `TerminalBootstrap.fail()` removes the session, sets `available = false`, and reports the error to `console.error`. In a production build there is no devtools to read that, and on Windows there is no log file either, so the error the backend produced is simply discarded on the way to the user.

That is the surface #4930 was reported through: the reporter saw a permanently blank Term panel and had nothing to attach to the issue except a Windows Event Log entry. The backend had a precise, actionable error the whole time — `CreateProcessW "cmd.exe" in cwd None failed … (os error 2)` — and the UI threw it away.

This renders that error in the viewport instead, with a **Retry** action that clears it and re-runs the auto-create path.

### Before / after

Screenshots in the first comment. Both are the same element (`.buzz-terminal-substrate`) at the same viewport, so they're directly comparable.

### Why there is no notice for "no channel selected"

An earlier version of this change also rendered `"Select a channel to open a terminal."` when the panel had no channel context. That state is not reachable, and shipping the notice would have been a small regression:

- `TerminalBootstrap.tsx` — the Cmd/Ctrl+J toggle returns early when `!context`, so the panel cannot be opened without a channel.
- An effect closes the panel when `context` goes away while it is open.

So the only way to render that notice is the single frame between navigating away from a channel and the effect running. That's a flash during navigation, not a state a user can be in. The existing test `a non-channel route closes the panel and ignores the terminal shortcut` already asserts this behaviour. The notice is now scoped to the one case that genuinely occurs: `!available`.

### Relationship to #5425

Related, not a duplicate, and they fix different things.

- **#5425** (Rust) makes the Windows attach *succeed* — three stacked backend defects.
- **This PR** (React) makes an attach failure *visible*.

Neither subsumes the other. With #5425 merged, a Windows user shouldn't reach the failure path by that route — but any future attach failure, on any platform, is silent again without this change. They can merge in either order; they touch no common files.

## Related issue

Related to #4930 — this addresses the *"Term panel renders permanently blank"* symptom, which #5425 explicitly leaves out of scope. Deliberately not marked `Fixes`, since the root cause of that issue is the backend spawn failure, not this rendering gap.

Searched for duplicates: no other open PR touches `desktop/src/features/terminal`.

The issue's remaining item — *"the desktop currently writes no log files on Windows"* — is not addressed here.

## Testing

- **Unit** (`TerminalBootstrap.test.mjs`, 10/10): the notice renders with the backend's own error text, and Retry re-attaches after a failure. Full desktop JS suite: **4536/4536**.
- **E2E screenshot spec** (`term-empty-states-screenshots.spec.ts`, registered in the `smoke` project): drives the real attach-failure path end to end. The mock bridge doesn't implement `terminal_attach`, so the panel takes the genuine failure route rather than a stubbed one — the notice, its text, and the Retry button are all asserted before the capture.
- `pnpm check` (biome, file sizes, px-text, pubkey truncation) and `pnpm typecheck` clean.

One note on reading the screenshot: the error string in it is the mock bridge's (`Unsupported mocked Tauri command: terminal_attach`), because that is what fails in an e2e build. On Windows the same slot carries the real `CreateProcessW …` error. The point of the shot is that whatever the backend said now reaches the user.
