### PR TITLE
fix(mobile): retry legacy upload after transport reset

### DIFF
--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -502,24 +502,37 @@ class MediaUploadService {
     }
 
     final sha256 = _sha256Hex(bytes);
-    var response = await _sendUploadRequest(
+    Future<http.Response> uploadTo(String path) => _sendUploadRequest(
       bytes: bytes,
       mimeType: mimeType,
       sha256: sha256,
-      path: _mediaUploadPath,
+      path: path,
       onProgress: onProgress,
       cancellationToken: cancellationToken,
     );
-    if (response.statusCode == HttpStatus.notFound ||
-        response.statusCode == HttpStatus.methodNotAllowed) {
-      response = await _sendUploadRequest(
-        bytes: bytes,
-        mimeType: mimeType,
-        sha256: sha256,
-        path: _legacyMediaUploadPath,
-        onProgress: onProgress,
-        cancellationToken: cancellationToken,
-      );
+
+    late http.Response response;
+    var usedLegacyRoute = false;
+    try {
+      response = await uploadTo(_mediaUploadPath);
+    } on http.ClientException {
+      _throwIfCancelled(cancellationToken);
+      // Older self-hosted relays can reject /upload before consuming the
+      // streamed request body. Dart then reports the half-closed stream as a
+      // connection reset instead of exposing the 404/405 response. Blossom
+      // uploads are SHA-256 idempotent, so retrying the legacy alias is safe
+      // even if the first response was lost after the server stored the blob.
+      usedLegacyRoute = true;
+      response = await uploadTo(_legacyMediaUploadPath);
+    } on SocketException {
+      _throwIfCancelled(cancellationToken);
+      usedLegacyRoute = true;
+      response = await uploadTo(_legacyMediaUploadPath);
+    }
+    if (!usedLegacyRoute &&
+        (response.statusCode == HttpStatus.notFound ||
+            response.statusCode == HttpStatus.methodNotAllowed)) {
+      response = await uploadTo(_legacyMediaUploadPath);
     }
     if (response.statusCode < 200 || response.statusCode >= 300) {
       if (_allowedImageMimeTypes.contains(mimeType) &&

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -470,6 +470,44 @@ void main() {
       },
     );
 
+    test(
+      'retries the legacy upload route when the standard route resets',
+      () async {
+        final requests = <Uri>[];
+        final client = http_testing.MockClient((request) async {
+          requests.add(request.url);
+          if (request.url.path == '/upload') {
+            throw http.ClientException('Connection reset by peer', request.url);
+          }
+          return http.Response(
+            jsonEncode({
+              'url': 'https://relay.example/media/test.png',
+              'sha256': request.headers['X-SHA-256'],
+              'size': _pngBytes.length,
+              'type': 'image/png',
+              'uploaded': 1,
+            }),
+            HttpStatus.ok,
+          );
+        });
+        final service = MediaUploadService(
+          baseUrl: 'https://relay.example',
+          nsec: nostr.Keys.generate().nsec,
+          httpClient: client,
+          pickGalleryVideo: () async => null,
+          pickGalleryImage: () async => null,
+        );
+
+        final descriptor = await service.uploadBytes(
+          _pngBytes,
+          mimeType: 'image/png',
+        );
+
+        expect(descriptor.type, 'image/png');
+        expect(requests.map((url) => url.path), ['/upload', '/media/upload']);
+      },
+    );
+
     for (final statusCode in [
       HttpStatus.unsupportedMediaType,
       HttpStatus.unprocessableEntity,


### PR DESCRIPTION
## Summary

- retry the legacy media upload alias when the standard upload route fails with a ClientException or SocketException
- preserve user cancellation before attempting the compatibility retry
- cover the observed connection-reset regression with a focused mobile test

Older self-hosted relays can reject the standard upload route before consuming the streamed request body. Dart then surfaces the half-closed request as “Connection reset by peer” instead of exposing the HTTP 404/405 that triggers the existing fallback. Blossom uploads are content-addressed and idempotent, so retrying the legacy alias is safe even if the first response was lost after storage.

### Related issue

No exact duplicate found. The closest upload reliability work is #3766, which covers cancellation rather than early-response transport resets.

### Testing

- flutter test test/shared/relay/media_upload_test.dart — 36 passed
- flutter analyze lib/shared/relay/media_upload.dart test/shared/relay/media_upload_test.dart — no issues
- reproduced against a self-hosted relay that returned 405 on the standard upload route; the mobile-visible failure was ClientException with SocketConnection reset by peer
