### PR TITLE
fix(agents): resolve managed agent runtime avatars

### DIFF
--- a/desktop/src/features/agents/lib/agentCardAvatar.test.mjs
+++ b/desktop/src/features/agents/lib/agentCardAvatar.test.mjs
@@ -4,7 +4,141 @@ import test from "node:test";
 import {
   isAgentCardAvatarLoading,
   resolveAgentCardAvatarUrl,
+  resolveCurrentRuntimeAvatarUrl,
 } from "./agentCardAvatar.ts";
+
+const previousStockAvatarUrl = "https://catalog.example/runtime-a.png";
+const currentStockAvatarUrl = "https://catalog.example/runtime-b.png";
+const stockAvatarUrls = new Set([
+  previousStockAvatarUrl,
+  currentStockAvatarUrl,
+]);
+
+const runtimes = [
+  {
+    id: "runtime-a",
+    command: "runtime-a-command",
+    binaryPath: "/usr/local/bin/runtime-a",
+    avatarUrl: previousStockAvatarUrl,
+  },
+  {
+    id: "runtime-b",
+    command: "runtime-b-command",
+    binaryPath: "/usr/local/bin/runtime-b",
+    avatarUrl: currentStockAvatarUrl,
+  },
+  {
+    id: "unavailable-runtime",
+    command: null,
+    binaryPath: null,
+    avatarUrl: "https://catalog.example/unavailable.png",
+  },
+  {
+    id: "runtime-without-avatar",
+    command: "runtime-without-avatar-command",
+    binaryPath: null,
+    avatarUrl: "",
+  },
+];
+
+test("current runtime avatar resolves stored runtime id before command aliases", () => {
+  assert.equal(
+    resolveCurrentRuntimeAvatarUrl(
+      {
+        agentCommand: "/different/path/runtime-b-alias",
+        agentCommandOverride: null,
+        runtime: "runtime-b",
+      },
+      { runtime: "runtime-a" },
+      runtimes,
+    ),
+    currentStockAvatarUrl,
+  );
+});
+
+test("current runtime avatar falls back to catalog command and executable path", () => {
+  for (const agentCommand of [
+    "runtime-b-command",
+    "/usr/local/bin/runtime-b",
+  ]) {
+    assert.equal(
+      resolveCurrentRuntimeAvatarUrl(
+        { agentCommand, agentCommandOverride: agentCommand, runtime: null },
+        { runtime: "runtime-a" },
+        runtimes,
+      ),
+      currentStockAvatarUrl,
+    );
+  }
+});
+
+test("current runtime avatar falls back to an inherited persona runtime", () => {
+  assert.equal(
+    resolveCurrentRuntimeAvatarUrl(
+      {
+        agentCommand: "missing-command",
+        agentCommandOverride: null,
+        runtime: null,
+      },
+      { runtime: "runtime-b" },
+      runtimes,
+    ),
+    currentStockAvatarUrl,
+  );
+});
+
+test("current runtime avatar does not use persona fallback for an explicit override", () => {
+  assert.equal(
+    resolveCurrentRuntimeAvatarUrl(
+      {
+        agentCommand: "custom-command",
+        agentCommandOverride: "custom-command",
+        runtime: null,
+      },
+      { runtime: "runtime-b" },
+      runtimes,
+    ),
+    null,
+  );
+});
+
+test("current runtime avatar resolves an unavailable command through its runtime id", () => {
+  assert.equal(
+    resolveCurrentRuntimeAvatarUrl(
+      {
+        agentCommand: "unavailable-runtime-command",
+        agentCommandOverride: null,
+        runtime: "unavailable-runtime",
+      },
+      { runtime: null },
+      runtimes,
+    ),
+    "https://catalog.example/unavailable.png",
+  );
+});
+
+test("running agent card clears stale stock for a runtime without an avatar", () => {
+  const runtimeAvatarUrl = resolveCurrentRuntimeAvatarUrl(
+    {
+      agentCommand: "runtime-without-avatar-command",
+      agentCommandOverride: "runtime-without-avatar-command",
+      runtime: "runtime-a",
+    },
+    { runtime: null },
+    runtimes,
+  );
+
+  assert.equal(runtimeAvatarUrl, null);
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      previousStockAvatarUrl,
+      null,
+      runtimeAvatarUrl,
+      stockAvatarUrls,
+    ),
+    null,
+  );
+});
 
 test("running agent card prefers the pubkey profile avatar", () => {
   assert.equal(
@@ -23,8 +157,92 @@ test("running agent card falls back to the definition avatar", () => {
   );
 });
 
-test("running agent card ignores blank avatar values", () => {
+test("running agent card keeps a matching stock avatar", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      currentStockAvatarUrl,
+      null,
+      currentStockAvatarUrl,
+      stockAvatarUrls,
+    ),
+    currentStockAvatarUrl,
+  );
+});
+
+test("running agent card replaces a stale stock avatar after a runtime transition", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      previousStockAvatarUrl,
+      null,
+      currentStockAvatarUrl,
+      stockAvatarUrls,
+    ),
+    currentStockAvatarUrl,
+  );
+});
+
+test("running agent card preserves a custom profile avatar", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      " https://profiles.example/custom.png ",
+      previousStockAvatarUrl,
+      currentStockAvatarUrl,
+      stockAvatarUrls,
+    ),
+    "https://profiles.example/custom.png",
+  );
+});
+
+test("running agent card replaces a stock definition fallback", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      null,
+      previousStockAvatarUrl,
+      currentStockAvatarUrl,
+      stockAvatarUrls,
+    ),
+    currentStockAvatarUrl,
+  );
+});
+
+test("running agent card preserves a custom definition fallback", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      " ",
+      " https://relay.example/custom-definition.png ",
+      currentStockAvatarUrl,
+      stockAvatarUrls,
+    ),
+    "https://relay.example/custom-definition.png",
+  );
+});
+
+test("missing catalog metadata preserves the existing fallback order", () => {
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      previousStockAvatarUrl,
+      "https://relay.example/definition.png",
+      currentStockAvatarUrl,
+    ),
+    previousStockAvatarUrl,
+  );
+  assert.equal(
+    resolveAgentCardAvatarUrl(
+      null,
+      "https://relay.example/definition.png",
+      currentStockAvatarUrl,
+    ),
+    "https://relay.example/definition.png",
+  );
+});
+
+test("running agent card trims and ignores blank avatar values", () => {
   assert.equal(resolveAgentCardAvatarUrl("  ", ""), null);
+  assert.equal(
+    resolveAgentCardAvatarUrl(" ", " ", " current.png ", stockAvatarUrls),
+    "current.png",
+  );
+  assert.equal(resolveAgentCardAvatarUrl(" ", " ", " ", stockAvatarUrls), null);
 });
 
 test("linked agent actions wait for the authoritative profile avatar", () => {

--- a/desktop/src/features/agents/lib/agentCardAvatar.ts
+++ b/desktop/src/features/agents/lib/agentCardAvatar.ts
@@ -1,19 +1,67 @@
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  ManagedAgent,
+} from "@/shared/api/types";
+
+export function resolveCurrentRuntimeAvatarUrl(
+  agent: Pick<
+    ManagedAgent,
+    "agentCommand" | "agentCommandOverride" | "runtime"
+  >,
+  persona: Pick<AgentPersona, "runtime">,
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+): string | null {
+  const effectiveCommand = agent.agentCommand.trim();
+  const inheritedRuntimeId =
+    agent.agentCommandOverride == null
+      ? agent.runtime?.trim() || persona.runtime?.trim()
+      : null;
+  const runtime =
+    runtimes.find((candidate) => candidate.id.trim() === inheritedRuntimeId) ??
+    runtimes.find((candidate) =>
+      [candidate.command, candidate.binaryPath].some(
+        (value) => value?.trim() === effectiveCommand,
+      ),
+    );
+
+  return runtime?.avatarUrl.trim() || null;
+}
+
 /**
  * Resolve the avatar for a running agent card.
  *
  * The card opens the concrete agent pubkey's profile, so that profile's kind:0
  * picture is authoritative. The linked definition remains a fallback while the
- * profile is missing or has no picture.
+ * profile is missing or has no picture. A catalog-recognized stock avatar may
+ * be replaced for display when the agent now uses a different runtime; unknown
+ * and custom URLs remain authoritative.
  */
 export function resolveAgentCardAvatarUrl(
   profileAvatarUrl: string | null | undefined,
   personaAvatarUrl: string | null | undefined,
+  currentRuntimeAvatarUrl?: string | null,
+  catalogStockAvatarUrls?: ReadonlySet<string> | null,
 ): string | null {
-  for (const candidate of [profileAvatarUrl, personaAvatarUrl]) {
+  const currentRuntimeAvatar = currentRuntimeAvatarUrl?.trim() || null;
+  const shouldReplaceStockAvatar =
+    currentRuntimeAvatarUrl !== undefined && catalogStockAvatarUrls != null;
+  const resolveCandidate = (candidate: string | null | undefined) => {
     const trimmed = candidate?.trim();
-    if (trimmed) return trimmed;
+    if (!trimmed) return null;
+
+    const isCatalogStockAvatar = catalogStockAvatarUrls?.has(trimmed) ?? false;
+    return isCatalogStockAvatar && shouldReplaceStockAvatar
+      ? currentRuntimeAvatar
+      : trimmed;
+  };
+
+  for (const candidate of [profileAvatarUrl, personaAvatarUrl]) {
+    const resolved = resolveCandidate(candidate);
+    if (resolved) return resolved;
   }
-  return null;
+
+  return shouldReplaceStockAvatar ? currentRuntimeAvatar : null;
 }
 
 /**

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -1,15 +1,21 @@
 import * as React from "react";
 import { AlertTriangle, ChevronDown, ChevronRight } from "lucide-react";
 
+import { useAcpRuntimesQuery } from "@/features/agents/hooks";
 import {
   isAgentCardAvatarLoading,
   resolveAgentCardAvatarUrl,
+  resolveCurrentRuntimeAvatarUrl,
 } from "@/features/agents/lib/agentCardAvatar";
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useUserProfileQuery } from "@/features/profile/hooks";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import type {
+  AcpRuntimeCatalogEntry,
+  AgentPersona,
+  ManagedAgent,
+} from "@/shared/api/types";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { Badge } from "@/shared/ui/badge";
@@ -97,6 +103,17 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     () => buildUnifiedGroups(personas, agents),
     [personas, agents],
   );
+  const runtimesQuery = useAcpRuntimesQuery();
+  const runtimes = runtimesQuery.data;
+  const catalogStockAvatarUrls = React.useMemo(() => {
+    if (!runtimes) return undefined;
+
+    return new Set(
+      runtimes
+        .map((runtime) => runtime.avatarUrl.trim())
+        .filter((avatarUrl) => avatarUrl.length > 0),
+    );
+  }, [runtimes]);
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
   function toggle(key: string) {
     setCollapsed((prev) => {
@@ -153,8 +170,10 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
                   key={group.persona.id}
                   persona={group.persona}
                   restartingAgentPubkey={restartingAgentPubkey}
+                  runtimes={runtimes}
                   startingAgentPubkey={startingAgentPubkey}
                   startingPersonaIds={startingPersonaIds}
+                  catalogStockAvatarUrls={catalogStockAvatarUrls}
                   onOpenAgentProfile={onOpenAgentProfile}
                   onOpenPersonaProfile={onOpenPersonaProfile}
                   onRestartAgent={onRestartAgent}
@@ -222,8 +241,10 @@ function AgentPersonaCard({
   defaultModel,
   persona,
   restartingAgentPubkey,
+  runtimes,
   startingAgentPubkey,
   startingPersonaIds,
+  catalogStockAvatarUrls,
   onOpenAgentProfile,
   onOpenPersonaProfile,
   onRestartAgent,
@@ -238,8 +259,10 @@ function AgentPersonaCard({
   defaultModel: string;
   persona: AgentPersona;
   restartingAgentPubkey: string | null;
+  runtimes: readonly AcpRuntimeCatalogEntry[] | undefined;
   startingAgentPubkey: string | null;
   startingPersonaIds: ReadonlySet<string>;
+  catalogStockAvatarUrls: ReadonlySet<string> | undefined;
   onOpenAgentProfile: (
     pubkey: string,
     options?: ProfilePanelOpenOptions,
@@ -257,8 +280,20 @@ function AgentPersonaCard({
   });
   const isActive = agent ? isManagedAgentActive(agent) : false;
   const profileQuery = useUserProfileQuery(agent?.pubkey);
-  const avatarUrl = agent
+  const actionAvatarUrl = agent
     ? resolveAgentCardAvatarUrl(profileQuery.data?.avatarUrl, persona.avatarUrl)
+    : persona.avatarUrl;
+  const currentRuntimeAvatarUrl =
+    agent && runtimes
+      ? resolveCurrentRuntimeAvatarUrl(agent, persona, runtimes)
+      : undefined;
+  const avatarUrl = agent
+    ? resolveAgentCardAvatarUrl(
+        profileQuery.data?.avatarUrl,
+        persona.avatarUrl,
+        currentRuntimeAvatarUrl,
+        catalogStockAvatarUrls,
+      )
     : persona.avatarUrl;
   const friendlyError = agent
     ? friendlyAgentLastError(agent.lastError, agent.lastErrorCode)?.copy
@@ -268,7 +303,7 @@ function AgentPersonaCard({
   return (
     <AgentIdentityCard
       actions={actions?.(
-        avatarUrl,
+        actionAvatarUrl,
         isAgentCardAvatarLoading(Boolean(agent), profileQuery.isPending),
       )}
       ariaLabel={`${title} agent profile`}


### PR DESCRIPTION
## Summary

- resolve linked managed-agent card stock avatars from the effective runtime catalog at render time
- preserve custom profile and persona avatars, including the existing fallback when catalog metadata is unavailable
- leave action/share avatars and unlinked persona cards unchanged

This is intentionally a display-only fix. It does not migrate or rewrite persisted profile identity or avatar data.

### Related issue

N/A — no matching open issue or pull request found.

### Testing

- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/agentCardAvatar.test.mjs` (17 passed)
- `pnpm typecheck`
- `pnpm exec biome check src/features/agents/lib/agentCardAvatar.ts src/features/agents/lib/agentCardAvatar.test.mjs src/features/agents/ui/UnifiedAgentsSection.tsx`
- `pnpm build:e2e`
- macOS application bundle build

Screenshots are not included because this changes data-dependent avatar selection without changing layout or styling; the runtime transitions and custom-avatar preservation cases are covered by focused regression tests.

### Deferred

Persisted avatar provenance and profile ownership are broader lifecycle concerns and are intentionally not changed in this PR.
