### PR TITLE
fix(desktop): map GNOME X11 window before Mutter management

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "getrandom 0.2.17",
+ "gtk",
  "hex",
  "image",
  "infer",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ libc = "0.2"
 ctrlc = { version = "3", features = ["termination"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18"
 keyring = { version = "3.6.3", default-features = false, features = ["sync-secret-service", "vendored"], optional = true }
 # Used directly (alongside tauri-plugin-notification) so we can hold the posting
 # D-Bus connection open. GNOME 46+ dismisses a notification the moment that

--- a/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/desktop/src-tauri/src/commands/window_chrome.rs
@@ -15,6 +15,28 @@ pub fn perform_sidebar_default_haptic() {
     }
 }
 
+/// Minimizes the main window through the native GTK path on Linux.
+/// Mutter ignores the generic Tauri request for Buzz's frameless window on
+/// affected GNOME/X11 systems.
+#[tauri::command]
+pub fn minimize_window(window: tauri::Window) {
+    #[cfg(target_os = "linux")]
+    match window.gtk_window() {
+        Ok(gtk_window) => {
+            use gtk::prelude::GtkWindowExt;
+            gtk_window.iconify();
+        }
+        Err(error) => {
+            eprintln!("buzz-desktop: failed to access GTK window for minimize: {error}");
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = window.minimize();
+    }
+}
+
 /// Performs the window action matching the macOS "double-click a window's
 /// title bar to" preference (`AppleActionOnDoubleClick`).
 ///

--- a/desktop/src-tauri/src/initial_window.rs
+++ b/desktop/src-tauri/src/initial_window.rs
@@ -3,6 +3,7 @@
 #[cfg(target_os = "macos")]
 pub(crate) const INITIAL_RENDER_READY_EVENT: &str = "initial-render-ready";
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>) {
     if let Err(error) = window.show() {
         eprintln!("buzz-desktop: failed to reveal main window: {error}");
@@ -11,6 +12,77 @@ pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>
     if let Err(error) = window.set_focus() {
         eprintln!("buzz-desktop: failed to focus main window: {error}");
     }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn reveal_linux_window(window: &gtk::ApplicationWindow) {
+    use gtk::prelude::{GtkWindowExt, WidgetExt};
+
+    // Mutter on GNOME/X11 can accept the Tauri GTK window as a managed
+    // client but leave it permanently in WM_STATE=Iconic without ever mapping
+    // a frame. Realize the hidden window first, then opt this Linux fallback
+    // out of window-manager redirection before its first map request.
+    window.realize();
+    if let Some(gdk_window) = window.window() {
+        gdk_window.set_override_redirect(true);
+        window.show_all();
+        gdk_window.raise();
+
+        let application_window = window.clone();
+        gtk::glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
+            // Once the surface has completed one successful map, hand it back
+            // to Mutter through GTK itself. Remapping only the low-level GDK
+            // surface leaves Mutter without a correctly registered
+            // _NET_WM_PING client, producing a false "not responding" dialog.
+            application_window.hide();
+            if let Some(managed_window) = application_window.window() {
+                managed_window.set_override_redirect(false);
+            }
+            application_window.show_all();
+            application_window.present();
+        });
+    } else {
+        window.show_all();
+    }
+}
+
+pub(crate) fn focus_existing_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    #[cfg(target_os = "linux")]
+    match window.gtk_window() {
+        Ok(window) => reveal_linux_window(&window),
+        Err(error) => {
+            eprintln!("buzz-desktop: failed to access native GTK window: {error}");
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn install_window_state<R: tauri::Runtime>(
+    builder: tauri::Builder<R>,
+) -> tauri::Builder<R> {
+    // Restoring a maximized window races Mutter's initial hidden map on
+    // affected GNOME/X11 systems and leaves WM_STATE=Iconic.
+    builder
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn install_window_state<R: tauri::Runtime>(
+    builder: tauri::Builder<R>,
+) -> tauri::Builder<R> {
+    use tauri_plugin_window_state::StateFlags;
+
+    builder.plugin(
+        tauri_plugin_window_state::Builder::default()
+            // Visibility is excluded: the native reveal plugin below
+            // shows the window after saved geometry has been restored.
+            .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
+            .build(),
+    )
 }
 
 #[cfg(target_os = "macos")]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -80,7 +80,6 @@ use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 #[cfg(target_os = "macos")]
 use tauri::Listener;
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
-use tauri_plugin_window_state::StateFlags;
 #[cfg(target_os = "macos")]
 use tray_menu::show_main_window;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -115,8 +114,8 @@ pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             // Focus the existing window when a duplicate instance launches.
-            if let Some(w) = app.get_webview_window("main") {
-                let _ = w.set_focus();
+            if let Some(window) = app.get_webview_window("main") {
+                focus_existing_window(&window);
             }
             // Forward any deep link URLs from the duplicate launch.
             for arg in &argv {
@@ -127,15 +126,11 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_opener::init())
-        .plugin(
-            tauri_plugin_window_state::Builder::default()
-                // Visibility is excluded: the native reveal plugin below
-                // shows the window after saved geometry has been restored.
-                .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
-                .build(),
-        )
-        .plugin(
+        .plugin(tauri_plugin_opener::init());
+
+    let builder = install_window_state(builder);
+
+    let builder = builder.plugin(
             tauri::plugin::Builder::<_, ()>::new("initial-window-reveal")
                 .on_webview_ready(|webview| {
                     if webview.label() != "main" {
@@ -150,7 +145,16 @@ pub fn run() {
                     // macOS applies the restored geometry asynchronously. Wait
                     // for several identical outer bounds and for React to
                     // commit the startup surface before revealing it.
+                    #[cfg(any(target_os = "macos", target_os = "windows"))]
                     let window = webview.window();
+
+                    #[cfg(target_os = "linux")]
+                    match webview.window().gtk_window() {
+                        Ok(window) => reveal_linux_window(&window),
+                        Err(error) => {
+                            eprintln!("buzz-desktop: failed to access native GTK window: {error}");
+                        }
+                    }
 
                     #[cfg(target_os = "macos")]
                     {
@@ -183,7 +187,7 @@ pub fn run() {
                         });
                     }
 
-                    #[cfg(not(target_os = "macos"))]
+                    #[cfg(target_os = "windows")]
                     {
                         reveal_initial_window(&window);
                     }
@@ -630,6 +634,7 @@ pub fn run() {
             unarchive_builderlab_community,
             transfer_builderlab_community,
             title_bar_double_click,
+            minimize_window,
             get_identity,
             get_nsec,
             generate_backup_passphrase,

--- a/desktop/src-tauri/tauri.linux.conf.json
+++ b/desktop/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,21 @@
+{
+  "app": {
+    "enableGTKAppId": true,
+    "windows": [
+      {
+        "title": "Buzz",
+        "width": 1200,
+        "height": 800,
+        "center": true,
+        "maximized": false,
+        "visible": false,
+        "transparent": false,
+        "decorations": false,
+        "dragDropEnabled": false,
+        "backgroundThrottling": "disabled",
+        "minWidth": 800,
+        "minHeight": 500
+      }
+    ]
+  }
+}

--- a/desktop/src/app/AppTopChrome.tsx
+++ b/desktop/src/app/AppTopChrome.tsx
@@ -2,11 +2,16 @@ import * as React from "react";
 import {
   ChevronLeft,
   ChevronRight,
+  Minus,
   PanelLeftClose,
   PanelLeftOpen,
+  Square,
+  X,
 } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
-import { isMacPlatform } from "@/shared/lib/platform";
+import { isLinuxPlatform, isMacPlatform } from "@/shared/lib/platform";
 import { useIsFullscreen } from "@/shared/lib/useIsFullscreen";
 import { Button } from "@/shared/ui/button";
 import { cn } from "@/shared/lib/cn";
@@ -29,6 +34,8 @@ const TOP_CHROME_ICON_BUTTON_CLASS =
   "h-[28px] w-[28px] rounded-[4px] text-sidebar-foreground/65 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-[16px]";
 const HISTORY_ICON_BUTTON_CLASS =
   "h-[28px] w-[24px] rounded-[4px] text-sidebar-foreground/65 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-[16px]";
+const WINDOW_CONTROL_BUTTON_CLASS =
+  "h-[28px] w-[36px] rounded-[4px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground [&_svg]:size-[14px]";
 
 function preventTopChromeWheel(event: WheelEvent) {
   event.preventDefault();
@@ -53,6 +60,54 @@ function TopChromeSidebarTrigger() {
       {sidebar?.open ? <PanelLeftClose /> : <PanelLeftOpen />}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
+  );
+}
+
+function LinuxWindowControls() {
+  if (!isLinuxPlatform()) {
+    return null;
+  }
+
+  const appWindow = getCurrentWindow();
+  return (
+    <div
+      className="ml-auto flex items-center gap-0.5"
+      data-testid="linux-window-controls"
+    >
+      <Button
+        aria-label="Minimize window"
+        className={WINDOW_CONTROL_BUTTON_CLASS}
+        onClick={() => void invoke("minimize_window")}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <Minus />
+      </Button>
+      <Button
+        aria-label="Maximize or restore window"
+        className={WINDOW_CONTROL_BUTTON_CLASS}
+        onClick={() => void appWindow.toggleMaximize()}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <Square />
+      </Button>
+      <Button
+        aria-label="Close window"
+        className={cn(
+          WINDOW_CONTROL_BUTTON_CLASS,
+          "hover:bg-destructive hover:text-destructive-foreground",
+        )}
+        onClick={() => void appWindow.close()}
+        size="icon"
+        type="button"
+        variant="ghost"
+      >
+        <X />
+      </Button>
+    </div>
   );
 }
 
@@ -131,6 +186,7 @@ export function AppTopChrome({
           <ChevronRight />
         </Button>
       </div>
+      <LinuxWindowControls />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- add a Linux-only GTK startup path that maps the hidden window once with `override_redirect`, then remaps it under Mutter management
- skip saved window-state restoration on Linux to avoid racing the initial hidden map
- ship an opaque, normal-size, frameless Linux window configuration with client-side minimize, maximize/restore, and close controls
- leave macOS and Windows startup behavior unchanged

## Root cause

On an NVIDIA DGX Spark running Ubuntu 24.04 with GNOME/X11, Mutter accepted Buzz's correctly sized GTK client but immediately left it in `WM_STATE=Iconic` and `Map State: IsUnMapped`. Calls to `show`, `unminimize`, focus, delayed reveal, opaque rendering, and the existing WebKit safe-rendering settings did not map it.

Realizing the hidden GTK `ApplicationWindow`, performing its first map outside window-manager redirection, and handing it back to Mutter after 100 ms produced a normal managed window. Native decorations reintroduced the Iconic state on the affected system, so the Linux configuration uses application chrome.

This addresses the GNOME/X11 mapping path reported in #2811. The original Fedora/Skia transparent-window report may have a separate rendering cause, so this PR does not close the broader issue.

## User impact

Affected Linux users get a visible, taskbar-managed window with working focus, movement, resizing, minimize/maximize, close, and Alt-F4 behavior. Linux starts at a normal size rather than restoring saved maximized state; macOS and Windows continue restoring window state.

The ARM64 sidecar packaging issue noted in the field report is intentionally out of scope.

## Validation

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml --lib`
- `pnpm -C desktop exec biome check src/app/AppTopChrome.tsx`
- `pnpm -C desktop typecheck`
- `pnpm -C desktop build`
- `pnpm -C desktop check:file-sizes`
- equivalent production ARM64 patch previously installed and verified on one DGX Spark: `IsViewable`, `WM_STATE=Normal`, override redirect disabled after remap, onboarding completed

Signed-off-by: Neo Days Off <neodaysoff@users.noreply.github.com>
