### PR TITLE
fix(desktop): retry persona sync backfill, persist agent start failures, cover scoped dev keyrings

### DIFF
--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -390,7 +390,7 @@ pub fn resolve_persisted_identity(app: &AppHandle, state: &AppState) -> Result<(
 
 #[path = "app_state_keyring.rs"]
 mod keyring_config;
-pub(crate) use keyring_config::keyring_service;
+pub(crate) use keyring_config::{is_dev_keyring_service, keyring_service};
 
 /// Keyring key name for the human identity nsec.
 const IDENTITY_KEY_NAME: &str = "identity";

--- a/desktop/src-tauri/src/app_state_keyring.rs
+++ b/desktop/src-tauri/src/app_state_keyring.rs
@@ -17,6 +17,13 @@ pub(crate) fn keyring_service() -> &'static str {
     }
 }
 
+/// True for the canonical dev service and every per-instance scoped dev
+/// service (`buzz-desktop-dev.<slug>`) — i.e. every service a dev build may
+/// use. The production service ("buzz-desktop") is never a dev service.
+pub(crate) fn is_dev_keyring_service(service: &str) -> bool {
+    service == "buzz-desktop-dev" || service.starts_with("buzz-desktop-dev.")
+}
+
 pub(super) fn migration_marker_name(service: &str, default_name: &str) -> String {
     if service == "buzz-desktop" || service == "buzz-desktop-dev" {
         default_name.to_string()
@@ -27,7 +34,15 @@ pub(super) fn migration_marker_name(service: &str, default_name: &str) -> String
 
 #[cfg(test)]
 mod tests {
-    use super::{dev_keyring_service, migration_marker_name};
+    use super::{dev_keyring_service, is_dev_keyring_service, migration_marker_name};
+
+    #[test]
+    fn scoped_dev_services_are_dev_services() {
+        assert!(is_dev_keyring_service("buzz-desktop-dev"));
+        assert!(is_dev_keyring_service("buzz-desktop-dev.example"));
+        assert!(!is_dev_keyring_service("buzz-desktop"));
+        assert!(!is_dev_keyring_service("buzz-desktop-developer"));
+    }
 
     #[test]
     fn standalone_scope_must_remain_under_dev_service() {

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -6,13 +6,13 @@ use crate::{
     managed_agents::{
         build_managed_agent_summary, current_instance_id, discover_provider_candidates,
         ensure_persona_is_active, find_managed_agent_mut, load_managed_agents, load_personas,
-        load_teams, managed_agent_avatar_url, normalize_agent_args, provider_deploy,
-        resolve_provider_binary, save_managed_agents, start_managed_agent_process,
-        stop_managed_agent_process, stop_managed_agent_workspace_pair,
-        sync_managed_agent_processes, try_regenerate_nest, validate_provider_config, BackendKind,
-        CreateManagedAgentRequest, CreateManagedAgentResponse, ManagedAgentRecord,
-        ManagedAgentSummary, RelayMeshConfig, DEFAULT_ACP_COMMAND, DEFAULT_AGENT_PARALLELISM,
-        DEFAULT_AGENT_TURN_TIMEOUT_SECONDS,
+        load_teams, managed_agent_avatar_url, normalize_agent_args, persist_agent_start_failure,
+        persist_record_start_failure, provider_deploy, resolve_provider_binary,
+        save_managed_agents, start_managed_agent_process, stop_managed_agent_process,
+        stop_managed_agent_workspace_pair, sync_managed_agent_processes, try_regenerate_nest,
+        validate_provider_config, BackendKind, CreateManagedAgentRequest,
+        CreateManagedAgentResponse, ManagedAgentRecord, ManagedAgentSummary, RelayMeshConfig,
+        DEFAULT_ACP_COMMAND, DEFAULT_AGENT_PARALLELISM, DEFAULT_AGENT_TURN_TIMEOUT_SECONDS,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
     util::now_iso,
@@ -292,7 +292,13 @@ pub(super) async fn start_local_agent_pairs_with_preflight(
             &personas_for_preflight,
             &global_for_preflight,
         );
-    ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), false).await?;
+    if let Err(error) = ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), false).await {
+        // The preflight runs before any mutable store load (and without the
+        // store lock, across the await) — persist the refusal under a fresh
+        // lock so a refused start leaves a durable forensic trace.
+        persist_agent_start_failure(app, pubkey, &error);
+        return Err(error);
+    }
 
     {
         let _store_guard = state
@@ -393,7 +399,15 @@ pub(super) async fn start_local_agent_with_preflight(
             &personas,
             &global,
         );
-    ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), allow_fresh_create_start).await?;
+    if let Err(error) =
+        ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), allow_fresh_create_start).await
+    {
+        // The preflight runs before the mutable store load below (and without
+        // the store lock, across the await) — persist the refusal under a
+        // fresh lock so a refused start leaves a durable forensic trace.
+        persist_agent_start_failure(app, pubkey, &error);
+        return Err(error);
+    }
 
     let _store_guard = state
         .managed_agents_store_lock
@@ -423,13 +437,23 @@ pub(super) async fn start_local_agent_with_preflight(
                 record.updated_at = crate::util::now_iso();
             }
             None => {
-                return Err(
-                    crate::managed_agents::effective_config::ORPHANED_INSTANCE_ERROR.to_string(),
-                );
+                let error =
+                    crate::managed_agents::effective_config::ORPHANED_INSTANCE_ERROR.to_string();
+                // The store lock and records are already in hand here —
+                // persist the refusal before returning so an orphaned instance
+                // explains itself on the durable record.
+                persist_record_start_failure(app, &mut records, pubkey, &error);
+                return Err(error);
             }
         }
     }
-    start_managed_agent_process(app, record, &mut runtimes, Some(owner_hex))?;
+    if let Err(error) = start_managed_agent_process(app, record, &mut runtimes, Some(owner_hex)) {
+        // Spawn refusal (missing identity key, harness-descriptor resolution
+        // failure, …): persist before returning so the failure is visible
+        // after the fact, not just in the returned error string.
+        persist_record_start_failure(app, &mut records, pubkey, &error);
+        return Err(error);
+    }
     save_managed_agents(app, &records)?;
     if let Some(saved_record) = records.iter().find(|r| r.pubkey == pubkey) {
         retain_managed_agent_pending(app, state, saved_record);

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -5,11 +5,11 @@ use tauri::{AppHandle, Emitter, Manager};
 use super::{
     agent_readiness, append_log_marker, current_instance_id, find_managed_agent_mut,
     load_global_agent_config, load_managed_agents, load_personas, managed_agent_runtime_log_path,
-    process_is_running, record_agent_command, resolve_effective_agent_env, save_managed_agents,
-    spawn_agent_child, terminate_process, terminate_untracked_pair_runtime,
-    write_agent_runtime_receipt, AgentReadiness, BackendKind, ManagedAgentPairRuntime,
-    ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle, ManagedAgentRuntimeReceipt,
-    ManagedAgentRuntimeStatus,
+    persist_record_start_failure, process_is_running, record_agent_command,
+    resolve_effective_agent_env, save_managed_agents, spawn_agent_child, terminate_process,
+    terminate_untracked_pair_runtime, write_agent_runtime_receipt, AgentReadiness, BackendKind,
+    ManagedAgentPairRuntime, ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle,
+    ManagedAgentRuntimeReceipt, ManagedAgentRuntimeStatus,
 };
 use crate::app_state::AppState;
 
@@ -283,7 +283,20 @@ fn start_pair(
         .lock()
         .ok()
         .map(|keys| keys.public_key().to_hex());
-    let mut process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
+    // The record's own pubkey (not the canonicalized pair key) is the stamp
+    // target — `persist_record_start_failure` matches records by exact pubkey.
+    let record_pubkey = record.pubkey.clone();
+    let mut process = match spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())
+    {
+        Ok(process) => process,
+        Err(error) => {
+            // Spawn refusal escaped this command with nothing persisted —
+            // stamp the durable record (store lock already held above) so the
+            // failure is visible after the fact.
+            persist_record_start_failure(&app, &mut records, &record_pubkey, &error);
+            return Err(error);
+        }
+    };
     let now = crate::util::now_iso();
     let receipt = ManagedAgentRuntimeReceipt {
         key: key.clone(),
@@ -294,6 +307,7 @@ fn start_pair(
     if let Err(error) = write_agent_runtime_receipt(&app, &receipt) {
         let _ = terminate_process(process.child.id());
         let _ = process.child.wait();
+        persist_record_start_failure(&app, &mut records, &record_pubkey, &error);
         return Err(error);
     }
     record.runtime_pid = None;

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -7,7 +7,7 @@ use std::{
 
 use tauri::{AppHandle, Manager};
 
-use crate::app_state::keyring_service;
+use crate::app_state::{is_dev_keyring_service, keyring_service};
 use crate::managed_agents::{
     ManagedAgentRecord, ManagedAgentRuntimeKey, ManagedAgentRuntimeReceipt,
 };
@@ -394,6 +394,64 @@ pub(crate) fn save_agent_definitions(
     write_agent_store(app, definitions, instances)
 }
 
+/// Stamp a start-path failure (spawn refusal, orphaned persona, relay-mesh
+/// preflight rejection) onto the matching record: bump `updated_at`, record
+/// the error message, and clear `last_error_code` — these paths carry no
+/// structured code. Mirrors the `sync_managed_agent_processes` failure
+/// convention in `runtime/lifecycle.rs`, so a refused start leaves a durable
+/// forensic trace instead of returning an error nothing persisted.
+pub(crate) fn stamp_agent_start_failure(
+    records: &mut [ManagedAgentRecord],
+    pubkey: &str,
+    error: &str,
+) -> Result<(), String> {
+    let record = records
+        .iter_mut()
+        .find(|record| record.pubkey == pubkey)
+        .ok_or_else(|| format!("agent {pubkey} not found"))?;
+    record.updated_at = crate::util::now_iso();
+    record.last_error = Some(error.to_string());
+    record.last_error_code = None;
+    Ok(())
+}
+
+/// Stamp + save a start-path failure. The caller MUST already hold
+/// `managed_agents_store_lock`. Best-effort: a persistence failure is logged
+/// and swallowed so it never masks the original start error.
+pub(crate) fn persist_record_start_failure(
+    app: &AppHandle,
+    records: &mut [ManagedAgentRecord],
+    pubkey: &str,
+    error: &str,
+) {
+    if let Err(e) = stamp_agent_start_failure(records, pubkey, error)
+        .and_then(|()| save_managed_agents(app, records))
+    {
+        eprintln!("buzz-desktop: failed to persist start error for agent {pubkey}: {e}");
+    }
+}
+
+/// Lock + load + stamp + save a start-path failure, for failure points that
+/// escape BEFORE the caller's mutable store load (the async relay-mesh
+/// preflight runs without the store lock held, by design). Never call this
+/// while holding `managed_agents_store_lock` — the mutex is not reentrant;
+/// use [`persist_record_start_failure`] there instead. Best-effort, same
+/// never-mask-the-original-error contract.
+pub fn persist_agent_start_failure(app: &AppHandle, pubkey: &str, error: &str) {
+    let state = app.state::<crate::app_state::AppState>();
+    let result = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| e.to_string())
+        .and_then(|_guard| load_managed_agents(app));
+    match result {
+        Ok(mut records) => persist_record_start_failure(app, &mut records, pubkey, error),
+        Err(e) => {
+            eprintln!("buzz-desktop: failed to persist start error for agent {pubkey}: {e}")
+        }
+    }
+}
+
 /// Serialize definitions + instances into the single unified store file.
 /// Definitions sort first (by slug) for stable diffs; instances keep the
 /// name/pubkey order their save path established.
@@ -444,7 +502,8 @@ fn persist_agent_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRec
 }
 
 /// One-time migration of agent keys from the production keyring service
-/// (`"buzz-desktop"`) to the dev service (`"buzz-desktop-dev"`). Only runs
+/// (`"buzz-desktop"`) to the active dev service (`"buzz-desktop-dev"` or a
+/// per-instance `"buzz-desktop-dev.<slug>"`). Only runs
 /// in debug builds — release builds never touch `"buzz-desktop"` from this
 /// path.
 ///
@@ -458,7 +517,11 @@ fn persist_agent_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRec
 /// after the service-name change.
 #[cfg(debug_assertions)]
 pub fn migrate_agent_keys_to_dev_service(app: &tauri::AppHandle) {
-    if !cfg!(feature = "system-keyring") || keyring_service() != "buzz-desktop-dev" {
+    // Runs for the canonical dev service and every per-instance scoped dev
+    // service (`buzz-desktop-dev.<slug>`) — a worktree build's agents need the
+    // same prod-keyring migration, otherwise instances synced from the user's
+    // prod install can never start (their keys are local-only by design).
+    if !cfg!(feature = "system-keyring") || !is_dev_keyring_service(keyring_service()) {
         return;
     }
 

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -13,7 +13,7 @@ use tempfile::NamedTempFile;
 
 use super::{
     agent_keyring_name, hydrate_keys_with, migrate_inline_key, persist_agent_keys_with,
-    KeyMigration, KeyStore, KeyringProbe, ManagedAgentRecord,
+    stamp_agent_start_failure, KeyMigration, KeyStore, KeyringProbe, ManagedAgentRecord,
 };
 
 /// In-memory [`KeyStore`] for testing the migrate decision without the OS
@@ -829,4 +829,70 @@ fn install_log_filename_accepts_ordinary_runtime_ids() {
             format!("install-{id}.log")
         );
     }
+}
+
+// ── Start-failure stamping ───────────────────────────────────────────────────
+//
+// `stamp_agent_start_failure` is the pure core of the start-path persistence
+// added so a refused start (spawn refusal, orphaned persona, relay-mesh
+// preflight rejection) leaves a durable `last_error` on the record instead of
+// returning an error nothing saved. The lock + load + save wrappers around it
+// (`persist_record_start_failure` / `persist_agent_start_failure`) need a live
+// `AppHandle`, which no test fixture in this crate provides — the stamping
+// contract is pinned here, and the save half is the same `save_managed_agents`
+// every other record-mutating path already exercises.
+
+/// A spawn refusal overwrites any stale error, clears the structured code
+/// (no code exists on the start path), and refreshes `updated_at`.
+#[test]
+fn start_failure_stamp_records_message_and_clears_structured_code() {
+    let mut record = record_with_pubkey_and_key("agent-pubkey", "");
+    record.last_error = Some("stale error".to_string());
+    record.last_error_code = Some(-32001);
+    record.updated_at = "2026-01-01T00:00:00Z".to_string();
+    let mut records = vec![record];
+
+    stamp_agent_start_failure(&mut records, "agent-pubkey", "identity key unavailable")
+        .expect("stamp must find the record");
+
+    let record = &records[0];
+    assert_eq!(
+        record.last_error.as_deref(),
+        Some("identity key unavailable")
+    );
+    assert_eq!(
+        record.last_error_code, None,
+        "start-path failures carry no structured code"
+    );
+    assert_ne!(
+        record.updated_at, "2026-01-01T00:00:00Z",
+        "a refused start must bump updated_at"
+    );
+}
+
+/// Other records in the store are untouched.
+#[test]
+fn start_failure_stamp_leaves_other_records_alone() {
+    let target = record_with_pubkey_and_key("agent-pubkey", "");
+    let bystander = record_with_pubkey_and_key("other-pubkey", "");
+    let mut records = vec![target, bystander];
+
+    stamp_agent_start_failure(&mut records, "agent-pubkey", "orphaned persona")
+        .expect("stamp must find the record");
+
+    assert_eq!(records[1].last_error, None);
+    assert_eq!(records[1].updated_at, "2026-01-01T00:00:00Z");
+}
+
+/// An unknown pubkey errors and mutates nothing — the caller still returns the
+/// original start error (the persistence layer never masks it).
+#[test]
+fn start_failure_stamp_unknown_pubkey_errors_without_touching_records() {
+    let mut records = vec![record_with_pubkey_and_key("agent-pubkey", "")];
+
+    let error = stamp_agent_start_failure(&mut records, "missing-pubkey", "spawn refused")
+        .expect_err("unknown pubkey must error");
+
+    assert!(error.contains("missing-pubkey"), "{error}");
+    assert_eq!(records[0].last_error, None);
 }

--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -158,7 +158,8 @@ fn run_boot_migrations_inner(app: &tauri::AppHandle, reset_completed: bool) {
     migrate_legacy_app_data_dir(app);
     sync_shared_agent_data(app);
     // Dev-build-only: copy any agent keys that exist in the production
-    // keyring ("buzz-desktop") into the dev service ("buzz-desktop-dev")
+    // keyring ("buzz-desktop") into the active dev service ("buzz-desktop-dev"
+    // or a per-instance "buzz-desktop-dev.<slug>")
     // so existing agents don't lose their keys after the service-name split.
     // Must run after sync_shared_agent_data (JSON symlinked) and before
     // any load_managed_agents call (which runs hydrate_keys against the

--- a/desktop/src/features/agents/lib/usePersonaSync.test.mjs
+++ b/desktop/src/features/agents/lib/usePersonaSync.test.mjs
@@ -254,3 +254,31 @@ test("startPersonaSync stops retrying once cancelled", async () => {
 
   mock.reset();
 });
+
+// Cancellation must short-circuit a backoff sleep too: an identity/community
+// switch during a 60s wait should stop the loop within one poll interval, not
+// after the full sleep plus another fetch.
+test("startPersonaSync aborts promptly when cancelled during a backoff sleep", async () => {
+  let fetches = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetches += 1;
+    return Promise.reject(new Error("relay unreachable"));
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+
+  let cancelled = false;
+  startPersonaSync("owner-pubkey", "wss://relay.example", () => cancelled, {
+    backfillRetryDelaysMs: [60_000],
+  });
+
+  assert.ok(await waitFor(() => fetches === 1), "first attempt must run");
+  cancelled = true;
+  // Well under the 60s backoff: the loop must notice cancellation within a
+  // few poll intervals and never fetch again.
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+  assert.equal(fetches, 1, "cancel during sleep must prevent the retry fetch");
+
+  mock.reset();
+});

--- a/desktop/src/features/agents/lib/usePersonaSync.test.mjs
+++ b/desktop/src/features/agents/lib/usePersonaSync.test.mjs
@@ -108,3 +108,149 @@ test("startPersonaSync forwards its own relay as the event arrival relay", async
   mock.reset();
   delete globalThis.window;
 });
+
+// Waits until `cond` holds, polling on a short timer. The retry loop under
+// test uses injected 1ms delays, so real-time polling keeps the tests honest
+// without fake timers.
+async function waitFor(cond, tries = 200) {
+  for (let i = 0; i < tries; i += 1) {
+    if (cond()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  return false;
+}
+
+function stubInvoke(behavior) {
+  const invokes = [];
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke: (cmd, args) => {
+        invokes.push({ cmd, args });
+        return behavior(invokes.length);
+      },
+    },
+  };
+  return invokes;
+}
+
+// Regression guard for the silent-forever-empty gap: a failed backfill must be
+// retried, because the live subscription only covers NEW events and can never
+// recover already-published persona/team/agent heads.
+test("startPersonaSync retries the backfill after a fetch failure", async () => {
+  const invokes = stubInvoke(() => Promise.resolve());
+  const ownEvent = { id: "e1", pubkey: "owner-pubkey", kind: KIND_PERSONA };
+
+  let fetches = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetches += 1;
+    return fetches === 1
+      ? Promise.reject(new Error("relay not ready"))
+      : Promise.resolve([ownEvent]);
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+
+  startPersonaSync("owner-pubkey", "wss://relay.example", () => false, {
+    backfillRetryDelaysMs: [1],
+  });
+
+  assert.ok(await waitFor(() => fetches === 2), "backfill must retry once");
+  assert.ok(
+    await waitFor(
+      () =>
+        invokes.filter((call) => call.cmd === "reconcile_inbound_persona_event")
+          .length === 1,
+    ),
+    "the retried backfill must reconcile its events",
+  );
+
+  mock.reset();
+  delete globalThis.window;
+});
+
+// A backfill whose fetch succeeds but whose reconciles all fail (e.g. identity
+// keys not loaded yet in the backend) must also be retried — reconcile is
+// idempotent, so re-applying already-landed events is a no-op.
+test("startPersonaSync retries the backfill when reconciles fail", async () => {
+  let invokeCalls = 0;
+  const invokes = stubInvoke(() => {
+    invokeCalls += 1;
+    return invokeCalls === 1
+      ? Promise.reject(new Error("signing keys not ready"))
+      : Promise.resolve();
+  });
+  const ownEvent = { id: "e1", pubkey: "owner-pubkey", kind: KIND_PERSONA };
+
+  let fetches = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetches += 1;
+    return Promise.resolve([ownEvent]);
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+
+  startPersonaSync("owner-pubkey", "wss://relay.example", () => false, {
+    backfillRetryDelaysMs: [1],
+  });
+
+  assert.ok(
+    await waitFor(() => fetches === 2),
+    "failed reconciles must trigger a backfill retry",
+  );
+  assert.ok(
+    await waitFor(() => invokes.length === 2),
+    "the retry must reconcile the same event again",
+  );
+
+  mock.reset();
+  delete globalThis.window;
+});
+
+// After the retry schedule is exhausted the backfill must stop — the live
+// subscription still covers new events, and an unreachable relay must not be
+// polled forever.
+test("startPersonaSync gives up after exhausting the retry delays", async () => {
+  let fetches = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetches += 1;
+    return Promise.reject(new Error("relay unreachable"));
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+
+  startPersonaSync("owner-pubkey", "wss://relay.example", () => false, {
+    backfillRetryDelaysMs: [1, 1],
+  });
+
+  // initial attempt + 2 retries, then stop.
+  assert.ok(await waitFor(() => fetches === 3), "must run all retries");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(fetches, 3, "must stop after the retry schedule is exhausted");
+
+  mock.reset();
+});
+
+// A cancelled sync (identity/community switch torn the effect down) must not
+// keep retrying in the background.
+test("startPersonaSync stops retrying once cancelled", async () => {
+  let fetches = 0;
+  mock.method(relayClient, "fetchEvents", () => {
+    fetches += 1;
+    return Promise.reject(new Error("relay unreachable"));
+  });
+  mock.method(relayClient, "subscribeLive", () =>
+    Promise.resolve(() => Promise.resolve()),
+  );
+
+  startPersonaSync("owner-pubkey", "wss://relay.example", () => true, {
+    backfillRetryDelaysMs: [1, 1],
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(fetches, 1, "a cancelled sync must not retry the backfill");
+
+  mock.reset();
+});

--- a/desktop/src/features/agents/lib/usePersonaSync.ts
+++ b/desktop/src/features/agents/lib/usePersonaSync.ts
@@ -29,8 +29,24 @@ const PERSONA_SYNC_KINDS = [
 // event that already landed is a no-op.
 const DEFAULT_BACKFILL_RETRY_DELAYS_MS = [2000, 5000, 15000, 30000, 60000];
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+// Poll cancellation during backoff sleeps: an identity/community switch during
+// a 60s wait must short-circuit the retry loop instead of running one more
+// full backfill for the torn-down subscription.
+const CANCEL_POLL_MS = 250;
+
+async function sleepCancellable(
+  ms: number,
+  onCancelled: () => boolean,
+): Promise<void> {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    if (onCancelled()) return;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(CANCEL_POLL_MS, remaining)),
+    );
+  }
 }
 
 // Start the persona/team/agent/deletion sync for `pubkey` on `relayUrl`:
@@ -108,7 +124,8 @@ export function startPersonaSync(
           `[usePersonaSync] backfill attempt ${attempt + 1} failed, retrying in ${delay}ms:`,
           error,
         );
-        await sleep(delay);
+        await sleepCancellable(delay, onCancelled);
+        if (onCancelled()) return;
       }
     }
   })();

--- a/desktop/src/features/agents/lib/usePersonaSync.ts
+++ b/desktop/src/features/agents/lib/usePersonaSync.ts
@@ -20,10 +20,23 @@ const PERSONA_SYNC_KINDS = [
   KIND_DELETION,
 ];
 
+// Backfill retry schedule: delays between attempts after the initial one.
+// A fresh device that fails its one-shot backfill (relay not ready, identity
+// keys not loaded yet, transient timeout) used to stay silently empty forever
+// — live subscriptions only cover NEW events, so already-published persona /
+// team / agent heads would never arrive. Retrying is safe: reconcile is
+// idempotent (retention store keeps last-writer-wins), so re-applying an
+// event that already landed is a no-op.
+const DEFAULT_BACKFILL_RETRY_DELAYS_MS = [2000, 5000, 15000, 30000, 60000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // Start the persona/team/agent/deletion sync for `pubkey` on `relayUrl`:
-// one-shot backfill of existing heads + tombstones, then a live subscription.
-// Returns a disposer that closes the live subscription. Extracted from the hook
-// so the wiring is unit-testable without a React renderer (see
+// backfill of existing heads + tombstones (retried with backoff), then a live
+// subscription. Returns a disposer that closes the live subscription. Extracted
+// from the hook so the wiring is unit-testable without a React renderer (see
 // `usePersonaSync.test.mjs`).
 //
 // `relayUrl` is the community this subscription is bound to, and every reconcile
@@ -34,27 +47,71 @@ export function startPersonaSync(
   pubkey: string,
   relayUrl: string,
   onCancelled: () => boolean,
+  options?: { backfillRetryDelaysMs?: readonly number[] },
 ): () => Promise<void> {
-  const reconcile = (event: RelayEvent) => {
-    if (event.pubkey !== pubkey) return;
-    void reconcileInboundPersonaEvent(JSON.stringify(event), relayUrl).catch(
-      (error) => {
-        console.warn("[usePersonaSync] reconcile failed:", error);
-      },
-    );
+  const retryDelays =
+    options?.backfillRetryDelaysMs ?? DEFAULT_BACKFILL_RETRY_DELAYS_MS;
+
+  // Returns true when the event reconciled (or was skipped as foreign), false
+  // when the backend rejected it — the backfill treats any false as a failed
+  // attempt and retries the whole batch.
+  const reconcileEvent = async (event: RelayEvent): Promise<boolean> => {
+    if (event.pubkey !== pubkey) return true;
+    try {
+      await reconcileInboundPersonaEvent(JSON.stringify(event), relayUrl);
+      return true;
+    } catch (error) {
+      console.warn("[usePersonaSync] reconcile failed:", error);
+      return false;
+    }
   };
 
-  // One-shot backfill of existing heads + tombstones (closes the fresh-start
-  // gap that live-only subscription + reconnect-replay cannot recover).
-  void relayClient
-    .fetchEvents({ kinds: PERSONA_SYNC_KINDS, authors: [pubkey], limit: 500 })
-    .then((events) => {
-      if (onCancelled()) return;
-      for (const event of events) reconcile(event);
-    })
-    .catch((error) => {
-      console.warn("[usePersonaSync] backfill failed:", error);
+  const reconcile = (event: RelayEvent) => {
+    void reconcileEvent(event);
+  };
+
+  // Backfill of existing heads + tombstones (closes the fresh-start gap that
+  // live-only subscription + reconnect-replay cannot recover), retried with
+  // backoff when the fetch or any reconcile fails.
+  const backfill = async () => {
+    const events = await relayClient.fetchEvents({
+      kinds: PERSONA_SYNC_KINDS,
+      authors: [pubkey],
+      limit: 500,
     });
+    if (onCancelled()) return;
+    const results = await Promise.all(events.map(reconcileEvent));
+    const failed = results.filter((ok) => !ok).length;
+    if (failed > 0) {
+      throw new Error(
+        `${failed} of ${events.length} persona sync event(s) failed to reconcile`,
+      );
+    }
+  };
+
+  void (async () => {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await backfill();
+        return;
+      } catch (error) {
+        if (onCancelled()) return;
+        const delay = retryDelays[attempt];
+        if (delay === undefined) {
+          console.warn(
+            "[usePersonaSync] backfill gave up after retries:",
+            error,
+          );
+          return;
+        }
+        console.warn(
+          `[usePersonaSync] backfill attempt ${attempt + 1} failed, retrying in ${delay}ms:`,
+          error,
+        );
+        await sleep(delay);
+      }
+    }
+  })();
 
   let unsub: (() => Promise<void>) | null = null;
   void relayClient


### PR DESCRIPTION
## Summary

Three desktop agent-reliability fixes, all reproduced from a real per-branch dev install (`xyz.block.buzz.app.dev.<branch>`) where the owner logged in with the same key + same community as the production install and found (a) only the 3 builtin agents available and (b) clicking Start did nothing visible.

### 1. Persona/agent sync backfill now retries with backoff

`startPersonaSync` did exactly one backfill fetch at startup; any failure (relay not ready, auth timeout, reconcile rejection because identity keys weren't loaded yet) was logged to the console and never retried. Since the live subscription only covers *new* events, a fresh install that missed its one backfill stayed silently builtin-only forever — already-published persona/team/agent heads never arrived.

- Backfill now retries with exponential backoff (2s/5s/15s/30s/60s), covering both fetch failures and per-event reconcile failures (any failed reconcile retries the whole batch — reconcile is idempotent via the retention store's last-writer-wins, so re-applying landed events is a no-op).
- Cancellation (identity/community switch) stops the retry loop; after the schedule is exhausted the sync gives up loudly instead of polling forever.

### 2. Start-path failures are persisted to the agent record

Every start refusal (relay-mesh preflight, orphaned persona, spawn refusal such as a missing identity key, harness-descriptor resolution failure) returned an `Err` that produced at most a transient toast — `last_error`/`last_error_code` on the record stayed `null` and no log was written, making failures invisible after the fact.

- New `stamp_agent_start_failure` core + `persist_record_start_failure` (caller holds the store lock) / `persist_agent_start_failure` (acquires it) helpers.
- All refusal paths in `start_local_agent_with_preflight`, `start_local_agent_pairs_with_preflight`, and the pair-scoped `start_pair` now stamp `last_error` + bump `updated_at` and save before returning the original error. Persistence failures never mask the original error.
- Effect: a refused start now leaves a persistent error badge on the agent card (via the existing `friendlyAgentLastError` path) instead of only a fleeting toast.

### 3. Agent-key migration covers scoped dev keyring services

`migrate_agent_keys_to_dev_service` gated on `keyring_service() == "buzz-desktop-dev"`, so per-instance dev builds (`buzz-desktop-dev.<slug>`, set via `BUZZ_DEV_KEYRING_SERVICE` for worktree/standalone launches) never copied agent keys from the production keyring — agents whose records exist in a shared/synced store could never start in those builds.

- New `is_dev_keyring_service` predicate (`buzz-desktop-dev` + `buzz-desktop-dev.*`); the migration now runs for every dev service. Prod (`buzz-desktop`) is never matched.

## Out of scope / deliberate non-changes

- Inbound kind:30177 reconcile still does not mint agent *instances* from relay events (`inbound_managed_agent_no_match_is_noop` pins this: an instance minted from a relay event would have no secret key). Cross-device restore works at the definition level; the user instantiates locally. With fix 3, same-machine dev builds can reuse the prod keyring for keys they do hold records for.
- No frontend→file logging introduced (the app has no such channel today); sync failures log to the console as before, but the retry makes transient failures self-healing.

## Test plan

- `desktop` JS unit tests: 4539/4539 pass (incl. 4 new backfill retry tests: fetch-failure retry, reconcile-failure retry, give-up after schedule, cancellation stops retries).
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`: pass (incl. 3 new `stamp_agent_start_failure` tests + `is_dev_keyring_service` predicate test).
- Manual verification on a per-branch dev install is coordinated separately (needs the owner's logged-in dev app); tracked in the team channel.
