### PR TITLE
feat(desktop): redeploy provider-backed managed agents after config edits

### DIFF
--- a/crates/buzz-backend-kubernetes/src/reconcile.rs
+++ b/crates/buzz-backend-kubernetes/src/reconcile.rs
@@ -843,6 +843,51 @@ mod tests {
         );
     }
 
+    /// The seam the desktop's "Redeploy" button reports against.
+    ///
+    /// Buzz Desktop lets an owner re-send a deployed agent's configuration and
+    /// stamps the returned `agent_id` on its record. This pins what that
+    /// answer is worth when the instance is live: the id is the one the
+    /// desktop already held, and *nothing* was applied — no Secret carrying
+    /// the edited environment was written, so the new configuration never even
+    /// reached the cluster. A desktop that reported "Redeployed" would be
+    /// reporting this call as a runtime change; what it may honestly report is
+    /// delivery plus the generation boundary (`:867-877`).
+    ///
+    /// Both shapes of edit are covered, because they fail differently: a
+    /// changed env *value* (an edited model or system prompt) does not even
+    /// move the create-intent fingerprint, and a changed env *key* does — and
+    /// the live row no-ops either way.
+    #[test]
+    fn started_pod_returns_its_id_having_applied_nothing() {
+        let id = identity();
+        let cfg = config();
+        let fake = Fake::default().with_pod(our_pod(&id, &cfg, Some(running())));
+
+        let mut edited = env();
+        edited.insert("BUZZ_RELAY_URL".into(), "wss://edited-after-deploy".into());
+        edited.insert("BUZZ_ACP_MODEL".into(), "edited-model".into());
+
+        let agent_id = block_on(deploy(&fake, &id, &cfg, edited)).expect("deploy answers");
+
+        assert_eq!(
+            agent_id,
+            id.pod_name(),
+            "the answer is the id the caller already had — success cannot \
+             distinguish an applied config from a no-op"
+        );
+        assert_eq!(
+            fake.mutations(),
+            [format!("ensure_namespace {}", cfg.namespace)],
+            "the live row mutated something while reporting success"
+        );
+        assert!(
+            fake.created_secrets.borrow().is_empty(),
+            "the edited configuration was written to the cluster — it must not \
+             be, and it is why success may not claim the agent is running it"
+        );
+    }
+
     /// Terminated → fenced delete → disappearance → recreate. The normal
     /// restart path, and the fence must carry the observed uid/rv.
     #[test]

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -26,7 +26,7 @@ use crate::{
         DEFAULT_ACP_COMMAND,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
-    util::now_iso,
+    util::bumped_updated_at,
 };
 
 /// Query available models from an agent via `buzz-acp models --json`.
@@ -824,7 +824,7 @@ pub async fn update_managed_agent(
             record.respond_to_allowlist = prospective_allowlist;
         }
 
-        record.updated_at = now_iso();
+        record.updated_at = bumped_updated_at(&record.updated_at);
 
         save_managed_agents(&app, &records)?;
 

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -1353,7 +1353,7 @@ pub async fn delete_managed_agent(
 // No backend Tauri command needed. Presence IS the status.
 #[path = "agents_deploy.rs"]
 mod deploy;
-pub(super) mod provider_access;
+pub(crate) mod provider_access;
 use deploy::build_deploy_payload;
 #[cfg(test)]
 use deploy::{deploy_payload_json, DeployProjections};

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -6,15 +6,14 @@ use super::managed_agent_definition::validate_create_definition;
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, current_instance_id, discover_provider_candidates,
-        ensure_persona_is_active, find_managed_agent_mut, load_managed_agents, load_personas,
-        load_teams, managed_agent_avatar_url, normalize_agent_args, provider_deploy,
-        resolve_provider_binary, save_managed_agents, start_managed_agent_process,
-        stop_managed_agent_process, stop_managed_agent_workspace_pair,
-        sync_managed_agent_processes, try_regenerate_nest, validate_provider_config, BackendKind,
-        CreateManagedAgentRequest, CreateManagedAgentResponse, ManagedAgentRecord,
-        ManagedAgentSummary, RelayMeshConfig, DEFAULT_ACP_COMMAND, DEFAULT_AGENT_PARALLELISM,
-        DEFAULT_AGENT_TURN_TIMEOUT_SECONDS,
+        build_managed_agent_summary, current_instance_id, ensure_persona_is_active,
+        find_managed_agent_mut, load_managed_agents, load_personas, load_teams,
+        managed_agent_avatar_url, normalize_agent_args, resolve_provider_binary,
+        save_managed_agents, start_managed_agent_process, stop_managed_agent_process,
+        stop_managed_agent_workspace_pair, sync_managed_agent_processes, try_regenerate_nest,
+        validate_provider_config, BackendKind, CreateManagedAgentRequest,
+        CreateManagedAgentResponse, ManagedAgentRecord, ManagedAgentSummary, RelayMeshConfig,
+        DEFAULT_ACP_COMMAND, DEFAULT_AGENT_PARALLELISM, DEFAULT_AGENT_TURN_TIMEOUT_SECONDS,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
     util::now_iso,
@@ -439,73 +438,6 @@ pub(super) async fn start_local_agent_with_preflight(
         &personas,
         &crate::managed_agents::load_global_agent_config(app).unwrap_or_default(),
     )
-}
-
-/// Deploy an agent to a provider backend. Resolves the binary, calls deploy via
-/// spawn_blocking, and persists the result (backend_agent_id or last_error).
-///
-/// Idempotency: calling deploy on an already-deployed agent sends the same payload
-/// again. Providers are expected to handle this as an update-in-place or no-op —
-/// the protocol does not include an explicit `undeploy` operation (deferred to v2).
-///
-/// Returns Ok(()) on success, Err(message) on failure. Either way the record is
-/// updated and saved before returning.
-async fn deploy_to_provider(
-    app: &AppHandle,
-    state: &AppState,
-    pubkey: &str,
-    provider_id: &str,
-    config: &serde_json::Value,
-    agent_json: serde_json::Value,
-    cached_binary_path: Option<&str>,
-) -> Result<(), String> {
-    // Resolve via discovered candidates only. Cached path must match BOTH
-    // "is a discovered candidate" AND "belongs to this provider_id". A tampered
-    // record cannot redirect deploys to a different provider's binary.
-    let bin_path = cached_binary_path
-        .map(std::path::PathBuf::from)
-        .filter(|p| p.exists())
-        .map(|p| p.canonicalize().unwrap_or(p))
-        .filter(|canonical| {
-            discover_provider_candidates().iter().any(|(id, cp)| {
-                id == provider_id && cp.canonicalize().ok().as_ref() == Some(canonical)
-            })
-        })
-        .map_or_else(|| resolve_provider_binary(provider_id), Ok)?;
-
-    let config_clone = config.clone();
-    let deploy_result =
-        tokio::task::spawn_blocking(move || provider_deploy(&bin_path, &agent_json, &config_clone))
-            .await
-            .map_err(|e| format!("spawn_blocking failed: {e}"))?;
-
-    // Persist result under lock.
-    let _store_guard = state
-        .managed_agents_store_lock
-        .lock()
-        .map_err(|e| e.to_string())?;
-    let mut records = load_managed_agents(app)?;
-    let rec = records
-        .iter_mut()
-        .find(|r| r.pubkey == pubkey)
-        .ok_or_else(|| format!("agent {pubkey} not found"))?;
-
-    match deploy_result {
-        Ok(backend_agent_id) => {
-            rec.backend_agent_id = Some(backend_agent_id);
-            rec.last_started_at = Some(now_iso());
-            rec.updated_at = now_iso();
-            rec.last_error = None;
-        }
-        Err(ref e) => {
-            rec.last_error = Some(e.clone());
-            rec.updated_at = now_iso();
-            save_managed_agents(app, &records)?;
-            return Err(e.clone());
-        }
-    }
-    save_managed_agents(app, &records)?;
-    Ok(())
 }
 
 // Async so the blocking body (disk reads of agent/persona records, per-agent
@@ -992,23 +924,15 @@ pub async fn create_managed_agent(
 
     // ── Phase 5: provider deploy (async, outside lock) ───────────────────────
     let spawn_error = if input.spawn_after_create && input.backend != BackendKind::Local {
-        if let BackendKind::Provider { ref id, ref config } = input.backend {
-            // Read the saved record to build the deploy payload (record has the
-            // canonical field values after Phase 3 normalization).
-            let agent_json = {
-                let _g = state
-                    .managed_agents_store_lock
-                    .lock()
-                    .map_err(|e| e.to_string())?;
-                let records = load_managed_agents(&app)?;
-                let rec = records
-                    .iter()
-                    .find(|r| r.pubkey == pubkey)
-                    .ok_or_else(|| "agent disappeared".to_string())?;
-                build_deploy_payload(&app, &state, rec)?
-            };
-            match deploy_to_provider(&app, &state, &pubkey, id, config, agent_json, None).await {
-                Ok(()) => spawn_error,
+        if let BackendKind::Provider { .. } = input.backend {
+            // The deploy snapshots the saved record (canonical field values
+            // after Phase 3 normalization) under the per-agent deploy lock
+            // and binds its completion to that snapshot. Any failure —
+            // including payload build — lands in `spawn_error`: the agent
+            // record exists either way, and this response field is the
+            // channel for "created but not deployed".
+            match provider_access::deploy_to_provider(&app, &state, &pubkey).await {
+                Ok(_) => spawn_error,
                 Err(e) => Some(e),
             }
         } else {
@@ -1065,11 +989,7 @@ pub async fn start_managed_agent(
     let owner_hex = workspace_owner_hex(&state)?;
     enum StartTarget {
         Local,
-        Provider {
-            backend: BackendKind,
-            cached_binary_path: Option<String>,
-            agent_json: serde_json::Value,
-        },
+        Provider,
     }
 
     // Collect backend info under lock; async preflight/spawn happens below.
@@ -1117,11 +1037,7 @@ pub async fn start_managed_agent(
         let target = if record.backend == BackendKind::Local {
             StartTarget::Local
         } else {
-            StartTarget::Provider {
-                backend: record.backend.clone(),
-                cached_binary_path: record.provider_binary_path.clone(),
-                agent_json: build_deploy_payload(&app, &state, record)?,
-            }
+            StartTarget::Provider
         };
 
         (target, reconcile)
@@ -1131,48 +1047,10 @@ pub async fn start_managed_agent(
         StartTarget::Local => {
             start_local_agent_with_preflight(&app, &state, &pubkey, &owner_hex, false).await
         }
-        StartTarget::Provider {
-            backend: BackendKind::Provider { id, config },
-            cached_binary_path,
-            agent_json,
-        } => {
-            deploy_to_provider(
-                &app,
-                &state,
-                &pubkey,
-                &id,
-                &config,
-                agent_json,
-                cached_binary_path.as_deref(),
-            )
-            .await?;
-
-            // Return updated summary.
-            let _store_guard = state
-                .managed_agents_store_lock
-                .lock()
-                .map_err(|e| e.to_string())?;
-            let records = load_managed_agents(&app)?;
-            let runtimes = state
-                .managed_agent_processes
-                .lock()
-                .map_err(|e| e.to_string())?;
-            let record = records
-                .iter()
-                .find(|r| r.pubkey == pubkey)
-                .ok_or_else(|| format!("agent {pubkey} not found"))?;
-            let personas = load_personas(&app).unwrap_or_default();
-            build_managed_agent_summary(
-                &app,
-                record,
-                &runtimes,
-                &personas,
-                &crate::managed_agents::load_global_agent_config(&app).unwrap_or_default(),
-            )
-        }
-        StartTarget::Provider { backend, .. } => Err(format!(
-            "agent {pubkey} has unsupported backend kind: {backend:?}"
-        )),
+        // Snapshots the record and payload under the per-agent deploy lock,
+        // binds completion to that snapshot, and returns the summary of the
+        // freshly persisted record on success-as-current.
+        StartTarget::Provider => provider_access::deploy_to_provider(&app, &state, &pubkey).await,
     };
 
     // ── Profile reconciliation (fire-and-forget) ────────────────────────────
@@ -1369,3 +1247,6 @@ pub(crate) use profile::{reconcile_agent_profile, ProfileReconcileData};
 #[cfg(test)]
 #[path = "agents_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod provider_access_tests;

--- a/desktop/src-tauri/src/commands/agents/provider_access.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access.rs
@@ -17,6 +17,10 @@ use crate::{
     util::now_iso,
 };
 
+pub(super) mod payload_digest;
+
+use payload_digest::{deploy_input_digest, digest_parts};
+
 type DeployLocks = StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>;
 
 /// Per-agent provider-deploy serialization: at most one provider call may be
@@ -49,27 +53,46 @@ pub(super) fn needs_reconciliation_with_policy(
 }
 
 /// A provider deploy captured under the store lock: the coordinates the
-/// provider call will use plus the record generation (`updated_at`) the
-/// completion is bound to. Every deploy path (create, start, reconcile,
-/// redeploy) snapshots one of these under the per-agent deploy lock before
-/// releasing the store lock for the long-running provider call.
+/// provider call will use, the record generation (`updated_at`), and the
+/// digest of the fully resolved deploy input the completion is bound to.
+/// Every deploy path (create, start, reconcile, redeploy) snapshots one of
+/// these under the per-agent deploy lock before releasing the store lock for
+/// the long-running provider call.
+///
+/// Two bindings, not one, and deliberately conservative — a completion is only
+/// reported as current when *both* hold:
+///
+/// * `updated_at` catches an owner edit to the agent row even when the edited
+///   field does not reach the provider, so a deploy is never reported as
+///   having applied an edit it did not carry.
+/// * `payload_digest` catches everything the agent row does not cover. The
+///   payload is re-resolved from the live persona, team, global agent config,
+///   effective harness descriptor, workspace relay URL and owner pubkey, and
+///   the provider config rides beside it — all of which can change with the
+///   agent row untouched.
 #[derive(Debug)]
 pub(super) struct CapturedDeploy {
     pub(super) provider_id: String,
     pub(super) config: serde_json::Value,
     pub(super) cached_binary_path: Option<String>,
     pub(super) updated_at: String,
+    pub(super) payload_digest: String,
 }
 
-/// Capture the provider coordinates and configuration generation of `record`
-/// for a deploy. Errors when the record is not provider-backed.
-fn capture_provider_deploy(record: &ManagedAgentRecord) -> Result<CapturedDeploy, String> {
+/// Capture the provider coordinates, configuration generation and resolved
+/// payload digest of `record` for a deploy. Errors when the record is not
+/// provider-backed.
+fn capture_provider_deploy(
+    record: &ManagedAgentRecord,
+    payload: &serde_json::Value,
+) -> Result<CapturedDeploy, String> {
     match &record.backend {
         BackendKind::Provider { id, config } => Ok(CapturedDeploy {
             provider_id: id.clone(),
             config: config.clone(),
             cached_binary_path: record.provider_binary_path.clone(),
             updated_at: record.updated_at.clone(),
+            payload_digest: digest_parts(id, config, payload)?,
         }),
         BackendKind::Local => Err(format!(
             "agent {} is not provider-backed and cannot be deployed to a provider",
@@ -244,9 +267,10 @@ mod tests {
 pub(super) fn redeploy_provider_target(
     pubkey: &str,
     record: &ManagedAgentRecord,
+    payload: &serde_json::Value,
 ) -> Result<CapturedDeploy, String> {
     match (&record.backend, record.backend_agent_id.as_deref()) {
-        (BackendKind::Provider { .. }, Some(_)) => capture_provider_deploy(record),
+        (BackendKind::Provider { .. }, Some(_)) => capture_provider_deploy(record, payload),
         (BackendKind::Provider { .. }, None) => Err(format!(
             "agent {pubkey} has not been deployed yet; deploy it before redeploying"
         )),
@@ -256,76 +280,154 @@ pub(super) fn redeploy_provider_target(
     }
 }
 
-/// Everything a deploy flow captures under the store lock before the
-/// provider call. `captured.updated_at` is the configuration generation the
-/// completion is bound to.
+/// Everything a deploy flow captures under the store lock before the provider
+/// call: the provider coordinates, the generation and digest the completion is
+/// bound to, and the fully resolved payload that will be sent.
+///
+/// The payload is resolved here — under the same lock, in the same instant as
+/// the digest — rather than after the lock is released, so the bytes on the
+/// wire and the digest the completion compares against can never come from two
+/// different reads of the persona, team or global config.
 pub(super) struct DeploySnapshot {
-    pub(super) record: ManagedAgentRecord,
     pub(super) captured: CapturedDeploy,
+    pub(super) payload: serde_json::Value,
 }
 
 /// How a finished provider call was bound to the store state found on
 /// completion. Computed by [`bind_completion`].
 #[derive(Debug)]
 pub(super) enum CompletionOutcome {
-    /// Record unchanged since the snapshot: success persisted as current.
+    /// Record and its fully resolved deploy input both unchanged since the
+    /// snapshot: success persisted as current.
     AppliedCurrent(Box<ManagedAgentRecord>),
-    /// Record edited mid-flight: the remote facts are persisted
+    /// The deploy input moved mid-flight — the agent row was edited, or an
+    /// input outside it (persona, team, global config, relay URL, owner,
+    /// provider config) resolved differently. The remote facts are persisted
     /// (`backend_agent_id`, `last_started_at`) because the deploy really
-    /// happened, but the running deployment carries the previously saved
-    /// configuration, so nothing may imply the current record was applied —
+    /// happened, but what the provider received is not what the store now
+    /// describes, so nothing may imply the current configuration was sent —
     /// `last_error` is left untouched.
     AppliedStale,
+    /// The deploy succeeded but the payload could not be re-resolved on
+    /// completion, so currency could not be *proved* either way. The remote
+    /// facts are persisted; nothing claims currency. Carries the resolution
+    /// error.
+    AppliedUnverified(String),
     /// Record switched away from the captured provider backend mid-flight
     /// (to local, or to a different provider): nothing persisted — the
     /// deployment id belongs to a backend the record no longer describes.
     BackendChanged,
     /// Record deleted mid-flight: nothing persisted.
     Deleted,
-    /// Provider call failed: the failure is stamped on the surviving record.
+    /// Provider call failed and the surviving record is still the one that
+    /// failed: the failure is stamped on it.
     Failed(String),
+    /// Provider call failed, but the record in the store is no longer the
+    /// deploy that failed — a different backend, or a moved generation.
+    /// Nothing is stamped: `last_error` on a record describes *that* record's
+    /// last attempt, and this attempt was of something else.
+    FailedUnstamped(String),
+}
+
+/// Re-resolves the full deploy input of a record found on completion and
+/// digests it, so inputs that live outside the agent row (persona, team,
+/// global config, relay URL, owner) are compared too. Supplied by the
+/// [`DeployEffects`] impl, which knows how to reach them.
+pub(super) type ResolveDigest<'a> = dyn Fn(&ManagedAgentRecord) -> Result<String, String> + 'a;
+
+/// The completion body [`DeployEffects::with_store`] runs against the loaded
+/// records, returning whether the caller must save.
+pub(super) type CompletionApply<'a, R> =
+    dyn FnMut(&mut Vec<ManagedAgentRecord>, &ResolveDigest<'_>) -> (bool, R) + 'a;
+
+/// Whether the record found on completion is still the deploy that was sent.
+#[derive(Debug)]
+enum Currency {
+    /// Same generation and same fully resolved deploy input.
+    Current,
+    /// The agent row, or an input resolved outside it, moved.
+    Moved,
+    /// The deploy input could not be re-resolved, so neither can be proved.
+    Unverified(String),
+}
+
+/// Compare the record in the store against the captured deploy. Must be called
+/// before the completion mutates `record.updated_at`.
+fn currency(
+    record: &ManagedAgentRecord,
+    captured: &CapturedDeploy,
+    resolve_digest: &ResolveDigest<'_>,
+) -> Currency {
+    if record.updated_at != captured.updated_at {
+        return Currency::Moved;
+    }
+    match resolve_digest(record) {
+        Ok(digest) if digest == captured.payload_digest => Currency::Current,
+        Ok(_) => Currency::Moved,
+        Err(error) => Currency::Unverified(error),
+    }
 }
 
 /// Bind a finished provider call to whatever the store holds now. Mutates
 /// `records` in place; the returned bool says whether the caller must save.
-/// A successful deploy is only stamped onto a record that is still backed by
-/// the captured provider; otherwise the id would describe a foreign backend.
+///
+/// Every stamp — success *and* failure — is gated on the surviving record
+/// still being the deploy this completion belongs to: same provider backend,
+/// same generation, same re-resolved deploy input. A success stamped onto a
+/// foreign backend would describe a deployment that backend never made; a
+/// failure stamped onto a moved record would report an attempt of a
+/// configuration that was never attempted.
+///
+/// `resolve_digest` re-resolves the full deploy input for the record found on
+/// completion, so inputs that live outside the agent row are compared too.
 pub(super) fn bind_completion(
     records: &mut [ManagedAgentRecord],
     pubkey: &str,
-    captured_provider_id: &str,
-    captured_updated_at: &str,
+    captured: &CapturedDeploy,
+    resolve_digest: &ResolveDigest<'_>,
     deploy_result: &Result<String, String>,
 ) -> (bool, CompletionOutcome) {
     let Some(record) = records.iter_mut().find(|record| record.pubkey == pubkey) else {
         return (false, CompletionOutcome::Deleted);
     };
+    let same_backend = matches!(
+        &record.backend,
+        BackendKind::Provider { id, .. } if *id == captured.provider_id
+    );
     match deploy_result {
         Err(error) => {
-            record.last_error = Some(error.clone());
-            record.updated_at = now_iso();
-            (true, CompletionOutcome::Failed(error.clone()))
+            if !same_backend {
+                return (false, CompletionOutcome::FailedUnstamped(error.clone()));
+            }
+            match currency(record, captured, resolve_digest) {
+                Currency::Current => {
+                    record.last_error = Some(error.clone());
+                    record.updated_at = now_iso();
+                    (true, CompletionOutcome::Failed(error.clone()))
+                }
+                Currency::Moved | Currency::Unverified(_) => {
+                    (false, CompletionOutcome::FailedUnstamped(error.clone()))
+                }
+            }
         }
         Ok(backend_agent_id) => {
-            let same_backend = matches!(
-                &record.backend,
-                BackendKind::Provider { id, .. } if id == captured_provider_id
-            );
             if !same_backend {
                 return (false, CompletionOutcome::BackendChanged);
             }
-            let unchanged = record.updated_at == captured_updated_at;
+            let currency = currency(record, captured, resolve_digest);
             record.backend_agent_id = Some(backend_agent_id.clone());
             record.last_started_at = Some(now_iso());
             record.updated_at = now_iso();
-            if unchanged {
-                record.last_error = None;
-                (
-                    true,
-                    CompletionOutcome::AppliedCurrent(Box::new(record.clone())),
-                )
-            } else {
-                (true, CompletionOutcome::AppliedStale)
+            match currency {
+                Currency::Current => {
+                    record.last_error = None;
+                    (
+                        true,
+                        CompletionOutcome::AppliedCurrent(Box::new(record.clone())),
+                    )
+                }
+                Currency::Moved => (true, CompletionOutcome::AppliedStale),
+                Currency::Unverified(error) => (true, CompletionOutcome::AppliedUnverified(error)),
             }
         }
     }
@@ -343,9 +445,13 @@ pub(super) fn completion_result(
     match outcome {
         CompletionOutcome::AppliedCurrent(record) => Ok(record),
         CompletionOutcome::AppliedStale => Err("Agent settings changed while the deploy was in \
-             flight, so the agent is running the previous configuration. Redeploy to apply the \
-             latest settings — a queued redeploy will do that automatically."
+             flight, so the provider was sent the previous settings. Redeploy to send the latest \
+             ones — a queued redeploy will do that automatically."
             .to_string()),
+        CompletionOutcome::AppliedUnverified(error) => Err(format!(
+            "The settings were sent, but Buzz could not re-read them afterwards to confirm the \
+             provider got the current ones: {error}"
+        )),
         CompletionOutcome::BackendChanged => Err("The agent's backend changed while the deploy \
              was in flight. The finished deployment may still be running on the previous \
              provider backend."
@@ -356,7 +462,10 @@ pub(super) fn completion_result(
                 .to_string(),
             Err(error) => error,
         }),
-        CompletionOutcome::Failed(error) => Err(error),
+        // The provider's own error either way. It is what the owner needs to
+        // act on, and it reaches them verbatim in a toast whether or not the
+        // moved record was a legitimate place to stamp it.
+        CompletionOutcome::Failed(error) | CompletionOutcome::FailedUnstamped(error) => Err(error),
     }
 }
 
@@ -367,19 +476,19 @@ pub(super) fn completion_result(
 pub(super) trait DeployEffects {
     type Success;
 
-    /// Under the store lock: load the record and validate it as a deploy
-    /// target.
+    /// Under the store lock: load the record, resolve its deploy payload, and
+    /// validate it as a deploy target.
     fn snapshot(&mut self, pubkey: &str) -> Result<DeploySnapshot, String>;
 
-    /// The provider call (payload build + deploy). Must not touch the store.
+    /// The provider call. Must not touch the store — the payload it sends was
+    /// resolved in [`DeployEffects::snapshot`].
     async fn deploy(&mut self, snapshot: &DeploySnapshot) -> Result<String, String>;
 
     /// Run `apply` on the loaded records under the store lock, saving when it
-    /// returns `true`.
-    fn with_store<R>(
-        &mut self,
-        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
-    ) -> Result<R, String>;
+    /// returns `true`. `apply`'s second argument re-resolves a record's full
+    /// deploy input digest, so the completion can compare inputs that live
+    /// outside the agent row.
+    fn with_store<R>(&mut self, apply: &mut CompletionApply<'_, R>) -> Result<R, String>;
 
     /// Build the success value from the freshly persisted record.
     fn success(&mut self, record: &ManagedAgentRecord) -> Result<Self::Success, String>;
@@ -402,14 +511,9 @@ pub(super) async fn run_deploy<E: DeployEffects>(
 
     let deploy_result = effects.deploy(&snapshot).await;
 
-    let outcome = effects.with_store(&mut |records| {
-        bind_completion(
-            records,
-            pubkey,
-            &snapshot.captured.provider_id,
-            &snapshot.captured.updated_at,
-            &deploy_result,
-        )
+    let captured = &snapshot.captured;
+    let outcome = effects.with_store(&mut |records, resolve_digest| {
+        bind_completion(records, pubkey, captured, resolve_digest, &deploy_result)
     })?;
 
     let record = completion_result(outcome, deploy_result)?;
@@ -421,8 +525,9 @@ pub(super) async fn run_deploy<E: DeployEffects>(
 fn deploy_provider_target(
     _pubkey: &str,
     record: &ManagedAgentRecord,
+    payload: &serde_json::Value,
 ) -> Result<CapturedDeploy, String> {
-    capture_provider_deploy(record)
+    capture_provider_deploy(record, payload)
 }
 
 /// [`DeployEffects`] wired to the real store, payload builder, and provider
@@ -433,7 +538,7 @@ fn deploy_provider_target(
 struct CommandDeployEffects<'a> {
     app: &'a AppHandle,
     state: &'a AppState,
-    target: fn(&str, &ManagedAgentRecord) -> Result<CapturedDeploy, String>,
+    target: fn(&str, &ManagedAgentRecord, &serde_json::Value) -> Result<CapturedDeploy, String>,
 }
 
 impl DeployEffects for CommandDeployEffects<'_> {
@@ -450,29 +555,33 @@ impl DeployEffects for CommandDeployEffects<'_> {
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| format!("agent {pubkey} not found"))?;
-        let captured = (self.target)(pubkey, record)?;
-        Ok(DeploySnapshot {
-            record: record.clone(),
-            captured,
-        })
+        let payload = super::build_deploy_payload(self.app, self.state, record)?;
+        let captured = (self.target)(pubkey, record, &payload)?;
+        Ok(DeploySnapshot { captured, payload })
     }
 
     async fn deploy(&mut self, snapshot: &DeploySnapshot) -> Result<String, String> {
-        let agent_json = super::build_deploy_payload(self.app, self.state, &snapshot.record)?;
-        call_provider_deploy(&snapshot.captured, agent_json).await?
+        call_provider_deploy(&snapshot.captured, snapshot.payload.clone()).await?
     }
 
-    fn with_store<R>(
-        &mut self,
-        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
-    ) -> Result<R, String> {
+    fn with_store<R>(&mut self, apply: &mut CompletionApply<'_, R>) -> Result<R, String> {
         let _store_guard = self
             .state
             .managed_agents_store_lock
             .lock()
             .map_err(|error| error.to_string())?;
         let mut records = load_managed_agents(self.app)?;
-        let (save, result) = apply(&mut records);
+        // Copies of two shared references, so the resolver borrows nothing
+        // that the save below needs back. Resolving under the store lock is
+        // deliberate: it reads personas, teams and global config, none of
+        // which take this lock, and it must see the same store state the
+        // completion is about to stamp.
+        let (app, state) = (self.app, self.state);
+        let resolve_digest = move |record: &ManagedAgentRecord| -> Result<String, String> {
+            let payload = super::build_deploy_payload(app, state, record)?;
+            deploy_input_digest(record, &payload)
+        };
+        let (save, result) = apply(&mut records, &resolve_digest);
         if save {
             save_managed_agents(self.app, &records)?;
         }

--- a/desktop/src-tauri/src/commands/agents/provider_access.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access.rs
@@ -1,12 +1,12 @@
 //! Upgrade reconciliation for provider-backed managed-agent access.
 
-use tauri::AppHandle;
+use tauri::{AppHandle, State};
 
 use crate::{
     app_state::AppState,
     managed_agents::{
-        find_managed_agent_mut, load_managed_agents, save_managed_agents, BackendKind,
-        ManagedAgentRecord,
+        build_managed_agent_summary, find_managed_agent_mut, load_managed_agents, load_personas,
+        save_managed_agents, BackendKind, ManagedAgentRecord, ManagedAgentSummary,
     },
     util::now_iso,
 };
@@ -193,4 +193,89 @@ mod tests {
             collect_targets_with(records, false, |_| { Ok(serde_json::Value::Null) }).is_empty()
         );
     }
+}
+
+pub(super) fn redeploy_provider_target(
+    pubkey: &str,
+    record: &ManagedAgentRecord,
+) -> Result<(String, serde_json::Value, Option<String>), String> {
+    match (&record.backend, record.backend_agent_id.as_deref()) {
+        (BackendKind::Provider { id, config }, Some(_)) => Ok((
+            id.clone(),
+            config.clone(),
+            record.provider_binary_path.clone(),
+        )),
+        (BackendKind::Provider { .. }, None) => Err(format!(
+            "agent {pubkey} has not been deployed yet; deploy it before redeploying"
+        )),
+        _ => Err(format!(
+            "agent {pubkey} is not provider-backed and cannot be redeployed"
+        )),
+    }
+}
+
+#[tauri::command]
+pub async fn redeploy_managed_agent(
+    pubkey: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ManagedAgentSummary, String> {
+    let (record, provider_id, config, cached_binary_path) = {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let records = load_managed_agents(&app)?;
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?;
+        let (provider_id, config, cached_binary_path) = redeploy_provider_target(&pubkey, record)?;
+        (record.clone(), provider_id, config, cached_binary_path)
+    };
+
+    let agent_json = match super::build_deploy_payload(&app, &state, &record) {
+        Ok(agent_json) => agent_json,
+        Err(error) => {
+            persist_failure(&app, &state, &pubkey, &error)?;
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = super::deploy_to_provider(
+        &app,
+        &state,
+        &pubkey,
+        &provider_id,
+        &config,
+        agent_json,
+        cached_binary_path.as_deref(),
+    )
+    .await
+    {
+        persist_failure(&app, &state, &pubkey, &error)?;
+        return Err(error);
+    }
+
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let records = load_managed_agents(&app)?;
+    let runtimes = state
+        .managed_agent_processes
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let record = records
+        .iter()
+        .find(|record| record.pubkey == pubkey)
+        .ok_or_else(|| format!("agent {pubkey} not found"))?;
+    let personas = load_personas(&app).unwrap_or_default();
+    build_managed_agent_summary(
+        &app,
+        record,
+        &runtimes,
+        &personas,
+        &crate::managed_agents::load_global_agent_config(&app).unwrap_or_default(),
+    )
 }

--- a/desktop/src-tauri/src/commands/agents/provider_access.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access.rs
@@ -513,8 +513,10 @@ pub(super) trait DeployEffects {
     /// store failed to save.
     fn record_ambiguous_success(&mut self, receipt: &AmbiguousDeployReceipt) -> Result<(), String>;
 
-    /// Drop any ambiguous-success receipt for `pubkey`: the store has just
-    /// recorded a known outcome for this agent, so the ambiguity is resolved.
+    /// Drop any ambiguous-success receipt for `pubkey`. Called only after a
+    /// provider success the store recorded: that deploy superseded the earlier
+    /// one remotely *and* left a local record of doing so, so the ambiguity is
+    /// genuinely resolved. A saved failure must not reach this.
     fn clear_ambiguous_success(&mut self, pubkey: &str);
 
     /// Build the success value from the freshly persisted record.
@@ -557,7 +559,13 @@ pub(super) async fn run_deploy<E: DeployEffects>(
             save_error,
         ));
     }
-    if saved {
+    // Only a provider success that the store also recorded resolves an earlier
+    // ambiguity. A saved *failure* records that this attempt never reached the
+    // provider, which says nothing about the deployment a previous attempt may
+    // have left running — it did not supersede it remotely. Clearing the
+    // receipt on it would delete the only evidence of a deployment the store
+    // never recorded.
+    if saved && deploy_result.is_ok() {
         effects.clear_ambiguous_success(pubkey);
     }
 

--- a/desktop/src-tauri/src/commands/agents/provider_access.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access.rs
@@ -1,15 +1,45 @@
 //! Upgrade reconciliation for provider-backed managed-agent access.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex as StdMutex, OnceLock},
+};
+
 use tauri::{AppHandle, State};
 
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, find_managed_agent_mut, load_managed_agents, load_personas,
-        save_managed_agents, BackendKind, ManagedAgentRecord, ManagedAgentSummary,
+        build_managed_agent_summary, discover_provider_candidates, load_managed_agents,
+        load_personas, provider_deploy, resolve_provider_binary, save_managed_agents, BackendKind,
+        ManagedAgentRecord, ManagedAgentSummary,
     },
     util::now_iso,
 };
+
+type DeployLocks = StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>;
+
+/// Per-agent provider-deploy serialization: at most one provider call may be
+/// in flight per agent pubkey, so two deploys for the same agent can never
+/// interleave and land out of order remotely. A module-level static rather
+/// than an `AppState` field because app_state.rs is at its file-size ratchet
+/// limit and may not grow, and because the map holds no community-scoped data
+/// (keys are agent pubkeys, values are bare mutexes), so it needs no
+/// community-switch reset.
+///
+/// Entries are deliberately never removed — not even on agent deletion.
+/// Removing an entry while a deploy still holds its `Arc` would let a
+/// recreated agent with the same pubkey mint a fresh mutex and run
+/// concurrently with the in-flight holder, silently breaking serialization.
+/// Growth is bounded by the number of distinct agent pubkeys seen in one app
+/// run, and each entry is a few dozen bytes.
+static PROVIDER_DEPLOY_LOCKS: OnceLock<DeployLocks> = OnceLock::new();
+
+fn agent_deploy_lock(pubkey: &str) -> Result<Arc<tokio::sync::Mutex<()>>, String> {
+    let locks = PROVIDER_DEPLOY_LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let mut locks = locks.lock().map_err(|error| error.to_string())?;
+    Ok(locks.entry(pubkey.to_string()).or_default().clone())
+}
 
 pub(super) fn needs_reconciliation_with_policy(
     record: &ManagedAgentRecord,
@@ -18,35 +48,44 @@ pub(super) fn needs_reconciliation_with_policy(
     owner_only_access && record.backend != BackendKind::Local && record.backend_agent_id.is_some()
 }
 
+/// A provider deploy captured under the store lock: the coordinates the
+/// provider call will use plus the record generation (`updated_at`) the
+/// completion is bound to. Every deploy path (create, start, reconcile,
+/// redeploy) snapshots one of these under the per-agent deploy lock before
+/// releasing the store lock for the long-running provider call.
 #[derive(Debug)]
-struct ProviderAccessTarget {
-    pubkey: String,
-    provider_id: String,
-    config: serde_json::Value,
-    cached_binary_path: Option<String>,
-    agent_json: Result<serde_json::Value, String>,
+pub(super) struct CapturedDeploy {
+    pub(super) provider_id: String,
+    pub(super) config: serde_json::Value,
+    pub(super) cached_binary_path: Option<String>,
+    pub(super) updated_at: String,
 }
 
-fn collect_targets_with(
+/// Capture the provider coordinates and configuration generation of `record`
+/// for a deploy. Errors when the record is not provider-backed.
+fn capture_provider_deploy(record: &ManagedAgentRecord) -> Result<CapturedDeploy, String> {
+    match &record.backend {
+        BackendKind::Provider { id, config } => Ok(CapturedDeploy {
+            provider_id: id.clone(),
+            config: config.clone(),
+            cached_binary_path: record.provider_binary_path.clone(),
+            updated_at: record.updated_at.clone(),
+        }),
+        BackendKind::Local => Err(format!(
+            "agent {} is not provider-backed and cannot be deployed to a provider",
+            record.pubkey
+        )),
+    }
+}
+
+fn collect_reconcile_pubkeys(
     records: Vec<ManagedAgentRecord>,
     owner_only_access: bool,
-    mut build_payload: impl FnMut(&ManagedAgentRecord) -> Result<serde_json::Value, String>,
-) -> Vec<ProviderAccessTarget> {
+) -> Vec<String> {
     records
         .into_iter()
         .filter(|record| needs_reconciliation_with_policy(record, owner_only_access))
-        .map(|record| match record.backend.clone() {
-            BackendKind::Provider { id, config } => ProviderAccessTarget {
-                agent_json: build_payload(&record),
-                pubkey: record.pubkey,
-                provider_id: id,
-                config,
-                cached_binary_path: record.provider_binary_path,
-            },
-            BackendKind::Local => {
-                unreachable!("provider access reconciliation selected a local agent")
-            }
-        })
+        .map(|record| record.pubkey)
         .collect()
 }
 
@@ -55,6 +94,10 @@ fn collect_targets_with(
 /// The saved `backend_agent_id` only proves that some provider deployment
 /// exists. A marked build sends the current owner-only payload before each
 /// community UI load. Workspace apply fails closed if any provider rejects it.
+/// Only the pubkeys are collected here — each deploy snapshots its own
+/// payload and generation under the per-agent deploy lock, so a redeploy or
+/// edit racing this loop can never make an older payload land after a newer
+/// one.
 pub(crate) async fn reconcile_on_workspace_apply(
     app: &AppHandle,
     state: &AppState,
@@ -63,44 +106,16 @@ pub(crate) async fn reconcile_on_workspace_apply(
         return Ok(());
     }
 
-    let targets = {
+    let pubkeys = {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
             .map_err(|error| error.to_string())?;
-        collect_targets_with(load_managed_agents(app)?, true, |record| {
-            super::build_deploy_payload(app, state, record)
-        })
+        collect_reconcile_pubkeys(load_managed_agents(app)?, true)
     };
 
-    for target in targets {
-        let ProviderAccessTarget {
-            pubkey,
-            provider_id,
-            config,
-            cached_binary_path,
-            agent_json,
-        } = target;
-        let agent_json = match agent_json {
-            Ok(agent_json) => agent_json,
-            Err(error) => {
-                persist_failure(app, state, &pubkey, &error)?;
-                return Err(format!(
-                    "provider access reconciliation failed for agent {pubkey}: {error}"
-                ));
-            }
-        };
-        if let Err(error) = super::deploy_to_provider(
-            app,
-            state,
-            &pubkey,
-            &provider_id,
-            &config,
-            agent_json,
-            cached_binary_path.as_deref(),
-        )
-        .await
-        {
+    for pubkey in pubkeys {
+        if let Err(error) = deploy_to_provider(app, state, &pubkey).await {
             return Err(format!(
                 "provider access reconciliation failed for agent {pubkey}: {error}"
             ));
@@ -110,21 +125,65 @@ pub(crate) async fn reconcile_on_workspace_apply(
     Ok(())
 }
 
-fn persist_failure(
+/// Resolve the provider binary and run the blocking deploy call off the async
+/// runtime. The outer `Err` is an infrastructure failure (binary resolution or
+/// `spawn_blocking`) that never reached the provider; the inner result is the
+/// provider's own answer — `Ok(backend_agent_id)` or the provider error.
+async fn call_provider_deploy(
+    captured: &CapturedDeploy,
+    agent_json: serde_json::Value,
+) -> Result<Result<String, String>, String> {
+    let provider_id = &captured.provider_id;
+    // Resolve via discovered candidates only. Cached path must match BOTH
+    // "is a discovered candidate" AND "belongs to this provider_id". A tampered
+    // record cannot redirect deploys to a different provider's binary.
+    let bin_path = captured
+        .cached_binary_path
+        .as_deref()
+        .map(std::path::PathBuf::from)
+        .filter(|p| p.exists())
+        .map(|p| p.canonicalize().unwrap_or(p))
+        .filter(|canonical| {
+            discover_provider_candidates().iter().any(|(id, cp)| {
+                id == provider_id && cp.canonicalize().ok().as_ref() == Some(canonical)
+            })
+        })
+        .map_or_else(|| resolve_provider_binary(provider_id), Ok)?;
+
+    let config_clone = captured.config.clone();
+    tokio::task::spawn_blocking(move || provider_deploy(&bin_path, &agent_json, &config_clone))
+        .await
+        .map_err(|e| format!("spawn_blocking failed: {e}"))
+}
+
+/// Deploy an agent to a provider backend. Snapshots the record under the
+/// per-agent deploy lock, resolves the binary, calls deploy via
+/// spawn_blocking, and persists the result (backend_agent_id or last_error).
+///
+/// Idempotency: calling deploy on an already-deployed agent sends the same payload
+/// again. Providers are expected to handle this as an update-in-place or no-op —
+/// the protocol does not include an explicit `undeploy` operation (deferred to v2).
+///
+/// Serialization and completion binding are shared with the redeploy command
+/// via [`run_deploy`]: the payload and generation are snapshotted only after
+/// this call holds the agent's deploy lock (so a queued deploy always sends
+/// the latest saved configuration), and the result is bound through
+/// [`bind_completion`] — success is only reported as applied when the record
+/// still exists, still points at the captured provider, and was not edited
+/// while the call was in flight. Otherwise the honest [`CompletionOutcome`]
+/// is surfaced as the `Err` — never a claim that the current record was
+/// applied.
+pub(super) async fn deploy_to_provider(
     app: &AppHandle,
     state: &AppState,
     pubkey: &str,
-    error: &str,
-) -> Result<(), String> {
-    let _store_guard = state
-        .managed_agents_store_lock
-        .lock()
-        .map_err(|lock_error| lock_error.to_string())?;
-    let mut records = load_managed_agents(app)?;
-    let record = find_managed_agent_mut(&mut records, pubkey)?;
-    record.last_error = Some(error.to_string());
-    record.updated_at = now_iso();
-    save_managed_agents(app, &records)
+) -> Result<ManagedAgentSummary, String> {
+    let mut effects = CommandDeployEffects {
+        app,
+        state,
+        target: deploy_provider_target,
+    };
+    run_deploy(pubkey, &mut effects).await
 }
 
 #[cfg(test)]
@@ -146,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn upgrade_collects_existing_provider_and_builds_projected_payload() {
+    fn upgrade_collects_only_existing_provider_deployments() {
         let records = vec![
             record(
                 BackendKind::Provider {
@@ -165,18 +224,7 @@ mod tests {
             record(BackendKind::Local, Some("stale")),
         ];
 
-        let targets = collect_targets_with(records, true, |_| {
-            Ok(serde_json::json!({"respond_to": "owner-only"}))
-        });
-
-        assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].pubkey, "agent");
-        assert_eq!(targets[0].provider_id, "provider");
-        assert_eq!(targets[0].config["region"], "test");
-        assert_eq!(
-            targets[0].agent_json.as_ref().unwrap()["respond_to"],
-            "owner-only"
-        );
+        assert_eq!(collect_reconcile_pubkeys(records, true), vec!["agent"]);
     }
 
     #[test]
@@ -189,22 +237,16 @@ mod tests {
             Some("existing"),
         )];
 
-        assert!(
-            collect_targets_with(records, false, |_| { Ok(serde_json::Value::Null) }).is_empty()
-        );
+        assert!(collect_reconcile_pubkeys(records, false).is_empty());
     }
 }
 
 pub(super) fn redeploy_provider_target(
     pubkey: &str,
     record: &ManagedAgentRecord,
-) -> Result<(String, serde_json::Value, Option<String>), String> {
+) -> Result<CapturedDeploy, String> {
     match (&record.backend, record.backend_agent_id.as_deref()) {
-        (BackendKind::Provider { id, config }, Some(_)) => Ok((
-            id.clone(),
-            config.clone(),
-            record.provider_binary_path.clone(),
-        )),
+        (BackendKind::Provider { .. }, Some(_)) => capture_provider_deploy(record),
         (BackendKind::Provider { .. }, None) => Err(format!(
             "agent {pubkey} has not been deployed yet; deploy it before redeploying"
         )),
@@ -214,68 +256,256 @@ pub(super) fn redeploy_provider_target(
     }
 }
 
+/// Everything a deploy flow captures under the store lock before the
+/// provider call. `captured.updated_at` is the configuration generation the
+/// completion is bound to.
+pub(super) struct DeploySnapshot {
+    pub(super) record: ManagedAgentRecord,
+    pub(super) captured: CapturedDeploy,
+}
+
+/// How a finished provider call was bound to the store state found on
+/// completion. Computed by [`bind_completion`].
+#[derive(Debug)]
+pub(super) enum CompletionOutcome {
+    /// Record unchanged since the snapshot: success persisted as current.
+    AppliedCurrent(Box<ManagedAgentRecord>),
+    /// Record edited mid-flight: the remote facts are persisted
+    /// (`backend_agent_id`, `last_started_at`) because the deploy really
+    /// happened, but the running deployment carries the previously saved
+    /// configuration, so nothing may imply the current record was applied —
+    /// `last_error` is left untouched.
+    AppliedStale,
+    /// Record switched away from the captured provider backend mid-flight
+    /// (to local, or to a different provider): nothing persisted — the
+    /// deployment id belongs to a backend the record no longer describes.
+    BackendChanged,
+    /// Record deleted mid-flight: nothing persisted.
+    Deleted,
+    /// Provider call failed: the failure is stamped on the surviving record.
+    Failed(String),
+}
+
+/// Bind a finished provider call to whatever the store holds now. Mutates
+/// `records` in place; the returned bool says whether the caller must save.
+/// A successful deploy is only stamped onto a record that is still backed by
+/// the captured provider; otherwise the id would describe a foreign backend.
+pub(super) fn bind_completion(
+    records: &mut [ManagedAgentRecord],
+    pubkey: &str,
+    captured_provider_id: &str,
+    captured_updated_at: &str,
+    deploy_result: &Result<String, String>,
+) -> (bool, CompletionOutcome) {
+    let Some(record) = records.iter_mut().find(|record| record.pubkey == pubkey) else {
+        return (false, CompletionOutcome::Deleted);
+    };
+    match deploy_result {
+        Err(error) => {
+            record.last_error = Some(error.clone());
+            record.updated_at = now_iso();
+            (true, CompletionOutcome::Failed(error.clone()))
+        }
+        Ok(backend_agent_id) => {
+            let same_backend = matches!(
+                &record.backend,
+                BackendKind::Provider { id, .. } if id == captured_provider_id
+            );
+            if !same_backend {
+                return (false, CompletionOutcome::BackendChanged);
+            }
+            let unchanged = record.updated_at == captured_updated_at;
+            record.backend_agent_id = Some(backend_agent_id.clone());
+            record.last_started_at = Some(now_iso());
+            record.updated_at = now_iso();
+            if unchanged {
+                record.last_error = None;
+                (
+                    true,
+                    CompletionOutcome::AppliedCurrent(Box::new(record.clone())),
+                )
+            } else {
+                (true, CompletionOutcome::AppliedStale)
+            }
+        }
+    }
+}
+
+/// Fold a bound completion into the command result: the applied record on
+/// success-as-current, a user-facing error otherwise. Shared by the redeploy
+/// command and [`deploy_to_provider`] (create/start/reconcile) so every
+/// deploy path surfaces the same honest outcome. Error strings reach the
+/// owner verbatim in a toast, so they are short sentences without pubkeys.
+pub(super) fn completion_result(
+    outcome: CompletionOutcome,
+    deploy_result: Result<String, String>,
+) -> Result<Box<ManagedAgentRecord>, String> {
+    match outcome {
+        CompletionOutcome::AppliedCurrent(record) => Ok(record),
+        CompletionOutcome::AppliedStale => Err("Agent settings changed while the deploy was in \
+             flight, so the agent is running the previous configuration. Redeploy to apply the \
+             latest settings — a queued redeploy will do that automatically."
+            .to_string()),
+        CompletionOutcome::BackendChanged => Err("The agent's backend changed while the deploy \
+             was in flight. The finished deployment may still be running on the previous \
+             provider backend."
+            .to_string()),
+        CompletionOutcome::Deleted => Err(match deploy_result {
+            Ok(_) => "The agent was deleted while the deploy was in flight. The finished \
+                 deployment may still be running on the provider."
+                .to_string(),
+            Err(error) => error,
+        }),
+        CompletionOutcome::Failed(error) => Err(error),
+    }
+}
+
+/// Effects a deploy orchestration runs against. The real commands wire
+/// these to the on-disk store and the provider binary; tests wire an
+/// in-memory store and a gated fake provider so mid-flight edits and
+/// deletions can be driven deterministically.
+pub(super) trait DeployEffects {
+    type Success;
+
+    /// Under the store lock: load the record and validate it as a deploy
+    /// target.
+    fn snapshot(&mut self, pubkey: &str) -> Result<DeploySnapshot, String>;
+
+    /// The provider call (payload build + deploy). Must not touch the store.
+    async fn deploy(&mut self, snapshot: &DeploySnapshot) -> Result<String, String>;
+
+    /// Run `apply` on the loaded records under the store lock, saving when it
+    /// returns `true`.
+    fn with_store<R>(
+        &mut self,
+        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
+    ) -> Result<R, String>;
+
+    /// Build the success value from the freshly persisted record.
+    fn success(&mut self, record: &ManagedAgentRecord) -> Result<Self::Success, String>;
+}
+
+/// The deploy orchestration shared by every provider-deploy path (create,
+/// start, reconcile, redeploy): per-agent serialization, a snapshot taken
+/// only after the deploy lock is held, the provider call, and a completion
+/// bound to the captured configuration generation. All decision logic lives
+/// here and in [`bind_completion`]; the commands and the tests differ only in
+/// the [`DeployEffects`] they plug in.
+pub(super) async fn run_deploy<E: DeployEffects>(
+    pubkey: &str,
+    effects: &mut E,
+) -> Result<E::Success, String> {
+    let deploy_lock = agent_deploy_lock(pubkey)?;
+    let _deploy_guard = deploy_lock.lock().await;
+
+    let snapshot = effects.snapshot(pubkey)?;
+
+    let deploy_result = effects.deploy(&snapshot).await;
+
+    let outcome = effects.with_store(&mut |records| {
+        bind_completion(
+            records,
+            pubkey,
+            &snapshot.captured.provider_id,
+            &snapshot.captured.updated_at,
+            &deploy_result,
+        )
+    })?;
+
+    let record = completion_result(outcome, deploy_result)?;
+    effects.success(&record)
+}
+
+/// Validate `record` as a plain deploy target (create/start/reconcile): any
+/// provider-backed record qualifies, deployed before or not.
+fn deploy_provider_target(
+    _pubkey: &str,
+    record: &ManagedAgentRecord,
+) -> Result<CapturedDeploy, String> {
+    capture_provider_deploy(record)
+}
+
+/// [`DeployEffects`] wired to the real store, payload builder, and provider
+/// binary. `target` validates the record under the store lock —
+/// [`deploy_provider_target`] for first-time deploys,
+/// [`redeploy_provider_target`] for the redeploy command, which additionally
+/// requires an existing deployment.
+struct CommandDeployEffects<'a> {
+    app: &'a AppHandle,
+    state: &'a AppState,
+    target: fn(&str, &ManagedAgentRecord) -> Result<CapturedDeploy, String>,
+}
+
+impl DeployEffects for CommandDeployEffects<'_> {
+    type Success = ManagedAgentSummary;
+
+    fn snapshot(&mut self, pubkey: &str) -> Result<DeploySnapshot, String> {
+        let _store_guard = self
+            .state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let records = load_managed_agents(self.app)?;
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?;
+        let captured = (self.target)(pubkey, record)?;
+        Ok(DeploySnapshot {
+            record: record.clone(),
+            captured,
+        })
+    }
+
+    async fn deploy(&mut self, snapshot: &DeploySnapshot) -> Result<String, String> {
+        let agent_json = super::build_deploy_payload(self.app, self.state, &snapshot.record)?;
+        call_provider_deploy(&snapshot.captured, agent_json).await?
+    }
+
+    fn with_store<R>(
+        &mut self,
+        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
+    ) -> Result<R, String> {
+        let _store_guard = self
+            .state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let mut records = load_managed_agents(self.app)?;
+        let (save, result) = apply(&mut records);
+        if save {
+            save_managed_agents(self.app, &records)?;
+        }
+        Ok(result)
+    }
+
+    fn success(&mut self, record: &ManagedAgentRecord) -> Result<ManagedAgentSummary, String> {
+        let runtimes = self
+            .state
+            .managed_agent_processes
+            .lock()
+            .map_err(|error| error.to_string())?;
+        let personas = load_personas(self.app).unwrap_or_default();
+        build_managed_agent_summary(
+            self.app,
+            record,
+            &runtimes,
+            &personas,
+            &crate::managed_agents::load_global_agent_config(self.app).unwrap_or_default(),
+        )
+    }
+}
+
 #[tauri::command]
 pub async fn redeploy_managed_agent(
     pubkey: String,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ManagedAgentSummary, String> {
-    let (record, provider_id, config, cached_binary_path) = {
-        let _store_guard = state
-            .managed_agents_store_lock
-            .lock()
-            .map_err(|error| error.to_string())?;
-        let records = load_managed_agents(&app)?;
-        let record = records
-            .iter()
-            .find(|record| record.pubkey == pubkey)
-            .ok_or_else(|| format!("agent {pubkey} not found"))?;
-        let (provider_id, config, cached_binary_path) = redeploy_provider_target(&pubkey, record)?;
-        (record.clone(), provider_id, config, cached_binary_path)
+    let mut effects = CommandDeployEffects {
+        app: &app,
+        state: &state,
+        target: redeploy_provider_target,
     };
-
-    let agent_json = match super::build_deploy_payload(&app, &state, &record) {
-        Ok(agent_json) => agent_json,
-        Err(error) => {
-            persist_failure(&app, &state, &pubkey, &error)?;
-            return Err(error);
-        }
-    };
-
-    if let Err(error) = super::deploy_to_provider(
-        &app,
-        &state,
-        &pubkey,
-        &provider_id,
-        &config,
-        agent_json,
-        cached_binary_path.as_deref(),
-    )
-    .await
-    {
-        persist_failure(&app, &state, &pubkey, &error)?;
-        return Err(error);
-    }
-
-    let _store_guard = state
-        .managed_agents_store_lock
-        .lock()
-        .map_err(|error| error.to_string())?;
-    let records = load_managed_agents(&app)?;
-    let runtimes = state
-        .managed_agent_processes
-        .lock()
-        .map_err(|error| error.to_string())?;
-    let record = records
-        .iter()
-        .find(|record| record.pubkey == pubkey)
-        .ok_or_else(|| format!("agent {pubkey} not found"))?;
-    let personas = load_personas(&app).unwrap_or_default();
-    build_managed_agent_summary(
-        &app,
-        record,
-        &runtimes,
-        &personas,
-        &crate::managed_agents::load_global_agent_config(&app).unwrap_or_default(),
-    )
+    run_deploy(&pubkey, &mut effects).await
 }

--- a/desktop/src-tauri/src/commands/agents/provider_access.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access.rs
@@ -17,8 +17,10 @@ use crate::{
     util::now_iso,
 };
 
+pub(super) mod deploy_receipt;
 pub(super) mod payload_digest;
 
+use deploy_receipt::AmbiguousDeployReceipt;
 use payload_digest::{deploy_input_digest, digest_parts};
 
 type DeployLocks = StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>;
@@ -293,6 +295,20 @@ pub(super) struct DeploySnapshot {
     pub(super) payload: serde_json::Value,
 }
 
+/// What one store transaction did: the value `apply` returned, whether a save
+/// was performed, and the error if the save was attempted and failed.
+///
+/// A failed save is *not* folded into the outer `Err`, because when the
+/// provider call already succeeded the difference matters: the outer `Err` is
+/// "nothing happened", while a save error is "something happened remotely and
+/// this app did not record it" — the ambiguous-success case that owes a
+/// durable receipt.
+pub(super) struct StoreOutcome<R> {
+    pub(super) result: R,
+    pub(super) saved: bool,
+    pub(super) save_error: Option<String>,
+}
+
 /// How a finished provider call was bound to the store state found on
 /// completion. Computed by [`bind_completion`].
 #[derive(Debug)]
@@ -488,7 +504,18 @@ pub(super) trait DeployEffects {
     /// returns `true`. `apply`'s second argument re-resolves a record's full
     /// deploy input digest, so the completion can compare inputs that live
     /// outside the agent row.
-    fn with_store<R>(&mut self, apply: &mut CompletionApply<'_, R>) -> Result<R, String>;
+    fn with_store<R>(
+        &mut self,
+        apply: &mut CompletionApply<'_, R>,
+    ) -> Result<StoreOutcome<R>, String>;
+
+    /// Persist a durable record of a deploy the provider accepted and the
+    /// store failed to save.
+    fn record_ambiguous_success(&mut self, receipt: &AmbiguousDeployReceipt) -> Result<(), String>;
+
+    /// Drop any ambiguous-success receipt for `pubkey`: the store has just
+    /// recorded a known outcome for this agent, so the ambiguity is resolved.
+    fn clear_ambiguous_success(&mut self, pubkey: &str);
 
     /// Build the success value from the freshly persisted record.
     fn success(&mut self, record: &ManagedAgentRecord) -> Result<Self::Success, String>;
@@ -512,12 +539,78 @@ pub(super) async fn run_deploy<E: DeployEffects>(
     let deploy_result = effects.deploy(&snapshot).await;
 
     let captured = &snapshot.captured;
-    let outcome = effects.with_store(&mut |records, resolve_digest| {
+    let store = effects.with_store(&mut |records, resolve_digest| {
         bind_completion(records, pubkey, captured, resolve_digest, &deploy_result)
     })?;
+    let StoreOutcome {
+        result: outcome,
+        saved,
+        save_error,
+    } = store;
+
+    if let Some(save_error) = save_error {
+        return Err(unrecorded_completion(
+            effects,
+            pubkey,
+            captured,
+            &deploy_result,
+            save_error,
+        ));
+    }
+    if saved {
+        effects.clear_ambiguous_success(pubkey);
+    }
 
     let record = completion_result(outcome, deploy_result)?;
     effects.success(&record)
+}
+
+/// The store write that should have recorded a finished provider call failed.
+///
+/// When the provider call *also* failed, the only thing lost is a local
+/// `last_error` stamp and the provider's error is what the owner needs, so it
+/// is surfaced with the save failure appended. When the provider call
+/// succeeded, this is the ambiguous-success case: something is running (or
+/// converging) remotely that this app has no record of asking for, so a
+/// durable receipt is written before the error is returned. Returns the
+/// message for the owner.
+fn unrecorded_completion<E: DeployEffects>(
+    effects: &mut E,
+    pubkey: &str,
+    captured: &CapturedDeploy,
+    deploy_result: &Result<String, String>,
+    save_error: String,
+) -> String {
+    let backend_agent_id = match deploy_result {
+        Err(error) => {
+            return format!("{error} (and the result could not be saved: {save_error})");
+        }
+        Ok(backend_agent_id) => backend_agent_id.clone(),
+    };
+
+    let receipt = AmbiguousDeployReceipt {
+        pubkey: pubkey.to_string(),
+        provider_id: captured.provider_id.clone(),
+        backend_agent_id,
+        payload_digest: captured.payload_digest.clone(),
+        captured_updated_at: captured.updated_at.clone(),
+        save_error: save_error.clone(),
+        observed_at: now_iso(),
+    };
+    match effects.record_ambiguous_success(&receipt) {
+        Ok(()) => format!(
+            "The provider accepted the deploy but Buzz could not save the result: {save_error}. \
+             The agent may be deployed with the settings that were just sent while this app's \
+             record does not show it — a receipt of what was sent was saved so it can be \
+             reconciled later."
+        ),
+        Err(receipt_error) => format!(
+            "The provider accepted the deploy but Buzz could not save the result: {save_error}. \
+             The agent may be deployed with the settings that were just sent while this app's \
+             record does not show it, and the receipt of what was sent could not be saved \
+             either: {receipt_error}"
+        ),
+    }
 }
 
 /// Validate `record` as a plain deploy target (create/start/reconcile): any
@@ -555,6 +648,23 @@ impl DeployEffects for CommandDeployEffects<'_> {
             .iter()
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| format!("agent {pubkey} not found"))?;
+        // Read side of the ambiguous-success receipt: a deploy for an agent
+        // whose last one was never recorded says so in the app log, where it
+        // is legible next to whatever this deploy goes on to do.
+        for receipt in deploy_receipt::read_deploy_receipts(self.app)
+            .iter()
+            .filter(|receipt| receipt.pubkey == pubkey)
+        {
+            eprintln!(
+                "buzz-desktop: agent {pubkey} has an unrecorded deploy from {} (provider {}, \
+                 deployment {}, input digest {}) — the provider may be running it; this deploy \
+                 supersedes it",
+                receipt.observed_at,
+                receipt.provider_id,
+                receipt.backend_agent_id,
+                receipt.payload_digest
+            );
+        }
         let payload = super::build_deploy_payload(self.app, self.state, record)?;
         let captured = (self.target)(pubkey, record, &payload)?;
         Ok(DeploySnapshot { captured, payload })
@@ -564,7 +674,10 @@ impl DeployEffects for CommandDeployEffects<'_> {
         call_provider_deploy(&snapshot.captured, snapshot.payload.clone()).await?
     }
 
-    fn with_store<R>(&mut self, apply: &mut CompletionApply<'_, R>) -> Result<R, String> {
+    fn with_store<R>(
+        &mut self,
+        apply: &mut CompletionApply<'_, R>,
+    ) -> Result<StoreOutcome<R>, String> {
         let _store_guard = self
             .state
             .managed_agents_store_lock
@@ -582,10 +695,24 @@ impl DeployEffects for CommandDeployEffects<'_> {
             deploy_input_digest(record, &payload)
         };
         let (save, result) = apply(&mut records, &resolve_digest);
-        if save {
-            save_managed_agents(self.app, &records)?;
-        }
-        Ok(result)
+        let save_error = if save {
+            save_managed_agents(self.app, &records).err()
+        } else {
+            None
+        };
+        Ok(StoreOutcome {
+            result,
+            saved: save && save_error.is_none(),
+            save_error,
+        })
+    }
+
+    fn record_ambiguous_success(&mut self, receipt: &AmbiguousDeployReceipt) -> Result<(), String> {
+        deploy_receipt::write_deploy_receipt(self.app, receipt)
+    }
+
+    fn clear_ambiguous_success(&mut self, pubkey: &str) {
+        deploy_receipt::clear_deploy_receipt(self.app, pubkey);
     }
 
     fn success(&mut self, record: &ManagedAgentRecord) -> Result<ManagedAgentSummary, String> {

--- a/desktop/src-tauri/src/commands/agents/provider_access/deploy_receipt.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access/deploy_receipt.rs
@@ -17,18 +17,36 @@
 //! ([`read_deploy_receipts`]) can then say precisely: the provider may be
 //! running the input with this digest, and the store does not reflect it.
 //!
-//! The receipt is cleared by the next completion for that agent that *does*
-//! save, because at that point the store records a known outcome again.
+//! The receipt is cleared only by the next provider *success* for that agent
+//! that the store also records: that deploy superseded the ambiguous one
+//! remotely and left a local record of doing so. A later attempt that fails at
+//! the provider does neither, however cleanly its `last_error` saves — the
+//! earlier deployment may still be running — so it leaves the receipt alone.
 //!
 //! Receipts hold no secrets: the digest is a hash, and no payload field is
 //! copied into them.
+//!
+//! Both ends of the I/O keep their own no-follow boundary — see
+//! [`write_receipt_file`] and [`read_receipt_file`]. A receipt is evidence
+//! about a deployment, so neither side may be redirected by a symlink dropped
+//! into the directory, and the reader treats every file it finds there as
+//! untrusted input with a size and a count bound.
 
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
-use crate::managed_agents::{atomic_write_json_restricted, managed_agents_base_dir};
+use crate::managed_agents::managed_agents_base_dir;
+
+/// Largest file this reader will accept as a receipt. A receipt is a handful
+/// of short strings, so this is generous by orders of magnitude and still
+/// bounds what one unreadable file can cost.
+const MAX_RECEIPT_BYTES: u64 = 64 * 1024;
+
+/// Most receipt files one read will open. There is one per agent, so this is
+/// far above any real store; past it the directory is not this directory.
+const MAX_RECEIPT_FILES: usize = 256;
 
 /// A deploy the provider accepted and the store failed to record.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,7 +102,9 @@ pub(in crate::commands::agents) fn write_deploy_receipt(
 
 /// Drop the receipt for `pubkey`, if any. Best-effort: a receipt that outlives
 /// its ambiguity is noise, but failing a save-succeeded path over it would be
-/// worse.
+/// worse. Callers must have observed a saved provider success first — see the
+/// module docs. `remove_file` unlinks the entry itself, so a symlink here
+/// costs its link and never its target.
 pub(in crate::commands::agents) fn clear_deploy_receipt(app: &AppHandle, pubkey: &str) {
     if let Ok(dir) = receipts_dir(app) {
         clear_deploy_receipt_in(&dir, pubkey);
@@ -110,7 +130,67 @@ pub(in crate::commands::agents) fn write_deploy_receipt_in(
     let path = dir.join(receipt_filename(&receipt.pubkey)?);
     let payload = serde_json::to_vec(receipt)
         .map_err(|error| format!("failed to serialize deploy receipt: {error}"))?;
-    atomic_write_json_restricted(&path, &payload)
+    write_receipt_file(&path, &payload)
+}
+
+/// Write `payload` to `path` atomically, `0o600`, without following a symlink
+/// at `path`.
+///
+/// Deliberately not [`crate::managed_agents::atomic_write_json_restricted`]:
+/// that canonicalizes the final path first, which is right for the agent store
+/// — dev worktrees legitimately symlink it into the shared dev data dir — and
+/// wrong here. The dev sync shares data files only, never per-run state like
+/// `agent-pids/`, so a symlink in this directory is not a configuration, it is
+/// a way to make Buzz write receipt contents somewhere of another party's
+/// choosing.
+///
+/// The temp file is created `O_EXCL`, which never follows a link, and renamed
+/// over `path`; rename replaces the link entry itself rather than writing
+/// through it. Replacing beats rejecting: refusing to write would let anyone
+/// who can drop a symlink into this directory suppress the very evidence the
+/// receipt exists to preserve.
+fn write_receipt_file(path: &Path, payload: &[u8]) -> Result<(), String> {
+    use std::io::Write as _;
+
+    let tmp = path.with_extension("json.tmp");
+    // A temp file left by an interrupted write is stale by definition, and
+    // removing it unlinks that entry (never a link's target) so the O_EXCL
+    // create below cannot be blocked forever by one.
+    let _ = std::fs::remove_file(&tmp);
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&tmp).map_err(|error| {
+        format!(
+            "failed to open {} for a deploy receipt: {error}",
+            tmp.display()
+        )
+    })?;
+    file.write_all(payload)
+        .map_err(|error| format!("failed to write {}: {error}", tmp.display()))?;
+    // The bytes must reach the disk before the rename publishes them. A receipt
+    // exists to survive the failure that lost the store write — often the same
+    // crash or full disk — so a rename that lands ahead of its own contents
+    // would leave exactly the empty evidence this file exists to prevent.
+    // `atomic_write_json_restricted` got this from `AtomicWriteFile::commit`;
+    // doing the write by hand means doing it here.
+    file.sync_all()
+        .map_err(|error| format!("failed to flush {}: {error}", tmp.display()))?;
+    drop(file);
+
+    std::fs::rename(&tmp, path).map_err(|error| {
+        let _ = std::fs::remove_file(&tmp);
+        format!(
+            "failed to move {} onto {}: {error}",
+            tmp.display(),
+            path.display()
+        )
+    })
 }
 
 pub(in crate::commands::agents) fn clear_deploy_receipt_in(dir: &Path, pubkey: &str) {
@@ -128,10 +208,53 @@ pub(in crate::commands::agents) fn read_deploy_receipts_in(
     let mut receipts: Vec<AmbiguousDeployReceipt> = entries
         .flatten()
         .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
-        .filter_map(|entry| serde_json::from_slice(&std::fs::read(entry.path()).ok()?).ok())
+        // The directory's own idea of the entry's type, which costs no syscall
+        // on whatever a link points at.
+        .filter(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
+        .take(MAX_RECEIPT_FILES)
+        .filter_map(|entry| read_receipt_file(&entry.path()))
         .collect();
     receipts.sort_by(|left, right| right.observed_at.cmp(&left.observed_at));
     receipts
+}
+
+/// Read one receipt through a single descriptor.
+///
+/// The open refuses a symlink outright, and every check after it — regular
+/// file, size — is made with `fstat` against the descriptor that is then read,
+/// so nothing can swap the path between the check and the read. The read is
+/// capped as well as the check, so a file that grows in between is truncated
+/// rather than followed to whatever it becomes. Anything that fails a check is
+/// skipped: this is a best-effort report, and one unreadable file must not
+/// hide the rest.
+fn read_receipt_file(path: &Path) -> Option<AmbiguousDeployReceipt> {
+    use std::io::Read as _;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        // Opens a reparse point itself instead of its target, and is ignored
+        // for files that are not one — so the `is_file` check below rejects a
+        // link rather than reading through it.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+
+    let file = options.open(path).ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.is_file() || metadata.len() > MAX_RECEIPT_BYTES {
+        return None;
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_RECEIPT_BYTES).read_to_end(&mut bytes).ok()?;
+    serde_json::from_slice(&bytes).ok()
 }
 
 #[cfg(test)]
@@ -202,6 +325,100 @@ mod tests {
         // Clearing an agent with no receipt is a no-op, not an error.
         clear_deploy_receipt_in(dir.path(), "agent3");
         assert_eq!(read_deploy_receipts_in(dir.path()).len(), 1);
+    }
+
+    /// The write must land on the receipt path itself. A symlink there is
+    /// replaced, and the file it pointed at is left byte-for-byte alone — a
+    /// receipt write is never a write to a path someone else chose.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_receipt_path_is_replaced_and_its_target_left_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let target = elsewhere.path().join("victim.json");
+        std::fs::write(&target, b"original").expect("seed the symlink target");
+        let link = dir.path().join("agent1.json");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        write_deploy_receipt_in(dir.path(), &receipt("agent1", "2026-01-01T00:00:00Z"))
+            .expect("write");
+
+        assert_eq!(
+            std::fs::read(&target).expect("read the symlink target"),
+            b"original",
+            "the write followed the symlink and overwrote its target"
+        );
+        assert!(
+            !std::fs::symlink_metadata(&link)
+                .expect("receipt path")
+                .file_type()
+                .is_symlink(),
+            "the symlink survived the write, so the next one goes through it"
+        );
+        // And the receipt really was written, at the real path.
+        assert_eq!(
+            read_deploy_receipts_in(dir.path()),
+            vec![receipt("agent1", "2026-01-01T00:00:00Z")]
+        );
+    }
+
+    /// The reader's side of the same boundary: a symlink is skipped even when
+    /// it points at a well-formed receipt, and reading does not touch it.
+    #[cfg(unix)]
+    #[test]
+    fn the_reader_skips_a_symlink_pointing_at_a_valid_receipt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let planted = elsewhere.path().join("planted.json");
+        let bytes = serde_json::to_vec(&receipt("agent2", "2026-01-02T00:00:00Z"))
+            .expect("serialize a receipt");
+        std::fs::write(&planted, &bytes).expect("seed the symlink target");
+        let link = dir.path().join("agent2.json");
+        std::os::unix::fs::symlink(&planted, &link).expect("symlink");
+
+        assert!(
+            read_deploy_receipts_in(dir.path()).is_empty(),
+            "the reader followed a symlink out of the receipts directory"
+        );
+        assert_eq!(
+            std::fs::read(&planted).expect("read the symlink target"),
+            bytes,
+            "the reader changed the symlink target"
+        );
+    }
+
+    /// Receipts are a few hundred bytes. A file too big to be one is not read
+    /// into memory to find that out.
+    #[test]
+    fn a_file_too_large_to_be_a_receipt_is_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut bloated = receipt("agent1", "2026-01-01T00:00:00Z");
+        bloated.save_error = "x".repeat(MAX_RECEIPT_BYTES as usize);
+        std::fs::write(
+            dir.path().join("agent1.json"),
+            serde_json::to_vec(&bloated).expect("serialize"),
+        )
+        .expect("write");
+
+        assert!(
+            read_deploy_receipts_in(dir.path()).is_empty(),
+            "an oversized file was read as a receipt"
+        );
+    }
+
+    /// One read opens a bounded number of files, whatever the directory holds.
+    #[test]
+    fn the_reader_stops_at_the_file_cap() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for index in 0..MAX_RECEIPT_FILES + 8 {
+            write_deploy_receipt_in(
+                dir.path(),
+                &receipt(&format!("agent-{index}"), "2026-01-01T00:00:00Z"),
+            )
+            .expect("write");
+        }
+
+        assert_eq!(read_deploy_receipts_in(dir.path()).len(), MAX_RECEIPT_FILES);
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agents/provider_access/deploy_receipt.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access/deploy_receipt.rs
@@ -1,0 +1,218 @@
+//! Durable receipts for deploys whose outcome the store did not record.
+//!
+//! A provider call and the store write that records it are two steps, and the
+//! second can fail: the disk fills, the keyring goes away mid-save, the file is
+//! replaced under us. When the *first* step succeeded, dropping the error on
+//! the floor leaves the worst possible state — a provider that may be running
+//! a configuration this app has no record of sending, and no way for a later
+//! reader to know.
+//!
+//! So that case writes a receipt: one `0o600` JSON file per agent under
+//! `agents/deploy-receipts/`, written atomically, mirroring the runtime
+//! receipts in [`crate::managed_agents::storage`]
+//! ([`crate::managed_agents::write_agent_runtime_receipt`]). It records what
+//! the provider accepted — the provider id, the returned deployment id, the
+//! digest of the fully resolved deploy input, and the record generation it was
+//! captured from — plus the store error that lost it. A later reader
+//! ([`read_deploy_receipts`]) can then say precisely: the provider may be
+//! running the input with this digest, and the store does not reflect it.
+//!
+//! The receipt is cleared by the next completion for that agent that *does*
+//! save, because at that point the store records a known outcome again.
+//!
+//! Receipts hold no secrets: the digest is a hash, and no payload field is
+//! copied into them.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+
+use crate::managed_agents::{atomic_write_json_restricted, managed_agents_base_dir};
+
+/// A deploy the provider accepted and the store failed to record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::commands::agents) struct AmbiguousDeployReceipt {
+    pub pubkey: String,
+    /// Provider the deploy was sent to.
+    pub provider_id: String,
+    /// The deployment id the provider returned — the value that never reached
+    /// the store.
+    pub backend_agent_id: String,
+    /// Digest of the fully resolved deploy input the provider accepted
+    /// (see [`super::payload_digest`]).
+    pub payload_digest: String,
+    /// The `updated_at` generation the deploy was captured from.
+    pub captured_updated_at: String,
+    /// Why the store write failed.
+    pub save_error: String,
+    pub observed_at: String,
+}
+
+fn receipts_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = managed_agents_base_dir(app)?.join("deploy-receipts");
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| format!("failed to create deploy-receipts dir: {error}"))?;
+    Ok(dir)
+}
+
+/// Filename for `pubkey`, or an error for one that must not become a path.
+/// Rejecting beats sanitizing: a rewritten pubkey could collide with another
+/// agent's receipt, and a receipt filed under the wrong agent is worse than no
+/// receipt at all.
+fn receipt_filename(pubkey: &str) -> Result<String, String> {
+    let safe = !pubkey.is_empty()
+        && pubkey
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if !safe {
+        return Err(format!(
+            "unsafe agent pubkey for a receipt filename: {pubkey}"
+        ));
+    }
+    Ok(format!("{pubkey}.json"))
+}
+
+/// Persist `receipt`, replacing any earlier one for the same agent.
+pub(in crate::commands::agents) fn write_deploy_receipt(
+    app: &AppHandle,
+    receipt: &AmbiguousDeployReceipt,
+) -> Result<(), String> {
+    write_deploy_receipt_in(&receipts_dir(app)?, receipt)
+}
+
+/// Drop the receipt for `pubkey`, if any. Best-effort: a receipt that outlives
+/// its ambiguity is noise, but failing a save-succeeded path over it would be
+/// worse.
+pub(in crate::commands::agents) fn clear_deploy_receipt(app: &AppHandle, pubkey: &str) {
+    if let Ok(dir) = receipts_dir(app) {
+        clear_deploy_receipt_in(&dir, pubkey);
+    }
+}
+
+/// Every receipt currently on disk, newest-first by `observed_at`. The reader
+/// side of the contract: a non-empty result means at least one provider may be
+/// running a configuration the store never recorded.
+pub(in crate::commands::agents) fn read_deploy_receipts(
+    app: &AppHandle,
+) -> Vec<AmbiguousDeployReceipt> {
+    match receipts_dir(app) {
+        Ok(dir) => read_deploy_receipts_in(&dir),
+        Err(_) => Vec::new(),
+    }
+}
+
+pub(in crate::commands::agents) fn write_deploy_receipt_in(
+    dir: &Path,
+    receipt: &AmbiguousDeployReceipt,
+) -> Result<(), String> {
+    let path = dir.join(receipt_filename(&receipt.pubkey)?);
+    let payload = serde_json::to_vec(receipt)
+        .map_err(|error| format!("failed to serialize deploy receipt: {error}"))?;
+    atomic_write_json_restricted(&path, &payload)
+}
+
+pub(in crate::commands::agents) fn clear_deploy_receipt_in(dir: &Path, pubkey: &str) {
+    if let Ok(name) = receipt_filename(pubkey) {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+}
+
+pub(in crate::commands::agents) fn read_deploy_receipts_in(
+    dir: &Path,
+) -> Vec<AmbiguousDeployReceipt> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut receipts: Vec<AmbiguousDeployReceipt> = entries
+        .flatten()
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
+        .filter_map(|entry| serde_json::from_slice(&std::fs::read(entry.path()).ok()?).ok())
+        .collect();
+    receipts.sort_by(|left, right| right.observed_at.cmp(&left.observed_at));
+    receipts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn receipt(pubkey: &str, observed_at: &str) -> AmbiguousDeployReceipt {
+        AmbiguousDeployReceipt {
+            pubkey: pubkey.to_string(),
+            provider_id: "kubernetes".to_string(),
+            backend_agent_id: "buzz-agent-abc".to_string(),
+            payload_digest: "d".repeat(64),
+            captured_updated_at: "t1".to_string(),
+            save_error: "disk full".to_string(),
+            observed_at: observed_at.to_string(),
+        }
+    }
+
+    /// The whole point of the receipt: a later reader learns what the provider
+    /// accepted and that the store does not reflect it.
+    #[test]
+    fn a_written_receipt_reads_back_intact() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_deploy_receipt_in(dir.path(), &receipt("agent1", "2026-01-01T00:00:00Z"))
+            .expect("write");
+
+        let read = read_deploy_receipts_in(dir.path());
+        assert_eq!(read, vec![receipt("agent1", "2026-01-01T00:00:00Z")]);
+        assert_eq!(read[0].payload_digest.len(), 64);
+    }
+
+    #[test]
+    fn a_second_receipt_replaces_the_first_for_the_same_agent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_deploy_receipt_in(dir.path(), &receipt("agent1", "2026-01-01T00:00:00Z"))
+            .expect("write");
+        let mut newer = receipt("agent1", "2026-01-02T00:00:00Z");
+        newer.backend_agent_id = "buzz-agent-def".into();
+        write_deploy_receipt_in(dir.path(), &newer).expect("write");
+
+        assert_eq!(read_deploy_receipts_in(dir.path()), vec![newer]);
+    }
+
+    #[test]
+    fn receipts_are_returned_newest_first_and_cleared_per_agent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_deploy_receipt_in(dir.path(), &receipt("agent1", "2026-01-01T00:00:00Z"))
+            .expect("write");
+        write_deploy_receipt_in(dir.path(), &receipt("agent2", "2026-01-03T00:00:00Z"))
+            .expect("write");
+
+        let read = read_deploy_receipts_in(dir.path());
+        assert_eq!(
+            read.iter().map(|r| r.pubkey.as_str()).collect::<Vec<_>>(),
+            vec!["agent2", "agent1"]
+        );
+
+        clear_deploy_receipt_in(dir.path(), "agent2");
+        assert_eq!(
+            read_deploy_receipts_in(dir.path())
+                .iter()
+                .map(|r| r.pubkey.as_str())
+                .collect::<Vec<_>>(),
+            vec!["agent1"],
+            "clearing one agent's receipt removed another's"
+        );
+
+        // Clearing an agent with no receipt is a no-op, not an error.
+        clear_deploy_receipt_in(dir.path(), "agent3");
+        assert_eq!(read_deploy_receipts_in(dir.path()).len(), 1);
+    }
+
+    #[test]
+    fn a_pubkey_that_could_escape_the_directory_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for pubkey in ["../escape", "a/b", "", "with space", "dot.dot"] {
+            assert!(
+                write_deploy_receipt_in(dir.path(), &receipt(pubkey, "t")).is_err(),
+                "accepted an unsafe receipt filename: {pubkey}"
+            );
+        }
+        assert!(read_deploy_receipts_in(dir.path()).is_empty());
+    }
+}

--- a/desktop/src-tauri/src/commands/agents/provider_access/payload_digest.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access/payload_digest.rs
@@ -1,0 +1,191 @@
+//! A stable digest over everything a provider deploy sends.
+//!
+//! A deploy's inputs are wider than the agent row it is keyed on: the payload
+//! is re-resolved from the live persona, the team, the global agent config,
+//! the effective harness descriptor, the workspace relay URL and the owner
+//! pubkey (see [`crate::commands::agents::build_deploy_payload`]), and the
+//! provider config travels beside it. Any of those can move without touching
+//! `record.updated_at`, so a completion bound to `updated_at` alone can stamp
+//! a stale deploy as current. Binding to a digest of the *fully resolved*
+//! inputs closes that: re-resolve on completion and compare.
+//!
+//! The digest covers the provider id, the provider config, and the agent
+//! payload — the whole of what [`crate::managed_agents::provider_deploy`]
+//! puts on the wire.
+//!
+//! Canonicalization: object keys are sorted recursively before serialization,
+//! so the digest does not depend on `serde_json`'s map implementation (the
+//! `preserve_order` feature swaps `BTreeMap` for insertion order) nor on the
+//! order the payload builder happens to insert keys in. Arrays keep their
+//! order — it is meaningful (`agent_args`, allowlists).
+//!
+//! The payload carries secrets (the agent nsec, env vars). The digest is a
+//! SHA-256 over a document containing a 256-bit private key, so it is not a
+//! guessing oracle, but it is still never logged or published — it lives in
+//! memory for the length of a deploy and, on the ambiguous-success path only,
+//! in a `0o600` receipt beside the store that holds those secrets in the
+//! clear anyway.
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::managed_agents::{BackendKind, ManagedAgentRecord};
+
+/// Digest the complete deploy input for `record` with its resolved `payload`.
+///
+/// Errors when the record is not provider-backed: there is no provider call to
+/// digest, and silently digesting a local record would let a completion
+/// compare two things that were never sent.
+pub(in crate::commands::agents) fn deploy_input_digest(
+    record: &ManagedAgentRecord,
+    payload: &Value,
+) -> Result<String, String> {
+    let BackendKind::Provider { id, config } = &record.backend else {
+        return Err(format!(
+            "agent {} is not provider-backed, so it has no deploy input to digest",
+            record.pubkey
+        ));
+    };
+    digest_parts(id, config, payload)
+}
+
+/// The digest of one deploy's three wire inputs. Split out so the snapshot can
+/// digest exactly the provider id and config it captured, rather than
+/// re-reading them from a record that may have moved on.
+pub(in crate::commands::agents) fn digest_parts(
+    provider_id: &str,
+    provider_config: &Value,
+    payload: &Value,
+) -> Result<String, String> {
+    let document = serde_json::json!({
+        "provider": provider_id,
+        "provider_config": provider_config,
+        "agent": payload,
+    });
+    let bytes = serde_json::to_vec(&canonical(&document))
+        .map_err(|error| format!("failed to serialize the deploy payload for hashing: {error}"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Rebuild `value` with every object's keys in sorted order.
+fn canonical(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut sorted: Vec<(&String, &Value)> = map.iter().collect();
+            sorted.sort_unstable_by(|left, right| left.0.cmp(right.0));
+            Value::Object(
+                sorted
+                    .into_iter()
+                    .map(|(key, entry)| (key.clone(), canonical(entry)))
+                    .collect::<Map<String, Value>>(),
+            )
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonical).collect()),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(model: &str) -> Value {
+        serde_json::json!({
+            "name": "agent",
+            "model": model,
+            "env_vars": {"B": "2", "A": "1"},
+            "launch": {"args": ["acp", "--x"], "policy_env": {"Z": "z", "Y": "y"}},
+        })
+    }
+
+    #[test]
+    fn key_order_does_not_change_the_digest() {
+        // The same document with every object's keys inserted in the opposite
+        // order. Under `preserve_order` these serialize differently; the
+        // digest must not notice.
+        let reordered = serde_json::json!({
+            "launch": {"policy_env": {"Y": "y", "Z": "z"}, "args": ["acp", "--x"]},
+            "env_vars": {"A": "1", "B": "2"},
+            "model": "m",
+            "name": "agent",
+        });
+
+        assert_eq!(
+            digest_parts(
+                "provider",
+                &serde_json::json!({"region": "a"}),
+                &payload("m")
+            )
+            .unwrap(),
+            digest_parts("provider", &serde_json::json!({"region": "a"}), &reordered).unwrap(),
+        );
+    }
+
+    #[test]
+    fn array_order_does_change_the_digest() {
+        let swapped = serde_json::json!({
+            "name": "agent",
+            "model": "m",
+            "env_vars": {"B": "2", "A": "1"},
+            "launch": {"args": ["--x", "acp"], "policy_env": {"Z": "z", "Y": "y"}},
+        });
+
+        assert_ne!(
+            digest_parts("provider", &Value::Null, &payload("m")).unwrap(),
+            digest_parts("provider", &Value::Null, &swapped).unwrap(),
+            "argv order is meaningful and must not be canonicalized away"
+        );
+    }
+
+    /// Each of the three wire inputs moves the digest on its own — a digest
+    /// blind to the provider config would let a namespace or image change be
+    /// stamped as applied.
+    #[test]
+    fn every_wire_input_moves_the_digest() {
+        let base = digest_parts(
+            "provider",
+            &serde_json::json!({"region": "a"}),
+            &payload("m"),
+        )
+        .expect("digest");
+
+        for (provider, config, resolved) in [
+            ("other", serde_json::json!({"region": "a"}), payload("m")),
+            ("provider", serde_json::json!({"region": "b"}), payload("m")),
+            (
+                "provider",
+                serde_json::json!({"region": "a"}),
+                payload("m2"),
+            ),
+        ] {
+            assert_ne!(
+                base,
+                digest_parts(provider, &config, &resolved).expect("digest"),
+                "a changed wire input left the digest unmoved"
+            );
+        }
+    }
+
+    #[test]
+    fn digest_is_stable_across_calls() {
+        let once = digest_parts("provider", &serde_json::json!({}), &payload("m")).unwrap();
+        let twice = digest_parts("provider", &serde_json::json!({}), &payload("m")).unwrap();
+        assert_eq!(once, twice);
+        assert_eq!(once.len(), 64, "expected a hex sha256");
+    }
+
+    #[test]
+    fn a_local_record_has_no_deploy_input() {
+        let mut record: ManagedAgentRecord = serde_json::from_value(serde_json::json!({
+            "pubkey": "agent", "name": "Agent", "relay_url": "", "acp_command": "",
+            "agent_command": "", "agent_args": [], "mcp_command": "",
+            "turn_timeout_seconds": 0, "created_at": "", "updated_at": ""
+        }))
+        .expect("record");
+        record.backend = BackendKind::Local;
+
+        assert!(deploy_input_digest(&record, &payload("m")).is_err());
+    }
+}

--- a/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
@@ -1,0 +1,439 @@
+//! Redeploy orchestration races: per-agent serialization + completion binding.
+//!
+//! These drive the real decision logic (`provider_access::run_deploy` /
+//! `bind_completion`) through an in-memory store and a fake provider gated on
+//! oneshot channels, so mid-flight edits and deletions are deterministic.
+
+use super::provider_access;
+use super::tests::bare_agent_record;
+use crate::managed_agents::ManagedAgentRecord;
+
+fn provider_backed_record(pubkey: &str, model: &str, updated_at: &str) -> ManagedAgentRecord {
+    use crate::managed_agents::BackendKind;
+
+    let mut record = bare_agent_record(None, Some(model), None);
+    record.pubkey = pubkey.to_string();
+    record.updated_at = updated_at.to_string();
+    record.backend = BackendKind::Provider {
+        id: "provider".to_string(),
+        config: serde_json::json!({"region": "test"}),
+    };
+    record.backend_agent_id = Some("existing".to_string());
+    record
+}
+
+/// In-memory [`provider_access::DeployEffects`]: the store is a shared Vec,
+/// the "provider" records the model of every payload it receives and can be
+/// gated (blocked until released) to hold a redeploy in flight. `saves`
+/// counts the completions that asked for a store write, so tests can assert
+/// that a deletion or backend switch produced no write at all.
+struct FakeDeployEffects {
+    store: std::sync::Arc<std::sync::Mutex<Vec<ManagedAgentRecord>>>,
+    sent: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    saves: std::sync::Arc<std::sync::Mutex<u32>>,
+    started: Option<tokio::sync::oneshot::Sender<()>>,
+    release: Option<tokio::sync::oneshot::Receiver<()>>,
+    result: Result<String, String>,
+}
+
+impl provider_access::DeployEffects for FakeDeployEffects {
+    type Success = ManagedAgentRecord;
+
+    fn snapshot(&mut self, pubkey: &str) -> Result<provider_access::DeploySnapshot, String> {
+        let store = self.store.lock().unwrap();
+        let record = store
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?
+            .clone();
+        let captured = provider_access::redeploy_provider_target(pubkey, &record)?;
+        Ok(provider_access::DeploySnapshot { record, captured })
+    }
+
+    async fn deploy(
+        &mut self,
+        snapshot: &provider_access::DeploySnapshot,
+    ) -> Result<String, String> {
+        if let Some(started) = self.started.take() {
+            let _ = started.send(());
+        }
+        if let Some(release) = self.release.take() {
+            let _ = release.await;
+        }
+        self.sent
+            .lock()
+            .unwrap()
+            .push(snapshot.record.model.clone().unwrap_or_default());
+        self.result.clone()
+    }
+
+    fn with_store<R>(
+        &mut self,
+        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
+    ) -> Result<R, String> {
+        let mut store = self.store.lock().unwrap();
+        let (save, result) = apply(&mut store);
+        if save {
+            *self.saves.lock().unwrap() += 1;
+        }
+        Ok(result)
+    }
+
+    fn success(&mut self, record: &ManagedAgentRecord) -> Result<ManagedAgentRecord, String> {
+        Ok(record.clone())
+    }
+}
+
+/// The reviewer's race: redeploy A blocks in the provider with config v1, an
+/// owner edit bumps the store to v2, redeploy B is issued, then A completes.
+/// The per-agent lock queues B behind A, so the provider must see v1 then v2
+/// (newest payload wins remotely), Desktop state must end on B, and A must not
+/// report the edited record as deployed.
+#[tokio::test]
+async fn redeploy_race_late_completion_does_not_claim_newer_config() {
+    use std::sync::{Arc, Mutex};
+
+    let pubkey = "race-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let saves = Arc::new(Mutex::new(0));
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects_a = FakeDeployEffects {
+        store: store.clone(),
+        sent: sent.clone(),
+        saves: saves.clone(),
+        started: Some(started_tx),
+        release: Some(release_rx),
+        result: Ok("deploy-a".to_string()),
+    };
+    let task_a =
+        tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects_a).await });
+    started_rx.await.expect("redeploy A entered the provider");
+
+    // Owner edit while A is blocked in the provider: config generation bumps.
+    {
+        let mut records = store.lock().unwrap();
+        let record = records
+            .iter_mut()
+            .find(|record| record.pubkey == pubkey)
+            .unwrap();
+        record.model = Some("model-v2".to_string());
+        record.updated_at = "t2".to_string();
+    }
+
+    let mut effects_b = FakeDeployEffects {
+        store: store.clone(),
+        sent: sent.clone(),
+        saves: saves.clone(),
+        started: None,
+        release: None,
+        result: Ok("deploy-b".to_string()),
+    };
+    let task_b =
+        tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects_b).await });
+    // Let B reach the per-agent lock so it is genuinely queued behind A.
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+
+    release_tx.send(()).expect("release redeploy A");
+    let result_a = task_a.await.expect("join A");
+    let result_b = task_b.await.expect("join B");
+
+    // A deployed the old config; it must not claim the current record was applied.
+    let error_a = result_a.expect_err("A must not report success-as-current");
+    assert!(
+        error_a.contains("running the previous configuration"),
+        "unexpected A error: {error_a}"
+    );
+
+    // B applied the latest config as current.
+    let applied_b = result_b.expect("B applies the latest config");
+    assert_eq!(applied_b.model.as_deref(), Some("model-v2"));
+    assert_eq!(applied_b.backend_agent_id.as_deref(), Some("deploy-b"));
+
+    // The provider saw v1 then v2 — the newest payload wins remotely.
+    assert_eq!(
+        *sent.lock().unwrap(),
+        vec!["model-v1".to_string(), "model-v2".to_string()]
+    );
+
+    // Desktop state ends on B: v2 config with B's deployment id, no error.
+    let records = store.lock().unwrap();
+    let record = records
+        .iter()
+        .find(|record| record.pubkey == pubkey)
+        .unwrap();
+    assert_eq!(record.model.as_deref(), Some("model-v2"));
+    assert_eq!(record.backend_agent_id.as_deref(), Some("deploy-b"));
+    assert!(record.last_started_at.is_some());
+    assert_eq!(record.last_error, None);
+
+    // Both completions persisted remote facts: A's stale stamp and B's current.
+    assert_eq!(*saves.lock().unwrap(), 2);
+}
+
+/// Deletion during the provider call: the completed deploy must not resurrect
+/// the record, and the caller is told the remote deployment may still exist.
+#[tokio::test]
+async fn redeploy_deletion_mid_flight_reports_and_does_not_resurrect() {
+    use std::sync::{Arc, Mutex};
+
+    let pubkey = "deleted-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let saves = Arc::new(Mutex::new(0));
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects = FakeDeployEffects {
+        store: store.clone(),
+        sent: sent.clone(),
+        saves: saves.clone(),
+        started: Some(started_tx),
+        release: Some(release_rx),
+        result: Ok("deploy-a".to_string()),
+    };
+    let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
+    started_rx.await.expect("redeploy entered the provider");
+
+    // Owner deletes the agent while the provider call is in flight.
+    store.lock().unwrap().clear();
+
+    release_tx.send(()).expect("release redeploy");
+    let error = task
+        .await
+        .expect("join redeploy")
+        .expect_err("deleted agent must not report success");
+    assert!(
+        error.contains("deleted while the deploy") && error.contains("may still be running"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        store.lock().unwrap().is_empty(),
+        "completion resurrected a deleted record"
+    );
+    assert_eq!(*saves.lock().unwrap(), 0, "deletion must not cause a write");
+}
+
+/// Backend switch during the provider call (Provider → Local here; a
+/// provider-id change is covered by the `bind_completion` unit test): the
+/// completed deploy belongs to the old backend, so nothing may be stamped
+/// onto the re-homed record and the caller is told the remote deployment may
+/// still exist.
+#[tokio::test]
+async fn redeploy_backend_switch_mid_flight_reports_and_stamps_nothing() {
+    use std::sync::{Arc, Mutex};
+
+    use crate::managed_agents::BackendKind;
+
+    let pubkey = "switched-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let saves = Arc::new(Mutex::new(0));
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects = FakeDeployEffects {
+        store: store.clone(),
+        sent: sent.clone(),
+        saves: saves.clone(),
+        started: Some(started_tx),
+        release: Some(release_rx),
+        result: Ok("deploy-a".to_string()),
+    };
+    let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
+    started_rx.await.expect("redeploy entered the provider");
+
+    // Owner switches the agent to the local backend while the call is in flight.
+    {
+        let mut records = store.lock().unwrap();
+        let record = records
+            .iter_mut()
+            .find(|record| record.pubkey == pubkey)
+            .unwrap();
+        record.backend = BackendKind::Local;
+        record.backend_agent_id = None;
+        record.updated_at = "t2".to_string();
+    }
+
+    release_tx.send(()).expect("release redeploy");
+    let error = task
+        .await
+        .expect("join redeploy")
+        .expect_err("switched-backend agent must not report success");
+    assert!(
+        error.contains("backend changed") && error.contains("may still be running"),
+        "unexpected error: {error}"
+    );
+
+    // The re-homed record is untouched by the completion, and nothing was
+    // written to the store at all.
+    let records = store.lock().unwrap();
+    let record = records
+        .iter()
+        .find(|record| record.pubkey == pubkey)
+        .unwrap();
+    assert_eq!(record.backend, BackendKind::Local);
+    assert_eq!(record.backend_agent_id, None);
+    assert_eq!(record.updated_at, "t2");
+    assert!(record.last_started_at.is_none());
+    assert_eq!(
+        *saves.lock().unwrap(),
+        0,
+        "backend switch must not cause a write"
+    );
+}
+
+/// Direct unit coverage of the completion-binding branches.
+#[test]
+fn redeploy_completion_binding_branches() {
+    use provider_access::{bind_completion, CompletionOutcome};
+
+    // Unchanged: success persisted as current, last_error cleared.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    records[0].last_error = Some("old failure".to_string());
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        "provider",
+        "t1",
+        &Ok("deploy-1".to_string()),
+    );
+    assert!(save);
+    assert!(matches!(outcome, CompletionOutcome::AppliedCurrent(_)));
+    assert_eq!(records[0].backend_agent_id.as_deref(), Some("deploy-1"));
+    assert_eq!(records[0].last_error, None);
+    assert!(records[0].last_started_at.is_some());
+
+    // Changed mid-flight: remote facts persisted, but nothing implies currency —
+    // last_error stays.
+    let mut records = vec![provider_backed_record("agent", "model-v2", "t2")];
+    records[0].last_error = Some("earlier failure".to_string());
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        "provider",
+        "t1",
+        &Ok("deploy-2".to_string()),
+    );
+    assert!(save);
+    assert!(matches!(outcome, CompletionOutcome::AppliedStale));
+    assert_eq!(records[0].backend_agent_id.as_deref(), Some("deploy-2"));
+    assert_eq!(records[0].last_error.as_deref(), Some("earlier failure"));
+
+    // Deleted: nothing to write, nothing resurrected.
+    let mut records: Vec<ManagedAgentRecord> = vec![];
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        "provider",
+        "t1",
+        &Ok("deploy-3".to_string()),
+    );
+    assert!(!save);
+    assert!(matches!(outcome, CompletionOutcome::Deleted));
+    assert!(records.is_empty());
+
+    // Moved to a different provider mid-flight: the deploy landed on the old
+    // provider, so its id must not be stamped onto the re-homed record.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t2")];
+    records[0].backend = crate::managed_agents::BackendKind::Provider {
+        id: "other-provider".to_string(),
+        config: serde_json::json!({}),
+    };
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        "provider",
+        "t1",
+        &Ok("deploy-4".to_string()),
+    );
+    assert!(!save);
+    assert!(matches!(outcome, CompletionOutcome::BackendChanged));
+    assert_eq!(records[0].backend_agent_id.as_deref(), Some("existing"));
+    assert_eq!(records[0].updated_at, "t2");
+
+    // Provider failure with a surviving record: failure stamped, id untouched.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        "provider",
+        "t1",
+        &Err("boom".to_string()),
+    );
+    assert!(save);
+    assert!(matches!(outcome, CompletionOutcome::Failed(_)));
+    assert_eq!(records[0].last_error.as_deref(), Some("boom"));
+    assert_eq!(records[0].backend_agent_id.as_deref(), Some("existing"));
+}
+
+/// Direct unit coverage of the outcome → command-result fold shared by the
+/// redeploy command and `deploy_to_provider` (create/start/reconcile). This is
+/// the testable seam for the deploy paths, which otherwise need a real Tauri
+/// app handle: `deploy_to_provider` is exactly `bind_completion` (covered
+/// above) + this fold.
+#[test]
+fn deploy_completion_result_mirrors_redeploy_semantics() {
+    use provider_access::{completion_result, CompletionOutcome};
+
+    // Applied as current: the freshly persisted record comes back.
+    let record = provider_backed_record("agent", "model-v1", "t1");
+    let applied = completion_result(
+        CompletionOutcome::AppliedCurrent(Box::new(record)),
+        Ok("deploy-1".to_string()),
+    )
+    .expect("applied current is success");
+    assert_eq!(applied.pubkey, "agent");
+
+    // Stale: the deploy happened, but success must not claim currency.
+    let error = completion_result(CompletionOutcome::AppliedStale, Ok("deploy-2".to_string()))
+        .expect_err("stale completion is not success");
+    assert!(
+        error.contains("running the previous configuration"),
+        "unexpected error: {error}"
+    );
+
+    // Backend switched away mid-flight: honest orphan warning.
+    let error = completion_result(
+        CompletionOutcome::BackendChanged,
+        Ok("deploy-3".to_string()),
+    )
+    .expect_err("backend change is not success");
+    assert!(
+        error.contains("backend changed") && error.contains("may still be running"),
+        "unexpected error: {error}"
+    );
+
+    // Deleted mid-flight: orphan warning on a successful deploy, the provider's
+    // own error on a failed one.
+    let error = completion_result(CompletionOutcome::Deleted, Ok("deploy-4".to_string()))
+        .expect_err("deleted agent is not success");
+    assert!(
+        error.contains("deleted while the deploy") && error.contains("may still be running"),
+        "unexpected error: {error}"
+    );
+    let error = completion_result(CompletionOutcome::Deleted, Err("boom".to_string()))
+        .expect_err("deleted agent is not success");
+    assert_eq!(error, "boom");
+
+    // Provider failure: surfaced verbatim.
+    let error = completion_result(
+        CompletionOutcome::Failed("kaput".to_string()),
+        Err("kaput".to_string()),
+    )
+    .expect_err("failed deploy is not success");
+    assert_eq!(error, "kaput");
+}

--- a/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
@@ -1,5 +1,5 @@
-//! Redeploy orchestration races: per-agent serialization and completion
-//! binding.
+//! Redeploy orchestration races: per-agent serialization, completion binding,
+//! and the two ways a completion can fail to be recorded.
 //!
 //! These drive the real decision logic (`provider_access::run_deploy` /
 //! `bind_completion`) through an in-memory store and a fake provider gated on
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use super::provider_access;
 use super::tests::bare_agent_record;
 use crate::managed_agents::ManagedAgentRecord;
+use provider_access::deploy_receipt::AmbiguousDeployReceipt;
 
 fn provider_backed_record(pubkey: &str, model: &str, updated_at: &str) -> ManagedAgentRecord {
     use crate::managed_agents::BackendKind;
@@ -73,9 +74,14 @@ struct FakeDeployEffects {
     world: World,
     sent: Arc<Mutex<Vec<String>>>,
     saves: Arc<Mutex<u32>>,
+    /// Receipts written by the ambiguous-success path, standing in for the
+    /// `deploy-receipts` directory.
+    receipts: Arc<Mutex<Vec<AmbiguousDeployReceipt>>>,
     started: Option<tokio::sync::oneshot::Sender<()>>,
     release: Option<tokio::sync::oneshot::Receiver<()>>,
     result: Result<String, String>,
+    /// Simulates a store write that fails after the provider already answered.
+    save_fails_with: Option<String>,
     /// Simulates a payload that can no longer be resolved on completion.
     world_unresolvable: bool,
 }
@@ -91,9 +97,11 @@ impl FakeDeployEffects {
             world: world.clone(),
             sent: Arc::new(Mutex::new(Vec::new())),
             saves: Arc::new(Mutex::new(0)),
+            receipts: Arc::new(Mutex::new(Vec::new())),
             started: None,
             release: None,
             result,
+            save_fails_with: None,
             world_unresolvable: false,
         }
     }
@@ -152,7 +160,7 @@ impl provider_access::DeployEffects for FakeDeployEffects {
     fn with_store<R>(
         &mut self,
         apply: &mut provider_access::CompletionApply<'_, R>,
-    ) -> Result<R, String> {
+    ) -> Result<provider_access::StoreOutcome<R>, String> {
         let mut store = self.store.lock().unwrap();
         let world = self.world.clone();
         let unresolvable = self.world_unresolvable;
@@ -165,11 +173,39 @@ impl provider_access::DeployEffects for FakeDeployEffects {
                 &fake_payload(record, &world.read()),
             )
         };
-        let (save, result) = apply(&mut store, &resolve_digest);
-        if save {
+        // Load-modify-save, like the real effects: `apply` mutates a *copy*,
+        // and the copy only reaches the store when the save succeeds. Mutating
+        // the live store in place would make a failed save still change the
+        // store, which is precisely the state the ambiguous-success receipt
+        // exists to describe the absence of.
+        let mut records = store.clone();
+        let (save, result) = apply(&mut records, &resolve_digest);
+        let save_error = if save {
+            self.save_fails_with.clone()
+        } else {
+            None
+        };
+        if save && save_error.is_none() {
+            *store = records;
             *self.saves.lock().unwrap() += 1;
         }
-        Ok(result)
+        Ok(provider_access::StoreOutcome {
+            result,
+            saved: save && save_error.is_none(),
+            save_error,
+        })
+    }
+
+    fn record_ambiguous_success(&mut self, receipt: &AmbiguousDeployReceipt) -> Result<(), String> {
+        self.receipts.lock().unwrap().push(receipt.clone());
+        Ok(())
+    }
+
+    fn clear_ambiguous_success(&mut self, pubkey: &str) {
+        self.receipts
+            .lock()
+            .unwrap()
+            .retain(|receipt| receipt.pubkey != pubkey);
     }
 
     fn success(&mut self, record: &ManagedAgentRecord) -> Result<ManagedAgentRecord, String> {
@@ -276,6 +312,7 @@ async fn persona_change_mid_deploy_is_not_applied_current() {
 
     let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()))
         .gated(started_tx, release_rx);
+    let receipts = effects.receipts.clone();
     let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
     started_rx.await.expect("redeploy entered the provider");
 
@@ -302,6 +339,7 @@ async fn persona_change_mid_deploy_is_not_applied_current() {
     let record = store.lock().unwrap()[0].clone();
     assert_eq!(record.backend_agent_id.as_deref(), Some("deploy-a"));
     assert!(record.last_started_at.is_some());
+    assert!(receipts.lock().unwrap().is_empty(), "nothing was ambiguous");
 }
 
 /// The same world change, arriving *before* the deploy rather than during it,
@@ -543,6 +581,120 @@ async fn provider_failure_does_not_stamp_a_switched_backend() {
         store.lock().unwrap()[0].last_error,
         None,
         "one provider's failure was stamped onto another provider's record"
+    );
+}
+
+/// The provider accepted the deploy and the store write failed: the app has no
+/// record of a deployment that may be live. A durable receipt records what was
+/// sent, and the owner is told plainly.
+#[tokio::test]
+async fn a_provider_success_the_store_could_not_save_leaves_a_receipt() {
+    let pubkey = "ambiguous-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()));
+    effects.save_fails_with = Some("no space left on device".to_string());
+    let receipts = effects.receipts.clone();
+
+    let error = provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect_err("an unsaved deploy is not a success");
+    assert!(
+        error.contains("could not save the result")
+            && error.contains("no space left on device")
+            && error.contains("receipt"),
+        "unexpected error: {error}"
+    );
+
+    let receipts = receipts.lock().unwrap();
+    assert_eq!(receipts.len(), 1, "no durable receipt was written");
+    let receipt = &receipts[0];
+    assert_eq!(receipt.pubkey, pubkey);
+    assert_eq!(receipt.provider_id, "provider");
+    assert_eq!(
+        receipt.backend_agent_id, "deploy-a",
+        "the receipt must name the deployment the store never recorded"
+    );
+    assert_eq!(receipt.captured_updated_at, "t1");
+    assert_eq!(receipt.save_error, "no space left on device");
+    // The digest is the one that was sent, so a later reader can compare it
+    // against what the store holds. Take the record out from under the guard
+    // first: two `store.lock()` calls in one expression are two live guards on
+    // a non-reentrant mutex held by the same thread, which deadlocks.
+    let stored = store.lock().unwrap()[0].clone();
+    let expected = provider_access::payload_digest::deploy_input_digest(
+        &stored,
+        &fake_payload(&stored, "persona-v1"),
+    )
+    .expect("digest");
+    assert_eq!(receipt.payload_digest, expected);
+    assert!(!receipt.observed_at.is_empty());
+
+    // The whole point of the receipt: the store does *not* know about this
+    // deployment, so the record must still be exactly the pre-deploy one.
+    assert_eq!(stored.backend_agent_id.as_deref(), Some("existing"));
+    assert_eq!(stored.updated_at, "t1");
+    assert_eq!(stored.last_started_at, None);
+}
+
+/// A provider failure whose store write also fails is *not* ambiguous —
+/// nothing is running that the store does not know about — so it gets no
+/// receipt, and both errors reach the owner.
+#[tokio::test]
+async fn a_failed_deploy_the_store_could_not_save_leaves_no_receipt() {
+    let pubkey = "failed-unsaved-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Err("image pull failed".to_string()));
+    effects.save_fails_with = Some("read-only file system".to_string());
+    let receipts = effects.receipts.clone();
+
+    let error = provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect_err("a failed deploy is not success");
+    assert!(
+        error.contains("image pull failed") && error.contains("read-only file system"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        receipts.lock().unwrap().is_empty(),
+        "a failed deploy left an ambiguous-success receipt"
+    );
+}
+
+/// The next deploy that *does* save resolves the ambiguity, so the receipt is
+/// dropped — a receipt on disk always means an outcome the store still does
+/// not reflect.
+#[tokio::test]
+async fn a_saved_completion_clears_an_earlier_receipt() {
+    let pubkey = "reconciled-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()));
+    effects.save_fails_with = Some("no space left on device".to_string());
+    let receipts = effects.receipts.clone();
+    let _ = provider_access::run_deploy(pubkey, &mut effects).await;
+    assert_eq!(receipts.lock().unwrap().len(), 1);
+
+    // Second attempt, store healthy again.
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-b".to_string()));
+    effects.receipts = receipts.clone();
+    provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect("the retry lands");
+
+    assert!(
+        receipts.lock().unwrap().is_empty(),
+        "a recorded completion left the stale receipt behind"
     );
 }
 

--- a/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
@@ -1,8 +1,20 @@
-//! Redeploy orchestration races: per-agent serialization + completion binding.
+//! Redeploy orchestration races: per-agent serialization and completion
+//! binding.
 //!
 //! These drive the real decision logic (`provider_access::run_deploy` /
 //! `bind_completion`) through an in-memory store and a fake provider gated on
 //! oneshot channels, so mid-flight edits and deletions are deterministic.
+//!
+//! The fake models the two halves of a deploy input the way the real one is
+//! shaped: the agent *row* (in the store) and the *world* outside it — the
+//! persona, team, global agent config, workspace relay URL and owner pubkey
+//! that `build_deploy_payload` re-resolves on every call. Both feed
+//! [`fake_payload`], and the digest is computed by the shipped
+//! `payload_digest::deploy_input_digest`, so a world-only change is exactly
+//! the case the reviewer named: the agent row is untouched and `updated_at`
+//! does not move.
+
+use std::sync::{Arc, Mutex};
 
 use super::provider_access;
 use super::tests::bare_agent_record;
@@ -22,18 +34,85 @@ fn provider_backed_record(pubkey: &str, model: &str, updated_at: &str) -> Manage
     record
 }
 
+/// The stand-in for `build_deploy_payload`: a projection of the agent row plus
+/// the world resolved around it.
+fn fake_payload(record: &ManagedAgentRecord, world: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": record.name,
+        "model": record.model,
+        // Everything the payload resolves from outside the agent row.
+        "resolved_world": world,
+    })
+}
+
+/// The world the fake resolves payloads against. Mutating it models a persona
+/// edit, a global-config change, a relay override or an owner switch — none of
+/// which touch the agent row.
+#[derive(Clone)]
+struct World(Arc<Mutex<String>>);
+
+impl World {
+    fn new(value: &str) -> Self {
+        World(Arc::new(Mutex::new(value.to_string())))
+    }
+    fn set(&self, value: &str) {
+        *self.0.lock().unwrap() = value.to_string();
+    }
+    fn read(&self) -> String {
+        self.0.lock().unwrap().clone()
+    }
+}
+
 /// In-memory [`provider_access::DeployEffects`]: the store is a shared Vec,
 /// the "provider" records the model of every payload it receives and can be
 /// gated (blocked until released) to hold a redeploy in flight. `saves`
 /// counts the completions that asked for a store write, so tests can assert
 /// that a deletion or backend switch produced no write at all.
 struct FakeDeployEffects {
-    store: std::sync::Arc<std::sync::Mutex<Vec<ManagedAgentRecord>>>,
-    sent: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    saves: std::sync::Arc<std::sync::Mutex<u32>>,
+    store: Arc<Mutex<Vec<ManagedAgentRecord>>>,
+    world: World,
+    sent: Arc<Mutex<Vec<String>>>,
+    saves: Arc<Mutex<u32>>,
     started: Option<tokio::sync::oneshot::Sender<()>>,
     release: Option<tokio::sync::oneshot::Receiver<()>>,
     result: Result<String, String>,
+    /// Simulates a payload that can no longer be resolved on completion.
+    world_unresolvable: bool,
+}
+
+impl FakeDeployEffects {
+    fn new(
+        store: &Arc<Mutex<Vec<ManagedAgentRecord>>>,
+        world: &World,
+        result: Result<String, String>,
+    ) -> Self {
+        FakeDeployEffects {
+            store: store.clone(),
+            world: world.clone(),
+            sent: Arc::new(Mutex::new(Vec::new())),
+            saves: Arc::new(Mutex::new(0)),
+            started: None,
+            release: None,
+            result,
+            world_unresolvable: false,
+        }
+    }
+
+    fn sharing(mut self, sent: &Arc<Mutex<Vec<String>>>, saves: &Arc<Mutex<u32>>) -> Self {
+        self.sent = sent.clone();
+        self.saves = saves.clone();
+        self
+    }
+
+    fn gated(
+        mut self,
+        started: tokio::sync::oneshot::Sender<()>,
+        release: tokio::sync::oneshot::Receiver<()>,
+    ) -> Self {
+        self.started = Some(started);
+        self.release = Some(release);
+        self
+    }
 }
 
 impl provider_access::DeployEffects for FakeDeployEffects {
@@ -46,8 +125,9 @@ impl provider_access::DeployEffects for FakeDeployEffects {
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| format!("agent {pubkey} not found"))?
             .clone();
-        let captured = provider_access::redeploy_provider_target(pubkey, &record)?;
-        Ok(provider_access::DeploySnapshot { record, captured })
+        let payload = fake_payload(&record, &self.world.read());
+        let captured = provider_access::redeploy_provider_target(pubkey, &record, &payload)?;
+        Ok(provider_access::DeploySnapshot { captured, payload })
     }
 
     async fn deploy(
@@ -60,19 +140,32 @@ impl provider_access::DeployEffects for FakeDeployEffects {
         if let Some(release) = self.release.take() {
             let _ = release.await;
         }
-        self.sent
-            .lock()
-            .unwrap()
-            .push(snapshot.record.model.clone().unwrap_or_default());
+        self.sent.lock().unwrap().push(
+            snapshot.payload["model"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+        );
         self.result.clone()
     }
 
     fn with_store<R>(
         &mut self,
-        apply: &mut dyn FnMut(&mut Vec<ManagedAgentRecord>) -> (bool, R),
+        apply: &mut provider_access::CompletionApply<'_, R>,
     ) -> Result<R, String> {
         let mut store = self.store.lock().unwrap();
-        let (save, result) = apply(&mut store);
+        let world = self.world.clone();
+        let unresolvable = self.world_unresolvable;
+        let resolve_digest = move |record: &ManagedAgentRecord| -> Result<String, String> {
+            if unresolvable {
+                return Err("persona is missing".to_string());
+            }
+            provider_access::payload_digest::deploy_input_digest(
+                record,
+                &fake_payload(record, &world.read()),
+            )
+        };
+        let (save, result) = apply(&mut store, &resolve_digest);
         if save {
             *self.saves.lock().unwrap() += 1;
         }
@@ -91,26 +184,20 @@ impl provider_access::DeployEffects for FakeDeployEffects {
 /// report the edited record as deployed.
 #[tokio::test]
 async fn redeploy_race_late_completion_does_not_claim_newer_config() {
-    use std::sync::{Arc, Mutex};
-
     let pubkey = "race-agent";
     let store = Arc::new(Mutex::new(vec![provider_backed_record(
         pubkey, "model-v1", "t1",
     )]));
+    let world = World::new("persona-v1");
     let sent = Arc::new(Mutex::new(Vec::new()));
     let saves = Arc::new(Mutex::new(0));
 
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
-    let mut effects_a = FakeDeployEffects {
-        store: store.clone(),
-        sent: sent.clone(),
-        saves: saves.clone(),
-        started: Some(started_tx),
-        release: Some(release_rx),
-        result: Ok("deploy-a".to_string()),
-    };
+    let mut effects_a = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()))
+        .sharing(&sent, &saves)
+        .gated(started_tx, release_rx);
     let task_a =
         tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects_a).await });
     started_rx.await.expect("redeploy A entered the provider");
@@ -126,14 +213,8 @@ async fn redeploy_race_late_completion_does_not_claim_newer_config() {
         record.updated_at = "t2".to_string();
     }
 
-    let mut effects_b = FakeDeployEffects {
-        store: store.clone(),
-        sent: sent.clone(),
-        saves: saves.clone(),
-        started: None,
-        release: None,
-        result: Ok("deploy-b".to_string()),
-    };
+    let mut effects_b =
+        FakeDeployEffects::new(&store, &world, Ok("deploy-b".to_string())).sharing(&sent, &saves);
     let task_b =
         tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects_b).await });
     // Let B reach the per-agent lock so it is genuinely queued behind A.
@@ -148,7 +229,7 @@ async fn redeploy_race_late_completion_does_not_claim_newer_config() {
     // A deployed the old config; it must not claim the current record was applied.
     let error_a = result_a.expect_err("A must not report success-as-current");
     assert!(
-        error_a.contains("running the previous configuration"),
+        error_a.contains("sent the previous settings"),
         "unexpected A error: {error_a}"
     );
 
@@ -178,30 +259,118 @@ async fn redeploy_race_late_completion_does_not_claim_newer_config() {
     assert_eq!(*saves.lock().unwrap(), 2);
 }
 
+/// The reviewer's second boundary: the agent row is untouched — same
+/// `updated_at`, same everything the store holds — but an input the payload
+/// resolves *outside* the row (here the persona) changed while the provider
+/// call was in flight. The old payload must not be stamped `AppliedCurrent`.
+#[tokio::test]
+async fn persona_change_mid_deploy_is_not_applied_current() {
+    let pubkey = "world-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()))
+        .gated(started_tx, release_rx);
+    let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
+    started_rx.await.expect("redeploy entered the provider");
+
+    // The persona (or global config, or relay override, or owner) changes.
+    // The agent row is deliberately NOT touched.
+    world.set("persona-v2");
+    let before = store.lock().unwrap()[0].clone();
+
+    release_tx.send(()).expect("release redeploy");
+    let error = task
+        .await
+        .expect("join redeploy")
+        .expect_err("a payload resolved from a changed world is not current");
+    assert!(
+        error.contains("sent the previous settings"),
+        "unexpected error: {error}"
+    );
+
+    // The agent row never moved, so an `updated_at`-only binding would have
+    // called this current.
+    assert_eq!(before.updated_at, "t1");
+
+    // The remote facts are still persisted — the deploy really happened.
+    let record = store.lock().unwrap()[0].clone();
+    assert_eq!(record.backend_agent_id.as_deref(), Some("deploy-a"));
+    assert!(record.last_started_at.is_some());
+}
+
+/// The same world change, arriving *before* the deploy rather than during it,
+/// must still be reported as current — a digest that never matches would make
+/// every deploy look stale and the honest report meaningless.
+#[tokio::test]
+async fn an_unchanged_world_is_reported_as_current() {
+    let pubkey = "steady-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v2");
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()));
+    let applied = provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect("an unchanged deploy input is current");
+
+    assert_eq!(applied.backend_agent_id.as_deref(), Some("deploy-a"));
+    assert_eq!(applied.last_error, None);
+}
+
+/// The payload cannot be re-resolved on completion (the persona the record
+/// points at is gone). Currency can be neither proved nor disproved, so the
+/// remote facts are persisted and the answer says exactly that.
+#[tokio::test]
+async fn an_unresolvable_payload_is_reported_as_unverified() {
+    let pubkey = "unresolvable-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()));
+    effects.world_unresolvable = true;
+    let error = provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect_err("an unverifiable completion must not claim currency");
+
+    assert!(
+        error.contains("could not re-read") && error.contains("persona is missing"),
+        "unexpected error: {error}"
+    );
+    let record = store.lock().unwrap()[0].clone();
+    assert_eq!(
+        record.backend_agent_id.as_deref(),
+        Some("deploy-a"),
+        "the deploy happened; its remote facts must still be persisted"
+    );
+}
+
 /// Deletion during the provider call: the completed deploy must not resurrect
 /// the record, and the caller is told the remote deployment may still exist.
 #[tokio::test]
 async fn redeploy_deletion_mid_flight_reports_and_does_not_resurrect() {
-    use std::sync::{Arc, Mutex};
-
     let pubkey = "deleted-agent";
     let store = Arc::new(Mutex::new(vec![provider_backed_record(
         pubkey, "model-v1", "t1",
     )]));
+    let world = World::new("persona-v1");
     let sent = Arc::new(Mutex::new(Vec::new()));
     let saves = Arc::new(Mutex::new(0));
 
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
-    let mut effects = FakeDeployEffects {
-        store: store.clone(),
-        sent: sent.clone(),
-        saves: saves.clone(),
-        started: Some(started_tx),
-        release: Some(release_rx),
-        result: Ok("deploy-a".to_string()),
-    };
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()))
+        .sharing(&sent, &saves)
+        .gated(started_tx, release_rx);
     let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
     started_rx.await.expect("redeploy entered the provider");
 
@@ -231,28 +400,22 @@ async fn redeploy_deletion_mid_flight_reports_and_does_not_resurrect() {
 /// still exist.
 #[tokio::test]
 async fn redeploy_backend_switch_mid_flight_reports_and_stamps_nothing() {
-    use std::sync::{Arc, Mutex};
-
     use crate::managed_agents::BackendKind;
 
     let pubkey = "switched-agent";
     let store = Arc::new(Mutex::new(vec![provider_backed_record(
         pubkey, "model-v1", "t1",
     )]));
+    let world = World::new("persona-v1");
     let sent = Arc::new(Mutex::new(Vec::new()));
     let saves = Arc::new(Mutex::new(0));
 
     let (started_tx, started_rx) = tokio::sync::oneshot::channel();
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
-    let mut effects = FakeDeployEffects {
-        store: store.clone(),
-        sent: sent.clone(),
-        saves: saves.clone(),
-        started: Some(started_tx),
-        release: Some(release_rx),
-        result: Ok("deploy-a".to_string()),
-    };
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()))
+        .sharing(&sent, &saves)
+        .gated(started_tx, release_rx);
     let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
     started_rx.await.expect("redeploy entered the provider");
 
@@ -296,19 +459,122 @@ async fn redeploy_backend_switch_mid_flight_reports_and_stamps_nothing() {
     );
 }
 
+/// A provider failure whose record moved on: the failure belongs to the
+/// configuration that was sent, not to the one the owner has since saved, so
+/// `last_error` must not be stamped on it. The owner still sees the error.
+#[tokio::test]
+async fn provider_failure_does_not_stamp_a_moved_record() {
+    let pubkey = "moved-failure-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects =
+        FakeDeployEffects::new(&store, &world, Err("cluster unreachable".to_string()))
+            .gated(started_tx, release_rx);
+    let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
+    started_rx
+        .await
+        .expect("failing deploy entered the provider");
+
+    // The agent row is untouched; only the world moves — the same case the
+    // success path now catches, applied to the failure path.
+    world.set("persona-v2");
+
+    release_tx.send(()).expect("release deploy");
+    let error = task
+        .await
+        .expect("join deploy")
+        .expect_err("a failed deploy is not success");
+    assert_eq!(
+        error, "cluster unreachable",
+        "the owner must see the failure"
+    );
+
+    let record = store.lock().unwrap()[0].clone();
+    assert_eq!(
+        record.last_error, None,
+        "a failure of the previous configuration was stamped on the current one"
+    );
+    assert_eq!(record.updated_at, "t1", "an unstamped failure wrote anyway");
+}
+
+/// A provider failure whose record switched backends: the failure describes a
+/// provider the record no longer names, so nothing is stamped.
+#[tokio::test]
+async fn provider_failure_does_not_stamp_a_switched_backend() {
+    use crate::managed_agents::BackendKind;
+
+    let pubkey = "switched-failure-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let mut effects = FakeDeployEffects::new(&store, &world, Err("quota exceeded".to_string()))
+        .gated(started_tx, release_rx);
+    let task = tokio::spawn(async move { provider_access::run_deploy(pubkey, &mut effects).await });
+    started_rx
+        .await
+        .expect("failing deploy entered the provider");
+
+    {
+        let mut records = store.lock().unwrap();
+        records[0].backend = BackendKind::Provider {
+            id: "other-provider".to_string(),
+            config: serde_json::json!({}),
+        };
+    }
+
+    release_tx.send(()).expect("release deploy");
+    let error = task
+        .await
+        .expect("join deploy")
+        .expect_err("a failed deploy is not success");
+    assert_eq!(error, "quota exceeded");
+    assert_eq!(
+        store.lock().unwrap()[0].last_error,
+        None,
+        "one provider's failure was stamped onto another provider's record"
+    );
+}
+
 /// Direct unit coverage of the completion-binding branches.
 #[test]
 fn redeploy_completion_binding_branches() {
     use provider_access::{bind_completion, CompletionOutcome};
 
+    // A digest resolver standing in for the world outside the agent row.
+    let resolve = |world: &'static str| {
+        move |record: &ManagedAgentRecord| {
+            provider_access::payload_digest::deploy_input_digest(
+                record,
+                &fake_payload(record, world),
+            )
+        }
+    };
+    let captured = |record: &ManagedAgentRecord, world: &'static str| {
+        let payload = fake_payload(record, world);
+        provider_access::redeploy_provider_target(&record.pubkey.clone(), record, &payload)
+            .expect("captured")
+    };
+
     // Unchanged: success persisted as current, last_error cleared.
     let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
     records[0].last_error = Some("old failure".to_string());
     let (save, outcome) = bind_completion(
         &mut records,
         "agent",
-        "provider",
-        "t1",
+        &capture,
+        &resolve("w1"),
         &Ok("deploy-1".to_string()),
     );
     assert!(save);
@@ -317,15 +583,16 @@ fn redeploy_completion_binding_branches() {
     assert_eq!(records[0].last_error, None);
     assert!(records[0].last_started_at.is_some());
 
-    // Changed mid-flight: remote facts persisted, but nothing implies currency —
-    // last_error stays.
+    // Agent row changed mid-flight: remote facts persisted, but nothing implies
+    // currency — last_error stays.
     let mut records = vec![provider_backed_record("agent", "model-v2", "t2")];
+    let capture = captured(&provider_backed_record("agent", "model-v1", "t1"), "w1");
     records[0].last_error = Some("earlier failure".to_string());
     let (save, outcome) = bind_completion(
         &mut records,
         "agent",
-        "provider",
-        "t1",
+        &capture,
+        &resolve("w1"),
         &Ok("deploy-2".to_string()),
     );
     assert!(save);
@@ -333,14 +600,32 @@ fn redeploy_completion_binding_branches() {
     assert_eq!(records[0].backend_agent_id.as_deref(), Some("deploy-2"));
     assert_eq!(records[0].last_error.as_deref(), Some("earlier failure"));
 
-    // Deleted: nothing to write, nothing resurrected.
-    let mut records: Vec<ManagedAgentRecord> = vec![];
+    // World changed with the agent row untouched: same `updated_at`, different
+    // resolved payload — still not current.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
     let (save, outcome) = bind_completion(
         &mut records,
         "agent",
-        "provider",
-        "t1",
+        &capture,
+        &resolve("w2"),
         &Ok("deploy-3".to_string()),
+    );
+    assert!(save);
+    assert!(
+        matches!(outcome, CompletionOutcome::AppliedStale),
+        "an input resolved outside the agent row was ignored"
+    );
+
+    // Deleted: nothing to write, nothing resurrected.
+    let mut records: Vec<ManagedAgentRecord> = vec![];
+    let capture = captured(&provider_backed_record("agent", "model-v1", "t1"), "w1");
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        &capture,
+        &resolve("w1"),
+        &Ok("deploy-4".to_string()),
     );
     assert!(!save);
     assert!(matches!(outcome, CompletionOutcome::Deleted));
@@ -349,6 +634,7 @@ fn redeploy_completion_binding_branches() {
     // Moved to a different provider mid-flight: the deploy landed on the old
     // provider, so its id must not be stamped onto the re-homed record.
     let mut records = vec![provider_backed_record("agent", "model-v1", "t2")];
+    let capture = captured(&provider_backed_record("agent", "model-v1", "t2"), "w1");
     records[0].backend = crate::managed_agents::BackendKind::Provider {
         id: "other-provider".to_string(),
         config: serde_json::json!({}),
@@ -356,28 +642,81 @@ fn redeploy_completion_binding_branches() {
     let (save, outcome) = bind_completion(
         &mut records,
         "agent",
-        "provider",
-        "t1",
-        &Ok("deploy-4".to_string()),
+        &capture,
+        &resolve("w1"),
+        &Ok("deploy-5".to_string()),
     );
     assert!(!save);
     assert!(matches!(outcome, CompletionOutcome::BackendChanged));
     assert_eq!(records[0].backend_agent_id.as_deref(), Some("existing"));
     assert_eq!(records[0].updated_at, "t2");
 
-    // Provider failure with a surviving record: failure stamped, id untouched.
+    // The provider config alone changed: it rides beside the payload on the
+    // wire, so it must move the binding too.
     let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
+    records[0].backend = crate::managed_agents::BackendKind::Provider {
+        id: "provider".to_string(),
+        config: serde_json::json!({"region": "elsewhere"}),
+    };
     let (save, outcome) = bind_completion(
         &mut records,
         "agent",
-        "provider",
-        "t1",
+        &capture,
+        &resolve("w1"),
+        &Ok("deploy-6".to_string()),
+    );
+    assert!(save);
+    assert!(
+        matches!(outcome, CompletionOutcome::AppliedStale),
+        "a changed provider config was reported as applied"
+    );
+
+    // Provider failure with the same record and world: failure stamped, id
+    // untouched.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        &capture,
+        &resolve("w1"),
         &Err("boom".to_string()),
     );
     assert!(save);
     assert!(matches!(outcome, CompletionOutcome::Failed(_)));
     assert_eq!(records[0].last_error.as_deref(), Some("boom"));
     assert_eq!(records[0].backend_agent_id.as_deref(), Some("existing"));
+
+    // Provider failure whose record has moved: nothing stamped at all.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        &capture,
+        &resolve("w2"),
+        &Err("boom".to_string()),
+    );
+    assert!(!save);
+    assert!(matches!(outcome, CompletionOutcome::FailedUnstamped(_)));
+    assert_eq!(records[0].last_error, None);
+    assert_eq!(records[0].updated_at, "t1");
+
+    // Provider failure that cannot be re-resolved: also unstamped — an
+    // unprovable match is not a match.
+    let mut records = vec![provider_backed_record("agent", "model-v1", "t1")];
+    let capture = captured(&records[0], "w1");
+    let (save, outcome) = bind_completion(
+        &mut records,
+        "agent",
+        &capture,
+        &|_record| Err("persona is missing".to_string()),
+        &Err("boom".to_string()),
+    );
+    assert!(!save);
+    assert!(matches!(outcome, CompletionOutcome::FailedUnstamped(_)));
+    assert_eq!(records[0].last_error, None);
 }
 
 /// Direct unit coverage of the outcome → command-result fold shared by the
@@ -402,14 +741,25 @@ fn deploy_completion_result_mirrors_redeploy_semantics() {
     let error = completion_result(CompletionOutcome::AppliedStale, Ok("deploy-2".to_string()))
         .expect_err("stale completion is not success");
     assert!(
-        error.contains("running the previous configuration"),
+        error.contains("sent the previous settings"),
+        "unexpected error: {error}"
+    );
+
+    // Unverified: the deploy happened and currency could not be checked.
+    let error = completion_result(
+        CompletionOutcome::AppliedUnverified("persona is missing".to_string()),
+        Ok("deploy-3".to_string()),
+    )
+    .expect_err("an unverified completion is not success");
+    assert!(
+        error.contains("could not re-read") && error.contains("persona is missing"),
         "unexpected error: {error}"
     );
 
     // Backend switched away mid-flight: honest orphan warning.
     let error = completion_result(
         CompletionOutcome::BackendChanged,
-        Ok("deploy-3".to_string()),
+        Ok("deploy-4".to_string()),
     )
     .expect_err("backend change is not success");
     assert!(
@@ -419,7 +769,7 @@ fn deploy_completion_result_mirrors_redeploy_semantics() {
 
     // Deleted mid-flight: orphan warning on a successful deploy, the provider's
     // own error on a failed one.
-    let error = completion_result(CompletionOutcome::Deleted, Ok("deploy-4".to_string()))
+    let error = completion_result(CompletionOutcome::Deleted, Ok("deploy-5".to_string()))
         .expect_err("deleted agent is not success");
     assert!(
         error.contains("deleted while the deploy") && error.contains("may still be running"),
@@ -429,9 +779,15 @@ fn deploy_completion_result_mirrors_redeploy_semantics() {
         .expect_err("deleted agent is not success");
     assert_eq!(error, "boom");
 
-    // Provider failure: surfaced verbatim.
+    // Provider failure: surfaced verbatim, stamped or not.
     let error = completion_result(
         CompletionOutcome::Failed("kaput".to_string()),
+        Err("kaput".to_string()),
+    )
+    .expect_err("failed deploy is not success");
+    assert_eq!(error, "kaput");
+    let error = completion_result(
+        CompletionOutcome::FailedUnstamped("kaput".to_string()),
         Err("kaput".to_string()),
     )
     .expect_err("failed deploy is not success");

--- a/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
+++ b/desktop/src-tauri/src/commands/agents/provider_access_tests.rs
@@ -668,9 +668,10 @@ async fn a_failed_deploy_the_store_could_not_save_leaves_no_receipt() {
     );
 }
 
-/// The next deploy that *does* save resolves the ambiguity, so the receipt is
-/// dropped — a receipt on disk always means an outcome the store still does
-/// not reflect.
+/// The next provider *success* that also saves resolves the ambiguity — it
+/// superseded the earlier deploy remotely and left a local record of doing so —
+/// so the receipt is dropped. A receipt on disk always means an outcome the
+/// store still does not reflect.
 #[tokio::test]
 async fn a_saved_completion_clears_an_earlier_receipt() {
     let pubkey = "reconciled-agent";
@@ -695,6 +696,61 @@ async fn a_saved_completion_clears_an_earlier_receipt() {
     assert!(
         receipts.lock().unwrap().is_empty(),
         "a recorded completion left the stale receipt behind"
+    );
+}
+
+/// A saved *failure* is not a resolution. Attempt A succeeds at the provider
+/// and loses its store write, leaving a receipt. Attempt B then fails at the
+/// provider, and that failure saves cleanly — but B never reached the
+/// provider's desired state, so it did not supersede A remotely. A's
+/// deployment may still be running with an input the store never recorded, and
+/// the receipt is the only evidence of it. It must survive B.
+#[tokio::test]
+async fn a_saved_failure_does_not_clear_an_earlier_receipt() {
+    let pubkey = "still-ambiguous-agent";
+    let store = Arc::new(Mutex::new(vec![provider_backed_record(
+        pubkey, "model-v1", "t1",
+    )]));
+    let world = World::new("persona-v1");
+
+    // Attempt A: the provider accepted it, the store write failed.
+    let mut effects = FakeDeployEffects::new(&store, &world, Ok("deploy-a".to_string()));
+    effects.save_fails_with = Some("no space left on device".to_string());
+    let receipts = effects.receipts.clone();
+    let _ = provider_access::run_deploy(pubkey, &mut effects).await;
+    assert_eq!(
+        receipts.lock().unwrap().len(),
+        1,
+        "attempt A left no receipt"
+    );
+
+    // Attempt B: the provider rejected it, and the store recorded that.
+    let saves = Arc::new(Mutex::new(0));
+    let mut effects = FakeDeployEffects::new(&store, &world, Err("image pull failed".to_string()))
+        .sharing(&Arc::new(Mutex::new(Vec::new())), &saves);
+    effects.receipts = receipts.clone();
+    let error = provider_access::run_deploy(pubkey, &mut effects)
+        .await
+        .expect_err("a provider failure is not a success");
+    assert_eq!(error, "image pull failed");
+
+    // The failure really did save — otherwise the assertion below would pass
+    // for the wrong reason.
+    assert_eq!(*saves.lock().unwrap(), 1, "attempt B did not save");
+    assert_eq!(
+        store.lock().unwrap()[0].last_error.as_deref(),
+        Some("image pull failed")
+    );
+
+    let receipts = receipts.lock().unwrap();
+    assert_eq!(
+        receipts.len(),
+        1,
+        "a saved provider failure cleared the earlier ambiguity receipt"
+    );
+    assert_eq!(
+        receipts[0].backend_agent_id, "deploy-a",
+        "the surviving receipt must still name attempt A's deployment"
     );
 }
 

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -641,25 +641,28 @@ fn provider_upgrade_reconciliation_targets_existing_deployments_only_in_marked_b
 fn redeploy_guard_requires_provider_backend_and_existing_deployment() {
     use crate::managed_agents::BackendKind;
 
+    let payload = serde_json::json!({"name": "Agent"});
     let mut record = bare_agent_record(None, None, None);
-    let error = provider_access::redeploy_provider_target("agent", &record).unwrap_err();
+    let error = provider_access::redeploy_provider_target("agent", &record, &payload).unwrap_err();
     assert!(error.contains("not provider-backed"));
 
     record.backend = BackendKind::Provider {
         id: "provider".to_string(),
         config: serde_json::json!({"region": "test"}),
     };
-    let error = provider_access::redeploy_provider_target("agent", &record).unwrap_err();
+    let error = provider_access::redeploy_provider_target("agent", &record, &payload).unwrap_err();
     assert!(error.contains("has not been deployed yet"));
 
     record.backend_agent_id = Some("existing-provider-agent".to_string());
     record.updated_at = "generation-1".to_string();
-    let captured = provider_access::redeploy_provider_target("agent", &record)
+    let captured = provider_access::redeploy_provider_target("agent", &record, &payload)
         .expect("deployed provider target");
     assert_eq!(captured.provider_id, "provider");
     assert_eq!(captured.config["region"], "test");
     assert_eq!(captured.cached_binary_path, None);
     assert_eq!(captured.updated_at, "generation-1");
+    // The captured generation now carries the digest of the whole deploy input.
+    assert_eq!(captured.payload_digest.len(), 64);
 }
 
 #[test]

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::managed_agents::AgentDefinition;
 
-fn bare_agent_record(
+pub(super) fn bare_agent_record(
     persona_id: Option<&str>,
     model: Option<&str>,
     provider: Option<&str>,
@@ -653,12 +653,13 @@ fn redeploy_guard_requires_provider_backend_and_existing_deployment() {
     assert!(error.contains("has not been deployed yet"));
 
     record.backend_agent_id = Some("existing-provider-agent".to_string());
-    let (provider_id, config, cached_binary_path) =
-        provider_access::redeploy_provider_target("agent", &record)
-            .expect("deployed provider target");
-    assert_eq!(provider_id, "provider");
-    assert_eq!(config["region"], "test");
-    assert_eq!(cached_binary_path, None);
+    record.updated_at = "generation-1".to_string();
+    let captured = provider_access::redeploy_provider_target("agent", &record)
+        .expect("deployed provider target");
+    assert_eq!(captured.provider_id, "provider");
+    assert_eq!(captured.config["region"], "test");
+    assert_eq!(captured.cached_binary_path, None);
+    assert_eq!(captured.updated_at, "generation-1");
 }
 
 #[test]

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -638,6 +638,30 @@ fn provider_upgrade_reconciliation_targets_existing_deployments_only_in_marked_b
 }
 
 #[test]
+fn redeploy_guard_requires_provider_backend_and_existing_deployment() {
+    use crate::managed_agents::BackendKind;
+
+    let mut record = bare_agent_record(None, None, None);
+    let error = provider_access::redeploy_provider_target("agent", &record).unwrap_err();
+    assert!(error.contains("not provider-backed"));
+
+    record.backend = BackendKind::Provider {
+        id: "provider".to_string(),
+        config: serde_json::json!({"region": "test"}),
+    };
+    let error = provider_access::redeploy_provider_target("agent", &record).unwrap_err();
+    assert!(error.contains("has not been deployed yet"));
+
+    record.backend_agent_id = Some("existing-provider-agent".to_string());
+    let (provider_id, config, cached_binary_path) =
+        provider_access::redeploy_provider_target("agent", &record)
+            .expect("deployed provider target");
+    assert_eq!(provider_id, "provider");
+    assert_eq!(config["region"], "test");
+    assert_eq!(cached_binary_path, None);
+}
+
+#[test]
 fn owner_only_access_deploy_payload_clamps_stale_access() {
     use crate::managed_agents::{BackendKind, RespondTo};
 

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -10,7 +10,7 @@ mod agent_models_env;
 mod agent_providers;
 mod agent_settings;
 mod agent_update_rollback;
-mod agents;
+pub(crate) mod agents;
 mod canvas;
 mod channel_templates;
 mod channel_window;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -770,6 +770,7 @@ pub fn run() {
             put_managed_agent_runtime_lifecycle,
             create_managed_agent,
             start_managed_agent,
+            commands::agents::provider_access::redeploy_managed_agent,
             stop_managed_agent,
             set_agent_managed_profiles,
             set_managed_agent_start_on_app_launch,

--- a/desktop/src-tauri/src/util.rs
+++ b/desktop/src-tauri/src/util.rs
@@ -4,6 +4,31 @@ pub fn now_iso() -> String {
     Utc::now().to_rfc3339()
 }
 
+/// Mint a fresh `updated_at` stamp guaranteed to differ from `previous`.
+///
+/// A managed agent's `updated_at` doubles as the configuration generation
+/// that in-flight provider deploys are bound to (see
+/// `commands::agents::provider_access::bind_completion`), so an edit must
+/// change the string even when the platform clock is too coarse to have
+/// ticked since `previous` was written, or has stepped backwards onto it.
+/// On a collision the fresh stamp is nudged forward by one nanosecond, which
+/// stays valid RFC 3339 and preserves ordering.
+pub(crate) fn bumped_updated_at(previous: &str) -> String {
+    bumped_updated_at_from(Utc::now(), previous)
+}
+
+fn bumped_updated_at_from(now: chrono::DateTime<Utc>, previous: &str) -> String {
+    let fresh = now.to_rfc3339();
+    if fresh != previous {
+        return fresh;
+    }
+    // `checked_add_signed` only fails at the far end of chrono's date range;
+    // degrade to the un-nudged stamp rather than panic.
+    now.checked_add_signed(chrono::TimeDelta::nanoseconds(1))
+        .map(|nudged| nudged.to_rfc3339())
+        .unwrap_or(fresh)
+}
+
 /// Deserialize an `Option<Option<T>>` field that distinguishes an absent key
 /// from an explicit JSON `null`.
 ///
@@ -298,6 +323,32 @@ mod tests {
         assert_eq!(absent.ttl, None);
         assert_eq!(null.ttl, Some(None));
         assert_eq!(set.ttl, Some(Some(3600)));
+    }
+
+    #[test]
+    fn bumped_updated_at_always_changes_the_generation() {
+        use chrono::Utc;
+
+        // Collision (coarse or stepped-back clock lands on the exact previous
+        // stamp): the result must still differ, stay valid RFC 3339, and sort
+        // after the previous stamp.
+        let now = Utc::now();
+        let previous = now.to_rfc3339();
+        let bumped = super::bumped_updated_at_from(now, &previous);
+        assert_ne!(bumped, previous);
+        let parsed = chrono::DateTime::parse_from_rfc3339(&bumped).expect("valid rfc3339");
+        assert_eq!(
+            parsed.timestamp_nanos_opt(),
+            now.timestamp_nanos_opt().map(|nanos| nanos + 1)
+        );
+
+        // No collision: the fresh stamp is returned untouched.
+        let stale = "2020-01-01T00:00:00+00:00";
+        let fresh = super::bumped_updated_at_from(now, stale);
+        assert_eq!(fresh, previous);
+
+        // The public wrapper never echoes its input back.
+        assert_ne!(super::bumped_updated_at(&previous), previous);
     }
 
     #[test]

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -188,7 +188,7 @@ function isCachedDmChannel(
   );
 }
 
-function invalidateManagedAgentQueriesInBackground(
+export function invalidateManagedAgentQueriesInBackground(
   queryClient: ReturnType<typeof useQueryClient>,
 ) {
   refreshAgentQueriesInBackground(() =>

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   getManagedAgentSecondaryAction,
+  REDEPLOY_SENT_NOTICE,
+  redeployManagedAgentWithRules,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
 } from "./managedAgentControlActions.ts";
@@ -110,6 +112,70 @@ test("deployed provider agents expose redeploy as their secondary action", () =>
     getManagedAgentSecondaryAction(agent({ status: "stopped" })),
     null,
   );
+});
+
+/**
+ * The claim boundary the reviewer flagged. A provider that answers a deploy
+ * with an `agent_id` has proved delivery, not application: the built-in
+ * Kubernetes provider's live row is a strict, zero-mutation no-op that returns
+ * the existing id (pinned in `crates/buzz-backend-kubernetes/src/reconcile.rs`,
+ * `started_pod_returns_its_id_having_applied_nothing`), and
+ * `docs/remote-agents.md` says edits reach a running agent only on its next
+ * fresh generation. So the notice may report the send and the generation
+ * boundary, and must not claim the agent was redeployed or updated.
+ */
+test("a successful redeploy reports delivery, never a proven runtime change", async () => {
+  const deployed = agent({
+    backend: { type: "provider", id: "kubernetes", config: {} },
+    backendAgentId: "buzz-agent-abc123",
+    status: "deployed",
+  });
+
+  let calledWith = null;
+  const result = await redeployManagedAgentWithRules({
+    agent: deployed,
+    redeployManagedAgent: async (pubkey) => {
+      calledWith = pubkey;
+      // What a provider can actually return: an id. It is the same id the
+      // live no-op row returns, so it distinguishes nothing.
+      return { ...deployed };
+    },
+  });
+
+  assert.equal(calledWith, deployed.pubkey);
+  assert.equal(result.noticeMessage, REDEPLOY_SENT_NOTICE);
+  assert.match(result.noticeMessage, /sent to the provider/i);
+  assert.match(result.noticeMessage, /until it next restarts/i);
+  for (const forbidden of [
+    /redeployed/i,
+    /\bapplied\b/i,
+    /now running/i,
+    /updated the agent/i,
+  ]) {
+    assert.doesNotMatch(
+      result.noticeMessage,
+      forbidden,
+      `redeploy notice must not claim a proven runtime change: ${forbidden}`,
+    );
+  }
+});
+
+test("redeploy refuses an agent that has no provider deployment", async () => {
+  let called = false;
+  await assert.rejects(
+    redeployManagedAgentWithRules({
+      agent: agent({
+        backend: { type: "provider", id: "kubernetes", config: {} },
+        backendAgentId: null,
+        status: "not_deployed",
+      }),
+      redeployManagedAgent: async () => {
+        called = true;
+      },
+    }),
+    /not deployed on a provider/i,
+  );
+  assert.equal(called, false, "refused redeploy still called the backend");
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getManagedAgentSecondaryAction,
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
 } from "./managedAgentControlActions.ts";
@@ -79,6 +80,36 @@ test("ordinary local agents still start normally", async () => {
     },
   });
   assert.equal(calledWith, "deadbeef".repeat(8));
+});
+
+test("deployed provider agents expose redeploy as their secondary action", () => {
+  assert.equal(
+    getManagedAgentSecondaryAction(
+      agent({
+        backend: { type: "provider", id: "provider", config: {} },
+        backendAgentId: "remote-agent",
+        status: "deployed",
+      }),
+    ),
+    "redeploy",
+  );
+  assert.equal(
+    getManagedAgentSecondaryAction(
+      agent({
+        backend: { type: "provider", id: "provider", config: {} },
+        status: "not_deployed",
+      }),
+    ),
+    null,
+  );
+  assert.equal(
+    getManagedAgentSecondaryAction(agent({ status: "running" })),
+    "restart",
+  );
+  assert.equal(
+    getManagedAgentSecondaryAction(agent({ status: "stopped" })),
+    null,
+  );
 });
 
 // --- respawnManagedAgentWithRules: stop→clear→start boundary tests -----------

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -101,18 +101,36 @@ export async function startManagedAgentWithRules({
   await startManagedAgent(agent.pubkey);
 }
 
+/**
+ * What a successful redeploy is allowed to claim.
+ *
+ * A provider returning an `agent_id` proves the configuration was *delivered*,
+ * never that the runtime changed: per `docs/remote-agents.md` (§Deploy State
+ * Machine, "Documented consequence") a deploy against a live instance is a
+ * strict no-op that mutates nothing, and "configuration edits to a running
+ * remote agent do not take effect until it next exits" — fresh configuration
+ * materializes exactly when a fresh generation does. So the notice reports the
+ * send and names the generation boundary, and never says "Redeployed".
+ * Pinned by the built-in provider's own contract test
+ * (`crates/buzz-backend-kubernetes/src/reconcile.rs`:
+ * `started_pod_returns_its_id_having_applied_nothing`).
+ */
+export const REDEPLOY_SENT_NOTICE =
+  "Settings sent to the provider. A running agent keeps its current configuration until it next restarts.";
+
 export async function redeployManagedAgentWithRules({
   agent,
   redeployManagedAgent,
 }: {
   agent: ManagedAgent;
   redeployManagedAgent: RedeployManagedAgent;
-}) {
+}): Promise<ManagedAgentActionResult> {
   if (getManagedAgentSecondaryAction(agent) !== "redeploy") {
     throw new Error("Agent is not deployed on a provider.");
   }
 
   await redeployManagedAgent(agent.pubkey);
+  return { noticeMessage: REDEPLOY_SENT_NOTICE };
 }
 
 export async function respawnManagedAgentWithRules({

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -14,6 +14,7 @@ type DeleteManagedAgentInput = {
 
 type StartManagedAgent = (pubkey: string) => Promise<unknown>;
 type StopManagedAgent = (pubkey: string) => Promise<unknown>;
+type RedeployManagedAgent = (pubkey: string) => Promise<unknown>;
 type DeleteManagedAgent = (input: DeleteManagedAgentInput) => Promise<unknown>;
 
 type ManagedAgentChannelContext = {
@@ -45,6 +46,18 @@ export function getManagedAgentPrimaryActionLabel(agent: ManagedAgent) {
   }
 
   return "Start agent";
+}
+
+export type ManagedAgentSecondaryAction = "restart" | "redeploy";
+
+export function getManagedAgentSecondaryAction(
+  agent: ManagedAgent,
+): ManagedAgentSecondaryAction | null {
+  if (agent.backend.type === "provider") {
+    return agent.backendAgentId ? "redeploy" : null;
+  }
+
+  return isManagedAgentActive(agent) ? "restart" : null;
 }
 
 export function resolveManagedAgentChannelId(
@@ -86,6 +99,20 @@ export async function startManagedAgentWithRules({
   // (ensure_relay_mesh_for_record) re-resolves a live serve target and dials
   // it, failing with an actionable error when no peer serves the model.
   await startManagedAgent(agent.pubkey);
+}
+
+export async function redeployManagedAgentWithRules({
+  agent,
+  redeployManagedAgent,
+}: {
+  agent: ManagedAgent;
+  redeployManagedAgent: RedeployManagedAgent;
+}) {
+  if (getManagedAgentSecondaryAction(agent) !== "redeploy") {
+    throw new Error("Agent is not deployed on a provider.");
+  }
+
+  await redeployManagedAgent(agent.pubkey);
 }
 
 export async function respawnManagedAgentWithRules({

--- a/desktop/src/features/agents/ui/RunOnSummarySection.tsx
+++ b/desktop/src/features/agents/ui/RunOnSummarySection.tsx
@@ -68,6 +68,11 @@ export function RunOnSummarySection({
         runs can&apos;t be changed afterwards — create a new agent to run
         somewhere else.
       </p>
+      {summary.location === "local" ? null : (
+        <p className="text-xs text-muted-foreground">
+          Saved changes don&apos;t reach a deployed agent until you redeploy it.
+        </p>
+      )}
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/RunOnSummarySection.tsx
+++ b/desktop/src/features/agents/ui/RunOnSummarySection.tsx
@@ -70,7 +70,8 @@ export function RunOnSummarySection({
       </p>
       {summary.location === "local" ? null : (
         <p className="text-xs text-muted-foreground">
-          Saved changes don&apos;t reach a deployed agent until you redeploy it.
+          Redeploy sends saved changes to the provider. A running agent keeps
+          its current configuration until it next restarts.
         </p>
       )}
     </div>

--- a/desktop/src/features/agents/useRedeployManagedAgentMutation.ts
+++ b/desktop/src/features/agents/useRedeployManagedAgentMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  invalidateManagedAgentQueriesInBackground,
+  managedAgentsQueryKey,
+} from "@/features/agents/hooks";
+import { redeployManagedAgent } from "@/shared/api/tauriManagedAgents";
+import type { ManagedAgent } from "@/shared/api/types";
+
+export function useRedeployManagedAgentMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (pubkey: string) => redeployManagedAgent(pubkey),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ManagedAgent[]>(
+        managedAgentsQueryKey,
+        (current) => {
+          if (!current) return current;
+          return current.map((agent) =>
+            agent.pubkey === updated.pubkey ? updated : agent,
+          );
+        },
+      );
+    },
+    onSettled: () => {
+      invalidateManagedAgentQueriesInBackground(queryClient);
+    },
+  });
+}

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -7,20 +7,10 @@ import {
   type AttachManagedAgentToChannelResult,
   useAcpRuntimesQuery,
   useAvailableAcpRuntimes,
-  useCreateManagedAgentMutation,
-  useCreatePersonaMutation,
-  useDeleteManagedAgentMutation,
-  useDeletePersonaMutation,
   useManagedAgentLogQuery,
   useRelayAgentsQuery,
   useManagedAgentsQuery,
   usePersonasQuery,
-  useSetManagedAgentStartOnAppLaunchMutation,
-  useSetPersonaActiveMutation,
-  useStartManagedAgentMutation,
-  useStopManagedAgentMutation,
-  useUpdateManagedAgentMutation,
-  useUpdatePersonaMutation,
 } from "@/features/agents/hooks";
 import { useGlobalAgentConfig } from "@/features/agents/useGlobalAgentConfig";
 import { AddAgentToChannelDialog } from "@/features/agents/ui/AddAgentToChannelDialog";
@@ -31,6 +21,7 @@ import {
 } from "@/features/agents/lib/instanceInputForDefinition";
 import { describeLogFile } from "@/features/agents/ui/agentUi";
 import { useAgentLifecycleActions } from "@/features/profile/ui/useAgentLifecycleActions";
+import { useAgentProfileMutations } from "@/features/profile/ui/useAgentProfileMutations";
 import {
   duplicatePersonaDialogState,
   editPersonaDialogState,
@@ -238,16 +229,20 @@ export function UserProfilePanel({
   const relayAgentsQuery = useRelayAgentsQuery({ enabled: true });
   const availableRuntimesQuery = useAvailableAcpRuntimes();
   const acpRuntimesQuery = useAcpRuntimesQuery();
-  const createAgentMutation = useCreateManagedAgentMutation();
-  const updateManagedAgentMutation = useUpdateManagedAgentMutation();
-  const startAgentMutation = useStartManagedAgentMutation();
-  const stopAgentMutation = useStopManagedAgentMutation();
-  const deleteAgentMutation = useDeleteManagedAgentMutation();
-  const startOnLaunchMutation = useSetManagedAgentStartOnAppLaunchMutation();
-  const createPersonaMutation = useCreatePersonaMutation();
-  const updatePersonaMutation = useUpdatePersonaMutation();
-  const deletePersonaMutation = useDeletePersonaMutation();
-  const setPersonaActiveMutation = useSetPersonaActiveMutation();
+  const {
+    createAgentMutation,
+    updateManagedAgentMutation,
+    startAgentMutation,
+    redeployAgentMutation,
+    stopAgentMutation,
+    deleteAgentMutation,
+    startOnLaunchMutation,
+    createPersonaMutation,
+    updatePersonaMutation,
+    deletePersonaMutation,
+    setPersonaActiveMutation,
+    isAgentActionPending,
+  } = useAgentProfileMutations();
   const usersBatchQuery = useUsersBatchQuery(
     effectivePubkey ? [effectivePubkey] : [],
   );
@@ -334,17 +329,6 @@ export function UserProfilePanel({
     isOwner === true &&
     resolvedPersona !== undefined &&
     managedAgent === undefined;
-  const isAgentActionPending =
-    createAgentMutation.isPending ||
-    updateManagedAgentMutation.isPending ||
-    startAgentMutation.isPending ||
-    stopAgentMutation.isPending ||
-    deleteAgentMutation.isPending ||
-    startOnLaunchMutation.isPending ||
-    createPersonaMutation.isPending ||
-    updatePersonaMutation.isPending ||
-    deletePersonaMutation.isPending ||
-    setPersonaActiveMutation.isPending;
   const isFollowing =
     !isSelf &&
     pubkeyLower.length > 0 &&
@@ -449,11 +433,12 @@ export function UserProfilePanel({
     ],
   );
 
-  const { handleAgentPrimaryAction, handleAgentRestart } =
+  const { handleAgentPrimaryAction, handleAgentRedeploy, handleAgentRestart } =
     useAgentLifecycleActions({
       channels: channelsQuery.data,
       managedAgent,
       relayAgents: relayAgentsQuery.data,
+      redeployManagedAgent: redeployAgentMutation.mutateAsync,
       startManagedAgent: startAgentMutation.mutateAsync,
       stopManagedAgent: stopAgentMutation.mutateAsync,
     });
@@ -796,6 +781,7 @@ export function UserProfilePanel({
           followMutation={followMutation}
           agentInstruction={agentInstruction}
           handleAgentPrimaryAction={handleAgentPrimaryAction}
+          handleAgentRedeploy={handleAgentRedeploy}
           handleAgentRestart={handleAgentRestart}
           handleEditAgent={handleEditAgent}
           handleToggleAgentAutoStart={handleToggleAgentAutoStart}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getManagedAgentPrimaryActionLabel,
+  getManagedAgentSecondaryAction,
   isManagedAgentActive,
 } from "@/features/agents/lib/managedAgentControlActions";
 import { RestartDiffBadge } from "@/features/agents/ui/RestartDiffBadge";
@@ -70,6 +71,7 @@ export type ProfileSummaryViewProps = {
   canInstantiateAgent: boolean;
   agentInstruction: string | null;
   handleAgentPrimaryAction: () => void;
+  handleAgentRedeploy: () => void;
   handleAgentRestart: () => void;
   handleEditAgent: () => void;
   handleToggleAgentAutoStart: () => void;
@@ -146,6 +148,7 @@ export function ProfileSummaryView({
   canInstantiateAgent,
   agentInstruction,
   handleAgentPrimaryAction,
+  handleAgentRedeploy,
   handleAgentRestart,
   handleEditAgent,
   handleToggleAgentAutoStart,
@@ -210,6 +213,9 @@ export function ProfileSummaryView({
     resetValue: "0px",
     targetRef: stickyLayoutRef,
   });
+  const managedAgentSecondaryAction = managedAgent
+    ? getManagedAgentSecondaryAction(managedAgent)
+    : null;
 
   const showMemoriesTab = isOwner === true && Boolean(pubkey);
   const showInstructionBlock =
@@ -441,11 +447,13 @@ export function ProfileSummaryView({
               : undefined
           }
           onAgentRestart={
-            isOwner === true &&
-            managedAgent?.backend.type === "local" &&
-            (managedAgent.status === "running" ||
-              managedAgent.status === "deployed")
+            isOwner === true && managedAgentSecondaryAction === "restart"
               ? handleAgentRestart
+              : undefined
+          }
+          onAgentRedeploy={
+            isOwner === true && managedAgentSecondaryAction === "redeploy"
+              ? handleAgentRedeploy
               : undefined
           }
           isFollowing={isFollowing}

--- a/desktop/src/features/profile/ui/UserProfilePrimaryActions.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePrimaryActions.tsx
@@ -34,6 +34,7 @@ export function ProfilePrimaryActions({
   isFollowing,
   messagePending,
   onAgentPrimaryAction,
+  onAgentRedeploy,
   onAgentRestart,
   onHuddle,
   onMessage,
@@ -53,6 +54,7 @@ export function ProfilePrimaryActions({
   isFollowing: boolean;
   messagePending?: boolean;
   onAgentPrimaryAction?: () => void;
+  onAgentRedeploy?: () => void;
   onAgentRestart?: () => void;
   onHuddle?: () => void;
   onMessage?: () => void;
@@ -79,7 +81,8 @@ export function ProfilePrimaryActions({
     onMessage !== undefined ||
     onHuddle !== undefined ||
     (onAgentPrimaryAction !== undefined && agentActionLabel !== undefined) ||
-    onAgentRestart !== undefined;
+    onAgentRestart !== undefined ||
+    onAgentRedeploy !== undefined;
 
   if (!hasActions) {
     return null;
@@ -108,6 +111,15 @@ export function ProfilePrimaryActions({
           label="Restart agent"
           onClick={onAgentRestart}
           testId="user-profile-agent-restart"
+        />
+      ) : null}
+      {onAgentRedeploy ? (
+        <ProfileActionTile
+          disabled={agentActionDisabled}
+          icon={RefreshCw}
+          label="Redeploy"
+          onClick={onAgentRedeploy}
+          testId="user-profile-agent-redeploy"
         />
       ) : null}
       {onMessage ? (

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 
 import {
   isManagedAgentActive,
+  redeployManagedAgentWithRules,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -14,12 +15,14 @@ export function useAgentLifecycleActions({
   channels,
   managedAgent,
   relayAgents,
+  redeployManagedAgent,
   startManagedAgent,
   stopManagedAgent,
 }: {
   channels: readonly Channel[] | undefined;
   managedAgent: ManagedAgent | undefined;
   relayAgents: readonly RelayAgent[] | undefined;
+  redeployManagedAgent: (pubkey: string) => Promise<unknown>;
   startManagedAgent: (pubkey: string) => Promise<unknown>;
   stopManagedAgent: (pubkey: string) => Promise<unknown>;
 }) {
@@ -81,5 +84,25 @@ export function useAgentLifecycleActions({
     }
   }, [managedAgent, startManagedAgent, stopManagedAgent]);
 
-  return { handleAgentPrimaryAction, handleAgentRestart };
+  const handleAgentRedeploy = React.useCallback(async () => {
+    if (!managedAgent) return;
+
+    try {
+      await redeployManagedAgentWithRules({
+        agent: managedAgent,
+        redeployManagedAgent,
+      });
+      toast.success(`Redeployed ${managedAgent.name}.`);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Agent redeploy failed.",
+      );
+    }
+  }, [managedAgent, redeployManagedAgent]);
+
+  return {
+    handleAgentPrimaryAction,
+    handleAgentRedeploy,
+    handleAgentRestart,
+  };
 }

--- a/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
+++ b/desktop/src/features/profile/ui/useAgentLifecycleActions.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import {
   isManagedAgentActive,
   redeployManagedAgentWithRules,
+  REDEPLOY_SENT_NOTICE,
   respawnManagedAgentWithRules,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -88,11 +89,13 @@ export function useAgentLifecycleActions({
     if (!managedAgent) return;
 
     try {
-      await redeployManagedAgentWithRules({
+      const result = await redeployManagedAgentWithRules({
         agent: managedAgent,
         redeployManagedAgent,
       });
-      toast.success(`Redeployed ${managedAgent.name}.`);
+      // Never "Redeployed" — the provider's answer proves delivery, not that
+      // the running agent picked the settings up. See REDEPLOY_SENT_NOTICE.
+      toast.success(result.noticeMessage ?? REDEPLOY_SENT_NOTICE);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Agent redeploy failed.",

--- a/desktop/src/features/profile/ui/useAgentProfileMutations.ts
+++ b/desktop/src/features/profile/ui/useAgentProfileMutations.ts
@@ -1,0 +1,55 @@
+import {
+  useCreateManagedAgentMutation,
+  useCreatePersonaMutation,
+  useDeleteManagedAgentMutation,
+  useDeletePersonaMutation,
+  useSetManagedAgentStartOnAppLaunchMutation,
+  useSetPersonaActiveMutation,
+  useStartManagedAgentMutation,
+  useStopManagedAgentMutation,
+  useUpdateManagedAgentMutation,
+  useUpdatePersonaMutation,
+} from "@/features/agents/hooks";
+import { useRedeployManagedAgentMutation } from "@/features/agents/useRedeployManagedAgentMutation";
+
+export function useAgentProfileMutations() {
+  const createAgentMutation = useCreateManagedAgentMutation();
+  const updateManagedAgentMutation = useUpdateManagedAgentMutation();
+  const startAgentMutation = useStartManagedAgentMutation();
+  const redeployAgentMutation = useRedeployManagedAgentMutation();
+  const stopAgentMutation = useStopManagedAgentMutation();
+  const deleteAgentMutation = useDeleteManagedAgentMutation();
+  const startOnLaunchMutation = useSetManagedAgentStartOnAppLaunchMutation();
+  const createPersonaMutation = useCreatePersonaMutation();
+  const updatePersonaMutation = useUpdatePersonaMutation();
+  const deletePersonaMutation = useDeletePersonaMutation();
+  const setPersonaActiveMutation = useSetPersonaActiveMutation();
+
+  const isAgentActionPending =
+    createAgentMutation.isPending ||
+    updateManagedAgentMutation.isPending ||
+    startAgentMutation.isPending ||
+    redeployAgentMutation.isPending ||
+    stopAgentMutation.isPending ||
+    deleteAgentMutation.isPending ||
+    startOnLaunchMutation.isPending ||
+    createPersonaMutation.isPending ||
+    updatePersonaMutation.isPending ||
+    deletePersonaMutation.isPending ||
+    setPersonaActiveMutation.isPending;
+
+  return {
+    createAgentMutation,
+    updateManagedAgentMutation,
+    startAgentMutation,
+    redeployAgentMutation,
+    stopAgentMutation,
+    deleteAgentMutation,
+    startOnLaunchMutation,
+    createPersonaMutation,
+    updatePersonaMutation,
+    deletePersonaMutation,
+    setPersonaActiveMutation,
+    isAgentActionPending,
+  };
+}

--- a/desktop/src/shared/api/tauriManagedAgents.ts
+++ b/desktop/src/shared/api/tauriManagedAgents.ts
@@ -15,6 +15,16 @@ export async function startManagedAgent(pubkey: string): Promise<ManagedAgent> {
   return fromRawManagedAgent(response);
 }
 
+export async function redeployManagedAgent(
+  pubkey: string,
+): Promise<ManagedAgent> {
+  const response = await invokeTauri<RawManagedAgent>(
+    "redeploy_managed_agent",
+    { pubkey },
+  );
+  return fromRawManagedAgent(response);
+}
+
 export async function stopManagedAgent(pubkey: string): Promise<ManagedAgent> {
   const response = await invokeTauri<RawManagedAgent>("stop_managed_agent", {
     pubkey,


### PR DESCRIPTION
## Problem

Desktop's edit dialog for a provider-backed managed agent lets you change model, env vars, respond-to, args, and parallelism — and Save silently writes only Desktop's local record. Nothing reaches the provider host. After the first deploy the Deploy action permanently becomes Shutdown, so there is no way to apply config changes to a running deployment short of hand-editing the host's unit file and bouncing the process yourself.

## Approach

The provider protocol already treats `deploy` as update-in-place: the host rewrites the agent's unit config and restarts it. So "redeploy" is just re-running the existing deploy path with the current record — no protocol or host changes.

- **`redeploy_managed_agent`** Tauri command (in `commands/agents/provider_access.rs`), reusing `build_deploy_payload` + `deploy_to_provider`. Guarded by `redeploy_provider_target`: provider-backed and already-deployed agents only. Payload/deploy failures persist to the record via the same `persist_failure` path reconciliation uses.
- **Redeploy quick action** on the agent profile panel, shown to the owner of a deployed provider-backed agent. Local agents keep Restart; both flow through a shared `getManagedAgentSecondaryAction` helper.
- **Honest copy** in the edit dialog's Run-on summary: saved changes don't reach a deployed agent until you redeploy it.

Two extractions keep over-limit files inside the file-size ratchet: the profile panel's mutation cluster moved to `useAgentProfileMutations`, and the redeploy mutation lives in its own module.

## Testing

- `cargo test --workspace` from `desktop/src-tauri`: 2372 passed, 0 failed (includes new `redeploy_guard_requires_provider_backend_and_existing_deployment`)
- `pnpm test`: 4536 passed, 0 failed (includes new secondary-action cases)
- `pnpm typecheck`, `pnpm check` (biome + file-size/px/pubkey guards), `cargo fmt --check`, clippy: clean
