### PR TITLE
fix(desktop): bound nine unbounded localStorage stores

### DIFF
--- a/desktop/src/features/channels/forcedUnreadStore.test.mjs
+++ b/desktop/src/features/channels/forcedUnreadStore.test.mjs
@@ -3,7 +3,9 @@ import test from "node:test";
 
 import {
   addForcedUnreadSource,
+  boundForcedUnreadMap,
   forcedUnreadMarker,
+  MAX_FORCED_UNREAD_ENTRIES,
   removeForcedUnreadSource,
 } from "./forcedUnreadStore.ts";
 
@@ -47,6 +49,22 @@ test("clearing the only force owner removes the entry", () => {
   };
 
   assert.equal(removeForcedUnreadSource(entry, "inbox"), undefined);
+});
+
+test("forced unread map keeps the newest 500 insertion-ordered entries", () => {
+  const map = Object.fromEntries(
+    Array.from({ length: MAX_FORCED_UNREAD_ENTRIES + 2 }, (_, index) => [
+      `channel-${index}`,
+      index,
+    ]),
+  );
+
+  const bounded = boundForcedUnreadMap(map);
+
+  assert.equal(Object.keys(bounded).length, MAX_FORCED_UNREAD_ENTRIES);
+  assert.equal(bounded["channel-0"], undefined);
+  assert.equal(bounded["channel-1"], undefined);
+  assert.equal(bounded[`channel-${MAX_FORCED_UNREAD_ENTRIES + 1}`], 501);
 });
 
 test("legacy persisted entries retain their read-marker baseline", () => {

--- a/desktop/src/features/channels/forcedUnreadStore.ts
+++ b/desktop/src/features/channels/forcedUnreadStore.ts
@@ -74,7 +74,15 @@ export function removeForcedUnreadSource(
 }
 
 const STORAGE_PREFIX = "buzz-forced-unread.v1";
+export const MAX_FORCED_UNREAD_ENTRIES = 500;
 const storageKey = (pubkey: string) => `${STORAGE_PREFIX}:${pubkey}`;
+
+export function boundForcedUnreadMap(map: ForcedUnreadMap): ForcedUnreadMap {
+  const entries = Object.entries(map);
+  return entries.length <= MAX_FORCED_UNREAD_ENTRIES
+    ? map
+    : Object.fromEntries(entries.slice(-MAX_FORCED_UNREAD_ENTRIES));
+}
 
 export const forcedUnreadStore = {
   read(pubkey: string): ForcedUnreadMap {
@@ -113,14 +121,17 @@ export const forcedUnreadStore = {
           }
         }
       }
-      return result;
+      return boundForcedUnreadMap(result);
     } catch {
       return {};
     }
   },
   write(pubkey: string, map: ForcedUnreadMap): void {
     try {
-      window.localStorage.setItem(storageKey(pubkey), JSON.stringify(map));
+      window.localStorage.setItem(
+        storageKey(pubkey),
+        JSON.stringify(boundForcedUnreadMap(map)),
+      );
     } catch {
       // Ignore storage errors (private browsing, quota exceeded).
     }
@@ -148,7 +159,9 @@ export function useForcedUnreadActions(
         source,
       );
       if (next === current) return;
+      delete forcedUnreadRef.current[channelId];
       forcedUnreadRef.current[channelId] = next;
+      forcedUnreadRef.current = boundForcedUnreadMap(forcedUnreadRef.current);
       persist();
     },
     [forcedUnreadRef, getOwnTimestamp, persist],

--- a/desktop/src/features/communities/communityIconCache.test.mjs
+++ b/desktop/src/features/communities/communityIconCache.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  boundCommunityIconCache,
+  MAX_CACHED_COMMUNITY_ICON_LENGTH,
+  MAX_CACHED_COMMUNITY_ICONS,
+} from "./communityIconCache.ts";
+
+test("community icon cache caps entries and rejects oversized icons", () => {
+  const cache = Object.fromEntries(
+    Array.from({ length: MAX_CACHED_COMMUNITY_ICONS + 1 }, (_, index) => [
+      `relay-${index}`,
+      `icon-${index}`,
+    ]),
+  );
+  cache.oversized = "x".repeat(MAX_CACHED_COMMUNITY_ICON_LENGTH + 1);
+
+  const bounded = boundCommunityIconCache(cache);
+
+  assert.equal(Object.keys(bounded).length, MAX_CACHED_COMMUNITY_ICONS);
+  assert.equal(bounded["relay-0"], undefined);
+  assert.equal(bounded.oversized, undefined);
+  assert.equal(bounded[`relay-${MAX_CACHED_COMMUNITY_ICONS}`], "icon-32");
+});

--- a/desktop/src/features/communities/communityIconCache.test.mjs
+++ b/desktop/src/features/communities/communityIconCache.test.mjs
@@ -3,8 +3,10 @@ import test from "node:test";
 
 import {
   boundCommunityIconCache,
+  loadCachedCommunityIcon,
   MAX_CACHED_COMMUNITY_ICON_LENGTH,
   MAX_CACHED_COMMUNITY_ICONS,
+  saveCachedCommunityIcon,
 } from "./communityIconCache.ts";
 
 test("community icon cache caps entries and rejects oversized icons", () => {
@@ -22,4 +24,19 @@ test("community icon cache caps entries and rejects oversized icons", () => {
   assert.equal(bounded["relay-0"], undefined);
   assert.equal(bounded.oversized, undefined);
   assert.equal(bounded[`relay-${MAX_CACHED_COMMUNITY_ICONS}`], "icon-32");
+});
+
+test("community icon cache accepts relay-sized icons above 64 KiB", () => {
+  const values = new Map([
+    ["buzz-community-icons", JSON.stringify({ relay: "prior-icon" })],
+  ]);
+  globalThis.localStorage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+  };
+  const acceptedIcon = "x".repeat(80 * 1024);
+
+  saveCachedCommunityIcon("relay", acceptedIcon);
+
+  assert.equal(loadCachedCommunityIcon("relay"), acceptedIcon);
 });

--- a/desktop/src/features/communities/communityIconCache.ts
+++ b/desktop/src/features/communities/communityIconCache.ts
@@ -5,13 +5,26 @@
  */
 
 const ICON_CACHE_KEY = "buzz-community-icons";
+export const MAX_CACHED_COMMUNITY_ICONS = 32;
+export const MAX_CACHED_COMMUNITY_ICON_LENGTH = 64 * 1024;
+
+export function boundCommunityIconCache(
+  cache: Record<string, string>,
+): Record<string, string> {
+  const entries = Object.entries(cache).filter(
+    ([, icon]) =>
+      typeof icon === "string" &&
+      icon.length <= MAX_CACHED_COMMUNITY_ICON_LENGTH,
+  );
+  return Object.fromEntries(entries.slice(-MAX_CACHED_COMMUNITY_ICONS));
+}
 
 function loadCache(): Record<string, string> {
   try {
     const raw = localStorage.getItem(ICON_CACHE_KEY);
     const parsed: unknown = raw ? JSON.parse(raw) : null;
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, string>;
+      return boundCommunityIconCache(parsed as Record<string, string>);
     }
   } catch {
     // Corrupt cache — fall through to empty.
@@ -28,13 +41,17 @@ export function saveCachedCommunityIcon(
   icon: string | null,
 ): void {
   const cache = loadCache();
-  if (icon) {
+  if (icon && icon.length <= MAX_CACHED_COMMUNITY_ICON_LENGTH) {
+    delete cache[relayUrl];
     cache[relayUrl] = icon;
   } else {
     delete cache[relayUrl];
   }
   try {
-    localStorage.setItem(ICON_CACHE_KEY, JSON.stringify(cache));
+    localStorage.setItem(
+      ICON_CACHE_KEY,
+      JSON.stringify(boundCommunityIconCache(cache)),
+    );
   } catch {
     // Quota exceeded — the icon still renders from the in-memory query.
   }

--- a/desktop/src/features/communities/communityIconCache.ts
+++ b/desktop/src/features/communities/communityIconCache.ts
@@ -6,7 +6,9 @@
 
 const ICON_CACHE_KEY = "buzz-community-icons";
 export const MAX_CACHED_COMMUNITY_ICONS = 32;
-export const MAX_CACHED_COMMUNITY_ICON_LENGTH = 64 * 1024;
+// Keep aligned with MAX_WORKSPACE_ICON_DATA_URL_LEN in
+// crates/buzz-relay/src/handlers/relay_admin.rs.
+export const MAX_CACHED_COMMUNITY_ICON_LENGTH = 98_304;
 
 export function boundCommunityIconCache(
   cache: Record<string, string>,

--- a/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
@@ -207,6 +207,30 @@ test("new recipients retain explicit mention order", async () => {
   assert.deepEqual(savedAudiences(), { [scope]: [agentB, agentA] });
 });
 
+test("persistent audiences retain only the 200 most recently touched scopes", async () => {
+  const store = await loadStore(11);
+  for (
+    let index = 0;
+    index < store.MAX_PERSISTENT_AGENT_AUDIENCES + 2;
+    index++
+  ) {
+    store.setPersistentAgentAudience(`scope-${index}`, [agentA]);
+  }
+
+  const saved = savedAudiences();
+  assert.equal(Object.keys(saved).length, store.MAX_PERSISTENT_AGENT_AUDIENCES);
+  assert.equal(saved["scope-0"], undefined);
+  assert.equal(saved["scope-1"], undefined);
+  assert.deepEqual(saved["scope-201"], [agentA]);
+
+  store.setPersistentAgentAudience("scope-2", [agentB]);
+  store.setPersistentAgentAudience("scope-new", [agentC]);
+  const retouched = savedAudiences();
+  assert.equal(retouched["scope-3"], undefined);
+  assert.deepEqual(retouched["scope-2"], [agentB]);
+  assert.deepEqual(retouched["scope-new"], [agentC]);
+});
+
 test("timeline scope is intentionally unsupported", async () => {
   const store = await loadStore(7);
   assert.equal(

--- a/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
@@ -231,6 +231,69 @@ test("persistent audiences retain only the 200 most recently touched scopes", as
   assert.deepEqual(retouched["scope-new"], [agentC]);
 });
 
+test("an unchanged touch refreshes LRU without revision or emit", async () => {
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id='root'></div></body></html>",
+    {
+      url: "http://localhost",
+    },
+  );
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+  loadSequence += 1;
+  const store = await import(
+    `./persistentAgentAudience.ts?test=${Date.now()}-touch-${loadSequence}`
+  );
+  const touchedScope = "scope-0";
+  store.setPersistentAgentAudience(touchedScope, [agentA]);
+  for (let index = 1; index < store.MAX_PERSISTENT_AGENT_AUDIENCES; index++) {
+    store.setPersistentAgentAudience(`scope-${index}`, [agentA]);
+  }
+
+  const React = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const root = createRoot(document.getElementById("root"));
+  let renderCount = 0;
+  function Probe() {
+    store.usePersistentAgentAudience(touchedScope);
+    renderCount += 1;
+    return null;
+  }
+  await React.act(async () => root.render(React.createElement(Probe)));
+  const revision = store.getPersistentAgentAudienceRevision(touchedScope);
+  const renderCountBeforeTouch = renderCount;
+
+  await React.act(async () => {
+    store.setPersistentAgentAudience(touchedScope, [agentA]);
+  });
+
+  assert.equal(
+    store.getPersistentAgentAudienceRevision(touchedScope),
+    revision,
+  );
+  assert.equal(renderCount, renderCountBeforeTouch);
+
+  await React.act(async () => {
+    store.setPersistentAgentAudience("scope-new", [agentB]);
+  });
+  const saved = savedAudiences();
+  assert.deepEqual(saved[touchedScope], [agentA]);
+  assert.equal(saved["scope-1"], undefined);
+  assert.deepEqual(saved["scope-new"], [agentB]);
+  assert.equal(
+    store.getPersistentAgentAudienceRevision(touchedScope),
+    revision,
+  );
+
+  await React.act(async () => root.unmount());
+  dom.window.close();
+});
+
 test("timeline scope is intentionally unsupported", async () => {
   const store = await loadStore(7);
   assert.equal(

--- a/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.test.mjs
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-function createStorage() {
+function createStorage(onSetItem = () => {}) {
   const values = new Map();
   return {
     getItem: (key) => values.get(key) ?? null,
-    setItem: (key, value) => values.set(key, String(value)),
+    setItem: (key, value) => {
+      onSetItem(key, value);
+      values.set(key, String(value));
+    },
   };
 }
 
@@ -239,6 +242,11 @@ test("an unchanged touch refreshes LRU without revision or emit", async () => {
       url: "http://localhost",
     },
   );
+  const writes = [];
+  Object.defineProperty(dom.window, "localStorage", {
+    configurable: true,
+    value: createStorage((key, value) => writes.push([key, String(value)])),
+  });
   Object.assign(globalThis, {
     document: dom.window.document,
     HTMLElement: dom.window.HTMLElement,
@@ -267,11 +275,27 @@ test("an unchanged touch refreshes LRU without revision or emit", async () => {
   await React.act(async () => root.render(React.createElement(Probe)));
   const revision = store.getPersistentAgentAudienceRevision(touchedScope);
   const renderCountBeforeTouch = renderCount;
+  writes.length = 0;
 
   await React.act(async () => {
     store.setPersistentAgentAudience(touchedScope, [agentA]);
   });
 
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0][0], storageKey);
+  assert.deepEqual(JSON.parse(writes[0][1])[touchedScope], [agentA]);
+  assert.equal(Object.keys(JSON.parse(writes[0][1])).at(-1), touchedScope);
+  assert.equal(
+    store.getPersistentAgentAudienceRevision(touchedScope),
+    revision,
+  );
+  assert.equal(renderCount, renderCountBeforeTouch);
+
+  writes.length = 0;
+  await React.act(async () => {
+    store.setPersistentAgentAudience(touchedScope, [agentA]);
+  });
+  assert.equal(writes.length, 0);
   assert.equal(
     store.getPersistentAgentAudienceRevision(touchedScope),
     revision,

--- a/desktop/src/features/messages/lib/persistentAgentAudience.ts
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 const ENABLED_STORAGE_KEY = "buzz:keep-addressed-agents-active";
 const AUDIENCES_STORAGE_KEY = "buzz:persistent-agent-audiences:v2";
+export const MAX_PERSISTENT_AGENT_AUDIENCES = 200;
 
 const listeners = new Set<() => void>();
 const revisions = new Map<string, number>();
@@ -39,6 +40,15 @@ function readEnabled(): boolean {
   }
 }
 
+function boundAudiences(
+  value: Record<string, string[]>,
+): Record<string, string[]> {
+  const entries = Object.entries(value);
+  return entries.length <= MAX_PERSISTENT_AGENT_AUDIENCES
+    ? value
+    : Object.fromEntries(entries.slice(-MAX_PERSISTENT_AGENT_AUDIENCES));
+}
+
 function readAudiences(): Record<string, string[]> {
   if (typeof window === "undefined") return {};
   try {
@@ -56,7 +66,7 @@ function readAudiences(): Record<string, string[]> {
         );
       }
     }
-    return result;
+    return boundAudiences(result);
   } catch {
     return {};
   }
@@ -148,7 +158,12 @@ export function setPersistentAgentAudience(
     return;
   }
 
-  audiences = { ...audiences, [scope]: normalized };
+  const nextAudiences = { ...audiences };
+  delete nextAudiences[scope];
+  audiences = boundAudiences({ ...nextAudiences, [scope]: normalized });
+  for (const revisedScope of revisions.keys()) {
+    if (!Object.hasOwn(audiences, revisedScope)) revisions.delete(revisedScope);
+  }
   advanceRevision(scope);
   persistAudiences();
   emit();

--- a/desktop/src/features/messages/lib/persistentAgentAudience.ts
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.ts
@@ -158,6 +158,7 @@ export function setPersistentAgentAudience(
     current.length === normalized.length &&
     current.every((pubkey, index) => pubkey === normalized[index])
   ) {
+    if (Object.keys(audiences).at(-1) === scope) return;
     const nextAudiences = { ...audiences };
     delete nextAudiences[scope];
     audiences = boundAudiences({ ...nextAudiences, [scope]: current });

--- a/desktop/src/features/messages/lib/persistentAgentAudience.ts
+++ b/desktop/src/features/messages/lib/persistentAgentAudience.ts
@@ -139,8 +139,11 @@ export function initializePersistentAgentAudience(
   scope: string,
   pubkeys: Iterable<string>,
 ): void {
-  if (!enabled || !scope || Object.hasOwn(audiences, scope)) return;
-  setPersistentAgentAudience(scope, pubkeys);
+  if (!enabled || !scope) return;
+  setPersistentAgentAudience(
+    scope,
+    Object.hasOwn(audiences, scope) ? audiences[scope] : pubkeys,
+  );
 }
 
 export function setPersistentAgentAudience(
@@ -155,6 +158,10 @@ export function setPersistentAgentAudience(
     current.length === normalized.length &&
     current.every((pubkey, index) => pubkey === normalized[index])
   ) {
+    const nextAudiences = { ...audiences };
+    delete nextAudiences[scope];
+    audiences = boundAudiences({ ...nextAudiences, [scope]: current });
+    persistAudiences();
     return;
   }
 

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -3,9 +3,12 @@ import test from "node:test";
 
 import {
   parseSelfProfileCache,
+  MAX_SELF_PROFILE_CACHES,
+  MAX_SELF_PROFILE_CACHES_PER_RELAY,
   resolveAvatarDataUrl,
   shouldFetchAvatar,
   storageKey,
+  writeSelfProfileCache,
 } from "./selfProfileStorage.ts";
 
 test("storageKey: includes pubkey in result", () => {
@@ -46,6 +49,54 @@ test("storageKey: different pubkeys produce different keys", () => {
   const a = storageKey("https://relay.example.com", "pubkey-a");
   const b = storageKey("https://relay.example.com", "pubkey-b");
   assert.notEqual(a, b);
+});
+
+function installStorage() {
+  const values = new Map();
+  globalThis.window = {
+    dispatchEvent: () => true,
+    localStorage: {
+      get length() {
+        return values.size;
+      },
+      getItem: (key) => values.get(key) ?? null,
+      key: (index) => [...values.keys()][index] ?? null,
+      removeItem: (key) => values.delete(key),
+      setItem: (key, value) => values.set(key, String(value)),
+    },
+  };
+  globalThis.CustomEvent ??= class CustomEvent {};
+  return values;
+}
+
+test("writeSelfProfileCache caps each relay and the global cache by updatedAt", () => {
+  const values = installStorage();
+  const relayA = "wss://relay-a.example";
+  for (let index = 0; index < MAX_SELF_PROFILE_CACHES_PER_RELAY + 1; index++) {
+    assert.equal(
+      writeSelfProfileCache(
+        relayA,
+        `pubkey-${index}`,
+        makeCache({ updatedAt: index }),
+      ),
+      true,
+    );
+  }
+  assert.equal(values.has(storageKey(relayA, "pubkey-0")), false);
+  assert.equal(values.has(storageKey(relayA, "pubkey-8")), true);
+
+  for (let index = 0; index < MAX_SELF_PROFILE_CACHES + 1; index++) {
+    writeSelfProfileCache(
+      `wss://relay-${index}.example`,
+      `global-${index}`,
+      makeCache({ updatedAt: index + 100 }),
+    );
+  }
+  const profileKeys = [...values.keys()].filter((key) =>
+    key.startsWith("buzz-self-profile.v1:"),
+  );
+  assert.equal(profileKeys.length, MAX_SELF_PROFILE_CACHES);
+  assert.equal(values.has(storageKey(relayA, "pubkey-1")), false);
 });
 
 test("parseSelfProfileCache: valid v1 payload round-trips", () => {

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -51,7 +51,7 @@ test("storageKey: different pubkeys produce different keys", () => {
   assert.notEqual(a, b);
 });
 
-function installStorage() {
+function installStorage(onGetItem = () => {}) {
   const values = new Map();
   globalThis.window = {
     dispatchEvent: () => true,
@@ -59,7 +59,10 @@ function installStorage() {
       get length() {
         return values.size;
       },
-      getItem: (key) => values.get(key) ?? null,
+      getItem: (key) => {
+        onGetItem(key);
+        return values.get(key) ?? null;
+      },
       key: (index) => [...values.keys()][index] ?? null,
       removeItem: (key) => values.delete(key),
       setItem: (key, value) => values.set(key, String(value)),
@@ -97,6 +100,24 @@ test("writeSelfProfileCache caps each relay and the global cache by updatedAt", 
   );
   assert.equal(profileKeys.length, MAX_SELF_PROFILE_CACHES);
   assert.equal(values.has(storageKey(relayA, "pubkey-1")), false);
+});
+
+test("writeSelfProfileCache does not read existing payloads below both caps", () => {
+  const readKeys = [];
+  const values = installStorage((key) => readKeys.push(key));
+  const relay = "wss://relay.example";
+  const existingKey = storageKey(relay, "existing");
+  const writtenKey = storageKey(relay, "written");
+  values.set(existingKey, JSON.stringify(makeCache({ updatedAt: 1 })));
+
+  assert.equal(
+    writeSelfProfileCache(relay, "written", makeCache({ updatedAt: 2 })),
+    true,
+  );
+
+  assert.deepEqual(readKeys, [writtenKey]);
+  assert.equal(values.has(existingKey), true);
+  assert.equal(values.has(writtenKey), true);
 });
 
 test("parseSelfProfileCache: valid v1 payload round-trips", () => {

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -131,6 +131,21 @@ export function readSelfProfileCache(
 
 function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
   const relayPrefix = `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:`;
+  let totalEntryCount = 0;
+  let relayEntryCount = 0;
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (!key?.startsWith(`${STORAGE_KEY_PREFIX}:`)) continue;
+    totalEntryCount += 1;
+    if (key.startsWith(relayPrefix)) relayEntryCount += 1;
+  }
+  if (
+    totalEntryCount <= MAX_SELF_PROFILE_CACHES &&
+    relayEntryCount <= MAX_SELF_PROFILE_CACHES_PER_RELAY
+  ) {
+    return;
+  }
+
   const entries: Array<{ key: string; updatedAt: number }> = [];
   for (let i = 0; i < window.localStorage.length; i++) {
     const key = window.localStorage.key(i);

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -15,6 +15,8 @@ export { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
 import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
 
 const STORAGE_KEY_PREFIX = "buzz-self-profile.v1";
+export const MAX_SELF_PROFILE_CACHES_PER_RELAY = 8;
+export const MAX_SELF_PROFILE_CACHES = 32;
 
 /**
  * Dispatched on window after a successful writeSelfProfileCache so that any
@@ -127,6 +129,48 @@ export function readSelfProfileCache(
   }
 }
 
+function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
+  const relayPrefix = `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:`;
+  const entries: Array<{ key: string; updatedAt: number }> = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (!key?.startsWith(`${STORAGE_KEY_PREFIX}:`)) continue;
+    const raw = window.localStorage.getItem(key);
+    if (!raw) continue;
+    try {
+      entries.push({
+        key,
+        updatedAt: parseSelfProfileCache(JSON.parse(raw))?.updatedAt ?? 0,
+      });
+    } catch {
+      entries.push({ key, updatedAt: 0 });
+    }
+  }
+  const relayEntries = entries.filter((entry) =>
+    entry.key.startsWith(relayPrefix),
+  );
+  const keysToRemove = new Set<string>();
+  for (const candidates of [relayEntries, entries]) {
+    const maxEntries =
+      candidates === relayEntries
+        ? MAX_SELF_PROFILE_CACHES_PER_RELAY
+        : MAX_SELF_PROFILE_CACHES;
+    const removable = candidates
+      .filter((entry) => entry.key !== preservedKey)
+      .sort((left, right) => left.updatedAt - right.updatedAt);
+    let removeCount =
+      candidates.filter((entry) => !keysToRemove.has(entry.key)).length -
+      maxEntries;
+    for (const entry of removable) {
+      if (removeCount <= 0) break;
+      if (keysToRemove.has(entry.key)) continue;
+      keysToRemove.add(entry.key);
+      removeCount -= 1;
+    }
+  }
+  for (const key of keysToRemove) window.localStorage.removeItem(key);
+}
+
 /**
  * Writes the cache to localStorage and fires SELF_PROFILE_CACHE_EVENT so
  * mounted components can re-read without polling.
@@ -146,6 +190,7 @@ export function writeSelfProfileCache(
     // when nothing changed. Skip the write and event entirely when identical.
     if (window.localStorage.getItem(key) === serialized) return true;
     window.localStorage.setItem(key, serialized);
+    trimSelfProfileCaches(relayUrl, key);
     // localStorage is not reactive — dispatch a custom event so any mounted
     // listeners (e.g. useEffect with addEventListener) can re-read the cache
     // without a polling interval.

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  boundMuteStore,
+  MAX_CHANNEL_MUTE_ENTRIES,
   parseMutePayload,
   mergeStores,
   mutedChannelIdsFromStore,
@@ -206,6 +208,51 @@ test("mergeStores: both empty returns empty", () => {
     { version: 1, channels: {} },
   );
   assert.deepEqual(result, { version: 1, channels: {} });
+});
+
+test("boundMuteStore: caps entries and evicts false tombstones before active mutes", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { muted: true, updatedAt: index },
+    ]),
+  );
+  channels["old-false"] = { muted: false, updatedAt: -1 };
+  channels["new-false"] = { muted: false, updatedAt: 9999 };
+
+  const result = boundMuteStore({ version: 1, channels });
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_MUTE_ENTRIES);
+  assert.equal(result.channels["old-false"], undefined);
+  assert.equal(result.channels["new-false"], undefined);
+  assert.deepEqual(result.channels["active-0"], { muted: true, updatedAt: 0 });
+});
+
+test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-trimmed", () => {
+  const localChannels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { muted: true, updatedAt: index + 10 },
+    ]),
+  );
+  const result = mergeStores(
+    { version: 1, channels: localChannels },
+    {
+      version: 1,
+      channels: {
+        "evicted-id": { muted: true, updatedAt: 9999 },
+        "active-0": { muted: false, updatedAt: 9998 },
+      },
+    },
+  );
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_MUTE_ENTRIES);
+  assert.deepEqual(result.channels["evicted-id"], {
+    muted: true,
+    updatedAt: 9999,
+  });
+  assert.equal(result.channels["active-0"], undefined);
+  assert.deepEqual(result.channels["active-1"], { muted: true, updatedAt: 11 });
 });
 
 // ── mutedChannelIdsFromStore ──────────────────────────────────────────────────

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
@@ -249,6 +249,44 @@ test("boundMuteStore: uses channel ID as an updatedAt tie-breaker", () => {
   });
 });
 
+test("boundMuteStore: preserves a same-second mute mutation by key", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { muted: true, updatedAt: 1 },
+    ]),
+  );
+  channels["a-target"] = { muted: true, updatedAt: 1 };
+
+  const result = boundMuteStore({ version: 1, channels }, "a-target");
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_MUTE_ENTRIES);
+  assert.deepEqual(result.channels["a-target"], {
+    muted: true,
+    updatedAt: 1,
+  });
+  assert.equal(result.channels["z-channel-000"], undefined);
+});
+
+test("boundMuteStore: preserves a same-second unmute mutation by key", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { muted: true, updatedAt: 1 },
+    ]),
+  );
+  channels["a-target"] = { muted: false, updatedAt: 1 };
+
+  const result = boundMuteStore({ version: 1, channels }, "a-target");
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_MUTE_ENTRIES);
+  assert.deepEqual(result.channels["a-target"], {
+    muted: false,
+    updatedAt: 1,
+  });
+  assert.equal(result.channels["z-channel-000"], undefined);
+});
+
 test("mergeStores: a fresh at-capacity unmute defeats an older remote mute", () => {
   const channels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
@@ -210,25 +210,67 @@ test("mergeStores: both empty returns empty", () => {
   assert.deepEqual(result, { version: 1, channels: {} });
 });
 
-test("boundMuteStore: caps entries and evicts false tombstones before active mutes", () => {
+test("boundMuteStore: retains newest entries regardless of muted value", () => {
   const channels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
       `active-${index}`,
-      { muted: true, updatedAt: index },
+      { muted: true, updatedAt: index + 1 },
     ]),
   );
-  channels["old-false"] = { muted: false, updatedAt: -1 };
+  channels["old-false"] = { muted: false, updatedAt: 0 };
   channels["new-false"] = { muted: false, updatedAt: 9999 };
 
   const result = boundMuteStore({ version: 1, channels });
 
   assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_MUTE_ENTRIES);
   assert.equal(result.channels["old-false"], undefined);
-  assert.equal(result.channels["new-false"], undefined);
-  assert.deepEqual(result.channels["active-0"], { muted: true, updatedAt: 0 });
+  assert.deepEqual(result.channels["new-false"], {
+    muted: false,
+    updatedAt: 9999,
+  });
+  assert.equal(result.channels["active-0"], undefined);
+  assert.deepEqual(result.channels["active-1"], { muted: true, updatedAt: 2 });
 });
 
-test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-trimmed", () => {
+test("boundMuteStore: uses channel ID as an updatedAt tie-breaker", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES + 1 }, (_, index) => [
+      `channel-${String(MAX_CHANNEL_MUTE_ENTRIES - index).padStart(3, "0")}`,
+      { muted: true, updatedAt: 1 },
+    ]),
+  );
+
+  const result = boundMuteStore({ version: 1, channels });
+
+  assert.equal(result.channels["channel-000"], undefined);
+  assert.deepEqual(result.channels["channel-500"], {
+    muted: true,
+    updatedAt: 1,
+  });
+});
+
+test("mergeStores: a fresh at-capacity unmute defeats an older remote mute", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { muted: true, updatedAt: index + 1 },
+    ]),
+  );
+  channels["unmuted"] = { muted: false, updatedAt: 9999 };
+  const bounded = boundMuteStore({ version: 1, channels });
+
+  const result = mergeStores(bounded, {
+    version: 1,
+    channels: { unmuted: { muted: true, updatedAt: 9998 } },
+  });
+
+  assert.deepEqual(result.channels.unmuted, {
+    muted: false,
+    updatedAt: 9999,
+  });
+});
+
+test("mergeStores: evicted remote ID re-enters and the oldest state is re-trimmed", () => {
   const localChannels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
       `active-${index}`,
@@ -251,8 +293,12 @@ test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-t
     muted: true,
     updatedAt: 9999,
   });
-  assert.equal(result.channels["active-0"], undefined);
-  assert.deepEqual(result.channels["active-1"], { muted: true, updatedAt: 11 });
+  assert.deepEqual(result.channels["active-0"], {
+    muted: false,
+    updatedAt: 9998,
+  });
+  assert.equal(result.channels["active-1"], undefined);
+  assert.deepEqual(result.channels["active-2"], { muted: true, updatedAt: 12 });
 });
 
 // ── mutedChannelIdsFromStore ──────────────────────────────────────────────────

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY_PREFIX = "buzz-channel-mutes.v1";
+export const MAX_CHANNEL_MUTE_ENTRIES = 500;
 
 export type ChannelMuteEntry = {
   muted: boolean;
@@ -45,7 +46,7 @@ export function parseMutePayload(json: unknown): ChannelMuteStore | null {
           ),
         )
       : {};
-  return { version: 1, channels };
+  return boundMuteStore({ version: 1, channels });
 }
 
 export function readChannelMutesStore(pubkey: string): ChannelMuteStore {
@@ -64,12 +65,28 @@ export function readChannelMutesStore(pubkey: string): ChannelMuteStore {
   }
 }
 
+export function boundMuteStore(store: ChannelMuteStore): ChannelMuteStore {
+  const entries = Object.entries(store.channels);
+  if (entries.length <= MAX_CHANNEL_MUTE_ENTRIES) return store;
+  entries.sort(([, left], [, right]) => {
+    if (left.muted !== right.muted) return left.muted ? 1 : -1;
+    return left.updatedAt - right.updatedAt;
+  });
+  return {
+    ...store,
+    channels: Object.fromEntries(entries.slice(-MAX_CHANNEL_MUTE_ENTRIES)),
+  };
+}
+
 export function writeChannelMutesStore(
   pubkey: string,
   store: ChannelMuteStore,
 ): boolean {
   try {
-    window.localStorage.setItem(storageKey(pubkey), JSON.stringify(store));
+    window.localStorage.setItem(
+      storageKey(pubkey),
+      JSON.stringify(boundMuteStore(store)),
+    );
     return true;
   } catch {
     return false;
@@ -94,7 +111,7 @@ export function mergeStores(
       merged[id] = (l ?? r) as ChannelMuteEntry;
     }
   }
-  return { version: 1, channels: merged };
+  return boundMuteStore({ version: 1, channels: merged });
 }
 
 export function mutedChannelIdsFromStore(store: ChannelMuteStore): Set<string> {

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.ts
@@ -68,9 +68,10 @@ export function readChannelMutesStore(pubkey: string): ChannelMuteStore {
 export function boundMuteStore(store: ChannelMuteStore): ChannelMuteStore {
   const entries = Object.entries(store.channels);
   if (entries.length <= MAX_CHANNEL_MUTE_ENTRIES) return store;
-  entries.sort(([, left], [, right]) => {
-    if (left.muted !== right.muted) return left.muted ? 1 : -1;
-    return left.updatedAt - right.updatedAt;
+  entries.sort(([leftId, left], [rightId, right]) => {
+    if (left.updatedAt !== right.updatedAt)
+      return left.updatedAt - right.updatedAt;
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
   });
   return {
     ...store,

--- a/desktop/src/features/sidebar/lib/channelMutesStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.ts
@@ -65,17 +65,31 @@ export function readChannelMutesStore(pubkey: string): ChannelMuteStore {
   }
 }
 
-export function boundMuteStore(store: ChannelMuteStore): ChannelMuteStore {
-  const entries = Object.entries(store.channels);
-  if (entries.length <= MAX_CHANNEL_MUTE_ENTRIES) return store;
+export function boundMuteStore(
+  store: ChannelMuteStore,
+  preservedKey?: string,
+): ChannelMuteStore {
+  const preservedEntry =
+    preservedKey === undefined ? undefined : store.channels[preservedKey];
+  const entries = Object.entries(store.channels).filter(
+    ([channelId]) => channelId !== preservedKey,
+  );
+  if (entries.length + (preservedEntry ? 1 : 0) <= MAX_CHANNEL_MUTE_ENTRIES)
+    return store;
   entries.sort(([leftId, left], [rightId, right]) => {
     if (left.updatedAt !== right.updatedAt)
       return left.updatedAt - right.updatedAt;
     return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
   });
+  const retainedEntries = entries.slice(
+    -(MAX_CHANNEL_MUTE_ENTRIES - (preservedEntry ? 1 : 0)),
+  );
+  if (preservedEntry && preservedKey !== undefined) {
+    retainedEntries.push([preservedKey, preservedEntry]);
+  }
   return {
     ...store,
-    channels: Object.fromEntries(entries.slice(-MAX_CHANNEL_MUTE_ENTRIES)),
+    channels: Object.fromEntries(retainedEntries),
   };
 }
 

--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  boundChannelSectionsStore,
   DEFAULT_STORE,
+  MAX_CHANNEL_SECTION_ASSIGNMENTS,
+  MAX_CHANNEL_SECTIONS,
   parseChannelSectionPayload,
   readChannelSectionsStore,
   storageKey,
@@ -150,6 +153,34 @@ test("stripOrphanedAssignments: store with all valid assignments returns same re
 test("stripOrphanedAssignments: empty store returns same reference", () => {
   const store = makeStore({ sections: [], assignments: {} });
   assert.equal(stripOrphanedAssignments(store), store);
+});
+
+test("boundChannelSectionsStore caps sections and assignments", () => {
+  const sections = Array.from(
+    { length: MAX_CHANNEL_SECTIONS + 1 },
+    (_, index) => makeSection({ id: `section-${index}`, order: index }),
+  );
+  const assignments = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_SECTION_ASSIGNMENTS + 1 }, (_, index) => [
+      `channel-${index}`,
+      "section-100",
+    ]),
+  );
+
+  const bounded = boundChannelSectionsStore(
+    makeStore({ sections, assignments }),
+  );
+
+  assert.equal(bounded.sections.length, MAX_CHANNEL_SECTIONS);
+  assert.equal(
+    bounded.sections.some((section) => section.id === "section-0"),
+    false,
+  );
+  assert.equal(
+    Object.keys(bounded.assignments).length,
+    MAX_CHANNEL_SECTION_ASSIGNMENTS,
+  );
+  assert.equal(bounded.assignments["channel-0"], undefined);
 });
 
 test("writeChannelSectionsStore + readChannelSectionsStore: write then read returns same data", () => {

--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
@@ -1,6 +1,8 @@
 import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
 
 const STORAGE_KEY_PREFIX = "buzz-channel-sections.v1";
+export const MAX_CHANNEL_SECTIONS = 100;
+export const MAX_CHANNEL_SECTION_ASSIGNMENTS = 1_000;
 
 export type ChannelSection = {
   id: string;
@@ -37,6 +39,28 @@ export function storageKey(pubkey: string, relayUrl?: string): string {
   return `${STORAGE_KEY_PREFIX}:${pubkey}:${encodeURIComponent(normalized)}`;
 }
 
+export function boundChannelSectionsStore(
+  store: ChannelSectionStore,
+): ChannelSectionStore {
+  const sections = store.sections
+    .slice()
+    .sort((left, right) => left.order - right.order)
+    .slice(-MAX_CHANNEL_SECTIONS);
+  const sectionIds = new Set(sections.map((section) => section.id));
+  const assignments = Object.fromEntries(
+    Object.entries(store.assignments)
+      .filter(([, sectionId]) => sectionIds.has(sectionId))
+      .slice(-MAX_CHANNEL_SECTION_ASSIGNMENTS),
+  );
+  if (
+    sections.length === store.sections.length &&
+    Object.keys(assignments).length === Object.keys(store.assignments).length
+  ) {
+    return store;
+  }
+  return { ...store, sections, assignments };
+}
+
 export function stripOrphanedAssignments(
   store: ChannelSectionStore,
 ): ChannelSectionStore {
@@ -44,9 +68,11 @@ export function stripOrphanedAssignments(
   const cleaned = Object.fromEntries(
     Object.entries(store.assignments).filter(([, sid]) => sectionIds.has(sid)),
   );
-  if (Object.keys(cleaned).length === Object.keys(store.assignments).length)
-    return store;
-  return { ...store, assignments: cleaned };
+  const stripped =
+    Object.keys(cleaned).length === Object.keys(store.assignments).length
+      ? store
+      : { ...store, assignments: cleaned };
+  return boundChannelSectionsStore(stripped);
 }
 
 export function parseChannelSectionPayload(
@@ -161,7 +187,7 @@ export function writeChannelSectionsStore(
   try {
     window.localStorage.setItem(
       storageKey(pubkey, relayUrl),
-      JSON.stringify(store),
+      JSON.stringify(boundChannelSectionsStore(store)),
     );
     return true;
   } catch {

--- a/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  boundChannelSortStore,
   DEFAULT_SORT_MODE,
   DEFAULT_STORE,
+  MAX_CHANNEL_SORT_GROUPS,
   parseChannelSortPayload,
   sectionSortGroupKey,
   sortChannelsForSidebar,
@@ -166,6 +168,25 @@ test("stripOrphanedSectionModes: does not mutate the input store", () => {
   };
   stripOrphanedSectionModes(store, []);
   assert.deepEqual(store.groups, { [sectionSortGroupKey("gone")]: "recent" });
+});
+
+test("boundChannelSortStore caps custom sections while preserving fixed groups", () => {
+  const groups = {
+    channels: "recent",
+    ...Object.fromEntries(
+      Array.from({ length: MAX_CHANNEL_SORT_GROUPS }, (_, index) => [
+        sectionSortGroupKey(String(index)),
+        "alpha",
+      ]),
+    ),
+  };
+
+  const bounded = boundChannelSortStore({ version: 1, groups });
+
+  assert.equal(Object.keys(bounded.groups).length, MAX_CHANNEL_SORT_GROUPS);
+  assert.equal(bounded.groups.channels, "recent");
+  assert.equal(bounded.groups[sectionSortGroupKey("0")], undefined);
+  assert.equal(bounded.groups[sectionSortGroupKey("99")], "alpha");
 });
 
 // ── sortChannelsForSidebar ───────────────────────────────────────────────────

--- a/desktop/src/features/sidebar/lib/channelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.ts
@@ -2,6 +2,7 @@ import { normalizeRelayUrl } from "@/shared/lib/normalizeRelayUrl";
 import type { Channel } from "@/shared/api/types";
 
 const STORAGE_KEY_PREFIX = "buzz-channel-sort.v1";
+export const MAX_CHANNEL_SORT_GROUPS = 104;
 
 export type ChannelSortMode = "alpha" | "recent";
 
@@ -66,6 +67,23 @@ export function stripOrphanedSectionModes(
   return { ...store, groups: Object.fromEntries(kept) };
 }
 
+export function boundChannelSortStore(
+  store: ChannelSortStore,
+): ChannelSortStore {
+  const entries = Object.entries(store.groups);
+  if (entries.length <= MAX_CHANNEL_SORT_GROUPS) return store;
+  const isFixedGroup = (key: string) =>
+    key === "starred" ||
+    key === "channels" ||
+    key === "forums" ||
+    key === "dms";
+  const fixed = entries.filter(([key]) => isFixedGroup(key));
+  const custom = entries
+    .filter(([key]) => !isFixedGroup(key))
+    .slice(-(MAX_CHANNEL_SORT_GROUPS - fixed.length));
+  return { ...store, groups: Object.fromEntries([...fixed, ...custom]) };
+}
+
 export function parseChannelSortPayload(
   json: unknown,
 ): ChannelSortStore | null {
@@ -83,7 +101,7 @@ export function parseChannelSortPayload(
           ),
         )
       : {};
-  return { version: 1, groups };
+  return boundChannelSortStore({ version: 1, groups });
 }
 
 export function readChannelSortStore(
@@ -107,7 +125,7 @@ export function writeChannelSortStore(
   try {
     window.localStorage.setItem(
       storageKey(pubkey, relayUrl),
-      JSON.stringify(store),
+      JSON.stringify(boundChannelSortStore(store)),
     );
     return true;
   } catch {

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  boundStarStore,
+  MAX_CHANNEL_STAR_ENTRIES,
   parseStarPayload,
   mergeStores,
   starredChannelIdsFromStore,
@@ -220,6 +222,57 @@ test("mergeStores: both empty returns empty", () => {
     { version: 1, channels: {} },
   );
   assert.deepEqual(result, { version: 1, channels: {} });
+});
+
+test("boundStarStore: caps entries and evicts false tombstones before active stars", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { starred: true, updatedAt: index },
+    ]),
+  );
+  channels["old-false"] = { starred: false, updatedAt: -1 };
+  channels["new-false"] = { starred: false, updatedAt: 9999 };
+
+  const result = boundStarStore({ version: 1, channels });
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_STAR_ENTRIES);
+  assert.equal(result.channels["old-false"], undefined);
+  assert.equal(result.channels["new-false"], undefined);
+  assert.deepEqual(result.channels["active-0"], {
+    starred: true,
+    updatedAt: 0,
+  });
+});
+
+test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-trimmed", () => {
+  const localChannels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { starred: true, updatedAt: index + 10 },
+    ]),
+  );
+  const result = mergeStores(
+    { version: 1, channels: localChannels },
+    {
+      version: 1,
+      channels: {
+        "evicted-id": { starred: true, updatedAt: 9999 },
+        "active-0": { starred: false, updatedAt: 9998 },
+      },
+    },
+  );
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_STAR_ENTRIES);
+  assert.deepEqual(result.channels["evicted-id"], {
+    starred: true,
+    updatedAt: 9999,
+  });
+  assert.equal(result.channels["active-0"], undefined);
+  assert.deepEqual(result.channels["active-1"], {
+    starred: true,
+    updatedAt: 11,
+  });
 });
 
 // ── starredChannelIdsFromStore ────────────────────────────────────────────────

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
@@ -266,6 +266,44 @@ test("boundStarStore: uses channel ID as an updatedAt tie-breaker", () => {
   });
 });
 
+test("boundStarStore: preserves a same-second star mutation by key", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { starred: true, updatedAt: 1 },
+    ]),
+  );
+  channels["a-target"] = { starred: true, updatedAt: 1 };
+
+  const result = boundStarStore({ version: 1, channels }, "a-target");
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_STAR_ENTRIES);
+  assert.deepEqual(result.channels["a-target"], {
+    starred: true,
+    updatedAt: 1,
+  });
+  assert.equal(result.channels["z-channel-000"], undefined);
+});
+
+test("boundStarStore: preserves a same-second unstar mutation by key", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { starred: true, updatedAt: 1 },
+    ]),
+  );
+  channels["a-target"] = { starred: false, updatedAt: 1 };
+
+  const result = boundStarStore({ version: 1, channels }, "a-target");
+
+  assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_STAR_ENTRIES);
+  assert.deepEqual(result.channels["a-target"], {
+    starred: false,
+    updatedAt: 1,
+  });
+  assert.equal(result.channels["z-channel-000"], undefined);
+});
+
 test("mergeStores: a fresh at-capacity unstar defeats an older remote star", () => {
   const channels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
@@ -224,28 +224,70 @@ test("mergeStores: both empty returns empty", () => {
   assert.deepEqual(result, { version: 1, channels: {} });
 });
 
-test("boundStarStore: caps entries and evicts false tombstones before active stars", () => {
+test("boundStarStore: retains newest entries regardless of starred value", () => {
   const channels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
       `active-${index}`,
-      { starred: true, updatedAt: index },
+      { starred: true, updatedAt: index + 1 },
     ]),
   );
-  channels["old-false"] = { starred: false, updatedAt: -1 };
+  channels["old-false"] = { starred: false, updatedAt: 0 };
   channels["new-false"] = { starred: false, updatedAt: 9999 };
 
   const result = boundStarStore({ version: 1, channels });
 
   assert.equal(Object.keys(result.channels).length, MAX_CHANNEL_STAR_ENTRIES);
   assert.equal(result.channels["old-false"], undefined);
-  assert.equal(result.channels["new-false"], undefined);
-  assert.deepEqual(result.channels["active-0"], {
+  assert.deepEqual(result.channels["new-false"], {
+    starred: false,
+    updatedAt: 9999,
+  });
+  assert.equal(result.channels["active-0"], undefined);
+  assert.deepEqual(result.channels["active-1"], {
     starred: true,
-    updatedAt: 0,
+    updatedAt: 2,
   });
 });
 
-test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-trimmed", () => {
+test("boundStarStore: uses channel ID as an updatedAt tie-breaker", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES + 1 }, (_, index) => [
+      `channel-${String(MAX_CHANNEL_STAR_ENTRIES - index).padStart(3, "0")}`,
+      { starred: true, updatedAt: 1 },
+    ]),
+  );
+
+  const result = boundStarStore({ version: 1, channels });
+
+  assert.equal(result.channels["channel-000"], undefined);
+  assert.deepEqual(result.channels["channel-500"], {
+    starred: true,
+    updatedAt: 1,
+  });
+});
+
+test("mergeStores: a fresh at-capacity unstar defeats an older remote star", () => {
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `active-${index}`,
+      { starred: true, updatedAt: index + 1 },
+    ]),
+  );
+  channels["unstarred"] = { starred: false, updatedAt: 9999 };
+  const bounded = boundStarStore({ version: 1, channels });
+
+  const result = mergeStores(bounded, {
+    version: 1,
+    channels: { unstarred: { starred: true, updatedAt: 9998 } },
+  });
+
+  assert.deepEqual(result.channels.unstarred, {
+    starred: false,
+    updatedAt: 9999,
+  });
+});
+
+test("mergeStores: evicted remote ID re-enters and the oldest state is re-trimmed", () => {
   const localChannels = Object.fromEntries(
     Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
       `active-${index}`,
@@ -268,10 +310,14 @@ test("mergeStores: evicted remote ID re-enters LWW merge and a tombstone is re-t
     starred: true,
     updatedAt: 9999,
   });
-  assert.equal(result.channels["active-0"], undefined);
-  assert.deepEqual(result.channels["active-1"], {
+  assert.deepEqual(result.channels["active-0"], {
+    starred: false,
+    updatedAt: 9998,
+  });
+  assert.equal(result.channels["active-1"], undefined);
+  assert.deepEqual(result.channels["active-2"], {
     starred: true,
-    updatedAt: 11,
+    updatedAt: 12,
   });
 });
 

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY_PREFIX = "buzz-channel-stars.v1";
+export const MAX_CHANNEL_STAR_ENTRIES = 500;
 
 export type ChannelStarEntry = {
   starred: boolean;
@@ -45,7 +46,7 @@ export function parseStarPayload(json: unknown): ChannelStarStore | null {
           ),
         )
       : {};
-  return { version: 1, channels };
+  return boundStarStore({ version: 1, channels });
 }
 
 export function readChannelStarsStore(pubkey: string): ChannelStarStore {
@@ -64,12 +65,28 @@ export function readChannelStarsStore(pubkey: string): ChannelStarStore {
   }
 }
 
+export function boundStarStore(store: ChannelStarStore): ChannelStarStore {
+  const entries = Object.entries(store.channels);
+  if (entries.length <= MAX_CHANNEL_STAR_ENTRIES) return store;
+  entries.sort(([, left], [, right]) => {
+    if (left.starred !== right.starred) return left.starred ? 1 : -1;
+    return left.updatedAt - right.updatedAt;
+  });
+  return {
+    ...store,
+    channels: Object.fromEntries(entries.slice(-MAX_CHANNEL_STAR_ENTRIES)),
+  };
+}
+
 export function writeChannelStarsStore(
   pubkey: string,
   store: ChannelStarStore,
 ): boolean {
   try {
-    window.localStorage.setItem(storageKey(pubkey), JSON.stringify(store));
+    window.localStorage.setItem(
+      storageKey(pubkey),
+      JSON.stringify(boundStarStore(store)),
+    );
     return true;
   } catch {
     return false;
@@ -94,7 +111,7 @@ export function mergeStores(
       merged[id] = (l ?? r) as ChannelStarEntry;
     }
   }
-  return { version: 1, channels: merged };
+  return boundStarStore({ version: 1, channels: merged });
 }
 
 export function starredChannelIdsFromStore(

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.ts
@@ -65,17 +65,31 @@ export function readChannelStarsStore(pubkey: string): ChannelStarStore {
   }
 }
 
-export function boundStarStore(store: ChannelStarStore): ChannelStarStore {
-  const entries = Object.entries(store.channels);
-  if (entries.length <= MAX_CHANNEL_STAR_ENTRIES) return store;
+export function boundStarStore(
+  store: ChannelStarStore,
+  preservedKey?: string,
+): ChannelStarStore {
+  const preservedEntry =
+    preservedKey === undefined ? undefined : store.channels[preservedKey];
+  const entries = Object.entries(store.channels).filter(
+    ([channelId]) => channelId !== preservedKey,
+  );
+  if (entries.length + (preservedEntry ? 1 : 0) <= MAX_CHANNEL_STAR_ENTRIES)
+    return store;
   entries.sort(([leftId, left], [rightId, right]) => {
     if (left.updatedAt !== right.updatedAt)
       return left.updatedAt - right.updatedAt;
     return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
   });
+  const retainedEntries = entries.slice(
+    -(MAX_CHANNEL_STAR_ENTRIES - (preservedEntry ? 1 : 0)),
+  );
+  if (preservedEntry && preservedKey !== undefined) {
+    retainedEntries.push([preservedKey, preservedEntry]);
+  }
   return {
     ...store,
-    channels: Object.fromEntries(entries.slice(-MAX_CHANNEL_STAR_ENTRIES)),
+    channels: Object.fromEntries(retainedEntries),
   };
 }
 

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.ts
@@ -68,9 +68,10 @@ export function readChannelStarsStore(pubkey: string): ChannelStarStore {
 export function boundStarStore(store: ChannelStarStore): ChannelStarStore {
   const entries = Object.entries(store.channels);
   if (entries.length <= MAX_CHANNEL_STAR_ENTRIES) return store;
-  entries.sort(([, left], [, right]) => {
-    if (left.starred !== right.starred) return left.starred ? 1 : -1;
-    return left.updatedAt - right.updatedAt;
+  entries.sort(([leftId, left], [rightId, right]) => {
+    if (left.updatedAt !== right.updatedAt)
+      return left.updatedAt - right.updatedAt;
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
   });
   return {
     ...store,

--- a/desktop/src/features/sidebar/lib/useChannelMutes.test.mjs
+++ b/desktop/src/features/sidebar/lib/useChannelMutes.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+test("same-second mute and unmute mutations survive at capacity", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { relayClient } = await import("@/shared/api/relayClient");
+  const { MAX_CHANNEL_MUTE_ENTRIES, readChannelMutesStore, storageKey } =
+    await import("./channelMutesStorage.ts");
+  const { useChannelMutes } = await import("./useChannelMutes.ts");
+
+  const originalFetchEvents = relayClient.fetchEvents;
+  const originalSubscribeLive = relayClient.subscribeLive;
+  const originalSubscribeToReconnects = relayClient.subscribeToReconnects;
+  const originalDateNow = Date.now;
+  const updatedAt = 1_234_567;
+  Date.now = () => updatedAt * 1_000;
+  relayClient.fetchEvents = async () => [];
+  relayClient.subscribeLive = async () => async () => {};
+  relayClient.subscribeToReconnects = () => () => {};
+
+  const relayUrl = "wss://relay.example";
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_MUTE_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { muted: true, updatedAt },
+    ]),
+  );
+
+  try {
+    for (const [pubkey, action, expectedMuted] of [
+      ["pk-mute", "muteChannel", true],
+      ["pk-unmute", "unmuteChannel", false],
+    ]) {
+      window.localStorage.setItem(
+        storageKey(pubkey),
+        JSON.stringify({ version: 1, channels }),
+      );
+      const { result, unmount } = renderHook(() =>
+        useChannelMutes(pubkey, relayUrl),
+      );
+
+      act(() => result.current[action]("a-target"));
+
+      const persisted = readChannelMutesStore(pubkey);
+      assert.equal(
+        Object.keys(persisted.channels).length,
+        MAX_CHANNEL_MUTE_ENTRIES,
+      );
+      assert.deepEqual(persisted.channels["a-target"], {
+        muted: expectedMuted,
+        updatedAt,
+      });
+      unmount();
+    }
+  } finally {
+    cleanup();
+    Date.now = originalDateNow;
+    relayClient.fetchEvents = originalFetchEvents;
+    relayClient.subscribeLive = originalSubscribeLive;
+    relayClient.subscribeToReconnects = originalSubscribeToReconnects;
+  }
+});

--- a/desktop/src/features/sidebar/lib/useChannelMutes.ts
+++ b/desktop/src/features/sidebar/lib/useChannelMutes.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import {
+  boundMuteStore,
   DEFAULT_STORE,
   mergeStores,
   mutedChannelIdsFromStore,
@@ -163,10 +164,10 @@ export function useChannelMutes(
         updatedAt: Math.floor(Date.now() / 1000),
       };
       setStore((prev) => {
-        const next: ChannelMuteStore = {
+        const next = boundMuteStore({
           version: 1,
           channels: { ...prev.channels, [channelId]: entry },
-        };
+        });
         if (!writeChannelMutesStore(pubkey, next)) return prev;
         managerRef.current?.publishMutes(next);
         return next;

--- a/desktop/src/features/sidebar/lib/useChannelMutes.ts
+++ b/desktop/src/features/sidebar/lib/useChannelMutes.ts
@@ -164,10 +164,13 @@ export function useChannelMutes(
         updatedAt: Math.floor(Date.now() / 1000),
       };
       setStore((prev) => {
-        const next = boundMuteStore({
-          version: 1,
-          channels: { ...prev.channels, [channelId]: entry },
-        });
+        const next = boundMuteStore(
+          {
+            version: 1,
+            channels: { ...prev.channels, [channelId]: entry },
+          },
+          channelId,
+        );
         if (!writeChannelMutesStore(pubkey, next)) return prev;
         managerRef.current?.publishMutes(next);
         return next;

--- a/desktop/src/features/sidebar/lib/useChannelSections.test.mjs
+++ b/desktop/src/features/sidebar/lib/useChannelSections.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+test("assignChannel refreshes an existing assignment before the next eviction", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { relayClient } = await import("@/shared/api/relayClient");
+  const { MAX_CHANNEL_SECTION_ASSIGNMENTS, storageKey } = await import(
+    "./channelSectionsStorage.ts"
+  );
+  const { useChannelSections } = await import("./useChannelSections.ts");
+
+  const originalFetchEvents = relayClient.fetchEvents;
+  const originalSubscribeLive = relayClient.subscribeLive;
+  const originalSubscribeToReconnects = relayClient.subscribeToReconnects;
+  relayClient.fetchEvents = async () => [];
+  relayClient.subscribeLive = async () => async () => {};
+  relayClient.subscribeToReconnects = () => () => {};
+
+  const pubkey = "pk-at-capacity";
+  const relayUrl = "wss://relay.example";
+  const assignments = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_SECTION_ASSIGNMENTS }, (_, index) => [
+      `chan-${String(index).padStart(4, "0")}`,
+      "section-1",
+    ]),
+  );
+  window.localStorage.setItem(
+    storageKey(pubkey, relayUrl),
+    JSON.stringify({
+      version: 1,
+      sections: [
+        { id: "section-1", name: "One", order: 0 },
+        { id: "section-2", name: "Two", order: 1 },
+      ],
+      assignments,
+    }),
+  );
+
+  try {
+    const { result, unmount } = renderHook(() =>
+      useChannelSections(pubkey, relayUrl),
+    );
+
+    act(() => result.current.assignChannel("chan-0000", "section-2"));
+    act(() => result.current.assignChannel("chan-new", "section-1"));
+
+    assert.equal(result.current.assignments["chan-0000"], "section-2");
+    assert.equal(result.current.assignments["chan-new"], "section-1");
+    assert.equal(result.current.assignments["chan-0001"], undefined);
+    assert.equal(
+      Object.keys(result.current.assignments).length,
+      MAX_CHANNEL_SECTION_ASSIGNMENTS,
+    );
+    unmount();
+  } finally {
+    cleanup();
+    relayClient.fetchEvents = originalFetchEvents;
+    relayClient.subscribeLive = originalSubscribeLive;
+    relayClient.subscribeToReconnects = originalSubscribeToReconnects;
+  }
+});

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import {
+  boundChannelSectionsStore,
   DEFAULT_STORE,
   readChannelSectionsStore,
   storageKey,
@@ -181,10 +182,10 @@ export function useChannelSections(
         order: maxOrder + 1,
       };
       setStore((current) => {
-        const next: ChannelSectionStore = {
+        const next = boundChannelSectionsStore({
           ...current,
           sections: [...current.sections, section],
-        };
+        });
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) return current;
         managerRef.current?.publishSections(next);
         return next;
@@ -301,10 +302,10 @@ export function useChannelSections(
         return;
       }
       setStore((prev) => {
-        const next: ChannelSectionStore = {
+        const next = boundChannelSectionsStore({
           ...prev,
           assignments: { ...prev.assignments, [channelId]: sectionId },
-        };
+        });
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
           return prev;
         }

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -302,9 +302,12 @@ export function useChannelSections(
         return;
       }
       setStore((prev) => {
+        const assignments = { ...prev.assignments };
+        delete assignments[channelId];
+        assignments[channelId] = sectionId;
         const next = boundChannelSectionsStore({
           ...prev,
-          assignments: { ...prev.assignments, [channelId]: sectionId },
+          assignments,
         });
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
           return prev;

--- a/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import {
+  boundChannelSortStore,
   DEFAULT_STORE,
   readChannelSortStore,
   sortModeForGroup,
@@ -174,9 +175,11 @@ export function useChannelSortPreference(
         };
         // Prune sort modes left behind by deleted custom sections on write so
         // the stored map can't grow unboundedly with stale `section:` keys.
-        const next = liveSectionIds
-          ? stripOrphanedSectionModes(withUpdate, liveSectionIds)
-          : withUpdate;
+        const next = boundChannelSortStore(
+          liveSectionIds
+            ? stripOrphanedSectionModes(withUpdate, liveSectionIds)
+            : withUpdate,
+        );
         if (!writeChannelSortStore(pubkey, next, relayUrl)) return prev;
         managerRef.current?.publishSortPrefs(next);
         return next;

--- a/desktop/src/features/sidebar/lib/useChannelStars.test.mjs
+++ b/desktop/src/features/sidebar/lib/useChannelStars.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+test("same-second star and unstar mutations survive at capacity", async () => {
+  const { act, cleanup, renderHook } = await import("@testing-library/react");
+  const { relayClient } = await import("@/shared/api/relayClient");
+  const { MAX_CHANNEL_STAR_ENTRIES, readChannelStarsStore, storageKey } =
+    await import("./channelStarsStorage.ts");
+  const { useChannelStars } = await import("./useChannelStars.ts");
+
+  const originalFetchEvents = relayClient.fetchEvents;
+  const originalSubscribeLive = relayClient.subscribeLive;
+  const originalSubscribeToReconnects = relayClient.subscribeToReconnects;
+  const originalDateNow = Date.now;
+  const updatedAt = 1_234_567;
+  Date.now = () => updatedAt * 1_000;
+  relayClient.fetchEvents = async () => [];
+  relayClient.subscribeLive = async () => async () => {};
+  relayClient.subscribeToReconnects = () => () => {};
+
+  const relayUrl = "wss://relay.example";
+  const channels = Object.fromEntries(
+    Array.from({ length: MAX_CHANNEL_STAR_ENTRIES }, (_, index) => [
+      `z-channel-${String(index).padStart(3, "0")}`,
+      { starred: true, updatedAt },
+    ]),
+  );
+
+  try {
+    for (const [pubkey, action, expectedStarred] of [
+      ["pk-star", "starChannel", true],
+      ["pk-unstar", "unstarChannel", false],
+    ]) {
+      window.localStorage.setItem(
+        storageKey(pubkey),
+        JSON.stringify({ version: 1, channels }),
+      );
+      const { result, unmount } = renderHook(() =>
+        useChannelStars(pubkey, relayUrl),
+      );
+
+      act(() => result.current[action]("a-target"));
+
+      const persisted = readChannelStarsStore(pubkey);
+      assert.equal(
+        Object.keys(persisted.channels).length,
+        MAX_CHANNEL_STAR_ENTRIES,
+      );
+      assert.deepEqual(persisted.channels["a-target"], {
+        starred: expectedStarred,
+        updatedAt,
+      });
+      unmount();
+    }
+  } finally {
+    cleanup();
+    Date.now = originalDateNow;
+    relayClient.fetchEvents = originalFetchEvents;
+    relayClient.subscribeLive = originalSubscribeLive;
+    relayClient.subscribeToReconnects = originalSubscribeToReconnects;
+  }
+});

--- a/desktop/src/features/sidebar/lib/useChannelStars.ts
+++ b/desktop/src/features/sidebar/lib/useChannelStars.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import {
+  boundStarStore,
   DEFAULT_STORE,
   mergeStores,
   readChannelStarsStore,
@@ -163,10 +164,10 @@ export function useChannelStars(
         updatedAt: Math.floor(Date.now() / 1000),
       };
       setStore((prev) => {
-        const next: ChannelStarStore = {
+        const next = boundStarStore({
           version: 1,
           channels: { ...prev.channels, [channelId]: entry },
-        };
+        });
         if (!writeChannelStarsStore(pubkey, next)) return prev;
         managerRef.current?.publishStars(next);
         return next;

--- a/desktop/src/features/sidebar/lib/useChannelStars.ts
+++ b/desktop/src/features/sidebar/lib/useChannelStars.ts
@@ -164,10 +164,13 @@ export function useChannelStars(
         updatedAt: Math.floor(Date.now() / 1000),
       };
       setStore((prev) => {
-        const next = boundStarStore({
-          version: 1,
-          channels: { ...prev.channels, [channelId]: entry },
-        });
+        const next = boundStarStore(
+          {
+            version: 1,
+            channels: { ...prev.channels, [channelId]: entry },
+          },
+          channelId,
+        );
         if (!writeChannelStarsStore(pubkey, next)) return prev;
         managerRef.current?.publishStars(next);
         return next;

--- a/desktop/src/shared/features/store.test.mjs
+++ b/desktop/src/shared/features/store.test.mjs
@@ -1,24 +1,49 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getOverrides, OVERRIDES_KEY } from "./store.ts";
+import { getOverrides, OVERRIDES_KEY, setOverride } from "./store.ts";
 
 function installStorage(value) {
   const values = new Map([[OVERRIDES_KEY, JSON.stringify(value)]]);
+  const writes = [];
   globalThis.window = {
     localStorage: {
       getItem: (key) => values.get(key) ?? null,
-      setItem: (key, next) => values.set(key, String(next)),
+      setItem: (key, next) => {
+        writes.push([key, String(next)]);
+        values.set(key, String(next));
+      },
     },
   };
-  return values;
+  return { values, writes };
 }
 
-test("getOverrides drops unknown feature IDs and compacts persisted storage", () => {
-  const values = installStorage({ workflows: true, removedFeature: false });
+test("getOverrides drops unknown feature IDs without writing to storage", () => {
+  const { values, writes } = installStorage({
+    workflows: true,
+    removedFeature: false,
+  });
 
   assert.deepEqual(getOverrides(), { workflows: true });
-  assert.equal(values.get(OVERRIDES_KEY), JSON.stringify({ workflows: true }));
+  assert.deepEqual(writes, []);
+  assert.equal(
+    values.get(OVERRIDES_KEY),
+    JSON.stringify({ workflows: true, removedFeature: false }),
+  );
+});
+
+test("setOverride persists filtered overrides", () => {
+  const { values } = installStorage({
+    workflows: true,
+    removedFeature: false,
+  });
+
+  setOverride("projects", true);
+
+  assert.equal(
+    values.get(OVERRIDES_KEY),
+    JSON.stringify({ workflows: true, projects: true }),
+  );
 });
 
 test("getOverrides drops non-boolean values", () => {

--- a/desktop/src/shared/features/store.test.mjs
+++ b/desktop/src/shared/features/store.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getOverrides, OVERRIDES_KEY } from "./store.ts";
+
+function installStorage(value) {
+  const values = new Map([[OVERRIDES_KEY, JSON.stringify(value)]]);
+  globalThis.window = {
+    localStorage: {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, next) => values.set(key, String(next)),
+    },
+  };
+  return values;
+}
+
+test("getOverrides drops unknown feature IDs and compacts persisted storage", () => {
+  const values = installStorage({ workflows: true, removedFeature: false });
+
+  assert.deepEqual(getOverrides(), { workflows: true });
+  assert.equal(values.get(OVERRIDES_KEY), JSON.stringify({ workflows: true }));
+});
+
+test("getOverrides drops non-boolean values", () => {
+  installStorage({ workflows: "yes", projects: false });
+
+  assert.deepEqual(getOverrides(), { projects: false });
+});

--- a/desktop/src/shared/features/store.ts
+++ b/desktop/src/shared/features/store.ts
@@ -17,7 +17,21 @@ export type FeatureOverrides = Record<string, boolean>;
 export function getOverrides(): FeatureOverrides {
   try {
     const raw = window.localStorage.getItem(OVERRIDES_KEY);
-    return raw ? (JSON.parse(raw) as FeatureOverrides) : {};
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {};
+    const featureIds = new Set(manifest.features.map((feature) => feature.id));
+    const overrides = Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, boolean] =>
+          featureIds.has(entry[0]) && typeof entry[1] === "boolean",
+      ),
+    );
+    const serialized = JSON.stringify(overrides);
+    if (serialized !== raw)
+      window.localStorage.setItem(OVERRIDES_KEY, serialized);
+    return overrides;
   } catch {
     return {};
   }

--- a/desktop/src/shared/features/store.ts
+++ b/desktop/src/shared/features/store.ts
@@ -22,16 +22,12 @@ export function getOverrides(): FeatureOverrides {
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
       return {};
     const featureIds = new Set(manifest.features.map((feature) => feature.id));
-    const overrides = Object.fromEntries(
+    return Object.fromEntries(
       Object.entries(parsed).filter(
         (entry): entry is [string, boolean] =>
           featureIds.has(entry[0]) && typeof entry[1] === "boolean",
       ),
     );
-    const serialized = JSON.stringify(overrides);
-    if (serialized !== raw)
-      window.localStorage.setItem(OVERRIDES_KEY, serialized);
-    return overrides;
   } catch {
     return {};
   }


### PR DESCRIPTION
Part of #5418 (Phase 1, lane A). Companion to #5453 (TTL sweep).

## What

Nine localStorage stores grew without bound (full 58-call-site audit in the tracking issue). Each now has an explicit leak-guard cap, applied wherever the store is parsed, merged, or written, preserving each file's merge/versioning semantics:

- **Community icons:** 32 entries, 96 KiB/value (aligned with the relay's `MAX_WORKSPACE_ICON_DATA_URL_LEN`); touched relay becomes newest.
- **Channel mutes/stars:** newest-500 cap each, bounded by recency (`updatedAt`, channel-ID lexical tie-breaker), with the just-written channel unconditionally preserved for that write (cap−1 recency slots + the mutated key). A bounded LWW store cannot guarantee permanent deletion history; the guarantee here is that **the just-written mutation survives its own bounding** and, as the newest entry, defeats an older remote `true` through the pre-publish `mergeStores`. Known residual (accepted): `updatedAt` is whole-second, so two distinct mutations inside the same second at exact capacity can still evict the earlier one before the debounced publish — same root cause as the merge-path same-second tie, tracked for the follow-up precision fix rather than more preservation machinery. Enforced at parse, post-merge, local state, and persistence.
- **Forced unread:** newest 500 insertion-ordered, touched channels refreshed.
- **Persistent agent audiences:** 200-scope LRU. An unchanged-audience touch (including re-initializing an existing scope) refreshes LRU order and persists without advancing the scope's revision or emitting; an already-most-recent touch is a pure no-op (no clone, no write), so render-path re-initialization causes zero storage traffic.
- **Self profiles:** newest 8 per relay / 32 globally by `updatedAt`, just-written key always preserved; trim count-gates before parsing payloads so under-cap writes skip the scan entirely.
- **Sections:** newest 100 + newest 1,000 assignments, orphans removed; `assignChannel` delete/reinserts the touched channel so a reassignment becomes newest in insertion order and cannot be evicted by the next assignment. **Sort prefs:** 104 groups (100 sections + 4 fixed).
- **Feature overrides:** `getOverrides()` filters to current-manifest boolean ids on read only — no write-back from the render-path getter.

## Review-driven revisions

- `237f25e4` — three narrow changes from the first adversarial review (no render-path storage write, icon cap aligned to relay constant, count-gated profile trim).
- `d864ffb0` — fixes for the two GitHub review findings on `237f25e4`: (P1) mute/star bounding switched from false-tombstone-first eviction to pure recency, with regressions proving an at-capacity unmute/unstar survives bounding and the pre-publish LWW merge; (P2) unchanged agent-audience touches now refresh LRU order (no revision advance, no emit), with a subscriber-mounted regression.
- `3ddbb26d` — MRU guard from the second adversarial VERIFY: the P2 touch path skips clone/persist entirely when the scope is already most-recently-inserted, eliminating repeat synchronous localStorage writes from render-path effects. Test proves a non-MRU identical touch writes exactly once (scope persisted last) and an already-MRU touch writes zero times.
- `e220ccd9` — fixes for the second GitHub review round (Carl, on Wes's behalf): (1) mute/star bounders preserve the just-mutated key so a same-second mutation at capacity survives its own bounding; merge/sync call sites unchanged; (2) `assignChannel` delete/reinserts the touched key so an at-capacity reassignment isn't evicted by the next new assignment. Regressions at storage and hook level for both; negative-control run of the 7 new tests against the old sources: 7 fail.

## Validation

- Full desktop suite 4555/4555 at both `d864ffb0` and `3ddbb26d`, plus desktop-check/typecheck via the push gate; focused storage/audience tests 62/62 at `d864ffb0`, 14/14 audience suite at `3ddbb26d`.
- Independent adversarial review: APPROVE at `88a55aee` (including 100 smoke E2E specs covering every seeded store, run manually since push hooks exclude Playwright), then a second VERIFY pass: **VERIFIED at `d864ffb0`** — P1/P2 confirmed closed via negative-control runs of the new suites against the old sources, plus smoke Playwright on the mute/star/audience specs (17 passed). That VERIFY requested one pre-merge change (no localStorage writes from the render path), landed as the narrow MRU guard in `3ddbb26d` within the reviewer's stated no-re-review boundary. A third VERIFY pass: **VERIFIED at `e220ccd9`** — both findings from the second GitHub review confirmed closed by sensitivity testing (new tests fail on old sources), hostile same-call section-trim case constructed and passed, full suite 4562/4562 re-run independently.

Authored by Meeseeks (agent), reviewed by Beth (agent), integrated by Rick (agent). Discussion: Buzz channel time-based-localstorage-eviction, thread 0d85a73ca43e54748128f89c3512a4726131bf5473253395d46bf8f3a7b58bd4.


