### PR TITLE
fix(desktop): keep error toasts on screen until dismissed

### DIFF
--- a/desktop/src/shared/hooks/useToastEffect.test.mjs
+++ b/desktop/src/shared/hooks/useToastEffect.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { feedbackToastOptions } from "./useToastEffect.ts";
+
+test("an error toast is given an explicit close control", () => {
+  assert.equal(feedbackToastOptions("error").closeButton, true);
+});
+
+test("an error toast is not on a timer", () => {
+  const { duration } = feedbackToastOptions("error");
+  // Sonner treats a non-finite duration as "never auto-close"; anything finite
+  // would put a multi-line error back into a race with the reader.
+  assert.equal(Number.isFinite(duration), false);
+});
+
+test("a success toast keeps Sonner's defaults", () => {
+  assert.equal(feedbackToastOptions("success"), undefined);
+});

--- a/desktop/src/shared/hooks/useToastEffect.ts
+++ b/desktop/src/shared/hooks/useToastEffect.ts
@@ -1,6 +1,21 @@
 import * as React from "react";
 import { toast } from "sonner";
 
+type ToastVariant = "success" | "error";
+
+/**
+ * Errors are the one class of feedback still needed after it is read: they run
+ * to several lines and are often worth copying into a bug report. Sonner's
+ * four-second default races that, so an error stays up until it is dismissed
+ * and carries an explicit close control. A success notice says nothing that
+ * outlives the glance, so it keeps the default treatment.
+ */
+export function feedbackToastOptions(variant: ToastVariant) {
+  return variant === "error"
+    ? { closeButton: true, duration: Number.POSITIVE_INFINITY }
+    : undefined;
+}
+
 /**
  * Show a toast when a message string becomes truthy. Uses a ref to avoid
  * double-firing in React StrictMode (where effects run twice with the same
@@ -8,14 +23,14 @@ import { toast } from "sonner";
  */
 function useToastEffect(
   message: string | null | undefined,
-  variant: "success" | "error",
+  variant: ToastVariant,
 ) {
   const shownRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (message && message !== shownRef.current) {
       shownRef.current = message;
-      toast[variant](message);
+      toast[variant](message, feedbackToastOptions(variant));
     }
     if (!message) {
       shownRef.current = null;

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -2415,11 +2415,18 @@ test("built-in removal failures show up from My Agents", async ({ page }) => {
   await page.getByLabel("Open actions for Honey").click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
 
-  await expect(
-    page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: "Honey is still referenced by a team." }),
-  ).toBeVisible();
+  const failureToast = page
+    .locator("[data-sonner-toast]")
+    .filter({ hasText: "Honey is still referenced by a team." });
+  await expect(failureToast).toBeVisible();
+
+  // The reported failure: Sonner's four-second default cleared this before a
+  // multi-line error could be read, let alone copied into a report.
+  await page.waitForTimeout(5_000);
+  await expect(failureToast).toBeVisible();
+
+  await failureToast.getByRole("button", { name: "Close toast" }).click();
+  await expect(failureToast).toHaveCount(0);
 });
 
 test("personas referenced by teams cannot be deleted", async ({ page }) => {


### PR DESCRIPTION
## Summary

- error toasts now stay until the user dismisses them, instead of clearing after four seconds
- error toasts now have a close control; its accessible name is `Close toast`
- success notices are unchanged: same short lifetime, no close control

Closes #5362.

## Why

`useToastEffect` called `toast[variant](message)` with no options. So every error that goes through `useFeedbackToasts` used Sonner's default `TOAST_LIFETIME`, which is 4000 ms. The deletion errors in the report run to several lines, and they are often the thing a user wants to copy. Four seconds regularly won that race.

Both halves fit in one options object at the single call site:

- Sonner skips the auto-close timer when `duration` is not finite, so the toast waits for the user.
- A per-toast `closeButton` overrides the `Toaster` setting, so this stays scoped to errors.

## Scope

This covers the four surfaces that use `useFeedbackToasts`: `UnifiedAgentsSection` (twice), `PersonaCatalogDialog`, and `MembersSidebar`. That includes the repro in the issue.

`desktop/src` also has 111 direct `toast.error(...)` calls that do not go through the hook. Those still use the defaults. Putting a close control on every error toast in the app looks like a product decision rather than a bug fix, so I left them alone. I can extend it if you want that.

## Validation

- RED to GREEN: I reverted only the source change and kept the test. The e2e then fails at the assertion after the 5-second wait, with `element(s) not found`. With the source change it passes.
- `pnpm --filter buzz test` — 4,538 passed
- `pnpm --filter buzz exec tsc --noEmit`
- `pnpm --filter buzz check` — biome, file sizes, px-text, pubkey truncation
- `agents.spec.ts` in full, twice — 35/35 each time
- `channels.spec.ts` in full — 78 of 79. The failure is `members sidebar can invite relay-authorized agents`. It passes twice in isolation, and the error is `waiting for getByTestId('channel-general')`, not a covered element. A control run on clean `main` fails 2 different tests in the same file. So the suite is flaky in my environment, and this branch is not worse than the base.

No existing e2e test asserts that a toast disappears on its own, so nothing depended on the old timeout.
