### PR TITLE
test(desktop): make the Playwright e2e suite runnable on Windows

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { staticWebServer } from "./tests/helpers/staticWebServer";
+
 export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 30_000,
@@ -174,10 +176,5 @@ export default defineConfig({
       },
     },
   ],
-  webServer: {
-    command: "python3 -m http.server 4173 -d dist",
-    cwd: ".",
-    reuseExistingServer: !process.env.CI,
-    url: "http://127.0.0.1:4173",
-  },
+  webServer: staticWebServer({ reuseExistingServer: !process.env.CI }),
 });

--- a/desktop/playwright.perf.config.ts
+++ b/desktop/playwright.perf.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { staticWebServer } from "./tests/helpers/staticWebServer";
+
 export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 60_000,
@@ -14,10 +16,5 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: {
-    command: "python3 -m http.server 4173 -d dist",
-    cwd: ".",
-    reuseExistingServer: true,
-    url: "http://127.0.0.1:4173",
-  },
+  webServer: staticWebServer({ reuseExistingServer: true }),
 });

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -993,8 +993,17 @@ test("copy a rendered code block and paste it back as code", async ({
   await codeBlock.hover();
   await expect(copyButton).toHaveCSS("opacity", "1");
   await copyButton.click();
+  // Chromium hands back CRLF when it reads text/plain off the Windows
+  // clipboard, so compare logical lines rather than the platform separator.
+  // The app writes LF: `copyCodeBlockToClipboard` puts `code` in the blob
+  // verbatim.
   await expect
-    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .poll(async () =>
+      (await page.evaluate(() => navigator.clipboard.readText())).replace(
+        /\r\n/g,
+        "\n",
+      ),
+    )
     .toBe(code);
 
   await input.click();

--- a/desktop/tests/helpers/staticWebServer.ts
+++ b/desktop/tests/helpers/staticWebServer.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+
+const PORT = 4173;
+
+/**
+ * `python3` is the right name on Linux and macOS. On Windows it is normally
+ * the Microsoft Store app-execution alias, which prints an install hint and
+ * exits 9009 even when a real interpreter is installed as `python`. Playwright
+ * then reports only `Process from config.webServer was not able to start.
+ * Exit code: 9009`, so the suite cannot be run at all on a stock Windows box.
+ *
+ * Probe the candidates rather than guessing. `-c ""` is a no-op that a real
+ * interpreter accepts and the alias stub rejects.
+ */
+function resolvePythonCommand() {
+  const candidates =
+    process.platform === "win32"
+      ? ["python", "python3"]
+      : ["python3", "python"];
+
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ["-c", ""], { stdio: "ignore" });
+    if (!probe.error && probe.status === 0) {
+      return candidate;
+    }
+  }
+
+  // Nothing answered. Keep the historical name so the failure still points at
+  // the missing interpreter instead of at this helper.
+  return "python3";
+}
+
+export function staticWebServer(options: { reuseExistingServer: boolean }) {
+  return {
+    command: `${resolvePythonCommand()} -m http.server ${PORT} -d dist`,
+    cwd: ".",
+    reuseExistingServer: options.reuseExistingServer,
+    url: `http://127.0.0.1:${PORT}`,
+  };
+}


### PR DESCRIPTION
## Summary

- probe for a Python interpreter that actually answers, instead of hardcoding `python3` in both Playwright configs
- compare logical lines in the code-block clipboard assertion, so it holds on Windows too

Two separate defects stop the desktop e2e suite on a stock Windows box. Neither is a product bug; both are in the test setup.

## 1. `python3` is an alias stub on Windows

`desktop/playwright.config.ts` and `desktop/playwright.perf.config.ts` both ran `python3 -m http.server 4173 -d dist`.

On Windows, `python3` is normally the Microsoft Store app-execution alias. It prints an install hint and exits 9009, even when a real interpreter is installed under the name `python`. Playwright shows only this:

```
[WebServer] Python was not found; run without arguments to install from the Microsoft Store...
Error: Process from config.webServer was not able to start. Exit code: 9009
```

So no test runs at all, and the message does not point at the cause.

On my machine:

```
python3 --version  -> the Store hint, exit 9009
python  --version  -> Python 3.13.5
```

`staticWebServer` now probes the candidates and takes the first one that answers. `-c ""` is a no-op that a real interpreter accepts and the stub rejects. Linux and macOS keep `python3` first, so the command CI runs does not change.

## 2. The clipboard assertion cannot hold on Windows

`copy a rendered code block and paste it back as code` compared `navigator.clipboard.readText()` to a string with LF. Chromium returns CRLF when it reads `text/plain` off the Windows clipboard, so the two never match, and the diff looks like two identical blocks.

The app is not at fault. `copyCodeBlockToClipboard` puts `code` into the `text/plain` blob verbatim, with LF. The normalization happens in the clipboard layer on read. So the test now compares logical lines.

Only this one assertion needed it. The other clipboard read in the suite (`agents.spec.ts`) copies a single-line URL, which has no line endings.

## Validation

All on Windows 11, `desktop/`:

- before: `npx playwright test tests/e2e/messaging.spec.ts --project=smoke` cannot start; exit code 9009
- after: the same command starts its own server and passes **48/48**
- clean `main` control, with a static server started by hand to get past defect 1: **47/48**, and the one failure is `copy a rendered code block and paste it back as code` — defect 2
- the `integration` project also starts the server and passes
- `--config=playwright.perf.config.ts --list` loads and lists its 6 tests
- `pnpm --filter buzz exec tsc --noEmit`
- `pnpm --filter buzz check` — biome, file sizes, px-text, pubkey truncation

I cannot run Linux or macOS here. The reason CI is unaffected is small enough to read: on any non-Windows platform the first candidate is `python3`, and when it answers, the command string is byte-for-byte what it was before.
