### PR TITLE
fix(desktop): accept ordinary agent snapshot filenames

### DIFF
--- a/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
@@ -46,6 +46,17 @@ type PersonaCatalogDialogProps = {
   personas: AgentPersona[];
 };
 
+/** File types offered by the agent snapshot picker. Keep aligned with isAgentSnapshotCandidateName. */
+export const AGENT_SNAPSHOT_IMPORT_ACCEPT = ".json,.png";
+
+/** Returns whether a dropped file can contain a snapshot understood by the import decoder. */
+export function isAgentSnapshotCandidateName(fileName: string) {
+  const lowerName = fileName.toLowerCase();
+  return lowerName.endsWith(".json") || lowerName.endsWith(".png");
+}
+
+const MAX_AGENT_SNAPSHOT_IMPORT_BYTES = 10 * 1024 * 1024;
+
 type PendingNavigation =
   | { type: "close" }
   | { type: "selection"; selection: string };
@@ -79,6 +90,9 @@ export function PersonaCatalogDialog({
   const dragDepthRef = React.useRef(0);
   const createDirtyRef = React.useRef(false);
   const [isDragOver, setIsDragOver] = React.useState(false);
+  const [importErrorMessage, setImportErrorMessage] = React.useState<
+    string | null
+  >(null);
   const [pendingNavigation, setPendingNavigation] =
     React.useState<PendingNavigation | null>(null);
   const [selection, setSelection] = React.useState("create");
@@ -100,6 +114,7 @@ export function PersonaCatalogDialog({
       setPendingNavigation(null);
       dragDepthRef.current = 0;
       setIsDragOver(false);
+      setImportErrorMessage(null);
     }
   }, [open]);
 
@@ -170,6 +185,7 @@ export function PersonaCatalogDialog({
     if (!isImportSelected) {
       dragDepthRef.current = 0;
       setIsDragOver(false);
+      setImportErrorMessage(null);
     }
   }, [isImportSelected]);
 
@@ -177,18 +193,28 @@ export function PersonaCatalogDialog({
     return event.dataTransfer.types.includes("Files");
   }
 
-  function isAgentSnapshot(file: File) {
-    const lowerName = file.name.toLowerCase();
-    return (
-      lowerName.endsWith(".agent.json") || lowerName.endsWith(".agent.png")
-    );
-  }
-
   async function importFile(file: File) {
-    if (!isAgentSnapshot(file)) return;
-    const buffer = await file.arrayBuffer();
-    onOpenChange(false);
-    onImportFile(Array.from(new Uint8Array(buffer)), file.name);
+    setImportErrorMessage(null);
+    if (!isAgentSnapshotCandidateName(file.name)) {
+      setImportErrorMessage("Choose a JSON or PNG agent snapshot.");
+      return;
+    }
+    if (file.size > MAX_AGENT_SNAPSHOT_IMPORT_BYTES) {
+      setImportErrorMessage(
+        "This snapshot is larger than 10 MB. Choose a smaller file.",
+      );
+      return;
+    }
+
+    try {
+      const buffer = await file.arrayBuffer();
+      onOpenChange(false);
+      onImportFile(Array.from(new Uint8Array(buffer)), file.name);
+    } catch {
+      setImportErrorMessage(
+        "Buzz couldn't read this snapshot. Choose the file again.",
+      );
+    }
   }
 
   return (
@@ -252,6 +278,7 @@ export function PersonaCatalogDialog({
               onRequestClose: requestClose,
             })}
             error={error}
+            importErrorMessage={importErrorMessage}
             isDragOver={isDragOver}
             isLoading={isLoading}
             isPending={isPending}
@@ -265,7 +292,7 @@ export function PersonaCatalogDialog({
             selectedPersonaId={selectedPersona?.id ?? null}
           />
           <input
-            accept=".agent.json,.agent.png"
+            accept={AGENT_SNAPSHOT_IMPORT_ACCEPT}
             className="hidden"
             data-testid="agent-catalog-import-input"
             onChange={(event) => {
@@ -309,6 +336,7 @@ export function PersonaCatalogDialog({
 type PersonaCatalogChooserProps = {
   createContent: React.ReactNode;
   error: Error | null;
+  importErrorMessage: string | null;
   isDragOver: boolean;
   isLoading: boolean;
   isPending: boolean;
@@ -325,6 +353,7 @@ type PersonaCatalogChooserProps = {
 function PersonaCatalogChooser({
   createContent,
   error,
+  importErrorMessage,
   isDragOver,
   isLoading,
   isPending,
@@ -345,7 +374,7 @@ function PersonaCatalogChooser({
           data-testid="agent-catalog-drop-overlay"
         >
           <p className="rounded-full bg-background/90 px-4 py-2 text-sm font-medium text-primary shadow-sm">
-            Drop .agent.json or .agent.png to import
+            Drop a JSON or PNG agent snapshot to import
           </p>
         </div>
       ) : null}
@@ -420,7 +449,10 @@ function PersonaCatalogChooser({
       <div className="relative z-10 mb-3 ml-px mr-3 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-xl bg-background shadow-[-1px_0_0_0_hsl(var(--sidebar-border)/0.45)]">
         {selection === "create" ? createContent : null}
         {selection === "import" ? (
-          <ImportAgentPane onImport={onImport} />
+          <ImportAgentPane
+            errorMessage={importErrorMessage}
+            onImport={onImport}
+          />
         ) : null}
         {selectedPersona ? (
           <>
@@ -497,7 +529,13 @@ function CatalogNavigationButton({
   );
 }
 
-function ImportAgentPane({ onImport }: { onImport: () => void }) {
+function ImportAgentPane({
+  errorMessage,
+  onImport,
+}: {
+  errorMessage: string | null;
+  onImport: () => void;
+}) {
   return (
     <button
       className="m-5 flex min-h-0 flex-1 flex-col items-center justify-center rounded-xl border-2 border-dashed border-border bg-muted/20 px-8 py-12 text-center transition-colors hover:border-primary/60 hover:bg-primary/5 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
@@ -510,9 +548,18 @@ function ImportAgentPane({ onImport }: { onImport: () => void }) {
       </span>
       <span className="mt-4 text-base font-semibold">Import an agent</span>
       <span className="mt-2 max-w-sm text-sm text-muted-foreground">
-        Drop an .agent.json or .agent.png file anywhere in this window, or
-        choose a file.
+        Drop a JSON or PNG agent snapshot anywhere in this window, or choose a
+        file.
       </span>
+      {errorMessage ? (
+        <span
+          className="mt-3 max-w-sm text-sm text-destructive"
+          data-testid="agent-catalog-import-error"
+          role="alert"
+        >
+          {errorMessage}
+        </span>
+      ) : null}
       <span className="mt-5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground">
         Choose file
       </span>

--- a/desktop/src/features/agents/ui/agentSnapshotImportFileName.test.mjs
+++ b/desktop/src/features/agents/ui/agentSnapshotImportFileName.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AGENT_SNAPSHOT_IMPORT_ACCEPT,
+  isAgentSnapshotCandidateName,
+} from "./PersonaCatalogDialog.tsx";
+
+test("agent import accepts ordinary JSON and PNG filenames", () => {
+  assert.equal(AGENT_SNAPSHOT_IMPORT_ACCEPT, ".json,.png");
+  assert.equal(isAgentSnapshotCandidateName("agent.json"), true);
+  assert.equal(isAgentSnapshotCandidateName("analyst.agent.json"), true);
+  assert.equal(isAgentSnapshotCandidateName("AGENT.PNG"), true);
+});
+
+test("agent import still rejects unrelated filenames before reading them", () => {
+  assert.equal(isAgentSnapshotCandidateName("agent.txt"), false);
+  assert.equal(isAgentSnapshotCandidateName("agent.json.zip"), false);
+});

--- a/desktop/src/features/agents/ui/personaLibraryCopy.ts
+++ b/desktop/src/features/agents/ui/personaLibraryCopy.ts
@@ -8,8 +8,7 @@ export const personaLibraryCopy = {
   emptyTitle: "No agents yet",
   emptyDescription:
     "Choose one from Agent Catalog, create your own, or import one to get started.",
-  emptyImportHint:
-    "Or drop an .agent.json or .agent.png snapshot here to import.",
+  emptyImportHint: "Or drop a JSON or PNG agent snapshot here to import.",
 } as const;
 
 export const personaCatalogCopy = {

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -452,15 +452,63 @@ test("the new agent card opens unified create, catalog, and import flows", async
 
   await page.getByTestId("agent-catalog-import").click();
   await expect(page.getByTestId("agent-catalog-import-dropzone")).toBeVisible();
+  await expect(page.getByTestId("agent-catalog-import-input")).toHaveAttribute(
+    "accept",
+    ".json,.png",
+  );
   const fileChooserPromise = page.waitForEvent("filechooser");
   await page.getByTestId("agent-catalog-import-dropzone").click();
   const fileChooser = await fileChooserPromise;
   await fileChooser.setFiles({
     buffer: Buffer.from("{}"),
     mimeType: "application/json",
-    name: "imported.agent.json",
+    name: "agent.json",
   });
   await expect(page.getByTestId("agent-snapshot-import-dialog")).toBeVisible();
+});
+
+test("ordinary agent snapshot filenames import by drag and drop", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+  await page.getByTestId("new-agent-card").click();
+  await page.getByTestId("agent-catalog-import").click();
+
+  const dataTransfer = await page.evaluateHandle(() => {
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["{}"], "agent.json", { type: "application/json" }),
+    );
+    return transfer;
+  });
+  const catalogDialog = page.getByTestId("persona-catalog-dialog");
+  await catalogDialog.dispatchEvent("dragenter", { dataTransfer });
+  await expect(page.getByTestId("agent-catalog-drop-overlay")).toBeVisible();
+  await catalogDialog.dispatchEvent("drop", { dataTransfer });
+
+  await expect(page.getByTestId("agent-snapshot-import-dialog")).toBeVisible();
+});
+
+test("oversized agent snapshots are rejected before import", async ({
+  page,
+}) => {
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+  await page.getByTestId("new-agent-card").click();
+  await page.getByTestId("agent-catalog-import").click();
+
+  await page.getByTestId("agent-catalog-import-input").setInputFiles({
+    buffer: Buffer.alloc(10 * 1024 * 1024 + 1),
+    mimeType: "application/json",
+    name: "agent.json",
+  });
+
+  await expect(page.getByTestId("agent-catalog-import-error")).toHaveText(
+    "This snapshot is larger than 10 MB. Choose a smaller file.",
+  );
+  await expect(page.getByTestId("persona-catalog-dialog")).toBeVisible();
+  await expect(page.getByTestId("agent-snapshot-import-dialog")).toHaveCount(0);
 });
 
 test("embedded create keeps its draft when discard is cancelled", async ({


### PR DESCRIPTION
Buzz already identifies snapshot format from the file contents and returns a useful validation error. The Add agent dialog never reached that code for files named agent.json or agent.png because Finder accepted only the compound .agent.json and .agent.png suffixes. Drag and drop rejected those names too.

This accepts ordinary JSON and PNG filenames as import candidates. It also rejects files larger than 10 MB before reading them into the renderer. The existing backend still detects the format and applies its 5 MB JSON and 10 MB PNG limits, so broader filename matching does not make malformed or oversized content importable.

Fixes #5458.

Checks:
- All 4,537 desktop tests
- Desktop typecheck
- Desktop checks
- Production picker, drag-and-drop, and oversized-file Playwright tests