### PR TITLE
fix(desktop): clarify owner-only agent access

### DIFF
--- a/desktop/src-tauri/src/managed_agents/access_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/access_policy.rs
@@ -33,9 +33,9 @@
 //! `welcomeTeammateHasExpectedAccess` in
 //! `desktop/src/features/onboarding/welcomeGuide.ts`). Read every use of
 //! "owner-only" in this module as `owner ∪ verified same-owner agents`. The
-//! setting's own copy says so: the line under Only me reads "Only you and your
-//! agents can send instructions." (`RespondToField.tsx`). The dropdown label
-//! stays "Only me", which is the audience the user picks.
+//! setting's own copy says so: the label reads "Me and my agents only", and the
+//! line under it reads "Only you and your agents can send instructions."
+//! (`RespondToField.tsx`).
 
 use super::{validate_respond_to_allowlist, ManagedAgentRecord, RespondTo};
 

--- a/desktop/src-tauri/src/managed_agents/agent_env.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_env.rs
@@ -376,8 +376,9 @@ mod tests {
     // `managed_agents/runtime.rs`), after Buzz sets the access gates. If a
     // baked reserved key survived here, an internal build packaged with
     // `BUZZ_ACP_RESPOND_TO=anyone` would answer anyone while the UI shows
-    // "Only me". `build.rs` rejects such a key at build time; these tests pin
-    // the runtime backstop for a binary built without that check.
+    // "Me and my agents only". `build.rs` rejects such a key at build time;
+    // these tests pin the runtime backstop for a binary built without that
+    // check.
 
     #[test]
     fn build_env_map_drops_baked_access_gate_keys() {

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -30,7 +30,7 @@ buzz agents draft-create \
   --system-prompt "Find reliable sources and summarize them concisely."
 ```
 
-Use the UUID from the current Buzz `[Context]`; do not ask the user for it. Do not ask about runtime, provider, model, credentials, environment variables, or access. Desktop uses the machine's real defaults, and new agents start as **Only me**. The command sends an encrypted draft to the owner's Desktop. It does not create the agent until the owner reviews and saves the form, so report the result as “ready for review,” never “created.”
+Use the UUID from the current Buzz `[Context]`; do not ask the user for it. Do not ask about runtime, provider, model, credentials, environment variables, or access. Desktop uses the machine's real defaults, and new agents start as **Me and my agents only**. The command sends an encrypted draft to the owner's Desktop. It does not create the agent until the owner reviews and saves the form, so report the result as “ready for review,” never “created.”
 
 For an explicit change to an existing personal agent, use:
 

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -25,7 +25,7 @@ import type { PersonaDropdownOption } from "./agentConfigOptions";
  * Inbound author gate UI for create/edit agent dialogs.
  *
  * Dropdown:
- *   - Only me        (default; maps to `buzz-acp --respond-to=owner-only`)
+ *   - Me and my agents only (default; maps to `buzz-acp --respond-to=owner-only`)
  *   - Anyone         (`--respond-to=anyone` — fully open agent)
  *   - Selected people (`--respond-to=allowlist`, plus the selected pubkeys as
  *                     `--respond-to-allowlist`)
@@ -36,14 +36,12 @@ import type { PersonaDropdownOption } from "./agentConfigOptions";
  * Anyone and Selected people both share the host's access with someone other
  * than the owner, so both render the persistent warning; only the audience
  * phrase differs. It leads with the audience so it reads as a warning rather
- * than an explanation, and stays one sentence — Only me already owns the line
- * below the control.
+ * than an explanation, and stays one sentence — Me and my agents only already
+ * has a line below the control.
  *
- * The line below Only me says "Only you and your agents", because the harness
- * gate admits the owner and every verified same-owner agent, not the owner
- * alone (see `managed_agents/access_policy.rs`). The dropdown label stays
- * "Only me": it is the audience the user picks, and it has meant this since
- * before agents could instruct each other.
+ * The label and line below it name both the owner and their agents because the
+ * harness gate admits the owner and every verified same-owner agent, not the
+ * owner alone (see `managed_agents/access_policy.rs`).
  *
  * Which machine and stakes it names follow the optional `runLocation` prop, and
  * an unknown location falls back to the local wording rather than hedging with
@@ -73,7 +71,7 @@ function formatSearchUserSecondary(user: UserSearchResult) {
 }
 
 const RESPOND_TO_OPTIONS: PersonaDropdownOption[] = [
-  { label: "Only me (default)", value: "owner-only" },
+  { label: "Me and my agents only (default)", value: "owner-only" },
   { label: "Anyone", value: "anyone" },
   { label: "Selected people", value: "allowlist" },
 ];
@@ -212,7 +210,7 @@ export function CreateAgentRespondToField({
           id="agent-respond-to"
           onValueChange={(value) => onModeChange(value as RespondToMode)}
           options={RESPOND_TO_OPTIONS}
-          placeholder="Only me (default)"
+          placeholder="Me and my agents only (default)"
           value={mode}
         />
       ) : (

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -14,7 +14,11 @@ const respondToFieldSource = await readFile(
  */
 const collapsedSource = respondToFieldSource.replace(/\s+/g, " ");
 
-for (const label of ["Only me (default)", "Selected people", "Anyone"]) {
+for (const label of [
+  "Me and my agents only (default)",
+  "Selected people",
+  "Anyone",
+]) {
   test(`respond-to control uses the plain-language label: ${label}`, () => {
     assert.ok(respondToFieldSource.includes(`label: "${label}"`));
   });
@@ -55,7 +59,7 @@ test("the warning copy comes from the shared helper, not inline text", () => {
   assert.match(collapsedSource, /<p aria-live="polite"[^>]*> \{warningText\}/);
 });
 
-test("the Only me line names the owner's agents, not the owner alone", () => {
+test("the owner-only copy names the owner's agents, not the owner alone", () => {
   // The harness gate admits the owner and every verified same-owner agent
   // (`managed_agents/access_policy.rs`), and the built-in Welcome team depends
   // on that, so a line promising the owner alone would overstate the boundary.

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -111,7 +111,7 @@ function formatRespondToLabel(agent: ManagedAgent) {
     case "allowlist":
       return `Selected people (${agent.respondToAllowlist.length})`;
     default:
-      return "Only me";
+      return "Me and my agents only";
   }
 }
 

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -119,7 +119,8 @@ test("open agent access explains the available access before save", async ({
     .getByRole("dialog", { name: "Manage agent access" })
     .screenshot({ path: `${SHOTS}/selected-people-warning.png` });
 
-  // Only me shares nothing, so the warning goes away entirely.
+  // Me and my agents only keeps access inside the owner's trust boundary, so
+  // the warning goes away entirely.
   await accessSelect.selectOption("owner-only");
   await expect(warning).toHaveCount(0);
 });
@@ -175,7 +176,7 @@ test("persona-backed edit warns before saving open access", async ({
   const dialog = page.getByTestId("edit-agent-dialog");
   await expect(dialog).toBeVisible();
   await expect(page.locator("#agent-respond-to")).toHaveText(
-    "Only me (default)",
+    "Me and my agents only (default)",
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -96,7 +96,7 @@ test.describe("agent definition dialog", () => {
     await expect(dialog.getByTestId("agent-respond-to")).toBeVisible();
     await expect(dialog.locator("#agent-respond-to")).toBeDisabled();
     await expect(dialog.locator("#agent-respond-to")).toContainText(
-      "Only me (default)",
+      "Me and my agents only (default)",
     );
     await expect(
       dialog.getByTestId("agent-respond-to-disabled-reason"),
@@ -128,7 +128,7 @@ test.describe("edit agent dialog", () => {
     await expect(accessControl).toBeVisible();
     await expect(page.locator("#agent-respond-to")).toBeDisabled();
     await expect(page.locator("#agent-respond-to")).toContainText(
-      "Only me (default)",
+      "Me and my agents only (default)",
     );
     await expect(
       page.getByTestId("agent-respond-to-disabled-reason"),


### PR DESCRIPTION
## What changed

- Rename the default agent access option from **Only me** to **Me and my agents only**.
- Update the matching member-card summary, tests, and internal documentation.

## Why

The `owner-only` policy admits both the owner and verified agents belonging to that owner. The previous label suggested the owner alone could send instructions, which was misleading during a real multi-agent setup.

## Impact

Copy only. The underlying `owner-only` value and its enforcement are unchanged.

## Verification

- `just ci`
- Respond-to copy contract: 9/9 passed
- Desktop test suite: 4,535/4,535 passed
- Tauri test suite: 2,270 passed, 14 ignored, 0 failed
- Mobile test suite: 1,261/1,261 passed

## Review notes

- Duplicate issue/PR search: none found
- Risk classification: Mechanical; no independent reviewer required

Created by Codex.
