### PR TITLE
fix(desktop): label channel action as add agents

### DIFF
--- a/desktop/src/features/channels/ui/useChannelIntro.tsx
+++ b/desktop/src/features/channels/ui/useChannelIntro.tsx
@@ -93,7 +93,7 @@ export function useChannelIntro({
         actions.push({
           description: "Add an agent here.",
           icon: <Bot aria-hidden className="h-6 w-6" />,
-          label: "Create agent",
+          label: "Add agents",
           onClick: onAddAgent,
           testId: "channel-intro-action-create-agent",
         });

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1712,6 +1712,9 @@ test("empty channel shows intro actions", async ({ page }) => {
     page.getByTestId("channel-intro-action-create-agent"),
   ).toBeVisible();
   await expect(
+    page.getByTestId("channel-intro-action-create-agent"),
+  ).toContainText("Add agents");
+  await expect(
     page.getByTestId("channel-intro-action-add-people"),
   ).toBeVisible();
   await expect(page.getByTestId("welcome-composer-guide-banner")).toHaveCount(


### PR DESCRIPTION
## What changed

- Rename the empty-channel action card from **Create agent** to **Add agents**.
- Assert the new card label in the existing channel-intro browser test.

## Why

The action opens the **Add agents** dialog and can add an existing agent, so **Create agent** described the workflow too narrowly. Matching the card to its destination makes the action clearer and keeps it parallel with **Add people**.

## Impact

Copy only. The action and agent-adding behavior are unchanged.

## Verification

- `pnpm check`
- `pnpm test` — 4,535 passed
- `pnpm build:e2e`
- Targeted Playwright smoke test: `empty channel shows intro actions` — passed

## Review notes

- Duplicate issue/PR search: no matching open item found
- Risk classification: Mechanical; no independent reviewer required

Created by Codex.
