### PR TITLE
fix(mcp): surface unsupported image input

### DIFF
--- a/crates/buzz-agent/src/mcp.rs
+++ b/crates/buzz-agent/src/mcp.rs
@@ -756,6 +756,10 @@ async fn spawn_one(
     for (k, v) in &spec.env {
         cmd.env(k, v);
     }
+    // This agent advertises `promptCapabilities.image: false`; make that
+    // capability available to MCP tools so image-producing tools can fail
+    // locally with an actionable result instead of sending an unusable payload.
+    cmd.env("BUZZ_MCP_IMAGE_INPUT_SUPPORTED", "false");
     cmd.current_dir(&spec.cwd);
     cmd.stderr(std::process::Stdio::inherit());
 

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -28,6 +28,10 @@ pub struct SharedState {
     pub shim: Shim,
     pub session_dir: TempDir,
     pub bootstrap_instructions: String,
+    /// Whether the active model route can accept MCP image content. The agent
+    /// supplies this explicitly when it starts the dev MCP; direct users retain
+    /// the historical vision-capable default unless they opt out.
+    pub image_input_supported: bool,
     /// The shell resolved at construction: `Ok((path, display_name))` when a shell
     /// is available, `Err(msg)` when none was found. Stored once so both the
     /// bootstrap hint and every `run()` call read the SAME resolution — no drift.
@@ -51,11 +55,18 @@ impl SharedState {
             Err(_) => "bash",
         };
         let bootstrap_instructions = build_bootstrap(&cwd, shell_hint);
+        // `buzz-agent` declares its capability explicitly. Retain the original
+        // behavior for standalone dev-MCP use and other hosts that do not set it.
+        let image_input_supported = !matches!(
+            std::env::var("BUZZ_MCP_IMAGE_INPUT_SUPPORTED").as_deref(),
+            Ok("false" | "0")
+        );
         Ok(Self {
             cwd,
             shim,
             session_dir,
             bootstrap_instructions,
+            image_input_supported,
             resolved_shell,
             artifacts: Mutex::new(VecDeque::with_capacity(ARTIFACT_RING_SIZE)),
             next_call_id: Mutex::new(0),
@@ -69,6 +80,12 @@ impl SharedState {
         };
         *g += 1;
         *g
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_image_input_supported(mut self, supported: bool) -> Self {
+        self.image_input_supported = supported;
+        self
     }
 }
 

--- a/crates/buzz-dev-mcp/src/view_image.rs
+++ b/crates/buzz-dev-mcp/src/view_image.rs
@@ -86,6 +86,12 @@ struct PreparedImage {
 }
 
 pub async fn run(state: &SharedState, p: ViewImageParams) -> Result<CallToolResult, ErrorData> {
+    if !state.image_input_supported {
+        return Ok(CallToolResult::error(vec![Content::text(
+            "This model cannot see images: its active route does not support image input. `view_image` cannot inspect this image for you. Do not retry this tool; use OCR or other text-based inspection tools instead.".to_string(),
+        )]));
+    }
+
     let max_dim = p
         .max_dim
         .unwrap_or(DEFAULT_MAX_DIM)
@@ -710,6 +716,39 @@ mod tests {
             .unwrap();
         fs::write(path, &bytes).unwrap();
         bytes
+    }
+
+    #[tokio::test]
+    async fn rejects_view_image_before_reading_when_model_lacks_vision() {
+        let dir = tempdir().unwrap();
+        let state = make_state(dir.path());
+        // A missing source proves the capability error is returned before the
+        // tool touches the filesystem or attempts image decoding.
+        let res = run(
+            &state.with_image_input_supported(false),
+            ViewImageParams {
+                source: "does-not-exist.png".into(),
+                max_dim: None,
+                workdir: Some(dir.path().display().to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(res.is_error, Some(true));
+        let text = res
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .expect("text error result")
+            .text
+            .as_str();
+        assert!(text.contains("cannot see images"), "{text}");
+        assert!(text.contains("Do not retry"), "{text}");
+        assert!(res
+            .content
+            .iter()
+            .all(|content| content.as_image().is_none()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why
Text-only `buzz-agent` routes currently allow `view_image` to return an image payload the active model cannot consume, causing blind retries and costly manual extraction attempts.

## What
- Pass the agent's declared image-input capability to spawned MCP servers
- Return a model-visible, actionable `view_image` error before reading or encoding the source when vision is unavailable
- Cover the rejection path, including no filesystem read and no image block

## Risk Assessment
Low — the behavior changes only for `buzz-agent`, which already advertises no image input; standalone MCP hosts retain their existing vision-capable default.

## References
- Originating Buzz thread: buzz://message?channel=c3252dd2-0142-4e01-88c7-a2183c3960a5&id=386c1ee51d52f9ab5dade989670b2931a0cdd3099fc986b3dd5c9980fbf9dfff

Generated with Codex
