### PR TITLE
feat(desktop): support Linux ARM64 and NVIDIA DGX Spark

### DIFF
--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -18,9 +18,19 @@ permissions:
 
 jobs:
   build:
-    name: Build Linux canary
+    name: Build Linux canary (${{ matrix.arch }})
     if: github.repository == 'block/buzz'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
     container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
     timeout-minutes: 60
     permissions:
@@ -95,16 +105,25 @@ jobs:
           esac
           wget -q --tries=3 --timeout=30 -O /tmp/appimagetool \
             "https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-${ARCH_SUFFIX}.AppImage"
-          if [[ "$ARCH_SUFFIX" == "x86_64" ]]; then
-            echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c
-          else
-            echo "::error::No pinned SHA256 for appimagetool-${ARCH_SUFFIX} — add it before enabling this architecture"
-            exit 1
-          fi
+          case "$ARCH_SUFFIX" in
+            x86_64)
+              echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c
+              ;;
+            aarch64)
+              echo "f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158  /tmp/appimagetool" | sha256sum -c
+              ;;
+          esac
           install -m 755 /tmp/appimagetool /usr/local/bin/appimagetool
           wget -q --tries=3 --timeout=30 -O /tmp/appimage-runtime \
             "https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-${ARCH_SUFFIX}"
-          echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum -c
+          case "$ARCH_SUFFIX" in
+            x86_64)
+              echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum -c
+              ;;
+            aarch64)
+              echo "00cbdfcf917cc6c0ff6d3347d59e0ca1f7f45a6df1a428a0d6d8a78664d87444  /tmp/appimage-runtime" | sha256sum -c
+              ;;
+          esac
           install -D -m 644 /tmp/appimage-runtime /usr/local/lib/appimage-runtime
           echo "APPIMAGETOOL_RUNTIME_FILE=/usr/local/lib/appimage-runtime" >> "$GITHUB_ENV"
 
@@ -116,8 +135,8 @@ jobs:
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: pnpm-${{ runner.os }}-
+          key: pnpm-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-${{ matrix.target }}-
 
       - name: Install desktop dependencies
         run: just desktop-install-ci
@@ -156,7 +175,7 @@ jobs:
         run: |
           KEY=$(scripts/desktop-release-cache-key.py \
             --platform "$RUNNER_OS" \
-            --target x86_64-unknown-linux-gnu \
+            --target "${{ matrix.target }}" \
             --features mesh-llm \
             --native-inputs "$NATIVE_TOOLCHAIN_ID")
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
@@ -232,7 +251,7 @@ jobs:
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: pnpm-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Locate Linux build artifacts
         id: artifacts
@@ -257,7 +276,7 @@ jobs:
       - name: Upload Linux canary packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-linux-canary-${{ github.sha }}
+          name: buzz-linux-${{ matrix.arch }}-canary-${{ github.sha }}
           path: |
             ${{ steps.artifacts.outputs.deb }}
             ${{ steps.artifacts.outputs.appimage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,9 +424,21 @@ jobs:
             ${{ steps.artifacts.outputs.sig }}
 
   release-linux:
-    name: Release Linux
+    name: Release Linux (${{ matrix.arch }})
     if: github.repository == 'block/buzz'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: desktop-release-linux-x64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact_name: desktop-release-linux-arm64
+    runs-on: ${{ matrix.runner }}
     # Digest-pinned like the SHA-pinned actions below; Renovate keeps it fresh.
     container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
     needs: setup
@@ -442,9 +454,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    outputs:
-      archive_name: ${{ steps.linux-artifacts.outputs.archive_name }}
-      sig: ${{ steps.read-sig.outputs.sig }}
     steps:
       - name: Install system dependencies
         env:
@@ -531,23 +540,31 @@ jobs:
           esac
           wget -q --tries=3 --timeout=30 -O /tmp/appimagetool \
             "https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-${ARCH_SUFFIX}.AppImage"
-          # SHA256 integrity check. Refuse to run an unverified binary: if a new
-          # arch (e.g. aarch64) is enabled in CI, compute its hash and add it here.
-          if [[ "$ARCH_SUFFIX" == "x86_64" ]]; then
-            echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c
-          else
-            echo "::error::No pinned SHA256 for appimagetool-${ARCH_SUFFIX} — add it before enabling this architecture"
-            exit 1
-          fi
+          # SHA256 integrity check. Refuse to run an unverified binary; add a
+          # pinned hash here before enabling any additional architecture.
+          case "$ARCH_SUFFIX" in
+            x86_64)
+              echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c
+              ;;
+            aarch64)
+              echo "f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158  /tmp/appimagetool" | sha256sum -c
+              ;;
+          esac
           install -m 755 /tmp/appimagetool /usr/local/bin/appimagetool
           # appimagetool otherwise fetches the AppImage type2 runtime from the
           # MUTABLE `continuous` tag at repack time — the runtime is the first
-          # code users execute, so pin it too. Tag: 20251108, hash is for the
-          # x86_64 asset (non-x86_64 already hard-fails above).
+          # code users execute, so pin it too. Tag: 20251108.
           # (https://github.com/AppImage/type2-runtime/releases/tag/20251108)
           wget -q --tries=3 --timeout=30 -O /tmp/appimage-runtime \
             "https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-${ARCH_SUFFIX}"
-          echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum -c
+          case "$ARCH_SUFFIX" in
+            x86_64)
+              echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum -c
+              ;;
+            aarch64)
+              echo "00cbdfcf917cc6c0ff6d3347d59e0ca1f7f45a6df1a428a0d6d8a78664d87444  /tmp/appimage-runtime" | sha256sum -c
+              ;;
+          esac
           install -D -m 644 /tmp/appimage-runtime /usr/local/lib/appimage-runtime
           echo "APPIMAGETOOL_RUNTIME_FILE=/usr/local/lib/appimage-runtime" >> "$GITHUB_ENV"
 
@@ -634,17 +651,11 @@ jobs:
           echo "archive_name=$(basename "$ARCHIVE")" >> "$GITHUB_OUTPUT"
           echo "sig=$SIG" >> "$GITHUB_OUTPUT"
 
-      - name: Read updater signature
-        id: read-sig
-        run: echo "sig=$(cat "$SIG_PATH")" >> "$GITHUB_OUTPUT"
-        env:
-          SIG_PATH: ${{ steps.linux-artifacts.outputs.sig }}
-
       # NOTE: .deb is NOT auto-updatable (Tauri updater constraint — only AppImage supports it on Linux)
       - name: Stage Linux release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: desktop-release-linux-x64
+          name: ${{ matrix.artifact_name }}
           if-no-files-found: error
           path: |
             ${{ steps.linux-artifacts.outputs.deb }}
@@ -823,6 +834,38 @@ jobs:
             cp "$file" "staged/$name"
           done < <(find staged-by-platform -type f -print0)
 
+      # Matrix job outputs are not deterministic when more than one matrix leg
+      # writes the same output. Resolve both Linux updater artifacts from the
+      # staged files instead, where Tauri's architecture suffix is unambiguous.
+      - name: Resolve staged Linux updater artifacts
+        id: linux-updaters
+        run: |
+          set -euo pipefail
+
+          resolve_linux_updater() {
+            local architecture="$1" output_prefix="$2"
+            mapfile -t appimages < <(find staged -maxdepth 1 -type f -name "*_${architecture}.AppImage")
+            if [[ "${#appimages[@]}" -ne 1 ]]; then
+              echo "::error::Expected exactly one Linux ${architecture} AppImage, found ${#appimages[@]}"
+              exit 1
+            fi
+
+            local archive="${appimages[0]}"
+            if [[ -f "${archive}.tar.gz" ]]; then
+              archive="${archive}.tar.gz"
+            fi
+            if [[ ! -f "${archive}.sig" ]]; then
+              echo "::error::Missing Linux ${architecture} updater signature: ${archive}.sig"
+              exit 1
+            fi
+
+            echo "${output_prefix}_archive=$(basename "$archive")" >> "$GITHUB_OUTPUT"
+            echo "${output_prefix}_sig=${archive}.sig" >> "$GITHUB_OUTPUT"
+          }
+
+          resolve_linux_updater amd64 linux_x64
+          resolve_linux_updater aarch64 linux_arm64
+
       - name: Write signature files
         env:
           RESULT_ARM64: ${{ needs.release.result }}
@@ -831,7 +874,8 @@ jobs:
           RESULT_WIN: ${{ needs.release-windows.result }}
           SIG_ARM64: ${{ needs.release.outputs.sig }}
           SIG_X64: ${{ needs.release-macos-x64.outputs.sig }}
-          SIG_LINUX: ${{ needs.release-linux.outputs.sig }}
+          SIG_LINUX_X64_PATH: ${{ steps.linux-updaters.outputs.linux_x64_sig }}
+          SIG_LINUX_ARM64_PATH: ${{ steps.linux-updaters.outputs.linux_arm64_sig }}
           SIG_WIN: ${{ needs.release-windows.outputs.sig }}
         run: |
           set -euo pipefail
@@ -847,7 +891,12 @@ jobs:
 
           write_sig "$RESULT_ARM64" darwin-aarch64 "$SIG_ARM64"
           write_sig "$RESULT_X64" darwin-x86_64 "$SIG_X64"
-          write_sig "$RESULT_LINUX" linux-x86_64 "$SIG_LINUX"
+          if [[ "$RESULT_LINUX" == "success" ]]; then
+            [[ -f "$SIG_LINUX_X64_PATH" ]] || { echo "::error::Missing signature for successful platform: linux-x86_64"; exit 1; }
+            [[ -f "$SIG_LINUX_ARM64_PATH" ]] || { echo "::error::Missing signature for successful platform: linux-aarch64"; exit 1; }
+            cp "$SIG_LINUX_X64_PATH" /tmp/sigs/linux-x86_64.sig
+            cp "$SIG_LINUX_ARM64_PATH" /tmp/sigs/linux-aarch64.sig
+          fi
           write_sig "$RESULT_WIN" windows-x86_64 "$SIG_WIN"
 
       - name: Verify draft release has every updater archive
@@ -858,7 +907,8 @@ jobs:
           RESULT_WIN: ${{ needs.release-windows.result }}
           ARCHIVE_ARM64: ${{ needs.release.outputs.archive_name }}
           ARCHIVE_X64: ${{ needs.release-macos-x64.outputs.archive_name }}
-          ARCHIVE_LINUX: ${{ needs.release-linux.outputs.archive_name }}
+          ARCHIVE_LINUX_X64: ${{ steps.linux-updaters.outputs.linux_x64_archive }}
+          ARCHIVE_LINUX_ARM64: ${{ steps.linux-updaters.outputs.linux_arm64_archive }}
           ARCHIVE_WIN: ${{ needs.release-windows.outputs.archive_name }}
         run: |
           set -euo pipefail
@@ -866,7 +916,8 @@ jobs:
           for spec in \
             "$RESULT_ARM64:$ARCHIVE_ARM64" \
             "$RESULT_X64:$ARCHIVE_X64" \
-            "$RESULT_LINUX:$ARCHIVE_LINUX" \
+            "$RESULT_LINUX:$ARCHIVE_LINUX_X64" \
+            "$RESULT_LINUX:$ARCHIVE_LINUX_ARM64" \
             "$RESULT_WIN:$ARCHIVE_WIN"; do
             result="${spec%%:*}"
             archive="${spec#*:}"
@@ -884,7 +935,8 @@ jobs:
           RESULT_WIN: ${{ needs.release-windows.result }}
           ARCHIVE_ARM64: ${{ needs.release.outputs.archive_name }}
           ARCHIVE_X64: ${{ needs.release-macos-x64.outputs.archive_name }}
-          ARCHIVE_LINUX: ${{ needs.release-linux.outputs.archive_name }}
+          ARCHIVE_LINUX_X64: ${{ steps.linux-updaters.outputs.linux_x64_archive }}
+          ARCHIVE_LINUX_ARM64: ${{ steps.linux-updaters.outputs.linux_arm64_archive }}
           ARCHIVE_WIN: ${{ needs.release-windows.outputs.archive_name }}
         run: |
           set -euo pipefail
@@ -901,10 +953,11 @@ jobs:
 
           add_triple "$RESULT_ARM64" darwin-aarch64 "$ARCHIVE_ARM64"
           add_triple "$RESULT_X64" darwin-x86_64 "$ARCHIVE_X64"
-          add_triple "$RESULT_LINUX" linux-x86_64 "$ARCHIVE_LINUX"
+          add_triple "$RESULT_LINUX" linux-x86_64 "$ARCHIVE_LINUX_X64"
+          add_triple "$RESULT_LINUX" linux-aarch64 "$ARCHIVE_LINUX_ARM64"
           add_triple "$RESULT_WIN" windows-x86_64 "$ARCHIVE_WIN"
 
-          [ "${#TRIPLES[@]}" -ge 3 ] || { echo "::error::too few platforms (${#TRIPLES[@]})"; exit 1; }
+          [ "${#TRIPLES[@]}" -ge 5 ] || { echo "::error::too few platforms (${#TRIPLES[@]})"; exit 1; }
           bash desktop/scripts/generate-oss-latest-json.sh "$VERSION" "${TRIPLES[@]}" > latest.json
           cat latest.json
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Grab a packaged build from the [latest release](https://github.com/block/buzz/re
 | macOS (Apple Silicon) | `Buzz_<version>_aarch64.dmg` |
 | macOS (Intel) | `Buzz_<version>_x64.dmg` |
 | Linux (x86_64) | `Buzz_<version>_amd64.AppImage` or `Buzz_<version>_amd64.deb` |
+| Linux (ARM64) | `Buzz_<version>_aarch64.AppImage` or `Buzz_<version>_arm64.deb` |
 | Windows (x64) | `Buzz_<version>_x64-setup_alpha-unsigned.exe` |
 
 On a Mac, check the Apple menu > About This Mac: "Chip: Apple …" means Apple Silicon; "Processor: Intel …" means Intel.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -214,9 +214,9 @@ GitHub Release or a stable `mobile-vX.Y.Z` alias.
 The release workflow builds **two separate macOS DMGs**: Apple
 Silicon (`darwin-aarch64`, the `release` job) and Intel
 (`darwin-x86_64`, the `release-macos-x64` job), an unsigned Windows x64
-NSIS installer (its filename includes `_alpha-unsigned`), and Linux `.deb` and
-`.AppImage` packages. Both macOS DMGs are codesigned, notarized, and attached
-to the same `desktop-v<version>` release. Intel users
+NSIS installer (its filename includes `_alpha-unsigned`), and Linux x86_64 and
+ARM64 `.deb` and `.AppImage` packages. Both macOS DMGs are codesigned,
+notarized, and attached to the same `desktop-v<version>` release. Intel users
 download the `_x64.dmg`.
 
 The Linux AppImage is post-processed by `desktop/scripts/fix-appimage.sh`,
@@ -224,9 +224,9 @@ which strips infra libraries over-bundled by linuxdeploy (they crash on
 Mesa 25+ / GLib 2.88 distros; see
 [tauri-apps/tauri#15665](https://github.com/tauri-apps/tauri/issues/15665))
 and re-signs the artifact. As a result the AppImage relies on the
-host's Wayland/GStreamer/graphics stack and requires GLib >= 2.72
-(Ubuntu 22.04 or newer). The `release-linux` job builds inside a
-`ubuntu:22.04` container for broad GLIBC compatibility.
+host's Wayland/GStreamer/graphics stack and requires GLib >= 2.72 and
+GLIBC >= 2.39 (Ubuntu 24.04 or newer). The `release-linux` matrix builds both
+architectures inside a pinned `ubuntu:24.04` container.
 
 ---
 
@@ -315,7 +315,7 @@ candidate tags must remain immutable.
 
 ### Auto-updater reports "no update available"
 Verify that the `buzz-desktop-latest` release exists and contains a
-valid `latest.json`. The manifest covers all four platform keys
-(`darwin-aarch64`, `darwin-x86_64`, `linux-x86_64`,
+valid `latest.json`. The manifest covers all five platform keys
+(`darwin-aarch64`, `darwin-x86_64`, `linux-x86_64`, `linux-aarch64`,
 `windows-x86_64`); a missing entry usually means that platform's
 release job failed. Check the workflow run.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "getrandom 0.2.17",
+ "gtk",
  "hex",
  "image",
  "infer",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ libc = "0.2"
 ctrlc = { version = "3", features = ["termination"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18.2"
 keyring = { version = "3.6.3", default-features = false, features = ["sync-secret-service", "vendored"], optional = true }
 # Used directly (alongside tauri-plugin-notification) so we can hold the posting
 # D-Bus connection open. GNOME 46+ dismisses a notification the moment that

--- a/desktop/src-tauri/src/initial_window.rs
+++ b/desktop/src-tauri/src/initial_window.rs
@@ -13,6 +13,56 @@ pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>
     }
 }
 
+/// Reveal a DGX Spark AppImage without handing its first WebKit surface to
+/// Mutter. GNOME Remote Login's virtual display can crash GNOME Shell when the
+/// initial XWayland surface is managed immediately. Realize and map it outside
+/// window-manager control, then hand the same window back after one frame.
+#[cfg(target_os = "linux")]
+pub(crate) fn reveal_initial_linux_window<R: tauri::Runtime>(
+    window: &tauri::Window<R>,
+    needs_unmanaged_first_map: bool,
+) {
+    if !needs_unmanaged_first_map {
+        reveal_initial_window(window);
+        return;
+    }
+
+    use gtk::prelude::*;
+
+    let gtk_window = match window.gtk_window() {
+        Ok(window) => window,
+        Err(error) => {
+            eprintln!("buzz-desktop: failed to obtain GTK main window: {error}");
+            reveal_initial_window(window);
+            return;
+        }
+    };
+
+    gtk_window.realize();
+    let Some(gdk_window) = gtk_window.window() else {
+        eprintln!("buzz-desktop: GTK main window has no realized GDK window");
+        reveal_initial_window(window);
+        return;
+    };
+
+    gdk_window.set_override_redirect(true);
+    gtk_window.show_all();
+    gdk_window.raise();
+    eprintln!("buzz-desktop: DGX Spark first map bypassed Mutter");
+
+    let tauri_window = window.clone();
+    gtk::glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
+        gdk_window.hide();
+        gdk_window.set_override_redirect(false);
+        gdk_window.show();
+        gdk_window.raise();
+        if let Err(error) = tauri_window.set_focus() {
+            eprintln!("buzz-desktop: failed to focus remapped main window: {error}");
+        }
+        eprintln!("buzz-desktop: DGX Spark window handed back to Mutter");
+    });
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) fn set_initial_window_backing<R: tauri::Runtime>(window: &tauri::Window<R>) {
     // The window remains transparent at runtime for vibrancy. Use an opaque

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -112,6 +112,16 @@ pub fn run() {
             eprintln!("buzz-mesh: failed to build big-stack tokio runtime, using default: {error}");
         }
     }
+    let dgx_spark_x11_window_workaround = webkit_rendering::needs_dgx_spark_window_workaround()
+        && webkit_rendering::uses_x11_backend();
+    let window_state_flags = if dgx_spark_x11_window_workaround {
+        // Restoring a saved maximized/decorated state before the two-stage map
+        // sends the Spark window back through the crashing Mutter path.
+        StateFlags::empty()
+    } else {
+        StateFlags::all() & !StateFlags::VISIBLE
+    };
+
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             // Focus the existing window when a duplicate instance launches.
@@ -132,12 +142,12 @@ pub fn run() {
             tauri_plugin_window_state::Builder::default()
                 // Visibility is excluded: the native reveal plugin below
                 // shows the window after saved geometry has been restored.
-                .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
+                .with_state_flags(window_state_flags)
                 .build(),
         )
         .plugin(
             tauri::plugin::Builder::<_, ()>::new("initial-window-reveal")
-                .on_webview_ready(|webview| {
+                .on_webview_ready(move |webview| {
                     if webview.label() != "main" {
                         return;
                     }
@@ -183,7 +193,15 @@ pub fn run() {
                         });
                     }
 
-                    #[cfg(not(target_os = "macos"))]
+                    #[cfg(target_os = "linux")]
+                    {
+                        reveal_initial_linux_window(
+                            &window,
+                            dgx_spark_x11_window_workaround,
+                        );
+                    }
+
+                    #[cfg(target_os = "windows")]
                     {
                         reveal_initial_window(&window);
                     }
@@ -915,7 +933,27 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             tray_menu::update_tray_agent_activity,
         ])
-        .build(tauri::generate_context!())
+        .build({
+            let mut context = tauri::generate_context!();
+            if dgx_spark_x11_window_workaround {
+                // The normal cross-platform config is transparent and starts
+                // maximized for macOS vibrancy. A Spark's first Linux map must
+                // instead be opaque, normal-sized, and client-decorated so the
+                // two-stage GTK reveal can safely transfer it to Mutter.
+                if let Some(window) = context
+                    .config_mut()
+                    .app
+                    .windows
+                    .iter_mut()
+                    .find(|window| window.label == "main")
+                {
+                    window.transparent = false;
+                    window.maximized = false;
+                    window.decorations = false;
+                }
+            }
+            context
+        })
         .expect("error while building tauri application");
     let shutdown_done = Arc::new(AtomicBool::new(false));
 

--- a/desktop/src-tauri/src/webkit_rendering.rs
+++ b/desktop/src-tauri/src/webkit_rendering.rs
@@ -16,7 +16,10 @@
 //! no second chance later in the same process. This module therefore decides
 //! from cheap preflight signals instead of reacting to a crash:
 //!
-//! * an NVIDIA GPU, the driver family behind most upstream reports; and
+//! * an NVIDIA GPU, the driver family behind most upstream reports;
+//! * an NVIDIA DGX Spark AppImage, where GNOME Remote Login's virtual Wayland
+//!   monitor can crash Mutter when WebKit submits an accelerated XWayland
+//!   surface; and
 //! * AppImage packaging, where linuxdeploy's AppRun hook pins `GDK_BACKEND=x11`
 //!   and the dmabuf renderer buys nothing on that XWayland path (#2338).
 //!
@@ -38,6 +41,12 @@ const NVIDIA_PCI_VENDOR: &str = "0x10de";
 
 /// Where DRM devices advertise their PCI vendor.
 const DRM_ROOT: &str = "/sys/class/drm";
+
+/// DMI product name exposed by Linux on the DGX Spark.
+const DMI_PRODUCT_NAME: &str = "/sys/devices/virtual/dmi/id/product_name";
+
+/// Product name reported by current DGX Spark firmware.
+const DGX_SPARK_PRODUCT_NAME: &str = "NVIDIA_DGX_Spark";
 
 /// Prefer shared-memory dmabuf transport. The #3654 replacement for
 /// `WEBKIT_DISABLE_DMABUF_RENDERER` on current WebKitGTK.
@@ -92,10 +101,21 @@ enum Plan {
 ///
 /// `Err` carries a user-facing diagnostic; the caller reports it and exits.
 pub fn apply() -> Result<(), String> {
+    // linuxdeploy's GTK AppRun hook pins every AppImage to X11. That is unsafe
+    // for GNOME Remote Login on a DGX Spark: presenting any Buzz XWayland
+    // surface crashes the remote Mutter process. Select the native Wayland
+    // backend before GTK initializes; physical/local sessions retain the
+    // packaging default and the two-stage X11 map below.
+    if needs_dgx_spark_window_workaround() && is_remote_login_session() {
+        std::env::set_var("GDK_BACKEND", "wayland");
+        eprintln!("buzz-desktop: GDK_BACKEND=wayland — remote NVIDIA DGX Spark AppImage");
+    }
+
     match plan(
         std::env::args_os(),
         &|key| std::env::var_os(key),
         Path::new(DRM_ROOT),
+        Path::new(DMI_PRODUCT_NAME),
     ) {
         Plan::Apply { vars, why } => {
             for var in vars {
@@ -114,12 +134,45 @@ pub fn apply() -> Result<(), String> {
     }
 }
 
+/// Whether this launch needs the DGX Spark/Mutter initial-map workaround.
+///
+/// Keep this predicate identical to the special case in [`plan`]. Rendering
+/// preflight runs before Tauri is built; the result is also used to prepare
+/// the initial native window and to choose its reveal path.
+pub(crate) fn needs_dgx_spark_window_workaround() -> bool {
+    std::env::var_os("APPIMAGE").is_some() && dgx_spark(Path::new(DMI_PRODUCT_NAME))
+}
+
+/// Whether the current login session is remote according to systemd-logind.
+///
+/// `loginctl ... auto` resolves the session that owns this process. It works
+/// both when Buzz is launched from GNOME and when an operator starts it from a
+/// remote shell. Non-systemd distributions simply fall back to `false`.
+pub(crate) fn is_remote_login_session() -> bool {
+    std::process::Command::new("loginctl")
+        .args(["show-session", "auto", "--property=Remote", "--value"])
+        .output()
+        .is_ok_and(|output| {
+            output.status.success()
+                && String::from_utf8_lossy(&output.stdout)
+                    .trim()
+                    .eq_ignore_ascii_case("yes")
+        })
+}
+
+/// Whether GTK will create an X11/XWayland rather than native Wayland window.
+pub(crate) fn uses_x11_backend() -> bool {
+    std::env::var_os("GDK_BACKEND")
+        .is_some_and(|backend| backend.eq_ignore_ascii_case(OsStr::new("x11")))
+}
+
 /// The whole decision, as a pure function of argv, the environment, and the DRM
 /// device tree.
 fn plan(
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     env: EnvLookup<'_>,
     drm_root: &Path,
+    dmi_product_name: &Path,
 ) -> Plan {
     let safe_rendering = args
         .into_iter()
@@ -165,10 +218,23 @@ fn plan(
         };
     }
 
-    let signals = [
-        (nvidia_gpu(drm_root), "NVIDIA GPU"),
-        (env("APPIMAGE").is_some(), "AppImage"),
-    ];
+    let appimage = env("APPIMAGE").is_some();
+
+    // Ubuntu 24.04 GNOME Remote Login creates a virtual Wayland monitor. On a
+    // DGX Spark, the AppImage's XWayland surface can make Mutter itself
+    // segfault as soon as Buzz's accelerated WebKit view appears, ending the
+    // whole remote session. Shared-memory transport alone is not sufficient;
+    // the existing safe-rendering mode also disables WebKit compositing and
+    // avoids the accelerated path that preceded the crash. Scope the cost to
+    // the exact product and package combination observed in the field.
+    if appimage && dgx_spark(dmi_product_name) {
+        return Plan::Apply {
+            vars: &SAFE_VARS,
+            why: "NVIDIA DGX Spark AppImage".to_string(),
+        };
+    }
+
+    let signals = [(nvidia_gpu(drm_root), "NVIDIA GPU"), (appimage, "AppImage")];
     let hits: Vec<&str> = signals
         .iter()
         .filter_map(|(hit, label)| hit.then_some(*label))
@@ -215,6 +281,12 @@ fn nvidia_gpu(drm_root: &Path) -> bool {
         std::fs::read_to_string(entry.path().join("device/vendor"))
             .is_ok_and(|vendor| vendor.trim().eq_ignore_ascii_case(NVIDIA_PCI_VENDOR))
     })
+}
+
+/// Whether Linux DMI identifies this machine as an NVIDIA DGX Spark.
+fn dgx_spark(product_name: &Path) -> bool {
+    std::fs::read_to_string(product_name)
+        .is_ok_and(|name| name.trim().eq_ignore_ascii_case(DGX_SPARK_PRODUCT_NAME))
 }
 
 /// The diagnostic for `--safe-rendering` against a user-set owned variable.

--- a/desktop/src-tauri/src/webkit_rendering/tests.rs
+++ b/desktop/src-tauri/src/webkit_rendering/tests.rs
@@ -33,6 +33,21 @@ fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<OsString> {
     }
 }
 
+/// Keep the existing decision tests independent from the machine running them.
+/// The Spark-specific cases below pass their own synthetic DMI product file.
+fn plan(
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    env: EnvLookup<'_>,
+    drm_root: &Path,
+) -> Plan {
+    super::plan(
+        args,
+        env,
+        drm_root,
+        Path::new("/nonexistent/dmi/product_name"),
+    )
+}
+
 /// The variables a plan would set, or `None` for a plan that sets nothing.
 fn applied(plan: &Plan) -> Option<&[&str]> {
     match plan {
@@ -96,6 +111,49 @@ fn test_an_appimage_launch_forces_shared_memory_dmabuf_transport() {
         unreachable!()
     };
     assert!(why.contains("AppImage"), "{why}");
+}
+
+#[test]
+fn test_a_dgx_spark_appimage_uses_full_safe_rendering() {
+    let drm = drm(&["0x10de"]);
+    let dmi = tempfile::tempdir().expect("dmi tempdir");
+    let product_name = dmi.path().join("product_name");
+    std::fs::write(&product_name, "NVIDIA_DGX_Spark\n").expect("product name");
+    let env = env_from(&[("APPIMAGE", "/home/u/Buzz.AppImage")]);
+
+    let plan = super::plan(NO_ARGS, &env, drm.path(), &product_name);
+
+    assert_eq!(
+        applied(&plan),
+        Some(
+            &[
+                "WEBKIT_DMABUF_RENDERER_FORCE_SHM",
+                "WEBKIT_DISABLE_COMPOSITING_MODE"
+            ][..]
+        )
+    );
+    let Plan::Apply { why, .. } = &plan else {
+        unreachable!()
+    };
+    assert!(why.contains("DGX Spark"), "{why}");
+}
+
+#[test]
+fn test_dgx_spark_source_build_keeps_the_nvidia_heuristic() {
+    let drm = drm(&["0x10de"]);
+    let dmi = tempfile::tempdir().expect("dmi tempdir");
+    let product_name = dmi.path().join("product_name");
+    std::fs::write(&product_name, "nvidia_dgx_spark\n").expect("product name");
+
+    assert_eq!(
+        applied(&super::plan(
+            NO_ARGS,
+            &env_from(&[]),
+            drm.path(),
+            &product_name,
+        )),
+        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

- build and publish Linux ARM64 `.deb` and `.AppImage` artifacts from native GitHub-hosted ARM runners
- add `linux-aarch64` to the desktop updater manifest and make Linux release artifact resolution matrix-safe
- make DGX Spark AppImages use native Wayland in GNOME Remote Login sessions, avoiding the XWayland/Mutter crash path
- use a staged first map for physical X11 Spark sessions and scope the heavier WebKit rendering safeguards to the exact DGX Spark AppImage combination
- document the new Linux ARM64 downloads and release requirements

## Why

Buzz currently publishes Linux packages only for x86_64 even though its Rust/sidecar stack builds natively on ARM64. On an NVIDIA DGX Spark, the generic AppImage GTK hook also pins `GDK_BACKEND=x11`. GNOME Remote Login presents a virtual Wayland monitor there, and submitting Buzz's WebKit XWayland surface can segfault Mutter and terminate the whole remote desktop.

The runtime change is deliberately narrow:

- DGX Spark + AppImage + remote logind session: override the packaging hook with native Wayland before GTK initializes
- DGX Spark + AppImage + X11: realize the initial GTK window outside WM control, then hand it to Mutter after its first map
- all other machines/packages: preserve the existing startup behavior

## Impact

Linux ARM64 becomes a first-class release architecture, including signed updater metadata. Existing x86_64, macOS, and Windows release paths remain in the same release. The Spark workaround is DMI- and package-scoped, so generic NVIDIA systems keep the existing shared-memory rendering heuristic.

## Validation

Validated on a physical NVIDIA DGX Spark running Ubuntu 24.04 and GNOME Remote Login:

- built a native ARM64 AppImage and verified the desktop binary plus all six sidecars are AArch64 ELF executables
- post-processed and installed the AppImage through the existing `fix-appimage.sh` release path
- launched through native Wayland without terminating GNOME Shell
- reached the intended Buzz identity onboarding flow and successfully persisted/imported an identity
- verified the local Buzz relay, Postgres, Redis, and MinIO services remain healthy
- `cargo fmt --all -- --check`
- focused WebKit policy suite: 18 passed
- desktop Rust workspace Clippy with `-D warnings`
- Actionlint and YAML parsing for both modified workflows
- a full local `just ci` run passed root, desktop, and web checks before the mobile check reached an architecture-external limitation: the pinned Flutter/Dart Hermit package is x86_64 and returns `Exec format error` on ARM64

## Prior work

Closes #2391.

Build-matrix direction builds on the earlier draft in #3339. The Spark runtime diagnosis also follows the physical-device report in #2811, including its two-stage X11 mapping finding.