### PR TITLE
docs(acp): make agent handoffs human-readable

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -54,6 +54,7 @@ For explicit changes to an existing personal agent, use `buzz agents draft-updat
 - Start every substantive agent-to-agent delegation with two short, plain-language lines: **Purpose:** why the work is being handed off, and **Goal:** what the receiving agent should deliver or decide.
 - Start every substantive returned result with **Outcome:** what was found or completed, and **What this means:** the practical impact or next decision for the human.
 - Put technical context, file paths, commit IDs, constraints, and verification details after this summary. Keep the opening understandable to a nontechnical reader following the thread.
+- Treat these opening lines as passive context: do not address or `@mention` the human in them. Mention the human only when they need to take an action, make a decision, or respond to an urgent blocker. A threaded reply does not need an extra human mention merely to identify its reader.
 - Do not add this template to routine acknowledgements or small clarification replies.
 
 ### Threading

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -49,6 +49,13 @@ For explicit changes to an existing personal agent, use `buzz agents draft-updat
 - When you **finish delegated work**, you MUST `@mention` the delegator in the message that reports the result, deliverable, or blocker. This is the #1 cause of stalled collaboration.
 - This applies to **completed work only.** Do not `@mention` to accept an assignment, confirm receipt, or close a loop conversationally. If you have nothing to report yet, say nothing and report when you do.
 
+### Readable Handoffs
+
+- Start every substantive agent-to-agent delegation with two short, plain-language lines: **Purpose:** why the work is being handed off, and **Goal:** what the receiving agent should deliver or decide.
+- Start every substantive returned result with **Outcome:** what was found or completed, and **What this means:** the practical impact or next decision for the human.
+- Put technical context, file paths, commit IDs, constraints, and verification details after this summary. Keep the opening understandable to a nontechnical reader following the thread.
+- Do not add this template to routine acknowledgements or small clarification replies.
+
 ### Threading
 
 Use the reply destination supplied in the `[Context]` block for ordinary replies in this turn. Do not reuse a remembered thread id, an older event id from prior work, or a stale conversation root.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3641,6 +3641,18 @@ mod agent_draft_prompt_tests {
             .contains("add them explicitly with `buzz channels add-member` only when authorized"));
         assert!(prompt.contains("never changes membership automatically"));
     }
+
+    #[test]
+    fn shared_base_prompt_teaches_readable_agent_handoffs() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("### Readable Handoffs"));
+        assert!(prompt.contains("**Purpose:**"));
+        assert!(prompt.contains("**Goal:**"));
+        assert!(prompt.contains("**Outcome:**"));
+        assert!(prompt.contains("**What this means:**"));
+        assert!(prompt.contains("understandable to a nontechnical reader"));
+        assert!(prompt.contains("routine acknowledgements or small clarification replies"));
+    }
 }
 
 fn default_heartbeat_prompt() -> String {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3651,6 +3651,10 @@ mod agent_draft_prompt_tests {
         assert!(prompt.contains("**Outcome:**"));
         assert!(prompt.contains("**What this means:**"));
         assert!(prompt.contains("understandable to a nontechnical reader"));
+        assert!(prompt.contains("opening lines as passive context"));
+        assert!(prompt.contains("do not address or `@mention` the human in them"));
+        assert!(prompt.contains("only when they need to take an action"));
+        assert!(prompt.contains("threaded reply does not need an extra human mention"));
         assert!(prompt.contains("routine acknowledgements or small clarification replies"));
     }
 }


### PR DESCRIPTION
## Summary
- require plain-language Purpose and Goal lines for substantive agent delegations
- require Outcome and What this means for returned results
- keep technical detail below the human-readable summary and exempt trivial replies
- add a regression test for the shared base prompt

## Verification
- cargo test -p buzz-acp (662 unit tests + 9 lifecycle tests passed)
- cargo fmt --all -- --check
- git diff --check

## Origin
Requested in Buzz Infra channel b5eae0ee-6e3a-43b1-91cb-6ea824425827.