### PR TITLE
fix(desktop): route same-owner remote agent mentions

### DIFF
--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -26,6 +26,7 @@ mod personas;
 mod process_lifecycle;
 pub(crate) mod readiness;
 pub(crate) mod reconcile;
+mod relay_agent_info;
 mod relay_mesh;
 mod repos;
 mod restore;
@@ -70,6 +71,7 @@ pub(crate) use readiness::{
     agent_readiness, resolve_effective_agent_env, resolve_effective_harness_descriptor,
     AgentReadiness, Requirement,
 };
+pub use relay_agent_info::*;
 pub use relay_mesh::*;
 pub use repos::{
     effective_repos_dir, ensure_repos_symlink, resolve_repos_at_boot, validate_repos_dir,

--- a/desktop/src-tauri/src/managed_agents/relay_agent_info.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_agent_info.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// Tolerant wire view of an agent profile advertised by the relay.
+///
+/// `respond_to` deliberately remains an opaque string: third-party harnesses
+/// may publish future modes, and one unknown string must not fail the entire
+/// relay directory. Desktop interprets only the modes it understands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayAgentInfo {
+    pub pubkey: String,
+    pub name: String,
+    pub agent_type: String,
+    pub channels: Vec<String>,
+    #[serde(default)]
+    pub channel_ids: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub status: String,
+    #[serde(default)]
+    pub respond_to: Option<String>,
+    #[serde(default)]
+    pub respond_to_allowlist: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn future_respond_to_mode_does_not_fail_its_directory_siblings() {
+        let parsed: Vec<RelayAgentInfo> = serde_json::from_value(serde_json::json!([
+            {
+                "pubkey": "a", "name": "Known", "agent_type": "agent",
+                "channels": [], "capabilities": [], "status": "online",
+                "respond_to": "anyone"
+            },
+            {
+                "pubkey": "b", "name": "Future", "agent_type": "agent",
+                "channels": [], "capabilities": [], "status": "online",
+                "respond_to": "future-mode"
+            }
+        ]))
+        .unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[1].respond_to.as_deref(), Some("future-mode"));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -193,21 +193,6 @@ impl ManagedAgentRecord {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RelayAgentInfo {
-    pub pubkey: String,
-    pub name: String,
-    pub agent_type: String,
-    pub channels: Vec<String>,
-    #[serde(default)]
-    pub channel_ids: Vec<String>,
-    pub capabilities: Vec<String>,
-    pub status: String,
-    #[serde(default)]
-    pub respond_to: Option<RespondTo>,
-    #[serde(default)]
-    pub respond_to_allowlist: Vec<String>,
-}
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {
     pub pubkey: String,

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -929,38 +929,23 @@ mod tests {
     }
 
     #[test]
-    fn agents_preserves_public_respond_to_mode_for_directory_parse() {
-        let e = ev(10100, r#"{"name":"Scout","respond_to":"anyone"}"#, vec![]);
-        let v = agents_from_events(std::slice::from_ref(&e));
-        let agents = v.get("agents").cloned().unwrap();
-        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
-            serde_json::from_value(agents).unwrap();
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(
-            parsed[0].respond_to,
-            Some(crate::managed_agents::RespondTo::Anyone)
-        );
-    }
-
-    #[test]
-    fn agents_preserves_allowlist_metadata_for_directory_parse() {
-        let e = ev(
-            10100,
-            r#"{"name":"Scout","respond_to":"allowlist","respond_to_allowlist":["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]}"#,
-            vec![],
-        );
-        let v = agents_from_events(std::slice::from_ref(&e));
-        let agents = v.get("agents").cloned().unwrap();
-        let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
-            serde_json::from_value(agents).unwrap();
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(
-            parsed[0].respond_to,
-            Some(crate::managed_agents::RespondTo::Allowlist)
-        );
-        assert_eq!(parsed[0].respond_to_allowlist, vec!["a".repeat(64)]);
+    fn agents_preserve_relay_respond_to_modes_for_directory_parse() {
+        for mode in ["owner-only", "allowlist", "anyone", "nobody"] {
+            let allowlist = if mode == "allowlist" {
+                format!(r#", "respond_to_allowlist":["{}"]"#, "a".repeat(64))
+            } else {
+                String::new()
+            };
+            let content = format!(r#"{{"name":"Scout","respond_to":"{mode}"{allowlist}}}"#);
+            let event = ev(10100, &content, vec![]);
+            let value = agents_from_events(std::slice::from_ref(&event));
+            let parsed: Vec<crate::managed_agents::RelayAgentInfo> =
+                serde_json::from_value(value["agents"].clone()).unwrap();
+            assert_eq!(parsed[0].respond_to.as_deref(), Some(mode));
+            if mode == "allowlist" {
+                assert_eq!(parsed[0].respond_to_allowlist, vec!["a".repeat(64)]);
+            }
+        }
     }
 
     #[test]

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   coalesceAgentAutocompleteCandidates,
   filterCachedAgentSuggestions,
+  getChannelOwnedAgentPubkeys,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
   isAgentIdentityInAllowedList,
@@ -198,6 +199,141 @@ test("getMentionableAgentPubkeys: scopes channel composers and fails closed with
       eligibilityScope: { type: "managed-only" },
     }),
     new Set([PUB_A]),
+  );
+});
+
+test("getMentionableAgentPubkeys: admits same-owner remote agents only in the active channel", () => {
+  const base = {
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [PUB_A],
+    channelOwnedAgentPubkeys: [PUB_B],
+    relayAgents: [],
+    sharedChannelIds: new Set(["general"]),
+  };
+
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "channel", channelId: "general" },
+    }),
+    new Set([PUB_A, PUB_B]),
+  );
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "community" },
+    }),
+    new Set([PUB_A]),
+  );
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      ...base,
+      eligibilityScope: { type: "managed-only" },
+    }),
+    new Set([PUB_A]),
+  );
+});
+
+test("getMentionableAgentPubkeys: owner admission overrides ordinary modes but not nobody", () => {
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY,
+      eligibilityScope: { type: "channel", channelId: "general" },
+      managedAgentPubkeys: [],
+      channelOwnedAgentPubkeys: [PUB_B],
+      relayAgents: undefined,
+      sharedChannelIds: new Set(["general"]),
+    }),
+    new Set(),
+    "owner admission must wait for a successful relay-directory response",
+  );
+
+  for (const respondTo of [
+    undefined,
+    null,
+    "owner-only",
+    "allowlist",
+    "anyone",
+    "future-mode",
+  ]) {
+    const relayAgents =
+      respondTo === undefined
+        ? []
+        : [
+            {
+              pubkey: PUB_B,
+              respondTo,
+              respondToAllowlist: [],
+              channelIds: ["other"],
+            },
+          ];
+    assert.deepEqual(
+      getMentionableAgentPubkeys({
+        currentPubkey: CURRENT_PUBKEY,
+        eligibilityScope: { type: "channel", channelId: "general" },
+        managedAgentPubkeys: [],
+        channelOwnedAgentPubkeys: [PUB_B.toUpperCase()],
+        relayAgents,
+        sharedChannelIds: new Set(["general"]),
+      }),
+      new Set([PUB_B]),
+      `owner admission should allow ${String(respondTo)}`,
+    );
+  }
+
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY,
+      eligibilityScope: { type: "channel", channelId: "general" },
+      managedAgentPubkeys: [],
+      channelOwnedAgentPubkeys: [PUB_B],
+      relayAgents: [
+        {
+          pubkey: PUB_B,
+          respondTo: "nobody",
+          respondToAllowlist: [],
+          channelIds: ["general"],
+        },
+      ],
+      sharedChannelIds: new Set(["general"]),
+    }),
+    new Set(),
+  );
+});
+
+test("getChannelOwnedAgentPubkeys: requires verified matching ownership and an agent signal", () => {
+  assert.deepEqual(
+    getChannelOwnedAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY.toUpperCase(),
+      channelMembers: [
+        { pubkey: PUB_A.toUpperCase(), role: "bot", isAgent: false },
+        { pubkey: PUB_B, role: "member", isAgent: true },
+        { pubkey: PUB_C, role: "member", isAgent: false },
+        { pubkey: PUB_D, role: "member", isAgent: false },
+      ],
+      profiles: {
+        [PUB_A]: { ownerPubkey: CURRENT_PUBKEY },
+        [PUB_B]: { ownerPubkey: CURRENT_PUBKEY },
+        [PUB_C]: { ownerPubkey: CURRENT_PUBKEY, isAgent: true },
+        [PUB_D]: { ownerPubkey: OTHER_OWNER_PUBKEY },
+      },
+    }),
+    new Set([PUB_A, PUB_B, PUB_C]),
+  );
+
+  assert.deepEqual(
+    getChannelOwnedAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY,
+      channelMembers: [
+        { pubkey: PUB_A, role: "member", isAgent: false },
+        { pubkey: PUB_B, role: "bot", isAgent: true },
+      ],
+      profiles: {
+        [PUB_A]: { ownerPubkey: CURRENT_PUBKEY, isAgent: false },
+        [PUB_B]: { ownerPubkey: OTHER_OWNER_PUBKEY, isAgent: true },
+      },
+    }),
+    new Set(),
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -46,13 +46,71 @@ export type AgentEligibilityScope =
   | { type: "channel"; channelId: string }
   | { type: "managed-only" };
 
+/**
+ * Returns agent identities that are both present in the active channel and
+ * cryptographically owned by the viewer. The caller must supply ownerPubkey
+ * values verified from NIP-OA profile events; display names and local persona
+ * cards are never ownership evidence.
+ *
+ * This set may override normal relay response policy only for channel mention
+ * routing after the relay directory has loaded successfully. It must not be
+ * used to seed community search or direct messages.
+ */
+export function getChannelOwnedAgentPubkeys({
+  channelMembers,
+  currentPubkey,
+  profiles,
+}: {
+  channelMembers:
+    | readonly {
+        pubkey: string;
+        role?: string | null;
+        isAgent?: boolean;
+      }[]
+    | undefined;
+  currentPubkey?: string | null;
+  profiles:
+    | Readonly<
+        Record<string, { ownerPubkey?: string | null; isAgent?: boolean }>
+      >
+    | undefined;
+}) {
+  const ownedAgentPubkeys = new Set<string>();
+  if (!currentPubkey) return ownedAgentPubkeys;
+
+  const normalizedCurrentPubkey = normalizePubkey(currentPubkey);
+  for (const member of channelMembers ?? []) {
+    const pubkey = normalizePubkey(member.pubkey);
+    const profile = profiles?.[pubkey];
+    const isAgent =
+      member.role === "bot" ||
+      member.isAgent === true ||
+      profile?.isAgent === true;
+    if (
+      isAgent &&
+      profile?.ownerPubkey &&
+      normalizePubkey(profile.ownerPubkey) === normalizedCurrentPubkey
+    ) {
+      ownedAgentPubkeys.add(pubkey);
+    }
+  }
+
+  return ownedAgentPubkeys;
+}
+
+function relayAgentIsHeartbeatOnly(agent: Pick<RelayAgent, "respondTo">) {
+  return agent.respondTo === "nobody";
+}
+
 export function getMentionableAgentPubkeys({
+  channelOwnedAgentPubkeys,
   currentPubkey,
   eligibilityScope,
   managedAgentPubkeys,
   relayAgents,
   sharedChannelIds,
 }: {
+  channelOwnedAgentPubkeys?: Iterable<string>;
   currentPubkey?: string | null;
   eligibilityScope: AgentEligibilityScope;
   managedAgentPubkeys: Iterable<string>;
@@ -62,6 +120,23 @@ export function getMentionableAgentPubkeys({
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
+
+  // A missing directory is not equivalent to an empty one: until a successful
+  // response proves there is no `nobody` entry, remote-owner admission must
+  // fail closed. Locally managed identities remain available above.
+  if (eligibilityScope.type === "channel" && relayAgents !== undefined) {
+    const heartbeatOnlyPubkeys = new Set(
+      (relayAgents ?? [])
+        .filter(relayAgentIsHeartbeatOnly)
+        .map((agent) => normalizePubkey(agent.pubkey)),
+    );
+    for (const pubkey of channelOwnedAgentPubkeys ?? []) {
+      const normalized = normalizePubkey(pubkey);
+      if (!heartbeatOnlyPubkeys.has(normalized)) {
+        pubkeys.add(normalized);
+      }
+    }
+  }
 
   for (const agent of relayAgents ?? []) {
     const isAllowed =

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -1,6 +1,7 @@
 import { MessageSquareText } from "lucide-react";
 import * as React from "react";
 
+import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { useProfileQuery, useUsersBatchQuery } from "@/features/profile/hooks";
 import { mergeCurrentProfileIntoLookup } from "@/features/profile/lib/identity";
 import { getMentionTagPubkey } from "@/shared/lib/resolveMentionNames";
@@ -52,6 +53,7 @@ export function ForumView({
   const postsScrollRef = React.useRef<HTMLDivElement>(null);
 
   const profileQuery = useProfileQuery();
+  const membersQuery = useChannelMembersQuery(channel.id);
   const postsQuery = useForumPostsQuery(channel);
   const threadQuery = useForumThreadQuery(
     selectedPostId ? channel.id : null,
@@ -67,7 +69,9 @@ export function ForumView({
 
   const posts = postsQuery.data?.posts ?? [];
 
-  // Collect all pubkeys from posts and thread for profile resolution.
+  // Collect channel members as well as post/thread identities. The composer
+  // needs verified owner metadata for same-owner remote agents even before
+  // they have authored or been mentioned in a forum post.
   // Mentioned pubkeys (`p`/`mention` tags) must be included too: mention
   // chips resolve names from this same lookup, and a mentioned user who
   // never authored a post would otherwise render as a dead chip.
@@ -81,6 +85,9 @@ export function ForumView({
         }
       }
     };
+    for (const member of membersQuery.data ?? []) {
+      pubkeys.add(member.pubkey);
+    }
     for (const post of posts) {
       pubkeys.add(post.pubkey);
       addMentionPubkeys(post.tags);
@@ -99,7 +106,7 @@ export function ForumView({
       }
     }
     return [...pubkeys];
-  }, [posts, threadQuery.data]);
+  }, [membersQuery.data, posts, threadQuery.data]);
 
   const profilesQuery = useUsersBatchQuery(allPubkeys, {
     enabled: allPubkeys.length > 0,

--- a/desktop/src/features/messages/lib/useMentionableAgentPubkeys.ts
+++ b/desktop/src/features/messages/lib/useMentionableAgentPubkeys.ts
@@ -1,0 +1,80 @@
+import * as React from "react";
+import {
+  getChannelOwnedAgentPubkeys,
+  getMentionableAgentPubkeys,
+  isAgentMentionChannelType,
+} from "@/features/agents/lib/agentAutocompleteEligibility";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type {
+  ChannelMember,
+  ChannelType,
+  RelayAgent,
+} from "@/shared/api/types";
+
+const EMPTY_AGENT_PUBKEYS: ReadonlySet<string> = new Set();
+
+/**
+ * Builds the composer allow-list without turning remote agent identities into
+ * local managed instances. For non-managed identities, `profiles.ownerPubkey`
+ * must be the NIP-OA-verified value returned by the profile query pipeline.
+ * The relay directory must also have loaded successfully so an explicit
+ * heartbeat-only (`nobody`) policy cannot be missed during startup or errors.
+ */
+export function useMentionableAgentPubkeys({
+  channelId,
+  channelMembers,
+  channelType,
+  currentPubkey,
+  managedAgentPubkeys,
+  profiles,
+  relayAgents,
+  sharedChannelIds,
+}: {
+  channelId: string | null;
+  channelMembers: readonly ChannelMember[] | undefined;
+  channelType?: ChannelType | null;
+  currentPubkey?: string | null;
+  managedAgentPubkeys: ReadonlySet<string>;
+  profiles: UserProfileLookup | undefined;
+  relayAgents: readonly RelayAgent[] | undefined;
+  sharedChannelIds: ReadonlySet<string>;
+}) {
+  const isChannelScope = Boolean(
+    channelId && isAgentMentionChannelType(channelType),
+  );
+  const channelOwnedAgentPubkeys = React.useMemo(
+    () =>
+      isChannelScope && relayAgents !== undefined
+        ? getChannelOwnedAgentPubkeys({
+            channelMembers,
+            currentPubkey,
+            profiles,
+          })
+        : EMPTY_AGENT_PUBKEYS,
+    [channelMembers, currentPubkey, isChannelScope, profiles, relayAgents],
+  );
+
+  return React.useMemo(
+    () =>
+      getMentionableAgentPubkeys({
+        channelOwnedAgentPubkeys,
+        currentPubkey,
+        eligibilityScope:
+          channelId && isChannelScope
+            ? { type: "channel", channelId }
+            : { type: "managed-only" },
+        managedAgentPubkeys,
+        relayAgents,
+        sharedChannelIds,
+      }),
+    [
+      channelId,
+      channelOwnedAgentPubkeys,
+      currentPubkey,
+      isChannelScope,
+      managedAgentPubkeys,
+      relayAgents,
+      sharedChannelIds,
+    ],
+  );
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -15,10 +15,8 @@ import {
   coalesceAgentAutocompleteCandidates,
   coalesceAutocompleteCandidatesByKey,
   filterCachedAgentSuggestions,
-  getMentionableAgentPubkeys,
   getSharedChannelIds,
   isAgentIdentityInAllowedList,
-  isAgentMentionChannelType,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
@@ -41,6 +39,7 @@ import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import { flushMentionDebounce } from "./flushMentionDebounce";
 import { hasMention } from "./hasMention";
 import { useDraftMentionRouting } from "./useDraftMentionRouting";
+import { useMentionableAgentPubkeys } from "./useMentionableAgentPubkeys";
 import { rankMentionCandidates } from "./mentionRanking";
 import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
 import {
@@ -194,28 +193,16 @@ export function useMentions(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
   );
-  const mentionChannelId = isAgentMentionChannelType(options?.channelType)
-    ? channelId
-    : null;
-  const mentionableAgentPubkeys = React.useMemo(
-    () =>
-      getMentionableAgentPubkeys({
-        currentPubkey,
-        eligibilityScope: mentionChannelId
-          ? { type: "channel", channelId: mentionChannelId }
-          : { type: "managed-only" },
-        managedAgentPubkeys,
-        relayAgents: relayAgentsQuery.data,
-        sharedChannelIds,
-      }),
-    [
-      currentPubkey,
-      managedAgentPubkeys,
-      mentionChannelId,
-      relayAgentsQuery.data,
-      sharedChannelIds,
-    ],
-  );
+  const mentionableAgentPubkeys = useMentionableAgentPubkeys({
+    channelId,
+    channelMembers: members,
+    channelType: options?.channelType,
+    currentPubkey,
+    managedAgentPubkeys,
+    profiles,
+    relayAgents: relayAgentsQuery.data,
+    sharedChannelIds,
+  });
   const personaNameByPubkey = React.useMemo(() => {
     const agents = managedAgentsQuery.data ?? [];
     const personas = personasQuery.data ?? [];

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -275,7 +275,7 @@ export type RelayAgent = {
   channelIds: string[];
   capabilities: string[];
   status: "online" | "away" | "offline";
-  respondTo: RespondToMode | null;
+  respondTo: string | null;
   respondToAllowlist: string[];
 };
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -815,7 +815,7 @@ type RawRelayAgent = {
   channel_ids: string[];
   capabilities: string[];
   status: PresenceStatus;
-  respond_to?: "owner-only" | "allowlist" | "anyone";
+  respond_to?: string;
   respond_to_allowlist?: string[];
 };
 

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -8,6 +8,7 @@ import {
 
 const MOCK_VIEWER_PUBKEY = "deadbeef".repeat(8);
 const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
@@ -31,6 +32,8 @@ const PROFILE_ONLY_AGENT_PUBKEY =
   "8f83d6b7f3d74f7d933ae3a54dd8c6cc85c7f98e531c16e5a827b953441a8d67";
 const OWNED_AGENT_PROFILE_PUBKEY =
   "1212121212121212121212121212121212121212121212121212121212121212";
+const OWNED_REMOTE_CHANNEL_AGENT_PUBKEY =
+  "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00";
 const SYSTEM_MESSAGE_KIND = 40099;
 const DM_THREAD_AGENT_MENTION_ERROR_TEXT =
   "Agents must already be in a DM to be mentioned in its threads. Start a new conversation that includes the agent.";
@@ -66,6 +69,81 @@ async function readCommandPayloadLog(page: import("@playwright/test").Page) {
       ).__BUZZ_E2E_COMMAND_LOG__ ?? []
     );
   });
+}
+
+async function invokeMockCommand<T>(
+  page: import("@playwright/test").Page,
+  command: string,
+  payload?: Record<string, unknown>,
+) {
+  await page.waitForFunction(
+    () =>
+      typeof (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: unknown;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__ === "function",
+  );
+  return page.evaluate(
+    async ({ command, payload }) => {
+      const bridgeWindow = window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+        __BUZZ_E2E_QUERY_CLIENT__?: {
+          invalidateQueries: () => Promise<void>;
+        };
+      };
+      const invoke = bridgeWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) throw new Error("Mock bridge is not installed.");
+      const result = await invoke(command, payload);
+      await bridgeWindow.__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries();
+      return result as T;
+    },
+    { command, payload },
+  );
+}
+
+async function waitForMentionSearch(
+  page: import("@playwright/test").Page,
+  query: string,
+) {
+  await expect
+    .poll(async () =>
+      (await readCommandPayloadLog(page)).some(
+        (entry) =>
+          entry.command === "search_users" &&
+          (entry.payload as { query?: string }).query === query,
+      ),
+    )
+    .toBe(true);
+
+  await expect
+    .poll(() =>
+      page.evaluate((normalizedQuery) => {
+        const queryClient = (
+          window as Window & {
+            __BUZZ_E2E_QUERY_CLIENT__?: {
+              getQueryState: (queryKey: readonly unknown[]) =>
+                | {
+                    dataUpdatedAt: number;
+                    fetchStatus: string;
+                  }
+                | undefined;
+            };
+          }
+        ).__BUZZ_E2E_QUERY_CLIENT__;
+        const state = queryClient?.getQueryState([
+          "user-search",
+          "infinite",
+          normalizedQuery,
+          50,
+        ]);
+        return state?.fetchStatus === "idle" && state.dataUpdatedAt > 0;
+      }, query.trim().toLowerCase()),
+    )
+    .toBe(true);
 }
 
 async function readOutgoingMentionPubkeys(
@@ -844,22 +922,205 @@ test("other-owned agents without a shared channel are hidden from mentions", asy
   await input.fill("@mira");
 
   const dropdown = autocomplete(page);
-  await expect(dropdown).not.toBeVisible();
+  await waitForMentionSearch(page, "mira");
+  await expect(
+    dropdown.getByTestId(`mention-suggestion-${PROFILE_ONLY_AGENT_PUBKEY}`),
+  ).toHaveCount(0);
   await expect(input.locator(".mention-chip")).toHaveCount(0);
 });
 
-test("stale channel-member agents absent from managed and relay directories stay hidden", async ({
+test("same-owner remote channel agents send to their existing pubkey without local lifecycle work", async ({
   page,
 }) => {
-  await installMockBridge(page, { userSearchDelayMs: 1_000 });
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: REUSABLE_PERSONA_AGENT_PUBKEY,
+        name: "nadia",
+        status: "stopped",
+      },
+    ],
+  });
   await page.goto("/");
-  await page.getByTestId("channel-general").click();
-  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
 
   const input = page.getByTestId("message-input");
-  await input.fill("@mira");
+  await input.fill("Ask @nad");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const dropdown = autocomplete(page);
+  const remoteRow = dropdown.getByTestId(
+    `mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`,
+  );
+  await expect(remoteRow).toBeVisible();
+  await expect(remoteRow.getByText("nadia", { exact: true })).toBeVisible();
+  await remoteRow.click();
+  await page.keyboard.type("if you are available");
+
+  const baselineCommands = await readCommandLog(page);
+  const content = "Ask @nadia if you are available";
+  await page.getByTestId("send-message").click();
+  await expect(page.getByRole("alertdialog")).toHaveCount(0);
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toEqual([OWNED_REMOTE_CHANNEL_AGENT_PUBKEY]);
+
+  const commands = await readCommandLog(page);
+  for (const command of [
+    "create_managed_agent",
+    "start_managed_agent",
+    "add_channel_members",
+    "add_agent_to_huddle",
+  ]) {
+    expect(commandCount(commands, command), command).toBe(
+      commandCount(baselineCommands, command),
+    );
+  }
+});
+
+test("same-owner remote agents stay unavailable even when present in DMs", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    searchProfiles: [
+      {
+        pubkey: TEST_IDENTITIES.outsider.pubkey,
+        displayName: "nadia human",
+        isAgent: false,
+      },
+    ],
+  });
+  await page.goto("/");
+  const dm = await invokeMockCommand<{ id: string }>(page, "open_dm", {
+    pubkeys: [
+      TEST_IDENTITIES.outsider.pubkey,
+      OWNED_REMOTE_CHANNEL_AGENT_PUBKEY,
+    ],
+  });
+  const dmLink = page.locator(`[data-channel-id="${dm.id}"]`);
+  await expect(dmLink).toBeVisible();
+  await dmLink.click();
+  await expect(
+    page.locator("[data-active='true'][data-channel-id]"),
+  ).toHaveAttribute("data-channel-id", dm.id);
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@nadia");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.outsider.pubkey}`,
+    ),
+  ).toBeVisible();
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`,
+    ),
+  ).toHaveCount(0);
+});
+
+test("same-owner remote channel agents respect an explicit nobody policy", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: OWNED_REMOTE_CHANNEL_AGENT_PUBKEY,
+        name: "nadia",
+        respondTo: "nobody",
+        channelNames: ["agents"],
+      },
+    ],
+    userSearchDelayMs: 1_000,
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  await page.getByTestId("message-input").fill("@nadia");
+  await waitForMentionSearch(page, "nadia");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`,
+    ),
+  ).toHaveCount(0);
+});
+
+test("same-owner remote channel agents join an active Huddle without starting locally", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: AGENTS_CHANNEL_ID,
+      ephemeralChannelId: "owned-agent-huddle",
+      phase: "active",
+      members: [{ pubkey: MOCK_VIEWER_PUBKEY, role: "owner" }],
+    },
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Ask @nad");
+  await autocomplete(page)
+    .getByTestId(`mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`)
+    .click();
+  await page.keyboard.type("to join the Huddle");
+
+  const baselineCommands = await readCommandLog(page);
+  const baselinePayloads = await readCommandPayloadLog(page);
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(async () =>
+      (await readCommandPayloadLog(page))
+        .slice(baselinePayloads.length)
+        .find((entry) => entry.command === "sync_agents_to_active_huddle"),
+    )
+    .toMatchObject({
+      payload: {
+        channelId: AGENTS_CHANNEL_ID,
+        agentPubkeys: [OWNED_REMOTE_CHANNEL_AGENT_PUBKEY],
+      },
+    });
+
+  const commands = await readCommandLog(page);
+  for (const command of [
+    "create_managed_agent",
+    "start_managed_agent",
+    "add_channel_members",
+    "add_agent_to_huddle",
+  ]) {
+    expect(commandCount(commands, command), command).toBe(
+      commandCount(baselineCommands, command),
+    );
+  }
+});
+
+test("same-owner remote channel agents wait for the relay directory before admission", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    agentListDelayMs: 1_000,
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@nadia");
+
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`,
+    ),
+  ).toHaveCount(0);
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`,
+    ),
+  ).toBeVisible({ timeout: 3_000 });
 });
 
 test("managed relay agents are visible in channel mentions regardless of relay policy", async ({
@@ -903,7 +1164,12 @@ test("relay-only shared agents stay hidden from DM mentions", async ({
 
   await page.getByTestId("message-input").fill("@alice");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  await waitForMentionSearch(page, "alice");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toHaveCount(0);
 });
 
 test("cached relay-agent suggestions are removed when channel authorization disappears", async ({
@@ -966,6 +1232,33 @@ test("relay-only shared agents appear in forum mentions", async ({ page }) => {
 
   await expect(
     page.getByTestId("mention-autocomplete").getByText("quinn"),
+  ).toBeVisible();
+});
+
+test("same-owner remote forum agents appear before authoring a post", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const forumChannelId = await page
+    .getByTestId("channel-watercooler")
+    .getAttribute("data-channel-id");
+  if (!forumChannelId) throw new Error("Watercooler channel id missing.");
+
+  await invokeMockCommand(page, "add_channel_members", {
+    channelId: forumChannelId,
+    pubkeys: [OWNED_REMOTE_CHANNEL_AGENT_PUBKEY],
+    role: "bot",
+  });
+  await page.getByTestId("channel-watercooler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+  await page.getByRole("button", { name: "Start a new post..." }).click();
+
+  await page.getByTestId("message-input").fill("@nadia");
+
+  await expect(
+    page
+      .getByTestId("mention-autocomplete")
+      .getByTestId(`mention-suggestion-${OWNED_REMOTE_CHANNEL_AGENT_PUBKEY}`),
   ).toBeVisible();
 });
 

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -59,7 +59,7 @@ type MockRelayAgentSeed = {
   name: string;
   agentType?: string;
   capabilities?: string[];
-  respondTo?: "owner-only" | "allowlist" | "anyone";
+  respondTo?: string;
   respondToAllowlist?: string[];
   channelNames?: string[];
   channelIds?: string[];


### PR DESCRIPTION
## Summary

- make a same-owner remote agent mentionable from a stream or forum channel where that exact agent pubkey is already a member
- route the existing remote pubkey without creating, starting, or adding a local managed-agent instance
- preserve strict boundaries for DMs, community search, other-owned agents, and relay agents configured with `respond_to: "nobody"`
- tolerate future relay response-mode strings without dropping the entire relay-agent directory

## Root cause

The composer allow-list treated the local managed-agent store as the primary source of agent identity. On another Buzz client, a channel could contain an agent owned and hosted by the same user, but that client had no local managed record for the pubkey. The remote member was therefore filtered from autocomplete or could be confused with a local instance lifecycle.

This change treats verified NIP-OA ownership plus active channel membership as the remote routing signal, scoped only to channel composers. Admission waits for a successful relay-directory response so an explicit heartbeat-only policy cannot be missed during startup or directory errors.

## User impact

A user can mention an agent hosted by another Buzz client in a shared stream or forum. Buzz sends the mention to the exact existing pubkey; local managed-agent setup remains untouched. Active Huddles reuse the existing remote-pubkey synchronization path.

Fixes #3277.

## Validation

- Claude peer review: `LGTM WITH NITS` after independent TypeScript, Biome, Rust, unit, and focused browser verification
- desktop unit suite: 4,538 passed
- desktop check, typecheck, file-size/style guards, and production/e2e builds passed
- complete mentions smoke suite: 62 passed in the full run; its one pre-existing typing-space flake passed immediately in isolation (63/63 scenarios green)
- focused Rust response-mode and future-mode compatibility tests passed; `cargo fmt --check` passed

## Scope

This deliberately does not broaden direct-message or community-search agent discovery, and it does not make a remote identity a local managed instance.
