### PR TITLE
fix(terminal): allow Windows paste shortcuts

### DIFF
--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -874,6 +874,54 @@ test("Windows paste chords reach paste instead of sending ^V", async (t) => {
   ]);
 });
 
+test("Linux keeps Ctrl+V quote-next and lets Ctrl+Shift+V paste", async (t) => {
+  Object.defineProperty(dom.window.navigator, "platform", {
+    configurable: true,
+    value: "Linux x86_64",
+  });
+  t.after(() => {
+    Object.defineProperty(dom.window.navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+  });
+
+  const subject = await revealed({ bracketedPaste: true });
+  const input = subject.view.getByLabelText("Terminal input");
+  const keyDown = (shiftKey) => {
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: "KeyV",
+      ctrlKey: true,
+      key: "v",
+      shiftKey,
+    });
+    act(() => input.dispatchEvent(event));
+    return event;
+  };
+
+  const quoteNext = keyDown(false);
+  assert.equal(quoteNext.defaultPrevented, true);
+  assert.deepEqual(subject.calls.input, ["\u0016"]);
+
+  const pasteChord = keyDown(true);
+  assert.equal(pasteChord.defaultPrevented, false);
+  assert.deepEqual(
+    subject.calls.input,
+    ["\u0016"],
+    "Ctrl+Shift+V must wait for the paste event",
+  );
+  fireEvent.paste(input, {
+    clipboardData: { getData: () => "from Linux" },
+  });
+
+  assert.deepEqual(subject.calls.input, [
+    "\u0016",
+    "\u001b[200~from Linux\u001b[201~",
+  ]);
+});
+
 test("⌘W on an already-closing tab does not re-fire close", async () => {
   const subject = await revealed({
     sessions: [

--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -823,6 +823,57 @@ test("control chords keep reaching the PTY instead of the tab layer", async () =
   );
 });
 
+test("Windows paste chords reach paste instead of sending ^V", async (t) => {
+  Object.defineProperty(dom.window.navigator, "platform", {
+    configurable: true,
+    value: "Win32",
+  });
+  t.after(() => {
+    Object.defineProperty(dom.window.navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+  });
+
+  const subject = await revealed({ bracketedPaste: true });
+  const input = subject.view.getByLabelText("Terminal input");
+  const keyDown = (shiftKey) => {
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      code: "KeyV",
+      ctrlKey: true,
+      key: "v",
+      shiftKey,
+    });
+    act(() => input.dispatchEvent(event));
+    return event;
+  };
+
+  const plain = keyDown(false);
+  assert.equal(plain.defaultPrevented, false);
+  assert.deepEqual(subject.calls.input, [], "Ctrl+V must not send ^V");
+  fireEvent.paste(input, {
+    clipboardData: { getData: () => "first" },
+  });
+
+  const shifted = keyDown(true);
+  assert.equal(shifted.defaultPrevented, false);
+  assert.deepEqual(
+    subject.calls.input,
+    ["\u001b[200~first\u001b[201~"],
+    "Ctrl+Shift+V must not send ^V",
+  );
+  fireEvent.paste(input, {
+    clipboardData: { getData: () => "second" },
+  });
+
+  assert.deepEqual(subject.calls.input, [
+    "\u001b[200~first\u001b[201~",
+    "\u001b[200~second\u001b[201~",
+  ]);
+});
+
 test("⌘W on an already-closing tab does not re-fire close", async () => {
   const subject = await revealed({
     sessions: [

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -3,12 +3,13 @@ import { ChevronRight, Maximize2, Minimize2, Plus, X } from "lucide-react";
 
 import { useTheme } from "@/shared/theme/ThemeProvider";
 import { cn } from "@/shared/lib/cn";
-import { isMacPlatform } from "@/shared/lib/platform";
+import { isLinuxPlatform, isMacPlatform } from "@/shared/lib/platform";
 import {
   INITIAL_HANDOFF_STATE,
   accumulateScrollLines,
   encodePaste,
   encodeTerminalKey,
+  isTerminalPasteChord,
   matchTabChord,
   reduceHandoff,
   stepSession,
@@ -785,6 +786,12 @@ export function TerminalSubstrate({
               return;
             }
             if (isToggleChord(event.nativeEvent)) return;
+            const pastePlatform = isMacPlatform()
+              ? "mac"
+              : isLinuxPlatform()
+                ? "linux"
+                : "windows";
+            if (isTerminalPasteChord(event.nativeEvent, pastePlatform)) return;
             const encoded = encodeTerminalKey(event);
             if (encoded) {
               event.preventDefault();

--- a/desktop/src/features/terminal/terminalState.test.mjs
+++ b/desktop/src/features/terminal/terminalState.test.mjs
@@ -6,6 +6,7 @@ import {
   accumulateScrollLines,
   encodePaste,
   encodeTerminalKey,
+  isTerminalPasteChord,
   matchTabChord,
   reduceHandoff,
   stepSession,
@@ -84,6 +85,37 @@ test("terminal key encoding covers control, navigation, and alt prefixes", () =>
 test("bracketed paste wraps the entire payload exactly once", () => {
   assert.equal(encodePaste("a\nb", false), "a\nb");
   assert.equal(encodePaste("a\nb", true), "\u001b[200~a\nb\u001b[201~");
+});
+
+test("paste chords preserve Windows and Linux terminal conventions", () => {
+  const chord = (overrides = {}) => ({
+    altKey: false,
+    code: "KeyV",
+    ctrlKey: true,
+    key: "v",
+    metaKey: false,
+    shiftKey: false,
+    ...overrides,
+  });
+
+  assert.equal(isTerminalPasteChord(chord(), "windows"), true);
+  assert.equal(
+    isTerminalPasteChord(chord({ shiftKey: true }), "windows"),
+    true,
+  );
+  assert.equal(isTerminalPasteChord(chord(), "linux"), false);
+  assert.equal(isTerminalPasteChord(chord({ shiftKey: true }), "linux"), true);
+  assert.equal(
+    isTerminalPasteChord(chord({ ctrlKey: false, metaKey: true }), "mac"),
+    true,
+  );
+  assert.equal(isTerminalPasteChord(chord({ altKey: true }), "windows"), false);
+  assert.equal(
+    isTerminalPasteChord(chord({ code: "Period", key: "v" }), "windows"),
+    true,
+    "matching follows the typed key across keyboard layouts",
+  );
+  assert.equal(isTerminalPasteChord(chord({ key: "c" }), "windows"), false);
 });
 
 test("pixel scrolling retains fractional lines in both directions", () => {

--- a/desktop/src/features/terminal/terminalState.ts
+++ b/desktop/src/features/terminal/terminalState.ts
@@ -93,6 +93,33 @@ export function encodeTerminalKey(event: {
   return null;
 }
 
+export type TerminalPastePlatform = "linux" | "mac" | "windows";
+
+/**
+ * Keep the platform's paste chords out of `encodeTerminalKey` so the focused
+ * textarea can emit its synchronous `paste` event. In particular, Windows
+ * treats both Ctrl+V and Ctrl+Shift+V as paste; encoding them first would turn
+ * them into the control byte ^V and `preventDefault()` the clipboard event.
+ * Linux retains the shell's traditional Ctrl+V quote-next byte and reserves
+ * Ctrl+Shift+V for paste.
+ */
+export function isTerminalPasteChord(
+  event: {
+    altKey: boolean;
+    code: string;
+    ctrlKey: boolean;
+    key: string;
+    metaKey: boolean;
+    shiftKey: boolean;
+  },
+  platform: TerminalPastePlatform,
+): boolean {
+  if (event.altKey || event.key.toLowerCase() !== "v") return false;
+  if (platform === "mac") return event.metaKey && !event.ctrlKey;
+  if (!event.ctrlKey || event.metaKey) return false;
+  return platform === "windows" || event.shiftKey;
+}
+
 export type TabChord = "close" | "new" | "next" | "previous";
 
 /**


### PR DESCRIPTION
## Problem

Buzz Term encoded both `Ctrl+V` and `Ctrl+Shift+V` as the `^V` control byte on Windows, then called `preventDefault()`. That prevented WebView2 from delivering the clipboard payload to the terminal's existing paste handler.

## Implementation

- Detect paste chords before terminal key encoding.
- Let WebView handle `Ctrl+V` and `Ctrl+Shift+V` on Windows.
- Preserve the existing platform conventions: `Cmd+V` on macOS and `Ctrl+Shift+V` on Linux, while Linux `Ctrl+V` remains Readline quoted-insert.
- Match the logical `event.key` so alternate keyboard layouts work, and reject Alt/mixed-modifier chords.
- Keep clipboard text on the existing synchronous `onPaste` path, including bracketed-paste wrapping.

This is a focused follow-up discovered while field-testing #5425 / #4930. It is not a duplicate: #5425 fixes native PTY spawn, teardown, and PATH behavior; this PR fixes frontend keyboard event routing. I searched open PRs and issues for the Windows paste shortcuts and found no existing report or patch.

## Tests

- Added platform-matrix unit tests for Windows, Linux, and macOS paste chords.
- Added a mounted Windows regression proving both shortcuts are not prevented, never send `^V`, and paste exactly once through bracketed paste.
- Added a mounted headless Linux regression proving `Ctrl+V` still sends `^V`, while `Ctrl+Shift+V` waits for the paste event and forwards the clipboard exactly once through bracketed paste.
- Targeted terminal suite: 35 passed, 0 failed.
- Full `just ci` component set passed. The aggregate invocation was interrupted during Tauri compilation only because the isolated worktree filled the host disk; after removing its regenerable root `target/`, `just desktop-tauri-test` and `just mobile-test` both passed. Notable totals: 2,383 Tauri app tests passed (14 environment-dependent tests ignored), terminal crate suites passed, and 1,261 Flutter tests passed.
- `pnpm check`, desktop typecheck, Rust fmt/clippy/check, web check/build, and `git diff --check` passed. The frontend check reports one warning and two informational findings already present on current `main`, outside these files.

## Windows field proof

The exact patch was built and tested on Windows 11 before being cleanly rebased onto current `main` (the canary commit and the production-code commit in this PR have the same stable patch ID).

- [Successful Windows canary workflow](https://github.com/Glucksberg/buzz/actions/runs/31348700927)
- Canary commit: `b00790a6ceb4cb0967fe07711d7174338cd92f8d`
- Installer: `Buzz_0.5.9-fork.8_x64-setup.exe`
- Installer SHA-256: `049a0507694002af0f7232c3158f5915f0536fd9e260f506075404023695f4ef`
- Manual result: both `Ctrl+V` and `Ctrl+Shift+V` paste once without emitting `^V`. In shells with bracketed paste enabled, the temporary active-region emphasis clears on the next keypress as expected.

## Manual test

1. Copy text in Windows and focus Buzz Term.
2. Press `Ctrl+V`; confirm it appears once and no `^V` is inserted.
3. Repeat with `Ctrl+Shift+V`.
4. With shell bracketed paste enabled, confirm the temporary active-region styling clears on the next keypress.

## Visual evidence

No screenshot is included because this changes keyboard event routing and has no persistent visual state. The Windows canary run and manual interaction results above are the relevant behavioral evidence.

## Deferred work

None for this fix.
