### PR TITLE
fix(buzz-agent): replay reasoning_content for DeepSeek thinking mode

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -669,6 +669,7 @@ impl RunCtx<'_> {
                 self.history.push(HistoryItem::Assistant {
                     text: response.text,
                     tool_calls: Vec::new(),
+                    reasoning: response.reasoning,
                     reasoning_details: response.reasoning_details,
                 });
                 if max_tokens_recoveries >= self.cfg.max_token_recoveries {
@@ -699,6 +700,7 @@ impl RunCtx<'_> {
                 self.history.push(HistoryItem::Assistant {
                     text: response.text,
                     tool_calls: Vec::new(),
+                    reasoning: response.reasoning.clone(),
                     reasoning_details: response.reasoning_details.clone(),
                 });
                 let stop = map_stop(response.stop);
@@ -752,6 +754,7 @@ impl RunCtx<'_> {
             self.history.push(HistoryItem::Assistant {
                 text: response.text,
                 tool_calls: calls.clone(),
+                reasoning: response.reasoning,
                 reasoning_details: response.reasoning_details,
             });
 
@@ -1220,6 +1223,7 @@ pub(crate) fn push_hook_outputs_as_tool_results(
                 // preserve.
                 provider_extra: Default::default(),
             }],
+            reasoning: String::new(),
             reasoning_details: None,
         });
         history.push(HistoryItem::ToolResult(ToolResult {
@@ -1315,6 +1319,7 @@ mod tests {
             history.push(HistoryItem::Assistant {
                 text: format!("a{i} {}", "y".repeat(1000)),
                 tool_calls: vec![],
+                reasoning: String::new(),
                 reasoning_details: None,
             });
         }
@@ -1446,12 +1451,14 @@ mod tests {
             HistoryItem::Assistant {
                 text: "first answer".into(),
                 tool_calls: vec![],
+                reasoning: String::new(),
                 reasoning_details: Some(big_reasoning),
             },
             HistoryItem::User("second question".into()),
             HistoryItem::Assistant {
                 text: "second answer".into(),
                 tool_calls: vec![],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
         ];
@@ -1492,6 +1499,7 @@ mod tests {
                     arguments: json!({ "source": "spec.png" }),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -1529,6 +1537,7 @@ mod tests {
             HistoryItem::Assistant {
                 text: "hello".into(),
                 tool_calls: vec![],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
         ];

--- a/crates/buzz-agent/src/handoff.rs
+++ b/crates/buzz-agent/src/handoff.rs
@@ -410,6 +410,7 @@ fn push_history_snippet(out: &mut String, item: &HistoryItem) {
         HistoryItem::Assistant {
             text,
             tool_calls,
+            reasoning: _,
             reasoning_details: _,
         } => {
             out.push_str("[assistant] ");

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -588,6 +588,7 @@ fn anthropic_body(
             HistoryItem::Assistant {
                 text,
                 tool_calls,
+                reasoning: _,
                 reasoning_details: _,
             } => {
                 flush(&mut messages, &mut pending);
@@ -740,12 +741,19 @@ fn openai_body(
             HistoryItem::Assistant {
                 text,
                 tool_calls,
+                reasoning,
                 reasoning_details,
             } => {
                 flush_images(&mut messages, &mut pending_images);
                 let mut msg = serde_json::Map::new();
                 msg.insert("role".into(), json!("assistant"));
                 msg.insert("content".into(), json!(text.as_str()));
+                // DeepSeek thinking mode requires reasoning_content echoed on subsequent
+                // requests that carry tools (and ignores it harmlessly on plain multi-turn).
+                // https://api-docs.deepseek.com/guides/thinking_mode
+                if !reasoning.is_empty() {
+                    msg.insert("reasoning_content".into(), json!(reasoning.as_str()));
+                }
                 if let Some(details) = reasoning_details {
                     msg.insert("reasoning_details".into(), details.clone());
                 }
@@ -859,6 +867,7 @@ fn responses_body(
             HistoryItem::Assistant {
                 text,
                 tool_calls,
+                reasoning: _,
                 reasoning_details: _,
             } => {
                 if !text.is_empty() {
@@ -2843,6 +2852,7 @@ mod tests {
                     arguments: serde_json::json!({"source":"x.png"}),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -2895,6 +2905,7 @@ mod tests {
                     arguments: serde_json::json!({"command": "ls"}),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -2995,6 +3006,7 @@ mod tests {
                     arguments: serde_json::json!({}),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
         ];
@@ -3366,6 +3378,7 @@ mod tests {
                         provider_extra: Default::default(),
                     },
                 ],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -3428,6 +3441,7 @@ mod tests {
                 HistoryItem::Assistant {
                     text: "hi".into(),
                     tool_calls: vec![],
+                    reasoning: String::new(),
                     reasoning_details: None,
                 },
                 HistoryItem::User("more".into()),
@@ -5298,6 +5312,7 @@ mod tests {
         let history = vec![HistoryItem::Assistant {
             text: r.text.clone(),
             tool_calls: r.tool_calls.clone(),
+            reasoning: String::new(),
             reasoning_details: None,
         }];
         let body = openai_body(
@@ -6480,6 +6495,7 @@ mod tests {
                     arguments: serde_json::json!({"source": "x.png"}),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -6580,6 +6596,7 @@ mod tests {
                     arguments: serde_json::json!({"source": "x.png"}),
                     provider_extra: Default::default(),
                 }],
+                reasoning: String::new(),
                 reasoning_details: None,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -6746,6 +6763,7 @@ mod tests {
             HistoryItem::Assistant {
                 text: String::new(),
                 tool_calls: r1.tool_calls,
+                reasoning: String::new(),
                 reasoning_details: r1.reasoning_details,
             },
             HistoryItem::ToolResult(ToolResult {
@@ -6798,6 +6816,7 @@ mod tests {
             HistoryItem::Assistant {
                 text: "hi back".into(),
                 tool_calls: Vec::new(),
+                reasoning: String::new(),
                 reasoning_details: None,
             },
         ];
@@ -6828,11 +6847,13 @@ mod tests {
         let with = HistoryItem::Assistant {
             text: "text".into(),
             tool_calls: Vec::new(),
+            reasoning: String::new(),
             reasoning_details: Some(details.clone()),
         };
         let without = HistoryItem::Assistant {
             text: "text".into(),
             tool_calls: Vec::new(),
+            reasoning: String::new(),
             reasoning_details: None,
         };
         assert!(
@@ -6858,6 +6879,7 @@ mod tests {
             HistoryItem::Assistant {
                 text: "ok".into(),
                 tool_calls: Vec::new(),
+                reasoning: String::new(),
                 reasoning_details: Some(
                     serde_json::json!([{"type": "thinking", "content": "hmm"}]),
                 ),
@@ -6890,6 +6912,7 @@ mod tests {
             HistoryItem::Assistant {
                 text: "ok".into(),
                 tool_calls: Vec::new(),
+                reasoning: String::new(),
                 reasoning_details: Some(
                     serde_json::json!([{"type": "thinking", "content": "hmm"}]),
                 ),
@@ -6901,6 +6924,129 @@ mod tests {
             !body_str.contains("reasoning_details"),
             "responses_body must not replay reasoning_details"
         );
+    }
+
+    // ---- DeepSeek reasoning_content replay (#5399) ----
+
+    #[test]
+    fn openai_body_replays_reasoning_content_on_tool_call_assistant() {
+        // With tools on the request (buzz-agent always can send them), DeepSeek
+        // thinking mode 400s unless prior assistant reasoning_content is echoed.
+        let history = vec![
+            HistoryItem::User("run ls".into()),
+            HistoryItem::Assistant {
+                text: String::new(),
+                tool_calls: vec![ToolCall {
+                    provider_id: "call_1".into(),
+                    name: "dev__shell".into(),
+                    arguments: serde_json::json!({"command": "ls"}),
+                    provider_extra: Default::default(),
+                }],
+                reasoning: "think…".into(),
+                reasoning_details: None,
+            },
+            HistoryItem::ToolResult(ToolResult {
+                provider_id: "call_1".into(),
+                content: vec![ToolResultContent::Text("file.txt".into())],
+                is_error: false,
+            }),
+        ];
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &history,
+            &tools_vec(),
+            "deepseek-reasoner",
+            None,
+        );
+        let assistant = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+            .expect("assistant message must exist");
+        assert_eq!(assistant["reasoning_content"], "think…");
+        assert!(
+            assistant.get("tool_calls").and_then(Value::as_array).is_some(),
+            "tool_calls must still be present alongside reasoning_content"
+        );
+    }
+
+    #[test]
+    fn openai_body_replays_reasoning_content_on_plain_assistant_when_present() {
+        // Harmless on plain multi-turn per DeepSeek docs; required once tools
+        // are on the request body.
+        let history = vec![
+            HistoryItem::User("hi".into()),
+            HistoryItem::Assistant {
+                text: "hello".into(),
+                tool_calls: Vec::new(),
+                reasoning: "brief thought".into(),
+                reasoning_details: None,
+            },
+        ];
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &history,
+            &tools_vec(),
+            "deepseek-reasoner",
+            None,
+        );
+        let assistant = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+            .expect("assistant message must exist");
+        assert_eq!(assistant["reasoning_content"], "brief thought");
+    }
+
+    #[test]
+    fn openai_body_omits_reasoning_content_when_empty() {
+        let history = vec![
+            HistoryItem::User("hi".into()),
+            HistoryItem::Assistant {
+                text: "hello".into(),
+                tool_calls: Vec::new(),
+                reasoning: String::new(),
+                reasoning_details: None,
+            },
+        ];
+        let body = openai_body(
+            &cfg(Provider::OpenAi),
+            "system",
+            &history,
+            &[],
+            "model",
+            None,
+        );
+        let assistant = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("role").and_then(Value::as_str) == Some("assistant"))
+            .expect("assistant message must exist");
+        assert!(
+            assistant.get("reasoning_content").is_none(),
+            "empty reasoning must not emit reasoning_content"
+        );
+    }
+
+    #[test]
+    fn parse_openai_captures_reasoning_content() {
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "content": "answer",
+                    "reasoning_content": "step by step…"
+                }
+            }]
+        });
+        let r = parse_openai(v).unwrap();
+        assert_eq!(r.reasoning, "step by step…");
+        assert_eq!(r.text, "answer");
     }
 
     // ---- T4: openrouter_post transport-level regressions ----

--- a/crates/buzz-agent/src/types.rs
+++ b/crates/buzz-agent/src/types.rs
@@ -62,6 +62,7 @@ pub enum HistoryItem {
     Assistant {
         text: String,
         tool_calls: Vec<ToolCall>,
+        reasoning: String,
         reasoning_details: Option<Value>,
     },
     ToolResult(ToolResult),
@@ -87,6 +88,7 @@ impl HistoryItem {
             Self::Assistant {
                 text,
                 tool_calls,
+                reasoning,
                 reasoning_details,
             } => {
                 text.len()
@@ -107,6 +109,7 @@ impl HistoryItem {
                                     .unwrap_or(0)
                         })
                         .sum::<usize>()
+                    + reasoning.len()
                     + reasoning_details
                         .as_ref()
                         .and_then(|v| serde_json::to_vec(v).ok())
@@ -717,6 +720,7 @@ mod tests {
                 arguments: Value::Null,
                 provider_extra: extra,
             }],
+            reasoning: String::new(),
             reasoning_details: None,
         };
         let without_extra = HistoryItem::Assistant {
@@ -727,6 +731,7 @@ mod tests {
                 arguments: Value::Null,
                 provider_extra: Map::new(),
             }],
+            reasoning: String::new(),
             reasoning_details: None,
         };
         assert!(with_extra.estimated_bytes() > without_extra.estimated_bytes() + 500);


### PR DESCRIPTION
## Problem

DeepSeek seats on `buzz-agent` with thinking mode fail on every continuation:

```
400 Bad Request: The `reasoning_content` in the thinking mode must be passed back to the API.
```

Reporter saw **79** hard failures across deepseek-v4-flash/pro in two days (#5399). Iterative tool-using roles break; retries burn tokens for nothing.

## Root cause

| Step | What happens on `main` |
|------|------------------------|
| Parse | `parse_openai` correctly reads `message.reasoning_content` → `LlmResponse.reasoning` |
| UI/ACP | Thought chunks emit that string |
| History | `HistoryItem::Assistant` only stored OpenRouter `reasoning_details` — **plain `reasoning` dropped** |
| Replay | `openai_body` never wrote `reasoning_content` back |

DeepSeek docs ([thinking mode](https://api-docs.deepseek.com/guides/thinking_mode)): for requests that carry `tools`, prior assistant `reasoning_content` must be fully passed back or the API 400s.

## Fix

1. Add `reasoning: String` on `HistoryItem::Assistant` (keep `reasoning_details`).
2. Persist `response.reasoning` at every assistant history push.
3. In `openai_body`, emit `reasoning_content` when non-empty.
4. Charge `reasoning.len()` in estimated bytes.

Single concern — no image_url gating, no provider feature work.

## Why not #4773

[block/buzz#4773](https://github.com/block/buzz/pull/4773) targets the same class but is stale vs current `HistoryItem` (`reasoning_details` era), bundles `supports_image_url`, emits only when that message has tool_calls, and has no unit tests. This PR is main-current, #5399-only, tested.

Closest PR search: #4773 (related), #3403 / #4332 (different). **none found** that closes #5399 on current main with tests.

## Test plan

```bash
cargo test -p buzz-agent --lib reasoning_content
cargo test -p buzz-agent --lib
```

- [x] `openai_body_omits_reasoning_content_when_empty`
- [x] `parse_openai_captures_reasoning_content`
- [x] `openai_body_replays_reasoning_content_on_plain_assistant_when_present`
- [x] `openai_body_replays_reasoning_content_on_tool_call_assistant`
- [x] Full `buzz-agent` lib suite **484 passed** @ head `49fc467` (rebased on current `main`)
- [ ] Full monorepo `just ci` not run for this change (package lib gate only)

## Risk / blast radius

- **In scope:** `buzz-agent` history + OpenAI-compat request body only
- **Not changed:** provider feature flags, image_url gating, non-OpenAI transports

Fixes #5399

Retested after rebase onto current main @ `49fc46796`.

### Acceptance retest (2026-08-18)
Rebased onto current `main`. Mini proof @ `7dd78e177`: cargo test -p buzz-agent --lib reasoning_content — 4/4.

## Mini retest (2026-08-24 acceptance)
- Head `fe4c1c77d7` · cargo test -p buzz-agent --lib reasoning_content → 4 passed
- Rebased onto current upstream `main` (force-with-lease, pre-review)
