### PR TITLE
fix(desktop): quiesce renderer polling while hidden (#3677)

### DIFF
--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -6,6 +6,10 @@ import {
   compareObserverEvents,
 } from "@/features/agents/observerRelayStore";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import {
+  isDocumentVisible,
+  subscribeDocumentVisibility,
+} from "@/shared/lib/useDocumentVisible";
 import type { ObserverEvent } from "./ui/agentSessionTypes";
 
 /** Harness emits turn_liveness every ~10s (BUZZ_ACP_TURN_LIVENESS_SECS). */
@@ -134,6 +138,7 @@ function watermarkChannelKey(event: ObserverEvent): string {
 const terminalAtByAgent = new Map<string, Map<string, number>>();
 
 let pruneInterval: ReturnType<typeof setInterval> | null = null;
+let unsubscribePruneVisibility: (() => void) | null = null;
 
 function invalidateCache(agentKey: string) {
   cachedTurnSummaries.delete(agentKey);
@@ -440,16 +445,31 @@ function processEvent(agentPubkey: string, event: ObserverEvent) {
   }
 }
 
-function ensurePruneInterval() {
-  if (pruneInterval) return;
+function startPruneInterval() {
+  if (pruneInterval || !isDocumentVisible()) return;
+  pruneExpired();
   pruneInterval = setInterval(pruneExpired, PRUNE_INTERVAL_MS);
 }
 
+function pausePruneInterval() {
+  if (!pruneInterval) return;
+  clearInterval(pruneInterval);
+  pruneInterval = null;
+}
+
+function ensurePruneInterval() {
+  if (unsubscribePruneVisibility) return;
+  startPruneInterval();
+  unsubscribePruneVisibility = subscribeDocumentVisibility((visible) => {
+    if (visible) startPruneInterval();
+    else pausePruneInterval();
+  });
+}
+
 function stopPruneInterval() {
-  if (pruneInterval) {
-    clearInterval(pruneInterval);
-    pruneInterval = null;
-  }
+  pausePruneInterval();
+  unsubscribePruneVisibility?.();
+  unsubscribePruneVisibility = null;
 }
 
 export function subscribeActiveAgentTurns(listener: () => void) {

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -19,6 +19,10 @@ import {
 import { updateCachedChannelMemberDisplayName } from "@/features/channels/channelMemberProfileCache";
 import { evictUsersBatchEntries } from "@/features/profile/hooks";
 import {
+  useDocumentVisible,
+  useVisibleRefetchInterval,
+} from "@/shared/lib/useDocumentVisible";
+import {
   createManagedAgent,
   deleteManagedAgent,
   deleteCustomHarness,
@@ -322,6 +326,7 @@ export function useManagedAgentPrereqsQuery(
 }
 
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
+  const refetchInterval = useVisibleRefetchInterval(5 * 60_000);
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
@@ -334,19 +339,21 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
     // the `agents-data-changed` event fires only for local persona/team/managed
     // reconcile (kinds PERSONA/TEAM/MANAGED_AGENT), never for kind:10100. So we
     // keep polling but at a relaxed cadence and pause it while backgrounded.
-    refetchInterval: 5 * 60_000,
-    refetchIntervalInBackground: false,
+    refetchInterval,
+    refetchOnWindowFocus: true,
     enabled: options?.enabled,
   });
 }
 
 export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
+  const documentVisible = useDocumentVisible();
   return useQuery({
     enabled: options?.enabled ?? true,
     queryKey: managedAgentsQueryKey,
     queryFn: listManagedAgents,
     staleTime: 5_000,
     refetchInterval: (query) => {
+      if (!documentVisible) return false;
       const agents = query.state.data as ManagedAgent[] | undefined;
       // Only local "running" agents need polling: process state can change
       // with no relay event to signal it, so this poll is the only liveness
@@ -357,6 +364,7 @@ export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
         ? 5_000
         : false;
     },
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -895,13 +903,15 @@ export function useManagedAgentLogQuery(
   pubkey: string | null,
   lineCount = 120,
 ) {
+  const refetchInterval = useVisibleRefetchInterval(pubkey ? 30_000 : false);
   return useQuery({
     queryKey: ["managed-agent-log", pubkey, lineCount],
     queryFn: () => getManagedAgentLog(pubkey as string, lineCount),
     enabled: pubkey !== null,
     retry: false,
     staleTime: 3_000,
-    refetchInterval: pubkey ? 30_000 : false,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -909,12 +919,14 @@ export const agentConfigSurfaceQueryKey = (pubkey: string) =>
   ["agent-config-surface", pubkey] as const;
 
 export function useAgentConfigSurface(pubkey: string | null) {
+  const refetchInterval = useVisibleRefetchInterval(30_000);
   return useQuery({
     queryKey: agentConfigSurfaceQueryKey(pubkey ?? ""),
     queryFn: () => getAgentConfigSurface(pubkey ?? ""),
     enabled: !!pubkey,
     staleTime: 10_000,
-    refetchInterval: 30_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -19,8 +19,8 @@ import {
 import { updateCachedChannelMemberDisplayName } from "@/features/channels/channelMemberProfileCache";
 import { evictUsersBatchEntries } from "@/features/profile/hooks";
 import {
-  useDocumentVisible,
-  useVisibleRefetchInterval,
+  useAppFocused,
+  useFocusedRefetchInterval,
 } from "@/shared/lib/useDocumentVisible";
 import {
   createManagedAgent,
@@ -326,7 +326,7 @@ export function useManagedAgentPrereqsQuery(
 }
 
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
-  const refetchInterval = useVisibleRefetchInterval(5 * 60_000);
+  const refetchInterval = useFocusedRefetchInterval(5 * 60_000);
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
@@ -346,14 +346,14 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
 }
 
 export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
-  const documentVisible = useDocumentVisible();
+  const appFocused = useAppFocused();
   return useQuery({
     enabled: options?.enabled ?? true,
     queryKey: managedAgentsQueryKey,
     queryFn: listManagedAgents,
     staleTime: 5_000,
     refetchInterval: (query) => {
-      if (!documentVisible) return false;
+      if (!appFocused) return false;
       const agents = query.state.data as ManagedAgent[] | undefined;
       // Only local "running" agents need polling: process state can change
       // with no relay event to signal it, so this poll is the only liveness
@@ -903,7 +903,7 @@ export function useManagedAgentLogQuery(
   pubkey: string | null,
   lineCount = 120,
 ) {
-  const refetchInterval = useVisibleRefetchInterval(pubkey ? 30_000 : false);
+  const refetchInterval = useFocusedRefetchInterval(pubkey ? 30_000 : false);
   return useQuery({
     queryKey: ["managed-agent-log", pubkey, lineCount],
     queryFn: () => getManagedAgentLog(pubkey as string, lineCount),
@@ -919,7 +919,7 @@ export const agentConfigSurfaceQueryKey = (pubkey: string) =>
   ["agent-config-surface", pubkey] as const;
 
 export function useAgentConfigSurface(pubkey: string | null) {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
   return useQuery({
     queryKey: agentConfigSurfaceQueryKey(pubkey ?? ""),
     queryFn: () => getAgentConfigSurface(pubkey ?? ""),

--- a/desktop/src/features/agents/lib/useAutoRestartPolicy.ts
+++ b/desktop/src/features/agents/lib/useAutoRestartPolicy.ts
@@ -12,6 +12,7 @@ import {
 } from "@/shared/api/tauriManagedAgents";
 import { listManagedAgents } from "@/shared/api/tauri";
 import type { ManagedAgent } from "@/shared/api/types";
+import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
 import { getAgentObserverSnapshot } from "../observerRelayStore";
 import { getAgentWorkingState } from "../agentWorkingSignal";
 import {
@@ -40,13 +41,17 @@ export function useAutoRestartPolicy() {
   const edgesRef = React.useRef(new Map<string, AutoRestartEdgeState>());
   const inFlightRef = React.useRef(new Set<string>());
   const [, setTick] = React.useState(0);
+  const documentVisible = useDocumentVisible();
 
   // Re-evaluate on an interval so the quiescence clock advances even when
   // summaries and observer stores are quiet.
   React.useEffect(() => {
+    if (!documentVisible) return;
+
+    setTick((t) => t + 1);
     const timer = setInterval(() => setTick((t) => t + 1), POLICY_TICK_MS);
     return () => clearInterval(timer);
-  }, []);
+  }, [documentVisible]);
 
   // No dependency array by design: the tick pattern re-runs this effect
   // every render so it reads live store state; all mutation is ref-local.

--- a/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/agents/lib/personaCatalogRelay";
 import { invalidatePersonaEditCaches } from "@/features/agents/lib/personaEditCaches";
 import { relayClient } from "@/shared/api/relayClient";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import {
   setPersonaShared,
   updatePersonaAndPublish,
@@ -19,12 +20,14 @@ export function personaCatalogQueryKey(communityId: string | null) {
 }
 
 export function usePersonaCatalogQuery(communityId: string | null) {
+  const refetchInterval = useVisibleRefetchInterval(120_000);
   return useQuery<PersonaCatalogPublication[]>({
     enabled: communityId !== null,
     queryKey: personaCatalogQueryKey(communityId),
     queryFn: fetchPersonaCatalogPublications,
     staleTime: 30_000,
-    refetchInterval: 120_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
@@ -7,7 +7,7 @@ import {
 } from "@/features/agents/lib/personaCatalogRelay";
 import { invalidatePersonaEditCaches } from "@/features/agents/lib/personaEditCaches";
 import { relayClient } from "@/shared/api/relayClient";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import {
   setPersonaShared,
   updatePersonaAndPublish,
@@ -20,7 +20,7 @@ export function personaCatalogQueryKey(communityId: string | null) {
 }
 
 export function usePersonaCatalogQuery(communityId: string | null) {
-  const refetchInterval = useVisibleRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(120_000);
   return useQuery<PersonaCatalogPublication[]>({
     enabled: communityId !== null,
     queryKey: personaCatalogQueryKey(communityId),

--- a/desktop/src/features/channel-templates/hooks.ts
+++ b/desktop/src/features/channel-templates/hooks.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+
 import {
   createChannelTemplate,
   deleteChannelTemplate,
@@ -16,11 +18,14 @@ import type {
 export const channelTemplatesQueryKey = ["channel-templates"] as const;
 
 export function useChannelTemplatesQuery() {
+  const refetchInterval = useVisibleRefetchInterval(30_000);
+
   return useQuery({
     queryKey: channelTemplatesQueryKey,
     queryFn: listChannelTemplates,
     staleTime: 30_000,
-    refetchInterval: 30_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/channel-templates/hooks.ts
+++ b/desktop/src/features/channel-templates/hooks.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
 import {
   createChannelTemplate,
@@ -18,7 +18,7 @@ import type {
 export const channelTemplatesQueryKey = ["channel-templates"] as const;
 
 export function useChannelTemplatesQuery() {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
 
   return useQuery({
     queryKey: channelTemplatesQueryKey,

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -33,6 +33,7 @@ import type {
   UpdateChannelInput,
 } from "@/shared/api/types";
 import { useIdentityQuery } from "@/shared/api/hooks";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { canAddChannelMembers } from "@/features/channels/lib/channelMemberAdmission";
 import {
@@ -193,6 +194,7 @@ function setChannelArchivedState(
 export function useChannelsQuery(options?: { enabled?: boolean }) {
   const { activeCommunity } = useCommunities();
   const relayUrl = activeCommunity?.relayUrl ?? null;
+  const refetchInterval = useVisibleRefetchInterval(60_000);
 
   return useQuery({
     enabled: options?.enabled ?? true,
@@ -215,8 +217,8 @@ export function useChannelsQuery(options?: { enabled?: boolean }) {
       : undefined,
     initialDataUpdatedAt: 0,
     staleTime: 60_000,
-    refetchInterval: 60_000,
-    refetchIntervalInBackground: false,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -33,7 +33,7 @@ import type {
   UpdateChannelInput,
 } from "@/shared/api/types";
 import { useIdentityQuery } from "@/shared/api/hooks";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { canAddChannelMembers } from "@/features/channels/lib/channelMemberAdmission";
 import {
@@ -194,7 +194,7 @@ function setChannelArchivedState(
 export function useChannelsQuery(options?: { enabled?: boolean }) {
   const { activeCommunity } = useCommunities();
   const relayUrl = activeCommunity?.relayUrl ?? null;
-  const refetchInterval = useVisibleRefetchInterval(60_000);
+  const refetchInterval = useFocusedRefetchInterval(60_000);
 
   return useQuery({
     enabled: options?.enabled ?? true,

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -10,7 +10,7 @@ import {
   setCustomEmoji,
 } from "@/shared/api/customEmoji";
 import { relayClient } from "@/shared/api/relayClient";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 
 /**
@@ -29,7 +29,7 @@ export const customEmojiQueryKey = ["custom-emoji"] as const;
 export const ownCustomEmojiQueryKey = ["custom-emoji-own"] as const;
 
 export function useCustomEmojiQuery() {
-  const refetchInterval = useVisibleRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(120_000);
 
   return useQuery<CustomEmoji[]>({
     queryKey: customEmojiQueryKey,

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -10,6 +10,7 @@ import {
   setCustomEmoji,
 } from "@/shared/api/customEmoji";
 import { relayClient } from "@/shared/api/relayClient";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 
 /**
@@ -28,13 +29,16 @@ export const customEmojiQueryKey = ["custom-emoji"] as const;
 export const ownCustomEmojiQueryKey = ["custom-emoji-own"] as const;
 
 export function useCustomEmojiQuery() {
+  const refetchInterval = useVisibleRefetchInterval(120_000);
+
   return useQuery<CustomEmoji[]>({
     queryKey: customEmojiQueryKey,
     queryFn: listCustomEmoji,
     // The palette changes rarely; avoid refetch storms while the picker is open,
     // but poll every 2 minutes as a backstop for any missed live event.
     staleTime: 60_000,
-    refetchInterval: 120_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getForumPosts, getForumThread } from "@/shared/api/forum";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import { deleteMessage, sendChannelMessage } from "@/shared/api/tauri";
 import type {
@@ -19,6 +20,8 @@ export function forumThreadQueryKey(channelId: string, eventId: string) {
 }
 
 export function useForumPostsQuery(channel: Channel | null) {
+  const refetchInterval = useVisibleRefetchInterval(15_000);
+
   const channelId = channel?.id ?? "";
   const enabled = channel !== null && channel.channelType === "forum";
   const relaySelfPubkey = useRelaySelfQuery(enabled).data;
@@ -28,7 +31,8 @@ export function useForumPostsQuery(channel: Channel | null) {
     queryKey: [...forumPostsQueryKey(channelId), relaySelfPubkey ?? null],
     queryFn: () => getForumPosts(channelId, 50, undefined, relaySelfPubkey),
     staleTime: 15_000,
-    refetchInterval: 15_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -36,6 +40,8 @@ export function useForumThreadQuery(
   channelId: string | null,
   eventId: string | null,
 ) {
+  const refetchInterval = useVisibleRefetchInterval(10_000);
+
   const enabled = channelId !== null && eventId !== null;
   const relaySelfPubkey = useRelaySelfQuery(enabled).data;
 
@@ -54,7 +60,8 @@ export function useForumThreadQuery(
         relaySelfPubkey,
       ),
     staleTime: 10_000,
-    refetchInterval: 10_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { getForumPosts, getForumThread } from "@/shared/api/forum";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { useRelaySelfQuery } from "@/features/moderation/hooks";
 import { deleteMessage, sendChannelMessage } from "@/shared/api/tauri";
 import type {
@@ -20,7 +20,7 @@ export function forumThreadQueryKey(channelId: string, eventId: string) {
 }
 
 export function useForumPostsQuery(channel: Channel | null) {
-  const refetchInterval = useVisibleRefetchInterval(15_000);
+  const refetchInterval = useFocusedRefetchInterval(15_000);
 
   const channelId = channel?.id ?? "";
   const enabled = channel !== null && channel.channelType === "forum";
@@ -40,7 +40,7 @@ export function useForumThreadQuery(
   channelId: string | null,
   eventId: string | null,
 ) {
-  const refetchInterval = useVisibleRefetchInterval(10_000);
+  const refetchInterval = useFocusedRefetchInterval(10_000);
 
   const enabled = channelId !== null && eventId !== null;
   const relaySelfPubkey = useRelaySelfQuery(enabled).data;

--- a/desktop/src/features/home/hooks.ts
+++ b/desktop/src/features/home/hooks.ts
@@ -2,10 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getHomeFeed } from "@/shared/api/tauri";
 import { useRelayConnection } from "@/shared/api/useRelayConnection";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
 export function useHomeFeedQuery() {
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
+  const refetchInterval = useVisibleRefetchInterval(connected ? 30_000 : false);
 
   return useQuery({
     queryKey: ["home-feed"],
@@ -19,6 +21,7 @@ export function useHomeFeedQuery() {
     // Pause background polling on degraded/stalled/disconnected connections.
     // The relay can't serve the request anyway, and the spurious failures
     // consume quota that the recovery path needs.
-    refetchInterval: connected ? 30_000 : false,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }

--- a/desktop/src/features/home/hooks.ts
+++ b/desktop/src/features/home/hooks.ts
@@ -2,12 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getHomeFeed } from "@/shared/api/tauri";
 import { useRelayConnection } from "@/shared/api/useRelayConnection";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
 export function useHomeFeedQuery() {
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
-  const refetchInterval = useVisibleRefetchInterval(connected ? 30_000 : false);
+  const refetchInterval = useFocusedRefetchInterval(connected ? 30_000 : false);
 
   return useQuery({
     queryKey: ["home-feed"],

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 
 import { setupAudioWorklet, type AudioWorkletHandle } from "./lib/audioWorklet";
 import { type AudioInputDevice, useAudioDevices } from "./lib/useAudioDevices";
+import { usePipelineHotstart } from "./lib/usePipelineHotstart";
 import { formatHuddleActionError } from "./lib/huddleError";
 import {
   type VoiceInputMode,
@@ -47,7 +48,6 @@ const HUDDLE_AUDIO_STATE_EVENT = "huddle-audio-state";
 const HUDDLE_AUDIO_LEVEL_EVENT = "huddle-audio-level";
 
 const MIC_ANALYSER_UPDATE_INTERVAL_MS = 33;
-const PIPELINE_HOTSTART_INTERVAL_MS = 15_000;
 const MIC_INITIAL_NOISE_FLOOR = 0.01;
 const MIC_VOICE_GATE_ON_RMS = 0.018;
 const MIC_VOICE_GATE_OFF_RMS = 0.012;
@@ -778,16 +778,7 @@ export function HuddleProvider({
     selfPubkeyRef,
   );
 
-  // Pipeline hot-start — check if voice models finished downloading mid-huddle
-  React.useEffect(() => {
-    if (!ephemeralChannelId) return;
-    const id = window.setInterval(() => {
-      invoke("check_pipeline_hotstart").catch(() => {
-        /* best-effort */
-      });
-    }, PIPELINE_HOTSTART_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [ephemeralChannelId]);
+  usePipelineHotstart(ephemeralChannelId);
 
   // Mic level analyser — drives the voice activity indicator
   React.useEffect(() => {

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -318,9 +318,13 @@ export function HuddleBar({
     return () => {
       cancelled = true;
       window.clearInterval(id);
-      setModelStatus(null); // Clear stale status on huddle end/phase change.
     };
   }, [documentVisible, huddlePhase]);
+
+  React.useEffect(() => {
+    if (huddlePhase === "active" || huddlePhase === "connected") return;
+    setModelStatus(null);
+  }, [huddlePhase]);
 
   const isHuddleVisible = isVisibleHuddleState(state);
   const companionHadActiveHuddleRef = React.useRef(false);

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -22,6 +22,7 @@ import type { RelayEvent } from "@/shared/api/types";
 import { KIND_HUDDLE_REACTION } from "@/shared/constants/kinds";
 import { cn } from "@/shared/lib/cn";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
 import { Button } from "@/shared/ui/button";
 import { useEmojiBurst } from "@/shared/ui/EmojiBurstProvider";
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
@@ -150,6 +151,7 @@ export function HuddleBar({
   onOpenHuddleWindow,
   onVisibilityChange,
 }: HuddleBarProps) {
+  const documentVisible = useDocumentVisible();
   const {
     leaveHuddle,
     micConnected,
@@ -238,7 +240,7 @@ export function HuddleBar({
       }
     }
 
-    void fetchState();
+    if (documentVisible) void fetchState();
 
     // Primary: listen for Rust-emitted state change events
     listen<HuddleState>("huddle-state-changed", (event) => {
@@ -253,21 +255,27 @@ export function HuddleBar({
 
     // Fallback in case events are missed; keep it slow so normal huddle use is
     // event-driven and does not keep a sync IPC command warm on the main thread.
-    const id = window.setInterval(
-      () => void fetchState(),
-      HUDDLE_STATE_FALLBACK_INTERVAL_MS,
-    );
+    const id = documentVisible
+      ? window.setInterval(
+          () => void fetchState(),
+          HUDDLE_STATE_FALLBACK_INTERVAL_MS,
+        )
+      : null;
 
     return () => {
       cancelled = true;
       unlisten?.();
-      window.clearInterval(id);
+      if (id !== null) window.clearInterval(id);
     };
-  }, [applyIncomingState]);
+  }, [applyIncomingState, documentVisible]);
 
   const huddlePhase = state?.phase;
   React.useEffect(() => {
-    if (huddlePhase !== "active" && huddlePhase !== "connected") return;
+    if (
+      !documentVisible ||
+      (huddlePhase !== "active" && huddlePhase !== "connected")
+    )
+      return;
 
     let cancelled = false;
 
@@ -312,7 +320,7 @@ export function HuddleBar({
       window.clearInterval(id);
       setModelStatus(null); // Clear stale status on huddle end/phase change.
     };
-  }, [huddlePhase]);
+  }, [documentVisible, huddlePhase]);
 
   const isHuddleVisible = isVisibleHuddleState(state);
   const companionHadActiveHuddleRef = React.useRef(false);

--- a/desktop/src/features/huddle/lib/usePipelineHotstart.ts
+++ b/desktop/src/features/huddle/lib/usePipelineHotstart.ts
@@ -1,0 +1,26 @@
+import { invoke } from "@tauri-apps/api/core";
+import * as React from "react";
+
+import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
+
+const PIPELINE_HOTSTART_INTERVAL_MS = 15_000;
+
+/** Check if voice models finished downloading mid-huddle. */
+export function usePipelineHotstart(ephemeralChannelId: string | null) {
+  const documentVisible = useDocumentVisible();
+
+  React.useEffect(() => {
+    if (!ephemeralChannelId || !documentVisible) return;
+    const checkPipelineHotstart = () => {
+      invoke("check_pipeline_hotstart").catch(() => {
+        /* best-effort */
+      });
+    };
+    checkPipelineHotstart();
+    const id = window.setInterval(
+      checkPipelineHotstart,
+      PIPELINE_HOTSTART_INTERVAL_MS,
+    );
+    return () => window.clearInterval(id);
+  }, [documentVisible, ephemeralChannelId]);
+}

--- a/desktop/src/features/huddle/lib/usePipelineHotstart.ts
+++ b/desktop/src/features/huddle/lib/usePipelineHotstart.ts
@@ -1,16 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import * as React from "react";
 
-import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
-
 const PIPELINE_HOTSTART_INTERVAL_MS = 15_000;
 
 /** Check if voice models finished downloading mid-huddle. */
 export function usePipelineHotstart(ephemeralChannelId: string | null) {
-  const documentVisible = useDocumentVisible();
-
   React.useEffect(() => {
-    if (!ephemeralChannelId || !documentVisible) return;
+    if (!ephemeralChannelId) return;
     const checkPipelineHotstart = () => {
       invoke("check_pipeline_hotstart").catch(() => {
         /* best-effort */
@@ -22,5 +18,5 @@ export function usePipelineHotstart(ephemeralChannelId: string | null) {
       PIPELINE_HOTSTART_INTERVAL_MS,
     );
     return () => window.clearInterval(id);
-  }, [documentVisible, ephemeralChannelId]);
+  }, [ephemeralChannelId]);
 }

--- a/desktop/src/features/huddle/lib/useTtsSubscription.ts
+++ b/desktop/src/features/huddle/lib/useTtsSubscription.ts
@@ -2,6 +2,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import * as React from "react";
 
+import {
+  isDocumentVisible,
+  subscribeDocumentVisibility,
+} from "@/shared/lib/useDocumentVisible";
 import { buildHuddleTtsLiveFilter } from "@/shared/api/relayChannelFilters";
 import { relayClient } from "@/shared/api/relayClient";
 import {
@@ -209,10 +213,29 @@ export function useTtsSubscription(
     }
 
     // Initial load + periodic refresh (catches mid-huddle agent additions).
+    // Keep the live subscription installed while hidden, but quiesce its REST
+    // membership backstop and refresh immediately when the window returns.
+    let agentRefreshId: number | null = null;
+    const startAgentRefresh = (refreshNow: boolean) => {
+      if (agentRefreshId !== null) window.clearInterval(agentRefreshId);
+      agentRefreshId = null;
+      if (!isDocumentVisible()) return;
+      if (refreshNow) void loadAgentPubkeys();
+      agentRefreshId = window.setInterval(() => {
+        void loadAgentPubkeys();
+      }, AGENT_PUBKEY_REFRESH_INTERVAL_MS);
+    };
     void loadAgentPubkeys(true);
-    const agentRefreshId = window.setInterval(() => {
-      void loadAgentPubkeys();
-    }, AGENT_PUBKEY_REFRESH_INTERVAL_MS);
+    startAgentRefresh(false);
+    const unsubscribeDocumentVisibility = subscribeDocumentVisibility(
+      (visible) => {
+        if (visible) startAgentRefresh(true);
+        else if (agentRefreshId !== null) {
+          window.clearInterval(agentRefreshId);
+          agentRefreshId = null;
+        }
+      },
+    );
 
     // Install the state listener before requesting a snapshot. If a newer
     // event arrives while IPC is pending, it supersedes the stale snapshot.
@@ -302,7 +325,8 @@ export function useTtsSubscription(
       speakInOrder.setEnabled(false);
       cleanup?.();
       unlistenHuddleState?.();
-      window.clearInterval(agentRefreshId);
+      unsubscribeDocumentVisibility();
+      if (agentRefreshId !== null) window.clearInterval(agentRefreshId);
       if (agentVerificationRetryId !== null) {
         window.clearTimeout(agentVerificationRetryId);
       }

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -7,7 +7,7 @@ import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { getOsIdleSeconds } from "@/shared/api/osIdle";
 import { getPresence } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import {
   mergePresenceUpdate,
   parseLivePresenceEvent,
@@ -84,7 +84,7 @@ export function usePresenceQuery(
   const enabled = (options?.enabled ?? true) && normalizedPubkeys.length > 0;
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
-  const refetchInterval = useVisibleRefetchInterval(connected ? 60_000 : false);
+  const refetchInterval = useFocusedRefetchInterval(connected ? 60_000 : false);
 
   return useQuery<PresenceLookup>({
     enabled,

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -7,6 +7,7 @@ import { useRelayConnection } from "@/shared/api/useRelayConnection";
 import { getOsIdleSeconds } from "@/shared/api/osIdle";
 import { getPresence } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import {
   mergePresenceUpdate,
   parseLivePresenceEvent,
@@ -83,6 +84,7 @@ export function usePresenceQuery(
   const enabled = (options?.enabled ?? true) && normalizedPubkeys.length > 0;
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
+  const refetchInterval = useVisibleRefetchInterval(connected ? 60_000 : false);
 
   return useQuery<PresenceLookup>({
     enabled,
@@ -92,7 +94,8 @@ export function usePresenceQuery(
     // Backstop poll: catches REST-only writers (ACP agents) and TTL expiry
     // (crashed clients). WS events handle the fast path. Pause on degraded
     // connections — HTTP presence calls fail anyway and consume relay quota.
-    refetchInterval: connected ? 60_000 : false,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/projects/repoSyncHooks.ts
+++ b/desktop/src/features/projects/repoSyncHooks.ts
@@ -11,6 +11,7 @@ import type {
   Repository as Project,
 } from "@/features/projects/hooks";
 import { useProjectRepoHost } from "@/features/projects/useProjectRepoHost";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { publishProjectPullRequestUpdate } from "./pullRequestMutations";
 
 /** Local-vs-remote git sync status for a project checkout (ahead/behind
@@ -24,6 +25,7 @@ export function useProjectRepoSyncStatusQuery(
   baseBranch?: string | null,
 ) {
   const selectedBranch = branchName ?? project?.defaultBranch ?? null;
+  const refetchInterval = useVisibleRefetchInterval(60_000);
   const selectedBaseBranch = baseBranch ?? project?.defaultBranch ?? null;
   const host = useProjectRepoHost(project);
 
@@ -48,7 +50,7 @@ export function useProjectRepoSyncStatusQuery(
       });
     },
     staleTime: 10_000,
-    refetchInterval: 60_000,
+    refetchInterval,
     refetchOnWindowFocus: true,
     retry: 1,
   });

--- a/desktop/src/features/projects/repoSyncHooks.ts
+++ b/desktop/src/features/projects/repoSyncHooks.ts
@@ -11,7 +11,7 @@ import type {
   Repository as Project,
 } from "@/features/projects/hooks";
 import { useProjectRepoHost } from "@/features/projects/useProjectRepoHost";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { publishProjectPullRequestUpdate } from "./pullRequestMutations";
 
 /** Local-vs-remote git sync status for a project checkout (ahead/behind
@@ -25,7 +25,7 @@ export function useProjectRepoSyncStatusQuery(
   baseBranch?: string | null,
 ) {
   const selectedBranch = branchName ?? project?.defaultBranch ?? null;
-  const refetchInterval = useVisibleRefetchInterval(60_000);
+  const refetchInterval = useFocusedRefetchInterval(60_000);
   const selectedBaseBranch = baseBranch ?? project?.defaultBranch ?? null;
   const host = useProjectRepoHost(project);
 

--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -12,7 +12,7 @@ import {
 import { allPulseTimelinesQueryKey } from "@/features/profile/hooks";
 import { withoutProjectComments } from "@/features/pulse/lib/projectComments";
 import type { UserNote, UserNotesResponse } from "@/shared/api/socialTypes";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
 // ── Query keys ──────────────────────────────────────────────────────────────
 
@@ -32,7 +32,7 @@ export const pulseQueryKeys = {
 // ── Own notes ───────────────────────────────────────────────────────────────
 
 export function useLikedNotesQuery(pubkey?: string, enabled = true) {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.likedNotes(pubkey ?? ""),
@@ -48,7 +48,7 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
 }
 
 export function useMyNotesQuery(pubkey?: string) {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.myNotes(pubkey ?? ""),
@@ -66,7 +66,7 @@ export function useMyNotesQuery(pubkey?: string) {
 // ── Timeline (notes from contacts) ─────────────────────────────────────────
 
 export function useTimelineQuery(contactPubkeys: string[], enabled: boolean) {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.timeline(contactPubkeys),
@@ -89,7 +89,7 @@ export function usePulseReactionsQuery(
   noteIds: string[],
   currentPubkey?: string,
 ) {
-  const refetchInterval = useVisibleRefetchInterval(60_000);
+  const refetchInterval = useFocusedRefetchInterval(60_000);
 
   return useQuery<Map<string, PulseReactionState>>({
     queryKey: pulseQueryKeys.reactions(noteIds),
@@ -128,7 +128,7 @@ export function useNoteByIdQuery(noteId: string | null) {
 }
 
 export function useGlobalNotesQuery(enabled: boolean) {
-  const refetchInterval = useVisibleRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(30_000);
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.globalNotes,

--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import * as React from "react";
 
 import {
   getGlobalNotes,
@@ -13,37 +12,7 @@ import {
 import { allPulseTimelinesQueryKey } from "@/features/profile/hooks";
 import { withoutProjectComments } from "@/features/pulse/lib/projectComments";
 import type { UserNote, UserNotesResponse } from "@/shared/api/socialTypes";
-
-function isDocumentVisible() {
-  return typeof document === "undefined"
-    ? true
-    : document.visibilityState === "visible";
-}
-
-function useDocumentVisible() {
-  const [visible, setVisible] = React.useState(isDocumentVisible);
-
-  React.useEffect(() => {
-    if (typeof document === "undefined") {
-      return;
-    }
-
-    function handleVisibilityChange() {
-      setVisible(isDocumentVisible());
-    }
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
-
-  return visible;
-}
-
-function useVisibleRefetchInterval(intervalMs: number) {
-  return useDocumentVisible() ? intervalMs : false;
-}
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
 // ── Query keys ──────────────────────────────────────────────────────────────
 
@@ -74,6 +43,7 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -89,6 +59,7 @@ export function useMyNotesQuery(pubkey?: string) {
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -105,6 +76,7 @@ export function useTimelineQuery(contactPubkeys: string[], enabled: boolean) {
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -141,6 +113,7 @@ export function usePulseReactionsQuery(
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -165,6 +138,7 @@ export function useGlobalNotesQuery(enabled: boolean) {
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/reminders/lib/reminderNotificationPoll.test.mjs
+++ b/desktop/src/features/reminders/lib/reminderNotificationPoll.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+
+import { startReminderNotificationPoll } from "./reminderNotificationPoll.ts";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  mock.timers.reset();
+  if (originalDocument === undefined) delete globalThis.document;
+  else globalThis.document = originalDocument;
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+});
+
+describe("reminder notification polling", () => {
+  it("keeps checking while the document is hidden and app is unfocused", () => {
+    mock.timers.enable({ apis: ["setInterval"] });
+    globalThis.document = {
+      visibilityState: "hidden",
+      hasFocus: () => false,
+    };
+    globalThis.window = {
+      setInterval,
+      clearInterval,
+    };
+
+    let checks = 0;
+    const stop = startReminderNotificationPoll(() => {
+      checks += 1;
+    });
+
+    assert.equal(checks, 1);
+    mock.timers.tick(30_000);
+    assert.equal(checks, 2);
+    stop();
+    mock.timers.tick(30_000);
+    assert.equal(checks, 2);
+  });
+});

--- a/desktop/src/features/reminders/lib/reminderNotificationPoll.ts
+++ b/desktop/src/features/reminders/lib/reminderNotificationPoll.ts
@@ -1,0 +1,11 @@
+const REMINDER_NOTIFICATION_POLL_INTERVAL_MS = 30_000;
+
+/** Keep due-reminder detection alive while Buzz is hidden or unfocused. */
+export function startReminderNotificationPoll(check: () => void): () => void {
+  check();
+  const interval = window.setInterval(
+    check,
+    REMINDER_NOTIFICATION_POLL_INTERVAL_MS,
+  );
+  return () => window.clearInterval(interval);
+}

--- a/desktop/src/features/reminders/useReminderNotifications.ts
+++ b/desktop/src/features/reminders/useReminderNotifications.ts
@@ -7,12 +7,12 @@ import {
 } from "@/features/reminders/hooks";
 import { dueSince } from "@/features/reminders/lib/reminderFilters";
 import type { Reminder } from "@/features/reminders/lib/reminderTypes";
-import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
 import {
   requestDockBounce,
   sendDesktopNotification,
 } from "@/features/notifications/lib/desktop";
 import type { NotificationSettings } from "@/features/notifications/hooks";
+import { startReminderNotificationPoll } from "@/features/reminders/lib/reminderNotificationPoll";
 import {
   formatNotificationTitle,
   resolveNotificationChannelLabel,
@@ -24,7 +24,6 @@ import {
 } from "@/features/notifications/lib/sound";
 
 const WATERMARK_STORAGE_PREFIX = "buzz:lastReminderCheck:";
-const POLL_INTERVAL_MS = 30_000;
 
 function watermarkStorageKey(pubkey: string): string {
   return `${WATERMARK_STORAGE_PREFIX}${pubkey.trim().toLowerCase()}`;
@@ -63,7 +62,6 @@ export function useReminderNotifications(
 ): void {
   const reminders = useRemindersQuery(pubkey).data;
   const queryClient = useQueryClient();
-  const documentVisible = useDocumentVisible();
   const remindersRef = React.useRef<Reminder[]>([]);
   remindersRef.current = reminders ?? [];
   const settingsRef = React.useRef(settings);
@@ -118,7 +116,7 @@ export function useReminderNotifications(
   });
 
   React.useEffect(() => {
-    if (!pubkey || !documentVisible) return;
+    if (!pubkey) return;
 
     const check = () => {
       // Defer until the query has resolved at least once — an empty array from
@@ -146,8 +144,6 @@ export function useReminderNotifications(
       });
     };
 
-    check();
-    const interval = window.setInterval(check, POLL_INTERVAL_MS);
-    return () => window.clearInterval(interval);
-  }, [documentVisible, pubkey, queryClient]);
+    return startReminderNotificationPoll(check);
+  }, [pubkey, queryClient]);
 }

--- a/desktop/src/features/reminders/useReminderNotifications.ts
+++ b/desktop/src/features/reminders/useReminderNotifications.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/reminders/hooks";
 import { dueSince } from "@/features/reminders/lib/reminderFilters";
 import type { Reminder } from "@/features/reminders/lib/reminderTypes";
+import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
 import {
   requestDockBounce,
   sendDesktopNotification,
@@ -62,6 +63,7 @@ export function useReminderNotifications(
 ): void {
   const reminders = useRemindersQuery(pubkey).data;
   const queryClient = useQueryClient();
+  const documentVisible = useDocumentVisible();
   const remindersRef = React.useRef<Reminder[]>([]);
   remindersRef.current = reminders ?? [];
   const settingsRef = React.useRef(settings);
@@ -116,7 +118,7 @@ export function useReminderNotifications(
   });
 
   React.useEffect(() => {
-    if (!pubkey) return;
+    if (!pubkey || !documentVisible) return;
 
     const check = () => {
       // Defer until the query has resolved at least once — an empty array from
@@ -147,5 +149,5 @@ export function useReminderNotifications(
     check();
     const interval = window.setInterval(check, POLL_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [pubkey, queryClient]);
+  }, [documentVisible, pubkey, queryClient]);
 }

--- a/desktop/src/features/user-status/hooks.ts
+++ b/desktop/src/features/user-status/hooks.ts
@@ -8,7 +8,7 @@ import type {
   UserStatusLookup,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
+import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { KIND_USER_STATUS } from "@/shared/constants/kinds";
 
 function normalizePubkeys(pubkeys: string[]) {
@@ -39,7 +39,7 @@ export function parseUserStatusEvent(event: RelayEvent): {
 }
 
 export function useUserStatusQuery(pubkeys: string[]) {
-  const refetchInterval = useVisibleRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(120_000);
   const normalizedPubkeys = normalizePubkeys(pubkeys);
   const enabled = normalizedPubkeys.length > 0;
 

--- a/desktop/src/features/user-status/hooks.ts
+++ b/desktop/src/features/user-status/hooks.ts
@@ -8,6 +8,7 @@ import type {
   UserStatusLookup,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { useVisibleRefetchInterval } from "@/shared/lib/useDocumentVisible";
 import { KIND_USER_STATUS } from "@/shared/constants/kinds";
 
 function normalizePubkeys(pubkeys: string[]) {
@@ -38,6 +39,7 @@ export function parseUserStatusEvent(event: RelayEvent): {
 }
 
 export function useUserStatusQuery(pubkeys: string[]) {
+  const refetchInterval = useVisibleRefetchInterval(120_000);
   const normalizedPubkeys = normalizePubkeys(pubkeys);
   const enabled = normalizedPubkeys.length > 0;
 
@@ -75,7 +77,8 @@ export function useUserStatusQuery(pubkeys: string[]) {
       return lookup;
     },
     staleTime: 60_000,
-    refetchInterval: 120_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -2,8 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { WorkflowRun, WorkflowRunStatus } from "@/shared/api/types";
 import {
-  useDocumentVisible,
-  useVisibleRefetchInterval,
+  useAppFocused,
+  useFocusedRefetchInterval,
 } from "@/shared/lib/useDocumentVisible";
 import {
   createWorkflow,
@@ -69,7 +69,7 @@ export function useWorkflowQuery(workflowId: string | null) {
 }
 
 export function useWorkflowRunsQuery(workflowId: string | null) {
-  const documentVisible = useDocumentVisible();
+  const appFocused = useAppFocused();
   return useQuery({
     queryKey: workflowRunsQueryKey(workflowId ?? ""),
     queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
@@ -77,7 +77,7 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     enabled: workflowId !== null,
     staleTime: 10_000,
     refetchInterval: (query) => {
-      if (!documentVisible) return false;
+      if (!appFocused) return false;
       const runs = query.state.data as WorkflowRun[] | undefined;
       return runs?.some((run) => isActiveWorkflowRunStatus(run.status))
         ? 1_000
@@ -91,7 +91,7 @@ export function useRunApprovalsQuery(
   workflowId: string | null,
   runId: string | null,
 ) {
-  const refetchInterval = useVisibleRefetchInterval(10_000);
+  const refetchInterval = useFocusedRefetchInterval(10_000);
 
   return useQuery({
     queryKey: runApprovalsQueryKey(workflowId ?? "", runId ?? ""),

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -2,6 +2,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { WorkflowRun, WorkflowRunStatus } from "@/shared/api/types";
 import {
+  useDocumentVisible,
+  useVisibleRefetchInterval,
+} from "@/shared/lib/useDocumentVisible";
+import {
   createWorkflow,
   deleteWorkflow,
   denyApproval,
@@ -65,6 +69,7 @@ export function useWorkflowQuery(workflowId: string | null) {
 }
 
 export function useWorkflowRunsQuery(workflowId: string | null) {
+  const documentVisible = useDocumentVisible();
   return useQuery({
     queryKey: workflowRunsQueryKey(workflowId ?? ""),
     queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
@@ -72,11 +77,13 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     enabled: workflowId !== null,
     staleTime: 10_000,
     refetchInterval: (query) => {
+      if (!documentVisible) return false;
       const runs = query.state.data as WorkflowRun[] | undefined;
       return runs?.some((run) => isActiveWorkflowRunStatus(run.status))
         ? 1_000
         : false;
     },
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -84,13 +91,16 @@ export function useRunApprovalsQuery(
   workflowId: string | null,
   runId: string | null,
 ) {
+  const refetchInterval = useVisibleRefetchInterval(10_000);
+
   return useQuery({
     queryKey: runApprovalsQueryKey(workflowId ?? "", runId ?? ""),
     queryFn: ({ queryKey: [, resolvedWorkflowId, resolvedRunId] }) =>
       getRunApprovals(resolvedWorkflowId, resolvedRunId),
     enabled: workflowId !== null && runId !== null,
     staleTime: 10_000,
-    refetchInterval: 10_000,
+    refetchInterval,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/shared/api/queryClient.ts
+++ b/desktop/src/shared/api/queryClient.ts
@@ -1,15 +1,27 @@
 import { focusManager, QueryClient } from "@tanstack/react-query";
 
 import {
-  isDocumentVisible,
-  subscribeDocumentVisibility,
+  isAppFocused,
+  subscribeAppFocus,
 } from "@/shared/lib/useDocumentVisible";
 
-export function createBuzzQueryClient() {
+let focusManagerConfigured = false;
+
+function configureQueryFocusManager() {
+  if (focusManagerConfigured) return;
+  focusManagerConfigured = true;
+
+  // Treat app blur as unfocused so query retries pause and stale queries with
+  // refetchOnWindowFocus refresh on return. Mutations are unaffected by this
+  // focus gate; presence heartbeats also explicitly use retry: 0.
   focusManager.setEventListener((setFocused) => {
-    setFocused(isDocumentVisible());
-    return subscribeDocumentVisibility(setFocused);
+    setFocused(isAppFocused());
+    return subscribeAppFocus(setFocused);
   });
+}
+
+export function createBuzzQueryClient() {
+  configureQueryFocusManager();
   return new QueryClient({
     defaultOptions: {
       queries: {

--- a/desktop/src/shared/api/queryClient.ts
+++ b/desktop/src/shared/api/queryClient.ts
@@ -1,6 +1,15 @@
-import { QueryClient } from "@tanstack/react-query";
+import { focusManager, QueryClient } from "@tanstack/react-query";
+
+import {
+  isDocumentVisible,
+  subscribeDocumentVisibility,
+} from "@/shared/lib/useDocumentVisible";
 
 export function createBuzzQueryClient() {
+  focusManager.setEventListener((setFocused) => {
+    setFocused(isDocumentVisible());
+    return subscribeDocumentVisibility(setFocused);
+  });
   return new QueryClient({
     defaultOptions: {
       queries: {

--- a/desktop/src/shared/lib/useDocumentVisible.test.mjs
+++ b/desktop/src/shared/lib/useDocumentVisible.test.mjs
@@ -1,70 +1,207 @@
 import assert from "node:assert/strict";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, describe, it, mock } from "node:test";
+
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 
 import {
+  isAppFocused,
   isDocumentVisible,
+  subscribeAppFocus,
   subscribeDocumentVisibility,
+  useFocusedRefetchInterval,
 } from "./useDocumentVisible.ts";
+import { useNow } from "./useNow.ts";
 
 const originalDocument = globalThis.document;
 const originalWindow = globalThis.window;
+const originalHTMLElement = globalThis.HTMLElement;
+const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
 
 afterEach(() => {
+  mock.timers.reset();
   if (originalDocument === undefined) delete globalThis.document;
   else globalThis.document = originalDocument;
   if (originalWindow === undefined) delete globalThis.window;
   else globalThis.window = originalWindow;
+  if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
+  else globalThis.HTMLElement = originalHTMLElement;
+  if (originalActEnvironment === undefined)
+    delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+  else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
 });
 
+function installVisibilityStub() {
+  let visibilityState = "visible";
+  let focused = true;
+  const documentListeners = new Map();
+  const windowListeners = new Map();
+  globalThis.document = {
+    get visibilityState() {
+      return visibilityState;
+    },
+    hasFocus: () => focused,
+    addEventListener(type, listener) {
+      const listeners = documentListeners.get(type) ?? new Set();
+      listeners.add(listener);
+      documentListeners.set(type, listeners);
+    },
+    removeEventListener(type, listener) {
+      const listeners = documentListeners.get(type);
+      listeners?.delete(listener);
+      if (listeners?.size === 0) documentListeners.delete(type);
+    },
+  };
+  globalThis.window = {
+    addEventListener(type, listener) {
+      const listeners = windowListeners.get(type) ?? new Set();
+      listeners.add(listener);
+      windowListeners.set(type, listeners);
+    },
+    removeEventListener(type, listener) {
+      const listeners = windowListeners.get(type);
+      listeners?.delete(listener);
+      if (listeners?.size === 0) windowListeners.delete(type);
+    },
+  };
+  return {
+    documentListeners,
+    windowListeners,
+    setFocused(value) {
+      focused = value;
+    },
+    setVisibility(value) {
+      visibilityState = value;
+    },
+  };
+}
+
 describe("document visibility", () => {
-  it("defaults to visible when document is unavailable", () => {
+  it("defaults to visible and focused when document is unavailable", () => {
     delete globalThis.document;
     assert.equal(isDocumentVisible(), true);
+    assert.equal(isAppFocused(), true);
   });
 
-  it("tracks visibility and focus changes and removes its listeners", () => {
-    let visibilityState = "visible";
-    let focused = true;
-    const documentListeners = new Map();
-    const windowListeners = new Map();
-    globalThis.document = {
-      get visibilityState() {
-        return visibilityState;
-      },
-      hasFocus: () => focused,
-      addEventListener(type, listener) {
-        documentListeners.set(type, listener);
-      },
-      removeEventListener(type, listener) {
-        if (documentListeners.get(type) === listener)
-          documentListeners.delete(type);
-      },
-    };
-    globalThis.window = {
-      addEventListener(type, listener) {
-        windowListeners.set(type, listener);
-      },
-      removeEventListener(type, listener) {
-        if (windowListeners.get(type) === listener)
-          windowListeners.delete(type);
-      },
-    };
-
-    const observed = [];
-    const unsubscribe = subscribeDocumentVisibility((visible) => {
-      observed.push(visible);
+  it("keeps true visibility separate from app focus", () => {
+    const stub = installVisibilityStub();
+    const visibleStates = [];
+    const focusedStates = [];
+    const unsubscribeVisibility = subscribeDocumentVisibility((visible) => {
+      visibleStates.push(visible);
+    });
+    const unsubscribeFocus = subscribeAppFocus((focused) => {
+      focusedStates.push(focused);
     });
 
-    focused = false;
-    windowListeners.get("blur")();
-    focused = true;
-    windowListeners.get("focus")();
-    visibilityState = "hidden";
-    documentListeners.get("visibilitychange")();
+    stub.setFocused(false);
+    for (const listener of stub.windowListeners.get("blur")) listener();
+    assert.equal(isDocumentVisible(), true);
+    assert.equal(isAppFocused(), false);
+    assert.deepEqual(visibleStates, []);
+    assert.deepEqual(focusedStates, [false]);
 
-    assert.deepEqual(observed, [false, true, false]);
-    unsubscribe();
-    assert.equal(documentListeners.size, 0);
-    assert.equal(windowListeners.size, 0);
+    stub.setFocused(true);
+    for (const listener of stub.windowListeners.get("focus")) listener();
+    stub.setVisibility("hidden");
+    for (const listener of stub.documentListeners.get("visibilitychange"))
+      listener();
+    assert.deepEqual(visibleStates, [false]);
+    assert.deepEqual(focusedStates, [false, true, false]);
+
+    unsubscribeVisibility();
+    unsubscribeFocus();
+    assert.equal(stub.documentListeners.size, 0);
+    assert.equal(stub.windowListeners.size, 0);
+  });
+});
+
+describe("visibility-gated hooks", () => {
+  it("useNow pauses while hidden and snaps fresh on return", async () => {
+    mock.timers.enable({ apis: ["Date", "setInterval"], now: 1_000 });
+    const dom = new JSDOM(
+      "<!doctype html><html><body><div id='root'></div></body></html>",
+    );
+    let visibilityState = "visible";
+    Object.defineProperty(dom.window.document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    Object.assign(globalThis, {
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+      IS_REACT_ACT_ENVIRONMENT: true,
+      window: dom.window,
+    });
+    const observed = [];
+    function Harness() {
+      const now = useNow(1_000);
+      React.useEffect(() => {
+        observed.push(now);
+      }, [now]);
+      return null;
+    }
+    const root = createRoot(document.getElementById("root"));
+
+    await act(async () => root.render(React.createElement(Harness)));
+    await act(async () => mock.timers.tick(1_000));
+    visibilityState = "hidden";
+    await act(async () =>
+      document.dispatchEvent(new window.Event("visibilitychange")),
+    );
+    await act(async () => mock.timers.tick(5_000));
+    assert.equal(observed.at(-1), 2_000);
+
+    visibilityState = "visible";
+    await act(async () =>
+      document.dispatchEvent(new window.Event("visibilitychange")),
+    );
+    assert.equal(observed.at(-1), 7_000);
+
+    await act(async () => root.unmount());
+    dom.window.close();
+  });
+
+  it("focused polling pauses on blur and refreshes immediately on focus", async () => {
+    const dom = new JSDOM(
+      "<!doctype html><html><body><div id='root'></div></body></html>",
+    );
+    let focused = true;
+    Object.defineProperty(dom.window.document, "hasFocus", {
+      configurable: true,
+      value: () => focused,
+    });
+    Object.defineProperty(dom.window.document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    Object.assign(globalThis, {
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+      IS_REACT_ACT_ENVIRONMENT: true,
+      window: dom.window,
+    });
+    const observed = [];
+    function Harness() {
+      const refetchInterval = useFocusedRefetchInterval(1_000);
+      React.useEffect(() => {
+        observed.push(refetchInterval);
+      }, [refetchInterval]);
+      return null;
+    }
+    const root = createRoot(document.getElementById("root"));
+
+    await act(async () => root.render(React.createElement(Harness)));
+    focused = false;
+    await act(async () => window.dispatchEvent(new window.Event("blur")));
+    assert.deepEqual(observed, [1_000, false]);
+    focused = true;
+    await act(async () => window.dispatchEvent(new window.Event("focus")));
+    assert.deepEqual(observed, [1_000, false, 1_000]);
+
+    await act(async () => root.unmount());
+    dom.window.close();
   });
 });

--- a/desktop/src/shared/lib/useDocumentVisible.test.mjs
+++ b/desktop/src/shared/lib/useDocumentVisible.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  isDocumentVisible,
+  subscribeDocumentVisibility,
+} from "./useDocumentVisible.ts";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalDocument === undefined) delete globalThis.document;
+  else globalThis.document = originalDocument;
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+});
+
+describe("document visibility", () => {
+  it("defaults to visible when document is unavailable", () => {
+    delete globalThis.document;
+    assert.equal(isDocumentVisible(), true);
+  });
+
+  it("tracks visibility and focus changes and removes its listeners", () => {
+    let visibilityState = "visible";
+    let focused = true;
+    const documentListeners = new Map();
+    const windowListeners = new Map();
+    globalThis.document = {
+      get visibilityState() {
+        return visibilityState;
+      },
+      hasFocus: () => focused,
+      addEventListener(type, listener) {
+        documentListeners.set(type, listener);
+      },
+      removeEventListener(type, listener) {
+        if (documentListeners.get(type) === listener)
+          documentListeners.delete(type);
+      },
+    };
+    globalThis.window = {
+      addEventListener(type, listener) {
+        windowListeners.set(type, listener);
+      },
+      removeEventListener(type, listener) {
+        if (windowListeners.get(type) === listener)
+          windowListeners.delete(type);
+      },
+    };
+
+    const observed = [];
+    const unsubscribe = subscribeDocumentVisibility((visible) => {
+      observed.push(visible);
+    });
+
+    focused = false;
+    windowListeners.get("blur")();
+    focused = true;
+    windowListeners.get("focus")();
+    visibilityState = "hidden";
+    documentListeners.get("visibilitychange")();
+
+    assert.deepEqual(observed, [false, true, false]);
+    unsubscribe();
+    assert.equal(documentListeners.size, 0);
+    assert.equal(windowListeners.size, 0);
+  });
+});

--- a/desktop/src/shared/lib/useDocumentVisible.ts
+++ b/desktop/src/shared/lib/useDocumentVisible.ts
@@ -2,9 +2,15 @@ import * as React from "react";
 
 export function isDocumentVisible(): boolean {
   if (typeof document === "undefined") return true;
+  return document.visibilityState === "visible";
+}
+
+export function isAppFocused(): boolean {
+  if (!isDocumentVisible()) return false;
   return (
-    document.visibilityState === "visible" &&
-    (typeof document.hasFocus !== "function" || document.hasFocus())
+    typeof document === "undefined" ||
+    typeof document.hasFocus !== "function" ||
+    document.hasFocus()
   );
 }
 
@@ -17,12 +23,26 @@ export function subscribeDocumentVisibility(
 
   const handleVisibilityChange = () => listener(isDocumentVisible());
   document.addEventListener("visibilitychange", handleVisibilityChange);
-  window.addEventListener("focus", handleVisibilityChange);
-  window.addEventListener("blur", handleVisibilityChange);
   return () => {
     document.removeEventListener("visibilitychange", handleVisibilityChange);
-    window.removeEventListener("focus", handleVisibilityChange);
-    window.removeEventListener("blur", handleVisibilityChange);
+  };
+}
+
+export function subscribeAppFocus(
+  listener: (focused: boolean) => void,
+): () => void {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  const handleFocusChange = () => listener(isAppFocused());
+  document.addEventListener("visibilitychange", handleFocusChange);
+  window.addEventListener("focus", handleFocusChange);
+  window.addEventListener("blur", handleFocusChange);
+  return () => {
+    document.removeEventListener("visibilitychange", handleFocusChange);
+    window.removeEventListener("focus", handleFocusChange);
+    window.removeEventListener("blur", handleFocusChange);
   };
 }
 
@@ -34,8 +54,16 @@ export function useDocumentVisible(): boolean {
   return visible;
 }
 
-export function useVisibleRefetchInterval(
+export function useAppFocused(): boolean {
+  const [focused, setFocused] = React.useState(isAppFocused);
+
+  React.useEffect(() => subscribeAppFocus(setFocused), []);
+
+  return focused;
+}
+
+export function useFocusedRefetchInterval(
   intervalMs: number | false,
 ): number | false {
-  return useDocumentVisible() ? intervalMs : false;
+  return useAppFocused() ? intervalMs : false;
 }

--- a/desktop/src/shared/lib/useDocumentVisible.ts
+++ b/desktop/src/shared/lib/useDocumentVisible.ts
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+export function isDocumentVisible(): boolean {
+  if (typeof document === "undefined") return true;
+  return (
+    document.visibilityState === "visible" &&
+    (typeof document.hasFocus !== "function" || document.hasFocus())
+  );
+}
+
+export function subscribeDocumentVisibility(
+  listener: (visible: boolean) => void,
+): () => void {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  const handleVisibilityChange = () => listener(isDocumentVisible());
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("focus", handleVisibilityChange);
+  window.addEventListener("blur", handleVisibilityChange);
+  return () => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("focus", handleVisibilityChange);
+    window.removeEventListener("blur", handleVisibilityChange);
+  };
+}
+
+export function useDocumentVisible(): boolean {
+  const [visible, setVisible] = React.useState(isDocumentVisible);
+
+  React.useEffect(() => subscribeDocumentVisibility(setVisible), []);
+
+  return visible;
+}
+
+export function useVisibleRefetchInterval(
+  intervalMs: number | false,
+): number | false {
+  return useDocumentVisible() ? intervalMs : false;
+}

--- a/desktop/src/shared/lib/useNow.ts
+++ b/desktop/src/shared/lib/useNow.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { useDocumentVisible } from "@/shared/lib/useDocumentVisible";
+
 /**
  * Returns `Date.now()`, re-rendering the calling component every `intervalMs`.
  * Each consumer owns one `setInterval` cleaned up on unmount — mount the hook
@@ -7,11 +9,15 @@ import * as React from "react";
  */
 export function useNow(intervalMs: number): number {
   const [now, setNow] = React.useState(() => Date.now());
+  const documentVisible = useDocumentVisible();
 
   React.useEffect(() => {
+    if (!documentVisible) return;
+
+    setNow(Date.now());
     const id = setInterval(() => setNow(Date.now()), intervalMs);
     return () => clearInterval(id);
-  }, [intervalMs]);
+  }, [documentVisible, intervalMs]);
 
   return now;
 }


### PR DESCRIPTION
Fixes #3677.

## Problem

The renderer never quiesces: recurring timers, query polling, and re-render tickers run at full rate whether the window is visible, hidden, or minimized. Measured on a live installed app: **27.5% mean renderer CPU visible vs 28.7% hidden** (60×1s `ps` samples of the WebContent process; `sample(1)` dominated by `WebCore::timerFired`/ThreadTimers, microtask checkpoints, JSON parsing, style matching). Matches all three reproductions in #3677 (macOS prerelease, Linux/WebKitGTK A/B/A minimize test, stable macOS).

Per-timer instrumentation (dev build, wrapped `setInterval`/`setTimeout`/rAF) attributed the recurring work: `useNow` 60 fires/min, 40 active TanStack refetch intervals, agent-turn pruning 12/min, auto-restart ticks, huddle/reminder polls — none visibility-gated.

## Fix (two-tier gating, standard mechanisms only)

Two separate signals in `desktop/src/shared/lib/useDocumentVisible.ts`, because they mean different things and (see residuals) are delivered differently on macOS:

- **`useDocumentVisible`** — true Page Visibility only (`document.visibilityState`). Gates local UI work that must keep running on a visible-but-unfocused window: `useNow` relative clocks, agent-turn pruning, huddle bar state/model-status polling, auto-restart tick. Hidden ⇒ paused; `useNow` snaps to fresh `Date.now()` on return.
- **`useAppFocused`** — visible AND `document.hasFocus()`. Gates network refetch polling only (`useFocusedRefetchInterval`, ~15 query families: forum/home/agents/channels/templates/emoji/user-status/projects/workflows/persona-catalog/pulse/presence-list). TanStack's `focusManager` is wired to this signal (idempotent, single install) with `refetchOnWindowFocus: true`, so stale queries refresh promptly on return. Deliberate side effect, documented in code: query retries pause on blur; mutations and the presence heartbeat (`retry: 0`) are unaffected.
- **Never gated:** reminder due-notification poll (fires while hidden/unfocused — extracted to `reminderNotificationPoll.ts` with regression test), huddle pipeline hot-start (`check_pipeline_hotstart` survives backgrounding for the duration of a huddle), relay stall watchdog, presence heartbeat. Live WebSocket delivery untouched throughout.
- Huddle model-status indicator now clears only on huddle phase end, not on visibility/focus changes.

## Validation

- Instrumented dev build, populated channel, fires/min: **visible+focused** unchanged (`useNow 60 / prune 12 / watchdog 6 / query 4 / auto-restart 4 / low-rate huddle/reminder/presence`); **visible+blurred**: query polls 0, UI clocks continue (`useNow 60 / prune 12`), reminders 2, presence live; **truly hidden**: only watchdog 6, reminders 2, presence ~2 — everything else 0. Return restored visible+focused, selection preserved, queries refreshed.
- Hide-vs-blur decomposition (instrumented probe instance, AppleScript-driven): on macOS WKWebView, Cmd-H / minimize / full occlusion did **not** reliably produce `visibilityState === "hidden"` — they reliably produced focus loss. The CPU-dominant quiescence path on macOS is therefore the focus gate; the visibility gate is exercised fully on platforms that report hidden (e.g. WebKitGTK minimize per the Linux repro).
- Gate-regression tests: signal separation, `useNow` hidden-pause + fresh-snap on return, focus-gated interval pause/resume-with-refresh, reminder delivery while hidden+unfocused (5 new, plus primitive wiring tests).
- Push gate: desktop check, typecheck, full desktop suite **4549/4549** at `1237548d1`.

## Known residuals

- **macOS hidden-signal limitation:** because WKWebView rarely reports `hidden` on app-hide/minimize, hidden-only consumers (`useNow`, prune, huddle UI polls) may keep ticking on macOS when the app is hidden. These are cheap local timers; the expensive network polling still quiesces via focus loss, which is what the measured 28% CPU was attributed to. If the residual local-timer cost proves measurable, the follow-up is bridging Tauri window hidden/minimized events into the visibility signal.
- End-to-end CPU confirmation on a packaged build is the post-merge follow-up (against the 28% idle baseline).
- Visible-state costs (skeleton animation pileups on stuck loading views, per-poll JSON payload churn) are intentionally out of scope — separate follow-up issue.
