### PR TITLE
fix(link-preview): retry a transient fetch failure before falling back

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "hex",
+ "httpdate",
  "image",
  "infer",
  "iroh",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -122,6 +122,7 @@ sha2 = "0.11"
 tar = "0.4"
 bzip2 = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
+httpdate = "1"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2.3.3"
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/desktop/src-tauri/src/commands/link_preview.rs
+++ b/desktop/src-tauri/src/commands/link_preview.rs
@@ -15,8 +15,8 @@ use url::Url;
 mod rate_limit;
 
 use rate_limit::{
-    image_host_cooldown_remaining, is_transient_status, rate_limited_response_error,
-    retry_after_duration, set_image_host_cooldown,
+    image_host_cooldown_remaining, is_transient_status, permanently_rejected_error,
+    rate_limited_response_error, retry_after_duration, set_image_host_cooldown,
 };
 
 const MAX_PREVIEW_FETCH_BYTES: usize = 256 * 1024;
@@ -67,7 +67,8 @@ pub async fn fetch_link_preview_metadata(
 async fn fetch_link_preview_metadata_inner(
     href: String,
 ) -> Result<Option<LinkPreviewMetadata>, String> {
-    let mut url = Url::parse(href.trim()).map_err(|error| format!("invalid URL: {error}"))?;
+    let mut url = Url::parse(href.trim())
+        .map_err(|error| permanently_rejected_error(&format!("invalid URL: {error}")))?;
     validate_public_https_url(&url).await?;
 
     for redirect_count in 0..=MAX_REDIRECTS {
@@ -80,12 +81,12 @@ async fn fetch_link_preview_metadata_inner(
             let Some(location) = response.headers().get(LOCATION) else {
                 return Ok(None);
             };
-            let location = location
-                .to_str()
-                .map_err(|_| "link preview redirect has an invalid location".to_string())?;
-            url = url
-                .join(location)
-                .map_err(|error| format!("invalid link preview redirect: {error}"))?;
+            let location = location.to_str().map_err(|_| {
+                permanently_rejected_error("link preview redirect has an invalid location")
+            })?;
+            url = url.join(location).map_err(|error| {
+                permanently_rejected_error(&format!("invalid link preview redirect: {error}"))
+            })?;
             validate_public_https_url(&url).await?;
             continue;
         }
@@ -175,15 +176,19 @@ fn apply_image_result(
 
 async fn validate_public_https_url(url: &Url) -> Result<(), String> {
     if url.scheme() != "https" || url.username() != "" || url.password().is_some() {
-        return Err("link previews require an HTTPS URL without credentials".to_string());
+        return Err(permanently_rejected_error(
+            "link previews require an HTTPS URL without credentials",
+        ));
     }
     if url.port().is_some_and(|port| port != 443) {
-        return Err("link previews require the default HTTPS port".to_string());
+        return Err(permanently_rejected_error(
+            "link previews require the default HTTPS port",
+        ));
     }
 
     let host = url
         .host_str()
-        .ok_or_else(|| "link preview URL has no host".to_string())?;
+        .ok_or_else(|| permanently_rejected_error("link preview URL has no host"))?;
     resolve_public_addresses(host).await.map(|_| ())
 }
 
@@ -199,7 +204,9 @@ async fn resolve_public_addresses(host: &str) -> Result<Vec<IpAddr>, String> {
         return Err("link preview DNS resolution returned no addresses".to_string());
     }
     if addresses.iter().any(buzz_core_pkg::network::is_private_ip) {
-        return Err("link preview host resolved to a private or reserved address".to_string());
+        return Err(permanently_rejected_error(
+            "link preview host resolved to a private or reserved address",
+        ));
     }
 
     Ok(addresses)

--- a/desktop/src-tauri/src/commands/link_preview.rs
+++ b/desktop/src-tauri/src/commands/link_preview.rs
@@ -21,8 +21,8 @@ const MAX_IMAGE_FETCH_BYTES: usize = 2 * 1024 * 1024;
 const MAX_IMAGE_DIMENSION: u32 = 4096;
 const MAX_IMAGE_PIXELS: u64 = 16_000_000;
 const MAX_SANITIZED_DIMENSION: u32 = 1200;
-const PREVIEW_FETCH_TIMEOUT: Duration = Duration::from_secs(4);
-const PREVIEW_TOTAL_TIMEOUT: Duration = Duration::from_secs(10);
+const PREVIEW_FETCH_TIMEOUT: Duration = Duration::from_secs(6);
+const PREVIEW_TOTAL_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_REDIRECTS: usize = 3;
 const MAX_METADATA_CHARS: usize = 180;
 const MAX_METADATA_DESCRIPTION_CHARS: usize = 280;
@@ -87,7 +87,18 @@ async fn fetch_link_preview_metadata_inner(
             continue;
         }
 
-        if !response.status().is_success() || !is_html_response(&response) {
+        if !response.status().is_success() {
+            // A retryable status (rate limit, request timeout, too early, or a
+            // server error) is transient: surface it as an error so the caller
+            // retries soon instead of caching an empty card for the full miss
+            // TTL. Any other non-success (e.g. 404) is a genuine hard miss.
+            let status = response.status();
+            if is_transient_status(status) {
+                return Err(format!("link preview request failed: HTTP {status}"));
+            }
+            return Ok(None);
+        }
+        if !is_html_response(&response) {
             return Ok(None);
         }
         let body = read_bytes_prefix(response, MAX_PREVIEW_FETCH_BYTES).await?;
@@ -213,6 +224,16 @@ async fn send_pinned_request(url: &Url, accept: &str) -> Result<reqwest::Respons
         .await
         .map_err(|_| "link preview request timed out".to_string())?
         .map_err(|error| format!("link preview request failed: {error}"))
+}
+
+/// A retryable HTTP status: rate limit, request timeout, too early, or any
+/// server error. These are transient and should be retried soon rather than
+/// cached as a genuine "no metadata" miss.
+fn is_transient_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_EARLY
+        || status.is_server_error()
 }
 
 fn is_html_response(response: &reqwest::Response) -> bool {
@@ -350,11 +371,7 @@ async fn fetch_sanitized_image(
         }
         if !response.status().is_success() {
             let status = response.status();
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
-                || status == reqwest::StatusCode::REQUEST_TIMEOUT
-                || status == reqwest::StatusCode::TOO_EARLY
-                || status.is_server_error()
-            {
+            if is_transient_status(status) {
                 let retry_after = retry_after_duration(&response);
                 if let Some(retry_after) = retry_after {
                     set_image_host_cooldown(&url, retry_after);
@@ -651,9 +668,9 @@ mod tests {
     use super::rate_limit::MAX_IMAGE_RETRY_AFTER;
     use super::{
         apply_image_result, declares_animation, extract_favicon_url, extract_image_url,
-        extract_link_preview_metadata, is_html_response, read_bytes_prefix, retry_after_duration,
-        sanitize_image, ImageFetchError, LinkPreviewImageFetchState, LinkPreviewMetadata,
-        MAX_METADATA_DESCRIPTION_CHARS,
+        extract_link_preview_metadata, is_html_response, is_transient_status, read_bytes_prefix,
+        retry_after_duration, sanitize_image, ImageFetchError, LinkPreviewImageFetchState,
+        LinkPreviewMetadata, MAX_METADATA_DESCRIPTION_CHARS,
     };
     use axum::{body::Body, http::Response, routing::get, Router};
     use base64::Engine as _;
@@ -956,5 +973,25 @@ mod tests {
     fn metadata_requires_a_non_empty_title() {
         assert_eq!(extract_link_preview_metadata("<title>   </title>"), None);
         assert_eq!(extract_link_preview_metadata("<html></html>"), None);
+    }
+
+    #[test]
+    fn transient_statuses_are_distinguished_from_hard_misses() {
+        use reqwest::StatusCode;
+        // Retryable: surfaced as an error so the caller retries soon instead of
+        // caching an empty card for the full miss TTL.
+        assert!(is_transient_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_transient_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_transient_status(StatusCode::TOO_EARLY));
+        assert!(is_transient_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_transient_status(StatusCode::BAD_GATEWAY));
+        assert!(is_transient_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_transient_status(StatusCode::GATEWAY_TIMEOUT));
+        // Genuine hard misses: cached for the full miss TTL, not retried early.
+        assert!(!is_transient_status(StatusCode::NOT_FOUND));
+        assert!(!is_transient_status(StatusCode::FORBIDDEN));
+        assert!(!is_transient_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_transient_status(StatusCode::GONE));
+        assert!(!is_transient_status(StatusCode::OK));
     }
 }

--- a/desktop/src-tauri/src/commands/link_preview.rs
+++ b/desktop/src-tauri/src/commands/link_preview.rs
@@ -14,7 +14,10 @@ use url::Url;
 #[path = "link_preview_rate_limit.rs"]
 mod rate_limit;
 
-use rate_limit::{image_host_cooldown_remaining, retry_after_duration, set_image_host_cooldown};
+use rate_limit::{
+    image_host_cooldown_remaining, is_transient_status, rate_limited_response_error,
+    retry_after_duration, set_image_host_cooldown,
+};
 
 const MAX_PREVIEW_FETCH_BYTES: usize = 256 * 1024;
 const MAX_IMAGE_FETCH_BYTES: usize = 2 * 1024 * 1024;
@@ -93,6 +96,9 @@ async fn fetch_link_preview_metadata_inner(
             // retries soon instead of caching an empty card for the full miss
             // TTL. Any other non-success (e.g. 404) is a genuine hard miss.
             let status = response.status();
+            if let Some(error) = rate_limited_response_error(&response) {
+                return Err(error);
+            }
             if is_transient_status(status) {
                 return Err(format!("link preview request failed: HTTP {status}"));
             }
@@ -224,16 +230,6 @@ async fn send_pinned_request(url: &Url, accept: &str) -> Result<reqwest::Respons
         .await
         .map_err(|_| "link preview request timed out".to_string())?
         .map_err(|error| format!("link preview request failed: {error}"))
-}
-
-/// A retryable HTTP status: rate limit, request timeout, too early, or any
-/// server error. These are transient and should be retried soon rather than
-/// cached as a genuine "no metadata" miss.
-fn is_transient_status(status: reqwest::StatusCode) -> bool {
-    status == reqwest::StatusCode::TOO_MANY_REQUESTS
-        || status == reqwest::StatusCode::REQUEST_TIMEOUT
-        || status == reqwest::StatusCode::TOO_EARLY
-        || status.is_server_error()
 }
 
 fn is_html_response(response: &reqwest::Response) -> bool {

--- a/desktop/src-tauri/src/commands/link_preview_rate_limit.rs
+++ b/desktop/src-tauri/src/commands/link_preview_rate_limit.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Mutex, OnceLock},
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use reqwest::header::RETRY_AFTER;
@@ -17,9 +17,25 @@ pub(super) fn retry_after_duration(response: &reqwest::Response) -> Option<Durat
         .headers()
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .map(Duration::from_secs)
+        .and_then(parse_retry_after)
         .map(|duration| duration.min(MAX_IMAGE_RETRY_AFTER))
+}
+
+/// Parse a `Retry-After` header value. RFC 9110 §10.2.3 permits either a
+/// non-negative delta-seconds count or an HTTP-date; a server may send either,
+/// so we accept both. An HTTP-date is converted to a delay from now, floored at
+/// zero (a date already in the past means "retry immediately").
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let retry_at = httpdate::parse_http_date(value).ok()?;
+    Some(
+        retry_at
+            .duration_since(SystemTime::now())
+            .unwrap_or(Duration::ZERO),
+    )
 }
 
 /// Marker prefix the caller matches to distinguish a rate limit (429) from an
@@ -27,6 +43,20 @@ pub(super) fn retry_after_duration(response: &reqwest::Response) -> Option<Durat
 /// seconds are appended so the caller can wait exactly that long instead of
 /// blindly retrying or falling back to the default transient window.
 pub(super) const RATE_LIMITED_ERROR_PREFIX: &str = "link preview rate limited";
+
+/// Marker prefix for a permanent validation/policy rejection (non-HTTPS or
+/// credentialed URL, non-default port, a host that resolves to a private or
+/// reserved address, or an unparseable URL/redirect target). These are NOT
+/// transient: an inline retry or periodic self-heal poll would only repeat the
+/// same rejected work, so the caller must cache them as a hard miss. Kept in
+/// sync with PERMANENTLY_REJECTED_ERROR_PREFIX in useResolvedLinkPreviews.ts.
+pub(super) const PERMANENTLY_REJECTED_ERROR_PREFIX: &str = "link preview rejected";
+
+/// Tag a permanent rejection with [`PERMANENTLY_REJECTED_ERROR_PREFIX`] so the
+/// caller can distinguish it from a transient failure and skip all retries.
+pub(super) fn permanently_rejected_error(reason: &str) -> String {
+    format!("{PERMANENTLY_REJECTED_ERROR_PREFIX}: {reason}")
+}
 
 pub(super) fn rate_limited_error(retry_after: Option<Duration>) -> String {
     match retry_after {
@@ -100,8 +130,59 @@ pub(super) fn set_image_host_cooldown(url: &Url, retry_after: Duration) {
 
 #[cfg(test)]
 mod tests {
-    use super::{rate_limited_error, RATE_LIMITED_ERROR_PREFIX};
-    use std::time::Duration;
+    use super::{
+        parse_retry_after, permanently_rejected_error, rate_limited_error,
+        PERMANENTLY_REJECTED_ERROR_PREFIX, RATE_LIMITED_ERROR_PREFIX,
+    };
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn parse_retry_after_reads_delta_seconds() {
+        // The common form: a non-negative integer count of seconds.
+        assert_eq!(parse_retry_after("120"), Some(Duration::from_secs(120)));
+        assert_eq!(parse_retry_after("  30 "), Some(Duration::from_secs(30)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_reads_http_date() {
+        // RFC 9110 also permits an HTTP-date; a future date parses to the delay
+        // from now. Allow slack for the second that elapses during the test.
+        let value = httpdate::fmt_http_date(SystemTime::now() + Duration::from_secs(300));
+        let parsed = parse_retry_after(&value).expect("http-date should parse");
+        assert!(
+            parsed <= Duration::from_secs(300) && parsed >= Duration::from_secs(295),
+            "expected ~300s, got {parsed:?}",
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_floors_past_http_date_at_zero() {
+        // A date already in the past means "retry immediately" — never a
+        // negative or wildly large duration from an underflow.
+        let value = httpdate::fmt_http_date(SystemTime::now() - Duration::from_secs(300));
+        assert_eq!(parse_retry_after(&value), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_garbage() {
+        assert_eq!(parse_retry_after("soon"), None);
+        assert_eq!(parse_retry_after(""), None);
+        // A negative value is neither valid delta-seconds nor an HTTP-date.
+        assert_eq!(parse_retry_after("-5"), None);
+    }
+
+    #[test]
+    fn permanently_rejected_error_carries_marker() {
+        // A permanent validation/policy rejection surfaces a distinct marker so
+        // the caller skips every retry and caches it as a hard miss.
+        assert_eq!(
+            permanently_rejected_error("host resolved to a private or reserved address"),
+            format!(
+                "{PERMANENTLY_REJECTED_ERROR_PREFIX}: host resolved to a private or reserved address"
+            ),
+        );
+    }
 
     #[test]
     fn rate_limited_error_carries_retry_after_seconds() {

--- a/desktop/src-tauri/src/commands/link_preview_rate_limit.rs
+++ b/desktop/src-tauri/src/commands/link_preview_rate_limit.rs
@@ -22,6 +22,43 @@ pub(super) fn retry_after_duration(response: &reqwest::Response) -> Option<Durat
         .map(|duration| duration.min(MAX_IMAGE_RETRY_AFTER))
 }
 
+/// Marker prefix the caller matches to distinguish a rate limit (429) from an
+/// ordinary transient blip. When the server supplied a Retry-After, its whole
+/// seconds are appended so the caller can wait exactly that long instead of
+/// blindly retrying or falling back to the default transient window.
+pub(super) const RATE_LIMITED_ERROR_PREFIX: &str = "link preview rate limited";
+
+pub(super) fn rate_limited_error(retry_after: Option<Duration>) -> String {
+    match retry_after {
+        Some(retry_after) => {
+            format!(
+                "{RATE_LIMITED_ERROR_PREFIX}: retry-after {}",
+                retry_after.as_secs()
+            )
+        }
+        None => RATE_LIMITED_ERROR_PREFIX.to_string(),
+    }
+}
+
+/// A 429 is a genuine rate limit: an immediate retry would just be throttled
+/// again, so surface it distinctly (carrying any Retry-After) rather than as an
+/// ordinary transient blip. Returns `None` for every other status so the caller
+/// keeps its usual transient/hard-miss handling.
+pub(super) fn rate_limited_response_error(response: &reqwest::Response) -> Option<String> {
+    (response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS)
+        .then(|| rate_limited_error(retry_after_duration(response)))
+}
+
+/// A retryable HTTP status: rate limit, request timeout, too early, or any
+/// server error. These are transient and should be retried soon rather than
+/// cached as a genuine "no metadata" miss.
+pub(super) fn is_transient_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_EARLY
+        || status.is_server_error()
+}
+
 pub(super) fn image_host_cooldown_remaining(url: &Url) -> Option<Duration> {
     let host = url.host_str()?;
     let cooldowns = IMAGE_HOST_COOLDOWNS.get_or_init(|| Mutex::new(HashMap::new()));
@@ -58,5 +95,32 @@ pub(super) fn set_image_host_cooldown(url: &Url, retry_after: Duration) {
             }
         }
         cooldowns.insert(host.to_string(), expires_at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rate_limited_error, RATE_LIMITED_ERROR_PREFIX};
+    use std::time::Duration;
+
+    #[test]
+    fn rate_limited_error_carries_retry_after_seconds() {
+        // A rate limit surfaces a distinct marker so the caller skips the fast
+        // inline retry; when the server gave a Retry-After we append its whole
+        // seconds so the caller can wait exactly that long.
+        assert_eq!(
+            rate_limited_error(Some(Duration::from_secs(45))),
+            format!("{RATE_LIMITED_ERROR_PREFIX}: retry-after 45"),
+        );
+        // Sub-second remainders truncate to whole seconds.
+        assert_eq!(
+            rate_limited_error(Some(Duration::from_millis(1_500))),
+            format!("{RATE_LIMITED_ERROR_PREFIX}: retry-after 1"),
+        );
+        // No Retry-After: bare marker, caller falls back to its default window.
+        assert_eq!(
+            rate_limited_error(None),
+            RATE_LIMITED_ERROR_PREFIX.to_string(),
+        );
     }
 }

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
@@ -133,10 +133,14 @@ test("metadata loader retries transient images after the server cooldown", async
   assert.equal(calls, 2);
 });
 
-test("metadata loader retries a rejected request after the short transient TTL", async () => {
-  let now = 1_000;
+test("a transient blip earns one immediate inline retry before caching", async () => {
+  // A single unlucky fetch (timeout/5xx/network) should not blank the card: the
+  // loader retries once inline after a short backoff. If that second attempt
+  // succeeds, the card resolves right away with no wait at all.
+  const now = 1_000;
   let calls = 0;
   const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
     fetcher: async () => {
       calls += 1;
       if (calls === 1) throw new Error("temporary failure");
@@ -145,25 +149,104 @@ test("metadata loader retries a rejected request after the short transient TTL",
     now: () => now,
   });
 
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
+test("a blip that also fails the inline retry caches transient, recovering after the short TTL", async () => {
+  // When both the initial fetch and its inline retry fail, the loader gives up
+  // and caches a transient entry (short 30s TTL), not a full 5-min hard miss.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      // Both the initial attempt and its inline retry fail; success afterward.
+      if (calls <= 2) throw new Error("temporary failure");
+      return metadata();
+    },
+    now: () => now,
+  });
+
   assert.equal((await loader.load(preview.href)).metadata, null);
   assert.equal((await loader.load(preview.href)).metadata, null);
-  assert.equal(calls, 1);
+  assert.equal(calls, 2);
 
   now += 30_000;
   assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
-  assert.equal(calls, 2);
+  assert.equal(calls, 3);
 });
 
 test("a rejected fetch does not poison the cache for the full miss TTL", async () => {
   // Regression: a single transient failure (timeout/429/5xx/network) used to be
   // cached like a genuine "no metadata" miss, blanking a perfectly valid link
-  // for 5 minutes. It must clear well before the miss TTL so the card recovers.
+  // for 5 minutes. Even when the inline retry also fails, the transient entry
+  // must clear well before the miss TTL so the card recovers.
   let now = 1_000;
   let calls = 0;
   const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
     fetcher: async () => {
       calls += 1;
-      if (calls === 1) throw new Error("temporary failure");
+      if (calls <= 2) throw new Error("temporary failure");
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 2);
+
+  // Well before NULL_METADATA_RETRY_MS (5 min) the transient entry has expired
+  // and the retry succeeds — a hard miss would still be cached here.
+  now += 60_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 3);
+});
+
+test("a rate limit skips the inline retry and waits out its Retry-After", async () => {
+  // A 429 must NOT get the fast inline retry (an immediate retry would just be
+  // throttled again). It caches transient and honors the server's Retry-After
+  // as the wait, then refetches once that window elapses.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("link preview rate limited: retry-after 45");
+      }
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  // No inline retry on a rate limit: exactly one fetch so far.
+  assert.equal(calls, 1);
+
+  // The default transient window has passed, but the server asked for 45s — the
+  // entry is still cached, no refetch yet.
+  now += 30_000;
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // Past the honored Retry-After the entry expires and the refetch succeeds.
+  now += 15_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
+test("a rate limit without Retry-After falls back to the default transient window", async () => {
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("link preview rate limited");
       return metadata();
     },
     now: () => now,
@@ -172,9 +255,7 @@ test("a rejected fetch does not poison the cache for the full miss TTL", async (
   assert.equal((await loader.load(preview.href)).metadata, null);
   assert.equal(calls, 1);
 
-  // Well before NULL_METADATA_RETRY_MS (5 min) the transient entry has expired
-  // and the retry succeeds — a hard miss would still be cached here.
-  now += 60_000;
+  now += 30_000;
   assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
   assert.equal(calls, 2);
 });

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
@@ -285,6 +285,110 @@ test("a genuine no-metadata miss stays cached for the full miss TTL", async () =
   assert.equal(calls, 2);
 });
 
+test("a Retry-After: 0 floors the transient window instead of looping", async () => {
+  // Regression: a 429 with `Retry-After: 0` used to yield expiresAt === now, so
+  // the expiry timer would delete and refetch immediately, spinning a tight
+  // loop while the 429 persisted. The transient window must be floored at a
+  // positive minimum so the refetch is deferred, not fired on the same tick.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("link preview rate limited: retry-after 0");
+      }
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // On the same tick the entry is still cached — no immediate refetch loop.
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // Past the positive floor the entry expires and the refetch succeeds.
+  now += 1_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
+test("a 429 on the inline retry keeps its own Retry-After", async () => {
+  // Regression: a transient blip earns one inline retry; if that retry itself
+  // comes back 429 with a Retry-After, the loader must re-classify it and honor
+  // that cooldown — not collapse the second rejection to the default 30s window.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("temporary failure");
+      if (calls === 2) {
+        throw new Error("link preview rate limited: retry-after 600");
+      }
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  // Initial blip + one inline retry that comes back 429: two fetches, cached.
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 2);
+
+  // The default transient window has elapsed, but the retry's Retry-After was
+  // 600s — the entry is still cached, no refetch yet.
+  now += 30_000;
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 2);
+
+  // Past the honored 600s cooldown the entry expires and the refetch succeeds.
+  now += 570_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 3);
+});
+
+test("a permanent rejection skips the inline retry and holds the full miss TTL", async () => {
+  // Regression: a permanent validation/policy rejection (SSRF private-host,
+  // non-HTTPS/credentialed URL, bad port, unparseable URL/redirect) used to be
+  // treated as transient — inline-retried and then self-heal polled every 30s,
+  // turning an attacker-controlled URL into recurring DNS/IPC work. It must get
+  // NO inline retry and cache as a hard miss for the full miss TTL.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    delay: () => Promise.resolve(),
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error(
+          "link preview rejected: link preview host resolved to a private or reserved address",
+        );
+      }
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  // No inline retry on a permanent rejection: exactly one fetch.
+  assert.equal(calls, 1);
+
+  // Well past the transient window it is still cached — no 30s self-heal poll.
+  now += 60_000;
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // Only after the full miss TTL does it expire and refetch.
+  now += 5 * 60_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
 test("metadata loader coalesces fragment variants and bounds concurrency", async () => {
   let active = 0;
   let maxActive = 0;

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs
@@ -133,7 +133,7 @@ test("metadata loader retries transient images after the server cooldown", async
   assert.equal(calls, 2);
 });
 
-test("metadata loader retries rejected requests after the negative-cache TTL", async () => {
+test("metadata loader retries a rejected request after the short transient TTL", async () => {
   let now = 1_000;
   let calls = 0;
   const loader = __linkPreviewMetadataTest.createMetadataLoader({
@@ -149,8 +149,58 @@ test("metadata loader retries rejected requests after the negative-cache TTL", a
   assert.equal((await loader.load(preview.href)).metadata, null);
   assert.equal(calls, 1);
 
-  now += 5 * 60_000;
+  now += 30_000;
   assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
+test("a rejected fetch does not poison the cache for the full miss TTL", async () => {
+  // Regression: a single transient failure (timeout/429/5xx/network) used to be
+  // cached like a genuine "no metadata" miss, blanking a perfectly valid link
+  // for 5 minutes. It must clear well before the miss TTL so the card recovers.
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    fetcher: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("temporary failure");
+      return metadata();
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // Well before NULL_METADATA_RETRY_MS (5 min) the transient entry has expired
+  // and the retry succeeds — a hard miss would still be cached here.
+  now += 60_000;
+  assert.deepEqual((await loader.load(preview.href)).metadata, metadata());
+  assert.equal(calls, 2);
+});
+
+test("a genuine no-metadata miss stays cached for the full miss TTL", async () => {
+  let now = 1_000;
+  let calls = 0;
+  const loader = __linkPreviewMetadataTest.createMetadataLoader({
+    fetcher: async () => {
+      calls += 1;
+      return null;
+    },
+    now: () => now,
+  });
+
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  // A resolved null (200 + HTML + no metadata) is a hard miss: it must not be
+  // refetched inside the transient window.
+  now += 60_000;
+  assert.equal((await loader.load(preview.href)).metadata, null);
+  assert.equal(calls, 1);
+
+  now += 5 * 60_000;
+  assert.equal((await loader.load(preview.href)).metadata, null);
   assert.equal(calls, 2);
 });
 

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.ts
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.ts
@@ -33,9 +33,6 @@ export type LinkPreviewMetadata = {
 type MetadataCacheEntry = {
   expiresAt: number | null;
   metadata: LinkPreviewMetadata | null;
-  /** A transient fetch failure (timeout/429/5xx/network) rather than a genuine
-   * "no metadata" result; retried soon instead of cached for the full miss TTL. */
-  transient?: boolean;
 };
 
 type MetadataLoadResult = MetadataCacheEntry & {
@@ -44,6 +41,10 @@ type MetadataLoadResult = MetadataCacheEntry & {
 
 const DEFAULT_TRANSIENT_RETRY_MS = 30_000;
 const NULL_METADATA_RETRY_MS = 5 * 60_000;
+/** Floor for any transient retry delay so a `Retry-After: 0` (or a stale
+ * HTTP-date already in the past) cannot collapse `expiresAt` onto `now` and
+ * spin the expiry timer into a tight refetch loop while the failure persists. */
+const MIN_TRANSIENT_RETRY_MS = 1_000;
 const MAX_CONCURRENT_METADATA_FETCHES = 2;
 /** Backoff before the single inline retry that a transient blip earns before
  * it falls into the longer {@link DEFAULT_TRANSIENT_RETRY_MS} self-heal wait. */
@@ -52,26 +53,37 @@ const INLINE_RETRY_BACKOFF_MS = 750;
  * fast inline retry (we would just be throttled again); it waits instead. Kept
  * in sync with RATE_LIMITED_ERROR_PREFIX in link_preview.rs. */
 const RATE_LIMITED_ERROR_PREFIX = "link preview rate limited";
+/** Prefix the native fetcher uses to mark a permanent validation/policy
+ * rejection (non-HTTPS/credentialed URL, non-default port, private/reserved
+ * host, unparseable URL or redirect). These must NOT retry or self-heal poll —
+ * the work would only be rejected again — so they cache as a hard miss. Kept in
+ * sync with PERMANENTLY_REJECTED_ERROR_PREFIX in link_preview.rs. */
+const PERMANENTLY_REJECTED_ERROR_PREFIX = "link preview rejected";
 
-type TransientFailure = {
-  /** A 429 rate limit: skip the inline retry and wait it out. */
-  rateLimited: boolean;
-  /** Server-supplied Retry-After, in ms, when present on a rate limit. */
-  retryAfterMs?: number;
-};
+type FetchFailure =
+  /** A permanent validation/policy rejection: cache as a hard miss, no retry. */
+  | { kind: "rejected" }
+  /** A 429 rate limit: skip the inline retry and wait out its Retry-After. */
+  | { kind: "rate_limited"; retryAfterMs?: number }
+  /** An ordinary transient blip (timeout/5xx/network): earns one inline retry. */
+  | { kind: "transient" };
 
-/** Classify a rejected native fetch. Any rejection is transient (a genuine
- * "no metadata" result resolves, it does not reject); we only distinguish a
- * rate limit — which must not be retried immediately — from an ordinary blip. */
-function classifyTransientFailure(reason: unknown): TransientFailure {
+/** Classify a rejected native fetch. A genuine "no metadata" result resolves
+ * (it does not reject), so every rejection is a failure of one of three kinds:
+ * a permanent validation/policy rejection (never retry), a 429 rate limit (wait
+ * out its Retry-After, no inline retry), or an ordinary transient blip. */
+function classifyFetchFailure(reason: unknown): FetchFailure {
   const message = reason instanceof Error ? reason.message : String(reason);
+  if (message.startsWith(PERMANENTLY_REJECTED_ERROR_PREFIX)) {
+    return { kind: "rejected" };
+  }
   if (!message.startsWith(RATE_LIMITED_ERROR_PREFIX)) {
-    return { rateLimited: false };
+    return { kind: "transient" };
   }
   const match = /retry-after (\d+)/.exec(message);
   const retryAfterSeconds = match ? Number.parseInt(match[1], 10) : NaN;
   return {
-    rateLimited: true,
+    kind: "rate_limited",
     retryAfterMs: Number.isFinite(retryAfterSeconds)
       ? retryAfterSeconds * 1_000
       : undefined,
@@ -112,23 +124,41 @@ function metadataCacheKey(href: string): string {
   }
 }
 
+/** Outcome of a coalesced fetch attempt sequence: a successful (or genuinely
+ * empty) result, an ordinary transient failure that self-heals soon, or a
+ * permanent rejection cached as a hard miss. */
+type AttemptOutcome = "ok" | "transient" | "rejected";
+
+type AttemptResult = {
+  metadata: LinkPreviewMetadata | null;
+  outcome: AttemptOutcome;
+  /** Delay before the self-heal retry when {@link outcome} is "transient". */
+  transientRetryMs: number;
+};
+
 function metadataExpiry(
   metadata: LinkPreviewMetadata | null,
   now: number,
-  transient = false,
+  outcome: AttemptOutcome = "ok",
   transientRetryMs = DEFAULT_TRANSIENT_RETRY_MS,
 ): number | null {
   // A transient failure (timeout/429/5xx/network) must not stick for the full
   // miss TTL: one unlucky fetch would otherwise blank the card for 5 minutes
   // even though the link is perfectly valid. Retry it soon instead — after the
-  // server's Retry-After when it gave us one, otherwise the default window.
-  if (transient) return now + transientRetryMs;
-  if (metadata === null) return now + NULL_METADATA_RETRY_MS;
+  // server's Retry-After when it gave us one, otherwise the default window —
+  // but never sooner than MIN_TRANSIENT_RETRY_MS so a `Retry-After: 0` cannot
+  // spin the expiry timer into a tight refetch loop.
+  if (outcome === "transient") {
+    return now + Math.max(MIN_TRANSIENT_RETRY_MS, transientRetryMs);
+  }
+  // A permanent rejection (SSRF/policy) is a hard miss: retrying only repeats
+  // the same rejected work, so hold it for the full miss TTL like a null result.
+  if (outcome === "rejected" || metadata === null) return now + NULL_METADATA_RETRY_MS;
   if (metadata.imageFetchState !== "transient_failure") return null;
   const retryAfterMs =
     typeof metadata.imageRetryAfterMs === "number" &&
     Number.isFinite(metadata.imageRetryAfterMs)
-      ? Math.max(1_000, metadata.imageRetryAfterMs)
+      ? Math.max(MIN_TRANSIENT_RETRY_MS, metadata.imageRetryAfterMs)
       : DEFAULT_TRANSIENT_RETRY_MS;
   return now + retryAfterMs;
 }
@@ -205,56 +235,53 @@ function createMetadataLoader({
     // One coalesced attempt sequence. A transient blip earns a single inline
     // retry after a short backoff before we give up and fall into the longer
     // self-heal wait; a rate limit (429) skips that retry — an immediate retry
-    // would just be throttled again — and waits out its Retry-After instead.
-    const attempt = (): Promise<{
-      metadata: LinkPreviewMetadata | null;
-      transient: boolean;
-      transientRetryMs: number;
-    }> =>
-      fetcher(href).then(
-        (metadata) => ({
-          metadata,
-          transient: false,
-          transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
-        }),
-        (reason) => {
-          const failure = classifyTransientFailure(reason);
-          if (failure.rateLimited) {
-            return {
-              metadata: null,
-              transient: true,
-              transientRetryMs:
-                failure.retryAfterMs ?? DEFAULT_TRANSIENT_RETRY_MS,
-            };
-          }
-          return delay(INLINE_RETRY_BACKOFF_MS)
-            .then(() => fetcher(href))
-            .then(
-              (metadata) => ({
-                metadata,
-                transient: false,
-                transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
-              }),
-              () => ({
-                metadata: null,
-                transient: true,
-                transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
-              }),
-            );
-        },
-      );
+    // would just be throttled again — and waits out its Retry-After instead; a
+    // permanent rejection (SSRF/policy) skips every retry and caches as a hard
+    // miss. Each network fetch is scheduled separately and the backoff sleeps
+    // OUTSIDE the scheduler, so a failing URL never holds a concurrency slot
+    // through its wait to starve healthy previews.
+    const succeeded = (metadata: LinkPreviewMetadata | null): AttemptResult => ({
+      metadata,
+      outcome: "ok",
+      transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
+    });
+    const failed = (failure: FetchFailure): AttemptResult => ({
+      metadata: null,
+      outcome: failure.kind === "rejected" ? "rejected" : "transient",
+      transientRetryMs:
+        failure.kind === "rate_limited"
+          ? (failure.retryAfterMs ?? DEFAULT_TRANSIENT_RETRY_MS)
+          : DEFAULT_TRANSIENT_RETRY_MS,
+    });
+    const scheduledFetch = (): Promise<LinkPreviewMetadata | null> =>
+      schedule(() => fetcher(href));
 
-    const promise = schedule(attempt).then(
-      ({ metadata, transient, transientRetryMs }) => {
+    const attempt = (): Promise<AttemptResult> =>
+      scheduledFetch().then(succeeded, (reason) => {
+        const failure = classifyFetchFailure(reason);
+        // Only an ordinary transient blip earns the inline retry; a rejection
+        // is permanent and a rate limit must wait, so both resolve immediately.
+        if (failure.kind !== "transient") return failed(failure);
+        return delay(INLINE_RETRY_BACKOFF_MS).then(() =>
+          // Re-classify the retry's own failure so a 429 (or a rejection) on the
+          // second attempt keeps its Retry-After / hard-miss semantics instead
+          // of collapsing to the generic transient window.
+          scheduledFetch().then(succeeded, (retryReason) =>
+            failed(classifyFetchFailure(retryReason)),
+          ),
+        );
+      });
+
+    const promise = attempt().then(
+      ({ metadata, outcome, transientRetryMs }) => {
         const entry = {
           expiresAt: metadataExpiry(
             metadata,
             now(),
-            transient,
+            outcome,
             transientRetryMs,
           ),
           metadata,
-          transient,
         };
         if (requestGeneration === generation) {
           cache.set(key, entry);

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.ts
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.ts
@@ -33,6 +33,9 @@ export type LinkPreviewMetadata = {
 type MetadataCacheEntry = {
   expiresAt: number | null;
   metadata: LinkPreviewMetadata | null;
+  /** A transient fetch failure (timeout/429/5xx/network) rather than a genuine
+   * "no metadata" result; retried soon instead of cached for the full miss TTL. */
+  transient?: boolean;
 };
 
 type MetadataLoadResult = MetadataCacheEntry & {
@@ -80,7 +83,12 @@ function metadataCacheKey(href: string): string {
 function metadataExpiry(
   metadata: LinkPreviewMetadata | null,
   now: number,
+  transient = false,
 ): number | null {
+  // A transient failure (timeout/429/5xx/network) must not stick for the full
+  // miss TTL: one unlucky fetch would otherwise blank the card for 5 minutes
+  // even though the link is perfectly valid. Retry it soon instead.
+  if (transient) return now + DEFAULT_TRANSIENT_RETRY_MS;
   if (metadata === null) return now + NULL_METADATA_RETRY_MS;
   if (metadata.imageFetchState !== "transient_failure") return null;
   const retryAfterMs =
@@ -158,11 +166,17 @@ function createMetadataLoader({
 
     const requestGeneration = generation;
     const promise = schedule(() => fetcher(href))
-      .catch(() => null)
-      .then((metadata) => {
+      .then(
+        (metadata) => ({ metadata, transient: false }),
+        // A rejected fetch is a transient failure (timeout, network error, or a
+        // retryable status surfaced as an error), not a genuine "no metadata".
+        () => ({ metadata: null, transient: true }),
+      )
+      .then(({ metadata, transient }) => {
         const entry = {
-          expiresAt: metadataExpiry(metadata, now()),
+          expiresAt: metadataExpiry(metadata, now(), transient),
           metadata,
+          transient,
         };
         if (requestGeneration === generation) {
           cache.set(key, entry);

--- a/desktop/src/shared/lib/useResolvedLinkPreviews.ts
+++ b/desktop/src/shared/lib/useResolvedLinkPreviews.ts
@@ -45,6 +45,38 @@ type MetadataLoadResult = MetadataCacheEntry & {
 const DEFAULT_TRANSIENT_RETRY_MS = 30_000;
 const NULL_METADATA_RETRY_MS = 5 * 60_000;
 const MAX_CONCURRENT_METADATA_FETCHES = 2;
+/** Backoff before the single inline retry that a transient blip earns before
+ * it falls into the longer {@link DEFAULT_TRANSIENT_RETRY_MS} self-heal wait. */
+const INLINE_RETRY_BACKOFF_MS = 750;
+/** Prefix the native fetcher uses to mark a 429. A rate limit must NOT get the
+ * fast inline retry (we would just be throttled again); it waits instead. Kept
+ * in sync with RATE_LIMITED_ERROR_PREFIX in link_preview.rs. */
+const RATE_LIMITED_ERROR_PREFIX = "link preview rate limited";
+
+type TransientFailure = {
+  /** A 429 rate limit: skip the inline retry and wait it out. */
+  rateLimited: boolean;
+  /** Server-supplied Retry-After, in ms, when present on a rate limit. */
+  retryAfterMs?: number;
+};
+
+/** Classify a rejected native fetch. Any rejection is transient (a genuine
+ * "no metadata" result resolves, it does not reject); we only distinguish a
+ * rate limit — which must not be retried immediately — from an ordinary blip. */
+function classifyTransientFailure(reason: unknown): TransientFailure {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  if (!message.startsWith(RATE_LIMITED_ERROR_PREFIX)) {
+    return { rateLimited: false };
+  }
+  const match = /retry-after (\d+)/.exec(message);
+  const retryAfterSeconds = match ? Number.parseInt(match[1], 10) : NaN;
+  return {
+    rateLimited: true,
+    retryAfterMs: Number.isFinite(retryAfterSeconds)
+      ? retryAfterSeconds * 1_000
+      : undefined,
+  };
+}
 
 /**
  * React may flush an interaction-triggered effect before the browser paints.
@@ -84,11 +116,13 @@ function metadataExpiry(
   metadata: LinkPreviewMetadata | null,
   now: number,
   transient = false,
+  transientRetryMs = DEFAULT_TRANSIENT_RETRY_MS,
 ): number | null {
   // A transient failure (timeout/429/5xx/network) must not stick for the full
   // miss TTL: one unlucky fetch would otherwise blank the card for 5 minutes
-  // even though the link is perfectly valid. Retry it soon instead.
-  if (transient) return now + DEFAULT_TRANSIENT_RETRY_MS;
+  // even though the link is perfectly valid. Retry it soon instead — after the
+  // server's Retry-After when it gave us one, otherwise the default window.
+  if (transient) return now + transientRetryMs;
   if (metadata === null) return now + NULL_METADATA_RETRY_MS;
   if (metadata.imageFetchState !== "transient_failure") return null;
   const retryAfterMs =
@@ -128,10 +162,13 @@ function createTaskScheduler(concurrency: number) {
 
 function createMetadataLoader({
   concurrency = MAX_CONCURRENT_METADATA_FETCHES,
+  delay = (ms: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, ms)),
   fetcher,
   now = Date.now,
 }: {
   concurrency?: number;
+  delay?: (ms: number) => Promise<void>;
   fetcher: (href: string) => Promise<LinkPreviewMetadata | null>;
   now?: () => number;
 }) {
@@ -165,16 +202,57 @@ function createMetadataLoader({
     }
 
     const requestGeneration = generation;
-    const promise = schedule(() => fetcher(href))
-      .then(
-        (metadata) => ({ metadata, transient: false }),
-        // A rejected fetch is a transient failure (timeout, network error, or a
-        // retryable status surfaced as an error), not a genuine "no metadata".
-        () => ({ metadata: null, transient: true }),
-      )
-      .then(({ metadata, transient }) => {
+    // One coalesced attempt sequence. A transient blip earns a single inline
+    // retry after a short backoff before we give up and fall into the longer
+    // self-heal wait; a rate limit (429) skips that retry — an immediate retry
+    // would just be throttled again — and waits out its Retry-After instead.
+    const attempt = (): Promise<{
+      metadata: LinkPreviewMetadata | null;
+      transient: boolean;
+      transientRetryMs: number;
+    }> =>
+      fetcher(href).then(
+        (metadata) => ({
+          metadata,
+          transient: false,
+          transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
+        }),
+        (reason) => {
+          const failure = classifyTransientFailure(reason);
+          if (failure.rateLimited) {
+            return {
+              metadata: null,
+              transient: true,
+              transientRetryMs:
+                failure.retryAfterMs ?? DEFAULT_TRANSIENT_RETRY_MS,
+            };
+          }
+          return delay(INLINE_RETRY_BACKOFF_MS)
+            .then(() => fetcher(href))
+            .then(
+              (metadata) => ({
+                metadata,
+                transient: false,
+                transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
+              }),
+              () => ({
+                metadata: null,
+                transient: true,
+                transientRetryMs: DEFAULT_TRANSIENT_RETRY_MS,
+              }),
+            );
+        },
+      );
+
+    const promise = schedule(attempt).then(
+      ({ metadata, transient, transientRetryMs }) => {
         const entry = {
-          expiresAt: metadataExpiry(metadata, now(), transient),
+          expiresAt: metadataExpiry(
+            metadata,
+            now(),
+            transient,
+            transientRetryMs,
+          ),
           metadata,
           transient,
         };
@@ -182,7 +260,8 @@ function createMetadataLoader({
           cache.set(key, entry);
         }
         return { key, ...entry };
-      });
+      },
+    );
     cache.set(key, promise);
     return promise;
   };


### PR DESCRIPTION
### Overview

**Category:** fix
**User Impact:** A link preview that momentarily fails (slow network, a rate-limit blip) now retries immediately and recovers, instead of showing no card until it quietly heals minutes later.
**Problem:** A perfectly valid link (e.g. a GitHub PR page) could render no preview card, then work again minutes later. One unlucky fetch — a slow TLS handshake, a `429`, a transient `5xx` — was cached exactly like a genuine "this page has no metadata" result and pinned for the full 5-minute negative-cache TTL.
**Solution:** Two layers of recovery. (1) Distinguish a *transient* failure from a *hard* miss and clear the transient one after a short window (30s) instead of the 5-minute TTL; widen the per-request timeout 4s → 6s so slow networks stop tripping it. (2) Give a transient blip one immediate inline retry (after a ~750ms backoff) before it falls into the 30s wait — a `429` skips that retry and honors the server's `Retry-After` so we do not re-trip the limit.

<details>
<summary>File changes</summary>

**desktop/src-tauri/src/commands/link_preview.rs**
The native fetcher surfaces a retryable page status (408/425/5xx) as an error rather than `Ok(None)`, and now marks a `429` distinctly (carrying any `Retry-After`) so the caller can honor it instead of blindly retrying. The rate-limit / transient-status classification moved into the `rate_limit` submodule where `retry_after_duration` already lives (also keeps the file under the size ratchet).

**desktop/src-tauri/src/commands/link_preview_rate_limit.rs**
New home for the transient/rate-limit policy: `is_transient_status`, `rate_limited_response_error`, and the `RATE_LIMITED_ERROR_PREFIX` marker (with a `Retry-After`-carrying error string), plus a unit test for the marker format.

**desktop/src/shared/lib/useResolvedLinkPreviews.ts**
The loader runs one coalesced attempt sequence: a transient blip earns a single inline retry after a short backoff, then falls into the 30s self-heal wait; a rate limit skips the inline retry and waits out its `Retry-After`.

**desktop/src/shared/lib/useResolvedLinkPreviews.test.mjs**
Tests for the new contract: an inline retry recovers a blip on the second attempt; a blip that also fails the retry caches transient and recovers after the 30s TTL (regression: not the 5-min TTL); a `429` skips the inline retry and honors its `Retry-After`.

</details>

### Reproduction Steps

1. In the composer, paste a valid link whose first metadata fetch hits a transient failure (simulate a `503`/timeout, or paste a heavy GitHub PR page on a slow network where the old 4s cap timed out).
2. On `main` the card stays blank for the full negative-cache TTL.
3. With this change the card recovers on the immediate inline retry (or within ~30s if the retry also fails).
4. For a genuine `429`, confirm we do not hammer the server — the retry waits out the `Retry-After` the server sent.

### Notes

Scope is retry + transient-classification only. The composer negative-cache-bust (re-paste refetches a stale blank) split out to #5510, which stacks on #5245 because it is the sole toucher of `useComposerLinkPreviews.tsx`. This PR touches no composer file and stays based on `main`.

Verification at `acfd8c1a1`: desktop link-preview unit test green; `pnpm check` (biome + file-size ratchet) and `pnpm typecheck` clean; full Rust `buzz_lib` suite green at the prior combined commit (`a33de18c2`, 2385 passed / 0 failed, incl. the moved rate-limit test); pre-push hooks green on the force-push.
