### PR TITLE
fix(messages): reject blank message bodies at every write layer

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -571,6 +571,29 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+/// Explain why a message body is unsendable, or `None` when it is fine.
+///
+/// The SDK builder rejects blank bodies too, but only the CLI knows *how* the
+/// content was supplied, and the stdin case is the one that actually bites:
+/// agent shells run every command with stdin on `/dev/null`, so a `--content -`
+/// that lost its upstream pipe reads `""`. Without this, that published an
+/// unreadable empty message and still exited 0, so the caller believed it had
+/// spoken. Media messages are exempt — an attachment with no caption is not
+/// blank, its payload is in the imeta tag.
+fn blank_content_message(content: &str, from_stdin: bool, no_files: bool) -> Option<&'static str> {
+    if !no_files || !content.trim().is_empty() {
+        return None;
+    }
+    Some(if from_stdin {
+        "--content - read nothing from stdin; pipe the message body in \
+         (e.g. `printf 'text\\n' | buzz messages send ... --content -`) \
+         or pass the text directly with --content"
+    } else {
+        "--content must not be empty; a blank message renders as an unreadable \
+         empty row (attach --files to send media without a caption)"
+    })
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -579,8 +602,12 @@ pub async fn cmd_send_message(
     // jam shell-metacharacter-heavy text (backticks, $vars, etc.) through argv
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
+    let from_stdin = p.content == "-";
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
+    if let Some(message) = blank_content_message(&p.content, from_stdin, p.files.is_empty()) {
+        return Err(CliError::Usage(message.into()));
+    }
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -993,8 +1020,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        blank_content_message, event_mention_pubkeys, find_root_from_tags, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
@@ -1005,6 +1032,51 @@ mod tests {
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const ID_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     const PUBKEY: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    // --- blank_content_message ---
+
+    #[test]
+    fn blank_content_allows_normal_body() {
+        assert!(blank_content_message("hello", false, true).is_none());
+    }
+
+    // Regression: an agent shell runs commands with stdin on /dev/null, so a
+    // `--content -` missing its upstream pipe read "" and published a blank
+    // message with exit code 0 — a silent failure the caller never saw.
+    #[test]
+    fn blank_content_from_stdin_names_the_missing_pipe() {
+        let message = blank_content_message("", true, true).expect("empty stdin must be rejected");
+        assert!(
+            message.contains("stdin"),
+            "stdin case must name stdin, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn blank_content_from_argv_does_not_blame_stdin() {
+        let message = blank_content_message("", false, true).expect("empty argv must be rejected");
+        assert!(
+            !message.contains("stdin"),
+            "argv case must not mention stdin, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn blank_content_rejects_whitespace_only_body() {
+        for blank in ["   ", "\n", "\t\n  \r\n"] {
+            assert!(
+                blank_content_message(blank, false, true).is_some(),
+                "whitespace-only body {blank:?} must be rejected"
+            );
+        }
+    }
+
+    // A caption-less attachment is not blank.
+    #[test]
+    fn blank_content_allows_empty_body_with_files() {
+        assert!(blank_content_message("", false, false).is_none());
+        assert!(blank_content_message("", true, false).is_none());
+    }
 
     // Three real pubkeys (lowercase 64-char hex) used by parse_member_pubkeys tests.
     // See the test's own comment on what `PublicKey::from_hex` actually validates.

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -273,6 +273,9 @@ mod tests {
 
     #[test]
     fn validate_content_size_empty() {
+        // Size-only helper: it enforces a ceiling, never a floor. Emptiness is
+        // a separate concern, rejected per-command (`cmd_send_message`) and in
+        // the SDK builders, because some content fields legitimately allow "".
         assert!(validate_content_size("").is_ok());
     }
 

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1031,6 +1031,30 @@ async fn validate_forum_vote_target(
     Ok(())
 }
 
+/// Reject a chat/forum message whose body is blank.
+///
+/// Relay-side backstop for the kinds that render as a readable row in the
+/// timeline: 9, 40002, 45001, 45003, and the 40003 edits that rewrite them.
+/// Clients guard this too, but the relay is the only chokepoint every client
+/// shares, and a blank message is indistinguishable from a delivery failure
+/// once it renders: an empty row with an author and a timestamp. Accepting one
+/// turns a caller's silent mistake into permanent, replicated noise.
+///
+/// A caption-less attachment is not blank — its payload lives in `imeta` tags,
+/// so a message carrying at least one is allowed through with empty content.
+/// This exemption is load-bearing for edits specifically: a client that drops
+/// the caption from an image but keeps the image sends exactly that shape.
+fn validate_message_not_blank(event: &Event) -> Result<(), String> {
+    if !event.content.trim().is_empty() {
+        return Ok(());
+    }
+    let has_media = event.tags.iter().any(|t| t.kind().to_string() == "imeta");
+    if has_media {
+        return Ok(());
+    }
+    Err("message content must not be empty".to_string())
+}
+
 /// Validate kind:40008 diff event metadata tags.
 fn validate_diff_event(event: &Event) -> Result<(), String> {
     // Content max 60KB
@@ -2475,6 +2499,18 @@ async fn ingest_event_inner(
         validate_diff_event(&event).map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
     }
 
+    if matches!(
+        kind_u32,
+        KIND_STREAM_MESSAGE
+            | KIND_STREAM_MESSAGE_V2
+            | KIND_STREAM_MESSAGE_EDIT
+            | KIND_FORUM_POST
+            | KIND_FORUM_COMMENT
+    ) {
+        validate_message_not_blank(&event)
+            .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
+    }
+
     if kind_u32 == KIND_AGENT_ENGRAM {
         validate_engram_envelope(&event)
             .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
@@ -3701,6 +3737,73 @@ mod tests {
             ],
         );
         assert!(validate_diff_event(&event).is_err());
+    }
+
+    // Regression: blank chat messages used to be accepted and stored, so a
+    // caller that published "" got a success response and readers got an empty
+    // row indistinguishable from a delivery failure.
+    #[test]
+    fn blank_message_validation_rejects_empty_content() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "", &[]);
+        assert!(validate_message_not_blank(&event).is_err());
+    }
+
+    #[test]
+    fn blank_message_validation_rejects_whitespace_only_content() {
+        for blank in ["   ", "\n", "\t\n  \r\n"] {
+            let event = make_event_with_tags(KIND_STREAM_MESSAGE, blank, &[]);
+            assert!(
+                validate_message_not_blank(&event).is_err(),
+                "whitespace-only body {blank:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn blank_message_validation_accepts_normal_content() {
+        let event = make_event_with_tags(KIND_STREAM_MESSAGE, "hello", &[]);
+        assert!(validate_message_not_blank(&event).is_ok());
+    }
+
+    // A caption-less attachment carries its payload in the imeta tag.
+    #[test]
+    fn blank_message_validation_accepts_empty_content_with_imeta() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "",
+            &[&["imeta", "url https://example.com/a.png"]],
+        );
+        assert!(validate_message_not_blank(&event).is_ok());
+    }
+
+    // kind:40002 renders in the timeline exactly like kind:9, so a blank one is
+    // equally unreadable and must be rejected on the same terms.
+    #[test]
+    fn blank_message_validation_covers_stream_message_v2() {
+        let blank = make_event_with_tags(KIND_STREAM_MESSAGE_V2, "  ", &[]);
+        assert!(validate_message_not_blank(&blank).is_err());
+        let ok = make_event_with_tags(KIND_STREAM_MESSAGE_V2, "hello", &[]);
+        assert!(validate_message_not_blank(&ok).is_ok());
+    }
+
+    // An edit rewrites its target's body, so a blank edit blanks a message that
+    // already said something.
+    #[test]
+    fn blank_message_validation_covers_edits() {
+        let blank = make_event_with_tags(KIND_STREAM_MESSAGE_EDIT, "", &[]);
+        assert!(validate_message_not_blank(&blank).is_err());
+    }
+
+    // …but dropping the caption from an image while keeping the image is a
+    // legitimate edit, and it arrives as empty content plus an imeta overlay.
+    #[test]
+    fn blank_message_validation_allows_edit_that_keeps_only_media() {
+        let event = make_event_with_tags(
+            KIND_STREAM_MESSAGE_EDIT,
+            "",
+            &[&["imeta", "url https://example.com/a.png"]],
+        );
+        assert!(validate_message_not_blank(&event).is_ok());
     }
 
     #[test]

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -40,6 +40,28 @@ fn check_content(content: &str, max: usize) -> Result<(), SdkError> {
     Ok(())
 }
 
+/// Reject a human-readable message body that carries no content.
+///
+/// A blank message renders as an empty row that nobody can read, and the write
+/// path has no other floor: `check_content` only enforces a ceiling, so an
+/// empty string signs, publishes, and is accepted like any other message. The
+/// caller then sees a success response for a message that says nothing —
+/// silent failure, and the reason agents in particular fail this way is that
+/// `--content -` reading from a closed stdin yields `""` rather than an error.
+///
+/// `has_media` keeps caption-less attachments legal: a message whose whole
+/// payload is an imeta-tagged image is not blank, it just has no text.
+fn check_content_not_blank(content: &str, has_media: bool) -> Result<(), SdkError> {
+    if !has_media && content.trim().is_empty() {
+        return Err(SdkError::InvalidInput(
+            "message content must not be empty — refusing to publish a blank message \
+             (if you passed `--content -`, nothing was piped into stdin)"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate hex string has at least `min_len` hex characters.
 fn check_hex_len(s: &str, min_len: usize, field: &str) -> Result<(), SdkError> {
     if s.len() < min_len || !s.chars().all(|c| c.is_ascii_hexdigit()) {
@@ -230,6 +252,7 @@ pub fn build_message(
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
+    check_content_not_blank(content, !media_tags.is_empty())?;
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(tr) = thread_ref {
         thread_tags(tr, &mut tags)?;
@@ -289,6 +312,7 @@ pub fn build_forum_post(
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
+    check_content_not_blank(content, !media_tags.is_empty())?;
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     mention_tags(mentions, &mut tags)?;
     imeta_tags(media_tags, &mut tags)?;
@@ -306,6 +330,7 @@ pub fn build_forum_comment(
     media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
     check_content(content, 64 * 1024)?;
+    check_content_not_blank(content, !media_tags.is_empty())?;
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     thread_tags(thread_ref, &mut tags)?;
     mention_tags(mentions, &mut tags)?;
@@ -386,12 +411,21 @@ pub fn build_diff_message(
 }
 
 /// Build an edit event targeting an existing message (kind 40003).
+///
+/// Blank content is rejected for the same reason it is on a new message: the
+/// edit replaces the target's body wholesale, so an empty one silently blanks a
+/// message that already said something. This builder emits no imeta tags, so an
+/// edit it produces can never be a caption-less attachment — the media-carrying
+/// edits that legitimately have empty content come from clients that overlay
+/// their own imeta tags, and those are unaffected by this path. Removing a
+/// message is `build_delete_message`, not an edit to "".
 pub fn build_edit(
     channel_id: Uuid,
     target_event_id: nostr::EventId,
     new_content: &str,
 ) -> Result<EventBuilder, SdkError> {
     check_content(new_content, 64 * 1024)?;
+    check_content_not_blank(new_content, false)?;
     let tags = vec![
         tag(&["h", &channel_id.to_string()])?,
         tag(&["e", &target_event_id.to_hex()])?,
@@ -2447,6 +2481,63 @@ mod tests {
         assert!(build_message(cid, &max, None, &[], false, &[]).is_ok());
     }
 
+    // Regression: a blank body used to sign and publish like any other message,
+    // rendering as an empty row while the caller got a success response. The
+    // path that produced it in practice was `--content -` reading from a closed
+    // stdin, which yields "" rather than an error.
+    #[test]
+    fn message_empty_content_rejected() {
+        let cid = uuid();
+        let result = build_message(cid, "", None, &[], false, &[]);
+        assert!(matches!(result, Err(SdkError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn message_whitespace_only_content_rejected() {
+        let cid = uuid();
+        for blank in ["   ", "\n", "\t\n  \r\n"] {
+            let result = build_message(cid, blank, None, &[], false, &[]);
+            assert!(
+                matches!(result, Err(SdkError::InvalidInput(_))),
+                "whitespace-only body {blank:?} must be rejected"
+            );
+        }
+    }
+
+    // A caption-less attachment is not blank — its payload is in the imeta tag.
+    #[test]
+    fn message_empty_content_allowed_with_media() {
+        let cid = uuid();
+        let media = vec![vec![
+            "imeta".to_string(),
+            "url https://example.com/a.png".to_string(),
+        ]];
+        assert!(build_message(cid, "", None, &[], false, &media).is_ok());
+    }
+
+    #[test]
+    fn forum_post_empty_content_rejected() {
+        let cid = uuid();
+        assert!(matches!(
+            build_forum_post(cid, "  ", &[], &[]),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn forum_comment_empty_content_rejected() {
+        let cid = uuid();
+        let eid = event_id();
+        let tr = ThreadRef {
+            root_event_id: eid,
+            parent_event_id: eid,
+        };
+        assert!(matches!(
+            build_forum_comment(cid, "", &tr, &[], &[]),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
     #[test]
     fn forum_post_happy_path() {
         let cid = uuid();
@@ -2609,6 +2700,20 @@ mod tests {
             build_edit(cid, eid, &big),
             Err(SdkError::ContentTooLarge { .. })
         ));
+    }
+
+    // An edit replaces the target's body wholesale, so an empty one blanks a
+    // message that already said something. Removing a message is a delete.
+    #[test]
+    fn edit_empty_content_rejected() {
+        let cid = uuid();
+        let eid = event_id();
+        for blank in ["", "   ", "\n"] {
+            assert!(
+                matches!(build_edit(cid, eid, blank), Err(SdkError::InvalidInput(_))),
+                "blank edit body {blank:?} must be rejected"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An empty message signs, publishes, and is accepted like any other message. `check_content` enforces only a ceiling, never a floor, so `""` passes every layer:

- `buzz-sdk`: `build_message` / `build_forum_post` / `build_forum_comment` / `build_edit` only bound the max size
- `buzz-cli`: `cmd_send_message` calls `validate_content_size`, which has an explicit test asserting `""` is valid
- `buzz-relay`: ingest has no empty-content rejection for message kinds

The caller gets `accepted: true` and exit code **0** for a message that says nothing. Readers get a row with an author and a timestamp and no body — indistinguishable from a delivery failure.

## How it happens in practice

Agent shells run every command with stdin on `/dev/null` (`buzz-dev-mcp/src/shell.rs:175`). The base prompt recommends `printf '…' | buzz messages send … --content -` for multiline bodies. Drop the pipe and `--content -` reads from a closed stdin, yields `""`, and silently publishes a blank message while reporting success — so the agent believes it spoke and moves on.

Observed repeatedly with a managed agent: the model produced output (539, 381, then 1290, 616 output tokens across two turns), the turn ended without error, and the published message was empty.

## Fix

Guard all three layers, mirroring the `content.trim().is_empty()` check `build_git_patch` already had:

- **buzz-sdk** — `check_content_not_blank` in `build_message` (kind:9), `build_forum_post` (45001), `build_forum_comment` (45003), and `build_edit` (40003). Catches every caller, not just the CLI.
- **buzz-cli** — reject in `cmd_send_message` via the pure, testable `blank_content_message` helper. The error names the actual cause, and the stdin case says so explicitly, so callers get exit 1 and can retry instead of silently "succeeding".
- **buzz-relay** — reject blank kinds 9 / 40002 / 40003 / 45001 / 45003 at ingest, the one chokepoint every client shares.

Caption-less attachments stay legal throughout: a body whose payload is an imeta-tagged image is not blank. That exemption is load-bearing for edits specifically — dropping a caption while keeping the image arrives as empty content plus an imeta overlay.

`validate_content_size` is deliberately left accepting `""`. It is a size-only helper shared with paths where empty content is legitimate; the floor belongs at the message layer.

## Testing

15 new tests: empty, whitespace-only (`"   "`, `"\n"`, `"\t\n  \r\n"`), media-exempt, per-kind coverage, and for the CLI that the stdin message names stdin while the argv message does not.

```
buzz-sdk    263 passed
buzz-cli    346 passed
buzz-acp    736 passed
buzz-relay  873 passed
```

`cargo fmt --all --check` and `cargo clippy --all-targets` clean. Full pre-push gate green.

Verified end to end against the rebuilt binary, through the multicall shim the agent actually uses:

| Invocation | Result |
|---|---|
| `--content -` with stdin on `/dev/null` | stdin error, exit 1 |
| `--content ""` | empty-content error, exit 1 |
| `--content "   "` | rejected, exit 1 |
| `printf 'hello\n' \| … --content -` | passes the guard, reaches the network |

One pre-existing unrelated failure, `api::mesh_demo::demo_join_forwarded_arm_round_trips_echo`, reproduces identically on a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)