### PR TITLE
fix(mobile): refresh agent directory from live profiles

### DIFF
--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -56,12 +56,67 @@ Map<String, dynamic>? _tryDecodeJsonMap(String content) {
   }
 }
 
+/// Subscribes to replaceable agent-profile events and bumps whenever the
+/// directory changes so already-connected clients refetch immediately.
+class _AgentDirectorySubscription extends Notifier<int> {
+  void Function()? _unsubscribe;
+  int _subscriptionVersion = 0;
+
+  @override
+  int build() {
+    final sessionState = ref.watch(relaySessionProvider);
+    final subscriptionVersion = ++_subscriptionVersion;
+    _clearSubscription();
+    ref.onDispose(() {
+      _subscriptionVersion++;
+      _clearSubscription();
+    });
+
+    if (sessionState.status != SessionStatus.connected) return 0;
+    Future.microtask(() => _subscribe(subscriptionVersion));
+    return 0;
+  }
+
+  void _subscribe(int subscriptionVersion) {
+    if (!_isCurrent(subscriptionVersion)) return;
+    final session = ref.read(relaySessionProvider.notifier);
+    try {
+      _unsubscribe = session.subscribeImmediately(
+        NostrFilters.agentProfiles().copyWithSince(
+          DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+        (_) {
+          if (_isCurrent(subscriptionVersion)) state++;
+        },
+      );
+    } catch (error) {
+      if (_isCurrent(subscriptionVersion)) {
+        debugPrint('[AgentDirectorySubscription] failed: $error');
+      }
+    }
+  }
+
+  bool _isCurrent(int subscriptionVersion) =>
+      subscriptionVersion == _subscriptionVersion;
+
+  void _clearSubscription() {
+    _unsubscribe?.call();
+    _unsubscribe = null;
+  }
+}
+
+final agentDirectoryUpdateProvider =
+    NotifierProvider<_AgentDirectorySubscription, int>(
+      _AgentDirectorySubscription.new,
+    );
+
 /// Relay agent directory from kind:10100 agent-profile events.
 ///
-/// Watches the session and only fetches after the WebSocket connects.
+/// Watches the session and refetches whenever a live profile update arrives.
 final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
   ref,
 ) async {
+  ref.watch(agentDirectoryUpdateProvider);
   final sessionState = ref.watch(relaySessionProvider);
   if (sessionState.status != SessionStatus.connected) return const [];
   final session = ref.read(relaySessionProvider.notifier);

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -83,7 +83,7 @@ class _AgentDirectorySubscription extends Notifier<int> {
     try {
       _unsubscribe = session.subscribeImmediately(
         NostrFilters.agentProfiles().copyWithSince(
-          DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          DateTime.now().millisecondsSinceEpoch ~/ 1000 - 5,
         ),
         (_) {
           if (_isCurrent(subscriptionVersion)) state++;

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -296,6 +296,24 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     return () => _unsubscribe(subId);
   }
 
+  /// Subscribe without waiting for EOSE. Use this for app-lifetime invalidation
+  /// feeds whose consumers do not need a ready barrier before rendering.
+  void Function() subscribeImmediately(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) {
+    if (_disposed) throw StateError('Relay session is disposed');
+    final subId = _nextSubId('l');
+    _liveSubscriptions[subId] = _LiveSubscription(
+      filter: filter,
+      onEvent: onEvent,
+      onClosed: onClosed,
+    );
+    _sendReq(subId, filter);
+    return () => _unsubscribe(subId);
+  }
+
   /// Publish an event and wait for the relay's OK confirmation.
   Future<NostrEvent> publish(
     NostrEvent event, {

--- a/mobile/test/shared/mentions/agent_identity_provider_test.dart
+++ b/mobile/test/shared/mentions/agent_identity_provider_test.dart
@@ -8,6 +8,38 @@ import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
+  test('refreshes the agent directory from live profile updates', () async {
+    final relaySession = _AgentDirectoryRelaySessionNotifier([
+      _agentProfileEvent(displayName: 'Old name'),
+      _agentProfileEvent(displayName: 'Johnny5'),
+    ]);
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+    );
+    addTearDown(container.dispose);
+    final keepAlive = container.listen(
+      agentDirectoryProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(keepAlive.close);
+
+    expect(
+      (await container.read(agentDirectoryProvider.future)).single.displayName,
+      'Old name',
+    );
+    await relaySession.subscribed;
+    expect(relaySession.liveFilters.single.kinds, const [10100]);
+
+    relaySession.emit(_agentProfileEvent(displayName: 'Johnny5'));
+    await _pumpEventQueue();
+
+    expect(
+      (await container.read(agentDirectoryProvider.future)).single.displayName,
+      'Johnny5',
+    );
+  });
+
   test('refreshes channel bot roles from live membership updates', () async {
     final relaySession = _MembershipRelaySessionNotifier([
       _membershipEvent(role: 'bot'),
@@ -154,6 +186,16 @@ NostrEvent _membershipEvent({required String role}) => NostrEvent(
   sig: 'sig',
 );
 
+NostrEvent _agentProfileEvent({required String displayName}) => NostrEvent(
+  id: 'agent-profile-$displayName',
+  pubkey: _agentPubkey,
+  createdAt: 1,
+  kind: 10100,
+  tags: const [],
+  content: '{"display_name":"$displayName"}',
+  sig: 'sig',
+);
+
 Future<void> _pumpEventQueue() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
@@ -196,6 +238,50 @@ class _MembershipRelaySessionNotifier extends RelaySessionNotifier {
       unsubscribeCount++;
       _subscriptions.remove(subscription);
     };
+  }
+
+  void emit(NostrEvent event) {
+    for (final subscription in List.of(_subscriptions)) {
+      if (_matches(subscription.filter, event)) {
+        subscription.onEvent(event);
+      }
+    }
+  }
+}
+
+class _AgentDirectoryRelaySessionNotifier extends RelaySessionNotifier {
+  final List<NostrEvent> _profiles;
+  final List<NostrFilter> liveFilters = [];
+  final List<_LiveSubscription> _subscriptions = [];
+  final Completer<void> _subscribed = Completer<void>();
+  var _profileIndex = 0;
+
+  _AgentDirectoryRelaySessionNotifier(this._profiles);
+
+  Future<void> get subscribed => _subscribed.future;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    return [_profiles[_profileIndex++]];
+  }
+
+  @override
+  void Function() subscribeImmediately(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) {
+    liveFilters.add(filter);
+    final subscription = _LiveSubscription(filter, onEvent);
+    _subscriptions.add(subscription);
+    if (!_subscribed.isCompleted) _subscribed.complete();
+    return () => _subscriptions.remove(subscription);
   }
 
   void emit(NostrEvent event) {

--- a/mobile/test/shared/mentions/agent_identity_provider_test.dart
+++ b/mobile/test/shared/mentions/agent_identity_provider_test.dart
@@ -30,6 +30,11 @@ void main() {
     );
     await relaySession.subscribed;
     expect(relaySession.liveFilters.single.kinds, const [10100]);
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    expect(
+      relaySession.liveFilters.single.since,
+      inInclusiveRange(now - 6, now),
+    );
 
     relaySession.emit(_agentProfileEvent(displayName: 'Johnny5'));
     await _pumpEventQueue();
@@ -38,6 +43,22 @@ void main() {
       (await container.read(agentDirectoryProvider.future)).single.displayName,
       'Johnny5',
     );
+  });
+
+  test('disposes the live agent-directory subscription', () async {
+    final relaySession = _AgentDirectoryRelaySessionNotifier([
+      _agentProfileEvent(displayName: 'Johnny5'),
+    ]);
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+    );
+    container.listen(agentDirectoryProvider, (_, _) {}, fireImmediately: true);
+
+    await container.read(agentDirectoryProvider.future);
+    await relaySession.subscribed;
+    container.dispose();
+
+    expect(relaySession.unsubscribeCount, 1);
   });
 
   test('refreshes channel bot roles from live membership updates', () async {
@@ -189,7 +210,7 @@ NostrEvent _membershipEvent({required String role}) => NostrEvent(
 NostrEvent _agentProfileEvent({required String displayName}) => NostrEvent(
   id: 'agent-profile-$displayName',
   pubkey: _agentPubkey,
-  createdAt: 1,
+  createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
   kind: 10100,
   tags: const [],
   content: '{"display_name":"$displayName"}',
@@ -255,6 +276,7 @@ class _AgentDirectoryRelaySessionNotifier extends RelaySessionNotifier {
   final List<_LiveSubscription> _subscriptions = [];
   final Completer<void> _subscribed = Completer<void>();
   var _profileIndex = 0;
+  var unsubscribeCount = 0;
 
   _AgentDirectoryRelaySessionNotifier(this._profiles);
 
@@ -281,7 +303,10 @@ class _AgentDirectoryRelaySessionNotifier extends RelaySessionNotifier {
     final subscription = _LiveSubscription(filter, onEvent);
     _subscriptions.add(subscription);
     if (!_subscribed.isCompleted) _subscribed.complete();
-    return () => _subscriptions.remove(subscription);
+    return () {
+      unsubscribeCount++;
+      _subscriptions.remove(subscription);
+    };
   }
 
   void emit(NostrEvent event) {


### PR DESCRIPTION
## Problem

The mobile `agentDirectoryProvider` fetched kind `10100` agent profiles only when the relay session connected. If an agent profile was created or updated while the app remained connected, the mobile mention picker kept the stale directory until the app reconnected. This produced cross-device inconsistency: a freshly opened desktop could mention the agent while an already-open phone could not.

## Changes

- add a live kind `10100` invalidation subscription for the mobile agent directory
- refetch the replaceable profile history whenever a live profile update arrives
- add a synchronous relay subscription registration path for invalidation feeds that do not need to wait for EOSE
- add a regression test proving an already-connected provider changes from an old agent profile to the newly published profile

This complements #4994, which publishes agent profiles; this PR makes already-connected mobile clients consume those updates without a force-quit/reconnect.

## Testing

- `flutter test test/shared/mentions/agent_identity_provider_test.dart` — 6 passed
- `flutter analyze lib/shared/relay/relay_session.dart lib/shared/mentions/agent_identity_provider.dart test/shared/mentions/agent_identity_provider_test.dart` — no issues
- full `flutter test` — 1,166 passed

The new regression test was run against the old behavior first and timed out waiting for a kind `10100` live subscription, then passed after the implementation.
