### PR TITLE
fix(desktop): preserve explicit Claude executable overrides

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -381,6 +381,14 @@ pub(crate) fn configure_runtime_cli(
     if runtime.id != "claude" {
         return;
     }
+    // Runtime discovery is a fallback. Preserve an explicit launcher supplied
+    // through the fully layered agent environment.
+    if command
+        .get_envs()
+        .any(|(key, value)| key == "CLAUDE_CODE_EXECUTABLE" && value.is_some())
+    {
+        return;
+    }
     if let Some(cli_path) = runtime.underlying_cli.and_then(resolve_command) {
         // On Windows, `.cmd` and `.bat` files are batch shims — they cannot be
         // passed directly to `CreateProcess` and cause EINVAL when the Claude

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -613,6 +613,43 @@ fn claude_spawn_uses_the_probed_cli_executable() {
 }
 
 #[test]
+fn claude_spawn_preserves_explicit_cli_executable_override() {
+    let _guard = crate::managed_agents::lock_path_mutex();
+    let temp = tempfile::tempdir().expect("temp dir");
+    let cli = temp
+        .path()
+        .join(format!("claude{}", std::env::consts::EXE_SUFFIX));
+    let launcher = temp
+        .path()
+        .join(format!("claude-launcher{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cli, "").expect("write fake cli");
+    std::fs::write(&launcher, "").expect("write fake launcher");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&cli, std::fs::Permissions::from_mode(0o755))
+            .expect("make fake cli executable");
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755))
+            .expect("make fake launcher executable");
+    }
+    let original_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", temp.path());
+
+    let mut command = std::process::Command::new("buzz-acp");
+    command.env("CLAUDE_CODE_EXECUTABLE", &launcher);
+    super::configure_runtime_cli(&mut command, super::known_acp_runtime("claude-agent-acp"));
+
+    if let Some(path) = original_path {
+        std::env::set_var("PATH", path);
+    } else {
+        std::env::remove_var("PATH");
+    }
+    assert!(command.get_envs().any(|(key, value)| {
+        key == "CLAUDE_CODE_EXECUTABLE" && value == Some(launcher.as_os_str())
+    }));
+}
+
+#[test]
 fn codex_spawn_does_not_set_a_claude_executable() {
     let mut command = std::process::Command::new("buzz-acp");
     super::configure_runtime_cli(&mut command, super::known_acp_runtime("codex-acp"));


### PR DESCRIPTION
## Summary

- preserve an explicit `CLAUDE_CODE_EXECUTABLE` already supplied by the fully layered managed-agent environment
- keep automatic Claude CLI discovery as the fallback when no explicit launcher is configured
- add a regression test covering the agent-specific launcher precedence

The managed-agent spawn path applies `descriptor.env`, then calls `configure_runtime_cli`. Before this change, runtime discovery unconditionally replaced an agent-specific executable with the discovered `claude` binary, contradicting the documented environment precedence.

### Related issue

None found after searching existing issues and pull requests for this exact override behavior.

### Testing

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::runtime::tests::` (61 passed)
- regression test confirmed red before the fix and green after the fix using temporary executable stubs only
