### PR TITLE
docs(deploy): document Coolify deployment

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -23,6 +23,54 @@ The bootstrap script should eventually replace manual `.env` editing for normal
 users. It is responsible for generating stable secrets and, optionally, an owner
 keypair.
 
+## Coolify
+
+Coolify can deploy this production Compose bundle directly from Git. Create a
+new resource with these settings:
+
+- Repository: `https://github.com/block/buzz`
+- Build pack: **Docker Compose**
+- Base directory: `/deploy/compose`
+- Docker Compose location: `/compose.yml`
+- Raw Compose: disabled
+
+Use only the base `compose.yml`; do not add `compose.caddy.yml`. Coolify's proxy
+terminates HTTPS and WebSockets, so the bundled Caddy service is unnecessary.
+
+In Coolify's service settings, assign the relay a domain such as
+`https://buzz.example.com:3000`. The `:3000` suffix selects the relay's internal
+container port; clients still connect over normal HTTPS/WSS on port 443.
+
+Add the variables from `.env.example` to Coolify's environment settings and
+replace every `CHANGE_ME` value. At minimum, update the public URLs for your
+domain:
+
+```dotenv
+BUZZ_DOMAIN=buzz.example.com
+RELAY_URL=wss://buzz.example.com
+BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
+BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
+BUZZ_CORS_ORIGINS=https://buzz.example.com
+```
+
+Keep all generated keys, passwords, and S3 credentials stable across deploys.
+Because the base Compose file also publishes the relay port, bind its fallback
+host listener to loopback on any unused port:
+
+```dotenv
+BUZZ_HTTP_PORT=127.0.0.1:33000
+```
+
+After the deployment is healthy, verify the public route:
+
+```bash
+curl -fsS https://buzz.example.com/_liveness
+```
+
+Then connect the Buzz desktop app to `wss://buzz.example.com`. The
+`minio-init` service is a one-shot setup job; an exit code of 0 after it creates
+the bucket is expected.
+
 ## Production notes
 
 - Requires Docker Compose v2.24.4 or newer; the TLS override uses Compose's


### PR DESCRIPTION
## Summary

- document the production Compose settings needed to deploy Buzz from Git in Coolify
- clarify that Coolify replaces the bundled Caddy/TLS override
- document the relay domain target, loopback-only fallback port, environment variables, and health check
- note the expected successful exit of the one-shot `minio-init` service

## Validation

- `git diff --check`
- verified Docker Compose expands `BUZZ_HTTP_PORT=127.0.0.1:33000` to a loopback-bound host port targeting container port 3000
- documentation-only change; full application test suite not run

## Related work

No matching open Coolify issue or pull request found.