### PR TITLE
fix(desktop): show member agents in autocomplete

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -17,7 +17,6 @@ import {
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
@@ -255,9 +254,6 @@ export function useMentions(
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
         return;
       }
       if (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -848,7 +848,7 @@ test("other-owned agents without a shared channel are hidden from mentions", asy
   await expect(input.locator(".mention-chip")).toHaveCount(0);
 });
 
-test("stale channel-member agents absent from managed and relay directories stay hidden", async ({
+test("channel-member agents absent from managed and relay directories remain mentionable", async ({
   page,
 }) => {
   await installMockBridge(page, { userSearchDelayMs: 1_000 });
@@ -859,7 +859,17 @@ test("stale channel-member agents absent from managed and relay directories stay
   const input = page.getByTestId("message-input");
   await input.fill("@mira");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const miraRow = autocomplete(page).locator("button", { hasText: "mira" });
+  await expect(miraRow).toBeVisible();
+  await miraRow.click();
+  await page.keyboard.type("hello");
+
+  const content = "@mira hello";
+  await expect(input).toHaveText(content);
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(PROFILE_ONLY_AGENT_PUBKEY);
 });
 
 test("managed relay agents are visible in channel mentions regardless of relay policy", async ({


### PR DESCRIPTION
## Summary
- keep channel-member agents eligible for mention autocomplete when the agent directory has no record
- preserve explicit directory exclusions
- add an end-to-end regression covering selection and outbound mention tags

## Verification
- `just ci`
- desktop mention E2E: 58 passed
- desktop unit suite: 4,583 passed