### PR TITLE
feat(desktop): separator-insensitive matching for identifier search

### DIFF
--- a/desktop/src/features/channels/lib/channelSearchScore.test.mjs
+++ b/desktop/src/features/channels/lib/channelSearchScore.test.mjs
@@ -111,3 +111,33 @@ test("scoreChannelMatch: no match anywhere returns null", () => {
     null,
   );
 });
+
+test("scoreChannelName: 'achannelname' finds 'a-channel-name'", () => {
+  assert.notEqual(scoreChannelName("a-channel-name", "achannelname"), null);
+});
+
+test("scoreChannelName: dashed query still matches 'a-channel-name'", () => {
+  assert.notEqual(scoreChannelName("a-channel-name", "a-channel-name"), null);
+  assert.notEqual(scoreChannelName("a-channel-name", "a-channel"), null);
+});
+
+test("scoreChannelName: 'achannelname' finds snake_case 'a_channel_name'", () => {
+  assert.notEqual(scoreChannelName("a_channel_name", "achannelname"), null);
+});
+
+test("scoreChannelName: 'achannelname' finds unicode-dash 'a\u2013channel\u2013name'", () => {
+  assert.notEqual(
+    scoreChannelName("a\u2013channel\u2013name", "achannelname"),
+    null,
+  );
+});
+
+test("scoreChannelName: dashed exact match ranks above collapsed-only match", () => {
+  const dashed = scoreChannelName("a-channel-name", "a-channel-name");
+  const collapsed = scoreChannelName("a-channel-name", "achannelname");
+  assert.ok(dashed !== null && collapsed !== null && dashed < collapsed);
+});
+
+test("scoreChannelName: separators-only query does not match everything", () => {
+  assert.equal(scoreChannelName("a-channel-name", "---"), null);
+});

--- a/desktop/src/features/channels/lib/channelSearchScore.ts
+++ b/desktop/src/features/channels/lib/channelSearchScore.ts
@@ -16,8 +16,11 @@
  * Lower score === better match. `null` means "no match".
  */
 
-/** Separators that delimit words in a channel name/description. */
-const WORD_SEPARATORS = /[\s\-_./]+/;
+import {
+  collapseSeparators,
+  isSubsequence,
+  WORD_SEPARATORS,
+} from "@/shared/lib/identifierMatch";
 
 // Score bands. Kept as named steps so the intent (and ordering) is legible.
 const SCORE_EXACT = 0;
@@ -28,27 +31,6 @@ const SCORE_SUBSTRING = 4;
 const SCORE_COLLAPSED_SEPARATORS = 5;
 const SCORE_SUBSEQUENCE = 6;
 const SCORE_DESCRIPTION = 7;
-
-/** Strip separators so `release-notes` and `releasenotes` compare equal. */
-function collapseSeparators(value: string): string {
-  return value.replace(/[\s\-_./]+/g, "");
-}
-
-/**
- * Whether every char of `query` appears in `text` in order (not necessarily
- * contiguously). e.g. `reln` is a subsequence of `release-notes`.
- */
-function isSubsequence(query: string, text: string): boolean {
-  if (query.length === 0) return true;
-  let queryIndex = 0;
-  for (const char of text) {
-    if (char === query[queryIndex]) {
-      queryIndex += 1;
-      if (queryIndex === query.length) return true;
-    }
-  }
-  return false;
-}
 
 /**
  * Score how well `name` matches `lowerQuery`. Returns the best (lowest) band,

--- a/desktop/src/features/messages/lib/mentionRanking.test.mjs
+++ b/desktop/src/features/messages/lib/mentionRanking.test.mjs
@@ -139,3 +139,18 @@ test("rankMentionCandidates: owned teams rank with runnable personas", () => {
     ["team", "identity"],
   );
 });
+
+test("rankMentionCandidates matches names with separators collapsed", () => {
+  const candidates = [
+    {
+      displayName: "jane-doe",
+      isAgent: false,
+      isMember: true,
+      kind: "identity",
+      pubkey: "a".repeat(64),
+    },
+  ];
+  const ranked = rankMentionCandidates(candidates, "janedoe");
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].candidate.displayName, "jane-doe");
+});

--- a/desktop/src/features/messages/lib/mentionRanking.ts
+++ b/desktop/src/features/messages/lib/mentionRanking.ts
@@ -1,3 +1,7 @@
+import {
+  collapseSeparators,
+  WORD_SEPARATORS,
+} from "@/shared/lib/identifierMatch";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 
 export type MentionCandidateForRanking = {
@@ -44,9 +48,19 @@ function scoreMentionCandidateLabel(
   if (lower === lowerQuery) return 0;
   if (lower.startsWith(lowerQuery)) return 1;
 
-  const words = lower.split(/[\s\-_]+/).filter(Boolean);
+  const words = lower.split(WORD_SEPARATORS).filter(Boolean);
   if (words.some((word) => word === lowerQuery)) return 2;
   if (words.some((word) => word.startsWith(lowerQuery))) return 3;
+
+  // Labels are identifiers: `janedoe` should find `jane-doe` / `Jane Doe`.
+  // Ranked below all literal matches so existing ordering is unchanged.
+  const collapsedQuery = collapseSeparators(lowerQuery);
+  if (
+    collapsedQuery.length > 0 &&
+    collapseSeparators(lower).startsWith(collapsedQuery)
+  ) {
+    return 4;
+  }
 
   return null;
 }
@@ -85,9 +99,9 @@ export function rankMentionCandidates<T extends MentionCandidateForRanking>(
 
       const pubkeyScore = candidate.pubkey
         ? pubkeyLower.startsWith(lowerQuery)
-          ? 4
+          ? 5
           : pubkeyLower.includes(lowerQuery)
-            ? 5
+            ? 6
             : null
         : null;
       const score = labelScore !== null ? labelScore : pubkeyScore;

--- a/desktop/src/features/profile/lib/userCandidateSearch.test.mjs
+++ b/desktop/src/features/profile/lib/userCandidateSearch.test.mjs
@@ -39,11 +39,11 @@ test("scoreUserCandidate ranks display labels before pubkeys", () => {
   );
   assert.equal(
     scoreUserCandidate({ label: "Alice Johnson", query: "abcd", user }),
-    3,
+    4,
   );
   assert.equal(
     scoreUserCandidate({ label: "Alice Johnson", query: "3456", user }),
-    4,
+    5,
   );
 });
 
@@ -125,6 +125,23 @@ test("getKeyboardSearchSelection ignores stale ranked results", () => {
       rankedQuery: "",
       results: [alice],
     }),
+    null,
+  );
+});
+
+test("scoreUserCandidate matches labels with separators collapsed", () => {
+  const user = makeUser({ displayName: "Jane Doe" });
+  // Collapsed match ranks below all literal label matches, above pubkeys.
+  assert.equal(
+    scoreUserCandidate({ label: "Jane Doe", query: "janedoe", user }),
+    3,
+  );
+  assert.equal(
+    scoreUserCandidate({ label: "jane-doe", query: "janedoe", user }),
+    3,
+  );
+  assert.equal(
+    scoreUserCandidate({ label: "Jane Doe", query: "zzz", user }),
     null,
   );
 });

--- a/desktop/src/features/profile/lib/userCandidateSearch.ts
+++ b/desktop/src/features/profile/lib/userCandidateSearch.ts
@@ -1,4 +1,8 @@
 import type { UserSearchResult } from "@/shared/api/types";
+import {
+  collapseSeparators,
+  WORD_SEPARATORS,
+} from "@/shared/lib/identifierMatch";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 type ScoreUserCandidateInput = {
@@ -44,16 +48,33 @@ export function scoreUserCandidate({
     const lower = candidateLabel.toLowerCase();
     if (lower.startsWith(normalizedQuery)) return 0;
     if (
-      lower.split(/[\s\-_]+/).some((word) => word.startsWith(normalizedQuery))
+      lower
+        .split(WORD_SEPARATORS)
+        .some((word) => word.startsWith(normalizedQuery))
     ) {
       return 1;
     }
     if (lower.includes(normalizedQuery)) return 2;
   }
 
+  // Labels are identifiers: `janedoe` should find `jane-doe` / `Jane Doe`.
+  // Ranked below all literal label matches so existing ordering is unchanged.
+  const collapsedQuery = collapseSeparators(normalizedQuery);
+  if (collapsedQuery.length > 0) {
+    for (const candidateLabel of labels) {
+      if (
+        collapseSeparators(candidateLabel.toLowerCase()).includes(
+          collapsedQuery,
+        )
+      ) {
+        return 3;
+      }
+    }
+  }
+
   const pubkey = normalizePubkey(user.pubkey);
-  if (pubkey.startsWith(normalizedQuery)) return 3;
-  if (pubkey.includes(normalizedQuery)) return 4;
+  if (pubkey.startsWith(normalizedQuery)) return 4;
+  if (pubkey.includes(normalizedQuery)) return 5;
 
   return null;
 }

--- a/desktop/src/features/search/useSearchResults.ts
+++ b/desktop/src/features/search/useSearchResults.ts
@@ -4,6 +4,10 @@ import {
   useManagedAgentsQuery,
   useRelayAgentsQuery,
 } from "@/features/agents/hooks";
+import {
+  scoreChannelMatch,
+  scoreChannelName,
+} from "@/features/channels/lib/channelSearchScore";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import {
   useUserSearchQuery,
@@ -234,36 +238,37 @@ export function useSearchResults({
       return [];
     }
 
-    const normalizedQuery = ftsQuery.toLowerCase();
+    // Channel names are identifiers: match with the same separator-aware
+    // scorer as the channel browser, so `achannelname` finds
+    // `a-channel-name`. A leading `#` is how users type channel names, not
+    // part of the name itself. Message search below stays literal.
+    const normalizedQuery = ftsQuery.toLowerCase().replace(/^#/, "");
 
     return channels
-      .filter(
-        (channel) =>
-          (channel.archivedAt
+      .map((channel) => {
+        if (
+          !(channel.archivedAt
             ? channel.isMember
-            : channel.visibility === "open" || channel.isMember) &&
-          [
-            channel.name,
-            channel.description,
-            channelLabels?.[channel.id] ?? "",
-          ].some((value) => value.toLowerCase().includes(normalizedQuery)),
-      )
-      .sort((a, b) => {
-        const aDisplayName = channelLabels?.[a.id]?.trim() || a.name;
-        const bDisplayName = channelLabels?.[b.id]?.trim() || b.name;
-        const aNameMatches = aDisplayName
-          .toLowerCase()
-          .includes(normalizedQuery);
-        const bNameMatches = bDisplayName
-          .toLowerCase()
-          .includes(normalizedQuery);
-
-        if (aNameMatches !== bNameMatches) {
-          return aNameMatches ? -1 : 1;
+            : channel.visibility === "open" || channel.isMember)
+        ) {
+          return null;
         }
-
-        return aDisplayName.localeCompare(bDisplayName);
+        const displayName = channelLabels?.[channel.id]?.trim() || channel.name;
+        const nameScore = Math.min(
+          scoreChannelMatch(channel, normalizedQuery) ?? Infinity,
+          scoreChannelName(displayName, normalizedQuery) ?? Infinity,
+        );
+        if (nameScore === Infinity) {
+          return null;
+        }
+        return { channel, displayName, score: nameScore };
       })
+      .filter((entry) => entry !== null)
+      .sort(
+        (a, b) =>
+          a.score - b.score || a.displayName.localeCompare(b.displayName),
+      )
+      .map((entry) => entry.channel)
       .slice(0, 5);
   }, [channelLabels, channels, ftsQuery]);
   const managedAgentPubkeys = React.useMemo(

--- a/desktop/src/shared/lib/identifierMatch.test.mjs
+++ b/desktop/src/shared/lib/identifierMatch.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collapseSeparators, isSubsequence } from "./identifierMatch.ts";
+
+test("collapseSeparators strips dashes, underscores, dots, slashes, spaces", () => {
+  assert.equal(collapseSeparators("a-channel-name"), "achannelname");
+  assert.equal(collapseSeparators("a_channel name"), "achannelname");
+  assert.equal(collapseSeparators("a.channel/name"), "achannelname");
+});
+
+test("collapseSeparators strips unicode dashes", () => {
+  assert.equal(collapseSeparators("a\u2013channel\u2014name"), "achannelname");
+  assert.equal(collapseSeparators("a\u2010channel\u2212name"), "achannelname");
+});
+
+test("collapseSeparators of a separators-only string is empty", () => {
+  assert.equal(collapseSeparators("-- __ .."), "");
+});
+
+test("isSubsequence matches in-order chars", () => {
+  assert.equal(isSubsequence("acn", "a-channel-name"), true);
+  assert.equal(isSubsequence("nca", "a-channel-name"), false);
+});

--- a/desktop/src/shared/lib/identifierMatch.ts
+++ b/desktop/src/shared/lib/identifierMatch.ts
@@ -1,0 +1,33 @@
+/**
+ * Separator handling shared by identifier matchers (channel names, user
+ * display names, mention labels). Identifiers use separators as cosmetic
+ * word breaks — `a-channel-name` and `achannelname` are the same word to a
+ * person — so matchers strip them on both query and candidate. Message
+ * bodies are prose and must stay literal; never use this on content.
+ */
+
+/** Separators that delimit words in an identifier, including unicode dashes. */
+export const WORD_SEPARATORS = /[\s\-_./\u2010-\u2015\u2212]+/;
+
+const WORD_SEPARATORS_GLOBAL = new RegExp(WORD_SEPARATORS.source, "g");
+
+/** Strip separators so `a-channel-name` and `achannelname` compare equal. */
+export function collapseSeparators(value: string): string {
+  return value.replace(WORD_SEPARATORS_GLOBAL, "");
+}
+
+/**
+ * Whether every char of `query` appears in `text` in order (not necessarily
+ * contiguously). e.g. `acn` is a subsequence of `a-channel-name`.
+ */
+export function isSubsequence(query: string, text: string): boolean {
+  if (query.length === 0) return true;
+  let queryIndex = 0;
+  for (const char of text) {
+    if (char === query[queryIndex]) {
+      queryIndex += 1;
+      if (queryIndex === query.length) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

Searching `achannelname` in ⌘K / the sidebar search does not find `#a-channel-name`; the dash must be typed exactly. (⌘K focuses the sidebar search box, so both surfaces share one code path.)

## Approach

Rule: normalize identifiers, keep content literal. Channel names, user display names, and mention labels are identifiers whose separators are cosmetic; message search stays untouched.

- Extract `collapseSeparators` / `isSubsequence` / `WORD_SEPARATORS` from `channelSearchScore.ts` into a shared `shared/lib/identifierMatch.ts`, extending the separator class with unicode dashes.
- ⌘K/sidebar channel results (`useSearchResults.ts`): replace the ad-hoc substring filter with the existing `scoreChannelMatch` scorer already used by the channel browser dialog, so both surfaces match identically. A leading `#` in the query is stripped. Ranking is by the scorer's bands, so literal matches keep today's ordering and normalized-only matches rank below - purely additive recall.
- People search (`userCandidateSearch.ts`) and @-mention autocomplete (`mentionRanking.ts`): add a collapsed-separator band below all literal-label bands (`janedoe` finds `jane-doe` / `Jane Doe`); pubkey bands shift down accordingly.

## Testing

- New unit tests: `identifierMatch.test.mjs`, plus cases in the three matcher suites - `achannelname` finds `a-channel-name`, snake_case, unicode dash, separators-only query matches nothing, dashed exact match ranks above collapsed-only match.
- `pnpm test`: 4596 pass, 0 fail. `pnpm typecheck` and `pnpm check` clean.

Design discussion: Buzz channel `feat-search-channels-ignore-dash`.
