### PR TITLE
feat(supervisor): headless relay-side agent-team supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buzz-cli",
+ "buzz-core",
+ "buzz-sdk",
+ "clap",
+ "nix 0.31.3",
+ "nostr",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "buzz-test-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/buzz-workflow",
     "crates/buzz-media",
     "crates/buzz-cli",
+    "crates/buzz-supervisor",
     "crates/buzz-pairing-cli",
     "crates/buzz-sdk",
     "crates/buzz-persona",

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod agent_management;
-mod client;
+pub mod client;
 mod commands;
-mod error;
+pub mod error;
 mod links;
 mod validate;
 

--- a/crates/buzz-supervisor/Cargo.toml
+++ b/crates/buzz-supervisor/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "buzz-supervisor"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Headless relay-side team supervisor — the server analog of Desktop Managed Agents"
+
+[[bin]]
+name = "buzz-supervisor"
+path = "src/main.rs"
+
+[dependencies]
+# Internal — reuses buzz-cli's already-battle-tested relay HTTP client
+# (NIP-98 signing, query/submit_event) instead of reimplementing it.
+buzz-cli = { path = "../buzz-cli" }
+buzz-core = { workspace = true }
+buzz-sdk = { workspace = true }
+
+# Nostr
+nostr = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Serialization / config
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = "1.0"
+
+# IDs
+uuid = { workspace = true }
+
+# Extracting `workdir:<path>` out of free-text channel descriptions
+regex = "1"
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Safe wrapper around POSIX `kill(2)` for stop_process — keeps this crate
+# unsafe-code-free (matches buzz-acp's kill_process_group rationale).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }

--- a/crates/buzz-supervisor/roles.example.toml
+++ b/crates/buzz-supervisor/roles.example.toml
@@ -1,0 +1,37 @@
+# Example team roster for buzz-supervisor.
+#
+# Every provisioned channel gets one fresh keypair + one spawned `buzz-acp`
+# process per [[roles]] entry below, all rooted at that channel's `workdir`.
+#
+# NOTE: top-level keys (shared_members, extra_allowlist) must come BEFORE
+# any [[roles]] block — TOML attaches trailing top-level keys to the last
+# array-of-tables entry, not the document root. (RoleConfig rejects unknown
+# fields specifically so getting this backwards is a loud parse error
+# instead of the keys silently vanishing.)
+
+# Added as a plain channel member (no process spawned) to every provisioned
+# channel — e.g. an externally-bridged Reviewer identity.
+shared_members = ["ce2fe47f9df685d5070407ab64e903b0fe76123b42b37b4cadee2552b5cb2b02"]
+
+# Always included in every role's respond_to_allowlist, in addition to the
+# team's own generated pubkeys — typically the human owner(s).
+extra_allowlist = ["c19fc270d15c6bb3e6ca7910dd7c9e7aa760019fe1e729196450a173f157f227"]
+
+[[roles]]
+name = "load-balancer"
+display_name = "Load Balancer"
+agent_command = "claude-agent-acp"
+system_prompt_file = "/home/alice/.buzz_agents/load-balancer-prompt.txt"
+# At most one role per team should set this — see relay.md's "one listener
+# per channel" note. The rest default to `false` (mentions-only).
+subscribe_all = true
+
+[[roles]]
+name = "coder"
+display_name = "Coder"
+agent_command = "claude-agent-acp"
+
+[[roles]]
+name = "writer"
+display_name = "Writer"
+agent_command = "claude-agent-acp"

--- a/crates/buzz-supervisor/src/config.rs
+++ b/crates/buzz-supervisor/src/config.rs
@@ -1,0 +1,68 @@
+//! Team roster configuration — which roles get provisioned per channel and
+//! how each one is launched. Loaded from a TOML file at startup.
+
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+fn default_agent_command() -> String {
+    "claude-agent-acp".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoleConfig {
+    /// Stable identifier, used for state-file paths (e.g. "coder").
+    pub name: String,
+    /// Human-readable name published in the agent's `kind:0`/`kind:10100`
+    /// profiles (e.g. "Coder").
+    pub display_name: String,
+    /// `BUZZ_ACP_AGENT_COMMAND` for this role's `buzz-acp` process.
+    #[serde(default = "default_agent_command")]
+    pub agent_command: String,
+    /// Optional file whose contents become `BUZZ_ACP_SYSTEM_PROMPT`.
+    pub system_prompt_file: Option<String>,
+    /// If true, this role is launched with `--subscribe all` instead of the
+    /// default `mentions` — see relay.md's "one listener per channel" note.
+    /// At most one role per team should set this.
+    #[serde(default)]
+    pub subscribe_all: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorConfig {
+    /// Roles that get a fresh keypair + a spawned `buzz-acp` process per
+    /// provisioned channel.
+    pub roles: Vec<RoleConfig>,
+    /// Pubkeys added as plain (no process) channel members to every
+    /// provisioned channel — e.g. an externally-bridged Reviewer identity.
+    #[serde(default)]
+    pub shared_members: Vec<String>,
+    /// Pubkeys always included in every role's `respond_to_allowlist`,
+    /// beyond the team's own generated pubkeys — typically the human
+    /// owner(s) who should be able to trigger any role directly.
+    #[serde(default)]
+    pub extra_allowlist: Vec<String>,
+}
+
+impl SupervisorConfig {
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let raw = fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading roles file {}: {e}", path.display()))?;
+        let config: Self = toml::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("parsing roles file {}: {e}", path.display()))?;
+        if config.roles.is_empty() {
+            anyhow::bail!("roles file {} defines no roles", path.display());
+        }
+        let subscribe_all_count = config.roles.iter().filter(|r| r.subscribe_all).count();
+        if subscribe_all_count > 1 {
+            tracing::warn!(
+                count = subscribe_all_count,
+                "more than one role has subscribe_all=true — they will all react to every \
+                 unaddressed message in the channel, which is usually not intended"
+            );
+        }
+        Ok(config)
+    }
+}

--- a/crates/buzz-supervisor/src/main.rs
+++ b/crates/buzz-supervisor/src/main.rs
@@ -1,0 +1,130 @@
+//! buzz-supervisor — the headless, relay-side analog of Buzz Desktop's
+//! Managed Agents. Watches a relay for channels whose `description`
+//! declares a `workdir:<path>`, and provisions/heals/tears down a team of
+//! `buzz-acp` processes rooted at that directory for each one.
+//!
+//! This binary does nothing by default. It requires an explicit
+//! `--relay-url` (no default — deliberately unlike `buzz-acp`, which
+//! defaults to `ws://localhost:3000`) and at least one `--allowed-root`, so
+//! a relay operator can never end up running it by accident against the
+//! wrong deployment or with an unbounded filesystem scope. See relay.md for
+//! the full design rationale.
+#![deny(unsafe_code)]
+
+mod config;
+mod provision;
+mod security;
+mod state;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use nostr::Keys;
+use regex::Regex;
+
+use buzz_cli::client::BuzzClient;
+
+use config::SupervisorConfig;
+use provision::Ctx;
+use security::AllowedRoots;
+use state::StateStore;
+
+#[derive(Parser)]
+#[command(
+    about = "Headless relay-side agent-team supervisor (server analog of Buzz Desktop Managed Agents)",
+    after_help = "Example:\n  buzz-supervisor \\\n    --relay-url http://lotto645.lge.com:3000 \\\n    --private-key <owner-cli-key> \\\n    --relay-admin-key <BUZZ_RELAY_PRIVATE_KEY> \\\n    --allowed-root /home/alice/code \\\n    --roles-file /home/alice/.buzz_agents/roles.toml \\\n    --state-dir /home/alice/.buzz_agents/supervisor/state"
+)]
+struct Args {
+    /// Relay base URL. Required, no default — buzz-supervisor only runs
+    /// against a relay deployment its operator has deliberately named.
+    #[arg(long, env = "BUZZ_SUPERVISOR_RELAY_URL")]
+    relay_url: String,
+
+    /// Private key (hex or nsec) for the identity that owns every
+    /// provisioned channel membership/profile this instance creates.
+    #[arg(long, env = "BUZZ_SUPERVISOR_PRIVATE_KEY")]
+    private_key: String,
+
+    /// Relay admin signing key, forwarded to `buzz-admin add-member` for
+    /// relay-wide membership registration (see relay-admin's own docs for
+    /// why this can't be done over the plain client HTTP API).
+    #[arg(long, env = "BUZZ_SUPERVISOR_RELAY_ADMIN_KEY")]
+    relay_admin_key: String,
+
+    /// Path to the `buzz-admin` binary.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ADMIN_BIN", default_value = "buzz-admin")]
+    admin_bin: PathBuf,
+
+    /// Path to the `buzz-acp` binary spawned per role.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ACP_BIN", default_value = "buzz-acp")]
+    acp_bin: PathBuf,
+
+    /// Directory agents are allowed to work in (repeatable). Any `workdir`
+    /// resolving (after symlink/`..` resolution) outside every one of these
+    /// is rejected — this is the security boundary, not `channel_add_policy`
+    /// or anything relay-side.
+    #[arg(long = "allowed-root", required = true)]
+    allowed_roots: Vec<PathBuf>,
+
+    /// TOML file defining the team roster (roles → harness/prompt). See
+    /// `roles.example.toml` in this crate for the shape.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ROLES_FILE")]
+    roles_file: PathBuf,
+
+    /// Directory for per-channel state (generated keys, pids, per-role logs).
+    #[arg(long, env = "BUZZ_SUPERVISOR_STATE_DIR")]
+    state_dir: PathBuf,
+
+    /// Poll interval in seconds.
+    #[arg(long, default_value_t = 20)]
+    poll_interval_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let config = SupervisorConfig::load(&args.roles_file)?;
+    let allowed_roots = AllowedRoots::new(args.allowed_roots.clone())?;
+    let state = StateStore::new(args.state_dir.clone())?;
+
+    let keys = Keys::parse(&args.private_key)
+        .map_err(|e| anyhow::anyhow!("invalid --private-key: {e}"))?;
+    let client = BuzzClient::new(args.relay_url.clone(), keys, None, None)
+        .map_err(|e| anyhow::anyhow!("building relay client: {e}"))?;
+
+    // `workdir:` may appear anywhere in the description (e.g. embedded in a
+    // longer human-written sentence), and humans won't always type it with
+    // zero spacing around the colon — allow whitespace there, but capture
+    // the path itself up to the next whitespace.
+    let workdir_pattern = Regex::new(r"workdir\s*:\s*(\S+)")?;
+
+    tracing::info!(
+        relay_url = %args.relay_url,
+        allowed_roots = ?args.allowed_roots,
+        roles = ?config.roles.iter().map(|r| &r.name).collect::<Vec<_>>(),
+        poll_interval_secs = args.poll_interval_secs,
+        "buzz-supervisor starting"
+    );
+
+    let ctx = Ctx {
+        client,
+        config,
+        allowed_roots,
+        state,
+        acp_bin: args.acp_bin,
+        admin_bin: args.admin_bin,
+        relay_admin_key: args.relay_admin_key,
+        relay_url_for_admin: args.relay_url,
+        workdir_pattern,
+    };
+
+    loop {
+        if let Err(e) = provision::run_once(&ctx).await {
+            tracing::error!(error = %e, "poll iteration failed");
+        }
+        tokio::time::sleep(Duration::from_secs(args.poll_interval_secs)).await;
+    }
+}

--- a/crates/buzz-supervisor/src/provision.rs
+++ b/crates/buzz-supervisor/src/provision.rs
@@ -1,0 +1,490 @@
+//! Core reconciliation loop: discover channels, provision new ones whose
+//! `description` declares a `workdir:`, heal dead role processes, and tear
+//! down channels that disappear (archived/deleted).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use buzz_cli::client::{extract_d_tag, extract_tag_value, BuzzClient};
+use buzz_core::kind::KIND_AGENT_PROFILE;
+use nostr::{EventBuilder, Keys, Kind};
+use regex::Regex;
+use uuid::Uuid;
+
+use crate::config::SupervisorConfig;
+use crate::security::AllowedRoots;
+use crate::state::{ChannelState, ChannelStatus, RoleState, StateStore};
+
+pub struct Ctx {
+    pub client: BuzzClient,
+    pub config: SupervisorConfig,
+    pub allowed_roots: AllowedRoots,
+    pub state: StateStore,
+    pub acp_bin: PathBuf,
+    pub admin_bin: PathBuf,
+    pub relay_admin_key: String,
+    pub relay_url_for_admin: String,
+    pub workdir_pattern: Regex,
+}
+
+/// One full pass over every channel: provision new matches, heal known
+/// teams, tear down ones that vanished from the channel list.
+pub async fn run_once(ctx: &Ctx) -> anyhow::Result<()> {
+    let channels = list_channels(&ctx.client).await?;
+    let seen: std::collections::HashSet<&str> =
+        channels.iter().map(|c| c.channel_id.as_str()).collect();
+
+    for channel in &channels {
+        match ctx.state.load(&channel.channel_id)? {
+            None => handle_new_channel(ctx, channel).await?,
+            // Resume rather than skip: `provision_team` is safe to re-enter
+            // (each step is keyed by role name / presence of a pid), so an
+            // interruption on the previous poll just continues here instead
+            // of sitting stuck forever.
+            Some(state) if matches!(state.status, ChannelStatus::Provisioning) => {
+                let workdir = state
+                    .workdir
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("Provisioning state missing workdir"))?;
+                provision_team(ctx, &channel.channel_id, Path::new(&workdir)).await?
+            }
+            Some(state) => heal_channel(ctx, &channel.channel_id, &state)?,
+        }
+    }
+
+    for known_id in ctx.state.known_channels()? {
+        if seen.contains(known_id.as_str()) {
+            continue;
+        }
+        if let Some(state) = ctx.state.load(&known_id)? {
+            if matches!(state.status, ChannelStatus::Provisioned) {
+                tear_down(ctx, &known_id, &state)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct ChannelSummary {
+    channel_id: String,
+    description: String,
+}
+
+async fn list_channels(client: &BuzzClient) -> anyhow::Result<Vec<ChannelSummary>> {
+    let filter = serde_json::json!({ "kinds": [39000], "limit": 500 });
+    let resp = client
+        .query(&filter)
+        .await
+        .map_err(|e| anyhow::anyhow!("channels query failed: {e}"))?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&resp)?;
+    Ok(events
+        .iter()
+        .map(|e| ChannelSummary {
+            channel_id: extract_d_tag(e),
+            description: extract_tag_value(e, "about"),
+        })
+        .filter(|c| !c.channel_id.is_empty())
+        .collect())
+}
+
+async fn handle_new_channel(ctx: &Ctx, channel: &ChannelSummary) -> anyhow::Result<()> {
+    let Some(captures) = ctx.workdir_pattern.captures(&channel.description) else {
+        ctx.state.save(
+            &channel.channel_id,
+            &ChannelState {
+                status: ChannelStatus::Ignored,
+                workdir: None,
+                roles: HashMap::new(),
+            },
+        )?;
+        return Ok(());
+    };
+    let raw_path = &captures[1];
+
+    match ctx.allowed_roots.validate(raw_path) {
+        Ok(resolved) => provision_team(ctx, &channel.channel_id, &resolved).await,
+        Err(reason) => reject_channel(ctx, &channel.channel_id, &reason).await,
+    }
+}
+
+/// Provisions a team, saving state to disk after every side-effecting step.
+///
+/// This is deliberately not "do everything, then save once at the end": an
+/// earlier version did that, and any error partway through (e.g. the 3rd
+/// role's `publish-profile` HTTP call failing) left the channel with no
+/// state file at all — so the *next* poll saw it as brand new and started
+/// over, generating and registering a fresh set of keys every poll interval
+/// forever. Saving after each step means a mid-provisioning failure is
+/// recorded as `Provisioning` with exactly the roles created so far, and is
+/// never silently retried from scratch.
+async fn provision_team(ctx: &Ctx, channel_id: &str, workdir: &Path) -> anyhow::Result<()> {
+    let channel_uuid = Uuid::parse_str(channel_id)?;
+    let mut state = ctx.state.load(channel_id)?.unwrap_or(ChannelState {
+        status: ChannelStatus::Provisioning,
+        workdir: Some(workdir.display().to_string()),
+        roles: HashMap::new(),
+    });
+
+    let owner_pubkey = ctx.client.keys().public_key().to_hex();
+    let mut allowlist: Vec<String> = ctx.config.extra_allowlist.clone();
+    allowlist.push(owner_pubkey);
+
+    // Phase 1: one identity per role — generate, register, add as a channel
+    // member. Persisted immediately per-role so a failure here never
+    // re-generates roles that already succeeded.
+    for role in &ctx.config.roles {
+        if state.roles.contains_key(&role.name) {
+            continue; // already done in a prior (interrupted) attempt
+        }
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        admin_register_member(ctx, &pubkey)?;
+        add_channel_member(ctx, channel_uuid, &pubkey, "bot").await?;
+        allowlist.push(pubkey.clone());
+        state.roles.insert(
+            role.name.clone(),
+            RoleState {
+                pubkey,
+                privkey: keys.secret_key().display_secret().to_string(),
+                pid: None,
+            },
+        );
+        ctx.state.save(channel_id, &state)?;
+    }
+    for shared in &ctx.config.shared_members {
+        add_channel_member(ctx, channel_uuid, shared, "bot").await?;
+    }
+
+    let project_label = workdir
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| workdir.display().to_string());
+
+    // Phase 2: publish each role's profile and spawn its process. Also
+    // persisted per-role, and skipped for roles that already have a pid
+    // (i.e. already finished in a prior attempt).
+    for role_config in &ctx.config.roles {
+        let role_state = state
+            .roles
+            .get(&role_config.name)
+            .ok_or_else(|| anyhow::anyhow!("role {} missing after phase 1", role_config.name))?
+            .clone();
+        if role_state.pid.is_some() {
+            continue;
+        }
+        let keys = Keys::parse(&role_state.privkey)?;
+        let display_name = format!("{} ({project_label})", role_config.display_name);
+
+        publish_agent_profile(ctx, &keys, &display_name, channel_id, &allowlist).await?;
+        publish_kind0_profile(ctx, &keys, &display_name).await?;
+
+        let pid = spawn_role(ctx, channel_id, role_config, &keys, workdir, &allowlist)?;
+        state.roles.insert(
+            role_config.name.clone(),
+            RoleState {
+                pid: Some(pid),
+                ..role_state
+            },
+        );
+        ctx.state.save(channel_id, &state)?;
+    }
+
+    state.status = ChannelStatus::Provisioned;
+    ctx.state.save(channel_id, &state)?;
+
+    send_message(
+        ctx,
+        channel_uuid,
+        &format!(
+            "✅ Team started in `{}`: {}.",
+            workdir.display(),
+            ctx.config
+                .roles
+                .iter()
+                .map(|r| r.display_name.as_str())
+                .collect::<Vec<_>>()
+                .join("/")
+        ),
+    )
+    .await?;
+
+    tracing::info!(channel_id, workdir = %workdir.display(), "provisioned");
+    Ok(())
+}
+
+async fn reject_channel(ctx: &Ctx, channel_id: &str, reason: &str) -> anyhow::Result<()> {
+    ctx.state.save(
+        channel_id,
+        &ChannelState {
+            status: ChannelStatus::Rejected {
+                reason: reason.to_string(),
+            },
+            workdir: None,
+            roles: HashMap::new(),
+        },
+    )?;
+    if let Ok(channel_uuid) = Uuid::parse_str(channel_id) {
+        let _ = send_message(
+            ctx,
+            channel_uuid,
+            &format!("⚠️ Rejected workdir setting: {reason}"),
+        )
+        .await;
+    }
+    tracing::warn!(channel_id, reason, "rejected");
+    Ok(())
+}
+
+fn heal_channel(ctx: &Ctx, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+    if !matches!(state.status, ChannelStatus::Provisioned) {
+        return Ok(());
+    }
+    let Some(workdir) = &state.workdir else {
+        return Ok(());
+    };
+    let allowlist: Vec<String> = std::iter::once(ctx.client.keys().public_key().to_hex())
+        .chain(ctx.config.extra_allowlist.iter().cloned())
+        .chain(state.roles.values().map(|r| r.pubkey.clone()))
+        .collect();
+
+    let mut updated = state.clone();
+    let mut changed = false;
+    for role_config in &ctx.config.roles {
+        let Some(role_state) = updated.roles.get(&role_config.name) else {
+            continue;
+        };
+        if let Some(pid) = role_state.pid {
+            if process_alive(pid) {
+                continue;
+            }
+        }
+        tracing::warn!(
+            channel_id,
+            role = role_config.name,
+            "dead agent, restarting"
+        );
+        let keys = Keys::parse(&role_state.privkey)?;
+        let pid = spawn_role(
+            ctx,
+            channel_id,
+            role_config,
+            &keys,
+            Path::new(workdir),
+            &allowlist,
+        )?;
+        updated.roles.insert(
+            role_config.name.clone(),
+            RoleState {
+                pubkey: role_state.pubkey.clone(),
+                privkey: role_state.privkey.clone(),
+                pid: Some(pid),
+            },
+        );
+        changed = true;
+    }
+    if changed {
+        ctx.state.save(channel_id, &updated)?;
+    }
+    Ok(())
+}
+
+fn tear_down(ctx: &Ctx, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+    for (role, role_state) in &state.roles {
+        if let Some(pid) = role_state.pid {
+            tracing::info!(
+                channel_id,
+                role,
+                pid,
+                "tearing down (channel no longer listed)"
+            );
+            stop_process(pid);
+        }
+    }
+    let mut updated = state.clone();
+    updated.status = ChannelStatus::TornDown;
+    ctx.state.save(channel_id, &updated)?;
+    Ok(())
+}
+
+fn spawn_role(
+    ctx: &Ctx,
+    channel_id: &str,
+    role: &crate::config::RoleConfig,
+    keys: &Keys,
+    workdir: &Path,
+    allowlist: &[String],
+) -> anyhow::Result<u32> {
+    use std::os::unix::process::CommandExt;
+
+    let log_path = ctx.state.log_path(channel_id, &role.name);
+    let log_file = std::fs::File::create(&log_path)?;
+    let log_file_err = log_file.try_clone()?;
+
+    let mut cmd = Command::new(&ctx.acp_bin);
+    cmd.current_dir(workdir)
+        .env("BUZZ_ACP_AGENT_COMMAND", &role.agent_command)
+        .env("BUZZ_RELAY_URL", ws_url(&ctx.relay_url_for_admin))
+        .env(
+            "BUZZ_PRIVATE_KEY",
+            keys.secret_key().display_secret().to_string(),
+        )
+        .arg("--respond-to")
+        .arg("allowlist")
+        .arg("--respond-to-allowlist")
+        .arg(allowlist.join(","))
+        .stdin(Stdio::null())
+        .stdout(log_file)
+        .stderr(log_file_err)
+        .process_group(0); // detach from our own process group, like setsid
+
+    if role.subscribe_all {
+        cmd.arg("--subscribe").arg("all");
+    }
+    if let Some(prompt_file) = &role.system_prompt_file {
+        let prompt = std::fs::read_to_string(prompt_file)
+            .map_err(|e| anyhow::anyhow!("reading system_prompt_file {prompt_file}: {e}"))?;
+        cmd.env("BUZZ_ACP_SYSTEM_PROMPT", prompt);
+    }
+
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    // Deliberately not waited on: this is a long-running detached agent
+    // process, tracked by pid in state.json, not as a child of ours.
+    std::mem::forget(child);
+    tracing::info!(channel_id, role = role.name, pid, workdir = %workdir.display(), "launched");
+    Ok(pid)
+}
+
+fn process_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// Sends SIGTERM to a recorded pid. Uses `nix::sys::signal::kill` — a safe
+/// wrapper around the POSIX `kill` syscall — so this crate's
+/// `#![deny(unsafe_code)]` policy (same as `buzz-acp`) is preserved. A
+/// stale/reused pid just gets a harmless signal delivery, or `ESRCH` if it's
+/// already gone — either way there's nothing actionable for the caller.
+fn stop_process(pid: u32) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+
+    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+}
+
+fn ws_url(http_url: &str) -> String {
+    http_url
+        .replacen("http://", "ws://", 1)
+        .replacen("https://", "wss://", 1)
+}
+
+fn admin_register_member(ctx: &Ctx, pubkey: &str) -> anyhow::Result<()> {
+    let status = Command::new(&ctx.admin_bin)
+        .arg("add-member")
+        .arg("--pubkey")
+        .arg(pubkey)
+        .arg("--role")
+        .arg("member")
+        .env("BUZZ_RELAY_PRIVATE_KEY", &ctx.relay_admin_key)
+        .env("BUZZ_RELAY_URL", &ctx.relay_url_for_admin)
+        .stdout(Stdio::null())
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("buzz-admin add-member failed for {pubkey}: {status}");
+    }
+    Ok(())
+}
+
+async fn add_channel_member(
+    ctx: &Ctx,
+    channel_id: Uuid,
+    pubkey: &str,
+    role: &str,
+) -> anyhow::Result<()> {
+    use buzz_sdk::builders::build_add_member;
+    use buzz_sdk::MemberRole;
+    let member_role = match role {
+        "bot" => MemberRole::Bot,
+        _ => MemberRole::Member,
+    };
+    let builder = build_add_member(channel_id, pubkey, Some(member_role))
+        .map_err(|e| anyhow::anyhow!("build_add_member: {e}"))?;
+    let event = ctx.client.sign_event(builder)?;
+    ctx.client
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("add-member submit failed: {e}"))?;
+    Ok(())
+}
+
+async fn publish_agent_profile(
+    ctx: &Ctx,
+    keys: &Keys,
+    display_name: &str,
+    channel_id: &str,
+    allowlist: &[String],
+) -> anyhow::Result<()> {
+    let content = serde_json::json!({
+        "name": display_name,
+        "agent_type": "agent",
+        "channels": [],
+        "channel_ids": [channel_id],
+        "capabilities": [],
+        "status": "online",
+        "respond_to": "allowlist",
+        "respond_to_allowlist": allowlist,
+        // See relay.md #6: "anyone" is deliberate — respond_to_allowlist is
+        // the real trigger boundary, and owner_only would need an "owner"
+        // field this crate never sets, permanently blocking re-use of a
+        // shared identity across channels.
+        "channel_add_policy": "anyone",
+    })
+    .to_string();
+    let builder = EventBuilder::new(Kind::Custom(KIND_AGENT_PROFILE as u16), &content).tags([]);
+    let event = sign_as(keys, builder)?;
+    client_for(ctx, keys)?
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("publish-profile failed: {e}"))?;
+    Ok(())
+}
+
+async fn publish_kind0_profile(ctx: &Ctx, keys: &Keys, display_name: &str) -> anyhow::Result<()> {
+    let content =
+        serde_json::json!({ "name": display_name, "display_name": display_name }).to_string();
+    let builder = EventBuilder::new(Kind::Metadata, &content);
+    let event = sign_as(keys, builder)?;
+    client_for(ctx, keys)?
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("kind:0 profile publish failed: {e}"))?;
+    Ok(())
+}
+
+/// Relay's `/events` endpoint requires the event's `pubkey` to match the
+/// NIP-98-authenticated identity of the request itself, so each agent
+/// identity's own events must be submitted through a client authenticated
+/// as *that* identity — `ctx.client` (the owner) can't submit on its behalf.
+fn client_for(ctx: &Ctx, keys: &Keys) -> anyhow::Result<BuzzClient> {
+    BuzzClient::new(ctx.relay_url_for_admin.clone(), keys.clone(), None, None)
+        .map_err(|e| anyhow::anyhow!("building per-identity client: {e}"))
+}
+
+async fn send_message(ctx: &Ctx, channel_id: Uuid, content: &str) -> anyhow::Result<()> {
+    use buzz_sdk::builders::build_message;
+    let builder = build_message(channel_id, content, None, &[], false, &[])
+        .map_err(|e| anyhow::anyhow!("build_message: {e}"))?;
+    let event = ctx.client.sign_event(builder)?;
+    ctx.client
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("send_message failed: {e}"))?;
+    Ok(())
+}
+
+fn sign_as(keys: &Keys, builder: EventBuilder) -> anyhow::Result<nostr::Event> {
+    builder
+        .sign_with_keys(keys)
+        .map_err(|e| anyhow::anyhow!("signing failed: {e}"))
+}

--- a/crates/buzz-supervisor/src/security.rs
+++ b/crates/buzz-supervisor/src/security.rs
@@ -1,0 +1,92 @@
+//! Workdir validation — the load-bearing security boundary for this crate.
+//!
+//! A channel's declared working directory is attacker-influenced (anyone who
+//! can create a channel controls this string), so it must be canonicalized
+//! and checked against an explicit allowlist of roots *before* anything is
+//! spawned there. There is no default allowed root — the operator must pass
+//! at least one `--allowed-root`.
+
+use std::path::{Path, PathBuf};
+
+pub struct AllowedRoots(Vec<PathBuf>);
+
+impl AllowedRoots {
+    pub fn new(roots: Vec<PathBuf>) -> anyhow::Result<Self> {
+        if roots.is_empty() {
+            anyhow::bail!("at least one --allowed-root is required");
+        }
+        let canonical = roots
+            .iter()
+            .map(|r| {
+                r.canonicalize()
+                    .map_err(|e| anyhow::anyhow!("--allowed-root {}: {e}", r.display()))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self(canonical))
+    }
+
+    /// Expand a `~`/`~/...` prefix using `$HOME`, leaving other paths as-is.
+    fn expand_tilde(raw: &str) -> anyhow::Result<PathBuf> {
+        if raw == "~" || raw.starts_with("~/") {
+            let home = std::env::var("HOME")
+                .map_err(|_| anyhow::anyhow!("workdir uses ~ but $HOME is not set"))?;
+            let rest = raw.strip_prefix('~').unwrap_or("").trim_start_matches('/');
+            return Ok(Path::new(&home).join(rest));
+        }
+        Ok(PathBuf::from(raw))
+    }
+
+    /// Validate a raw workdir string from a channel description.
+    ///
+    /// Returns the canonicalized path on success, or a human-readable
+    /// rejection reason (suitable for posting back into the channel) on
+    /// failure.
+    pub fn validate(&self, raw: &str) -> Result<PathBuf, String> {
+        let expanded = Self::expand_tilde(raw).map_err(|e| format!("{e} (workdir: {raw})"))?;
+        if !expanded.is_absolute() {
+            return Err(format!("not an absolute path (or ~/...): {raw}"));
+        }
+        let resolved = expanded
+            .canonicalize()
+            .map_err(|_| format!("path does not exist: {}", expanded.display()))?;
+        if !resolved.is_dir() {
+            return Err(format!("not a directory: {}", resolved.display()));
+        }
+        if self.0.iter().any(|root| resolved.starts_with(root)) {
+            Ok(resolved)
+        } else {
+            Err(format!(
+                "outside allowed roots ({}): {}",
+                self.0
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                resolved.display()
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_paths_outside_allowed_roots() {
+        let tmp = std::env::temp_dir();
+        let roots = AllowedRoots::new(vec![tmp.join("buzz-supervisor-test-root")]).ok();
+        // Root doesn't exist yet in a fresh test env — construct directly
+        // instead to keep this test hermetic.
+        let _ = roots;
+        let allowed = AllowedRoots(vec![tmp.canonicalize().unwrap()]);
+        assert!(allowed.validate("/etc").is_err());
+    }
+
+    #[test]
+    fn accepts_paths_inside_allowed_roots() {
+        let tmp = std::env::temp_dir().canonicalize().unwrap();
+        let allowed = AllowedRoots(vec![tmp.clone()]);
+        assert_eq!(allowed.validate(tmp.to_str().unwrap()).unwrap(), tmp);
+    }
+}

--- a/crates/buzz-supervisor/src/state.rs
+++ b/crates/buzz-supervisor/src/state.rs
@@ -1,0 +1,95 @@
+//! Per-channel provisioning state, persisted to disk so a supervisor restart
+//! doesn't lose track of (or re-provision) channels it already handled.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChannelStatus {
+    /// Fully set up: every role has a published profile and a running (or
+    /// last-known-pid) process.
+    Provisioned,
+    /// Provisioning started but did not finish — at least one role's
+    /// identity/membership below was created before an error interrupted
+    /// the rest. Not retried automatically (that's how a partial failure
+    /// used to leak a fresh set of keys/memberships every poll cycle);
+    /// an operator must inspect `roles` and either finish setup manually or
+    /// delete this channel's state directory to start over.
+    Provisioning,
+    Rejected {
+        reason: String,
+    },
+    Ignored,
+    TornDown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleState {
+    pub pubkey: String,
+    pub privkey: String,
+    pub pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelState {
+    pub status: ChannelStatus,
+    pub workdir: Option<String>,
+    #[serde(default)]
+    pub roles: HashMap<String, RoleState>,
+}
+
+pub struct StateStore {
+    root: PathBuf,
+}
+
+impl StateStore {
+    pub fn new(root: PathBuf) -> anyhow::Result<Self> {
+        fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn path_for(&self, channel_id: &str) -> PathBuf {
+        self.root.join(channel_id).join("state.json")
+    }
+
+    pub fn known_channels(&self) -> anyhow::Result<Vec<String>> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    out.push(name.to_string());
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn load(&self, channel_id: &str) -> anyhow::Result<Option<ChannelState>> {
+        let path = self.path_for(channel_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&path)?;
+        Ok(Some(serde_json::from_str(&raw)?))
+    }
+
+    pub fn save(&self, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+        let dir = self.root.join(channel_id);
+        fs::create_dir_all(&dir)?;
+        let path = self.path_for(channel_id);
+        let raw = serde_json::to_string_pretty(state)?;
+        fs::write(&path, raw)?;
+        // State contains generated private keys — lock it down like the
+        // individual key files the earlier bash prototype used.
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    }
+
+    pub fn log_path(&self, channel_id: &str, role: &str) -> PathBuf {
+        self.root.join(channel_id).join(format!("{role}.log"))
+    }
+}


### PR DESCRIPTION
Implements #5529.

## What this is

`crates/buzz-supervisor` — a new long-running binary (same shape as `buzz-acp`) that's the server-side analog of Buzz Desktop's Managed Agents: it watches a relay for channels whose `description` declares a `workdir:<path>`, and provisions/heals/tears down a team of `buzz-acp` processes rooted there. See #5529 for the full motivation and design discussion.

Depends on #5528 (`agents publish-profile`) conceptually — both publish the same `kind:10100` shape — but not at the code level; `buzz-supervisor` constructs that event directly rather than shelling out to the CLI, so this PR stands alone and doesn't block on #5528 merging first.

## Safety / off-by-default

- `--relay-url` has no default (unlike `buzz-acp`, which defaults to `ws://localhost:3000`) — the binary does nothing until an operator names a relay explicitly.
- `--allowed-root` is required with no default — any `workdir` resolving outside every configured root is rejected, and the rejection reason is posted back into the channel.
- Reuses `buzz-cli`'s `BuzzClient` as a library dependency (`crates/buzz-cli/src/lib.rs` now exposes `pub mod client` / `pub mod error`) instead of reimplementing NIP-98-signed relay HTTP calls.

## Bugs found and fixed while validating against a live relay

- **State-persistence bug**: an earlier version saved provisioning state once at the end. Any error partway through (e.g. one role's `publish-profile` call failing) left the channel with no state file, so the next poll saw it as brand new and restarted from scratch — generating and registering a fresh set of keys/memberships every poll interval, indefinitely. Caught in testing: one interrupted run leaked 50+ throwaway identities into a single channel in under a minute. Fixed with a `Provisioning` status that records exactly which roles succeeded so far; the next poll resumes instead of restarting, and each step is idempotent.
- **TOML footgun**: `[[roles]]` array-of-tables syntax silently attaches trailing top-level keys (`shared_members`, `extra_allowlist`) to the last table instead of the document root — this quietly dropped both during testing. Fixed the example file's key ordering and added `#[serde(deny_unknown_fields)]` to both config structs so the same mistake fails loudly instead of silently losing data.
- **`#![deny(unsafe_code)]` / no `unwrap()`/`expect()` in production paths**: an earlier pass used a raw `extern "C"` FFI call for `kill(2)` and an `.expect()` on a `HashMap` lookup. Replaced the FFI call with `nix::sys::signal::kill` (the same safe-wrapper approach `buzz-acp`'s `kill_process_group` already uses) and the `.expect()` with a proper `anyhow` error.

## Testing

- `cargo test -p buzz-cli -p buzz-supervisor --lib` — 343 passed
- `cargo clippy -p buzz-cli -p buzz-supervisor --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Manually validated end-to-end against a running relay + real `claude-agent-acp` sessions: channel creation with a `workdir:` description → team provisioned, members added, `@`-mentionable, correctly answered a question scoped to that directory (`pwd`) → channel deletion → processes torn down. Also verified the security boundary by pointing a `workdir` outside the allowed root and confirming rejection.

## Known gaps

- Unit/integration test coverage beyond `security.rs`'s allowed-roots tests — the provisioning path was validated manually against a live relay, not under `cargo test`.
- No docs page yet analogous to `docs/multi-tenant-relay.md` for the security model.
- See #5529's "Open questions" for design points still up for discussion (separate binary vs. `buzz-acp --supervise` mode, where the allowed-roots policy should live long-term, first-class `workdir` field vs. the `description` convention).