### PR TITLE
fix(acp): correct heartbeat reply guidance

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4301,13 +4301,32 @@ fn default_heartbeat_prompt() -> String {
          1. Run `buzz feed get --types needs_action` to check for pending workflow approvals or\n\
             high-priority requests addressed to you.\n\
          2. Run `buzz feed get --types mentions` to check for unanswered @mentions.\n\
-         3. If you find actionable items, address them using the appropriate CLI commands\n\
-            (e.g., `buzz workflows approve --token <UUID>`, `buzz messages send`,\n\
-            `buzz messages send --reply-to <event-id>`).\n\
-         4. If there are no pending actions or mentions, end your turn immediately.\n\n\
+         3. For each actionable feed mention, reply directly with\n\
+            `buzz messages send --channel <channel-uuid-from-h-tag> --reply-to <feed-event-id> --content \"...\"`.\n\
+            The `--reply-to` flag resolves the thread root automatically.\n\
+         4. Address other actionable items using the appropriate CLI commands\n\
+            (e.g., `buzz workflows approve --token <UUID>`, `buzz messages send`).\n\
+         5. If there are no pending actions or mentions, end your turn immediately.\n\n\
          Do not run `buzz channels list` or `buzz messages search` unless you have a specific reason.\n\
          Do not invent work — only act on items surfaced by the feed commands."
     )
+}
+
+#[cfg(test)]
+mod heartbeat_prompt_tests {
+    use super::default_heartbeat_prompt;
+
+    #[test]
+    fn default_heartbeat_prompt_replies_directly_to_feed_mentions() {
+        let prompt = default_heartbeat_prompt();
+
+        assert!(prompt.contains("For each actionable feed mention"));
+        assert!(prompt.contains(
+            "buzz messages send --channel <channel-uuid-from-h-tag> --reply-to <feed-event-id> --content \"...\""
+        ));
+        assert!(prompt.contains("The `--reply-to` flag resolves the thread root automatically"));
+        assert!(!prompt.contains("buzz messages thread"));
+    }
 }
 
 /// Spawn a background respawn task for a crashed agent slot.


### PR DESCRIPTION
Agents responding to feed mentions during heartbeat turns had no thread context,
causing replies to go unthreaded or silent. This adds explicit instructions to
`default_heartbeat_prompt` telling agents to reply directly to the feed mention
ID with `--reply-to`; the CLI resolves the thread root automatically.

Fixes https://github.com/block/buzz/issues/5532

Signed-off-by: Cameron Hotchkies <chotchkies@block.xyz>
refs: https://github.com/block/buzz/issues/5532
