### PR TITLE
fix(desktop): pass managed-agent owner attestation to git credential helper

### DIFF
--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -48,6 +48,7 @@ pub(crate) struct GitAuthConfig {
     git_path: std::path::PathBuf,
     credential_helper: Option<std::path::PathBuf>,
     nsec: String,
+    auth_tag: Option<String>,
     allow_file_transport: bool,
 }
 
@@ -173,6 +174,13 @@ fn configure_git_auth(command: &mut Command, auth: &GitAuthConfig, needs_credent
             return apply_git_config(command, &entries);
         };
         command.env("NOSTR_PRIVATE_KEY", &auth.nsec);
+        // A managed-agent identity is only a relay member together with its
+        // NIP-OA owner attestation; without it the relay refuses the key with
+        // `403 restricted: not a relay member`. git-credential-nostr reads the
+        // attestation from BUZZ_AUTH_TAG and folds it into the NIP-98 event.
+        if let Some(auth_tag) = &auth.auth_tag {
+            command.env("BUZZ_AUTH_TAG", auth_tag);
+        }
         entries.push((
             "credential.helper",
             credential_helper_config_value(cred_helper),
@@ -213,6 +221,7 @@ pub(crate) fn build_git_clone_auth_config(
                 .ok_or_else(|| "git was not found on PATH".to_string())?,
             credential_helper: None,
             nsec: String::new(),
+            auth_tag: None,
             allow_file_transport: false,
         });
     }
@@ -230,8 +239,24 @@ pub(crate) fn build_git_auth_config_for_keys(keys: &Keys) -> Result<GitAuthConfi
         git_path,
         credential_helper,
         nsec,
+        auth_tag: None,
         allow_file_transport: false,
     })
+}
+
+/// Like [`build_git_auth_config_for_keys`], but for identities that carry a
+/// NIP-OA owner attestation (managed agents acting as repository owner). The
+/// attestation is required for the relay to accept the key as a member.
+pub(crate) fn build_git_auth_config_for_identity(
+    keys: &Keys,
+    auth_tag: Option<&str>,
+) -> Result<GitAuthConfig, String> {
+    let mut auth = build_git_auth_config_for_keys(keys)?;
+    auth.auth_tag = auth_tag
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    Ok(auth)
 }
 
 #[cfg(test)]
@@ -393,10 +418,42 @@ fn validate_clone_url_against_relay(clone_url: &str, relay_base: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        clean_branch, clean_target_ref, credential_helper_config_value, git_needs_credentials,
-        git_subcommand, validate_clone_url, validate_clone_url_against_relay,
-        validate_local_clone_url,
+        clean_branch, clean_target_ref, configure_git_auth, credential_helper_config_value,
+        git_needs_credentials, git_subcommand, validate_clone_url,
+        validate_clone_url_against_relay, validate_local_clone_url, GitAuthConfig,
     };
+
+    fn env_value(command: &std::process::Command, name: &str) -> Option<String> {
+        command.get_envs().find_map(|(key, value)| {
+            (key == name).then(|| value.unwrap_or_default().to_string_lossy().into_owned())
+        })
+    }
+
+    fn auth_config_with_tag(auth_tag: Option<&str>) -> GitAuthConfig {
+        GitAuthConfig {
+            git_path: std::path::PathBuf::from("git"),
+            credential_helper: Some(std::path::PathBuf::from("git-credential-nostr")),
+            nsec: "nsec1test".to_string(),
+            auth_tag: auth_tag.map(ToString::to_string),
+            allow_file_transport: false,
+        }
+    }
+
+    #[test]
+    fn credentialed_git_receives_owner_attestation_when_present() {
+        let tag = r#"["auth","owner","conditions","signature"]"#;
+        let mut command = std::process::Command::new("git");
+        configure_git_auth(&mut command, &auth_config_with_tag(Some(tag)), true);
+        assert_eq!(env_value(&command, "BUZZ_AUTH_TAG").as_deref(), Some(tag));
+        assert!(env_value(&command, "NOSTR_PRIVATE_KEY").is_some());
+    }
+
+    #[test]
+    fn credentialed_git_omits_attestation_when_absent() {
+        let mut command = std::process::Command::new("git");
+        configure_git_auth(&mut command, &auth_config_with_tag(None), true);
+        assert_eq!(env_value(&command, "BUZZ_AUTH_TAG"), None);
+    }
 
     #[test]
     fn credential_helper_config_value_uses_forward_slashes() {

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -3,7 +3,7 @@
 use super::project_git::{first_output_line, normalize_branch_option};
 use super::project_git_diff::clean_commit;
 use super::project_git_exec::{
-    build_git_auth_config_for_keys, build_git_clone_auth_config, clone_url_owner, run_git,
+    build_git_auth_config_for_identity, build_git_clone_auth_config, clone_url_owner, run_git,
     validate_local_clone_url, validate_local_clone_url_for_workspace, validate_workspace_clone_url,
     GitAuthConfig,
 };
@@ -548,7 +548,10 @@ pub async fn merge_project_pull_request(
         &pull_request_id,
         &pull_request_author,
     )?;
-    let auth = build_git_auth_config_for_keys(&owner_identity.keys)?;
+    let auth = build_git_auth_config_for_identity(
+        &owner_identity.keys,
+        owner_identity.auth_tag.as_deref(),
+    )?;
 
     let git_result = tauri::async_runtime::spawn_blocking(
         move || -> Result<ProjectRepoMergeGitResult, ProjectPullRequestMergeError> {


### PR DESCRIPTION
## Problem

Merging a pull request from Desktop fails with `403 restricted: not a relay member` whenever the target repository is owned by a **managed agent**. The failure happens during the merge's temporary clone, before any merge or push.

`merge_project_pull_request` resolves the repository owner's identity (`project_owner_identity`), which for a managed agent includes the NIP-OA owner attestation (`record.auth_tag`). The status-event path passes that attestation to `submit_signed_event_with_keys`, but the git path built its credentials with `build_git_auth_config_for_keys`, which only exports `NOSTR_PRIVATE_KEY`. `git-credential-nostr` already supports folding the attestation into the signed NIP-98 event via `BUZZ_AUTH_TAG` (it can't use a separate HTTP header, so the tag must ride in the signed event) — the desktop app just never handed it over. The relay therefore sees a bare agent key, refuses it as a non-member, and every Desktop merge of an agent-owned repo fails.

## Fix

- Add an optional `auth_tag` to `GitAuthConfig`, exported as `BUZZ_AUTH_TAG` alongside `NOSTR_PRIVATE_KEY` when git needs credentials.
- Add `build_git_auth_config_for_identity(keys, auth_tag)` and use it at the merge call site with the attestation from `ProjectOwnerIdentity`.
- All other builders default the tag to `None`, so viewer-identity flows are unchanged.

## Reproduction

1. Create a repo owned by a managed agent on a relay that enforces NIP-OA membership for agent keys.
2. Open a PR on it and click **Merge** in Desktop.
3. Before this patch, the temporary clone fails with `403 restricted: not a relay member`; after it, the merge completes.

## Testing

- `just desktop-tauri-test` — all suites pass, including two new unit tests: `credentialed_git_receives_owner_attestation_when_present` and `credentialed_git_omits_attestation_when_absent`.
- `just desktop-tauri-clippy` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
