### PR TITLE
feat(agents): add ephemeral filesystem isolation

### DIFF
--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -85,6 +85,29 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
             Ok(())
         }
 
+        AgentsCmd::IsolationExplain { pubkey } => {
+            let receipt = fetch_isolation_receipt_from_desktop().await?;
+            if let Some(expected) = pubkey {
+                crate::validate::validate_hex64(&expected)?;
+                let actual = receipt
+                    .get("identity_pubkey")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                if !actual.eq_ignore_ascii_case(&expected) {
+                    return Err(CliError::Other(format!(
+                        "filesystem-isolation receipt is bound to {actual}, not {expected}"
+                    )));
+                }
+            }
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&receipt).map_err(|error| {
+                    CliError::Other(format!("failed to render isolation receipt: {error}"))
+                })?
+            );
+            Ok(())
+        }
+
         AgentsCmd::Archive {
             target_pubkey,
             reason,
@@ -164,6 +187,52 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
         }
 
         AgentsCmd::Archived => cmd_archived(client).await,
+    }
+}
+
+async fn fetch_isolation_receipt_from_desktop() -> Result<serde_json::Value, CliError> {
+    // Every child-delivered value is intentionally ignored, including the
+    // legacy receipt, URL, token, PID, and key variables. The fixed operator-
+    // side Unix socket is protected by the sandbox; Desktop authenticates the
+    // kernel-reported peer PID against its live process-tree registry.
+    #[cfg(target_os = "macos")]
+    {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+
+        let mut stream = UnixStream::connect("/private/tmp/buzz-isolation-control-v1.sock")
+            .map_err(|error| {
+                CliError::Other(format!(
+                    "Desktop isolation control plane unavailable: {error}"
+                ))
+            })?;
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+            .map_err(|error| {
+                CliError::Other(format!("failed to configure control read: {error}"))
+            })?;
+        stream.write_all(b"EXPLAIN\n").map_err(|error| {
+            CliError::Other(format!("failed to request isolation receipt: {error}"))
+        })?;
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).map_err(|error| {
+            CliError::Other(format!("failed to read isolation receipt: {error}"))
+        })?;
+        let receipt: serde_json::Value = serde_json::from_slice(&raw).map_err(|error| {
+            CliError::Other(format!("invalid Desktop isolation receipt: {error}"))
+        })?;
+        if let Some(error) = receipt.get("error").and_then(serde_json::Value::as_str) {
+            return Err(CliError::Other(format!(
+                "Desktop refused the isolation receipt: {error}"
+            )));
+        }
+        Ok(receipt)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(CliError::Other(
+            "filesystem isolation explain is currently supported only on macOS".into(),
+        ))
     }
 }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -296,6 +296,12 @@ pub enum AgentsCmd {
         #[arg(long, value_enum)]
         respond_to: Option<RespondToArg>,
     },
+    /// Print the effective filesystem boundary inherited by this agent run
+    IsolationExplain {
+        /// Require the receipt to be bound to this exact agent pubkey
+        #[arg(long)]
+        pubkey: Option<String>,
+    },
     /// Submit a NIP-IA archive request for an identity (kind 9035)
     #[command(
         after_help = "Auth flow: when target != signer, the CLI fetches the target's kind:0 and \
@@ -2175,6 +2181,7 @@ mod tests {
                 "archived",
                 "draft-create",
                 "draft-update",
+                "isolation-explain",
                 "unarchive"
             ]
         );
@@ -2313,7 +2320,7 @@ mod tests {
     #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
-            ("agents", 5),
+            ("agents", 6),
             ("canvas", 2),
             ("channels", 16),
             ("dms", 4),

--- a/crates/buzz-cli/tests/isolation_control.rs
+++ b/crates/buzz-cli/tests/isolation_control.rs
@@ -1,0 +1,47 @@
+#[cfg(target_os = "macos")]
+#[test]
+fn forged_child_endpoint_and_receipt_are_rejected() {
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::process::Command;
+    use std::thread;
+
+    let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let address = listener.local_addr().unwrap();
+    let fake = serde_json::json!({
+        "version": 1,
+        "enforcement": "forged",
+        "identity_pubkey": "ab".repeat(32),
+        "run_id": "forged",
+        "run_root": "/",
+        "allowed_read_roots": ["/"],
+        "allowed_write_roots": ["/"],
+        "denied_roots": []
+    });
+    let body = serde_json::to_vec(&fake).unwrap();
+    let server = thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len());
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.write_all(&body);
+        }
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_buzz"))
+        .args(["agents", "isolation-explain", "--pubkey", &"ab".repeat(32)])
+        .env("BUZZ_PRIVATE_KEY", "11".repeat(32))
+        .env("BUZZ_RELAY_URL", "ws://127.0.0.1:1")
+        .env("BUZZ_FILESYSTEM_ISOLATION_ATTESTATION", fake.to_string())
+        .env(
+            "BUZZ_FILESYSTEM_ISOLATION_CONTROL_URL",
+            format!("http://{address}/v1/isolation"),
+        )
+        .env("BUZZ_FILESYSTEM_ISOLATION_CONTROL_TOKEN", "aa".repeat(32))
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("\"forged\""));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("\"/\""));
+    drop(server);
+}

--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -84,6 +84,7 @@ fn agent_record() -> ManagedAgentRecord {
         system_prompt: None,
         model: None,
         env_vars: Default::default(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -813,7 +813,7 @@ pub async fn update_managed_agent(
             crate::managed_agents::validate_user_env_keys(&env_vars)?;
             record.env_vars = env_vars;
         }
-
+        record.apply_filesystem_isolation_update(input.filesystem_isolation)?;
         // Native provider/model fields are authoritative. Keep the typed marker
         // derived for new records while retaining legacy typed records for
         // non-native providers.

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -583,14 +583,13 @@ pub async fn create_managed_agent(
         }
     }
     crate::managed_agents::validate_user_env_keys(&input.env_vars)?;
-
-    // Validate & normalize the respond-to allowlist BEFORE any side effects.
-    // The harness has its own validator (buzz-acp/src/config.rs) but we want
+    input.validate_filesystem_isolation()?;
+    // Validate & normalize the respond-to allowlist before side effects. The
+    // harness has its own validator (buzz-acp/src/config.rs) but we want
     // to catch malformed input at the boundary so the agent never tries to
     // start with a list that will crash it on launch. The mode/allowlist
-    // pairing (and the definition-default fallback) is resolved later at the
-    // mint site via `resolve_mint_behavioral_defaults`, where the linked
-    // definition is in hand.
+    // pairing (and definition fallback) is resolved later at the mint site via
+    // `resolve_mint_behavioral_defaults`, where the linked definition is in hand.
     let respond_to_allowlist =
         crate::managed_agents::validate_respond_to_allowlist(&input.respond_to_allowlist)?;
     if input.respond_to == Some(crate::managed_agents::RespondTo::Allowlist)
@@ -882,6 +881,7 @@ pub async fn create_managed_agent(
             persona_team_dir: None,
             persona_name_in_team: None,
             env_vars: input.env_vars.clone(),
+            filesystem_isolation: input.filesystem_isolation.clone(),
             created_at: now_iso(),
             updated_at: now_iso(),
             last_started_at: None,

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -30,6 +30,7 @@ fn bare_agent_record(
         provider: provider.map(str::to_string),
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         runtime_pid: None,
         backend: BackendKind::Local,

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -38,6 +38,7 @@ fn make_agent(
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         runtime_pid,
         backend: BackendKind::Local,

--- a/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound/inbound_tests.rs
@@ -180,6 +180,7 @@ fn local_agent() -> ManagedAgentRecord {
         provider: Some("local-provider".to_string()),
         persona_source_version: Some("local-hash".to_string()),
         env_vars: BTreeMap::from([("API_KEY".to_string(), "localsecret".to_string())]),
+        filesystem_isolation: None,
         start_on_app_launch: true,
         auto_restart_on_config_change: true,
         runtime_pid: Some(1234),

--- a/desktop/src-tauri/src/commands/personas/snapshot/fidelity_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/fidelity_tests.rs
@@ -34,6 +34,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: false,
         runtime_pid: None,

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -621,6 +621,7 @@ pub async fn confirm_agent_snapshot_import(
             provider: snapshot.definition.provider.clone(),
             persona_source_version: None,
             env_vars: std::collections::BTreeMap::new(),
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -43,6 +43,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: false,
         runtime_pid: None,

--- a/desktop/src-tauri/src/commands/personas/update/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/update/name_propagation_tests.rs
@@ -26,6 +26,7 @@ fn agent(persona_id: &str, name: &str, display_name: Option<&str>) -> ManagedAge
         provider: None,
         persona_source_version: None,
         env_vars: std::collections::BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -574,6 +574,7 @@ pub async fn confirm_team_snapshot_import(
             provider: member.definition.provider.clone(),
             persona_source_version: None,
             env_vars: std::collections::BTreeMap::new(),
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -201,6 +201,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
         provider: None,
         persona_source_version: None,
         env_vars: Default::default(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -66,10 +66,11 @@ use huddle::{
 };
 use initial_window::*;
 use managed_agents::{
-    backfill_persona_snapshots, ensure_nest, list_managed_agent_runtimes,
-    put_managed_agent_runtime_lifecycle, reconcile_managed_agent_runtimes,
-    restart_managed_agent_runtime, start_managed_agent_runtime, stop_managed_agent_runtime,
-    try_regenerate_nest,
+    abort_managed_agent_isolation, backfill_persona_snapshots, ensure_nest,
+    get_prepared_managed_agent_isolation, list_managed_agent_runtimes,
+    prepare_managed_agent_isolation, put_managed_agent_runtime_lifecycle,
+    reconcile_managed_agent_runtimes, restart_managed_agent_runtime, start_managed_agent_runtime,
+    stop_managed_agent_runtime, try_regenerate_nest,
 };
 #[cfg(not(feature = "mesh-llm"))]
 use mesh_llm_stubs::*;
@@ -503,6 +504,10 @@ pub fn run() {
                 }
             }
 
+            if let Err(error) = managed_agents::recover_abandoned_isolation_runs() {
+                eprintln!("buzz-desktop: filesystem-isolation recovery failed closed: {error}");
+            }
+
             try_regenerate_nest(&app_handle);
 
             if let Some(mgr) = huddle::models::global_model_manager() {
@@ -758,6 +763,9 @@ pub fn run() {
             list_relay_agents,
             list_managed_agents,
             list_managed_agent_runtimes,
+            prepare_managed_agent_isolation,
+            get_prepared_managed_agent_isolation,
+            abort_managed_agent_isolation,
             start_managed_agent_runtime,
             stop_managed_agent_runtime,
             restart_managed_agent_runtime,
@@ -978,7 +986,6 @@ pub fn run() {
             if restart_requested.load(Ordering::SeqCst) {
                 relaunch_after_mesh_shutdown(app_handle);
             }
-
             // AppKit terminates through libc exit(), which runs C++ static
             // destructors. The embedded ggml/Metal runtime currently aborts in
             // that destructor phase even after its node has stopped cleanly.

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -179,6 +179,7 @@ mod tests {
             provider: Some("anthropic".to_string()),
             persona_source_version: Some("abc123".to_string()),
             env_vars: BTreeMap::from([("OPENAI_API_KEY".to_string(), "sk-secret".to_string())]),
+            filesystem_isolation: None,
             start_on_app_launch: true,
             auto_restart_on_config_change: true,
             runtime_pid: Some(4242),

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_envelope.rs
@@ -384,6 +384,7 @@ mod tests {
             system_prompt: None,
             model: None,
             env_vars: std::collections::BTreeMap::new(),
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot_tests.rs
@@ -38,6 +38,7 @@ fn minimal_record() -> ManagedAgentRecord {
             m.insert("API_KEY".to_string(), "secret123".to_string()); // MUST NOT appear
             m
         },
+        filesystem_isolation: None,
         start_on_app_launch: true,
         auto_restart_on_config_change: true,
         runtime_pid: Some(12345), // MUST NOT appear

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -83,6 +83,7 @@ fn test_record() -> ManagedAgentRecord {
         system_prompt: None,
         model: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -222,8 +222,7 @@ fn effective_agent_command_explicit_override_wins() {
     );
 }
 
-/// Minimal record for `record_agent_command` tests. Only the resolution
-/// inputs (runtime / persona_id / agent_command_override) vary.
+/// Minimal record for `record_agent_command`; only its resolution inputs vary.
 fn record_with(
     runtime: Option<&str>,
     persona_id: Option<&str>,
@@ -250,6 +249,7 @@ fn record_with(
         model: None,
         provider: None,
         persona_source_version: None,
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
@@ -60,6 +60,7 @@ fn record(
         provider: provider.map(str::to_string),
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         runtime_pid: None,
         backend: BackendKind::Local,

--- a/desktop/src-tauri/src/managed_agents/filesystem_isolation.rs
+++ b/desktop/src-tauri/src/managed_agents/filesystem_isolation.rs
@@ -1,0 +1,935 @@
+//! Per-run filesystem isolation for local managed-agent process trees.
+//!
+//! macOS Seatbelt is applied to the outer `buzz-acp` process, so every agent,
+//! MCP server, shell, and background descendant inherits the same boundary.
+//! The run root is fresh for every spawn and removed only after the process
+//! tree has exited and the runtime entry is dropped.
+
+use std::{
+    collections::HashMap,
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Mutex, OnceLock},
+    thread,
+    time::Duration,
+};
+
+#[cfg(target_os = "macos")]
+use std::os::unix::{
+    fs::PermissionsExt as _,
+    net::{UnixListener, UnixStream},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{BackendKind, FilesystemIsolationProfile, ManagedAgentRecord};
+
+pub const ISOLATION_ATTESTATION_ENV: &str = "BUZZ_FILESYSTEM_ISOLATION_ATTESTATION";
+pub const ISOLATION_RUN_ROOT_ENV: &str = "BUZZ_FILESYSTEM_ISOLATION_RUN_ROOT";
+
+const RUNS_DIR: &str = "buzz-agent-runs";
+const RECEIPTS_DIR: &str = ".receipts";
+const CONTROL_SOCKET: &str = "/private/tmp/buzz-isolation-control-v1.sock";
+
+mod prepared;
+pub use prepared::*;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FilesystemIsolationAttestation {
+    pub version: u8,
+    pub enforcement: &'static str,
+    pub identity_pubkey: String,
+    pub run_id: String,
+    pub run_root: PathBuf,
+    pub allowed_read_roots: Vec<PathBuf>,
+    pub allowed_write_roots: Vec<PathBuf>,
+    pub denied_roots: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedFilesystemIsolation {
+    pub identity_pubkey: String,
+    pub run_id: String,
+    pub run_root: PathBuf,
+    pub attestation: FilesystemIsolationAttestation,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum IsolationRunPhase {
+    Prepared,
+    Spawning,
+    Bound,
+}
+
+#[derive(Debug)]
+pub struct FilesystemIsolationRun {
+    root: PathBuf,
+    base: PathBuf,
+    ownership_path: PathBuf,
+    ownership: IsolationRunOwnership,
+    control: IsolationControlPlane,
+    #[allow(dead_code)] // exposed through the Desktop registry; inspected directly in tests
+    pub attestation: FilesystemIsolationAttestation,
+}
+
+impl FilesystemIsolationRun {
+    #[cfg(test)]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Bind the immutable control-plane receipt and durable ownership record to
+    /// the exact outer harness PID after spawn, before the runtime is exposed.
+    pub fn bind_pid(&mut self, pid: u32) -> Result<(), String> {
+        if pid == 0 {
+            return Err("filesystem isolation cannot bind an invalid process id".to_string());
+        }
+        self.ownership.agent_pid = Some(pid);
+        self.ownership.phase = Some(IsolationRunPhase::Bound);
+        write_ownership_receipt(&self.ownership_path, &self.ownership, false)?;
+        self.control.bind_pid(pid)?;
+        Ok(())
+    }
+}
+
+/// Durably bind a spawned outer harness to its isolation receipt.
+///
+/// A bind failure must never return a still-running, untracked harness. Stop
+/// the process group and reap the exact child before the run guard can be
+/// dropped and its root removed.
+pub(crate) fn bind_isolation_process(
+    run: &mut FilesystemIsolationRun,
+    child: &mut std::process::Child,
+) -> Result<(), String> {
+    let Err(bind_error) = run.bind_pid(child.id()) else {
+        return Ok(());
+    };
+
+    let terminate_error = super::terminate_process(child.id()).err();
+    if terminate_error.is_some() {
+        // The group-aware path is authoritative. `Child::kill` is a final
+        // same-process fallback so we can still reap the exact spawned child.
+        let _ = child.kill();
+    }
+    let wait_result = child.wait();
+    match (terminate_error, wait_result) {
+        (None, Ok(_)) => Err(format!(
+            "failed to bind filesystem isolation to the tracked process: {bind_error}"
+        )),
+        (Some(terminate_error), Ok(_)) => Err(format!(
+            "failed to bind filesystem isolation to the tracked process: {bind_error}; group termination required fallback: {terminate_error}"
+        )),
+        (terminate_error, Err(wait_error)) => Err(format!(
+            "failed to bind filesystem isolation to the tracked process: {bind_error}; termination={terminate_error:?}; failed to confirm child exit: {wait_error}"
+        )),
+    }
+}
+
+impl Drop for FilesystemIsolationRun {
+    fn drop(&mut self) {
+        self.control.shutdown();
+        if let Err(error) = remove_run_root(&self.base, &self.root) {
+            eprintln!(
+                "buzz-desktop: failed to remove isolated run root {}: {error}",
+                self.root.display()
+            );
+            return;
+        }
+        let _ = fs::remove_file(&self.ownership_path);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct IsolationRunOwnership {
+    version: u8,
+    identity_pubkey: String,
+    desktop_instance_id: String,
+    run_id: String,
+    run_root: PathBuf,
+    desktop_pid: u32,
+    agent_pid: Option<u32>,
+    /// `None` is a legacy receipt. Legacy unbound receipts remain ambiguous
+    /// and are never reclaimed automatically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    phase: Option<IsolationRunPhase>,
+}
+
+#[derive(Debug)]
+struct PreparedIsolationRun {
+    run: FilesystemIsolationRun,
+    profile: FilesystemIsolationProfile,
+    desktop_instance_id: String,
+    acp_command: PathBuf,
+}
+
+fn prepared_isolation_registry() -> &'static Mutex<HashMap<String, PreparedIsolationRun>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, PreparedIsolationRun>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[derive(Debug)]
+struct IsolationControlPlane {
+    run_id: String,
+    attestation: FilesystemIsolationAttestation,
+    registered: bool,
+}
+
+impl IsolationControlPlane {
+    fn start(attestation: &FilesystemIsolationAttestation) -> Result<Self, String> {
+        ensure_control_server()?;
+        Ok(Self {
+            run_id: attestation.run_id.clone(),
+            attestation: attestation.clone(),
+            registered: false,
+        })
+    }
+
+    fn bind_pid(&mut self, pid: u32) -> Result<(), String> {
+        let mut registry = live_isolation_registry()
+            .lock()
+            .map_err(|error| format!("isolation registry lock poisoned: {error}"))?;
+        if registry.contains_key(&self.run_id) {
+            return Err(format!(
+                "isolation run {} is already registered",
+                self.run_id
+            ));
+        }
+        registry.insert(
+            self.run_id.clone(),
+            LiveIsolationRun {
+                root_pid: pid,
+                attestation: self.attestation.clone(),
+            },
+        );
+        self.registered = true;
+        Ok(())
+    }
+
+    fn shutdown(&mut self) {
+        if self.registered {
+            if let Ok(mut registry) = live_isolation_registry().lock() {
+                registry.remove(&self.run_id);
+            }
+            self.registered = false;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LiveIsolationRun {
+    root_pid: u32,
+    attestation: FilesystemIsolationAttestation,
+}
+
+fn live_isolation_registry() -> &'static Mutex<HashMap<String, LiveIsolationRun>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<String, LiveIsolationRun>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_control_server() -> Result<(), String> {
+    static SERVER: OnceLock<Result<(), String>> = OnceLock::new();
+    SERVER
+        .get_or_init(|| {
+            let path = Path::new(CONTROL_SOCKET);
+            if path.exists() {
+                if UnixStream::connect(path).is_ok() {
+                    return Err(format!(
+                        "another Buzz isolation control plane already owns {CONTROL_SOCKET}"
+                    ));
+                }
+                fs::remove_file(path).map_err(|error| {
+                    format!("failed to remove stale isolation control socket: {error}")
+                })?;
+            }
+            let listener = UnixListener::bind(path)
+                .map_err(|error| format!("failed to bind isolation control socket: {error}"))?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+                .map_err(|error| format!("failed to protect isolation control socket: {error}"))?;
+            thread::Builder::new()
+                .name("buzz-isolation-control".into())
+                .spawn(move || {
+                    for stream in listener.incoming() {
+                        match stream {
+                            Ok(stream) => serve_control_request(stream),
+                            Err(_) => break,
+                        }
+                    }
+                })
+                .map_err(|error| format!("failed to start isolation control plane: {error}"))?;
+            Ok(())
+        })
+        .clone()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn ensure_control_server() -> Result<(), String> {
+    Err("filesystem isolation control plane is currently supported only on macOS".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn serve_control_request(mut stream: UnixStream) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut request = [0_u8; 64];
+    let Ok(read) = stream.read(&mut request) else {
+        return;
+    };
+    if &request[..read] != b"EXPLAIN\n" {
+        let _ = stream.write_all(b"{\"error\":\"invalid request\"}\n");
+        return;
+    }
+    let Some(peer_pid) = control_peer_pid(&stream) else {
+        let _ = stream.write_all(b"{\"error\":\"unverified peer\"}\n");
+        return;
+    };
+    let receipt = live_isolation_registry().lock().ok().and_then(|registry| {
+        registry
+            .values()
+            .find(|run| {
+                process_is_live(run.root_pid) && process_is_descendant_of(peer_pid, run.root_pid)
+            })
+            .map(|run| run.attestation.clone())
+    });
+    let response = match receipt {
+        Some(receipt) => serde_json::to_vec(&receipt)
+            .unwrap_or_else(|_| b"{\"error\":\"failed to serialize Desktop receipt\"}".to_vec()),
+        None => b"{\"error\":\"peer is not a tracked isolated process\"}".to_vec(),
+    };
+    let _ = stream.write_all(&response);
+    let _ = stream.write_all(b"\n");
+}
+
+#[cfg(target_os = "macos")]
+fn control_peer_pid(stream: &UnixStream) -> Option<u32> {
+    use std::os::fd::AsRawFd;
+    const SOL_LOCAL: libc::c_int = 0;
+    const LOCAL_PEERPID: libc::c_int = 2;
+    let mut pid: libc::pid_t = 0;
+    let mut length = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            SOL_LOCAL,
+            LOCAL_PEERPID,
+            &mut pid as *mut _ as *mut libc::c_void,
+            &mut length,
+        )
+    };
+    (result == 0 && pid > 0).then_some(pid as u32)
+}
+
+#[cfg(target_os = "macos")]
+fn process_is_descendant_of(mut pid: u32, root_pid: u32) -> bool {
+    for _ in 0..64 {
+        if pid == root_pid {
+            return true;
+        }
+        let Some(parent) = process_parent_pid(pid) else {
+            return false;
+        };
+        if parent == 0 || parent == pid {
+            return false;
+        }
+        pid = parent;
+    }
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn process_parent_pid(pid: u32) -> Option<u32> {
+    let output = Command::new("/bin/ps")
+        .args(["-o", "ppid=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    output.status.success().then(|| {
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<u32>()
+            .ok()
+    })?
+}
+
+fn process_is_live(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let result = unsafe { libc::kill(pid as i32, 0) };
+        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Build the outer command and fresh run-root guard for one isolated spawn.
+///
+/// The returned `Command` launches the existing ACP harness through the host
+/// boundary. Callers configure stdio and environment on it exactly as they do
+/// for an unisolated harness, then retain the guard for the process lifetime.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn isolated_agent_command(
+    profile: &FilesystemIsolationProfile,
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    acp_command: &Path,
+) -> Result<(Command, FilesystemIsolationRun), String> {
+    let mut run = create_isolation_run(profile, identity_pubkey, desktop_instance_id, acp_command)?;
+    let command = command_for_prepared_run(&mut run, acp_command)?;
+    Ok((command, run))
+}
+
+/// Validate an owner-authored profile without creating a run root.
+pub fn validate_filesystem_isolation_profile(
+    profile: &FilesystemIsolationProfile,
+) -> Result<(), String> {
+    let FilesystemIsolationProfile::Ephemeral { read_only_roots } = profile;
+    validate_read_only_roots(read_only_roots, &protected_data_roots()?).map(|_| ())
+}
+
+/// Apply the tri-state update field while preserving the update command's
+/// backend-first validation and clear semantics.
+impl ManagedAgentRecord {
+    pub(crate) fn apply_filesystem_isolation_update(
+        &mut self,
+        update: Option<Option<FilesystemIsolationProfile>>,
+    ) -> Result<(), String> {
+        let Some(filesystem_isolation) = update else {
+            return Ok(());
+        };
+        if let Some(profile) = &filesystem_isolation {
+            if self.backend != BackendKind::Local {
+                return Err(
+                    "filesystem isolation is available only for local managed agents".into(),
+                );
+            }
+            validate_filesystem_isolation_profile(profile)?;
+        }
+        self.filesystem_isolation = filesystem_isolation;
+        Ok(())
+    }
+}
+
+/// Build the common outer harness command, consuming an exact prepared run
+/// only when the record enables isolation.
+pub(crate) fn managed_agent_command(
+    app: &tauri::AppHandle,
+    record: &ManagedAgentRecord,
+    resolved_acp_command: &Path,
+) -> Result<(Command, Option<FilesystemIsolationRun>), String> {
+    match &record.filesystem_isolation {
+        Some(profile) => {
+            let (command, run) = consume_prepared_isolated_agent_command(
+                profile,
+                &record.pubkey,
+                &super::current_instance_id(app),
+                resolved_acp_command,
+            )?;
+            Ok((command, Some(run)))
+        }
+        None => {
+            let mut command = Command::new(resolved_acp_command);
+            if let Some(home) = super::default_agent_workdir() {
+                command.current_dir(home);
+            }
+            Ok((command, None))
+        }
+    }
+}
+
+fn validate_identity(identity_pubkey: &str) -> Result<(), String> {
+    if identity_pubkey.len() == 64 && identity_pubkey.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err("filesystem isolation requires an exact 64-character agent pubkey".to_string())
+    }
+}
+
+fn create_run_root(identity_pubkey: &str) -> Result<(PathBuf, String, PathBuf), String> {
+    let temp = std::env::temp_dir()
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve temporary directory: {error}"))?;
+    let base = temp.join(RUNS_DIR);
+    reject_protected_overlap(&base)?;
+    if base.exists() {
+        let metadata = base
+            .symlink_metadata()
+            .map_err(|error| format!("failed to inspect isolation root: {error}"))?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err(format!("refusing unsafe isolation base {}", base.display()));
+        }
+    } else {
+        create_private_dir(&base)?;
+    }
+    let _ = receipts_dir(&base)?;
+
+    let run_id = uuid::Uuid::new_v4().simple().to_string();
+    let root = base.join(format!(
+        "{}-{run_id}",
+        &identity_pubkey.to_ascii_lowercase()[..16]
+    ));
+    create_private_dir(&root)?;
+    Ok((base, run_id, root))
+}
+
+fn create_private_dir(path: &Path) -> Result<(), String> {
+    fs::create_dir(path).map_err(|error| {
+        format!(
+            "failed to create isolated directory {}: {error}",
+            path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(|error| {
+            format!(
+                "failed to protect isolated directory {}: {error}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn protected_data_roots() -> Result<Vec<PathBuf>, String> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        "filesystem isolation requires a resolvable home directory for fail-closed denial"
+            .to_string()
+    })?;
+    let mut roots = vec![home.join(".buzz")];
+    if let Some(nest) = super::nest_dir() {
+        roots.push(nest);
+    }
+    normalize_paths(&mut roots);
+    Ok(roots)
+}
+
+fn denied_roots() -> Result<Vec<PathBuf>, String> {
+    let mut roots = vec![
+        PathBuf::from("/Users"),
+        PathBuf::from("/Volumes"),
+        PathBuf::from("/Network"),
+        PathBuf::from("/cores"),
+        PathBuf::from("/private"),
+    ];
+    normalize_paths(&mut roots);
+    Ok(roots)
+}
+
+fn reject_protected_overlap(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("isolation base has no parent: {}", path.display()))?;
+    let canonical_parent = parent.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve isolation base parent {}: {error}",
+            parent.display()
+        )
+    })?;
+    let canonical = canonical_parent.join(
+        path.file_name()
+            .ok_or_else(|| format!("isolation base has no name: {}", path.display()))?,
+    );
+    if protected_data_roots()?
+        .iter()
+        .any(|protected| canonical.starts_with(protected) || protected.starts_with(&canonical))
+    {
+        return Err(format!(
+            "filesystem isolation base overlaps protected Buzz data: {}",
+            canonical.display()
+        ));
+    }
+    Ok(())
+}
+
+fn receipts_dir(base: &Path) -> Result<PathBuf, String> {
+    let path = base.join(RECEIPTS_DIR);
+    match fs::create_dir(&path) {
+        Ok(()) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                    .map_err(|error| format!("failed to protect isolation receipts: {error}"))?;
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(format!("failed to create isolation receipts: {error}"));
+        }
+    }
+    let metadata = path
+        .symlink_metadata()
+        .map_err(|error| format!("failed to inspect isolation receipts: {error}"))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(format!(
+            "refusing unsafe isolation receipts {}",
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
+fn write_ownership_receipt(
+    path: &Path,
+    receipt: &IsolationRunOwnership,
+    create_new: bool,
+) -> Result<(), String> {
+    let payload = serde_json::to_vec(receipt)
+        .map_err(|error| format!("failed to serialize isolation ownership: {error}"))?;
+    if create_new {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = options.open(path).map_err(|error| {
+            format!(
+                "failed to create isolation ownership {}: {error}",
+                path.display()
+            )
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(fs::Permissions::from_mode(0o600))
+                .map_err(|error| format!("failed to protect isolation ownership: {error}"))?;
+        }
+        return file
+            .write_all(&payload)
+            .and_then(|_| file.sync_all())
+            .map_err(|error| format!("failed to persist isolation ownership: {error}"));
+    }
+
+    let temp = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4().simple()));
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    let mut file = options.open(&temp).map_err(|error| {
+        format!(
+            "failed to create isolation ownership {}: {error}",
+            temp.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("failed to protect isolation ownership: {error}"))?;
+    }
+    file.write_all(&payload)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| format!("failed to persist isolation ownership: {error}"))?;
+    fs::rename(&temp, path)
+        .map_err(|error| format!("failed to install isolation ownership: {error}"))
+}
+
+fn validate_read_only_roots(
+    roots: &[PathBuf],
+    denied_roots: &[PathBuf],
+) -> Result<Vec<PathBuf>, String> {
+    let home = dirs::home_dir();
+    let mut validated = Vec::with_capacity(roots.len());
+    for root in roots {
+        if !root.is_absolute() {
+            return Err(format!(
+                "filesystem isolation read root must be absolute: {}",
+                root.display()
+            ));
+        }
+        let canonical = root.canonicalize().map_err(|error| {
+            format!(
+                "filesystem isolation read root must exist ({}): {error}",
+                root.display()
+            )
+        })?;
+        let metadata = canonical.symlink_metadata().map_err(|error| {
+            format!(
+                "failed to inspect read root {}: {error}",
+                canonical.display()
+            )
+        })?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err(format!(
+                "filesystem isolation read root must be a real directory: {}",
+                canonical.display()
+            ));
+        }
+        if canonical == Path::new("/") || home.as_ref().is_some_and(|path| canonical == *path) {
+            return Err(format!(
+                "filesystem isolation refuses broad read root {}",
+                canonical.display()
+            ));
+        }
+        if denied_roots
+            .iter()
+            .any(|denied| canonical.starts_with(denied) || denied.starts_with(&canonical))
+        {
+            return Err(format!(
+                "filesystem isolation read root overlaps protected Buzz data: {}",
+                canonical.display()
+            ));
+        }
+        validated.push(canonical);
+    }
+    normalize_paths(&mut validated);
+    Ok(validated)
+}
+
+#[cfg(target_os = "macos")]
+fn system_read_roots() -> Vec<PathBuf> {
+    [
+        "/System",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/Library",
+        "/Applications",
+        "/private/etc",
+        "/private/var/db",
+        "/private/var/run",
+        "/dev",
+        "/opt",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .filter(|path| path.exists())
+    .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn executable_read_roots(command: &Path) -> Result<Vec<PathBuf>, String> {
+    let canonical = command.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve ACP command {} for isolation: {error}",
+            command.display()
+        )
+    })?;
+    let parent = canonical.parent().ok_or_else(|| {
+        format!(
+            "ACP command has no parent directory: {}",
+            canonical.display()
+        )
+    })?;
+    Ok(vec![parent.to_path_buf()])
+}
+
+#[cfg(target_os = "macos")]
+fn seatbelt_profile(attestation: &FilesystemIsolationAttestation) -> Result<String, String> {
+    // A global file deny causes macOS libSystem to abort before the harness can
+    // start. Preserve the platform bootstrap default, close every user-data and
+    // mutable-private namespace, then reopen only the attested runtime roots
+    // and this run's fresh write root. Specific allows override parent denies.
+    let mut profile = String::from("(version 1)\n(allow default)\n");
+    for root in &attestation.denied_roots {
+        profile.push_str(&format!(
+            "(deny file-read* file-write* (subpath \"{}\"))\n",
+            escape_seatbelt_path(root)?
+        ));
+    }
+    for root in &attestation.allowed_read_roots {
+        profile.push_str(&format!(
+            "(allow file-read* (subpath \"{}\"))\n",
+            escape_seatbelt_path(root)?
+        ));
+    }
+    for root in &attestation.allowed_write_roots {
+        profile.push_str(&format!(
+            "(allow file-write* (subpath \"{}\"))\n",
+            escape_seatbelt_path(root)?
+        ));
+    }
+    for device in ["/dev/null", "/dev/zero", "/dev/random", "/dev/urandom"] {
+        profile.push_str(&format!(
+            "(allow file-read* file-write* (literal \"{device}\"))\n"
+        ));
+    }
+    profile.push_str(&format!(
+        "(allow network-outbound (literal \"{}\"))\n",
+        CONTROL_SOCKET
+    ));
+    Ok(profile)
+}
+
+/// Remove only crash residue whose durable receipt proves the exact run root,
+/// has a durably bound outer harness PID, and whose Desktop owner and harness
+/// are both no longer live. An unbound receipt is an ambiguous spawn window,
+/// never proof of abandonment. Live or ambiguous receipts are preserved so a
+/// concurrent app instance cannot lose a workspace underneath it.
+pub fn recover_abandoned_isolation_runs() -> Result<Vec<PathBuf>, String> {
+    let temp = std::env::temp_dir()
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve temporary directory: {error}"))?;
+    recover_abandoned_isolation_runs_in(&temp.join(RUNS_DIR), process_is_live)
+}
+
+fn ensure_no_existing_isolation_receipt(identity_pubkey: &str) -> Result<(), String> {
+    let temp = std::env::temp_dir()
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve temporary directory: {error}"))?;
+    let base = temp.join(RUNS_DIR);
+    if !base.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(receipts_dir(&base)?)
+        .map_err(|error| format!("failed to read isolation receipts: {error}"))?
+        .flatten()
+    {
+        let Ok(bytes) = fs::read(entry.path()) else {
+            continue;
+        };
+        let Ok(receipt) = serde_json::from_slice::<IsolationRunOwnership>(&bytes) else {
+            continue;
+        };
+        if receipt
+            .identity_pubkey
+            .eq_ignore_ascii_case(identity_pubkey)
+        {
+            return Err(format!(
+                "agent {identity_pubkey} already has a durable filesystem-isolation receipt ({})",
+                receipt.run_id
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn recover_abandoned_isolation_runs_in(
+    base: &Path,
+    is_live: impl Fn(u32) -> bool,
+) -> Result<Vec<PathBuf>, String> {
+    reject_protected_overlap(base)?;
+    if !base.exists() {
+        return Ok(Vec::new());
+    }
+    let base_metadata = base
+        .symlink_metadata()
+        .map_err(|error| format!("failed to inspect isolation base: {error}"))?;
+    if !base_metadata.is_dir() || base_metadata.file_type().is_symlink() {
+        return Err(format!("refusing unsafe isolation base {}", base.display()));
+    }
+    let receipts = receipts_dir(base)?;
+    let mut removed = Vec::new();
+    let entries = fs::read_dir(&receipts)
+        .map_err(|error| format!("failed to read isolation receipts: {error}"))?;
+    for entry in entries.flatten() {
+        let receipt_path = entry.path();
+        if receipt_path
+            .extension()
+            .is_none_or(|extension| extension != "json")
+        {
+            continue;
+        }
+        let Ok(metadata) = receipt_path.symlink_metadata() else {
+            continue;
+        };
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&receipt_path) else {
+            continue;
+        };
+        let Ok(receipt) = serde_json::from_slice::<IsolationRunOwnership>(&bytes) else {
+            continue;
+        };
+        if receipt.version != 1
+            || receipt.identity_pubkey.len() != 64
+            || !receipt
+                .identity_pubkey
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+            || receipt.desktop_instance_id.trim().is_empty()
+            || receipt.run_id.len() != 32
+            || !receipt.run_id.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || receipt.run_root.parent() != Some(base)
+            || !receipt.run_root.starts_with(base)
+            || receipt_path.file_stem().and_then(|stem| stem.to_str())
+                != Some(receipt.run_id.as_str())
+            || !receipt
+                .run_root
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().ends_with(&receipt.run_id))
+        {
+            continue;
+        }
+        let owner_live = is_live(receipt.desktop_pid);
+        if receipt.phase == Some(IsolationRunPhase::Prepared) {
+            if owner_live {
+                continue;
+            }
+            remove_run_root(base, &receipt.run_root)?;
+            fs::remove_file(&receipt_path).map_err(|error| {
+                format!(
+                    "failed to remove recovered prepared isolation receipt {}: {error}",
+                    receipt_path.display()
+                )
+            })?;
+            removed.push(receipt.run_root);
+            continue;
+        }
+        let Some(agent_pid) = receipt.agent_pid else {
+            // `spawning` and legacy-unbound receipts may represent a Desktop
+            // crash after spawn but before PID fsync. Preserve them as
+            // ambiguous; only an explicit prepared phase is safe to reclaim.
+            continue;
+        };
+        let agent_live = is_live(agent_pid);
+        if owner_live || agent_live {
+            continue;
+        }
+        remove_run_root(base, &receipt.run_root)?;
+        fs::remove_file(&receipt_path).map_err(|error| {
+            format!(
+                "failed to remove recovered isolation receipt {}: {error}",
+                receipt_path.display()
+            )
+        })?;
+        removed.push(receipt.run_root);
+    }
+    Ok(removed)
+}
+
+#[cfg(target_os = "macos")]
+fn escape_seatbelt_path(path: &Path) -> Result<String, String> {
+    let raw = path
+        .to_str()
+        .ok_or_else(|| format!("isolation path is not valid UTF-8: {}", path.display()))?;
+    if raw.contains(['\n', '\r', '\0']) {
+        return Err(format!(
+            "isolation path contains invalid bytes: {}",
+            path.display()
+        ));
+    }
+    Ok(raw.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn normalize_paths(paths: &mut Vec<PathBuf>) {
+    paths.sort();
+    paths.dedup();
+}
+
+fn remove_run_root(base: &Path, root: &Path) -> Result<(), String> {
+    if root.parent() != Some(base) || !root.starts_with(base) {
+        return Err(format!(
+            "refusing to remove unscoped path {}",
+            root.display()
+        ));
+    }
+    match root.symlink_metadata() {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(root)
+                .map_err(|error| format!("failed to remove {}: {error}", root.display()))
+        }
+        Ok(_) => Err(format!(
+            "refusing to remove non-directory run root {}",
+            root.display()
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to inspect {}: {error}", root.display())),
+    }
+}
+
+#[cfg(test)]
+#[path = "filesystem_isolation/tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/managed_agents/filesystem_isolation/prepared.rs
+++ b/desktop/src-tauri/src/managed_agents/filesystem_isolation/prepared.rs
@@ -1,0 +1,226 @@
+use super::*;
+
+/// Create one fresh owner-inspectable root without starting any harness.
+/// A second prepare for the same identity fails until the first is consumed
+/// or explicitly aborted.
+pub fn prepare_isolated_agent_run(
+    profile: &FilesystemIsolationProfile,
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    acp_command: &Path,
+) -> Result<PreparedFilesystemIsolation, String> {
+    let key = identity_pubkey.to_ascii_lowercase();
+    validate_identity(&key)?;
+    recover_abandoned_isolation_runs()?;
+    ensure_no_existing_isolation_receipt(&key)?;
+
+    let mut registry = prepared_isolation_registry()
+        .lock()
+        .map_err(|error| format!("prepared isolation registry lock poisoned: {error}"))?;
+    if registry.contains_key(&key) {
+        return Err(format!(
+            "agent {key} already has a prepared filesystem-isolation run"
+        ));
+    }
+    let run = create_isolation_run(profile, &key, desktop_instance_id, acp_command)?;
+    let prepared = PreparedFilesystemIsolation {
+        identity_pubkey: key.clone(),
+        run_id: run.attestation.run_id.clone(),
+        run_root: run.attestation.run_root.clone(),
+        attestation: run.attestation.clone(),
+    };
+    registry.insert(
+        key,
+        PreparedIsolationRun {
+            run,
+            profile: profile.clone(),
+            desktop_instance_id: desktop_instance_id.to_string(),
+            acp_command: acp_command.to_path_buf(),
+        },
+    );
+    Ok(prepared)
+}
+
+/// Consume exactly one prepared root. Removal from the registry happens
+/// before the durable `spawning` transition, so no concurrent start can reuse
+/// the same root.
+pub fn consume_prepared_isolated_agent_command(
+    profile: &FilesystemIsolationProfile,
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    acp_command: &Path,
+) -> Result<(Command, FilesystemIsolationRun), String> {
+    let key = identity_pubkey.to_ascii_lowercase();
+    let prepared = prepared_isolation_registry()
+        .lock()
+        .map_err(|error| format!("prepared isolation registry lock poisoned: {error}"))?
+        .remove(&key)
+        .ok_or_else(|| {
+            format!("agent {key} requires an owner-prepared filesystem-isolation run before start")
+        })?;
+    if prepared.profile != *profile
+        || prepared.desktop_instance_id != desktop_instance_id
+        || prepared.acp_command != acp_command
+    {
+        return Err(
+            "prepared filesystem-isolation run no longer matches the effective agent configuration"
+                .to_string(),
+        );
+    }
+    let mut run = prepared.run;
+    let command = command_for_prepared_run(&mut run, acp_command)?;
+    Ok((command, run))
+}
+
+pub fn abort_prepared_isolated_agent_run(
+    identity_pubkey: &str,
+    expected_run_id: &str,
+) -> Result<(), String> {
+    let key = identity_pubkey.to_ascii_lowercase();
+    let mut registry = prepared_isolation_registry()
+        .lock()
+        .map_err(|error| format!("prepared isolation registry lock poisoned: {error}"))?;
+    let current = registry
+        .get(&key)
+        .ok_or_else(|| format!("agent {key} has no prepared filesystem-isolation run"))?;
+    if current.run.attestation.run_id != expected_run_id {
+        return Err("prepared filesystem-isolation run id does not match".to_string());
+    }
+    registry.remove(&key);
+    Ok(())
+}
+
+pub fn get_prepared_isolated_agent_run(
+    identity_pubkey: &str,
+) -> Result<Option<PreparedFilesystemIsolation>, String> {
+    let key = identity_pubkey.to_ascii_lowercase();
+    validate_identity(&key)?;
+    let registry = prepared_isolation_registry()
+        .lock()
+        .map_err(|error| format!("prepared isolation registry lock poisoned: {error}"))?;
+    Ok(registry
+        .get(&key)
+        .map(|prepared| PreparedFilesystemIsolation {
+            identity_pubkey: key,
+            run_id: prepared.run.attestation.run_id.clone(),
+            run_root: prepared.run.attestation.run_root.clone(),
+            attestation: prepared.run.attestation.clone(),
+        }))
+}
+
+pub(super) fn create_isolation_run(
+    profile: &FilesystemIsolationProfile,
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    acp_command: &Path,
+) -> Result<FilesystemIsolationRun, String> {
+    let FilesystemIsolationProfile::Ephemeral { read_only_roots } = profile;
+    validate_identity(identity_pubkey)?;
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (read_only_roots, desktop_instance_id, acp_command);
+        return Err(
+            "ephemeral filesystem isolation is currently supported only on macOS".to_string(),
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        recover_abandoned_isolation_runs()?;
+        let sandbox_exec = Path::new("/usr/bin/sandbox-exec");
+        if !sandbox_exec.is_file() {
+            return Err("macOS filesystem isolation requires /usr/bin/sandbox-exec".to_string());
+        }
+        let (base, run_id, root) = create_run_root(identity_pubkey)?;
+        let result = (|| {
+            let home = root.join("home");
+            let temp = root.join("tmp");
+            create_private_dir(&home)?;
+            create_private_dir(&temp)?;
+            let denied_roots = denied_roots()?;
+            let mut allowed_read_roots = system_read_roots();
+            allowed_read_roots.extend(validate_read_only_roots(
+                read_only_roots,
+                &protected_data_roots()?,
+            )?);
+            allowed_read_roots.extend(executable_read_roots(acp_command)?);
+            allowed_read_roots.push(root.clone());
+            normalize_paths(&mut allowed_read_roots);
+            let attestation = FilesystemIsolationAttestation {
+                version: 1,
+                enforcement: "macos_seatbelt_process_tree_control_plane_v1",
+                identity_pubkey: identity_pubkey.to_ascii_lowercase(),
+                run_id: run_id.clone(),
+                run_root: root.clone(),
+                allowed_read_roots,
+                allowed_write_roots: vec![root.clone()],
+                denied_roots,
+            };
+            // Validate the profile before publishing the durable prepared receipt.
+            let _ = seatbelt_profile(&attestation)?;
+            let control = IsolationControlPlane::start(&attestation)?;
+            let ownership_path = receipts_dir(&base)?.join(format!("{run_id}.json"));
+            let ownership = IsolationRunOwnership {
+                version: 1,
+                identity_pubkey: identity_pubkey.to_ascii_lowercase(),
+                desktop_instance_id: desktop_instance_id.to_string(),
+                run_id,
+                run_root: root.clone(),
+                desktop_pid: std::process::id(),
+                agent_pid: None,
+                phase: Some(IsolationRunPhase::Prepared),
+            };
+            write_ownership_receipt(&ownership_path, &ownership, true)?;
+            Ok(FilesystemIsolationRun {
+                root: root.clone(),
+                base: base.clone(),
+                ownership_path,
+                ownership,
+                control,
+                attestation,
+            })
+        })();
+        if result.is_err() {
+            let _ = remove_run_root(&base, &root);
+        }
+        result
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn command_for_prepared_run(
+    run: &mut FilesystemIsolationRun,
+    acp_command: &Path,
+) -> Result<Command, String> {
+    run.ownership.phase = Some(IsolationRunPhase::Spawning);
+    write_ownership_receipt(&run.ownership_path, &run.ownership, false)?;
+    let home = run.root.join("home");
+    let temp = run.root.join("tmp");
+    let mut command = Command::new("/usr/bin/sandbox-exec");
+    command
+        .arg("-p")
+        .arg(seatbelt_profile(&run.attestation)?)
+        .arg(acp_command)
+        .current_dir(&run.root)
+        .env("HOME", &home)
+        .env("TMPDIR", &temp)
+        .env("XDG_CACHE_HOME", home.join(".cache"))
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"))
+        .env(ISOLATION_RUN_ROOT_ENV, &run.root)
+        .env(
+            ISOLATION_ATTESTATION_ENV,
+            serde_json::to_string(&run.attestation)
+                .map_err(|error| format!("failed to serialize isolation receipt: {error}"))?,
+        );
+    Ok(command)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn command_for_prepared_run(
+    _run: &mut FilesystemIsolationRun,
+    _acp_command: &Path,
+) -> Result<Command, String> {
+    Err("ephemeral filesystem isolation is currently supported only on macOS".to_string())
+}

--- a/desktop/src-tauri/src/managed_agents/filesystem_isolation/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/filesystem_isolation/tests.rs
@@ -1,0 +1,320 @@
+use super::*;
+
+#[test]
+fn broad_and_buzz_overlapping_read_roots_fail_closed() {
+    let protected = protected_data_roots().unwrap();
+    assert!(validate_read_only_roots(&[PathBuf::from("/")], &protected).is_err());
+    if let Some(home) = dirs::home_dir() {
+        assert!(validate_read_only_roots(std::slice::from_ref(&home), &protected).is_err());
+        let buzz = home.join(".buzz");
+        if buzz.is_dir() {
+            assert!(validate_read_only_roots(&[buzz], &protected).is_err());
+        }
+    }
+}
+
+#[test]
+fn invalid_identity_is_rejected_before_creating_a_run_root() {
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let error =
+        isolated_agent_command(&profile, "not-a-pubkey", "test", Path::new("/bin/sh")).unwrap_err();
+    assert!(error.contains("exact 64-character"));
+}
+
+#[test]
+fn prepared_receipt_uses_owner_ui_shape_without_changing_attestation_shape() {
+    let receipt = PreparedFilesystemIsolation {
+        identity_pubkey: "ab".repeat(32),
+        run_id: "c".repeat(32),
+        run_root: PathBuf::from("/tmp/run"),
+        attestation: FilesystemIsolationAttestation {
+            version: 1,
+            enforcement: "test",
+            identity_pubkey: "ab".repeat(32),
+            run_id: "c".repeat(32),
+            run_root: PathBuf::from("/tmp/run"),
+            allowed_read_roots: Vec::new(),
+            allowed_write_roots: vec![PathBuf::from("/tmp/run")],
+            denied_roots: vec![PathBuf::from("/Users")],
+        },
+    };
+    let value = serde_json::to_value(receipt).unwrap();
+    assert_eq!(value["runId"], "c".repeat(32));
+    assert_eq!(value["runRoot"], "/tmp/run");
+    assert_eq!(value["attestation"]["run_id"], "c".repeat(32));
+    assert!(value["attestation"].get("runId").is_none());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_receipt_never_allows_home_or_shared_buzz_root() {
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let (_command, run) =
+        isolated_agent_command(&profile, &"ab".repeat(32), "test", Path::new("/bin/sh")).unwrap();
+    let home = dirs::home_dir().unwrap();
+    assert!(!run.attestation.allowed_read_roots.contains(&home));
+    assert!(!run
+        .attestation
+        .allowed_read_roots
+        .iter()
+        .any(|root| root == &home.join(".buzz")));
+    assert!(run
+        .attestation
+        .denied_roots
+        .contains(&PathBuf::from("/Users")));
+    assert!(run
+        .root()
+        .starts_with(std::env::temp_dir().canonicalize().unwrap()));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn prepared_root_exists_before_spawn_and_is_consumed_exactly_once() {
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let identity = "cd".repeat(32);
+    let prepared =
+        prepare_isolated_agent_run(&profile, &identity, "test", Path::new("/bin/sh")).unwrap();
+    assert!(prepared.run_root.is_dir());
+    assert_eq!(
+        get_prepared_isolated_agent_run(&identity).unwrap(),
+        Some(prepared.clone())
+    );
+
+    let marker = prepared.run_root.join("M2");
+    fs::write(&marker, "harmless-marker").unwrap();
+    assert_eq!(fs::read_to_string(&marker).unwrap(), "harmless-marker");
+
+    let (_command, run) =
+        consume_prepared_isolated_agent_command(&profile, &identity, "test", Path::new("/bin/sh"))
+            .unwrap();
+    assert!(marker.is_file(), "prepared marker disappeared before spawn");
+    assert!(consume_prepared_isolated_agent_command(
+        &profile,
+        &identity,
+        "test",
+        Path::new("/bin/sh"),
+    )
+    .unwrap_err()
+    .contains("owner-prepared"));
+    drop(run);
+    assert!(!prepared.run_root.exists());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn concurrent_prepare_fails_closed_and_abort_is_exact() {
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let identity = "ef".repeat(32);
+    let first =
+        prepare_isolated_agent_run(&profile, &identity, "test", Path::new("/bin/sh")).unwrap();
+    assert!(
+        prepare_isolated_agent_run(&profile, &identity, "test", Path::new("/bin/sh"))
+            .unwrap_err()
+            .contains("durable filesystem-isolation receipt")
+    );
+    assert!(abort_prepared_isolated_agent_run(&identity, &"0".repeat(32)).is_err());
+    assert!(first.run_root.exists());
+    abort_prepared_isolated_agent_run(&identity, &first.run_id).unwrap();
+    assert!(!first.run_root.exists());
+
+    let second =
+        prepare_isolated_agent_run(&profile, &identity, "test", Path::new("/bin/sh")).unwrap();
+    assert_ne!(first.run_id, second.run_id);
+    abort_prepared_isolated_agent_run(&identity, &second.run_id).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_denies_sibling_markers_and_nested_children_across_fresh_runs() {
+    let operator = tempfile::tempdir().unwrap();
+    let outside = operator.path().join("outside.txt");
+    let outside_write = operator.path().join("outside-write.txt");
+    fs::write(&outside, "OUTSIDE-TOKEN").unwrap();
+    assert!(outside.metadata().unwrap().is_file());
+
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let mut previous_root = None;
+    for _ in 0..2 {
+        let (mut command, mut run) =
+            isolated_agent_command(&profile, &"ab".repeat(32), "test", Path::new("/bin/sh"))
+                .unwrap();
+        let run_root = run.root().to_path_buf();
+        if let Some(previous) = &previous_root {
+            assert_ne!(previous, &run_root);
+        }
+        let inside = run_root.join("inside.txt");
+        fs::write(&inside, "INSIDE-TOKEN").unwrap();
+
+        command
+            .arg("-c")
+            .arg(
+                r#"
+cat "$1" > "$3/inside.out"
+inside_status=$?
+cat "$2" > "$3/outside.out" 2>&1
+outside_status=$?
+printf x > "$3/inside-write.txt"
+inside_write_status=$?
+printf x > "$4" 2>/dev/null
+outside_write_status=$?
+/bin/sh -c 'cat "$1"' probe "$2" > "$3/nested.out" 2>&1
+nested_status=$?
+printf 'EXPLAIN\n' | /usr/bin/nc -U /private/tmp/buzz-isolation-control-v1.sock > "$3/receipt.json" 2>&1
+control_status=$?
+printf '%s %s %s %s %s %s' "$inside_status" "$outside_status" "$inside_write_status" "$outside_write_status" "$nested_status" "$control_status"
+"#,
+            )
+            .arg("probe")
+            .arg(&inside)
+            .arg(&outside)
+            .arg(&run_root)
+            .arg(&outside_write)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let child = command.spawn().unwrap();
+        run.bind_pid(child.id()).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "status={:?} stdout={:?} stderr={:?}",
+            output.status,
+            output.stdout,
+            output.stderr
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "0 1 0 1 1 0");
+        assert_eq!(
+            fs::read_to_string(run_root.join("inside.out")).unwrap(),
+            "INSIDE-TOKEN"
+        );
+        assert!(!fs::read_to_string(run_root.join("outside.out"))
+            .unwrap()
+            .contains("OUTSIDE-TOKEN"));
+        assert!(!fs::read_to_string(run_root.join("nested.out"))
+            .unwrap()
+            .contains("OUTSIDE-TOKEN"));
+        assert!(!outside_write.exists());
+        let receipt: serde_json::Value =
+            serde_json::from_slice(&fs::read(run_root.join("receipt.json")).unwrap()).unwrap();
+        assert_eq!(receipt["identity_pubkey"], "ab".repeat(32));
+        assert_eq!(receipt["run_root"], run_root.to_string_lossy().as_ref());
+
+        drop(run);
+        assert!(!run_root.exists());
+        previous_root = Some(run_root);
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn bind_failure_terminates_and_reaps_spawned_harness_before_cleanup() {
+    use std::os::unix::process::CommandExt;
+
+    let profile = FilesystemIsolationProfile::Ephemeral {
+        read_only_roots: Vec::new(),
+    };
+    let (mut command, mut run) =
+        isolated_agent_command(&profile, &"ab".repeat(32), "test", Path::new("/bin/sh")).unwrap();
+    let root = run.root().to_path_buf();
+    command
+        .arg("-c")
+        .arg("while :; do :; done")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .process_group(0);
+    let mut child = command.spawn().unwrap();
+    let pid = child.id();
+
+    // Pre-register the same run to force the post-fsync control-registry
+    // collision path inside bind_pid.
+    run.control.bind_pid(pid).unwrap();
+    let error = bind_isolation_process(&mut run, &mut child).unwrap_err();
+    assert!(error.contains("failed to bind filesystem isolation"));
+    assert!(!process_is_live(pid), "bind failure left child {pid} live");
+    assert!(
+        child.try_wait().unwrap().is_some(),
+        "bind failure did not reap child {pid}"
+    );
+
+    drop(run);
+    assert!(!root.exists(), "normal run cleanup left residue");
+}
+
+#[test]
+fn startup_recovery_preserves_spawn_window_and_live_runs() {
+    let operator = tempfile::tempdir().unwrap();
+    let base = operator.path().join(RUNS_DIR);
+    create_private_dir(&base).unwrap();
+    let receipts = receipts_dir(&base).unwrap();
+
+    let make_run = |run_id: &str,
+                    desktop_pid: u32,
+                    agent_pid: Option<u32>,
+                    phase: Option<IsolationRunPhase>| {
+        let root = base.join(format!("abababababababab-{run_id}"));
+        create_private_dir(&root).unwrap();
+        fs::write(root.join("residue"), "test").unwrap();
+        let receipt = IsolationRunOwnership {
+            version: 1,
+            identity_pubkey: "ab".repeat(32),
+            desktop_instance_id: "test".into(),
+            run_id: run_id.into(),
+            run_root: root.clone(),
+            desktop_pid,
+            agent_pid,
+            phase,
+        };
+        write_ownership_receipt(&receipts.join(format!("{run_id}.json")), &receipt, true).unwrap();
+        root
+    };
+
+    let abandoned = make_run(
+        &"a".repeat(32),
+        10,
+        Some(11),
+        Some(IsolationRunPhase::Bound),
+    );
+    let unbound_spawn_window =
+        make_run(&"b".repeat(32), 10, None, Some(IsolationRunPhase::Spawning));
+    let live_desktop = make_run(
+        &"c".repeat(32),
+        20,
+        Some(21),
+        Some(IsolationRunPhase::Bound),
+    );
+    let live_agent = make_run(
+        &"d".repeat(32),
+        10,
+        Some(30),
+        Some(IsolationRunPhase::Bound),
+    );
+    let dead_prepared = make_run(&"e".repeat(32), 10, None, Some(IsolationRunPhase::Prepared));
+    let live_prepared = make_run(&"f".repeat(32), 20, None, Some(IsolationRunPhase::Prepared));
+    let mut removed =
+        recover_abandoned_isolation_runs_in(&base, |pid| pid == 20 || pid == 30).unwrap();
+    removed.sort();
+    let mut expected_removed = vec![abandoned.clone(), dead_prepared.clone()];
+    expected_removed.sort();
+
+    assert_eq!(removed, expected_removed);
+    assert!(!abandoned.exists());
+    assert!(unbound_spawn_window.exists());
+    assert!(
+        receipts.join(format!("{}.json", "b".repeat(32))).exists(),
+        "ambiguous crash-between-spawn-and-bind receipt was removed"
+    );
+    assert!(live_desktop.exists());
+    assert!(live_agent.exists());
+    assert!(!dead_prepared.exists());
+    assert!(live_prepared.exists());
+}

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -320,6 +320,7 @@ fn bare_record() -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         runtime_pid: None,
         backend: BackendKind::Local,

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod custom_harnesses;
 mod discovery;
 pub(crate) mod effective_config;
 mod env_vars;
+mod filesystem_isolation;
 pub(crate) mod git_bash;
 pub(crate) mod global_config;
 mod managed_node_paths;
@@ -53,6 +54,7 @@ pub(crate) fn lock_path_mutex() -> std::sync::MutexGuard<'static, ()> {
 pub use backend::*;
 pub use discovery::*;
 pub use env_vars::*;
+pub use filesystem_isolation::*;
 #[cfg(windows)]
 pub(crate) use git_bash::git_bash_available;
 pub(crate) use git_bash::{discover_git_bash, GitBashPrerequisite};

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -469,6 +469,7 @@ fn make_agent(name: &str, persona_id: Option<&str>) -> ManagedAgentRecord {
         model: None,
         provider: None,
         persona_source_version: None,
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/parallelism.rs
+++ b/desktop/src-tauri/src/managed_agents/parallelism.rs
@@ -84,6 +84,7 @@ mod tests {
             model: None,
             provider: None,
             persona_source_version: None,
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
@@ -26,6 +26,7 @@ pub(super) fn sample_record() -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
+++ b/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
@@ -137,6 +137,7 @@ pub fn finish_spawn(
     setup_mode: bool,
     adapter_availability: Option<super::AcpAvailabilityStatus>,
     start_nonce: String,
+    isolation_run: Option<super::FilesystemIsolationRun>,
     agent_name: &str,
 ) -> super::ManagedAgentProcess {
     let job = create_job_for_child(child.id());
@@ -153,6 +154,7 @@ pub fn finish_spawn(
         setup_mode,
         adapter_availability,
         start_nonce,
+        isolation_run,
         job,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1465,9 +1465,8 @@ mod tests {
 
     #[test]
     fn resolve_effective_agent_env_user_env_wins_over_structured_fields() {
-        // A record whose env_vars explicitly set provider/model must win over
-        // any baked defaults. In OSS test builds the baked map is empty, so
-        // this test validates the user-env layer is present in the output.
+        // Explicit provider/model env vars must win over baked defaults. The OSS
+        // baked map is empty, so this validates that the user-env layer is present.
         let mut env_vars = BTreeMap::new();
         env_vars.insert("BUZZ_AGENT_PROVIDER".to_string(), "anthropic".to_string());
         env_vars.insert(
@@ -1498,6 +1497,7 @@ mod tests {
             provider: None,
             persona_source_version: None,
             env_vars,
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
+++ b/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
@@ -70,6 +70,13 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     // for same-session sweep decisions.
     "BUZZ_MANAGED_AGENT",
     "BUZZ_MANAGED_AGENT_START_NONCE",
+    // Filesystem boundary receipt and run-root identity are stamped only by
+    // the Desktop wrapper. User env must not forge cosmetic attestation or
+    // point tools at a different root than the enforced profile.
+    "BUZZ_FILESYSTEM_ISOLATION_ATTESTATION",
+    "BUZZ_FILESYSTEM_ISOLATION_RUN_ROOT",
+    "BUZZ_FILESYSTEM_ISOLATION_CONTROL_URL",
+    "BUZZ_FILESYSTEM_ISOLATION_CONTROL_TOKEN",
 ];
 
 pub(crate) fn is_reserved_env_key(key: &str) -> bool {

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -31,7 +31,9 @@ pub(crate) use stop::managed_agent_runtime_keys;
 pub use stop::{stop_managed_agent_process, stop_managed_agent_workspace_pair};
 
 mod sweep;
-pub(crate) use sweep::sweep_untracked_bundle_harnesses;
+pub(crate) use sweep::{
+    collect_untracked_bundle_harnesses_checked, sweep_untracked_bundle_harnesses,
+};
 
 mod process;
 #[cfg(test)]
@@ -48,8 +50,8 @@ mod orphan_sweep;
 #[cfg(target_os = "macos")]
 use orphan_sweep::proc_pidinfo;
 pub(crate) use orphan_sweep::{
-    sweep_orphaned_agent_processes, sweep_system_agent_processes,
-    sweep_system_agent_processes_with_grace,
+    collect_same_instance_orphans_checked, sweep_orphaned_agent_processes,
+    sweep_system_agent_processes, sweep_system_agent_processes_with_grace,
 };
 #[cfg(target_os = "macos")]
 use orphan_sweep::{BSDInfo, PROC_PIDTBSDINFO};
@@ -322,6 +324,7 @@ pub fn build_managed_agent_summary(
         needs_restart,
         restart_diff,
         env_vars: record.env_vars.clone(),
+        filesystem_isolation: record.filesystem_isolation.clone(),
         backend: record.backend.clone(),
         backend_agent_id: record.backend_agent_id.clone(),
         status,
@@ -458,21 +461,6 @@ pub fn spawn_agent_child(
     let effective_command = &descriptor.command;
     let agent_args = &descriptor.args;
 
-    let log_path = super::managed_agent_runtime_log_path(app, &runtime_key)?;
-    append_log_marker(
-        &log_path,
-        &format!(
-            "\n=== starting {} ({}) at {} ===",
-            record.name,
-            record.pubkey,
-            now_iso()
-        ),
-    )?;
-
-    let stdout = open_log_file(&log_path)?;
-    let stderr = stdout
-        .try_clone()
-        .map_err(|error| format!("failed to clone log handle: {error}"))?;
     let resolved_acp_command = resolve_command(&record.acp_command)
         .ok_or_else(|| missing_command_message(&record.acp_command, "ACP harness command"))?;
     let effective_mcp_command = known_acp_runtime(effective_command)
@@ -517,10 +505,27 @@ pub fn spawn_agent_child(
         nvm_bin,
     );
 
-    let mut command = std::process::Command::new(&resolved_acp_command);
-    if let Some(home) = super::default_agent_workdir() {
-        command.current_dir(home);
-    }
+    // The boundary wraps the outer buzz-acp process, not the inner runtime.
+    // That is the only shared spawn seam inherited by the harness, ACP
+    // runtime, MCP/tool servers, shells, and background descendants.
+    let (mut command, isolation_run) =
+        super::managed_agent_command(app, record, &resolved_acp_command)?;
+    // Consume the prepared root before the first spawn-side mutation. A start
+    // without an exact lease must not even append a log marker.
+    let log_path = super::managed_agent_runtime_log_path(app, &runtime_key)?;
+    append_log_marker(
+        &log_path,
+        &format!(
+            "\n=== starting {} ({}) at {} ===",
+            record.name,
+            record.pubkey,
+            now_iso()
+        ),
+    )?;
+    let stdout = open_log_file(&log_path)?;
+    let stderr = stdout
+        .try_clone()
+        .map_err(|error| format!("failed to clone log handle: {error}"))?;
     command.stdin(std::process::Stdio::null());
     command.stdout(std::process::Stdio::from(stdout));
     command.stderr(std::process::Stdio::from(stderr));
@@ -864,13 +869,17 @@ pub fn spawn_agent_child(
         command.creation_flags(CREATE_NO_WINDOW);
     }
 
-    let child = command.spawn().map_err(|error| {
+    let mut child = command.spawn().map_err(|error| {
         format!(
             "failed to spawn `{}` for agent {}: {error}",
             resolved_acp_command.display(),
             record.name
         )
     })?;
+    let mut isolation_run = isolation_run;
+    if let Some(run) = isolation_run.as_mut() {
+        super::bind_isolation_process(run, &mut child)?;
+    }
 
     // Stamp the adapter availability for runtimes with a version gate (codex
     // only). The summary builder compares this against the current cached value
@@ -898,6 +907,7 @@ pub fn spawn_agent_child(
         spawned_setup_mode,
         spawned_adapter_availability,
         start_nonce,
+        isolation_run,
         &record.name,
     ));
     #[cfg(not(windows))]
@@ -908,6 +918,7 @@ pub fn spawn_agent_child(
         setup_mode: spawned_setup_mode,
         adapter_availability: spawned_adapter_availability,
         start_nonce,
+        isolation_run,
     })
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime/orphan_sweep.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/orphan_sweep.rs
@@ -282,14 +282,23 @@ pub(crate) fn collect_same_instance_orphans(
     instance_id: &str,
     skip_pids: &[u32],
 ) -> std::collections::HashSet<u32> {
+    collect_same_instance_orphans_checked(instance_id, skip_pids).unwrap_or_default()
+}
+
+/// Fail-closed process snapshot used by security-sensitive preflight paths.
+/// Unlike the periodic sweep helper, process-table enumeration errors are
+/// surfaced so an empty set cannot be mistaken for proof that no harness is
+/// live.
+#[cfg(target_os = "macos")]
+pub(crate) fn collect_same_instance_orphans_checked(
+    instance_id: &str,
+    skip_pids: &[u32],
+) -> Result<std::collections::HashSet<u32>, String> {
     let my_uid = unsafe { libc::getuid() };
     let my_pid = std::process::id() as i32;
     let mut orphans = std::collections::HashSet::new();
 
-    let pids = sweep::collect_all_pids();
-    if pids.is_empty() {
-        return orphans;
-    }
+    let pids = sweep::collect_all_pids_checked()?;
 
     for &pid in &pids {
         if pid <= 0 || pid == my_pid {
@@ -327,7 +336,7 @@ pub(crate) fn collect_same_instance_orphans(
         }
         orphans.insert(upid);
     }
-    orphans
+    Ok(orphans)
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -378,10 +387,26 @@ pub(crate) fn collect_same_instance_orphans(
     orphans
 }
 
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(crate) fn collect_same_instance_orphans_checked(
+    instance_id: &str,
+    skip_pids: &[u32],
+) -> Result<std::collections::HashSet<u32>, String> {
+    Ok(collect_same_instance_orphans(instance_id, skip_pids))
+}
+
 #[cfg(not(unix))]
 pub(crate) fn collect_same_instance_orphans(
     _instance_id: &str,
     _skip_pids: &[u32],
 ) -> std::collections::HashSet<u32> {
     std::collections::HashSet::new()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn collect_same_instance_orphans_checked(
+    instance_id: &str,
+    skip_pids: &[u32],
+) -> Result<std::collections::HashSet<u32>, String> {
+    Ok(collect_same_instance_orphans(instance_id, skip_pids))
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/sweep.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/sweep.rs
@@ -27,12 +27,15 @@ extern "C" {
 /// storm the count can grow between the probe and the fill call. Returns an
 /// empty vec on any kernel error.
 #[cfg(target_os = "macos")]
-pub(super) fn collect_all_pids() -> Vec<libc::c_int> {
+pub(super) fn collect_all_pids_checked() -> Result<Vec<libc::c_int>, String> {
     let mut pids: Vec<libc::c_int>;
     loop {
         let count = unsafe { proc_listallpids(std::ptr::null_mut(), 0) };
         if count <= 0 {
-            return Vec::new();
+            return Err(format!(
+                "failed to enumerate processes: {}",
+                std::io::Error::last_os_error()
+            ));
         }
         let buf_len = (count as usize) * 2;
         pids = vec![0; buf_len];
@@ -43,13 +46,21 @@ pub(super) fn collect_all_pids() -> Vec<libc::c_int> {
             )
         };
         if actual <= 0 {
-            return Vec::new();
+            return Err(format!(
+                "failed to enumerate processes: {}",
+                std::io::Error::last_os_error()
+            ));
         }
         pids.truncate(actual as usize);
         if (actual as usize) < buf_len {
-            return pids;
+            return Ok(pids);
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn collect_all_pids() -> Vec<libc::c_int> {
+    collect_all_pids_checked().unwrap_or_default()
 }
 
 /// Read the raw `KERN_PROCARGS2` buffer for the given PID.
@@ -321,12 +332,12 @@ fn proc_exe_path_from_procargs2(pid: u32) -> Option<PathBuf> {
 /// two-sysctl call by ~99.9% (there are typically O(hundreds) of user
 /// processes but at most a handful of `buzz-acp` instances).
 #[cfg(target_os = "macos")]
-fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
+fn collect_process_snapshots_checked(harness_name: &str) -> Result<Vec<ProcessSnapshot>, String> {
     let my_uid = unsafe { libc::getuid() };
     let my_pid = std::process::id() as i32;
     let mut snapshots = Vec::new();
 
-    let pids = collect_all_pids();
+    let pids = collect_all_pids_checked()?;
 
     for &pid in &pids {
         if pid <= 0 || pid == my_pid {
@@ -375,7 +386,12 @@ fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
             });
         }
     }
-    snapshots
+    Ok(snapshots)
+}
+
+#[cfg(target_os = "macos")]
+fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
+    collect_process_snapshots_checked(harness_name).unwrap_or_default()
 }
 
 /// Collect process snapshots for all user-owned processes on Linux via /proc.
@@ -385,14 +401,13 @@ fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
 /// launch — exactly the stale-install class this sweep targets. The suffix is
 /// stripped so the comparison against `expected_harness_exe_path` succeeds.
 #[cfg(all(unix, not(target_os = "macos")))]
-fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
+fn collect_process_snapshots_checked(harness_name: &str) -> Result<Vec<ProcessSnapshot>, String> {
     let my_uid = unsafe { libc::getuid() };
     let my_pid = std::process::id() as i32;
     let mut snapshots = Vec::new();
 
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return snapshots;
-    };
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|error| format!("failed to enumerate processes: {error}"))?;
     for entry in entries.flatten() {
         let name = entry.file_name();
         let Some(name_str) = name.to_str() else {
@@ -430,7 +445,12 @@ fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
             });
         }
     }
-    snapshots
+    Ok(snapshots)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn collect_process_snapshots(harness_name: &str) -> Vec<ProcessSnapshot> {
+    collect_process_snapshots_checked(harness_name).unwrap_or_default()
 }
 
 // ── expected_harness_exe_path ─────────────────────────────────────────────
@@ -471,6 +491,30 @@ pub fn expected_harness_exe_path() -> Option<PathBuf> {
 /// The basename of the harness binary — used for the cheap name pre-filter in
 /// `collect_process_snapshots` before the expensive exe-path lookup.
 const HARNESS_BINARY_NAME: &str = "buzz-acp";
+
+/// Return exact-path outer harnesses that are not tracked by this Desktop.
+/// Enumeration and current-executable failures are surfaced so callers can
+/// use an empty result as positive evidence instead of a best-effort sweep.
+#[cfg(unix)]
+pub(crate) fn collect_untracked_bundle_harnesses_checked(
+    tracked_pids: &[u32],
+) -> Result<Vec<u32>, String> {
+    let harness_exe = expected_harness_exe_path()
+        .ok_or_else(|| "failed to resolve this Buzz bundle's harness path".to_string())?;
+    let snapshots = collect_process_snapshots_checked(HARNESS_BINARY_NAME)?;
+    Ok(select_untracked_bundle_harnesses(
+        &snapshots,
+        &harness_exe,
+        tracked_pids,
+    ))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn collect_untracked_bundle_harnesses_checked(
+    _tracked_pids: &[u32],
+) -> Result<Vec<u32>, String> {
+    Ok(Vec::new())
+}
 
 // ── sweep_untracked_bundle_harnesses ─────────────────────────────────────
 

--- a/desktop/src-tauri/src/managed_agents/runtime/test_fixtures.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/test_fixtures.rs
@@ -57,6 +57,7 @@ pub(super) fn fixture(
         provider: None,
         persona_source_version: None,
         env_vars: std::collections::BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1237,8 +1237,7 @@ fn minimal_record(pubkey: &str) -> crate::managed_agents::ManagedAgentRecord {
 
 fn make_pair_runtime_placeholder() -> crate::managed_agents::ManagedAgentPairRuntime {
     use std::process::{Command, Stdio};
-    // Spawn a real child so ManagedAgentProcess's Child field is satisfied.
-    // `true` exits immediately with 0 — just a handle we need for type purposes.
+    // Spawn `true` for the real Child handle required by ManagedAgentProcess.
     //
     // Absolute `/usr/bin/true` on unix (present on both macOS and Linux):
     // parallel tests holding `lock_path_mutex` swap PATH to a tempdir, and a
@@ -1267,6 +1266,7 @@ fn make_pair_runtime_placeholder() -> crate::managed_agents::ManagedAgentPairRun
         setup_mode: false,
         adapter_availability: None,
         start_nonce: "test-nonce".to_string(),
+        isolation_run: None,
         #[cfg(windows)]
         job: None,
     };

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -3,15 +3,19 @@ use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Emitter, Manager};
 
 use super::{
-    agent_readiness, append_log_marker, current_instance_id, find_managed_agent_mut,
-    load_global_agent_config, load_managed_agents, load_personas, managed_agent_runtime_log_path,
-    process_is_running, record_agent_command, resolve_effective_agent_env, save_managed_agents,
-    spawn_agent_child, terminate_process, terminate_untracked_pair_runtime,
-    write_agent_runtime_receipt, AgentReadiness, BackendKind, ManagedAgentPairRuntime,
-    ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle, ManagedAgentRuntimeReceipt,
-    ManagedAgentRuntimeStatus,
+    abort_prepared_isolated_agent_run, agent_readiness, append_log_marker, current_instance_id,
+    find_managed_agent_mut, get_prepared_isolated_agent_run, load_global_agent_config,
+    load_managed_agents, load_personas, managed_agent_runtime_log_path, missing_command_message,
+    prepare_isolated_agent_run, process_is_running, record_agent_command, resolve_command,
+    resolve_effective_agent_env, save_managed_agents, spawn_agent_child, terminate_process,
+    terminate_untracked_pair_runtime, write_agent_runtime_receipt, AgentReadiness, BackendKind,
+    ManagedAgentPairRuntime, ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle,
+    ManagedAgentRuntimeReceipt, ManagedAgentRuntimeStatus,
 };
 use crate::app_state::AppState;
+
+mod preflight;
+use preflight::ensure_no_runtime_before_isolation_prepare;
 
 const STATUS_EVENT: &str = "managed-agent-runtime-status";
 
@@ -225,6 +229,96 @@ pub(crate) fn start_managed_agent_runtime_pair_lazy(
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
     start_pair(pubkey, relay_url, true, None, app)
+}
+
+#[tauri::command]
+pub fn prepare_managed_agent_isolation(
+    pubkey: String,
+    app: AppHandle,
+) -> Result<super::PreparedFilesystemIsolation, String> {
+    let state = app.state::<AppState>();
+    let _transition = state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|e| e.to_string())?;
+    if state.shutdown_started.load(Ordering::Acquire) {
+        return Err("desktop shutdown has started".into());
+    }
+    let _store = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| e.to_string())?;
+    let records = load_managed_agents(&app)?;
+    let record = records
+        .iter()
+        .find(|record| record.pubkey.eq_ignore_ascii_case(&pubkey))
+        .ok_or_else(|| format!("agent {pubkey} not found"))?;
+    if record.backend != BackendKind::Local {
+        return Err("filesystem isolation requires a local agent".into());
+    }
+    let mut runtimes = state
+        .managed_agent_processes
+        .lock()
+        .map_err(|e| e.to_string())?;
+    let mut tracked_pids = Vec::new();
+    for (key, runtime) in runtimes.iter_mut() {
+        match runtime.child.try_wait() {
+            Ok(None) => {
+                if key.pubkey.eq_ignore_ascii_case(&record.pubkey) {
+                    return Err(
+                        "stop every runtime for this agent before preparing isolation".into(),
+                    );
+                }
+                tracked_pids.push(runtime.child.id());
+            }
+            Ok(Some(_)) => {}
+            Err(error) => {
+                return Err(format!(
+                    "cannot prove managed runtimes are stopped before preparing isolation: {error}"
+                ));
+            }
+        }
+    }
+    ensure_no_runtime_before_isolation_prepare(
+        &app,
+        &record.pubkey,
+        &current_instance_id(&app),
+        &tracked_pids,
+    )?;
+    drop(runtimes);
+    let profile = record
+        .filesystem_isolation
+        .as_ref()
+        .ok_or_else(|| "filesystem isolation is not enabled for this agent".to_string())?;
+    let acp_command = resolve_command(&record.acp_command)
+        .ok_or_else(|| missing_command_message(&record.acp_command, "ACP harness command"))?;
+    prepare_isolated_agent_run(
+        profile,
+        &record.pubkey,
+        &current_instance_id(&app),
+        &acp_command,
+    )
+}
+
+#[tauri::command]
+pub fn abort_managed_agent_isolation(
+    pubkey: String,
+    run_id: String,
+    app: AppHandle,
+) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let _transition = state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|e| e.to_string())?;
+    abort_prepared_isolated_agent_run(&pubkey, &run_id)
+}
+
+#[tauri::command]
+pub fn get_prepared_managed_agent_isolation(
+    pubkey: String,
+) -> Result<Option<super::PreparedFilesystemIsolation>, String> {
+    get_prepared_isolated_agent_run(&pubkey)
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/managed_agents/runtime_commands/preflight.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands/preflight.rs
@@ -1,0 +1,242 @@
+use std::{fs, path::PathBuf};
+
+use tauri::AppHandle;
+
+use crate::managed_agents::{
+    collect_same_instance_orphans_checked, collect_untracked_bundle_harnesses_checked,
+    managed_agents_base_dir, process_has_buzz_marker, process_is_running, ManagedAgentRuntimeKey,
+    ManagedAgentRuntimeReceipt,
+};
+
+fn runtime_receipt_entries(
+    app: &AppHandle,
+) -> Result<Vec<(PathBuf, ManagedAgentRuntimeReceipt)>, String> {
+    let dir = managed_agents_base_dir(app)?.join("agent-pids");
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut receipts = Vec::new();
+    for entry in fs::read_dir(&dir)
+        .map_err(|error| format!("failed to inspect managed runtime receipts: {error}"))?
+    {
+        let entry = entry
+            .map_err(|error| format!("failed to inspect managed runtime receipt entry: {error}"))?;
+        let path = entry.path();
+        if path.extension().is_none_or(|extension| extension != "json") {
+            continue;
+        }
+        let metadata = path.symlink_metadata().map_err(|error| {
+            format!(
+                "failed to inspect runtime receipt {}: {error}",
+                path.display()
+            )
+        })?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(format!(
+                "ambiguous managed runtime receipt path {}",
+                path.display()
+            ));
+        }
+        let bytes = fs::read(&path).map_err(|error| {
+            format!("failed to read runtime receipt {}: {error}", path.display())
+        })?;
+        let receipt = serde_json::from_slice(&bytes).map_err(|error| {
+            format!(
+                "ambiguous managed runtime receipt {}: {error}",
+                path.display()
+            )
+        })?;
+        receipts.push((path, receipt));
+    }
+    Ok(receipts)
+}
+
+fn reconcile_agent_runtime_receipts_with(
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    receipts: Vec<(PathBuf, ManagedAgentRuntimeReceipt)>,
+    is_running: impl Fn(u32) -> bool,
+    has_marker: impl Fn(u32, &str) -> bool,
+    mut remove: impl FnMut(&std::path::Path) -> Result<(), String>,
+) -> Result<(), String> {
+    for (path, receipt) in receipts {
+        if !receipt.key.pubkey.eq_ignore_ascii_case(identity_pubkey) {
+            continue;
+        }
+        if !is_running(receipt.pid) {
+            remove(&path)?;
+            continue;
+        }
+
+        let canonical = ManagedAgentRuntimeKey::new(
+            receipt.key.pubkey.clone(),
+            &receipt.key.relay_url,
+        )
+        .map_err(|_| {
+            format!(
+                "ambiguous live runtime receipt for agent {identity_pubkey}; stop it before preparing isolation"
+            )
+        })?;
+        let filename_matches = path.file_name().and_then(|name| name.to_str())
+            == Some(&format!("{}.json", canonical.runtime_id()));
+        if canonical != receipt.key
+            || !filename_matches
+            || receipt.desktop_instance_id != desktop_instance_id
+            || !has_marker(receipt.pid, desktop_instance_id)
+        {
+            return Err(format!(
+                "ambiguous live runtime receipt for agent {identity_pubkey}; stop it before preparing isolation"
+            ));
+        }
+        return Err(format!(
+            "agent {identity_pubkey} still has live harness {} on {}; stop it before preparing isolation",
+            receipt.pid, receipt.key.relay_url
+        ));
+    }
+    Ok(())
+}
+
+/// Prove that Prepare starts from a process-free boundary. The caller holds
+/// both the runtime transition and managed-agent store locks, so receipt
+/// reconciliation, the process snapshot, and run-root creation cannot race a
+/// managed start in this Desktop process.
+pub(crate) fn ensure_no_runtime_before_isolation_prepare(
+    app: &AppHandle,
+    identity_pubkey: &str,
+    desktop_instance_id: &str,
+    tracked_pids: &[u32],
+) -> Result<(), String> {
+    reconcile_agent_runtime_receipts_with(
+        identity_pubkey,
+        desktop_instance_id,
+        runtime_receipt_entries(app)?,
+        process_is_running,
+        process_has_buzz_marker,
+        |path| {
+            fs::remove_file(path).map_err(|error| {
+                format!(
+                    "failed to remove dead runtime receipt {}: {error}",
+                    path.display()
+                )
+            })
+        },
+    )?;
+
+    let mut ambiguous = collect_same_instance_orphans_checked(desktop_instance_id, tracked_pids)?;
+    ambiguous.extend(collect_untracked_bundle_harnesses_checked(tracked_pids)?);
+    if !ambiguous.is_empty() {
+        let mut pids: Vec<u32> = ambiguous.into_iter().collect();
+        pids.sort_unstable();
+        return Err(format!(
+            "cannot prove the agent harness is stopped; untracked harness or same-instance process(es) {pids:?} remain"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn receipt(
+        pubkey: &str,
+        pid: u32,
+        instance: &str,
+    ) -> (tempfile::TempDir, PathBuf, ManagedAgentRuntimeReceipt) {
+        let dir = tempfile::tempdir().unwrap();
+        let key = ManagedAgentRuntimeKey::new(pubkey.to_string(), "wss://relay.example").unwrap();
+        let path = dir.path().join(format!("{}.json", key.runtime_id()));
+        let receipt = ManagedAgentRuntimeReceipt {
+            key,
+            pid,
+            desktop_instance_id: instance.to_string(),
+            started_at: "now".into(),
+        };
+        fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+        (dir, path, receipt)
+    }
+
+    #[test]
+    fn live_prior_runtime_blocks_prepare_before_any_isolation_run() {
+        let identity = format!("{:064x}", std::process::id());
+        let instance = "test-isolation-preflight";
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg("while :; do sleep 1; done")
+            .env("BUZZ_MANAGED_AGENT", instance)
+            .spawn()
+            .unwrap();
+        let (_dir, path, receipt) = receipt(&identity, child.id(), instance);
+
+        let profile = crate::managed_agents::FilesystemIsolationProfile::Ephemeral {
+            read_only_roots: Vec::new(),
+        };
+        let result = reconcile_agent_runtime_receipts_with(
+            &identity,
+            instance,
+            vec![(path.clone(), receipt)],
+            process_is_running,
+            |_, _| true,
+            |_| panic!("live receipt must not be removed"),
+        )
+        .and_then(|()| {
+            crate::managed_agents::prepare_isolated_agent_run(
+                &profile,
+                &identity,
+                instance,
+                std::path::Path::new("/bin/sh"),
+            )
+        });
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        if let Ok(prepared) = &result {
+            crate::managed_agents::abort_prepared_isolated_agent_run(&identity, &prepared.run_id)
+                .unwrap();
+        }
+
+        assert!(
+            result.unwrap_err().contains("still has live harness"),
+            "live persisted runtime did not fail closed"
+        );
+        assert!(path.exists(), "live prior-session receipt was removed");
+        assert_eq!(
+            crate::managed_agents::get_prepared_isolated_agent_run(&identity).unwrap(),
+            None,
+            "Prepare published an isolation run despite the live harness"
+        );
+    }
+
+    #[test]
+    fn dead_exact_receipt_is_cleaned_before_prepare() {
+        let identity = "da".repeat(32);
+        let (_dir, path, receipt) = receipt(&identity, u32::MAX, "test");
+        reconcile_agent_runtime_receipts_with(
+            &identity,
+            "test",
+            vec![(path.clone(), receipt)],
+            |_| false,
+            |_, _| false,
+            |path| fs::remove_file(path).map_err(|error| error.to_string()),
+        )
+        .unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn ambiguous_live_exact_receipt_fails_closed() {
+        let identity = "db".repeat(32);
+        let (_dir, path, receipt) = receipt(&identity, 42, "test");
+        let error = reconcile_agent_runtime_receipts_with(
+            &identity,
+            "test",
+            vec![(path.clone(), receipt)],
+            |_| true,
+            |_, _| false,
+            |_| panic!("ambiguous live receipt must not be removed"),
+        )
+        .unwrap_err();
+        assert!(error.contains("ambiguous live runtime receipt"));
+        assert!(path.exists());
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot.rs
@@ -123,6 +123,7 @@ pub(crate) struct SpawnConfigSnapshot {
     pub idle_timeout_seconds: Option<u64>,
     pub max_turn_duration_seconds: Option<u64>,
     pub parallelism: u32,
+    pub filesystem_isolation: Option<super::FilesystemIsolationProfile>,
 }
 
 impl SpawnConfigSnapshot {
@@ -174,6 +175,7 @@ impl SpawnConfigSnapshot {
             // pool and must badge. The diff surface consequently displays the
             // effective value — that is correct, it is what actually runs.
             parallelism: super::effective_parallelism(&descriptor.command, record.parallelism),
+            filesystem_isolation: record.filesystem_isolation.clone(),
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
@@ -28,6 +28,7 @@ fn base() -> SpawnConfigSnapshot {
         idle_timeout_seconds: Some(600),
         max_turn_duration_seconds: Some(7200),
         parallelism: 1,
+        filesystem_isolation: None,
     }
 }
 
@@ -70,6 +71,12 @@ fn mutations() -> Vec<Mutation> {
             s.max_turn_duration_seconds = None
         }),
         ("parallelism", |s| s.parallelism = 8),
+        ("filesystem_isolation", |s| {
+            s.filesystem_isolation =
+                Some(super::super::super::FilesystemIsolationProfile::Ephemeral {
+                    read_only_roots: Vec::new(),
+                })
+        }),
     ]
 }
 
@@ -442,6 +449,7 @@ fn no_sentinel_reaches_the_owning_process_debug_output() {
         setup_mode: false,
         adapter_availability: None,
         start_nonce: "test-nonce".to_string(),
+        isolation_run: None,
         #[cfg(windows)]
         job: None,
     };

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/tests.rs
@@ -38,6 +38,7 @@ fn record() -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: true,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -278,6 +278,7 @@ mod tests {
                 m.insert("API_KEY".to_string(), "secret123".to_string()); // MUST NOT appear
                 m
             },
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -185,6 +185,7 @@ fn managed_agent(name: &str) -> ManagedAgentRecord {
         provider: None,
         persona_source_version: None,
         env_vars: std::collections::BTreeMap::new(),
+        filesystem_isolation: None,
         start_on_app_launch: false,
         auto_restart_on_config_change: false,
         runtime_pid: None,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, path::PathBuf, process::Child};
+use std::{collections::BTreeMap, path::PathBuf};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -120,6 +120,7 @@ impl AgentDefinition {
             provider: self.provider,
             persona_source_version: None,
             env_vars: self.env_vars,
+            filesystem_isolation: None,
             start_on_app_launch: false,
             auto_restart_on_config_change: true,
             runtime_pid: None,
@@ -307,6 +308,10 @@ pub struct ManagedAgentRecord {
     /// To "override" a persona env var: set the same key here.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env_vars: BTreeMap<String, String>,
+    /// Enforced local process-tree filesystem boundary. `None` preserves the
+    /// pre-isolation behavior for existing agents and remote backends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filesystem_isolation: Option<FilesystemIsolationProfile>,
     #[serde(default = "default_start_on_app_launch")]
     pub start_on_app_launch: bool,
     /// Auto-restart this agent when its effective spawn config drifts from
@@ -458,38 +463,6 @@ pub struct RelayMeshConfig {
     pub model_ref: String,
 }
 
-#[derive(Debug)]
-pub struct ManagedAgentProcess {
-    pub child: Child,
-    pub log_path: PathBuf,
-    /// The effective spawn config this process was launched with (see
-    /// `spawn_snapshot::SpawnConfigSnapshot`). Runtime-only — never persisted.
-    /// The summary builder recomputes a prospective snapshot and reports
-    /// differing fields via `ManagedAgentSummary::restart_diff`. Agents
-    /// adopted via `runtime_pid` have none; their config is unknown.
-    pub spawn_config: super::spawn_snapshot::SpawnConfigSnapshot,
-    /// Whether this process was spawned in setup-listener mode (i.e.
-    /// `BUZZ_ACP_SETUP_PAYLOAD` was set at launch because the agent was
-    /// `NotReady`). Runtime-only — never persisted. Used by
-    /// `install_acp_runtime` to target only stuck agents for auto-restart,
-    /// excluding healthy in-pool agents.
-    pub setup_mode: bool,
-    /// Adapter availability status stamped at spawn time for runtimes with a
-    /// version gate (currently codex only; `None` for all others). Runtime-only
-    /// — never persisted. The summary builder compares this against the current
-    /// cached availability and sets `needs_restart` on drift, catching out-of-
-    /// band adapter changes that Phase-1 auto-restart doesn't cover.
-    pub adapter_availability: Option<AcpAvailabilityStatus>,
-    /// Unpredictable identity shared only with this harness generation.
-    pub start_nonce: String,
-    /// Win32 Job Object owning the harness + its entire process tree. Closing
-    /// the handle (via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) kills the whole
-    /// tree — the Windows mirror of the Unix process-group teardown. `None`
-    /// if job creation/assignment failed (we fall back to `Child::kill()`).
-    #[cfg(windows)]
-    pub job: Option<crate::managed_agents::JobHandle>,
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct ManagedAgentSummary {
     pub pubkey: String,
@@ -550,6 +523,8 @@ pub struct ManagedAgentSummary {
     pub restart_diff: Vec<super::spawn_snapshot::RestartDiffEntry>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env_vars: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filesystem_isolation: Option<FilesystemIsolationProfile>,
     pub backend: BackendKind,
     pub backend_agent_id: Option<String>,
     pub status: String,
@@ -990,8 +965,12 @@ pub fn resolve_mint_behavioral_defaults(
 
 mod catalog_source;
 pub use catalog_source::CatalogSource;
+mod filesystem_isolation_profile;
+pub use filesystem_isolation_profile::FilesystemIsolationProfile;
 mod requests;
 pub use requests::*;
+mod runtime_process;
+pub use runtime_process::ManagedAgentProcess;
 
 #[cfg(test)]
 mod tests;

--- a/desktop/src-tauri/src/managed_agents/types/filesystem_isolation_profile.rs
+++ b/desktop/src-tauri/src/managed_agents/types/filesystem_isolation_profile.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Owner-reviewed filesystem boundary for a local managed agent.
+///
+/// The profile is instance-local and is never published with a persona. Each
+/// start creates a new run root; additional roots are read-only and must be
+/// explicitly declared by the owner. The shared Buzz nest is denied even when
+/// a configured root would otherwise overlap it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum FilesystemIsolationProfile {
+    Ephemeral {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        read_only_roots: Vec<PathBuf>,
+    },
+}

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use super::{
     default_start_on_app_launch, validate_respond_to_allowlist, AgentDefinition, BackendKind,
-    CatalogSource, RelayMeshConfig, RespondTo,
+    CatalogSource, FilesystemIsolationProfile, RelayMeshConfig, RespondTo,
 };
 
 /// The NIP-AP behavioral group as one grouped request field.
@@ -170,6 +170,9 @@ pub struct CreateManagedAgentRequest {
     /// Environment variables for this agent. Layered on top of persona env.
     #[serde(default)]
     pub env_vars: BTreeMap<String, String>,
+    /// Optional local process-tree boundary. Provider-backed agents reject it.
+    #[serde(default)]
+    pub filesystem_isolation: Option<FilesystemIsolationProfile>,
     #[serde(default)]
     pub spawn_after_create: bool,
     #[serde(default = "default_start_on_app_launch")]
@@ -188,6 +191,19 @@ pub struct CreateManagedAgentRequest {
     pub respond_to_allowlist: Vec<String>,
     #[serde(default)]
     pub relay_mesh: Option<RelayMeshConfig>,
+}
+
+impl CreateManagedAgentRequest {
+    pub fn validate_filesystem_isolation(&self) -> Result<(), String> {
+        let Some(profile) = &self.filesystem_isolation else {
+            return Ok(());
+        };
+        crate::managed_agents::validate_filesystem_isolation_profile(profile)?;
+        if self.backend != BackendKind::Local {
+            return Err("filesystem isolation is available only for local managed agents".into());
+        }
+        Ok(())
+    }
 }
 
 /// Patch request for updating a managed agent's mutable fields.
@@ -211,6 +227,9 @@ pub struct UpdateManagedAgentRequest {
     /// Absent = don't touch. Present = replace the env_vars map entirely.
     #[serde(default)]
     pub env_vars: Option<BTreeMap<String, String>>,
+    /// Absent = don't touch, null = disable, object = replace profile.
+    #[serde(default, deserialize_with = "crate::util::double_option")]
+    pub filesystem_isolation: Option<Option<FilesystemIsolationProfile>>,
     #[serde(default)]
     pub parallelism: Option<u32>,
     /// Accepted for wire compatibility; not applied to the stored record.

--- a/desktop/src-tauri/src/managed_agents/types/runtime_process.rs
+++ b/desktop/src-tauri/src/managed_agents/types/runtime_process.rs
@@ -1,0 +1,39 @@
+use std::{path::PathBuf, process::Child};
+
+use super::AcpAvailabilityStatus;
+
+#[derive(Debug)]
+pub struct ManagedAgentProcess {
+    pub child: Child,
+    pub log_path: PathBuf,
+    /// The effective spawn config this process was launched with (see
+    /// `spawn_snapshot::SpawnConfigSnapshot`). Runtime-only — never persisted.
+    /// The summary builder recomputes a prospective snapshot and reports
+    /// differing fields via `ManagedAgentSummary::restart_diff`. Agents
+    /// adopted via `runtime_pid` have none; their config is unknown.
+    pub spawn_config: crate::managed_agents::spawn_snapshot::SpawnConfigSnapshot,
+    /// Whether this process was spawned in setup-listener mode (i.e.
+    /// `BUZZ_ACP_SETUP_PAYLOAD` was set at launch because the agent was
+    /// `NotReady`). Runtime-only — never persisted. Used by
+    /// `install_acp_runtime` to target only stuck agents for auto-restart,
+    /// excluding healthy in-pool agents.
+    pub setup_mode: bool,
+    /// Adapter availability status stamped at spawn time for runtimes with a
+    /// version gate (currently codex only; `None` for all others). Runtime-only
+    /// — never persisted. The summary builder compares this against the current
+    /// cached availability and sets `needs_restart` on drift, catching out-of-
+    /// band adapter changes that Phase-1 auto-restart doesn't cover.
+    pub adapter_availability: Option<AcpAvailabilityStatus>,
+    /// Unpredictable identity shared only with this harness generation.
+    pub start_nonce: String,
+    /// Owns the fresh run root. Dropping it after the process tree exits
+    /// removes all per-run residue before another session can start.
+    #[allow(dead_code)] // lifecycle ownership is the read: Drop performs cleanup
+    pub isolation_run: Option<crate::managed_agents::FilesystemIsolationRun>,
+    /// Win32 Job Object owning the harness + its entire process tree. Closing
+    /// the handle (via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) kills the whole
+    /// tree — the Windows mirror of the Unix process-group teardown. `None`
+    /// if job creation/assignment failed (we fall back to `Child::kill()`).
+    #[cfg(windows)]
+    pub job: Option<crate::managed_agents::JobHandle>,
+}

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -728,6 +728,7 @@ fn summary_fixture(
         needs_restart: !restart_diff.is_empty(),
         restart_diff,
         env_vars: Default::default(),
+        filesystem_isolation: None,
         backend: super::BackendKind::Local,
         backend_agent_id: None,
         status: "running".into(),

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -172,6 +172,16 @@ with a TypeScript lookup table or an id comparison in a component.
    locked to owner-only, including provider-backed agents. A provider backend
    does not prove remote execution and must never create a policy carve-out.
 
+12. **Filesystem isolation is instance-local and enforced at the outer spawn.**
+    `ManagedAgentRecord.filesystem_isolation` is never a persona capability or
+    public catalog field. Desktop wraps `buzz-acp` in `runtime.rs`, before the
+    harness creates the ACP runtime or MCP/tool children, and retains the fresh
+    run-root guard on `ManagedAgentProcess` until the whole process tree exits.
+    Do not move the boundary into `AcpClient::spawn`, represent it as a `cwd`,
+    or expose an attestation env key that user `env_vars` can override. Extra
+    read-only roots are explicit owner-reviewed instance paths; `/`, the bare
+    home directory, and any root overlapping the Buzz nest must fail closed.
+
 ## The tests that enforce this
 
 - `lib/agentConfigCore.test.mjs` — field model per harness × scope, clearing

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -95,6 +95,7 @@ import {
   runtimeDropdownAction,
   usePendingHarnessSelection,
 } from "./addCustomHarness";
+import { useFilesystemIsolationDraft } from "./filesystemIsolation";
 
 export function AgentInstanceEditDialog({
   agent,
@@ -145,6 +146,7 @@ export function AgentInstanceEditDialog({
   const [envVars, setEnvVars] = React.useState<EnvVarsValue>(agent.envVars);
   const [autoRestartOnConfigChange, setAutoRestartOnConfigChange] =
     React.useState(agent.autoRestartOnConfigChange);
+  const filesystemIsolation = useFilesystemIsolationDraft(agent, open);
   const personasQuery = usePersonasQuery();
   const linkedPersona = React.useMemo(
     () =>
@@ -167,14 +169,10 @@ export function AgentInstanceEditDialog({
   const [isAddHarnessOpen, setIsAddHarnessOpen] = React.useState(false);
   const shouldReduceMotion = useReducedMotion();
 
-  // Runtime selector: defaults to "custom" until the dialog opens and the
-  // catalog loads. The open-effect re-derives the correct id from the catalog.
+  // The open-effect replaces this default after the runtime catalog loads.
   const [selectedRuntimeId, setSelectedRuntimeId] = React.useState("custom");
-
-  // Tracks whether the user has made an in-dialog runtime selection.
   const runtimeTouched = React.useRef(false);
 
-  // Reset form state only when the dialog opens or when switching to a different agent.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — including agent fields would re-fire on every 5s poll and wipe edits
   React.useEffect(() => {
     if (open) {
@@ -613,6 +611,7 @@ export function AgentInstanceEditDialog({
       requiredEnvKeyMissing,
     }) &&
     providerValid &&
+    filesystemIsolation.valid &&
     !updateMutation.isPending &&
     !isAvatarUploadPending;
 
@@ -713,6 +712,7 @@ export function AgentInstanceEditDialog({
         envVars: envVarsEqual(submitEnvVars, agent.envVars)
           ? undefined
           : submitEnvVars,
+        filesystemIsolation: filesystemIsolation.update,
         respondTo: respondTo !== agent.respondTo ? respondTo : undefined,
         // The allowlist is preserved across mode toggles in local UI state
         // (so a user can flip away from allowlist and back without losing
@@ -729,8 +729,7 @@ export function AgentInstanceEditDialog({
 
       const result = await updateMutation.mutateAsync(input);
       if (autoRestartOnConfigChange !== agent.autoRestartOnConfigChange) {
-        // Standalone setter (mirrors start-on-app-launch) — not part of
-        // UpdateManagedAgentInput, so the frozen update shape stays frozen.
+        // Lifecycle preference uses its standalone setter.
         await setManagedAgentAutoRestart(
           agent.pubkey,
           autoRestartOnConfigChange,
@@ -1180,6 +1179,7 @@ export function AgentInstanceEditDialog({
                       autoRestartOnConfigChange={autoRestartOnConfigChange}
                       disabled={updateMutation.isPending}
                       envVars={envVars}
+                      filesystemIsolation={filesystemIsolation.fieldProps}
                       fileSatisfiedEnvKeys={fileSatisfiedEnvKeys}
                       hiddenEnvKeys={
                         topLevelSecretEnvVar ? [topLevelSecretEnvVar] : []

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -28,6 +28,7 @@ import {
   structuredEnvKeys,
   type RuntimeCatalogStatus,
 } from "../lib/agentConfigCore";
+import type { FilesystemIsolationFieldProps } from "./filesystemIsolation";
 
 export function EditAgentAdvancedFields({
   acpCommand,
@@ -35,6 +36,7 @@ export function EditAgentAdvancedFields({
   autoRestartOnConfigChange,
   disabled,
   envVars,
+  filesystemIsolation,
   fileSatisfiedEnvKeys,
   hiddenEnvKeys = [],
   focusKey,
@@ -62,6 +64,7 @@ export function EditAgentAdvancedFields({
   autoRestartOnConfigChange: boolean;
   disabled: boolean;
   envVars: EnvVarsValue;
+  filesystemIsolation: FilesystemIsolationFieldProps;
   fileSatisfiedEnvKeys: readonly string[];
   hiddenEnvKeys?: readonly string[];
   /** When set, EnvVarsEditor scrolls and focuses this key's input on mount. */
@@ -193,6 +196,113 @@ export function EditAgentAdvancedFields({
             ? "Restarts this agent automatically when its configuration changes, once it is idle and connected."
             : "Configuration changes only show the restart badge; restart manually to apply them."}
         </p>
+      </div>
+
+      {/* Instance-local, inherited process-tree boundary. macOS is the first
+          enforcement backend; unsupported hosts must not advertise a cosmetic setting. */}
+      <div className="space-y-1.5">
+        <label
+          className="flex items-center gap-2 text-sm font-medium"
+          htmlFor="edit-agent-filesystem-isolation"
+        >
+          <input
+            checked={filesystemIsolation.enabled}
+            disabled={disabled || !filesystemIsolation.available}
+            id="edit-agent-filesystem-isolation"
+            onChange={(event) =>
+              filesystemIsolation.onEnabledChange(event.target.checked)
+            }
+            type="checkbox"
+          />
+          Isolate filesystem for each run
+        </label>
+        <p className="text-xs text-muted-foreground">
+          {!filesystemIsolation.available
+            ? "Available for local managed agents on macOS."
+            : filesystemIsolation.enabled
+              ? "Creates a fresh writable run root and applies one inherited boundary to the harness, runtime, tools, and child processes. Shared Buzz data stays denied."
+              : "This agent keeps normal host filesystem access."}
+        </p>
+        {filesystemIsolation.enabled ? (
+          <div className="space-y-1.5 pt-1">
+            <label
+              className="text-sm font-medium text-foreground"
+              htmlFor="edit-agent-filesystem-read-roots"
+            >
+              Additional read-only directories
+              <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+            </label>
+            <div className={PERSONA_FIELD_SHELL_CLASS}>
+              <Textarea
+                autoCorrect="off"
+                className={cn(
+                  "min-h-20 resize-y px-3 py-3 font-mono text-xs leading-5",
+                  PERSONA_FIELD_CONTROL_CLASS,
+                )}
+                disabled={disabled || !filesystemIsolation.available}
+                id="edit-agent-filesystem-read-roots"
+                onChange={(event) =>
+                  filesystemIsolation.onReadOnlyRootsChange(event.target.value)
+                }
+                placeholder="One existing absolute directory per line"
+                value={filesystemIsolation.readOnlyRoots}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              `/`, your home directory, and protected Buzz data are always
+              rejected. Restart the agent after saving to apply this boundary.
+            </p>
+            <div className="space-y-2 rounded-md border border-border/70 p-3">
+              <p className="text-xs text-muted-foreground">
+                Prepare creates the fresh root without starting the agent. Add
+                and verify preflight markers there, then use Start to consume
+                this exact root once.
+              </p>
+              {filesystemIsolation.prepared ? (
+                <div className="space-y-1">
+                  <p className="break-all font-mono text-xs">
+                    {filesystemIsolation.prepared.runRoot}
+                  </p>
+                  <p className="font-mono text-xs text-muted-foreground">
+                    Run {filesystemIsolation.prepared.runId}
+                  </p>
+                </div>
+              ) : null}
+              <button
+                className="rounded-md border border-input px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={
+                  disabled ||
+                  filesystemIsolation.preparePending ||
+                  (!filesystemIsolation.prepared &&
+                    !filesystemIsolation.canPrepare)
+                }
+                onClick={() =>
+                  void (filesystemIsolation.prepared
+                    ? filesystemIsolation.onAbort()
+                    : filesystemIsolation.onPrepare())
+                }
+                type="button"
+              >
+                {filesystemIsolation.preparePending
+                  ? "Working…"
+                  : filesystemIsolation.prepared
+                    ? "Abort prepared run"
+                    : "Prepare isolated run"}
+              </button>
+              {!filesystemIsolation.canPrepare &&
+              !filesystemIsolation.prepared ? (
+                <p className="text-xs text-muted-foreground">
+                  Save the enabled isolation profile before preparing a run.
+                </p>
+              ) : null}
+              {filesystemIsolation.prepareError ? (
+                <p className="text-xs text-destructive">
+                  {filesystemIsolation.prepareError}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {/* Agent runtime args */}

--- a/desktop/src/features/agents/ui/filesystemIsolation.test.mjs
+++ b/desktop/src/features/agents/ui/filesystemIsolation.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filesystemIsolationIsAvailable,
+  filesystemIsolationProfilesEqual,
+  isolationReadOnlyRootsAreAbsolute,
+  parseIsolationReadOnlyRoots,
+  resolveFilesystemIsolationUpdate,
+} from "./filesystemIsolation.ts";
+
+test("read-only root parser trims blanks and removes duplicates", () => {
+  assert.deepEqual(
+    parseIsolationReadOnlyRoots(
+      " /opt/runtime \n\n/usr/local/share\n/opt/runtime\n",
+    ),
+    ["/opt/runtime", "/usr/local/share"],
+  );
+});
+
+test("read-only roots must all be absolute", () => {
+  assert.equal(
+    isolationReadOnlyRootsAreAbsolute(["/opt/runtime", "/usr/local/share"]),
+    true,
+  );
+  assert.equal(
+    isolationReadOnlyRootsAreAbsolute(["/opt/runtime", "relative/path"]),
+    false,
+  );
+});
+
+test("profile equality ignores duplicate and presentation order", () => {
+  assert.equal(
+    filesystemIsolationProfilesEqual(
+      {
+        mode: "ephemeral",
+        readOnlyRoots: ["/opt/runtime", "/usr/local/share"],
+      },
+      {
+        mode: "ephemeral",
+        readOnlyRoots: ["/usr/local/share", "/opt/runtime", "/opt/runtime"],
+      },
+    ),
+    true,
+  );
+  assert.equal(
+    filesystemIsolationProfilesEqual(
+      { mode: "ephemeral", readOnlyRoots: [] },
+      null,
+    ),
+    false,
+  );
+});
+
+test("unchanged disabled profile emits no update", () => {
+  assert.equal(resolveFilesystemIsolationUpdate(false, "", null), undefined);
+});
+
+test("enabling with no extra roots sends an explicit empty profile", () => {
+  assert.deepEqual(resolveFilesystemIsolationUpdate(true, "\n", null), {
+    mode: "ephemeral",
+    readOnlyRoots: [],
+  });
+});
+
+test("disabling an existing profile sends explicit null removal", () => {
+  assert.equal(
+    resolveFilesystemIsolationUpdate(false, "", {
+      mode: "ephemeral",
+      readOnlyRoots: ["/opt/runtime"],
+    }),
+    null,
+  );
+});
+
+test("unchanged enabled profile emits no update", () => {
+  assert.equal(
+    resolveFilesystemIsolationUpdate(true, "/usr/local/share\n/opt/runtime\n", {
+      mode: "ephemeral",
+      readOnlyRoots: ["/opt/runtime", "/usr/local/share"],
+    }),
+    undefined,
+  );
+});
+
+test("availability is explicit for local macOS agents only", () => {
+  assert.equal(filesystemIsolationIsAvailable("local", true), true);
+  assert.equal(filesystemIsolationIsAvailable("local", false), false);
+  assert.equal(filesystemIsolationIsAvailable("provider", true), false);
+});

--- a/desktop/src/features/agents/ui/filesystemIsolation.ts
+++ b/desktop/src/features/agents/ui/filesystemIsolation.ts
@@ -1,0 +1,165 @@
+import * as React from "react";
+import {
+  abortManagedAgentIsolation,
+  getPreparedManagedAgentIsolation,
+  prepareManagedAgentIsolation,
+} from "@/shared/api/tauriManagedAgents";
+import type {
+  FilesystemIsolationProfile,
+  ManagedAgent,
+  PreparedFilesystemIsolation,
+} from "@/shared/api/types";
+import { isMacPlatform } from "@/shared/lib/platform";
+
+export type FilesystemIsolationFieldProps = {
+  available: boolean;
+  enabled: boolean;
+  readOnlyRoots: string;
+  prepared: PreparedFilesystemIsolation | null;
+  prepareError: string | null;
+  preparePending: boolean;
+  canPrepare: boolean;
+  onEnabledChange: (value: boolean) => void;
+  onReadOnlyRootsChange: (value: string) => void;
+  onPrepare: () => Promise<void>;
+  onAbort: () => Promise<void>;
+};
+
+export function parseIsolationReadOnlyRoots(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split("\n")
+        .map((root) => root.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function isolationReadOnlyRootsAreAbsolute(roots: string[]): boolean {
+  return roots.every((root) => root.startsWith("/"));
+}
+
+export function filesystemIsolationIsAvailable(
+  backendType: ManagedAgent["backend"]["type"],
+  macPlatform: boolean,
+): boolean {
+  return backendType === "local" && macPlatform;
+}
+
+export function filesystemIsolationProfilesEqual(
+  left: FilesystemIsolationProfile | null,
+  right: FilesystemIsolationProfile | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  if (left.mode !== right.mode) return false;
+  return (
+    [...new Set(left.readOnlyRoots)].sort().join("\n") ===
+    [...new Set(right.readOnlyRoots)].sort().join("\n")
+  );
+}
+
+export function resolveFilesystemIsolationUpdate(
+  enabled: boolean,
+  readOnlyRoots: string,
+  current: FilesystemIsolationProfile | null,
+): FilesystemIsolationProfile | null | undefined {
+  const next: FilesystemIsolationProfile | null = enabled
+    ? {
+        mode: "ephemeral",
+        readOnlyRoots: parseIsolationReadOnlyRoots(readOnlyRoots),
+      }
+    : null;
+  return filesystemIsolationProfilesEqual(next, current) ? undefined : next;
+}
+
+export function useFilesystemIsolationDraft(
+  agent: ManagedAgent,
+  open: boolean,
+): {
+  fieldProps: FilesystemIsolationFieldProps;
+  valid: boolean;
+  update: FilesystemIsolationProfile | null | undefined;
+} {
+  const [enabled, setEnabled] = React.useState(
+    agent.filesystemIsolation?.mode === "ephemeral",
+  );
+  const [readOnlyRoots, setReadOnlyRoots] = React.useState(
+    agent.filesystemIsolation?.readOnlyRoots.join("\n") ?? "",
+  );
+  const [prepared, setPrepared] =
+    React.useState<PreparedFilesystemIsolation | null>(null);
+  const [prepareError, setPrepareError] = React.useState<string | null>(null);
+  const [preparePending, setPreparePending] = React.useState(false);
+
+  // Polling refreshes must not wipe an in-progress edit.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset only on open or identity switch
+  React.useEffect(() => {
+    if (!open) return;
+    setEnabled(agent.filesystemIsolation?.mode === "ephemeral");
+    setReadOnlyRoots(agent.filesystemIsolation?.readOnlyRoots.join("\n") ?? "");
+    setPrepareError(null);
+    void getPreparedManagedAgentIsolation(agent.pubkey)
+      .then(setPrepared)
+      .catch((error) =>
+        setPrepareError(error instanceof Error ? error.message : String(error)),
+      );
+  }, [open, agent.pubkey]);
+
+  const parsedRoots = parseIsolationReadOnlyRoots(readOnlyRoots);
+
+  const update = resolveFilesystemIsolationUpdate(
+    enabled,
+    readOnlyRoots,
+    agent.filesystemIsolation,
+  );
+  const canPrepare =
+    enabled && agent.filesystemIsolation !== null && update === undefined;
+
+  async function prepare() {
+    setPreparePending(true);
+    setPrepareError(null);
+    try {
+      setPrepared(await prepareManagedAgentIsolation(agent.pubkey));
+    } catch (error) {
+      setPrepareError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPreparePending(false);
+    }
+  }
+
+  async function abort() {
+    if (!prepared) return;
+    setPreparePending(true);
+    setPrepareError(null);
+    try {
+      await abortManagedAgentIsolation(agent.pubkey, prepared.runId);
+      setPrepared(null);
+    } catch (error) {
+      setPrepareError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPreparePending(false);
+    }
+  }
+
+  return {
+    fieldProps: {
+      available: filesystemIsolationIsAvailable(
+        agent.backend.type,
+        isMacPlatform(),
+      ),
+      enabled,
+      readOnlyRoots,
+      prepared,
+      prepareError,
+      preparePending,
+      canPrepare,
+      onEnabledChange: setEnabled,
+      onReadOnlyRootsChange: setReadOnlyRoots,
+      onPrepare: prepare,
+      onAbort: abort,
+    },
+    valid: !enabled || isolationReadOnlyRootsAreAbsolute(parsedRoots),
+    update,
+  };
+}

--- a/desktop/src/shared/api/managedAgentTypes.ts
+++ b/desktop/src/shared/api/managedAgentTypes.ts
@@ -1,0 +1,52 @@
+export type ManagedAgentRuntimeLifecycle =
+  | "starting"
+  | "listening"
+  | "waking"
+  | "ready"
+  | "failed"
+  | "stopped";
+
+export type ManagedAgentRuntimeStatus = {
+  pubkey: string;
+  /** Exact submitted descriptor, present only on startup reconcile results. */
+  requestedRelayUrl?: string;
+  /** Canonical, backend-owned pair identity component. Do not normalize in TS. */
+  relayUrl: string;
+  localSetup: boolean;
+  lifecycle: ManagedAgentRuntimeLifecycle;
+  pid: number | null;
+  error: string | null;
+  logPath: string | null;
+};
+
+export type ManagedAgentBackend =
+  | { type: "local" }
+  | { type: "provider"; id: string; config: Record<string, unknown> };
+
+/** Owner-reviewed, instance-local filesystem boundary for local agents. */
+export type FilesystemIsolationProfile = {
+  mode: "ephemeral";
+  /** Existing absolute directories exposed read-only in addition to runtime roots. */
+  readOnlyRoots: string[];
+};
+
+export type FilesystemIsolationAttestation = {
+  version: number;
+  enforcement: string;
+  identity_pubkey: string;
+  run_id: string;
+  run_root: string;
+  allowed_read_roots: string[];
+  allowed_write_roots: string[];
+  denied_roots: string[];
+};
+
+export type PreparedFilesystemIsolation = {
+  identityPubkey: string;
+  runId: string;
+  runRoot: string;
+  attestation: FilesystemIsolationAttestation;
+};
+
+/** Inbound author gate mode. Mirrors buzz-acp's --respond-to CLI flag. */
+export type RespondToMode = "owner-only" | "allowlist" | "anyone";

--- a/desktop/src/shared/api/managedAgentWire.ts
+++ b/desktop/src/shared/api/managedAgentWire.ts
@@ -1,0 +1,138 @@
+import type {
+  FilesystemIsolationProfile,
+  ManagedAgent,
+  ManagedAgentBackend,
+  UpdateManagedAgentInput,
+} from "./types";
+import type { RestartDiffEntry } from "./restartDiff";
+
+export type RawFilesystemIsolationProfile = {
+  mode: "ephemeral";
+  read_only_roots?: string[];
+};
+
+export type RawManagedAgent = {
+  pubkey: string;
+  name: string;
+  persona_id: string | null;
+  runtime?: string | null;
+  team_id?: string | null;
+  relay_url: string;
+  acp_command: string;
+  agent_command: string;
+  agent_command_override?: string | null;
+  agent_args: string[];
+  mcp_command: string;
+  turn_timeout_seconds: number;
+  idle_timeout_seconds: number | null;
+  max_turn_duration_seconds: number | null;
+  parallelism: number;
+  system_prompt: string | null;
+  avatar_url?: string | null;
+  model: string | null;
+  model_source?: ManagedAgent["modelSource"];
+  provider: string | null;
+  persona_out_of_date: boolean;
+  persona_orphaned: boolean;
+  needs_restart: boolean;
+  restart_diff?: RestartDiffEntry[];
+  env_vars?: Record<string, string>;
+  filesystem_isolation?: RawFilesystemIsolationProfile | null;
+  status: ManagedAgent["status"];
+  pid: number | null;
+  created_at: string;
+  updated_at: string;
+  last_started_at: string | null;
+  last_stopped_at: string | null;
+  last_exit_code: number | null;
+  last_error: string | null;
+  last_error_code: number | null;
+  log_path: string;
+  start_on_app_launch: boolean;
+  auto_restart_on_config_change?: boolean;
+  backend: ManagedAgentBackend;
+  backend_agent_id: string | null;
+  respond_to?: ManagedAgent["respondTo"];
+  respond_to_allowlist?: string[];
+};
+
+export function fromRawFilesystemIsolationProfile(
+  profile: RawFilesystemIsolationProfile | null | undefined,
+): FilesystemIsolationProfile | null {
+  return profile == null
+    ? null
+    : {
+        mode: profile.mode,
+        readOnlyRoots: profile.read_only_roots ?? [],
+      };
+}
+
+export function toRawFilesystemIsolationProfile(
+  profile: FilesystemIsolationProfile,
+): RawFilesystemIsolationProfile {
+  return {
+    mode: profile.mode,
+    read_only_roots: profile.readOnlyRoots,
+  };
+}
+
+export function toRawUpdateManagedAgentInput(input: UpdateManagedAgentInput) {
+  return {
+    ...input,
+    filesystemIsolation:
+      input.filesystemIsolation === undefined
+        ? undefined
+        : input.filesystemIsolation === null
+          ? null
+          : toRawFilesystemIsolationProfile(input.filesystemIsolation),
+  };
+}
+
+export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
+  return {
+    pubkey: agent.pubkey,
+    name: agent.name,
+    personaId: agent.persona_id,
+    runtime: agent.runtime ?? null,
+    teamId: agent.team_id ?? null,
+    relayUrl: agent.relay_url,
+    acpCommand: agent.acp_command,
+    agentCommand: agent.agent_command,
+    agentCommandOverride: agent.agent_command_override ?? null,
+    agentArgs: agent.agent_args,
+    mcpCommand: agent.mcp_command,
+    turnTimeoutSeconds: agent.turn_timeout_seconds,
+    idleTimeoutSeconds: agent.idle_timeout_seconds,
+    maxTurnDurationSeconds: agent.max_turn_duration_seconds,
+    parallelism: agent.parallelism,
+    systemPrompt: agent.system_prompt,
+    avatarUrl: agent.avatar_url ?? null,
+    model: agent.model,
+    modelSource: agent.model_source ?? null,
+    provider: agent.provider ?? null,
+    personaOutOfDate: agent.persona_out_of_date ?? false,
+    personaOrphaned: agent.persona_orphaned ?? false,
+    needsRestart: agent.needs_restart ?? false,
+    restartDiff: agent.restart_diff ?? [],
+    envVars: agent.env_vars ?? {},
+    filesystemIsolation: fromRawFilesystemIsolationProfile(
+      agent.filesystem_isolation,
+    ),
+    status: agent.status,
+    pid: agent.pid,
+    createdAt: agent.created_at,
+    updatedAt: agent.updated_at,
+    lastStartedAt: agent.last_started_at,
+    lastStoppedAt: agent.last_stopped_at,
+    lastExitCode: agent.last_exit_code,
+    lastError: agent.last_error,
+    lastErrorCode: agent.last_error_code ?? null,
+    logPath: agent.log_path,
+    startOnAppLaunch: agent.start_on_app_launch,
+    autoRestartOnConfigChange: agent.auto_restart_on_config_change ?? true,
+    backend: agent.backend,
+    backendAgentId: agent.backend_agent_id,
+    respondTo: agent.respond_to ?? "owner-only",
+    respondToAllowlist: agent.respond_to_allowlist ?? [],
+  };
+}

--- a/desktop/src/shared/api/tauri.test.mjs
+++ b/desktop/src/shared/api/tauri.test.mjs
@@ -121,6 +121,65 @@ test("relay rate-limited: prefix check is case-sensitive (Rust always emits lowe
 
 const { fromRawAcpRuntimeCatalogEntry } = await import("./tauri.ts");
 
+const {
+  fromRawFilesystemIsolationProfile,
+  toRawFilesystemIsolationProfile,
+  toRawUpdateManagedAgentInput,
+} = await import("./tauri.ts");
+
+test("filesystem isolation profile maps across the nested Tauri wire boundary", () => {
+  const frontend = {
+    mode: "ephemeral",
+    readOnlyRoots: ["/opt/runtime", "/usr/local/share"],
+  };
+  const raw = toRawFilesystemIsolationProfile(frontend);
+  assert.deepEqual(raw, {
+    mode: "ephemeral",
+    read_only_roots: ["/opt/runtime", "/usr/local/share"],
+  });
+  assert.deepEqual(fromRawFilesystemIsolationProfile(raw), frontend);
+});
+
+test("absent filesystem isolation maps to an explicit disabled profile", () => {
+  assert.equal(fromRawFilesystemIsolationProfile(undefined), null);
+  assert.equal(fromRawFilesystemIsolationProfile(null), null);
+});
+
+test("managed-agent update omits an unchanged isolation profile", () => {
+  const raw = toRawUpdateManagedAgentInput({ pubkey: "ab" });
+  assert.equal(raw.filesystemIsolation, undefined);
+  assert.equal(JSON.stringify(raw).includes("filesystemIsolation"), false);
+});
+
+test("managed-agent update preserves explicit null isolation removal", () => {
+  assert.deepEqual(
+    toRawUpdateManagedAgentInput({
+      pubkey: "ab",
+      filesystemIsolation: null,
+    }),
+    { pubkey: "ab", filesystemIsolation: null },
+  );
+});
+
+test("managed-agent update serializes declared roots without defaults", () => {
+  assert.deepEqual(
+    toRawUpdateManagedAgentInput({
+      pubkey: "ab",
+      filesystemIsolation: {
+        mode: "ephemeral",
+        readOnlyRoots: ["/opt/runtime"],
+      },
+    }),
+    {
+      pubkey: "ab",
+      filesystemIsolation: {
+        mode: "ephemeral",
+        read_only_roots: ["/opt/runtime"],
+      },
+    },
+  );
+});
+
 test("fromRawAcpRuntimeCatalogEntry maps definition_env to definitionEnv", () => {
   const raw = {
     id: "my-harness",

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -16,7 +16,6 @@ import type {
   GetHomeFeedInput,
   HomeFeedResponse,
   ManagedAgent,
-  ManagedAgentBackend,
   RelayAgent,
   RelayMember,
   RelayMemberRole,
@@ -41,6 +40,20 @@ import type {
   GitBashPrerequisite,
   RuntimeConfigSurface,
 } from "@/shared/api/types";
+import {
+  fromRawManagedAgent,
+  toRawFilesystemIsolationProfile,
+  toRawUpdateManagedAgentInput,
+  type RawManagedAgent,
+} from "./managedAgentWire";
+export {
+  fromRawFilesystemIsolationProfile,
+  fromRawManagedAgent,
+  toRawFilesystemIsolationProfile,
+  toRawUpdateManagedAgentInput,
+  type RawFilesystemIsolationProfile,
+  type RawManagedAgent,
+} from "./managedAgentWire";
 
 export * from "@/shared/api/tauriChannels";
 
@@ -114,53 +127,6 @@ type RawRelayAgent = {
   capabilities: string[];
   status: RelayAgent["status"];
   respond_to?: RelayAgent["respondTo"];
-  respond_to_allowlist?: string[];
-};
-
-import type { RestartDiffEntry as RawRestartDiffEntry } from "./restartDiff";
-export type RawManagedAgent = {
-  pubkey: string;
-  name: string;
-  persona_id: string | null;
-  // Optional: pre-feature fixtures may omit it. The record's harness/runtime id.
-  runtime?: string | null;
-  team_id?: string | null;
-  relay_url: string;
-  acp_command: string;
-  agent_command: string;
-  agent_command_override?: string | null;
-  agent_args: string[];
-  mcp_command: string;
-  turn_timeout_seconds: number;
-  idle_timeout_seconds: number | null;
-  max_turn_duration_seconds: number | null;
-  parallelism: number;
-  system_prompt: string | null;
-  avatar_url?: string | null;
-  model: string | null;
-  model_source?: ManagedAgent["modelSource"];
-  provider: string | null;
-  persona_out_of_date: boolean;
-  persona_orphaned: boolean;
-  needs_restart: boolean;
-  restart_diff?: RawRestartDiffEntry[];
-  env_vars?: Record<string, string>;
-  status: ManagedAgent["status"];
-  pid: number | null;
-  created_at: string;
-  updated_at: string;
-  last_started_at: string | null;
-  last_stopped_at: string | null;
-  last_exit_code: number | null;
-  last_error: string | null;
-  last_error_code: number | null;
-  log_path: string;
-  start_on_app_launch: boolean;
-  auto_restart_on_config_change?: boolean;
-  backend: ManagedAgentBackend;
-  backend_agent_id: string | null;
-  // Pre-feature fixtures may omit these; mapped to "owner-only"/[] in fromRawManagedAgent.
-  respond_to?: ManagedAgent["respondTo"];
   respond_to_allowlist?: string[];
 };
 
@@ -673,52 +639,6 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
   };
 }
 
-export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
-  return {
-    pubkey: agent.pubkey,
-    name: agent.name,
-    personaId: agent.persona_id,
-    runtime: agent.runtime ?? null,
-    teamId: agent.team_id ?? null,
-    relayUrl: agent.relay_url,
-    acpCommand: agent.acp_command,
-    agentCommand: agent.agent_command,
-    agentCommandOverride: agent.agent_command_override ?? null,
-    agentArgs: agent.agent_args,
-    mcpCommand: agent.mcp_command,
-    turnTimeoutSeconds: agent.turn_timeout_seconds,
-    idleTimeoutSeconds: agent.idle_timeout_seconds,
-    maxTurnDurationSeconds: agent.max_turn_duration_seconds,
-    parallelism: agent.parallelism,
-    systemPrompt: agent.system_prompt,
-    avatarUrl: agent.avatar_url ?? null,
-    model: agent.model,
-    modelSource: agent.model_source ?? null,
-    provider: agent.provider ?? null,
-    personaOutOfDate: agent.persona_out_of_date ?? false,
-    personaOrphaned: agent.persona_orphaned ?? false,
-    needsRestart: agent.needs_restart ?? false,
-    restartDiff: agent.restart_diff ?? [],
-    envVars: agent.env_vars ?? {},
-    status: agent.status,
-    pid: agent.pid,
-    createdAt: agent.created_at,
-    updatedAt: agent.updated_at,
-    lastStartedAt: agent.last_started_at,
-    lastStoppedAt: agent.last_stopped_at,
-    lastExitCode: agent.last_exit_code,
-    lastError: agent.last_error,
-    lastErrorCode: agent.last_error_code ?? null,
-    logPath: agent.log_path,
-    startOnAppLaunch: agent.start_on_app_launch,
-    autoRestartOnConfigChange: agent.auto_restart_on_config_change ?? true,
-    backend: agent.backend,
-    backendAgentId: agent.backend_agent_id,
-    respondTo: agent.respond_to ?? "owner-only",
-    respondToAllowlist: agent.respond_to_allowlist ?? [],
-  };
-}
-
 export function fromRawAcpRuntimeCatalogEntry(
   entry: RawAcpRuntimeCatalogEntry,
 ): AcpRuntimeCatalogEntry {
@@ -850,6 +770,10 @@ export async function createManagedAgent(input: CreateManagedAgentInput) {
         model: input.model,
         provider: input.provider,
         envVars: input.envVars ?? {},
+        filesystemIsolation:
+          input.filesystemIsolation == null
+            ? undefined
+            : toRawFilesystemIsolationProfile(input.filesystemIsolation),
         spawnAfterCreate: input.spawnAfterCreate,
         startOnAppLaunch: input.startOnAppLaunch,
         backend: input.backend,
@@ -1076,7 +1000,7 @@ export async function updateManagedAgent(
 ): Promise<{ agent: ManagedAgent; profileSyncError: string | null }> {
   const response = await invokeTauri<RawUpdateManagedAgentResponse>(
     "update_managed_agent",
-    { input },
+    { input: toRawUpdateManagedAgentInput(input) },
   );
   return {
     agent: fromRawManagedAgent(response.agent),

--- a/desktop/src/shared/api/tauriManagedAgents.ts
+++ b/desktop/src/shared/api/tauriManagedAgents.ts
@@ -6,6 +6,7 @@ import {
 import type {
   ManagedAgent,
   ManagedAgentRuntimeStatus,
+  PreparedFilesystemIsolation,
 } from "@/shared/api/types";
 
 export async function startManagedAgent(pubkey: string): Promise<ManagedAgent> {
@@ -63,6 +64,25 @@ export async function startManagedAgentRuntime(
   relayUrl: string,
 ): Promise<ManagedAgentRuntimeStatus> {
   return invokeTauri("start_managed_agent_runtime", { pubkey, relayUrl });
+}
+
+export async function prepareManagedAgentIsolation(
+  pubkey: string,
+): Promise<PreparedFilesystemIsolation> {
+  return invokeTauri("prepare_managed_agent_isolation", { pubkey });
+}
+
+export async function abortManagedAgentIsolation(
+  pubkey: string,
+  runId: string,
+): Promise<void> {
+  return invokeTauri("abort_managed_agent_isolation", { pubkey, runId });
+}
+
+export async function getPreparedManagedAgentIsolation(
+  pubkey: string,
+): Promise<PreparedFilesystemIsolation | null> {
+  return invokeTauri("get_prepared_managed_agent_isolation", { pubkey });
 }
 
 export async function stopManagedAgentRuntime(

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -1,3 +1,17 @@
+import type {
+  FilesystemIsolationProfile,
+  ManagedAgentBackend,
+  RespondToMode,
+} from "./managedAgentTypes";
+export type {
+  FilesystemIsolationProfile,
+  PreparedFilesystemIsolation,
+  ManagedAgentBackend,
+  ManagedAgentRuntimeLifecycle,
+  ManagedAgentRuntimeStatus,
+  RespondToMode,
+} from "./managedAgentTypes";
+
 export type ChannelType = "stream" | "forum" | "dm";
 export type ChannelVisibility = "open" | "private";
 export type ChannelRole = "owner" | "admin" | "member" | "guest" | "bot";
@@ -279,31 +293,6 @@ export type RelayAgent = {
   respondToAllowlist: string[];
 };
 
-export type ManagedAgentRuntimeLifecycle =
-  | "starting"
-  | "listening"
-  | "waking"
-  | "ready"
-  | "failed"
-  | "stopped";
-
-export type ManagedAgentRuntimeStatus = {
-  pubkey: string;
-  /** Exact submitted descriptor, present only on startup reconcile results. */
-  requestedRelayUrl?: string;
-  /** Canonical, backend-owned pair identity component. Do not normalize in TS. */
-  relayUrl: string;
-  localSetup: boolean;
-  lifecycle: ManagedAgentRuntimeLifecycle;
-  pid: number | null;
-  error: string | null;
-  logPath: string | null;
-};
-
-export type ManagedAgentBackend =
-  | { type: "local" }
-  | { type: "provider"; id: string; config: Record<string, unknown> };
-
 import type { RestartDiffEntry } from "./restartDiff";
 export type { JsonValue, RestartChange, RestartDiffEntry } from "./restartDiff";
 export type ManagedAgent = {
@@ -363,6 +352,8 @@ export type ManagedAgent = {
   restartDiff: RestartDiffEntry[];
   /** Per-agent env vars. Layered on top of persona envVars. */
   envVars: Record<string, string>;
+  /** Fresh-run process-tree filesystem boundary. `null` preserves host access. */
+  filesystemIsolation: FilesystemIsolationProfile | null;
   status: "running" | "stopped" | "deployed" | "not_deployed";
   pid: number | null;
   createdAt: string;
@@ -385,9 +376,6 @@ export type ManagedAgent = {
    */
   respondToAllowlist: string[];
 };
-
-/** Inbound author gate mode. Mirrors buzz-acp's --respond-to CLI flag. */
-export type RespondToMode = "owner-only" | "allowlist" | "anyone";
 
 export type BackendProviderCandidate = {
   id: string;
@@ -432,6 +420,7 @@ export type CreateManagedAgentInput = {
   model?: string;
   provider?: string;
   envVars?: Record<string, string>;
+  filesystemIsolation?: FilesystemIsolationProfile;
   spawnAfterCreate?: boolean;
   startOnAppLaunch?: boolean;
   backend?: ManagedAgentBackend;
@@ -685,6 +674,8 @@ export type UpdateManagedAgentInput = {
   systemPrompt?: string | null;
   /** Absent = don't touch. Present = replace the env_vars map entirely. */
   envVars?: Record<string, string>;
+  /** Absent = don't touch. null = disable. object = replace the profile. */
+  filesystemIsolation?: FilesystemIsolationProfile | null;
   parallelism?: number;
   turnTimeoutSeconds?: number;
   relayUrl?: string;


### PR DESCRIPTION
## Summary

Adds owner-controlled ephemeral filesystem isolation for managed local macOS agents.

- Each prepared run receives a fresh, attested sandbox root.
- The outer buzz-acp harness and its child process tree inherit the boundary.
- Owners can explicitly enable or disable the profile, configure read-only roots, and prepare, start, abort, and inspect isolated runs.
- The implementation rejects protected roots and fails closed on stale, ambiguous, untracked, or live persisted runtime state.

## Why

The prior shared workspace meant a Validator could potentially read material outside its assigned context. Self-restraint is not structural independence. This change provides a reusable boundary for source-free and future blind-validation workflows, while remaining disabled by default and owner-controlled.

## User and developer impact

Owners of supported local macOS managed agents can opt in to a per-run isolated workspace. Existing agents remain unchanged unless the owner saves an explicit isolation profile. The Desktop-owned attestation and lifecycle controls make preparation, one-time start, cleanup, and recovery observable and fail closed.

## Validation

Independent review passed at b2efe5659bf092880c8dce80886d91f86eeafdfe.

- Full just ci passed at unchanged HEAD.
- Focused persisted-runtime preflight: 3/3 passed.
- Filesystem isolation lifecycle and boundary suite: 9/9 passed.
- Forged child attestation regression: 1/1 passed.
- Exact parent, clean worktree, diff check, and required Co-authored-by and Signed-off-by trailers were independently verified.

## Merge requirement

**Frozen review base: 538e5e113fc33571f939c87b925567fd4e277109. Current main advanced after review; rebase plus fresh exact-SHA review is required before merge.**

No merge, release, deployment, canary execution, runtime/profile change, or source dispatch is included in this PR.