### PR TITLE
fix(desktop): avoid HTMLAudioElement construction at PoofBurstProvider mount

### DIFF
--- a/desktop/src/shared/ui/PoofBurstProvider.test.mjs
+++ b/desktop/src/shared/ui/PoofBurstProvider.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Regression: the poof sound must be warmed through the Web Audio API, never
+// by constructing an HTMLAudioElement at mount time. Constructing an
+// HTMLAudioElement and calling `load()` makes the renderer synchronously wait
+// on the media pipeline (`selectMediaResource` ->
+// `RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs`) before the relay
+// TCP connection is up, which deadlocks the app on macOS 27 beta. The
+// HTMLAudioElement fallback is constructed only after an actual user-triggered
+// Web Audio playback failure.
+test("warmPoofAudio warms Web Audio and constructs zero HTMLAudioElements", async () => {
+  let audioConstructed = 0;
+  let audioContextConstructed = 0;
+  let bufferSourceStarted = 0;
+
+  class FakeBufferSource {
+    constructor() {
+      this.buffer = null;
+    }
+    connect() {}
+    start() {
+      bufferSourceStarted += 1;
+    }
+  }
+
+  class FakeAudioContext {
+    constructor() {
+      this.state = "running";
+      this.destination = {};
+      audioContextConstructed += 1;
+    }
+    createBufferSource() {
+      return new FakeBufferSource();
+    }
+    createGain() {
+      return { gain: { value: 0 }, connect() {} };
+    }
+    async decodeAudioData() {
+      return { duration: 0.2 };
+    }
+    async resume() {
+      this.state = "running";
+    }
+  }
+
+  const priorAudioContext = globalThis.AudioContext;
+  const priorFetch = globalThis.fetch;
+  const priorAudio = globalThis.Audio;
+  const priorImage = globalThis.Image;
+
+  globalThis.AudioContext = FakeAudioContext;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => new ArrayBuffer(8),
+  });
+  globalThis.Audio = class {
+    constructor() {
+      audioConstructed += 1;
+    }
+    play() {
+      return Promise.resolve();
+    }
+  };
+  globalThis.Image = class {};
+
+  try {
+    // Fresh module instance so the module-level AudioContext/buffer caches
+    // pick up the mocks installed above. (No query string: the test-loader's
+    // `.tsx` hook matches on `url.endsWith(".tsx")`, so a `?query` suffix
+    // would bypass it and fail with ERR_UNKNOWN_FILE_EXTENSION.)
+    const mod = await import(`./PoofBurstProvider.tsx`);
+
+    mod.warmPoofAudio();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(
+      audioConstructed,
+      0,
+      "warmPoofAudio must not construct an HTMLAudioElement",
+    );
+    assert.equal(
+      audioContextConstructed,
+      1,
+      "warmPoofAudio must warm the Web Audio buffer via an AudioContext",
+    );
+    assert.equal(bufferSourceStarted, 0, "warming must not start playback");
+  } finally {
+    globalThis.AudioContext = priorAudioContext;
+    globalThis.fetch = priorFetch;
+    globalThis.Audio = priorAudio;
+    globalThis.Image = priorImage;
+  }
+});

--- a/desktop/src/shared/ui/PoofBurstProvider.tsx
+++ b/desktop/src/shared/ui/PoofBurstProvider.tsx
@@ -94,6 +94,22 @@ function loadPoofAudioBuffer() {
   return poofAudioBufferPromise;
 }
 
+/**
+ * Warm the Web Audio poof buffer without touching any HTMLAudioElement.
+ *
+ * Constructing an HTMLAudioElement at mount time (and calling `load()` on it)
+ * makes the renderer synchronously wait on the media pipeline
+ * (`selectMediaResource` -> `RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs`)
+ * before the relay TCP connection is up, which deadlocks the app on macOS 27
+ * beta. The poof sound is a throwaway UI blip, so it plays through the Web
+ * Audio API (AudioContext + AudioBufferSourceNode) rather than an
+ * HTMLAudioElement; the HTMLAudioElement fallback is constructed only
+ * after an actual user-triggered Web Audio playback failure.
+ */
+export function warmPoofAudio() {
+  void loadPoofAudioBuffer();
+}
+
 function playFallbackPoofSound() {
   try {
     poofAudio ??= new Audio(POOF_SOUND_URL);
@@ -146,14 +162,7 @@ export function PoofBurstProvider({ children }: { children: React.ReactNode }) {
       image.src = frame.src;
     }
 
-    void loadPoofAudioBuffer();
-    try {
-      poofAudio ??= new Audio(POOF_SOUND_URL);
-      poofAudio.preload = "auto";
-      poofAudio.load();
-    } catch {
-      // Best-effort only.
-    }
+    warmPoofAudio();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the eager `HTMLAudioElement` construction and `load()` from `PoofBurstProvider` mount
- retain Web Audio buffer warmup
- keep the HTML audio fallback lazy behind user-triggered Web Audio playback failure
- add a regression proving warmup constructs zero HTML audio elements and does not start playback

This addresses the macOS 27 beta startup deadlock where mount-time media loading synchronously waits in the media MIME capability IPC path before the relay connection is established. It complements #5222, which does not cover `PoofBurstProvider`.

## Verification
- focused `PoofBurstProvider.test.mjs`: 1/1 pass
- sibling `sound.test.mjs`: 1/1 pass
- all 127 `shared/ui` tests: pass (independent review)
- Biome check on changed files: clean
- TypeScript: no new errors; the existing `TimelineMessageList.tsx` error is unchanged from `main`