### PR TITLE
fix(mobile): address DM recipients on send

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -524,6 +524,9 @@ class ChannelDetailPage extends HookConsumerWidget {
                             channelId: channel.id,
                             content: content,
                             mentionPubkeys: mentionPubkeys,
+                            isDirectMessage: resolvedChannel.isDm,
+                            directMessageRecipientPubkeys:
+                                resolvedChannel.participantPubkeys,
                             mediaTags: mediaTags,
                           ),
                     ),

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -16,6 +16,7 @@ class SendMessage {
   final void Function(String channelId, String eventId) _completeLocalMessage;
   final void Function(String channelId, String eventId) _removeLocalMessage;
   final bool Function()? _isDeliveryValid;
+  final Future<bool> Function(String channelId)? _resolveIsDirectMessage;
 
   SendMessage({
     required SignedEventRelay signedEventRelay,
@@ -27,13 +28,15 @@ class SendMessage {
     completeLocalMessage,
     required void Function(String channelId, String eventId) removeLocalMessage,
     bool Function()? isDeliveryValid,
+    Future<bool> Function(String channelId)? resolveIsDirectMessage,
   }) : _signedEventRelay = signedEventRelay,
        _fetchMembers = fetchMembers,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
        _completeLocalMessage = completeLocalMessage,
        _removeLocalMessage = removeLocalMessage,
-       _isDeliveryValid = isDeliveryValid;
+       _isDeliveryValid = isDeliveryValid,
+       _resolveIsDirectMessage = resolveIsDirectMessage;
 
   /// Send a text message to a channel.
   ///
@@ -41,13 +44,19 @@ class SendMessage {
   /// If [rootEventId] is null it defaults to [parentEventId] (direct reply to
   /// thread head). Tags are built to match the desktop's `buildReplyTags`
   /// convention with `root` / `reply` markers. Pass [mediaTags] to append
-  /// relay-validated `imeta` tags and NIP-30 `emoji` tags.
+  /// relay-validated `imeta` tags and NIP-30 `emoji` tags. Direct-message
+  /// callers can pass [isDirectMessage] and cached
+  /// [directMessageRecipientPubkeys]; otherwise the provider resolves the
+  /// channel and its members. Agent wakeups and human notifications rely on
+  /// recipient `p` tags even without an explicit `@mention` in the content.
   Future<void> call({
     required String channelId,
     required String content,
     String? parentEventId,
     String? rootEventId,
     List<String>? mentionPubkeys,
+    bool? isDirectMessage,
+    List<String> directMessageRecipientPubkeys = const [],
     List<List<String>> mediaTags = const [],
   }) async {
     _ensureDeliveryValid();
@@ -56,14 +65,37 @@ class SendMessage {
     final resolvedMentions =
         mentionPubkeys ?? await _resolveMentions(content, channelId);
     final authorPubkey = _signedEventRelay.pubkey;
+    final sendsDirectMessage =
+        isDirectMessage ?? await _channelIsDirectMessage(channelId);
 
-    // Normalize mentions: lowercase, deduplicate, exclude self (matching
-    // the desktop's normalizeMentionPubkeys).
+    final recipients = <String>[
+      ...resolvedMentions,
+      if (sendsDirectMessage) ...directMessageRecipientPubkeys,
+    ];
+
+    // A newly discovered DM can briefly lack cached participant pubkeys. Fall
+    // back to the authoritative member list so its first plain message still
+    // addresses the other participant. Failure remains non-fatal: publishing
+    // the message is preferable to losing it because recipient metadata is
+    // temporarily unavailable.
+    if (sendsDirectMessage && directMessageRecipientPubkeys.isEmpty) {
+      try {
+        recipients.addAll(
+          (await _fetchMembers(channelId)).map((member) => member.pubkey),
+        );
+      } catch (_) {
+        // Non-fatal — publish with any explicit mentions already resolved.
+      }
+    }
+
+    // Normalize recipients: lowercase, deduplicate, exclude self (matching
+    // the desktop's messageMentionPubkeys/normalizeMentionPubkeys path).
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
-        if (seenMentions.add(pk.toLowerCase())) pk,
+      for (final pk in recipients)
+        if (pk.isNotEmpty && seenMentions.add(pk.toLowerCase()))
+          pk.toLowerCase(),
     ];
 
     final tags = <List<String>>[
@@ -99,6 +131,16 @@ class SendMessage {
       throw StateError(
         'Message delivery cancelled because the active community changed',
       );
+    }
+  }
+
+  Future<bool> _channelIsDirectMessage(String channelId) async {
+    final resolve = _resolveIsDirectMessage;
+    if (resolve == null) return false;
+    try {
+      return await resolve(channelId);
+    } catch (_) {
+      return false;
     }
   }
 
@@ -192,6 +234,11 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     removeLocalMessage: (channelId, eventId) => ref
         .read(channelMessagesProvider(channelId).notifier)
         .removeLocalMessage(eventId),
+    resolveIsDirectMessage: (channelId) async =>
+        (await ref.read(
+          channelDetailsProvider(channelId).future,
+        )).channelType ==
+        'dm',
     isDeliveryValid: () {
       final currentConfig = ref.read(relayConfigProvider);
       return currentConfig.baseUrl == config.baseUrl &&

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
@@ -68,6 +69,146 @@ void main() {
     expect(removedIds, [localMessages.single.id]);
   });
 
+  test('plain DM messages p-tag every recipient except the sender', () async {
+    final session = _PendingPublishRelaySession();
+    final signer = nostr.Keys.generate();
+    final agentPubkey = 'A' * 64;
+    final send = _sendMessage(session, nsec: signer.nsec);
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello',
+      isDirectMessage: true,
+      directMessageRecipientPubkeys: [signer.public, agentPubkey],
+    );
+    await session.published;
+
+    expect(
+      session.event.tags,
+      contains(equals(['p', agentPubkey.toLowerCase()])),
+    );
+    expect(
+      session.event.tags.where((tag) => tag.isNotEmpty && tag[0] == 'p'),
+      hasLength(1),
+    );
+
+    session.accept();
+    await result;
+  });
+
+  test(
+    'DM recipients and explicit mentions are normalized and deduplicated',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signer = nostr.Keys.generate();
+      final agentPubkey = 'B' * 64;
+      final thirdPubkey = 'c' * 64;
+      final send = _sendMessage(session, nsec: signer.nsec);
+
+      final result = send(
+        channelId: _channelId,
+        content: 'hello',
+        mentionPubkeys: [agentPubkey.toLowerCase(), thirdPubkey],
+        isDirectMessage: true,
+        directMessageRecipientPubkeys: [signer.public, agentPubkey],
+      );
+      await session.published;
+
+      expect(
+        session.event.tags.where((tag) => tag.isNotEmpty && tag[0] == 'p'),
+        [
+          ['p', agentPubkey.toLowerCase()],
+          ['p', thirdPubkey],
+        ],
+      );
+
+      session.accept();
+      await result;
+    },
+  );
+
+  test('plain stream messages preserve explicit-mention semantics', () async {
+    final session = _PendingPublishRelaySession();
+    final signer = nostr.Keys.generate();
+    final send = _sendMessage(session, nsec: signer.nsec);
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello',
+      directMessageRecipientPubkeys: ['d' * 64],
+    );
+    await session.published;
+
+    expect(
+      session.event.tags.where((tag) => tag.isNotEmpty && tag[0] == 'p'),
+      isEmpty,
+    );
+
+    session.accept();
+    await result;
+  });
+
+  test('DM thread replies preserve recipient and reply tags', () async {
+    final session = _PendingPublishRelaySession();
+    final signer = nostr.Keys.generate();
+    final agentPubkey = 'd' * 64;
+    final send = _sendMessage(session, nsec: signer.nsec);
+
+    final result = send(
+      channelId: _channelId,
+      content: 'thread reply',
+      parentEventId: 'parent-id',
+      rootEventId: 'root-id',
+      isDirectMessage: true,
+      directMessageRecipientPubkeys: [signer.public, agentPubkey],
+    );
+    await session.published;
+
+    expect(session.event.tags, contains(equals(['e', 'root-id', '', 'root'])));
+    expect(
+      session.event.tags,
+      contains(equals(['e', 'parent-id', '', 'reply'])),
+    );
+    expect(session.event.tags, contains(equals(['p', agentPubkey])));
+
+    session.accept();
+    await result;
+  });
+
+  test(
+    'DM send falls back to channel members when participants are uncached',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final signer = nostr.Keys.generate();
+      final agentPubkey = 'e' * 64;
+      final send = _sendMessage(
+        session,
+        nsec: signer.nsec,
+        resolveIsDirectMessage: (_) async => true,
+        members: [
+          ChannelMember(
+            pubkey: signer.public,
+            role: 'member',
+            joinedAt: DateTime(2026),
+          ),
+          ChannelMember(
+            pubkey: agentPubkey,
+            role: 'bot',
+            joinedAt: DateTime(2026),
+          ),
+        ],
+      );
+
+      final result = send(channelId: _channelId, content: 'hello');
+      await session.published;
+
+      expect(session.event.tags, contains(equals(['p', agentPubkey])));
+
+      session.accept();
+      await result;
+    },
+  );
+
   test('cancels delivery after the active community changes', () async {
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -94,6 +235,21 @@ void main() {
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
+
+SendMessage _sendMessage(
+  RelaySessionNotifier session, {
+  required String nsec,
+  List<ChannelMember> members = const [],
+  Future<bool> Function(String channelId)? resolveIsDirectMessage,
+}) => SendMessage(
+  signedEventRelay: SignedEventRelay(session: session, nsec: nsec),
+  fetchMembers: (_) async => members,
+  readUserCache: () => const {},
+  addLocalMessage: (_, _) {},
+  completeLocalMessage: (_, _) {},
+  removeLocalMessage: (_, _) {},
+  resolveIsDirectMessage: resolveIsDirectMessage,
+);
 
 class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();


### PR DESCRIPTION
## Summary

- add every other DM participant as a recipient `p` tag at the mobile send boundary
- preserve explicit mentions while normalising, deduplicating, and excluding the sender
- cover plain DMs, uncached member lookup, and threaded replies

## Verification

- Flutter analyser passed
- mobile file-size gate passed
- full mobile suite passed: 1,266 tests

Originated from Buzz DM channel `d22c8a5f-83ca-44aa-82ad-a6ef09ae1398`.