### PR TITLE
fix(desktop): classify git credential prompt failures as authentication

### DIFF
--- a/desktop/src/features/projects/lib/projectRepoAvailability.test.mjs
+++ b/desktop/src/features/projects/lib/projectRepoAvailability.test.mjs
@@ -27,6 +27,28 @@ test("classifies authentication failures before generic availability errors", ()
   );
 });
 
+test("classifies a git credential prompt failure as authentication", () => {
+  // git 2.46+ is required by git-credential-nostr; on an older git the helper
+  // declines, no credential is supplied, and git reports this instead of ever
+  // surfacing the relay's 401.
+  assert.equal(
+    projectRepoUnavailableReason(
+      new Error(
+        "fatal: could not read Username for 'https://relay.example': Device not configured",
+      ),
+    ),
+    "authentication",
+  );
+  assert.equal(
+    projectRepoUnavailableReason(
+      new Error(
+        "fatal: could not read Password for 'https://relay.example': terminal prompts disabled",
+      ),
+    ),
+    "authentication",
+  );
+});
+
 test("classifies branch and network failures", () => {
   assert.equal(
     projectRepoUnavailableReason(

--- a/desktop/src/features/projects/lib/projectRepoAvailability.ts
+++ b/desktop/src/features/projects/lib/projectRepoAvailability.ts
@@ -19,7 +19,11 @@ export function projectRepoUnavailableReason(
 
   if (!message) return "missing";
   if (
-    /\b(?:401|403)\b|authenticat|authoriz|permission denied|access denied/.test(
+    // `could not read Username/Password` is how git reports that no credential
+    // helper answered, so it never reaches the relay and never sees the 401 in
+    // the patterns above. Without this the message lands in `unknown` and the
+    // panel blames the project owner for what is a local credential failure.
+    /\b(?:401|403)\b|authenticat|authoriz|permission denied|access denied|could not read (?:username|password)/.test(
       message,
     )
   ) {


### PR DESCRIPTION
## Summary

- classify git's `could not read Username` / `could not read Password` as `authentication` instead of `unknown`
- the Projects repo panel now says "Repository access failed — Buzz could not authenticate with this repository" instead of "Repository unavailable — try again or contact the project owner"

This is suggestion 3 from #5348. It is a subset, not the whole issue — see Scope below.

## Why

`projectRepoUnavailableReason` matches `401`, `403`, `authenticat`, `authoriz`, `permission denied` and `access denied`. git's credential-prompt failure looks like none of those:

```
fatal: could not read Username for 'https://relay.example': Device not configured
```

So it fell through to `unknown`, and the panel blamed the project owner for a problem that is local to the user's machine.

The path is easy to reach. `git-credential-nostr` needs the credential-protocol `authtype` capability, which arrived in git 2.46. On an older git the helper exits silently, no credential is supplied, and git prints the error above. The relay's 401 never reaches the classifier, so no existing pattern can match.

## Scope

Only the message classification. #5348 also suggests version-aware `git` resolution and a typed error from the snapshot command; both sit in `src-tauri` and are larger changes. The reporter wrote "any subset", so I took the one that is self-contained.

Worth saying plainly: this improves the message, it does not fix the underlying setup. A user on git 2.39 still cannot clone. But "Buzz could not authenticate" points at the right thing, and `unknown` did not.

## Validation

- RED to GREEN: the new test fails on unmodified `projectRepoAvailability.ts` (`expected 'unknown' to equal 'authentication'`) and passes with the change. The other 9 tests in the file are unaffected in both runs.
- `pnpm --filter buzz test` — 4,605 passed
- `pnpm --filter buzz exec tsc --noEmit`
- `pnpm --filter buzz check` — biome, file sizes, px-text, pubkey truncation

I also checked the classifier by hand against four strings before writing the fix: both credential-prompt variants returned `unknown`, while `The requested URL returned error: 403` returned `authentication` and `remote: Repository not found` returned `missing`. Only the credential path was wrong.
