### PR TITLE
fix(desktop): preserve early read-only relay frames

### DIFF
--- a/desktop/src/shared/api/readOnlyRelayClient.test.mjs
+++ b/desktop/src/shared/api/readOnlyRelayClient.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ReadOnlyRelayClient } from "./readOnlyRelayClient.ts";
+
+const AUTH_EVENT = {
+  id: "observer-auth-event",
+  pubkey: "observer-pubkey",
+  created_at: 1,
+  kind: 22242,
+  tags: [],
+  content: "",
+  sig: "observer-signature",
+};
+
+test("connect preserves AUTH delivered before the socket ID resolves", async () => {
+  const previousWindow = globalThis.window;
+  let callbackId = 0;
+  let messageChannel;
+  const sentTypes = [];
+
+  globalThis.window = {
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+    __TAURI_INTERNALS__: {
+      transformCallback: () => ++callbackId,
+      unregisterCallback: () => {},
+      invoke: async (command, args) => {
+        if (command === "plugin:websocket|connect") {
+          messageChannel = args.onMessage;
+          messageChannel.onmessage({
+            type: "Text",
+            data: JSON.stringify(["AUTH", "early-observer-challenge"]),
+          });
+          await new Promise((resolve) => globalThis.setTimeout(resolve, 10));
+          return 7;
+        }
+
+        if (command === "create_auth_event") {
+          assert.equal(args.challenge, "early-observer-challenge");
+          assert.equal(args.relayUrl, "wss://observer.example");
+          return JSON.stringify(AUTH_EVENT);
+        }
+
+        if (command === "plugin:websocket|send") {
+          const [type, event] = JSON.parse(args.message.data);
+          sentTypes.push(type);
+          if (type === "AUTH") {
+            messageChannel.onmessage({
+              type: "Text",
+              data: JSON.stringify(["OK", event.id, true, ""]),
+            });
+          }
+          return;
+        }
+
+        if (command === "plugin:websocket|disconnect") return;
+        throw new Error(`Unexpected Tauri command: ${command}`);
+      },
+    },
+  };
+
+  const client = new ReadOnlyRelayClient("wss://observer.example");
+  const connection = client.connect();
+  try {
+    const connected = await Promise.race([
+      connection.then(() => true),
+      new Promise((resolve) =>
+        globalThis.setTimeout(() => resolve(false), 250),
+      ),
+    ]);
+
+    assert.equal(connected, true, "early AUTH must complete the connection");
+    assert.deepEqual(sentTypes, ["AUTH"]);
+  } finally {
+    client.disconnect();
+    await connection.catch(() => {});
+    globalThis.window = previousWindow;
+  }
+});

--- a/desktop/src/shared/api/readOnlyRelayClient.ts
+++ b/desktop/src/shared/api/readOnlyRelayClient.ts
@@ -132,7 +132,9 @@ export class ReadOnlyRelayClient {
 
   private async openConnection(): Promise<void> {
     const generation = ++this.generation;
+    let pendingInbound: unknown[] | null = [];
     this.onMessageChannel = new Channel<unknown>((message) => {
+      if (pendingInbound) return void pendingInbound.push(message);
       void this.handleWsMessage(message, generation);
     });
 
@@ -142,7 +144,7 @@ export class ReadOnlyRelayClient {
       config: {},
     });
 
-    await new Promise<void>((resolve, reject) => {
+    const authentication = new Promise<void>((resolve, reject) => {
       const timeout = window.setTimeout(() => {
         this.authRequest = null;
         this.disconnect();
@@ -156,6 +158,12 @@ export class ReadOnlyRelayClient {
         timeout,
       };
     });
+
+    while (pendingInbound.length > 0) {
+      await this.handleWsMessage(pendingInbound.shift(), generation);
+    }
+    pendingInbound = null;
+    await authentication;
   }
 
   private requestHistory(


### PR DESCRIPTION
Follow-up to #3320. Applies the same all-frame inbound gate to ReadOnlyRelayClient, which is used for inactive-community observation and cross-relay mark-as-read publishing.

Without the gate, an AUTH challenge delivered synchronously by the native Channel can run before wsId and authRequest exist, so the observer connection waits until its authentication timeout.

The added deterministic unit test delivers AUTH before the connect command resolves, then delivers the AUTH OK while the queue is draining. It verifies that the read-only connection completes and preserves ordering.

Validation:
- focused readOnlyRelayClient test
- full Desktop unit suite: 3722 passed
- Desktop typecheck
- Biome check on changed files
- git diff --check