### PR TITLE
fix(desktop): show every managed agent instance

### DIFF
--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -11,6 +11,7 @@ type AgentIdentityCardProps = {
   avatarUrl?: string | null;
   dataTestId: string;
   label: string;
+  identityLabel?: string | null;
   modelLabel?: string | null;
   onClick: () => void;
   /** Optional badge rendered below the label (e.g. "Restart required"). */
@@ -24,6 +25,7 @@ export function AgentIdentityCard({
   avatarUrl,
   dataTestId,
   label,
+  identityLabel,
   modelLabel,
   onClick,
   statusBadge,
@@ -72,6 +74,11 @@ export function AgentIdentityCard({
         <span className="min-w-0 truncate font-semibold text-foreground tracking-normal">
           {label}
         </span>
+        {identityLabel ? (
+          <span className="min-w-0 truncate font-mono text-2xs font-normal text-secondary-foreground/75">
+            {identityLabel}
+          </span>
+        ) : null}
         {modelLabel ? (
           <span className="min-w-0 truncate text-xs font-normal text-secondary-foreground/75">
             {modelLabel}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -8,19 +8,22 @@ import {
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
-import { pickProfileAgent } from "@/features/agents/lib/pickProfileAgent";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useUserProfileQuery } from "@/features/profile/hooks";
 import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
+import { truncatePubkey } from "@/shared/lib/pubkey";
 import { Badge } from "@/shared/ui/badge";
 import { IdentityCardSkeleton } from "@/shared/ui/identity-card-skeleton";
 import { AgentIdentityCard } from "./AgentIdentityCard";
 import { AgentRuntimeAvatarControl } from "./AgentRuntimeAvatarControl";
 import { CreateIdentityCard } from "./CreateIdentityCard";
 import { PersonaActionsMenu } from "./PersonaActionsMenu";
-import { buildUnifiedGroups } from "./unifiedAgentGroups";
+import {
+  buildUnifiedGroups,
+  profileAgentsForGroup,
+} from "./unifiedAgentGroups";
 
 type UnifiedAgentsSectionProps = {
   defaultModel: string;
@@ -130,41 +133,99 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
               disabled={isPersonasPending}
               onClick={onOpenCatalog}
             />
-            {groups.map((group) => {
-              const profileAgent = pickProfileAgent(group.agents, isArchived);
-              return (
-                <AgentPersonaCard
-                  actions={(effectiveAvatarUrl, isEffectiveAvatarLoading) => (
-                    <PersonaActionsMenu
-                      isActionPending={
-                        isActionPending || isEffectiveAvatarLoading
-                      }
-                      isPending={isPersonasPending}
-                      persona={group.persona}
-                      linkedAgent={profileAgent}
-                      onDeactivate={onDeactivatePersona}
-                      onDelete={onDeletePersona}
-                      onDuplicate={onDuplicatePersona}
-                      onEdit={onEditPersona}
-                      onShare={(persona, linkedAgent) =>
-                        onSharePersona(persona, linkedAgent, effectiveAvatarUrl)
-                      }
-                    />
-                  )}
-                  agent={profileAgent}
-                  defaultModel={defaultModel}
-                  key={group.persona.id}
-                  persona={group.persona}
-                  restartingAgentPubkey={restartingAgentPubkey}
-                  startingAgentPubkey={startingAgentPubkey}
-                  startingPersonaIds={startingPersonaIds}
-                  onOpenAgentProfile={onOpenAgentProfile}
-                  onOpenPersonaProfile={onOpenPersonaProfile}
-                  onRestartAgent={onRestartAgent}
-                  onStartAgent={onStartAgent}
-                  onStartPersona={onStartPersona}
-                />
+            {groups.flatMap((group) => {
+              const profileAgents = profileAgentsForGroup(
+                group.agents,
+                isArchived,
               );
+              const cards: Array<React.ReactElement> = [];
+
+              if (profileAgents.length === 0) {
+                cards.push(
+                  <AgentPersonaCard
+                    actions={(effectiveAvatarUrl, isEffectiveAvatarLoading) => (
+                      <PersonaActionsMenu
+                        isActionPending={
+                          isActionPending || isEffectiveAvatarLoading
+                        }
+                        isPending={isPersonasPending}
+                        persona={group.persona}
+                        linkedAgent={undefined}
+                        onDeactivate={onDeactivatePersona}
+                        onDelete={onDeletePersona}
+                        onDuplicate={onDuplicatePersona}
+                        onEdit={onEditPersona}
+                        onShare={(persona, linkedAgent) =>
+                          onSharePersona(
+                            persona,
+                            linkedAgent,
+                            effectiveAvatarUrl,
+                          )
+                        }
+                      />
+                    )}
+                    agent={undefined}
+                    defaultModel={defaultModel}
+                    key={`persona:${group.persona.id}`}
+                    persona={group.persona}
+                    restartingAgentPubkey={restartingAgentPubkey}
+                    startingAgentPubkey={startingAgentPubkey}
+                    startingPersonaIds={startingPersonaIds}
+                    onOpenAgentProfile={onOpenAgentProfile}
+                    onOpenPersonaProfile={onOpenPersonaProfile}
+                    onRestartAgent={onRestartAgent}
+                    onStartAgent={onStartAgent}
+                    onStartPersona={onStartPersona}
+                  />,
+                );
+                return cards;
+              }
+
+              for (const [index, profileAgent] of profileAgents.entries()) {
+                cards.push(
+                  <AgentPersonaCard
+                    actions={
+                      index === 0
+                        ? (effectiveAvatarUrl, isEffectiveAvatarLoading) => (
+                            <PersonaActionsMenu
+                              isActionPending={
+                                isActionPending || isEffectiveAvatarLoading
+                              }
+                              isPending={isPersonasPending}
+                              persona={group.persona}
+                              linkedAgent={profileAgent}
+                              onDeactivate={onDeactivatePersona}
+                              onDelete={onDeletePersona}
+                              onDuplicate={onDuplicatePersona}
+                              onEdit={onEditPersona}
+                              onShare={(persona, linkedAgent) =>
+                                onSharePersona(
+                                  persona,
+                                  linkedAgent,
+                                  effectiveAvatarUrl,
+                                )
+                              }
+                            />
+                          )
+                        : undefined
+                    }
+                    agent={profileAgent}
+                    defaultModel={defaultModel}
+                    key={`agent:${profileAgent.pubkey}`}
+                    persona={group.persona}
+                    restartingAgentPubkey={restartingAgentPubkey}
+                    startingAgentPubkey={startingAgentPubkey}
+                    startingPersonaIds={startingPersonaIds}
+                    onOpenAgentProfile={onOpenAgentProfile}
+                    onOpenPersonaProfile={onOpenPersonaProfile}
+                    onRestartAgent={onRestartAgent}
+                    onStartAgent={onStartAgent}
+                    onStartPersona={onStartPersona}
+                  />,
+                );
+              }
+
+              return cards;
             })}
           </div>
 
@@ -256,7 +317,6 @@ function AgentPersonaCard({
   const modelLabel = resolveAgentCardModelLabel({
     agent,
     personaModel: persona.model,
-    provider: persona.provider,
     defaultModel,
   });
   const isActive = agent ? isManagedAgentActive(agent) : false;
@@ -311,18 +371,18 @@ function AgentPersonaCard({
       }
       avatarUrl={avatarUrl}
       dataTestId={`persona-agent-row-${persona.id}`}
+      identityLabel={agent ? truncatePubkey(agent.pubkey) : null}
       label={title}
       modelLabel={modelLabel}
       onClick={() => {
         // The card's main click always opens the PERSONA target, never an
         // explicit pubkey. A pubkey target is durable in the panel, so a pick
         // made during the archive-snapshot fail-open window would strand the
-        // panel on an archived identity after hydration (Carl's cold-hydration
-        // race). A persona target re-resolves every render through the shared
-        // archive-aware selector, so it self-corrects to a live sibling — or
-        // persona-only mode when every instance is archived. Deliberate
+        // panel on an archived identity after hydration. A persona target
+        // re-resolves every render through the archive-aware selector. The
+        // per-instance card remains visually and test-id distinct; deliberate
         // instance navigation and the runtime-error affordance keep their
-        // explicit-pubkey path via the avatar control below.
+        // explicit-pubkey path via the avatar control above.
         onOpenPersonaProfile(persona);
       }}
       statusBadge={
@@ -397,7 +457,6 @@ function StandaloneAgentCard({
       modelLabel={resolveAgentCardModelLabel({
         agent,
         personaModel: null,
-        provider: agent.provider,
         defaultModel,
       })}
       onClick={() => {

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -370,7 +370,11 @@ function AgentPersonaCard({
         )
       }
       avatarUrl={avatarUrl}
-      dataTestId={`persona-agent-row-${persona.id}`}
+      dataTestId={
+        agent
+          ? `managed-agent-${agent.pubkey}`
+          : `persona-agent-row-${persona.id}`
+      }
       identityLabel={agent ? truncatePubkey(agent.pubkey) : null}
       label={title}
       modelLabel={modelLabel}

--- a/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSectionCardTarget.test.mjs
@@ -220,7 +220,9 @@ test("persona card main click records a persona target, never an explicit pubkey
   });
 
   fireEvent.click(
-    screen.getByRole("button", { name: "Fizz Prime agent profile" }),
+    screen.getAllByRole("button", {
+      name: "Fizz Prime agent profile",
+    })[0],
   );
 
   assert.ok(recordedPersona, "the click must record a persona target");

--- a/desktop/src/features/agents/ui/unifiedAgentGroups.test.mjs
+++ b/desktop/src/features/agents/ui/unifiedAgentGroups.test.mjs
@@ -1,75 +1,132 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildUnifiedGroups } from "./unifiedAgentGroups.ts";
+import {
+  buildUnifiedGroups,
+  profileAgentsForGroup,
+} from "./unifiedAgentGroups.ts";
 
-const NONE_ARCHIVED = () => false;
-
-function agent(overrides = {}) {
+function agent(pubkey, overrides = {}) {
   return {
-    name: "Agent",
-    pubkey: "a".repeat(64),
-    personaId: null,
-    status: "stopped",
+    pubkey,
+    name: overrides.name ?? "Fizz",
+    personaId: overrides.personaId ?? "builtin:fizz",
+    status: overrides.status ?? "stopped",
     ...overrides,
   };
 }
 
-function persona(overrides = {}) {
-  return { id: "persona-1", displayName: "Persona", ...overrides };
-}
+const fizz = { id: "builtin:fizz", displayName: "Fizz" };
+const NONE_ARCHIVED = () => false;
+
+test("buildUnifiedGroups retains every managed instance for one persona", () => {
+  const first = agent("a".repeat(64));
+  const second = agent("b".repeat(64));
+
+  const { groups, ungrouped, unknown } = buildUnifiedGroups(
+    [fizz],
+    [first, second],
+    NONE_ARCHIVED,
+  );
+
+  assert.deepEqual(groups, [{ persona: fizz, agents: [first, second] }]);
+  assert.deepEqual(ungrouped, []);
+  assert.deepEqual(unknown, []);
+});
+
+test("profileAgentsForGroup returns every instance in stable order without mutating input", () => {
+  const stopped = agent("a".repeat(64), { name: "Zulu" });
+  const runningLater = agent("c".repeat(64), {
+    name: "Alpha",
+    status: "running",
+  });
+  const runningEarlier = agent("b".repeat(64), {
+    name: "Alpha",
+    status: "running",
+  });
+  const input = [stopped, runningLater, runningEarlier];
+
+  assert.deepEqual(profileAgentsForGroup(input, NONE_ARCHIVED), [
+    runningEarlier,
+    runningLater,
+    stopped,
+  ]);
+  assert.deepEqual(input, [stopped, runningLater, runningEarlier]);
+});
+
+test("a relay-restored persona instance follows the same visible group path", () => {
+  const relayRestored = agent("c".repeat(64), {
+    name: "Recovered Fizz",
+    status: "stopped",
+  });
+
+  const { groups } = buildUnifiedGroups([fizz], [relayRestored], NONE_ARCHIVED);
+
+  assert.deepEqual(profileAgentsForGroup(groups[0].agents, NONE_ARCHIVED), [
+    relayRestored,
+  ]);
+});
+
+test("a persona with no managed instance remains an empty group", () => {
+  const { groups } = buildUnifiedGroups([fizz], [], NONE_ARCHIVED);
+
+  assert.deepEqual(groups, [{ persona: fizz, agents: [] }]);
+  assert.deepEqual(profileAgentsForGroup(groups[0].agents, NONE_ARCHIVED), []);
+});
+
+test("profileAgentsForGroup omits archived instances while preserving visible peers", () => {
+  const archived = agent("a".repeat(64), { status: "running" });
+  const visible = agent("b".repeat(64), { status: "stopped" });
+
+  assert.deepEqual(
+    profileAgentsForGroup(
+      [archived, visible],
+      (pubkey) => pubkey === archived.pubkey,
+    ),
+    [visible],
+  );
+});
 
 test("archived standalone custom agents are omitted while live peers remain", () => {
-  const archived = agent({ pubkey: "a".repeat(64), personaId: null });
-  const live = agent({ pubkey: "b".repeat(64), personaId: null });
+  const archived = agent("a".repeat(64), { personaId: null });
+  const live = agent("b".repeat(64), { personaId: null });
   const isArchived = (pubkey) => pubkey === archived.pubkey;
 
   const { ungrouped } = buildUnifiedGroups([], [archived, live], isArchived);
 
   assert.deepEqual(
-    ungrouped.map((agent) => agent.pubkey),
+    ungrouped.map((candidate) => candidate.pubkey),
     [live.pubkey],
   );
 });
 
 test("archived unknown-persona agents are omitted while live peers remain", () => {
-  const archived = agent({ pubkey: "a".repeat(64), personaId: "orphan" });
-  const live = agent({ pubkey: "b".repeat(64), personaId: "orphan" });
+  const archived = agent("a".repeat(64), { personaId: "orphan" });
+  const live = agent("b".repeat(64), { personaId: "orphan" });
   const isArchived = (pubkey) => pubkey === archived.pubkey;
 
-  // No persona matches "orphan", so both land in the unknown bucket.
   const { unknown } = buildUnifiedGroups([], [archived, live], isArchived);
 
   assert.deepEqual(
-    unknown.map((agent) => agent.pubkey),
+    unknown.map((candidate) => candidate.pubkey),
     [live.pubkey],
   );
 });
 
-test("matched persona groups keep their full instance list including archived", () => {
-  const archived = agent({ pubkey: "a".repeat(64), personaId: "persona-1" });
-  const live = agent({ pubkey: "b".repeat(64), personaId: "persona-1" });
+test("matched persona groups retain archived instances for profile history", () => {
+  const archived = agent("a".repeat(64));
+  const live = agent("b".repeat(64));
   const isArchived = (pubkey) => pubkey === archived.pubkey;
 
-  // The card resolves its own target via pickProfileAgent; the group keeps the
-  // archived record so an all-archived persona still forms a card in
-  // persona-only mode rather than vanishing from the library.
-  const { groups } = buildUnifiedGroups(
-    [persona()],
-    [archived, live],
-    isArchived,
-  );
+  const { groups } = buildUnifiedGroups([fizz], [archived, live], isArchived);
 
-  assert.equal(groups.length, 1);
-  assert.deepEqual(
-    groups[0].agents.map((agent) => agent.pubkey).sort(),
-    [archived.pubkey, live.pubkey].sort(),
-  );
+  assert.deepEqual(groups, [{ persona: fizz, agents: [archived, live] }]);
+  assert.deepEqual(profileAgentsForGroup(groups[0].agents, isArchived), [live]);
 });
 
 test("a fail-open predicate keeps every standalone agent discoverable", () => {
-  const first = agent({ pubkey: "a".repeat(64), personaId: null });
-  const second = agent({ pubkey: "b".repeat(64), personaId: null });
+  const first = agent("a".repeat(64), { personaId: null });
+  const second = agent("b".repeat(64), { personaId: null });
 
   const { ungrouped } = buildUnifiedGroups([], [first, second], NONE_ARCHIVED);
 

--- a/desktop/src/features/agents/ui/unifiedAgentGroups.ts
+++ b/desktop/src/features/agents/ui/unifiedAgentGroups.ts
@@ -1,3 +1,4 @@
+import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
 
 type PersonaGroup = { persona: AgentPersona; agents: ManagedAgent[] };
@@ -8,8 +9,8 @@ type PersonaGroup = { persona: AgentPersona; agents: ManagedAgent[] };
  * Archived instances are dropped from the standalone `ungrouped` (custom
  * agents) and `unknown` buckets so a relay-archived identity never shows as a
  * clickable library card of its own. Matched persona groups keep their full
- * instance list — the persona card resolves its own target through
- * `pickProfileAgent`, which applies the same `isArchived` filter and falls back
+ * instance list so profile resolution and history still have the complete
+ * input. Card rendering applies the same `isArchived` predicate and falls back
  * to persona-only mode when every instance is archived. `isArchived` is
  * fail-open (returns `false` while the relay archive snapshot loads).
  */
@@ -45,4 +46,21 @@ export function buildUnifiedGroups(
   }
 
   return { groups, ungrouped, unknown };
+}
+
+export function profileAgentsForGroup(
+  agents: readonly ManagedAgent[],
+  isArchived: (pubkey: string) => boolean,
+) {
+  return agents
+    .filter((agent) => !isArchived(agent.pubkey))
+    .sort((left, right) => {
+      const activeDiff =
+        Number(isManagedAgentActive(right)) -
+        Number(isManagedAgentActive(left));
+      if (activeDiff !== 0) return activeDiff;
+      const nameDiff = left.name.localeCompare(right.name);
+      if (nameDiff !== 0) return nameDiff;
+      return left.pubkey.localeCompare(right.pubkey);
+    });
 }

--- a/desktop/src/features/profile/ui/UserProfileAgentManagementRows.tsx
+++ b/desktop/src/features/profile/ui/UserProfileAgentManagementRows.tsx
@@ -11,6 +11,7 @@ import {
 
 import type { IdentityArchiveActions } from "@/features/identity-archive/hooks";
 import { ArchiveConfirmDialog } from "@/features/profile/ui/ArchiveConfirmDialog";
+import { useAgentMemoryQuery } from "@/features/agent-memory/hooks";
 import type { ManagedAgent } from "@/shared/api/types";
 import {
   AlertDialog,
@@ -31,6 +32,7 @@ export function UserProfileAgentManagementRows({
   canDeleteAgent,
   isDeletePending,
   managedAgent,
+  channelCount,
   onCreateCard,
   onDeleteAgent,
   onDuplicateAgent,
@@ -41,6 +43,7 @@ export function UserProfileAgentManagementRows({
   canDeleteAgent: boolean;
   isDeletePending: boolean;
   managedAgent?: ManagedAgent;
+  channelCount: number;
   /** Mint an agent trading card. Present only for owner-managed personas. */
   onCreateCard?: () => void;
   onDeleteAgent: () => void;
@@ -91,9 +94,11 @@ export function UserProfileAgentManagementRows({
       ) : null}
       {canDeleteAgent ? (
         <ProfileDeleteAgentRow
+          channelCount={channelCount}
           isPending={isDeletePending}
           managedAgent={managedAgent}
           onDelete={onDeleteAgent}
+          onExport={onExportAgent}
         />
       ) : null}
     </PanelSectionGroup>
@@ -194,15 +199,25 @@ function ProfileArchiveAgentRow({
 }
 
 function ProfileDeleteAgentRow({
+  channelCount,
   isPending,
   managedAgent,
   onDelete,
+  onExport,
 }: {
+  channelCount: number;
   isPending: boolean;
   managedAgent?: ManagedAgent;
   onDelete: () => void;
+  onExport?: () => void;
 }) {
   const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const memoryQuery = useAgentMemoryQuery(managedAgent?.pubkey, {
+    enabled: confirmOpen && managedAgent !== undefined,
+  });
+  const memoryCount =
+    memoryQuery.data &&
+    (memoryQuery.data.core ? 1 : 0) + memoryQuery.data.memories.length;
 
   return (
     <>
@@ -223,11 +238,15 @@ function ProfileDeleteAgentRow({
       {managedAgent ? (
         <AgentDeleteConfirmDialog
           agent={managedAgent}
+          channelCount={channelCount}
           isPending={isPending}
+          memoryCount={memoryCount}
+          memoriesLoading={memoryQuery.isLoading}
           onConfirm={() => {
             setConfirmOpen(false);
             onDelete();
           }}
+          onExport={onExport}
           onOpenChange={setConfirmOpen}
           open={confirmOpen}
         />
@@ -238,44 +257,82 @@ function ProfileDeleteAgentRow({
 
 function AgentDeleteConfirmDialog({
   agent,
+  channelCount,
   isPending,
+  memoryCount,
+  memoriesLoading,
   onConfirm,
+  onExport,
   onOpenChange,
   open,
 }: {
   agent: ManagedAgent;
+  channelCount: number;
   isPending: boolean;
+  memoryCount?: number;
+  memoriesLoading: boolean;
   onConfirm: () => void;
+  onExport?: () => void;
   onOpenChange: (open: boolean) => void;
   open: boolean;
 }) {
   const isProviderAgent = agent.backend.type === "provider";
+  const showExportRecommendation =
+    onExport !== undefined && memoryCount !== undefined && memoryCount > 0;
 
   return (
     <AlertDialog onOpenChange={onOpenChange} open={open}>
       <AlertDialogContent data-testid="agent-delete-confirm-dialog">
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete this agent?</AlertDialogTitle>
+          <AlertDialogTitle>Delete {agent.name}?</AlertDialogTitle>
           <AlertDialogDescription>
-            Deleting this agent stops and removes the agent from this community.
+            This permanently removes the agent, its saved key, and its channel
+            access.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <ul className="list-disc space-y-1.5 pl-5 text-sm text-muted-foreground">
-          <li>Removes the local management record and saved agent key</li>
-          <li>Removes the agent from every channel it belongs to</li>
-          <li>
-            Archives the agent&apos;s identity on the relay so it no longer
-            appears in member lists or mention suggestions
-          </li>
-          <li>
-            {isProviderAgent
-              ? "Requests remote deletion; if it is online, Buzz first sends a shutdown command when possible. If the deployment cannot be reached through a channel, the remote process may keep running without local management."
-              : "Stops any local agent process before deleting the record"}
-          </li>
-        </ul>
-        <p className="text-sm text-muted-foreground">
-          Archive this agent if you want to hide it instead of removing it.
-        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg border bg-muted/30 px-4 py-3">
+            <p className="text-xs text-muted-foreground">Memories</p>
+            <p
+              className="mt-1 text-2xl font-semibold tabular-nums"
+              data-testid="agent-delete-memory-count"
+            >
+              {memoriesLoading ? "…" : (memoryCount ?? "—")}
+            </p>
+          </div>
+          <div className="rounded-lg border bg-muted/30 px-4 py-3">
+            <p className="text-xs text-muted-foreground">Channels</p>
+            <p
+              className="mt-1 text-2xl font-semibold tabular-nums"
+              data-testid="agent-delete-channel-count"
+            >
+              {channelCount}
+            </p>
+          </div>
+        </div>
+        {showExportRecommendation ? (
+          <p className="text-sm text-muted-foreground">
+            Want a backup?{" "}
+            <Button
+              className="h-auto p-0 align-baseline font-medium underline underline-offset-2"
+              data-testid="agent-delete-export-action"
+              onClick={() => {
+                onOpenChange(false);
+                onExport();
+              }}
+              type="button"
+              variant="link"
+            >
+              Export this agent
+            </Button>
+            .
+          </p>
+        ) : null}
+        {isProviderAgent ? (
+          <p className="text-sm text-muted-foreground">
+            The remote process may keep running if Buzz can&apos;t reach it.
+          </p>
+        ) : null}
         <AlertDialogFooter>
           <AlertDialogCancel asChild>
             <Button type="button" variant="outline">

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -511,6 +511,7 @@ export function ProfileSummaryView({
                 archiveActions={archiveActions}
                 canArchiveAgent={isBot && archiveActions.canArchive}
                 canDeleteAgent={canDeleteAgent}
+                channelCount={channelCount}
                 channelIdToName={channelIdToName}
                 isArchived={isArchived}
                 isDeleteAgentPending={isAgentActionPending}

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -203,6 +203,7 @@ export function ProfileInfoTabContent({
   archiveActions,
   canArchiveAgent,
   canDeleteAgent,
+  channelCount,
   channelIdToName,
   isArchived,
   isDeleteAgentPending,
@@ -223,6 +224,7 @@ export function ProfileInfoTabContent({
   archiveActions: IdentityArchiveActions;
   canArchiveAgent: boolean;
   canDeleteAgent: boolean;
+  channelCount: number;
   channelIdToName: Record<string, string>;
   isArchived: boolean;
   isDeleteAgentPending: boolean;
@@ -311,6 +313,7 @@ export function ProfileInfoTabContent({
         canDeleteAgent={canDeleteAgent}
         isDeletePending={isDeleteAgentPending}
         managedAgent={managedAgent}
+        channelCount={channelCount}
         onCreateCard={onCreateCard}
         onDeleteAgent={onDeleteAgent}
         onDuplicateAgent={onDuplicateAgent}

--- a/desktop/tests/e2e/agent-lifecycle-feedback.spec.ts
+++ b/desktop/tests/e2e/agent-lifecycle-feedback.spec.ts
@@ -106,9 +106,9 @@ test.describe("agent lifecycle feedback screenshots", () => {
 
     await openAgentsView(page);
 
-    // The custom persona card appears in the library.
+    // The running instance is visible and owns the persona actions menu.
     await expect(
-      page.getByText("Cascade Test Agent", { exact: true }),
+      page.getByTestId(`managed-agent-${CASCADE_AGENT_B_PUBKEY}`),
     ).toBeVisible({ timeout: 10_000 });
 
     // Open the actions menu for the custom persona. The trigger button carries
@@ -240,7 +240,7 @@ test.describe("agent lifecycle feedback screenshots", () => {
     await openAgentsView(page);
 
     await expect(
-      page.getByText("Cascade Test Agent", { exact: true }),
+      page.getByTestId(`managed-agent-${CASCADE_AGENT_A_PUBKEY}`),
     ).toBeVisible({ timeout: 10_000 });
 
     await page

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -226,6 +226,35 @@ async function countCommandInvocations(
   );
 }
 
+test("Agents view keeps every managed instance that shares a persona visible", async ({
+  page,
+}) => {
+  const personaId = "custom:multi-fizz";
+  const firstPubkey = "a".repeat(64);
+  const secondPubkey = "b".repeat(64);
+  await installMockBridge(page, {
+    personas: [
+      {
+        id: personaId,
+        displayName: "Fizz",
+        systemPrompt: "Move fast.",
+      },
+    ],
+    managedAgents: [
+      { pubkey: firstPubkey, name: "Fizz", personaId },
+      { pubkey: secondPubkey, name: "Fizz", personaId },
+    ],
+  });
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+
+  const cards = page.getByTestId(`persona-agent-row-${personaId}`);
+  await expect(cards).toHaveCount(2);
+  await expect(cards.nth(0)).toContainText("aaaaaaaa…aaaa");
+  await expect(cards.nth(1)).toContainText("bbbbbbbb…bbbb");
+  await expect(page.getByLabel("Open actions for Fizz")).toHaveCount(1);
+});
+
 test("catalog hides built-ins and shows the shared-agent empty state", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -248,10 +248,16 @@ test("Agents view keeps every managed instance that shares a persona visible", a
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
 
-  const cards = page.getByTestId(`persona-agent-row-${personaId}`);
+  const cards = page.locator(
+    `[data-testid="managed-agent-${firstPubkey}"], [data-testid="managed-agent-${secondPubkey}"]`,
+  );
   await expect(cards).toHaveCount(2);
-  await expect(cards.nth(0)).toContainText("aaaaaaaa…aaaa");
-  await expect(cards.nth(1)).toContainText("bbbbbbbb…bbbb");
+  await expect(page.getByTestId(`managed-agent-${firstPubkey}`)).toContainText(
+    "aaaaaaaa…aaaa",
+  );
+  await expect(page.getByTestId(`managed-agent-${secondPubkey}`)).toContainText(
+    "bbbbbbbb…bbbb",
+  );
   await expect(page.getByLabel("Open actions for Fizz")).toHaveCount(1);
 });
 
@@ -2618,7 +2624,7 @@ test("start pill morphs into the running dot without remounting the avatar", asy
   await gotoApp(page);
   await page.getByTestId("open-agents-view").click();
 
-  const card = page.getByTestId(`persona-agent-row-${personaId}`);
+  const card = page.getByTestId(`managed-agent-${pubkey}`);
   const startButton = page.getByTestId(`agent-runtime-start-${pubkey}`);
   const badge = startButton.locator("xpath=../..");
   const initialAvatar = await card
@@ -2684,7 +2690,7 @@ test("start pill morphs into the running dot without remounting the avatar", asy
   ).toBe(true);
 });
 
-test("duplicate instances move from the agents gallery into the agent profile", async ({
+test("duplicate instances stay visible in the gallery and agent profile", async ({
   page,
 }) => {
   const personaId = "custom:duplicate-auditor";
@@ -2719,10 +2725,9 @@ test("duplicate instances move from the agents gallery into the agent profile", 
   await expect(page.getByText("Additional running agents")).toHaveCount(0);
   await expect(
     page.getByTestId(`managed-agent-${additionalPubkey}`),
-  ).toHaveCount(0);
+  ).toBeVisible();
 
-  await page.getByTestId(`persona-agent-row-${personaId}`).click();
-  await page.getByTestId("user-profile-tab-runtime").click();
+  await page.getByTestId(`managed-agent-${primaryPubkey}`).click();
   await page.getByTestId("user-profile-instances").click();
   await page.getByTestId(`user-profile-instance-${additionalPubkey}`).click();
 

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -7,7 +7,11 @@ import type { RelayEvent } from "@/shared/api/types";
 import { emojiAvatarDataUrl } from "@/features/profile/ui/ProfileAvatarEditor.utils";
 
 import { waitForAnimations } from "../helpers/animations";
-import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import {
+  createMockAgentMemoryListing,
+  installMockBridge,
+  TEST_IDENTITIES,
+} from "../helpers/bridge";
 import { seedActiveIdentity } from "../helpers/onboarding";
 
 function createCatalogEvent(input: {
@@ -2695,8 +2699,9 @@ test("duplicate instances stay visible in the gallery and agent profile", async 
 }) => {
   const personaId = "custom:duplicate-auditor";
   const primaryPubkey = TEST_IDENTITIES.alice.pubkey;
-  const additionalPubkey = TEST_IDENTITIES.charlie.pubkey;
+  const additionalPubkey = TEST_IDENTITIES.outsider.pubkey;
   await installMockBridge(page, {
+    agentMemory: createMockAgentMemoryListing(),
     personas: [
       {
         id: personaId,
@@ -2716,6 +2721,14 @@ test("duplicate instances stay visible in the gallery and agent profile", async 
         name: "Duplicate Auditor",
         personaId,
         status: "stopped",
+        channelNames: ["general", "random"],
+      },
+    ],
+    relayAgents: [
+      {
+        pubkey: additionalPubkey,
+        name: "Duplicate Auditor",
+        channelNames: ["general", "random"],
       },
     ],
   });
@@ -2728,8 +2741,10 @@ test("duplicate instances stay visible in the gallery and agent profile", async 
   ).toBeVisible();
 
   await page.getByTestId(`managed-agent-${primaryPubkey}`).click();
+  await page.getByTestId("user-profile-tab-runtime").click();
   await page.getByTestId("user-profile-instances").click();
   await page.getByTestId(`user-profile-instance-${additionalPubkey}`).click();
+  await page.getByTestId("user-profile-tab-info").click();
 
   await expect(page.getByTestId("user-profile-panel")).toBeVisible();
   await expect(page.getByTestId("user-profile-agent-status")).toContainText(
@@ -2739,6 +2754,20 @@ test("duplicate instances stay visible in the gallery and agent profile", async 
     page.getByTestId("user-profile-settings-menu-trigger"),
   ).toHaveCount(0);
   await expect(
-    page.getByTestId(`user-profile-agent-delete-${additionalPubkey}`),
-  ).toHaveCount(0);
+    page.getByTestId("user-profile-duplicate-agent-row"),
+  ).toBeVisible();
+  await expect(page.getByTestId("user-profile-export-agent-row")).toBeVisible();
+  await page.getByTestId("user-profile-delete-agent-row").click();
+
+  const deleteDialog = page.getByTestId("agent-delete-confirm-dialog");
+  await expect(deleteDialog).toBeVisible();
+  await expect(deleteDialog.getByRole("heading")).toHaveText(
+    "Delete Duplicate Auditor?",
+  );
+  await expect(page.getByTestId("agent-delete-memory-count")).toHaveText("9");
+  await expect(page.getByTestId("agent-delete-channel-count")).toHaveText("2");
+
+  await page.getByTestId("agent-delete-export-action").click();
+  await expect(deleteDialog).toHaveCount(0);
+  await expect(page.getByTestId("agent-snapshot-export-dialog")).toBeVisible();
 });

--- a/desktop/tests/e2e/needs-restart-screenshots.spec.ts
+++ b/desktop/tests/e2e/needs-restart-screenshots.spec.ts
@@ -261,7 +261,7 @@ test.describe("restart-diff screenshots", () => {
     await gotoAgentsView(page);
 
     const personaCard = page.getByTestId(
-      `persona-agent-row-${PERSONA_AGENT.personaId}`,
+      `managed-agent-${PERSONA_AGENT.pubkey}`,
     );
     await expect(personaCard).toBeVisible({ timeout: 10_000 });
     await expect(

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -1871,7 +1871,7 @@ test("an older agent message opens the same persona instance as the Agents libra
   await page.goto("/");
 
   await page.getByTestId("open-agents-view").click();
-  await page.getByTestId(`persona-agent-row-${personaId}`).click();
+  await page.getByTestId(`managed-agent-${currentPubkey}`).click();
   await expect(
     page.getByTestId("user-profile-agent-primary-action"),
   ).toHaveAttribute("aria-label", "Stop");


### PR DESCRIPTION
## Overview

**Category:** fix  
**User impact:** The Agents page now shows every managed agent instance that mention autocomplete can target, even when multiple instances share the same persona and display name.

**Problem:** Mention autocomplete preserves managed-agent identity by pubkey, but the Agents page grouped agents by persona and selected only one representative. Multiple same-persona instances therefore appeared in autocomplete while all but one were hidden from the Agents page.

**Solution:**
- Render one identity card per managed-agent pubkey within each persona group.
- Show a truncated pubkey on managed cards so identically named instances are distinguishable.
- Keep persona-only cards when no managed instance exists.
- Keep persona-level edit/share/delete actions on the first stably sorted instance rather than duplicating them on every runtime card.
- Preserve relay-restored managed agents, including the ingestion path changed by #4999.

## Reproduction steps

1. Configure or restore two managed agents with the same persona ID.
2. Confirm both identities appear in mention autocomplete.
3. Open the Agents page.
4. Before this fix, only one card appeared for that persona. With this fix, both pubkey-backed cards appear and can open their respective profiles.

## Validation

At commit `f2a0ecff82d36525c77e0ed7a2dd978a5785cdb6` with a clean working tree:

- Pre-push desktop check, typecheck, and full unit suite passed (4,616 tests).
- Purpose-built Playwright regression passed after a fresh E2E build.
- Focused grouping tests passed (4 tests), including relay-restored and persona-only cases.
- Mutation check passed: limiting the group back to one instance made the Playwright regression fail at the two-card assertion.
- `git diff --check` passed.

Originating conversation: Buzz channel `dcbc45d2-e9cc-45b3-940b-568dd06652ff`, thread `fd2e3ae323021b0314203dc0709f624669f278b344fdbe21f6cd65bae9582b2c`.


## Screenshot

Agents page with three managed Fizz instances sharing one persona. Each card is individually visible and distinguished by its truncated pubkey.

![Agents page showing three same-persona managed instances](https://raw.githubusercontent.com/block/buzz/965ca1114adde6c8b18b63e02a662304eb3697b5/pr-5575--agents-page-branch.png)

---------

Generated with Brainy Bumble

## Delete-popup UX proof

The individual-agent delete confirmation now makes the backup action visibly clickable with an underlined **Export this agent** link. Clicking it opens the existing export dialog. The seeded proof state shows 9 memories and 2 channels; both captures wait for the dialog animation to settle.

![Individual-agent delete confirmation with underlined Export this agent link](https://raw.githubusercontent.com/block/buzz/383bb4628d3188d7521ef97ac8387ff21c5767d1/pr-5575--delete-confirmation-delayed.png)

![Existing agent export dialog opened from the delete confirmation](https://raw.githubusercontent.com/block/buzz/383bb4628d3188d7521ef97ac8387ff21c5767d1/pr-5575--export-dialog-delayed.png)