### PR TITLE
fix(buzz-acp): treat hermes-acp as a zero-arg agent

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -701,7 +701,9 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent" | "hermes" | "hermes-agent" | "hermes-acp" => {
+            Some(Vec::new())
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- \`default_agent_args()\` already special-cases other zero-arg ACP adapters (\`codex-acp\`, \`claude-agent-acp\`, \`buzz-agent\`), and \`default_agent_env()\` a few lines above already special-cases \`hermes\`/\`hermes-agent\`/\`hermes-acp\` by name — but \`default_agent_args()\` was missing the same three identities.
- Without this, the harness's clap default (\`"acp"\`) is passed straight through as a positional argument to \`hermes-acp\`, which doesn't expect one.

## Test plan
- [x] Built \`buzz-acp\` in release mode and ran it against a local relay with \`BUZZ_ACP_AGENT_COMMAND=hermes-acp\`; confirmed it spawns \`hermes acp\` with no stray positional argument and authenticates successfully (NIP-42 auth succeeded, presence set to online).