### PR TITLE
fix(acp): follow channel membership changes at runtime

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -332,8 +332,16 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_KINDS", value_delimiter = ',')]
     pub kinds: Option<Vec<u32>>,
 
+    /// Comma-separated channels to seed explicitly. Relay membership remains
+    /// authoritative unless --no-follow-memberships is set.
     #[arg(long, env = "BUZZ_ACP_CHANNELS", value_delimiter = ',')]
     pub channels: Option<Vec<String>>,
+
+    /// Keep channel subscriptions fixed to --channels instead of following
+    /// relay membership. By default, adding or removing this agent through
+    /// channel membership changes its subscriptions immediately.
+    #[arg(long, env = "BUZZ_ACP_NO_FOLLOW_MEMBERSHIPS")]
+    pub no_follow_memberships: bool,
 
     #[arg(long, env = "BUZZ_ACP_NO_MENTION_FILTER")]
     pub no_mention_filter: bool,
@@ -519,6 +527,10 @@ pub struct Config {
     pub ignore_self: bool,
     pub kinds_override: Option<Vec<u32>>,
     pub channels_override: Option<Vec<String>>,
+    /// Whether relay membership is authoritative for startup and live channel
+    /// subscriptions. Enabled by default; --no-follow-memberships preserves a
+    /// fixed --channels scope.
+    pub follow_memberships: bool,
     pub no_mention_filter: bool,
     pub config_path: PathBuf,
     pub context_message_limit: u32,
@@ -896,8 +908,10 @@ impl Config {
             if args.kinds.is_some() {
                 tracing::warn!("--kinds is ignored in config mode");
             }
-            if args.channels.is_some() {
-                tracing::warn!("--channels is ignored in config mode");
+            if args.channels.is_some() && !args.no_follow_memberships {
+                tracing::warn!(
+                    "--channels is ignored in config mode unless --no-follow-memberships is set"
+                );
             }
             if args.no_mention_filter {
                 tracing::warn!("--no-mention-filter is ignored in config mode");
@@ -1086,6 +1100,7 @@ impl Config {
             ignore_self: !args.no_ignore_self,
             kinds_override: args.kinds,
             channels_override: args.channels,
+            follow_memberships: !args.no_follow_memberships,
             no_mention_filter: args.no_mention_filter,
             config_path: args.config,
             context_message_limit: args.context_message_limit,
@@ -1247,7 +1262,9 @@ pub fn resolve_channel_filters(
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
 
-    let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
+    let target_channels: Vec<Uuid> = if config.follow_memberships {
+        discovered_channels.to_vec()
+    } else if let Some(ref overrides) = config.channels_override {
         overrides
             .iter()
             .filter_map(|s| s.parse::<Uuid>().ok())
@@ -1291,7 +1308,7 @@ pub fn resolve_channel_filters(
             }
         }
         SubscribeMode::Config => {
-            for ch in discovered_channels {
+            for ch in &target_channels {
                 let mut merged_kinds: Option<Vec<u32>> = Some(vec![]);
                 let mut require_mention = true;
                 let mut has_rule = false;
@@ -1333,12 +1350,12 @@ pub fn resolve_channel_filters(
 
 /// Resolve the subscription filter for a single dynamically-discovered channel.
 ///
-/// In Mentions/All mode, `channels_override` (--channels) is enforced — the agent
-/// won't subscribe to channels outside the operator's allowlist. In Config mode,
-/// `--channels` is ignored (per CLI contract) and rule-matching determines scope.
+/// Relay membership is authoritative by default in every mode. The
+/// `channels_override` (--channels) allowlist is enforced in every mode only
+/// when `--no-follow-memberships` is set; Config rules then narrow that scope.
 ///
 /// Returns `None` when the channel is outside the agent's configured scope:
-/// - Mentions/All: channel not in `channels_override` (if set)
+/// - fixed scope: channel not in `channels_override` (if set)
 /// - Config: no subscription rules match the channel
 pub fn resolve_dynamic_channel_filter(
     config: &Config,
@@ -1349,21 +1366,22 @@ pub fn resolve_dynamic_channel_filter(
         KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
 
-    // In Mentions/All mode, if the operator explicitly constrained channels
-    // with --channels, only allow dynamic subscription to channels in that
-    // allowlist. Config mode ignores --channels (per CLI contract) and uses
-    // rule-matching instead.
-    if config.subscribe_mode != SubscribeMode::Config {
-        if let Some(ref overrides) = config.channels_override {
-            let allowed = overrides
-                .iter()
-                .any(|s| s.parse::<Uuid>().ok() == Some(channel_id));
-            if !allowed {
-                return None;
-            }
+    // Fixed scope is an authority boundary in every mode. Config rules may
+    // narrow an allowed scope, but cannot expand beyond it.
+    if !config.follow_memberships {
+        let Some(ref overrides) = config.channels_override else {
+            // With no explicit list, --no-follow-memberships freezes the
+            // startup-discovered set. A later channel was not in that set.
+            return None;
+        };
+        let allowed = overrides
+            .iter()
+            .filter_map(|s| s.parse::<Uuid>().ok())
+            .any(|id| id == channel_id);
+        if !allowed {
+            return None;
         }
     }
-
     match config.subscribe_mode {
         SubscribeMode::Mentions => Some(ChannelFilter {
             kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
@@ -1431,6 +1449,23 @@ fn rule_applies_to_channel(rule: &SubscriptionRule, channel_id: Uuid) -> bool {
     }
 }
 
+/// Resolve a membership-triggered channel against both the dynamic policy and
+/// the immutable startup snapshot used by fixed-scope mode without --channels.
+pub fn resolve_membership_channel_filter(
+    config: &Config,
+    channel_id: Uuid,
+    rules: &[crate::filter::SubscriptionRule],
+    startup_channel_ids: &[Uuid],
+) -> Option<ChannelFilter> {
+    if !config.follow_memberships
+        && config.channels_override.is_none()
+        && startup_channel_ids.contains(&channel_id)
+    {
+        return resolve_channel_filters(config, &[channel_id], rules).remove(&channel_id);
+    }
+    resolve_dynamic_channel_filter(config, channel_id, rules)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1460,6 +1495,7 @@ mod tests {
             ignore_self: true,
             kinds_override: None,
             channels_override: None,
+            follow_memberships: true,
             no_mention_filter: false,
             config_path: PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
@@ -1799,6 +1835,7 @@ mod tests {
     #[test]
     fn test_channels_override_filters_to_discovered() {
         let mut config = test_config(SubscribeMode::All);
+        config.follow_memberships = false;
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
         let ch_unknown = Uuid::new_v4();
@@ -1813,6 +1850,105 @@ mod tests {
         assert!(result.contains_key(&ch_a));
         assert!(!result.contains_key(&ch_b));
         assert!(!result.contains_key(&ch_unknown));
+    }
+
+    #[test]
+    fn test_membership_following_is_authoritative_by_default() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        let configured = Uuid::new_v4();
+        let joined_later = Uuid::new_v4();
+        config.channels_override = Some(vec![configured.to_string()]);
+
+        let startup = resolve_channel_filters(&config, &[configured, joined_later], &[]);
+        assert!(startup.contains_key(&configured));
+        assert!(startup.contains_key(&joined_later));
+        assert!(resolve_dynamic_channel_filter(&config, joined_later, &[]).is_some());
+    }
+
+    #[test]
+    fn test_static_scope_opt_out_rejects_later_membership() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        let configured = Uuid::new_v4();
+        let joined_later = Uuid::new_v4();
+        config.channels_override = Some(vec![configured.to_string()]);
+        config.follow_memberships = false;
+
+        let startup = resolve_channel_filters(&config, &[configured, joined_later], &[]);
+        assert!(startup.contains_key(&configured));
+        assert!(!startup.contains_key(&joined_later));
+        assert!(resolve_dynamic_channel_filter(&config, joined_later, &[]).is_none());
+    }
+
+    #[test]
+    fn test_static_scope_without_pins_freezes_startup_discovery() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        let joined_at_startup = Uuid::new_v4();
+        let joined_later = Uuid::new_v4();
+        config.follow_memberships = false;
+
+        let startup = resolve_channel_filters(&config, &[joined_at_startup], &[]);
+        assert!(startup.contains_key(&joined_at_startup));
+        assert!(resolve_dynamic_channel_filter(&config, joined_later, &[]).is_none());
+        assert!(resolve_membership_channel_filter(
+            &config,
+            joined_at_startup,
+            &[],
+            &[joined_at_startup],
+        )
+        .is_some());
+        assert!(resolve_membership_channel_filter(
+            &config,
+            joined_later,
+            &[],
+            &[joined_at_startup],
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn config_mode_static_scope_cannot_be_expanded_by_catch_all_rule() {
+        let mut config = test_config(SubscribeMode::Config);
+        let joined_at_startup = Uuid::new_v4();
+        let joined_later = Uuid::new_v4();
+        config.follow_memberships = false;
+        let rules = vec![make_rule(
+            "catch-all",
+            ChannelScope::All("all".into()),
+            vec![9],
+            false,
+        )];
+
+        let startup = resolve_channel_filters(&config, &[joined_at_startup], &rules);
+        assert!(startup.contains_key(&joined_at_startup));
+        assert!(resolve_membership_channel_filter(
+            &config,
+            joined_at_startup,
+            &rules,
+            &[joined_at_startup],
+        )
+        .is_some());
+        assert!(resolve_membership_channel_filter(
+            &config,
+            joined_later,
+            &rules,
+            &[joined_at_startup],
+        )
+        .is_none());
+
+        config.channels_override = Some(vec![joined_at_startup.to_string()]);
+        assert!(resolve_dynamic_channel_filter(&config, joined_at_startup, &rules).is_some());
+        assert!(resolve_dynamic_channel_filter(&config, joined_later, &rules).is_none());
+    }
+
+    #[test]
+    fn membership_following_cli_defaults_on_with_explicit_opt_out() {
+        let key = "0".repeat(64);
+        let default = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert!(!default.no_follow_memberships);
+
+        let fixed =
+            CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--no-follow-memberships"]);
+        assert!(fixed.no_follow_memberships);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -66,6 +66,52 @@ const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
 /// human interaction, so it must not share the short probe timeout.
 const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
+/// Resolve a membership notification against the current relay snapshot.
+///
+/// The notification kind is validated for callers, but deliberately does not
+/// choose the resulting state: equal-second add/remove delivery order is not
+/// an authority contract.
+pub(crate) fn authoritative_membership_state(
+    notification_kind: u32,
+    currently_joined: bool,
+) -> bool {
+    debug_assert!(
+        notification_kind == KIND_MEMBER_ADDED_NOTIFICATION
+            || notification_kind == KIND_MEMBER_REMOVED_NOTIFICATION
+    );
+    currently_joined
+}
+
+#[cfg(test)]
+mod membership_authority_tests {
+    use super::*;
+
+    #[test]
+    fn equal_second_notification_order_cannot_override_current_membership() {
+        let orders = [
+            [
+                KIND_MEMBER_ADDED_NOTIFICATION,
+                KIND_MEMBER_REMOVED_NOTIFICATION,
+            ],
+            [
+                KIND_MEMBER_REMOVED_NOTIFICATION,
+                KIND_MEMBER_ADDED_NOTIFICATION,
+            ],
+        ];
+
+        for order in orders {
+            let mut absent_state = true;
+            let mut present_state = false;
+            for kind in order {
+                absent_state = authoritative_membership_state(kind, false);
+                present_state = authoritative_membership_state(kind, true);
+            }
+            assert!(!absent_state);
+            assert!(present_state);
+        }
+    }
+}
+
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
 /// Ephemeral kinds (20000-29999) are rejected by the HTTP bridge, so presence
@@ -1759,12 +1805,10 @@ async fn tokio_main() -> Result<()> {
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
-    let mut subscribed_channel_ids = HashSet::with_capacity(channel_filters.len());
     for (channel_id, filter) in &channel_filters {
         if let Err(e) = relay.subscribe_channel(*channel_id, filter.clone()).await {
             tracing::warn!("failed to subscribe to channel {channel_id}: {e}");
         } else {
-            subscribed_channel_ids.insert(*channel_id);
             tracing::info!("subscribed to channel {channel_id}");
         }
     }
@@ -2242,12 +2286,6 @@ async fn tokio_main() -> Result<()> {
                                     );
                                     continue;
                                 }
-                                seen_membership_current.insert(eid);
-                                // Rotate at 1000: current → previous, no amnesia window.
-                                if seen_membership_current.len() >= 1000 {
-                                    seen_membership_previous =
-                                        std::mem::take(&mut seen_membership_current);
-                                }
                                 if let Some(&newest) = membership_newest_ts.get(&ch) {
                                     if ts < newest {
                                         tracing::debug!(
@@ -2260,27 +2298,67 @@ async fn tokio_main() -> Result<()> {
                                         continue;
                                     }
                                 }
+
+                                // Notification timestamps have one-second precision and the
+                                // relay does not promise causal delivery order for equal-second
+                                // add/remove pairs. Resolve the current relay membership rather
+                                // than treating delivery order as authority.
+                                let currently_joined = match relay.discover_channels().await {
+                                    Ok(channels) => authoritative_membership_state(
+                                        kind_u32,
+                                        channels.contains_key(&ch),
+                                    ),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            channel_id = %ch,
+                                            notification_kind = kind_u32,
+                                            "membership notification: authoritative channel discovery failed; queueing replay: {e}"
+                                        );
+                                        if let Err(retry_err) = relay
+                                            .retry_membership_notification(eid.clone(), ts)
+                                            .await
+                                        {
+                                            tracing::error!(
+                                                channel_id = %ch,
+                                                "failed to queue membership notification replay: {retry_err}"
+                                            );
+                                        }
+                                        continue;
+                                    }
+                                };
+
+                                seen_membership_current.insert(eid);
+                                // Rotate at 1000: current → previous, no amnesia window.
+                                if seen_membership_current.len() >= 1000 {
+                                    seen_membership_previous =
+                                        std::mem::take(&mut seen_membership_current);
+                                }
                                 membership_newest_ts.insert(ch, ts);
 
-                                if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
+                                if currently_joined {
                                     // Clear removal tracking so sessions are not
                                     // stripped for a legitimately re-added channel.
                                     removed_channels.remove(&ch);
 
-                                    if subscribed_channel_ids.contains(&ch) {
-                                        tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
+                                    if let Some(filter) = config::resolve_membership_channel_filter(
+                                        &config,
+                                        ch,
+                                        &rules,
+                                        &channel_ids,
+                                    ) {
+                                        tracing::info!(channel_id = %ch, "membership notification: reconciling channel subscription");
                                         if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
                                             tracing::warn!("failed to subscribe to new channel {ch}: {e}");
-                                        } else {
-                                            subscribed_channel_ids.insert(ch);
                                         }
+                                    } else if !config.follow_memberships {
+                                        tracing::info!(
+                                            channel_id = %ch,
+                                            "membership notification: fixed --channels scope excludes channel"
+                                        );
                                     } else {
-                                        tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        tracing::debug!(channel_id = %ch, "membership notification: no matching config rule — skipping");
                                     }
                                 } else {
-                                    subscribed_channel_ids.remove(&ch);
                                     tracing::info!(channel_id = %ch, "membership notification: unsubscribing from channel");
                                     if let Err(e) = relay.unsubscribe_channel(ch).await {
                                         tracing::warn!("failed to unsubscribe from channel {ch}: {e}");
@@ -6231,6 +6309,7 @@ mod build_mcp_servers_tests {
             ignore_self: true,
             kinds_override: None,
             channels_override: None,
+            follow_memberships: true,
             no_mention_filter: false,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
@@ -6453,6 +6532,7 @@ mod error_outcome_emission_tests {
             ignore_self: true,
             kinds_override: None,
             channels_override: None,
+            follow_memberships: true,
             no_mention_filter: false,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -536,6 +536,8 @@ enum RelayCommand {
     PublishEvent { event: Box<Event> },
     /// Floor `since` for membership notification replay; events before startup are never re-delivered.
     SetStartupWatermark { ts: u64 },
+    /// Re-offer a forwarded membership event after authoritative discovery failed.
+    RetryMembership { event_id: String, ts: u64 },
 }
 
 type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
@@ -897,6 +899,19 @@ impl HarnessRelay {
             .map_err(|_| RelayError::ConnectionClosed)
     }
 
+    /// Make a forwarded membership notification replayable after its
+    /// authoritative REST reconciliation failed.
+    pub async fn retry_membership_notification(
+        &self,
+        event_id: String,
+        ts: u64,
+    ) -> Result<(), RelayError> {
+        self.cmd_tx
+            .send(RelayCommand::RetryMembership { event_id, ts })
+            .await
+            .map_err(|_| RelayError::ConnectionClosed)
+    }
+
     /// Reconnect after connection loss. Instructs the background task to
     /// re-authenticate and resubscribe to all previously active channels.
     pub async fn reconnect(&mut self) -> Result<(), RelayError> {
@@ -1248,6 +1263,16 @@ impl BgState {
     }
 }
 
+fn mark_membership_for_retry(state: &mut BgState, event_id: &str, ts: u64) {
+    state.seen_ids.remove(event_id);
+    state.membership_dropped_since = Some(
+        state
+            .membership_dropped_since
+            .map_or(ts, |floor| floor.min(ts)),
+    );
+    state.proactive_resubscribe_needed = true;
+}
+
 /// Record a command's intent in state while disconnected (no WebSocket).
 ///
 /// Subscribe/Unsubscribe/SubscribeMembership record intent so reconnect
@@ -1292,6 +1317,9 @@ fn apply_command_to_state(state: &mut BgState, cmd: RelayCommand) {
             if state.membership_last_seen.is_none() {
                 state.membership_last_seen = Some(ts);
             }
+        }
+        RelayCommand::RetryMembership { event_id, ts } => {
+            mark_membership_for_retry(state, &event_id, ts);
         }
         // Observer telemetry frames are durable: park them (bounded, visible
         // overflow) so they are delivered by the post-reconnect drain. Other
@@ -1529,6 +1557,10 @@ async fn execute_connected_command(
                 state.membership_last_seen = Some(ts);
             }
             debug!("startup watermark set to {ts}");
+            true
+        }
+        RelayCommand::RetryMembership { event_id, ts } => {
+            mark_membership_for_retry(state, &event_id, ts);
             true
         }
         // Control-flow commands — callers handle these before dispatching.
@@ -2091,6 +2123,13 @@ async fn handle_ws_message(
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
                     } else if subscription_id == MEMBERSHIP_NOTIF_SUB_ID {
+                        if !is_membership_event_for_agent(&event, agent_pubkey_hex) {
+                            warn!(
+                                event_id = %event.id,
+                                "membership notification has wrong kind or target — dropping"
+                            );
+                            return true;
+                        }
                         // Membership notification — extract channel UUID from h tag.
                         let channel_uuid = match extract_h_tag_uuid(&event) {
                             Some(uuid) => uuid,
@@ -3442,6 +3481,16 @@ fn extract_h_tag_uuid(event: &nostr::Event) -> Option<Uuid> {
     })
 }
 
+fn is_membership_event_for_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
+    if !matches!(event.kind, nostr::Kind::Custom(44100 | 44101)) {
+        return false;
+    }
+    event.tags.iter().any(|tag| {
+        let values = tag.as_slice();
+        values.len() >= 2 && values[0] == "p" && values[1].eq_ignore_ascii_case(agent_pubkey_hex)
+    })
+}
+
 /// Build and send a NIP-42 AUTH response event.
 ///
 /// If `auth_tag` is provided (NIP-OA owner attestation), it is included in the
@@ -4010,6 +4059,72 @@ async fn wait_for_any_ok(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn failed_authoritative_reconciliation_rewinds_membership_replay() {
+        let mut state = BgState::new();
+        let event_id = "membership-event".to_string();
+        state.seen_ids.insert(event_id.clone());
+        state.membership_last_seen = Some(200);
+
+        apply_command_to_state(
+            &mut state,
+            RelayCommand::RetryMembership {
+                event_id: event_id.clone(),
+                ts: 150,
+            },
+        );
+
+        assert!(!state.seen_ids.contains(&event_id));
+        assert_eq!(state.membership_dropped_since, Some(150));
+        assert!(state.proactive_resubscribe_needed);
+        assert_eq!(state.membership_last_seen, Some(200));
+    }
+
+    #[tokio::test]
+    async fn missing_and_wrong_membership_targets_do_not_mutate_replay_state() {
+        let agent_keys = Keys::generate();
+        let other_keys = Keys::generate();
+        let agent_pubkey = agent_keys.public_key().to_hex();
+        let channel_id = Uuid::new_v4();
+        let h_tag = nostr::Tag::parse(["h", channel_id.to_string().as_str()]).unwrap();
+        let wrong_p = nostr::Tag::parse(["p", other_keys.public_key().to_hex().as_str()]).unwrap();
+        let missing_target = EventBuilder::new(nostr::Kind::Custom(44100), "")
+            .tags([h_tag.clone()])
+            .sign_with_keys(&other_keys)
+            .unwrap();
+        let wrong_target = EventBuilder::new(nostr::Kind::Custom(44101), "")
+            .tags([h_tag, wrong_p])
+            .sign_with_keys(&other_keys)
+            .unwrap();
+        let (mut ws, _server) = test_ws_pair().await;
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let (control_tx, _control_rx) = mpsc::channel(1);
+        let mut state = BgState::new();
+
+        for event in [missing_target, wrong_target] {
+            let event_id = event.id.to_hex();
+            let frame =
+                serde_json::to_string(&json!(["EVENT", MEMBERSHIP_NOTIF_SUB_ID, event])).unwrap();
+            assert!(
+                handle_ws_message(
+                    Message::Text(frame.into()),
+                    &mut ws,
+                    &event_tx,
+                    &control_tx,
+                    &mut state,
+                    &agent_keys,
+                    "ws://localhost",
+                    &agent_pubkey,
+                    None,
+                )
+                .await
+            );
+            assert!(!state.seen_ids.contains(&event_id));
+            assert_eq!(state.membership_last_seen, None);
+            assert!(event_rx.try_recv().is_err());
+        }
+    }
 
     #[test]
     fn relay_ws_to_http_plain() {

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -565,23 +565,55 @@ async fn handle_setup_membership(
     buzz_event: &crate::relay::BuzzEvent,
     config: &Config,
     rules: &[filter::SubscriptionRule],
-    _initial_channel_ids: &[Uuid],
+    initial_channel_ids: &[Uuid],
 ) {
     let kind_u32 = buzz_event.event.kind.as_u16() as u32;
     let channel_id = buzz_event.channel_id;
 
-    if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
+    // Equal-second add/remove notifications have no causal delivery-order
+    // guarantee. Query the current relay membership before changing scope.
+    let currently_joined = match relay.discover_channels().await {
+        Ok(channels) => {
+            crate::authoritative_membership_state(kind_u32, channels.contains_key(&channel_id))
+        }
+        Err(e) => {
+            tracing::warn!(
+                channel_id = %channel_id,
+                notification_kind = kind_u32,
+                "setup-mode: authoritative membership discovery failed; queueing replay: {e}"
+            );
+            if let Err(retry_err) = relay
+                .retry_membership_notification(
+                    buzz_event.event.id.to_hex(),
+                    buzz_event.event.created_at.as_secs(),
+                )
+                .await
+            {
+                tracing::error!(
+                    channel_id = %channel_id,
+                    "setup-mode: failed to queue membership notification replay: {retry_err}"
+                );
+            }
+            return;
+        }
+    };
+
+    if currently_joined {
         // Subscribe to the newly-joined channel.
-        let ids = vec![channel_id];
-        let filters = crate::config::resolve_channel_filters(config, &ids, rules);
-        for (cid, filter) in filters {
+        if let Some(filter) = crate::config::resolve_membership_channel_filter(
+            config,
+            channel_id,
+            rules,
+            initial_channel_ids,
+        ) {
+            let cid = channel_id;
             if let Err(e) = relay.subscribe_channel(cid, filter).await {
                 tracing::warn!("setup-mode: failed to subscribe to new channel {cid}: {e}");
             } else {
                 tracing::info!("setup-mode: subscribed to new channel {cid}");
             }
         }
-    } else if kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION {
+    } else {
         if let Err(e) = relay.unsubscribe_channel(channel_id).await {
             tracing::warn!("setup-mode: failed to unsubscribe from channel {channel_id}: {e}");
         }


### PR DESCRIPTION
## Summary

- treat relay membership as authoritative by default while retaining configured channels as startup seeds
- subscribe and unsubscribe running ACP agents on kind `44100` / `44101` without a restart
- preserve an explicit fixed-scope opt-out, including immutable startup snapshots and empty explicit scopes
- reconcile membership across reconnects, setup/listener mode, failed authority lookups, equal-second events and channel-specific relay closure
- reject malformed or wrongly targeted membership notifications before replay/deduplication state changes

Buzz issue root: `46cebe91d0ad7b7ac26e177afa57197ddb682eac02e042d2160640dc126f3abb`

## Verification

- `cargo fmt --check`
- `cargo check -p buzz-acp`
- `cargo test -p buzz-acp` — 753 passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo build -p buzz-acp --release`
- `git diff --check`
- independent exact-diff review: `PASS`

## Runtime acceptance

Deployment and live no-restart membership add/remove proof will be attached to the originating Buzz issue after rollout.
