### PR TITLE
fix(deploy): enable mobile pairing relay

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -8,6 +8,7 @@ BUZZ_IMAGE=ghcr.io/block/buzz:main
 # Public host name. Used by compose.caddy.yml and URL-derived settings below.
 BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
+BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
 BUZZ_CORS_ORIGINS=https://buzz.example.com

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,11 @@
 {$BUZZ_DOMAIN} {
   encode zstd gzip
 
-  reverse_proxy relay:3000
+  handle /pair {
+    reverse_proxy pairing-relay:5000
+  }
+
+  handle {
+    reverse_proxy relay:3000
+  }
 }

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -3,6 +3,10 @@
 This is the single-node/VPS deployment bundle. It is intentionally separate from
 the root `docker-compose.yml`, which remains local development infrastructure.
 
+The bundle also runs the stateless `buzz-pair-relay` sidecar. Caddy routes only
+`/pair` to that service, and `BUZZ_PAIRING_RELAY_URL` advertises the public
+WebSocket URL to desktop and mobile clients.
+
 ## Quick start
 
 ```bash

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       relay:
         condition: service_healthy
+      pairing-relay:
+        condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}
     ports:

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -48,6 +48,21 @@ services:
     networks:
       - buzz-net
 
+  pairing-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    healthcheck:
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
   postgres:
     image: postgres:17-alpine
     environment:


### PR DESCRIPTION
## Summary
- run the stateless `buzz-pair-relay` binary as a production Compose sidecar
- route only `/pair` to the sidecar through Caddy
- advertise the public pairing WebSocket URL in the example environment
- make Caddy wait for a healthy pairing sidecar

## Validation
- `docker compose ... config`
- `caddy validate --config /etc/caddy/Caddyfile`
- live EC2 qualification with Relay 0.2.1 / `ghcr.io/block/buzz:sha-6e5c462`:
  - pairing sidecar healthy, zero restarts
  - NIP-11 advertises `wss://buzz-test.hiveq.ai/pair`
  - pairing and main relay WebSocket handshakes succeed
  - liveness/readiness return HTTP 200
  - community/channel/member/event counts preserved
  - recent relay, pairing, and Caddy logs clean

## Test limitation
- `cargo test -p buzz-pair-relay` could not start on this Windows checkout because Hermit Git-Bash bootstrap failed with `HERMIT_STATE_DIR_RAW: unbound variable`; no Rust code changed.