### PR TITLE
buzz-acp: recover from a dead agent session instead of wedging forever

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -114,8 +114,21 @@ pub enum AcpError {
 /// detail (e.g. a `data` field) is not lost.
 fn agent_error_from_json(error: &serde_json::Value) -> AcpError {
     let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-32000);
+    // The `None` arm below was the only path that preserved `data`, and it is
+    // unreachable in practice: every JSON-RPC error the ACP SDK emits carries a
+    // string `message`, so `data` was dropped on every single error.
+    //
+    // That is not cosmetic. `claude-agent-acp` reports a vanished session as
+    // `{code: -32603, message: "Internal error", data: {details: "Session not
+    // found"}}`. Dropping `data` reduces that to a bare "Internal error" in the
+    // agent log, with no way to tell it apart from any other internal error. A
+    // roster ran wedged for ~9.5h on 2026-08-11 because the one word that
+    // explained it never reached a log line.
     let message = match error.get("message").and_then(|m| m.as_str()) {
-        Some(m) => m.to_string(),
+        Some(m) => match error.get("data") {
+            Some(d) if !d.is_null() => format!("{m} ({d})"),
+            _ => m.to_string(),
+        },
         None => error.to_string(),
     };
     AcpError::AgentError { code, message }
@@ -4389,6 +4402,35 @@ mod tests {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32001);
                 assert_eq!(message, "auth denied");
+            }
+            other => panic!("expected AgentError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_error_from_json_keeps_data_alongside_a_present_message() {
+        // The regression this exists for: `data` used to be preserved ONLY when
+        // `message` was absent, and every ACP error carries a string `message` —
+        // so `data` was dropped every time. claude-agent-acp reports a vanished
+        // session exactly this way, which reduced a fatal, permanent condition to
+        // an indistinguishable "Internal error" in the log and left a roster
+        // wedged for ~9.5h with nothing to diagnose it from.
+        let error = serde_json::json!({
+            "code": -32603,
+            "message": "Internal error",
+            "data": {"details": "Session not found"}
+        });
+        match super::agent_error_from_json(&error) {
+            AcpError::AgentError { code, message } => {
+                assert_eq!(code, -32603);
+                assert!(
+                    message.contains("Internal error"),
+                    "the original message must survive, got: {message}"
+                );
+                assert!(
+                    message.contains("Session not found"),
+                    "the data payload must reach the message, got: {message}"
+                );
             }
             other => panic!("expected AgentError, got {other:?}"),
         }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2503,7 +2503,31 @@ pub async fn run_prompt_task(
             // AgentError means the agent caught a problem before mutating
             // session state (e.g. bad LLM response). The session is healthy —
             // don't invalidate it. Other errors may have corrupted state.
-            if !matches!(e, AcpError::AgentError { .. }) {
+            //
+            // EXCEPT when the AgentError *is* "the session is gone". Then the
+            // session is the opposite of healthy, and keeping it is fatal: the
+            // channel's id stays in `state.sessions`, every later turn reuses
+            // it, the agent answers "Session not found" forever, and nothing
+            // ever calls session/new again. The seat is dead until the process
+            // restarts.
+            //
+            // This is not hypothetical. `claude-agent-acp` deletes its session
+            // whenever the Claude worker process dies for any reason — reaped,
+            // OOM-killed, crashed — and then answers exactly this. On
+            // 2026-08-11 a stale-turn reaper killed the workers of 13 seats and
+            // the whole roster stayed wedged for ~9.5h overnight, then ~2.5h
+            // again the next morning, while `launchctl` showed live PIDs and
+            // every log stayed fresh.
+            //
+            // Invalidating only this source is the conservative repair: the
+            // very next turn creates a fresh session and the seat recovers on
+            // its own, with no restart and nothing else discarded.
+            let session_is_gone = matches!(
+                &e,
+                AcpError::AgentError { message, .. }
+                    if message.to_ascii_lowercase().contains("session not found")
+            );
+            if !matches!(e, AcpError::AgentError { .. }) || session_is_gone {
                 agent.state.invalidate(&source);
             }
             let usage = agent.acp.take_turn_usage();


### PR DESCRIPTION
## Symptom

A seat stops answering and never recovers. `launchctl` shows a live PID, the log keeps growing, and every turn from that moment logs:

```
WARN buzz_acp: agent_returned (application error — pipe intact) agent=0 outcome="error" ... error=Agent reported error (code -32603): Internal error
```

Bare `Internal error`, nothing after it. Only restarting the process fixes it.

I hit this on a 13-seat roster: it stayed wedged ~9.5h overnight, then ~2.5h again the next morning. Agents were re-dispatched for work they had already delivered, because both the status view and a ping-based health check reported the seats as fine.

## Root cause

Two defects that compound — one hides the other.

**1. `acp.rs` / `agent_error_from_json` drops `data` on every error.**

```rust
let message = match error.get("message").and_then(|m| m.as_str()) {
    Some(m) => m.to_string(),   // data discarded
    None => error.to_string(),  // unreachable in practice
};
```

The doc comment says `data` is preserved when `message` is missing — but every JSON-RPC error the ACP SDK emits carries a string `message`, so the `None` arm never runs and `data` is dropped every time.

That matters here because `claude-agent-acp` reports a vanished session as:

```json
{"jsonrpc":"2.0","id":16,"error":{"code":-32603,"message":"Internal error","data":{"details":"Session not found"}}}
```

Captured on the wire by putting a pass-through tee between `buzz-acp` and the adapter — it was the only way to see it, since the payload never reaches a log line.

**2. `pool.rs` protects the dead session from invalidation.**

```rust
// AgentError means the agent caught a problem before mutating
// session state (e.g. bad LLM response). The session is healthy —
// don't invalidate it. Other errors may have corrupted state.
if !matches!(e, AcpError::AgentError { .. }) {
    agent.state.invalidate(&source);
}
```

That holds for every `AgentError` except the one that says *the session is gone*. The channel's id stays in `state.sessions`, every later turn reuses the dead id, `session/new` is never called again, and the seat is dead until the process restarts.

`claude-agent-acp` deletes its session whenever the Claude worker process dies for **any** reason — OOM, crash, or an external kill (in my case a stale-process reaper that assumed a long-lived worker must be a leaked turn). So this is reachable on any host where a worker can die.

## The fix

1. Append `data` to the message when present, so the cause is visible.
2. Treat "session not found" as invalidating **only that source**, so the next turn opens a fresh session and the seat recovers on its own — no restart, nothing else discarded.

(2) depends on (1): the discriminator only exists in the message once `data` stops being discarded.

**On the discriminator:** matching message text is the only signal available today, since the adapter sends this as `data.details` rather than a typed `errorKind`. A structured field would be a better long-term contract, and I'd be glad to rework this if you'd prefer that shape — including on the adapter side.

## Tests

Both existing tests for `agent_error_from_json` pass unchanged, because both omit `data` — which is also how this survived: they cover the two cases where the bug doesn't bite. A third test pins the case that does.

## Verification

`aarch64-apple-darwin`, rustc 1.95.0 (repo hermit toolchain):

- `cargo check -p buzz-acp` — clean
- `cargo fmt -p buzz-acp -- --check` — clean
- `cargo clippy -p buzz-acp --all-targets` — clean, zero warnings
- `cargo test -p buzz-acp --lib` — **669 passed, 0 failed**

I ran the Rust subset relevant to this change rather than full `just ci`, which also builds desktop and mobile.
