### PR TITLE
fix(desktop): remove 0.5.9+ perf regressions, speed up get_channels

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -3,7 +3,7 @@ use tauri::State;
 use crate::{
     app_state::AppState,
     events,
-    models::{ChannelDetailInfo, ChannelInfo, ChannelMembersResponse},
+    models::{ChannelDetailInfo, ChannelInfo, ChannelMembersResponse, GetChannelsPayload},
     nostr_convert,
     relay::{query_relay, relay_api_base_url_with_override, submit_event, submit_event_with_keys},
 };
@@ -75,79 +75,189 @@ fn classify_pending_owner(state: &AppState, my_pubkey: &str, d_tag: Option<&str>
     d_tag.is_some_and(|d| state.is_pending_owned_channel(my_pubkey, d))
 }
 
-#[tauri::command]
-pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>, String> {
+// ── FNV-1a hash for the not-modified short-circuit ───────────────────────────
+
+/// FNV-1a 64-bit hash over arbitrary bytes. Used in preference to
+/// `std::collections::hash_map::DefaultHasher` because the standard library
+/// does not guarantee cross-invocation stability.
+fn fnv1a_64(data: &[u8]) -> u64 {
+    const OFFSET: u64 = 14695981039346656037;
+    const PRIME: u64 = 1099511628211;
+    let mut hash = OFFSET;
+    for &byte in data {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// Stable projection of `ChannelInfo` for hashing. Excludes `last_message_at`
+/// so routine message traffic does not invalidate the not-modified short-circuit
+/// for the channel list.
+#[derive(serde::Serialize)]
+struct ChannelInfoForHash<'a> {
+    id: &'a str,
+    name: &'a str,
+    channel_type: &'a str,
+    visibility: &'a str,
+    description: &'a str,
+    topic: &'a Option<String>,
+    purpose: &'a Option<String>,
+    member_count: i64,
+    member_pubkeys: &'a Vec<String>,
+    archived_at: &'a Option<String>,
+    participants: &'a Vec<String>,
+    participant_pubkeys: &'a Vec<String>,
+    is_member: bool,
+    ttl_seconds: &'a Option<i32>,
+    ttl_deadline: &'a Option<String>,
+}
+
+/// Compute a stable 64-bit FNV-1a hash over the channel list, canonicalized
+/// by sorting on channel id and excluding `last_message_at`. Returns a
+/// 16-character lowercase hex string.
+fn compute_channels_hash(channels: &[ChannelInfo]) -> String {
+    let mut sorted: Vec<&ChannelInfo> = channels.iter().collect();
+    sorted.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let projections: Vec<ChannelInfoForHash<'_>> = sorted
+        .iter()
+        .map(|c| ChannelInfoForHash {
+            id: &c.id,
+            name: &c.name,
+            channel_type: &c.channel_type,
+            visibility: &c.visibility,
+            description: &c.description,
+            topic: &c.topic,
+            purpose: &c.purpose,
+            member_count: c.member_count,
+            member_pubkeys: &c.member_pubkeys,
+            archived_at: &c.archived_at,
+            participants: &c.participants,
+            participant_pubkeys: &c.participant_pubkeys,
+            is_member: c.is_member,
+            ttl_seconds: &c.ttl_seconds,
+            ttl_deadline: &c.ttl_deadline,
+        })
+        .collect();
+
+    let canonical = serde_json::to_string(&projections).unwrap_or_default();
+    format!("{:016x}", fnv1a_64(canonical.as_bytes()))
+}
+
+// ── Core fetch implementation ─────────────────────────────────────────────────
+
+/// Fetch the full channel list from the relay. Called by both `get_channels`
+/// (the Tauri command, which wraps the result with hash-based short-circuit
+/// logic) and `ensure_starter_channels` (which needs the raw list directly).
+///
+/// Relay round-trips run in two concurrent phases:
+/// - Phase 1 (parallel): member-chain (kind:39002→kind:39000), open directory
+///   (kind:39000 all-open), and hidden-DM snapshot (kind:30622).
+/// - Phase 2 (parallel): member counts (kind:39002 batch) and last-message
+///   timestamps (per-channel kind:9/40002).
+async fn fetch_channels(state: &AppState) -> Result<Vec<ChannelInfo>, String> {
+    #[cfg(debug_assertions)]
     let _profile_start = std::time::Instant::now();
+
     let my_pubkey = {
         let keys = state.keys.lock().map_err(|e| e.to_string())?;
         keys.public_key().to_hex()
     };
 
-    // Step 1: find all kind:39002 (members) events that mention me, then
-    // pull the channel ids out of their `d` tags.
-    let member_events = query_relay_all(
-        &state,
-        serde_json::json!({"kinds": [39002], "#p": [&my_pubkey]}),
-    )
-    .await?;
+    // Phase 1 — concurrent: member-chain (steps 1→2), open directory (step 3),
+    // and hidden-DM snapshot (step 6). These three have no mutual dependencies.
+    let (member_chain_result, open_meta_result, hidden_dms) = tokio::join!(
+        // Steps 1+2: find the channels this identity belongs to, then fetch
+        // their metadata events.
+        async {
+            // Step 1: kind:39002 events listing my pubkey as a member.
+            let member_events = query_relay_all(
+                state,
+                serde_json::json!({"kinds": [39002], "#p": [&my_pubkey]}),
+            )
+            .await?;
+
+            let mut member_channel_ids: Vec<String> = member_events
+                .iter()
+                .filter_map(|ev| {
+                    ev.tags.iter().find_map(|t| {
+                        let s = t.as_slice();
+                        if s.len() >= 2 && s[0] == "d" {
+                            Some(s[1].clone())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect();
+            member_channel_ids.sort();
+            member_channel_ids.dedup();
+
+            // Real kind:39002 membership has landed — clear the pending-owner
+            // overlay so a subsequent leave correctly flips `is_member` back
+            // to false. See `AppState::pending_owned_channels`.
+            for id in &member_channel_ids {
+                state.clear_pending_owned_channel(&my_pubkey, id);
+            }
+
+            // Step 2: fetch channel metadata events (kind:39000) for member channels.
+            // kind:39000 is addressable: exactly one event per `d` tag, so a limit
+            // equal to the number of ids is both necessary and sufficient.
+            let meta_events = if !member_channel_ids.is_empty() {
+                query_relay(
+                    state,
+                    &[serde_json::json!({
+                        "kinds": [39000],
+                        "#d": &member_channel_ids,
+                        "limit": member_channel_ids.len(),
+                    })],
+                )
+                .await?
+            } else {
+                Vec::new()
+            };
+
+            Ok::<_, String>(meta_events)
+        },
+        // Step 3: fetch ALL open channel metadata so the channel browser can show
+        // discoverable channels the user hasn't joined yet.
+        query_relay_all(state, serde_json::json!({"kinds": [39000]})),
+        // Step 6: NIP-DV hidden-DM snapshot. Tolerant — a failure means no DMs
+        // are hidden rather than aborting the whole fetch.
+        async {
+            let events = query_relay(
+                state,
+                &[serde_json::json!({
+                    "kinds": [buzz_core_pkg::kind::KIND_DM_VISIBILITY],
+                    "#p": [&my_pubkey],
+                    "limit": 1,
+                })],
+            )
+            .await
+            .unwrap_or_default();
+            events
+                .iter()
+                .max_by_key(|e| e.created_at.as_secs())
+                .map(|e| {
+                    e.tags
+                        .iter()
+                        .filter_map(|t| {
+                            let s = t.as_slice();
+                            (s.len() >= 2 && s[0] == "h").then(|| s[1].clone())
+                        })
+                        .collect::<std::collections::HashSet<String>>()
+                })
+                .unwrap_or_default()
+        },
+    );
 
     #[cfg(debug_assertions)]
-    let t_members = _profile_start.elapsed();
+    let t_phase1 = _profile_start.elapsed();
 
-    let mut channel_ids: Vec<String> = member_events
-        .iter()
-        .filter_map(|ev| {
-            ev.tags.iter().find_map(|t| {
-                let s = t.as_slice();
-                if s.len() >= 2 && s[0] == "d" {
-                    Some(s[1].clone())
-                } else {
-                    None
-                }
-            })
-        })
-        .collect();
-    channel_ids.sort();
-    channel_ids.dedup();
-
-    // The real kind:39002 membership has now resolved for these channels —
-    // drop them from the pending-owner overlay (see `AppState::pending_owned_channels`)
-    // so a channel this identity created no longer speaks through the overlay
-    // once genuine membership is observable, and a later leave correctly
-    // flips it back to `is_member=false`.
-    for id in &channel_ids {
-        state.clear_pending_owned_channel(&my_pubkey, id);
-    }
-
-    // Step 2: fetch channel metadata events (kind:39000) for member channels.
-    // kind:39000 is addressable: exactly one event per `d` tag, so a limit
-    // equal to the number of ids is both necessary and sufficient. Without
-    // an explicit limit, multi-value `#d` filters fall through to the relay's
-    // default LIMIT and can drop results when there are many channels.
-    let meta_events = if !channel_ids.is_empty() {
-        query_relay(
-            &state,
-            &[serde_json::json!({
-                "kinds": [39000],
-                "#d": channel_ids,
-                "limit": channel_ids.len(),
-            })],
-        )
-        .await?
-    } else {
-        Vec::new()
-    };
-
-    #[cfg(debug_assertions)]
-    let t_member_meta = _profile_start.elapsed();
-
-    // Step 3: fetch ALL open channel metadata so the channel browser can show
-    // discoverable channels the user hasn't joined yet. The relay's access
-    // control allows reading kind:39000 for open channels regardless of membership.
-    let open_meta_events = query_relay_all(&state, serde_json::json!({"kinds": [39000]})).await?;
-
-    #[cfg(debug_assertions)]
-    let t_open_meta = _profile_start.elapsed();
+    let meta_events = member_chain_result?;
+    let open_meta_events = open_meta_result?;
+    // hidden_dms is already a resolved HashSet (tolerant path above)
 
     // Merge: member channels (marked as member) + open channels (not yet joined).
     let member_d_tags: std::collections::HashSet<String> = meta_events
@@ -187,58 +297,19 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
         }
         // The overlay (`AppState::pending_owned_channels`) marks channels this
         // identity just created via `create_channel` whose kind:39002 owner
-        // membership hasn't propagated yet (#1761) — a fresh channel has no
-        // member event and would otherwise fall through to `is_member=false`
-        // here, disabling the owner's own composer until that snapshot lands.
-        // The overlay can only be populated by this process's own
-        // `create_channel` call (never by relay data) and is keyed by
-        // `(my_pubkey, d_tag)`, so it adds no trust-boundary risk and can
-        // never speak for a channel a different identity created; `channel_ids`
-        // above clears it once real membership is observed for `my_pubkey`.
-        let is_pending_owner = classify_pending_owner(&state, &my_pubkey, d_tag.as_deref());
+        // membership hasn't propagated yet (#1761).
+        let is_pending_owner = classify_pending_owner(state, &my_pubkey, d_tag.as_deref());
         if let Ok(info) = nostr_convert::channel_info_from_event(ev, None, Some(is_pending_owner)) {
             channels.push(info);
         }
     }
 
-    // Populate member_count by batch-fetching kind:39002 for every listed
-    // channel and counting unique p-tag pubkeys. The kind:40901 summary
-    // sidecar that channel_info_from_event prefers isn't emitted by the
-    // relay today, so without this step every channel reports 0 members
-    // in the channel browser (the active-channel top bar masks this with
-    // its own live members query).
-    let all_d_tags: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
-    if !all_d_tags.is_empty() {
-        let members_events = query_relay(
-            &state,
-            &[serde_json::json!({
-                "kinds": [39002],
-                "#d": all_d_tags,
-                "limit": all_d_tags.len(),
-            })],
-        )
-        .await
-        .unwrap_or_default();
-
-        let membership = collect_members_by_channel(&members_events);
-        for channel in &mut channels {
-            if let Some(info) = membership.get(&channel.id) {
-                channel.member_count = info.count;
-                channel.member_pubkeys = info.pubkeys.clone();
-            }
-        }
-    }
-
-    #[cfg(debug_assertions)]
-    let t_member_counts = _profile_start.elapsed();
-
-    // Populate last_message_at by fetching the most recent human message per
-    // channel. Uses per-channel filters (single #h value each) so the relay can
-    // push the query to its indexed channel_id column. Multi-value #h is NOT
-    // SQL-pushed and would silently drop quieter channels under the global limit.
-    let channel_ids: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
-    if !channel_ids.is_empty() {
-        let filters: Vec<serde_json::Value> = channel_ids
+    // Phase 2 — concurrent: member counts (step 4) and last-message timestamps
+    // (step 5). Both tolerate failures — empty defaults leave counts at 0 and
+    // timestamps at None rather than aborting.
+    let all_channel_ids: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
+    if !all_channel_ids.is_empty() {
+        let last_msg_filters: Vec<serde_json::Value> = all_channel_ids
             .iter()
             .map(|id| {
                 serde_json::json!({
@@ -249,11 +320,32 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
             })
             .collect();
 
-        let message_events = query_relay(&state, &filters).await.unwrap_or_default();
+        // Bind both filter arrays before the join so their lifetimes cover
+        // both branches of the concurrent pair.
+        let member_count_filters = [serde_json::json!({
+            "kinds": [39002],
+            "#d": &all_channel_ids,
+            "limit": all_channel_ids.len(),
+        })];
+        let (members_result, message_result) = tokio::join!(
+            // Step 4: batch-fetch kind:39002 for member counts.
+            query_relay(state, &member_count_filters),
+            // Step 5: per-channel last-message filter. Uses per-channel `#h`
+            // so the relay can push each query to its indexed channel_id column.
+            query_relay(state, &last_msg_filters),
+        );
+
+        let membership = collect_members_by_channel(&members_result.unwrap_or_default());
+        for channel in &mut channels {
+            if let Some(info) = membership.get(&channel.id) {
+                channel.member_count = info.count;
+                channel.member_pubkeys = info.pubkeys.clone();
+            }
+        }
 
         let mut last_message_by_channel: std::collections::HashMap<String, u64> =
             std::collections::HashMap::new();
-        for ev in &message_events {
+        for ev in &message_result.unwrap_or_default() {
             if let Some(ch_id) = ev.tags.iter().find_map(|t| {
                 let s = t.as_slice();
                 (s.len() >= 2 && s[0] == "h").then(|| s[1].clone())
@@ -269,7 +361,6 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
                     .or_insert(ts);
             }
         }
-
         for channel in &mut channels {
             if let Some(&ts) = last_message_by_channel.get(&channel.id) {
                 channel.last_message_at = Some(nostr_convert::timestamp_to_iso(ts));
@@ -278,60 +369,68 @@ pub async fn get_channels(state: State<'_, AppState>) -> Result<Vec<ChannelInfo>
     }
 
     #[cfg(debug_assertions)]
-    let t_last_message = _profile_start.elapsed();
-
-    // NIP-DV: drop DMs the viewer has hidden. The relay maintains a per-viewer
-    // parameterized-replaceable snapshot (kind:30622, d=my pubkey) whose `h`
-    // tags list currently-hidden DM channel ids. The snapshot also carries
-    // `p`=my pubkey so the relay's #p read-gate scopes it to me; we query by
-    // `#p` for that reason. Reading the latest one is the only way the client
-    // learns hide state, which the relay tracks privately.
-    let hidden_dms: std::collections::HashSet<String> = {
-        let events = query_relay(
-            &state,
-            &[serde_json::json!({
-                "kinds": [buzz_core_pkg::kind::KIND_DM_VISIBILITY],
-                "#p": [&my_pubkey],
-                "limit": 1,
-            })],
-        )
-        .await
-        .unwrap_or_default();
-        events
-            .iter()
-            .max_by_key(|e| e.created_at.as_secs())
-            .map(|e| {
-                e.tags
-                    .iter()
-                    .filter_map(|t| {
-                        let s = t.as_slice();
-                        (s.len() >= 2 && s[0] == "h").then(|| s[1].clone())
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
-    };
-    if !hidden_dms.is_empty() {
-        channels.retain(|c| c.channel_type != "dm" || !hidden_dms.contains(&c.id));
-    }
-
-    #[cfg(debug_assertions)]
     {
         let total = _profile_start.elapsed();
         eprintln!(
-            "buzz-desktop: get_channels profile channels={} members={:?} member_meta={:?} open_meta={:?} member_counts={:?} last_message={:?} hidden_dm={:?} total={:?}",
+            "buzz-desktop: get_channels profile channels={} phase1(member_chain+open_meta+hidden_dm)={:?} phase2(member_counts+last_msg)={:?} total={:?}",
             channels.len(),
-            t_members,
-            t_member_meta - t_members,
-            t_open_meta - t_member_meta,
-            t_member_counts - t_open_meta,
-            t_last_message - t_member_counts,
-            total - t_last_message,
+            t_phase1,
+            total - t_phase1,
             total,
         );
     }
 
+    // NIP-DV: drop DMs the viewer has hidden.
+    if !hidden_dms.is_empty() {
+        channels.retain(|c| c.channel_type != "dm" || !hidden_dms.contains(&c.id));
+    }
+
     Ok(channels)
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────────
+
+/// Return the full channel list for the active identity.
+///
+/// `known_hash` is a previously returned `hash` value. When it matches the
+/// computed stable hash (which excludes `last_message_at`), the response
+/// carries `channels: null` so the multi-MB list is not serialized across IPC.
+/// `last_messages` is always included because it is cheap and changes with
+/// every new message.
+#[tauri::command]
+pub async fn get_channels(
+    known_hash: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<GetChannelsPayload, String> {
+    let channels = fetch_channels(&state).await?;
+
+    let last_messages: std::collections::HashMap<String, String> = channels
+        .iter()
+        .filter_map(|c| {
+            c.last_message_at
+                .as_ref()
+                .map(|ts| (c.id.clone(), ts.clone()))
+        })
+        .collect();
+
+    let hash = compute_channels_hash(&channels);
+
+    // Not-modified short-circuit: skip the multi-MB IPC payload when the
+    // caller's hash matches. `last_messages` still ships so the TS side can
+    // update sidebar timestamps without re-rendering the full list.
+    if known_hash.as_deref() == Some(hash.as_str()) {
+        return Ok(GetChannelsPayload {
+            hash,
+            channels: None,
+            last_messages,
+        });
+    }
+
+    Ok(GetChannelsPayload {
+        hash,
+        channels: Some(channels),
+        last_messages,
+    })
 }
 
 struct ChannelMembership {
@@ -612,7 +711,7 @@ pub async fn create_channel(
 pub async fn ensure_starter_channels(
     state: State<'_, AppState>,
 ) -> Result<Vec<ChannelInfo>, String> {
-    let mut existing_channels = get_channels(state.clone()).await?;
+    let mut existing_channels = fetch_channels(&state).await?;
     let relay_scope = relay_api_base_url_with_override(&state);
     let creator_keys = state.signing_keys()?;
     let creator_pubkey = creator_keys.public_key().to_hex();
@@ -671,7 +770,7 @@ pub async fn ensure_starter_channels(
     }
 
     if !has_all_starter_channels(&existing_channels) {
-        existing_channels = get_channels(state.clone()).await?;
+        existing_channels = fetch_channels(&state).await?;
     }
 
     if !has_all_starter_channels(&existing_channels) {

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -2,6 +2,7 @@
 // channels.rs under the per-file line cap.
 
 use super::*;
+use crate::models::ChannelInfo;
 use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
 
 /// Build a signed event for testing with the given kind, content, and tags.
@@ -264,6 +265,131 @@ fn duplicate_channel_rejection_is_ensure_success_only() {
     assert!(!is_duplicate_channel_rejection(
         "duplicate: unrelated local error"
     ));
+}
+
+// ── compute_channels_hash ─────────────────────────────────────────────────────
+
+fn make_channel(id: &str, name: &str, last_message_at: Option<String>) -> ChannelInfo {
+    ChannelInfo {
+        id: id.to_string(),
+        name: name.to_string(),
+        channel_type: "stream".to_string(),
+        visibility: "open".to_string(),
+        description: "".to_string(),
+        topic: None,
+        purpose: None,
+        member_count: 0,
+        member_pubkeys: Vec::new(),
+        last_message_at,
+        archived_at: None,
+        participants: Vec::new(),
+        participant_pubkeys: Vec::new(),
+        is_member: true,
+        ttl_seconds: None,
+        ttl_deadline: None,
+    }
+}
+
+#[test]
+fn hash_is_order_insensitive() {
+    let c1 = make_channel("aaa", "Alpha", None);
+    let c2 = make_channel("bbb", "Beta", None);
+    let c3 = make_channel("aaa", "Alpha", None);
+    let c4 = make_channel("bbb", "Beta", None);
+
+    assert_eq!(
+        compute_channels_hash(&[c1, c2]),
+        compute_channels_hash(&[c4, c3]),
+        "hash must be insensitive to channel list ordering",
+    );
+}
+
+#[test]
+fn hash_ignores_last_message_at() {
+    let c_none = make_channel("chan-1", "Alpha", None);
+    let c_some = make_channel("chan-1", "Alpha", Some("2026-01-01T00:00:00Z".to_string()));
+
+    assert_eq!(
+        compute_channels_hash(&[c_none]),
+        compute_channels_hash(&[c_some]),
+        "hash must be insensitive to last_message_at",
+    );
+}
+
+#[test]
+fn hash_changes_on_metadata_change() {
+    let c1 = make_channel("chan-1", "Alpha", None);
+    let c2 = make_channel("chan-1", "AlphaRenamed", None);
+
+    assert_ne!(
+        compute_channels_hash(&[c1]),
+        compute_channels_hash(&[c2]),
+        "hash must change when channel name changes",
+    );
+}
+
+#[test]
+fn hash_changes_on_membership_change() {
+    let mut c1 = make_channel("chan-1", "Alpha", None);
+    let mut c2 = make_channel("chan-1", "Alpha", None);
+    c1.member_pubkeys = vec![PK_A.to_string()];
+    c2.member_pubkeys = vec![PK_A.to_string(), PK_B.to_string()];
+
+    assert_ne!(
+        compute_channels_hash(&[c1]),
+        compute_channels_hash(&[c2]),
+        "hash must change when member_pubkeys changes",
+    );
+}
+
+#[test]
+fn not_modified_returns_none_when_hash_matches() {
+    let channels = vec![make_channel("chan-1", "General", None)];
+    let hash = compute_channels_hash(&channels);
+
+    // Mirror the get_channels command decision logic.
+    let known_hash = Some(hash.clone());
+    let is_not_modified = known_hash.as_deref() == Some(hash.as_str());
+
+    assert!(
+        is_not_modified,
+        "identical hash must trigger the not-modified short-circuit",
+    );
+}
+
+#[test]
+fn not_modified_does_not_trigger_on_hash_mismatch() {
+    let channels = vec![make_channel("chan-1", "General", None)];
+    let hash = compute_channels_hash(&channels);
+    let known_hash = Some("0000000000000000".to_string());
+
+    let is_not_modified = known_hash.as_deref() == Some(hash.as_str());
+
+    assert!(
+        !is_not_modified,
+        "stale hash must NOT trigger the not-modified short-circuit",
+    );
+}
+
+#[test]
+fn hash_is_stable_for_same_input() {
+    // Verifies that the FNV-1a output is deterministic across calls within
+    // the same process (unlike std DefaultHasher which uses random seeds).
+    let channels = vec![
+        make_channel("aaa", "General", Some("2026-01-01T00:00:00Z".to_string())),
+        make_channel("bbb", "Random", None),
+    ];
+    let first = compute_channels_hash(&channels);
+    let channels2 = vec![
+        make_channel("aaa", "General", None), // last_message_at change is ignored
+        make_channel("bbb", "Random", None),
+    ];
+    let second = compute_channels_hash(&channels2);
+
+    assert_eq!(
+        first, second,
+        "hash must be deterministic and ignore last_message_at"
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/src/commands/window_vibrancy.rs
+++ b/desktop/src-tauri/src/commands/window_vibrancy.rs
@@ -35,13 +35,15 @@ pub fn set_window_vibrancy(
             .ok_or_else(|| "main window not found".to_string())?;
 
         if !enabled {
-            clear_vibrancy(&window).map_err(|e| e.to_string())?;
-            // Restore the default opaque background so WindowServer can use its
-            // opaque-window fast path. `None` resets both the NSWindow backing
-            // and the WKWebView canvas to their platform defaults.
+            // Restore opaque backing first: a failure of clear_vibrancy leaves
+            // the window with an opaque canvas and a blur layer hidden behind
+            // it, not a see-through webview. Either mixed state self-corrects
+            // on the next toggle. `None` resets both the NSWindow backing and
+            // the WKWebView canvas to their platform defaults.
             window
                 .set_background_color(None)
                 .map_err(|e| e.to_string())?;
+            clear_vibrancy(&window).map_err(|e| e.to_string())?;
             return Ok(());
         }
 
@@ -64,6 +66,9 @@ pub fn set_window_vibrancy(
         // clear is a no-op (returns `false`) when none is present.
         let _ = clear_vibrancy(&window);
 
+        // Install the blur layer first: a failure of set_background_color leaves
+        // the window opaque with vibrancy behind it, not a see-through webview.
+        // Either mixed state self-corrects on the next toggle.
         apply_vibrancy(&window, material, None, None).map_err(|e| e.to_string())?;
 
         // Make the WKWebView canvas and NSWindow backing transparent so native

--- a/desktop/src-tauri/src/commands/window_vibrancy.rs
+++ b/desktop/src-tauri/src/commands/window_vibrancy.rs
@@ -1,15 +1,29 @@
 //! Runtime macOS window vibrancy (blur-behind) toggle.
 //!
+//! **Invariant:** the main window is created opaque (`tauri.conf.json`
+//! `transparent: false`) and the NSWindow is never made transparent at runtime.
+//! Behind-window vibrancy renders correctly inside opaque windows — this is
+//! exactly how Finder and Notes render vibrant sidebars — so glass only requires
+//! runtime webview-canvas transparency, which this command sets on the enable
+//! path. When glass is disabled the webview canvas may remain non-drawing
+//! (wry's `drawsBackground` flag is one-way at runtime), but that is harmless:
+//! glass-off CSS paints the full background opaque and the always-opaque NSWindow
+//! is beneath it.
+//!
+//! Why not `transparent: true`? A creation-time transparent window causes tao to
+//! call `NSWindow.setOpaque(false)` and `setBackgroundColor(clearColor)`. The
+//! runtime `Window::set_background_color(None)` then resolves `None` to
+//! `clearColor` instead of the opaque system default — and there is no runtime
+//! `setOpaque(true)` path through tauri — leaving the compositor blending the
+//! whole window even with glass off.
+//!
 //! Vibrancy applies an `NSVisualEffectView` behind the webview so the desktop
-//! (and windows behind Buzz) blur through wherever the app's CSS is
+//! (and windows behind Buzz) blurs through wherever the WKWebView canvas is
 //! transparent. It is a native, macOS-only effect: there is no "intensity"
 //! setting at the OS level, only a set of material presets. The frontend tunes
-//! perceived intensity by changing CSS surface opacity while this command
-//! handles the native material.
-//!
-//! This is fully reversible at runtime: enabling applies the chosen material,
-//! disabling clears it. On non-macOS platforms the command is a no-op so the
-//! shared frontend can call it unconditionally.
+//! perceived intensity by adjusting CSS surface opacity while this command
+//! handles the native material. On non-macOS platforms the command is a no-op
+//! so the shared frontend can call it unconditionally.
 
 #[cfg(target_os = "macos")]
 use tauri::Manager;
@@ -35,14 +49,16 @@ pub fn set_window_vibrancy(
             .ok_or_else(|| "main window not found".to_string())?;
 
         if !enabled {
-            // Restore opaque backing first: a failure of clear_vibrancy leaves
-            // the window with an opaque canvas and a blur layer hidden behind
-            // it, not a see-through webview. Either mixed state self-corrects
-            // on the next toggle. `None` resets both the NSWindow backing and
-            // the WKWebView canvas to their platform defaults.
-            window
-                .set_background_color(None)
-                .map_err(|e| e.to_string())?;
+            // The NSWindow layer is permanently opaque, so no window-layer
+            // reset is needed here. Skipping `set_background_color(None)` at
+            // the webview layer also avoids tauri mapping `None` to opaque
+            // white, which would still force `drawsBackground=false` on the
+            // WKWebView (counterproductive). After a glass session the webview
+            // canvas may stay non-drawing — wry's `drawsBackground` flag is
+            // one-way at runtime — but that is harmless: glass-off CSS paints
+            // the full background opaque and the always-opaque NSWindow is
+            // beneath it. If `clear_vibrancy` fails, the opaque CSS already
+            // covers everything, so no see-through state is reachable.
             clear_vibrancy(&window).map_err(|e| e.to_string())?;
             return Ok(());
         }
@@ -66,15 +82,19 @@ pub fn set_window_vibrancy(
         // clear is a no-op (returns `false`) when none is present.
         let _ = clear_vibrancy(&window);
 
-        // Install the blur layer first: a failure of set_background_color leaves
-        // the window opaque with vibrancy behind it, not a see-through webview.
-        // Either mixed state self-corrects on the next toggle.
+        // Install the blur layer first: a failure of the canvas write leaves
+        // the window with vibrancy behind an opaque webview, not a see-through
+        // one. Either mixed state self-corrects on the next toggle.
         apply_vibrancy(&window, material, None, None).map_err(|e| e.to_string())?;
 
-        // Make the WKWebView canvas and NSWindow backing transparent so native
-        // vibrancy shows through. Must follow apply_vibrancy so the blur layer
-        // is present before the canvas becomes see-through.
-        window
+        // Make only the WKWebView canvas transparent so native vibrancy shows
+        // through; the NSWindow layer stays opaque by design. Targeting the
+        // webview layer directly (via `AsRef<Webview>`) avoids the
+        // `WebviewWindow::set_background_color` path, which also writes the
+        // NSWindow layer. Must follow `apply_vibrancy` so the blur layer is
+        // present before the canvas becomes see-through.
+        let webview: &tauri::Webview<_> = window.as_ref();
+        webview
             .set_background_color(Some(tauri::window::Color(0, 0, 0, 0)))
             .map_err(|e| e.to_string())?;
 

--- a/desktop/src-tauri/src/commands/window_vibrancy.rs
+++ b/desktop/src-tauri/src/commands/window_vibrancy.rs
@@ -36,6 +36,12 @@ pub fn set_window_vibrancy(
 
         if !enabled {
             clear_vibrancy(&window).map_err(|e| e.to_string())?;
+            // Restore the default opaque background so WindowServer can use its
+            // opaque-window fast path. `None` resets both the NSWindow backing
+            // and the WKWebView canvas to their platform defaults.
+            window
+                .set_background_color(None)
+                .map_err(|e| e.to_string())?;
             return Ok(());
         }
 
@@ -59,6 +65,14 @@ pub fn set_window_vibrancy(
         let _ = clear_vibrancy(&window);
 
         apply_vibrancy(&window, material, None, None).map_err(|e| e.to_string())?;
+
+        // Make the WKWebView canvas and NSWindow backing transparent so native
+        // vibrancy shows through. Must follow apply_vibrancy so the blur layer
+        // is present before the canvas becomes see-through.
+        window
+            .set_background_color(Some(tauri::window::Color(0, 0, 0, 0)))
+            .map_err(|e| e.to_string())?;
+
         Ok(())
     }
 

--- a/desktop/src-tauri/src/initial_window.rs
+++ b/desktop/src-tauri/src/initial_window.rs
@@ -15,10 +15,16 @@ pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>
 
 #[cfg(target_os = "macos")]
 pub(crate) fn set_initial_window_backing<R: tauri::Runtime>(window: &tauri::Window<R>) {
-    // Runtime transparency exists only while glass is enabled via
-    // `set_window_vibrancy`; with glass off the webview stays opaque. Use an
-    // opaque native backing across the first visible frames so the previous app
-    // cannot show through before WebKit has submitted its first surface.
+    // Both this write and the deferred clear target the Window (NSWindow)
+    // backing color only; they never touch the webview canvas or the
+    // NSVisualEffectView, so they are not load-bearing for glass. Glass state
+    // — the effect view and webview-canvas transparency — is managed entirely
+    // by `set_window_vibrancy`, which the ThemeProvider calls after mount. The
+    // 250ms-delayed clear cannot clobber a persisted-glass-on cold boot
+    // regardless of ordering with that call.
+    //
+    // Write an opaque dark backing so the previous app cannot show through
+    // before WebKit submits its first composited surface.
     if let Err(error) = window.set_background_color(Some(tauri::window::Color(17, 21, 24, 255))) {
         eprintln!("buzz-desktop: failed to set initial window backing: {error}");
     }
@@ -27,6 +33,10 @@ pub(crate) fn set_initial_window_backing<R: tauri::Runtime>(window: &tauri::Wind
 #[cfg(target_os = "macos")]
 pub(crate) async fn clear_initial_window_backing<R: tauri::Runtime>(window: &tauri::Window<R>) {
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    // Restore the default system window background so fast-resize gutter
+    // flashes match the platform theme rather than the hardcoded dark color
+    // written at reveal. Targets the Window (NSWindow) layer only; webview
+    // canvas and glass state are unaffected.
     if let Err(error) = window.set_background_color(None) {
         eprintln!("buzz-desktop: failed to clear initial window backing: {error}");
     }

--- a/desktop/src-tauri/src/initial_window.rs
+++ b/desktop/src-tauri/src/initial_window.rs
@@ -15,8 +15,9 @@ pub(crate) fn reveal_initial_window<R: tauri::Runtime>(window: &tauri::Window<R>
 
 #[cfg(target_os = "macos")]
 pub(crate) fn set_initial_window_backing<R: tauri::Runtime>(window: &tauri::Window<R>) {
-    // The window remains transparent at runtime for vibrancy. Use an opaque
-    // native backing only across the first visible frames so the previous app
+    // Runtime transparency exists only while glass is enabled via
+    // `set_window_vibrancy`; with glass off the webview stays opaque. Use an
+    // opaque native backing across the first visible frames so the previous app
     // cannot show through before WebKit has submitted its first surface.
     if let Err(error) = window.set_background_color(Some(tauri::window::Color(17, 21, 24, 255))) {
         eprintln!("buzz-desktop: failed to set initial window backing: {error}");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -147,13 +147,6 @@ pub fn run() {
                     // on macOS/Windows.
                     linux_media::enable_media_capture(&webview);
 
-                    #[cfg(target_os = "macos")]
-                    if let Err(error) = webview
-                        .set_background_color(Some(tauri::window::Color(0, 0, 0, 0)))
-                    {
-                        eprintln!("buzz-desktop: failed to make the macOS webview transparent: {error}");
-                    }
-
                     // macOS applies the restored geometry asynchronously. Wait
                     // for several identical outer bounds and for React to
                     // commit the startup surface before revealing it.

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -358,6 +358,21 @@ fn default_true() -> bool {
     true
 }
 
+/// Response payload for `get_channels`. When the caller supplies a hash that
+/// matches the computed stable hash, `channels` is `None` so the multi-MB
+/// channel list is not serialized across IPC. `last_messages` is always
+/// included — it is cheap and changes frequently (every new message).
+#[derive(Serialize)]
+pub struct GetChannelsPayload {
+    pub hash: String,
+    /// `None` on a not-modified response (hash matched); `Some` with the full
+    /// sorted list otherwise.
+    pub channels: Option<Vec<ChannelInfo>>,
+    /// Map of channel id → ISO-8601 timestamp of its most recent message.
+    /// Empty for channels with no messages.
+    pub last_messages: std::collections::HashMap<String, String>,
+}
+
 // ── Social / Contact list ───────────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize)]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "height": 600,
         "maximized": true,
         "visible": false,
-        "transparent": true,
+        "transparent": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "dragDropEnabled": false,

--- a/desktop/src/features/agents/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/focusRefetchPolicy.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import { AGENTS_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("agents: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: AGENTS_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("agents: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: AGENTS_FOCUS_STALE_TIME_MS + 1,
+      staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/agents/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/focusRefetchPolicy.test.mjs
@@ -8,22 +8,22 @@ import {
 } from "@tanstack/react-query";
 
 import {
-  AGENTS_FOCUS_STALE_TIME_MS,
-  MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+  agentsFocusRefetchPolicy,
+  managedAgentLogFocusRefetchPolicy,
 } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -35,8 +35,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -51,8 +50,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("agents: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: AGENTS_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+      ageMs: agentsFocusRefetchPolicy.staleTime - 1_000,
+      policy: agentsFocusRefetchPolicy,
     }),
     0,
   );
@@ -61,8 +60,8 @@ test("agents: skips fresh focus refetch", async () => {
 test("agents: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: AGENTS_FOCUS_STALE_TIME_MS + 1,
-      staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+      ageMs: agentsFocusRefetchPolicy.staleTime + 1,
+      policy: agentsFocusRefetchPolicy,
     }),
     1,
   );
@@ -71,8 +70,8 @@ test("agents: refetches genuinely stale data on focus", async () => {
 test("managed-agent-log: skips focus refetch when data is fresher than one poll tick", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+      ageMs: managedAgentLogFocusRefetchPolicy.staleTime - 1_000,
+      policy: managedAgentLogFocusRefetchPolicy,
     }),
     0,
   );
@@ -81,8 +80,8 @@ test("managed-agent-log: skips focus refetch when data is fresher than one poll 
 test("managed-agent-log: refetches on focus when data is older than one poll tick", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS + 1,
-      staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+      ageMs: managedAgentLogFocusRefetchPolicy.staleTime + 1,
+      policy: managedAgentLogFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/agents/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/focusRefetchPolicy.test.mjs
@@ -7,7 +7,10 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { AGENTS_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import {
+  AGENTS_FOCUS_STALE_TIME_MS,
+  MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+} from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -60,6 +63,26 @@ test("agents: refetches genuinely stale data on focus", async () => {
     await focusRefetchCount({
       ageMs: AGENTS_FOCUS_STALE_TIME_MS + 1,
       staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});
+
+test("managed-agent-log: skips focus refetch when data is fresher than one poll tick", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("managed-agent-log: refetches on focus when data is older than one poll tick", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS + 1,
+      staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
     }),
     1,
   );

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -108,6 +108,18 @@ export const AGENTS_FOCUS_STALE_TIME_MS = 5 * 60_000;
  */
 export const MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS = 30_000;
 
+/** Focus-refetch policy for relay-agent and managed-agent queries; consumed by focusRefetchPolicy.test.mjs. */
+export const agentsFocusRefetchPolicy = {
+  staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
+/** Focus-refetch policy for the managed-agent-log query; consumed by focusRefetchPolicy.test.mjs. */
+export const managedAgentLogFocusRefetchPolicy = {
+  staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export const relayAgentsQueryKey = ["relay-agents"] as const;
 export const managedAgentsQueryKey = ["managed-agents"] as const;
 export const personasQueryKey = ["personas"] as const;
@@ -329,7 +341,6 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
-    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     // Relay agent profiles (kind:10100) are near-static and the backing
     // `list_relay_agents` command is an unfiltered relay query for the whole
     // profile set — mounted on ~13 always-live surfaces (channel screen,
@@ -339,8 +350,8 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
     // reconcile (kinds PERSONA/TEAM/MANAGED_AGENT), never for kind:10100. So we
     // keep polling but at a relaxed cadence and pause it while backgrounded.
     refetchInterval,
-    refetchOnWindowFocus: true,
     enabled: options?.enabled,
+    ...agentsFocusRefetchPolicy,
   });
 }
 
@@ -350,7 +361,6 @@ export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
     enabled: options?.enabled ?? true,
     queryKey: managedAgentsQueryKey,
     queryFn: listManagedAgents,
-    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     refetchInterval: (query) => {
       if (!appFocused) return false;
       const agents = query.state.data as ManagedAgent[] | undefined;
@@ -363,7 +373,7 @@ export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
         ? 5_000
         : false;
     },
-    refetchOnWindowFocus: true,
+    ...agentsFocusRefetchPolicy,
   });
 }
 
@@ -828,9 +838,8 @@ export function useManagedAgentLogQuery(
     queryFn: () => getManagedAgentLog(pubkey as string, lineCount),
     enabled: pubkey !== null,
     retry: false,
-    staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...managedAgentLogFocusRefetchPolicy,
   });
 }
 
@@ -843,9 +852,8 @@ export function useAgentConfigSurface(pubkey: string | null) {
     queryKey: agentConfigSurfaceQueryKey(pubkey ?? ""),
     queryFn: () => getAgentConfigSurface(pubkey ?? ""),
     enabled: !!pubkey,
-    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...agentsFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -109,6 +109,8 @@ export type {
   ProvisionChannelManagedAgentResult,
 } from "@/features/agents/channelAgents";
 
+export const AGENTS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export const relayAgentsQueryKey = ["relay-agents"] as const;
 export const managedAgentsQueryKey = ["managed-agents"] as const;
 export const personasQueryKey = ["personas"] as const;
@@ -330,7 +332,7 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
-    staleTime: 30_000,
+    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     // Relay agent profiles (kind:10100) are near-static and the backing
     // `list_relay_agents` command is an unfiltered relay query for the whole
     // profile set — mounted on ~13 always-live surfaces (channel screen,
@@ -351,7 +353,7 @@ export function useManagedAgentsQuery(options?: { enabled?: boolean }) {
     enabled: options?.enabled ?? true,
     queryKey: managedAgentsQueryKey,
     queryFn: listManagedAgents,
-    staleTime: 5_000,
+    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     refetchInterval: (query) => {
       if (!appFocused) return false;
       const agents = query.state.data as ManagedAgent[] | undefined;
@@ -909,7 +911,7 @@ export function useManagedAgentLogQuery(
     queryFn: () => getManagedAgentLog(pubkey as string, lineCount),
     enabled: pubkey !== null,
     retry: false,
-    staleTime: 3_000,
+    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });
@@ -924,7 +926,7 @@ export function useAgentConfigSurface(pubkey: string | null) {
     queryKey: agentConfigSurfaceQueryKey(pubkey ?? ""),
     queryFn: () => getAgentConfigSurface(pubkey ?? ""),
     enabled: !!pubkey,
-    staleTime: 10_000,
+    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -11,7 +11,6 @@ import {
   ensureChannelAgentPresetInChannel,
   provisionChannelManagedAgent,
 } from "@/features/agents/channelAgents";
-import { resolveSnapshotAvatarPng } from "@/features/agents/ui/snapshotAvatarPng";
 import {
   channelsQueryKey,
   upsertCachedChannelMember,
@@ -54,16 +53,6 @@ import { bootstrapManagedAgentRuntimePairs } from "@/features/agents/managedAgen
 import {
   createPersona,
   deletePersona,
-  exportAgentSnapshot,
-  encodeAgentSnapshotForSend,
-  previewAgentSnapshotImport,
-  confirmAgentSnapshotImport,
-  type AgentSnapshotImportPreview,
-  type AgentSnapshotImportConfirm,
-  type AgentSnapshotImportResult,
-  type EncodedSnapshotPayload,
-  type SnapshotMemoryLevel,
-  type SnapshotFormat,
   listPersonas,
   setPersonaActive,
   updatePersona,
@@ -97,6 +86,7 @@ export {
   useTeamsQuery,
   useUpdateTeamMutation,
 } from "@/features/agents/teamHooks";
+export * from "@/features/agents/snapshotHooks";
 export type {
   AttachManagedAgentToChannelInput,
   AttachManagedAgentToChannelResult,
@@ -110,6 +100,13 @@ export type {
 } from "@/features/agents/channelAgents";
 
 export const AGENTS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
+/**
+ * Matches the query's 30 s poll so a focus-return refetches anything older
+ * than one poll tick. This detail-view query mounts only on the agent-detail
+ * surface and is not part of the app-wide focus storm.
+ */
+export const MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS = 30_000;
 
 export const relayAgentsQueryKey = ["relay-agents"] as const;
 export const managedAgentsQueryKey = ["managed-agents"] as const;
@@ -328,7 +325,7 @@ export function useManagedAgentPrereqsQuery(
 }
 
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
-  const refetchInterval = useFocusedRefetchInterval(5 * 60_000);
+  const refetchInterval = useFocusedRefetchInterval(AGENTS_FOCUS_STALE_TIME_MS);
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
@@ -819,99 +816,19 @@ export function useCreateChannelManagedAgentsMutation(
   });
 }
 
-export function useExportAgentSnapshotMutation() {
-  return useMutation({
-    mutationFn: async ({
-      id,
-      memoryLevel,
-      format,
-      memorySourcePubkey,
-      avatarUrl,
-    }: {
-      id: string;
-      memoryLevel: SnapshotMemoryLevel;
-      format: SnapshotFormat;
-      memorySourcePubkey?: string | null;
-      avatarUrl?: string | null;
-    }) => {
-      const avatarPngDataUrl =
-        format === "png"
-          ? await resolveSnapshotAvatarPng(avatarUrl)
-          : undefined;
-      return exportAgentSnapshot(
-        id,
-        memoryLevel,
-        format,
-        memorySourcePubkey,
-        avatarPngDataUrl,
-      );
-    },
-  });
-}
-
-export function useEncodeAgentSnapshotForSendMutation() {
-  return useMutation({
-    mutationFn: ({
-      id,
-      memoryLevel,
-      format,
-      memorySourcePubkey,
-      avatarPngDataUrl,
-    }: {
-      id: string;
-      memoryLevel: SnapshotMemoryLevel;
-      format: SnapshotFormat;
-      memorySourcePubkey?: string | null;
-      avatarPngDataUrl?: string;
-    }) =>
-      encodeAgentSnapshotForSend(
-        id,
-        memoryLevel,
-        format,
-        memorySourcePubkey,
-        avatarPngDataUrl,
-      ),
-  });
-}
-
-export function usePreviewAgentSnapshotImportMutation() {
-  return useMutation({
-    mutationFn: ({
-      fileBytes,
-      fileName,
-    }: {
-      fileBytes: number[];
-      fileName: string;
-    }) => previewAgentSnapshotImport(fileBytes, fileName),
-  });
-}
-
-export function useConfirmAgentSnapshotImportMutation() {
-  return useMutation({
-    mutationFn: (input: AgentSnapshotImportConfirm) =>
-      confirmAgentSnapshotImport(input),
-  });
-}
-
-// Re-export import types for consumers that import from hooks.
-export type {
-  AgentSnapshotImportPreview,
-  AgentSnapshotImportConfirm,
-  AgentSnapshotImportResult,
-  EncodedSnapshotPayload,
-};
-
 export function useManagedAgentLogQuery(
   pubkey: string | null,
   lineCount = 120,
 ) {
-  const refetchInterval = useFocusedRefetchInterval(pubkey ? 30_000 : false);
+  const refetchInterval = useFocusedRefetchInterval(
+    pubkey ? MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS : false,
+  );
   return useQuery({
     queryKey: ["managed-agent-log", pubkey, lineCount],
     queryFn: () => getManagedAgentLog(pubkey as string, lineCount),
     enabled: pubkey !== null,
     retry: false,
-    staleTime: AGENTS_FOCUS_STALE_TIME_MS,
+    staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
@@ -7,10 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
-  PERSONA_CATALOG_REFETCH_INTERVAL_MS,
-} from "./usePersonaCatalogRelay.ts";
+import { PERSONA_CATALOG_FOCUS_STALE_TIME_MS } from "./usePersonaCatalogRelay.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -47,10 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("persona-catalog: polling constant is locked at 2 minutes", () => {
-  assert.equal(PERSONA_CATALOG_REFETCH_INTERVAL_MS, 120_000);
-});
 
 test("persona-catalog: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+  PERSONA_CATALOG_REFETCH_INTERVAL_MS,
+} from "./usePersonaCatalogRelay.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("persona-catalog: polling constant is locked at 2 minutes", () => {
+  assert.equal(PERSONA_CATALOG_REFETCH_INTERVAL_MS, 120_000);
+});
+
+test("persona-catalog: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PERSONA_CATALOG_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("persona-catalog: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PERSONA_CATALOG_FOCUS_STALE_TIME_MS + 1,
+      staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { PERSONA_CATALOG_FOCUS_STALE_TIME_MS } from "./usePersonaCatalogRelay.ts";
+import { personaCatalogFocusRefetchPolicy } from "./usePersonaCatalogRelay.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("persona-catalog: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PERSONA_CATALOG_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+      ageMs: personaCatalogFocusRefetchPolicy.staleTime - 1_000,
+      policy: personaCatalogFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("persona-catalog: skips fresh focus refetch", async () => {
 test("persona-catalog: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PERSONA_CATALOG_FOCUS_STALE_TIME_MS + 1,
-      staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+      ageMs: personaCatalogFocusRefetchPolicy.staleTime + 1,
+      policy: personaCatalogFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
@@ -21,6 +21,12 @@ export const PERSONA_CATALOG_REFETCH_INTERVAL_MS = 120_000;
  * The live subscription (invalidateQueries) is the primary freshness path. */
 export const PERSONA_CATALOG_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for the persona catalog query; consumed by focusRefetchPolicy.test.mjs. */
+export const personaCatalogFocusRefetchPolicy = {
+  staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export function personaCatalogQueryKey(communityId: string | null) {
   return ["persona-catalog", communityId] as const;
 }
@@ -33,9 +39,8 @@ export function usePersonaCatalogQuery(communityId: string | null) {
     enabled: communityId !== null,
     queryKey: personaCatalogQueryKey(communityId),
     queryFn: fetchPersonaCatalogPublications,
-    staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...personaCatalogFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
@@ -15,17 +15,25 @@ import {
 import type { AgentPersona, UpdatePersonaInput } from "@/shared/api/types";
 import { KIND_PERSONA } from "@/shared/constants/kinds";
 
+/** Keeps focused polling at the established 2-minute backstop cadence. */
+export const PERSONA_CATALOG_REFETCH_INTERVAL_MS = 120_000;
+/** Suppresses the focus refetch until persona catalog data is genuinely stale.
+ * The live subscription (invalidateQueries) is the primary freshness path. */
+export const PERSONA_CATALOG_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export function personaCatalogQueryKey(communityId: string | null) {
   return ["persona-catalog", communityId] as const;
 }
 
 export function usePersonaCatalogQuery(communityId: string | null) {
-  const refetchInterval = useFocusedRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PERSONA_CATALOG_REFETCH_INTERVAL_MS,
+  );
   return useQuery<PersonaCatalogPublication[]>({
     enabled: communityId !== null,
     queryKey: personaCatalogQueryKey(communityId),
     queryFn: fetchPersonaCatalogPublications,
-    staleTime: 30_000,
+    staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/agents/snapshotHooks.ts
+++ b/desktop/src/features/agents/snapshotHooks.ts
@@ -1,0 +1,97 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { resolveSnapshotAvatarPng } from "@/features/agents/ui/snapshotAvatarPng";
+import {
+  confirmAgentSnapshotImport,
+  encodeAgentSnapshotForSend,
+  exportAgentSnapshot,
+  previewAgentSnapshotImport,
+  type AgentSnapshotImportConfirm,
+  type AgentSnapshotImportPreview,
+  type AgentSnapshotImportResult,
+  type EncodedSnapshotPayload,
+  type SnapshotFormat,
+  type SnapshotMemoryLevel,
+} from "@/shared/api/tauriPersonas";
+
+export function useExportAgentSnapshotMutation() {
+  return useMutation({
+    mutationFn: async ({
+      id,
+      memoryLevel,
+      format,
+      memorySourcePubkey,
+      avatarUrl,
+    }: {
+      id: string;
+      memoryLevel: SnapshotMemoryLevel;
+      format: SnapshotFormat;
+      memorySourcePubkey?: string | null;
+      avatarUrl?: string | null;
+    }) => {
+      const avatarPngDataUrl =
+        format === "png"
+          ? await resolveSnapshotAvatarPng(avatarUrl)
+          : undefined;
+      return exportAgentSnapshot(
+        id,
+        memoryLevel,
+        format,
+        memorySourcePubkey,
+        avatarPngDataUrl,
+      );
+    },
+  });
+}
+
+export function useEncodeAgentSnapshotForSendMutation() {
+  return useMutation({
+    mutationFn: ({
+      id,
+      memoryLevel,
+      format,
+      memorySourcePubkey,
+      avatarPngDataUrl,
+    }: {
+      id: string;
+      memoryLevel: SnapshotMemoryLevel;
+      format: SnapshotFormat;
+      memorySourcePubkey?: string | null;
+      avatarPngDataUrl?: string;
+    }) =>
+      encodeAgentSnapshotForSend(
+        id,
+        memoryLevel,
+        format,
+        memorySourcePubkey,
+        avatarPngDataUrl,
+      ),
+  });
+}
+
+export function usePreviewAgentSnapshotImportMutation() {
+  return useMutation({
+    mutationFn: ({
+      fileBytes,
+      fileName,
+    }: {
+      fileBytes: number[];
+      fileName: string;
+    }) => previewAgentSnapshotImport(fileBytes, fileName),
+  });
+}
+
+export function useConfirmAgentSnapshotImportMutation() {
+  return useMutation({
+    mutationFn: (input: AgentSnapshotImportConfirm) =>
+      confirmAgentSnapshotImport(input),
+  });
+}
+
+// Re-export import types for consumers that import from hooks.
+export type {
+  AgentSnapshotImportPreview,
+  AgentSnapshotImportConfirm,
+  AgentSnapshotImportResult,
+  EncodedSnapshotPayload,
+};

--- a/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { channelTemplatesFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("channel-templates: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+      ageMs: channelTemplatesFocusRefetchPolicy.staleTime - 1_000,
+      policy: channelTemplatesFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("channel-templates: skips fresh focus refetch", async () => {
 test("channel-templates: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS + 1,
-      staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+      ageMs: channelTemplatesFocusRefetchPolicy.staleTime + 1,
+      policy: channelTemplatesFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+  CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("channel-templates: polling constant is locked at 30 seconds", () => {
+  assert.equal(CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS, 30_000);
+});
+
+test("channel-templates: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("channel-templates: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS + 1,
+      staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
@@ -7,10 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
-  CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -47,10 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("channel-templates: polling constant is locked at 30 seconds", () => {
-  assert.equal(CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS, 30_000);
-});
 
 test("channel-templates: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/channel-templates/hooks.ts
+++ b/desktop/src/features/channel-templates/hooks.ts
@@ -15,15 +15,23 @@ import type {
   UpdateChannelTemplateInput,
 } from "@/shared/api/types";
 
+/** Keeps focused polling at the established 30-second cadence. */
+export const CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS = 30_000;
+/** Suppresses the focus refetch until channel template data is genuinely stale.
+ * Templates change rarely; mutations cover all writes with push-invalidation. */
+export const CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export const channelTemplatesQueryKey = ["channel-templates"] as const;
 
 export function useChannelTemplatesQuery() {
-  const refetchInterval = useFocusedRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery({
     queryKey: channelTemplatesQueryKey,
     queryFn: listChannelTemplates,
-    staleTime: 30_000,
+    staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/channel-templates/hooks.ts
+++ b/desktop/src/features/channel-templates/hooks.ts
@@ -21,6 +21,12 @@ export const CHANNEL_TEMPLATES_REFETCH_INTERVAL_MS = 30_000;
  * Templates change rarely; mutations cover all writes with push-invalidation. */
 export const CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for the channel templates query; consumed by focusRefetchPolicy.test.mjs. */
+export const channelTemplatesFocusRefetchPolicy = {
+  staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export const channelTemplatesQueryKey = ["channel-templates"] as const;
 
 export function useChannelTemplatesQuery() {
@@ -31,9 +37,8 @@ export function useChannelTemplatesQuery() {
   return useQuery({
     queryKey: channelTemplatesQueryKey,
     queryFn: listChannelTemplates,
-    staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...channelTemplatesFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/channels/hooks.test.mjs
+++ b/desktop/src/features/channels/hooks.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  applyLastMessages,
   reconcileRefreshedCachedChannel,
   upsertCachedChannel,
   upsertCachedChannelMember,
@@ -107,6 +108,59 @@ test("reconcileRefreshedCachedChannel_restoresOpenedDmAfterStaleRefresh", () => 
     fizzPubkey,
   ]);
   assert.deepEqual(reconciled[0], openedDm);
+});
+
+// ── applyLastMessages ─────────────────────────────────────────────────────────
+
+test("applyLastMessages_preservesReferenceWhenTimestampUnchanged", () => {
+  const channel = makeChannel("general", "General");
+  channel.lastMessageAt = "2026-01-01T00:00:00Z";
+
+  const result = applyLastMessages([channel], {
+    general: "2026-01-01T00:00:00Z",
+  });
+
+  // Must be the same object reference — structural sharing avoids re-renders.
+  assert.strictEqual(
+    result[0],
+    channel,
+    "reference must be preserved when lastMessageAt is unchanged",
+  );
+});
+
+test("applyLastMessages_createsNewObjectWhenTimestampChanges", () => {
+  const channel = makeChannel("general", "General");
+  channel.lastMessageAt = "2026-01-01T00:00:00Z";
+
+  const result = applyLastMessages([channel], {
+    general: "2026-06-15T12:00:00Z",
+  });
+
+  assert.notStrictEqual(
+    result[0],
+    channel,
+    "must create a new object when timestamp changes",
+  );
+  assert.equal(result[0].lastMessageAt, "2026-06-15T12:00:00Z");
+});
+
+test("applyLastMessages_setsNullWhenChannelAbsentFromMap", () => {
+  const channel = makeChannel("general", "General");
+  channel.lastMessageAt = "2026-01-01T00:00:00Z";
+
+  const result = applyLastMessages([channel], {});
+
+  assert.notStrictEqual(result[0], channel);
+  assert.equal(result[0].lastMessageAt, null);
+});
+
+test("applyLastMessages_preservesReferenceWhenBothNull", () => {
+  const channel = makeChannel("general", "General");
+  // lastMessageAt defaults to null in makeChannel
+
+  const result = applyLastMessages([channel], {});
+
+  assert.strictEqual(result[0], channel, "null→null must preserve reference");
 });
 
 test("reconcileRefreshedCachedChannel_preservesRefreshedDmRecency", () => {

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -46,6 +46,13 @@ export const channelsQueryKey = ["channels"] as const;
 export const CHANNELS_REFETCH_INTERVAL_MS = 60_000;
 /** Suppresses the expensive focus refetch until the channel list is old. */
 export const CHANNELS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+/**
+ * Query-cache key for the channels payload hash. Stored alongside the channel
+ * list so its lifecycle is tied to the channel cache — a community switch that
+ * evicts the channel cache implicitly invalidates the stored hash, preventing a
+ * stale hash from short-circuiting into an empty list.
+ */
+const channelsHashKey = ["channels", "_hash"] as const;
 const channelDetailQueryKey = (channelId: string) =>
   ["channels", channelId, "detail"] as const;
 const channelMembersQueryKey = (channelId: string) =>
@@ -195,22 +202,74 @@ function setChannelArchivedState(
   );
 }
 
+/**
+ * Overlays `last_messages` timestamps onto channels without creating new object
+ * references for channels whose `lastMessageAt` is unchanged. Preserving
+ * references lets React Query's structural sharing skip re-renders for
+ * channels that received no new messages. Exported for unit testing.
+ */
+export function applyLastMessages(
+  channels: Channel[],
+  lastMessages: Record<string, string>,
+): Channel[] {
+  return channels.map((channel) => {
+    const newTs = lastMessages[channel.id] ?? null;
+    if (channel.lastMessageAt === newTs) {
+      return channel;
+    }
+    return { ...channel, lastMessageAt: newTs };
+  });
+}
+
 export function useChannelsQuery(options?: { enabled?: boolean }) {
   const { activeCommunity } = useCommunities();
   const relayUrl = activeCommunity?.relayUrl ?? null;
   const refetchInterval = useFocusedRefetchInterval(
     CHANNELS_REFETCH_INTERVAL_MS,
   );
+  const queryClient = useQueryClient();
 
   return useQuery({
     enabled: options?.enabled ?? true,
     queryKey: channelsQueryKey,
     queryFn: async () => {
-      const channels = sortChannels(await getChannels());
-      if (relayUrl) {
-        writeChannelSnapshot(relayUrl, channels);
+      // Supply the stored hash only when the channel list is still in cache.
+      // If cache is absent (community switch, eviction) we send null so the
+      // Rust side never short-circuits into an empty list.
+      const cachedChannels =
+        queryClient.getQueryData<Channel[]>(channelsQueryKey);
+      const knownHash = cachedChannels
+        ? (queryClient.getQueryData<string>(channelsHashKey) ?? null)
+        : null;
+
+      const payload = await getChannels(knownHash);
+
+      // Pin the hash alongside the channel cache so it is implicitly
+      // invalidated whenever the channel list is evicted.
+      queryClient.setQueryData(channelsHashKey, payload.hash);
+
+      // Determine the base channel list: full payload on a normal response,
+      // or the still-valid cached list on a not-modified (channels === null) response.
+      const base = payload.channels ?? cachedChannels;
+
+      if (!base) {
+        // hash-match but cache somehow empty — shouldn't happen given the
+        // null-hash guard above, but handle defensively by re-fetching without
+        // the stale hash so we always have a channel list to return.
+        const full = await getChannels(null);
+        queryClient.setQueryData(channelsHashKey, full.hash);
+        const sorted = sortChannels(
+          applyLastMessages(full.channels ?? [], full.lastMessages),
+        );
+        if (relayUrl) writeChannelSnapshot(relayUrl, sorted);
+        return sorted;
       }
-      return channels;
+
+      const sorted = sortChannels(
+        applyLastMessages(base, payload.lastMessages),
+      );
+      if (relayUrl) writeChannelSnapshot(relayUrl, sorted);
+      return sorted;
     },
     // Paint the sidebar instantly from the last-known list for this relay, then
     // revalidate. initialDataUpdatedAt:0 marks the seed as already-stale so the

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -46,6 +46,12 @@ export const channelsQueryKey = ["channels"] as const;
 export const CHANNELS_REFETCH_INTERVAL_MS = 60_000;
 /** Suppresses the expensive focus refetch until the channel list is old. */
 export const CHANNELS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
+/** Focus-refetch policy for the channels query; consumed by focusRefetchPolicy.test.mjs. */
+export const channelsFocusRefetchPolicy = {
+  staleTime: CHANNELS_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
 /**
  * Query-cache key for the channels payload hash. Stored alongside the channel
  * list so its lifecycle is tied to the channel cache — a community switch that
@@ -281,9 +287,8 @@ export function useChannelsQuery(options?: { enabled?: boolean }) {
         }
       : undefined,
     initialDataUpdatedAt: 0,
-    staleTime: CHANNELS_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...channelsFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+  CUSTOM_EMOJI_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("custom-emoji: polling constant is locked at 2 minutes", () => {
+  assert.equal(CUSTOM_EMOJI_REFETCH_INTERVAL_MS, 120_000);
+});
+
+test("custom-emoji: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("custom-emoji: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS + 1,
+      staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { CUSTOM_EMOJI_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { customEmojiFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("custom-emoji: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+      ageMs: customEmojiFocusRefetchPolicy.staleTime - 1_000,
+      policy: customEmojiFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("custom-emoji: skips fresh focus refetch", async () => {
 test("custom-emoji: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS + 1,
-      staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+      ageMs: customEmojiFocusRefetchPolicy.staleTime + 1,
+      policy: customEmojiFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
@@ -7,10 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
-  CUSTOM_EMOJI_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { CUSTOM_EMOJI_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -47,10 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("custom-emoji: polling constant is locked at 2 minutes", () => {
-  assert.equal(CUSTOM_EMOJI_REFETCH_INTERVAL_MS, 120_000);
-});
 
 test("custom-emoji: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -23,20 +23,28 @@ import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
  * live event is missed. Mirrors `user-status/hooks.ts`.
  */
 
+/** Keeps focused polling at the established 2-minute backstop cadence. */
+export const CUSTOM_EMOJI_REFETCH_INTERVAL_MS = 120_000;
+/** Suppresses the focus refetch until emoji data is genuinely stale.
+ * The live subscription (invalidateQueries) is the primary freshness path. */
+export const CUSTOM_EMOJI_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export const customEmojiQueryKey = ["custom-emoji"] as const;
 
 /** Query key for the caller's OWN editable 30030 set (distinct from the union). */
 export const ownCustomEmojiQueryKey = ["custom-emoji-own"] as const;
 
 export function useCustomEmojiQuery() {
-  const refetchInterval = useFocusedRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    CUSTOM_EMOJI_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<CustomEmoji[]>({
     queryKey: customEmojiQueryKey,
     queryFn: listCustomEmoji,
     // The palette changes rarely; avoid refetch storms while the picker is open,
     // but poll every 2 minutes as a backstop for any missed live event.
-    staleTime: 60_000,
+    staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -29,6 +29,12 @@ export const CUSTOM_EMOJI_REFETCH_INTERVAL_MS = 120_000;
  * The live subscription (invalidateQueries) is the primary freshness path. */
 export const CUSTOM_EMOJI_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for the custom emoji query; consumed by focusRefetchPolicy.test.mjs. */
+export const customEmojiFocusRefetchPolicy = {
+  staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export const customEmojiQueryKey = ["custom-emoji"] as const;
 
 /** Query key for the caller's OWN editable 30030 set (distinct from the union). */
@@ -44,9 +50,8 @@ export function useCustomEmojiQuery() {
     queryFn: listCustomEmoji,
     // The palette changes rarely; avoid refetch storms while the picker is open,
     // but poll every 2 minutes as a backstop for any missed live event.
-    staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...customEmojiFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/forum/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/forum/focusRefetchPolicy.test.mjs
@@ -7,11 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  FORUM_FOCUS_STALE_TIME_MS,
-  FORUM_POSTS_REFETCH_INTERVAL_MS,
-  FORUM_THREAD_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { FORUM_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -48,14 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("forum-posts: polling constant is locked at 15 seconds", () => {
-  assert.equal(FORUM_POSTS_REFETCH_INTERVAL_MS, 15_000);
-});
-
-test("forum-thread: polling constant is locked at 10 seconds", () => {
-  assert.equal(FORUM_THREAD_REFETCH_INTERVAL_MS, 10_000);
-});
 
 test("forum: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/forum/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/forum/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { FORUM_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { forumFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("forum: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: FORUM_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: FORUM_FOCUS_STALE_TIME_MS,
+      ageMs: forumFocusRefetchPolicy.staleTime - 1_000,
+      policy: forumFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("forum: skips fresh focus refetch", async () => {
 test("forum: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: FORUM_FOCUS_STALE_TIME_MS + 1,
-      staleTime: FORUM_FOCUS_STALE_TIME_MS,
+      ageMs: forumFocusRefetchPolicy.staleTime + 1,
+      policy: forumFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/forum/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/forum/focusRefetchPolicy.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  FORUM_FOCUS_STALE_TIME_MS,
+  FORUM_POSTS_REFETCH_INTERVAL_MS,
+  FORUM_THREAD_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("forum-posts: polling constant is locked at 15 seconds", () => {
+  assert.equal(FORUM_POSTS_REFETCH_INTERVAL_MS, 15_000);
+});
+
+test("forum-thread: polling constant is locked at 10 seconds", () => {
+  assert.equal(FORUM_THREAD_REFETCH_INTERVAL_MS, 10_000);
+});
+
+test("forum: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: FORUM_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: FORUM_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("forum: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: FORUM_FOCUS_STALE_TIME_MS + 1,
+      staleTime: FORUM_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -19,6 +19,12 @@ export const FORUM_THREAD_REFETCH_INTERVAL_MS = 10_000;
  * Both families poll while focused and have push-invalidation from mutations. */
 export const FORUM_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy shared by forum-posts and forum-thread queries; consumed by focusRefetchPolicy.test.mjs. */
+export const forumFocusRefetchPolicy = {
+  staleTime: FORUM_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export function forumPostsQueryKey(channelId: string) {
   return ["forum-posts", channelId] as const;
 }
@@ -40,9 +46,8 @@ export function useForumPostsQuery(channel: Channel | null) {
     enabled,
     queryKey: [...forumPostsQueryKey(channelId), relaySelfPubkey ?? null],
     queryFn: () => getForumPosts(channelId, 50, undefined, relaySelfPubkey),
-    staleTime: FORUM_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...forumFocusRefetchPolicy,
   });
 }
 
@@ -71,9 +76,8 @@ export function useForumThreadQuery(
         undefined,
         relaySelfPubkey,
       ),
-    staleTime: FORUM_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...forumFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -11,6 +11,14 @@ import type {
 } from "@/shared/api/types";
 import { KIND_FORUM_COMMENT, KIND_FORUM_POST } from "@/shared/constants/kinds";
 
+/** Keeps focused polling for forum posts at the established 15-second cadence. */
+export const FORUM_POSTS_REFETCH_INTERVAL_MS = 15_000;
+/** Keeps focused polling for forum threads at the established 10-second cadence. */
+export const FORUM_THREAD_REFETCH_INTERVAL_MS = 10_000;
+/** Suppresses the focus refetch until forum data is genuinely stale.
+ * Both families poll while focused and have push-invalidation from mutations. */
+export const FORUM_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export function forumPostsQueryKey(channelId: string) {
   return ["forum-posts", channelId] as const;
 }
@@ -20,7 +28,9 @@ export function forumThreadQueryKey(channelId: string, eventId: string) {
 }
 
 export function useForumPostsQuery(channel: Channel | null) {
-  const refetchInterval = useFocusedRefetchInterval(15_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    FORUM_POSTS_REFETCH_INTERVAL_MS,
+  );
 
   const channelId = channel?.id ?? "";
   const enabled = channel !== null && channel.channelType === "forum";
@@ -30,7 +40,7 @@ export function useForumPostsQuery(channel: Channel | null) {
     enabled,
     queryKey: [...forumPostsQueryKey(channelId), relaySelfPubkey ?? null],
     queryFn: () => getForumPosts(channelId, 50, undefined, relaySelfPubkey),
-    staleTime: 15_000,
+    staleTime: FORUM_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });
@@ -40,7 +50,9 @@ export function useForumThreadQuery(
   channelId: string | null,
   eventId: string | null,
 ) {
-  const refetchInterval = useFocusedRefetchInterval(10_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    FORUM_THREAD_REFETCH_INTERVAL_MS,
+  );
 
   const enabled = channelId !== null && eventId !== null;
   const relaySelfPubkey = useRelaySelfQuery(enabled).data;
@@ -59,7 +71,7 @@ export function useForumThreadQuery(
         undefined,
         relaySelfPubkey,
       ),
-    staleTime: 10_000,
+    staleTime: FORUM_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/home/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/home/focusRefetchPolicy.test.mjs
@@ -8,11 +8,11 @@ import {
 } from "@tanstack/react-query";
 
 import {
-  CHANNELS_FOCUS_STALE_TIME_MS,
+  channelsFocusRefetchPolicy,
   CHANNELS_REFETCH_INTERVAL_MS,
 } from "@/features/channels/hooks.ts";
 import {
-  HOME_FEED_FOCUS_STALE_TIME_MS,
+  homeFeedFocusRefetchPolicy,
   HOME_FEED_REFETCH_INTERVAL_MS,
 } from "./hooks.ts";
 
@@ -20,14 +20,14 @@ afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -40,8 +40,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
     },
     // Keep setup from fetching stale cache before the simulated focus return.
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -53,36 +52,36 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   return fetchCount;
 }
 
-for (const policy of [
+for (const entry of [
   {
     name: "channels",
-    staleTime: CHANNELS_FOCUS_STALE_TIME_MS,
+    focusPolicy: channelsFocusRefetchPolicy,
     refetchInterval: CHANNELS_REFETCH_INTERVAL_MS,
     expectedRefetchInterval: 60_000,
   },
   {
     name: "home feed",
-    staleTime: HOME_FEED_FOCUS_STALE_TIME_MS,
+    focusPolicy: homeFeedFocusRefetchPolicy,
     refetchInterval: HOME_FEED_REFETCH_INTERVAL_MS,
     expectedRefetchInterval: 30_000,
   },
 ]) {
-  test(`${policy.name} skips fresh focus refetch and preserves polling`, async () => {
-    assert.equal(policy.refetchInterval, policy.expectedRefetchInterval);
+  test(`${entry.name} skips fresh focus refetch and preserves polling`, async () => {
+    assert.equal(entry.refetchInterval, entry.expectedRefetchInterval);
     assert.equal(
       await focusRefetchCount({
-        ageMs: policy.staleTime - 1_000,
-        staleTime: policy.staleTime,
+        ageMs: entry.focusPolicy.staleTime - 1_000,
+        policy: entry.focusPolicy,
       }),
       0,
     );
   });
 
-  test(`${policy.name} refetches genuinely stale data on focus`, async () => {
+  test(`${entry.name} refetches genuinely stale data on focus`, async () => {
     assert.equal(
       await focusRefetchCount({
-        ageMs: policy.staleTime + 1,
-        staleTime: policy.staleTime,
+        ageMs: entry.focusPolicy.staleTime + 1,
+        policy: entry.focusPolicy,
       }),
       1,
     );

--- a/desktop/src/features/home/hooks.ts
+++ b/desktop/src/features/home/hooks.ts
@@ -9,6 +9,12 @@ export const HOME_FEED_REFETCH_INTERVAL_MS = 30_000;
 /** Suppresses the expensive focus refetch until the home feed is old. */
 export const HOME_FEED_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for the home feed query; consumed by focusRefetchPolicy.test.mjs. */
+export const homeFeedFocusRefetchPolicy = {
+  staleTime: HOME_FEED_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export function useHomeFeedQuery() {
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
@@ -23,12 +29,11 @@ export function useHomeFeedQuery() {
         limit: 50,
         types: "mentions,needs_action,activity,agent_activity",
       }),
-    staleTime: HOME_FEED_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60 * 1_000,
     // Pause background polling on degraded/stalled/disconnected connections.
     // The relay can't serve the request anyway, and the spurious failures
     // consume quota that the recovery path needs.
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...homeFeedFocusRefetchPolicy,
   });
 }

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -31,6 +31,11 @@ import {
   updateChannel,
 } from "@/shared/api/tauri";
 
+// Adapter: resolves the full channel list without the not-modified short-circuit.
+// Onboarding paths run once and always need fresh data.
+const getChannelsList = (): Promise<Channel[]> =>
+  getChannels(null).then((payload) => payload.channels ?? []);
+
 const STARTER_CHANNEL_SETUP_TOAST_ID = "starter-channel-setup-error";
 
 export type ChannelInitResult =
@@ -85,7 +90,7 @@ export async function initializeStarterChannels(
     try {
       starterChannels = await ensureStarterChannels({
         ensureStarterChannels: ensureStarterChannelsCommand,
-        getChannels,
+        getChannels: getChannelsList,
       });
     } catch (error) {
       // Public starter channels are optional. Owners may have deliberately
@@ -99,7 +104,7 @@ export async function initializeStarterChannels(
         createChannel,
         deleteChannel,
         getChannelMembers,
-        getChannels,
+        getChannels: getChannelsList,
         updateChannel,
       },
       {
@@ -163,7 +168,7 @@ async function refreshChannelsCache(
   queryClient: ReturnType<typeof useQueryClient>,
 ) {
   try {
-    queryClient.setQueryData(channelsQueryKey, await getChannels());
+    queryClient.setQueryData(channelsQueryKey, await getChannelsList());
   } catch {
     // The next mounted channels query can still retry; this cache refresh is
     // only here to avoid a blank Home flash after first-run setup.

--- a/desktop/src/features/presence/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/presence/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { PRESENCE_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { presenceFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("presence: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PRESENCE_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
+      ageMs: presenceFocusRefetchPolicy.staleTime - 1_000,
+      policy: presenceFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("presence: skips fresh focus refetch", async () => {
 test("presence: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PRESENCE_FOCUS_STALE_TIME_MS + 1,
-      staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
+      ageMs: presenceFocusRefetchPolicy.staleTime + 1,
+      policy: presenceFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/presence/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/presence/focusRefetchPolicy.test.mjs
@@ -7,10 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  PRESENCE_FOCUS_STALE_TIME_MS,
-  PRESENCE_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { PRESENCE_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -47,10 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("presence: polling constant is locked at 60 seconds", () => {
-  assert.equal(PRESENCE_REFETCH_INTERVAL_MS, 60_000);
-});
 
 test("presence: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/presence/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/presence/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  PRESENCE_FOCUS_STALE_TIME_MS,
+  PRESENCE_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("presence: polling constant is locked at 60 seconds", () => {
+  assert.equal(PRESENCE_REFETCH_INTERVAL_MS, 60_000);
+});
+
+test("presence: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PRESENCE_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("presence: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PRESENCE_FOCUS_STALE_TIME_MS + 1,
+      staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -19,6 +19,12 @@ import {
 import type { PresenceLookup, PresenceStatus } from "@/shared/api/types";
 
 const PRESENCE_STATUS_TICK_INTERVAL_MS = 30_000;
+/** Keeps focused polling for presence at the established 60-second backstop cadence. */
+export const PRESENCE_REFETCH_INTERVAL_MS = 60_000;
+/** Suppresses the focus refetch until presence data is genuinely stale.
+ * The live subscription (setQueriesData) and reconnect invalidation are the
+ * primary freshness paths; the 60s poll is the backstop. */
+export const PRESENCE_FOCUS_STALE_TIME_MS = 5 * 60_000;
 const PRESENCE_ACTIVITY_THROTTLE_MS = 1_000;
 const PRESENCE_PREFERENCE_STORAGE_KEY = "buzz-presence-preference";
 
@@ -84,13 +90,15 @@ export function usePresenceQuery(
   const enabled = (options?.enabled ?? true) && normalizedPubkeys.length > 0;
   const connectionState = useRelayConnection();
   const connected = connectionState === "connected";
-  const refetchInterval = useFocusedRefetchInterval(connected ? 60_000 : false);
+  const refetchInterval = useFocusedRefetchInterval(
+    connected ? PRESENCE_REFETCH_INTERVAL_MS : false,
+  );
 
   return useQuery<PresenceLookup>({
     enabled,
     queryKey: presenceQueryKey(normalizedPubkeys),
     queryFn: () => getPresence(normalizedPubkeys),
-    staleTime: 30_000,
+    staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
     // Backstop poll: catches REST-only writers (ACP agents) and TTL expiry
     // (crashed clients). WS events handle the fast path. Pause on degraded
     // connections — HTTP presence calls fail anyway and consume relay quota.

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -25,6 +25,12 @@ export const PRESENCE_REFETCH_INTERVAL_MS = 60_000;
  * The live subscription (setQueriesData) and reconnect invalidation are the
  * primary freshness paths; the 60s poll is the backstop. */
 export const PRESENCE_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
+/** Focus-refetch policy for the presence query; consumed by focusRefetchPolicy.test.mjs. */
+export const presenceFocusRefetchPolicy = {
+  staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
 const PRESENCE_ACTIVITY_THROTTLE_MS = 1_000;
 const PRESENCE_PREFERENCE_STORAGE_KEY = "buzz-presence-preference";
 
@@ -98,12 +104,11 @@ export function usePresenceQuery(
     enabled,
     queryKey: presenceQueryKey(normalizedPubkeys),
     queryFn: () => getPresence(normalizedPubkeys),
-    staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
     // Backstop poll: catches REST-only writers (ACP agents) and TTL expiry
     // (crashed clients). WS events handle the fast path. Pause on degraded
     // connections — HTTP presence calls fail anyway and consume relay quota.
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...presenceFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -2,9 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  parseSelfProfileCache,
   MAX_SELF_PROFILE_CACHES,
   MAX_SELF_PROFILE_CACHES_PER_RELAY,
+  _resetProfileKeyCountForTest,
+  parseSelfProfileCache,
   resolveAvatarDataUrl,
   shouldFetchAvatar,
   storageKey,
@@ -73,6 +74,7 @@ function installStorage(onGetItem = () => {}) {
 }
 
 test("writeSelfProfileCache caps each relay and the global cache by updatedAt", () => {
+  _resetProfileKeyCountForTest();
   const values = installStorage();
   const relayA = "wss://relay-a.example";
   for (let index = 0; index < MAX_SELF_PROFILE_CACHES_PER_RELAY + 1; index++) {
@@ -103,6 +105,7 @@ test("writeSelfProfileCache caps each relay and the global cache by updatedAt", 
 });
 
 test("writeSelfProfileCache does not read existing payloads below both caps", () => {
+  _resetProfileKeyCountForTest();
   const readKeys = [];
   const values = installStorage((key) => readKeys.push(key));
   const relay = "wss://relay.example";
@@ -413,5 +416,111 @@ test("resolveAvatarDataUrl: fetch failed, URL changed → null", () => {
   assert.equal(
     resolveAvatarDataUrl("https://relay.example.com/new.jpg", null, existing),
     null,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Memoized key-count tests
+// ---------------------------------------------------------------------------
+
+function installStorageTracked() {
+  const values = new Map();
+  let keyCallCount = 0;
+  const mock = {
+    values,
+    get keyCallCount() {
+      return keyCallCount;
+    },
+    get length() {
+      return values.size;
+    },
+    key(index) {
+      keyCallCount++;
+      return [...values.keys()][index] ?? null;
+    },
+    getItem: (key) => values.get(key) ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, String(value)),
+  };
+  globalThis.window = {
+    dispatchEvent: () => true,
+    localStorage: mock,
+  };
+  globalThis.CustomEvent ??= class CustomEvent {};
+  return mock;
+}
+
+test("trim does not call key() when memo is initialized and total is under per-relay cap", () => {
+  _resetProfileKeyCountForTest();
+  const storage = installStorageTracked();
+  const relay = "wss://relay.example";
+
+  // First write: memo uninitialized → ensureProfileKeyCount scans (calls key()).
+  writeSelfProfileCache(relay, "pk-0", makeCache({ updatedAt: 1 }));
+  const keyCallsAfterFirst = storage.keyCallCount;
+  assert.ok(
+    keyCallsAfterFirst > 0,
+    "first write triggers key scan to init memo",
+  );
+
+  // Second write with total still ≤ MAX_SELF_PROFILE_CACHES_PER_RELAY (8).
+  // Memo already initialized → trim returns in O(1), no key() calls.
+  const before = storage.keyCallCount;
+  writeSelfProfileCache(relay, "pk-1", makeCache({ updatedAt: 2 }));
+  const after = storage.keyCallCount;
+  assert.equal(
+    after - before,
+    0,
+    "no key() calls in trim when memo is hot and count is under cap",
+  );
+});
+
+test("memoized count resyncs when a full scan finds external deletions", () => {
+  _resetProfileKeyCountForTest();
+  const storage = installStorageTracked();
+  const relay = "wss://relay.example";
+
+  // Fill to just above per-relay cap so trim does a key-only scan.
+  for (let i = 0; i < MAX_SELF_PROFILE_CACHES_PER_RELAY + 1; i++) {
+    writeSelfProfileCache(relay, `pk-${i}`, makeCache({ updatedAt: i + 1 }));
+  }
+
+  // Externally delete some keys to make the memo stale.
+  const keysToDelete = [...storage.values.keys()]
+    .filter((k) => k.startsWith("buzz-self-profile.v1:"))
+    .slice(0, 3);
+  for (const k of keysToDelete) storage.values.delete(k);
+
+  // Next write: trim does key-only scan, detects mismatch, resyncs memo.
+  // Should not throw and should cap correctly.
+  assert.doesNotThrow(() => {
+    writeSelfProfileCache(relay, "pk-new", makeCache({ updatedAt: 999 }));
+  });
+  // After resync the memo reflects actual storage (no stale inflation).
+  const finalKeys = [...storage.values.keys()].filter((k) =>
+    k.startsWith("buzz-self-profile.v1:"),
+  );
+  assert.ok(
+    finalKeys.length <= MAX_SELF_PROFILE_CACHES_PER_RELAY,
+    `expected ≤${MAX_SELF_PROFILE_CACHES_PER_RELAY} keys after trim, got ${finalKeys.length}`,
+  );
+});
+
+test("over-cap write still trims correctly after memo init", () => {
+  _resetProfileKeyCountForTest();
+  const values = installStorage();
+  const relay = "wss://relay-a.example";
+
+  // Fill to cap + 1 (triggers the full parse+evict path).
+  for (let i = 0; i <= MAX_SELF_PROFILE_CACHES_PER_RELAY; i++) {
+    writeSelfProfileCache(relay, `pk-${i}`, makeCache({ updatedAt: i }));
+  }
+
+  // Oldest (updatedAt=0) should have been evicted; newest preserved.
+  assert.equal(values.has(storageKey(relay, "pk-0")), false, "oldest evicted");
+  assert.equal(
+    values.has(storageKey(relay, `pk-${MAX_SELF_PROFILE_CACHES_PER_RELAY}`)),
+    true,
+    "newest preserved",
   );
 });

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -524,3 +524,74 @@ test("over-cap write still trims correctly after memo init", () => {
     "newest preserved",
   );
 });
+
+test("scan failure in ensureProfileKeyCount: write succeeds, memo stays null, next write rescans and enforces cap", () => {
+  _resetProfileKeyCountForTest();
+
+  const values = new Map();
+  let throwOnScan = false;
+  globalThis.window = {
+    dispatchEvent: () => true,
+    localStorage: {
+      get length() {
+        if (throwOnScan) throw new Error("Storage unavailable");
+        return values.size;
+      },
+      getItem: (k) => values.get(k) ?? null,
+      key: (i) => [...values.keys()][i] ?? null,
+      removeItem: (k) => values.delete(k),
+      setItem: (k, v) => values.set(k, String(v)),
+    },
+  };
+  globalThis.CustomEvent ??= class CustomEvent {};
+
+  const relay = "wss://relay.example";
+
+  // Write with scan disabled — ensureProfileKeyCount should catch the throw,
+  // leave memo null, and let the write succeed.
+  throwOnScan = true;
+  const result = writeSelfProfileCache(
+    relay,
+    "pk-0",
+    makeCache({ updatedAt: 1 }),
+  );
+  throwOnScan = false;
+
+  assert.equal(result, true, "write returns true despite scan failure");
+  assert.equal(
+    values.has(storageKey(relay, "pk-0")),
+    true,
+    "entry was written",
+  );
+
+  // Pre-seed enough entries (directly into the map) to push total above cap.
+  for (let i = 1; i <= MAX_SELF_PROFILE_CACHES_PER_RELAY; i++) {
+    values.set(
+      storageKey(relay, `pk-${i}`),
+      JSON.stringify(makeCache({ updatedAt: i + 1 })),
+    );
+  }
+
+  // Replace key() with a tracking version to confirm memo was null (i.e. a
+  // fresh scan is triggered on the next write).
+  let keyCalls = 0;
+  globalThis.window.localStorage.key = (i) => {
+    keyCalls++;
+    return [...values.keys()][i] ?? null;
+  };
+
+  writeSelfProfileCache(relay, "pk-new", makeCache({ updatedAt: 999 }));
+
+  assert.ok(
+    keyCalls > 0,
+    "key() was called, confirming memo was null after scan failure",
+  );
+
+  const finalKeys = [...values.keys()].filter((k) =>
+    k.startsWith("buzz-self-profile.v1:"),
+  );
+  assert.ok(
+    finalKeys.length <= MAX_SELF_PROFILE_CACHES_PER_RELAY,
+    `cap enforced after rescan: got ${finalKeys.length}, expected ≤${MAX_SELF_PROFILE_CACHES_PER_RELAY}`,
+  );
+});

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -136,22 +136,33 @@ export function readSelfProfileCache(
  * This is NOT community-scoped: localStorage is shared across all communities
  * in the same origin, so the count persists across community switches. It must
  * not be added to resetCommunityState().
+ *
+ * Multi-tab caveat: writes from other tabs bypass this tab's memo, so the count
+ * can under-count. The resync-on-divergence check in trimSelfProfileCaches
+ * corrects this on the next over-cap scan, bounded by MAX_SELF_PROFILE_CACHES.
  */
 let _memoizedProfileKeyCount: number | null = null;
 
 /**
  * Returns the memoized key count, scanning once on first call.
- * Subsequent calls are O(1).
+ * Subsequent calls are O(1). Returns null if the scan throws (storage
+ * locked/unavailable); callers treat null as "skip trimming."
  */
-function ensureProfileKeyCount(): number {
+function ensureProfileKeyCount(): number | null {
   if (_memoizedProfileKeyCount !== null) return _memoizedProfileKeyCount;
-  let count = 0;
-  for (let i = 0; i < window.localStorage.length; i++) {
-    const key = window.localStorage.key(i);
-    if (key?.startsWith(`${STORAGE_KEY_PREFIX}:`)) count++;
+  try {
+    let count = 0;
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key?.startsWith(`${STORAGE_KEY_PREFIX}:`)) count++;
+    }
+    _memoizedProfileKeyCount = count;
+    return count;
+  } catch {
+    // Leave memo null — a partial count must never be memoized. The next
+    // call will rescan when storage recovers.
+    return null;
   }
-  _memoizedProfileKeyCount = count;
-  return count;
 }
 
 /** Reset module state between tests. Not for production use. */
@@ -175,8 +186,10 @@ function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
   const relayPrefix = `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:`;
 
   // O(1) fast path: ≤ per-relay cap total → definitely under both caps.
+  // null = scan failed (storage locked); skip trimming so the write still lands.
   const memoTotal = ensureProfileKeyCount();
-  if (memoTotal <= MAX_SELF_PROFILE_CACHES_PER_RELAY) return;
+  if (memoTotal === null || memoTotal <= MAX_SELF_PROFILE_CACHES_PER_RELAY)
+    return;
 
   // Key-only scan to get accurate totals (no getItem, no parsing).
   let totalEntryCount = 0;

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -129,8 +129,56 @@ export function readSelfProfileCache(
   }
 }
 
+/**
+ * Memoized count of localStorage keys matching the self-profile prefix.
+ * null = uninitialized (first write triggers the scan).
+ *
+ * This is NOT community-scoped: localStorage is shared across all communities
+ * in the same origin, so the count persists across community switches. It must
+ * not be added to resetCommunityState().
+ */
+let _memoizedProfileKeyCount: number | null = null;
+
+/**
+ * Returns the memoized key count, scanning once on first call.
+ * Subsequent calls are O(1).
+ */
+function ensureProfileKeyCount(): number {
+  if (_memoizedProfileKeyCount !== null) return _memoizedProfileKeyCount;
+  let count = 0;
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (key?.startsWith(`${STORAGE_KEY_PREFIX}:`)) count++;
+  }
+  _memoizedProfileKeyCount = count;
+  return count;
+}
+
+/** Reset module state between tests. Not for production use. */
+export function _resetProfileKeyCountForTest(): void {
+  _memoizedProfileKeyCount = null;
+}
+
+/**
+ * Trims self-profile caches to stay within per-relay and global caps.
+ *
+ * Fast path (O(1)): when the memoized total is ≤ MAX_SELF_PROFILE_CACHES_PER_RELAY,
+ * no relay can exceed the per-relay cap, so both caps are satisfied without
+ * any localStorage iteration.
+ *
+ * Slow path: key-only scan to check per-relay and global counts; if over cap,
+ * a full parse-scan selects entries for eviction by updatedAt. The memoized
+ * count is resynced if the scan finds it diverged (e.g. another tab deleted
+ * keys between writes).
+ */
 function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
   const relayPrefix = `${STORAGE_KEY_PREFIX}:${normalizeRelayUrl(relayUrl)}:`;
+
+  // O(1) fast path: ≤ per-relay cap total → definitely under both caps.
+  const memoTotal = ensureProfileKeyCount();
+  if (memoTotal <= MAX_SELF_PROFILE_CACHES_PER_RELAY) return;
+
+  // Key-only scan to get accurate totals (no getItem, no parsing).
   let totalEntryCount = 0;
   let relayEntryCount = 0;
   for (let i = 0; i < window.localStorage.length; i++) {
@@ -139,6 +187,13 @@ function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
     totalEntryCount += 1;
     if (key.startsWith(relayPrefix)) relayEntryCount += 1;
   }
+
+  // Resync memo if it diverged due to external deletions (another tab, the
+  // TTL sweep, etc.).
+  if (totalEntryCount !== memoTotal) {
+    _memoizedProfileKeyCount = totalEntryCount;
+  }
+
   if (
     totalEntryCount <= MAX_SELF_PROFILE_CACHES &&
     relayEntryCount <= MAX_SELF_PROFILE_CACHES_PER_RELAY
@@ -146,6 +201,7 @@ function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
     return;
   }
 
+  // Full parse-scan: collect entries for eviction by updatedAt.
   const entries: Array<{ key: string; updatedAt: number }> = [];
   for (let i = 0; i < window.localStorage.length; i++) {
     const key = window.localStorage.key(i);
@@ -184,6 +240,15 @@ function trimSelfProfileCaches(relayUrl: string, preservedKey: string): void {
     }
   }
   for (const key of keysToRemove) window.localStorage.removeItem(key);
+
+  // Update memo to reflect evictions.
+  if (_memoizedProfileKeyCount !== null) {
+    _memoizedProfileKeyCount = Math.max(
+      0,
+      (totalEntryCount !== memoTotal ? totalEntryCount : memoTotal) -
+        keysToRemove.size,
+    );
+  }
 }
 
 /**
@@ -203,8 +268,14 @@ export function writeSelfProfileCache(
     // The 30s profile refetch otherwise re-stringifies ~341KB, rewrites it,
     // dispatches the cache event, and re-parses on the listener side even
     // when nothing changed. Skip the write and event entirely when identical.
-    if (window.localStorage.getItem(key) === serialized) return true;
+    const existingRaw = window.localStorage.getItem(key);
+    if (existingRaw === serialized) return true;
+    const isNew = existingRaw === null;
     window.localStorage.setItem(key, serialized);
+    // Increment memo when a genuinely new key is added.
+    if (isNew && _memoizedProfileKeyCount !== null) {
+      _memoizedProfileKeyCount++;
+    }
     trimSelfProfileCaches(relayUrl, key);
     // localStorage is not reactive — dispatch a custom event so any mounted
     // listeners (e.g. useEffect with addEventListener) can re-read the cache
@@ -233,6 +304,13 @@ export function removeSelfProfileCachesForRelay(relayUrl: string): void {
     }
     for (const key of toRemove) {
       window.localStorage.removeItem(key);
+    }
+    // Keep memo consistent with the removals performed by this module.
+    if (_memoizedProfileKeyCount !== null) {
+      _memoizedProfileKeyCount = Math.max(
+        0,
+        _memoizedProfileKeyCount - toRemove.length,
+      );
     }
   } catch {
     // Storage access failures are non-fatal.

--- a/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { PULSE_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { pulseFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("pulse: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PULSE_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: PULSE_FOCUS_STALE_TIME_MS,
+      ageMs: pulseFocusRefetchPolicy.staleTime - 1_000,
+      policy: pulseFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("pulse: skips fresh focus refetch", async () => {
 test("pulse: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: PULSE_FOCUS_STALE_TIME_MS + 1,
-      staleTime: PULSE_FOCUS_STALE_TIME_MS,
+      ageMs: pulseFocusRefetchPolicy.staleTime + 1,
+      policy: pulseFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  PULSE_FOCUS_STALE_TIME_MS,
+  PULSE_NOTES_REFETCH_INTERVAL_MS,
+  PULSE_REACTIONS_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("pulse: note feed polling constant is locked at 30 seconds", () => {
+  assert.equal(PULSE_NOTES_REFETCH_INTERVAL_MS, 30_000);
+});
+
+test("pulse: reactions polling constant is locked at 60 seconds", () => {
+  assert.equal(PULSE_REACTIONS_REFETCH_INTERVAL_MS, 60_000);
+});
+
+test("pulse: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PULSE_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: PULSE_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("pulse: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: PULSE_FOCUS_STALE_TIME_MS + 1,
+      staleTime: PULSE_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
@@ -7,11 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  PULSE_FOCUS_STALE_TIME_MS,
-  PULSE_NOTES_REFETCH_INTERVAL_MS,
-  PULSE_REACTIONS_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { PULSE_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -48,14 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("pulse: note feed polling constant is locked at 30 seconds", () => {
-  assert.equal(PULSE_NOTES_REFETCH_INTERVAL_MS, 30_000);
-});
-
-test("pulse: reactions polling constant is locked at 60 seconds", () => {
-  assert.equal(PULSE_REACTIONS_REFETCH_INTERVAL_MS, 60_000);
-});
 
 test("pulse: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -22,6 +22,12 @@ export const PULSE_REACTIONS_REFETCH_INTERVAL_MS = 60_000;
  * Polls every 30s while focused — the focus refetch would duplicate that work. */
 export const PULSE_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy shared by all pulse queries; consumed by focusRefetchPolicy.test.mjs. */
+export const pulseFocusRefetchPolicy = {
+  staleTime: PULSE_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 // ── Query keys ──────────────────────────────────────────────────────────────
 
 export const pulseQueryKeys = {
@@ -50,10 +56,9 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
       // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getLikedNotes(pubkey!, 50)),
     enabled: enabled && !!pubkey,
-    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...pulseFocusRefetchPolicy,
   });
 }
 
@@ -68,10 +73,9 @@ export function useMyNotesQuery(pubkey?: string) {
       // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getUserNotes(pubkey!, { limit: 50 })),
     enabled: !!pubkey,
-    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...pulseFocusRefetchPolicy,
   });
 }
 
@@ -87,10 +91,9 @@ export function useTimelineQuery(contactPubkeys: string[], enabled: boolean) {
     queryFn: async () =>
       withoutProjectComments(await getNotesTimeline(contactPubkeys, 10)),
     enabled: enabled && contactPubkeys.length > 0,
-    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...pulseFocusRefetchPolicy,
   });
 }
 
@@ -126,10 +129,9 @@ export function usePulseReactionsQuery(
       return result;
     },
     enabled: noteIds.length > 0,
-    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...pulseFocusRefetchPolicy,
   });
 }
 
@@ -153,10 +155,9 @@ export function useGlobalNotesQuery(enabled: boolean) {
     queryFn: async () =>
       withoutProjectComments(await getGlobalNotes({ limit: 50 })),
     enabled,
-    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...pulseFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -14,6 +14,14 @@ import { withoutProjectComments } from "@/features/pulse/lib/projectComments";
 import type { UserNote, UserNotesResponse } from "@/shared/api/socialTypes";
 import { useFocusedRefetchInterval } from "@/shared/lib/useDocumentVisible";
 
+/** Keeps focused polling at the established 30-second cadence for note feeds. */
+export const PULSE_NOTES_REFETCH_INTERVAL_MS = 30_000;
+/** Keeps focused polling at the established 60-second cadence for reactions. */
+export const PULSE_REACTIONS_REFETCH_INTERVAL_MS = 60_000;
+/** Suppresses the focus refetch until pulse data is genuinely stale.
+ * Polls every 30s while focused — the focus refetch would duplicate that work. */
+export const PULSE_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 // ── Query keys ──────────────────────────────────────────────────────────────
 
 export const pulseQueryKeys = {
@@ -32,7 +40,9 @@ export const pulseQueryKeys = {
 // ── Own notes ───────────────────────────────────────────────────────────────
 
 export function useLikedNotesQuery(pubkey?: string, enabled = true) {
-  const refetchInterval = useFocusedRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PULSE_NOTES_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.likedNotes(pubkey ?? ""),
@@ -40,7 +50,7 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
       // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getLikedNotes(pubkey!, 50)),
     enabled: enabled && !!pubkey,
-    staleTime: 15_000,
+    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
     refetchOnWindowFocus: true,
@@ -48,7 +58,9 @@ export function useLikedNotesQuery(pubkey?: string, enabled = true) {
 }
 
 export function useMyNotesQuery(pubkey?: string) {
-  const refetchInterval = useFocusedRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PULSE_NOTES_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.myNotes(pubkey ?? ""),
@@ -56,7 +68,7 @@ export function useMyNotesQuery(pubkey?: string) {
       // biome-ignore lint/style/noNonNullAssertion: guarded by enabled: !!pubkey
       withoutProjectComments(await getUserNotes(pubkey!, { limit: 50 })),
     enabled: !!pubkey,
-    staleTime: 15_000,
+    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
     refetchOnWindowFocus: true,
@@ -66,14 +78,16 @@ export function useMyNotesQuery(pubkey?: string) {
 // ── Timeline (notes from contacts) ─────────────────────────────────────────
 
 export function useTimelineQuery(contactPubkeys: string[], enabled: boolean) {
-  const refetchInterval = useFocusedRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PULSE_NOTES_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.timeline(contactPubkeys),
     queryFn: async () =>
       withoutProjectComments(await getNotesTimeline(contactPubkeys, 10)),
     enabled: enabled && contactPubkeys.length > 0,
-    staleTime: 15_000,
+    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
     refetchOnWindowFocus: true,
@@ -89,7 +103,9 @@ export function usePulseReactionsQuery(
   noteIds: string[],
   currentPubkey?: string,
 ) {
-  const refetchInterval = useFocusedRefetchInterval(60_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PULSE_REACTIONS_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<Map<string, PulseReactionState>>({
     queryKey: pulseQueryKeys.reactions(noteIds),
@@ -110,7 +126,7 @@ export function usePulseReactionsQuery(
       return result;
     },
     enabled: noteIds.length > 0,
-    staleTime: 15_000,
+    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
     refetchOnWindowFocus: true,
@@ -128,14 +144,16 @@ export function useNoteByIdQuery(noteId: string | null) {
 }
 
 export function useGlobalNotesQuery(enabled: boolean) {
-  const refetchInterval = useFocusedRefetchInterval(30_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    PULSE_NOTES_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery<UserNotesResponse>({
     queryKey: pulseQueryKeys.globalNotes,
     queryFn: async () =>
       withoutProjectComments(await getGlobalNotes({ limit: 50 })),
     enabled,
-    staleTime: 15_000,
+    staleTime: PULSE_FOCUS_STALE_TIME_MS,
     gcTime: 5 * 60_000,
     refetchInterval,
     refetchOnWindowFocus: true,

--- a/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
@@ -7,20 +7,20 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import { USER_STATUS_FOCUS_STALE_TIME_MS } from "./hooks.ts";
+import { userStatusFocusRefetchPolicy } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -32,8 +32,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -48,8 +47,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("user-status: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: USER_STATUS_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
+      ageMs: userStatusFocusRefetchPolicy.staleTime - 1_000,
+      policy: userStatusFocusRefetchPolicy,
     }),
     0,
   );
@@ -58,8 +57,8 @@ test("user-status: skips fresh focus refetch", async () => {
 test("user-status: refetches genuinely stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: USER_STATUS_FOCUS_STALE_TIME_MS + 1,
-      staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
+      ageMs: userStatusFocusRefetchPolicy.staleTime + 1,
+      policy: userStatusFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
@@ -7,10 +7,7 @@ import {
   QueryObserver,
 } from "@tanstack/react-query";
 
-import {
-  USER_STATUS_FOCUS_STALE_TIME_MS,
-  USER_STATUS_REFETCH_INTERVAL_MS,
-} from "./hooks.ts";
+import { USER_STATUS_FOCUS_STALE_TIME_MS } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
@@ -47,10 +44,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   queryClient.unmount();
   return fetchCount;
 }
-
-test("user-status: polling constant is locked at 2 minutes", () => {
-  assert.equal(USER_STATUS_REFETCH_INTERVAL_MS, 120_000);
-});
 
 test("user-status: skips fresh focus refetch", async () => {
   assert.equal(

--- a/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  USER_STATUS_FOCUS_STALE_TIME_MS,
+  USER_STATUS_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("user-status: polling constant is locked at 2 minutes", () => {
+  assert.equal(USER_STATUS_REFETCH_INTERVAL_MS, 120_000);
+});
+
+test("user-status: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: USER_STATUS_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("user-status: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: USER_STATUS_FOCUS_STALE_TIME_MS + 1,
+      staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/user-status/hooks.ts
+++ b/desktop/src/features/user-status/hooks.ts
@@ -38,8 +38,16 @@ export function parseUserStatusEvent(event: RelayEvent): {
   };
 }
 
+/** Keeps focused polling at the established 2-minute backstop cadence. */
+export const USER_STATUS_REFETCH_INTERVAL_MS = 120_000;
+/** Suppresses the focus refetch until user-status data is genuinely stale.
+ * The live subscription (setQueriesData) is the primary freshness path. */
+export const USER_STATUS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+
 export function useUserStatusQuery(pubkeys: string[]) {
-  const refetchInterval = useFocusedRefetchInterval(120_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    USER_STATUS_REFETCH_INTERVAL_MS,
+  );
   const normalizedPubkeys = normalizePubkeys(pubkeys);
   const enabled = normalizedPubkeys.length > 0;
 
@@ -76,7 +84,7 @@ export function useUserStatusQuery(pubkeys: string[]) {
 
       return lookup;
     },
-    staleTime: 60_000,
+    staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/user-status/hooks.ts
+++ b/desktop/src/features/user-status/hooks.ts
@@ -44,6 +44,12 @@ export const USER_STATUS_REFETCH_INTERVAL_MS = 120_000;
  * The live subscription (setQueriesData) is the primary freshness path. */
 export const USER_STATUS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for the user-status query; consumed by focusRefetchPolicy.test.mjs. */
+export const userStatusFocusRefetchPolicy = {
+  staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export function useUserStatusQuery(pubkeys: string[]) {
   const refetchInterval = useFocusedRefetchInterval(
     USER_STATUS_REFETCH_INTERVAL_MS,
@@ -84,9 +90,8 @@ export function useUserStatusQuery(pubkeys: string[]) {
 
       return lookup;
     },
-    staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...userStatusFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -9,7 +9,7 @@ import {
 
 import {
   WORKFLOWS_FOCUS_STALE_TIME_MS,
-  RUN_APPROVALS_REFETCH_INTERVAL_MS,
+  WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
 } from "./hooks.ts";
 
 afterEach(() => {
@@ -48,10 +48,6 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   return fetchCount;
 }
 
-test("workflows: run-approvals polling constant is locked at 10 seconds", () => {
-  assert.equal(RUN_APPROVALS_REFETCH_INTERVAL_MS, 10_000);
-});
-
 test("workflows: skips fresh focus refetch", async () => {
   assert.equal(
     await focusRefetchCount({
@@ -67,6 +63,26 @@ test("workflows: refetches genuinely stale data on focus", async () => {
     await focusRefetchCount({
       ageMs: WORKFLOWS_FOCUS_STALE_TIME_MS + 1,
       staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});
+
+test("workflow-runs: skips focus refetch when data is fresh (< 10s)", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("workflow-runs: refetches on focus when data is stale (> 10s)", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS + 1,
+      staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
     }),
     1,
   );

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  focusManager,
+  QueryClient,
+  QueryObserver,
+} from "@tanstack/react-query";
+
+import {
+  WORKFLOWS_FOCUS_STALE_TIME_MS,
+  RUN_APPROVALS_REFETCH_INTERVAL_MS,
+} from "./hooks.ts";
+
+afterEach(() => {
+  focusManager.setFocused(undefined);
+});
+
+async function focusRefetchCount({ ageMs, staleTime }) {
+  focusManager.setFocused(false);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.mount();
+
+  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  queryClient.setQueryData(queryKey, "cached", {
+    updatedAt: Date.now() - ageMs,
+  });
+  let fetchCount = 0;
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    queryFn: async () => {
+      fetchCount += 1;
+      return "refetched";
+    },
+    refetchOnMount: false,
+    refetchOnWindowFocus: true,
+    staleTime,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+
+  focusManager.setFocused(true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  queryClient.unmount();
+  return fetchCount;
+}
+
+test("workflows: run-approvals polling constant is locked at 10 seconds", () => {
+  assert.equal(RUN_APPROVALS_REFETCH_INTERVAL_MS, 10_000);
+});
+
+test("workflows: skips fresh focus refetch", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: WORKFLOWS_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("workflows: refetches genuinely stale data on focus", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: WORKFLOWS_FOCUS_STALE_TIME_MS + 1,
+      staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -8,23 +8,23 @@ import {
 } from "@tanstack/react-query";
 
 import {
-  WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
-  WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
-  RUN_APPROVALS_FOCUS_STALE_TIME_MS,
+  workflowListFocusRefetchPolicy,
+  workflowRunsFocusRefetchPolicy,
+  runApprovalsFocusRefetchPolicy,
 } from "./hooks.ts";
 
 afterEach(() => {
   focusManager.setFocused(undefined);
 });
 
-async function focusRefetchCount({ ageMs, staleTime }) {
+async function focusRefetchCount({ ageMs, policy }) {
   focusManager.setFocused(false);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   queryClient.mount();
 
-  const queryKey = ["focus-refetch-policy", staleTime, ageMs];
+  const queryKey = ["focus-refetch-policy", policy.staleTime, ageMs];
   queryClient.setQueryData(queryKey, "cached", {
     updatedAt: Date.now() - ageMs,
   });
@@ -36,8 +36,7 @@ async function focusRefetchCount({ ageMs, staleTime }) {
       return "refetched";
     },
     refetchOnMount: false,
-    refetchOnWindowFocus: true,
-    staleTime,
+    ...policy,
   });
   const unsubscribe = observer.subscribe(() => {});
 
@@ -52,8 +51,8 @@ async function focusRefetchCount({ ageMs, staleTime }) {
 test("workflow-list: skips focus refetch when data is fresh (< 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOW_LIST_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
+      ageMs: workflowListFocusRefetchPolicy.staleTime - 1_000,
+      policy: workflowListFocusRefetchPolicy,
     }),
     0,
   );
@@ -62,8 +61,8 @@ test("workflow-list: skips focus refetch when data is fresh (< 10s)", async () =
 test("workflow-list: refetches on focus when data is stale (> 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOW_LIST_FOCUS_STALE_TIME_MS + 1,
-      staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
+      ageMs: workflowListFocusRefetchPolicy.staleTime + 1,
+      policy: workflowListFocusRefetchPolicy,
     }),
     1,
   );
@@ -72,8 +71,8 @@ test("workflow-list: refetches on focus when data is stale (> 10s)", async () =>
 test("workflow-runs: skips focus refetch when data is fresh (< 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+      ageMs: workflowRunsFocusRefetchPolicy.staleTime - 1_000,
+      policy: workflowRunsFocusRefetchPolicy,
     }),
     0,
   );
@@ -82,8 +81,8 @@ test("workflow-runs: skips focus refetch when data is fresh (< 10s)", async () =
 test("workflow-runs: refetches on focus when data is stale (> 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS + 1,
-      staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+      ageMs: workflowRunsFocusRefetchPolicy.staleTime + 1,
+      policy: workflowRunsFocusRefetchPolicy,
     }),
     1,
   );
@@ -92,8 +91,8 @@ test("workflow-runs: refetches on focus when data is stale (> 10s)", async () =>
 test("run-approvals: skips focus refetch when data is fresh (< 5 min)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: RUN_APPROVALS_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
+      ageMs: runApprovalsFocusRefetchPolicy.staleTime - 1_000,
+      policy: runApprovalsFocusRefetchPolicy,
     }),
     0,
   );
@@ -102,8 +101,8 @@ test("run-approvals: skips focus refetch when data is fresh (< 5 min)", async ()
 test("run-approvals: refetches on focus when data is stale (> 5 min)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: RUN_APPROVALS_FOCUS_STALE_TIME_MS + 1,
-      staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
+      ageMs: runApprovalsFocusRefetchPolicy.staleTime + 1,
+      policy: runApprovalsFocusRefetchPolicy,
     }),
     1,
   );

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -8,8 +8,9 @@ import {
 } from "@tanstack/react-query";
 
 import {
-  WORKFLOWS_FOCUS_STALE_TIME_MS,
+  WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
   WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+  RUN_APPROVALS_FOCUS_STALE_TIME_MS,
 } from "./hooks.ts";
 
 afterEach(() => {
@@ -48,21 +49,21 @@ async function focusRefetchCount({ ageMs, staleTime }) {
   return fetchCount;
 }
 
-test("workflows: skips fresh focus refetch", async () => {
+test("workflow-list: skips focus refetch when data is fresh (< 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOWS_FOCUS_STALE_TIME_MS - 1_000,
-      staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+      ageMs: WORKFLOW_LIST_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
     }),
     0,
   );
 });
 
-test("workflows: refetches genuinely stale data on focus", async () => {
+test("workflow-list: refetches on focus when data is stale (> 10s)", async () => {
   assert.equal(
     await focusRefetchCount({
-      ageMs: WORKFLOWS_FOCUS_STALE_TIME_MS + 1,
-      staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+      ageMs: WORKFLOW_LIST_FOCUS_STALE_TIME_MS + 1,
+      staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
     }),
     1,
   );
@@ -83,6 +84,26 @@ test("workflow-runs: refetches on focus when data is stale (> 10s)", async () =>
     await focusRefetchCount({
       ageMs: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS + 1,
       staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+    }),
+    1,
+  );
+});
+
+test("run-approvals: skips focus refetch when data is fresh (< 5 min)", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: RUN_APPROVALS_FOCUS_STALE_TIME_MS - 1_000,
+      staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
+    }),
+    0,
+  );
+});
+
+test("run-approvals: refetches on focus when data is stale (> 5 min)", async () => {
+  assert.equal(
+    await focusRefetchCount({
+      ageMs: RUN_APPROVALS_FOCUS_STALE_TIME_MS + 1,
+      staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
     }),
     1,
   );

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -18,10 +18,12 @@ import {
   updateWorkflow,
 } from "@/shared/api/tauriWorkflows";
 
-/** Suppresses focus refetches until workflow data is genuinely stale.
- * Channel workflows and run approvals have push-invalidation from mutations;
- * workflow runs poll when active (making the focus refetch redundant). */
-export const WORKFLOWS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+/** Stale gate for workflow list queries (useChannelWorkflowsQuery, allWorkflowsQuery).
+ * These queries have no poll and no relay push subscription; invalidateWorkflowListQueries
+ * only fires for mutations performed by this renderer, so remote workflow creates/edits/deletes
+ * surface only via refetch on focus return.  10 s suppresses rapid focus-flip burst refetches
+ * while keeping remote changes visible on the next focus return. */
+export const WORKFLOW_LIST_FOCUS_STALE_TIME_MS = 10_000;
 /** Keeps focused polling for run approvals at the established 10-second cadence. */
 export const RUN_APPROVALS_REFETCH_INTERVAL_MS = 10_000;
 /** Tighter stale gate for the workflow-runs detail query.
@@ -34,6 +36,10 @@ export const RUN_APPROVALS_REFETCH_INTERVAL_MS = 10_000;
  * 1 s poll alive until the run finishes, so the fix only matters for the
  * "no active runs" → "new remote run" transition.) */
 export const WORKFLOW_RUNS_FOCUS_STALE_TIME_MS = 10_000;
+/** Suppresses redundant focus refetches for the run-approvals query.
+ * The focused 10-second poll (RUN_APPROVALS_REFETCH_INTERVAL_MS) already keeps
+ * this data fresh; a focus return within 5 minutes adds no new information. */
+export const RUN_APPROVALS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
 export const allWorkflowsQueryKey = (channelIdKey: string) =>
   ["workflows-all", channelIdKey] as const;
@@ -70,7 +76,7 @@ export function useChannelWorkflowsQuery(channelId: string | null) {
     queryFn: ({ queryKey: [, resolvedChannelId] }) =>
       getChannelWorkflows(resolvedChannelId),
     enabled: channelId !== null,
-    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
   });
 }
@@ -117,7 +123,7 @@ export function useRunApprovalsQuery(
     queryFn: ({ queryKey: [, resolvedWorkflowId, resolvedRunId] }) =>
       getRunApprovals(resolvedWorkflowId, resolvedRunId),
     enabled: workflowId !== null && runId !== null,
-    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -41,6 +41,24 @@ export const WORKFLOW_RUNS_FOCUS_STALE_TIME_MS = 10_000;
  * this data fresh; a focus return within 5 minutes adds no new information. */
 export const RUN_APPROVALS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 
+/** Focus-refetch policy for workflow list queries; consumed by focusRefetchPolicy.test.mjs. */
+export const workflowListFocusRefetchPolicy = {
+  staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
+/** Focus-refetch policy for the workflow-runs query; consumed by focusRefetchPolicy.test.mjs. */
+export const workflowRunsFocusRefetchPolicy = {
+  staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
+/** Focus-refetch policy for the run-approvals query; consumed by focusRefetchPolicy.test.mjs. */
+export const runApprovalsFocusRefetchPolicy = {
+  staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
+  refetchOnWindowFocus: true,
+} as const;
+
 export const allWorkflowsQueryKey = (channelIdKey: string) =>
   ["workflows-all", channelIdKey] as const;
 export const workflowsQueryKey = (channelId: string) =>
@@ -76,8 +94,7 @@ export function useChannelWorkflowsQuery(channelId: string | null) {
     queryFn: ({ queryKey: [, resolvedChannelId] }) =>
       getChannelWorkflows(resolvedChannelId),
     enabled: channelId !== null,
-    staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
-    refetchOnWindowFocus: true,
+    ...workflowListFocusRefetchPolicy,
   });
 }
 
@@ -98,7 +115,6 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
       getWorkflowRuns(resolvedWorkflowId),
     enabled: workflowId !== null,
-    staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
     refetchInterval: (query) => {
       if (!appFocused) return false;
       const runs = query.state.data as WorkflowRun[] | undefined;
@@ -106,7 +122,7 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
         ? 1_000
         : false;
     },
-    refetchOnWindowFocus: true,
+    ...workflowRunsFocusRefetchPolicy,
   });
 }
 
@@ -123,9 +139,8 @@ export function useRunApprovalsQuery(
     queryFn: ({ queryKey: [, resolvedWorkflowId, resolvedRunId] }) =>
       getRunApprovals(resolvedWorkflowId, resolvedRunId),
     enabled: workflowId !== null && runId !== null,
-    staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    ...runApprovalsFocusRefetchPolicy,
   });
 }
 

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -24,6 +24,16 @@ import {
 export const WORKFLOWS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Keeps focused polling for run approvals at the established 10-second cadence. */
 export const RUN_APPROVALS_REFETCH_INTERVAL_MS = 10_000;
+/** Tighter stale gate for the workflow-runs detail query.
+ * The refetchInterval is conditional — 1 s while any run is active, false
+ * otherwise — so when there are no active runs the poll stops.  Remote-started
+ * runs (webhook / another user) do not push an invalidation, meaning a 5-min
+ * focus gate would leave the detail view stale for up to 5 minutes.  10 s
+ * restores the pre-PR behavior and surfaces remote starts quickly without
+ * excess load.  (Completed runs self-heal: the stale "active" cache keeps the
+ * 1 s poll alive until the run finishes, so the fix only matters for the
+ * "no active runs" → "new remote run" transition.) */
+export const WORKFLOW_RUNS_FOCUS_STALE_TIME_MS = 10_000;
 
 export const allWorkflowsQueryKey = (channelIdKey: string) =>
   ["workflows-all", channelIdKey] as const;
@@ -82,7 +92,7 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
       getWorkflowRuns(resolvedWorkflowId),
     enabled: workflowId !== null,
-    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
     refetchInterval: (query) => {
       if (!appFocused) return false;
       const runs = query.state.data as WorkflowRun[] | undefined;

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -18,6 +18,13 @@ import {
   updateWorkflow,
 } from "@/shared/api/tauriWorkflows";
 
+/** Suppresses focus refetches until workflow data is genuinely stale.
+ * Channel workflows and run approvals have push-invalidation from mutations;
+ * workflow runs poll when active (making the focus refetch redundant). */
+export const WORKFLOWS_FOCUS_STALE_TIME_MS = 5 * 60_000;
+/** Keeps focused polling for run approvals at the established 10-second cadence. */
+export const RUN_APPROVALS_REFETCH_INTERVAL_MS = 10_000;
+
 export const allWorkflowsQueryKey = (channelIdKey: string) =>
   ["workflows-all", channelIdKey] as const;
 export const workflowsQueryKey = (channelId: string) =>
@@ -53,7 +60,7 @@ export function useChannelWorkflowsQuery(channelId: string | null) {
     queryFn: ({ queryKey: [, resolvedChannelId] }) =>
       getChannelWorkflows(resolvedChannelId),
     enabled: channelId !== null,
-    staleTime: 30_000,
+    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
   });
 }
@@ -75,7 +82,7 @@ export function useWorkflowRunsQuery(workflowId: string | null) {
     queryFn: ({ queryKey: [, resolvedWorkflowId] }) =>
       getWorkflowRuns(resolvedWorkflowId),
     enabled: workflowId !== null,
-    staleTime: 10_000,
+    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
     refetchInterval: (query) => {
       if (!appFocused) return false;
       const runs = query.state.data as WorkflowRun[] | undefined;
@@ -91,14 +98,16 @@ export function useRunApprovalsQuery(
   workflowId: string | null,
   runId: string | null,
 ) {
-  const refetchInterval = useFocusedRefetchInterval(10_000);
+  const refetchInterval = useFocusedRefetchInterval(
+    RUN_APPROVALS_REFETCH_INTERVAL_MS,
+  );
 
   return useQuery({
     queryKey: runApprovalsQueryKey(workflowId ?? "", runId ?? ""),
     queryFn: ({ queryKey: [, resolvedWorkflowId, resolvedRunId] }) =>
       getRunApprovals(resolvedWorkflowId, resolvedRunId),
     enabled: workflowId !== null && runId !== null,
-    staleTime: 10_000,
+    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
     refetchInterval,
     refetchOnWindowFocus: true,
   });

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   allWorkflowsQueryKey,
-  WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
+  workflowListFocusRefetchPolicy,
 } from "@/features/workflows/hooks";
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDeleteDialog } from "@/features/workflows/ui/WorkflowDeleteDialog";
@@ -104,8 +104,7 @@ export function WorkflowsView({
       return results;
     },
     enabled: memberChannels.length > 0,
-    staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
-    refetchOnWindowFocus: true,
+    ...workflowListFocusRefetchPolicy,
   });
 
   const allWorkflows = allWorkflowsQuery.data ?? [];

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   allWorkflowsQueryKey,
-  WORKFLOWS_FOCUS_STALE_TIME_MS,
+  WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
 } from "@/features/workflows/hooks";
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDeleteDialog } from "@/features/workflows/ui/WorkflowDeleteDialog";
@@ -104,7 +104,7 @@ export function WorkflowsView({
       return results;
     },
     enabled: memberChannels.length > 0,
-    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
+    staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
   });
 

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -2,7 +2,10 @@ import { Plus, RefreshCw, Zap } from "lucide-react";
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { allWorkflowsQueryKey } from "@/features/workflows/hooks";
+import {
+  allWorkflowsQueryKey,
+  WORKFLOWS_FOCUS_STALE_TIME_MS,
+} from "@/features/workflows/hooks";
 import { WorkflowCard } from "@/features/workflows/ui/WorkflowCard";
 import { WorkflowDeleteDialog } from "@/features/workflows/ui/WorkflowDeleteDialog";
 import { WorkflowDetailPanel } from "@/features/workflows/ui/WorkflowDetailPanel";
@@ -101,7 +104,7 @@ export function WorkflowsView({
       return results;
     },
     enabled: memberChannels.length > 0,
-    staleTime: 30_000,
+    staleTime: WORKFLOWS_FOCUS_STALE_TIME_MS,
     refetchOnWindowFocus: true,
   });
 

--- a/desktop/src/shared/api/tauriChannels.ts
+++ b/desktop/src/shared/api/tauriChannels.ts
@@ -32,6 +32,22 @@ export type RawChannel = {
   ttl_deadline: string | null;
 };
 
+/**
+ * Response payload for the `get_channels` Tauri command.
+ *
+ * When `channels` is `null`, the caller's `knownHash` matched the relay
+ * snapshot and the expensive channel list was not re-serialized across IPC.
+ * `lastMessages` is always present so the caller can update sidebar
+ * timestamps without a full channel-list re-render.
+ */
+export type GetChannelsPayload = {
+  hash: string;
+  /** Full channel list, or `null` on a not-modified (hash-match) response. */
+  channels: Channel[] | null;
+  /** Map of channel id → ISO-8601 timestamp of its most recent message. */
+  lastMessages: Record<string, string>;
+};
+
 type RawChannelDetail = RawChannel & {
   created_by: string;
   created_at: string;
@@ -105,9 +121,27 @@ function fromRawChannelMember(member: RawChannelMember): ChannelMember {
   };
 }
 
-export async function getChannels(): Promise<Channel[]> {
-  const channels = await invokeTauri<RawChannel[]>("get_channels");
-  return channels.map(fromRawChannel);
+/**
+ * Fetch the channel list from the backend.
+ *
+ * Pass `knownHash` from a previous response to enable the not-modified
+ * short-circuit: when the relay snapshot is unchanged, `channels` in the
+ * returned payload will be `null` so the multi-MB list is not deserialized.
+ * Pass `null` to always request the full list.
+ */
+export async function getChannels(
+  knownHash: string | null,
+): Promise<GetChannelsPayload> {
+  const raw = await invokeTauri<{
+    hash: string;
+    channels: RawChannel[] | null;
+    last_messages: Record<string, string>;
+  }>("get_channels", { knownHash });
+  return {
+    hash: raw.hash,
+    channels: raw.channels !== null ? raw.channels.map(fromRawChannel) : null,
+    lastMessages: raw.last_messages,
+  };
 }
 
 export async function createChannel(

--- a/desktop/src/shared/lib/localStorageSweep.test.mjs
+++ b/desktop/src/shared/lib/localStorageSweep.test.mjs
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  BOOT_SWEEP_FLOOR_MS,
   LOCAL_STORAGE_SWEEP_RULES,
+  SWEEP_CHUNK_ENTRY_BUDGET,
+  SWEEP_FALLBACK_TIMER_MS,
+  SWEEP_IDLE_TIMEOUT_MS,
   startLocalStorageSweep,
   sweepStaleLocalStorage,
 } from "./localStorageSweep.ts";
@@ -136,17 +140,9 @@ test("storage access failures warn and never escape", () => {
 });
 
 test("scheduler setup failures warn and never escape startup", () => {
-  const originalDocument = globalThis.document;
   const originalWarn = console.warn;
   const warnings = [];
   console.warn = (...args) => warnings.push(args);
-  globalThis.document = {
-    addEventListener() {
-      throw new Error("listener unavailable");
-    },
-    removeEventListener() {},
-    visibilityState: "visible",
-  };
   installWindow(makeLocalStorage(), {
     clearInterval() {},
     setInterval() {
@@ -163,29 +159,23 @@ test("scheduler setup failures warn and never escape startup", () => {
     assert.equal(warnings.length, 1);
   } finally {
     console.warn = originalWarn;
-    globalThis.document = originalDocument;
   }
 });
 
-test("scheduler uses a deferred timer when requestIdleCallback is unavailable", () => {
-  const originalDocument = globalThis.document;
+test("fallback path: boot-floor setTimeout fires first, then per-slice setTimeout processes entries", () => {
   const originalSetTimeout = globalThis.setTimeout;
   const originalClearTimeout = globalThis.clearTimeout;
-  const documentTarget = new EventTarget();
-  Object.defineProperty(documentTarget, "visibilityState", {
-    value: "visible",
-  });
-  globalThis.document = documentTarget;
 
   const timeouts = new Map();
-  let nextTimeoutId = 50;
+  let nextId = 50;
   globalThis.setTimeout = (callback, delay) => {
-    const id = nextTimeoutId++;
+    const id = nextId++;
     timeouts.set(id, { callback, delay });
     return id;
   };
   globalThis.clearTimeout = (id) => timeouts.delete(id);
 
+  // Stale entry with updatedAt=0 (older than any 14-day TTL)
   const localStorage = makeLocalStorage([
     ["buzz-channel-messages.v1:startup", snapshot(0)],
   ]);
@@ -196,47 +186,69 @@ test("scheduler uses a deferred timer when requestIdleCallback is unavailable", 
 
   const stop = startLocalStorageSweep();
   try {
+    // One boot-floor timer scheduled; no sweep yet.
+    assert.equal(timeouts.size, 1);
+    const [bootId, bootEntry] = [...timeouts.entries()][0];
+    assert.equal(bootEntry.delay, BOOT_SWEEP_FLOOR_MS);
     assert.notEqual(
       localStorage.getItem("buzz-channel-messages.v1:startup"),
       null,
+      "sweep must not run before boot floor",
     );
-    const [{ callback, delay }] = timeouts.values();
-    assert.equal(delay, 250);
-    callback();
+
+    // Fire boot timer — sweepChunked snapshots keys and schedules a slice.
+    timeouts.delete(bootId);
+    bootEntry.callback();
+
+    // One per-slice fallback timer now pending; still no removal.
+    assert.equal(timeouts.size, 1);
+    const [, sliceEntry] = [...timeouts.entries()][0];
+    assert.equal(sliceEntry.delay, SWEEP_FALLBACK_TIMER_MS);
+    assert.notEqual(
+      localStorage.getItem("buzz-channel-messages.v1:startup"),
+      null,
+      "sweep must not run before slice fires",
+    );
+
+    // Fire slice — stale entry removed.
+    sliceEntry.callback();
     assert.equal(
       localStorage.getItem("buzz-channel-messages.v1:startup"),
       null,
+      "stale entry removed after slice fires",
     );
   } finally {
     stop();
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
-    globalThis.document = originalDocument;
   }
-  assert.equal(timeouts.size, 0);
 });
 
-test("scheduler sweeps after idle, on debounced visibility, and hourly", () => {
+test("scheduler: boot-floor gate, idle callback with SWEEP_IDLE_TIMEOUT_MS, hourly interval, no visibilitychange listener", () => {
   const originalNow = Date.now;
-  const originalDocument = globalThis.document;
-  let now = 100 * DAY_MS;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const now = 100 * DAY_MS;
   Date.now = () => now;
-
-  const documentTarget = new EventTarget();
-  Object.defineProperty(documentTarget, "visibilityState", {
-    configurable: true,
-    value: "visible",
-    writable: true,
-  });
-  globalThis.document = documentTarget;
 
   const intervals = new Map();
   const idleCallbacks = new Map();
-  const cancelledIdleCallbacks = [];
   let nextIntervalId = 1;
   let nextIdleId = 100;
+
+  // Capture the boot setTimeout.
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 9999;
+  };
+  globalThis.clearTimeout = () => {};
+
+  // Track visibilitychange listeners to assert none are registered.
+  const visibilityListeners = [];
+
   const localStorage = makeLocalStorage([
-    ["buzz-channel-messages.v1:startup", snapshot(now - 14 * DAY_MS)],
+    ["buzz-channel-messages.v1:stale", snapshot(now - 14 * DAY_MS)],
   ]);
   installWindow(localStorage, {
     requestIdleCallback(callback, options) {
@@ -245,7 +257,6 @@ test("scheduler sweeps after idle, on debounced visibility, and hourly", () => {
       return id;
     },
     cancelIdleCallback(id) {
-      cancelledIdleCallbacks.push(id);
       idleCallbacks.delete(id);
     },
     setInterval(callback, delay) {
@@ -255,62 +266,218 @@ test("scheduler sweeps after idle, on debounced visibility, and hourly", () => {
     },
     clearInterval: (id) => intervals.delete(id),
   });
+  globalThis.document = {
+    addEventListener(event, fn) {
+      if (event === "visibilitychange") visibilityListeners.push(fn);
+    },
+    removeEventListener() {},
+    visibilityState: "visible",
+  };
 
-  let idleId;
   const stop = startLocalStorageSweep();
   try {
+    // Boot floor: no idle callbacks before the boot timer fires.
+    assert.equal(idleCallbacks.size, 0, "no idle callback before boot floor");
+    assert.equal(visibilityListeners.length, 0, "no visibilitychange listener");
     assert.notEqual(
-      localStorage.getItem("buzz-channel-messages.v1:startup"),
+      localStorage.getItem("buzz-channel-messages.v1:stale"),
       null,
-      "initial sweep must not run synchronously on the boot path",
+      "sweep not run before boot floor",
     );
-    assert.equal(idleCallbacks.size, 1);
-    const idleEntry = idleCallbacks.entries().next().value;
-    idleId = idleEntry[0];
-    const { callback: idleCallback, options } = idleEntry[1];
-    assert.equal(options.timeout, 1_500);
-    idleCallback();
+
+    // Fire boot timer — sweepChunked schedules first idle callback.
+    assert.ok(bootCallback, "boot timer was registered");
+    bootCallback();
+    assert.equal(idleCallbacks.size, 1, "idle callback scheduled after boot");
+    const [firstId, firstEntry] = [...idleCallbacks.entries()][0];
     assert.equal(
-      localStorage.getItem("buzz-channel-messages.v1:startup"),
-      null,
+      firstEntry.options.timeout,
+      SWEEP_IDLE_TIMEOUT_MS,
+      "idle callback uses SWEEP_IDLE_TIMEOUT_MS, not a forcing 1500ms",
     );
+
+    // Fire idle callback with ample time remaining — sweep completes in one slice.
+    firstEntry.callback({ timeRemaining: () => 50 });
+    idleCallbacks.delete(firstId);
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:stale"),
+      null,
+      "stale entry removed after idle callback fires",
+    );
+
+    // Hourly interval is registered.
     assert.equal(intervals.size, 1);
-    const [{ callback, delay }] = intervals.values();
+    const [{ callback: intervalCallback, delay }] = intervals.values();
     assert.equal(delay, 60 * 60 * 1_000);
 
-    localStorage.setItem(
-      "buzz-channel-messages.v1:visibility",
-      snapshot(now - 14 * DAY_MS),
-    );
-    now += 60 * 1_000;
-    documentTarget.dispatchEvent(new Event("visibilitychange"));
-    assert.notEqual(
-      localStorage.getItem("buzz-channel-messages.v1:visibility"),
-      null,
-    );
-
-    now += 5 * 60 * 1_000;
-    documentTarget.dispatchEvent(new Event("visibilitychange"));
-    assert.equal(
-      localStorage.getItem("buzz-channel-messages.v1:visibility"),
-      null,
-    );
-
+    // Hourly fires — schedules another idle callback sweep.
     localStorage.setItem(
       "buzz-channel-messages.v1:interval",
       snapshot(now - 14 * DAY_MS),
     );
-    now += 60 * 60 * 1_000;
-    callback();
+    intervalCallback();
+    assert.equal(
+      idleCallbacks.size,
+      1,
+      "idle callback scheduled for hourly sweep",
+    );
+    const hourlyEntry = [...idleCallbacks.values()][0];
+    hourlyEntry.callback({ timeRemaining: () => 50 });
     assert.equal(
       localStorage.getItem("buzz-channel-messages.v1:interval"),
       null,
+      "hourly sweep removes stale entry",
+    );
+
+    // Visibility change does NOT trigger sweep — listener was never registered.
+    localStorage.setItem(
+      "buzz-channel-messages.v1:vis",
+      snapshot(now - 14 * DAY_MS),
+    );
+    assert.equal(
+      visibilityListeners.length,
+      0,
+      "visibilitychange listener absent",
+    );
+    assert.notEqual(
+      localStorage.getItem("buzz-channel-messages.v1:vis"),
+      null,
+      "visibility change does not trigger sweep",
     );
   } finally {
     stop();
     Date.now = originalNow;
-    globalThis.document = originalDocument;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    globalThis.document = undefined;
   }
-  assert.equal(intervals.size, 0);
-  assert.deepEqual(cancelledIdleCallbacks, [idleId]);
+});
+
+test("chunked sweep: keys processed across multiple idle slices; stale entries removed only at end", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  const idleCallbacks = [];
+  const now = 100 * DAY_MS;
+
+  // Create more entries than SWEEP_CHUNK_ENTRY_BUDGET so multiple slices fire.
+  const entryCount = SWEEP_CHUNK_ENTRY_BUDGET + 5;
+  const entries = Array.from({ length: entryCount }, (_, i) => [
+    `buzz-channel-messages.v1:key-${i}`,
+    snapshot(now - 14 * DAY_MS), // all stale
+  ]);
+  const localStorage = makeLocalStorage(entries);
+
+  installWindow(localStorage, {
+    requestIdleCallback(callback, _options) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    cancelIdleCallback() {},
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    // Fire boot timer.
+    assert.ok(bootCallback);
+    bootCallback();
+
+    // First idle callback scheduled — fire it with zero time remaining so it
+    // processes exactly SWEEP_CHUNK_ENTRY_BUDGET entries and reschedules.
+    assert.equal(idleCallbacks.length, 1, "first idle callback scheduled");
+    idleCallbacks[0]({ timeRemaining: () => 0 });
+
+    // With zero time remaining the slice stops at SWEEP_CHUNK_ENTRY_BUDGET
+    // entries; stale keys not yet removed (second slice pending).
+    const removedAfterFirst = entries.filter(
+      ([key]) => localStorage.getItem(key) === null,
+    ).length;
+    assert.equal(
+      removedAfterFirst,
+      0,
+      "no keys removed until all slices complete",
+    );
+
+    // A second idle callback was scheduled for the remaining entries.
+    assert.equal(idleCallbacks.length, 2, "second idle callback scheduled");
+    idleCallbacks[1]({ timeRemaining: () => 50 }); // ample time — completes all
+
+    // All stale keys now removed.
+    const remaining = entries.filter(
+      ([key]) => localStorage.getItem(key) !== null,
+    );
+    assert.equal(
+      remaining.length,
+      0,
+      "all stale entries removed after final slice",
+    );
+  } finally {
+    stop();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("chunked sweep: keys deleted between snapshot and slice are silently skipped", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  const idleCallbacks = [];
+  // Use real Date.now() so timestamps are relative to the actual clock.
+  const now = Date.now();
+
+  const localStorage = makeLocalStorage([
+    ["buzz-channel-messages.v1:gone", snapshot(now - 14 * DAY_MS)],
+    ["buzz-channel-messages.v1:fresh", snapshot(now - DAY_MS)],
+  ]);
+
+  installWindow(localStorage, {
+    requestIdleCallback(callback, _options) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    cancelIdleCallback() {},
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    bootCallback();
+    assert.equal(idleCallbacks.length, 1);
+
+    // Delete "gone" externally before the slice fires.
+    localStorage.store.delete("buzz-channel-messages.v1:gone");
+
+    // Slice processes — should not throw on missing key.
+    assert.doesNotThrow(() => {
+      idleCallbacks[0]({ timeRemaining: () => 50 });
+    });
+
+    // "fresh" key untouched.
+    assert.notEqual(
+      localStorage.getItem("buzz-channel-messages.v1:fresh"),
+      null,
+    );
+  } finally {
+    stop();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
 });

--- a/desktop/src/shared/lib/localStorageSweep.test.mjs
+++ b/desktop/src/shared/lib/localStorageSweep.test.mjs
@@ -7,6 +7,7 @@ import {
   SWEEP_CHUNK_ENTRY_BUDGET,
   SWEEP_FALLBACK_TIMER_MS,
   SWEEP_IDLE_TIMEOUT_MS,
+  SWEEP_LARGE_VALUE_DEFER_BYTES,
   startLocalStorageSweep,
   sweepStaleLocalStorage,
 } from "./localStorageSweep.ts";
@@ -392,12 +393,12 @@ test("chunked sweep: keys processed across multiple idle slices; stale entries r
     bootCallback();
 
     // First idle callback scheduled — fire it with zero time remaining so it
-    // processes exactly SWEEP_CHUNK_ENTRY_BUDGET entries and reschedules.
+    // processes exactly one entry (min-progress guarantee) and reschedules.
     assert.equal(idleCallbacks.length, 1, "first idle callback scheduled");
     idleCallbacks[0]({ timeRemaining: () => 0 });
 
-    // With zero time remaining the slice stops at SWEEP_CHUNK_ENTRY_BUDGET
-    // entries; stale keys not yet removed (second slice pending).
+    // With zero time remaining the slice stops after one entry;
+    // stale keys not yet removed (second slice pending).
     const removedAfterFirst = entries.filter(
       ([key]) => localStorage.getItem(key) === null,
     ).length;
@@ -474,6 +475,323 @@ test("chunked sweep: keys deleted between snapshot and slice are silently skippe
     assert.notEqual(
       localStorage.getItem("buzz-channel-messages.v1:fresh"),
       null,
+    );
+  } finally {
+    stop();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+// --- New hardening tests ---
+
+test("chunked sweep: key rewritten fresh before batch removal is not removed", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  const idleCallbacks = [];
+  const now = Date.now();
+
+  const staleValue = JSON.stringify({
+    updatedAt: now - 14 * DAY_MS,
+    payload: "old",
+  });
+  const freshValue = JSON.stringify({
+    updatedAt: now - DAY_MS,
+    payload: "new",
+  });
+
+  // "target" will be rewritten fresh between slices; "other" stays stale.
+  // Two entries force two slices when timeRemaining() === 0 (1 entry per slice).
+  const localStorage = makeLocalStorage([
+    ["buzz-channel-messages.v1:target", staleValue],
+    ["buzz-channel-messages.v1:other", staleValue],
+  ]);
+
+  installWindow(localStorage, {
+    requestIdleCallback(callback, _options) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    cancelIdleCallback() {},
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    bootCallback();
+    assert.equal(idleCallbacks.length, 1);
+
+    // Slice 1: zero budget → processes exactly one entry ("target", judged stale).
+    idleCallbacks[0]({ timeRemaining: () => 0 });
+
+    // App rewrites "target" to a fresh value before slice 2 fires.
+    localStorage.setItem("buzz-channel-messages.v1:target", freshValue);
+
+    assert.equal(idleCallbacks.length, 2, "second slice scheduled");
+
+    // Slice 2: processes "other", then batch-removes. Re-check on "target"
+    // finds it fresh — must not be removed.
+    idleCallbacks[1]({ timeRemaining: () => 50 });
+
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:target"),
+      freshValue,
+      "key rewritten fresh before batch removal must not be removed",
+    );
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:other"),
+      null,
+      "still-stale key must be removed",
+    );
+  } finally {
+    stop();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("chunked sweep: getItem error on one key does not abort sweep; stale siblings still removed", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  const idleCallbacks = [];
+  const now = Date.now();
+
+  const localStorage = makeLocalStorage([
+    ["buzz-channel-messages.v1:error-key", "value"],
+    ["buzz-channel-messages.v1:stale-key", snapshot(now - 14 * DAY_MS)],
+    ["buzz-channel-messages.v1:fresh-key", snapshot(now - DAY_MS)],
+  ]);
+
+  // Override getItem so that reading "error-key" throws.
+  const realGetItem = localStorage.getItem.bind(localStorage);
+  localStorage.getItem = (key) => {
+    if (key === "buzz-channel-messages.v1:error-key") {
+      throw new Error("storage error");
+    }
+    return realGetItem(key);
+  };
+
+  installWindow(localStorage, {
+    requestIdleCallback(callback, _options) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    cancelIdleCallback() {},
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    bootCallback();
+    assert.equal(idleCallbacks.length, 1);
+
+    // Fire with ample time — all entries processed in one slice.
+    idleCallbacks[0]({ timeRemaining: () => 50 });
+
+    // Stale key removed despite the per-key error on its sibling.
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:stale-key"),
+      null,
+      "stale-key must be removed despite error on error-key",
+    );
+    // Fresh key untouched.
+    assert.notEqual(
+      localStorage.getItem("buzz-channel-messages.v1:fresh-key"),
+      null,
+      "fresh-key must not be removed",
+    );
+    // Exactly one warning emitted for the failing key.
+    const sweepWarnings = warnings.filter((w) =>
+      String(w[0]).includes("[localStorageSweep]"),
+    );
+    assert.equal(
+      sweepWarnings.length,
+      1,
+      "exactly one warning per sweep for key errors",
+    );
+  } finally {
+    stop();
+    console.warn = originalWarn;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("fallback path: multiple slices when entries exceed SWEEP_CHUNK_ENTRY_BUDGET; sweep converges", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  const timeouts = [];
+  let nextId = 200;
+  globalThis.setTimeout = (callback, delay) => {
+    const id = nextId++;
+    timeouts.push({ id, callback, delay });
+    return id;
+  };
+  globalThis.clearTimeout = (id) => {
+    const idx = timeouts.findIndex((t) => t.id === id);
+    if (idx !== -1) timeouts.splice(idx, 1);
+  };
+
+  const now = Date.now();
+  const entryCount = SWEEP_CHUNK_ENTRY_BUDGET + 5;
+  const entries = Array.from({ length: entryCount }, (_, i) => [
+    `buzz-channel-messages.v1:key-${i}`,
+    snapshot(now - 14 * DAY_MS), // all stale
+  ]);
+  const localStorage = makeLocalStorage(entries);
+
+  // No requestIdleCallback on window → forces fallback path.
+  installWindow(localStorage, {
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    // Boot timer registered.
+    const bootTimer = timeouts.find((t) => t.delay === BOOT_SWEEP_FLOOR_MS);
+    assert.ok(bootTimer, "boot timer registered");
+    timeouts.splice(timeouts.indexOf(bootTimer), 1);
+    bootTimer.callback();
+
+    // Process all per-slice timers until no more are scheduled.
+    let slicesProcessed = 0;
+    const MAX_SLICES = 20;
+    while (slicesProcessed < MAX_SLICES) {
+      const sliceTimer = timeouts.find(
+        (t) => t.delay === SWEEP_FALLBACK_TIMER_MS,
+      );
+      if (!sliceTimer) break;
+      timeouts.splice(timeouts.indexOf(sliceTimer), 1);
+      sliceTimer.callback();
+      slicesProcessed++;
+    }
+
+    // entryCount > SWEEP_CHUNK_ENTRY_BUDGET → at least 2 slices required.
+    assert.ok(
+      slicesProcessed >= 2,
+      `expected ≥2 slices, got ${slicesProcessed}`,
+    );
+
+    // All stale entries removed.
+    const remaining = entries.filter(
+      ([key]) => localStorage.getItem(key) !== null,
+    );
+    assert.equal(
+      remaining.length,
+      0,
+      "all stale entries must be removed via fallback path",
+    );
+  } finally {
+    stop();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("chunked sweep: large values deferred once on zero-budget slices then parsed; converges when all values are large", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  let bootCallback = null;
+  globalThis.setTimeout = (callback, _delay) => {
+    bootCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  const idleCallbacks = [];
+  const now = Date.now();
+
+  // Build values exceeding SWEEP_LARGE_VALUE_DEFER_BYTES with a valid updatedAt.
+  const largePayload = "x".repeat(SWEEP_LARGE_VALUE_DEFER_BYTES + 1);
+  const largeStaleValue = JSON.stringify({
+    updatedAt: now - 14 * DAY_MS,
+    payload: largePayload,
+  });
+  assert.ok(
+    largeStaleValue.length > SWEEP_LARGE_VALUE_DEFER_BYTES,
+    "test value must exceed the defer threshold",
+  );
+
+  const localStorage = makeLocalStorage([
+    ["buzz-channel-messages.v1:large-a", largeStaleValue],
+    ["buzz-channel-messages.v1:large-b", largeStaleValue],
+  ]);
+
+  installWindow(localStorage, {
+    requestIdleCallback(callback, _options) {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    },
+    cancelIdleCallback() {},
+    setInterval: () => 1,
+    clearInterval() {},
+  });
+
+  const stop = startLocalStorageSweep();
+  try {
+    bootCallback();
+    assert.equal(idleCallbacks.length, 1, "first slice scheduled after boot");
+
+    // Slice 0 (zero budget): large-a is deferred (not yet parsed).
+    idleCallbacks[0]({ timeRemaining: () => 0 });
+    assert.notEqual(
+      localStorage.getItem("buzz-channel-messages.v1:large-a"),
+      null,
+      "large-a must not be removed after first slice (deferred)",
+    );
+    assert.ok(
+      idleCallbacks.length >= 2,
+      "second slice scheduled after deferral",
+    );
+
+    // Fire remaining slices with zero budget until sweep converges.
+    // Worst-case: 2 defer slices (one per key) + 2 parse slices = 4 total.
+    const MAX_SLICES = 20;
+    let sliceCount = 1; // slice 0 already fired
+    while (sliceCount < MAX_SLICES && idleCallbacks.length > sliceCount) {
+      idleCallbacks[sliceCount]({ timeRemaining: () => 0 });
+      sliceCount++;
+    }
+
+    // Both large stale entries must be removed after convergence.
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:large-a"),
+      null,
+      "large-a must be removed after convergence",
+    );
+    assert.equal(
+      localStorage.getItem("buzz-channel-messages.v1:large-b"),
+      null,
+      "large-b must be removed after convergence",
+    );
+    // Sweep converged in a bounded number of slices (≤ 2 * number of keys).
+    assert.ok(
+      sliceCount <= MAX_SLICES,
+      `sweep did not converge within ${MAX_SLICES} slices`,
     );
   } finally {
     stop();

--- a/desktop/src/shared/lib/localStorageSweep.ts
+++ b/desktop/src/shared/lib/localStorageSweep.ts
@@ -8,9 +8,21 @@
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const SWEEP_INTERVAL_MS = 60 * 60 * 1_000;
-const SWEEP_DEBOUNCE_MS = 5 * 60 * 1_000;
-const INITIAL_SWEEP_FALLBACK_MS = 250;
-const INITIAL_SWEEP_IDLE_TIMEOUT_MS = 1_500;
+/** Minimum time after app boot before the first sweep begins. */
+export const BOOT_SWEEP_FLOOR_MS = 30_000;
+/**
+ * Generous idle-callback ceiling. Unlike the original 1 500 ms value this is
+ * not a forcing timeout that lands during busy startup — the browser schedules
+ * the callback when the main thread is genuinely idle.
+ */
+export const SWEEP_IDLE_TIMEOUT_MS = 60_000;
+/** Per-slice setTimeout delay in environments without requestIdleCallback. */
+export const SWEEP_FALLBACK_TIMER_MS = 250;
+/**
+ * Maximum number of localStorage entries to parse per chunk when an
+ * IdleDeadline is unavailable (rIC-free fallback path).
+ */
+export const SWEEP_CHUNK_ENTRY_BUDGET = 20;
 
 type LocalStorageSweepRule = {
   keyPrefix: string;
@@ -69,6 +81,9 @@ function updatedAtFromJson(value: string): number | null {
  * Removes whitelisted cache entries older than their configured TTL.
  * Entries without a trustworthy `updatedAt` are left alone rather than guessed
  * stale. Storage and parse failures never escape into app startup.
+ *
+ * This synchronous form is preserved for direct test use. The scheduler calls
+ * sweepChunked instead, which splits the same work across idle-time slices.
  */
 export function sweepStaleLocalStorage(now = Date.now()): number {
   let removed = 0;
@@ -103,53 +118,129 @@ export function sweepStaleLocalStorage(now = Date.now()): number {
   return removed;
 }
 
+type SliceCallback = (deadline?: { timeRemaining(): number }) => void;
+
+function scheduleSlice(fn: SliceCallback): void {
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(fn as IdleRequestCallback, {
+      timeout: SWEEP_IDLE_TIMEOUT_MS,
+    });
+  } else {
+    globalThis.setTimeout(fn, SWEEP_FALLBACK_TIMER_MS);
+  }
+}
+
 /**
- * Defers the first sweep until the browser is idle (or a short timer fallback),
- * then sweeps hourly while the app remains open and when a hidden app becomes
- * visible. Visibility sweeps are debounced to avoid repeated work from rapid
- * focus changes. Returns a cleanup function for tests or future teardown.
+ * Snapshots matching key names synchronously (cheap — no parsing), then
+ * processes entries across successive idle-time slices. Keys removed between
+ * the snapshot and their slice are silently skipped via a re-getItem check.
+ *
+ * `isAlive` is checked at the start of each slice; returning false aborts
+ * further processing without removing accumulated stale keys.
  */
-export function startLocalStorageSweep(): () => void {
-  let lastSweepAt = Number.NEGATIVE_INFINITY;
-  let listening = false;
-  let intervalId: ReturnType<typeof window.setInterval> | null = null;
-  let idleCallbackId: number | null = null;
-  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
-  const runIfDue = () => {
-    const now = Date.now();
-    if (now - lastSweepAt < SWEEP_DEBOUNCE_MS) return;
-    lastSweepAt = now;
-    sweepStaleLocalStorage(now);
-  };
-  const onVisibilityChange = () => {
-    if (document.visibilityState === "visible") runIfDue();
+function sweepChunked(now: number, isAlive: () => boolean): void {
+  // Step 1: cheap key-only snapshot — no getItem, no parsing.
+  let pendingKeys: string[];
+  try {
+    const storage = window.localStorage;
+    pendingKeys = [];
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (!key) continue;
+      if (LOCAL_STORAGE_SWEEP_RULES.some((r) => key.startsWith(r.keyPrefix))) {
+        pendingKeys.push(key);
+      }
+    }
+  } catch (err) {
+    console.warn("[localStorageSweep] key snapshot failed:", err);
+    return;
+  }
+
+  if (!pendingKeys.length) return;
+
+  const staleKeys: string[] = [];
+  let pos = 0;
+
+  // Step 2: parse entries in idle-time slices; reschedule until all done.
+  const processSlice: SliceCallback = (deadline) => {
+    if (!isAlive()) return;
+    try {
+      const storage = window.localStorage;
+      const sliceStart = pos;
+      while (pos < pendingKeys.length) {
+        // Always process at least one entry per slice: a timeout-fired idle
+        // callback reports timeRemaining() === 0, and breaking before any
+        // progress would reschedule forever on a persistently busy thread.
+        const processedInSlice = pos - sliceStart;
+        if (deadline && processedInSlice > 0 && deadline.timeRemaining() <= 0) {
+          break;
+        }
+        if (!deadline && processedInSlice >= SWEEP_CHUNK_ENTRY_BUDGET) break;
+        const key = pendingKeys[pos++];
+        const value = storage.getItem(key);
+        if (value === null) continue; // deleted since snapshot — skip
+        const rule = LOCAL_STORAGE_SWEEP_RULES.find((r) =>
+          key.startsWith(r.keyPrefix),
+        );
+        if (!rule) continue;
+        const updatedAt = updatedAtFromJson(value);
+        if (updatedAt !== null && updatedAt <= now - rule.maxAgeMs) {
+          staleKeys.push(key);
+        }
+      }
+
+      if (pos < pendingKeys.length) {
+        scheduleSlice(processSlice);
+        return;
+      }
+
+      // All entries processed — batch-remove stale keys.
+      for (const key of staleKeys) {
+        try {
+          storage.removeItem(key);
+        } catch {
+          // Non-fatal: key may have been concurrently removed by another tab.
+        }
+      }
+    } catch (err) {
+      console.warn("[localStorageSweep] stale cache cleanup failed:", err);
+    }
   };
 
+  scheduleSlice(processSlice);
+}
+
+/**
+ * Schedules background sweeps:
+ * - First sweep is delayed by BOOT_SWEEP_FLOOR_MS (30 s) so it never lands
+ *   on the startup critical path. After the floor the browser picks the
+ *   actual execution time (no forcing timeout).
+ * - Subsequent sweeps run hourly via setInterval.
+ * - The hidden→visible trigger has been removed. It stacked the sweep onto
+ *   the exact moment focus-refetch storms fire. Hourly + boot-delayed covers
+ *   the TTL contract — all rule TTLs are 14 days.
+ *
+ * Returns a cleanup function for tests or future teardown.
+ */
+export function startLocalStorageSweep(): () => void {
+  let alive = true;
+  let intervalId: ReturnType<typeof window.setInterval> | null = null;
+  let bootTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  const runSweep = () => sweepChunked(Date.now(), () => alive);
+
   try {
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    listening = true;
-    intervalId = window.setInterval(runIfDue, SWEEP_INTERVAL_MS);
-    if ("requestIdleCallback" in window) {
-      idleCallbackId = window.requestIdleCallback(runIfDue, {
-        timeout: INITIAL_SWEEP_IDLE_TIMEOUT_MS,
-      });
-    } else {
-      timeoutId = globalThis.setTimeout(runIfDue, INITIAL_SWEEP_FALLBACK_MS);
-    }
+    bootTimeoutId = globalThis.setTimeout(runSweep, BOOT_SWEEP_FLOOR_MS);
+    intervalId = window.setInterval(runSweep, SWEEP_INTERVAL_MS);
   } catch (error) {
     console.warn("[localStorageSweep] scheduler setup failed:", error);
   }
 
   return () => {
+    alive = false;
     try {
-      if (listening) {
-        document.removeEventListener("visibilitychange", onVisibilityChange);
-      }
+      if (bootTimeoutId !== null) globalThis.clearTimeout(bootTimeoutId);
       if (intervalId !== null) window.clearInterval(intervalId);
-      if (idleCallbackId !== null && "cancelIdleCallback" in window) {
-        window.cancelIdleCallback(idleCallbackId);
-      }
-      if (timeoutId !== null) globalThis.clearTimeout(timeoutId);
     } catch (error) {
       console.warn("[localStorageSweep] scheduler cleanup failed:", error);
     }

--- a/desktop/src/shared/lib/localStorageSweep.ts
+++ b/desktop/src/shared/lib/localStorageSweep.ts
@@ -23,6 +23,15 @@ export const SWEEP_FALLBACK_TIMER_MS = 250;
  * IdleDeadline is unavailable (rIC-free fallback path).
  */
 export const SWEEP_CHUNK_ENTRY_BUDGET = 20;
+/**
+ * Values larger than this threshold are deferred to the next slice when the
+ * idle deadline has already expired (timeRemaining() <= 0) and the key has
+ * not been previously deferred. Each key is deferred at most once, guaranteeing
+ * convergence: every slice either parses ≥1 entry or grows deferredKeys by
+ * exactly one (a set bounded by the snapshot size). Both quantities are finite,
+ * so the sweep always terminates.
+ */
+export const SWEEP_LARGE_VALUE_DEFER_BYTES = 128 * 1024;
 
 type LocalStorageSweepRule = {
   keyPrefix: string;
@@ -77,6 +86,15 @@ function updatedAtFromJson(value: string): number | null {
   }
 }
 
+/** Returns true when the entry is older than its rule TTL at `now`. */
+function isStale(
+  updatedAt: number | null,
+  rule: LocalStorageSweepRule,
+  now: number,
+): boolean {
+  return updatedAt !== null && updatedAt <= now - rule.maxAgeMs;
+}
+
 /**
  * Removes whitelisted cache entries older than their configured TTL.
  * Entries without a trustworthy `updatedAt` are left alone rather than guessed
@@ -102,7 +120,7 @@ export function sweepStaleLocalStorage(now = Date.now()): number {
       const value = storage.getItem(key);
       if (value === null) continue;
       const updatedAt = updatedAtFromJson(value);
-      if (updatedAt !== null && updatedAt <= now - rule.maxAgeMs) {
+      if (isStale(updatedAt, rule, now)) {
         staleKeys.push(key);
       }
     }
@@ -120,16 +138,6 @@ export function sweepStaleLocalStorage(now = Date.now()): number {
 
 type SliceCallback = (deadline?: { timeRemaining(): number }) => void;
 
-function scheduleSlice(fn: SliceCallback): void {
-  if ("requestIdleCallback" in window) {
-    window.requestIdleCallback(fn as IdleRequestCallback, {
-      timeout: SWEEP_IDLE_TIMEOUT_MS,
-    });
-  } else {
-    globalThis.setTimeout(fn, SWEEP_FALLBACK_TIMER_MS);
-  }
-}
-
 /**
  * Snapshots matching key names synchronously (cheap — no parsing), then
  * processes entries across successive idle-time slices. Keys removed between
@@ -137,8 +145,43 @@ function scheduleSlice(fn: SliceCallback): void {
  *
  * `isAlive` is checked at the start of each slice; returning false aborts
  * further processing without removing accumulated stale keys.
+ *
+ * Returns a cancel function that cancels any pending scheduled-slice handle.
+ * The `isAlive` flag remains the correctness backstop even after cancellation.
  */
-function sweepChunked(now: number, isAlive: () => boolean): void {
+function sweepChunked(now: number, isAlive: () => boolean): () => void {
+  type SliceHandle =
+    | { kind: "idle"; id: number }
+    | { kind: "timeout"; id: ReturnType<typeof globalThis.setTimeout> };
+
+  let currentHandle: SliceHandle | null = null;
+
+  function scheduleSlice(fn: SliceCallback): void {
+    if ("requestIdleCallback" in window) {
+      const id = window.requestIdleCallback(fn as IdleRequestCallback, {
+        timeout: SWEEP_IDLE_TIMEOUT_MS,
+      });
+      currentHandle = { kind: "idle", id };
+    } else {
+      const id = globalThis.setTimeout(fn, SWEEP_FALLBACK_TIMER_MS);
+      currentHandle = { kind: "timeout", id };
+    }
+  }
+
+  function cancelHandle(): void {
+    if (currentHandle === null) return;
+    try {
+      if (currentHandle.kind === "idle") {
+        window.cancelIdleCallback(currentHandle.id);
+      } else {
+        globalThis.clearTimeout(currentHandle.id);
+      }
+    } catch {
+      // Non-fatal: handle may already be consumed.
+    }
+    currentHandle = null;
+  }
+
   // Step 1: cheap key-only snapshot — no getItem, no parsing.
   let pendingKeys: string[];
   try {
@@ -153,20 +196,32 @@ function sweepChunked(now: number, isAlive: () => boolean): void {
     }
   } catch (err) {
     console.warn("[localStorageSweep] key snapshot failed:", err);
-    return;
+    return cancelHandle;
   }
 
-  if (!pendingKeys.length) return;
+  if (!pendingKeys.length) return cancelHandle;
 
+  // Keys judged stale during slices, accumulated for batch removal at the end.
+  // If the sweep is stopped mid-flight (alive=false), these are intentionally
+  // dropped — the next hourly sweep will re-detect them.
   const staleKeys: string[] = [];
+  // Keys that have been deferred once due to large value + zero budget;
+  // a key in this set is always parsed on its second encounter regardless of budget.
+  const deferredKeys = new Set<string>();
   let pos = 0;
+  let warnedThisSweep = false;
 
   // Step 2: parse entries in idle-time slices; reschedule until all done.
   const processSlice: SliceCallback = (deadline) => {
+    // Consume the handle — we are now inside the callback, so it has fired.
+    currentHandle = null;
+
     if (!isAlive()) return;
+
     try {
       const storage = window.localStorage;
       const sliceStart = pos;
+
       while (pos < pendingKeys.length) {
         // Always process at least one entry per slice: a timeout-fired idle
         // callback reports timeRemaining() === 0, and breaking before any
@@ -176,16 +231,48 @@ function sweepChunked(now: number, isAlive: () => boolean): void {
           break;
         }
         if (!deadline && processedInSlice >= SWEEP_CHUNK_ENTRY_BUDGET) break;
+
         const key = pendingKeys[pos++];
-        const value = storage.getItem(key);
-        if (value === null) continue; // deleted since snapshot — skip
-        const rule = LOCAL_STORAGE_SWEEP_RULES.find((r) =>
-          key.startsWith(r.keyPrefix),
-        );
-        if (!rule) continue;
-        const updatedAt = updatedAtFromJson(value);
-        if (updatedAt !== null && updatedAt <= now - rule.maxAgeMs) {
-          staleKeys.push(key);
+
+        try {
+          const value = storage.getItem(key);
+          if (value === null) continue; // deleted since snapshot — skip
+
+          // Defer-once: on a zero-budget slice, avoid parsing large values
+          // that would cause a jank frame. Move the key to the back of the
+          // queue and mark it deferred; on second encounter parse regardless.
+          // Invariant: each slice either parses ≥1 entry or grows deferredKeys
+          // by exactly one — both are bounded by pendingKeys.length, so the
+          // sweep always converges.
+          if (
+            deadline &&
+            deadline.timeRemaining() <= 0 &&
+            value.length > SWEEP_LARGE_VALUE_DEFER_BYTES &&
+            !deferredKeys.has(key)
+          ) {
+            pendingKeys.push(key); // move to back of queue
+            deferredKeys.add(key); // will not be deferred a second time
+            break; // reschedule; deferredKeys grew, so progress was made
+          }
+
+          const rule = LOCAL_STORAGE_SWEEP_RULES.find((r) =>
+            key.startsWith(r.keyPrefix),
+          );
+          if (!rule) continue;
+          const updatedAt = updatedAtFromJson(value);
+          if (isStale(updatedAt, rule, now)) {
+            staleKeys.push(key);
+          }
+        } catch (err) {
+          // Per-key errors skip the entry; remaining keys are still processed.
+          // Log at most once per sweep to avoid flooding on a corrupt store.
+          if (!warnedThisSweep) {
+            console.warn(
+              "[localStorageSweep] key read failed, continuing sweep:",
+              err,
+            );
+            warnedThisSweep = true;
+          }
         }
       }
 
@@ -195,19 +282,34 @@ function sweepChunked(now: number, isAlive: () => boolean): void {
       }
 
       // All entries processed — batch-remove stale keys.
+      // Re-check each key before removing: app code may have rewritten it
+      // fresh between its slice judgment and this final step.
       for (const key of staleKeys) {
         try {
+          const currentValue = storage.getItem(key);
+          if (currentValue === null) continue; // already gone
+          const rule = LOCAL_STORAGE_SWEEP_RULES.find((r) =>
+            key.startsWith(r.keyPrefix),
+          );
+          if (!rule) continue;
+          const currentUpdatedAt = updatedAtFromJson(currentValue);
+          if (!isStale(currentUpdatedAt, rule, now)) continue; // rewritten fresh
           storage.removeItem(key);
         } catch {
           // Non-fatal: key may have been concurrently removed by another tab.
         }
       }
     } catch (err) {
-      console.warn("[localStorageSweep] stale cache cleanup failed:", err);
+      // Last-resort catch: reached only if localStorage itself becomes
+      // unavailable mid-slice (e.g. SecurityError). Stale keys accumulated so
+      // far are dropped; the next hourly sweep re-detects them.
+      console.warn("[localStorageSweep] slice aborted unexpectedly:", err);
     }
   };
 
   scheduleSlice(processSlice);
+
+  return cancelHandle;
 }
 
 /**
@@ -226,8 +328,12 @@ export function startLocalStorageSweep(): () => void {
   let alive = true;
   let intervalId: ReturnType<typeof window.setInterval> | null = null;
   let bootTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let cancelCurrentSweep: (() => void) | null = null;
 
-  const runSweep = () => sweepChunked(Date.now(), () => alive);
+  const runSweep = () => {
+    cancelCurrentSweep?.();
+    cancelCurrentSweep = sweepChunked(Date.now(), () => alive);
+  };
 
   try {
     bootTimeoutId = globalThis.setTimeout(runSweep, BOOT_SWEEP_FLOOR_MS);
@@ -241,6 +347,8 @@ export function startLocalStorageSweep(): () => void {
     try {
       if (bootTimeoutId !== null) globalThis.clearTimeout(bootTimeoutId);
       if (intervalId !== null) window.clearInterval(intervalId);
+      cancelCurrentSweep?.();
+      cancelCurrentSweep = null;
     } catch (error) {
       console.warn("[localStorageSweep] scheduler cleanup failed:", error);
     }

--- a/desktop/src/shared/theme/ThemeProvider.tsx
+++ b/desktop/src/shared/theme/ThemeProvider.tsx
@@ -560,6 +560,11 @@ export function ThemeProvider({
   }, [effectiveTheme]);
 
   useEffect(() => {
+    // `initial-render-ready` fires from a layout effect, so it is already
+    // enqueued before this passive effect's IPC call is dispatched. The native
+    // reveal can in theory precede the transparency call; the Rust-side
+    // stable-geometry wait provides the gap in practice, and a brief opaque
+    // first frame is the accepted worst case for glass users.
     void applyWindowGlass(glassBackground);
   }, [glassBackground]);
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5703,7 +5703,12 @@ async function handleGetChannels(config: E2eConfig | undefined) {
 
   const identity = getIdentity(config);
   if (!identity) {
-    return listMockChannels(config);
+    // Return the mock payload shape: always full channels, no last_messages.
+    return {
+      hash: "mock-hash",
+      channels: listMockChannels(config),
+      last_messages: {},
+    };
   }
 
   // Pure Nostr: query kind:39002 (membership) for our pubkey, extract channel
@@ -5749,7 +5754,7 @@ async function handleGetChannels(config: E2eConfig | undefined) {
   );
 
   // Convert kind:39000 events to the RawChannel shape the frontend expects.
-  return metaEvents
+  const channels = metaEvents
     .map((ev) => {
       const tags = (ev.tags ?? []) as string[][];
       const getTag = (name: string) =>
@@ -5792,6 +5797,8 @@ async function handleGetChannels(config: E2eConfig | undefined) {
       };
     })
     .filter((c) => c.channel_type !== "dm" || !hiddenDms.has(c.id));
+
+  return { hash: "mock-hash", channels, last_messages: {} };
 }
 
 async function handleGetProfile(config: E2eConfig | undefined) {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5686,6 +5686,19 @@ async function submitSignedEvent(
   });
 }
 
+/** Build the channel-id → last-message-at map from the returned channel list. */
+function buildLastMessages(
+  channels: Array<{ id: string; last_message_at: string | null }>,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const ch of channels) {
+    if (ch.last_message_at !== null) {
+      map[ch.id] = ch.last_message_at;
+    }
+  }
+  return map;
+}
+
 async function handleGetChannels(config: E2eConfig | undefined) {
   const channelsReadDelayMs = config?.mock?.channelsReadDelayMs ?? 0;
   if (channelsReadDelayMs > 0) {
@@ -5703,11 +5716,16 @@ async function handleGetChannels(config: E2eConfig | undefined) {
 
   const identity = getIdentity(config);
   if (!identity) {
-    // Return the mock payload shape: always full channels, no last_messages.
+    // The hash is constant ("mock-hash") and channels are always returned in
+    // full — the not-modified short-circuit is intentionally never exercised
+    // here: mock channel data mutates during tests (last_message_at updates on
+    // message emission) while the hash never changes, so honoring knownHash
+    // would wrongly short-circuit after mutations.
+    const channels = listMockChannels(config);
     return {
       hash: "mock-hash",
-      channels: listMockChannels(config),
-      last_messages: {},
+      channels,
+      last_messages: buildLastMessages(channels),
     };
   }
 
@@ -5798,7 +5816,11 @@ async function handleGetChannels(config: E2eConfig | undefined) {
     })
     .filter((c) => c.channel_type !== "dm" || !hiddenDms.has(c.id));
 
-  return { hash: "mock-hash", channels, last_messages: {} };
+  return {
+    hash: "mock-hash",
+    channels,
+    last_messages: buildLastMessages(channels),
+  };
 }
 
 async function handleGetProfile(config: E2eConfig | undefined) {

--- a/desktop/tests/e2e/integration.spec.ts
+++ b/desktop/tests/e2e/integration.spec.ts
@@ -93,10 +93,10 @@ async function sendChannelMessage(
         throw new Error("Tauri invoke bridge is unavailable.");
       }
 
-      const channels = (await invoke("get_channels")) as Array<{
-        id: string;
-        name: string;
-      }>;
+      const payload = (await invoke("get_channels")) as {
+        channels: Array<{ id: string; name: string }> | null;
+      };
+      const channels = payload.channels ?? [];
       const channel = channels.find(({ name }) => name === targetChannelName);
       if (!channel) {
         throw new Error(`Channel not found: ${targetChannelName}`);
@@ -134,10 +134,10 @@ async function joinChannel(
       throw new Error("Tauri invoke bridge is unavailable.");
     }
 
-    const channels = (await invoke("get_channels")) as Array<{
-      id: string;
-      name: string;
-    }>;
+    const payload = (await invoke("get_channels")) as {
+      channels: Array<{ id: string; name: string }> | null;
+    };
+    const channels = payload.channels ?? [];
     const channel = channels.find(({ name }) => name === targetChannelName);
     if (!channel) {
       throw new Error(`Channel not found: ${targetChannelName}`);

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -500,15 +500,18 @@ async function getMockChannels(page: Page) {
       throw new Error("Mock invoke bridge is unavailable.");
     }
 
-    return (await invoke("get_channels")) as Array<{
-      id: string;
-      name: string;
-      channel_type: string;
-      visibility: "open" | "private";
-      member_count: number;
-      is_member: boolean;
-      ttl_seconds: number | null;
-    }>;
+    const payload = (await invoke("get_channels")) as {
+      channels: Array<{
+        id: string;
+        name: string;
+        channel_type: string;
+        visibility: "open" | "private";
+        member_count: number;
+        is_member: boolean;
+        ttl_seconds: number | null;
+      }> | null;
+    };
+    return payload.channels ?? [];
   });
 }
 

--- a/desktop/tests/e2e/stream.spec.ts
+++ b/desktop/tests/e2e/stream.spec.ts
@@ -139,10 +139,10 @@ async function sendChannelMessage(
         throw new Error("Tauri invoke bridge is unavailable.");
       }
 
-      const channels = (await invoke("get_channels")) as Array<{
-        id: string;
-        name: string;
-      }>;
+      const payload = (await invoke("get_channels")) as {
+        channels: Array<{ id: string; name: string }> | null;
+      };
+      const channels = payload.channels ?? [];
       const channel = channels.find(({ name }) => name === targetChannelName);
       if (!channel) {
         throw new Error(`Channel not found: ${targetChannelName}`);


### PR DESCRIPTION
Desktop input latency regressed sharply for users on v0.5.9 and worsened on latest main: multi-second stalls when clicking back into the app, slow fresh boots, intermittent lockups, and scroll/mouse degradation. Reverting to `119a84897` (pre-0.5.9) was confirmed to resolve it, isolating the regression to that range. Profiling a live production renderer plus a commit-level audit of the range found three independent, additive causes — fixed here — plus a long-standing `get_channels` cost that made every remaining refetch expensive, also addressed here.

## 1. Focus-return refetch storm (`refetchOnWindowFocus`)

#5490 wired TanStack's `focusManager` to app focus and flipped ~20 query sites to `refetchOnWindowFocus: true`. A focus return after >60s away fires them all within milliseconds — and a click into an unfocused window *is* a focus return, so the burst runs before the click is processed. That is the "click into the composer, wait 5 seconds" symptom, and it also explains why mouse input feels worse than keyboard (clicks arrive with focus transitions; typing happens while already focused). A 5-second `sample` of a live production renderer caught a single window activity-state transition consuming ~1.25s of main-thread time, dominated by `JSON.parse` in the focus listener's microtask drain.

#5535 already established the fix pattern but applied it to only two families (channels, home-feed). This PR extends the same 5-minute `staleTime` discipline to the remaining families: pulse (×5), workflows (×4), agents (×4), forum (×2), presence, user-status, custom-emoji, channel-templates, and the persona catalog. Polling cadences and push-invalidation paths are untouched — interval refetches and `invalidateQueries` both bypass `staleTime`, so live-update behavior is unchanged. Each gated family exports its focus-refetch policy as an options object that the production hook spreads into `useQuery`, and a `focusRefetchPolicy.test.mjs` drives a `QueryObserver` with that same production object — locking the policy behaviorally (fresh focus return → 0 fetches; stale → refetch) and failing if a hook's `staleTime`/`refetchOnWindowFocus` wiring drifts.

Four families deliberately keep tighter freshness, all surfaces where the 5-minute gate would suppress the only refresh path and none of which feed the app-wide storm: `repo-sync-status` keeps its fresh focus refetch (its inline comment documents the "committed in a terminal, switched back to the app" flow as intended); the workflow-runs list stale-gates at 10s because a remotely-started run has no push invalidation and its conditional 1s poll is off while the cache shows no active runs; the workflow list queries (`useChannelWorkflowsQuery` and the all-channels aggregate) stale-gate at 10s because they have no poll and no relay subscription, and mutation-driven invalidation only covers this renderer — remote workflow creates/edits/deletes surface only via focus refetch; and the managed-agent log stale-gates at one poll tick (30s) so returning to a live agent log refreshes immediately. Run approvals keep the 5-minute gate under `RUN_APPROVALS_FOCUS_STALE_TIME_MS` — their focused 10s poll already covers freshness.

## 2. Synchronous localStorage sweep on the boot/focus path

#5453's stale-cache sweep synchronously `getItem` + `JSON.parse`s every whitelisted localStorage entry on the main thread (multi-MB on seasoned profiles), scheduled with a `requestIdleCallback` timeout of 1.5s that guaranteed it landed mid-boot, and re-armed on every hidden→visible transition — stacking it onto the exact moment the focus storm fires. #5454's `trimSelfProfileCaches()` additionally scanned every localStorage key on every `writeSelfProfileCache()` call (which fires per relay self-profile delivery at boot).

Now: the first sweep waits `BOOT_SWEEP_FLOOR_MS` (30s) after startup, the scan is time-sliced across idle callbacks, and the visibility trigger is removed — boot-delayed plus hourly still covers the 14-day TTL contract. The sliced sweep re-checks staleness immediately before each removal (a key rewritten fresh mid-sweep survives), isolates per-key storage errors so one bad entry can't strand the rest of the snapshot, defers oversized values once rather than parsing them on a zero-budget slice, guarantees forward progress on timeout-fired callbacks, and cancels its scheduled slice when stopped. The profile trim keeps a lazily-initialized memoized key count so the common under-cap write is O(1); the full parse scan runs only when the count exceeds a cap, resyncs if external deletions made it stale, and a failed scan skips the trim instead of aborting the write. Sweep semantics (rules, TTLs, eviction) are unchanged, and tests cover the scheduling, slice-progress, error-isolation, defer-once, and trim short-circuit behaviors.

## 3. The macOS window was never opaque

#5478's glass appearance is correctly opt-in at the CSS layer, but the compositor cost was baked in deeper than its native `on_webview_ready` transparency call: the main window is declared `"transparent": true` in `tauri.conf.json` (added for the original glass work in #1671), which makes tao call `NSWindow.setOpaque(false)` at creation and resolve every later `set_background_color(None)` to `clearColor` — and no runtime `setOpaque(true)` path exists through tauri, while wry's runtime background setter can only force the WKWebView's `drawsBackground` off, never back on. So "restore the platform default" was unreachable: every launch, glass or not, ran with a non-opaque NSWindow, defeating WindowServer's opaque-window compositing fast path and forcing full window compositing every frame — compounded by the existing `backdrop-blur` chrome overlapping the scrolling timeline. This matches the compositor-shaped symptoms (scroll and pointer input degrading first).

The window is now created opaque (`"transparent": false`) and the NSWindow layer is never made transparent at runtime. Glass never needed a transparent window: behind-window `NSVisualEffectView` vibrancy renders inside opaque windows (this is how Finder and Notes draw vibrant sidebars); it only requires a transparent WKWebView canvas, which the `set_window_vibrancy` enable path already establishes at runtime (`macos-private-api` compiles that in independent of the window flag). Enabling glass installs the vibrancy layer and then makes only the webview canvas see-through; disabling clears the vibrancy layer — the canvas may stay non-drawing afterwards (wry's flag is one-way at runtime), which is harmless because glass-off CSS paints fully opaque above an always-opaque NSWindow. The boot-path first-frame backing writes touch only the NSWindow backing color and are therefore inert to glass state regardless of how they order against the `ThemeProvider`'s vibrancy call on a persisted-glass-on cold boot. Glass-off users (the default) get an end-to-end opaque window from boot for the first time.

## 4. `get_channels`: serial round-trips and a multi-MB payload on every refetch

The stale gates in (1) cut refetch frequency; this cuts the cost of the refetches that legitimately remain (boot, and focus returns after more than 5 minutes away — previously still a multi-second stall). `get_channels` made ~8 fully serial relay round-trips (~3.2–3.6s at 1,100+ channels), then shipped the full `ChannelInfo` list — including every channel's member pubkeys — across IPC, where the renderer's `JSON.parse` of the multi-MB payload froze the main thread (the ~1.25s stall captured in the live sample).

- **Concurrent stages**: the membership chain, the open-channel directory scan, and the hidden-DM snapshot run concurrently, as do the member-count and last-message queries that follow. The critical path drops from ~8 sequential round-trips to 2 phases. Filters, limits, pagination, and merge semantics are unchanged.
- **Not-modified short-circuit**: the command now takes a client-supplied content hash (FNV-1a 64 over the channel list, canonicalized by id and excluding `last_message_at`) and omits the channel list from the response when nothing else changed. Last-message timestamps — which change on nearly every message anywhere — ship as a small separate map that the client overlays onto its cached list with reference preservation, so React Query's structural sharing also skips downstream re-renders. On a typical refocus the renderer parses kilobytes instead of megabytes. The hash is stored in the query cache itself, tying its lifecycle to the data it describes so a community switch can never leak a stale hash.

The E2E mock bridge speaks the new payload shape — including the complete `last_messages` map the client treats as authoritative — and hash canonicalization plus overlay reference-preservation are unit-tested on both sides.
