### PR TITLE
fix(agents): generation-CAS the kind:10100 directory and stop publishing the allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buzz-cli",
+ "buzz-core",
+ "buzz-sdk",
+ "clap",
+ "nix 0.31.3",
+ "nostr 0.44.7",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "buzz-test-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/buzz-workflow",
     "crates/buzz-media",
     "crates/buzz-cli",
+    "crates/buzz-supervisor",
     "crates/buzz-pairing-cli",
     "crates/buzz-sdk",
     "crates/buzz-persona",

--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -164,7 +164,129 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
         }
 
         AgentsCmd::Archived => cmd_archived(client).await,
+
+        AgentsCmd::PublishProfile {
+            name,
+            agent_type,
+            channel_ids,
+            status,
+            respond_to,
+            channel_add_policy,
+        } => {
+            cmd_publish_profile(
+                client,
+                buzz_sdk::builders::AgentProfilePatch {
+                    name,
+                    agent_type,
+                    channels: None,
+                    channel_ids,
+                    capabilities: None,
+                    status,
+                    respond_to,
+                    channel_add_policy,
+                },
+            )
+            .await
+        }
     }
+}
+
+/// Fetches this identity's current `kind:10100` record (if any), applies
+/// `patch` on top of it via `buzz_sdk::builders::build_agent_profile_update`,
+/// and publishes. If the relay rejects the write as a stale generation —
+/// another writer published in between our read and our submit — re-fetches
+/// once and retries with a fresh generation before giving up.
+async fn cmd_publish_profile(
+    client: &BuzzClient,
+    patch: buzz_sdk::builders::AgentProfilePatch,
+) -> Result<(), CliError> {
+    for attempt in 0..2 {
+        let current = fetch_agent_profile_state(client).await?;
+        let builder =
+            buzz_sdk::builders::build_agent_profile_update(current.as_ref(), patch.clone())
+                .map_err(|e| CliError::Usage(e.to_string()))?;
+        let event = client.sign_event(builder)?;
+        match client.submit_event(event).await {
+            Ok(resp) => {
+                println!("{resp}");
+                return Ok(());
+            }
+            Err(CliError::Relay { status, body })
+                if attempt == 0 && body.contains("stale generation") =>
+            {
+                let _ = status;
+                // Another writer published between our read and our submit —
+                // re-fetch the now-current record and retry once.
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(CliError::Other(
+        "publish-profile: still hit a stale generation after retrying once".into(),
+    ))
+}
+
+/// Queries the relay for this identity's current `kind:10100` record and
+/// parses it into `AgentProfileState`. Returns `None` if it's never
+/// published one.
+async fn fetch_agent_profile_state(
+    client: &BuzzClient,
+) -> Result<Option<buzz_sdk::builders::AgentProfileState>, CliError> {
+    let my_pubkey = client.keys().public_key().to_hex();
+    let filter = serde_json::json!({
+        "kinds": [buzz_sdk::kind::KIND_AGENT_PROFILE],
+        "authors": [my_pubkey],
+        "limit": 1,
+    });
+    let resp = client.query(&filter).await?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&resp)
+        .map_err(|e| CliError::Other(format!("invalid relay response: {e}")))?;
+    let Some(event) = events.into_iter().next() else {
+        return Ok(None);
+    };
+    let content: serde_json::Value = event
+        .get("content")
+        .and_then(|c| c.as_str())
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    let as_str_vec = |key: &str| -> Vec<String> {
+        content
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let as_str = |key: &str| -> String {
+        content
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    Ok(Some(buzz_sdk::builders::AgentProfileState {
+        name: content
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        agent_type: as_str("agent_type"),
+        channels: as_str_vec("channels"),
+        channel_ids: as_str_vec("channel_ids"),
+        capabilities: as_str_vec("capabilities"),
+        status: as_str("status"),
+        respond_to: as_str("respond_to"),
+        channel_add_policy: as_str("channel_add_policy"),
+        generation: content
+            .get("generation")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+    }))
 }
 
 /// Require `BUZZ_AUTH_TAG` and parse the owner pubkey from it. Used only by

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod agent_management;
-mod client;
+pub mod client;
 mod commands;
-mod error;
+pub mod error;
 mod links;
 mod validate;
 
@@ -365,6 +365,45 @@ Examples:\n  \
 buzz agents archived"
     )]
     Archived,
+    /// Publish this identity's relay agent profile (kind:10100) — makes a headless
+    /// (non-managed) agent discoverable and @mentionable by Buzz Desktop clients.
+    #[command(
+        after_help = "kind:10100 is a replaceable event with a generation counter: this fetches \
+the current record for the signing identity, applies your changes on top of it (fields you \
+don't pass are left as-is), and republishes with generation + 1. If another writer published \
+in between, the relay rejects the write as a stale generation and this command re-fetches and \
+retries once automatically.\n\n\
+There is no --respond-to-allowlist flag. kind:10100 is community-visible, so the exact pubkeys \
+allowed to trigger an `allowlist`-mode agent are never published here — that's a private access \
+boundary, not public routing state. The harness enforces the real allowlist locally; this \
+command only advertises the mode.\n\n\
+Examples:\n  \
+buzz agents publish-profile --name Coder --channel-ids <UUID> --respond-to allowlist\n  \
+buzz agents publish-profile --status away"
+    )]
+    PublishProfile {
+        /// Display name shown in Buzz Desktop. Leaves the current name unchanged if omitted.
+        #[arg(long)]
+        name: Option<String>,
+        /// Free-form agent type label. Defaults to "agent" on first publish.
+        #[arg(long)]
+        agent_type: Option<String>,
+        /// Channel UUIDs this agent should be considered mentionable in (comma-separated).
+        /// Replaces the full list; leaves it unchanged if omitted.
+        #[arg(long, value_delimiter = ',')]
+        channel_ids: Option<Vec<String>>,
+        /// Presence status: online, away, or offline. Defaults to "online" on first publish.
+        #[arg(long)]
+        status: Option<String>,
+        /// Who this agent responds to: owner-only, allowlist, or anyone.
+        /// Defaults to "owner-only" on first publish.
+        #[arg(long)]
+        respond_to: Option<String>,
+        /// Who may add this agent to new channels: anyone, owner_only, or nobody.
+        /// Defaults to "owner_only" on first publish.
+        #[arg(long)]
+        channel_add_policy: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2175,6 +2214,7 @@ mod tests {
                 "archived",
                 "draft-create",
                 "draft-update",
+                "publish-profile",
                 "unarchive"
             ]
         );
@@ -2313,7 +2353,7 @@ mod tests {
     #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
-            ("agents", 5),
+            ("agents", 6),
             ("canvas", 2),
             ("channels", 16),
             ("dms", 4),

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -897,6 +897,142 @@ pub(crate) fn effective_message_author(event: &Event, relay_pubkey: &nostr::Publ
     event.pubkey.to_bytes().to_vec()
 }
 
+const VALID_AGENT_STATUSES: &[&str] = &["online", "away", "offline"];
+const VALID_AGENT_RESPOND_TO: &[&str] = &["owner-only", "allowlist", "anyone"];
+const VALID_AGENT_CHANNEL_ADD_POLICIES: &[&str] = &["anyone", "owner_only", "nobody"];
+const MAX_AGENT_NAME_LEN: usize = 256;
+
+/// Validates and CAS-checks a `kind:10100` agent-directory publish before
+/// it's accepted.
+///
+/// `kind:10100` is a plain replaceable event (NIP-01: highest `created_at`
+/// wins on read), so without an explicit generation counter, two writers
+/// that both read an older record and republish it "whole" can silently
+/// clobber each other's fields depending on wall-clock timing — the exact
+/// failure mode reported against #5528/#5530/#5546. This makes the loss
+/// loud instead of silent: a publish whose `generation` isn't strictly
+/// greater than the currently stored value is rejected, forcing the writer
+/// to re-fetch and retry against the latest state
+/// (`buzz_sdk::builders::build_agent_profile_update` is the shared helper
+/// every writer should use to do that correctly).
+///
+/// Also enforces the schema `build_agent_profile_update` produces,
+/// independent of that helper, so a raw/malformed publish can't bypass
+/// validation: bounded `status`/`respond_to`/`channel_add_policy` enums,
+/// UUID-shaped `channel_ids`, a non-empty bounded `name` when present, and
+/// — the other half of the same reports — **no `respond_to_allowlist`
+/// field**. That field would publish the exact pubkeys allowed to trigger
+/// an `allowlist`-mode agent to every member of the community via a
+/// world-readable event; real enforcement already lives entirely in the
+/// harness process, so the public directory has no legitimate need for it.
+async fn validate_agent_profile_publish(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    event: &Event,
+) -> Result<(), IngestError> {
+    let content: serde_json::Value = serde_json::from_str(&event.content)
+        .map_err(|_| IngestError::Rejected("invalid: kind:10100 content must be JSON".into()))?;
+    let obj = content.as_object().ok_or_else(|| {
+        IngestError::Rejected("invalid: kind:10100 content must be a JSON object".into())
+    })?;
+
+    if obj.contains_key("respond_to_allowlist") {
+        return Err(IngestError::Rejected(
+            "invalid: respond_to_allowlist is not publishable — kind:10100 is community-visible; \
+             this field would disclose an agent's exact access list to every member. Enforcement \
+             belongs to the harness, not the public directory."
+                .into(),
+        ));
+    }
+
+    if let Some(name) = obj.get("name") {
+        let s = name
+            .as_str()
+            .ok_or_else(|| IngestError::Rejected("invalid: name must be a string".into()))?;
+        if s.is_empty() || s.chars().count() > MAX_AGENT_NAME_LEN {
+            return Err(IngestError::Rejected(format!(
+                "invalid: name must be 1..={MAX_AGENT_NAME_LEN} chars"
+            )));
+        }
+    }
+    if let Some(status) = obj.get("status") {
+        let s = status.as_str().unwrap_or_default();
+        if !VALID_AGENT_STATUSES.contains(&s) {
+            return Err(IngestError::Rejected(format!(
+                "invalid: status must be one of {VALID_AGENT_STATUSES:?}"
+            )));
+        }
+    }
+    if let Some(respond_to) = obj.get("respond_to") {
+        let s = respond_to.as_str().unwrap_or_default();
+        if !VALID_AGENT_RESPOND_TO.contains(&s) {
+            return Err(IngestError::Rejected(format!(
+                "invalid: respond_to must be one of {VALID_AGENT_RESPOND_TO:?}"
+            )));
+        }
+    }
+    if let Some(policy) = obj.get("channel_add_policy") {
+        let s = policy.as_str().unwrap_or_default();
+        if !VALID_AGENT_CHANNEL_ADD_POLICIES.contains(&s) {
+            return Err(IngestError::Rejected(format!(
+                "invalid: channel_add_policy must be one of {VALID_AGENT_CHANNEL_ADD_POLICIES:?}"
+            )));
+        }
+    }
+    if let Some(ids) = obj.get("channel_ids") {
+        let arr = ids
+            .as_array()
+            .ok_or_else(|| IngestError::Rejected("invalid: channel_ids must be an array".into()))?;
+        for id in arr {
+            let s = id.as_str().unwrap_or_default();
+            if uuid::Uuid::parse_str(s).is_err() {
+                return Err(IngestError::Rejected(format!(
+                    "invalid: channel_ids entries must be UUIDs (got: {s})"
+                )));
+            }
+        }
+    }
+
+    let new_generation = obj
+        .get("generation")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| {
+            IngestError::Rejected(
+                "invalid: kind:10100 requires a positive integer generation field \
+             (use buzz_sdk::builders::build_agent_profile_update to construct this event)"
+                    .into(),
+            )
+        })?;
+    if new_generation == 0 {
+        return Err(IngestError::Rejected(
+            "invalid: generation must be >= 1".into(),
+        ));
+    }
+
+    let pubkey_bytes = event.pubkey.to_bytes().to_vec();
+    let existing = state
+        .db
+        .get_latest_global_replaceable(tenant.community(), KIND_AGENT_PROFILE as i32, &pubkey_bytes)
+        .await
+        .map_err(|e| IngestError::Rejected(format!("db error: {e}")))?;
+
+    if let Some(existing) = existing {
+        let existing_generation: u64 =
+            serde_json::from_str::<serde_json::Value>(&existing.event.content)
+                .ok()
+                .and_then(|v| v.get("generation").and_then(|g| g.as_u64()))
+                .unwrap_or(0);
+        if new_generation <= existing_generation {
+            return Err(IngestError::Rejected(format!(
+                "invalid: stale generation ({new_generation} <= {existing_generation}) — \
+                 re-fetch the current record and retry"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Validate kind:40003 edit ownership — event.pubkey must match target's effective author,
 /// or the actor must be the owning human of the agent that authored the target message.
 async fn validate_edit_ownership(
@@ -2711,6 +2847,10 @@ async fn ingest_event_inner(
             accepted: true,
             message: String::new(),
         });
+    }
+
+    if kind_u32 == KIND_AGENT_PROFILE {
+        validate_agent_profile_publish(tenant, state, &event).await?;
     }
 
     let tenant_media_base =

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -5,9 +5,9 @@
 
 use buzz_core::{
     kind::{
-        KIND_AGENT_OBSERVER_FRAME, KIND_APPROVAL_DENY, KIND_APPROVAL_GRANT, KIND_DELETION,
-        KIND_DM_ADD_MEMBER, KIND_DM_OPEN, KIND_EMOJI_SET, KIND_GIT_ISSUE, KIND_GIT_PATCH,
-        KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST, KIND_GIT_REPO_ANNOUNCEMENT,
+        KIND_AGENT_OBSERVER_FRAME, KIND_AGENT_PROFILE, KIND_APPROVAL_DENY, KIND_APPROVAL_GRANT,
+        KIND_DELETION, KIND_DM_ADD_MEMBER, KIND_DM_OPEN, KIND_EMOJI_SET, KIND_GIT_ISSUE,
+        KIND_GIT_PATCH, KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST, KIND_GIT_REPO_ANNOUNCEMENT,
         KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED,
         KIND_GIT_STATUS_OPEN, KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST,
         KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
@@ -211,6 +211,174 @@ fn imeta_tags(media_tags: &[Vec<String>], tags: &mut Vec<Tag>) -> Result<(), Sdk
         tags.push(Tag::parse(parts).map_err(|e| SdkError::InvalidTag(e.to_string()))?);
     }
     Ok(())
+}
+
+/// Current state of an agent's `kind:10100` directory record, as read back
+/// from the relay before applying an update.
+///
+/// Deliberately has **no `respond_to_allowlist` field**. `kind:10100` is
+/// queried community-wide, so the exact pubkeys allowed to trigger an
+/// `allowlist`-mode agent must never be published there — that's a private
+/// access boundary, not public routing state. Enforcement stays where it
+/// already lives: the harness process that actually decides whether to act
+/// on a mention. Consumers should treat `respond_to: "allowlist"` the same
+/// as `"anyone"` for *eligibility* purposes (can this be mentioned at all)
+/// and let the harness silently no-op for unauthorized senders.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentProfileState {
+    /// Display name shown in Buzz Desktop. Falls back to the pubkey/npub
+    /// when absent.
+    pub name: Option<String>,
+    /// Free-form agent type label (e.g. `"agent"`).
+    pub agent_type: String,
+    /// Legacy channel-name list, kept for wire compatibility. Prefer `channel_ids`.
+    pub channels: Vec<String>,
+    /// Channel UUIDs this agent is mentionable in.
+    pub channel_ids: Vec<String>,
+    /// Free-form capability tags.
+    pub capabilities: Vec<String>,
+    /// Presence status: `"online"`, `"away"`, or `"offline"`.
+    pub status: String,
+    /// Who this agent responds to: `"owner-only"`, `"allowlist"`, or `"anyone"`.
+    pub respond_to: String,
+    /// Who may add this agent to new channels: `"anyone"`, `"owner_only"`, or `"nobody"`.
+    pub channel_add_policy: String,
+    /// Monotonically increasing per write. The relay rejects a `kind:10100`
+    /// publish whose `generation` isn't strictly greater than the currently
+    /// stored value (see the ingest check in `buzz-relay`), turning the
+    /// "two writers silently clobber each other's fields" race into a loud,
+    /// retryable rejection instead of lost data.
+    pub generation: u64,
+}
+
+/// Fields an update wants to change. `None` means "leave as-is" (carried
+/// forward from the current record); collections replace wholesale when
+/// `Some`.
+#[derive(Debug, Clone, Default)]
+pub struct AgentProfilePatch {
+    /// New display name, or `None` to leave unchanged.
+    pub name: Option<String>,
+    /// New agent-type label, or `None` to leave unchanged (defaults to `"agent"`).
+    pub agent_type: Option<String>,
+    /// New legacy channel-name list, or `None` to leave unchanged.
+    pub channels: Option<Vec<String>>,
+    /// New channel UUID list, or `None` to leave unchanged.
+    pub channel_ids: Option<Vec<String>>,
+    /// New capability tags, or `None` to leave unchanged.
+    pub capabilities: Option<Vec<String>>,
+    /// New presence status, or `None` to leave unchanged (defaults to `"online"`).
+    pub status: Option<String>,
+    /// New respond-to mode, or `None` to leave unchanged (defaults to `"owner-only"`).
+    pub respond_to: Option<String>,
+    /// New channel-add policy, or `None` to leave unchanged (defaults to `"owner_only"`).
+    pub channel_add_policy: Option<String>,
+}
+
+const VALID_AGENT_STATUSES: &[&str] = &["online", "away", "offline"];
+const VALID_AGENT_RESPOND_TO: &[&str] = &["owner-only", "allowlist", "anyone"];
+const VALID_AGENT_CHANNEL_ADD_POLICIES: &[&str] = &["anyone", "owner_only", "nobody"];
+const MAX_AGENT_NAME_LEN: usize = 256;
+
+fn check_enum<'a>(value: &str, allowed: &[&'a str], field: &str) -> Result<&'a str, SdkError> {
+    allowed
+        .iter()
+        .find(|v| **v == value)
+        .copied()
+        .ok_or_else(|| {
+            SdkError::InvalidInput(format!("{field} must be one of {allowed:?} (got: {value})"))
+        })
+}
+
+/// Build a `kind:10100` agent-directory update by merging `patch` onto
+/// `current` (the latest known record for this identity, or `None` if it
+/// has never published one) and bumping `generation`.
+///
+/// This is meant to be the *only* place that constructs `kind:10100`
+/// content — every writer (the ACP harness, `buzz agents publish-profile`,
+/// `buzz-supervisor`) should go through this so a partial update from one
+/// writer can never silently erase fields another writer set, and so
+/// validation (enum bounds, UUID-shaped channel ids, name length) is
+/// enforced once instead of per-caller.
+pub fn build_agent_profile_update(
+    current: Option<&AgentProfileState>,
+    patch: AgentProfilePatch,
+) -> Result<EventBuilder, SdkError> {
+    let base = current.cloned().unwrap_or_default();
+
+    let name = patch.name.or(base.name);
+    if let Some(n) = &name {
+        if n.is_empty() || n.len() > MAX_AGENT_NAME_LEN {
+            return Err(SdkError::InvalidInput(format!(
+                "name must be 1..={MAX_AGENT_NAME_LEN} chars"
+            )));
+        }
+    }
+
+    let agent_type = patch.agent_type.unwrap_or_else(|| {
+        if base.agent_type.is_empty() {
+            "agent".to_string()
+        } else {
+            base.agent_type
+        }
+    });
+
+    let status = patch.status.unwrap_or_else(|| {
+        if base.status.is_empty() {
+            "online".to_string()
+        } else {
+            base.status
+        }
+    });
+    let status = check_enum(&status, VALID_AGENT_STATUSES, "status")?.to_string();
+
+    let respond_to = patch.respond_to.unwrap_or_else(|| {
+        if base.respond_to.is_empty() {
+            "owner-only".to_string()
+        } else {
+            base.respond_to
+        }
+    });
+    let respond_to = check_enum(&respond_to, VALID_AGENT_RESPOND_TO, "respond_to")?.to_string();
+
+    let channel_add_policy = patch.channel_add_policy.unwrap_or_else(|| {
+        if base.channel_add_policy.is_empty() {
+            "owner_only".to_string()
+        } else {
+            base.channel_add_policy
+        }
+    });
+    let channel_add_policy = check_enum(
+        &channel_add_policy,
+        VALID_AGENT_CHANNEL_ADD_POLICIES,
+        "channel_add_policy",
+    )?
+    .to_string();
+
+    let channel_ids = patch.channel_ids.unwrap_or(base.channel_ids);
+    for id in &channel_ids {
+        Uuid::parse_str(id)
+            .map_err(|_| SdkError::InvalidInput(format!("invalid channel_id: {id}")))?;
+    }
+
+    let channels = patch.channels.unwrap_or(base.channels);
+    let capabilities = patch.capabilities.unwrap_or(base.capabilities);
+    let generation = base.generation + 1;
+
+    let mut content = serde_json::json!({
+        "agent_type": agent_type,
+        "channels": channels,
+        "channel_ids": channel_ids,
+        "capabilities": capabilities,
+        "status": status,
+        "respond_to": respond_to,
+        "channel_add_policy": channel_add_policy,
+        "generation": generation,
+    });
+    if let Some(n) = name {
+        content["name"] = serde_json::Value::String(n);
+    }
+
+    Ok(EventBuilder::new(Kind::Custom(KIND_AGENT_PROFILE as u16), content.to_string()).tags([]))
 }
 
 /// Build a stream message (kind 9).
@@ -4594,5 +4762,123 @@ mod tests {
 
         assert_eq!(accept_count, 11, "expected 11 accept cases");
         assert_eq!(reject_count, 20, "expected 20 reject cases");
+    }
+
+    // ── build_agent_profile_update ──────────────────────────────────────
+
+    fn parse_content(ev: &nostr::Event) -> serde_json::Value {
+        serde_json::from_str(&ev.content).expect("valid json content")
+    }
+
+    #[test]
+    fn agent_profile_first_publish_defaults_and_generation_one() {
+        let builder = build_agent_profile_update(
+            None,
+            AgentProfilePatch {
+                name: Some("Coder".into()),
+                respond_to: Some("anyone".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let ev = sign(builder);
+        assert_eq!(ev.kind, Kind::Custom(KIND_AGENT_PROFILE as u16));
+        let c = parse_content(&ev);
+        assert_eq!(c["name"], "Coder");
+        assert_eq!(c["agent_type"], "agent");
+        assert_eq!(c["status"], "online");
+        assert_eq!(c["respond_to"], "anyone");
+        assert_eq!(c["channel_add_policy"], "owner_only");
+        assert_eq!(c["generation"], 1);
+        // No allowlist field must ever appear in the public content.
+        assert!(c.get("respond_to_allowlist").is_none());
+    }
+
+    #[test]
+    fn agent_profile_patch_preserves_untouched_fields_and_bumps_generation() {
+        let current = AgentProfileState {
+            name: Some("Coder".into()),
+            agent_type: "agent".into(),
+            channels: vec![],
+            channel_ids: vec!["11111111-1111-1111-1111-111111111111".into()],
+            capabilities: vec!["code".into()],
+            status: "online".into(),
+            respond_to: "anyone".into(),
+            channel_add_policy: "owner_only".into(),
+            generation: 5,
+        };
+        // Only changing status — everything else should carry forward.
+        let builder = build_agent_profile_update(
+            Some(&current),
+            AgentProfilePatch {
+                status: Some("away".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let ev = sign(builder);
+        let c = parse_content(&ev);
+        assert_eq!(c["name"], "Coder");
+        assert_eq!(
+            c["channel_ids"],
+            serde_json::json!(["11111111-1111-1111-1111-111111111111"])
+        );
+        assert_eq!(c["capabilities"], serde_json::json!(["code"]));
+        assert_eq!(c["respond_to"], "anyone");
+        assert_eq!(c["channel_add_policy"], "owner_only");
+        assert_eq!(c["status"], "away");
+        assert_eq!(c["generation"], 6);
+    }
+
+    #[test]
+    fn agent_profile_rejects_invalid_status() {
+        let err = build_agent_profile_update(
+            None,
+            AgentProfilePatch {
+                status: Some("bogus".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("status"));
+    }
+
+    #[test]
+    fn agent_profile_rejects_invalid_respond_to() {
+        let err = build_agent_profile_update(
+            None,
+            AgentProfilePatch {
+                respond_to: Some("sometimes".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("respond_to"));
+    }
+
+    #[test]
+    fn agent_profile_rejects_non_uuid_channel_id() {
+        let err = build_agent_profile_update(
+            None,
+            AgentProfilePatch {
+                channel_ids: Some(vec!["not-a-uuid".into()]),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("channel_id"));
+    }
+
+    #[test]
+    fn agent_profile_rejects_empty_name() {
+        let err = build_agent_profile_update(
+            None,
+            AgentProfilePatch {
+                name: Some("".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("name"));
     }
 }

--- a/crates/buzz-supervisor/Cargo.toml
+++ b/crates/buzz-supervisor/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "buzz-supervisor"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Headless relay-side team supervisor — the server analog of Desktop Managed Agents"
+
+[[bin]]
+name = "buzz-supervisor"
+path = "src/main.rs"
+
+[dependencies]
+# Internal — reuses buzz-cli's already-battle-tested relay HTTP client
+# (NIP-98 signing, query/submit_event) instead of reimplementing it.
+buzz-cli = { path = "../buzz-cli" }
+buzz-core = { workspace = true }
+buzz-sdk = { workspace = true }
+
+# Nostr
+nostr = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Serialization / config
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = "1.0"
+
+# IDs
+uuid = { workspace = true }
+
+# Extracting `workdir:<path>` out of free-text channel descriptions
+regex = "1"
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Safe wrapper around POSIX `kill(2)` for stop_process — keeps this crate
+# unsafe-code-free (matches buzz-acp's kill_process_group rationale).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }

--- a/crates/buzz-supervisor/roles.example.toml
+++ b/crates/buzz-supervisor/roles.example.toml
@@ -1,0 +1,37 @@
+# Example team roster for buzz-supervisor.
+#
+# Every provisioned channel gets one fresh keypair + one spawned `buzz-acp`
+# process per [[roles]] entry below, all rooted at that channel's `workdir`.
+#
+# NOTE: top-level keys (shared_members, extra_allowlist) must come BEFORE
+# any [[roles]] block — TOML attaches trailing top-level keys to the last
+# array-of-tables entry, not the document root. (RoleConfig rejects unknown
+# fields specifically so getting this backwards is a loud parse error
+# instead of the keys silently vanishing.)
+
+# Added as a plain channel member (no process spawned) to every provisioned
+# channel — e.g. an externally-bridged Reviewer identity.
+shared_members = ["ce2fe47f9df685d5070407ab64e903b0fe76123b42b37b4cadee2552b5cb2b02"]
+
+# Always included in every role's respond_to_allowlist, in addition to the
+# team's own generated pubkeys — typically the human owner(s).
+extra_allowlist = ["c19fc270d15c6bb3e6ca7910dd7c9e7aa760019fe1e729196450a173f157f227"]
+
+[[roles]]
+name = "load-balancer"
+display_name = "Load Balancer"
+agent_command = "claude-agent-acp"
+system_prompt_file = "/home/alice/.buzz_agents/load-balancer-prompt.txt"
+# At most one role per team should set this — see relay.md's "one listener
+# per channel" note. The rest default to `false` (mentions-only).
+subscribe_all = true
+
+[[roles]]
+name = "coder"
+display_name = "Coder"
+agent_command = "claude-agent-acp"
+
+[[roles]]
+name = "writer"
+display_name = "Writer"
+agent_command = "claude-agent-acp"

--- a/crates/buzz-supervisor/src/config.rs
+++ b/crates/buzz-supervisor/src/config.rs
@@ -1,0 +1,68 @@
+//! Team roster configuration — which roles get provisioned per channel and
+//! how each one is launched. Loaded from a TOML file at startup.
+
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+fn default_agent_command() -> String {
+    "claude-agent-acp".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoleConfig {
+    /// Stable identifier, used for state-file paths (e.g. "coder").
+    pub name: String,
+    /// Human-readable name published in the agent's `kind:0`/`kind:10100`
+    /// profiles (e.g. "Coder").
+    pub display_name: String,
+    /// `BUZZ_ACP_AGENT_COMMAND` for this role's `buzz-acp` process.
+    #[serde(default = "default_agent_command")]
+    pub agent_command: String,
+    /// Optional file whose contents become `BUZZ_ACP_SYSTEM_PROMPT`.
+    pub system_prompt_file: Option<String>,
+    /// If true, this role is launched with `--subscribe all` instead of the
+    /// default `mentions` — see relay.md's "one listener per channel" note.
+    /// At most one role per team should set this.
+    #[serde(default)]
+    pub subscribe_all: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorConfig {
+    /// Roles that get a fresh keypair + a spawned `buzz-acp` process per
+    /// provisioned channel.
+    pub roles: Vec<RoleConfig>,
+    /// Pubkeys added as plain (no process) channel members to every
+    /// provisioned channel — e.g. an externally-bridged Reviewer identity.
+    #[serde(default)]
+    pub shared_members: Vec<String>,
+    /// Pubkeys always included in every role's `respond_to_allowlist`,
+    /// beyond the team's own generated pubkeys — typically the human
+    /// owner(s) who should be able to trigger any role directly.
+    #[serde(default)]
+    pub extra_allowlist: Vec<String>,
+}
+
+impl SupervisorConfig {
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let raw = fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading roles file {}: {e}", path.display()))?;
+        let config: Self = toml::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("parsing roles file {}: {e}", path.display()))?;
+        if config.roles.is_empty() {
+            anyhow::bail!("roles file {} defines no roles", path.display());
+        }
+        let subscribe_all_count = config.roles.iter().filter(|r| r.subscribe_all).count();
+        if subscribe_all_count > 1 {
+            tracing::warn!(
+                count = subscribe_all_count,
+                "more than one role has subscribe_all=true — they will all react to every \
+                 unaddressed message in the channel, which is usually not intended"
+            );
+        }
+        Ok(config)
+    }
+}

--- a/crates/buzz-supervisor/src/main.rs
+++ b/crates/buzz-supervisor/src/main.rs
@@ -1,0 +1,130 @@
+//! buzz-supervisor — the headless, relay-side analog of Buzz Desktop's
+//! Managed Agents. Watches a relay for channels whose `description`
+//! declares a `workdir:<path>`, and provisions/heals/tears down a team of
+//! `buzz-acp` processes rooted at that directory for each one.
+//!
+//! This binary does nothing by default. It requires an explicit
+//! `--relay-url` (no default — deliberately unlike `buzz-acp`, which
+//! defaults to `ws://localhost:3000`) and at least one `--allowed-root`, so
+//! a relay operator can never end up running it by accident against the
+//! wrong deployment or with an unbounded filesystem scope. See relay.md for
+//! the full design rationale.
+#![deny(unsafe_code)]
+
+mod config;
+mod provision;
+mod security;
+mod state;
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use nostr::Keys;
+use regex::Regex;
+
+use buzz_cli::client::BuzzClient;
+
+use config::SupervisorConfig;
+use provision::Ctx;
+use security::AllowedRoots;
+use state::StateStore;
+
+#[derive(Parser)]
+#[command(
+    about = "Headless relay-side agent-team supervisor (server analog of Buzz Desktop Managed Agents)",
+    after_help = "Example:\n  buzz-supervisor \\\n    --relay-url http://lotto645.lge.com:3000 \\\n    --private-key <owner-cli-key> \\\n    --relay-admin-key <BUZZ_RELAY_PRIVATE_KEY> \\\n    --allowed-root /home/alice/code \\\n    --roles-file /home/alice/.buzz_agents/roles.toml \\\n    --state-dir /home/alice/.buzz_agents/supervisor/state"
+)]
+struct Args {
+    /// Relay base URL. Required, no default — buzz-supervisor only runs
+    /// against a relay deployment its operator has deliberately named.
+    #[arg(long, env = "BUZZ_SUPERVISOR_RELAY_URL")]
+    relay_url: String,
+
+    /// Private key (hex or nsec) for the identity that owns every
+    /// provisioned channel membership/profile this instance creates.
+    #[arg(long, env = "BUZZ_SUPERVISOR_PRIVATE_KEY")]
+    private_key: String,
+
+    /// Relay admin signing key, forwarded to `buzz-admin add-member` for
+    /// relay-wide membership registration (see relay-admin's own docs for
+    /// why this can't be done over the plain client HTTP API).
+    #[arg(long, env = "BUZZ_SUPERVISOR_RELAY_ADMIN_KEY")]
+    relay_admin_key: String,
+
+    /// Path to the `buzz-admin` binary.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ADMIN_BIN", default_value = "buzz-admin")]
+    admin_bin: PathBuf,
+
+    /// Path to the `buzz-acp` binary spawned per role.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ACP_BIN", default_value = "buzz-acp")]
+    acp_bin: PathBuf,
+
+    /// Directory agents are allowed to work in (repeatable). Any `workdir`
+    /// resolving (after symlink/`..` resolution) outside every one of these
+    /// is rejected — this is the security boundary, not `channel_add_policy`
+    /// or anything relay-side.
+    #[arg(long = "allowed-root", required = true)]
+    allowed_roots: Vec<PathBuf>,
+
+    /// TOML file defining the team roster (roles → harness/prompt). See
+    /// `roles.example.toml` in this crate for the shape.
+    #[arg(long, env = "BUZZ_SUPERVISOR_ROLES_FILE")]
+    roles_file: PathBuf,
+
+    /// Directory for per-channel state (generated keys, pids, per-role logs).
+    #[arg(long, env = "BUZZ_SUPERVISOR_STATE_DIR")]
+    state_dir: PathBuf,
+
+    /// Poll interval in seconds.
+    #[arg(long, default_value_t = 20)]
+    poll_interval_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    let config = SupervisorConfig::load(&args.roles_file)?;
+    let allowed_roots = AllowedRoots::new(args.allowed_roots.clone())?;
+    let state = StateStore::new(args.state_dir.clone())?;
+
+    let keys = Keys::parse(&args.private_key)
+        .map_err(|e| anyhow::anyhow!("invalid --private-key: {e}"))?;
+    let client = BuzzClient::new(args.relay_url.clone(), keys, None, None)
+        .map_err(|e| anyhow::anyhow!("building relay client: {e}"))?;
+
+    // `workdir:` may appear anywhere in the description (e.g. embedded in a
+    // longer human-written sentence), and humans won't always type it with
+    // zero spacing around the colon — allow whitespace there, but capture
+    // the path itself up to the next whitespace.
+    let workdir_pattern = Regex::new(r"workdir\s*:\s*(\S+)")?;
+
+    tracing::info!(
+        relay_url = %args.relay_url,
+        allowed_roots = ?args.allowed_roots,
+        roles = ?config.roles.iter().map(|r| &r.name).collect::<Vec<_>>(),
+        poll_interval_secs = args.poll_interval_secs,
+        "buzz-supervisor starting"
+    );
+
+    let ctx = Ctx {
+        client,
+        config,
+        allowed_roots,
+        state,
+        acp_bin: args.acp_bin,
+        admin_bin: args.admin_bin,
+        relay_admin_key: args.relay_admin_key,
+        relay_url_for_admin: args.relay_url,
+        workdir_pattern,
+    };
+
+    loop {
+        if let Err(e) = provision::run_once(&ctx).await {
+            tracing::error!(error = %e, "poll iteration failed");
+        }
+        tokio::time::sleep(Duration::from_secs(args.poll_interval_secs)).await;
+    }
+}

--- a/crates/buzz-supervisor/src/provision.rs
+++ b/crates/buzz-supervisor/src/provision.rs
@@ -1,0 +1,564 @@
+//! Core reconciliation loop: discover channels, provision new ones whose
+//! `description` declares a `workdir:`, heal dead role processes, and tear
+//! down channels that disappear (archived/deleted).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use buzz_cli::client::{extract_d_tag, extract_tag_value, BuzzClient};
+use nostr::{EventBuilder, Keys, Kind};
+use regex::Regex;
+use uuid::Uuid;
+
+use crate::config::SupervisorConfig;
+use crate::security::AllowedRoots;
+use crate::state::{ChannelState, ChannelStatus, RoleState, StateStore};
+
+pub struct Ctx {
+    pub client: BuzzClient,
+    pub config: SupervisorConfig,
+    pub allowed_roots: AllowedRoots,
+    pub state: StateStore,
+    pub acp_bin: PathBuf,
+    pub admin_bin: PathBuf,
+    pub relay_admin_key: String,
+    pub relay_url_for_admin: String,
+    pub workdir_pattern: Regex,
+}
+
+/// One full pass over every channel: provision new matches, heal known
+/// teams, tear down ones that vanished from the channel list.
+pub async fn run_once(ctx: &Ctx) -> anyhow::Result<()> {
+    let channels = list_channels(&ctx.client).await?;
+    let seen: std::collections::HashSet<&str> =
+        channels.iter().map(|c| c.channel_id.as_str()).collect();
+
+    for channel in &channels {
+        match ctx.state.load(&channel.channel_id)? {
+            None => handle_new_channel(ctx, channel).await?,
+            // Resume rather than skip: `provision_team` is safe to re-enter
+            // (each step is keyed by role name / presence of a pid), so an
+            // interruption on the previous poll just continues here instead
+            // of sitting stuck forever.
+            Some(state) if matches!(state.status, ChannelStatus::Provisioning) => {
+                let workdir = state
+                    .workdir
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("Provisioning state missing workdir"))?;
+                provision_team(ctx, &channel.channel_id, Path::new(&workdir)).await?
+            }
+            Some(state) => heal_channel(ctx, &channel.channel_id, &state)?,
+        }
+    }
+
+    for known_id in ctx.state.known_channels()? {
+        if seen.contains(known_id.as_str()) {
+            continue;
+        }
+        if let Some(state) = ctx.state.load(&known_id)? {
+            if matches!(state.status, ChannelStatus::Provisioned) {
+                tear_down(ctx, &known_id, &state)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct ChannelSummary {
+    channel_id: String,
+    description: String,
+}
+
+async fn list_channels(client: &BuzzClient) -> anyhow::Result<Vec<ChannelSummary>> {
+    let filter = serde_json::json!({ "kinds": [39000], "limit": 500 });
+    let resp = client
+        .query(&filter)
+        .await
+        .map_err(|e| anyhow::anyhow!("channels query failed: {e}"))?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&resp)?;
+    Ok(events
+        .iter()
+        .map(|e| ChannelSummary {
+            channel_id: extract_d_tag(e),
+            description: extract_tag_value(e, "about"),
+        })
+        .filter(|c| !c.channel_id.is_empty())
+        .collect())
+}
+
+async fn handle_new_channel(ctx: &Ctx, channel: &ChannelSummary) -> anyhow::Result<()> {
+    let Some(captures) = ctx.workdir_pattern.captures(&channel.description) else {
+        ctx.state.save(
+            &channel.channel_id,
+            &ChannelState {
+                status: ChannelStatus::Ignored,
+                workdir: None,
+                roles: HashMap::new(),
+            },
+        )?;
+        return Ok(());
+    };
+    let raw_path = &captures[1];
+
+    match ctx.allowed_roots.validate(raw_path) {
+        Ok(resolved) => provision_team(ctx, &channel.channel_id, &resolved).await,
+        Err(reason) => reject_channel(ctx, &channel.channel_id, &reason).await,
+    }
+}
+
+/// Provisions a team, saving state to disk after every side-effecting step.
+///
+/// This is deliberately not "do everything, then save once at the end": an
+/// earlier version did that, and any error partway through (e.g. the 3rd
+/// role's `publish-profile` HTTP call failing) left the channel with no
+/// state file at all — so the *next* poll saw it as brand new and started
+/// over, generating and registering a fresh set of keys every poll interval
+/// forever. Saving after each step means a mid-provisioning failure is
+/// recorded as `Provisioning` with exactly the roles created so far, and is
+/// never silently retried from scratch.
+async fn provision_team(ctx: &Ctx, channel_id: &str, workdir: &Path) -> anyhow::Result<()> {
+    let channel_uuid = Uuid::parse_str(channel_id)?;
+    let mut state = ctx.state.load(channel_id)?.unwrap_or(ChannelState {
+        status: ChannelStatus::Provisioning,
+        workdir: Some(workdir.display().to_string()),
+        roles: HashMap::new(),
+    });
+
+    let owner_pubkey = ctx.client.keys().public_key().to_hex();
+    let mut allowlist: Vec<String> = ctx.config.extra_allowlist.clone();
+    allowlist.push(owner_pubkey);
+
+    // Phase 1: one identity per role — generate, register, add as a channel
+    // member. Persisted immediately per-role so a failure here never
+    // re-generates roles that already succeeded.
+    for role in &ctx.config.roles {
+        if state.roles.contains_key(&role.name) {
+            continue; // already done in a prior (interrupted) attempt
+        }
+        let keys = Keys::generate();
+        let pubkey = keys.public_key().to_hex();
+        admin_register_member(ctx, &pubkey)?;
+        add_channel_member(ctx, channel_uuid, &pubkey, "bot").await?;
+        allowlist.push(pubkey.clone());
+        state.roles.insert(
+            role.name.clone(),
+            RoleState {
+                pubkey,
+                privkey: keys.secret_key().display_secret().to_string(),
+                pid: None,
+            },
+        );
+        ctx.state.save(channel_id, &state)?;
+    }
+    for shared in &ctx.config.shared_members {
+        add_channel_member(ctx, channel_uuid, shared, "bot").await?;
+    }
+
+    let project_label = workdir
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| workdir.display().to_string());
+
+    // Phase 2: publish each role's profile and spawn its process. Also
+    // persisted per-role, and skipped for roles that already have a pid
+    // (i.e. already finished in a prior attempt).
+    for role_config in &ctx.config.roles {
+        let role_state = state
+            .roles
+            .get(&role_config.name)
+            .ok_or_else(|| anyhow::anyhow!("role {} missing after phase 1", role_config.name))?
+            .clone();
+        if role_state.pid.is_some() {
+            continue;
+        }
+        let keys = Keys::parse(&role_state.privkey)?;
+        let display_name = format!("{} ({project_label})", role_config.display_name);
+
+        publish_agent_profile(ctx, &keys, &display_name, channel_id).await?;
+        publish_kind0_profile(ctx, &keys, &display_name).await?;
+
+        let pid = spawn_role(ctx, channel_id, role_config, &keys, workdir, &allowlist)?;
+        state.roles.insert(
+            role_config.name.clone(),
+            RoleState {
+                pid: Some(pid),
+                ..role_state
+            },
+        );
+        ctx.state.save(channel_id, &state)?;
+    }
+
+    state.status = ChannelStatus::Provisioned;
+    ctx.state.save(channel_id, &state)?;
+
+    send_message(
+        ctx,
+        channel_uuid,
+        &format!(
+            "✅ Team started in `{}`: {}.",
+            workdir.display(),
+            ctx.config
+                .roles
+                .iter()
+                .map(|r| r.display_name.as_str())
+                .collect::<Vec<_>>()
+                .join("/")
+        ),
+    )
+    .await?;
+
+    tracing::info!(channel_id, workdir = %workdir.display(), "provisioned");
+    Ok(())
+}
+
+async fn reject_channel(ctx: &Ctx, channel_id: &str, reason: &str) -> anyhow::Result<()> {
+    ctx.state.save(
+        channel_id,
+        &ChannelState {
+            status: ChannelStatus::Rejected {
+                reason: reason.to_string(),
+            },
+            workdir: None,
+            roles: HashMap::new(),
+        },
+    )?;
+    if let Ok(channel_uuid) = Uuid::parse_str(channel_id) {
+        let _ = send_message(
+            ctx,
+            channel_uuid,
+            &format!("⚠️ Rejected workdir setting: {reason}"),
+        )
+        .await;
+    }
+    tracing::warn!(channel_id, reason, "rejected");
+    Ok(())
+}
+
+fn heal_channel(ctx: &Ctx, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+    if !matches!(state.status, ChannelStatus::Provisioned) {
+        return Ok(());
+    }
+    let Some(workdir) = &state.workdir else {
+        return Ok(());
+    };
+    let allowlist: Vec<String> = std::iter::once(ctx.client.keys().public_key().to_hex())
+        .chain(ctx.config.extra_allowlist.iter().cloned())
+        .chain(state.roles.values().map(|r| r.pubkey.clone()))
+        .collect();
+
+    let mut updated = state.clone();
+    let mut changed = false;
+    for role_config in &ctx.config.roles {
+        let Some(role_state) = updated.roles.get(&role_config.name) else {
+            continue;
+        };
+        if let Some(pid) = role_state.pid {
+            if process_alive(pid) {
+                continue;
+            }
+        }
+        tracing::warn!(
+            channel_id,
+            role = role_config.name,
+            "dead agent, restarting"
+        );
+        let keys = Keys::parse(&role_state.privkey)?;
+        let pid = spawn_role(
+            ctx,
+            channel_id,
+            role_config,
+            &keys,
+            Path::new(workdir),
+            &allowlist,
+        )?;
+        updated.roles.insert(
+            role_config.name.clone(),
+            RoleState {
+                pubkey: role_state.pubkey.clone(),
+                privkey: role_state.privkey.clone(),
+                pid: Some(pid),
+            },
+        );
+        changed = true;
+    }
+    if changed {
+        ctx.state.save(channel_id, &updated)?;
+    }
+    Ok(())
+}
+
+fn tear_down(ctx: &Ctx, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+    for (role, role_state) in &state.roles {
+        if let Some(pid) = role_state.pid {
+            tracing::info!(
+                channel_id,
+                role,
+                pid,
+                "tearing down (channel no longer listed)"
+            );
+            stop_process(pid);
+        }
+    }
+    let mut updated = state.clone();
+    updated.status = ChannelStatus::TornDown;
+    ctx.state.save(channel_id, &updated)?;
+    Ok(())
+}
+
+fn spawn_role(
+    ctx: &Ctx,
+    channel_id: &str,
+    role: &crate::config::RoleConfig,
+    keys: &Keys,
+    workdir: &Path,
+    allowlist: &[String],
+) -> anyhow::Result<u32> {
+    use std::os::unix::process::CommandExt;
+
+    let log_path = ctx.state.log_path(channel_id, &role.name);
+    let log_file = std::fs::File::create(&log_path)?;
+    let log_file_err = log_file.try_clone()?;
+
+    let mut cmd = Command::new(&ctx.acp_bin);
+    cmd.current_dir(workdir)
+        .env("BUZZ_ACP_AGENT_COMMAND", &role.agent_command)
+        .env("BUZZ_RELAY_URL", ws_url(&ctx.relay_url_for_admin))
+        .env(
+            "BUZZ_PRIVATE_KEY",
+            keys.secret_key().display_secret().to_string(),
+        )
+        .arg("--respond-to")
+        .arg("allowlist")
+        .arg("--respond-to-allowlist")
+        .arg(allowlist.join(","))
+        .stdin(Stdio::null())
+        .stdout(log_file)
+        .stderr(log_file_err)
+        .process_group(0); // detach from our own process group, like setsid
+
+    if role.subscribe_all {
+        cmd.arg("--subscribe").arg("all");
+    }
+    if let Some(prompt_file) = &role.system_prompt_file {
+        let prompt = std::fs::read_to_string(prompt_file)
+            .map_err(|e| anyhow::anyhow!("reading system_prompt_file {prompt_file}: {e}"))?;
+        cmd.env("BUZZ_ACP_SYSTEM_PROMPT", prompt);
+    }
+
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    // Deliberately not waited on: this is a long-running detached agent
+    // process, tracked by pid in state.json, not as a child of ours.
+    std::mem::forget(child);
+    tracing::info!(channel_id, role = role.name, pid, workdir = %workdir.display(), "launched");
+    Ok(pid)
+}
+
+fn process_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// Sends SIGTERM to a recorded pid. Uses `nix::sys::signal::kill` — a safe
+/// wrapper around the POSIX `kill` syscall — so this crate's
+/// `#![deny(unsafe_code)]` policy (same as `buzz-acp`) is preserved. A
+/// stale/reused pid just gets a harmless signal delivery, or `ESRCH` if it's
+/// already gone — either way there's nothing actionable for the caller.
+fn stop_process(pid: u32) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+
+    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+}
+
+fn ws_url(http_url: &str) -> String {
+    http_url
+        .replacen("http://", "ws://", 1)
+        .replacen("https://", "wss://", 1)
+}
+
+fn admin_register_member(ctx: &Ctx, pubkey: &str) -> anyhow::Result<()> {
+    let status = Command::new(&ctx.admin_bin)
+        .arg("add-member")
+        .arg("--pubkey")
+        .arg(pubkey)
+        .arg("--role")
+        .arg("member")
+        .env("BUZZ_RELAY_PRIVATE_KEY", &ctx.relay_admin_key)
+        .env("BUZZ_RELAY_URL", &ctx.relay_url_for_admin)
+        .stdout(Stdio::null())
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("buzz-admin add-member failed for {pubkey}: {status}");
+    }
+    Ok(())
+}
+
+async fn add_channel_member(
+    ctx: &Ctx,
+    channel_id: Uuid,
+    pubkey: &str,
+    role: &str,
+) -> anyhow::Result<()> {
+    use buzz_sdk::builders::build_add_member;
+    use buzz_sdk::MemberRole;
+    let member_role = match role {
+        "bot" => MemberRole::Bot,
+        _ => MemberRole::Member,
+    };
+    let builder = build_add_member(channel_id, pubkey, Some(member_role))
+        .map_err(|e| anyhow::anyhow!("build_add_member: {e}"))?;
+    let event = ctx.client.sign_event(builder)?;
+    ctx.client
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("add-member submit failed: {e}"))?;
+    Ok(())
+}
+
+/// Publishes this role's `kind:10100` directory record via the shared
+/// `buzz_sdk::builders::build_agent_profile_update` builder — fetching the
+/// current record first (always `None` here in practice, since the identity
+/// is freshly generated in phase 1, but going through the same fetch/patch
+/// path as every other writer keeps this from ever hand-rolling content
+/// that could drift from what the CLI/harness publish) and retrying once if
+/// the relay rejects the write as a stale generation.
+///
+/// Deliberately does **not** publish `respond_to_allowlist` — see the doc
+/// comment on `AgentProfileState` in `buzz-sdk`. `--respond-to-allowlist`
+/// passed to the spawned `buzz-acp` process (in `spawn_role`) is the real,
+/// local enforcement boundary; the public directory only advertises the
+/// `respond_to` mode.
+async fn publish_agent_profile(
+    ctx: &Ctx,
+    keys: &Keys,
+    display_name: &str,
+    channel_id: &str,
+) -> anyhow::Result<()> {
+    let client = client_for(ctx, keys)?;
+    for attempt in 0..2 {
+        let current = fetch_agent_profile_state(&client, keys).await?;
+        let builder = buzz_sdk::builders::build_agent_profile_update(
+            current.as_ref(),
+            buzz_sdk::builders::AgentProfilePatch {
+                name: Some(display_name.to_string()),
+                channel_ids: Some(vec![channel_id.to_string()]),
+                status: Some("online".to_string()),
+                respond_to: Some("allowlist".to_string()),
+                channel_add_policy: Some("anyone".to_string()),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("build_agent_profile_update: {e}"))?;
+        let event = sign_as(keys, builder)?;
+        match client.submit_event(event).await {
+            Ok(_) => return Ok(()),
+            Err(e) if attempt == 0 && e.to_string().contains("stale generation") => continue,
+            Err(e) => return Err(anyhow::anyhow!("publish-profile failed: {e}")),
+        }
+    }
+    anyhow::bail!("publish-profile: still hit a stale generation after retrying once")
+}
+
+/// Queries the relay for `keys`' current `kind:10100` record and parses it
+/// into `AgentProfileState`. Returns `None` if it's never published one.
+async fn fetch_agent_profile_state(
+    client: &BuzzClient,
+    keys: &Keys,
+) -> anyhow::Result<Option<buzz_sdk::builders::AgentProfileState>> {
+    let filter = serde_json::json!({
+        "kinds": [buzz_sdk::kind::KIND_AGENT_PROFILE],
+        "authors": [keys.public_key().to_hex()],
+        "limit": 1,
+    });
+    let resp = client
+        .query(&filter)
+        .await
+        .map_err(|e| anyhow::anyhow!("agent profile query failed: {e}"))?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&resp)?;
+    let Some(event) = events.into_iter().next() else {
+        return Ok(None);
+    };
+    let content: serde_json::Value = event
+        .get("content")
+        .and_then(|c| c.as_str())
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+
+    let as_str_vec = |key: &str| -> Vec<String> {
+        content
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let as_str = |key: &str| -> String {
+        content
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    Ok(Some(buzz_sdk::builders::AgentProfileState {
+        name: content
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        agent_type: as_str("agent_type"),
+        channels: as_str_vec("channels"),
+        channel_ids: as_str_vec("channel_ids"),
+        capabilities: as_str_vec("capabilities"),
+        status: as_str("status"),
+        respond_to: as_str("respond_to"),
+        channel_add_policy: as_str("channel_add_policy"),
+        generation: content
+            .get("generation")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+    }))
+}
+
+async fn publish_kind0_profile(ctx: &Ctx, keys: &Keys, display_name: &str) -> anyhow::Result<()> {
+    let content =
+        serde_json::json!({ "name": display_name, "display_name": display_name }).to_string();
+    let builder = EventBuilder::new(Kind::Metadata, &content);
+    let event = sign_as(keys, builder)?;
+    client_for(ctx, keys)?
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("kind:0 profile publish failed: {e}"))?;
+    Ok(())
+}
+
+/// Relay's `/events` endpoint requires the event's `pubkey` to match the
+/// NIP-98-authenticated identity of the request itself, so each agent
+/// identity's own events must be submitted through a client authenticated
+/// as *that* identity — `ctx.client` (the owner) can't submit on its behalf.
+fn client_for(ctx: &Ctx, keys: &Keys) -> anyhow::Result<BuzzClient> {
+    BuzzClient::new(ctx.relay_url_for_admin.clone(), keys.clone(), None, None)
+        .map_err(|e| anyhow::anyhow!("building per-identity client: {e}"))
+}
+
+async fn send_message(ctx: &Ctx, channel_id: Uuid, content: &str) -> anyhow::Result<()> {
+    use buzz_sdk::builders::build_message;
+    let builder = build_message(channel_id, content, None, &[], false, &[])
+        .map_err(|e| anyhow::anyhow!("build_message: {e}"))?;
+    let event = ctx.client.sign_event(builder)?;
+    ctx.client
+        .submit_event(event)
+        .await
+        .map_err(|e| anyhow::anyhow!("send_message failed: {e}"))?;
+    Ok(())
+}
+
+fn sign_as(keys: &Keys, builder: EventBuilder) -> anyhow::Result<nostr::Event> {
+    builder
+        .sign_with_keys(keys)
+        .map_err(|e| anyhow::anyhow!("signing failed: {e}"))
+}

--- a/crates/buzz-supervisor/src/security.rs
+++ b/crates/buzz-supervisor/src/security.rs
@@ -1,0 +1,92 @@
+//! Workdir validation — the load-bearing security boundary for this crate.
+//!
+//! A channel's declared working directory is attacker-influenced (anyone who
+//! can create a channel controls this string), so it must be canonicalized
+//! and checked against an explicit allowlist of roots *before* anything is
+//! spawned there. There is no default allowed root — the operator must pass
+//! at least one `--allowed-root`.
+
+use std::path::{Path, PathBuf};
+
+pub struct AllowedRoots(Vec<PathBuf>);
+
+impl AllowedRoots {
+    pub fn new(roots: Vec<PathBuf>) -> anyhow::Result<Self> {
+        if roots.is_empty() {
+            anyhow::bail!("at least one --allowed-root is required");
+        }
+        let canonical = roots
+            .iter()
+            .map(|r| {
+                r.canonicalize()
+                    .map_err(|e| anyhow::anyhow!("--allowed-root {}: {e}", r.display()))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self(canonical))
+    }
+
+    /// Expand a `~`/`~/...` prefix using `$HOME`, leaving other paths as-is.
+    fn expand_tilde(raw: &str) -> anyhow::Result<PathBuf> {
+        if raw == "~" || raw.starts_with("~/") {
+            let home = std::env::var("HOME")
+                .map_err(|_| anyhow::anyhow!("workdir uses ~ but $HOME is not set"))?;
+            let rest = raw.strip_prefix('~').unwrap_or("").trim_start_matches('/');
+            return Ok(Path::new(&home).join(rest));
+        }
+        Ok(PathBuf::from(raw))
+    }
+
+    /// Validate a raw workdir string from a channel description.
+    ///
+    /// Returns the canonicalized path on success, or a human-readable
+    /// rejection reason (suitable for posting back into the channel) on
+    /// failure.
+    pub fn validate(&self, raw: &str) -> Result<PathBuf, String> {
+        let expanded = Self::expand_tilde(raw).map_err(|e| format!("{e} (workdir: {raw})"))?;
+        if !expanded.is_absolute() {
+            return Err(format!("not an absolute path (or ~/...): {raw}"));
+        }
+        let resolved = expanded
+            .canonicalize()
+            .map_err(|_| format!("path does not exist: {}", expanded.display()))?;
+        if !resolved.is_dir() {
+            return Err(format!("not a directory: {}", resolved.display()));
+        }
+        if self.0.iter().any(|root| resolved.starts_with(root)) {
+            Ok(resolved)
+        } else {
+            Err(format!(
+                "outside allowed roots ({}): {}",
+                self.0
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                resolved.display()
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_paths_outside_allowed_roots() {
+        let tmp = std::env::temp_dir();
+        let roots = AllowedRoots::new(vec![tmp.join("buzz-supervisor-test-root")]).ok();
+        // Root doesn't exist yet in a fresh test env — construct directly
+        // instead to keep this test hermetic.
+        let _ = roots;
+        let allowed = AllowedRoots(vec![tmp.canonicalize().unwrap()]);
+        assert!(allowed.validate("/etc").is_err());
+    }
+
+    #[test]
+    fn accepts_paths_inside_allowed_roots() {
+        let tmp = std::env::temp_dir().canonicalize().unwrap();
+        let allowed = AllowedRoots(vec![tmp.clone()]);
+        assert_eq!(allowed.validate(tmp.to_str().unwrap()).unwrap(), tmp);
+    }
+}

--- a/crates/buzz-supervisor/src/state.rs
+++ b/crates/buzz-supervisor/src/state.rs
@@ -1,0 +1,95 @@
+//! Per-channel provisioning state, persisted to disk so a supervisor restart
+//! doesn't lose track of (or re-provision) channels it already handled.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChannelStatus {
+    /// Fully set up: every role has a published profile and a running (or
+    /// last-known-pid) process.
+    Provisioned,
+    /// Provisioning started but did not finish — at least one role's
+    /// identity/membership below was created before an error interrupted
+    /// the rest. Not retried automatically (that's how a partial failure
+    /// used to leak a fresh set of keys/memberships every poll cycle);
+    /// an operator must inspect `roles` and either finish setup manually or
+    /// delete this channel's state directory to start over.
+    Provisioning,
+    Rejected {
+        reason: String,
+    },
+    Ignored,
+    TornDown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleState {
+    pub pubkey: String,
+    pub privkey: String,
+    pub pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelState {
+    pub status: ChannelStatus,
+    pub workdir: Option<String>,
+    #[serde(default)]
+    pub roles: HashMap<String, RoleState>,
+}
+
+pub struct StateStore {
+    root: PathBuf,
+}
+
+impl StateStore {
+    pub fn new(root: PathBuf) -> anyhow::Result<Self> {
+        fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn path_for(&self, channel_id: &str) -> PathBuf {
+        self.root.join(channel_id).join("state.json")
+    }
+
+    pub fn known_channels(&self) -> anyhow::Result<Vec<String>> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    out.push(name.to_string());
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn load(&self, channel_id: &str) -> anyhow::Result<Option<ChannelState>> {
+        let path = self.path_for(channel_id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&path)?;
+        Ok(Some(serde_json::from_str(&raw)?))
+    }
+
+    pub fn save(&self, channel_id: &str, state: &ChannelState) -> anyhow::Result<()> {
+        let dir = self.root.join(channel_id);
+        fs::create_dir_all(&dir)?;
+        let path = self.path_for(channel_id);
+        let raw = serde_json::to_string_pretty(state)?;
+        fs::write(&path, raw)?;
+        // State contains generated private keys — lock it down like the
+        // individual key files the earlier bash prototype used.
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    }
+
+    pub fn log_path(&self, channel_id: &str, role: &str) -> PathBuf {
+        self.root.join(channel_id).join(format!("{role}.log"))
+    }
+}

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -110,6 +110,48 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
   );
 });
 
+test("relayAgentIsSharedWithUser: allowlist agents with no published allowlist are eligible in shared channels", () => {
+  const sharedChannelIds = new Set(["general"]);
+
+  // The public directory no longer carries respondToAllowlist (see
+  // buzz-relay's ingest rejection + buzz-sdk's build_agent_profile_update).
+  // A record with an empty/absent allowlist falls back to "anyone" behavior
+  // for eligibility — the harness remains the real enforcement point.
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        respondTo: "allowlist",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+    ),
+    true,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      { respondTo: "allowlist", respondToAllowlist: [], channelIds: ["other"] },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+  // No signed-in viewer and no legacy allowlist data — still falls back to
+  // channel-membership eligibility rather than requiring a pubkey to check.
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        respondTo: "allowlist",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+      sharedChannelIds,
+    ),
+    true,
+  );
+});
+
 test("relayAgentCanRespondInChannel: requires exact channel membership and viewer access", () => {
   const agent = {
     respondTo: "allowlist",

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -18,10 +18,29 @@ export function relayAgentIsSharedWithUser(
     ? normalizePubkey(currentPubkey)
     : null;
 
-  if (agent.respondTo === "allowlist" && normalizedCurrentPubkey) {
-    return agent.respondToAllowlist
-      .map((pubkey) => normalizePubkey(pubkey))
-      .includes(normalizedCurrentPubkey);
+  if (agent.respondTo === "allowlist") {
+    // The public directory (kind:10100, community-visible) no longer
+    // carries the exact allowlist — publishing precise access pubkeys there
+    // would leak a private boundary to every member (see the relay-side
+    // rejection in buzz-relay/handlers/ingest.rs). Treat "allowlist" the
+    // same as "anyone" for eligibility: the harness is the real enforcement
+    // point and silently no-ops for senders it doesn't authorize, so
+    // showing the agent as mentionable here is a UI-level "you may try",
+    // not a security decision.
+    //
+    // Records published before this change may still carry a non-empty
+    // respondToAllowlist; honor it while present so they don't regress to
+    // over-permissive until naturally republished with the new schema.
+    if (agent.respondToAllowlist.length > 0) {
+      return normalizedCurrentPubkey
+        ? agent.respondToAllowlist
+            .map((pubkey) => normalizePubkey(pubkey))
+            .includes(normalizedCurrentPubkey)
+        : false;
+    }
+    return agent.channelIds.some((channelId) =>
+      sharedChannelIds.has(channelId),
+    );
   }
 
   return (


### PR DESCRIPTION
## Related PRs / issues

This addresses the review-blocking findings on our own two open PRs, and is directly relevant to two others' in-flight work on the same `kind:10100` directory:

- #5528 (ours, `agents publish-profile`) — wolfyy970's two `CHANGES_REQUESTED` passes: empty-allowlist-but-succeeds, `respond_to_allowlist` publicly exposed, competing whole-state writers.
- #5530 (ours, `buzz-supervisor`) — explicitly named in the same reviews as another writer constructing this event independently.
- #5546 (jjalora, harness self-publish) — same reviewer, same two open findings (allowlist exposure, read-modify-write race on `channel_add_policy` carry-forward). This PR's schema/CAS mechanism is meant to be something #5546 can adopt rather than compete with — see "Compatibility with #5546" below.
- #5483 (rmichelena, directory enrichment for `@mention` eligibility) — a different, complementary layer (client-side tolerance for records that don't exist yet); not touched by this PR, but the eligibility fix here (item 3 below) sits next to the code #5483 also touches.
- Underlying symptom reports these all trace back to: #5363, #4548, #4489, #3809, #3663, #4490, #2987.

## Problem

`kind:10100` is a plain NIP-01 replaceable event (highest `created_at` wins on read), but it has *multiple independent writers* today: `buzz channels set-add-policy`, `buzz agents publish-profile` (#5528), `buzz-supervisor` (#5530), and soon the ACP harness itself (#5546). None of them know what the others last wrote, so whichever publishes last silently wins — often with *less* information than what it clobbered. On top of that, every writer so far has published `respond_to_allowlist` — the exact pubkeys allowed to trigger an `allowlist`-mode agent — into an event anyone in the community can query.

## Fix

1. **`buzz-sdk::builders::build_agent_profile_update(current, patch)`** is now the one function that constructs `kind:10100` content. It takes the caller's best-known current record plus a partial patch, merges them, bumps a `generation` counter, and validates `status`/`respond_to`/`channel_add_policy` against known enums and `channel_ids` as UUIDs. It has no `respond_to_allowlist` field in its input or output at all — the schema itself can't carry it, so a caller can't accidentally leak it even by mistake.

2. **Relay-side generation CAS.** `kind:10100` ingest now requires a positive integer `generation` and rejects a publish whose `generation` isn't strictly greater than the currently stored value ("stale generation") — the same compare-and-swap pattern already used for `kind:30350` push leases (`buzz-relay/src/handlers/push_lease.rs`), reusing the existing `get_latest_global_replaceable` lookup. A publish that includes `respond_to_allowlist` at all is rejected outright, independent of which client produced it. This turns "two writers silently clobber each other" into a loud, immediately-retryable rejection instead of lost data.

3. **`buzz agents publish-profile` and `buzz-supervisor` both fetch-then-patch.** Each now queries its own current `kind:10100` record, applies the requested change through the shared builder, and retries once if the relay rejects it as a stale generation (i.e. something else published in between). `--respond-to-allowlist` is gone from `publish-profile`'s flags — there's nothing left for it to do.

4. **Desktop eligibility no longer requires the allowlist to be present.** `relayAgentIsSharedWithUser` previously hid an `allowlist`-mode agent entirely unless the *exact* allowlist (now nonexistent for new publishes) contained the viewer's pubkey. It now treats `allowlist` the same as `anyone` for eligibility when no allowlist is present — the harness remains the real enforcement point and simply won't act on an unauthorized mention, so showing the agent as "you may try" is a UI decision, not a security one. Records that still carry a legacy non-empty allowlist (published before this change) are still honored, so nothing regresses to over-permissive mid-flight.

## Compatibility with #5546

#5546 has the harness publish its own record, carrying `channel_add_policy` forward via a read-then-write. Its reviewer flagged the same race this PR's generation CAS is built to close, and the same allowlist-exposure concern this PR's schema removes structurally. The intent is for #5546 to route its writes through `build_agent_profile_update` too (fetch current → patch → the relay enforces the generation bump) rather than hand-rolling its own read-modify-write — happy to help wire that up once the direction here is agreed, rather than have two independent fixes for the same race.

## Testing

- `cargo test -p buzz-sdk -p buzz-cli -p buzz-supervisor --lib` — all passing; new tests cover the builder's merge/generation-bump/validation behavior (first-publish defaults, field carry-forward, invalid status/respond_to/channel_id/name rejection) and confirm `respond_to_allowlist` never appears in constructed content.
- `cargo clippy -p buzz-sdk -p buzz-cli -p buzz-supervisor -p buzz-relay --all-targets --all-features -- -D warnings` — clean on all four touched crates.
- `cargo fmt --all -- --check` — clean.
- `pnpm typecheck` (desktop) — clean.
- `node --test src/features/agents/lib/agentAutocompleteEligibility.test.mjs` — 23/23 passing, including new coverage for the empty-allowlist fallback and legacy-allowlist compatibility.
- Could not run `buzz-relay`'s own `#[test]` suite in this sandbox — the built test binary fails at runtime with a missing `libssl.so.3`, unrelated to this change (pre-existing environment gap, not something this diff touches). Relying on a clean `clippy --all-targets` build plus full CI for that suite.

## Known gaps / follow-ups

- `buzz channels set-add-policy` still writes a sparse, non-generation-aware content body directly — it should be ported onto the same builder in a follow-up so it participates in the CAS instead of being a fifth uncoordinated writer.
- No migration path for pre-existing `kind:10100` records published without a `generation` field — they'll simply fail the next patch attempt's *read* gracefully (treated as generation 0) but a raw legacy record with no generation at all currently can't be published fresh either; happy to relax the ingest check to backfill `generation: 1` for a first-seen record if that's preferred over requiring every legacy identity to republish.
- Doesn't address #5483's "records that were never published at all stay invisible" gap — that's a different, client-side layer and can land independently.