### PR TITLE
fix(desktop): refuse sidebar drags from a press with no button held

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -114,6 +114,7 @@ export default defineConfig({
         "**/inbox-refactor-screenshots.spec.ts",
         "**/buzz-theme-screenshots.spec.ts",
         "**/channel-sort.spec.ts",
+        "**/sidebar-drag-activation.spec.ts",
         "**/identity-lost.spec.ts",
         "**/deep-link-invite.spec.ts",
         "**/invite-link-copy.spec.ts",

--- a/desktop/src/features/sidebar/lib/pressAwarePointerSensor.ts
+++ b/desktop/src/features/sidebar/lib/pressAwarePointerSensor.ts
@@ -1,0 +1,43 @@
+import { PointerSensor } from "@dnd-kit/core";
+import type { PointerSensorOptions } from "@dnd-kit/core";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+/**
+ * A {@link PointerSensor} that refuses a `pointerdown` reporting no button
+ * held, instead of arming a drag it will never see released.
+ *
+ * dnd-kit starts a drag from pointer travel alone and never re-reads the button
+ * state, so a `pointerup` the page does not receive leaves the sensor armed:
+ * the next cursor move begins a drag nobody asked for, and the click that move
+ * belonged to is swallowed, because dnd-kit installs a capture-phase `click`
+ * blocker as soon as a drag activates.
+ *
+ * The macOS webview does exactly that with tap-to-click. A tap is recognised
+ * after the finger has already lifted, so `pointerdown` arrives with
+ * `buttons: 0` and the matching `pointerup` is deferred — measured at 356ms to
+ * over 1.2s, and sometimes not before the next input at all. A deliberate
+ * press-and-hold reports `buttons: 1` throughout, which is what makes the two
+ * separable at the one moment that decides everything: over 38 measured
+ * gestures, every `buttons: 0` press was a click and every `buttons: 1` press
+ * was a real drag, with nothing in between.
+ *
+ * So the fix is to not start. dnd-kit only instantiates a sensor when the
+ * activator returns exactly `true` (`@dnd-kit/core` 6.3.1,
+ * `bindActivatorToSensorInstantiator`), and reads `activators` off the sensor
+ * class, so declining here means no session, no click blocker, and nothing to
+ * unwind. The base handler is delegated to for everything else — it is what
+ * rejects non-primary and non-left presses, and what fires `onActivation`.
+ */
+export class PressAwarePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: "onPointerDown" as const,
+      handler: (
+        event: ReactPointerEvent,
+        options: PointerSensorOptions,
+      ): boolean =>
+        event.nativeEvent.buttons !== 0 &&
+        PointerSensor.activators[0].handler(event, options),
+    },
+  ];
+}

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -2,7 +2,6 @@ import {
   DndContext,
   DragOverlay,
   KeyboardSensor,
-  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -35,6 +34,7 @@ import {
   ContextMenuTrigger,
 } from "@/shared/ui/context-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { PressAwarePointerSensor } from "@/features/sidebar/lib/pressAwarePointerSensor";
 import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
@@ -328,7 +328,9 @@ export function CommunityRail({
   const [draggingId, setDraggingId] = React.useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(PressAwarePointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),

--- a/desktop/src/features/sidebar/ui/SidebarDnd.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarDnd.tsx
@@ -2,7 +2,6 @@
 import {
   DndContext,
   DragOverlay,
-  PointerSensor,
   pointerWithin,
   useDraggable,
   useDroppable,
@@ -20,6 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Hash } from "lucide-react";
 import * as React from "react";
 
+import { PressAwarePointerSensor } from "@/features/sidebar/lib/pressAwarePointerSensor";
 import { cn } from "@/shared/lib/cn";
 
 export type DndChannelData = { type: "channel"; channelId: string };
@@ -192,7 +192,9 @@ export function SidebarDndContext({
   const [activeDragItem, setActiveDragItem] =
     React.useState<SidebarDragItem | null>(null);
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(PressAwarePointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
   );
 
   const handleDragStart = React.useCallback(

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -1085,6 +1085,50 @@ test.describe("community rail", () => {
     expect(reloadBoxB.y).toBeLessThan(reloadBoxA.y);
   });
 
+  test("a press reporting no button held does not arm a rail drag or eat the next click", async ({
+    page,
+  }) => {
+    await installMockBridge(page, undefined, { skipCommunitySeed: true });
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_A.id);
+    await page.goto("/");
+
+    const buttonA = page.getByTestId(`community-rail-button-${COMMUNITY_A.id}`);
+    const buttonB = page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`);
+    // B must not already be the active community, or the assertion at the end
+    // would hold with the click never landing.
+    await expect(buttonA).toHaveAttribute("aria-current", "true");
+    await expect(buttonB).not.toHaveAttribute("aria-current", "true");
+
+    const boxA = await buttonA.boundingBox();
+    const boxB = await buttonB.boundingBox();
+    if (!boxA || !boxB) throw new Error("community buttons not laid out");
+
+    // The press the macOS webview reports for tap-to-click: no button held, and
+    // the release deferred past the next input. page.mouse.down() always
+    // reports a held button, so it has to be dispatched directly.
+    await buttonA.dispatchEvent("pointerdown", {
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: boxA.x + boxA.width / 2,
+      clientY: boxA.y + boxA.height / 2,
+    });
+    await page.mouse.move(boxA.x + boxA.width / 2, boxA.y + boxA.height / 2);
+
+    // Travelling to the other community is well past the 6px activation
+    // distance; a drag armed here would swallow the click that follows and the
+    // community switch would silently fail.
+    await page.mouse.move(boxB.x + boxB.width / 2, boxB.y + boxB.height / 2, {
+      steps: 10,
+    });
+    await page.mouse.down();
+    await page.mouse.up();
+
+    await expect(buttonB).toHaveAttribute("aria-current", "true");
+  });
+
   test("keyboard reorder: Space to pick up, ArrowUp to move, Space to drop updates stored order", async ({
     page,
   }) => {

--- a/desktop/tests/e2e/sidebar-drag-activation.spec.ts
+++ b/desktop/tests/e2e/sidebar-drag-activation.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// Mock-mode current-user pubkey (DEFAULT_MOCK_IDENTITY); custom channel
+// sections persist under buzz-channel-sections.v1:<pubkey>.
+const MOCK_PUBKEY = "deadbeef".repeat(8);
+const SECTIONS_KEY = `buzz-channel-sections.v1:${MOCK_PUBKEY}`;
+const SECTION_TOP = { id: "sec-top", name: "Priority", order: 0 };
+const SECTION_BOTTOM = { id: "sec-bottom", name: "Archive", order: 1 };
+
+async function seedChannelSections(page: Page) {
+  await page.addInitScript(
+    ({ key, sections }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ version: 1, sections, assignments: {} }),
+      );
+    },
+    { key: SECTIONS_KEY, sections: [SECTION_TOP, SECTION_BOTTOM] },
+  );
+}
+
+// dnd-kit marks each section's wrapping row with aria-roledescription
+// ="sortable" and spreads the drag listeners there, so the row is the handle.
+function sectionRows(page: Page) {
+  return page.locator('[aria-roledescription="sortable"]');
+}
+
+// Returns each row's own section name, so an unexpected row shows up as its
+// text instead of being collapsed into a catch-all bucket.
+async function sectionOrder(page: Page) {
+  return sectionRows(page).evaluateAll(
+    (rows, names) =>
+      rows.map((row) => {
+        const text = row.textContent?.trim() ?? "";
+        return names.find((name) => text.startsWith(name)) ?? text;
+      }),
+    [SECTION_TOP.name, SECTION_BOTTOM.name],
+  );
+}
+
+/**
+ * The press the macOS webview reports for tap-to-click: a `pointerdown` with no
+ * button held, whose `pointerup` arrives hundreds of milliseconds later or not
+ * before the next input at all. `page.mouse.down()` cannot produce it — it
+ * always reports a held button — so it is dispatched directly, with real
+ * viewport coordinates so dnd-kit measures activation distance from the row
+ * rather than from the origin.
+ */
+async function pressWithNoButtonHeld(target: Locator) {
+  const box = await target.boundingBox();
+  if (!box) throw new Error("press target is not laid out");
+  const clientX = box.x + box.width / 2;
+  const clientY = box.y + box.height / 2;
+  await target.dispatchEvent("pointerdown", {
+    button: 0,
+    buttons: 0,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: "mouse",
+    clientX,
+    clientY,
+  });
+  return { clientX, clientY };
+}
+
+test("a press reporting no button held does not arm a drag or eat the next click", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+
+  const random = page.getByTestId("channel-random");
+  const general = page.getByTestId("channel-general");
+  await expect(random).toBeVisible();
+  // The channel the click has to reach must not already be the selected one, or
+  // the assertion at the end would hold with the click never landing.
+  await expect(general).not.toHaveAttribute("data-active", "true");
+  const target = await general.boundingBox();
+  if (!target) throw new Error("channel rows are not laid out");
+
+  const { clientX, clientY } = await pressWithNoButtonHeld(random);
+  await page.mouse.move(clientX, clientY);
+
+  // Travel far past the 6px activation distance with no release in between:
+  // this is the move that used to start a drag out of a finished click.
+  await page.mouse.move(
+    target.x + target.width / 2,
+    target.y + target.height / 2,
+    { steps: 10 },
+  );
+
+  // An ordinary click, which dnd-kit swallows from its capture-phase blocker
+  // whenever a drag is live.
+  await page.mouse.down();
+  await page.mouse.up();
+
+  await expect(general).toHaveAttribute("data-active", "true");
+});
+
+test("a real press still drags right after one was refused", async ({
+  page,
+}) => {
+  await seedChannelSections(page);
+  await installMockBridge(page);
+  await page.goto("/");
+
+  const rows = sectionRows(page);
+  await expect(rows).toHaveCount(2);
+  const top = rows.filter({ hasText: SECTION_TOP.name });
+  const bottom = rows.filter({ hasText: SECTION_BOTTOM.name });
+  expect(await sectionOrder(page)).toEqual([
+    SECTION_TOP.name,
+    SECTION_BOTTOM.name,
+  ]);
+
+  const from = await top.boundingBox();
+  const to = await bottom.boundingBox();
+  if (!from || !to) throw new Error("section rows are not laid out");
+  const toX = to.x + to.width / 2;
+  const toY = to.y + to.height / 2;
+
+  // Refuse a press, then drag for real from the same row. Nothing may be left
+  // armed or half-torn-down by the refusal.
+  const { clientX, clientY } = await pressWithNoButtonHeld(top);
+  await page.mouse.move(clientX, clientY);
+  await page.mouse.move(toX, toY, { steps: 10 });
+  expect(await sectionOrder(page)).toEqual([
+    SECTION_TOP.name,
+    SECTION_BOTTOM.name,
+  ]);
+
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 14);
+  await page.mouse.move(toX, toY, { steps: 10 });
+  await page.mouse.up();
+
+  // The drop committed, so the order flipped: refusing button-free presses
+  // costs nothing a deliberate drag needs.
+  await expect
+    .poll(() => sectionOrder(page))
+    .toEqual([SECTION_BOTTOM.name, SECTION_TOP.name]);
+});


### PR DESCRIPTION
## Summary

Clicking a channel in the sidebar sometimes started a drag nobody asked for: a
preview followed the cursor and the channel never opened.

dnd-kit's `PointerSensor` decides to start a drag from pointer travel alone and
never re-reads the button state, so a `pointerup` the page does not receive
leaves the sensor armed. The next cursor move begins a drag, and because dnd-kit
installs a capture-phase `click` blocker as soon as a drag activates
(`@dnd-kit/core` 6.3.1, in `handleStart`), the click that move belonged to is
swallowed. The channel selection never runs.

**The releases really do go missing.** I instrumented the macOS webview and
logged every pointer event over 38 gestures of ordinary sidebar use:

| | `pointerdown` | `pointerup` | count |
|---|---|---|---|
| deliberate press-and-hold | `buttons: 1` | prompt | 4, of which **all 3 attempted drags worked** |
| tap-to-click | **`buttons: 0`** | **deferred 356ms – 1.2s+**; 8 times not within 700ms | 34, of which **23 would have started a drag** |

A tap is recognised after the finger has already lifted, so the webview reports
`pointerdown` with no button pressed and defers the matching `pointerup`. During
that window dnd-kit is still armed, and moving the cursor a few pixels toward
the next channel starts a drag.

The two gesture shapes never crossed in the measurements: every `buttons: 0`
press was a click, every `buttons: 1` press was a real drag. So the fix is to
not start. dnd-kit only instantiates a sensor when the activator returns exactly
`true`, and reads `activators` off the sensor class, so a subclass that checks
`buttons` before delegating to the base handler means no session, no click
blocker, and nothing to unwind.

```ts
export class PressAwarePointerSensor extends PointerSensor {
  static activators = [
    {
      eventName: "onPointerDown" as const,
      handler: (event: ReactPointerEvent, options: PointerSensorOptions) =>
        event.nativeEvent.buttons !== 0 &&
        PointerSensor.activators[0].handler(event, options),
    },
  ];
}
```

### Key decisions

- **Declining before instantiation, rather than cancelling a live session.** An
  earlier revision watched for button-free movement and dispatched a synthetic
  `pointercancel`. That was 45 lines and it could tear down a drag that was
  going fine, on the strength of a single move event from the same webview whose
  button reporting the change exists to distrust. Declining at `pointerdown`
  cannot do that, and it also sidesteps dnd-kit deferring its document-listener
  teardown by 50ms, which leaves the click blocker up for a moment after a
  cancel.
- **`buttons !== 0`, not a bitmask test.** The base handler already rejects
  non-primary and non-left presses; the only new claim is that a press with no
  button pressed is not a press. Touch contact and pen contact both report a
  button, so neither is affected.
- **The base handler is delegated to rather than replaced**, so `onActivation`
  and the primary/left checks keep coming from dnd-kit.
- **The activation distance is unchanged (6px).** Measured travel during the bug
  was 21–170px, so no threshold value separates these gestures; raising it would
  have been an unrelated change that fixed nothing.
- **The community rail gets the same sensor.** It is the same bug there, and a
  swallowed click means a failed community switch, which is heavier than a
  missed channel.

One case is deliberately not covered: a drag that starts with a button held and
loses its release later. It never appeared in the measurements, and <kbd>Esc</kbd>
already cancels a live drag, so nothing is built for it until it is reported.

### Related issue

None found. I searched open issues and PRs for `drag`, `sidebar`, `pointerup`,
`dnd-kit` and `click drag sidebar` — no existing report of this behaviour.

Adjacent, not duplicates:
- #5253 — forum channels *cannot* be dragged into custom sections. Opposite
  direction (missing capability), untouched here.
- #4652 — `test(desktop): stabilize keyboard community reorder`. Touches
  `desktop/tests/e2e/community-rail.spec.ts`, the same file this PR appends a
  test to, so one of the two will need a trivial rebase.

### Testing

`just ci` passes locally.

Regression coverage is e2e rather than a unit test because the behaviour needs a
real DOM and dnd-kit's full sensor pipeline; a `*.test.mjs` beside the module
could only re-assert the code it is testing.

Each test reproduces the production sequence — a `pointerdown` reporting no
button held, which `page.mouse.down()` cannot produce — and asserts what the
user loses, that the following click selects its target:

- `sidebar-drag-activation.spec.ts` — a refused press does not arm a drag or eat
  the next channel click; and a real press-and-drag still commits its section
  reorder right after one was refused.
- `community-rail.spec.ts` — the same for the rail, asserting the community
  switch lands.

**Each test was validated by mutation**, both directions, checking the build
exit code separately so a type error could not silently serve a stale bundle:

| mutation | refused-press tests | deliberate-drag tests |
|---|---|---|
| drop the button check | **fail** (click swallowed, target never activates) | pass |
| refuse every press | pass | **fail** (`sidebar-drag-activation`, and the existing rail reorder test at `community-rail.spec.ts:1005`) |

Manual verification on macOS, in two passes. The instrumented 38-gesture session
above was taken with an earlier revision of this change; it is where the
`buttons` separation and the count of 23 come from. This revision was then
checked by using a dev build normally — the recording below is that check.

#### Recording

Nothing renders differently, so before/after screenshots would be identical
pixels; these are the interaction instead, from a dev build on macOS with
tap-to-click.

Clicking channels — each click opens its channel, and no drag preview appears:

![clicking channels opens them](https://raw.githubusercontent.com/kunsanglee/buzz/561cee34b921e9a49f95e34864e8d397bde07661/sidebar-drag-after-click.gif)

Deliberately pressing and dragging — the preview appears, follows the cursor,
and the drop lands:

![a deliberate drag still works](https://raw.githubusercontent.com/kunsanglee/buzz/561cee34b921e9a49f95e34864e8d397bde07661/sidebar-drag-after-drag.gif)

### Deferred to follow-up PRs

- `desktop/src/features/home/useResizableInboxListWidth.ts` and
  `desktop/src/shared/hooks/useThreadPanelWidth.ts` have the same defect class —
  they listen for `pointerup` with `{ once: true }` and handle no
  `pointercancel`, so a lost release leaves `document.body.style.cursor` and
  `userSelect: none` stuck app-wide.
- Neither `DndContext` wires `onDragCancel`, so cancelling a live drag with
  <kbd>Esc</kbd> leaves the dimmed source row dimmed. Pre-existing, unrelated to
  the press that starts it.
- A drop that changes nothing still writes localStorage and publishes a
  `kind:KIND_CHANNEL_SECTIONS` event (`useChannelSections.ts`). Not caused by
  this bug, but it made each spurious drag reach the relay.
- `SidebarDndContext` advertises `aria-roledescription="draggable"` without
  registering a `KeyboardSensor` (the rail has one), so keyboard users are told
  about an interaction they cannot perform.
