### PR TITLE
feat(cli): include reaction event ids and timestamps in `reactions get`

### DIFF
--- a/crates/buzz-cli/src/commands/reactions.rs
+++ b/crates/buzz-cli/src/commands/reactions.rs
@@ -86,7 +86,7 @@ pub async fn cmd_get_reactions(client: &BuzzClient, event_id: &str) -> Result<()
     let resp = client.query(&filter).await?;
     let events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
 
-    let mut groups: HashMap<String, Vec<String>> = HashMap::new();
+    let mut groups: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
     for e in &events {
         let emoji = e
             .get("content")
@@ -99,16 +99,40 @@ pub async fn cmd_get_reactions(client: &BuzzClient, event_id: &str) -> Result<()
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        groups.entry(emoji).or_default().push(pubkey);
+        let id = e
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let created_at = e.get("created_at").and_then(|v| v.as_i64()).unwrap_or(0);
+        groups.entry(emoji).or_default().push(serde_json::json!({
+            "id": id,
+            "pubkey": pubkey,
+            "created_at": created_at,
+        }));
     }
 
     let mut reactions: Vec<serde_json::Value> = groups
         .into_iter()
-        .map(|(emoji, pubkeys)| {
+        .map(|(emoji, mut group)| {
+            group.sort_by_key(|ev| {
+                (
+                    ev.get("created_at").and_then(|v| v.as_i64()).unwrap_or(0),
+                    ev.get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                )
+            });
+            let pubkeys: Vec<serde_json::Value> = group
+                .iter()
+                .map(|ev| ev.get("pubkey").cloned().unwrap_or_default())
+                .collect();
             serde_json::json!({
                 "emoji": emoji,
-                "count": pubkeys.len(),
+                "count": group.len(),
                 "pubkeys": pubkeys,
+                "events": group,
             })
         })
         .collect();


### PR DESCRIPTION
## Summary

`buzz reactions get` aggregates kind:7 reactions by emoji and returns only `emoji`, `count`, and `pubkeys`. Flows that need to reference the reaction events themselves — for example, to audit who reacted and when, or to resolve a reaction event id for follow-up — must re-query the relay and regroup by hand.

This change adds an `events` array to each emoji group. Each entry carries the reaction event `id`, the author `pubkey`, and `created_at`, sorted by `(created_at, id)` so output is deterministic. The kind:7 events the command fetches already contain this data; the change includes it in the output instead of discarding it.

Existing fields keep their shape, so current consumers keep working. `pubkeys` now follows the same `(created_at, id)` order as `events` (previously relay return order).

### Related issue

None found — searched existing issues and PRs for `reactions get` and reaction output.

### Testing

Ran the patched CLI against a live relay at `desktop-v0.5.10` and verified the response by hand:

```json
{"reactions":[{"count":1,"emoji":"👍",
  "events":[{"created_at":1786501702,"id":"7f143b9b6a24e8d1d3522b0f2de90626c02c2b0ec988eb3df3249bd40d5e71b5","pubkey":"92fe4fa1ce687378092485cd63f99f4443b510714ccb3f58caf839f9631993cf"}],
  "pubkeys":["92fe4fa1ce687378092485cd63f99f4443b510714ccb3f58caf839f9631993cf"]}]}
```

`cargo build -p buzz-cli` and `cargo clippy -p buzz-cli -- -D warnings` pass. No UI change.
