### PR TITLE
fix(desktop): recover Linux WebKit startup crash loops

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -45,6 +45,8 @@ mod tray_menu;
 mod util;
 #[cfg(target_os = "linux")]
 pub mod webkit_rendering;
+#[cfg(target_os = "linux")]
+mod webkit_startup_recovery;
 use app_state::{build_app_state, resolve_persisted_identity, AppState};
 use builderlab::*;
 use commands::*;
@@ -77,6 +79,8 @@ use mesh_llm_stubs::*;
 use shutdown::{hard_exit_after_mesh_shutdown, relaunch_after_mesh_shutdown};
 use shutdown::{is_restart_request, shut_down_app};
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
+#[cfg(target_os = "linux")]
+use tauri::webview::PageLoadEvent;
 #[cfg(target_os = "macos")]
 use tauri::Listener;
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
@@ -112,6 +116,25 @@ pub fn run() {
             eprintln!("buzz-mesh: failed to build big-stack tokio runtime, using default: {error}");
         }
     }
+    let context = tauri::generate_context!();
+    #[cfg(target_os = "linux")]
+    let webkit_startup_data_dir =
+        dirs::data_dir().map(|dir| dir.join(&context.config().identifier));
+    #[cfg(target_os = "linux")]
+    if let Some(data_dir) = webkit_startup_data_dir.as_deref() {
+        match webkit_startup_recovery::prepare(data_dir) {
+            Ok(outcome) if outcome.quarantined_cache => {
+                eprintln!(
+                    "buzz-desktop: prior WebKit startup was incomplete; quarantined disposable WebKitCache"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("buzz-desktop: WebKit startup recovery failed: {error}");
+            }
+        }
+    }
+
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             // Focus the existing window when a duplicate instance launches.
@@ -293,6 +316,16 @@ pub fn run() {
     };
 
     let app = app_menu::install(builder)
+        .on_page_load(move |webview, payload| {
+            #[cfg(target_os = "linux")]
+            if webview.label() == "main" && matches!(payload.event(), PageLoadEvent::Finished) {
+                if let Some(data_dir) = webkit_startup_data_dir.as_deref() {
+                    if let Err(error) = webkit_startup_recovery::mark_ready(data_dir) {
+                        eprintln!("buzz-desktop: WebKit startup recovery cleanup failed: {error}");
+                    }
+                }
+            }
+        })
         .register_asynchronous_uri_scheme_protocol("buzz-media", |ctx, request, responder| {
             let app = ctx.app_handle().clone();
             tauri::async_runtime::spawn(async move {
@@ -915,7 +948,7 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             tray_menu::update_tray_agent_activity,
         ])
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building tauri application");
     let shutdown_done = Arc::new(AtomicBool::new(false));
 

--- a/desktop/src-tauri/src/webkit_startup_recovery.rs
+++ b/desktop/src-tauri/src/webkit_startup_recovery.rs
@@ -1,0 +1,148 @@
+//! Crash-loop recovery for Linux WebKitGTK startup.
+//!
+//! Some WebKitGTK/GPU combinations abort or segfault while opening a persisted
+//! `WebKitCache`. The process dies after Tauri setup starts but before the main
+//! page finishes loading, so the next launch can detect that incomplete startup.
+//! Only the disposable WebKit cache is quarantined; identity and user data are
+//! never removed.
+
+use std::path::{Path, PathBuf};
+
+const STARTUP_PENDING: &str = ".webkit-startup-pending";
+const WEBKIT_CACHE: &str = "WebKitCache";
+const RECOVERY_TRASH: &str = ".WebKitCache.startup-recovery";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct PrepareOutcome {
+    pub quarantined_cache: bool,
+}
+
+fn marker_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(STARTUP_PENDING)
+}
+
+fn cache_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(WEBKIT_CACHE)
+}
+
+fn trash_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(RECOVERY_TRASH)
+}
+
+/// Mark this startup as pending and quarantine WebKit's cache when the previous
+/// launch never reached a finished main-page load.
+pub(crate) fn prepare(app_data_dir: &Path) -> Result<PrepareOutcome, String> {
+    std::fs::create_dir_all(app_data_dir)
+        .map_err(|error| format!("create app data directory: {error}"))?;
+
+    let marker = marker_path(app_data_dir);
+    let mut outcome = PrepareOutcome::default();
+    if marker.exists() {
+        let cache = cache_path(app_data_dir);
+        let trash = trash_path(app_data_dir);
+        if trash.exists() {
+            std::fs::remove_dir_all(&trash).map_err(|error| {
+                format!(
+                    "remove prior WebKit recovery trash {}: {error}",
+                    trash.display()
+                )
+            })?;
+        }
+        if cache.exists() {
+            std::fs::rename(&cache, &trash).map_err(|error| {
+                format!(
+                    "quarantine WebKit cache {} to {}: {error}",
+                    cache.display(),
+                    trash.display()
+                )
+            })?;
+            outcome.quarantined_cache = true;
+        }
+    }
+
+    // Write after recovery so another crash during/after setup remains visible.
+    std::fs::write(&marker, b"pending\n")
+        .map_err(|error| format!("write WebKit startup marker {}: {error}", marker.display()))?;
+    Ok(outcome)
+}
+
+/// A finished main-page load proves WebKit startup succeeded. Remove the marker
+/// and any quarantined cache from the prior failed launch.
+pub(crate) fn mark_ready(app_data_dir: &Path) -> Result<(), String> {
+    let marker = marker_path(app_data_dir);
+    match std::fs::remove_file(&marker) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "remove WebKit startup marker {}: {error}",
+                marker.display()
+            ));
+        }
+    }
+
+    let trash = trash_path(app_data_dir);
+    match std::fs::remove_dir_all(&trash) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "remove WebKit recovery trash {}: {error}",
+            trash.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_start_marks_pending_without_touching_data() {
+        let root = tempfile::tempdir().unwrap();
+        let app = root.path().join("app");
+        std::fs::create_dir_all(&app).unwrap();
+        std::fs::write(app.join("identity.migrated"), b"1").unwrap();
+
+        let outcome = prepare(&app).unwrap();
+
+        assert_eq!(outcome, PrepareOutcome::default());
+        assert!(marker_path(&app).is_file());
+        assert_eq!(std::fs::read(app.join("identity.migrated")).unwrap(), b"1");
+    }
+
+    #[test]
+    fn incomplete_start_quarantines_only_webkit_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let app = root.path().join("app");
+        let cache = cache_path(&app);
+        std::fs::create_dir_all(cache.join("Version 17")).unwrap();
+        std::fs::write(cache.join("Version 17/salt"), b"stale").unwrap();
+        std::fs::write(app.join("identity.migrated"), b"1").unwrap();
+        std::fs::write(marker_path(&app), b"pending\n").unwrap();
+
+        let outcome = prepare(&app).unwrap();
+
+        assert!(outcome.quarantined_cache);
+        assert!(!cache.exists());
+        assert_eq!(
+            std::fs::read(trash_path(&app).join("Version 17/salt")).unwrap(),
+            b"stale"
+        );
+        assert_eq!(std::fs::read(app.join("identity.migrated")).unwrap(), b"1");
+        assert!(marker_path(&app).is_file());
+    }
+
+    #[test]
+    fn ready_clears_marker_and_recovery_trash() {
+        let root = tempfile::tempdir().unwrap();
+        let app = root.path().join("app");
+        std::fs::create_dir_all(trash_path(&app)).unwrap();
+        std::fs::write(trash_path(&app).join("salt"), b"old").unwrap();
+        std::fs::write(marker_path(&app), b"pending\n").unwrap();
+
+        mark_ready(&app).unwrap();
+
+        assert!(!marker_path(&app).exists());
+        assert!(!trash_path(&app).exists());
+    }
+}


### PR DESCRIPTION
## Summary

Recover Linux Desktop from WebKitGTK startup crash loops without deleting Buzz user data.

- write a startup-pending marker before Tauri creates the configured webview
- after an incomplete previous startup, atomically quarantine only `WebKitCache`
- clear the marker and quarantined cache after the main page finishes loading
- leave identities, message/storage data, agents, HSTS, and settings untouched

## Runtime error

I reproduced intermittent startup failures with the upstream 0.5.10 Desktop on this host:

- Ubuntu 25.04, Linux 6.14.0-1013-nvidia
- aarch64
- NVIDIA GB10, driver 580.95.05
- WebKitGTK 2.50.4, GLib 2.84.1, GTK 3.24.49

Observed failures included:

```text
Segmentation fault (core dumped)
Fatal glibc error: tpp.c:83 (__pthread_tpp_change_priority): assertion failed
KMS: DRM_IOCTL_MODE_CREATE_DUMB failed: Permission denied
Failed to create GBM buffer ... Permission denied
```

`--safe-rendering` reduces the GPU surface involved but did not reliably prevent the WebKit/GLib failures. Trials against copies of the same application state also showed a higher failure incidence with the persisted `WebKitCache`. The native failure is nondeterministic, so this change does not claim to fix WebKitGTK or the driver; it prevents a bad disposable cache from trapping Buzz in a repeated startup failure.

## Recovery behavior

The pending marker is created before `Builder::build`, which is important because Tauri creates configured webviews before invoking the application `setup()` callback. If the prior launch did not reach `PageLoadEvent::Finished` for `main`, the next launch renames `WebKitCache` to recovery trash before webview creation. A successful main-page load removes both the marker and trash.

Recovery errors are logged and startup continues. No durable Buzz data is selected for removal.

## Verification

Automated:

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 2405 library tests passed, 14 ignored; 7 CSP and 3 mixer integration tests passed
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib --tests -- -D warnings`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo build --release --manifest-path desktop/src-tauri/Cargo.toml --bin buzz-desktop`

The new focused tests verify:

1. first startup creates the marker without touching an identity sentinel
2. incomplete startup quarantines only `WebKitCache`
3. successful page load clears the marker and recovery trash

Manual recovery test:

1. copied the pre-reset application state to isolated `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME` directories
2. added the pending marker and an identity-preservation sentinel
3. launched the patched release binary with `--safe-rendering`
4. kept it alive for 30 seconds, then intentionally stopped it with `timeout`

Result:

```text
buzz-desktop: prior WebKit startup was incomplete; quarantined disposable WebKitCache
```

The main page finished loading, the marker and recovery trash were removed, WebKit created a fresh cache, and the identity sentinel remained byte-for-byte unchanged.
