### PR TITLE
fix(buzz-acp): log author-gate rejections at INFO, not DEBUG

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2462,9 +2462,16 @@ async fn tokio_main() -> Result<()> {
                                 )
                                 .await;
                                 if !allowed {
-                                    tracing::debug!(
+                                    // INFO, not DEBUG: a gate rejection is invisible to the
+                                    // sender (their mention just sits there), so the operator's
+                                    // log is the only place the refusal exists at all. At debug
+                                    // level a blocked mention is indistinguishable from a
+                                    // working one under default logging — "@agent doesn't
+                                    // work" then has no evidence to find, only absence.
+                                    tracing::info!(
                                         channel_id = %buzz_event.channel_id,
                                         author = %buzz_event.event.pubkey.to_hex(),
+                                        event_id = %buzz_event.event.id.to_hex(),
                                         mode = %config.respond_to,
                                         is_dm,
                                         "inbound author gate — dropping event"

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -499,7 +499,9 @@ pub(crate) fn should_nudge_for_event(
     nudged_event_ids: &mut HashSet<EventId>,
 ) -> bool {
     if !author_allowed {
-        tracing::debug!("setup-mode: event filtered by author gate");
+        // INFO to match the normal-mode gate: a rejection produces no sender
+        // feedback, so the log line is the only evidence it happened.
+        tracing::info!(%event_id, "setup-mode: event filtered by author gate");
         return false;
     }
     if !filter_matched {


### PR DESCRIPTION
## Problem

`author_allowed` returning false drops the inbound event with a DEBUG-level log line. Under default (INFO) logging that means a rejection produces **no operator-visible signal at all** — and the sender gets nothing back either, so a blocked mention fails identically to a working one from both ends.

Measured on a production fleet: 7 days of `journalctl` across 8 agents contained zero gate lines while a user's mentions were being silently dropped. The only diagnosis path was reasoning about the absence of evidence.

## Change

Both gate rejection sites — the normal-mode inbound loop and the setup-mode nudge gate (`should_nudge_for_event`) — now log at INFO with the event id included, so one grep answers "why did @agent ignore this message": author pubkey, channel, respond_to mode, is_dm, event id.

A refusal that produces no signal is indistinguishable from success; this keeps the gate's behavior identical while making it observable.

## Testing

- `cargo check -p buzz-acp`, `cargo fmt --check` clean; full pre-push suite (rust-tests, desktop, mobile) green.
- No behavioral change — log level and fields only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)