### PR TITLE
fix(acp): recover omitted channel replies

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -108,6 +108,52 @@ pub enum AcpError {
     AgentError { code: i64, message: String },
 }
 
+#[derive(Debug)]
+struct CapturedAgentMessage {
+    message_id: String,
+    text: String,
+}
+
+fn capture_agent_message_chunk(
+    messages: &mut Vec<CapturedAgentMessage>,
+    update: &serde_json::Value,
+) {
+    let Some(text) = update
+        .get("content")
+        .and_then(|content| content.get("text"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return;
+    };
+    let message_id = update
+        .get("messageId")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("__legacy_agent_message");
+
+    if let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.message_id == message_id)
+    {
+        message.text.push_str(text);
+        return;
+    }
+
+    messages.push(CapturedAgentMessage {
+        message_id: message_id.to_string(),
+        text: text.to_string(),
+    });
+}
+
+fn take_final_captured_agent_message(messages: &mut Vec<CapturedAgentMessage>) -> Option<String> {
+    while let Some(message) = messages.pop() {
+        if !message.text.trim().is_empty() {
+            return Some(message.text);
+        }
+    }
+    None
+}
+
 /// Build an [`AcpError::AgentError`] from a JSON-RPC error object,
 /// preserving the numeric code. When the `message` field is missing or
 /// non-string, fall back to the full JSON object so provider-specific
@@ -211,6 +257,13 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Text messages emitted by the agent during the active `session/prompt`.
+    ///
+    /// ACP returns only a stop reason. The visible answer arrives separately as
+    /// `agent_message_chunk` notifications. Keep the message boundaries so the
+    /// harness can recover the final assistant message when an external agent
+    /// forgets to publish it to Buzz.
+    captured_agent_messages: Vec<CapturedAgentMessage>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +603,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            captured_agent_messages: Vec::new(),
         })
     }
 
@@ -584,6 +638,12 @@ impl AcpClient {
                 payload,
             );
         }
+    }
+
+    /// Remove and return the final non-empty agent text message captured during
+    /// the most recent prompt.
+    pub(crate) fn take_final_agent_message(&mut self) -> Option<String> {
+        take_final_captured_agent_message(&mut self.captured_agent_messages)
     }
 
     /// Send the `initialize` request and return the agent's response result value.
@@ -768,6 +828,7 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        self.captured_agent_messages.clear();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -1744,6 +1805,7 @@ impl AcpClient {
 
         match update_type {
             "agent_message_chunk" => {
+                capture_agent_message_chunk(&mut self.captured_agent_messages, update);
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
                 }
@@ -2269,6 +2331,51 @@ fn configure_no_window(cmd: &mut tokio::process::Command) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn captured_agent_chunks_join_by_message_id() {
+        let mut messages = Vec::new();
+        capture_agent_message_chunk(
+            &mut messages,
+            &serde_json::json!({
+                "messageId": "answer-1",
+                "content": { "text": "Hello " }
+            }),
+        );
+        capture_agent_message_chunk(
+            &mut messages,
+            &serde_json::json!({
+                "messageId": "answer-1",
+                "content": { "text": "world" }
+            }),
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text, "Hello world");
+    }
+
+    #[test]
+    fn final_captured_agent_message_uses_latest_non_empty_message() {
+        let mut messages = Vec::new();
+        for (message_id, text) in [
+            ("answer-1", "first"),
+            ("answer-2", "final"),
+            ("answer-3", "   "),
+        ] {
+            capture_agent_message_chunk(
+                &mut messages,
+                &serde_json::json!({
+                    "messageId": message_id,
+                    "content": { "text": text }
+                }),
+            );
+        }
+
+        assert_eq!(
+            take_final_captured_agent_message(&mut messages),
+            Some("final".to_string())
+        );
+    }
 
     #[test]
     fn stop_reason_parses_all_known_values() {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2118,6 +2118,7 @@ pub async fn run_prompt_task(
         "turn starting for {}",
         prompt_label(&source)
     );
+    let reply_check_since = nostr::Timestamp::now();
 
     // When control_rx is Some (channel tasks), wrap the prompt in select! so
     // the main loop can cancel, interrupt, or rotate it. Heartbeats
@@ -2256,6 +2257,14 @@ pub async fn run_prompt_task(
                                 "control signal arrived but turn already completed — treating as success"
                             );
                         }
+                        recover_missing_agent_reply(
+                            &mut agent,
+                            &ctx,
+                            &source,
+                            batch.as_ref(),
+                            reply_check_since,
+                        )
+                        .await;
                         if let PromptSource::Channel(cid) = &source {
                             let standing_sent = !agent.has_system_prompt_support();
                             agent.state.mark_channel_delivery_success(
@@ -2297,6 +2306,17 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            if matches!(stop_reason, StopReason::EndTurn) {
+                recover_missing_agent_reply(
+                    &mut agent,
+                    &ctx,
+                    &source,
+                    batch.as_ref(),
+                    reply_check_since,
+                )
+                .await;
+            }
 
             if let PromptSource::Channel(cid) = &source {
                 let standing_sent = !agent.has_system_prompt_support();
@@ -4147,6 +4167,196 @@ pub(crate) async fn post_failure_notice(
     }
 }
 
+const FALLBACK_REPLY_MAX_BYTES: usize = 64 * 1024;
+
+fn fallback_reply_content(content: &str) -> &str {
+    if content.len() <= FALLBACK_REPLY_MAX_BYTES {
+        return content;
+    }
+    let mut end = FALLBACK_REPLY_MAX_BYTES;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    &content[..end]
+}
+
+fn fallback_reply_thread_ref(
+    triggering_event: &nostr::Event,
+    is_dm: bool,
+) -> Option<buzz_sdk::ThreadRef> {
+    let thread = crate::queue::parse_thread_tags(triggering_event);
+    if let Some(root) = thread.root_event_id {
+        let root_event_id = nostr::EventId::from_hex(&root).ok()?;
+        return Some(buzz_sdk::ThreadRef {
+            root_event_id,
+            parent_event_id: triggering_event.id,
+        });
+    }
+    if is_dm {
+        return None;
+    }
+    Some(buzz_sdk::ThreadRef {
+        root_event_id: triggering_event.id,
+        parent_event_id: triggering_event.id,
+    })
+}
+
+fn agent_channel_message_filter(
+    author: nostr::PublicKey,
+    channel_id: Uuid,
+    since: nostr::Timestamp,
+) -> nostr::Filter {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let channel = channel_id.to_string();
+    nostr::Filter::new()
+        .kinds([
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_DIFF as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_FORUM_POST as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_FORUM_COMMENT as u16),
+        ])
+        .author(author)
+        .custom_tags(h_tag, [channel.as_str()])
+        .since(since)
+        .limit(1)
+}
+
+async fn agent_published_channel_message_since(
+    rest: &crate::relay::RestClient,
+    channel_id: Uuid,
+    since: nostr::Timestamp,
+) -> Result<bool, crate::relay::RelayError> {
+    let filter = agent_channel_message_filter(rest.keys.public_key(), channel_id, since);
+    let response = rest.query(&[filter]).await?;
+    Ok(response.as_array().is_some_and(|events| !events.is_empty()))
+}
+
+/// Recover an external ACP answer that reached the Activity transcript but was
+/// never published as a channel message.
+///
+/// The model still owns ordinary publishing through `buzz messages send`.
+/// Querying for a message from this agent inside the active turn prevents the
+/// safety net from duplicating a successful explicit send.
+async fn ensure_agent_reply_published(
+    rest: &crate::relay::RestClient,
+    channel_id: Uuid,
+    triggering_event: &nostr::Event,
+    is_dm: bool,
+    since: nostr::Timestamp,
+    content: &str,
+) -> bool {
+    match tokio::time::timeout(
+        Duration::from_secs(3),
+        agent_published_channel_message_since(rest, channel_id, since),
+    )
+    .await
+    {
+        Ok(Ok(true)) => return false,
+        Ok(Ok(false)) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(
+                channel = %channel_id,
+                "reply safety check failed; skipping recovery to avoid a duplicate: {error}"
+            );
+            return false;
+        }
+        Err(_) => {
+            tracing::warn!(
+                channel = %channel_id,
+                "reply safety check timed out; skipping recovery to avoid a duplicate"
+            );
+            return false;
+        }
+    }
+
+    let content = fallback_reply_content(content);
+    if content.trim().is_empty() {
+        return false;
+    }
+    let thread_ref = fallback_reply_thread_ref(triggering_event, is_dm);
+    let builder =
+        match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
+            Ok(builder) => builder,
+            Err(error) => {
+                tracing::warn!(channel = %channel_id, "reply recovery build failed: {error}");
+                return false;
+            }
+        };
+    let event = match builder.sign_with_keys(&rest.keys) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(channel = %channel_id, "reply recovery sign failed: {error}");
+            return false;
+        }
+    };
+    match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
+        Ok(Ok(_)) => {
+            tracing::info!(
+                channel = %channel_id,
+                event_id = %event.id,
+                "published captured ACP answer after the agent omitted buzz messages send"
+            );
+            true
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(channel = %channel_id, "reply recovery publish failed: {error}");
+            false
+        }
+        Err(_) => {
+            tracing::warn!(channel = %channel_id, "reply recovery publish timed out");
+            false
+        }
+    }
+}
+
+async fn recover_missing_agent_reply(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    source: &PromptSource,
+    batch: Option<&FlushBatch>,
+    since: nostr::Timestamp,
+) {
+    let PromptSource::Channel(channel_id) = source else {
+        return;
+    };
+    let Some(batch) = batch else {
+        return;
+    };
+    let Some(content) = agent.acp.take_final_agent_message() else {
+        return;
+    };
+    let Some(triggering_event) = batch.events.last().map(|item| &item.event) else {
+        return;
+    };
+    let is_dm = ctx
+        .channel_info
+        .resolve(*channel_id)
+        .await
+        .as_ref()
+        .is_some_and(|channel| channel.channel_type == "dm");
+    if ensure_agent_reply_published(
+        &ctx.rest_client,
+        *channel_id,
+        triggering_event,
+        is_dm,
+        since,
+        &content,
+    )
+    .await
+    {
+        agent.acp.observe(
+            "fallback_reply_published",
+            serde_json::json!({
+                "channelId": channel_id,
+                "triggeringEventId": triggering_event.id.to_hex(),
+            }),
+        );
+    }
+}
+
 /// Best-effort: remove a reaction via a signed kind:5 (NIP-09) deletion event.
 ///
 /// Queries kind:7 reactions by our pubkey targeting the event, finds the matching
@@ -4267,6 +4477,121 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+
+    #[test]
+    fn fallback_reply_content_truncates_on_utf8_boundary() {
+        let content = format!("{}🐝", "a".repeat(FALLBACK_REPLY_MAX_BYTES - 1));
+        let truncated = fallback_reply_content(&content);
+
+        assert_eq!(truncated.len(), FALLBACK_REPLY_MAX_BYTES - 1);
+        assert!(truncated.chars().all(|character| character == 'a'));
+    }
+
+    #[test]
+    fn fallback_reply_thread_ref_keeps_top_level_dm_flat() {
+        let event = EventBuilder::new(Kind::Custom(9), "hello")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        assert!(fallback_reply_thread_ref(&event, true).is_none());
+
+        let channel_reply = fallback_reply_thread_ref(&event, false).unwrap();
+        assert_eq!(channel_reply.root_event_id, event.id);
+        assert_eq!(channel_reply.parent_event_id, event.id);
+    }
+
+    #[test]
+    fn fallback_reply_thread_ref_replies_to_trigger_inside_existing_thread() {
+        let keys = Keys::generate();
+        let root = EventBuilder::new(Kind::Custom(9), "root")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let root_hex = root.id.to_hex();
+        let root_tag = Tag::parse(["e", root_hex.as_str(), "", "root"]).unwrap();
+        let reply_tag = Tag::parse(["e", root_hex.as_str(), "", "reply"]).unwrap();
+        let trigger = EventBuilder::new(Kind::Custom(9), "follow-up")
+            .tags([root_tag, reply_tag])
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let thread_ref = fallback_reply_thread_ref(&trigger, true).unwrap();
+        assert_eq!(thread_ref.root_event_id, root.id);
+        assert_eq!(thread_ref.parent_event_id, trigger.id);
+    }
+
+    #[test]
+    fn agent_channel_message_filter_limits_duplicate_check_to_this_turn() {
+        let keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let filter = agent_channel_message_filter(
+            keys.public_key(),
+            channel_id,
+            Timestamp::from_secs(1_765_000_000),
+        );
+        let value = serde_json::to_value(filter).unwrap();
+
+        assert_eq!(value["authors"], json!([keys.public_key().to_hex()]));
+        assert_eq!(value["#h"], json!([channel_id.to_string()]));
+        assert_eq!(value["since"], json!(1_765_000_000));
+        assert_eq!(value["limit"], json!(1));
+        assert_eq!(value["kinds"], json!([9, 40002, 40008, 45001, 45003]));
+    }
+
+    #[tokio::test]
+    async fn ensure_agent_reply_publishes_when_turn_has_no_visible_message() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let submitted = Arc::new(AtomicBool::new(false));
+        let server_submitted = Arc::clone(&submitted);
+        let server = tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let mut request = vec![0; 16 * 1024];
+                let bytes_read = socket.read(&mut request).await.unwrap_or_default();
+                let request = String::from_utf8_lossy(&request[..bytes_read]);
+                let body = if request.starts_with("POST /query ") {
+                    "[]"
+                } else if request.starts_with("POST /events ") {
+                    server_submitted.store(true, Ordering::SeqCst);
+                    "{}"
+                } else {
+                    "{}"
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+
+        let rest = crate::relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        let trigger = EventBuilder::new(Kind::Custom(9), "question")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+
+        let recovered = ensure_agent_reply_published(
+            &rest,
+            Uuid::new_v4(),
+            &trigger,
+            true,
+            Timestamp::now(),
+            "recovered answer",
+        )
+        .await;
+
+        assert!(recovered);
+        assert!(submitted.load(Ordering::SeqCst));
+        server.abort();
+    }
 
     fn test_mcp_server() -> McpServer {
         McpServer {


### PR DESCRIPTION
## Summary

- capture final ACP assistant messages by `messageId`
- check for an agent-authored channel message at successful turn completion
- publish the captured answer as a signed kind-9 event when the relay confirms that the turn produced no visible message
- preserve flat top-level DMs and the triggering reply context for existing threads

## Root cause

ACP sends generated assistant text through `agent_message_chunk` updates. Buzz Desktop shows those updates in Activity. The `session/prompt` result contains only a stop reason.

External ACP runtimes can finish a turn without calling `buzz messages send`. When that happens, the answer exists in Activity but no channel event exists for desktop or mobile clients to render.

This patch adds a harness-level delivery safety net at `end_turn`. An explicit agent send still wins. A relay query error or timeout skips recovery to protect against duplicate messages.

The same recovery path covers the race where a control signal arrives after the ACP prompt has already completed.

## Related reports

This addresses the missing-event failure mode reported in #5388.

It complements #5635, which handles a separate desktop Inbox case where a signed NIP-10 reply exists on the relay but the DM projection omits it. The two patches have no file overlap.

## Validation

- `cargo test -p buzz-acp` with 743 library tests and 9 lifecycle tests passing
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

