### PR TITLE
fix(desktop): show cross-owner channel agents in mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,6 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
+  isAgentIdentityEligibleForMentions,
   isAgentIdentityInManagedList,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
@@ -156,6 +157,25 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   assert.equal(
     isAgentIdentityInManagedList(
       { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+});
+
+test("isAgentIdentityEligibleForMentions: keeps channel-member agents owned by someone else", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  assert.equal(
+    isAgentIdentityEligibleForMentions(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityEligibleForMentions(
+      { isAgent: true, isMember: false, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     false,

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -64,6 +64,17 @@ export function isAgentIdentityInManagedList(
   );
 }
 
+/** Keeps live channel members mentionable while excluding unmanaged relay-only identities. */
+export function isAgentIdentityEligibleForMentions(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
+  managedAgentPubkeys: ReadonlySet<string>,
+) {
+  return (
+    candidate.isMember === true ||
+    isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+  );
+}
+
 export function shouldHideAgentFromMentions({
   isAgent,
   isMember,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityEligibleForMentions,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentIdentityEligibleForMentions(candidate, managedAgentPubkeys)) {
         return;
       }
       if (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -187,7 +187,7 @@ async function expectAgentProfileActionsHidden(
   ).toHaveCount(0);
 }
 
-test("@ trigger prioritizes channel members before runnable personas and other managed agents", async ({
+test("@ trigger prioritizes channel members, including external agents, before runnable personas and managed agents", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -209,7 +209,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -226,6 +226,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
+  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
     text.includes("charlie"),
@@ -234,9 +235,11 @@ test("@ trigger prioritizes channel members before runnable personas and other m
     text.includes("outsider"),
   );
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
+  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
+  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });


### PR DESCRIPTION
## Summary

- keep agent identities mentionable when they are actual members of the current channel, even if another user owns/manages them
- retain the existing managed-agent gate for relay/profile-only identities so stale non-member agents stay out of autocomplete
- add unit and Playwright regression coverage for cross-owner channel agents

## Root cause

Mention autocomplete filtered every bot candidate through the current user's managed-agent list before applying the existing invocation policy. That excluded a channel agent owned by another participant even when both identities shared the channel and the current user was allowlisted.

## User impact

A permitted channel member can now discover and select a cross-owner agent from `@` autocomplete. Selecting it creates the agent p-tag needed to trigger the agent.

## Verification

- `pnpm check` — passed (two unrelated informational notices)
- `pnpm typecheck` — passed
- `pnpm test` — 4,130 passed
- full `pnpm test:e2e` — 1,032 passed, including the complete mentions spec; four integration setup failures require a relay on `localhost:3000`; two unrelated smoke failures passed when rerun in isolation
- isolated smoke rerun — 2 passed

Originating Buzz channel: `0e98d010-8533-4df5-8e1f-896a94aa1e1a`
