### PR TITLE
fix(desktop): rank read-marker eviction by read recency

### DIFF
--- a/desktop/src/features/channels/readState/readStateBudget.ts
+++ b/desktop/src/features/channels/readState/readStateBudget.ts
@@ -1,0 +1,189 @@
+/**
+ * Byte-budget eviction for NIP-RS read-state blobs.
+ *
+ * Pure helpers, split out of `readStateManager` so the eviction policy lives
+ * next to the recency signal it ranks by. Callers should prefer the manager's
+ * `currentContexts()` / `splitContextsIntoSlots()`; these are exported for
+ * direct unit testing.
+ */
+import {
+  MSG_PREFIX,
+  THREAD_PREFIX,
+  readActionRecency,
+} from "@/features/channels/readState/readStateFormat";
+
+/**
+ * Result of a `splitContextsIntoBudgetedSlots` call.
+ */
+export interface SlotSplitResult {
+  /** Contexts record for each slot (primary slot first). */
+  slots: Array<Record<string, number>>;
+  /**
+   * Extra slot IDs allocated beyond the first. Length is `slots.length - 1`.
+   * The caller is responsible for persisting these.
+   */
+  extraSlotIds: string[];
+}
+
+/**
+ * Partition `channelEntries` across slots so each slot's blob fits within
+ * `maxBytes`. Thread/msg entries are added to the primary slot (index 0) and
+ * trimmed to budget.
+ *
+ * `initialSlotCount` is the number of slots already available (≥ 1). If the
+ * initial distribution doesn't fit, new slot IDs are generated via
+ * `slotIdGenerator` until everything fits or `maxSlots` is reached.
+ *
+ * Returns `{ slots, extraSlotIds }` on success, or `null` when even `maxSlots`
+ * slots can't accommodate all channel keys.
+ *
+ * Exported for unit testing; callers should prefer `splitContextsIntoSlots()`.
+ */
+export function splitContextsIntoBudgetedSlots(args: {
+  channelEntries: [string, number][];
+  threadMsgEntries: [string, number][];
+  clientId: string;
+  initialSlotCount: number;
+  maxSlots: number;
+  maxBytes: number;
+  slotIdGenerator: () => string;
+  contextSourceCreatedAt?: ReadonlyMap<string, number>;
+}): SlotSplitResult | null {
+  const {
+    channelEntries,
+    threadMsgEntries,
+    clientId,
+    initialSlotCount,
+    maxSlots,
+    maxBytes,
+    slotIdGenerator,
+    contextSourceCreatedAt,
+  } = args;
+
+  const encoder = new TextEncoder();
+  const blobFor = (c: Record<string, number>) =>
+    JSON.stringify({ v: 1, client_id: clientId, contexts: c });
+
+  let slotCount = initialSlotCount;
+  const extraSlotIds: string[] = [];
+
+  // Distribute channel keys and check fit. Grow slot count until all fit.
+  const distribute = (count: number): Array<Record<string, number>> => {
+    const slotContexts: Array<Record<string, number>> = Array.from(
+      { length: count },
+      () => ({}),
+    );
+    for (let i = 0; i < channelEntries.length; i++) {
+      const [key, ts] = channelEntries[i];
+      slotContexts[i % count][key] = ts;
+    }
+    return slotContexts;
+  };
+
+  let slotContexts = distribute(slotCount);
+  while (
+    slotContexts.some((c) => encoder.encode(blobFor(c)).length > maxBytes) &&
+    slotCount < maxSlots
+  ) {
+    extraSlotIds.push(slotIdGenerator());
+    slotCount++;
+    slotContexts = distribute(slotCount);
+  }
+
+  if (slotContexts.some((c) => encoder.encode(blobFor(c)).length > maxBytes)) {
+    return null;
+  }
+
+  // Add thread/msg entries to the primary slot and trim to budget.
+  for (const [key, ts] of threadMsgEntries) {
+    slotContexts[0][key] = ts;
+  }
+  trimContextsToBudget(
+    slotContexts[0],
+    clientId,
+    maxBytes,
+    contextSourceCreatedAt,
+  );
+
+  return { slots: slotContexts, extraSlotIds };
+}
+
+/**
+ * Result of a `trimContextsToBudget` call.
+ */
+export interface TrimResult {
+  /** Number of entries removed from `contexts`. */
+  evicted: number;
+  /** True when the serialized blob fits within `maxBytes` after trimming. */
+  fitsAfterTrim: boolean;
+}
+
+/**
+ * Trim a contexts map to fit within `maxBytes` when serialized as the JSON
+ * blob `{v:1, client_id, contexts}`. Evicts least-recently-read `msg:` entries
+ * first, then least-recently-read `thread:` entries. Channel keys are never
+ * evicted. Mutates `contexts` in place.
+ *
+ * Recency comes from `contextSourceCreatedAt` (see `readActionRecency`) and
+ * falls back to the marker value. Ranking by the marker value alone evicts a
+ * marker the user just created on an older message ahead of markers they last
+ * touched days ago, so the read never survives the publish.
+ *
+ * Returns `{ evicted, fitsAfterTrim }`. `fitsAfterTrim` is false when the
+ * remaining blob (channel keys only) still exceeds `maxBytes` — the caller
+ * must not publish in that case.
+ *
+ * Exported for unit testing; callers should prefer `currentContexts()`.
+ */
+export function trimContextsToBudget(
+  contexts: Record<string, number>,
+  clientId: string,
+  maxBytes: number,
+  contextSourceCreatedAt?: ReadonlyMap<string, number>,
+): TrimResult {
+  const encoder = new TextEncoder();
+  const blobFor = (c: Record<string, number>) =>
+    JSON.stringify({ v: 1, client_id: clientId, contexts: c });
+
+  let currentBytes = encoder.encode(blobFor(contexts)).length;
+  if (currentBytes <= maxBytes) {
+    return { evicted: 0, fitsAfterTrim: true };
+  }
+
+  const msgEntries: [string, number][] = [];
+  const threadEntries: [string, number][] = [];
+  for (const [key, ts] of Object.entries(contexts)) {
+    if (key.startsWith(MSG_PREFIX)) {
+      msgEntries.push([key, ts]);
+    } else if (key.startsWith(THREAD_PREFIX)) {
+      threadEntries.push([key, ts]);
+    }
+  }
+  // Least-recently-read first within each tier.
+  const byReadRecency = (a: [string, number], b: [string, number]) =>
+    readActionRecency(a[0], a[1], contextSourceCreatedAt) -
+    readActionRecency(b[0], b[1], contextSourceCreatedAt);
+  msgEntries.sort(byReadRecency);
+  threadEntries.sort(byReadRecency);
+
+  // O(n) pass: subtract each entry's byte contribution from currentBytes and
+  // collect entries to evict. The per-entry estimate is `,"key":timestamp`
+  // (key.length + 3 bytes for `"`, `"`, `:` plus 1 comma) + timestamp digits.
+  // This is an approximation — the final encode below is the authoritative check.
+  const toEvict: string[] = [];
+  for (const [key, ts] of [...msgEntries, ...threadEntries]) {
+    if (currentBytes <= maxBytes) break;
+    // Contribution: `,"key":timestamp` — comma + quoted key + colon + value
+    currentBytes -= key.length + 3 + String(ts).length + 1;
+    toEvict.push(key);
+  }
+
+  for (const key of toEvict) {
+    delete contexts[key];
+  }
+
+  // Final authoritative check — handles JSON comma-accounting edge cases
+  // (e.g. last-entry comma disappears) that the per-entry estimate ignores.
+  const fitsAfterTrim = encoder.encode(blobFor(contexts)).length <= maxBytes;
+  return { evicted: toEvict.length, fitsAfterTrim };
+}

--- a/desktop/src/features/channels/readState/readStateFormat.ts
+++ b/desktop/src/features/channels/readState/readStateFormat.ts
@@ -37,6 +37,24 @@ export const THREAD_PREFIX = "thread:";
 
 const EVENT_ID_PATTERN = /^[0-9a-f]{64}$/;
 
+/**
+ * Recency of the READ ACTION behind a marker — when this read fact entered the
+ * client — falling back to the marker value when unknown (contexts seeded
+ * before this signal was recorded).
+ *
+ * Eviction must rank by this, never by the marker timestamp. The marker value
+ * is the age of the *message* that was read, so ranking by it discards a marker
+ * the user just created on an older message while keeping long-stale markers
+ * that happen to point at recent messages.
+ */
+export function readActionRecency(
+  contextId: string,
+  markerTimestamp: number,
+  contextSourceCreatedAt?: ReadonlyMap<string, number>,
+): number {
+  return contextSourceCreatedAt?.get(contextId) ?? markerTimestamp;
+}
+
 export function maxReadAt(...markers: Array<number | null>): number | null {
   return markers.reduce<number | null>((latest, marker) => {
     if (marker === null) return latest;

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -270,6 +270,66 @@ test("publish flushes pending local state first", async () => {
   }
 });
 
+test("publishing does not refresh read recency", async () => {
+  globalThis.window.localStorage = makeLocalStorage();
+  const { restore } = withFakeTimers();
+  const pubkey = "7".repeat(64);
+  const manager = new ReadStateManager(pubkey, makeFakeRelay());
+  const msgKey = `msg:${"c".repeat(64)}`;
+  const markerValue = 1_000_000; // timestamp of the message that was read
+  const readHappenedAt = 1_500_000; // when that read entered the client
+
+  // @tauri-apps/api/core reads `window.__TAURI_INTERNALS__.invoke`.
+  const originalInternals = globalThis.window.__TAURI_INTERNALS__;
+  const invoked = [];
+  globalThis.window.__TAURI_INTERNALS__ = {
+    invoke: (cmd, args) => {
+      invoked.push(cmd);
+      if (cmd === "nip44_encrypt_to_self") return Promise.resolve("ciphertext");
+      if (cmd === "sign_event") {
+        return Promise.resolve(
+          JSON.stringify({
+            id: "e".repeat(64),
+            pubkey,
+            created_at: args.createdAt,
+            kind: args.kind,
+            tags: args.tags,
+            content: args.content,
+            sig: "f".repeat(128),
+          }),
+        );
+      }
+      return Promise.resolve(null);
+    },
+  };
+
+  try {
+    manager.markContextRead(msgKey, markerValue);
+    manager.contextSourceCreatedAt.set(msgKey, readHappenedAt);
+    // Fresh launch on an account whose blob is trimmed: the relay copy that
+    // seeds lastPublishedContexts does not carry this key, so it reads as
+    // changed on the next publish.
+    manager.lastPublishedContexts = {};
+    manager.fetchOwnBlobBeforePublish = async () => {};
+
+    await manager.publish();
+
+    assert.ok(
+      invoked.includes("sign_event"),
+      "precondition: the blob must actually publish",
+    );
+    assert.equal(
+      manager.contextSourceCreatedAt.get(msgKey),
+      readHappenedAt,
+      "a publish is not a read: recency must stay at the time of the read",
+    );
+  } finally {
+    globalThis.window.__TAURI_INTERNALS__ = originalInternals;
+    manager.destroy();
+    restore();
+  }
+});
+
 test("destroyed manager cannot persist after an in-flight fetch resolves", async () => {
   const storage = makeLocalStorage();
   globalThis.window.localStorage = storage;

--- a/desktop/src/features/channels/readState/readStateManager.test.mjs
+++ b/desktop/src/features/channels/readState/readStateManager.test.mjs
@@ -5,9 +5,11 @@ import {
   ReadStateManager,
   applyRemoteContextTimestamp,
   resolveEffectiveTimestamp,
+} from "./readStateManager.ts";
+import {
   splitContextsIntoBudgetedSlots,
   trimContextsToBudget,
-} from "./readStateManager.ts";
+} from "./readStateBudget.ts";
 
 // ── ReadStateManager integration helpers ─────────────────────────────────────
 // Provide browser globals required by ReadStateManager (localStorage,
@@ -414,7 +416,28 @@ test("applyRemoteContextTimestamp ignores older remote read markers from newer s
 
   assert.equal(result, "unchanged");
   assert.equal(effectiveState.get("channel-1"), 200);
-  assert.equal(contextSourceCreatedAt.get("channel-1"), 11);
+  // Recency tracks the last read ADVANCE, not the last blob that mentioned the
+  // context — a routine republish carrying nothing new must not refresh it.
+  assert.equal(contextSourceCreatedAt.get("channel-1"), 10);
+});
+
+test("applyRemoteContextTimestamp keeps recency stable across repeated republishes", () => {
+  const effectiveState = new Map([["channel-1", 200]]);
+  const contextSourceCreatedAt = new Map([["channel-1", 10]]);
+
+  for (const eventCreatedAt of [50, 60, 70]) {
+    applyRemoteContextTimestamp({
+      effectiveState,
+      contextSourceCreatedAt,
+      contextId: "channel-1",
+      timestamp: 200,
+      eventCreatedAt,
+    });
+  }
+
+  // Without this, every context in every republished blob would look freshly
+  // read and recency-ranked eviction would degenerate to publish order.
+  assert.equal(contextSourceCreatedAt.get("channel-1"), 10);
 });
 
 test("applyRemoteContextTimestamp advances to newer remote read markers", () => {
@@ -503,6 +526,44 @@ test("trimContextsToBudget_overBudget_evictsMsgEntriesOldestFirst", () => {
   assert.ok(
     resultSize <= budget,
     `result ${resultSize} exceeds budget ${budget}`,
+  );
+});
+
+test("trimContextsToBudget_evictsLeastRecentlyRead_notOldestMessage", () => {
+  // msg A points at the OLDEST message but was read just now; msg B and C point
+  // at newer messages read long ago. Ranking by marker value would evict A —
+  // the read the user just performed.
+  const justReadOldMessage = `msg:${MSG_ID}`;
+  const contexts = {
+    [justReadOldMessage]: 1,
+    [`msg:${"c".repeat(64)}`]: 3,
+    [`msg:${"d".repeat(64)}`]: 2,
+  };
+  const readRecency = new Map([
+    [justReadOldMessage, 9_000],
+    [`msg:${"c".repeat(64)}`, 10],
+    [`msg:${"d".repeat(64)}`, 20],
+  ]);
+  const encoder = new TextEncoder();
+  const budget =
+    encoder.encode(JSON.stringify({ v: 1, client_id: CLIENT_ID, contexts }))
+      .length - 10;
+
+  const { fitsAfterTrim } = trimContextsToBudget(
+    contexts,
+    CLIENT_ID,
+    budget,
+    readRecency,
+  );
+
+  assert.equal(fitsAfterTrim, true);
+  assert.ok(
+    justReadOldMessage in contexts,
+    "the marker read most recently must survive",
+  );
+  assert.ok(
+    !(`msg:${"c".repeat(64)}` in contexts),
+    "the least recently read marker should be evicted",
   );
 });
 

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -143,8 +143,8 @@ export function applyRemoteContextTimestamp(args: {
     // Only an advance is a NEW read fact. Re-learning an unchanged context from
     // a routine republish must not refresh its recency, or every context in
     // every blob would look freshly read and `contextSourceCreatedAt` would
-    // collapse to "time of last publish" — useless as an eviction key. Mirrors
-    // the publish path, which already bumps only changed keys.
+    // collapse to "time of last publish" — useless as an eviction key. The
+    // publish path does not write recency at all, for the same reason.
     if (eventCreatedAt > sourceCreatedAt) {
       contextSourceCreatedAt.set(contextId, eventCreatedAt);
     }
@@ -571,11 +571,15 @@ export class ReadStateManager {
         `[ReadStateManager] publish accepted slotId=${slotId} createdAt=${createdAt}`,
       );
 
-      for (const key of Object.keys(contexts)) {
-        if (this.lastPublishedContexts[key] !== contexts[key]) {
-          this.contextSourceCreatedAt.set(key, createdAt);
-        }
-      }
+      // Publishing is not a read action, so it must not refresh
+      // `contextSourceCreatedAt`. Stamping "keys that changed since the last
+      // publish" is not the narrow filter it looks like: lastPublishedContexts
+      // is seeded from the *trimmed* relay blob, so every key
+      // trimContextsToBudget dropped reads as changed on the first publish
+      // after each launch, and the recency signal collapses to "time of last
+      // publish" for the whole prunable tier. Recency is written only where a
+      // read happens — markContextRead, and the advance branch of
+      // applyRemoteContextTimestamp.
       // Merge this slot's contexts into lastPublishedContexts (union).
       for (const [key, ts] of Object.entries(contexts)) {
         this.lastPublishedContexts[key] = ts;

--- a/desktop/src/features/channels/readState/readStateManager.ts
+++ b/desktop/src/features/channels/readState/readStateManager.ts
@@ -13,6 +13,10 @@ import {
   localExtraSlotIdsKey,
   type ReadStateBlob,
 } from "@/features/channels/readState/readStateFormat";
+import {
+  splitContextsIntoBudgetedSlots,
+  trimContextsToBudget,
+} from "@/features/channels/readState/readStateBudget";
 import { parseReadStateEvent } from "@/features/channels/readState/readStateSnapshot";
 import {
   readStoredReadState,
@@ -136,171 +140,16 @@ export function applyRemoteContextTimestamp(args: {
 
   if (result === "advanced") {
     effectiveState.set(contextId, next);
-  }
-  if (eventCreatedAt > sourceCreatedAt) {
-    contextSourceCreatedAt.set(contextId, eventCreatedAt);
+    // Only an advance is a NEW read fact. Re-learning an unchanged context from
+    // a routine republish must not refresh its recency, or every context in
+    // every blob would look freshly read and `contextSourceCreatedAt` would
+    // collapse to "time of last publish" — useless as an eviction key. Mirrors
+    // the publish path, which already bumps only changed keys.
+    if (eventCreatedAt > sourceCreatedAt) {
+      contextSourceCreatedAt.set(contextId, eventCreatedAt);
+    }
   }
   return result;
-}
-
-/**
- * Result of a `splitContextsIntoBudgetedSlots` call.
- */
-export interface SlotSplitResult {
-  /** Contexts record for each slot (primary slot first). */
-  slots: Array<Record<string, number>>;
-  /**
-   * Extra slot IDs allocated beyond the first. Length is `slots.length - 1`.
-   * The caller is responsible for persisting these.
-   */
-  extraSlotIds: string[];
-}
-
-/**
- * Partition `channelEntries` across slots so each slot's blob fits within
- * `maxBytes`. Thread/msg entries are added to the primary slot (index 0) and
- * trimmed to budget.
- *
- * `initialSlotCount` is the number of slots already available (≥ 1). If the
- * initial distribution doesn't fit, new slot IDs are generated via
- * `slotIdGenerator` until everything fits or `maxSlots` is reached.
- *
- * Returns `{ slots, extraSlotIds }` on success, or `null` when even `maxSlots`
- * slots can't accommodate all channel keys.
- *
- * Exported for unit testing; callers should prefer `splitContextsIntoSlots()`.
- */
-export function splitContextsIntoBudgetedSlots(args: {
-  channelEntries: [string, number][];
-  threadMsgEntries: [string, number][];
-  clientId: string;
-  initialSlotCount: number;
-  maxSlots: number;
-  maxBytes: number;
-  slotIdGenerator: () => string;
-}): SlotSplitResult | null {
-  const {
-    channelEntries,
-    threadMsgEntries,
-    clientId,
-    initialSlotCount,
-    maxSlots,
-    maxBytes,
-    slotIdGenerator,
-  } = args;
-
-  const encoder = new TextEncoder();
-  const blobFor = (c: Record<string, number>) =>
-    JSON.stringify({ v: 1, client_id: clientId, contexts: c });
-
-  let slotCount = initialSlotCount;
-  const extraSlotIds: string[] = [];
-
-  // Distribute channel keys and check fit. Grow slot count until all fit.
-  const distribute = (count: number): Array<Record<string, number>> => {
-    const slotContexts: Array<Record<string, number>> = Array.from(
-      { length: count },
-      () => ({}),
-    );
-    for (let i = 0; i < channelEntries.length; i++) {
-      const [key, ts] = channelEntries[i];
-      slotContexts[i % count][key] = ts;
-    }
-    return slotContexts;
-  };
-
-  let slotContexts = distribute(slotCount);
-  while (
-    slotContexts.some((c) => encoder.encode(blobFor(c)).length > maxBytes) &&
-    slotCount < maxSlots
-  ) {
-    extraSlotIds.push(slotIdGenerator());
-    slotCount++;
-    slotContexts = distribute(slotCount);
-  }
-
-  if (slotContexts.some((c) => encoder.encode(blobFor(c)).length > maxBytes)) {
-    return null;
-  }
-
-  // Add thread/msg entries to the primary slot and trim to budget.
-  for (const [key, ts] of threadMsgEntries) {
-    slotContexts[0][key] = ts;
-  }
-  trimContextsToBudget(slotContexts[0], clientId, maxBytes);
-
-  return { slots: slotContexts, extraSlotIds };
-}
-
-/**
- * Result of a `trimContextsToBudget` call.
- */
-export interface TrimResult {
-  /** Number of entries removed from `contexts`. */
-  evicted: number;
-  /** True when the serialized blob fits within `maxBytes` after trimming. */
-  fitsAfterTrim: boolean;
-}
-
-/**
- * Trim a contexts map to fit within `maxBytes` when serialized as the JSON
- * blob `{v:1, client_id, contexts}`. Evicts oldest `msg:` entries first
- * (lowest timestamp), then oldest `thread:` entries. Channel keys are never
- * evicted. Mutates `contexts` in place.
- *
- * Returns `{ evicted, fitsAfterTrim }`. `fitsAfterTrim` is false when the
- * remaining blob (channel keys only) still exceeds `maxBytes` — the caller
- * must not publish in that case.
- *
- * Exported for unit testing; callers should prefer `currentContexts()`.
- */
-export function trimContextsToBudget(
-  contexts: Record<string, number>,
-  clientId: string,
-  maxBytes: number,
-): TrimResult {
-  const encoder = new TextEncoder();
-  const blobFor = (c: Record<string, number>) =>
-    JSON.stringify({ v: 1, client_id: clientId, contexts: c });
-
-  let currentBytes = encoder.encode(blobFor(contexts)).length;
-  if (currentBytes <= maxBytes) {
-    return { evicted: 0, fitsAfterTrim: true };
-  }
-
-  const msgEntries: [string, number][] = [];
-  const threadEntries: [string, number][] = [];
-  for (const [key, ts] of Object.entries(contexts)) {
-    if (key.startsWith(MSG_PREFIX)) {
-      msgEntries.push([key, ts]);
-    } else if (key.startsWith(THREAD_PREFIX)) {
-      threadEntries.push([key, ts]);
-    }
-  }
-  // Oldest-first within each tier.
-  msgEntries.sort((a, b) => a[1] - b[1]);
-  threadEntries.sort((a, b) => a[1] - b[1]);
-
-  // O(n) pass: subtract each entry's byte contribution from currentBytes and
-  // collect entries to evict. The per-entry estimate is `,"key":timestamp`
-  // (key.length + 3 bytes for `"`, `"`, `:` plus 1 comma) + timestamp digits.
-  // This is an approximation — the final encode below is the authoritative check.
-  const toEvict: string[] = [];
-  for (const [key, ts] of [...msgEntries, ...threadEntries]) {
-    if (currentBytes <= maxBytes) break;
-    // Contribution: `,"key":timestamp` — comma + quoted key + colon + value
-    currentBytes -= key.length + 3 + String(ts).length + 1;
-    toEvict.push(key);
-  }
-
-  for (const key of toEvict) {
-    delete contexts[key];
-  }
-
-  // Final authoritative check — handles JSON comma-accounting edge cases
-  // (e.g. last-entry comma disappears) that the per-entry estimate ignores.
-  const fitsAfterTrim = encoder.encode(blobFor(contexts)).length <= maxBytes;
-  return { evicted: toEvict.length, fitsAfterTrim };
 }
 
 export class ReadStateManager {
@@ -855,6 +704,7 @@ export class ReadStateManager {
       contexts,
       this.clientId,
       READ_STATE_MAX_PLAINTEXT_BYTES,
+      this.contextSourceCreatedAt,
     );
     if (evicted > 0) {
       console.warn(
@@ -907,6 +757,7 @@ export class ReadStateManager {
       maxSlots: READ_STATE_MAX_SLOTS,
       maxBytes: READ_STATE_MAX_PLAINTEXT_BYTES,
       slotIdGenerator: () => generateHex(16),
+      contextSourceCreatedAt: this.contextSourceCreatedAt,
     });
 
     if (result === null) {

--- a/desktop/src/features/channels/readState/readStateStorage.test.mjs
+++ b/desktop/src/features/channels/readState/readStateStorage.test.mjs
@@ -76,6 +76,74 @@ test("pruneStaleContexts caps within-horizon prunable entries, newest kept", () 
   assert.equal(pruned.has(`msg:${String(total - 1).padStart(64, "0")}`), false);
 });
 
+test("pruneStaleContexts keeps a marker just read on an old message", () => {
+  // The user marks a 30-day-old message read today. The marker carries the
+  // MESSAGE's timestamp, so a value-ranked horizon drops it on the same write.
+  const oldMessage = `msg:${"e".repeat(64)}`;
+  const contexts = new Map([
+    [oldMessage, NOW - READ_STATE_HORIZON_SECONDS * 4],
+  ]);
+  const readJustNow = new Map([[oldMessage, NOW]]);
+
+  assert.equal(
+    pruneStaleContexts(contexts, NOW).has(oldMessage),
+    false,
+    "value-ranked horizon drops it (documents the old behavior)",
+  );
+  assert.equal(
+    pruneStaleContexts(contexts, NOW, readJustNow).has(oldMessage),
+    true,
+    "read-recency horizon keeps it",
+  );
+});
+
+test("pruneStaleContexts cap evicts least recently read, not oldest message", () => {
+  const contexts = new Map();
+  const recency = new Map();
+  const total = LOCAL_MAX_PRUNABLE_CONTEXTS + 1;
+  // Newest messages first (i=0 newest), all read a long time ago...
+  for (let i = 0; i < total - 1; i++) {
+    const key = `msg:${String(i).padStart(64, "0")}`;
+    contexts.set(key, NOW - i);
+    recency.set(key, NOW - READ_STATE_HORIZON_SECONDS / 2);
+  }
+  // ...and one old message read just now, which must survive the cap.
+  const justRead = `msg:${"f".repeat(64)}`;
+  contexts.set(justRead, NOW - READ_STATE_HORIZON_SECONDS + 60);
+  recency.set(justRead, NOW);
+
+  const valueRanked = pruneStaleContexts(contexts, NOW);
+  assert.equal(valueRanked.size, LOCAL_MAX_PRUNABLE_CONTEXTS);
+  assert.equal(
+    valueRanked.has(justRead),
+    false,
+    "value-ranked cap evicts it (documents the old behavior)",
+  );
+
+  const recencyRanked = pruneStaleContexts(contexts, NOW, recency);
+  assert.equal(recencyRanked.size, LOCAL_MAX_PRUNABLE_CONTEXTS);
+  assert.equal(recencyRanked.has(justRead), true, "read-recency cap keeps it");
+});
+
+test("writeStoredReadState keeps a marker just read on an old message", () => {
+  installLocalStorage();
+  const pubkey = "c".repeat(64);
+  const nowSeconds = Math.floor(Date.now() / 1_000);
+  const oldMessage = `msg:${"a".repeat(64)}`;
+
+  writeStoredReadState(
+    pubkey,
+    new Map([[oldMessage, nowSeconds - READ_STATE_HORIZON_SECONDS * 4]]),
+    new Set([oldMessage]),
+    new Map([[oldMessage, nowSeconds]]),
+  );
+
+  const state = JSON.parse(
+    window.localStorage.getItem(localReadStateKey(pubkey)),
+  );
+  assert.deepEqual(Object.keys(state), [oldMessage]);
+});
+
 test("writeStoredReadState prunes all three keys consistently", () => {
   installLocalStorage();
   const pubkey = "f".repeat(64);

--- a/desktop/src/features/channels/readState/readStateStorage.ts
+++ b/desktop/src/features/channels/readState/readStateStorage.ts
@@ -8,6 +8,7 @@ import {
   MSG_PREFIX,
   READ_STATE_HORIZON_SECONDS,
   THREAD_PREFIX,
+  readActionRecency,
 } from "@/features/channels/readState/readStateFormat";
 import { setLocalStorageItemWithRecovery } from "@/shared/lib/localStorageQuota";
 
@@ -110,33 +111,51 @@ function isPrunableContextKey(contextId: string): boolean {
 }
 
 /**
- * Drops msg:/thread: markers older than the relay's 7-day horizon, then caps
- * the survivors at LOCAL_MAX_PRUNABLE_CONTEXTS (oldest first). Channel keys
- * are never pruned — they are small, bounded by membership, and losing one
- * would resurrect the channel's unread badge. Mirrors the eviction order the
- * publish path already applies in trimContextsToBudget.
+ * Drops msg:/thread: markers whose READ ACTION is older than the 7-day horizon,
+ * then caps the survivors at LOCAL_MAX_PRUNABLE_CONTEXTS (least recently read
+ * evicted first). Channel keys are never pruned — they are small, bounded by
+ * membership, and losing one would resurrect the channel's unread badge.
+ * Mirrors the eviction order the publish path applies in trimContextsToBudget.
+ *
+ * Both the horizon and the cap rank by `contextSourceCreatedAt` (see
+ * `readActionRecency`), NOT by the marker value. Ranking by the marker value
+ * means marking an older message read is undone by the very write that records
+ * it: the new marker carries that message's old timestamp, so it sorts below
+ * the cap — or below the horizon — and is dropped before it ever reaches disk.
  */
 export function pruneStaleContexts(
   contexts: ReadonlyMap<string, number>,
   nowUnixSeconds: number,
+  contextSourceCreatedAt?: ReadonlyMap<string, number>,
 ): Map<string, number> {
   const cutoff = nowUnixSeconds - READ_STATE_HORIZON_SECONDS;
   const kept = new Map<string, number>();
-  const prunable: [string, number][] = [];
+  const prunable: Array<{
+    contextId: string;
+    timestamp: number;
+    recency: number;
+  }> = [];
 
   for (const [contextId, timestamp] of contexts) {
     if (!isPrunableContextKey(contextId)) {
       kept.set(contextId, timestamp);
-    } else if (timestamp >= cutoff) {
-      prunable.push([contextId, timestamp]);
+      continue;
+    }
+    const recency = readActionRecency(
+      contextId,
+      timestamp,
+      contextSourceCreatedAt,
+    );
+    if (recency >= cutoff) {
+      prunable.push({ contextId, timestamp, recency });
     }
   }
 
   if (prunable.length > LOCAL_MAX_PRUNABLE_CONTEXTS) {
-    prunable.sort((a, b) => b[1] - a[1]);
+    prunable.sort((a, b) => b.recency - a.recency);
     prunable.length = LOCAL_MAX_PRUNABLE_CONTEXTS;
   }
-  for (const [contextId, timestamp] of prunable) {
+  for (const { contextId, timestamp } of prunable) {
     kept.set(contextId, timestamp);
   }
   return kept;
@@ -148,7 +167,11 @@ export function writeStoredReadState(
   publishableContextIds: ReadonlySet<string>,
   contextSourceCreatedAt: ReadonlyMap<string, number>,
 ): void {
-  const pruned = pruneStaleContexts(contexts, Math.floor(Date.now() / 1_000));
+  const pruned = pruneStaleContexts(
+    contexts,
+    Math.floor(Date.now() / 1_000),
+    contextSourceCreatedAt,
+  );
 
   const state: Record<string, string> = {};
   for (const [contextId, timestamp] of pruned) {


### PR DESCRIPTION
## Summary

Marking an older message read is undone by the very write that records it.

Read markers for `msg:`/`thread:` contexts are evicted at two points, and both rank by the
**marker's value** — which is the timestamp of the *message that was read*, not of the read:

- `pruneStaleContexts` (`readStateStorage.ts`) drops any prunable marker whose value is older
  than the 7-day horizon, then caps the survivors at `LOCAL_MAX_PRUNABLE_CONTEXTS` (1 000),
  keeping the *highest values*.
- `trimContextsToBudget` (`readStateManager.ts`) evicts the *lowest values* first to fit the
  32 KB publish budget.

So when a user marks an older message read, the new marker carries that message's old
timestamp, sorts to the bottom of both rankings, and is discarded before it reaches disk or the
relay. The row reads correctly for the rest of the session (in-memory `effectiveState` holds it)
and is unread again after the next reload — permanently, no matter how many times it is clicked.

The horizon alone reproduces this at any volume: **no message older than 7 days can ever be
durably marked read.** The cap makes it bite much sooner on busy accounts.

### Evidence from a live account

`localStorage["buzz.channel-read-state.v2:<pubkey>"]`:

```text
1024 contexts = 24 channel + 984 msg + 16 thread
prunable tier = 1000 / 1000   ← LOCAL_MAX_PRUNABLE_CONTEXTS, saturated
oldest surviving msg marker = 3 days old; nothing older can be written
```

Relay side, two `kind:30078` slots for the same pubkey:

```text
read-state:adec4aea…  43780 B ciphertext
read-state:9db0bc01…  43780 B ciphertext
```

43 780 B of base64 NIP-44 = `1 + 32 + (2 + 32768) + 32` bytes, i.e. the padded-plaintext bucket
at exactly `READ_STATE_MAX_PLAINTEXT_BYTES`. Those 1 024 contexts serialize to roughly 84 KB, so
`trimContextsToBudget` is dropping about 60 % of the markers on every publish — oldest message
first.

### Why the Inbox row cannot recover

`resolveInboxItemReadAt` resolves a thread row through `msg:<id>` alone, so the channel marker —
which is never pruned, and was current the whole time — does not cover it. That is deliberate
(NIP-RS makes the thread fold a MAY, and the per-message predicate is what keeps reading an
ancestor from covering a descendant), so this PR does not touch it. It is what turns the
eviction bug from cosmetic into permanent, which is why it is worth stating.

### Fix

Rank eviction by *when the read happened*, using the signal the manager already persists:

1. `applyRemoteContextTimestamp` refreshes `contextSourceCreatedAt` **only on an actual
   advance**. Today every republished blob bumps every context it mentions, so the field
   collapses to "time of last publish" — on the account above all 1 024 entries land inside a
   2-day window, including channel markers first read weeks earlier. Item 4 closes the same
   hole on the publish side.
2. `pruneStaleContexts` applies both the horizon and the cap to that recency
   (`readActionRecency`, falling back to the marker value for contexts seeded before the
   signal existed).
3. `trimContextsToBudget` evicts least-recently-read first instead of oldest-message first.
4. `publishOneSlot` no longer stamps recency at all. It used to stamp every key whose value
   differed from `lastPublishedContexts`, which is not the narrow filter it looks like:
   `initialize` seeds `lastPublishedContexts` from the union of the *relay* blobs while local
   storage restores the full context set, so every key `trimContextsToBudget` dropped reads as
   changed on the first publish after each launch and is restamped with a single `createdAt`.
   Recency is now written only where a read happens — `markContextRead`, and the advance branch
   of `applyRemoteContextTimestamp`, which is also how blob-seeded contexts arrive.

Item 4 comes from @rmichelena's independent reproduction below. On his account 330 of 330
prunable contexts carried a recency value but only three distinct ones, all minutes apart —
publish-shaped, not read-shaped. Left in place, that distribution makes the horizon check evict
nothing and turns cap comparisons into ties, so eviction order would fall back to sort stability
rather than read recency. It errs toward keeping markers, so it does not reintroduce the bug,
but the ranking this PR argues for only holds once publishing stops overwriting the signal.

No storage format change, no new key, no wire change. Contexts carrying no recency behave
exactly as before — and in practice there are fewer of those than the first draft of this
description assumed: `main` already records the signal in `markContextRead`, so existing
installs get the corrected ranking on upgrade rather than only for reads written afterwards.

`trimContextsToBudget` and `splitContextsIntoBudgetedSlots` move verbatim into a new
`readStateBudget.ts`. That is not gratuitous: `readStateManager.ts` sat at 999 of the 1 000-line
ceiling enforced by `scripts/check-file-sizes.mjs`, so the fix could not land in it at all. Both
are pure functions that were already exported solely for unit testing, and the eviction policy
now lives beside the recency helper it ranks by. Manager drops to 846 lines; the new module is
189. No behavioural change in the move itself — happy to reshape the split if you'd rather have
it drawn elsewhere.

**Behaviour change worth calling out:** the 7-day horizon now measures time since the *read*
rather than the age of the message read. Same retention window, correct anchor — a marker you
created today survives a week; a marker you have not touched in a week ages out, as intended.

Desktop only. `mobile/lib/shared/read_state/` has no equivalent tiered eviction (searched for
`evict`, `prune`, `horizon`, byte-budget constants under `mobile/lib`), so there is no parity
change to make.

### Related issue

None found — searched `block/buzz` issues and PRs for `resolveInboxItemReadAt`,
`useHomeInboxReadState`, `trimContextsToBudget`, `read marker eviction`, `mark as read reverts`,
`inbox unread returns`. Closest prior art is #1305 and #1502, which introduced these two
eviction points, and #1242, which routed Inbox rows through per-message markers.

### Testing

`just ci` green locally (Hermit toolchain, macOS 26.5, Node 24.15):

```text
check + clippy         clean
Rust workspace tests   all crates pass (buzz-relay 2402 passed / 0 failed, …)
desktop tests          4721 passed / 0 failed / 0 skipped (67 suites)
desktop build          ok        desktop tauri check + test   ok
web build              ok        mobile flutter test          1261 passed
```

New unit tests, each asserting the old value-ranked behaviour alongside the new one so the
regression is documented rather than merely fixed:

- `pruneStaleContexts keeps a marker just read on an old message`
- `pruneStaleContexts cap evicts least recently read, not oldest message`
- `writeStoredReadState keeps a marker just read on an old message`
- `trimContextsToBudget_evictsLeastRecentlyRead_notOldestMessage`
- `applyRemoteContextTimestamp keeps recency stable across repeated republishes`
- `publishing does not refresh read recency` — publishes a real blob with `lastPublishedContexts`
  empty and asserts an old read keeps its recency; fails on the parent commit, where the recency
  jumps to the publish time

No screenshots: this changes storage eviction and read-marker bookkeeping, with no visual,
layout or styling delta. The user-visible effect is an Inbox row staying read across a restart,
which a static capture cannot show.

