### PR TITLE
fix(desktop): restore candidate-scoped keyring service

### DIFF
--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -18,7 +18,23 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_RELAY_RECONNECT_CMD");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AGENT_ACCESS_OWNER_ONLY");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY");
+    println!("cargo:rerun-if-env-changed=BUZZ_BUILD_CANDIDATE_ID");
     println!("cargo:rustc-check-cfg=cfg(buzz_updater_enabled)");
+
+    // Restored from the 0.5.4-era upstream: scopes the OS keyring service for
+    // candidate builds so a test build never shares an identity with the
+    // released Buzz app. Removed upstream by 0.5.10 with no replacement.
+    if let Ok(candidate_id) = std::env::var("BUZZ_BUILD_CANDIDATE_ID") {
+        let valid = !candidate_id.is_empty()
+            && candidate_id.len() <= 48
+            && candidate_id.chars().all(|character| {
+                character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+            });
+        if !valid {
+            panic!("BUZZ_BUILD_CANDIDATE_ID must match [a-z0-9-] and be at most 48 characters");
+        }
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_CANDIDATE_ID={candidate_id}");
+    }
 
     // Explicit owner-only agent-access capability. Release packaging sets this
     // presence-only marker; OSS/custom builds leave agent access configurable.

--- a/desktop/src-tauri/src/app_state_keyring.rs
+++ b/desktop/src-tauri/src/app_state_keyring.rs
@@ -7,7 +7,15 @@ fn dev_keyring_service(configured: Option<String>) -> String {
 }
 
 pub(crate) fn keyring_service() -> &'static str {
-    if cfg!(debug_assertions) {
+    // Candidate builds get their own keyring service so an installed test build
+    // never reads or writes the released Buzz app's stored identity. Set at
+    // compile time by build.rs from BUZZ_BUILD_CANDIDATE_ID.
+    if let Some(candidate_id) = option_env!("BUZZ_DESKTOP_BUILD_CANDIDATE_ID") {
+        static CANDIDATE_SERVICE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        CANDIDATE_SERVICE
+            .get_or_init(|| format!("buzz-desktop-candidate.{candidate_id}"))
+            .as_str()
+    } else if cfg!(debug_assertions) {
         static DEV_SERVICE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
         DEV_SERVICE
             .get_or_init(|| dev_keyring_service(std::env::var("BUZZ_DEV_KEYRING_SERVICE").ok()))
@@ -54,6 +62,19 @@ mod tests {
         assert_eq!(
             migration_marker_name("buzz-desktop-dev.example", "identity.migrated"),
             "identity.buzz-desktop-dev.example.migrated"
+        );
+    }
+
+    #[test]
+    fn candidate_builds_never_share_the_release_identity() {
+        // A candidate build must not read or write the released app's stored
+        // identity: its keyring service and its migration marker both have to
+        // stay distinct from the plain "buzz-desktop" release pair.
+        let candidate = "buzz-desktop-candidate.test-release";
+        assert_ne!(candidate, "buzz-desktop");
+        assert_eq!(
+            migration_marker_name(candidate, "identity.migrated"),
+            "identity.buzz-desktop-candidate.test-release.migrated"
         );
     }
 }


### PR DESCRIPTION
## Problem

Release builds hardcode the OS keyring service to `"buzz-desktop"`:

```rust
pub(crate) fn keyring_service() -> &'static str {
    if cfg!(debug_assertions) { /* BUZZ_DEV_KEYRING_SERVICE */ }
    else { "buzz-desktop" }
}
```

So a candidate build — anything produced by `buzz-test-release.yml`, or any locally packaged release build — reads and writes **the released Buzz app's stored identity**. Install a candidate next to a release and both use the same private key.

The bundle identifier (`xyz.block.buzz.app.dev.test-release`) already isolates the *data directory*, which makes this easy to miss: the app looks correctly separated right up until it touches the keyring.

A `keyring_service()` branch for candidate builds used to exist and was removed between 0.5.4 and 0.5.10 with no replacement. `migration_marker_name()` still has its candidate-aware `else` arm, but nothing can reach it in a release build any more.

## Symptom

Building a test candidate from current `main` and launching it:

- lands on the onboarding screen instead of the existing community, because the identity saved under `buzz-desktop-candidate.<id>` is no longer looked up
- every managed agent then fails with `agent <pubkey> has no private key available — the OS keyring may be unreachable` (`managed_agents/storage.rs:230`), since agent keys resolve through the same `keyring_service()`

Completing onboarding in that state writes a fresh identity into the shared `buzz-desktop` slot.

## Fix

Restore both halves:

- `build.rs` re-emits `BUZZ_BUILD_CANDIDATE_ID` as the compile-time `BUZZ_DESKTOP_BUILD_CANDIDATE_ID` (with the original `[a-z0-9-]`, ≤48 char validation)
- `keyring_service()` returns `buzz-desktop-candidate.<id>` when that is set

Unset — every OSS and normal release build — behaviour is byte-for-byte unchanged.

Adds a test pinning that a candidate service and its migration marker stay distinct from the release pair.

## Verification

- `just desktop-tauri-fmt-check` — passed
- `just desktop-tauri-clippy` — passed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml keyring` — passed
- built a candidate with `BUZZ_BUILD_CANDIDATE_ID=test-release`, confirmed it loads the existing community and starts managed agents again