### PR TITLE
Fix sidebar collapse shortcuts and spacing

### DIFF
--- a/desktop/src/app/AppShellChannelSurface.tsx
+++ b/desktop/src/app/AppShellChannelSurface.tsx
@@ -4,7 +4,7 @@ import { HuddleRoomHeader, HuddleStartingView } from "@/features/huddle";
 import { MainInsetProvider } from "@/shared/layout/MainInsetContext";
 import { chromeCssVarDefaults } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
-import { SidebarInset } from "@/shared/ui/sidebar";
+import { SidebarInset, useSidebar } from "@/shared/ui/sidebar";
 
 type AppShellChannelSurfaceProps = {
   children: React.ReactNode;
@@ -21,6 +21,8 @@ export function AppShellChannelSurface({
   mainInsetRef,
   terminal,
 }: AppShellChannelSurfaceProps) {
+  const { state: sidebarState } = useSidebar();
+
   return (
     <MainInsetProvider mainInsetRef={mainInsetRef}>
       <SidebarInset
@@ -36,7 +38,11 @@ export function AppShellChannelSurface({
         style={chromeCssVarDefaults as React.CSSProperties}
       >
         {isHuddleRoom && !isHuddleRoomStarting ? <HuddleRoomHeader /> : null}
-        <BuzzTheme.ContentSurface terminal={terminal} unframed={isHuddleRoom}>
+        <BuzzTheme.ContentSurface
+          insetLeft={sidebarState === "collapsed"}
+          terminal={terminal}
+          unframed={isHuddleRoom}
+        >
           {isHuddleRoomStarting ? <HuddleStartingView /> : children}
         </BuzzTheme.ContentSurface>
       </SidebarInset>

--- a/desktop/src/app/BuzzThemeSurfaces.tsx
+++ b/desktop/src/app/BuzzThemeSurfaces.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/cn";
 
 export function GradientLayer() {
   return (
@@ -22,21 +23,26 @@ export function GradientLayer() {
 
 export function ContentSurface({
   children,
+  insetLeft = false,
   unframed = false,
   terminal,
 }: {
   children: ReactNode;
+  /** Match the outer card gutter when no sidebar is visible to its left. */
+  insetLeft?: boolean;
   terminal?: ReactNode;
   /** Used by dedicated huddle windows, which should not resemble app cards. */
   unframed?: boolean;
 }) {
   return (
     <div
-      className={
+      className={cn(
+        "relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden bg-background",
         unframed
-          ? "relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden bg-background"
-          : "relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
-      }
+          ? undefined
+          : "mb-2 mr-2 mt-px rounded-2xl shadow-content-edge motion-safe:transition-[margin] motion-safe:duration-200 motion-safe:ease-linear",
+        !unframed && (insetLeft ? "ml-2" : "ml-px"),
+      )}
       data-buzz-content-surface
       data-buzz-content-unframed={unframed ? true : undefined}
     >

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -374,7 +374,7 @@ export function CommunityRail({
   return (
     <nav
       aria-label="Communities"
-      className="relative z-0 flex w-14 shrink-0 flex-col items-center gap-2.5 overflow-y-auto bg-sidebar px-2.5 pb-5 pt-[calc(var(--buzz-top-chrome-height,40px)+7px)]"
+      className="relative z-20 flex w-14 shrink-0 flex-col items-center gap-2.5 overflow-y-auto bg-sidebar px-2.5 pb-5 pt-[calc(var(--buzz-top-chrome-height,40px)+7px)]"
       data-testid="community-rail"
     >
       <DndContext

--- a/desktop/src/shared/lib/keyboard-shortcuts.ts
+++ b/desktop/src/shared/lib/keyboard-shortcuts.ts
@@ -93,8 +93,8 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     id: "toggle-sidebar",
     label: "Toggle sidebar",
     description: "Show or hide the sidebar",
-    keys: "⌘S",
-    keysWindows: "Ctrl+S",
+    keys: "⌘B",
+    keysWindows: "Ctrl+B",
     category: "Navigation",
   },
   {

--- a/desktop/src/shared/lib/sidebar-shortcut.ts
+++ b/desktop/src/shared/lib/sidebar-shortcut.ts
@@ -1,0 +1,31 @@
+import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
+
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_KEYBOARD_SHORTCUT_ALIAS = "s";
+
+function isEditableKeyboardTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return (
+    target.closest("input, textarea, select, [contenteditable='true']") !== null
+  );
+}
+
+export function isSidebarToggleShortcut(event: KeyboardEvent) {
+  if (
+    !hasPrimaryShortcutModifier(event) ||
+    event.altKey ||
+    event.shiftKey ||
+    event.repeat ||
+    event.defaultPrevented
+  ) {
+    return false;
+  }
+
+  const key = event.key.toLowerCase();
+  return (
+    key === SIDEBAR_KEYBOARD_SHORTCUT_ALIAS ||
+    (key === SIDEBAR_KEYBOARD_SHORTCUT &&
+      !isEditableKeyboardTarget(event.target))
+  );
+}

--- a/desktop/src/shared/ui/sidebar.tsx
+++ b/desktop/src/shared/ui/sidebar.tsx
@@ -5,7 +5,7 @@ import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 
 import { cn } from "@/shared/lib/cn";
 import { performSidebarDefaultHaptic } from "@/shared/lib/haptics";
-import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
+import { isSidebarToggleShortcut } from "@/shared/lib/sidebar-shortcut";
 import { useIsMobile } from "@/shared/hooks/use-mobile";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
@@ -36,7 +36,6 @@ const SIDEBAR_WIDTH_MIN = 220;
 const SIDEBAR_WIDTH_MAX = 420;
 const SIDEBAR_WIDTH_MOBILE = "288px";
 const SIDEBAR_WIDTH_ICON = "48px";
-const SIDEBAR_KEYBOARD_SHORTCUT = "s";
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
@@ -207,10 +206,7 @@ const SidebarProvider = React.forwardRef<
 
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (
-          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-          hasPrimaryShortcutModifier(event)
-        ) {
+        if (isSidebarToggleShortcut(event)) {
           event.preventDefault();
           toggleSidebar();
         }

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -59,7 +59,7 @@ test.describe("community rail", () => {
       "overflow",
       "visible",
     );
-    await expect(rail).toHaveCSS("z-index", "0");
+    await expect(rail).toHaveCSS("z-index", "20");
 
     const buttonA = page.getByTestId(`community-rail-button-${COMMUNITY_A.id}`);
     const buttonB = page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`);
@@ -933,6 +933,46 @@ test.describe("community rail", () => {
       page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`),
     ).toBeVisible();
     await expect(page.getByTestId("community-rail-add")).toBeVisible();
+  });
+
+  test("keeps the rail above the sidebar throughout the collapse animation", async ({
+    page,
+  }) => {
+    await installMockBridge(page, undefined, { skipCommunitySeed: true });
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_A.id);
+    await page.goto("/");
+
+    const rail = page.getByTestId("community-rail");
+    const communityButton = page.getByTestId(
+      `community-rail-button-${COMMUNITY_A.id}`,
+    );
+    await expect(rail).toBeVisible();
+    await expect(communityButton).toBeVisible();
+
+    // Slow only the moving sidebar surface so the assertion samples the
+    // transition rather than the steady expanded or collapsed endpoint.
+    await page.addStyleTag({
+      content:
+        '[data-testid="app-sidebar"] { transition-duration: 1000ms !important; }',
+    });
+    await page
+      .getByRole("button", { name: "Toggle Sidebar", exact: true })
+      .click();
+    await page.waitForTimeout(100);
+
+    const railOwnsCommunityButtonPoint = await communityButton.evaluate(
+      (button) => {
+        const bounds = button.getBoundingClientRect();
+        const topmost = document.elementFromPoint(
+          bounds.left + bounds.width / 2,
+          bounds.top + bounds.height / 2,
+        );
+        return (
+          topmost === button || (topmost !== null && button.contains(topmost))
+        );
+      },
+    );
+    expect(railOwnsCommunityButtonPoint).toBe(true);
   });
 
   test("clears the macOS traffic lights", async ({ page }) => {

--- a/desktop/tests/e2e/composer-link-shortcut.spec.ts
+++ b/desktop/tests/e2e/composer-link-shortcut.spec.ts
@@ -177,3 +177,49 @@ test("⌘K outside the composer opens quick search", async ({ page }) => {
 
   await expect(page.getByTestId("search-dialog-input")).toBeVisible();
 });
+
+test("⌘B toggles the sidebar outside the composer", async ({ page }) => {
+  await installMockBridge(page);
+  await openGeneral(page);
+
+  const contentSurface = page.locator("[data-buzz-content-surface]").first();
+  await expect(contentSurface).toHaveCSS("margin-left", "1px");
+
+  await page.getByTestId("chat-title").click();
+  await page.keyboard.press("ControlOrMeta+b");
+
+  await expect(page.getByTestId("app-sidebar").locator("..")).toHaveAttribute(
+    "data-state",
+    "collapsed",
+  );
+  await expect(contentSurface).toHaveCSS("margin-left", "8px");
+});
+
+test("⌘S remains a sidebar shortcut alias", async ({ page }) => {
+  await installMockBridge(page);
+  await openGeneral(page);
+
+  await page.getByTestId("chat-title").click();
+  await page.keyboard.press("ControlOrMeta+s");
+
+  await expect(page.getByTestId("app-sidebar").locator("..")).toHaveAttribute(
+    "data-state",
+    "collapsed",
+  );
+});
+
+test("⌘B keeps bold formatting inside the composer", async ({ page }) => {
+  await installMockBridge(page);
+  await openGeneral(page);
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await page.keyboard.press("ControlOrMeta+b");
+  await input.pressSequentially("Bold");
+
+  await expect(input.locator("strong")).toHaveText("Bold");
+  await expect(page.getByTestId("app-sidebar").locator("..")).toHaveAttribute(
+    "data-state",
+    "expanded",
+  );
+});


### PR DESCRIPTION
## Summary

- make Cmd/Ctrl+B the primary sidebar toggle while retaining Cmd/Ctrl+S as a compatibility alias
- preserve editor bold behavior by ignoring Cmd/Ctrl+B in editable surfaces
- keep the community rail above the collapsing sidebar
- give collapsed content an animated 8px left gutter matching the outer frame

## Root cause

The sidebar used Cmd/Ctrl+S globally, its off-canvas layer could paint over the community rail during transition, and the content card retained its expanded 1px sidebar seam after the sidebar disappeared.

## Validation

https://github.com/user-attachments/assets/21a7111c-f136-411d-90a1-f196eed5c9ee


- desktop E2E build
- focused Playwright coverage for Cmd/Ctrl+B, the Cmd/Ctrl+S alias, composer bold behavior, rail stacking during animation, and the collapsed 8px gutter
- desktop file-size ratchet against upstream/main
- Biome and TypeScript checks


Fixes #5655