### PR TITLE
feat(cli): expose channel type and visibility in channels list/get

### DIFF
--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -13,11 +13,34 @@ use crate::commands::channel_templates::{self, ChannelTemplateRecord, TemplateAg
 use crate::error::CliError;
 use crate::validate::{parse_uuid, read_or_stdin, validate_hex64, validate_uuid};
 
+fn extract_channel_visibility(e: &serde_json::Value) -> Option<&'static str> {
+    e.get("tags")
+        .and_then(|tags| tags.as_array())
+        .and_then(|tags| {
+            tags.iter().find_map(|tag| {
+                let key = tag
+                    .as_array()
+                    .and_then(|parts| parts.first())
+                    .and_then(|value| value.as_str());
+                match key {
+                    Some("private") => Some("private"),
+                    Some("public") => Some("public"),
+                    _ => None,
+                }
+            })
+        })
+}
+
 fn extract_channel_metadata(e: &serde_json::Value) -> serde_json::Value {
     serde_json::json!({
         "channel_id": extract_d_tag(e),
         "name": extract_tag_value(e, "name"),
+        "channel_type": extract_tag_value(e, "t"),
+        "visibility": extract_channel_visibility(e),
         "description": extract_tag_value(e, "about"),
+        "topic": extract_tag_value(e, "topic"),
+        "purpose": extract_tag_value(e, "purpose"),
+        "archived": extract_tag_value(e, "archived") == "true",
         "created_at": e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
     })
 }
@@ -1193,9 +1216,9 @@ pub async fn dispatch_canvas(cmd: crate::CanvasCmd, client: &BuzzClient) -> Resu
 mod tests {
     use super::{
         apply_cardinality_rule, build_template_report, cmd_set_add_policy,
-        finalize_roster_resolution, name_matches, resolve_roster_with_archive_filter,
-        validate_ttl_seconds, validate_update_channel_fields, ArchivedExclusion, ChannelSummary,
-        ResolvedAgent, RosterResolution, SkippedSlug,
+        extract_channel_metadata, finalize_roster_resolution, name_matches,
+        resolve_roster_with_archive_filter, validate_ttl_seconds, validate_update_channel_fields,
+        ArchivedExclusion, ChannelSummary, ResolvedAgent, RosterResolution, SkippedSlug,
     };
     use crate::client::BuzzClient;
     use crate::CliError;
@@ -1225,6 +1248,24 @@ mod tests {
         assert_eq!(s.about.as_deref(), Some("About text"));
         assert_eq!(s.topic.as_deref(), Some("Composer work"));
         assert_eq!(s.purpose.as_deref(), Some("Track UI for the composer"));
+    }
+
+    #[test]
+    fn list_and_get_metadata_expose_surface_type_and_visibility() {
+        let ev = json!({
+            "created_at": 123,
+            "tags": [
+                ["d", "11111111-1111-1111-1111-111111111111"],
+                ["name", "design"],
+                ["t", "forum"],
+                ["private"],
+                ["about", "Design discussions"]
+            ]
+        });
+
+        let metadata = extract_channel_metadata(&ev);
+        assert_eq!(metadata["channel_type"], "forum");
+        assert_eq!(metadata["visibility"], "private");
     }
 
     #[test]


### PR DESCRIPTION
`channels list` and `channels get` return `name`, `description`, and `created_at`, but omit the channel's surface type (`stream` vs `forum`) and visibility (`open` vs `private`) — both of which the relay already serves in the kind:39000 tags the CLI parses.

For agents this matters: posting into a forum requires kind 45001/45003 while streams take kind 9, so an agent routing a message has to issue a raw event query just to learn what kind of surface it is addressing. Same for visibility when deciding whether content can reference a channel externally.

This adds `channel_type`, `visibility`, `topic`, `purpose`, and `archived` to the metadata returned by both subcommands — read from tags already present on the events, no new relay round-trips.

## Testing

- `cargo test -p buzz-cli --lib` — 344 passed (includes new unit test asserting type/visibility extraction)
- `cargo clippy -p buzz-cli --all-targets` / `cargo fmt --check` — clean

Additive JSON fields only; existing consumers are unaffected.
