### PR TITLE
fix(desktop): identify native relay requests

### DIFF
--- a/desktop/src-tauri/src/commands/join_policy.rs
+++ b/desktop/src-tauri/src/commands/join_policy.rs
@@ -34,6 +34,7 @@ fn join_policy_url(relay_url: &str) -> Result<Url, String> {
 pub async fn fetch_join_policy(relay_url: String) -> Result<Option<Value>, String> {
     let url = join_policy_url(&relay_url)?;
     let client = reqwest::Client::builder()
+        .user_agent(concat!("Buzz Desktop/", env!("CARGO_PKG_VERSION")))
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|error| format!("failed to build join policy client: {error}"))?;
@@ -84,7 +85,7 @@ mod tests {
     use super::*;
     use axum::{
         body::{Body, Bytes},
-        http::Response,
+        http::{HeaderMap, Response},
         response::Redirect,
         routing::get,
         Json, Router,
@@ -120,6 +121,23 @@ mod tests {
     fn rejects_non_relay_schemes_and_credentials() {
         assert!(join_policy_url("https://relay.example.com").is_err());
         assert!(join_policy_url("wss://user:secret@relay.example.com").is_err());
+    }
+
+    #[tokio::test]
+    async fn sends_versioned_user_agent() {
+        let relay_url = test_relay(Router::new().route(
+            "/api/join-policy",
+            get(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers.get(reqwest::header::USER_AGENT).unwrap(),
+                    concat!("Buzz Desktop/", env!("CARGO_PKG_VERSION"))
+                );
+                Json(serde_json::json!({ "policy": null }))
+            }),
+        ))
+        .await;
+
+        assert!(fetch_join_policy(relay_url).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/desktop/src-tauri/src/native_websocket.rs
+++ b/desktop/src-tauri/src/native_websocket.rs
@@ -6,7 +6,11 @@ use tauri::{ipc::Channel, plugin::TauriPlugin, Manager, Runtime};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_tungstenite::{
     connect_async,
-    tungstenite::protocol::{frame::coding::CloseCode, CloseFrame, Message},
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{header::USER_AGENT, HeaderValue},
+        protocol::{frame::coding::CloseCode, CloseFrame, Message},
+    },
 };
 use tokio_util::sync::CancellationToken;
 
@@ -127,9 +131,16 @@ async fn open_connection(
     on_message: Channel<serde_json::Value>,
 ) -> Result<Id, String> {
     let connect_cancel = manager.connect_cancel.lock().await.clone();
+    let mut request = url
+        .into_client_request()
+        .map_err(|error| error.to_string())?;
+    request.headers_mut().insert(
+        USER_AGENT,
+        HeaderValue::from_static(concat!("Buzz Desktop/", env!("CARGO_PKG_VERSION"))),
+    );
     let (socket, _) = tokio::select! {
         _ = connect_cancel.cancelled() => return Err("WebSocket connection cancelled".to_string()),
-        result = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(url)) => result
+        result = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(request)) => result
             .map_err(|_| "WebSocket connection timed out".to_string())?
             .map_err(|error| error.to_string())?,
     };
@@ -343,7 +354,14 @@ mod tests {
 
     use tauri::ipc::InvokeResponseBody;
     use tokio::io::duplex;
-    use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
+    use tokio_tungstenite::{
+        tungstenite::{
+            handshake::server::{Request, Response},
+            http::header::USER_AGENT,
+            protocol::Role,
+        },
+        WebSocketStream,
+    };
 
     fn silent_channel() -> Channel<serde_json::Value> {
         Channel::new(|_: InvokeResponseBody| Ok(()))
@@ -365,6 +383,48 @@ mod tests {
         .await;
 
         assert!(result.is_ok(), "TLS setup must not panic");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::result_large_err)]
+    async fn websocket_upgrade_sends_versioned_user_agent() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (user_agent_tx, user_agent_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut user_agent_tx = Some(user_agent_tx);
+            let mut socket = tokio_tungstenite::accept_hdr_async(
+                stream,
+                move |request: &Request, response: Response| {
+                    user_agent_tx
+                        .take()
+                        .unwrap()
+                        .send(request.headers().get(USER_AGENT).cloned())
+                        .unwrap();
+                    Ok(response)
+                },
+            )
+            .await
+            .unwrap();
+            while let Some(message) = socket.next().await {
+                if matches!(message, Ok(Message::Close(_))) {
+                    break;
+                }
+            }
+        });
+
+        let manager = WebSocketManager::default();
+        let id = open_connection(&manager, &format!("ws://{address}"), silent_channel())
+            .await
+            .unwrap();
+        assert_eq!(
+            user_agent_rx.await.unwrap().unwrap(),
+            concat!("Buzz Desktop/", env!("CARGO_PKG_VERSION"))
+        );
+
+        manager.disconnect(id).await;
         server.await.unwrap();
     }
 


### PR DESCRIPTION
## Context

Buzz Desktop's native join-policy request and native WebSocket handshake did not send a `User-Agent`. Deployments using AWS `AWSManagedRulesCommonRuleSet` therefore match `NoUserAgent_HEADER` and can reject both requests with HTTP 403. A live join-policy repro returns 403 without a User-Agent and 200 with one.

## Change

- Send `Buzz Desktop/<CARGO_PKG_VERSION>` from the native reqwest join-policy client.
- Convert the WebSocket URL with `IntoClientRequest`, then add the same header so tungstenite's generated upgrade headers are preserved.
- Capture and assert the actual server-observed HTTP and WebSocket upgrade headers in regression tests.

The User-Agent is stable client identification for network compatibility, not authentication or authorization. Relay authentication remains NIP-42/NIP-43.

No duplicate open PR was found.

## Testing

Strict TDD red runs before production changes:

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml commands::join_policy::tests::sends_versioned_user_agent -- --exact --nocapture` — failed because the server observed no User-Agent.
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml native_websocket::tests::websocket_upgrade_sends_versioned_user_agent -- --exact --nocapture` — failed because the upgrade request had no User-Agent.

Green verification:

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml commands::join_policy::tests -- --nocapture` — 7 passed.
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml native_websocket::tests -- --nocapture` — 7 passed.
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings`
