### PR TITLE
fix(acp): add durable final reply delivery

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -211,6 +211,8 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Concatenated `agent_message_chunk` text for the current ACP turn.
+    turn_output: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +552,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            turn_output: String::new(),
         })
     }
 
@@ -768,6 +771,7 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        self.begin_turn_output_capture();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -879,6 +883,18 @@ impl AcpClient {
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
         self.goose_usage.take()
+    }
+
+    fn begin_turn_output_capture(&mut self) {
+        self.turn_output.clear();
+    }
+
+    /// Consume the ordinary ACP text emitted by the most recent turn.
+    /// Whitespace-only output is treated as absent.
+    pub fn take_turn_output(&mut self) -> Option<String> {
+        let output = std::mem::take(&mut self.turn_output);
+        let output = output.trim();
+        (!output.is_empty()).then(|| output.to_string())
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1731,6 +1747,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    self.turn_output.push_str(text);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
@@ -3549,9 +3566,52 @@ mod tests {
     /// which is fine — these tests don't read from the agent, they just
     /// feed JSON into the parser.
     async fn spawn_inert_client() -> AcpClient {
-        AcpClient::spawn("cat", &[], &[], false)
+        #[cfg(unix)]
+        let (command, args): (&str, Vec<String>) = ("cat", Vec::new());
+        #[cfg(windows)]
+        let (command, args): (&str, Vec<String>) = (
+            "cmd.exe",
+            vec!["/Q".into(), "/D".into(), "/C".into(), "more".into()],
+        );
+        AcpClient::spawn(command, &args, &[], false)
             .await
-            .expect("spawn cat as inert client")
+            .expect("spawn inert stdio client")
+    }
+
+    fn agent_message_chunk(text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "test-session",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "text": text },
+                },
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn turn_output_capture_joins_agent_message_chunks_and_is_take_once() {
+        let mut client = spawn_inert_client().await;
+        client.begin_turn_output_capture();
+        let _ = client.handle_session_update(&agent_message_chunk("first "));
+        let _ = client.handle_session_update(&agent_message_chunk("second"));
+
+        assert_eq!(client.take_turn_output().as_deref(), Some("first second"));
+        assert_eq!(client.take_turn_output(), None);
+    }
+
+    #[tokio::test]
+    async fn beginning_a_new_turn_discards_stale_or_whitespace_only_output() {
+        let mut client = spawn_inert_client().await;
+        client.begin_turn_output_capture();
+        let _ = client.handle_session_update(&agent_message_chunk("stale"));
+        client.begin_turn_output_capture();
+        let _ = client.handle_session_update(&agent_message_chunk("  \n"));
+
+        assert_eq!(client.take_turn_output(), None);
     }
 
     /// Build a `session/update` JSON-RPC notification carrying a

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -30,6 +30,8 @@ pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 /// Override via `--max-turn-duration` / `BUZZ_ACP_MAX_TURN_DURATION`.
 pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
 
+const NATIVE_DELIVERY_TEAM_INSTRUCTIONS: &str = "The harness durably publishes the ordinary final response. Emit exactly one complete final answer as ACP text. Do not use `buzz messages send` to republish that final response. The Buzz CLI may still be used for intentional interim milestones or explicit side effects.";
+
 /// Upper bound for `max_turn_duration` (7 days). Any higher is operationally
 /// meaningless and risks arithmetic overflow when deriving the in-flight
 /// deadline (`max_turn_duration + IN_FLIGHT_DEADLINE_BUFFER_SECS`).
@@ -470,6 +472,14 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_TEAM_INSTRUCTIONS")]
     pub team_instructions: Option<String>,
 
+    /// Durably publish completed ACP responses from the harness.
+    #[arg(long, env = "BUZZ_ACP_NATIVE_DELIVERY", default_value_t = false)]
+    pub native_delivery: bool,
+
+    /// Absolute path for native-delivery pending and delivered receipts.
+    #[arg(long, env = "BUZZ_ACP_DELIVERY_OUTBOX_DIR")]
+    pub delivery_outbox_dir: Option<PathBuf>,
+
     /// Publish encrypted ACP observer frames over the relay.
     #[arg(long, env = "BUZZ_ACP_RELAY_OBSERVER", default_value_t = false)]
     pub relay_observer: bool,
@@ -512,6 +522,10 @@ pub struct Config {
     pub system_prompt: Option<String>,
     /// Team-owned instructions layered separately from the agent system prompt.
     pub team_instructions: Option<String>,
+    /// Whether the harness owns durable publication of completed ACP responses.
+    pub native_delivery: bool,
+    /// Absolute native-delivery receipt root. Present only when enabled.
+    pub delivery_outbox_dir: Option<PathBuf>,
     pub initial_message: Option<String>,
     pub subscribe_mode: SubscribeMode,
     pub dedup_mode: DedupMode,
@@ -1060,6 +1074,43 @@ impl Config {
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
+        let delivery_outbox_dir = if args.native_delivery {
+            let path = args.delivery_outbox_dir.ok_or_else(|| {
+                ConfigError::ConfigFile(
+                    "native delivery requires an explicit delivery outbox path".into(),
+                )
+            })?;
+            if !path.is_absolute() {
+                return Err(ConfigError::ConfigFile(format!(
+                    "native delivery outbox must be an absolute path: {}",
+                    path.display()
+                )));
+            }
+            Some(path)
+        } else {
+            if args.delivery_outbox_dir.is_some() {
+                tracing::warn!(
+                    "--delivery-outbox-dir is ignored unless --native-delivery is enabled"
+                );
+            }
+            None
+        };
+
+        let mut team_instructions = args
+            .team_instructions
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if args.native_delivery {
+            team_instructions = Some(match team_instructions {
+                Some(existing) => {
+                    format!("{existing}\n\n{NATIVE_DELIVERY_TEAM_INSTRUCTIONS}")
+                }
+                None => NATIVE_DELIVERY_TEAM_INSTRUCTIONS.to_string(),
+            });
+        }
+
         let config = Config {
             keys,
             relay_url: args.relay_url,
@@ -1073,12 +1124,9 @@ impl Config {
             turn_liveness_secs,
             heartbeat_prompt,
             system_prompt,
-            team_instructions: args
-                .team_instructions
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string),
+            team_instructions,
+            native_delivery: args.native_delivery,
+            delivery_outbox_dir,
             initial_message: args.initial_message,
             subscribe_mode: args.subscribe,
             dedup_mode: args.dedup,
@@ -1131,7 +1179,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} native_delivery={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1150,6 +1198,7 @@ impl Config {
             self.presence_enabled,
             self.typing_enabled,
             self.memory_enabled,
+            self.native_delivery,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
             respond_to_detail,
@@ -1453,6 +1502,8 @@ mod tests {
             heartbeat_prompt: None,
             system_prompt: None,
             team_instructions: None,
+            native_delivery: false,
+            delivery_outbox_dir: None,
             initial_message: None,
             subscribe_mode: mode,
             dedup_mode: DedupMode::Queue,
@@ -2922,6 +2973,100 @@ channels = "ALL"
     fn compose_session_title_drops_the_channel_when_the_agent_name_fills_the_cap() {
         let agent = "a".repeat(SESSION_TITLE_MAX_CHARS);
         assert_eq!(compose_session_title(&agent, Some("buzz-dev")), agent);
+    }
+
+    #[test]
+    fn native_delivery_defaults_off_without_an_outbox() {
+        let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", TEST_PRIVATE_KEY])
+            .expect("clap should parse args");
+        let config = Config::from_args(args).expect("default config should remain valid");
+
+        assert!(!config.native_delivery);
+        assert_eq!(config.delivery_outbox_dir, None);
+        assert!(config.summary().contains("native_delivery=false"));
+    }
+
+    #[test]
+    fn native_delivery_requires_an_explicit_outbox() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--native-delivery",
+        ])
+        .expect("clap should parse args");
+        let error = Config::from_args(args).expect_err("missing outbox must fail closed");
+
+        assert!(error.to_string().contains("delivery outbox"));
+    }
+
+    #[test]
+    fn native_delivery_rejects_a_relative_outbox() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--native-delivery",
+            "--delivery-outbox-dir",
+            "relative-outbox",
+        ])
+        .expect("clap should parse args");
+        let error = Config::from_args(args).expect_err("relative outbox must fail closed");
+
+        assert!(error.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn native_delivery_opt_in_adds_the_no_republish_instruction() {
+        let outbox = std::env::temp_dir().join("buzz-acp-native-delivery-config-test");
+        let outbox_arg = outbox.to_string_lossy().to_string();
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--native-delivery",
+            "--delivery-outbox-dir",
+            &outbox_arg,
+            "--team-instructions",
+            "Keep existing guidance.",
+        ])
+        .expect("clap should parse args");
+        let config = Config::from_args(args).expect("valid native delivery config");
+
+        assert!(config.native_delivery);
+        assert_eq!(
+            config.delivery_outbox_dir.as_deref(),
+            Some(outbox.as_path())
+        );
+        let instructions = config
+            .team_instructions
+            .expect("native instruction is present");
+        assert!(instructions.starts_with("Keep existing guidance."));
+        assert!(instructions.contains("Do not use `buzz messages send` to republish"));
+    }
+
+    #[test]
+    fn disabled_native_delivery_ignores_an_outbox_and_keeps_instructions_unchanged() {
+        let outbox = std::env::temp_dir().join("unused-buzz-acp-outbox");
+        let outbox_arg = outbox.to_string_lossy().to_string();
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--delivery-outbox-dir",
+            &outbox_arg,
+            "--team-instructions",
+            "Keep existing guidance.",
+        ])
+        .expect("clap should parse args");
+        let config = Config::from_args(args).expect("disabled native delivery remains valid");
+
+        assert!(!config.native_delivery);
+        assert_eq!(config.delivery_outbox_dir, None);
+        assert_eq!(
+            config.team_instructions.as_deref(),
+            Some("Keep existing guidance.")
+        );
     }
 
     /// Every arg whose env var name contains KEY/SECRET/TOKEN/PASSWORD/CRED/AUTH

--- a/crates/buzz-acp/src/delivery.rs
+++ b/crates/buzz-acp/src/delivery.rs
@@ -1,0 +1,896 @@
+use crate::queue::{self, FlushBatch, PromptProfileLookup};
+use crate::relay::RestClient;
+use nostr::{Event, EventId, Filter, Keys};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::future::Future;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tokio::sync::Mutex;
+
+const RECORD_VERSION: u8 = 1;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeliveryError {
+    #[error("outbox I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("outbox JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid outbox record: {0}")]
+    InvalidRecord(String),
+    #[error("reply build failed: {0}")]
+    Build(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DeliveryRecord {
+    version: u8,
+    delivery_key: String,
+    event: Event,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordLocation {
+    Pending,
+    Delivered,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryState {
+    Confirmed { event_id: EventId },
+    Pending { event_id: EventId },
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RecoveryReport {
+    pub confirmed: usize,
+    pub pending: usize,
+    pub quarantined: usize,
+}
+
+/// Durable, idempotent final-reply outbox.
+///
+/// A batch-derived delivery key owns one signed event for its lifetime. Pending
+/// records are retried after ambiguous acknowledgements or restart; confirmed
+/// records are retained as receipts so the same triggering batch can never sign
+/// and publish a second event.
+pub struct NativeDelivery {
+    root: PathBuf,
+    operation_lock: Mutex<()>,
+}
+
+impl NativeDelivery {
+    pub fn open(root: impl AsRef<Path>) -> Result<Self, DeliveryError> {
+        let root = root.as_ref().to_path_buf();
+        for path in [
+            root.join("pending"),
+            root.join("delivered"),
+            root.join("corrupt"),
+        ] {
+            std::fs::create_dir_all(path)?;
+        }
+        Ok(Self {
+            root,
+            operation_lock: Mutex::new(()),
+        })
+    }
+
+    pub(crate) fn pending_path(&self, key: &str) -> PathBuf {
+        self.root.join("pending").join(format!("{key}.json"))
+    }
+
+    pub(crate) fn delivered_path(&self, key: &str) -> PathBuf {
+        self.root.join("delivered").join(format!("{key}.json"))
+    }
+
+    pub(crate) fn corrupt_dir(&self) -> PathBuf {
+        self.root.join("corrupt")
+    }
+
+    fn validate_key(key: &str) -> Result<(), DeliveryError> {
+        if key.is_empty()
+            || key.len() > 128
+            || !key
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(DeliveryError::InvalidRecord(
+                "delivery key must contain only ASCII letters, digits, '-' or '_'".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn prepare<F>(
+        &self,
+        key: &str,
+        build_event: F,
+    ) -> Result<(DeliveryRecord, RecordLocation), DeliveryError>
+    where
+        F: FnOnce() -> Result<Event, DeliveryError>,
+    {
+        Self::validate_key(key)?;
+
+        let delivered = self.delivered_path(key);
+        if delivered.is_file() {
+            return Ok((
+                load_record_for_key(&delivered, key)?,
+                RecordLocation::Delivered,
+            ));
+        }
+
+        let pending = self.pending_path(key);
+        if pending.is_file() {
+            return Ok((load_record_for_key(&pending, key)?, RecordLocation::Pending));
+        }
+
+        let event = build_event()?;
+        event.verify().map_err(|error| {
+            DeliveryError::InvalidRecord(format!("new signed event failed verification: {error}"))
+        })?;
+        let record = DeliveryRecord {
+            version: RECORD_VERSION,
+            delivery_key: key.to_string(),
+            event,
+        };
+        persist_record_atomically(&pending, &record)?;
+        Ok((record, RecordLocation::Pending))
+    }
+
+    pub async fn deliver_with<B, S, SF, Q, QF>(
+        &self,
+        key: &str,
+        build_event: B,
+        submit: S,
+        contains: Q,
+    ) -> Result<DeliveryState, DeliveryError>
+    where
+        B: FnOnce() -> Result<Event, DeliveryError>,
+        S: Fn(Event) -> SF,
+        SF: Future<Output = Result<(), String>>,
+        Q: Fn(Event) -> QF,
+        QF: Future<Output = Result<bool, String>>,
+    {
+        let _guard = self.operation_lock.lock().await;
+        let (record, location) = self.prepare(key, build_event)?;
+        self.reconcile_record(key, record, location, &submit, &contains)
+            .await
+    }
+
+    async fn reconcile_record<S, SF, Q, QF>(
+        &self,
+        key: &str,
+        record: DeliveryRecord,
+        mut location: RecordLocation,
+        submit: &S,
+        contains: &Q,
+    ) -> Result<DeliveryState, DeliveryError>
+    where
+        S: Fn(Event) -> SF,
+        SF: Future<Output = Result<(), String>>,
+        Q: Fn(Event) -> QF,
+        QF: Future<Output = Result<bool, String>>,
+    {
+        let event_id = record.event.id;
+
+        if location == RecordLocation::Delivered {
+            match contains(record.event.clone()).await {
+                Ok(true) => return Ok(DeliveryState::Confirmed { event_id }),
+                Ok(false) | Err(_) => {
+                    self.move_record(key, RecordLocation::Delivered, RecordLocation::Pending)?;
+                    location = RecordLocation::Pending;
+                }
+            }
+        }
+
+        debug_assert_eq!(location, RecordLocation::Pending);
+        if let Err(error) = submit(record.event.clone()).await {
+            tracing::warn!(delivery_key = key, %event_id, "native delivery submit was ambiguous: {error}");
+        }
+
+        match contains(record.event.clone()).await {
+            Ok(true) => {
+                self.move_record(key, RecordLocation::Pending, RecordLocation::Delivered)?;
+                Ok(DeliveryState::Confirmed { event_id })
+            }
+            Ok(false) => Ok(DeliveryState::Pending { event_id }),
+            Err(error) => {
+                tracing::warn!(delivery_key = key, %event_id, "native delivery read-back failed: {error}");
+                Ok(DeliveryState::Pending { event_id })
+            }
+        }
+    }
+
+    fn move_record(
+        &self,
+        key: &str,
+        from: RecordLocation,
+        to: RecordLocation,
+    ) -> Result<(), DeliveryError> {
+        let source = match from {
+            RecordLocation::Pending => self.pending_path(key),
+            RecordLocation::Delivered => self.delivered_path(key),
+        };
+        let target = match to {
+            RecordLocation::Pending => self.pending_path(key),
+            RecordLocation::Delivered => self.delivered_path(key),
+        };
+
+        if !source.exists() {
+            if target.exists() {
+                load_record_for_key(&target, key)?;
+                return Ok(());
+            }
+            return Err(DeliveryError::InvalidRecord(format!(
+                "record for {key} disappeared before state transition"
+            )));
+        }
+
+        if target.exists() {
+            let source_record = load_record_for_key(&source, key)?;
+            let target_record = load_record_for_key(&target, key)?;
+            if source_record.event.id != target_record.event.id {
+                return Err(DeliveryError::InvalidRecord(format!(
+                    "conflicting records for delivery key {key}"
+                )));
+            }
+            std::fs::remove_file(&source)?;
+            sync_parent_directory(&source)?;
+            return Ok(());
+        }
+
+        std::fs::rename(&source, &target)?;
+        sync_parent_directory(&source)?;
+        sync_parent_directory(&target)?;
+        Ok(())
+    }
+
+    pub async fn recover_with<S, SF, Q, QF>(&self, submit: S, contains: Q) -> RecoveryReport
+    where
+        S: Fn(Event) -> SF,
+        SF: Future<Output = Result<(), String>>,
+        Q: Fn(Event) -> QF,
+        QF: Future<Output = Result<bool, String>>,
+    {
+        let _guard = self.operation_lock.lock().await;
+        let mut report = RecoveryReport::default();
+        let mut paths = match std::fs::read_dir(self.root.join("pending")) {
+            Ok(entries) => entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+                .collect::<Vec<_>>(),
+            Err(error) => {
+                tracing::error!("native delivery recovery could not read outbox: {error}");
+                return report;
+            }
+        };
+        paths.sort();
+
+        for path in paths {
+            let key = match path.file_stem().and_then(|stem| stem.to_str()) {
+                Some(key) => key.to_string(),
+                None => {
+                    if self.quarantine(&path).is_ok() {
+                        report.quarantined += 1;
+                    }
+                    continue;
+                }
+            };
+            let record = match load_record_for_key(&path, &key) {
+                Ok(record) => record,
+                Err(error) => {
+                    tracing::error!(path = %path.display(), "quarantining invalid native delivery record: {error}");
+                    if self.quarantine(&path).is_ok() {
+                        report.quarantined += 1;
+                    }
+                    continue;
+                }
+            };
+
+            match self
+                .reconcile_record(&key, record, RecordLocation::Pending, &submit, &contains)
+                .await
+            {
+                Ok(DeliveryState::Confirmed { .. }) => report.confirmed += 1,
+                Ok(DeliveryState::Pending { .. }) => report.pending += 1,
+                Err(error) => {
+                    tracing::error!(
+                        delivery_key = key,
+                        "native delivery recovery failed: {error}"
+                    );
+                    report.pending += 1;
+                }
+            }
+        }
+        report
+    }
+
+    fn quarantine(&self, path: &Path) -> Result<(), DeliveryError> {
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("invalid-record");
+        let target = self
+            .corrupt_dir()
+            .join(format!("{file_name}.{}.corrupt", uuid::Uuid::new_v4()));
+        std::fs::rename(path, &target)?;
+        sync_parent_directory(path)?;
+        sync_parent_directory(&target)?;
+        Ok(())
+    }
+
+    pub async fn deliver<B>(
+        &self,
+        key: &str,
+        build_event: B,
+        rest: &RestClient,
+    ) -> Result<DeliveryState, DeliveryError>
+    where
+        B: FnOnce() -> Result<Event, DeliveryError>,
+    {
+        let submit_rest = rest.clone();
+        let query_rest = rest.clone();
+        self.deliver_with(
+            key,
+            build_event,
+            move |event| {
+                let rest = submit_rest.clone();
+                async move {
+                    rest.submit_event(&event)
+                        .await
+                        .map(|_| ())
+                        .map_err(|error| error.to_string())
+                }
+            },
+            move |event| {
+                let rest = query_rest.clone();
+                async move { relay_contains_event(&rest, &event).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn recover(&self, rest: &RestClient) -> RecoveryReport {
+        let submit_rest = rest.clone();
+        let query_rest = rest.clone();
+        self.recover_with(
+            move |event| {
+                let rest = submit_rest.clone();
+                async move {
+                    rest.submit_event(&event)
+                        .await
+                        .map(|_| ())
+                        .map_err(|error| error.to_string())
+                }
+            },
+            move |event| {
+                let rest = query_rest.clone();
+                async move { relay_contains_event(&rest, &event).await }
+            },
+        )
+        .await
+    }
+}
+
+fn persist_record_atomically(path: &Path, record: &DeliveryRecord) -> Result<(), DeliveryError> {
+    let parent = path.parent().ok_or_else(|| {
+        DeliveryError::InvalidRecord(format!("outbox path has no parent: {}", path.display()))
+    })?;
+    let bytes = serde_json::to_vec(record)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("record.json");
+    let temporary = parent.join(format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4()));
+
+    let write_result = (|| -> Result<(), DeliveryError> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.flush()?;
+        file.sync_all()?;
+        drop(file);
+
+        // A hard link is an atomic create-if-absent operation on both Unix and
+        // Windows. Unlike `rename`, it cannot overwrite another harness's
+        // record on Unix if twin processes race on the same delivery key.
+        match std::fs::hard_link(&temporary, path) {
+            Ok(()) => {
+                sync_parent_directory(path)?;
+                if let Err(error) = std::fs::remove_file(&temporary) {
+                    tracing::warn!(path = %temporary.display(), "native delivery could not remove staged temporary file: {error}");
+                } else {
+                    sync_parent_directory(&temporary)?;
+                }
+                Ok(())
+            }
+            Err(_error) if path.exists() => {
+                let existing = load_record(path)?;
+                if existing.delivery_key == record.delivery_key
+                    && existing.event.id == record.event.id
+                {
+                    std::fs::remove_file(&temporary)?;
+                    Ok(())
+                } else {
+                    Err(DeliveryError::InvalidRecord(format!(
+                        "outbox destination {} already contains a different event",
+                        path.display()
+                    )))
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    write_result
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<(), DeliveryError> {
+    let parent = path.parent().ok_or_else(|| {
+        DeliveryError::InvalidRecord(format!("outbox path has no parent: {}", path.display()))
+    })?;
+    std::fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<(), DeliveryError> {
+    Ok(())
+}
+
+fn load_record(path: &Path) -> Result<DeliveryRecord, DeliveryError> {
+    let bytes = std::fs::read(path)?;
+    let record: DeliveryRecord = serde_json::from_slice(&bytes)?;
+    if record.version != RECORD_VERSION {
+        return Err(DeliveryError::InvalidRecord(format!(
+            "unsupported record version {}",
+            record.version
+        )));
+    }
+    record.event.verify().map_err(|error| {
+        DeliveryError::InvalidRecord(format!("signed event verification failed: {error}"))
+    })?;
+    Ok(record)
+}
+
+fn load_record_for_key(path: &Path, expected_key: &str) -> Result<DeliveryRecord, DeliveryError> {
+    let record = load_record(path)?;
+    if record.delivery_key != expected_key {
+        return Err(DeliveryError::InvalidRecord(format!(
+            "record key {} does not match filename key {expected_key}",
+            record.delivery_key
+        )));
+    }
+    Ok(record)
+}
+
+async fn relay_contains_event(rest: &RestClient, expected: &Event) -> Result<bool, String> {
+    let response = rest
+        .query(&[Filter::new().id(expected.id).limit(1)])
+        .await
+        .map_err(|error| error.to_string())?;
+    let Some(events) = response.as_array() else {
+        return Err("relay query response was not an array".into());
+    };
+
+    Ok(events.iter().any(|raw| {
+        serde_json::from_value::<Event>(raw.clone())
+            .is_ok_and(|event| event.id == expected.id && event.verify().is_ok())
+    }))
+}
+
+/// Derive a stable delivery identity from the publishing agent and immutable
+/// triggering batch. Including the agent avoids collisions if two harnesses
+/// are accidentally configured with the same outbox root.
+pub fn delivery_key(agent_pubkey: &nostr::PublicKey, batch: &FlushBatch) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"buzz-acp-native-delivery-v1\0");
+    digest.update(agent_pubkey.to_hex().as_bytes());
+    digest.update(batch.channel_id.as_bytes());
+    for event in &batch.cancelled_events {
+        digest.update(b"\0cancelled\0");
+        digest.update(event.event.id.to_hex().as_bytes());
+    }
+    for event in &batch.events {
+        digest.update(b"\0event\0");
+        digest.update(event.event.id.to_hex().as_bytes());
+    }
+    hex::encode(digest.finalize())
+}
+
+/// Build and sign the one native reply event for a completed batch.
+pub fn build_reply_event(
+    keys: &Keys,
+    batch: &FlushBatch,
+    content: &str,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> Result<Event, DeliveryError> {
+    let triggering = batch
+        .events
+        .last()
+        .ok_or_else(|| DeliveryError::Build("cannot build a reply for an empty batch".into()))?;
+    let triggering_id = triggering.event.id.to_hex();
+    let sender = triggering.event.pubkey.to_hex();
+    let thread_tags = queue::parse_thread_tags(&triggering.event);
+    let human_anchor =
+        queue::resolve_reply_anchor(&sender, &thread_tags, &triggering_id, profile_lookup);
+
+    let (root, parent) = if let Some(anchor) = human_anchor {
+        let id = EventId::from_hex(&anchor)
+            .map_err(|error| DeliveryError::Build(format!("invalid reply anchor: {error}")))?;
+        (id, id)
+    } else {
+        let root = thread_tags
+            .root_event_id
+            .as_deref()
+            .map(EventId::from_hex)
+            .transpose()
+            .map_err(|error| DeliveryError::Build(format!("invalid thread root: {error}")))?
+            .unwrap_or(triggering.event.id);
+        (root, triggering.event.id)
+    };
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id: root,
+        parent_event_id: parent,
+    };
+    let builder = buzz_sdk::build_message(
+        batch.channel_id,
+        content,
+        Some(&thread_ref),
+        &[sender.as_str()],
+        false,
+        &[],
+    )
+    .map_err(|error| DeliveryError::Build(error.to_string()))?;
+    builder
+        .sign_with_keys(keys)
+        .map_err(|error| DeliveryError::Build(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::queue::{BatchEvent, FlushBatch, PromptProfile, PromptProfileLookup};
+    use nostr::{Event, EventBuilder, Keys, Kind, Tag};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+    use uuid::Uuid;
+
+    fn test_root() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("buzz-acp-delivery-test-{}", Uuid::new_v4()))
+    }
+
+    fn signed_event(keys: &Keys, content: &str) -> Event {
+        EventBuilder::new(Kind::Custom(9), content)
+            .tags([])
+            .sign_with_keys(keys)
+            .expect("sign test event")
+    }
+
+    fn tagged_event(keys: &Keys, content: &str, tags: Vec<Vec<String>>) -> Event {
+        let tags = tags
+            .iter()
+            .map(|tag| {
+                Tag::parse(tag.iter().map(String::as_str).collect::<Vec<_>>())
+                    .expect("parse test tag")
+            })
+            .collect::<Vec<_>>();
+        EventBuilder::new(Kind::Custom(9), content)
+            .tags(tags)
+            .sign_with_keys(keys)
+            .expect("sign tagged test event")
+    }
+
+    fn batch(event: Event, channel_id: Uuid) -> FlushBatch {
+        FlushBatch {
+            channel_id,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: Vec::new(),
+            cancel_reason: None,
+        }
+    }
+
+    fn tag_values(event: &Event, kind: &str, marker: Option<&str>) -> Vec<String> {
+        event
+            .tags
+            .iter()
+            .filter_map(|tag| {
+                let parts = tag.as_slice();
+                if parts.first().map(String::as_str) != Some(kind) {
+                    return None;
+                }
+                if marker.is_some() && parts.get(3).map(String::as_str) != marker {
+                    return None;
+                }
+                parts.get(1).cloned()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn signed_event_is_durable_before_submit_and_readback_confirms_it() {
+        let root = test_root();
+        let delivery = NativeDelivery::open(&root).expect("open outbox");
+        let keys = Keys::generate();
+        let event = signed_event(&keys, "answer");
+        let event_id = event.id;
+        let key = "batch-a";
+        let pending_path = delivery.pending_path(key);
+        let observed = Arc::new(Mutex::new(Vec::new()));
+
+        let submit_observed = Arc::clone(&observed);
+        let state = delivery
+            .deliver_with(
+                key,
+                || Ok(event.clone()),
+                move |submitted| {
+                    let submit_observed = Arc::clone(&submit_observed);
+                    let pending_path = pending_path.clone();
+                    async move {
+                        assert!(pending_path.is_file(), "event must exist before submit");
+                        let record = load_record(&pending_path).expect("load staged record");
+                        assert_eq!(record.event.id, submitted.id);
+                        record.event.verify().expect("staged event must verify");
+                        submit_observed.lock().unwrap().push(submitted.id);
+                        Err("landed but response was malformed".to_string())
+                    }
+                },
+                move |candidate| async move { Ok(candidate.id == event_id) },
+            )
+            .await
+            .expect("reconcile ambiguous acknowledgement");
+
+        assert_eq!(state, DeliveryState::Confirmed { event_id });
+        assert_eq!(observed.lock().unwrap().as_slice(), &[event_id]);
+        assert!(!delivery.pending_path(key).exists());
+        assert!(delivery.delivered_path(key).is_file());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn restart_recovery_reuses_exact_event_without_rebuilding_or_rerunning() {
+        let root = test_root();
+        let keys = Keys::generate();
+        let event = signed_event(&keys, "completed once");
+        let event_id = event.id;
+        let key = "batch-restart";
+
+        let first = NativeDelivery::open(&root).expect("open first manager");
+        let first_state = first
+            .deliver_with(
+                key,
+                || Ok(event.clone()),
+                |_submitted| async { Ok(()) },
+                |_candidate| async { Ok(false) },
+            )
+            .await
+            .expect("leave event pending");
+        assert!(matches!(first_state, DeliveryState::Pending { .. }));
+        drop(first);
+
+        let second = NativeDelivery::open(&root).expect("open after restart");
+        let submitted = Arc::new(Mutex::new(Vec::new()));
+        let submitted_clone = Arc::clone(&submitted);
+        let second_state = second
+            .deliver_with(
+                key,
+                || panic!("existing delivery key must not rebuild or rerun the model"),
+                move |candidate| {
+                    let submitted_clone = Arc::clone(&submitted_clone);
+                    async move {
+                        submitted_clone.lock().unwrap().push(candidate.id);
+                        Ok(())
+                    }
+                },
+                move |candidate| async move { Ok(candidate.id == event_id) },
+            )
+            .await
+            .expect("recover staged event");
+
+        assert_eq!(second_state, DeliveryState::Confirmed { event_id });
+        assert_eq!(submitted.lock().unwrap().as_slice(), &[event_id]);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn absent_readback_keeps_exact_event_pending() {
+        let root = test_root();
+        let delivery = NativeDelivery::open(&root).expect("open outbox");
+        let event = signed_event(&Keys::generate(), "not visible yet");
+        let event_id = event.id;
+        let state = delivery
+            .deliver_with(
+                "batch-pending",
+                || Ok(event),
+                |_submitted| async { Ok(()) },
+                |_candidate| async { Ok(false) },
+            )
+            .await
+            .expect("pending result");
+
+        assert_eq!(state, DeliveryState::Pending { event_id });
+        assert!(delivery.pending_path("batch-pending").is_file());
+        assert!(!delivery.delivered_path("batch-pending").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn corrupt_pending_record_is_quarantined_and_never_submitted() {
+        let root = test_root();
+        let delivery = NativeDelivery::open(&root).expect("open outbox");
+        std::fs::write(delivery.pending_path("broken"), b"{partial").expect("write corrupt record");
+        let submits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let submits_clone = Arc::clone(&submits);
+
+        let report = delivery
+            .recover_with(
+                move |_candidate| {
+                    let submits_clone = Arc::clone(&submits_clone);
+                    async move {
+                        submits_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+                |_candidate| async { Ok(false) },
+            )
+            .await;
+
+        assert_eq!(report.quarantined, 1);
+        assert_eq!(submits.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(!delivery.pending_path("broken").exists());
+        assert_eq!(
+            std::fs::read_dir(delivery.corrupt_dir()).unwrap().count(),
+            1
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn delivery_key_is_stable_for_the_same_immutable_batch() {
+        let agent_keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let inbound = signed_event(&Keys::generate(), "request");
+        let one = batch(inbound.clone(), channel_id);
+        let two = batch(inbound, channel_id);
+        let key = delivery_key(&agent_keys.public_key(), &one);
+        assert_eq!(key, delivery_key(&agent_keys.public_key(), &two));
+        assert_eq!(key.len(), 64);
+        assert_ne!(
+            key,
+            delivery_key(&Keys::generate().public_key(), &two),
+            "different publishing agents must not collide"
+        );
+    }
+
+    #[test]
+    fn twin_writers_cannot_replace_the_first_signed_event() {
+        let root = test_root();
+        let pending = root.join("pending");
+        std::fs::create_dir_all(&pending).expect("create pending directory");
+        let path = pending.join("shared-batch.json");
+        let first_event = signed_event(&Keys::generate(), "first answer");
+        let second_event = signed_event(&Keys::generate(), "second answer");
+        let first = DeliveryRecord {
+            version: RECORD_VERSION,
+            delivery_key: "shared-batch".into(),
+            event: first_event.clone(),
+        };
+        let second = DeliveryRecord {
+            version: RECORD_VERSION,
+            delivery_key: "shared-batch".into(),
+            event: second_event.clone(),
+        };
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+
+        let writer = |record: DeliveryRecord, barrier: Arc<std::sync::Barrier>| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                persist_record_atomically(&path, &record)
+            })
+        };
+        let first_result = writer(first, Arc::clone(&barrier));
+        let second_result = writer(second, barrier);
+        let results = [
+            first_result.join().expect("first writer joins"),
+            second_result.join().expect("second writer joins"),
+        ];
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(DeliveryError::InvalidRecord(_))))
+                .count(),
+            1
+        );
+        let stored = load_record_for_key(&path, "shared-batch").expect("load winning record");
+        assert!(stored.event.id == first_event.id || stored.event.id == second_event.id);
+        std::fs::remove_dir_all(root).expect("remove test outbox");
+    }
+
+    #[test]
+    fn human_top_level_reply_opens_thread_and_notifies_triggering_author() {
+        let agent_keys = Keys::generate();
+        let human_keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let inbound = signed_event(&human_keys, "@agent help");
+        let inbound_id = inbound.id.to_hex();
+        let event = build_reply_event(&agent_keys, &batch(inbound, channel_id), "done", None)
+            .expect("build native reply");
+
+        assert_eq!(tag_values(&event, "h", None), vec![channel_id.to_string()]);
+        assert_eq!(tag_values(&event, "e", Some("reply")), vec![inbound_id]);
+        assert_eq!(
+            tag_values(&event, "p", None),
+            vec![human_keys.public_key().to_hex()]
+        );
+    }
+
+    #[test]
+    fn human_thread_reply_is_flat_at_root() {
+        let agent_keys = Keys::generate();
+        let human_keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root_id = signed_event(&Keys::generate(), "root").id.to_hex();
+        let parent_id = signed_event(&Keys::generate(), "parent").id.to_hex();
+        let inbound = tagged_event(
+            &human_keys,
+            "@agent nested request",
+            vec![
+                vec!["e".into(), root_id.clone(), "".into(), "root".into()],
+                vec!["e".into(), parent_id, "".into(), "reply".into()],
+            ],
+        );
+        let event = build_reply_event(&agent_keys, &batch(inbound, channel_id), "done", None)
+            .expect("build native reply");
+
+        // A direct reply to the root uses the canonical single `reply` marker;
+        // `parse_thread_tags` derives root == parent from that shape.
+        assert!(tag_values(&event, "e", Some("root")).is_empty());
+        assert_eq!(tag_values(&event, "e", Some("reply")), vec![root_id]);
+    }
+
+    #[test]
+    fn agent_only_thread_reply_nests_under_triggering_event() {
+        let agent_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root_id = signed_event(&Keys::generate(), "root").id.to_hex();
+        let inbound = tagged_event(
+            &sender_keys,
+            "agent coordination",
+            vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
+        );
+        let inbound_id = inbound.id.to_hex();
+        let profiles: PromptProfileLookup = HashMap::from([(
+            sender_keys.public_key().to_hex(),
+            PromptProfile {
+                is_agent: true,
+                ..Default::default()
+            },
+        )]);
+        let event = build_reply_event(
+            &agent_keys,
+            &batch(inbound, channel_id),
+            "done",
+            Some(&profiles),
+        )
+        .expect("build native reply");
+
+        assert_eq!(tag_values(&event, "e", Some("root")), vec![root_id]);
+        assert_eq!(tag_values(&event, "e", Some("reply")), vec![inbound_id]);
+    }
+}

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod acp;
 mod config;
+mod delivery;
 mod engram_fetch;
 mod filter;
 mod observer;
@@ -1332,7 +1333,6 @@ async fn tokio_main() -> Result<()> {
         .init();
 
     let mut config = Config::from_cli().map_err(|e| anyhow::anyhow!("configuration error: {e}"))?;
-
     // ── Setup-mode early branch ───────────────────────────────────────────────
     //
     // When the desktop determines an agent is not ready (missing credentials,
@@ -1344,6 +1344,13 @@ async fn tokio_main() -> Result<()> {
         tracing::info!("buzz-acp: setup payload present, entering setup-listener mode");
         return setup_mode::run_setup_listener(config, payload).await;
     }
+
+    let native_delivery = config
+        .delivery_outbox_dir
+        .as_ref()
+        .map(|path| delivery::NativeDelivery::open(path).map(Arc::new))
+        .transpose()
+        .map_err(|error| anyhow::anyhow!("native delivery outbox error: {error}"))?;
 
     tracing::info!("buzz-acp starting: {}", config.summary());
 
@@ -1405,6 +1412,16 @@ async fn tokio_main() -> Result<()> {
     }
 
     tracing::info!("connected to relay at {}", config.relay_url);
+
+    if let Some(delivery) = native_delivery.as_ref() {
+        let report = delivery.recover(&relay.rest_client()).await;
+        tracing::info!(
+            confirmed = report.confirmed,
+            pending = report.pending,
+            quarantined = report.quarantined,
+            "native delivery startup recovery complete"
+        );
+    }
 
     relay
         .subscribe_membership_notifications()
@@ -1588,6 +1605,7 @@ async fn tokio_main() -> Result<()> {
         system_prompt: config.system_prompt.clone(),
         session_title: config.session_title.clone(),
         team_instructions: config.team_instructions.clone(),
+        native_delivery: native_delivery.clone(),
         base_prompt: if config.no_base_prompt {
             None
         } else if let Some(content) = base_prompt_content {
@@ -1612,6 +1630,27 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+    });
+
+    let native_delivery_recovery_task = native_delivery.as_ref().map(|delivery| {
+        let delivery = Arc::clone(delivery);
+        let rest = relay.rest_client();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let report = delivery.recover(&rest).await;
+                if report.confirmed > 0 || report.pending > 0 || report.quarantined > 0 {
+                    tracing::info!(
+                        confirmed = report.confirmed,
+                        pending = report.pending,
+                        quarantined = report.quarantined,
+                        "native delivery periodic recovery complete"
+                    );
+                }
+            }
+        })
     });
 
     if !config.memory_enabled {
@@ -2814,6 +2853,10 @@ async fn tokio_main() -> Result<()> {
         handle.abort();
     }
 
+    if let Some(handle) = native_delivery_recovery_task {
+        handle.abort();
+    }
+
     // Graceful relay shutdown — sends WebSocket close frame and waits up to 5s
     // for the background task to finish, rather than aborting immediately (#40).
     relay.shutdown().await;
@@ -3139,15 +3182,16 @@ fn spawn_failure_notice(
     content: String,
 ) {
     if let Some(rest) = rest_client {
-        let thread_tags = batch
-            .events
-            .last()
-            .map(|be| queue::parse_thread_tags(&be.event))
-            .unwrap_or_default();
+        let Some(casualty) = batch.events.last().map(|be| be.event.clone()) else {
+            tracing::warn!(channel_id = %batch.channel_id, "cannot post failure notice for empty batch");
+            return;
+        };
         let rest = rest.clone();
         let channel_id = batch.channel_id;
+        let casualty_id = casualty.id.to_hex();
         tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
+            tracing::warn!(channel_id = %channel_id, event_id = casualty_id, "posting attributed failure notice");
+            pool::post_failure_notice(&rest, channel_id, &casualty, &content).await;
         });
     }
 }
@@ -3187,6 +3231,11 @@ fn handle_prompt_result(
     // every retry starts at attempt 1 — defeating exponential backoff and
     // dead-letter protection.
     if let Some(batch) = result.batch.take() {
+        let request_event_id = batch
+            .events
+            .last()
+            .map(|event| event.event.id.to_hex())
+            .unwrap_or_else(|| "<empty-batch>".to_string());
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
         if !removed_channels.contains(&batch.channel_id) {
@@ -3218,6 +3267,7 @@ fn handle_prompt_result(
             ) {
                 tracing::error!(
                     channel_id = %batch.channel_id,
+                    event_id = request_event_id,
                     events = batch.events.len(),
                     "dead-lettering batch after hard-cap timeout (no recent activity) — discarding {} events",
                     batch.events.len(),
@@ -3236,6 +3286,7 @@ fn handle_prompt_result(
             ) {
                 tracing::warn!(
                     channel_id = %batch.channel_id,
+                    event_id = request_event_id,
                     events = batch.events.len(),
                     "hard-cap timeout with recent activity — requeueing for retry"
                 );
@@ -3256,6 +3307,7 @@ fn handle_prompt_result(
                 // the user to re-authenticate the CLI.
                 tracing::warn!(
                     channel_id = %batch.channel_id,
+                    event_id = request_event_id,
                     events = batch.events.len(),
                     "dead-lettering batch immediately — non-retryable auth error"
                 );
@@ -3282,6 +3334,7 @@ fn handle_prompt_result(
         } else {
             tracing::debug!(
                 channel_id = %batch.channel_id,
+                event_id = request_event_id,
                 events = batch.events.len(),
                 "dropping failed batch for removed channel"
             );
@@ -5109,6 +5162,8 @@ mod build_mcp_servers_tests {
             heartbeat_prompt: None,
             system_prompt: None,
             team_instructions: None,
+            native_delivery: false,
+            delivery_outbox_dir: None,
             initial_message: None,
             subscribe_mode: config::SubscribeMode::All,
             dedup_mode: config::DedupMode::Queue,
@@ -5331,6 +5386,8 @@ mod error_outcome_emission_tests {
             heartbeat_prompt: None,
             system_prompt: None,
             team_instructions: None,
+            native_delivery: false,
+            delivery_outbox_dir: None,
             initial_message: None,
             subscribe_mode: config::SubscribeMode::All,
             dedup_mode: config::DedupMode::Queue,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -35,10 +35,11 @@ use crate::acp::{
     StopReason, SystemPromptTransport,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
+use crate::delivery::{self, DeliveryState, NativeDelivery};
 use crate::observer;
 use crate::queue::{
     CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
-    PromptProfile, PromptProfileLookup, ThreadTags,
+    PromptProfile, PromptProfileLookup,
 };
 use crate::relay::{ChannelInfo, RestClient};
 
@@ -526,6 +527,8 @@ pub struct PromptContext {
     /// on `session/new`. Never part of the prompt.
     pub session_title: Option<String>,
     pub team_instructions: Option<String>,
+    /// Durable final-response outbox, present only after explicit opt-in.
+    pub native_delivery: Option<Arc<NativeDelivery>>,
     pub heartbeat_prompt: Option<String>,
     /// Base prompt content, or `None` if `--no-base-prompt` was passed.
     ///
@@ -1375,6 +1378,81 @@ fn send_prompt_result(
     });
 }
 
+/// Persist, publish, and reconcile the ordinary ACP text for a completed
+/// channel turn. Delivery state never changes the model outcome: pending
+/// records are retried from the outbox without rerunning the model.
+async fn deliver_completed_turn(
+    agent: &mut OwnedAgent,
+    batch: Option<&FlushBatch>,
+    profile_lookup: Option<&PromptProfileLookup>,
+    ctx: &PromptContext,
+) {
+    let Some(delivery) = ctx.native_delivery.as_ref() else {
+        return;
+    };
+    let Some(batch) = batch else {
+        // Heartbeats have no immutable inbound route and are never auto-published.
+        let _ = agent.acp.take_turn_output();
+        return;
+    };
+    let casualty_id = batch
+        .events
+        .last()
+        .map(|event| event.event.id.to_hex())
+        .unwrap_or_else(|| "<empty-batch>".to_string());
+    let Some(output) = agent.acp.take_turn_output() else {
+        tracing::error!(
+            channel_id = %batch.channel_id,
+            event_id = casualty_id,
+            "native delivery has no ACP text for completed turn"
+        );
+        if let Some(casualty) = batch.events.last() {
+            post_failure_notice(
+                &ctx.rest_client,
+                batch.channel_id,
+                &casualty.event,
+                "⚠️ I completed the request but produced no deliverable response. Please re-send if it is still needed.",
+            )
+            .await;
+        }
+        return;
+    };
+
+    let key = delivery::delivery_key(&ctx.agent_keys.public_key(), batch);
+    let keys = ctx.agent_keys.clone();
+    match delivery
+        .deliver(
+            &key,
+            || delivery::build_reply_event(&keys, batch, &output, profile_lookup),
+            &ctx.rest_client,
+        )
+        .await
+    {
+        Ok(DeliveryState::Confirmed { event_id }) => {
+            tracing::info!(delivery_key = key, %event_id, request_event_id = casualty_id, "native delivery confirmed by relay read-back");
+        }
+        Ok(DeliveryState::Pending { event_id }) => {
+            tracing::warn!(delivery_key = key, %event_id, request_event_id = casualty_id, "native delivery remains pending for recovery");
+        }
+        Err(error) => {
+            tracing::error!(
+                delivery_key = key,
+                event_id = casualty_id,
+                "native delivery could not stage the completed response: {error}"
+            );
+            if let Some(casualty) = batch.events.last() {
+                post_failure_notice(
+                    &ctx.rest_client,
+                    batch.channel_id,
+                    &casualty.event,
+                    "⚠️ I completed the request but could not stage its response for delivery. The request will not be rerun automatically; please re-send if it is still needed.",
+                )
+                .await;
+            }
+        }
+    }
+}
+
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
@@ -1861,6 +1939,7 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    let mut delivery_profile_lookup: Option<PromptProfileLookup> = None;
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
@@ -1887,6 +1966,7 @@ pub async fn run_prompt_task(
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
+        delivery_profile_lookup = profile_lookup.clone();
 
         let known_names: Vec<&str> = profile_lookup
             .iter()
@@ -2110,6 +2190,13 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        deliver_completed_turn(
+                            &mut agent,
+                            batch.as_ref(),
+                            delivery_profile_lookup.as_ref(),
+                            &ctx,
+                        )
+                        .await;
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2138,6 +2225,14 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            deliver_completed_turn(
+                &mut agent,
+                batch.as_ref(),
+                delivery_profile_lookup.as_ref(),
+                &ctx,
+            )
+            .await;
 
             let should_rotate = matches!(
                 stop_reason,
@@ -3865,47 +3960,62 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
+/// Best-effort: build a visible failure notice (kind:9) after dead-lettering.
+/// It retains the thread root and replies to the exact discarded event.
+/// Errors are logged and swallowed; a notice failure never stops the loop.
+/// The author is mentioned so the notice is attributable and actionable.
+fn build_failure_notice_event(
+    keys: &nostr::Keys,
+    channel_id: Uuid,
+    casualty: &nostr::Event,
+    content: &str,
+) -> Result<nostr::Event, String> {
+    let thread_tags = crate::queue::parse_thread_tags(casualty);
+    let root_id = thread_tags
+        .root_event_id
+        .as_deref()
+        .and_then(|root| nostr::EventId::from_hex(root).ok())
+        .unwrap_or(casualty.id);
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id: root_id,
+        parent_event_id: casualty.id,
+    };
+    let sender = casualty.pubkey.to_hex();
+    buzz_sdk::build_message(
+        channel_id,
+        content,
+        Some(&thread_ref),
+        &[sender.as_str()],
+        false,
+        &[],
+    )
+    .map_err(|error| error.to_string())?
+    .sign_with_keys(keys)
+    .map_err(|error| error.to_string())
+}
+
 pub(crate) async fn post_failure_notice(
     rest: &crate::relay::RestClient,
     channel_id: Uuid,
-    thread_tags: &ThreadTags,
+    casualty: &nostr::Event,
     content: &str,
 ) {
-    let thread_ref = thread_tags.root_event_id.as_deref().and_then(|root| {
-        let root_id = nostr::EventId::from_hex(root).ok()?;
-        let parent_id = thread_tags
-            .parent_event_id
-            .as_deref()
-            .and_then(|p| nostr::EventId::from_hex(p).ok())
-            .unwrap_or(root_id);
-        Some(buzz_sdk::ThreadRef {
-            root_event_id: root_id,
-            parent_event_id: parent_id,
-        })
-    });
-    let builder =
-        match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
-                return;
-            }
-        };
-    let event = match builder.sign_with_keys(&rest.keys) {
-        Ok(e) => e,
+    let casualty_id = casualty.id.to_hex();
+    let event = match build_failure_notice_event(&rest.keys, channel_id, casualty, content) {
+        Ok(event) => event,
         Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
+            tracing::warn!(channel = %channel_id, event_id = casualty_id, "failure notice: build/sign failed: {e}");
             return;
         }
     };
     match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
-        Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
+        Ok(Err(e)) => {
+            tracing::warn!(channel = %channel_id, event_id = casualty_id, "failure notice failed: {e}")
+        }
+        Err(_) => {
+            tracing::warn!(channel = %channel_id, event_id = casualty_id, "failure notice timed out")
+        }
     }
 }
 
@@ -4037,6 +4147,43 @@ mod tests {
             args: vec![],
             env: vec![],
         }
+    }
+
+    #[test]
+    fn failure_notice_replies_to_and_mentions_the_exact_casualty() {
+        let agent_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root = EventBuilder::new(Kind::Custom(9), "root")
+            .tags([])
+            .sign_with_keys(&Keys::generate())
+            .expect("sign root");
+        let casualty = EventBuilder::new(Kind::Custom(9), "request")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).expect("h tag"),
+                Tag::parse(["e", &root.id.to_hex(), "", "root"]).expect("root tag"),
+            ])
+            .sign_with_keys(&sender_keys)
+            .expect("sign casualty");
+
+        let notice =
+            build_failure_notice_event(&agent_keys, channel_id, &casualty, "could not deliver")
+                .expect("build failure notice");
+        let tags: Vec<Vec<String>> = notice
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+
+        assert!(tags.iter().any(|tag| {
+            tag.len() >= 4 && tag[0] == "e" && tag[1] == root.id.to_hex() && tag[3] == "root"
+        }));
+        assert!(tags.iter().any(|tag| {
+            tag.len() >= 4 && tag[0] == "e" && tag[1] == casualty.id.to_hex() && tag[3] == "reply"
+        }));
+        assert!(tags.iter().any(|tag| {
+            tag.len() >= 2 && tag[0] == "p" && tag[1] == sender_keys.public_key().to_hex()
+        }));
     }
 
     #[test]
@@ -6516,6 +6663,7 @@ mod tests {
             system_prompt: None,
             session_title: None,
             team_instructions: None,
+            native_delivery: None,
             heartbeat_prompt: None,
             base_prompt: None,
             cwd: ".".to_string(),

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -428,6 +428,11 @@ impl EventQueue {
     /// `mark_complete` separately.
     pub fn requeue(&mut self, batch: FlushBatch) -> Option<FlushBatch> {
         let channel_id = batch.channel_id;
+        let event_id = batch
+            .events
+            .last()
+            .map(|event| event.event.id.to_hex())
+            .unwrap_or_else(|| "<empty-batch>".to_string());
         let attempt = {
             let count = self.retry_counts.entry(channel_id).or_insert(0);
             *count += 1;
@@ -437,6 +442,7 @@ impl EventQueue {
         if attempt > MAX_RETRIES {
             tracing::error!(
                 channel_id = %channel_id,
+                event_id,
                 attempt,
                 events = batch.events.len(),
                 "dead-lettering batch after {} retries — discarding {} events",
@@ -465,6 +471,7 @@ impl EventQueue {
 
         tracing::warn!(
             channel_id = %channel_id,
+            event_id,
             attempt,
             max = MAX_RETRIES,
             delay_secs = delay.as_secs_f64(),
@@ -1211,7 +1218,7 @@ fn turn_is_human_facing(
 ///
 /// Returns `None` for agent↔agent turns, leaving the agent free to nest deeply
 /// (intentional for agent coordination).
-fn resolve_reply_anchor(
+pub(crate) fn resolve_reply_anchor(
     sender_pubkey: &str,
     thread_tags: &ThreadTags,
     triggering_event_id: &str,


### PR DESCRIPTION
## Summary

- capture the completed ACP reply in the relay-facing `buzz-acp` harness
- persist one signed Nostr event before network I/O and retry that exact event
- reconcile ambiguous publish acknowledgements through exact relay read-back
- recover pending deliveries after restart without rerunning the model
- attribute exhausted-retry notices and logs to the exact discarded request
- keep native delivery explicitly opt-in with an absolute outbox path

This keeps final-reply delivery deterministic across all child runtimes and removes the spawned CLI from that path. It is host-neutral: the same harness can run on Windows now and be qualified on Linux later.

Related to #2698 and #2883.

## Safety properties

- delivery key is derived from agent pubkey, channel UUID, and immutable ordered input event IDs
- the signed event is durable before the first submit
- relay read-back must return the exact event ID and payload before delivery is recorded
- atomic create-if-absent prevents twin harnesses from replacing the first signed event
- corrupt pending records are quarantined and never submitted
- delivered receipts are retained to prevent batch replay from signing a second event
- child agent processes no longer need reply-signing credentials when this path is enabled

## Verification

Exact revision: `f8027ccf40f57b2365e4dbcad4515a364a731634`

- 17/17 new acceptance tests passed
- `cargo fmt --all -- --check` passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings` passed
- `cargo build --release -p buzz-acp` passed
- release artifact: 12,728,832 bytes, SHA-256 `EB0DAF0ADEA32B01A89C5662CE7F5ABC806880F61DB6F06A74541C7E4B2F04DC`
- full Windows package run: 657/686 passed
- unchanged `desktop-v0.5.5` baseline: 640/669 passed
- machine comparison: identical 29-name failure set, zero branch-only failures

The 29 failures are existing Windows tests that launch inline POSIX shell scripts through `bash -c`; this is a documented platform-baseline exception, not a green full-suite claim. Repository-wide `just ci` was unavailable because the repository's Hermit bootstrap returns HTTP 404 for this Windows 26200 identifier and the host does not have the unrelated `just`, `pnpm`, or Flutter toolchains. Upstream CI remains required for Linux and repository-wide closure.

## Rollout boundary

This PR does not change the installed executable, running harnesses, agent definitions, profiles, memberships, or keys. The feature defaults off. A separately approved canary and per-agent relay nonce proof remain required before rollout.
