### PR TITLE
fix(forum): open thread at the newest reply instead of the top

### DIFF
--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -145,6 +145,7 @@ export function ForumThreadPanel({
   targetEventId,
 }: ForumThreadPanelProps) {
   const scrollRef = React.useRef<HTMLDivElement>(null);
+  const autoScrolledPostIdRef = React.useRef<string | null>(null);
   const { channels } = useChannelNavigation();
   const channelNames = React.useMemo(
     () => channels.filter((c) => c.channelType !== "dm").map((c) => c.name),
@@ -167,6 +168,29 @@ export function ForumThreadPanel({
     targetElement.scrollIntoView({ block: "center" });
     onTargetReached?.(targetEventId);
   }, [onTargetReached, targetEventId, thread]);
+
+  // Opening a thread without a link target lands on the newest reply, matching
+  // the stream timeline. Runs once per opened post so live replies never yank
+  // a reader who has scrolled elsewhere; a link target owns positioning
+  // instead, including after it is cleared via onTargetReached.
+  React.useEffect(() => {
+    if (!thread) {
+      return;
+    }
+    if (autoScrolledPostIdRef.current === thread.post.eventId) {
+      return;
+    }
+    autoScrolledPostIdRef.current = thread.post.eventId;
+
+    if (targetEventId) {
+      return;
+    }
+
+    const scrollElement = scrollRef.current;
+    if (scrollElement) {
+      scrollElement.scrollTop = scrollElement.scrollHeight;
+    }
+  }, [targetEventId, thread]);
 
   if (isLoading || !thread) {
     return (


### PR DESCRIPTION
## Problem

Opening a forum thread always lands at the top of the post. The panel's only scroll positioning runs when arriving via a link target (`targetEventId`); a plain open just renders the container at scroll position 0, so returning readers scroll past the entire thread to find what's new. Stream timelines already land at the newest message on open.

## Change

Add a second positioning effect to `ForumThreadPanel`: when a thread opens without a link target, scroll to the bottom (newest reply). It runs once per opened post — live replies arriving while reading never yank a reader who has scrolled elsewhere — and a link target keeps owning positioning, including after the parent clears it via `onTargetReached`.

## Testing

- desktop test suite: 4719 passed, 0 failed
- `tsc --noEmit` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)