### PR TITLE
fix(desktop): show display names on agent access allowlist chips

### DIFF
--- a/desktop/src/features/agents/lib/respondToAllowlist.test.mjs
+++ b/desktop/src/features/agents/lib/respondToAllowlist.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { mergeAllowlist, parsePubkeyInput } from "./respondToAllowlist.ts";
+import {
+  allowlistChipPresentation,
+  mergeAllowlist,
+  parsePubkeyInput,
+} from "./respondToAllowlist.ts";
 
 const HEX_A = "a".repeat(64);
 const HEX_B = "b".repeat(64);
@@ -59,4 +63,39 @@ test("mergeAllowlist skips invalid additions silently", () => {
   // Invalid additions are caller-validated; merge ignores them defensively.
   const merged = mergeAllowlist([HEX_A], ["not-hex", HEX_B]);
   assert.deepEqual(merged, [HEX_A, HEX_B]);
+});
+
+test("allowlistChipPresentation prefers the display name", () => {
+  assert.deepEqual(
+    allowlistChipPresentation({
+      displayName: "Ada Lovelace",
+      nip05Handle: "ada@example.com",
+      avatarUrl: "https://example.com/a.png",
+    }),
+    { name: "Ada Lovelace", avatarUrl: "https://example.com/a.png" },
+  );
+});
+
+test("allowlistChipPresentation falls back to the NIP-05 handle", () => {
+  assert.deepEqual(
+    allowlistChipPresentation({
+      displayName: "   ",
+      nip05Handle: "ada@example.com",
+      avatarUrl: null,
+    }),
+    { name: "ada@example.com", avatarUrl: null },
+  );
+});
+
+test("allowlistChipPresentation reports no name when nothing resolved", () => {
+  // The caller renders the truncated pubkey for a null name — an unresolved
+  // profile must not turn into an empty-looking chip.
+  assert.deepEqual(allowlistChipPresentation(undefined), {
+    name: null,
+    avatarUrl: null,
+  });
+  assert.deepEqual(
+    allowlistChipPresentation({ displayName: null, nip05Handle: "  " }),
+    { name: null, avatarUrl: null },
+  );
 });

--- a/desktop/src/features/agents/lib/respondToAllowlist.ts
+++ b/desktop/src/features/agents/lib/respondToAllowlist.ts
@@ -61,3 +61,36 @@ export function mergeAllowlist(existing: string[], add: string[]): string[] {
   }
   return out;
 }
+
+/** The subset of a resolved profile the allowlist chip renders. */
+export type AllowlistChipProfile = {
+  displayName?: string | null;
+  nip05Handle?: string | null;
+  avatarUrl?: string | null;
+};
+
+export type AllowlistChipPresentation = {
+  /** Chip label, or `null` when no name resolved and the caller must fall
+   * back to the pubkey. */
+  name: string | null;
+  avatarUrl: string | null;
+};
+
+/**
+ * Resolve how one allowlist entry presents.
+ *
+ * The allowlist persists hex pubkeys, so a chip has no name of its own — it
+ * comes from a profile lookup. Precedence matches the people pickers
+ * (`formatShareRecipientName`): display name, then NIP-05 handle. A `null`
+ * name means nothing resolved, and the caller keeps showing the truncated
+ * pubkey — the right answer for a key pasted directly, for an entry whose
+ * profile has not been fetched yet, and for an identity with no kind-0 at all.
+ */
+export function allowlistChipPresentation(
+  profile: AllowlistChipProfile | null | undefined,
+): AllowlistChipPresentation {
+  return {
+    name: profile?.displayName?.trim() || profile?.nip05Handle?.trim() || null,
+    avatarUrl: profile?.avatarUrl ?? null,
+  };
+}

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -1,14 +1,22 @@
 import * as React from "react";
 import { AlertTriangle, ChevronDown, Search, X } from "lucide-react";
 import {
+  allowlistChipPresentation,
   mergeAllowlist,
   parsePubkeyInput,
 } from "@/features/agents/lib/respondToAllowlist";
 import { truncatePubkey } from "@/shared/lib/pubkey";
 import { PubKey } from "@/shared/ui/PubKey";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
-import { useUserSearchQuery } from "@/features/profile/hooks";
-import type { RespondToMode, UserSearchResult } from "@/shared/api/types";
+import {
+  useUserSearchQuery,
+  useUsersBatchQuery,
+} from "@/features/profile/hooks";
+import type {
+  RespondToMode,
+  UserProfileSummary,
+  UserSearchResult,
+} from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
@@ -138,6 +146,14 @@ export function CreateAgentRespondToField({
     [allowlistSet, isArchivedDiscovery, userSearchQuery.data],
   );
 
+  // Chips persist as hex pubkeys, so their names come from a profile lookup.
+  // Only the selected keys are requested, and only while the picker is the
+  // visible mode.
+  const allowlistProfilesQuery = useUsersBatchQuery(allowlist, {
+    enabled: mode === "allowlist" && allowlist.length > 0,
+  });
+  const allowlistProfiles = allowlistProfilesQuery.data?.profiles;
+
   const pasteParsed = React.useMemo(
     () => parsePubkeyInput(pasteText),
     [pasteText],
@@ -248,6 +264,7 @@ export function CreateAgentRespondToField({
       {mode === "allowlist" ? (
         <AllowlistPicker
           allowlist={allowlist}
+          allowlistProfiles={allowlistProfiles}
           deferredQuery={deferredQuery}
           disabled={disabled}
           isDirectEntryOpen={isDirectEntryOpen}
@@ -282,6 +299,7 @@ const HEX_64_RE = /^[0-9a-f]{64}$/i;
 
 function AllowlistPicker({
   allowlist,
+  allowlistProfiles,
   deferredQuery,
   disabled,
   isDirectEntryOpen,
@@ -303,6 +321,8 @@ function AllowlistPicker({
   variant = "default",
 }: {
   allowlist: string[];
+  /** Resolved profiles keyed by lowercase hex pubkey; absent while loading. */
+  allowlistProfiles?: Record<string, UserProfileSummary>;
   deferredQuery: string;
   disabled?: boolean;
   isDirectEntryOpen: boolean;
@@ -374,29 +394,46 @@ function AllowlistPicker({
         </div>
         {allowlist.length > 0 ? (
           <div className="flex flex-wrap gap-1.5 border-t border-border/70 px-2.5 py-2">
-            {allowlist.map((pubkey) => (
-              <div
-                className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-muted/60 px-2.5 py-1 text-2xs leading-none"
-                data-testid={`agent-respond-to-chip-${pubkey}`}
-                key={pubkey}
-              >
-                <UserAvatar
-                  avatarUrl={null}
-                  displayName={truncatePubkey(pubkey)}
-                  size="xs"
-                />
-                <PubKey pubkey={pubkey} />
-                <button
-                  aria-label={`Remove ${truncatePubkey(pubkey)}`}
-                  className="text-muted-foreground transition-colors hover:text-foreground"
-                  disabled={disabled}
-                  onClick={() => onRemove(pubkey)}
-                  type="button"
+            {allowlist.map((pubkey) => {
+              const { avatarUrl, name } = allowlistChipPresentation(
+                allowlistProfiles?.[pubkey.toLowerCase()],
+              );
+              // The key stays on the chip even next to a name: this list
+              // decides who reaches the agent's host, and a display name is
+              // not unique enough to approve that against.
+              const label = name ?? truncatePubkey(pubkey);
+              return (
+                <div
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border/80 bg-muted/60 px-2.5 py-1 text-2xs leading-none"
+                  data-testid={`agent-respond-to-chip-${pubkey}`}
+                  key={pubkey}
                 >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-            ))}
+                  <UserAvatar
+                    avatarUrl={avatarUrl}
+                    displayName={label}
+                    size="xs"
+                  />
+                  {name ? (
+                    <span
+                      className="max-w-32 truncate font-medium"
+                      data-testid={`agent-respond-to-chip-name-${pubkey}`}
+                    >
+                      {name}
+                    </span>
+                  ) : null}
+                  <PubKey pubkey={pubkey} />
+                  <button
+                    aria-label={`Remove ${label}`}
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                    disabled={disabled}
+                    onClick={() => onRemove(pubkey)}
+                    type="button"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         ) : null}
         {deferredQuery.length > 0 ? (


### PR DESCRIPTION
The allowlist in Edit agent -> Who can send instructions -> Selected people persists hex pubkeys, so `AllowlistPicker` had nothing but the key to render: every chip showed `truncatePubkey` with `avatarUrl={null}`. The search results directly above the chips already resolve display names, so the same person reads two different ways depending on whether they have been added yet, and reopening the dialog gives no hint who was granted access to the agent host.

Resolve the selected keys with `useUsersBatchQuery` and render the name (display name, then NIP-05 handle) beside the key, with the avatar when the profile has one.

Two deliberate choices:

- **The key stays on the chip.** This list decides who can reach the agent's computer, files and tools; a display name is not unique enough to approve that against, so the chip shows the name *and* keeps `<PubKey>`.
- **No name means no change.** `allowlistChipPresentation` returns `null` when nothing resolved, and the chip falls back to exactly what it renders today. That covers a pubkey pasted directly, a profile still in flight, and an identity with no kind-0 at all — none of them turn into a blank-looking chip.

The lookup is scoped to the selected keys and gated on `mode === "allowlist"`, so owner-only and anyone issue no extra query.

Persistence is untouched — `respond_to_allowlist` stays hex pubkeys.

Verified locally: `pnpm typecheck`, `pnpm check`, and `pnpm test` (4719 pass) in `desktop/`. I did not build or run the Tauri app, so the visual result is unverified beyond the unit tests on the presentation helper.

Closes #5678