### PR TITLE
feat(agents): persist Claude effort across sessions

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -423,6 +423,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MODEL")]
     pub model: Option<String>,
 
+    /// Desired native ACP effort level. Applied through config option
+    /// `effort` after every fresh session when the adapter advertises it.
+    #[arg(long, env = "BUZZ_ACP_EFFORT")]
+    pub effort: Option<String>,
+
     /// Title for the agent's ACP sessions, passed out-of-band in `session/new`
     /// `_meta`. Adapters that recognize it name the session after this value;
     /// others ignore it. Never enters the prompt.
@@ -533,6 +538,8 @@ pub struct Config {
     pub memory_enabled: bool,
     /// Desired LLM model ID. Applied after every `session_new_full()`.
     pub model: Option<String>,
+    /// Desired native ACP effort value. Applied after every fresh session.
+    pub effort: Option<String>,
     /// Sanitized session title, sent as `_meta.sessionTitle` on `session/new`.
     /// `None` when unset or when the configured value sanitized to empty.
     pub session_title: Option<String>,
@@ -1046,6 +1053,12 @@ impl Config {
         // instructions arrive independently so they can be layered at runtime.
         let mut persona_env_vars = Vec::new();
         let model = args.model;
+        let effort = args
+            .effort
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
 
         // Inject CODEX_CONFIG so the @agentclientprotocol/codex-acp adapter (1.x)
         // opens the Seatbelt network sandbox for buzz-cli (an MCP subprocess). No-op
@@ -1094,6 +1107,7 @@ impl Config {
             typing_enabled: !args.no_typing,
             memory_enabled: args.memory && !args.no_memory,
             model,
+            effort,
             session_title: args
                 .session_title
                 .as_deref()
@@ -1468,6 +1482,7 @@ mod tests {
             typing_enabled: true,
             memory_enabled: true,
             model: None,
+            effort: None,
             session_title: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1836,6 +1836,7 @@ async fn tokio_main() -> Result<()> {
         context_message_limit: config.context_message_limit,
         max_turns_per_session: config.max_turns_per_session,
         permission_mode: config.permission_mode,
+        effort: config.effort.clone(),
         agent_keys: config.keys.clone(),
         agent_owner_pubkey: startup_owner
             .as_deref()
@@ -6242,6 +6243,7 @@ mod build_mcp_servers_tests {
             typing_enabled: true,
             memory_enabled: false,
             model: None,
+            effort: None,
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
@@ -6464,6 +6466,7 @@ mod error_outcome_emission_tests {
             typing_enabled: true,
             memory_enabled: false,
             model: None,
+            effort: None,
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -587,6 +587,8 @@ pub struct PromptContext {
     pub max_turns_per_session: u32,
     /// Permission mode to apply after session creation. `Default` = skip.
     pub permission_mode: PermissionMode,
+    /// Native ACP effort value to apply after every fresh session.
+    pub effort: Option<String>,
     /// Agent identity — used to derive the NIP-AE conversation key at
     /// session creation for core injection.
     pub agent_keys: nostr::Keys,
@@ -908,6 +910,8 @@ const CONTROL_CANCEL_GRACE: Duration = Duration::from_secs(5);
 
 /// Timeout for permission-mode requests (`session/set_config_option` with `configId: "mode"`).
 const PERMISSION_MODE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Timeout for native effort requests (`session/set_config_option`, configId `effort`).
+const EFFORT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Placeholder [`fetch_channel_info`] substitutes when a channel's metadata
 /// event carries no `name` tag. Not a real channel name — consumers that need
@@ -996,7 +1000,7 @@ async fn create_session_and_apply_model(
         ctx.session_title.as_deref(),
     );
 
-    let resp = agent
+    let mut resp = agent
         .acp
         .session_new_full(
             &ctx.cwd,
@@ -1071,6 +1075,24 @@ async fn create_session_and_apply_model(
     } else {
         false
     };
+
+    // A session rotation resets adapter-native configuration. Reapply the
+    // persisted effort on every fresh session, but only when the adapter
+    // advertises both the option and selected value. Update the captured
+    // session snapshot only after the wire request succeeds so the desktop's
+    // ACP tier reflects the setting actually in force.
+    if let Some(effort) = ctx.effort.as_deref() {
+        if agent_supports_config_option_value(&resp.raw, "effort", effort) {
+            if apply_effort(&mut agent.acp, &resp.session_id, effort).await? {
+                set_config_option_selected_value(&mut resp.raw, "effort", effort);
+            }
+        } else {
+            tracing::warn!(
+                target: "pool::effort",
+                "configured effort {effort:?} is not advertised by this ACP session; using adapter default"
+            );
+        }
+    }
 
     // Emit session config for desktop consumption (config bridge tier 1b).
     // Emitted AFTER desired_model resolution so the desktop caches the
@@ -1224,6 +1246,85 @@ fn agent_supports_mode(session_new_result: &serde_json::Value, mode_wire: &str) 
                 .any(|m| m.get("id").and_then(|v| v.as_str()) == Some(mode_wire))
         })
         .unwrap_or(false)
+}
+
+fn agent_supports_config_option_value(
+    session_new_result: &serde_json::Value,
+    config_id: &str,
+    desired: &str,
+) -> bool {
+    session_new_result
+        .get("configOptions")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|options| {
+            options.iter().any(|option| {
+                option
+                    .get("configId")
+                    .or_else(|| option.get("id"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(config_id)
+                    && option
+                        .get("options")
+                        .and_then(serde_json::Value::as_array)
+                        .is_some_and(|values| {
+                            values.iter().any(|value| {
+                                value.get("value").and_then(serde_json::Value::as_str)
+                                    == Some(desired)
+                            })
+                        })
+            })
+        })
+}
+
+fn set_config_option_selected_value(
+    session_new_result: &mut serde_json::Value,
+    config_id: &str,
+    selected: &str,
+) {
+    let Some(options) = session_new_result
+        .get_mut("configOptions")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    if let Some(option) = options.iter_mut().find(|option| {
+        option
+            .get("configId")
+            .or_else(|| option.get("id"))
+            .and_then(serde_json::Value::as_str)
+            == Some(config_id)
+    }) {
+        option["value"] = serde_json::Value::String(selected.to_string());
+        option["currentValue"] = serde_json::Value::String(selected.to_string());
+    }
+}
+
+async fn apply_effort(
+    acp: &mut AcpClient,
+    session_id: &str,
+    effort: &str,
+) -> Result<bool, AcpError> {
+    match tokio::time::timeout(
+        EFFORT_TIMEOUT,
+        acp.session_set_config_option(session_id, "effort", effort),
+    )
+    .await
+    {
+        Ok(Ok(_)) => {
+            tracing::info!(target: "pool::effort", "applied effort {effort:?} on session {session_id}");
+            Ok(true)
+        }
+        Ok(Err(e @ AcpError::Io(_)))
+        | Ok(Err(e @ AcpError::WriteTimeout(_)))
+        | Ok(Err(e @ AcpError::Timeout(_)))
+        | Ok(Err(e @ AcpError::Protocol(_)))
+        | Ok(Err(e @ AcpError::AgentExited)) => Err(e),
+        Ok(Err(error)) => {
+            tracing::warn!(target: "pool::effort", "failed to apply effort {effort:?}: {error}; using adapter default");
+            Ok(false)
+        }
+        Err(_) => Err(AcpError::Timeout(EFFORT_TIMEOUT)),
+    }
 }
 
 /// per-tool auto-approval in `handle_permission_request`.
@@ -7425,6 +7526,56 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         make_prompt_context_impl(&agent_keys, None)
     }
 
+    #[test]
+    fn effort_support_accepts_claude_id_key_and_selected_value() {
+        let response = serde_json::json!({
+            "configOptions": [{
+                "id": "effort",
+                "category": "thought_level",
+                "options": [
+                    { "value": "low", "displayName": "Low" },
+                    { "value": "medium", "displayName": "Medium" },
+                    { "value": "high", "displayName": "High" }
+                ]
+            }]
+        });
+        assert!(agent_supports_config_option_value(
+            &response, "effort", "medium"
+        ));
+        assert!(!agent_supports_config_option_value(
+            &response, "effort", "xhigh"
+        ));
+    }
+
+    #[test]
+    fn effort_support_accepts_spec_config_id_and_rejects_other_option() {
+        let response = serde_json::json!({
+            "configOptions": [{
+                "configId": "mode",
+                "options": [{ "value": "medium" }]
+            }]
+        });
+        assert!(!agent_supports_config_option_value(
+            &response, "effort", "medium"
+        ));
+    }
+
+    #[test]
+    fn selected_effort_updates_captured_session_snapshot() {
+        let mut response = serde_json::json!({
+            "configOptions": [{
+                "id": "effort",
+                "category": "thought_level",
+                "value": "high",
+                "currentValue": "high",
+                "options": [{ "value": "medium" }, { "value": "high" }]
+            }]
+        });
+        set_config_option_selected_value(&mut response, "effort", "medium");
+        assert_eq!(response["configOptions"][0]["value"], "medium");
+        assert_eq!(response["configOptions"][0]["currentValue"], "medium");
+    }
+
     fn make_prompt_context_with_owner(
         agent_keys: &nostr::Keys,
         owner_pubkey: nostr::PublicKey,
@@ -7468,6 +7619,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             context_message_limit: 0,
             max_turns_per_session: 0,
             permission_mode: PermissionMode::Default,
+            effort: None,
             agent_keys: agent_keys.clone(),
             agent_owner_pubkey: owner_pubkey,
             memory_enabled: false,

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -136,7 +136,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         config_file_path: Some("~/.claude/settings.json"),
         config_file_format: Some("json"),
         supports_acp_native_config: false,
-        thinking_env_var: None,
+        // Buzz persists effort under the shared BUZZ_AGENT_THINKING_EFFORT key.
+        // At spawn the desktop bridges that value to buzz-acp, which applies
+        // Claude's native ACP `effort` config option after every session/new.
+        thinking_env_var: Some("BUZZ_ACP_EFFORT"),
         max_tokens_env_var: None,
         context_limit_env_var: None,
         max_rounds_env_var: None,

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -22,8 +22,8 @@ pub(crate) use super::access_policy::{build_respond_to_env_with_policy, RespondT
 
 mod metadata;
 pub(crate) use metadata::{
-    apply_agent_display_env, resolve_session_title, runtime_metadata_env_vars,
-    DISPLAY_NAME_ENV_VAR, SESSION_TITLE_ENV_VAR,
+    apply_agent_display_env, resolve_session_title, runtime_metadata_effort_env_var,
+    runtime_metadata_env_vars, DISPLAY_NAME_ENV_VAR, SESSION_TITLE_ENV_VAR,
 };
 
 mod stop;
@@ -819,6 +819,12 @@ pub fn spawn_agent_child(
     // written above — reserved keys were already stripped from descriptor.env so they
     // cannot clobber BUZZ_PRIVATE_KEY, NOSTR_PRIVATE_KEY, etc.
     for (key, value) in &descriptor.env {
+        command.env(key, value);
+    }
+    if let Some((key, value)) = runtime_metadata_effort_env_var(
+        runtime_meta.and_then(|meta| meta.thinking_env_var),
+        &descriptor.env,
+    ) {
         command.env(key, value);
     }
     configure_runtime_cli(&mut command, runtime_meta);

--- a/desktop/src-tauri/src/managed_agents/runtime/metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/metadata.rs
@@ -24,6 +24,18 @@ pub(crate) fn runtime_metadata_env_vars<'a>(
     vars
 }
 
+/// Bridge Buzz's persisted, harness-neutral effort key to the runtime's
+/// spawn-time application key. The source remains stable across harness
+/// changes; `KnownAcpRuntime::thinking_env_var` owns the destination fact.
+pub(crate) fn runtime_metadata_effort_env_var<'a>(
+    thinking_env_var: Option<&'a str>,
+    effective_env: &'a std::collections::BTreeMap<String, String>,
+) -> Option<(&'a str, &'a str)> {
+    let destination = thinking_env_var?;
+    let effort = effective_env.get("BUZZ_AGENT_THINKING_EFFORT")?.trim();
+    (!effort.is_empty()).then_some((destination, effort))
+}
+
 /// Env var carrying the session title to the harness. Shared with
 /// `spawn_snapshot` so the restart badge records the same key the spawn writes.
 pub(crate) const SESSION_TITLE_ENV_VAR: &str = "BUZZ_ACP_SESSION_TITLE";

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -501,7 +501,37 @@ fn non_persona_agent_never_drifts() {
     assert!(!orphaned);
 }
 
-use super::runtime_metadata_env_vars;
+use super::{runtime_metadata_effort_env_var, runtime_metadata_env_vars};
+
+#[test]
+fn runtime_metadata_effort_bridges_persisted_key_to_claude_acp() {
+    let env = std::collections::BTreeMap::from([(
+        "BUZZ_AGENT_THINKING_EFFORT".to_string(),
+        "medium".to_string(),
+    )]);
+    assert_eq!(
+        runtime_metadata_effort_env_var(Some("BUZZ_ACP_EFFORT"), &env),
+        Some(("BUZZ_ACP_EFFORT", "medium"))
+    );
+}
+
+#[test]
+fn runtime_metadata_effort_skips_absent_or_blank_values() {
+    let absent = std::collections::BTreeMap::new();
+    let blank = std::collections::BTreeMap::from([(
+        "BUZZ_AGENT_THINKING_EFFORT".to_string(),
+        "   ".to_string(),
+    )]);
+    assert_eq!(
+        runtime_metadata_effort_env_var(Some("BUZZ_ACP_EFFORT"), &absent),
+        None
+    );
+    assert_eq!(
+        runtime_metadata_effort_env_var(Some("BUZZ_ACP_EFFORT"), &blank),
+        None
+    );
+    assert_eq!(runtime_metadata_effort_env_var(None, &blank), None);
+}
 
 #[test]
 fn runtime_metadata_env_vars_injects_model_and_provider() {

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -50,7 +50,10 @@ with a TypeScript lookup table or an id comparison in a component.
    Goose/Claude — do not "fix" one to match the other without doing the
    migration work.
 3. **Field absence has a named reason, not a boolean.** Codex effort is
-   `ownedByModelId`; Claude effort is `deferredUntilNativeOptionsAvailable`.
+   `ownedByModelId`. Claude effort is rendered and persisted under the shared
+   `BUZZ_AGENT_THINKING_EFFORT` key; runtime metadata maps it to
+   `BUZZ_ACP_EFFORT`, and buzz-acp applies ACP config option `effort` after
+   every fresh session.
    New absences get new named reasons in `AgentConfigOmission` /
    `render` — never a `showX` prop.
 4. **The clearing policy is the named types.** `onContextChange:

--- a/desktop/src/features/agents/lib/agentConfigCore.test.mjs
+++ b/desktop/src/features/agents/lib/agentConfigCore.test.mjs
@@ -93,10 +93,10 @@ test("Goose exposes provider, model, and its real effort application key", () =>
   });
 });
 
-test("Claude models effort as a deferred native ACP option", () => {
+test("Claude exposes persisted effort applied through its native ACP option", () => {
   const model = deriveAgentConfigFieldModel({
     config,
-    runtime: runtime("claude"),
+    runtime: runtime("claude", { thinkingEnvVar: "BUZZ_ACP_EFFORT" }),
     scope: "global",
   });
 
@@ -104,12 +104,10 @@ test("Claude models effort as a deferred native ACP option", () => {
     model.fields.map((item) => item.kind),
     ["model", "effort"],
   );
-  assert.equal(
-    field(model, "effort").render,
-    "deferredUntilNativeOptionsAvailable",
-  );
+  assert.equal(field(model, "effort").render, "control");
   assert.deepEqual(field(model, "effort").currentPersistence, {
-    kind: "unavailable",
+    kind: "envVar",
+    key: "BUZZ_AGENT_THINKING_EFFORT",
   });
   assert.deepEqual(field(model, "effort").targetApplication, {
     kind: "acpConfigOption",

--- a/desktop/src/features/agents/lib/agentConfigCore.ts
+++ b/desktop/src/features/agents/lib/agentConfigCore.ts
@@ -204,32 +204,28 @@ export function deriveAgentConfigFieldModel({
   });
 
   if (runtime?.thinkingEnvVar) {
+    const usesNativeAcpEffort = runtime.thinkingEnvVar === "BUZZ_ACP_EFFORT";
     fields.push({
       kind: "effort",
       optionSource:
-        runtime.id === "buzz-agent"
+        usesNativeAcpEffort
+          ? "harnessNative"
+          : runtime.id === "buzz-agent"
           ? "buzzAgentCatalog"
           : "legacyProviderModelCatalog",
       currentPersistence: {
         kind: "envVar",
         key: BUZZ_AGENT_THINKING_EFFORT,
       },
-      targetApplication: { kind: "envVar", key: runtime.thinkingEnvVar },
+      targetApplication: usesNativeAcpEffort
+        ? {
+            kind: "acpConfigOption",
+            id: "effort",
+            category: "thought_level",
+          }
+        : { kind: "envVar", key: runtime.thinkingEnvVar },
       render: "control",
       value: valueFromEnv(config, BUZZ_AGENT_THINKING_EFFORT),
-    });
-  } else if (runtime?.id === "claude") {
-    fields.push({
-      kind: "effort",
-      optionSource: "harnessNative",
-      currentPersistence: { kind: "unavailable" },
-      targetApplication: {
-        kind: "acpConfigOption",
-        id: "effort",
-        category: "thought_level",
-      },
-      render: "deferredUntilNativeOptionsAvailable",
-      value: null,
     });
   } else {
     omissions.push({

--- a/desktop/src/features/agents/lib/editAgentEffortControl.test.mjs
+++ b/desktop/src/features/agents/lib/editAgentEffortControl.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deriveEditAgentEffortControl } from "./editAgentEffortControl.ts";
+
+function runtime(id, thinkingEnvVar) {
+  return {
+    id,
+    label: id,
+    thinkingEnvVar,
+  };
+}
+
+test("per-agent edit renders Claude effort with its implicit Anthropic provider", () => {
+  assert.deepEqual(
+    deriveEditAgentEffortControl({
+      catalogStatus: "ready",
+      envVars: { BUZZ_AGENT_THINKING_EFFORT: "medium" },
+      model: "claude-fable-5[1m]",
+      runtime: runtime("claude", "BUZZ_ACP_EFFORT"),
+      runtimeId: "claude",
+    }),
+    {
+      persistenceKey: "BUZZ_AGENT_THINKING_EFFORT",
+      provider: "anthropic",
+    },
+  );
+});
+
+test("per-agent edit keeps Buzz Agent effort descriptor-driven", () => {
+  assert.deepEqual(
+    deriveEditAgentEffortControl({
+      catalogStatus: "ready",
+      envVars: {},
+      provider: "openai",
+      runtime: runtime("buzz-agent", "BUZZ_AGENT_THINKING_EFFORT"),
+      runtimeId: "buzz-agent",
+    }),
+    {
+      persistenceKey: "BUZZ_AGENT_THINKING_EFFORT",
+      provider: "openai",
+    },
+  );
+});
+
+test("per-agent edit omits effort for Codex and unsupported runtimes", () => {
+  for (const selectedRuntime of [
+    runtime("codex", null),
+    runtime("custom", null),
+  ]) {
+    assert.equal(
+      deriveEditAgentEffortControl({
+        catalogStatus: "ready",
+        envVars: {},
+        runtime: selectedRuntime,
+        runtimeId: selectedRuntime.id,
+      }),
+      undefined,
+    );
+  }
+});
+
+test("per-agent edit does not hide the generic key before catalog readiness", () => {
+  assert.equal(
+    deriveEditAgentEffortControl({
+      catalogStatus: "loading",
+      envVars: { BUZZ_AGENT_THINKING_EFFORT: "medium" },
+      runtime: runtime("claude", "BUZZ_ACP_EFFORT"),
+      runtimeId: "claude",
+    }),
+    undefined,
+  );
+});

--- a/desktop/src/features/agents/lib/editAgentEffortControl.ts
+++ b/desktop/src/features/agents/lib/editAgentEffortControl.ts
@@ -1,0 +1,49 @@
+import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
+import type { EnvVarsValue } from "../ui/EnvVarsEditor";
+import {
+  deriveAgentConfigFieldModel,
+  getRenderableEffortField,
+  type RuntimeCatalogStatus,
+} from "./agentConfigCore";
+
+/** Descriptor-backed presentation data for the per-agent edit effort control. */
+export function deriveEditAgentEffortControl({
+  catalogStatus,
+  envVars,
+  model,
+  provider,
+  runtime,
+  runtimeId,
+}: {
+  catalogStatus: RuntimeCatalogStatus;
+  envVars: EnvVarsValue;
+  model?: string;
+  provider?: string;
+  runtime?: AcpRuntimeCatalogEntry;
+  runtimeId: string;
+}): { persistenceKey: string; provider: string } | undefined {
+  if (catalogStatus !== "ready") return undefined;
+
+  const effortField = getRenderableEffortField(
+    deriveAgentConfigFieldModel({
+      config: {
+        env_vars: envVars,
+        model: model?.trim() || null,
+        preferred_runtime: runtimeId || null,
+        provider: provider?.trim() || null,
+      },
+      runtime,
+      scope: "instance",
+    }),
+  );
+  if (effortField?.currentPersistence.kind !== "envVar") return undefined;
+
+  return {
+    persistenceKey: effortField.currentPersistence.key,
+    // Native effort currently belongs to Claude's implicit Anthropic provider;
+    // unlike Buzz Agent, it has no provider picker to supply this value.
+    provider:
+      provider?.trim() ||
+      (effortField.optionSource === "harnessNative" ? "anthropic" : ""),
+  };
+}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -16,10 +16,6 @@ import {
   NumericTuningFields,
 } from "./buzzAgentModelTuningFields";
 import {
-  isBuzzAgentRuntime,
-  BUZZ_AGENT_THINKING_EFFORT,
-} from "./buzzAgentConfig";
-import {
   EDIT_AGENT_PARALLELISM_HELP,
   parallelismCapHint,
 } from "../lib/agentParallelism";
@@ -28,6 +24,7 @@ import {
   structuredEnvKeys,
   type RuntimeCatalogStatus,
 } from "../lib/agentConfigCore";
+import { deriveEditAgentEffortControl } from "../lib/editAgentEffortControl";
 
 export function EditAgentAdvancedFields({
   acpCommand,
@@ -72,9 +69,9 @@ export function EditAgentAdvancedFields({
   /** Active LLM model — forwarded to BuzzAgentModelTuningFields for effort filtering. */
   model?: string;
   /**
-   * The actual/prospective runtime id used to decide whether to show the
-   * buzz-agent effort-tuning field. Uses `prospectiveRuntimeId` from
-   * EditAgentDialog — the resolved runtime, not the "inherit"/"custom" sentinel.
+   * The actual/prospective runtime id used in the descriptor field model.
+   * Uses `prospectiveRuntimeId` from EditAgentDialog — the resolved runtime,
+   * not the "inherit"/"custom" sentinel.
    */
   modelTuningRuntimeId: string;
   parallelism: string;
@@ -118,17 +115,36 @@ export function EditAgentAdvancedFields({
     [catalogStatus, selectedRuntime],
   );
 
+  const effortControl = React.useMemo(
+    () =>
+      deriveEditAgentEffortControl({
+        catalogStatus,
+        envVars,
+        model,
+        provider,
+        runtime: selectedRuntime,
+        runtimeId: modelTuningRuntimeId,
+      }),
+    [
+      catalogStatus,
+      envVars,
+      model,
+      modelTuningRuntimeId,
+      provider,
+      selectedRuntime,
+    ],
+  );
+  const effortPersistenceKey = effortControl?.persistenceKey;
+
   // Build the effective hidden-key list: caller's secrets + effort key (when
   // rendered by BuzzAgentModelTuningFields) + numeric keys via structuredEnvKeys.
   const effectiveHiddenKeys = React.useMemo(
     () => [
       ...hiddenEnvKeys,
-      ...(isBuzzAgentRuntime(modelTuningRuntimeId)
-        ? [BUZZ_AGENT_THINKING_EFFORT]
-        : []),
+      ...(effortPersistenceKey ? [effortPersistenceKey] : []),
       ...structuredEnvKeys(numericDescriptors),
     ],
-    [hiddenEnvKeys, modelTuningRuntimeId, numericDescriptors],
+    [effortPersistenceKey, hiddenEnvKeys, numericDescriptors],
   );
 
   // Harness cap hint: show only when the selected runtime has a cap and the
@@ -358,12 +374,13 @@ export function EditAgentAdvancedFields({
         />
       ) : null}
 
-      {/* Effort-tuning knob — only shown for buzz-agent. */}
-      {isBuzzAgentRuntime(modelTuningRuntimeId) ? (
+      {/* Effort is descriptor-driven by the selected runtime catalog entry. */}
+      {effortPersistenceKey ? (
         <BuzzAgentModelTuningFields
           envVars={envVars}
           inheritedEnvVars={inheritedEnvVars}
           model={model}
+          effortPersistenceKey={effortPersistenceKey}
           onEnvVarChange={(key, value) => {
             const next = { ...envVars };
             if (value === "") {
@@ -373,7 +390,7 @@ export function EditAgentAdvancedFields({
             }
             onEnvVarsChange(next);
           }}
-          provider={provider}
+          provider={effortControl.provider}
         />
       ) : null}
     </div>

--- a/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
+++ b/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
@@ -298,6 +298,8 @@ export function BuzzAgentModelTuningFields({
   model,
   onEnvVarChange,
   provider,
+  effortPersistenceKey = BUZZ_AGENT_THINKING_EFFORT,
+  heading = "Model tuning",
 }: {
   envVars: EnvVarsValue;
   inheritedEnvVars: EnvVarsValue;
@@ -306,22 +308,26 @@ export function BuzzAgentModelTuningFields({
   onEnvVarChange: (key: string, value: string) => void;
   /** Active LLM provider id (optional) — used for effort filtering + default labels. */
   provider?: string;
+  /** Descriptor-provided key holding the per-agent effort override. */
+  effortPersistenceKey?: string;
+  /** Harness-neutral section heading used by shared config surfaces. */
+  heading?: string;
 }) {
   const effortConfig = getProviderEffortConfig(provider ?? "", model);
   const { validValues: effortValid, defaultValue: effortDefault } =
     effortConfig;
 
-  const currentEffort = envVars[BUZZ_AGENT_THINKING_EFFORT] ?? "";
+  const currentEffort = envVars[effortPersistenceKey] ?? "";
   useEffortAutoClear({
     currentEffort,
     effortValid,
-    onClear: () => onEnvVarChange(BUZZ_AGENT_THINKING_EFFORT, ""),
+    onClear: () => onEnvVarChange(effortPersistenceKey, ""),
   });
 
   return (
     <div className="space-y-4">
       <p className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
-        buzz-agent model tuning
+        {heading}
       </p>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -332,12 +338,10 @@ export function BuzzAgentModelTuningFields({
             effortDefault={effortDefault}
             effortValid={effortValid}
             htmlFor="ba-thinking-effort"
-            inheritedEffort={inheritedEnvVars[BUZZ_AGENT_THINKING_EFFORT]}
+            inheritedEffort={inheritedEnvVars[effortPersistenceKey]}
             inheritFallbackLabel="Inherit (agent default)"
             label="Thinking / Effort"
-            onChange={(value) =>
-              onEnvVarChange(BUZZ_AGENT_THINKING_EFFORT, value)
-            }
+            onChange={(value) => onEnvVarChange(effortPersistenceKey, value)}
             testId="ba-thinking-effort-select"
           />
           <p


### PR DESCRIPTION
## Summary

- expose Claude Code's native ACP effort control in Buzz agent configuration
- persist the selected effort through Buzz's existing harness-neutral effort setting
- bridge that value to `buzz-acp` at spawn and reapply it after every fresh ACP session
- keep the captured session configuration synchronized with the applied value

## Why

Claude Code defaults to High effort when no effort is specified. Buzz already receives Claude's native `effort` config option from `claude-agent-acp`, but the UI intentionally hid it and Buzz did not retain or reapply a selection. Long-running managed agents therefore silently returned to High after session creation or rotation.

## Behavior

The selected value is stored under the existing `BUZZ_AGENT_THINKING_EFFORT` persistence key. Claude runtime metadata maps it to `BUZZ_ACP_EFFORT`; `buzz-acp` validates the requested value against the live session's advertised `effort` options before applying `session/set_config_option`.

Unsupported or stale values fail safely: Buzz logs a warning and leaves the adapter default unchanged.

## Verification

- `cargo test -p buzz-acp --lib effort` — 3 passed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml runtime_metadata_effort --lib` — 2 passed
- `pnpm --dir desktop exec node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/agentConfigCore.test.mjs` — 22 passed
- `pnpm --dir desktop typecheck` — passed
- `cargo check -p buzz-acp` — passed
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml` — passed
- `git diff --check` — passed
- unsigned macOS release bundle built successfully

## Notes

No new dependency or wire protocol is introduced. The implementation uses the ACP config option already advertised by `claude-agent-acp`.
