### PR TITLE
fix(desktop): defer foreground resume work

### DIFF
--- a/desktop/src/app/useAppShellLifecycleEffects.ts
+++ b/desktop/src/app/useAppShellLifecycleEffects.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { setDesktopAppBadge } from "@/features/notifications/lib/desktop";
-import { useWorkflowForegroundRefresh } from "@/features/workflows/hooks";
+import { useForegroundQueryRefresh } from "@/features/workflows/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { useRelayResumeTriggers } from "@/shared/api/useRelayResumeTriggers";
 
@@ -21,7 +21,7 @@ export function useAppShellLifecycleEffects({
   // Event-driven reconnect: network online / focus / visibility short-circuit
   // the backoff timer when the relay session is degraded (CMD+R gap G1).
   useRelayResumeTriggers();
-  useWorkflowForegroundRefresh();
+  useForegroundQueryRefresh();
 
   // Prevent webview file:/// navigation on file drop outside the composer.
   // Scoped to file drags only (text drag-and-drop into inputs still works).

--- a/desktop/src/app/useAppShellLifecycleEffects.ts
+++ b/desktop/src/app/useAppShellLifecycleEffects.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { setDesktopAppBadge } from "@/features/notifications/lib/desktop";
+import { useWorkflowForegroundRefresh } from "@/features/workflows/hooks";
 import { relayClient } from "@/shared/api/relayClient";
 import { useRelayResumeTriggers } from "@/shared/api/useRelayResumeTriggers";
 
@@ -20,6 +21,7 @@ export function useAppShellLifecycleEffects({
   // Event-driven reconnect: network online / focus / visibility short-circuit
   // the backoff timer when the relay session is degraded (CMD+R gap G1).
   useRelayResumeTriggers();
+  useWorkflowForegroundRefresh();
 
   // Prevent webview file:/// navigation on file drop outside the composer.
   // Scoped to file drags only (text drag-and-drop into inputs still works).

--- a/desktop/src/features/agents/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/focusRefetchPolicy.test.mjs
@@ -57,13 +57,13 @@ test("agents: skips fresh focus refetch", async () => {
   );
 });
 
-test("agents: refetches genuinely stale data on focus", async () => {
+test("agents: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: agentsFocusRefetchPolicy.staleTime + 1,
       policy: agentsFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });
 
@@ -77,12 +77,12 @@ test("managed-agent-log: skips focus refetch when data is fresher than one poll 
   );
 });
 
-test("managed-agent-log: refetches on focus when data is older than one poll tick", async () => {
+test("managed-agent-log: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: managedAgentLogFocusRefetchPolicy.staleTime + 1,
       policy: managedAgentLogFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -111,13 +111,13 @@ export const MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS = 30_000;
 /** Focus-refetch policy for relay-agent and managed-agent queries; consumed by focusRefetchPolicy.test.mjs. */
 export const agentsFocusRefetchPolicy = {
   staleTime: AGENTS_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 /** Focus-refetch policy for the managed-agent-log query; consumed by focusRefetchPolicy.test.mjs. */
 export const managedAgentLogFocusRefetchPolicy = {
   staleTime: MANAGED_AGENT_LOG_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export const relayAgentsQueryKey = ["relay-agents"] as const;

--- a/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/agents/lib/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("persona-catalog: skips fresh focus refetch", async () => {
   );
 });
 
-test("persona-catalog: refetches genuinely stale data on focus", async () => {
+test("persona-catalog: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: personaCatalogFocusRefetchPolicy.staleTime + 1,
       policy: personaCatalogFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
+++ b/desktop/src/features/agents/lib/usePersonaCatalogRelay.ts
@@ -24,7 +24,7 @@ export const PERSONA_CATALOG_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the persona catalog query; consumed by focusRefetchPolicy.test.mjs. */
 export const personaCatalogFocusRefetchPolicy = {
   staleTime: PERSONA_CATALOG_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export function personaCatalogQueryKey(communityId: string | null) {

--- a/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/channel-templates/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("channel-templates: skips fresh focus refetch", async () => {
   );
 });
 
-test("channel-templates: refetches genuinely stale data on focus", async () => {
+test("channel-templates: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: channelTemplatesFocusRefetchPolicy.staleTime + 1,
       policy: channelTemplatesFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/channel-templates/hooks.ts
+++ b/desktop/src/features/channel-templates/hooks.ts
@@ -24,7 +24,7 @@ export const CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the channel templates query; consumed by focusRefetchPolicy.test.mjs. */
 export const channelTemplatesFocusRefetchPolicy = {
   staleTime: CHANNEL_TEMPLATES_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export const channelTemplatesQueryKey = ["channel-templates"] as const;

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -50,7 +50,7 @@ export const CHANNELS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the channels query; consumed by focusRefetchPolicy.test.mjs. */
 export const channelsFocusRefetchPolicy = {
   staleTime: CHANNELS_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 /**
  * Query-cache key for the channels payload hash. Stored alongside the channel

--- a/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/custom-emoji/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("custom-emoji: skips fresh focus refetch", async () => {
   );
 });
 
-test("custom-emoji: refetches genuinely stale data on focus", async () => {
+test("custom-emoji: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: customEmojiFocusRefetchPolicy.staleTime + 1,
       policy: customEmojiFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/custom-emoji/hooks.ts
+++ b/desktop/src/features/custom-emoji/hooks.ts
@@ -32,7 +32,7 @@ export const CUSTOM_EMOJI_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the custom emoji query; consumed by focusRefetchPolicy.test.mjs. */
 export const customEmojiFocusRefetchPolicy = {
   staleTime: CUSTOM_EMOJI_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export const customEmojiQueryKey = ["custom-emoji"] as const;

--- a/desktop/src/features/forum/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/forum/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("forum: skips fresh focus refetch", async () => {
   );
 });
 
-test("forum: refetches genuinely stale data on focus", async () => {
+test("forum: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: forumFocusRefetchPolicy.staleTime + 1,
       policy: forumFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/forum/hooks.ts
+++ b/desktop/src/features/forum/hooks.ts
@@ -22,7 +22,7 @@ export const FORUM_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy shared by forum-posts and forum-thread queries; consumed by focusRefetchPolicy.test.mjs. */
 export const forumFocusRefetchPolicy = {
   staleTime: FORUM_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export function forumPostsQueryKey(channelId: string) {

--- a/desktop/src/features/home/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/home/focusRefetchPolicy.test.mjs
@@ -77,13 +77,13 @@ for (const entry of [
     );
   });
 
-  test(`${entry.name} refetches genuinely stale data on focus`, async () => {
+  test(`${entry.name} does not refetch stale data on focus`, async () => {
     assert.equal(
       await focusRefetchCount({
         ageMs: entry.focusPolicy.staleTime + 1,
         policy: entry.focusPolicy,
       }),
-      1,
+      0,
     );
   });
 }

--- a/desktop/src/features/home/hooks.ts
+++ b/desktop/src/features/home/hooks.ts
@@ -12,7 +12,7 @@ export const HOME_FEED_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the home feed query; consumed by focusRefetchPolicy.test.mjs. */
 export const homeFeedFocusRefetchPolicy = {
   staleTime: HOME_FEED_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export function useHomeFeedQuery() {

--- a/desktop/src/features/notifications/hooks.ts
+++ b/desktop/src/features/notifications/hooks.ts
@@ -4,6 +4,7 @@ import { useHomeFeedQuery } from "@/features/home/hooks";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel, FeedItem, HomeFeedResponse } from "@/shared/api/types";
+import { scheduleAfterForegroundReady } from "@/shared/lib/foregroundReady";
 import {
   getDesktopNotificationPermissionState,
   requestDesktopNotificationAccess,
@@ -210,14 +211,23 @@ export function useNotificationSettings(pubkey?: string) {
   }, [normalizedPubkey]);
 
   React.useEffect(() => {
+    let cancelPendingRefresh: (() => void) | null = null;
     const refreshWhenVisible = () => {
-      if (document.visibilityState === "visible") {
-        void refreshPermission();
+      if (document.visibilityState !== "visible") {
+        cancelPendingRefresh?.();
+        cancelPendingRefresh = null;
+        return;
       }
+      if (cancelPendingRefresh) return;
+      cancelPendingRefresh = scheduleAfterForegroundReady(() => {
+        cancelPendingRefresh = null;
+        if (document.visibilityState === "visible") void refreshPermission();
+      });
     };
     document.addEventListener("visibilitychange", refreshWhenVisible);
     window.addEventListener("focus", refreshWhenVisible);
     return () => {
+      cancelPendingRefresh?.();
       document.removeEventListener("visibilitychange", refreshWhenVisible);
       window.removeEventListener("focus", refreshWhenVisible);
     };

--- a/desktop/src/features/presence/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/presence/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("presence: skips fresh focus refetch", async () => {
   );
 });
 
-test("presence: refetches genuinely stale data on focus", async () => {
+test("presence: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: presenceFocusRefetchPolicy.staleTime + 1,
       policy: presenceFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/presence/hooks.ts
+++ b/desktop/src/features/presence/hooks.ts
@@ -29,7 +29,7 @@ export const PRESENCE_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the presence query; consumed by focusRefetchPolicy.test.mjs. */
 export const presenceFocusRefetchPolicy = {
   staleTime: PRESENCE_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 const PRESENCE_ACTIVITY_THROTTLE_MS = 1_000;
 const PRESENCE_PREFERENCE_STORAGE_KEY = "buzz-presence-preference";

--- a/desktop/src/features/projects/repoSyncHooks.ts
+++ b/desktop/src/features/projects/repoSyncHooks.ts
@@ -51,7 +51,7 @@ export function useProjectRepoSyncStatusQuery(
     },
     staleTime: 10_000,
     refetchInterval,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 }

--- a/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/pulse/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("pulse: skips fresh focus refetch", async () => {
   );
 });
 
-test("pulse: refetches genuinely stale data on focus", async () => {
+test("pulse: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: pulseFocusRefetchPolicy.staleTime + 1,
       policy: pulseFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/pulse/hooks.ts
+++ b/desktop/src/features/pulse/hooks.ts
@@ -25,7 +25,7 @@ export const PULSE_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy shared by all pulse queries; consumed by focusRefetchPolicy.test.mjs. */
 export const pulseFocusRefetchPolicy = {
   staleTime: PULSE_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 // ── Query keys ──────────────────────────────────────────────────────────────

--- a/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/user-status/focusRefetchPolicy.test.mjs
@@ -54,12 +54,12 @@ test("user-status: skips fresh focus refetch", async () => {
   );
 });
 
-test("user-status: refetches genuinely stale data on focus", async () => {
+test("user-status: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: userStatusFocusRefetchPolicy.staleTime + 1,
       policy: userStatusFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });

--- a/desktop/src/features/user-status/hooks.ts
+++ b/desktop/src/features/user-status/hooks.ts
@@ -47,7 +47,7 @@ export const USER_STATUS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for the user-status query; consumed by focusRefetchPolicy.test.mjs. */
 export const userStatusFocusRefetchPolicy = {
   staleTime: USER_STATUS_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 export function useUserStatusQuery(pubkeys: string[]) {

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -108,36 +108,47 @@ test("run-approvals: does not refetch stale data on focus", async () => {
   );
 });
 
-test("workflow foreground refresh targets only lists and inactive runs", async () => {
-  const { shouldRefreshWorkflowOnForeground } = await import("./hooks.ts");
-  assert.equal(shouldRefreshWorkflowOnForeground(["workflows", "c"], []), true);
+test("foreground refresh targets workflow gaps and repo sync", async () => {
+  const { shouldRefreshQueryOnForeground } = await import("./hooks.ts");
+  assert.equal(shouldRefreshQueryOnForeground(["workflows", "c"], []), true);
   assert.equal(
-    shouldRefreshWorkflowOnForeground(["workflows-all", "c"], []),
+    shouldRefreshQueryOnForeground(["workflows-all", "c"], []),
     true,
   );
   assert.equal(
-    shouldRefreshWorkflowOnForeground(["workflow-runs", "w"], []),
+    shouldRefreshQueryOnForeground(["workflow-runs", "w"], []),
     true,
   );
   assert.equal(
-    shouldRefreshWorkflowOnForeground(
+    shouldRefreshQueryOnForeground(
       ["workflow-runs", "w"],
       [{ status: "completed" }],
     ),
     true,
   );
   assert.equal(
-    shouldRefreshWorkflowOnForeground(
+    shouldRefreshQueryOnForeground(
       ["workflow-runs", "w"],
       [{ status: "running" }],
     ),
     false,
   );
-  assert.equal(shouldRefreshWorkflowOnForeground(["run-approvals"], []), false);
+  assert.equal(
+    shouldRefreshQueryOnForeground(
+      ["project", "p", "repo-sync-status", "default"],
+      undefined,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldRefreshQueryOnForeground(["project", "p", "issues"], []),
+    false,
+  );
+  assert.equal(shouldRefreshQueryOnForeground(["run-approvals"], []), false);
 });
 
-test("workflow foreground refresh query contract includes only stale active targets", async () => {
-  const { shouldRefreshWorkflowOnForeground } = await import("./hooks.ts");
+test("foreground refresh query contract includes only stale active targets", async () => {
+  const { shouldRefreshQueryOnForeground } = await import("./hooks.ts");
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -161,6 +172,11 @@ test("workflow foreground refresh query contract includes only stale active targ
     subscribe(["workflows", "stale-active"], [], staleAt),
     subscribe(["workflows", "fresh-active"], [], freshAt),
     subscribe(
+      ["project", "p", "repo-sync-status", "default"],
+      { aheadCount: 1 },
+      staleAt,
+    ),
+    subscribe(
       ["workflow-runs", "inactive"],
       [{ status: "completed" }],
       staleAt,
@@ -173,12 +189,13 @@ test("workflow foreground refresh query contract includes only stale active targ
 
   await queryClient.refetchQueries({
     predicate: (query) =>
-      shouldRefreshWorkflowOnForeground(query.queryKey, query.state.data),
+      shouldRefreshQueryOnForeground(query.queryKey, query.state.data),
     stale: true,
     type: "active",
   });
 
   assert.deepEqual(fetches.sort(), [
+    "project:p:repo-sync-status:default",
     "workflow-runs:inactive",
     "workflows:stale-active",
   ]);

--- a/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
+++ b/desktop/src/features/workflows/focusRefetchPolicy.test.mjs
@@ -58,13 +58,13 @@ test("workflow-list: skips focus refetch when data is fresh (< 10s)", async () =
   );
 });
 
-test("workflow-list: refetches on focus when data is stale (> 10s)", async () => {
+test("workflow-list: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: workflowListFocusRefetchPolicy.staleTime + 1,
       policy: workflowListFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });
 
@@ -78,13 +78,13 @@ test("workflow-runs: skips focus refetch when data is fresh (< 10s)", async () =
   );
 });
 
-test("workflow-runs: refetches on focus when data is stale (> 10s)", async () => {
+test("workflow-runs: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: workflowRunsFocusRefetchPolicy.staleTime + 1,
       policy: workflowRunsFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
 });
 
@@ -98,12 +98,90 @@ test("run-approvals: skips focus refetch when data is fresh (< 5 min)", async ()
   );
 });
 
-test("run-approvals: refetches on focus when data is stale (> 5 min)", async () => {
+test("run-approvals: does not refetch stale data on focus", async () => {
   assert.equal(
     await focusRefetchCount({
       ageMs: runApprovalsFocusRefetchPolicy.staleTime + 1,
       policy: runApprovalsFocusRefetchPolicy,
     }),
-    1,
+    0,
   );
+});
+
+test("workflow foreground refresh targets only lists and inactive runs", async () => {
+  const { shouldRefreshWorkflowOnForeground } = await import("./hooks.ts");
+  assert.equal(shouldRefreshWorkflowOnForeground(["workflows", "c"], []), true);
+  assert.equal(
+    shouldRefreshWorkflowOnForeground(["workflows-all", "c"], []),
+    true,
+  );
+  assert.equal(
+    shouldRefreshWorkflowOnForeground(["workflow-runs", "w"], []),
+    true,
+  );
+  assert.equal(
+    shouldRefreshWorkflowOnForeground(
+      ["workflow-runs", "w"],
+      [{ status: "completed" }],
+    ),
+    true,
+  );
+  assert.equal(
+    shouldRefreshWorkflowOnForeground(
+      ["workflow-runs", "w"],
+      [{ status: "running" }],
+    ),
+    false,
+  );
+  assert.equal(shouldRefreshWorkflowOnForeground(["run-approvals"], []), false);
+});
+
+test("workflow foreground refresh query contract includes only stale active targets", async () => {
+  const { shouldRefreshWorkflowOnForeground } = await import("./hooks.ts");
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const fetches = [];
+  const subscribe = (queryKey, data, updatedAt) => {
+    queryClient.setQueryData(queryKey, data, { updatedAt });
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: async () => {
+        fetches.push(queryKey.join(":"));
+        return data;
+      },
+      refetchOnMount: false,
+      staleTime: 10_000,
+    });
+    return observer.subscribe(() => {});
+  };
+  const staleAt = Date.now() - 20_000;
+  const freshAt = Date.now();
+  const unsubscribers = [
+    subscribe(["workflows", "stale-active"], [], staleAt),
+    subscribe(["workflows", "fresh-active"], [], freshAt),
+    subscribe(
+      ["workflow-runs", "inactive"],
+      [{ status: "completed" }],
+      staleAt,
+    ),
+    subscribe(["workflow-runs", "active"], [{ status: "running" }], staleAt),
+  ];
+  queryClient.setQueryData(["workflows-all", "inactive-cache"], [], {
+    updatedAt: staleAt,
+  });
+
+  await queryClient.refetchQueries({
+    predicate: (query) =>
+      shouldRefreshWorkflowOnForeground(query.queryKey, query.state.data),
+    stale: true,
+    type: "active",
+  });
+
+  assert.deepEqual(fetches.sort(), [
+    "workflow-runs:inactive",
+    "workflows:stale-active",
+  ]);
+  for (const unsubscribe of unsubscribers) unsubscribe();
+  queryClient.clear();
 });

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { WorkflowRun, WorkflowRunStatus } from "@/shared/api/types";
@@ -19,10 +20,8 @@ import {
 } from "@/shared/api/tauriWorkflows";
 
 /** Stale gate for workflow list queries (useChannelWorkflowsQuery, allWorkflowsQuery).
- * These queries have no poll and no relay push subscription; invalidateWorkflowListQueries
- * only fires for mutations performed by this renderer, so remote workflow creates/edits/deletes
- * surface only via refetch on focus return.  10 s suppresses rapid focus-flip burst refetches
- * while keeping remote changes visible on the next focus return. */
+ * These queries have no poll and no relay push subscription; foreground return
+ * explicitly refreshes them after the interaction-first activation boundary. */
 export const WORKFLOW_LIST_FOCUS_STALE_TIME_MS = 10_000;
 /** Keeps focused polling for run approvals at the established 10-second cadence. */
 export const RUN_APPROVALS_REFETCH_INTERVAL_MS = 10_000;
@@ -44,20 +43,49 @@ export const RUN_APPROVALS_FOCUS_STALE_TIME_MS = 5 * 60_000;
 /** Focus-refetch policy for workflow list queries; consumed by focusRefetchPolicy.test.mjs. */
 export const workflowListFocusRefetchPolicy = {
   staleTime: WORKFLOW_LIST_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 /** Focus-refetch policy for the workflow-runs query; consumed by focusRefetchPolicy.test.mjs. */
 export const workflowRunsFocusRefetchPolicy = {
   staleTime: WORKFLOW_RUNS_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
 
 /** Focus-refetch policy for the run-approvals query; consumed by focusRefetchPolicy.test.mjs. */
 export const runApprovalsFocusRefetchPolicy = {
   staleTime: RUN_APPROVALS_FOCUS_STALE_TIME_MS,
-  refetchOnWindowFocus: true,
+  refetchOnWindowFocus: false,
 } as const;
+
+export function shouldRefreshWorkflowOnForeground(
+  queryKey: readonly unknown[],
+  data: unknown,
+): boolean {
+  const family = queryKey[0];
+  if (family === "workflows" || family === "workflows-all") return true;
+  if (family !== "workflow-runs") return false;
+  const runs = data as WorkflowRun[] | undefined;
+  return !runs?.some((run) => isActiveWorkflowRunStatus(run.status));
+}
+
+export function useWorkflowForegroundRefresh(): void {
+  const queryClient = useQueryClient();
+  const appFocused = useAppFocused();
+  const wasFocused = React.useRef(appFocused);
+  React.useEffect(() => {
+    const returnedToForeground = appFocused && !wasFocused.current;
+    wasFocused.current = appFocused;
+    if (!returnedToForeground) return;
+
+    void queryClient.refetchQueries({
+      predicate: (query) =>
+        shouldRefreshWorkflowOnForeground(query.queryKey, query.state.data),
+      stale: true,
+      type: "active",
+    });
+  }, [appFocused, queryClient]);
+}
 
 export const allWorkflowsQueryKey = (channelIdKey: string) =>
   ["workflows-all", channelIdKey] as const;

--- a/desktop/src/features/workflows/hooks.ts
+++ b/desktop/src/features/workflows/hooks.ts
@@ -58,18 +58,19 @@ export const runApprovalsFocusRefetchPolicy = {
   refetchOnWindowFocus: false,
 } as const;
 
-export function shouldRefreshWorkflowOnForeground(
+export function shouldRefreshQueryOnForeground(
   queryKey: readonly unknown[],
   data: unknown,
 ): boolean {
   const family = queryKey[0];
   if (family === "workflows" || family === "workflows-all") return true;
+  if (family === "project" && queryKey[2] === "repo-sync-status") return true;
   if (family !== "workflow-runs") return false;
   const runs = data as WorkflowRun[] | undefined;
   return !runs?.some((run) => isActiveWorkflowRunStatus(run.status));
 }
 
-export function useWorkflowForegroundRefresh(): void {
+export function useForegroundQueryRefresh(): void {
   const queryClient = useQueryClient();
   const appFocused = useAppFocused();
   const wasFocused = React.useRef(appFocused);
@@ -80,7 +81,7 @@ export function useWorkflowForegroundRefresh(): void {
 
     void queryClient.refetchQueries({
       predicate: (query) =>
-        shouldRefreshWorkflowOnForeground(query.queryKey, query.state.data),
+        shouldRefreshQueryOnForeground(query.queryKey, query.state.data),
       stale: true,
       type: "active",
     });

--- a/desktop/src/shared/api/useRelayResumeTriggers.test.mjs
+++ b/desktop/src/shared/api/useRelayResumeTriggers.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { installRelayResumeTriggers } from "./useRelayResumeTriggers.ts";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalDocument === undefined) delete globalThis.document;
+  else globalThis.document = originalDocument;
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+});
+
+function installEventStub() {
+  let visibilityState = "visible";
+  const documentListeners = new Map();
+  const windowListeners = new Map();
+  const add = (listeners, type, listener) => {
+    const values = listeners.get(type) ?? new Set();
+    values.add(listener);
+    listeners.set(type, values);
+  };
+  const remove = (listeners, type, listener) => {
+    const values = listeners.get(type);
+    values?.delete(listener);
+    if (values?.size === 0) listeners.delete(type);
+  };
+  globalThis.document = {
+    get visibilityState() {
+      return visibilityState;
+    },
+    addEventListener: (type, listener) =>
+      add(documentListeners, type, listener),
+    removeEventListener: (type, listener) =>
+      remove(documentListeners, type, listener),
+  };
+  globalThis.window = {
+    addEventListener: (type, listener) => add(windowListeners, type, listener),
+    removeEventListener: (type, listener) =>
+      remove(windowListeners, type, listener),
+  };
+  return {
+    documentListeners,
+    windowListeners,
+    emitDocument(type) {
+      for (const listener of documentListeners.get(type) ?? []) listener();
+    },
+    emitWindow(type) {
+      for (const listener of windowListeners.get(type) ?? []) listener();
+    },
+    setVisibility(value) {
+      visibilityState = value;
+    },
+  };
+}
+
+describe("relay resume triggers", () => {
+  it("defers and coalesces foreground signals", () => {
+    const stub = installEventStub();
+    const scheduled = [];
+    let attempts = 0;
+    const dispose = installRelayResumeTriggers(
+      () => attempts++,
+      (callback) => {
+        const pending = { callback, cancelled: false };
+        scheduled.push(pending);
+        return () => {
+          pending.cancelled = true;
+        };
+      },
+    );
+
+    stub.emitWindow("focus");
+    stub.emitWindow("online");
+    stub.emitDocument("visibilitychange");
+    assert.equal(attempts, 0, "resume is not attempted in the event turn");
+    assert.equal(scheduled.length, 1, "foreground burst is coalesced");
+
+    scheduled[0].callback();
+    assert.equal(attempts, 1);
+    dispose();
+    assert.equal(stub.documentListeners.size, 0);
+    assert.equal(stub.windowListeners.size, 0);
+  });
+
+  it("cancels a pending resume when hidden", () => {
+    const stub = installEventStub();
+    let pending;
+    let attempts = 0;
+    installRelayResumeTriggers(
+      () => attempts++,
+      (callback) => {
+        pending = {
+          cancelled: false,
+          run() {
+            if (!this.cancelled) callback();
+          },
+        };
+        return () => {
+          pending.cancelled = true;
+        };
+      },
+    );
+
+    stub.emitWindow("focus");
+    stub.setVisibility("hidden");
+    stub.emitDocument("visibilitychange");
+    assert.equal(pending.cancelled, true);
+    pending.run();
+    assert.equal(attempts, 0, "hidden state suppresses pending resume");
+  });
+
+  it("cancels a pending resume on dispose", () => {
+    const stub = installEventStub();
+    let pending;
+    let attempts = 0;
+    const dispose = installRelayResumeTriggers(
+      () => attempts++,
+      (callback) => {
+        pending = {
+          cancelled: false,
+          run() {
+            if (!this.cancelled) callback();
+          },
+        };
+        return () => {
+          pending.cancelled = true;
+        };
+      },
+    );
+
+    stub.emitWindow("focus");
+    dispose();
+    pending.run();
+    assert.equal(attempts, 0);
+    assert.equal(stub.documentListeners.size, 0);
+    assert.equal(stub.windowListeners.size, 0);
+  });
+});

--- a/desktop/src/shared/api/useRelayResumeTriggers.ts
+++ b/desktop/src/shared/api/useRelayResumeTriggers.ts
@@ -2,11 +2,46 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import { shouldTriggerResumeReconnect } from "@/shared/api/relayResumeTriggerPolicy";
+import { scheduleAfterForegroundReady } from "@/shared/lib/foregroundReady";
+
+type ScheduleForegroundWork = (callback: () => void) => () => void;
+
+export function installRelayResumeTriggers(
+  attempt: () => void,
+  schedule: ScheduleForegroundWork = scheduleAfterForegroundReady,
+): () => void {
+  let cancelPendingResume: (() => void) | null = null;
+  const scheduleAttempt = () => {
+    if (cancelPendingResume) return;
+    cancelPendingResume = schedule(() => {
+      cancelPendingResume = null;
+      attempt();
+    });
+  };
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "visible") scheduleAttempt();
+    else {
+      cancelPendingResume?.();
+      cancelPendingResume = null;
+    }
+  };
+
+  window.addEventListener("online", scheduleAttempt);
+  window.addEventListener("focus", scheduleAttempt);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  return () => {
+    cancelPendingResume?.();
+    window.removeEventListener("online", scheduleAttempt);
+    window.removeEventListener("focus", scheduleAttempt);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+  };
+}
 
 /**
  * Event-driven reconnect triggers: network `online`, window `focus`, and
- * visibility→visible each attempt an immediate `resumeReconnect()` when the
- * relay session is degraded (reconnecting/stalled), rate-limited by
+ * visibility→visible coalesce a foreground-ready `resumeReconnect()` attempt
+ * when the relay session is degraded (reconnecting/stalled), rate-limited by
  * `RESUME_TRIGGER_MIN_INTERVAL_MS`.
  *
  * Rationale (CMD+R gap audit G1): without these, recovery rides solely on
@@ -43,18 +78,6 @@ export function useRelayResumeTriggers(): void {
       void relayClient.resumeReconnect().catch(() => {});
     };
 
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") attempt();
-    };
-
-    window.addEventListener("online", attempt);
-    window.addEventListener("focus", attempt);
-    document.addEventListener("visibilitychange", onVisibilityChange);
-
-    return () => {
-      window.removeEventListener("online", attempt);
-      window.removeEventListener("focus", attempt);
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-    };
+    return installRelayResumeTriggers(attempt);
   }, []);
 }

--- a/desktop/src/shared/lib/foregroundReady.test.mjs
+++ b/desktop/src/shared/lib/foregroundReady.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { scheduleAfterForegroundReady } from "./foregroundReady.ts";
+
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalWindow === undefined) delete globalThis.window;
+  else globalThis.window = originalWindow;
+});
+
+function installSchedulerStub({ animationFrame = true } = {}) {
+  const tasks = new Map();
+  const frames = new Map();
+  let nextId = 0;
+  globalThis.window = {
+    setTimeout(callback) {
+      const id = ++nextId;
+      tasks.set(id, callback);
+      return id;
+    },
+    clearTimeout(id) {
+      tasks.delete(id);
+    },
+    ...(animationFrame
+      ? {
+          requestAnimationFrame(callback) {
+            const id = ++nextId;
+            frames.set(id, callback);
+            return id;
+          },
+          cancelAnimationFrame(id) {
+            frames.delete(id);
+          },
+        }
+      : {}),
+  };
+  const runFirst = (queue, argument) => {
+    const entry = queue.entries().next().value;
+    assert.ok(entry, "expected queued work");
+    const [id, callback] = entry;
+    queue.delete(id);
+    callback(argument);
+  };
+  return {
+    frames,
+    tasks,
+    runTask: () => runFirst(tasks),
+    runFrame: () => runFirst(frames, 0),
+  };
+}
+
+describe("scheduleAfterForegroundReady", () => {
+  it("runs after task, animation frame, and trailing task", () => {
+    const stub = installSchedulerStub();
+    let calls = 0;
+
+    scheduleAfterForegroundReady(() => calls++);
+    assert.equal(calls, 0);
+    stub.runTask();
+    assert.equal(calls, 0);
+    stub.runFrame();
+    assert.equal(calls, 0);
+    stub.runTask();
+    assert.equal(calls, 1);
+  });
+
+  it("falls back to two tasks when animation frames are unavailable", () => {
+    const stub = installSchedulerStub({ animationFrame: false });
+    let calls = 0;
+
+    scheduleAfterForegroundReady(() => calls++);
+    stub.runTask();
+    assert.equal(calls, 0);
+    stub.runTask();
+    assert.equal(calls, 1);
+  });
+
+  it("cancels work at every scheduling stage", () => {
+    for (const cancelAfter of ["schedule", "task", "frame"]) {
+      const stub = installSchedulerStub();
+      let calls = 0;
+      const cancel = scheduleAfterForegroundReady(() => calls++);
+      if (cancelAfter !== "schedule") stub.runTask();
+      if (cancelAfter === "frame") stub.runFrame();
+      cancel();
+
+      assert.equal(stub.tasks.size, 0, `${cancelAfter}: tasks cleared`);
+      assert.equal(stub.frames.size, 0, `${cancelAfter}: frames cleared`);
+      assert.equal(calls, 0, `${cancelAfter}: callback suppressed`);
+    }
+  });
+});

--- a/desktop/src/shared/lib/foregroundReady.ts
+++ b/desktop/src/shared/lib/foregroundReady.ts
@@ -1,0 +1,45 @@
+/**
+ * Run foreground-resume work only after the activation event has returned,
+ * the browser has painted one frame, and a following task gets a turn.
+ *
+ * A single timeout is not enough: it can run before the activating click is
+ * delivered. The task -> frame -> task sequence gives WebKit an interaction
+ * boundary before query refresh, reconnect, and polling resume work begins.
+ */
+export function scheduleAfterForegroundReady(callback: () => void): () => void {
+  if (typeof window === "undefined") {
+    callback();
+    return () => {};
+  }
+
+  let cancelled = false;
+  let frameId: number | null = null;
+  let trailingTaskId: number | null = null;
+
+  const leadingTaskId = window.setTimeout(() => {
+    if (cancelled) return;
+    const afterFrame = () => {
+      if (cancelled) return;
+      trailingTaskId = window.setTimeout(() => {
+        if (!cancelled) callback();
+      }, 0);
+    };
+
+    if (typeof window.requestAnimationFrame === "function") {
+      frameId = window.requestAnimationFrame(afterFrame);
+    } else {
+      trailingTaskId = window.setTimeout(() => {
+        if (!cancelled) callback();
+      }, 0);
+    }
+  }, 0);
+
+  return () => {
+    cancelled = true;
+    window.clearTimeout(leadingTaskId);
+    if (frameId !== null && typeof window.cancelAnimationFrame === "function") {
+      window.cancelAnimationFrame(frameId);
+    }
+    if (trailingTaskId !== null) window.clearTimeout(trailingTaskId);
+  };
+}

--- a/desktop/src/shared/lib/useDocumentVisible.test.mjs
+++ b/desktop/src/shared/lib/useDocumentVisible.test.mjs
@@ -38,6 +38,8 @@ function installVisibilityStub() {
   let focused = true;
   const documentListeners = new Map();
   const windowListeners = new Map();
+  const tasks = [];
+  const frames = [];
   globalThis.document = {
     get visibilityState() {
       return visibilityState;
@@ -65,10 +67,29 @@ function installVisibilityStub() {
       listeners?.delete(listener);
       if (listeners?.size === 0) windowListeners.delete(type);
     },
+    setTimeout(callback) {
+      tasks.push(callback);
+      return tasks.length;
+    },
+    clearTimeout() {},
+    requestAnimationFrame(callback) {
+      frames.push(callback);
+      return frames.length;
+    },
+    cancelAnimationFrame() {},
   };
   return {
     documentListeners,
     windowListeners,
+    flushLeadingTask() {
+      tasks.shift()?.();
+    },
+    flushFrame() {
+      frames.shift()?.(0);
+    },
+    flushTrailingTask() {
+      tasks.shift()?.();
+    },
     setFocused(value) {
       focused = value;
     },
@@ -105,6 +126,18 @@ describe("document visibility", () => {
 
     stub.setFocused(true);
     for (const listener of stub.windowListeners.get("focus")) listener();
+    assert.deepEqual(
+      focusedStates,
+      [false],
+      "focus resume must not notify inside the activation turn",
+    );
+    stub.flushLeadingTask();
+    assert.deepEqual(focusedStates, [false]);
+    stub.flushFrame();
+    assert.deepEqual(focusedStates, [false]);
+    stub.flushTrailingTask();
+    assert.deepEqual(focusedStates, [false, true]);
+
     stub.setVisibility("hidden");
     for (const listener of stub.documentListeners.get("visibilitychange"))
       listener();
@@ -164,7 +197,7 @@ describe("visibility-gated hooks", () => {
     dom.window.close();
   });
 
-  it("focused polling pauses on blur and refreshes immediately on focus", async () => {
+  it("focused polling pauses on blur and resumes after activation yields", async () => {
     const dom = new JSDOM(
       "<!doctype html><html><body><div id='root'></div></body></html>",
     );
@@ -199,6 +232,10 @@ describe("visibility-gated hooks", () => {
     assert.deepEqual(observed, [1_000, false]);
     focused = true;
     await act(async () => window.dispatchEvent(new window.Event("focus")));
+    assert.deepEqual(observed, [1_000, false]);
+    await act(
+      async () => new Promise((resolve) => window.setTimeout(resolve, 10)),
+    );
     assert.deepEqual(observed, [1_000, false, 1_000]);
 
     await act(async () => root.unmount());

--- a/desktop/src/shared/lib/useDocumentVisible.ts
+++ b/desktop/src/shared/lib/useDocumentVisible.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { scheduleAfterForegroundReady } from "@/shared/lib/foregroundReady";
+
 export function isDocumentVisible(): boolean {
   if (typeof document === "undefined") return true;
   return document.visibilityState === "visible";
@@ -35,11 +37,25 @@ export function subscribeAppFocus(
     return () => {};
   }
 
-  const handleFocusChange = () => listener(isAppFocused());
+  let cancelPendingResume: (() => void) | null = null;
+  const handleFocusChange = () => {
+    cancelPendingResume?.();
+    cancelPendingResume = null;
+    const focused = isAppFocused();
+    if (!focused) {
+      listener(false);
+      return;
+    }
+    cancelPendingResume = scheduleAfterForegroundReady(() => {
+      cancelPendingResume = null;
+      if (isAppFocused()) listener(true);
+    });
+  };
   document.addEventListener("visibilitychange", handleFocusChange);
   window.addEventListener("focus", handleFocusChange);
   window.addEventListener("blur", handleFocusChange);
   return () => {
+    cancelPendingResume?.();
     document.removeEventListener("visibilitychange", handleFocusChange);
     window.removeEventListener("focus", handleFocusChange);
     window.removeEventListener("blur", handleFocusChange);
@@ -54,12 +70,36 @@ export function useDocumentVisible(): boolean {
   return visible;
 }
 
+const appFocusStoreListeners = new Set<() => void>();
+let appFocusStoreSnapshot = isAppFocused();
+let stopAppFocusStore: (() => void) | null = null;
+
+function subscribeAppFocusStore(listener: () => void): () => void {
+  appFocusStoreListeners.add(listener);
+  if (!stopAppFocusStore) {
+    appFocusStoreSnapshot = isAppFocused();
+    stopAppFocusStore = subscribeAppFocus((focused) => {
+      if (appFocusStoreSnapshot === focused) return;
+      appFocusStoreSnapshot = focused;
+      for (const storeListener of appFocusStoreListeners) storeListener();
+    });
+  }
+
+  return () => {
+    appFocusStoreListeners.delete(listener);
+    if (appFocusStoreListeners.size === 0) {
+      stopAppFocusStore?.();
+      stopAppFocusStore = null;
+    }
+  };
+}
+
 export function useAppFocused(): boolean {
-  const [focused, setFocused] = React.useState(isAppFocused);
-
-  React.useEffect(() => subscribeAppFocus(setFocused), []);
-
-  return focused;
+  return React.useSyncExternalStore(
+    subscribeAppFocusStore,
+    () => appFocusStoreSnapshot,
+    () => true,
+  );
 }
 
 export function useFocusedRefetchInterval(


### PR DESCRIPTION
## Summary

- defer foreground resume work until the activation task has returned, a frame has painted, and a trailing task gets a turn
- centralize app-focus subscribers and remove the broad TanStack `refetchOnWindowFocus` fan-out
- coalesce relay recovery and preserve an explicit deferred refresh only for workflow data without a polling/push freshness path
- defer the notification permission native check while keeping blur and cheap correctness signals immediate

## Why

Buzz Desktop 0.5.10 can spend roughly 1.5 seconds in the WebKit window-focus listener/microtask checkpoint before returning to the run loop. Focus currently fans out into query refetches, React polling updates, relay reconnect/replay, and native work in one activation turn. This patch establishes an interaction-first foreground boundary rather than letting those consumers compete with the activating input and first paint.

## Validation

- focused foreground/workflow/relay tests: 18/18 passed before commit
- `pnpm --dir desktop typecheck`: passed before commit
- pre-commit desktop check and file-size gate: passed
- pre-push desktop check, typecheck, and full desktop unit suite: 4,743/4,743 passed at `704e7b4b6618fafce655bb2b07c7a9fe0fc8c643`
- Princess Donut independent adversarial review: PASS after two lifecycle/freshness blockers were resolved

## Manual test

1. Install the PR build and use Buzz long enough to populate channels, home, workflows, agents, and other polling surfaces.
2. Switch to another app for 30-60 seconds.
3. Return by clicking Buzz and immediately click a channel or scroll.
4. Confirm the first interaction and paint are prompt, then confirm channels/home/workflows refresh and a degraded relay reconnects after the activation boundary.
5. Repeat while rapidly switching away again to verify no resume work starts after focus has been lost.
