### PR TITLE
fix(acp): preserve edit routing and steer delivery

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -222,16 +222,16 @@ Start with **N=2** for most deployments. Increase if queue depth grows under loa
 
 ## Forum Channels
 
-By default, the ACP harness subscribes to stream message kinds (9, 46010, 40007). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
+By default, the ACP harness subscribes to actionable stream kinds (9 messages, 40003 edits that add a mention, 46010 workflow approvals, and 40007 reminders). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
 
 **CLI flags:**
 ```bash
-buzz-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
+buzz-acp --kinds 9,40003,46010,40007,45001,45002,45003 --no-mention-filter
 ```
 
 **Or with `--subscribe all`:**
 ```bash
-buzz-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
+buzz-acp --subscribe all --kinds 9,40003,46010,40007,45001,45002,45003
 ```
 
 **Per-channel config:**

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -6,6 +6,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+use buzz_core::kind::{
+    KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_REMINDER,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
+};
 use clap::Parser;
 use clap::ValueEnum;
 use nostr::Keys;
@@ -1237,16 +1241,26 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
     Ok(config.rules)
 }
 
+/// Event kinds that carry actionable direct mentions by default.
+///
+/// Message edits are included because Desktop emits `p` tags only for
+/// recipients newly added by an edit. Receiving kind 40003 therefore wakes an
+/// agent once for a newly added mention without re-waking it for ordinary edits.
+pub(crate) fn default_mention_kinds() -> Vec<u32> {
+    vec![
+        KIND_STREAM_MESSAGE,
+        KIND_STREAM_MESSAGE_EDIT,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_REMINDER,
+    ]
+}
+
 /// Resolve per-channel NIP-01 filters from config + discovered channels.
 pub fn resolve_channel_filters(
     config: &Config,
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
         overrides
             .iter()
@@ -1261,13 +1275,10 @@ pub fn resolve_channel_filters(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => {
-            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            });
+            let kinds = config
+                .kinds_override
+                .clone()
+                .unwrap_or_else(default_mention_kinds);
             let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
@@ -1345,10 +1356,6 @@ pub fn resolve_dynamic_channel_filter(
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     // In Mentions/All mode, if the operator explicitly constrained channels
     // with --channels, only allow dynamic subscription to channels in that
     // allowlist. Config mode ignores --channels (per CLI contract) and uses
@@ -1366,13 +1373,12 @@ pub fn resolve_dynamic_channel_filter(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => Some(ChannelFilter {
-            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            })),
+            kinds: Some(
+                config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(default_mention_kinds),
+            ),
             require_mention: !config.no_mention_filter,
         }),
         SubscribeMode::All => Some(ChannelFilter {
@@ -1516,9 +1522,26 @@ mod tests {
             assert!(f.require_mention, "mentions mode requires mention");
             let kinds = f.kinds.as_ref().expect("should have kinds");
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
+            assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE_EDIT));
             assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
         }
+    }
+
+    #[test]
+    fn test_dynamic_mentions_mode_includes_message_edits() {
+        let config = test_config(SubscribeMode::Mentions);
+        let filter = resolve_dynamic_channel_filter(&config, Uuid::new_v4(), &[])
+            .expect("dynamic channel should be subscribed");
+
+        assert!(filter.require_mention);
+        assert!(
+            filter
+                .kinds
+                .expect("mentions mode should constrain kinds")
+                .contains(&KIND_STREAM_MESSAGE_EDIT),
+            "newly mentioned agents must receive message edits on dynamic channels"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1410,6 +1410,44 @@ fn native_steer_preparation_is_stale(
             != prepared_generation
 }
 
+/// Reserve an edit before its asynchronous enrichment starts, returning the
+/// membership generation that completion must still match.
+fn reserve_native_edit_preparation(
+    queue: &mut EventQueue,
+    membership_generations: &HashMap<Uuid, u64>,
+    channel_id: Uuid,
+    event_id: &str,
+) -> Option<u64> {
+    queue
+        .mark_native_steer_pending(channel_id, event_id)
+        .then(|| {
+            membership_generations
+                .get(&channel_id)
+                .copied()
+                .unwrap_or(0)
+        })
+}
+
+/// Apply the queue and membership state transition for a channel removal.
+/// The generation deliberately advances even if a later add restores access.
+fn remove_channel_for_membership_change(
+    queue: &mut EventQueue,
+    removed_channels: &mut HashSet<Uuid>,
+    membership_generations: &mut HashMap<Uuid, u64>,
+    channel_id: Uuid,
+) -> Vec<String> {
+    let drained_ids = queue.drain_channel(channel_id);
+    removed_channels.insert(channel_id);
+    let generation = membership_generations.entry(channel_id).or_default();
+    *generation = generation.wrapping_add(1);
+    drained_ids
+}
+
+/// Restore current membership without validating work prepared before removal.
+fn readd_channel_after_membership_change(removed_channels: &mut HashSet<Uuid>, channel_id: Uuid) {
+    removed_channels.remove(&channel_id);
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -2299,7 +2337,7 @@ async fn tokio_main() -> Result<()> {
                                 if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
                                     // Clear removal tracking so sessions are not
                                     // stripped for a legitimately re-added channel.
-                                    removed_channels.remove(&ch);
+                                    readd_channel_after_membership_change(&mut removed_channels, ch);
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
@@ -2323,7 +2361,12 @@ async fn tokio_main() -> Result<()> {
                                     // removed channel. Events already in-flight will
                                     // complete normally (the relay may reject actions if
                                     // the agent lost access).
-                                    let drained_ids = queue.drain_channel(ch);
+                                    let drained_ids = remove_channel_for_membership_change(
+                                        &mut queue,
+                                        &mut removed_channels,
+                                        &mut membership_generations,
+                                        ch,
+                                    );
                                     let invalidated = if pool_ready {
                                         pool.invalidate_channel_sessions(ch)
                                     } else {
@@ -2331,9 +2374,6 @@ async fn tokio_main() -> Result<()> {
                                     };
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
-                                    removed_channels.insert(ch);
-                                    let generation = membership_generations.entry(ch).or_default();
-                                    *generation = generation.wrapping_add(1);
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -2581,18 +2621,16 @@ async fn tokio_main() -> Result<()> {
                                     {
                                         if queue::edit_target_id(&event_for_steer).is_some() {
                                             let event_id = event_for_steer.id.to_hex();
-                                            let reserved = queue.mark_native_steer_pending(
-                                                buzz_event.channel_id,
+                                            let channel_id = buzz_event.channel_id;
+                                            let membership_generation = reserve_native_edit_preparation(
+                                                &mut queue,
+                                                &membership_generations,
+                                                channel_id,
                                                 &event_id,
-                                            );
-                                            debug_assert!(reserved, "accepted edit must still be queued");
+                                            )
+                                            .expect("accepted edit must still be queued");
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
-                                            let channel_id = buzz_event.channel_id;
-                                            let membership_generation = membership_generations
-                                                .get(&channel_id)
-                                                .copied()
-                                                .unwrap_or(0);
                                             tokio::spawn(async move {
                                                 let prompt_blocks = pool::format_native_steer_prompt(
                                                     channel_id,
@@ -8235,5 +8273,65 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod native_edit_membership_lifecycle_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind};
+
+    fn edit_event(target: &str) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([nostr::Tag::parse(["e", target]).expect("target tag")])
+            .sign_with_keys(&Keys::generate())
+            .expect("signed edit")
+    }
+
+    #[test]
+    fn late_prepared_edit_is_discarded_across_remove_then_readd() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+
+        // This is the production reservation/capture boundary used before the
+        // detached REST preparation task is spawned.
+        let mut generations = HashMap::new();
+        let prepared_generation =
+            reserve_native_edit_preparation(&mut queue, &generations, channel_id, &event_id)
+                .expect("accepted edit is reserved before preparation");
+
+        // These are the production removal and re-add transitions. Removal
+        // drains the reservation and advances generation; re-add restores
+        // access without revalidating old prepared work.
+        let mut removed_channels = HashSet::new();
+        assert!(remove_channel_for_membership_change(
+            &mut queue,
+            &mut removed_channels,
+            &mut generations,
+            channel_id,
+        )
+        .is_empty());
+        readd_channel_after_membership_change(&mut removed_channels, channel_id);
+
+        // This is the completion-arm guard. A false result would enter
+        // try_native_steer or its release/fallback path; stale completion must
+        // instead be discarded, leaving neither queued nor withheld work to
+        // steer, release, or resurrect.
+        assert!(native_steer_preparation_is_stale(
+            &removed_channels,
+            &generations,
+            channel_id,
+            prepared_generation,
+        ));
+        queue.release_native_steer(channel_id, &event_id);
+        assert!(queue.flush_next().is_none());
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1389,6 +1389,13 @@ struct NativeSteerPrepared {
     prompt_blocks: Vec<String>,
 }
 
+/// Async edit enrichment may finish after channel membership was revoked.
+/// Such prepared work is stale: removal drains its queue reservation, and it
+/// must never be forwarded to an otherwise still-live ACP turn.
+fn native_steer_preparation_is_stale(removed_channels: &HashSet<Uuid>, channel_id: Uuid) -> bool {
+    removed_channels.contains(&channel_id)
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -2792,6 +2799,14 @@ async fn tokio_main() -> Result<()> {
                 event,
                 prompt_blocks,
             })) => {
+                if native_steer_preparation_is_stale(&removed_channels, channel_id) {
+                    tracing::debug!(
+                        %channel_id,
+                        event_id = %event.id.to_hex(),
+                        "discarding native steer prepared after channel removal"
+                    );
+                    continue;
+                }
                 if !try_native_steer(
                     &mut pool,
                     &mut queue,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1385,15 +1385,29 @@ struct RespawnResult {
 /// `event_id` is the hex id of the single event the steer carried.
 struct NativeSteerPrepared {
     channel_id: Uuid,
+    /// Membership generation captured when this edit was reserved. A removal
+    /// advances the generation even if the agent is subsequently re-added.
+    membership_generation: u64,
     event: nostr::Event,
     prompt_blocks: Vec<String>,
 }
 
-/// Async edit enrichment may finish after channel membership was revoked.
-/// Such prepared work is stale: removal drains its queue reservation, and it
-/// must never be forwarded to an otherwise still-live ACP turn.
-fn native_steer_preparation_is_stale(removed_channels: &HashSet<Uuid>, channel_id: Uuid) -> bool {
+/// Async edit enrichment may finish after channel membership changed. Such
+/// prepared work is stale: removal drains its queue reservation, and it must
+/// never be forwarded into either the removed membership period or a later
+/// re-added period.
+fn native_steer_preparation_is_stale(
+    removed_channels: &HashSet<Uuid>,
+    membership_generations: &HashMap<Uuid, u64>,
+    channel_id: Uuid,
+    prepared_generation: u64,
+) -> bool {
     removed_channels.contains(&channel_id)
+        || membership_generations
+            .get(&channel_id)
+            .copied()
+            .unwrap_or(0)
+            != prepared_generation
 }
 
 struct SteerAckEvent {
@@ -1990,6 +2004,9 @@ async fn tokio_main() -> Result<()> {
     // causal invalidation is needed, add a monotonic epoch counter per channel
     // and capture it in TaskMeta at dispatch time.
     let mut removed_channels: HashSet<Uuid> = HashSet::new();
+    // Incremented on removal, rather than reset on re-add, so asynchronous
+    // edit preparation cannot cross a membership boundary.
+    let mut membership_generations: HashMap<Uuid, u64> = HashMap::new();
 
     //
     // One SlotCircuit per agent slot. crash_times entries are pruned to the last
@@ -2315,6 +2332,8 @@ async fn tokio_main() -> Result<()> {
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
+                                    let generation = membership_generations.entry(ch).or_default();
+                                    *generation = generation.wrapping_add(1);
                                     typing_channels.remove(&ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
@@ -2570,6 +2589,10 @@ async fn tokio_main() -> Result<()> {
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
                                             let channel_id = buzz_event.channel_id;
+                                            let membership_generation = membership_generations
+                                                .get(&channel_id)
+                                                .copied()
+                                                .unwrap_or(0);
                                             tokio::spawn(async move {
                                                 let prompt_blocks = pool::format_native_steer_prompt(
                                                     channel_id,
@@ -2580,6 +2603,7 @@ async fn tokio_main() -> Result<()> {
                                                 .await;
                                                 let _ = tx.send(NativeSteerPrepared {
                                                     channel_id,
+                                                    membership_generation,
                                                     event: event_for_steer,
                                                     prompt_blocks,
                                                 });
@@ -2796,10 +2820,16 @@ async fn tokio_main() -> Result<()> {
             }
             Some(PoolEvent::NativeSteerPrepared(NativeSteerPrepared {
                 channel_id,
+                membership_generation,
                 event,
                 prompt_blocks,
             })) => {
-                if native_steer_preparation_is_stale(&removed_channels, channel_id) {
+                if native_steer_preparation_is_stale(
+                    &removed_channels,
+                    &membership_generations,
+                    channel_id,
+                    membership_generation,
+                ) {
                     tracing::debug!(
                         %channel_id,
                         event_id = %event.id.to_hex(),

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2622,31 +2622,41 @@ async fn tokio_main() -> Result<()> {
                                         if queue::edit_target_id(&event_for_steer).is_some() {
                                             let event_id = event_for_steer.id.to_hex();
                                             let channel_id = buzz_event.channel_id;
-                                            let membership_generation = reserve_native_edit_preparation(
+                                            match reserve_native_edit_preparation(
                                                 &mut queue,
                                                 &membership_generations,
                                                 channel_id,
                                                 &event_id,
-                                            )
-                                            .expect("accepted edit must still be queued");
-                                            let tx = native_steer_tx.clone();
-                                            let ctx = Arc::clone(&ctx);
-                                            tokio::spawn(async move {
-                                                let prompt_blocks = pool::format_native_steer_prompt(
-                                                    channel_id,
-                                                    event_for_steer.clone(),
-                                                    prompt_tag_for_steer,
-                                                    &ctx,
-                                                )
-                                                .await;
-                                                let _ = tx.send(NativeSteerPrepared {
-                                                    channel_id,
-                                                    membership_generation,
-                                                    event: event_for_steer,
-                                                    prompt_blocks,
-                                                });
-                                            });
-                                            true
+                                            ) {
+                                                Some(membership_generation) => {
+                                                    let tx = native_steer_tx.clone();
+                                                    let ctx = Arc::clone(&ctx);
+                                                    tokio::spawn(async move {
+                                                        let prompt_blocks = pool::format_native_steer_prompt(
+                                                            channel_id,
+                                                            event_for_steer.clone(),
+                                                            prompt_tag_for_steer,
+                                                            &ctx,
+                                                        )
+                                                        .await;
+                                                        let _ = tx.send(NativeSteerPrepared {
+                                                            channel_id,
+                                                            membership_generation,
+                                                            event: event_for_steer,
+                                                            prompt_blocks,
+                                                        });
+                                                    });
+                                                    true
+                                                }
+                                                None => {
+                                                    tracing::warn!(
+                                                        %channel_id,
+                                                        %event_id,
+                                                        "native edit steer preparation could not reserve queued event; falling back to cancel+merge"
+                                                    );
+                                                    false
+                                                }
+                                            }
                                         } else {
                                             let prompt_blocks =
                                                 pool::format_native_steer_prompt_sync(
@@ -2883,8 +2893,15 @@ async fn tokio_main() -> Result<()> {
                     prompt_blocks,
                     &steer_ack_tx,
                 ) {
-                    queue.release_native_steer(channel_id, &event.id.to_hex());
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    release_prepared_native_steer_fallback(
+                        &mut pool,
+                        &mut queue,
+                        channel_id,
+                        &event.id.to_hex(),
+                        &ctx,
+                        &mut last_activity,
+                        &mut typing_channels,
+                    );
                 }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
@@ -3357,6 +3374,26 @@ fn try_native_steer(
             );
             false
         }
+    }
+}
+
+/// Recover a prepared edit whose native steer could not be accepted. The edit
+/// was withheld before asynchronous preparation, so release it, request the
+/// universal cancel+merge fallback, and immediately try dispatch in case the
+/// original turn already ended.
+fn release_prepared_native_steer_fallback(
+    pool: &mut AgentPool,
+    queue: &mut EventQueue,
+    channel_id: Uuid,
+    event_id: &str,
+    ctx: &Arc<PromptContext>,
+    last_activity: &mut tokio::time::Instant,
+    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+) {
+    queue.release_native_steer(channel_id, event_id);
+    signal_in_flight_task(pool, channel_id, ControlSignal::Steer);
+    for (channel_id, thread_tags) in dispatch_pending(pool, queue, ctx, last_activity) {
+        typing_channels.insert(channel_id, thread_tags);
     }
 }
 
@@ -8286,6 +8323,114 @@ mod native_edit_membership_lifecycle_tests {
             .tags([nostr::Tag::parse(["e", target]).expect("target tag")])
             .sign_with_keys(&Keys::generate())
             .expect("signed edit")
+    }
+
+    async fn dummy_agent(index: usize) -> OwnedAgent {
+        OwnedAgent {
+            index,
+            acp: AcpClient::spawn("cat", &[], &[], false)
+                .await
+                .expect("spawn inert agent"),
+            state: Default::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "unknown".into(),
+            protocol_version: 1,
+            goose_system_prompt_supported: None,
+        }
+    }
+
+    fn prompt_context() -> Arc<PromptContext> {
+        let keys = Keys::generate();
+        let rest_client = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:0".into(),
+            keys: keys.clone(),
+            auth_tag_json: None,
+        };
+        Arc::new(PromptContext {
+            mcp_servers: vec![],
+            initial_message: None,
+            idle_timeout: Duration::from_secs(60),
+            max_turn_duration: Duration::from_secs(120),
+            turn_liveness_interval: Duration::ZERO,
+            dedup_mode: DedupMode::Queue,
+            system_prompt: None,
+            session_title: None,
+            team_instructions: None,
+            heartbeat_prompt: None,
+            base_prompt: None,
+            cwd: ".".into(),
+            channel_info: pool::ChannelInfoResolver::new(HashMap::new(), rest_client.clone()),
+            rest_client,
+            context_message_limit: 0,
+            max_turns_per_session: 0,
+            permission_mode: config::PermissionMode::Default,
+            agent_keys: keys,
+            agent_owner_pubkey: None,
+            memory_enabled: false,
+            harness_name: "goose".into(),
+            relay_url: "ws://127.0.0.1:0".into(),
+        })
+    }
+
+    #[tokio::test]
+    async fn prepared_native_steer_rejection_releases_and_dispatches_immediately() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        assert!(queue.push(QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "@mention".into(),
+        }));
+        assert!(queue.mark_native_steer_pending(channel_id, &event_id));
+
+        // The original turn completed while edit enrichment ran. The native
+        // transport rejection must synchronously release and re-dispatch the
+        // edit; no maintenance tick may be needed to observe the work.
+        let mut pool = AgentPool::from_slots(vec![Some(dummy_agent(0).await)]);
+        let mut last_activity = tokio::time::Instant::now();
+        let mut typing_channels = HashMap::new();
+        release_prepared_native_steer_fallback(
+            &mut pool,
+            &mut queue,
+            channel_id,
+            &event_id,
+            &prompt_context(),
+            &mut last_activity,
+            &mut typing_channels,
+        );
+
+        assert!(typing_channels.contains_key(&channel_id));
+        assert_eq!(
+            pool.task_map().len(),
+            1,
+            "released edit dispatched exactly once"
+        );
+        assert!(
+            queue.flush_next().is_none(),
+            "dispatch consumed the released edit"
+        );
+    }
+
+    #[test]
+    fn unreservable_edit_leaves_universal_fallback_work_queued() {
+        let channel_id = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        let generations = HashMap::new();
+
+        assert_eq!(
+            reserve_native_edit_preparation(&mut queue, &generations, channel_id, &event_id),
+            None,
+            "a missing queue entry must not panic or claim a native attempt"
+        );
+        assert!(queue.flush_next().is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,7 +22,6 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1723,13 +1722,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(config::default_mention_kinds),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2554,6 +2554,12 @@ async fn tokio_main() -> Result<()> {
                                     let native_attempted = if matches!(signal, ControlSignal::Steer)
                                     {
                                         if queue::edit_target_id(&event_for_steer).is_some() {
+                                            let event_id = event_for_steer.id.to_hex();
+                                            let reserved = queue.mark_native_steer_pending(
+                                                buzz_event.channel_id,
+                                                &event_id,
+                                            );
+                                            debug_assert!(reserved, "accepted edit must still be queued");
                                             let tx = native_steer_tx.clone();
                                             let ctx = Arc::clone(&ctx);
                                             let channel_id = buzz_event.channel_id;
@@ -2790,10 +2796,11 @@ async fn tokio_main() -> Result<()> {
                     &mut pool,
                     &mut queue,
                     channel_id,
-                    event,
+                    event.clone(),
                     prompt_blocks,
                     &steer_ack_tx,
                 ) {
+                    queue.release_native_steer(channel_id, &event.id.to_hex());
                     signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
                 }
             }
@@ -3237,25 +3244,14 @@ fn try_native_steer(
 
     match pool.send_steer(channel_id, request) {
         Ok(()) => {
-            // Withhold the queued event synchronously BEFORE spawning
-            // the watcher: this closes the race where `mark_complete`
-            // clears `in_flight_channels` and a stray `flush_next` could
-            // re-deliver the event via normal dispatch. See
-            // `EventQueue::mark_native_steer_pending` docs at queue.rs:606.
+            // Ordinary events are withheld after send. Edit preparation reserves
+            // its event before leaving the main loop, so this is idempotent.
             let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
             if !withheld {
-                // Race: the event was already drained out of the queue
-                // before we got here (e.g. a concurrent flush picked it
-                // up). The steer is on the wire; if it succeeds the
-                // agent gets it via the native path AND normal
-                // dispatch — duplicate delivery is benign (agent gets
-                // the same message twice). Log so this is visible if it
-                // ever happens in production.
-                tracing::warn!(
+                tracing::debug!(
                     channel = %channel_id,
                     event_id = %event_id_hex,
-                    "native steer accepted by read loop but event was not in queue to withhold \
-                     — possible duplicate delivery if steer succeeds"
+                    "native steer event was already reserved during async preparation"
                 );
             }
             let ack_tx_clone = steer_ack_tx.clone();

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1392,14 +1392,16 @@ struct NativeSteerPrepared {
     prompt_blocks: Vec<String>,
 }
 
-/// Async edit enrichment may finish after channel membership changed. Such
-/// prepared work is stale: removal drains its queue reservation, and it must
-/// never be forwarded into either the removed membership period or a later
-/// re-added period.
+/// Async edit enrichment may finish after channel membership changed or after
+/// its queue reservation was recovered/consumed. Such prepared work is stale:
+/// it must never be forwarded into a removed/later membership period or into a
+/// replacement turn that already received the recovered edit.
 fn native_steer_preparation_is_stale(
+    queue: &EventQueue,
     removed_channels: &HashSet<Uuid>,
     membership_generations: &HashMap<Uuid, u64>,
     channel_id: Uuid,
+    event_id: &str,
     prepared_generation: u64,
 ) -> bool {
     removed_channels.contains(&channel_id)
@@ -1408,6 +1410,7 @@ fn native_steer_preparation_is_stale(
             .copied()
             .unwrap_or(0)
             != prepared_generation
+        || !queue.has_native_steer_reservation(channel_id, event_id)
 }
 
 /// Reserve an edit before its asynchronous enrichment starts, returning the
@@ -2872,16 +2875,19 @@ async fn tokio_main() -> Result<()> {
                 event,
                 prompt_blocks,
             })) => {
+                let event_id = event.id.to_hex();
                 if native_steer_preparation_is_stale(
+                    &queue,
                     &removed_channels,
                     &membership_generations,
                     channel_id,
+                    &event_id,
                     membership_generation,
                 ) {
                     tracing::debug!(
                         %channel_id,
-                        event_id = %event.id.to_hex(),
-                        "discarding native steer prepared after channel removal"
+                        %event_id,
+                        "discarding native steer prepared after its reservation became stale"
                     );
                     continue;
                 }
@@ -8471,9 +8477,11 @@ mod native_edit_membership_lifecycle_tests {
         // instead be discarded, leaving neither queued nor withheld work to
         // steer, release, or resurrect.
         assert!(native_steer_preparation_is_stale(
+            &queue,
             &removed_channels,
             &generations,
             channel_id,
+            &event_id,
             prepared_generation,
         ));
         queue.release_native_steer(channel_id, &event_id);

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2544,8 +2544,10 @@ async fn tokio_main() -> Result<()> {
                                             buzz_event.channel_id,
                                             event_for_steer,
                                             prompt_tag_for_steer,
+                                            &ctx,
                                             &steer_ack_tx,
-                                        );
+                                        )
+                                        .await;
                                     if !native_attempted {
                                         signal_in_flight_task(
                                             &mut pool,
@@ -3158,40 +3160,21 @@ fn signal_in_flight_task(
 ///
 /// The withheld event is NOT released here on `false` because no withhold
 /// was established: `mark_native_steer_pending` only runs on `Ok(())`.
-fn try_native_steer(
+async fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     channel_id: uuid::Uuid,
     event: nostr::Event,
     prompt_tag: String,
+    ctx: &PromptContext,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
-    // Build the steer body: framing strings come from
-    // `queue::native_steer_framing()` (Eva's drift-proof requirement —
-    // native and cancel+merge fallback share these so the agent gets the
-    // same orientation regardless of transport). The single event block
-    // is rendered by `queue::format_event_block`, the same function
-    // `queue::format_prompt` uses internally for `[Buzz event: …]`
-    // sections, so the rendering also cannot drift.
-    //
-    // Passing `None` for `channel_info` / `profile_lookup` is intentional:
-    // native steer is a *delta* into a live turn — the agent already saw
-    // channel context and the actor's profile in the original prompt,
-    // duplicating it here would defeat the point of non-cancelling
-    // steering (which is to inject only what's new).
-    let (header, closing) = queue::native_steer_framing();
     let event_id_hex = event.id.to_hex();
-    let be = queue::BatchEvent {
-        event,
-        prompt_tag: prompt_tag.clone(),
-        received_at: std::time::Instant::now(),
-    };
-    let event_block = queue::format_event_block(channel_id, None, &be, None);
-    let body = format!("{header}\n\n[Buzz event: {prompt_tag}]\n{event_block}\n\n{closing}");
+    let prompt_blocks = pool::format_native_steer_prompt(channel_id, event, prompt_tag, ctx).await;
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {
-        prompt_blocks: vec![body],
+        prompt_blocks,
         ack_tx,
     };
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2622,7 +2622,19 @@ async fn tokio_main() -> Result<()> {
                                     // agent.
                                     let native_attempted = if matches!(signal, ControlSignal::Steer)
                                     {
-                                        if queue::edit_target_id(&event_for_steer).is_some() {
+                                        let is_edit =
+                                            queue::edit_target_id(&event_for_steer).is_some();
+                                        if queue.has_native_steer_reservations(
+                                            buzz_event.channel_id,
+                                        ) {
+                                            tracing::debug!(
+                                                channel_id = %buzz_event.channel_id,
+                                                "native steer preparation already pending; preserving channel order via cancel+merge"
+                                            );
+                                            false
+                                        } else if is_edit
+                                            && pool.native_steer_available(buzz_event.channel_id)
+                                        {
                                             let event_id = event_for_steer.id.to_hex();
                                             let channel_id = buzz_event.channel_id;
                                             match reserve_native_edit_preparation(
@@ -2660,6 +2672,12 @@ async fn tokio_main() -> Result<()> {
                                                     false
                                                 }
                                             }
+                                        } else if is_edit {
+                                            tracing::debug!(
+                                                channel_id = %buzz_event.channel_id,
+                                                "native edit steer unavailable before preparation; falling back to cancel+merge"
+                                            );
+                                            false
                                         } else {
                                             let prompt_blocks =
                                                 pool::format_native_steer_prompt_sync(

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1383,6 +1383,12 @@ struct RespawnResult {
 /// Carries enough identity to operate on the right withheld event in
 /// `EventQueue::withheld_native_steer`: `channel_id` is the routing key,
 /// `event_id` is the hex id of the single event the steer carried.
+struct NativeSteerPrepared {
+    channel_id: Uuid,
+    event: nostr::Event,
+    prompt_blocks: Vec<String>,
+}
+
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
@@ -1921,6 +1927,10 @@ async fn tokio_main() -> Result<()> {
     //      withheld event in `EventQueue::withheld_native_steer` until
     //      `IN_FLIGHT_DEADLINE_SECS` expires.
     let (steer_ack_tx, mut steer_ack_rx) = mpsc::unbounded_channel::<SteerAckEvent>();
+    // Edit-aware native steer enrichment performs bounded REST lookups. Keep it
+    // off the relay select arm, then return the immutable prompt payload here
+    // for queue/pool mutation on the main loop.
+    let (native_steer_tx, mut native_steer_rx) = mpsc::unbounded_channel::<NativeSteerPrepared>();
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
@@ -1995,6 +2005,7 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
+        NativeSteerPrepared(NativeSteerPrepared),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2141,6 +2152,9 @@ async fn tokio_main() -> Result<()> {
                 // locked semantics (Eva + Max + Perci).
                 Some(ack_event) = steer_ack_rx.recv() => {
                     Some(PoolEvent::SteerAck(ack_event))
+                }
+                Some(prepared) = native_steer_rx.recv() => {
+                    Some(PoolEvent::NativeSteerPrepared(prepared))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -2537,17 +2551,46 @@ async fn tokio_main() -> Result<()> {
                                     // to the universal cancel+merge `Steer`
                                     // signal so the event still reaches the
                                     // agent.
-                                    let native_attempted = matches!(signal, ControlSignal::Steer)
-                                        && try_native_steer(
-                                            &mut pool,
-                                            &mut queue,
-                                            buzz_event.channel_id,
-                                            event_for_steer,
-                                            prompt_tag_for_steer,
-                                            &ctx,
-                                            &steer_ack_tx,
-                                        )
-                                        .await;
+                                    let native_attempted = if matches!(signal, ControlSignal::Steer)
+                                    {
+                                        if queue::edit_target_id(&event_for_steer).is_some() {
+                                            let tx = native_steer_tx.clone();
+                                            let ctx = Arc::clone(&ctx);
+                                            let channel_id = buzz_event.channel_id;
+                                            tokio::spawn(async move {
+                                                let prompt_blocks = pool::format_native_steer_prompt(
+                                                    channel_id,
+                                                    event_for_steer.clone(),
+                                                    prompt_tag_for_steer,
+                                                    &ctx,
+                                                )
+                                                .await;
+                                                let _ = tx.send(NativeSteerPrepared {
+                                                    channel_id,
+                                                    event: event_for_steer,
+                                                    prompt_blocks,
+                                                });
+                                            });
+                                            true
+                                        } else {
+                                            let prompt_blocks =
+                                                pool::format_native_steer_prompt_sync(
+                                                    buzz_event.channel_id,
+                                                    &event_for_steer,
+                                                    &prompt_tag_for_steer,
+                                                );
+                                            try_native_steer(
+                                                &mut pool,
+                                                &mut queue,
+                                                buzz_event.channel_id,
+                                                event_for_steer,
+                                                prompt_blocks,
+                                                &steer_ack_tx,
+                                            )
+                                        }
+                                    } else {
+                                        false
+                                    };
                                     if !native_attempted {
                                         signal_in_flight_task(
                                             &mut pool,
@@ -2736,6 +2779,22 @@ async fn tokio_main() -> Result<()> {
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
                     typing_channels.insert(channel_id, thread_tags);
+                }
+            }
+            Some(PoolEvent::NativeSteerPrepared(NativeSteerPrepared {
+                channel_id,
+                event,
+                prompt_blocks,
+            })) => {
+                if !try_native_steer(
+                    &mut pool,
+                    &mut queue,
+                    channel_id,
+                    event,
+                    prompt_blocks,
+                    &steer_ack_tx,
+                ) {
+                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
                 }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
@@ -3160,17 +3219,15 @@ fn signal_in_flight_task(
 ///
 /// The withheld event is NOT released here on `false` because no withhold
 /// was established: `mark_native_steer_pending` only runs on `Ok(())`.
-async fn try_native_steer(
+fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     channel_id: uuid::Uuid,
     event: nostr::Event,
-    prompt_tag: String,
-    ctx: &PromptContext,
+    prompt_blocks: Vec<String>,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
     let event_id_hex = event.id.to_hex();
-    let prompt_blocks = pool::format_native_steer_prompt(channel_id, event, prompt_tag, ctx).await;
 
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2627,9 +2627,13 @@ async fn tokio_main() -> Result<()> {
                                         if queue.has_native_steer_reservations(
                                             buzz_event.channel_id,
                                         ) {
+                                            let released = queue.release_native_steers(
+                                                buzz_event.channel_id,
+                                            );
                                             tracing::debug!(
                                                 channel_id = %buzz_event.channel_id,
-                                                "native steer preparation already pending; preserving channel order via cancel+merge"
+                                                released,
+                                                "native steer preparation already pending; releasing reservations for ordered cancel+merge"
                                             );
                                             false
                                         } else if is_edit

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2627,15 +2627,24 @@ async fn tokio_main() -> Result<()> {
                                         if queue.has_native_steer_reservations(
                                             buzz_event.channel_id,
                                         ) {
-                                            let released = queue.release_native_steers(
+                                            let released = queue.release_native_steer_preparations(
+                                                buzz_event.channel_id,
+                                            );
+                                            let sent_steer_pending = queue.has_sent_native_steer(
                                                 buzz_event.channel_id,
                                             );
                                             tracing::debug!(
                                                 channel_id = %buzz_event.channel_id,
                                                 released,
-                                                "native steer preparation already pending; releasing reservations for ordered cancel+merge"
+                                                sent_steer_pending,
+                                                "native steer reservation already pending; released preparations and retained sent steers"
                                             );
-                                            false
+                                            // A sent steer must settle before later work can
+                                            // cancel or replace its turn. Treat it as an
+                                            // accepted native attempt so the later event stays
+                                            // queued; the ack arm will settle the reservation
+                                            // and drive fallback/dispatch as needed.
+                                            sent_steer_pending
                                         } else if is_edit
                                             && pool.native_steer_available(buzz_event.channel_id)
                                         {
@@ -3375,6 +3384,7 @@ fn try_native_steer(
             // Ordinary events are withheld after send. Edit preparation reserves
             // its event before leaving the main loop, so this is idempotent.
             let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
+            queue.mark_native_steer_sent(channel_id, &event_id_hex);
             if !withheld {
                 tracing::debug!(
                     channel = %channel_id,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2927,6 +2927,23 @@ pub(crate) async fn resolve_edit_routing(
     })
 }
 
+pub(crate) fn format_native_steer_prompt_sync(
+    channel_id: Uuid,
+    event: &nostr::Event,
+    prompt_tag: &str,
+) -> Vec<String> {
+    let (header, closing) = crate::queue::native_steer_framing();
+    let event = crate::queue::BatchEvent {
+        event: event.clone(),
+        prompt_tag: prompt_tag.to_string(),
+        received_at: std::time::Instant::now(),
+    };
+    vec![format!(
+        "{header}\n\n[Buzz event: {prompt_tag}]\n{}\n\n{closing}",
+        crate::queue::format_event_block(channel_id, None, &event, None)
+    )]
+}
+
 /// Resolve an edit-aware native-steer delta through the same routing and
 /// context boundary as ordinary batch dispatch. This keeps successful native
 /// steering from exposing the invisible kind:40003 event as a reply anchor.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2888,7 +2888,7 @@ fn conversation_context_delta(
 
 /// Resolve a kind:40003 edit through its original event for reply routing.
 /// Failure deliberately falls back to the edit target id in `format_prompt`.
-async fn resolve_edit_routing(
+pub(crate) async fn resolve_edit_routing(
     event: &nostr::Event,
     rest: &RestClient,
 ) -> Option<crate::queue::ResolvedEdit> {
@@ -2925,6 +2925,73 @@ async fn resolve_edit_routing(
         target_event_id,
         target_thread_tags: crate::queue::parse_thread_tags(&original),
     })
+}
+
+/// Resolve an edit-aware native-steer delta through the same routing and
+/// context boundary as ordinary batch dispatch. This keeps successful native
+/// steering from exposing the invisible kind:40003 event as a reply anchor.
+pub(crate) async fn format_native_steer_prompt(
+    channel_id: Uuid,
+    event: nostr::Event,
+    prompt_tag: String,
+    ctx: &PromptContext,
+) -> Vec<String> {
+    let batch = FlushBatch {
+        channel_id,
+        events: vec![crate::queue::BatchEvent {
+            event,
+            prompt_tag,
+            received_at: std::time::Instant::now(),
+        }],
+        cancelled_events: Vec::new(),
+        cancel_reason: None,
+    };
+    if crate::queue::edit_target_id(&batch.events[0].event).is_none() {
+        let (header, closing) = crate::queue::native_steer_framing();
+        let event = &batch.events[0];
+        return vec![format!(
+            "{header}\n\n[Buzz event: {}]\n{}\n\n{closing}",
+            event.prompt_tag,
+            crate::queue::format_event_block(channel_id, None, event, None)
+        )];
+    }
+    let channel_info = ctx.channel_info.resolve(channel_id).await;
+    let resolved_edit = resolve_edit_routing(&batch.events[0].event, &ctx.rest_client).await;
+    let conversation_context = if ctx.context_message_limit > 0 {
+        match resolved_edit
+            .as_ref()
+            .and_then(|edit| edit.target_thread_tags.root_event_id.as_deref())
+        {
+            Some(root_id) => {
+                fetch_thread_context(
+                    channel_id,
+                    root_id,
+                    ctx.context_message_limit,
+                    ctx.agent_keys.public_key(),
+                    &ctx.rest_client,
+                )
+                .await
+            }
+            None => fetch_conversation_context(&batch, &channel_info, ctx).await,
+        }
+    } else {
+        None
+    };
+    let profile_lookup =
+        fetch_prompt_profile_lookup(&batch, conversation_context.as_ref(), &ctx.rest_client).await;
+
+    crate::queue::format_native_steer_prompt(
+        &batch,
+        &crate::queue::FormatPromptArgs {
+            channel_info: channel_info.as_ref(),
+            conversation_context: conversation_context.as_ref(),
+            profile_lookup: profile_lookup.as_ref(),
+            resolved_edit: resolved_edit.as_ref(),
+            has_system_prompt_support: true,
+            standing_context_sent: true,
+            ..Default::default()
+        },
+    )
 }
 
 /// Fetch conversation context (thread or DM) for a batch before prompting.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -24,6 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use nostr::EventId;
 use tokio::sync::mpsc;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::timeout;
@@ -1981,8 +1982,28 @@ pub async fn run_prompt_task(
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
         let channel_info = ctx.channel_info.resolve(b.channel_id).await;
 
+        let resolved_edit = match b.events.last() {
+            Some(event) => resolve_edit_routing(&event.event, &ctx.rest_client).await,
+            None => None,
+        };
+
         let conversation_context = if ctx.context_message_limit > 0 {
-            fetch_conversation_context(b, &channel_info, &ctx).await
+            match resolved_edit
+                .as_ref()
+                .and_then(|edit| edit.target_thread_tags.root_event_id.as_deref())
+            {
+                Some(root_id) => {
+                    fetch_thread_context(
+                        b.channel_id,
+                        root_id,
+                        ctx.context_message_limit,
+                        ctx.agent_keys.public_key(),
+                        &ctx.rest_client,
+                    )
+                    .await
+                }
+                None => fetch_conversation_context(b, &channel_info, &ctx).await,
+            }
         } else {
             None
         };
@@ -2039,6 +2060,7 @@ pub async fn run_prompt_task(
                 conversation_context: conversation_context.as_ref(),
                 conversation_context_had_delivered_events,
                 profile_lookup: profile_lookup.as_ref(),
+                resolved_edit: resolved_edit.as_ref(),
                 has_system_prompt_support: agent.has_system_prompt_support(),
                 base_prompt: standing.base_prompt,
                 system_prompt: standing.system_prompt,
@@ -2862,6 +2884,47 @@ fn conversation_context_delta(
             })
         }
     }
+}
+
+/// Resolve a kind:40003 edit through its original event for reply routing.
+/// Failure deliberately falls back to the edit target id in `format_prompt`.
+async fn resolve_edit_routing(
+    event: &nostr::Event,
+    rest: &RestClient,
+) -> Option<crate::queue::ResolvedEdit> {
+    let target_event_id = crate::queue::edit_target_id(event)?;
+    let target_id = EventId::from_hex(&target_event_id).ok()?;
+    let filter = nostr::Filter::new().id(target_id).limit(1);
+    let response = match timeout(Duration::from_millis(2_000), rest.query(&[filter])).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event fetch failed: {error}");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event fetch timed out");
+            return None;
+        }
+    };
+    let Some(raw) = response.as_array().and_then(|events| events.first()) else {
+        tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event was not returned");
+        return None;
+    };
+    let original = match serde_json::from_value::<nostr::Event>(raw.clone()) {
+        Ok(original) if original.id == target_id && original.verify().is_ok() => original,
+        Ok(_) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: original event failed id/signature verification");
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!(edit_event_id = %event.id, target_event_id, "edit routing: malformed original event: {error}");
+            return None;
+        }
+    };
+    Some(crate::queue::ResolvedEdit {
+        target_event_id,
+        target_thread_tags: crate::queue::parse_thread_tags(&original),
+    })
 }
 
 /// Fetch conversation context (thread or DM) for a batch before prompting.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -698,6 +698,21 @@ impl AgentPool {
         &mut self.task_map
     }
 
+    /// Return whether the current channel task can accept a native steer now.
+    ///
+    /// This is a main-loop preflight for edit enrichment: avoid withholding an
+    /// edit and performing REST work when the task has no steer transport or
+    /// its capacity-one request slot is already occupied. Availability can
+    /// still change while enrichment runs, so callers must retain the normal
+    /// send-time fallback.
+    pub fn native_steer_available(&self, channel_id: Uuid) -> bool {
+        self.task_map
+            .values()
+            .find(|meta| meta.channel_id == Some(channel_id))
+            .and_then(|meta| meta.steer_tx.as_ref())
+            .is_some_and(|tx| !tx.is_closed() && tx.capacity() > 0)
+    }
+
     /// Try to send a goose-native steer request to the in-flight task for
     /// `channel_id`.
     ///

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -170,6 +170,11 @@ pub struct EventQueue {
     /// Reservations absent from this set are still only being prepared and
     /// may be safely released before cancel+merge.
     sent_native_steers: HashMap<Uuid, HashSet<String>>,
+    /// Channels whose prompt task returned while a sent native steer still
+    /// awaits acknowledgement. The acknowledgement is the authority that
+    /// settles delivery, so replacement dispatch must remain fenced until it
+    /// consumes or restores that event.
+    completed_awaiting_native_steer: HashSet<Uuid>,
     /// Duration after which an in-flight channel is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
@@ -195,6 +200,7 @@ impl EventQueue {
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
             sent_native_steers: HashMap::new(),
+            completed_awaiting_native_steer: HashSet::new(),
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
         }
     }
@@ -361,11 +367,20 @@ impl EventQueue {
             }
         };
 
+        // Relay replay delivers stored events newest-first (`ORDER BY
+        // created_at DESC`). Establish chronological order before locating an
+        // edit boundary: partitioning the raw replay deque would otherwise
+        // dispatch a newer ordinary event before an older edit. Stable sort
+        // preserves delivery order for same-second events.
+        let queue = self.queues.entry(channel_id).or_default();
+        queue
+            .make_contiguous()
+            .sort_by_key(|event| event.event.created_at);
+
         // Drain up to MAX_BATCH_EVENTS, but isolate edit events. Edit routing
         // is resolved per dispatched prompt, so allowing an edit to share a
         // batch with a later event would make the later event's reply anchor
         // hide the edit's original-message anchor.
-        let queue = self.queues.entry(channel_id).or_default();
         let max_drain = MAX_BATCH_EVENTS.min(queue.len());
         let drain_count = if queue
             .front()
@@ -379,7 +394,7 @@ impl EventQueue {
                 .position(|event| edit_target_id(&event.event).is_some())
                 .unwrap_or(max_drain)
         };
-        let mut events: Vec<BatchEvent> = queue
+        let events: Vec<BatchEvent> = queue
             .drain(..drain_count)
             .map(|qe| BatchEvent {
                 event: qe.event,
@@ -387,12 +402,6 @@ impl EventQueue {
                 received_at: qe.received_at,
             })
             .collect();
-        // Relay replay delivers stored events newest-first (`ORDER BY
-        // created_at DESC`), but batch consumers — `format_prompt` scope and
-        // reply-anchor selection — require the LAST event to be the newest.
-        // Stable sort: same-second events keep delivery order.
-        events.sort_by_key(|be| be.event.created_at);
-
         // Remove the queue entry if now empty.
         if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {
             self.queues.remove(&channel_id);
@@ -434,6 +443,22 @@ impl EventQueue {
     ///
     /// Also cleans up any already-expired `retry_after` entry.
     pub fn mark_complete(&mut self, channel_id: Uuid) {
+        if self.has_sent_native_steer(channel_id) {
+            // A result can win the main loop's select before the native-steer
+            // watcher posts its ack. Keep this channel in-flight: otherwise a
+            // later queued event can start a replacement turn before a neutral
+            // ack restores the older withheld event.
+            self.completed_awaiting_native_steer.insert(channel_id);
+            return;
+        }
+        self.clear_complete(channel_id);
+    }
+
+    /// Clear a channel after its prompt and every sent native steer have
+    /// settled. Kept private so only `mark_complete` and acknowledgement
+    /// settlement can open the replacement-dispatch gate.
+    fn clear_complete(&mut self, channel_id: Uuid) {
+        self.completed_awaiting_native_steer.remove(&channel_id);
         self.in_flight_channels.remove(&channel_id);
         self.in_flight_deadlines.remove(&channel_id);
         self.in_flight_batch_sizes.remove(&channel_id);
@@ -678,6 +703,7 @@ impl EventQueue {
         self.cancel_reasons.remove(&channel_id);
         self.withheld_native_steer.remove(&channel_id);
         self.sent_native_steers.remove(&channel_id);
+        self.completed_awaiting_native_steer.remove(&channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
@@ -803,6 +829,15 @@ impl EventQueue {
         n
     }
 
+    /// Open a completion fence once the last sent steer has settled.
+    fn settle_sent_native_steer(&mut self, channel_id: Uuid) {
+        if self.completed_awaiting_native_steer.contains(&channel_id)
+            && !self.has_sent_native_steer(channel_id)
+        {
+            self.clear_complete(channel_id);
+        }
+    }
+
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
@@ -833,6 +868,7 @@ impl EventQueue {
         if entries.is_empty() {
             self.withheld_native_steer.remove(&channel_id);
         }
+        self.settle_sent_native_steer(channel_id);
         // Push to FRONT so original `received_at` keeps the event at the head
         // of the channel's queue. Per-channel cap is enforced below in case
         // a flood of events arrived during the ack window.
@@ -873,6 +909,7 @@ impl EventQueue {
                 self.queues.remove(&channel_id);
             }
         }
+        self.settle_sent_native_steer(channel_id);
     }
 
     /// Release every native-steer reservation for `channel_id` to the queue
@@ -883,6 +920,7 @@ impl EventQueue {
             return 0;
         };
         self.sent_native_steers.remove(&channel_id);
+        self.settle_sent_native_steer(channel_id);
         let n = entries.len();
         let queue = self.queues.entry(channel_id).or_default();
         for qe in entries.into_iter().rev() {
@@ -1921,6 +1959,25 @@ mod tests {
         let event = EventBuilder::new(Kind::Custom(9), content)
             .custom_created_at(Timestamp::from(created_at_secs))
             .tags([])
+            .sign_with_keys(&keys)
+            .unwrap();
+        QueuedEvent {
+            channel_id,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "test".into(),
+        }
+    }
+
+    fn make_edit_queued_created_at(
+        channel_id: Uuid,
+        target: &str,
+        created_at_secs: u64,
+    ) -> QueuedEvent {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .custom_created_at(Timestamp::from(created_at_secs))
+            .tags([nostr::Tag::parse(["e", target]).unwrap()])
             .sign_with_keys(&keys)
             .unwrap();
         QueuedEvent {
@@ -4847,6 +4904,83 @@ mod tests {
             &event_id,
             0,
         ));
+    }
+
+    /// Replay arrives newest-first. Chronology must be restored before the
+    /// edit boundary is selected, or the newer ordinary event starts a turn
+    /// before the older edit can recover its original-message routing.
+    #[test]
+    fn replay_orders_before_partitioning_at_edit_boundaries() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let older = make_queued_created_at(ch, "older", 100);
+        let older_id = older.event.id.to_hex();
+        let edit = make_edit_queued_created_at(ch, &"cd".repeat(32), 200);
+        let edit_id = edit.event.id.to_hex();
+        let newer = make_queued_created_at(ch, "newer", 300);
+        let newer_id = newer.event.id.to_hex();
+
+        // Production relay replay order: newest first.
+        q.push(newer);
+        q.push(edit);
+        q.push(older);
+
+        let first = q
+            .flush_next()
+            .expect("older ordinary event dispatches first");
+        assert_eq!(
+            first
+                .events
+                .iter()
+                .map(|event| event.event.id.to_hex())
+                .collect::<Vec<_>>(),
+            vec![older_id],
+        );
+        q.mark_complete(ch);
+        let second = q.flush_next().expect("edit dispatches at its own boundary");
+        assert_eq!(second.events[0].event.id.to_hex(), edit_id);
+        q.mark_complete(ch);
+        let third = q
+            .flush_next()
+            .expect("newer ordinary event remains after edit");
+        assert_eq!(third.events[0].event.id.to_hex(), newer_id);
+    }
+
+    #[test]
+    fn sent_steer_fences_replacement_until_ack_settles() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.push(make_queued(ch, "original turn"));
+        let _original = q.flush_next().expect("initial prompt in flight");
+
+        let steered = make_edit_queued_created_at(ch, &"cd".repeat(32), 100);
+        let steered_id = steered.event.id.to_hex();
+        let replacement = make_queued_created_at(ch, "later replacement", 200);
+        let replacement_id = replacement.event.id.to_hex();
+        q.push(steered);
+        assert!(q.mark_native_steer_pending(ch, &steered_id));
+        q.mark_native_steer_sent(ch, &steered_id);
+        q.push(replacement);
+
+        // Adversarial select schedule: prompt result is processed before the
+        // delayed neutral acknowledgement. It must not start replacement work.
+        q.mark_complete(ch);
+        assert!(q.is_channel_in_flight(ch));
+        assert!(
+            q.flush_next().is_none(),
+            "sent steer fences replacement dispatch"
+        );
+
+        // Neutral acknowledgement restores the older steered event and opens
+        // the fence atomically, so chronological delivery cannot reverse.
+        q.release_native_steer(ch, &steered_id);
+        let restored = q
+            .flush_next()
+            .expect("neutral ack restores the steer first");
+        assert_eq!(restored.events[0].event.id.to_hex(), steered_id);
+        q.mark_complete(ch);
+        let later = q.flush_next().expect("replacement follows settled steer");
+        assert_eq!(later.events[0].event.id.to_hex(), replacement_id);
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -96,6 +96,7 @@ pub struct FlushBatch {
 /// ```text
 /// State:
 ///   queues:               Map<channel_id, VecDeque<QueuedEvent>>  (capped at MAX_PENDING_PER_CHANNEL)
+///   withheld_native_steer: Map<channel_id, Vec<QueuedEvent>>       (native reservations)
 ///   in_flight_channels:   HashSet<Uuid>
 ///   in_flight_deadlines:  Map<channel_id, Instant>                (auto-expire after in_flight_deadline)
 ///   retry_after:          Map<channel_id, Instant>
@@ -106,8 +107,8 @@ pub struct FlushBatch {
 ///   push(event):
 ///     if dedup_mode == Drop AND in_flight_channels.contains(event.channel_id):
 ///       debug log + discard
-///     else if queues[channel].len() >= MAX_PENDING_PER_CHANNEL:
-///       drop oldest (pop_front), warn, push_back new event
+///     else if queued + withheld events for channel reach MAX_PENDING_PER_CHANNEL:
+///       drop oldest queued event, or reject the new event if all slots are withheld
 ///     else:
 ///       queues[event.channel_id].push_back(event)
 ///
@@ -237,17 +238,39 @@ impl EventQueue {
             );
             return false;
         }
-        let queue = self.queues.entry(event.channel_id).or_default();
-        // Enforce per-channel depth cap: drop oldest to make room.
-        if queue.len() >= MAX_PENDING_PER_CHANNEL {
-            queue.pop_front();
-            tracing::warn!(
-                channel_id = %event.channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "queue depth cap reached — dropped oldest event"
-            );
+        let channel_id = event.channel_id;
+        let withheld = self
+            .withheld_native_steer
+            .get(&channel_id)
+            .map_or(0, Vec::len);
+        let queued = self.queues.get(&channel_id).map_or(0, VecDeque::len);
+        // A native-steer reservation owns its event until its asynchronous
+        // attempt resolves, so it counts toward the per-channel cap too.
+        // Never evict a withheld reservation: its completion may still steer.
+        // If every slot is reserved, reject the new event rather than creating
+        // an unbounded preparation task or violating exact-once delivery.
+        if queued + withheld >= MAX_PENDING_PER_CHANNEL {
+            if self
+                .queues
+                .get_mut(&channel_id)
+                .and_then(VecDeque::pop_front)
+                .is_some()
+            {
+                tracing::warn!(
+                    %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "queue depth cap reached — dropped oldest queued event"
+                );
+            } else {
+                tracing::warn!(
+                    %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "queue depth cap reached by native steer reservations — dropped new event"
+                );
+                return false;
+            }
         }
-        queue.push_back(event);
+        self.queues.entry(channel_id).or_default().push_back(event);
         true
     }
 
@@ -4542,6 +4565,26 @@ mod tests {
     /// steer must be invisible to both `flush_next` and `has_flushable_work`.
     /// The withhold is the whole point of the side table — it must close the
     /// `mark_complete` → ack race window.
+    #[test]
+    fn test_native_steer_reservations_count_toward_channel_cap() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        for i in 0..MAX_PENDING_PER_CHANNEL {
+            let qe = make_queued(ch, &format!("reserved-{i}"));
+            let event_id = qe.event.id.to_hex();
+            assert!(q.push(qe));
+            assert!(q.mark_native_steer_pending(ch, &event_id));
+        }
+        assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
+        assert!(
+            !q.push(make_queued(ch, "over-cap")),
+            "all cap slots are reserved, so a new event must not create another preparation"
+        );
+        assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
+        assert!(q.queues.get(&ch).is_none());
+    }
+
     #[test]
     fn test_native_steer_withhold_only_channel_not_flushable() {
         let mut q = EventQueue::new(DedupMode::Queue);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -165,6 +165,11 @@ pub struct EventQueue {
     /// by `flush_next` / `has_flushable_work` (recover, not log-and-drop —
     /// the events were never delivered to the agent).
     withheld_native_steer: HashMap<Uuid, Vec<QueuedEvent>>,
+    /// Event ids whose reserved payload has already been accepted by the
+    /// in-flight task's steer transport and is awaiting its acknowledgement.
+    /// Reservations absent from this set are still only being prepared and
+    /// may be safely released before cancel+merge.
+    sent_native_steers: HashMap<Uuid, HashSet<String>>,
     /// Duration after which an in-flight channel is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
@@ -189,6 +194,7 @@ impl EventQueue {
             cancelled_batches: HashMap::new(),
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
+            sent_native_steers: HashMap::new(),
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
         }
     }
@@ -355,9 +361,24 @@ impl EventQueue {
             }
         };
 
-        // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
+        // Drain up to MAX_BATCH_EVENTS, but isolate edit events. Edit routing
+        // is resolved per dispatched prompt, so allowing an edit to share a
+        // batch with a later event would make the later event's reply anchor
+        // hide the edit's original-message anchor.
         let queue = self.queues.entry(channel_id).or_default();
-        let drain_count = MAX_BATCH_EVENTS.min(queue.len());
+        let max_drain = MAX_BATCH_EVENTS.min(queue.len());
+        let drain_count = if queue
+            .front()
+            .is_some_and(|event| edit_target_id(&event.event).is_some())
+        {
+            1
+        } else {
+            queue
+                .iter()
+                .take(max_drain)
+                .position(|event| edit_target_id(&event.event).is_some())
+                .unwrap_or(max_drain)
+        };
         let mut events: Vec<BatchEvent> = queue
             .drain(..drain_count)
             .map(|qe| BatchEvent {
@@ -656,6 +677,7 @@ impl EventQueue {
         self.cancelled_batches.remove(&channel_id);
         self.cancel_reasons.remove(&channel_id);
         self.withheld_native_steer.remove(&channel_id);
+        self.sent_native_steers.remove(&channel_id);
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
@@ -736,6 +758,51 @@ impl EventQueue {
             .is_some_and(|entries| entries.iter().any(|qe| qe.event.id.to_hex() == event_id))
     }
 
+    /// Mark an existing reservation as accepted by the steer transport.
+    pub fn mark_native_steer_sent(&mut self, channel_id: Uuid, event_id: &str) {
+        if self.has_native_steer_reservation(channel_id, event_id) {
+            self.sent_native_steers
+                .entry(channel_id)
+                .or_default()
+                .insert(event_id.to_string());
+        }
+    }
+
+    /// Return whether this channel has a sent steer awaiting acknowledgement.
+    pub fn has_sent_native_steer(&self, channel_id: Uuid) -> bool {
+        self.sent_native_steers
+            .get(&channel_id)
+            .is_some_and(|ids| !ids.is_empty())
+    }
+
+    /// Release only reservations that are still in asynchronous preparation.
+    /// Sent steers remain withheld until their acknowledgement settles them.
+    pub fn release_native_steer_preparations(&mut self, channel_id: Uuid) -> usize {
+        let sent = self.sent_native_steers.get(&channel_id);
+        let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) else {
+            return 0;
+        };
+        let mut released = Vec::new();
+        let mut i = 0;
+        while i < entries.len() {
+            let event_id = entries[i].event.id.to_hex();
+            if sent.is_some_and(|ids| ids.contains(&event_id)) {
+                i += 1;
+            } else {
+                released.push(entries.remove(i));
+            }
+        }
+        if entries.is_empty() {
+            self.withheld_native_steer.remove(&channel_id);
+        }
+        let n = released.len();
+        let queue = self.queues.entry(channel_id).or_default();
+        for event in released.into_iter().rev() {
+            queue.push_front(event);
+        }
+        n
+    }
+
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
@@ -757,6 +824,12 @@ impl EventQueue {
             return;
         };
         let qe = entries.remove(pos);
+        if let Some(sent) = self.sent_native_steers.get_mut(&channel_id) {
+            sent.remove(event_id);
+            if sent.is_empty() {
+                self.sent_native_steers.remove(&channel_id);
+            }
+        }
         if entries.is_empty() {
             self.withheld_native_steer.remove(&channel_id);
         }
@@ -782,6 +855,12 @@ impl EventQueue {
     /// event has been "delivered" via the non-cancelling path and must not
     /// be redelivered via normal dispatch. Idempotent across both stores.
     pub fn remove_event(&mut self, channel_id: Uuid, event_id: &str) {
+        if let Some(sent) = self.sent_native_steers.get_mut(&channel_id) {
+            sent.remove(event_id);
+            if sent.is_empty() {
+                self.sent_native_steers.remove(&channel_id);
+            }
+        }
         if let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) {
             entries.retain(|qe| qe.event.id.to_hex() != event_id);
             if entries.is_empty() {
@@ -803,6 +882,7 @@ impl EventQueue {
         let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
             return 0;
         };
+        self.sent_native_steers.remove(&channel_id);
         let n = entries.len();
         let queue = self.queues.entry(channel_id).or_default();
         for qe in entries.into_iter().rev() {
@@ -4767,6 +4847,64 @@ mod tests {
             &event_id,
             0,
         ));
+    }
+
+    #[test]
+    fn mixed_batch_stops_before_edit_and_dispatches_edit_separately() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let first = make_queued_at(ch, "first", Duration::from_millis(30));
+        let first_id = first.event.id.to_hex();
+        let edit = edit_event(&"cd".repeat(32));
+        let edit_id = edit.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        let later_id = later.event.id.to_hex();
+        q.push(first);
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event: edit,
+            received_at: Instant::now() - Duration::from_millis(20),
+            prompt_tag: "@mention".into(),
+        });
+        q.push(later);
+
+        let first_batch = q.flush_next().expect("pre-edit event should dispatch");
+        assert_eq!(first_batch.events.len(), 1);
+        assert_eq!(first_batch.events[0].event.id.to_hex(), first_id);
+        q.mark_complete(ch);
+
+        let edit_batch = q.flush_next().expect("edit should dispatch separately");
+        assert_eq!(edit_batch.events.len(), 1);
+        assert_eq!(edit_batch.events[0].event.id.to_hex(), edit_id);
+        q.mark_complete(ch);
+
+        let later_batch = q
+            .flush_next()
+            .expect("post-edit event should remain queued");
+        assert_eq!(later_batch.events.len(), 1);
+        assert_eq!(later_batch.events[0].event.id.to_hex(), later_id);
+    }
+
+    #[test]
+    fn releasing_preparations_does_not_release_sent_steer() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let sent = make_queued_at(ch, "sent", Duration::from_millis(20));
+        let sent_id = sent.event.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        q.push(sent);
+        assert!(q.mark_native_steer_pending(ch, &sent_id));
+        q.mark_native_steer_sent(ch, &sent_id);
+        q.push(later);
+
+        assert_eq!(q.release_native_steer_preparations(ch), 0);
+        assert!(q.has_native_steer_reservation(ch, &sent_id));
+        assert!(q.has_sent_native_steer(ch));
+        q.remove_event(ch, &sent_id);
+        assert!(!q.has_sent_native_steer(ch));
+        let replacement = q.flush_next().expect("only later event should dispatch");
+        assert_eq!(replacement.events.len(), 1);
+        assert_ne!(replacement.events[0].event.id.to_hex(), sent_id);
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1729,6 +1729,21 @@ pub(crate) fn native_steer_framing() -> (&'static str, &'static str) {
     (framing.new_header_single, framing.closing_note)
 }
 
+/// Format the delta delivered through native steering.
+///
+/// Routing and context use the same formatter as ordinary dispatch, while the
+/// native framing remains a concise "weave this into the live turn" envelope.
+pub(crate) fn format_native_steer_prompt(
+    batch: &FlushBatch,
+    args: &FormatPromptArgs<'_>,
+) -> Vec<String> {
+    let (header, closing) = native_steer_framing();
+    let mut sections = format_prompt(batch, args);
+    sections.insert(0, header.to_string());
+    sections.push(closing.to_string());
+    sections
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5052,6 +5067,46 @@ mod tests {
         let edit = edit_event(&original_id);
         let edit_id = edit.id.to_hex();
         let prompt = format_prompt(&one_event_batch(edit), &FormatPromptArgs::default()).join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
+    }
+
+    #[test]
+    fn native_steer_edit_uses_original_thread_anchor() {
+        let original_id = "66".repeat(32);
+        let root_id = "77".repeat(32);
+        let batch = one_event_batch(edit_event(&original_id));
+        let edit_id = batch.events[0].event.id.to_hex();
+        let prompt = format_native_steer_prompt(
+            &batch,
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id,
+                    target_thread_tags: ThreadTags {
+                        root_event_id: Some(root_id.clone()),
+                        parent_event_id: Some("88".repeat(32)),
+                        mentioned_pubkeys: vec![],
+                    },
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+
+        assert!(prompt.contains(&format!("--reply-to {root_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
+        let (header, closing) = native_steer_framing();
+        assert!(prompt.contains(header));
+        assert!(prompt.contains(closing));
+    }
+
+    #[test]
+    fn native_steer_edit_fetch_failure_anchors_target_never_auxiliary_event() {
+        let original_id = "99".repeat(32);
+        let batch = one_event_batch(edit_event(&original_id));
+        let edit_id = batch.events[0].event.id.to_hex();
+        let prompt = format_native_steer_prompt(&batch, &FormatPromptArgs::default()).join("\n");
+
         assert!(prompt.contains(&format!("--reply-to {original_id}")));
         assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
     }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -4582,7 +4582,7 @@ mod tests {
             "all cap slots are reserved, so a new event must not create another preparation"
         );
         assert_eq!(q.withheld_native_steer[&ch].len(), MAX_PENDING_PER_CHANNEL);
-        assert!(q.queues.get(&ch).is_none());
+        assert!(!q.queues.contains_key(&ch));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -851,6 +851,23 @@ pub struct ThreadTags {
 /// NOTE: Only handles NIP-10 marker-based format (preferred). The deprecated
 /// positional format (no markers, `["e", id, relay_url]`) is not supported —
 /// Buzz always generates marker-based tags (see relay messages.rs:762-783).
+/// Return the original message id targeted by a kind:40003 edit event.
+///
+/// Edit events deliberately use a bare two-element `e` tag; this is not the
+/// deprecated positional NIP-10 thread format and must not be accepted by
+/// [`parse_thread_tags`] for other event kinds.
+pub fn edit_target_id(event: &Event) -> Option<String> {
+    (event.kind.as_u16() == 40003)
+        .then(|| {
+            event.tags.iter().find_map(|tag| {
+                let parts = tag.as_slice();
+                (parts.len() == 2 && parts.first().map(String::as_str) == Some("e"))
+                    .then(|| parts[1].clone())
+            })
+        })
+        .flatten()
+}
+
 pub fn parse_thread_tags(event: &Event) -> ThreadTags {
     let mut root = None;
     let mut reply = None;
@@ -1363,6 +1380,13 @@ fn format_conversation_context(
     s
 }
 
+/// Original-message routing recovered for a kind:40003 edit event.
+#[derive(Debug, Clone)]
+pub struct ResolvedEdit {
+    pub target_event_id: String,
+    pub target_thread_tags: ThreadTags,
+}
+
 /// Arguments for [`format_prompt`] beyond the required [`FlushBatch`].
 #[derive(Default)]
 pub struct FormatPromptArgs<'a> {
@@ -1373,6 +1397,10 @@ pub struct FormatPromptArgs<'a> {
     /// live session had already received. Trigger-only context does not set it.
     pub conversation_context_had_delivered_events: bool,
     pub profile_lookup: Option<&'a PromptProfileLookup>,
+    /// Routing derived by resolving a kind:40003 edit target. When present,
+    /// prompt scope and reply instructions use the original message rather
+    /// than the invisible edit auxiliary event.
+    pub resolved_edit: Option<&'a ResolvedEdit>,
     /// When true, base_prompt and system_prompt are delivered via the system
     /// role (session/new) and omitted from the user message. When false
     /// (legacy agents), they are injected as `[Base]` and `[System]` sections.
@@ -1486,7 +1514,17 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
             return Vec::new();
         }
     };
-    let thread_tags = parse_thread_tags(&last_event.event);
+    let edit_target = edit_target_id(&last_event.event);
+    let resolved_edit = args.resolved_edit.filter(|_| edit_target.is_some());
+    // An edit's own bare `e` tag is not a thread tag. Route via the original
+    // message when it was fetched, or its target id as the safe fallback.
+    let thread_tags = resolved_edit
+        .map(|edit| edit.target_thread_tags.clone())
+        .unwrap_or_else(|| parse_thread_tags(&last_event.event));
+    let routing_event_id = resolved_edit
+        .map(|edit| edit.target_event_id.clone())
+        .or(edit_target.clone())
+        .unwrap_or_else(|| last_event.event.id.to_hex());
     let is_dm = args
         .channel_info
         .map(|ci| ci.channel_type == "dm")
@@ -1524,12 +1562,12 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         thread_tags
             .root_event_id
             .is_some()
-            .then(|| last_event.event.id.to_hex())
+            .then(|| routing_event_id.to_string())
     } else {
         resolve_reply_anchor(
             &sender_pubkey,
             &thread_tags,
-            &last_event.event.id.to_hex(),
+            &routing_event_id,
             args.profile_lookup,
         )
     };
@@ -1542,6 +1580,16 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         args.conversation_context_had_delivered_events,
         reply_anchor.as_deref(),
     ));
+    if let Some(edit) = resolved_edit {
+        sections.push(format!(
+            "[Edit routing]\nTrigger is a kind:40003 edit event; original message ID: {}",
+            edit.target_event_id
+        ));
+    } else if let Some(target_id) = edit_target {
+        sections.push(format!(
+            "[Edit routing]\nTrigger is a kind:40003 edit event; original message ID: {target_id} (original event fetch failed; using target as reply anchor)"
+        ));
+    }
 
     // 3. Conversation context (thread or DM).
     if let Some(ctx) = args.conversation_context {
@@ -4934,6 +4982,78 @@ mod tests {
             q.in_flight_channels.contains(&ch),
             "ch must still be in-flight after has_flushable_work finds ch2 work"
         );
+    }
+
+    fn edit_event(target: &str) -> Event {
+        let keys = Keys::generate();
+        EventBuilder::new(Kind::Custom(40003), "edited mention")
+            .tags([nostr::Tag::parse(["e", target]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    fn one_event_batch(event: Event) -> FlushBatch {
+        FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
+
+    #[test]
+    fn edit_of_top_level_anchors_original_message_in_rendered_prompt() {
+        let original_id = "11".repeat(32);
+        let edit = edit_event(&original_id);
+        let prompt = format_prompt(
+            &one_event_batch(edit),
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id.clone(),
+                    target_thread_tags: ThreadTags::default(),
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(prompt.contains(&format!("original message ID: {original_id}")));
+    }
+
+    #[test]
+    fn edit_of_threaded_reply_anchors_original_thread_root_in_rendered_prompt() {
+        let original_id = "22".repeat(32);
+        let root_id = "33".repeat(32);
+        let prompt = format_prompt(
+            &one_event_batch(edit_event(&original_id)),
+            &FormatPromptArgs {
+                resolved_edit: Some(&ResolvedEdit {
+                    target_event_id: original_id,
+                    target_thread_tags: ThreadTags {
+                        root_event_id: Some(root_id.clone()),
+                        parent_event_id: Some("44".repeat(32)),
+                        mentioned_pubkeys: vec![],
+                    },
+                }),
+                ..Default::default()
+            },
+        )
+        .join("\n");
+        assert!(prompt.contains(&format!("--reply-to {root_id}")));
+    }
+
+    #[test]
+    fn edit_fetch_failure_anchors_target_never_auxiliary_edit_event() {
+        let original_id = "55".repeat(32);
+        let edit = edit_event(&original_id);
+        let edit_id = edit.id.to_hex();
+        let prompt = format_prompt(&one_event_batch(edit), &FormatPromptArgs::default()).join("\n");
+        assert!(prompt.contains(&format!("--reply-to {original_id}")));
+        assert!(!prompt.contains(&format!("--reply-to {edit_id}")));
     }
 
     // ── F2 case 2.5: steer renewal is monotonic across repeated steers ───────

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -796,6 +796,29 @@ impl EventQueue {
         }
     }
 
+    /// Release every native-steer reservation for `channel_id` to the queue
+    /// front, preserving original FIFO order. Detached edit preparation then
+    /// observes its missing reservation and discards the stale completion.
+    pub fn release_native_steers(&mut self, channel_id: Uuid) -> usize {
+        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+            return 0;
+        };
+        let n = entries.len();
+        let queue = self.queues.entry(channel_id).or_default();
+        for qe in entries.into_iter().rev() {
+            queue.push_front(qe);
+        }
+        while queue.len() > MAX_PENDING_PER_CHANNEL {
+            queue.pop_back();
+            tracing::warn!(
+                channel_id = %channel_id,
+                limit = MAX_PENDING_PER_CHANNEL,
+                "withheld-steer release overflow — dropped newest event to enforce cap"
+            );
+        }
+        n
+    }
+
     /// Bulk-release every withheld event for `channel_id` back to the queue
     /// front, preserving relative FIFO order.
     ///
@@ -810,21 +833,9 @@ impl EventQueue {
     /// composes to original-FIFO order at the queue front (same discipline
     /// as `requeue_preserve_timestamps` at line 453).
     fn recover_withheld_for_expired_channel(&mut self, channel_id: Uuid) {
-        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+        let n = self.release_native_steers(channel_id);
+        if n == 0 {
             return;
-        };
-        let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
-        for qe in entries.into_iter().rev() {
-            queue.push_front(qe);
-        }
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "withheld-steer recovery overflow — dropped newest event to enforce cap"
-            );
         }
         tracing::warn!(
             channel_id = %channel_id,
@@ -4756,6 +4767,32 @@ mod tests {
             &event_id,
             0,
         ));
+    }
+
+    #[test]
+    fn releasing_pending_preparation_restores_fifo_ahead_of_later_event() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let edit = make_queued_at(ch, "edit", Duration::from_millis(20));
+        let edit_id = edit.event.id.to_hex();
+        let later = make_queued_at(ch, "later", Duration::from_millis(10));
+        let later_id = later.event.id.to_hex();
+        q.push(edit);
+        assert!(q.mark_native_steer_pending(ch, &edit_id));
+        q.push(later);
+
+        // A later event triggers cancel+merge. Releasing the pending edit first
+        // makes both events visible to the next flush in original arrival order;
+        // the detached preparation will be stale because its reservation is gone.
+        assert_eq!(q.release_native_steers(ch), 1);
+        assert!(!q.has_native_steer_reservation(ch, &edit_id));
+        let replacement = q.flush_next().expect("both events should dispatch");
+        let ids: Vec<_> = replacement
+            .events
+            .iter()
+            .map(|event| event.event.id.to_hex())
+            .collect();
+        assert_eq!(ids, vec![edit_id, later_id]);
     }
 
     /// Bulk-release on expiry must preserve original FIFO. The

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5118,9 +5118,12 @@ mod tests {
         assert!(q.mark_native_steer_pending(ch, &event_id));
         q.drain_channel(ch);
         let removed_channels = HashSet::from([ch]);
+        let membership_generations = HashMap::new();
         assert!(crate::native_steer_preparation_is_stale(
             &removed_channels,
-            ch
+            &membership_generations,
+            ch,
+            0,
         ));
 
         // A late preparation is discarded by the main loop. Its reservation
@@ -5128,6 +5131,27 @@ mod tests {
         q.release_native_steer(ch, &event_id);
         q.mark_complete(ch);
         assert!(q.flush_next().is_none());
+    }
+
+    #[test]
+    fn removed_then_readded_channel_discards_late_async_edit_preparation() {
+        let ch = Uuid::new_v4();
+        // Preparation was reserved during the original membership period.
+        let prepared_generation = 0;
+        let mut membership_generations = HashMap::from([(ch, prepared_generation)]);
+        let mut removed_channels = HashSet::from([ch]);
+
+        // Re-add makes the channel usable again but must not validate work
+        // which was prepared before the intervening removal.
+        removed_channels.remove(&ch);
+        *membership_generations.get_mut(&ch).unwrap() += 1;
+
+        assert!(crate::native_steer_preparation_is_stale(
+            &removed_channels,
+            &membership_generations,
+            ch,
+            prepared_generation,
+        ));
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -718,6 +718,17 @@ impl EventQueue {
         true
     }
 
+    /// Return whether this exact event still owns a native-steer reservation.
+    ///
+    /// Async edit preparation uses this at completion time: deadline recovery,
+    /// membership removal, or any other reservation settlement removes the
+    /// entry, so a late preparation cannot steer a replacement turn.
+    pub fn has_native_steer_reservation(&self, channel_id: Uuid, event_id: &str) -> bool {
+        self.withheld_native_steer
+            .get(&channel_id)
+            .is_some_and(|entries| entries.iter().any(|qe| qe.event.id.to_hex() == event_id))
+    }
+
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
@@ -4705,6 +4716,37 @@ mod tests {
         assert_eq!(batch.events[0].event.id.to_hex(), event_id);
     }
 
+    #[test]
+    fn recovered_reservation_invalidates_late_native_steer_preparation() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let qe = make_queued(ch, "prepared edit");
+        let event_id = qe.event.id.to_hex();
+        q.push(qe);
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.in_flight_batch_sizes.insert(ch, 1);
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+
+        // Deadline recovery releases the reservation and normal dispatch takes
+        // the edit into a replacement turn.
+        let replacement = q.flush_next().expect("recovered edit should dispatch");
+        assert_eq!(replacement.events.len(), 1);
+        assert_eq!(replacement.events[0].event.id.to_hex(), event_id);
+
+        // The detached enrichment completion from the expired turn must not be
+        // allowed to steer that replacement turn with the same edit again.
+        assert!(crate::native_steer_preparation_is_stale(
+            &q,
+            &HashSet::new(),
+            &HashMap::new(),
+            ch,
+            &event_id,
+            0,
+        ));
+    }
+
     /// Bulk-release on expiry must preserve original FIFO. The
     /// implementation iterates the side-table entries in reverse and
     /// `push_front`s each — composing to original-FIFO at the queue front.
@@ -5163,9 +5205,11 @@ mod tests {
         let removed_channels = HashSet::from([ch]);
         let membership_generations = HashMap::new();
         assert!(crate::native_steer_preparation_is_stale(
+            &q,
             &removed_channels,
             &membership_generations,
             ch,
+            &event_id,
             0,
         ));
 
@@ -5179,6 +5223,8 @@ mod tests {
     #[test]
     fn removed_then_readded_channel_discards_late_async_edit_preparation() {
         let ch = Uuid::new_v4();
+        let event_id = "ab".repeat(32);
+        let q = EventQueue::new(DedupMode::Queue);
         // Preparation was reserved during the original membership period.
         let prepared_generation = 0;
         let mut membership_generations = HashMap::from([(ch, prepared_generation)]);
@@ -5190,9 +5236,11 @@ mod tests {
         *membership_generations.get_mut(&ch).unwrap() += 1;
 
         assert!(crate::native_steer_preparation_is_stale(
+            &q,
             &removed_channels,
             &membership_generations,
             ch,
+            &event_id,
             prepared_generation,
         ));
     }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -718,6 +718,13 @@ impl EventQueue {
         true
     }
 
+    /// Return whether this channel has any native-steer reservation in flight.
+    pub fn has_native_steer_reservations(&self, channel_id: Uuid) -> bool {
+        self.withheld_native_steer
+            .get(&channel_id)
+            .is_some_and(|entries| !entries.is_empty())
+    }
+
     /// Return whether this exact event still owns a native-steer reservation.
     ///
     /// Async edit preparation uses this at completion time: deadline recovery,
@@ -4688,6 +4695,8 @@ mod tests {
         q.in_flight_deadlines.insert(ch, Instant::now());
         q.in_flight_batch_sizes.insert(ch, 1);
         assert!(q.mark_native_steer_pending(ch, &event_id));
+        assert!(q.has_native_steer_reservations(ch));
+        assert!(q.has_native_steer_reservation(ch, &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
         // steer ack never arriving and the read loop hanging long enough
@@ -4705,6 +4714,8 @@ mod tests {
 
         // The withheld event has been moved back to `queues[ch]`.
         assert!(q.withheld_native_steer.is_empty());
+        assert!(!q.has_native_steer_reservations(ch));
+        assert!(!q.has_native_steer_reservation(ch, &event_id));
         assert_eq!(pending_count(&q), 1);
 
         // Normal dispatch delivers it.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5072,6 +5072,34 @@ mod tests {
     }
 
     #[test]
+    fn async_edit_steer_reservation_prevents_normal_redispatch() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let event = edit_event(&"aa".repeat(32));
+        let event_id = event.id.to_hex();
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "@mention".into(),
+        });
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() + Duration::from_secs(60));
+
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+        q.mark_complete(ch);
+        assert!(
+            q.flush_next().is_none(),
+            "reserved edit must not redispatch"
+        );
+
+        q.release_native_steer(ch, &event_id);
+        let batch = q.flush_next().expect("failed preparation restores edit");
+        assert_eq!(batch.events[0].event.id.to_hex(), event_id);
+    }
+
+    #[test]
     fn native_steer_edit_uses_original_thread_anchor() {
         let original_id = "66".repeat(32);
         let root_id = "77".repeat(32);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -5100,6 +5100,37 @@ mod tests {
     }
 
     #[test]
+    fn removed_channel_discards_late_async_edit_steer_preparation() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let event = edit_event(&"ab".repeat(32));
+        let event_id = event.id.to_hex();
+        q.push(QueuedEvent {
+            channel_id: ch,
+            event,
+            received_at: Instant::now(),
+            prompt_tag: "@mention".into(),
+        });
+        q.in_flight_channels.insert(ch);
+        q.in_flight_deadlines
+            .insert(ch, Instant::now() + Duration::from_secs(60));
+
+        assert!(q.mark_native_steer_pending(ch, &event_id));
+        q.drain_channel(ch);
+        let removed_channels = HashSet::from([ch]);
+        assert!(crate::native_steer_preparation_is_stale(
+            &removed_channels,
+            ch
+        ));
+
+        // A late preparation is discarded by the main loop. Its reservation
+        // was already drained, so release cannot resurrect stale work.
+        q.release_native_steer(ch, &event_id);
+        q.mark_complete(ch);
+        assert!(q.flush_next().is_none());
+    }
+
+    #[test]
     fn native_steer_edit_uses_original_thread_anchor() {
         let original_id = "66".repeat(32);
         let root_id = "77".repeat(32);

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -37,7 +37,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_STREAM_MESSAGE_EDIT, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use nostr::EventId;
 use serde::{Deserialize, Serialize};
@@ -410,7 +410,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         }
 
         // Ignore non-message kinds (relay housekeeping, etc.).
-        if kind_u32 != KIND_STREAM_MESSAGE && kind_u32 != KIND_WORKFLOW_APPROVAL_REQUESTED {
+        if !is_setup_nudge_kind(kind_u32) {
             continue;
         }
 
@@ -512,6 +512,13 @@ pub(crate) fn should_nudge_for_event(
     true
 }
 
+fn is_setup_nudge_kind(kind: u32) -> bool {
+    matches!(
+        kind,
+        KIND_STREAM_MESSAGE | KIND_STREAM_MESSAGE_EDIT | KIND_WORKFLOW_APPROVAL_REQUESTED
+    )
+}
+
 /// Build the subscription rules used in setup mode.
 ///
 /// Always uses "mentions" mode: setup mode must not react to every event.
@@ -524,7 +531,7 @@ fn build_setup_subscription_rules(config: &Config) -> Vec<filter::SubscriptionRu
     let kinds = config
         .kinds_override
         .clone()
-        .unwrap_or_else(|| vec![KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED]);
+        .unwrap_or_else(crate::config::default_mention_kinds);
 
     match &config.subscribe_mode {
         // Config mode: load the actual rules, but they will be filtered by
@@ -697,6 +704,18 @@ mod tests {
             payload.requirements.as_slice(),
             [RequirementPayload::GitBash]
         ));
+    }
+
+    #[test]
+    fn setup_listener_defaults_include_newly_mentioned_message_edits() {
+        assert!(
+            crate::config::default_mention_kinds().contains(&KIND_STREAM_MESSAGE_EDIT),
+            "setup listener shares the normal actionable-mention defaults"
+        );
+        assert!(
+            is_setup_nudge_kind(KIND_STREAM_MESSAGE_EDIT),
+            "setup listener must process a delivered mention edit"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -638,6 +638,46 @@ fn setup_nudge_thread_ref(target_event_id: &str) -> Result<buzz_sdk::ThreadRef> 
     })
 }
 
+/// Resolve the flat reply anchor for a setup-mode nudge. This is the exact
+/// routing seam used by [`publish_setup_nudge`]; `original` is `None` only
+/// when the bounded relay fetch for a kind:40003 edit failed.
+fn setup_nudge_anchor(triggering_event: &nostr::Event, original: Option<&nostr::Event>) -> String {
+    match crate::queue::edit_target_id(triggering_event) {
+        Some(target) => original
+            .and_then(|event| crate::queue::parse_thread_tags(event).root_event_id)
+            .unwrap_or(target),
+        None => crate::queue::parse_thread_tags(triggering_event)
+            .root_event_id
+            .unwrap_or_else(|| triggering_event.id.to_hex()),
+    }
+}
+
+/// Build the signed setup nudge event at the supplied resolved anchor.
+/// Kept separate so the production path and output tests share event building.
+fn build_setup_nudge_event(
+    keys: &nostr::Keys,
+    channel_id: Uuid,
+    triggering_event: &nostr::Event,
+    payload: &SetupPayload,
+    anchor_event_id: &str,
+) -> Result<nostr::Event> {
+    let thread_ref = Some(setup_nudge_thread_ref(anchor_event_id)?);
+    let body = payload.nudge_body();
+    let author_hex = triggering_event.pubkey.to_hex();
+    let event_builder = buzz_sdk::build_message(
+        channel_id,
+        &body,
+        thread_ref.as_ref(),
+        &[&author_hex],
+        false,
+        &[],
+    )
+    .map_err(|e| anyhow::anyhow!("failed to build setup nudge: {e}"))?;
+    event_builder
+        .sign_with_keys(keys)
+        .map_err(|e| anyhow::anyhow!("failed to sign setup nudge: {e}"))
+}
+
 /// Build and publish a setup nudge reply to the triggering event.
 ///
 /// Threading: flat reply to the thread root if one exists; otherwise reply
@@ -650,49 +690,26 @@ async fn publish_setup_nudge(
     triggering_event: &nostr::Event,
     payload: &SetupPayload,
 ) -> Result<()> {
-    let edit_target = crate::queue::edit_target_id(triggering_event);
-    let target_event_id = match edit_target.as_deref() {
-        Some(target) => match fetch_edit_original(target, rest_client).await {
-            Some(original) => {
-                let thread_tags = crate::queue::parse_thread_tags(&original);
-                thread_tags
-                    .root_event_id
-                    .unwrap_or_else(|| target.to_string())
-            }
-            None => {
-                tracing::warn!(edit_event_id = %triggering_event.id, target_event_id = target,
-                    "setup-mode: original edit target unavailable; using target as nudge anchor");
-                target.to_string()
-            }
-        },
-        None => crate::queue::parse_thread_tags(triggering_event)
-            .root_event_id
-            .unwrap_or_else(|| triggering_event.id.to_hex()),
+    let original = match crate::queue::edit_target_id(triggering_event) {
+        Some(target) => fetch_edit_original(&target, rest_client).await,
+        None => None,
     };
-    let thread_ref = Some(setup_nudge_thread_ref(&target_event_id)?);
-
-    let body = payload.nudge_body();
-    let author_hex = triggering_event.pubkey.to_hex();
-
-    let event_builder = buzz_sdk::build_message(
+    let anchor_event_id = setup_nudge_anchor(triggering_event, original.as_ref());
+    if crate::queue::edit_target_id(triggering_event).is_some() && original.is_none() {
+        tracing::warn!(edit_event_id = %triggering_event.id, anchor_event_id,
+            "setup-mode: original edit target unavailable; using target as nudge anchor");
+    }
+    let signed = build_setup_nudge_event(
+        keys,
         channel_id,
-        &body,
-        thread_ref.as_ref(),
-        &[&author_hex], // p-tag the asker
-        false,
-        &[],
-    )
-    .map_err(|e| anyhow::anyhow!("failed to build setup nudge: {e}"))?;
-
-    let signed = event_builder
-        .sign_with_keys(keys)
-        .map_err(|e| anyhow::anyhow!("failed to sign setup nudge: {e}"))?;
-
+        triggering_event,
+        payload,
+        &anchor_event_id,
+    )?;
     publisher
         .publish_event(signed)
         .await
         .map_err(|e| anyhow::anyhow!("failed to publish setup nudge: {e}"))?;
-
     Ok(())
 }
 
@@ -1056,12 +1073,85 @@ mod tests {
     // nudge. They use the extracted `should_nudge_for_event` helper, which is
     // the exact code the live loop calls.
 
+    fn setup_test_payload() -> SetupPayload {
+        SetupPayload {
+            agent_name: "Fizz".into(),
+            agent_pubkey: "agent".into(),
+            requirements: vec![],
+        }
+    }
+
+    fn setup_edit(target: &str) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        nostr::EventBuilder::new(
+            nostr::Kind::Custom(KIND_STREAM_MESSAGE_EDIT as u16),
+            "edited",
+        )
+        .tags([nostr::Tag::parse(["e", target]).unwrap()])
+        .sign_with_keys(&keys)
+        .unwrap()
+    }
+
+    fn setup_original_threaded(root: &str) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "original")
+            .tags([nostr::Tag::parse(["e", root, "", "reply"]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    fn nudge_e_tags(event: &nostr::Event) -> Vec<Vec<String>> {
+        event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .filter(|tag| tag[0] == "e")
+            .collect()
+    }
+
     #[test]
-    fn setup_nudge_edit_fallback_anchors_edit_target_not_edit_event() {
-        let target = "66".repeat(32);
-        let thread_ref = setup_nudge_thread_ref(&target).unwrap();
-        assert_eq!(thread_ref.root_event_id.to_hex(), target);
-        assert_eq!(thread_ref.parent_event_id.to_hex(), target);
+    fn setup_nudge_edit_threaded_original_builds_at_original_root() {
+        let original_id = "66".repeat(32);
+        let root_id = "77".repeat(32);
+        let edit = setup_edit(&original_id);
+        let original = setup_original_threaded(&root_id);
+        let anchor = setup_nudge_anchor(&edit, Some(&original));
+        let nudge = build_setup_nudge_event(
+            &nostr::Keys::generate(),
+            Uuid::new_v4(),
+            &edit,
+            &setup_test_payload(),
+            &anchor,
+        )
+        .unwrap();
+        assert_eq!(anchor, root_id);
+        assert_eq!(
+            nudge_e_tags(&nudge),
+            vec![vec!["e".into(), root_id, "".into(), "reply".into()]]
+        );
+    }
+
+    #[test]
+    fn setup_nudge_edit_fetch_failure_builds_at_target_never_edit_event() {
+        let target_id = "88".repeat(32);
+        let edit = setup_edit(&target_id);
+        let edit_id = edit.id.to_hex();
+        let anchor = setup_nudge_anchor(&edit, None);
+        let nudge = build_setup_nudge_event(
+            &nostr::Keys::generate(),
+            Uuid::new_v4(),
+            &edit,
+            &setup_test_payload(),
+            &anchor,
+        )
+        .unwrap();
+        assert_eq!(anchor, target_id);
+        let e_tags = nudge_e_tags(&nudge);
+        assert_eq!(
+            e_tags,
+            vec![vec!["e".into(), target_id, "".into(), "reply".into()]]
+        );
+        assert_ne!(e_tags[0][1], edit_id);
     }
 
     fn fake_event_id(byte: u8) -> EventId {

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -464,6 +464,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         if let Err(e) = publish_setup_nudge(
             &publisher,
             &config.keys,
+            &rest_client,
             buzz_event.channel_id,
             &buzz_event.event,
             &payload,
@@ -595,6 +596,48 @@ async fn handle_setup_membership(
     }
 }
 
+/// Fetch and verify the original event targeted by a kind:40003 edit.
+async fn fetch_edit_original(
+    target_event_id: &str,
+    rest_client: &crate::relay::RestClient,
+) -> Option<nostr::Event> {
+    use std::time::Duration;
+
+    let target_id = nostr::EventId::from_hex(target_event_id).ok()?;
+    let filter = nostr::Filter::new().id(target_id).limit(1);
+    let response = match tokio::time::timeout(
+        Duration::from_millis(2_000),
+        rest_client.query(&[filter]),
+    )
+    .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            tracing::warn!(
+                target_event_id,
+                "setup-mode: edit original fetch failed: {error}"
+            );
+            return None;
+        }
+        Err(_) => return None,
+    };
+    let raw = response.as_array()?.first()?;
+    match serde_json::from_value::<nostr::Event>(raw.clone()) {
+        Ok(event) if event.id == target_id && event.verify().is_ok() => Some(event),
+        _ => None,
+    }
+}
+
+/// Construct the flat thread reference used by a setup nudge.
+fn setup_nudge_thread_ref(target_event_id: &str) -> Result<buzz_sdk::ThreadRef> {
+    let target_id = nostr::EventId::from_hex(target_event_id)
+        .map_err(|e| anyhow::anyhow!("invalid nudge anchor event id: {e}"))?;
+    Ok(buzz_sdk::ThreadRef {
+        root_event_id: target_id,
+        parent_event_id: target_id,
+    })
+}
+
 /// Build and publish a setup nudge reply to the triggering event.
 ///
 /// Threading: flat reply to the thread root if one exists; otherwise reply
@@ -602,30 +645,31 @@ async fn handle_setup_membership(
 async fn publish_setup_nudge(
     publisher: &RelayEventPublisher,
     keys: &nostr::Keys,
+    rest_client: &crate::relay::RestClient,
     channel_id: Uuid,
     triggering_event: &nostr::Event,
     payload: &SetupPayload,
 ) -> Result<()> {
-    use buzz_sdk::ThreadRef;
-
-    // Parse NIP-10 thread tags to determine reply target.
-    let thread_tags = crate::queue::parse_thread_tags(triggering_event);
-
-    let thread_ref = if let Some(root_str) = &thread_tags.root_event_id {
-        // Threaded event: reply flat to the root.
-        let root_id = nostr::EventId::from_hex(root_str)
-            .map_err(|e| anyhow::anyhow!("invalid root event id: {e}"))?;
-        Some(ThreadRef {
-            root_event_id: root_id,
-            parent_event_id: root_id,
-        })
-    } else {
-        // Top-level event: reply to the triggering event.
-        Some(ThreadRef {
-            root_event_id: triggering_event.id,
-            parent_event_id: triggering_event.id,
-        })
+    let edit_target = crate::queue::edit_target_id(triggering_event);
+    let target_event_id = match edit_target.as_deref() {
+        Some(target) => match fetch_edit_original(target, rest_client).await {
+            Some(original) => {
+                let thread_tags = crate::queue::parse_thread_tags(&original);
+                thread_tags
+                    .root_event_id
+                    .unwrap_or_else(|| target.to_string())
+            }
+            None => {
+                tracing::warn!(edit_event_id = %triggering_event.id, target_event_id = target,
+                    "setup-mode: original edit target unavailable; using target as nudge anchor");
+                target.to_string()
+            }
+        },
+        None => crate::queue::parse_thread_tags(triggering_event)
+            .root_event_id
+            .unwrap_or_else(|| triggering_event.id.to_hex()),
     };
+    let thread_ref = Some(setup_nudge_thread_ref(&target_event_id)?);
 
     let body = payload.nudge_body();
     let author_hex = triggering_event.pubkey.to_hex();
@@ -1011,6 +1055,14 @@ mod tests {
     // (a) non-allowlisted author → no nudge, (b) same event-id → exactly one
     // nudge. They use the extracted `should_nudge_for_event` helper, which is
     // the exact code the live loop calls.
+
+    #[test]
+    fn setup_nudge_edit_fallback_anchors_edit_target_not_edit_event() {
+        let target = "66".repeat(32);
+        let thread_ref = setup_nudge_thread_ref(&target).unwrap();
+        assert_eq!(thread_ref.root_event_id.to_hex(), target);
+        assert_eq!(thread_ref.parent_event_id.to_hex(), target);
+    }
 
     fn fake_event_id(byte: u8) -> EventId {
         EventId::from_byte_array([byte; 32])


### PR DESCRIPTION
## Summary

- Preserve original-message routing for edits that add agent mentions.
- Serialize queued native steer preparation and fallback handling, including membership invalidation and acknowledgement fencing.

### Related issue

N/A

### Testing

- `cargo test -p buzz-acp` — 758 unit + 9 integration passed on `a3f356cb28007c7696c51b368659f4b39930efc9`
- `cargo clippy -p buzz-acp -- -D warnings`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`

The required pre-push hook was run once and blocked publication only because the unrelated full mobile suite had four existing failures in channel/search tests; none of those files are changed by this branch. The approved exact head was then pushed unchanged.
