### PR TITLE
fix(cli): channels get exits non-zero on unknown channel instead of printing null

### DIFF
--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -230,14 +230,15 @@ pub async fn cmd_get_channel(client: &BuzzClient, channel_id: &str) -> Result<()
     });
     let resp = client.query(&filter).await?;
     let events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
-    if let Some(e) = events.first() {
-        let mut normalized = extract_channel_metadata(e);
-        normalized["pubkey"] =
-            serde_json::json!(e.get("pubkey").and_then(|v| v.as_str()).unwrap_or(""));
-        println!("{normalized}");
-    } else {
-        println!("null");
-    }
+    let Some(e) = events.first() else {
+        return Err(CliError::NotFound(format!(
+            "channel '{channel_id}' not found"
+        )));
+    };
+    let mut normalized = extract_channel_metadata(e);
+    normalized["pubkey"] =
+        serde_json::json!(e.get("pubkey").and_then(|v| v.as_str()).unwrap_or(""));
+    println!("{normalized}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`buzz channels get --channel <id>` for a channel that doesn't exist prints the literal string `null` to stdout and exits `0` — indistinguishable from success for any script or agent automation that checks exit codes. We hit this in agent tooling where a typo'd channel UUID sailed through a pipeline as "success".

Minimal fix in `cmd_get_channel`: empty relay response now returns `CliError::NotFound("channel '<id>' not found")` — the same not-found convention the CLI already uses elsewhere (`mem get`, `projects get`, team lookup in this same file) — so it prints an error to stderr and exits `1`.

### Related issue

N/A — none found (searched issues/PRs for `channels get` null/exit-code).

### Testing

- `cargo test -p buzz-cli`: **343 passed, 0 failed** (Linux x86_64, rust:1-bookworm).
- No new unit test: `cmd_get_channel` calls the live client directly and the file has no mock-relay infrastructure for async command paths; happy to add one if you'd prefer wiremock-style coverage.
- Manual before/after semantics: before — stdout `null`, exit 0; after — stderr `error: channel '00000000-0000-0000-0000-000000000000' not found`, exit 1.

Signed-off-by: obbax <robinniclasandersson@gmail.com>