### PR TITLE
docs(acp): add a Subscription Scope section to the configuration reference

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -178,6 +178,29 @@ buzz-acp --respond-to anyone
 buzz-acp --respond-to nobody --heartbeat-interval 300
 ```
 
+### Subscription Scope
+
+The author gate above decides **whose** events reach the agent. These settings decide **which channels** are watched and **what opens a turn** once an event gets through.
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--subscribe` | `BUZZ_ACP_SUBSCRIBE` | `mentions` | `mentions`: the kinds below, and the event must mention this agent. `all`: no mention required, and no kind restriction unless `--kinds` is set. `config`: use the subscription rules from the `--config` file (default `./buzz-acp.toml`). Both `mentions` and `all` cover the agent's member channels, subject to `--channels`. |
+| `--channels` | `BUZZ_ACP_CHANNELS` | (none, so no filtering) | Comma-separated channel ids. Discovery still runs; this filters it, at startup and for later membership notifications. Ignored in `config` mode. |
+| `--kinds` | `BUZZ_ACP_KINDS` | in `mentions`: stream message, workflow approval, reminder. In `all`: unrestricted | Comma-separated event kinds that may open a turn. Applies to both `mentions` and `all`. Ignored in `config` mode. |
+| `--no-mention-filter` | `BUZZ_ACP_NO_MENTION_FILTER` | `false` | In `mentions` mode, drop the requirement that an event mention this agent. Ignored in `config` mode, and redundant in `all` mode. |
+| `--context-message-limit` | `BUZZ_ACP_CONTEXT_MESSAGE_LIMIT` | `12` | Messages of prior context fetched for thread replies and DMs. `0` disables it, max `100`. |
+
+> **`--no-mention-filter` is wider than it looks.** The harness subscribes to **every channel the agent's identity is a member of**, and the membership notification subscription adds new ones as the agent is added to them (see [Channels](#channels)). In `mentions` mode, dropping the mention requirement means the agent opens a turn on **every event of the subscribed kinds, in every one of those channels, from any author the gate above allows**, including events addressed to a different agent. With several agents sharing a workspace and `--respond-to` widened, one message can wake all of them.
+>
+> Two things bound it, and neither is on by default alongside this flag:
+>
+> ```bash
+> # Answers without being mentioned, but only in one channel
+> buzz-acp --no-mention-filter --channels "<channel-uuid>"
+> ```
+>
+> The [Inbound Author Gate](#inbound-author-gate) is the other bound: at its `owner-only` default, only the owner's events get through in the first place.
+
 ### Configuration Examples
 
 **Single agent, no heartbeat (default):**


### PR DESCRIPTION
## Summary

Adds a "Subscription Scope" section to the buzz-acp configuration reference, covering five flags
that had no entry there: `BUZZ_ACP_SUBSCRIBE`, `BUZZ_ACP_CHANNELS`, `BUZZ_ACP_KINDS`,
`BUZZ_ACP_NO_MENTION_FILTER` and `BUZZ_ACP_CONTEXT_MESSAGE_LIMIT`. None of those env var names
appear anywhere in the README today, while every other group of flags has a table.

It sits after the Inbound Author Gate on purpose: that section decides **whose** events arrive,
this one decides **which channels** are watched and **what opens a turn**.

The Forum Channels section already uses `--no-mention-filter` and explains what it enables, so this
is not introducing the flag. What is missing there is its **scope**, which is the part that bites:
the harness subscribes to every channel the identity belongs to and the membership notification
subscription adds more over time, so in `mentions` mode the flag applies across all of them at
once. With several agents in one workspace and the author gate widened, one message can open a turn
on several agents.

The callout says that and points at the two things that bound it, `--channels` and the author gate.
I lost a day to this, which is why it seemed worth writing down.

## Duplicate search

No open PR documents these flags. #4922 touches `BUZZ_ACP_NO_MENTION_FILTER` but is a code fix for
boolean parsing rather than documentation. Five open PRs touch this file; none edits the
configuration tables.

## Testing

Documentation only, no code paths changed. Every flag name, default and behaviour statement was
checked against `crates/buzz-acp/src/config.rs`, specifically `resolve_channel_filters`
(`require_mention = !no_mention_filter`, applied per channel) and `resolve_dynamic_channel_filter`
(`channels_override` filters discovery rather than replacing it, and is ignored in `config` mode).

Rebased on current `main`.

## Logging

No logging changes.
