### PR TITLE
deploy(compose): serve device pairing via the buzz-pair-relay sidecar

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -8,6 +8,11 @@ BUZZ_IMAGE=ghcr.io/block/buzz:main
 # Public host name. Used by compose.caddy.yml and URL-derived settings below.
 BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
+# Where devices run the NIP-AB pairing handshake. Advertised in the relay's
+# NIP-11 document; must be ws:// or wss:// or the relay refuses to start. This
+# default matches the /pair route in the Caddyfile. See README.md § Device
+# pairing for the bring-your-own-proxy case.
+BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
 BUZZ_CORS_ORIGINS=https://buzz.example.com
@@ -39,14 +44,12 @@ BUZZ_S3_ADDRESSING_STYLE=path
 # Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.
 BUZZ_HTTP_PORT=3000
 
-# Device pairing (NIP-AB). The pairing-relay sidecar is loopback-only by
-# default; your reverse proxy must route /pair to it with a WebSocket upgrade.
-# Set the advertised URL so the relay publishes it in NIP-11 — without it,
-# clients fall back to the legacy <host>/pair convention.
-# Left commented so it does not trip run.sh's CHANGE_ME check; uncomment and
-# set it to your own domain.
+# Pairing sidecar host port. Loopback by default: buzz-pair-relay has no auth
+# and no membership check by design, so it must not face the internet directly.
+# A reverse proxy on this host reaches it at 127.0.0.1:5000. compose.caddy.yml
+# unpublishes it entirely. Change to 0.0.0.0:5000 only if something off-box has
+# to reach it without a proxy, and read README.md § Device pairing first.
 BUZZ_PAIR_RELAY_PORT=127.0.0.1:5000
-#BUZZ_PAIRING_RELAY_URL=wss://your.domain/pair
 
 # Caddy host ports. Only used with compose.caddy.yml.
 CADDY_HTTP_PORT=80

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -39,6 +39,15 @@ BUZZ_S3_ADDRESSING_STYLE=path
 # Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.
 BUZZ_HTTP_PORT=3000
 
+# Device pairing (NIP-AB). The pairing-relay sidecar is loopback-only by
+# default; your reverse proxy must route /pair to it with a WebSocket upgrade.
+# Set the advertised URL so the relay publishes it in NIP-11 — without it,
+# clients fall back to the legacy <host>/pair convention.
+# Left commented so it does not trip run.sh's CHANGE_ME check; uncomment and
+# set it to your own domain.
+BUZZ_PAIR_RELAY_PORT=127.0.0.1:5000
+#BUZZ_PAIRING_RELAY_URL=wss://your.domain/pair
+
 # Caddy host ports. Only used with compose.caddy.yml.
 CADDY_HTTP_PORT=80
 CADDY_HTTPS_PORT=443

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -8,11 +8,14 @@ BUZZ_IMAGE=ghcr.io/block/buzz:main
 # Public host name. Used by compose.caddy.yml and URL-derived settings below.
 BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
-# Where devices run the NIP-AB pairing handshake. Advertised in the relay's
-# NIP-11 document; must be ws:// or wss:// or the relay refuses to start. This
-# default matches the /pair route in the Caddyfile. See README.md § Device
-# pairing for the bring-your-own-proxy case.
-BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
+# Where devices run the NIP-AB pairing handshake. Deliberately left unset:
+# with no value, clients fall back to <RELAY_URL>/pair, which is exactly what
+# the bundled Caddyfile serves — so the default install needs no edit here.
+# Set it only when pairing lives somewhere else, e.g. a dedicated host name.
+# Must be ws:// or wss:// or the relay refuses to start. Getting it wrong is
+# quiet and expensive: a stale value advertises a pairing endpoint on another
+# domain, and the handshake payload is an nsec. See README.md § Device pairing.
+#BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
 BUZZ_CORS_ORIGINS=https://buzz.example.com
@@ -44,12 +47,15 @@ BUZZ_S3_ADDRESSING_STYLE=path
 # Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.
 BUZZ_HTTP_PORT=3000
 
-# Pairing sidecar host port. Loopback by default: buzz-pair-relay has no auth
-# and no membership check by design, so it must not face the internet directly.
-# A reverse proxy on this host reaches it at 127.0.0.1:5000. compose.caddy.yml
-# unpublishes it entirely. Change to 0.0.0.0:5000 only if something off-box has
-# to reach it without a proxy, and read README.md § Device pairing first.
-BUZZ_PAIR_RELAY_PORT=127.0.0.1:5000
+# Pairing sidecar bind address. The host IP is a separate variable on purpose:
+# buzz-pair-relay has no auth and no membership check by design, so it must not
+# face the internet directly, and a bare port number would silently bind
+# 0.0.0.0. A reverse proxy on this host reaches it at 127.0.0.1:5000;
+# compose.caddy.yml unpublishes it entirely. Widen the host IP only if
+# something off-box must reach it without a proxy — README.md § Device pairing
+# covers what that costs.
+BUZZ_PAIR_RELAY_HOST_IP=127.0.0.1
+BUZZ_PAIR_RELAY_PORT=5000
 
 # Caddy host ports. Only used with compose.caddy.yml.
 CADDY_HTTP_PORT=80

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,9 @@
 {$BUZZ_DOMAIN} {
   encode zstd gzip
 
+  # Device pairing (NIP-AB) goes to the auth-less sidecar, not the main relay:
+  # a device mid-pairing is not a relay member yet and would be refused.
+  reverse_proxy /pair* pairing-relay:5000
+
   reverse_proxy relay:3000
 }

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -2,8 +2,19 @@
   encode zstd gzip
 
   # Device pairing (NIP-AB) goes to the auth-less sidecar, not the main relay:
-  # a device mid-pairing is not a relay member yet and would be refused.
-  reverse_proxy /pair* pairing-relay:5000
+  # a device mid-pairing holds a fresh ephemeral key that is not a relay member
+  # yet, so BUZZ_REQUIRE_RELAY_MEMBERSHIP would refuse it.
+  #
+  # Match the two paths a client actually uses and nothing else. A `/pair*`
+  # prefix match, or `handle_path /pair*`, also swallows `/pairfoo` and any
+  # future relay route starting with "pair"; `handle /pair` on its own misses
+  # the trailing slash. Caddy proxies the WebSocket upgrade transparently.
+  @pairing path /pair /pair/*
+  handle @pairing {
+    reverse_proxy pairing-relay:5000
+  }
 
-  reverse_proxy relay:3000
+  handle {
+    reverse_proxy relay:3000
+  }
 }

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -56,20 +56,25 @@ default in `.env.example` — makes the main relay reject it outright. The
 history, just an in-flight match between two kind-24134 subscriptions.
 
 The binary already ships inside the relay image, so this bundle runs it as the
-`pairing-relay` service. Two things have to line up:
+`pairing-relay` service. With `BUZZ_COMPOSE_TLS=true` the bundled `Caddyfile`
+routes `/pair` and `/pair/*` to `pairing-relay:5000`; everything else still goes
+to the relay. That is the whole setup — there is nothing to configure.
 
-1. **A route to the sidecar.** With `BUZZ_COMPOSE_TLS=true` the bundled
-   `Caddyfile` routes `/pair` and `/pair/*` to `pairing-relay:5000`; everything
-   else still goes to the relay.
-2. **An advertised URL.** `BUZZ_PAIRING_RELAY_URL` is published in the relay's
-   NIP-11 document, and clients use it directly. Leave it at
-   `wss://<your-domain>/pair` to match the Caddy route. The value must be
-   `ws://` or `wss://`; the relay refuses to start otherwise.
+`BUZZ_PAIRING_RELAY_URL` is left **unset** deliberately. A client reads the
+relay's NIP-11 document and uses `pairing_relay_url` if it is there; with no
+value, it falls back to `<RELAY_URL>/pair`, which is precisely the route above.
+Set it only when pairing lives somewhere else — a dedicated host name, or a
+proxy that exposes a different path. The value must be `ws://` or `wss://` or
+the relay refuses to start.
+
+Be careful with it. A stale value is quiet: the relay starts, the site works,
+and pairing sends devices to whatever host name is in that string. The handshake
+payload is a private key. Change it only alongside the route that serves it.
 
 ### Bringing your own reverse proxy
 
-The sidecar is published on **loopback only** (`BUZZ_PAIR_RELAY_PORT`, default
-`127.0.0.1:5000`). It performs no authentication and enforces no membership, so
+The sidecar is published on **loopback only** (`BUZZ_PAIR_RELAY_HOST_IP`, default
+`127.0.0.1`). It performs no authentication and enforces no membership, so
 putting it on a public interface would expose an unauthenticated WebSocket
 endpoint to the internet — don't. A proxy running on the same host reaches it at
 `127.0.0.1:5000`; a proxy in another container can join `buzz-net` and use
@@ -78,13 +83,14 @@ endpoint to the internet — don't. A proxy running on the same host reaches it 
 Whatever proxy you use, it must terminate TLS, route only `/pair`, pass the
 WebSocket upgrade headers, and keep read timeouts tight — the sidecar caps each
 connection at 120 seconds itself and delegates slowloris protection to the proxy
-(see `crates/buzz-pair-relay/src/lib.rs`). Then point `BUZZ_PAIRING_RELAY_URL` at
-whatever public URL that proxy serves.
+(see `crates/buzz-pair-relay/src/lib.rs`). If it serves `/pair` on the same host
+name as the relay, you still need no `BUZZ_PAIRING_RELAY_URL`; set it only if the
+public URL differs.
 
 If something genuinely off-box must reach the sidecar without a proxy, set
-`BUZZ_PAIR_RELAY_PORT=0.0.0.0:5000` — but note that pairing then runs
-unencrypted over `ws://`, which iOS will refuse, and the endpoint is open to
-anyone who can reach the port.
+`BUZZ_PAIR_RELAY_HOST_IP=0.0.0.0` — but note that pairing then runs unencrypted
+over `ws://`, which iOS will refuse, and the endpoint is open to anyone who can
+reach the port.
 
 ### Checking it works
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -46,6 +46,67 @@ keypair.
 
 Run `./run.sh backup-hint` for the backup checklist.
 
+## Device pairing
+
+Mobile QR pairing (NIP-AB, kind 24134) runs through a **separate** relay, and it
+has to. A device mid-pairing holds a freshly generated ephemeral key that is not
+a relay member yet, so `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true` — the production
+default in `.env.example` — makes the main relay reject it outright. The
+`buzz-pair-relay` sidecar exists for exactly this: no auth, no persistence, no
+history, just an in-flight match between two kind-24134 subscriptions.
+
+The binary already ships inside the relay image, so this bundle runs it as the
+`pairing-relay` service. Two things have to line up:
+
+1. **A route to the sidecar.** With `BUZZ_COMPOSE_TLS=true` the bundled
+   `Caddyfile` routes `/pair` and `/pair/*` to `pairing-relay:5000`; everything
+   else still goes to the relay.
+2. **An advertised URL.** `BUZZ_PAIRING_RELAY_URL` is published in the relay's
+   NIP-11 document, and clients use it directly. Leave it at
+   `wss://<your-domain>/pair` to match the Caddy route. The value must be
+   `ws://` or `wss://`; the relay refuses to start otherwise.
+
+### Bringing your own reverse proxy
+
+The sidecar is published on **loopback only** (`BUZZ_PAIR_RELAY_PORT`, default
+`127.0.0.1:5000`). It performs no authentication and enforces no membership, so
+putting it on a public interface would expose an unauthenticated WebSocket
+endpoint to the internet — don't. A proxy running on the same host reaches it at
+`127.0.0.1:5000`; a proxy in another container can join `buzz-net` and use
+`pairing-relay:5000` instead.
+
+Whatever proxy you use, it must terminate TLS, route only `/pair`, pass the
+WebSocket upgrade headers, and keep read timeouts tight — the sidecar caps each
+connection at 120 seconds itself and delegates slowloris protection to the proxy
+(see `crates/buzz-pair-relay/src/lib.rs`). Then point `BUZZ_PAIRING_RELAY_URL` at
+whatever public URL that proxy serves.
+
+If something genuinely off-box must reach the sidecar without a proxy, set
+`BUZZ_PAIR_RELAY_PORT=0.0.0.0:5000` — but note that pairing then runs
+unencrypted over `ws://`, which iOS will refuse, and the endpoint is open to
+anyone who can reach the port.
+
+### Checking it works
+
+```bash
+# Is the URL advertised?
+curl -sS -H 'Accept: application/nostr+json' "https://<your-domain>" \
+  | grep -o '"pairing_relay_url":"[^"]*"'
+
+# Is something answering on /pair?
+curl -sS -o /dev/null -w "%{http_code}\n" "https://<your-domain>/pair"
+```
+
+A bare **400** is the healthy answer: the sidecar serves no NIP-11 document and
+rejects any request that is not a WebSocket upgrade. **404** means no route or
+no sidecar — pairing will fail. **401/403**, or a socket that closes while the
+desktop waits for EOSE, means `/pair` is reaching the *main* relay, which is
+refusing the not-yet-member device.
+
+Note that the sidecar requires a `#p` filter: a `REQ` for `kinds:[24134]`
+without one is closed with `#p filter required`. Real clients always send it;
+this only surprises people probing by hand.
+
 ## Validation
 
 Before sharing an install link publicly, verify a fresh install with:

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -71,6 +71,13 @@ Be careful with it. A stale value is quiet: the relay starts, the site works,
 and pairing sends devices to whatever host name is in that string. The handshake
 payload is a private key. Change it only alongside the route that serves it.
 
+One precondition on that fallback: clients only try `<RELAY_URL>/pair` when the
+relay advertises NIP-43, which it does when it has a stable
+`BUZZ_RELAY_PRIVATE_KEY` **and** `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true` — both
+defaults here. On an open relay (`BUZZ_REQUIRE_RELAY_MEMBERSHIP=false`) clients
+pair against the main relay directly, which works because there is no membership
+gate to fail; the sidecar is then unused.
+
 ### Bringing your own reverse proxy
 
 The sidecar is published on **loopback only** (`BUZZ_PAIR_RELAY_HOST_IP`, default
@@ -95,11 +102,6 @@ reach the port.
 ### Checking it works
 
 ```bash
-# Is the URL advertised?
-curl -sS -H 'Accept: application/nostr+json' "https://<your-domain>" \
-  | grep -o '"pairing_relay_url":"[^"]*"'
-
-# Is something answering on /pair?
 curl -sS -o /dev/null -w "%{http_code}\n" "https://<your-domain>/pair"
 ```
 
@@ -108,6 +110,16 @@ rejects any request that is not a WebSocket upgrade. **404** means no route or
 no sidecar — pairing will fail. **401/403**, or a socket that closes while the
 desktop waits for EOSE, means `/pair` is reaching the *main* relay, which is
 refusing the not-yet-member device.
+
+Only if you set `BUZZ_PAIRING_RELAY_URL`, check that it is advertised:
+
+```bash
+curl -sS -H 'Accept: application/nostr+json' "https://<your-domain>" \
+  | grep -o '"pairing_relay_url":"[^"]*"'
+```
+
+Empty output is correct on a default install — the field is omitted entirely
+when unset, and clients use the `/pair` fallback.
 
 Note that the sidecar requires a `#p` filter: a `REQ` for `kinds:[24134]`
 without one is closed with `#p filter required`. Real clients always send it;

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -2,10 +2,15 @@ services:
   relay:
     ports: !reset []
 
+  pairing-relay:
+    ports: !reset []
+
   caddy:
     image: caddy:2-alpine
     depends_on:
       relay:
+        condition: service_healthy
+      pairing-relay:
         condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -10,8 +10,12 @@ services:
     depends_on:
       relay:
         condition: service_healthy
+      # service_started, not service_healthy: pairing is one route. Gating the
+      # proxy on the sidecar's health would let an unhealthy sidecar keep the
+      # whole site — messaging, media, git — from coming up. Pairing degrades
+      # on its own; a stopped sidecar just makes /pair a 502.
       pairing-relay:
-        condition: service_healthy
+        condition: service_started
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}
     ports:

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -110,10 +110,12 @@ services:
   # Published on loopback only. It has no auth by design, so exposing it on a
   # public interface is not an acceptable default; a reverse proxy on this host
   # reaches it at 127.0.0.1:5000 and compose.caddy.yml unpublishes it entirely.
-  # Override with BUZZ_PAIR_RELAY_PORT — see README.md § Device pairing.
+  # BUZZ_PAIR_RELAY_HOST_IP widens it — see README.md § Device pairing.
   #
-  # The relay advertises BUZZ_PAIRING_RELAY_URL from .env via its env_file, so
-  # this service needs no wiring into the relay's environment block.
+  # Nothing needs to be added to the relay's environment: with
+  # BUZZ_PAIRING_RELAY_URL unset, clients fall back to <RELAY_URL>/pair, which
+  # is the route the Caddyfile serves. Setting it is for split-host setups, and
+  # the relay reads it from .env through its env_file.
   pairing-relay:
     image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
     # The image ENTRYPOINT is buzz-relay, so this must override entrypoint, not
@@ -123,7 +125,7 @@ services:
     environment:
       BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
     ports:
-      - "${BUZZ_PAIR_RELAY_PORT:-127.0.0.1:5000}:5000"
+      - "${BUZZ_PAIR_RELAY_HOST_IP:-127.0.0.1}:${BUZZ_PAIR_RELAY_PORT:-5000}:5000"
     # Same /dev/tcp trick as the relay: the runtime image has bash but no curl.
     healthcheck:
       test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -105,8 +105,15 @@ services:
   # Ephemeral NIP-AB device-pairing relay (kind 24134). Separate from the main
   # relay on purpose: a device mid-pairing holds a fresh ephemeral key that is
   # not a relay member yet, so it cannot pass BUZZ_REQUIRE_RELAY_MEMBERSHIP.
-  # No persistence, no auth, no history. Published on loopback only; the reverse
-  # proxy terminates TLS and routes /pair here (see Caddyfile).
+  # No persistence, no auth, no history.
+  #
+  # Published on loopback only. It has no auth by design, so exposing it on a
+  # public interface is not an acceptable default; a reverse proxy on this host
+  # reaches it at 127.0.0.1:5000 and compose.caddy.yml unpublishes it entirely.
+  # Override with BUZZ_PAIR_RELAY_PORT — see README.md § Device pairing.
+  #
+  # The relay advertises BUZZ_PAIRING_RELAY_URL from .env via its env_file, so
+  # this service needs no wiring into the relay's environment block.
   pairing-relay:
     image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
     # The image ENTRYPOINT is buzz-relay, so this must override entrypoint, not

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -102,6 +102,32 @@ services:
     networks:
       - buzz-net
 
+  # Ephemeral NIP-AB device-pairing relay (kind 24134). Separate from the main
+  # relay on purpose: a device mid-pairing holds a fresh ephemeral key that is
+  # not a relay member yet, so it cannot pass BUZZ_REQUIRE_RELAY_MEMBERSHIP.
+  # No persistence, no auth, no history. Published on loopback only; the reverse
+  # proxy terminates TLS and routes /pair here (see Caddyfile).
+  pairing-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    # The image ENTRYPOINT is buzz-relay, so this must override entrypoint, not
+    # command. Compose `command:` maps to CMD and would pass args to buzz-relay.
+    # (Helm can use command: because k8s command maps to ENTRYPOINT.)
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    ports:
+      - "${BUZZ_PAIR_RELAY_PORT:-127.0.0.1:5000}:5000"
+    # Same /dev/tcp trick as the relay: the runtime image has bash but no curl.
+    healthcheck:
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
   minio-init:
     image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:

--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -129,8 +129,10 @@ Environment switches:
 
 Device pairing:
   The pairing-relay sidecar always runs and is published on loopback only.
-  Set BUZZ_PAIRING_RELAY_URL in .env to the public /pair URL your proxy
-  serves. Check it with:
+  With BUZZ_COMPOSE_TLS=true it needs no configuration: clients fall back
+  to <RELAY_URL>/pair, which the bundled Caddyfile serves. Set
+  BUZZ_PAIRING_RELAY_URL only if pairing lives on another host name.
+  Check it with:
     curl -sS -o /dev/null -w "%{http_code}\n" https://<domain>/pair
   400 = the sidecar is answering, 404 = no route or no sidecar.
   See README.md § Device pairing.

--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -60,7 +60,9 @@ case "${1:-help}" in
     ;;
   restart)
     require_env
-    compose up -d --wait --force-recreate relay
+    # pairing-relay too: it shares BUZZ_IMAGE with the relay, so restarting only
+    # the relay after an image or .env change silently leaves the sidecar stale.
+    compose up -d --wait --force-recreate relay pairing-relay
     ;;
   pull)
     require_env
@@ -122,7 +124,16 @@ Commands:
 
 Environment switches:
   BUZZ_COMPOSE_TLS=true   Include compose.caddy.yml for automatic HTTPS
+                          (also routes /pair to the device-pairing sidecar)
   BUZZ_COMPOSE_DEV=true   Include compose.dev.yml for local admin ports/tools
+
+Device pairing:
+  The pairing-relay sidecar always runs and is published on loopback only.
+  Set BUZZ_PAIRING_RELAY_URL in .env to the public /pair URL your proxy
+  serves. Check it with:
+    curl -sS -o /dev/null -w "%{http_code}\n" https://<domain>/pair
+  400 = the sidecar is answering, 404 = no route or no sidecar.
+  See README.md § Device pairing.
 MSG
     ;;
   *)


### PR DESCRIPTION
## Summary

Mobile QR pairing fails on compose deployments: the desktop resolves the pairing relay from the main relay's NIP-11 document, or falls back to `<relay>/pair`, and the compose bundle serves neither — so the phone gets a 404.

Pairing cannot run on the main relay. A device mid-pairing holds a freshly generated ephemeral key that is not a relay member yet, so `BUZZ_REQUIRE_RELAY_MEMBERSHIP` — the production default in `.env.example` — rejects it. Pointing `BUZZ_PAIRING_RELAY_URL` at the main relay only converts the 404 into an auth rejection. The `buzz-pair-relay` sidecar exists for this: no auth, no persistence, no history.

The binary already ships in the image (`Dockerfile:178`) and the Helm chart already deploys it (`deploy/charts/buzz/templates/pairing-relay.yaml`). Helm is the only shipped deployment config that does. This adds the same thing to the compose bundle.

- `compose.yml` — `pairing-relay` service. `entrypoint:`, not `command:`: the image ENTRYPOINT is `buzz-relay`, so `command:` would pass the path as an argument to the wrong binary. Helm can use `command:` because k8s `command` maps to ENTRYPOINT.
- Published on **loopback only**, via a separate `BUZZ_PAIR_RELAY_HOST_IP`. A same-host reverse proxy reaches it at `127.0.0.1:5000`; `compose.caddy.yml` unpublishes it entirely.
- `Caddyfile` — `@pairing path /pair /pair/*` ahead of the catch-all.
- `compose.caddy.yml` — Caddy waits on the sidecar with `service_started`, not `service_healthy`: pairing is one route and should not be able to hold the whole site down.
- `.env.example` — `BUZZ_PAIRING_RELAY_URL` documented but left **unset**. With no value the client falls back to `<RELAY_URL>/pair`, which is exactly what the Caddyfile serves, so the default install needs no edit.
- `run.sh` — `restart` also recreates the sidecar, which shares `BUZZ_IMAGE` with the relay; help text carries the diagnostic.
- `README.md` — a Device pairing section: bring-your-own-proxy requirements and how to read `curl /pair` (400 healthy, 404 no route, 401 hitting the main relay).

### Related issue

Diagnoses #5631. Same root cause as #3779, #2734, #3842, #3291.

**Six open PRs already fix this, and they are all correct about the fix:** #2736, #3627, #3875, #4082, #4656, #5589. The oldest has been open since 2026-07-24; none has been reviewed. This is a seventh entry in that queue, offered as a consolidation rather than a new idea, and it should be closed in favour of any of them a maintainer prefers.

Nothing in the *shape* of this PR is new. #2736 and #4082 already route with `path /pair /pair/*` — #2736 as `@pair` + `handle` blocks, which is this PR's routing block character for character, #4082 the same matcher inside a `route {}`. #3627 already publishes the sidecar on loopback only. #2736 and #3627 already leave `BUZZ_PAIRING_RELAY_URL` commented out. Every individual decision here was already made correctly by someone in this queue; what is new is that they have not been made together, and that some of them are now checked on the wire.

Where the six differ, and what this PR picks:

- **Routing.** Four matcher shapes appear across the six. Driven side by side with real handshakes, `path /pair /pair/*` (#2736, #4082) is the only precise one: `handle_path /pair*` (#3875) also captures `/pairfoo`, and `handle /pair` (#4656, #5589) misses a trailing slash. Evidence in Testing.
- **Host binding.** #2736 and #3875 publish on all interfaces, which puts an auth-free WebSocket endpoint on the internet for non-Caddy installs. #4082, #4656 and #5589 publish nothing, so a bring-your-own-proxy install must join the compose network to reach it. #3627 gets this right with a loopback publish, and this PR follows it — splitting the host IP into its own variable so that changing the port cannot silently widen the bind.
- **`BUZZ_PAIRING_RELAY_URL`.** #3875, #4082 and #5589 ship a literal `wss://buzz.example.com/pair` in `.env.example`. That is a footgun: the operator who edits `BUZZ_DOMAIN` and misses this line advertises pairing on a domain they do not control, silently, and the handshake payload is a private key. Unset is already correct — `pairing_relay_from_nip11` prefers a configured URL and otherwise returns `LegacyPath` = `<RELAY_URL>/pair`, which these Caddyfiles serve. #2736 and #3627 comment it out, which is right; #4656 interpolates it from `${BUZZ_DOMAIN}`, which cannot go stale and is equally safe.
- **Startup coupling.** This PR gates Caddy on the sidecar with `service_started`. #2736, #3875, #4082 and #5589 use `service_healthy`, which lets an unhealthy sidecar keep the whole site — messaging, media, git — from coming up for the sake of one route.
- **Documentation.** #2736, #4082, #4656 and #5589 all add README material; #3627 does not. The README here adds the failure-mode reading of `curl /pair` and the bring-your-own-proxy requirements.

Two things worth fixing wherever this lands, offered as help rather than as a comparison:

- **#3875's healthcheck is `bash -ec exec 3<>/dev/tcp/127.0.0.1:5000`** — a colon where bash needs a slash. Run verbatim it gives `No such file or directory`, so the container never reports healthy; combined with that PR's `condition: service_healthy`, Caddy never starts. One character. Separately, its `BUZZ_PAIRING_RELAY_URL: ${BUZZ_PAIRING_RELAY_URL:?set BUZZ_PAIRING_RELAY_URL}` makes the variable mandatory, so `docker compose config` fails for every existing `.env`.
- **#3627** keeps the service behind `--profile pairing`, so a default deploy still 404s — worth reconsidering if that PR is the one that lands, since the bug is that pairing does not work out of the box.

### Testing

Verified on a live compose deployment (Docker 24.0.5, Compose 2.20.2) and a throwaway stack on the same host.

**In production.** This sidecar shape has served device pairing on a real relay since 2026-08-12 — behind nginx rather than Caddy — with a phone paired successfully through it.

**Handshake through this PR's Caddyfile**, throwaway stack, `buzz-pair source` and `buzz-pair target` from `crates/buzz-pairing-cli`:

```
SOURCE                        TARGET
Offer received from target.   Offer sent. Waiting for source...
SAS code: 849190              SAS code: 849190
Sending identity...           Received nsec payload!
Transfer complete! ✓          Transfer complete! ✓
```

**Routing**, same stack, with a 404-returning stub behind the catch-all:

```
                                  /pair  /pair/  /pairfoo   /
@pairing path /pair /pair/*        400    400      404     404
handle_path /pair*                 400    400      400     404
handle /pair                       400    404      404     404
```

400 = reached the sidecar, 404 = reached the stub. 400 is the correct answer to a non-WebSocket request: the sidecar serves no NIP-11 document and rejects anything that is not an upgrade (`crates/buzz-pair-relay/src/lib.rs`).

**Config.** `docker compose config` rc=0 for base, `+compose.caddy.yml` and `+compose.dev.yml`; `caddy validate` returns Valid configuration; `bash -n run.sh` clean. Rendered output confirms `entrypoint: [/usr/local/bin/buzz-pair-relay]`, the sidecar bound to `127.0.0.1:5000`, its port removed under the Caddy overlay, and no `BUZZ_PAIRING_RELAY_URL` on the relay.

**Not tested:** TLS with a real certificate — the throwaway Caddy ran on plain HTTP with no DNS. Caddy terminates TLS above the routing layer, so this should not affect `/pair` matching or the upgrade, but it is unproven here.

No UI change.
