### PR TITLE
fix(acp): honour the relay's retry hint on a rate-limited REST call

### DIFF
--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -269,6 +269,27 @@ const REST_RETRY_BASE_DELAYS: [Duration; 3] = [
     Duration::from_millis(2000),
 ];
 
+/// Ceiling on a relay-supplied `retry in Ns` hint.
+///
+/// The hint comes from the relay's own admission limiter, so it is trusted in
+/// the ordinary case; the cap only stops a pathological value from parking the
+/// harness for minutes.
+const RETRY_HINT_MAX: Duration = Duration::from_secs(30);
+
+/// Choose the wait before the next REST attempt.
+///
+/// The relay states how long the caller must wait when it rate-limits. Backing
+/// off for less than that guarantees another rejection, and a client that
+/// re-arrives early keeps its own limit window alive — so take the hint when
+/// it is longer than the schedule's delay, capped. A shorter hint never
+/// shortens the schedule, and no hint leaves it untouched.
+fn retry_delay(base: Duration, hint: Option<Duration>) -> Duration {
+    match hint {
+        Some(hint) => base.max(hint.min(RETRY_HINT_MAX)),
+        None => base,
+    }
+}
+
 fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -340,25 +361,42 @@ impl RestClient {
         Fut: std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>,
     {
         let mut last_err = None;
+        // Carried from a rate-limit rejection to the sleep that follows it.
+        let mut retry_hint: Option<Duration> = None;
 
         for (attempt, delay) in std::iter::once(None)
             .chain(REST_RETRY_BASE_DELAYS.iter().map(|d| Some(*d)))
             .enumerate()
         {
             if let Some(base) = delay {
-                let jittered = jittered_duration(base);
+                let wait = retry_delay(jittered_duration(base), retry_hint.take());
                 tracing::debug!(
                     "retrying {method} {path} (attempt {attempt}) in {:.1}s",
-                    jittered.as_secs_f64()
+                    wait.as_secs_f64()
                 );
-                tokio::time::sleep(jittered).await;
+                tokio::time::sleep(wait).await;
             }
 
             match build_request().await {
                 Ok(resp) if resp.status().is_success() => return Ok(resp),
                 Ok(resp) if is_retriable_status(resp.status()) => {
                     let status = resp.status();
-                    tracing::warn!("{method} {path} returned retriable HTTP {status}");
+                    // The relay states how long to wait when it rate-limits;
+                    // the subscription path already reads that hint, so read it
+                    // here too rather than backing off on our own schedule.
+                    retry_hint = resp
+                        .text()
+                        .await
+                        .ok()
+                        .and_then(|body| parse_rate_limit_retry_secs(&body))
+                        .map(Duration::from_secs);
+                    match retry_hint {
+                        Some(hint) => tracing::warn!(
+                            "{method} {path} returned retriable HTTP {status}; relay asked to retry in {}s",
+                            hint.as_secs()
+                        ),
+                        None => tracing::warn!("{method} {path} returned retriable HTTP {status}"),
+                    }
                     last_err = Some(RelayError::Http(format!(
                         "{method} {path} returned HTTP {status}"
                     )));

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -4065,6 +4065,53 @@ mod tests {
     use super::*;
 
     #[test]
+    fn without_a_hint_the_rest_schedule_is_unchanged() {
+        assert_eq!(
+            retry_delay(Duration::from_millis(500), None),
+            Duration::from_millis(500)
+        );
+    }
+
+    #[test]
+    fn a_longer_hint_wins_over_the_rest_schedule() {
+        // The schedule tops out at 2s, so a relay asking for 4s means retrying
+        // on schedule is a guaranteed second rejection.
+        assert_eq!(
+            retry_delay(Duration::from_millis(2000), Some(Duration::from_secs(4))),
+            Duration::from_secs(4)
+        );
+    }
+
+    #[test]
+    fn a_shorter_hint_does_not_shorten_the_backoff() {
+        assert_eq!(
+            retry_delay(Duration::from_millis(2000), Some(Duration::from_secs(1))),
+            Duration::from_millis(2000)
+        );
+    }
+
+    #[test]
+    fn a_pathological_hint_is_capped() {
+        assert_eq!(
+            retry_delay(Duration::from_millis(500), Some(Duration::from_secs(3600))),
+            RETRY_HINT_MAX
+        );
+    }
+
+    #[test]
+    fn the_relays_own_429_body_yields_a_delay() {
+        // The shape enforce_http_admission actually sends
+        // (crates/buzz-relay/src/api/bridge.rs).
+        let body = r#"{"error":"rate-limited: quota exceeded; retry in 6s"}"#;
+        let hint = parse_rate_limit_retry_secs(body).map(Duration::from_secs);
+        assert_eq!(hint, Some(Duration::from_secs(6)));
+        assert_eq!(
+            retry_delay(Duration::from_millis(500), hint),
+            Duration::from_secs(6)
+        );
+    }
+
+    #[test]
     fn relay_ws_to_http_plain() {
         assert_eq!(
             relay_ws_to_http("ws://localhost:3000"),


### PR DESCRIPTION
Partial fix for #5557 — one of the two mechanisms the report named, and I want to be clear up front about which.

## What I found

The report offered two candidate mechanisms and said it could not tell them apart from outside. From inside the code, **"no backoff on retry" is not it**: `request_with_retry` (`crates/buzz-acp/src/relay.rs`) already sleeps 500ms / 1s / 2s with ±20% jitter between attempts. Sub-millisecond gaps at 20–42/sec cannot come from that loop, so the observed storm is fan-out — many concurrent requests each getting their own 429 — which this PR does **not** fix.

What it does fix is a real gap on the same path. The relay computes exactly how long a rate-limited principal must wait (`enforce_http_admission`, `crates/buzz-relay/src/api/bridge.rs`) and spends it in the 429 body:

```
{"error":"rate-limited: quota exceeded; retry in 4s"}
```

The **subscription** path already reads that hint — `parse_rate_limit_retry_secs` arms a gate and parks until it clears. The **REST** path parsed nothing and backed off on its own schedule, which tops out at 2s. Against a 4s hint every retry is a guaranteed second rejection, and a client that re-arrives inside its own window keeps that window alive. That is a self-sustaining component of the loop even if it is not the whole amplifier.

## The change

Read the hint off the retriable response with the parser the WebSocket path already uses, and wait at least that long before the next attempt:

- capped at 30s, so a pathological value cannot park the harness;
- a **shorter** hint never shortens the existing backoff — this only ever waits longer;
- **no** hint leaves today's schedule byte-for-byte unchanged, so nothing regresses on 502/503/504;
- the warn line now names the hint when there is one, which also makes the storm legible in a log.

## Not in this PR

- **The concurrency cap on in-flight publishes** — the mechanism I believe actually produces 20–42 rejections/sec. That is a bigger change to the publish path and deserves its own review; happy to take it next if you agree with the read above.
- **Log rate-limiting for this path** (the report's third bullet). One line per rejection is still one line per rejection.

Also worth noting: `buzz-cli` carries its own private copy of this parser (`parse_retry_hint_text` in `crates/buzz-cli/src/client.rs`). I left it alone rather than widen this diff into another crate, but the two could collapse onto a shared helper if you want that.

## Verification

`cargo fmt --all --check`, `cargo clippy -p buzz-acp --all-targets` (clean), `cargo test -p buzz-acp --lib` — 778 pass, including 5 new tests. The last one parses the relay's real 429 body end to end into a delay, pinning the wire shape. I did not reproduce the live rate-limit storm, so the claim I can stand behind is the delay choice, not a measured reduction in 429 volume.

Refs #5557