### PR TITLE
fix(mobile): show jump-to-latest in thread views

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math' show min;
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
@@ -54,6 +53,7 @@ import 'reaction_row.dart';
 import 'send_message_provider.dart';
 import '../profile/user_profile_sheet.dart';
 import 'small_avatar.dart';
+import 'jump_to_latest_button.dart';
 import 'thread_detail_page.dart';
 import 'timeline_message.dart';
 

--- a/mobile/lib/features/channels/channel_detail_page/message_list.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_list.dart
@@ -550,74 +550,14 @@ class _MessageList extends HookConsumerWidget {
             right: 0,
             bottom: composerBottomInset + Grid.xs,
             child: Center(
-              child: _JumpToLatestButton(
+              child: JumpToLatestButton(
                 key: const ValueKey('channel-jump-to-latest'),
+                surfaceKey: const ValueKey('channel-jump-to-latest-surface'),
                 onPressed: scrollToLatest,
               ),
             ),
           ),
       ],
-    );
-  }
-}
-
-class _JumpToLatestButton extends StatelessWidget {
-  final VoidCallback onPressed;
-
-  const _JumpToLatestButton({required this.onPressed, super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final borderRadius = BorderRadius.circular(Radii.full);
-    return Semantics(
-      button: true,
-      child: ClipRRect(
-        borderRadius: borderRadius,
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            key: const ValueKey('channel-jump-to-latest-surface'),
-            decoration: BoxDecoration(
-              color: context.colors.surface.withValues(alpha: 0.5),
-              borderRadius: borderRadius,
-              border: Border.all(
-                color: Colors.black.withValues(alpha: 0.04),
-                width: 1,
-              ),
-            ),
-            child: Material(
-              type: MaterialType.transparency,
-              child: InkWell(
-                onTap: onPressed,
-                borderRadius: borderRadius,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: Grid.gutter,
-                    vertical: Grid.xxs,
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        LucideIcons.arrowDown,
-                        size: 16,
-                        color: context.colors.onSurface,
-                      ),
-                      const SizedBox(width: Grid.half),
-                      Text(
-                        'Latest',
-                        style: context.textTheme.labelLarge?.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/features/channels/jump_to_latest_button.dart
+++ b/mobile/lib/features/channels/jump_to_latest_button.dart
@@ -1,0 +1,73 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/theme/theme.dart';
+
+/// Pill that jumps a scrolled-away timeline back to the newest message.
+class JumpToLatestButton extends StatelessWidget {
+  final VoidCallback onPressed;
+  final Key? surfaceKey;
+
+  const JumpToLatestButton({
+    required this.onPressed,
+    this.surfaceKey,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(Radii.full);
+    return Semantics(
+      button: true,
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            key: surfaceKey,
+            decoration: BoxDecoration(
+              color: context.colors.surface.withValues(alpha: 0.5),
+              borderRadius: borderRadius,
+              border: Border.all(
+                color: Colors.black.withValues(alpha: 0.04),
+                width: 1,
+              ),
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: onPressed,
+                borderRadius: borderRadius,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Grid.gutter,
+                    vertical: Grid.xxs,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        LucideIcons.arrowDown,
+                        size: 16,
+                        color: context.colors.onSurface,
+                      ),
+                      const SizedBox(width: Grid.half),
+                      Text(
+                        'Latest',
+                        style: context.textTheme.labelLarge?.copyWith(
+                          color: context.colors.onSurface,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/channels/thread_detail_nested_summary.dart
+++ b/mobile/lib/features/channels/thread_detail_nested_summary.dart
@@ -1,0 +1,113 @@
+part of 'thread_detail_page.dart';
+
+/// Tappable summary row shown below a reply that itself has replies.
+/// Pushes a new [ThreadDetailPage] for the nested thread.
+class _NestedThreadSummaryRow extends ConsumerWidget {
+  final ThreadSummary summary;
+  final TimelineMessage replyMessage;
+  final List<TimelineMessage> allMessages;
+  final String channelId;
+  final String? currentPubkey;
+  final bool isMember;
+  final bool isArchived;
+
+  const _NestedThreadSummaryRow({
+    required this.summary,
+    required this.replyMessage,
+    required this.allMessages,
+    required this.channelId,
+    required this.currentPubkey,
+    required this.isMember,
+    required this.isArchived,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userCache = ref.watch(userCacheProvider);
+
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: replyMessage,
+              allMessages: allMessages,
+              channelId: channelId,
+              currentPubkey: currentPubkey,
+              isMember: isMember,
+              isArchived: isArchived,
+            ),
+          ),
+        );
+      },
+      child: Padding(
+        key: ValueKey('nested-thread-summary-${replyMessage.id}'),
+        padding: const EdgeInsets.only(
+          left: messageAvatarSize + messageAvatarContentGap,
+          top: Grid.half,
+          bottom: Grid.xs,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Stacked participant avatars.
+            SizedBox(
+              width:
+                  32.0 +
+                  (summary.participantPubkeys.length - 1).clamp(0, 2) * 20.0,
+              height: 32,
+              child: Stack(
+                children: [
+                  for (var i = 0; i < summary.participantPubkeys.length; i++)
+                    Positioned(
+                      left: i * 20.0,
+                      child: SmallAvatar(
+                        pubkey: summary.participantPubkeys[i],
+                        userCache: userCache,
+                        size: 32,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: Grid.xxs),
+            Flexible(
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(
+                      text:
+                          '${summary.replyCount} ${summary.replyCount == 1 ? 'reply' : 'replies'}',
+                      style: replyPreviewTextStyle.copyWith(
+                        color: context.colors.primary,
+                      ),
+                    ),
+                    if (summary.lastReplyAt case final lastReplyAt?) ...[
+                      TextSpan(
+                        text: ' · ',
+                        style: replyPreviewTextStyle.copyWith(
+                          color: context.colors.onSurfaceVariant.withValues(
+                            alpha: 0.5,
+                          ),
+                        ),
+                      ),
+                      TextSpan(
+                        text:
+                            'last reply ${formatThreadSummaryLastReplyTime(lastReplyAt)}',
+                        style: replyPreviewTextStyle.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -135,6 +135,7 @@ class ThreadDetailPage extends HookConsumerWidget {
 
     useEffect(() {
       void onPositionsChanged() {
+        if (itemPositionsListener.itemPositions.value.isEmpty) return;
         final tailVisible = threadTailIsVisible();
         if (!userOptedOutOfTailFollow.value && tailVisible) {
           followsThreadTail.value = true;
@@ -222,6 +223,7 @@ class ThreadDetailPage extends HookConsumerWidget {
           if (restoreFollow) {
             userOptedOutOfTailFollow.value = false;
             followsThreadTail.value = true;
+            isAtLatest.value = true;
           }
           if (animate) {
             itemScrollController.scrollTo(

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -25,6 +25,7 @@ import 'date_formatters.dart';
 import 'day_divider.dart';
 import '../profile/user_profile_sheet.dart';
 import 'initial_thread_tail_settle.dart';
+import 'jump_to_latest_button.dart';
 import 'laid_out_viewport.dart';
 import 'message_actions.dart';
 import 'message_long_press_region.dart';
@@ -37,6 +38,7 @@ import 'small_avatar.dart';
 import 'timeline_message.dart';
 
 part 'thread_detail_helpers.dart';
+part 'thread_detail_nested_summary.dart';
 
 /// Full-screen thread detail page.
 ///
@@ -111,6 +113,7 @@ class ThreadDetailPage extends HookConsumerWidget {
     final didJumpToInitialMessage = useRef(false);
     final followsThreadTail = useRef(false);
     final userOptedOutOfTailFollow = useRef(false);
+    final isAtLatest = useState(true);
     final tailIntent = useMemoized(_ThreadTailIntent.new);
     final pendingTailAlignment = useRef<double?>(null);
     const headIndex = 0;
@@ -132,8 +135,14 @@ class ThreadDetailPage extends HookConsumerWidget {
 
     useEffect(() {
       void onPositionsChanged() {
-        if (!userOptedOutOfTailFollow.value && threadTailIsVisible()) {
+        final tailVisible = threadTailIsVisible();
+        if (!userOptedOutOfTailFollow.value && tailVisible) {
           followsThreadTail.value = true;
+        }
+        if (tailVisible) {
+          if (!isAtLatest.value) isAtLatest.value = true;
+        } else if (userOptedOutOfTailFollow.value && isAtLatest.value) {
+          isAtLatest.value = false;
         }
       }
 
@@ -165,6 +174,7 @@ class ThreadDetailPage extends HookConsumerWidget {
         action: () {
           tailIntent.detach();
           followsThreadTail.value = false;
+          isAtLatest.value = false;
           pendingTailAlignment.value = null;
           itemScrollController.jumpTo(index: targetIndex, alignment: 0.35);
         },
@@ -228,6 +238,11 @@ class ThreadDetailPage extends HookConsumerWidget {
           }
         },
       );
+    }
+
+    void scrollToLatest() {
+      if (!itemScrollController.isAttached || tailIntent.isDragging) return;
+      queueTailRealignment(allowIdleDetached: true, restoreFollow: true);
     }
 
     useEffect(() {
@@ -559,6 +574,21 @@ class ThreadDetailPage extends HookConsumerWidget {
                 _ThreadTypingIndicator(entries: threadTyping, animated: false),
             ],
           ),
+          if (!isAtLatest.value)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom:
+                  (isMember && !isArchived ? composerDockHeight.value : 0) +
+                  Grid.xs,
+              child: Center(
+                child: JumpToLatestButton(
+                  key: const ValueKey('thread-jump-to-latest'),
+                  surfaceKey: const ValueKey('thread-jump-to-latest-surface'),
+                  onPressed: scrollToLatest,
+                ),
+              ),
+            ),
           if (isMember && !isArchived)
             Align(
               alignment: Alignment.bottomCenter,
@@ -593,118 +623,6 @@ class ThreadDetailPage extends HookConsumerWidget {
               ),
             ),
         ],
-      ),
-    );
-  }
-}
-
-/// Tappable summary row shown below a reply that itself has replies.
-/// Pushes a new [ThreadDetailPage] for the nested thread.
-class _NestedThreadSummaryRow extends ConsumerWidget {
-  final ThreadSummary summary;
-  final TimelineMessage replyMessage;
-  final List<TimelineMessage> allMessages;
-  final String channelId;
-  final String? currentPubkey;
-  final bool isMember;
-  final bool isArchived;
-
-  const _NestedThreadSummaryRow({
-    required this.summary,
-    required this.replyMessage,
-    required this.allMessages,
-    required this.channelId,
-    required this.currentPubkey,
-    required this.isMember,
-    required this.isArchived,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final userCache = ref.watch(userCacheProvider);
-
-    return GestureDetector(
-      onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => ThreadDetailPage(
-              threadHead: replyMessage,
-              allMessages: allMessages,
-              channelId: channelId,
-              currentPubkey: currentPubkey,
-              isMember: isMember,
-              isArchived: isArchived,
-            ),
-          ),
-        );
-      },
-      child: Padding(
-        key: ValueKey('nested-thread-summary-${replyMessage.id}'),
-        padding: const EdgeInsets.only(
-          left: messageAvatarSize + messageAvatarContentGap,
-          top: Grid.half,
-          bottom: Grid.xs,
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Stacked participant avatars.
-            SizedBox(
-              width:
-                  32.0 +
-                  (summary.participantPubkeys.length - 1).clamp(0, 2) * 20.0,
-              height: 32,
-              child: Stack(
-                children: [
-                  for (var i = 0; i < summary.participantPubkeys.length; i++)
-                    Positioned(
-                      left: i * 20.0,
-                      child: SmallAvatar(
-                        pubkey: summary.participantPubkeys[i],
-                        userCache: userCache,
-                        size: 32,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-            const SizedBox(width: Grid.xxs),
-            Flexible(
-              child: Text.rich(
-                TextSpan(
-                  children: [
-                    TextSpan(
-                      text:
-                          '${summary.replyCount} ${summary.replyCount == 1 ? 'reply' : 'replies'}',
-                      style: replyPreviewTextStyle.copyWith(
-                        color: context.colors.primary,
-                      ),
-                    ),
-                    if (summary.lastReplyAt case final lastReplyAt?) ...[
-                      TextSpan(
-                        text: ' · ',
-                        style: replyPreviewTextStyle.copyWith(
-                          color: context.colors.onSurfaceVariant.withValues(
-                            alpha: 0.5,
-                          ),
-                        ),
-                      ),
-                      TextSpan(
-                        text:
-                            'last reply ${formatThreadSummaryLastReplyTime(lastReplyAt)}',
-                        style: replyPreviewTextStyle.copyWith(
-                          color: context.colors.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -6045,6 +6045,214 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets('thread jump-to-latest is hidden while settled on the tail', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 30; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('thread-jump-to-latest')), findsNothing);
+    });
+
+    testWidgets('thread jump-to-latest appears after leaving the tail', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 30; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final list = find.byKey(const ValueKey('thread-message-list'));
+      await tester.drag(list, const Offset(0, 24));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('thread-jump-to-latest')),
+        findsOneWidget,
+      );
+      final latestSurface = tester.widget<Container>(
+        find.byKey(const ValueKey('thread-jump-to-latest-surface')),
+      );
+      final latestDecoration = latestSurface.decoration! as BoxDecoration;
+      expect(latestDecoration.borderRadius, BorderRadius.circular(Radii.full));
+    });
+
+    testWidgets('thread jump-to-latest returns to the newest reply', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 30; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final list = find.byKey(const ValueKey('thread-message-list'));
+      for (var i = 0; i < 8; i++) {
+        await tester.drag(list, const Offset(0, 100));
+        await tester.pumpAndSettle();
+      }
+
+      expect(
+        find.byKey(const ValueKey('thread-jump-to-latest')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-29')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('thread-jump-to-latest')));
+      await tester.pumpAndSettle();
+
+      final latestReply = find.byKey(
+        const ValueKey('thread-message-group-reply-29'),
+      );
+      expect(latestReply, findsOneWidget);
+      expect(
+        tester.getBottomLeft(latestReply).dy,
+        lessThanOrEqualTo(
+          tester.getTopLeft(find.byKey(const ValueKey('composer-surface'))).dy,
+        ),
+      );
+      expect(find.byKey(const ValueKey('thread-jump-to-latest')), findsNothing);
+    });
   });
 }
 

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -6156,9 +6156,15 @@ void main() {
       await tester.pumpAndSettle();
 
       final list = find.byKey(const ValueKey('thread-message-list'));
-      await tester.drag(list, const Offset(0, 24));
-      await tester.pumpAndSettle();
+      for (var i = 0; i < 8; i++) {
+        await tester.drag(list, const Offset(0, 100));
+        await tester.pumpAndSettle();
+      }
 
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-29')),
+        findsNothing,
+      );
       expect(
         find.byKey(const ValueKey('thread-jump-to-latest')),
         findsOneWidget,


### PR DESCRIPTION
## Summary

Thread views on mobile never showed the channel "Latest" pill, so after scrolling up in a long thread there was no way to jump back to the newest reply. This ports the existing channel affordance onto `ThreadDetailPage` and extracts a shared `JumpToLatestButton`.

- Show the pill when the user has opted out of tail-follow and the newest reply is no longer at the tail.
- Hide it while settled on the tail, after a deep-link jump away, and after tapping the pill to realign.
- Extract `_NestedThreadSummaryRow` so `thread_detail_page.dart` stays under the 1000-line mobile file cap.

### Related issue

Fixes #5650

Closest existing PRs (found after opening; overlap is real):
- #5364 — also adds a thread jump-to-latest pill and opens threads at the newest reply
- #5657 — jump-to-latest plus last-read resume on mobile and desktop (updated 2026-08-13)

This PR is intentionally smaller: mobile thread pill only, reusing the existing tail-follow machinery. Happy to close as duplicate if a maintainer prefers one of the earlier PRs.

### Testing

- [x] `flutter test test/features/channels/channel_detail_page_test.dart --name 'thread |Thread |nested thread|jump-to-latest'` — 16 passed, including:
  - hidden while settled on the tail
  - appears after leaving the tail
  - tap returns to the newest reply and hides the pill
  - existing channel jump-to-latest still works
- [x] `flutter analyze` on touched lib files — no issues
- [x] `mobile/scripts/check-file-sizes.mjs` — `thread_detail_page.dart` is 912 lines
- [ ] Manual Android: open a long thread, scroll up, tap Latest, confirm it lands on the newest reply above the composer

Did not run `flutter run` / device UI (repo agent policy). Did not run full `just ci`.