### PR TITLE
fix(desktop): refresh agent lists when a member is added to a channel

### DIFF
--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -797,6 +797,20 @@ export function useAddChannelMembersMutation(channelId: string | null) {
       // live hook-closure channel, which may have changed mid-send.
       const effectiveChannelId = variables?.channelId ?? channelId;
       await invalidateChannelState(queryClient, effectiveChannelId);
+      // A just-added agent must become mentionable in this channel without
+      // waiting for the relay-agents 5-minute poll or an app restart. Removing
+      // a member already refreshes the agent lists; adding one must too, or the
+      // mention autocomplete keeps showing a stale set that omits the new agent.
+      // A relay agent's kind:10100 record only lists this channel after the
+      // agent (re)publishes it in response to the membership change, which lands
+      // a moment later — so invalidate now and once more shortly after to catch
+      // that republish rather than racing it.
+      const refreshAgentLists = () => {
+        void queryClient.invalidateQueries({ queryKey: ["managed-agents"] });
+        void queryClient.invalidateQueries({ queryKey: ["relay-agents"] });
+      };
+      refreshAgentLists();
+      setTimeout(refreshAgentLists, 4_000);
     },
   });
 }


### PR DESCRIPTION
## Problem

Adding an agent to a channel does not make it `@`-mentionable there until the relay-agents query's 5-minute poll fires or the app is restarted. Repro: create a channel, add a relay agent (e.g. a self-hosted `buzz-acp` agent) as a member, open the composer — the agent is missing from the mention autocomplete for up to 5 minutes.

## Root cause

`useAddChannelMembersMutation` (`desktop/src/features/channels/hooks.ts`) invalidates only the channel state in `onSettled`. It does **not** invalidate `relay-agents` / `managed-agents`. Its siblings already do — `useRemoveChannelMemberMutation` and `useDeleteChannelMutation` both invalidate these lists — so the omission is an asymmetry: removing a member refreshes the agent lists, adding one doesn't. Because the relay-agents query's only other refresh path is a 5-minute `refetchInterval` (paused while backgrounded), a newly added agent stays absent from mentions until that poll or a restart.

## Fix

Invalidate `managed-agents` and `relay-agents` in the add-member `onSettled`, matching remove-member. A relay agent's kind:10100 discovery record only lists the new channel after the agent republishes it in response to the membership change (a moment later), so invalidate immediately and once more after a short delay to catch that republish rather than racing it.

## Notes

- Matches the existing invalidation style/keys used by the sibling mutations.
- Pairs with the harness-side fix that makes externally-deployed agents self-publish and refresh their kind:10100 record on channel join (separate PR) — together they close the "added an agent, can't mention it" gap end to end.