### PR TITLE
fix(desktop): clarify definition parallelism

### DIFF
--- a/desktop/src/features/agents/lib/agentParallelism.test.mjs
+++ b/desktop/src/features/agents/lib/agentParallelism.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  AGENT_PARALLELISM_HELP,
   DEFAULT_AGENT_PARALLELISM,
   resolveAgentParallelism,
   parallelismCapHint,
@@ -18,6 +19,14 @@ test("parallelism uses the app default only when input and definition omit it", 
   );
   assert.equal(resolveAgentParallelism(undefined, 4), 4);
   assert.equal(resolveAgentParallelism(2, 4), 2);
+});
+
+test("definition parallelism help distinguishes new and existing instances", () => {
+  assert.match(AGENT_PARALLELISM_HELP, /new agent instances/i);
+  assert.match(
+    AGENT_PARALLELISM_HELP,
+    /Existing instances keep their current value/i,
+  );
 });
 
 // ── parallelismCapHint: persona/instance hint data path ───────────────────────

--- a/desktop/src/features/agents/lib/agentParallelism.ts
+++ b/desktop/src/features/agents/lib/agentParallelism.ts
@@ -6,7 +6,7 @@
 export const DEFAULT_AGENT_PARALLELISM = 10;
 
 export const AGENT_PARALLELISM_PLACEHOLDER = `App default (${DEFAULT_AGENT_PARALLELISM})`;
-export const AGENT_PARALLELISM_HELP = `Leave blank to use the app default (currently ${DEFAULT_AGENT_PARALLELISM}). Custom values may be 1–32.`;
+export const AGENT_PARALLELISM_HELP = `Default for new agent instances. Existing instances keep their current value. Leave blank to let new instances use the app default (currently ${DEFAULT_AGENT_PARALLELISM}). Custom values may be 1–32.`;
 export const EDIT_AGENT_PARALLELISM_HELP =
   "Current value for this agent. Custom values may be 1–32.";
 


### PR DESCRIPTION
## Summary

- clarify that definition parallelism is the default for new agent instances
- make clear that existing instances retain their configured value
- cover the user-facing distinction with a focused unit test

## Why

The definition dialog is presented as Edit agent, but its parallelism help only described the app default. That made it reasonable to expect an edit from 10 to 2 followed by a restart to reduce the running worker pool. In fact, the value is copied only when an instance is created; existing instances remain independently configured.

## Testing

- pre-push desktop-check
- pre-push desktop-typecheck
- pre-push desktop-test: 4,716 passed
- just ci reached cargo clippy but could not complete because Cargo repeatedly timed out while updating the rust-s3 and mesh-llm git dependencies