### PR TITLE
Fix slow managed-agent shutdown

### DIFF
--- a/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs
@@ -173,26 +173,36 @@ fn signal_group(pid: i32, signal: i32) {
 #[cfg(unix)]
 fn leader_exited_by(pid: i32, deadline: Instant) -> bool {
     loop {
-        // SAFETY: `info` is a valid, fully-initialised out-pointer for the
-        // duration of the call. `WNOWAIT` leaves the child waitable, so the
-        // later `wait` still returns its status.
-        let exited = unsafe {
-            let mut info: libc::siginfo_t = std::mem::zeroed();
-            let rc = libc::waitid(
-                libc::P_PID,
-                pid as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
-            );
-            rc == 0 && info.si_pid() == pid
-        };
-        if exited {
+        if child_exited_without_reaping(pid as u32) {
             return true;
         }
         if Instant::now() >= deadline {
             return false;
         }
         std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Reports whether a direct child has exited without reaping it.
+///
+/// `kill(pid, 0)` cannot make this distinction: it still succeeds for a
+/// zombie. `WNOWAIT` observes the exit while keeping the child waitable and
+/// its PID reserved, which lets callers safely finish process-group cleanup
+/// before releasing that PID back to the kernel.
+#[cfg(unix)]
+pub fn child_exited_without_reaping(pid: u32) -> bool {
+    // SAFETY: `info` is a valid, fully-initialised out-pointer for the
+    // duration of the call. `WNOWAIT` leaves the child waitable, so a later
+    // `wait` still returns its status.
+    unsafe {
+        let mut info: libc::siginfo_t = std::mem::zeroed();
+        let rc = libc::waitid(
+            libc::P_PID,
+            pid as libc::id_t,
+            &mut info,
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        );
+        rc == 0 && info.si_pid() == pid as i32
     }
 }
 

--- a/desktop/src-tauri/src/shutdown.rs
+++ b/desktop/src-tauri/src/shutdown.rs
@@ -7,6 +7,10 @@ use crate::managed_agents::{
 };
 use crate::{prevent_sleep, util};
 
+const MANAGED_AGENT_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const MANAGED_AGENT_SHUTDOWN_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(50);
+
 #[cfg(unix)]
 fn managed_agent_leader_exited(pid: u32, owns_child: bool) -> bool {
     if owns_child && buzz_terminal::lifecycle::child_exited_without_reaping(pid) {
@@ -19,6 +23,27 @@ fn managed_agent_leader_exited(pid: u32, owns_child: bool) -> bool {
 #[cfg(not(unix))]
 fn managed_agent_leader_exited(pid: u32, _owns_child: bool) -> bool {
     !managed_agents::process_is_running(pid)
+}
+
+fn wait_for_managed_agent_shutdown_grace(mut all_leaders_exited: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + MANAGED_AGENT_SHUTDOWN_TIMEOUT;
+
+    loop {
+        if all_leaders_exited() {
+            #[cfg(unix)]
+            {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                std::thread::sleep(buzz_terminal::lifecycle::TERM_GRACE.min(remaining));
+            }
+            break;
+        }
+
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(MANAGED_AGENT_SHUTDOWN_POLL_INTERVAL.min(remaining));
+    }
 }
 
 pub(crate) fn is_restart_request(code: Option<i32>) -> bool {
@@ -209,20 +234,14 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
         // detect an exited direct child: it continues to report a zombie as
         // present until that child is reaped. Observe owned children with
         // waitid(WNOWAIT) instead, keeping their PIDs reserved until the group
-        // sweep below has killed any surviving descendants.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        loop {
-            if to_stop
+        // sweep below has killed any surviving descendants. Once every leader
+        // is out, retain those zombies for one short descendant drain window;
+        // the original two-second deadline remains the hard ceiling.
+        wait_for_managed_agent_shutdown_grace(|| {
+            to_stop
                 .iter()
                 .all(|agent| managed_agent_leader_exited(agent.pid, agent.runtime.is_some()))
-            {
-                break;
-            }
-            if std::time::Instant::now() >= deadline {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
+        });
 
         // Fan-out: SIGKILL surviving groups even when their leaders exited
         // politely. A WNOWAIT-observed leader remains a zombie, so kill(0)
@@ -290,7 +309,44 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
 
 #[cfg(test)]
 mod tests {
-    use super::{is_restart_request, managed_agent_leader_exited};
+    use super::is_restart_request;
+
+    #[cfg(unix)]
+    use super::{managed_agent_leader_exited, wait_for_managed_agent_shutdown_grace};
+
+    #[cfg(unix)]
+    struct ProcessGroupGuard {
+        leader: std::process::Child,
+        pgid: i32,
+        group_killed: bool,
+    }
+
+    #[cfg(unix)]
+    impl ProcessGroupGuard {
+        fn signal(&self, signal: i32) -> i32 {
+            // SAFETY: the fixture leader was spawned with process_group(0), so
+            // its PID is the PGID and the negative target names only that group.
+            unsafe { libc::kill(-self.pgid, signal) }
+        }
+
+        fn kill_group(&mut self) -> i32 {
+            let result = self.signal(libc::SIGKILL);
+            if result == 0 {
+                self.group_killed = true;
+            }
+            result
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for ProcessGroupGuard {
+        fn drop(&mut self) {
+            if !self.group_killed {
+                let _ = self.kill_group();
+            }
+            let _ = self.leader.wait();
+        }
+    }
 
     #[test]
     fn only_tauri_restart_exit_code_requests_a_relaunch() {
@@ -303,7 +359,6 @@ mod tests {
     #[test]
     fn exited_agent_leaders_are_observed_before_reaping() {
         use std::process::{Command, Stdio};
-        use std::time::{Duration, Instant};
 
         let mut children: Vec<_> = (0..3)
             .map(|_| {
@@ -317,15 +372,11 @@ mod tests {
             })
             .collect();
         let pids: Vec<_> = children.iter().map(std::process::Child::id).collect();
-        let deadline = Instant::now() + Duration::from_millis(500);
 
-        while !pids
-            .iter()
-            .all(|pid| managed_agent_leader_exited(*pid, true))
-            && Instant::now() < deadline
-        {
-            std::thread::sleep(Duration::from_millis(5));
-        }
+        wait_for_managed_agent_shutdown_grace(|| {
+            pids.iter()
+                .all(|pid| managed_agent_leader_exited(*pid, true))
+        });
 
         assert!(
             pids.iter()
@@ -339,7 +390,106 @@ mod tests {
         );
 
         for child in &mut children {
-            child.wait().expect("reap cooperative agent fixture");
+            assert!(
+                child
+                    .try_wait()
+                    .expect("reap cooperative agent fixture")
+                    .is_some(),
+                "the production try_wait step must reap a WNOWAIT-observed child"
+            );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_leader_leaves_a_short_term_grace_for_group_descendants() {
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        let temp = tempfile::tempdir().expect("create process-group fixture directory");
+        let descendant_ready = temp.path().join("descendant-ready");
+        let descendant_pid_path = temp.path().join("descendant-pid");
+        let leader_ready = temp.path().join("leader-ready");
+        let drained = temp.path().join("descendant-drained");
+
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                r#"
+trap 'exit 0' TERM
+(
+  trap '/bin/sleep 0.1; /usr/bin/touch "$BUZZ_TEST_DRAINED"; while :; do /bin/sleep 1; done' TERM
+  /usr/bin/touch "$BUZZ_TEST_DESCENDANT_READY"
+  while :; do /bin/sleep 1; done
+) &
+printf '%s\n' "$!" > "$BUZZ_TEST_DESCENDANT_PID"
+while [ ! -f "$BUZZ_TEST_DESCENDANT_READY" ]; do /bin/sleep 0.01; done
+/usr/bin/touch "$BUZZ_TEST_LEADER_READY"
+while :; do /bin/sleep 1; done
+"#,
+            ])
+            .env("BUZZ_TEST_DESCENDANT_READY", &descendant_ready)
+            .env("BUZZ_TEST_DESCENDANT_PID", &descendant_pid_path)
+            .env("BUZZ_TEST_LEADER_READY", &leader_ready)
+            .env("BUZZ_TEST_DRAINED", &drained)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+
+        let leader = command.spawn().expect("spawn process-group fixture");
+        let leader_pid = leader.id();
+        let mut group = ProcessGroupGuard {
+            leader,
+            pgid: leader_pid as i32,
+            group_killed: false,
+        };
+
+        let ready_deadline = Instant::now() + Duration::from_secs(2);
+        while !leader_ready.exists() && Instant::now() < ready_deadline {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(leader_ready.exists(), "fixture did not arm its TERM traps");
+
+        let descendant_pid: i32 = std::fs::read_to_string(&descendant_pid_path)
+            .expect("read descendant PID")
+            .trim()
+            .parse()
+            .expect("parse descendant PID");
+        // SAFETY: getpgid only inspects the live fixture PID.
+        assert_eq!(
+            unsafe { libc::getpgid(descendant_pid) },
+            leader_pid as i32,
+            "fixture descendant must share the harness process group"
+        );
+
+        assert_eq!(group.signal(libc::SIGTERM), 0, "signal fixture group");
+        let started = Instant::now();
+        wait_for_managed_agent_shutdown_grace(|| managed_agent_leader_exited(leader_pid, true));
+        let elapsed = started.elapsed();
+
+        assert!(
+            crate::managed_agents::process_is_running(leader_pid),
+            "WNOWAIT must reserve the leader PID through descendant cleanup"
+        );
+        assert_eq!(group.kill_group(), 0, "sweep fixture group");
+        assert!(
+            group
+                .leader
+                .try_wait()
+                .expect("reap fixture leader")
+                .is_some(),
+            "the exited leader should be waitable after the group sweep"
+        );
+        assert!(
+            drained.exists(),
+            "same-group descendants should finish their TERM handler before SIGKILL"
+        );
+        assert!(
+            elapsed >= buzz_terminal::lifecycle::TERM_GRACE,
+            "the post-leader descendant grace must not be skipped"
+        );
     }
 }

--- a/desktop/src-tauri/src/shutdown.rs
+++ b/desktop/src-tauri/src/shutdown.rs
@@ -7,6 +7,20 @@ use crate::managed_agents::{
 };
 use crate::{prevent_sleep, util};
 
+#[cfg(unix)]
+fn managed_agent_leader_exited(pid: u32, owns_child: bool) -> bool {
+    if owns_child && buzz_terminal::lifecycle::child_exited_without_reaping(pid) {
+        return true;
+    }
+
+    !managed_agents::process_is_running(pid)
+}
+
+#[cfg(not(unix))]
+fn managed_agent_leader_exited(pid: u32, _owns_child: bool) -> bool {
+    !managed_agents::process_is_running(pid)
+}
+
 pub(crate) fn is_restart_request(code: Option<i32>) -> bool {
     code == Some(tauri::RESTART_EXIT_CODE)
 }
@@ -191,12 +205,16 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
             }
         }
 
-        // Wait up to 2s for all to exit, checking in a polling loop.
+        // Wait up to 2s for all leaders to exit. `kill(pid, 0)` alone cannot
+        // detect an exited direct child: it continues to report a zombie as
+        // present until that child is reaped. Observe owned children with
+        // waitid(WNOWAIT) instead, keeping their PIDs reserved until the group
+        // sweep below has killed any surviving descendants.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             if to_stop
                 .iter()
-                .all(|a| !managed_agents::process_is_running(a.pid))
+                .all(|agent| managed_agent_leader_exited(agent.pid, agent.runtime.is_some()))
             {
                 break;
             }
@@ -206,7 +224,10 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
-        // Fan-out: SIGKILL any survivors.
+        // Fan-out: SIGKILL surviving groups even when their leaders exited
+        // politely. A WNOWAIT-observed leader remains a zombie, so kill(0)
+        // still holds the group ID safe while this catches descendants that
+        // did not honor SIGTERM.
         #[cfg(unix)]
         for agent in &to_stop {
             if managed_agents::process_is_running(agent.pid) {
@@ -269,12 +290,56 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
 
 #[cfg(test)]
 mod tests {
-    use super::is_restart_request;
+    use super::{is_restart_request, managed_agent_leader_exited};
 
     #[test]
     fn only_tauri_restart_exit_code_requests_a_relaunch() {
         assert!(is_restart_request(Some(tauri::RESTART_EXIT_CODE)));
         assert!(!is_restart_request(None));
         assert!(!is_restart_request(Some(0)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_agent_leaders_are_observed_before_reaping() {
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+
+        let mut children: Vec<_> = (0..3)
+            .map(|_| {
+                Command::new("/bin/sh")
+                    .args(["-c", "exit 0"])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("spawn cooperative agent fixture")
+            })
+            .collect();
+        let pids: Vec<_> = children.iter().map(std::process::Child::id).collect();
+        let deadline = Instant::now() + Duration::from_millis(500);
+
+        while !pids
+            .iter()
+            .all(|pid| managed_agent_leader_exited(*pid, true))
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert!(
+            pids.iter()
+                .all(|pid| managed_agent_leader_exited(*pid, true)),
+            "cooperative leaders should be detected without reaching the shutdown grace ceiling"
+        );
+        assert!(
+            pids.iter()
+                .all(|pid| crate::managed_agents::process_is_running(*pid)),
+            "the exit probe must leave child PIDs reserved until group cleanup"
+        );
+
+        for child in &mut children {
+            child.wait().expect("reap cooperative agent fixture");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- reuse the existing non-reaping `waitid(..., WNOWAIT)` child-exit probe for managed-agent shutdown
- stop treating cooperative child zombies as live processes for the full two-second grace period
- add a real-child regression test covering three promptly exiting agent leaders

## Root cause

Buzz sent `SIGTERM` to managed-agent process groups and then polled `kill(pid, 0)` for up to two seconds. A cooperative direct child becomes a zombie until its `Child` handle is reaped, and `kill(pid, 0)` continues to report that zombie as present. Because reaping happened only after the polling loop, normal quits consistently exhausted the full grace period even though the agents had already stopped.

The new probe observes direct-child exit with `waitid(P_PID, ..., WEXITED | WNOHANG | WNOWAIT)`. This keeps the leader PID reserved until the final process-group sweep, so surviving descendants are still killed safely before the child is reaped.

## Impact

Cooperative managed agents can now leave the shutdown wait on the next poll instead of adding roughly two seconds to every quit. The existing two-second ceiling and `SIGKILL` escalation remain in place for genuinely stubborn process groups.

## Validation

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml shutdown::tests -- --nocapture`
  - 2 passed; new three-child regression completed in 0.01s
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml -p buzz-terminal lifecycle_tests -- --nocapture`
  - 6 passed, including cooperative exit, forced escalation, reader draining, and descendant cleanup
- `rustfmt --edition 2021 --check desktop/src-tauri/src/shutdown.rs desktop/src-tauri/crates/buzz-terminal/src/lifecycle.rs`
- `git diff --check`
