### PR TITLE
docs: remove stale MCP references from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,8 @@ If you have questions that aren't answered here, [open an issue](https://github.
 7. [Architecture Overview](#architecture-overview)
 8. [Ecosystem](#ecosystem)
 9. [How to Add a New Event Kind](#how-to-add-a-new-event-kind)
-10. [How to Add a New MCP Tool](#how-to-add-a-new-mcp-tool)
-11. [How to Add a New API Endpoint](#how-to-add-a-new-api-endpoint)
-12. [License and CLA](#license-and-cla)
+10. [How to Add a New API Endpoint](#how-to-add-a-new-api-endpoint)
+11. [License and CLA](#license-and-cla)
 
 ---
 
@@ -216,7 +215,6 @@ already running.
 End-to-end tests live in `crates/buzz-test-client/tests/`:
 
 - `e2e_relay.rs` — WebSocket relay tests
-- `e2e_mcp.rs` — MCP tool tests
 - `e2e_nostr_interop.rs` — Nostr protocol interoperability tests
 - `e2e_media.rs` — media upload/download tests
 - `e2e_media_extended.rs` — extended media tests (GIF, image processing)


### PR DESCRIPTION
Two references to removed MCP-tool content in CONTRIBUTING.md were stale and pointed at things that no longer exist.

## Summary
The Table of Contents linked to a "How to Add a New MCP Tool" section (`#how-to-add-a-new-mcp-tool`), but no such heading exists — the document jumps straight from "How to Add a New Event Kind" to "How to Add a New API Endpoint". This change removes the dead entry and renumbers the two entries below it to 10 and 11.

Separately, the "End-to-End Tests" list referenced `e2e_mcp.rs`, which is not present in `crates/buzz-test-client/tests/` (the other four files listed there all exist). That line is removed.

Docs-only change; no code affected.

## Related issue
None found — searched open issues and PRs for duplicates.

## Testing
Verified against the tree: `#how-to-add-a-new-mcp-tool` has no matching heading (the only broken same-file anchor in the docs), and `e2e_mcp.rs` exists nowhere in the repo while the other listed test files do.