### PR TITLE
fix(mobile): subscribe to live job lifecycle events

### DIFF
--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -59,6 +59,12 @@ abstract final class EventKind {
     streamMessageEdit, // 40003
     streamMessageDiff, // 40008
     systemMessage, // 40099
+    jobRequest, // 43001 — job request row
+    jobAccepted, // 43002 — job accepted row
+    jobProgress, // 43003 — job progress row
+    jobResult, // 43004 — job result row
+    jobCancel, // 43005 — job cancellation row
+    jobError, // 43006 — job error row
     huddleStarted, // 48100 — visible huddle session row
     huddleParticipantJoined, // 48101 — huddle lifecycle metadata
     huddleParticipantLeft, // 48102 — huddle lifecycle metadata

--- a/mobile/test/shared/relay/nostr_models_test.dart
+++ b/mobile/test/shared/relay/nostr_models_test.dart
@@ -2,6 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:buzz/shared/relay/nostr_models.dart';
 
 void main() {
+  test('channel live kinds include every timeline content kind', () {
+    for (final kind in EventKind.channelTimelineContentKinds) {
+      expect(
+        EventKind.channelEventKinds,
+        contains(kind),
+        reason:
+            'timeline kind $kind is missing from live channel subscriptions',
+      );
+    }
+  });
+
   test('NostrFilter serializes and preserves authors', () {
     const filter = NostrFilter(
       kinds: [EventKind.readState],


### PR DESCRIPTION
## Summary

Mobile fetches job lifecycle events (kinds 43001–43006) as visible timeline history, but its live channel subscription was built from `channelEventKinds`, which omitted all six. Job request, progress, result, cancellation, and error rows could therefore remain invisible until a history refresh.

This change:

- adds all six job lifecycle kinds to the mobile live channel event set; and
- adds an invariant test requiring every visible timeline content kind to be present in the live set.

### Related issue

N/A — no matching mobile issue or PR found. This complements #4130, which includes the equivalent desktop subscription fix in a larger stacked desktop feature.

### Testing

Passed locally:

- `flutter test --reporter expanded test/shared/relay/nostr_models_test.dart` (5/5)
- `dart analyze lib/shared/relay/nostr_models.dart test/shared/relay/nostr_models_test.dart`
- `dart format --output=none --set-exit-if-changed lib/shared/relay/nostr_models.dart test/shared/relay/nostr_models_test.dart`
- `node scripts/check-file-sizes.mjs`
- `git diff --check`

A full local `just mobile-check` could not complete in the 4 GiB/no-swap audit environment because the Flutter analysis server was killed with signal 9. Targeted analysis of both changed Dart files completed with no issues; CI should provide the full-project analysis result.
