### PR TITLE
fix(desktop): let channel-member agents reach the mention picker

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -409,3 +409,44 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
 });
+
+test("shouldHideAgentFromMentions subsumes isAgentIdentityInAllowedList except for directory-less members", () => {
+  const cases = [
+    { agent: true, member: false, allowed: false, dir: false, hidden: true },
+    { agent: true, member: false, allowed: false, dir: true, hidden: true },
+    { agent: true, member: true, allowed: false, dir: true, hidden: true },
+    { agent: true, member: true, allowed: false, dir: false, hidden: false },
+    { agent: true, member: true, allowed: true, dir: true, hidden: false },
+    { agent: true, member: false, allowed: true, dir: false, hidden: false },
+    { agent: false, member: false, allowed: false, dir: false, hidden: false },
+  ];
+
+  for (const { agent, member, allowed, dir, hidden } of cases) {
+    const mentionableAgentPubkeys = new Set(allowed ? [PUB_A] : []);
+    const directoryAgentPubkeys = new Set(dir ? [PUB_A] : []);
+    const label = `agent=${agent} member=${member} allowed=${allowed} dir=${dir}`;
+
+    assert.equal(
+      shouldHideAgentFromMentions({
+        isAgent: agent,
+        isMember: member,
+        pubkey: PUB_A,
+        mentionableAgentPubkeys,
+        directoryAgentPubkeys,
+      }),
+      hidden,
+      `policy mismatch for ${label}`,
+    );
+
+    const allowListWouldAdmit = isAgentIdentityInAllowedList(
+      { isAgent: agent, pubkey: PUB_A },
+      mentionableAgentPubkeys,
+    );
+    const onlyTheAllowListRejects = agent && member && !allowed && !dir;
+    assert.equal(
+      allowListWouldAdmit,
+      !onlyTheAllowListRejects && !hidden,
+      `allow-list divergence expectation wrong for ${label}`,
+    );
+  }
+});

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -17,7 +17,6 @@ import {
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
   shouldHideAgentFromMentions,
   uniqueAutocompleteLabels,
@@ -255,9 +254,6 @@ export function useMentions(
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
`useMentions.addCandidate` ran two agent-admission gates in sequence: `isAgentIdentityInAllowedList` first, then `shouldHideAgentFromMentions`.

The first is strictly harsher — it rejects every agent absent from `mentionableAgentPubkeys`. That made the second's "member with unknown invocability => show" branch unreachable, even though that branch is deliberate ("Option B") and has its own passing unit test.

The unreachable branch is exactly the case that matters in a shared community: an agent owned by another install is a channel member, but its invocability cannot be established, because nothing in-tree publishes the kind:10100 agent-profile entry that `getMentionableAgentPubkeys` reads. `relayAgentsQuery` therefore comes back without it, the agent never enters `mentionableAgentPubkeys`, and the allow-list gate drops it before the fallback can admit it.

Result today: an agent is mentionable only by its owner, whose own client seeds `mentionableAgentPubkeys` from local disk and never consults the relay directory at all. Every other member sees nothing, whatever `respond_to` is set to. Reported repeatedly — #4548, #3776, #2603, #3277, #3809, #4489, #4776.

Drop the redundant gate so `shouldHideAgentFromMentions` is the single admission policy, matching the module's documented intent, and add a truth table locking the relationship the two functions have: they agree everywhere except directory-less members, where the allow-list check was wrong.

Note the intended trade-off, unchanged from Option B's design: a member agent whose invocability is unknown is now shown optimistically, so a mention may still be dropped by the harness if `respond_to` excludes the sender. Showing it is what lets the sender discover the agent at all.

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
