### PR TITLE
fix(cli): keep author and channel in compact message output

### DIFF
--- a/crates/buzz-cli/src/commands/feed.rs
+++ b/crates/buzz-cli/src/commands/feed.rs
@@ -42,24 +42,11 @@ pub async fn cmd_get_feed(
     let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
     events.sort_by_key(|e| Reverse(e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0)));
     let normalized = normalize_events(&events);
-    let output = match format {
-        crate::OutputFormat::Compact => {
-            let evts: Vec<serde_json::Value> =
-                serde_json::from_str(&normalized).unwrap_or_default();
-            let compact: Vec<serde_json::Value> = evts
-                .iter()
-                .map(|e| {
-                    serde_json::json!({
-                        "id": e.get("id").cloned().unwrap_or_default(),
-                        "content": e.get("content").cloned().unwrap_or_default(),
-                        "created_at": e.get("created_at").cloned().unwrap_or_default(),
-                    })
-                })
-                .collect();
-            serde_json::to_string(&compact).unwrap_or_default()
-        }
-        crate::OutputFormat::Json => normalized,
-    };
+    // One projection, shared with `messages`. `buzz feed` filters on `#p` across
+    // everything, so its results are cross-channel and cross-author by
+    // construction — a hit that carries neither is the least actionable output
+    // of the three, and a second copy of this shape is how the two drifted.
+    let output = crate::commands::messages::format_events(&normalized, format);
     println!("{output}");
     Ok(())
 }
@@ -76,5 +63,64 @@ pub async fn dispatch(
             limit,
             types,
         } => cmd_get_feed(client, since, limit, types.as_deref(), format).await,
+    }
+}
+
+#[cfg(test)]
+mod feed_compact_projection_tests {
+    use crate::commands::messages::format_events;
+    use crate::OutputFormat;
+
+    const AUTHOR: &str = "ff04bc24c4a5fd1b6450d3bf62c049b106bb701777adc8f1f51716fde45550c3";
+    const CHANNEL_A: &str = "fb298e44-68b0-46f9-988c-f994b938deb9";
+    const CHANNEL_B: &str = "740851fb-09dd-4e7c-b507-bd1f9106d1b6";
+
+    fn feed_events() -> String {
+        serde_json::json!([
+            {"id": "a", "pubkey": AUTHOR, "content": "one", "created_at": 1,
+             "tags": [["h", CHANNEL_A]]},
+            {"id": "b", "pubkey": AUTHOR, "content": "two", "created_at": 2,
+             "tags": [["h", CHANNEL_B]]}
+        ])
+        .to_string()
+    }
+
+    /// `buzz feed` filters on `#p` across everything, so its results are
+    /// cross-channel and cross-author by construction. A hit that carries
+    /// neither is the least actionable output of the three commands: there is
+    /// nothing to reply to and nothing to open.
+    #[test]
+    fn compact_feed_rows_carry_author_and_channel() {
+        let out = format_events(&feed_events(), &OutputFormat::Compact);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&out).expect("valid json");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert_eq!(row["pubkey"], AUTHOR, "a feed hit with no author");
+        }
+        assert_eq!(rows[0]["channel"], CHANNEL_A);
+        assert_eq!(
+            rows[1]["channel"], CHANNEL_B,
+            "distinct channels must survive"
+        );
+    }
+
+    /// The projection is shared with `messages` rather than copied. The two
+    /// copies had already drifted once, which is what this test guards.
+    #[test]
+    fn feed_and_messages_agree_on_the_compact_shape() {
+        let out = format_events(&feed_events(), &OutputFormat::Compact);
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&out).expect("valid json");
+        let keys: Vec<&str> = rows[0]
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        for expected in ["id", "pubkey", "channel", "content", "created_at"] {
+            assert!(
+                keys.contains(&expected),
+                "compact row lost `{expected}`: {keys:?}"
+            );
+        }
     }
 }

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -329,6 +329,19 @@ fn parse_member_pubkeys(event: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
+/// Project events for output.
+///
+/// Compact drops event fields to keep agent context small, but it must not drop
+/// the fields a reader needs to ACT on a message. It previously kept only id,
+/// content and created_at, which made every message anonymous — a channel read
+/// back through `messages get --format compact` shows text with no author, and
+/// a `messages search` hit (results span channels) carries no channel, so there
+/// is nothing to reply to or open. `--format compact` is the documented default
+/// for agents, so this was the normal reading path.
+///
+/// `pubkey` and `channel` are therefore part of the compact projection. Both are
+/// small next to `content`, and without them the caller has to re-query in the
+/// full format to do anything with a result.
 fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
     match format {
         crate::OutputFormat::Compact => {
@@ -337,11 +350,21 @@ fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
             let compact: Vec<serde_json::Value> = events
                 .iter()
                 .map(|e| {
-                    serde_json::json!({
+                    // NIP-29 scopes messages by `h`, not `e` — a channel read
+                    // from any other tag would be wrong rather than merely absent.
+                    let channel = crate::client::extract_tag_value(e, "h");
+                    let mut row = serde_json::json!({
                         "id": e.get("id").cloned().unwrap_or_default(),
+                        "pubkey": e.get("pubkey").cloned().unwrap_or_default(),
                         "content": e.get("content").cloned().unwrap_or_default(),
                         "created_at": e.get("created_at").cloned().unwrap_or_default(),
-                    })
+                    });
+                    // Omitted rather than emitted empty for events that carry no
+                    // channel (DMs), so absence stays distinguishable from "".
+                    if !channel.is_empty() {
+                        row["channel"] = serde_json::json!(channel);
+                    }
+                    row
                 })
                 .collect();
             serde_json::to_string(&compact).unwrap_or_default()
@@ -1371,5 +1394,83 @@ mod tests {
             profile_event(PK_VALID_A, Some("Aaron"), None),
         ];
         assert_eq!(match_profiles_by_name(&events, "Aaron").len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod compact_projection_tests {
+    use super::format_events;
+    use crate::client::normalize_events;
+    use crate::OutputFormat;
+
+    const AUTHOR: &str = "ff04bc24c4a5fd1b6450d3bf62c049b106bb701777adc8f1f51716fde45550c3";
+    const CHANNEL: &str = "fb298e44-68b0-46f9-988c-f994b938deb9";
+
+    fn event(with_channel: bool) -> serde_json::Value {
+        let tags = if with_channel {
+            serde_json::json!([["h", CHANNEL], ["e", "root-id"]])
+        } else {
+            serde_json::json!([])
+        };
+        serde_json::json!({
+            "id": "a".repeat(64),
+            "pubkey": AUTHOR,
+            "kind": 9,
+            "content": "flagging a token anomaly",
+            "created_at": 1_786_000_000_u64,
+            "tags": tags,
+        })
+    }
+
+    fn compact(with_channel: bool) -> serde_json::Value {
+        let normalized = normalize_events(&[event(with_channel)]);
+        let out = format_events(&normalized, &OutputFormat::Compact);
+        serde_json::from_str::<serde_json::Value>(&out).unwrap()[0].clone()
+    }
+
+    #[test]
+    fn compact_keeps_the_author() {
+        // Without this every message an agent reads is anonymous — the whole
+        // channel history comes back as text with no sender.
+        assert_eq!(compact(true)["pubkey"], AUTHOR);
+    }
+
+    #[test]
+    fn compact_keeps_the_channel() {
+        // Search results span channels; a hit with no channel cannot be replied
+        // to or opened, so the caller must re-query in the full format.
+        assert_eq!(compact(true)["channel"], CHANNEL);
+    }
+
+    #[test]
+    fn compact_still_carries_id_content_and_time() {
+        let row = compact(true);
+        assert_eq!(row["id"], "a".repeat(64));
+        assert_eq!(row["content"], "flagging a token anomaly");
+        assert_eq!(row["created_at"], 1_786_000_000_u64);
+    }
+
+    #[test]
+    fn channel_is_absent_not_empty_for_events_without_one() {
+        // DMs carry no `h`. An empty string would read as a real channel id of
+        // zero length; absence is the honest representation.
+        let row = compact(false);
+        assert!(
+            row.get("channel").is_none(),
+            "expected no channel key: {row}"
+        );
+    }
+
+    #[test]
+    fn channel_comes_from_the_h_tag_not_the_e_tag() {
+        // NIP-29 scopes by `h`; reading `e` would yield a thread root and look
+        // like a channel id, which is worse than having none.
+        assert_ne!(compact(true)["channel"], "root-id");
+    }
+
+    #[test]
+    fn json_format_is_unchanged() {
+        let normalized = normalize_events(&[event(true)]);
+        assert_eq!(format_events(&normalized, &OutputFormat::Json), normalized);
     }
 }

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -342,7 +342,7 @@ fn parse_member_pubkeys(event: &serde_json::Value) -> Vec<String> {
 /// `pubkey` and `channel` are therefore part of the compact projection. Both are
 /// small next to `content`, and without them the caller has to re-query in the
 /// full format to do anything with a result.
-fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
+pub(crate) fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
     match format {
         crate::OutputFormat::Compact => {
             let events: Vec<serde_json::Value> =

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -78,7 +78,7 @@ Output varies by command group — `--help` shows flags but not response shapes.
 
 ```bash
 buzz --format compact channels list          # [{channel_id, name}]
-buzz --format compact messages get --channel <UUID>  # [{id, content, created_at}]
+buzz --format compact messages get --channel <UUID>  # [{id, pubkey, channel, content, created_at}]
 buzz --format compact users get              # [{pubkey, display_name}]
 buzz --format compact feed get               # [{id, content, created_at}]
 ```


### PR DESCRIPTION
`--format compact` reduced every message to `id`, `content`, `created_at`, dropping the two fields a reader needs to act on a result.

**Author.** Every message read back in compact form is anonymous — a whole channel history returns as text with no senders, so "who said this" requires a second query in the full format.

**Channel.** `messages search` results span channels, so a hit carries no indication of where it came from: nothing to reply to, nothing to open. That is the one thing a search result exists to enable.

This is the documented default path for agents (`--format compact` is the global flag in the agent guide), so it is how messages are normally read, not an edge case. It is also quietly misleading rather than merely sparse — the fields are absent, so a caller can conclude the author or channel is unknown when the relay returned both. I hit exactly that reading a channel history and had to re-fetch the raw event to find where a message had been posted.

Compact stays compact: a pubkey and a UUID are small beside `content`, and the alternative is re-querying every result in full.

`channel` comes from the `h` tag — NIP-29 scopes by `h`, and reading `e` would yield a thread root that looks like a channel id, which is worse than none. It is omitted rather than emitted empty for events that legitimately have no channel (DMs), so absence stays distinguishable from a zero-length id.

6 tests; mutation-verified (removing either field fails exactly the test naming it), and the `json` format is asserted unchanged. `fmt`/`clippy` clean, 349 tests pass.