### PR TITLE
fix(desktop): amortize observer journal eviction

### DIFF
--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -27,6 +27,13 @@ import {
 } from "./ui/agentSessionTranscript";
 
 const MAX_OBSERVER_EVENTS = 3000;
+// Length the per-agent journal is evicted back down to when it exceeds
+// MAX_OBSERVER_EVENTS. Eviction rebuilds the transcript from the retained
+// window (see appendAgentEvents), so evicting back to exactly the cap means an
+// agent parked at the cap evicts — and therefore replays its whole history — on
+// every single append. Leaving headroom amortizes one rebuild across the
+// appends that refill it, while keeping the journal within the cap.
+const OBSERVER_EVENTS_LOW_WATER = MAX_OBSERVER_EVENTS - 500;
 const MAX_PENDING_UNKNOWN_AGENT_FRAMES = 100;
 
 export type ObserverSnapshot = {
@@ -219,7 +226,7 @@ function appendAgentEvents(
   const sorted = [...current, ...sortedAdded].sort(compareObserverEvents);
   const trimmed = sorted.length > MAX_OBSERVER_EVENTS;
   const final = trimmed
-    ? sorted.slice(sorted.length - MAX_OBSERVER_EVENTS)
+    ? sorted.slice(sorted.length - OBSERVER_EVENTS_LOW_WATER)
     : sorted;
   eventsByAgent.set(key, final);
 

--- a/desktop/src/features/agents/observerTranscriptRetention.test.mjs
+++ b/desktop/src/features/agents/observerTranscriptRetention.test.mjs
@@ -1,0 +1,116 @@
+/**
+ * Retention behaviour of the per-agent live observer journal.
+ *
+ * `appendAgentEvents` derives the transcript incrementally when a batch lands
+ * after the retained window, and falls back to a full `buildTranscriptState`
+ * replay when the window is evicted. Evicting back to exactly the cap made that
+ * fallback permanent: an agent parked at the cap evicts one event per append, so
+ * every steady-state append replayed the whole history.
+ *
+ * These tests pin the retention window's shape — that is the observable
+ * signal for which path ingest takes — and the invariant that the derived
+ * transcript still matches a replay of the retained window either way.
+ */
+
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+import {
+  syncAgentObserverEvents,
+  getAgentObserverSnapshot,
+  getAgentTranscript,
+  resetAgentObserverStore,
+} from "@/features/agents/observerRelayStore.ts";
+import { buildTranscript } from "@/features/agents/ui/agentSessionTranscript.ts";
+
+const AGENT_PUBKEY = "a".repeat(64);
+const MAX_OBSERVER_EVENTS = 3000;
+
+function makeEvent(seq) {
+  return {
+    seq,
+    timestamp: new Date(1_760_000_000_000 + seq * 1000).toISOString(),
+    kind: "turn_started",
+    agentIndex: 0,
+    channelId: "chan-1",
+    sessionId: "sess-1",
+    turnId: `turn-${seq}`,
+    payload: {},
+  };
+}
+
+function windowLength() {
+  return getAgentObserverSnapshot(AGENT_PUBKEY).events.length;
+}
+
+describe("live observer journal retention", () => {
+  beforeEach(() => {
+    resetAgentObserverStore();
+  });
+
+  it("never exceeds the retention cap", () => {
+    for (let seq = 1; seq <= MAX_OBSERVER_EVENTS + 750; seq += 1) {
+      syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(seq)]);
+      assert.ok(
+        windowLength() <= MAX_OBSERVER_EVENTS,
+        `window grew to ${windowLength()} at seq ${seq}`,
+      );
+    }
+  });
+
+  it("evicts with headroom so appends past the cap do not each evict", () => {
+    for (let seq = 1; seq <= MAX_OBSERVER_EVENTS; seq += 1) {
+      syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(seq)]);
+    }
+    assert.equal(windowLength(), MAX_OBSERVER_EVENTS);
+
+    // The append that crosses the cap must leave the window below it. Evicting
+    // back to the cap instead would re-arm eviction on the very next append and
+    // keep it armed forever.
+    syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(MAX_OBSERVER_EVENTS + 1)]);
+    const afterFirstEviction = windowLength();
+    assert.ok(
+      afterFirstEviction < MAX_OBSERVER_EVENTS,
+      `expected headroom after eviction, window is still ${afterFirstEviction}`,
+    );
+
+    // ...and that headroom has to be refilled by ordinary appends before the
+    // next eviction, so evictions are amortized rather than per-append.
+    syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(MAX_OBSERVER_EVENTS + 2)]);
+    assert.equal(windowLength(), afterFirstEviction + 1);
+  });
+
+  it("keeps the newest events and drops the oldest", () => {
+    const total = MAX_OBSERVER_EVENTS + 400;
+    for (let seq = 1; seq <= total; seq += 1) {
+      syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(seq)]);
+    }
+    const events = getAgentObserverSnapshot(AGENT_PUBKEY).events;
+    assert.equal(events.at(-1).seq, total);
+    assert.equal(events.at(0).seq, total - events.length + 1);
+  });
+
+  it("derives the same transcript as a replay of the retained window", () => {
+    for (let seq = 1; seq <= MAX_OBSERVER_EVENTS + 600; seq += 1) {
+      syncAgentObserverEvents(AGENT_PUBKEY, [makeEvent(seq)]);
+    }
+    const retained = getAgentObserverSnapshot(AGENT_PUBKEY).events;
+    assert.deepEqual(
+      getAgentTranscript(AGENT_PUBKEY),
+      buildTranscript(retained),
+    );
+  });
+
+  it("handles a single batch larger than the cap", () => {
+    const batch = [];
+    for (let seq = 1; seq <= MAX_OBSERVER_EVENTS + 900; seq += 1) {
+      batch.push(makeEvent(seq));
+    }
+    syncAgentObserverEvents(AGENT_PUBKEY, batch);
+    assert.ok(windowLength() <= MAX_OBSERVER_EVENTS);
+    assert.equal(
+      getAgentObserverSnapshot(AGENT_PUBKEY).events.at(-1).seq,
+      MAX_OBSERVER_EVENTS + 900,
+    );
+  });
+});


### PR DESCRIPTION
Refs #5718.

## What happens

`appendAgentEvents` evicts the per-agent live journal back to *exactly*
`MAX_OBSERVER_EVENTS`:

```ts
const trimmed = sorted.length > MAX_OBSERVER_EVENTS;
const final = trimmed ? sorted.slice(sorted.length - MAX_OBSERVER_EVENTS) : sorted;
```

So once an agent's journal reaches 3000, `current.length` is 3000 forever, every
later append makes `sorted.length >= 3001`, and `trimmed` is true on every call.
That permanently disables this gate:

```ts
if (allAtEnd && !trimmed) { /* incremental fold */ }
else { transcriptByAgent.set(key, buildTranscriptState(final)); }
```

Every steady-state append then replays the whole retained window through
`buildTranscriptState`. Nothing shrinks `eventsByAgent` except a full store
reset, so it is permanent for the life of the renderer process, per agent.

It is worth being precise that this is not an off-by-one — a cap of 3000 does
want `>`. The defect is that trimming to the cap re-arms eviction on the very
next append, and eviction is what forces the replay.

## Fix

Evict to a low-water mark instead of back to the cap. The journal still never
exceeds `MAX_OBSERVER_EVENTS`; it now has to be refilled by ordinary appends
before the next eviction, so one replay is amortized across the appends that
refill it. Three lines, no change to retention semantics or to the transcript
that is derived.

## Evidence

New `observerTranscriptRetention.test.mjs` pins the retention window's shape —
that is the observable signal for which ingest path runs — plus the invariant
that the derived transcript still equals a replay of the retained window.

Against current `main` the headroom test fails on the mechanism itself:

```
✖ evicts with headroom so appends past the cap do not each evict
  AssertionError: expected headroom after eviction, window is still 3000
```

and the cost shows up directly in how long that same file takes to run:

| | 5 tests, ~13k single-event appends |
|---|---|
| `main` | **299,397 ms** |
| this branch | **10,599 ms** |

~28x on this workload, consistent with the 188x the issue measured on a heavier
one (their events accumulate streaming text, mine do not, so mine understates
it).

## What I ran

- `pnpm test` (desktop) — 4766/4766 pass, 70 suites
- `pnpm typecheck` — clean
- `pnpm exec biome check src` — clean on both changed files
- Verified the new test fails on `main` and passes here

Not run locally: the Rust workspace and the desktop E2E suite — neither is
touched by this diff. CI covers them.

## Scope

The issue also notes that `buildTranscriptState` is itself O(T) because
`agentSessionTranscript.ts:305` folds streaming text with `existing.text + text`
uncapped, and that `ensureMutable`/`replaceItem` copy per mutation. Those are
real but separate — they make each replay expensive, whereas this change stops
a replay from happening on every append. Left alone here to keep the diff to one
concern.
