### PR TITLE
fix(desktop): keep the timeline settle write out of the resize pass

### DIFF
--- a/desktop/src/features/messages/ui/useVirtualizedViewportResize.test.mjs
+++ b/desktop/src/features/messages/ui/useVirtualizedViewportResize.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldSettleVirtualizedViewportResize } from "./useVirtualizedViewportResize.ts";
+import {
+  createVirtualizedViewportResizeHandler,
+  readObservedViewportSize,
+  shouldSettleVirtualizedViewportResize,
+} from "./useVirtualizedViewportResize.ts";
 
 test("viewport resize follows the virtualizer's explicit bottom state", () => {
   assert.equal(
@@ -12,4 +16,144 @@ test("viewport resize follows the virtualizer's explicit bottom state", () => {
     shouldSettleVirtualizedViewportResize({ virtualizerAtBottom: false }),
     false,
   );
+});
+
+test("a resize that does not change geometry does not settle", () => {
+  const size = { width: 800, height: 600 };
+  assert.equal(
+    shouldSettleVirtualizedViewportResize({
+      virtualizerAtBottom: true,
+      previousSize: size,
+      nextSize: { ...size },
+    }),
+    false,
+  );
+});
+
+test("a real geometry change still settles", () => {
+  const previousSize = { width: 800, height: 600 };
+  assert.equal(
+    shouldSettleVirtualizedViewportResize({
+      virtualizerAtBottom: true,
+      previousSize,
+      nextSize: { width: 800, height: 540 },
+    }),
+    true,
+  );
+  assert.equal(
+    shouldSettleVirtualizedViewportResize({
+      virtualizerAtBottom: true,
+      previousSize,
+      nextSize: { width: 783, height: 600 },
+    }),
+    true,
+  );
+});
+
+test("the first delivery settles because there is no baseline to compare", () => {
+  assert.equal(
+    shouldSettleVirtualizedViewportResize({
+      virtualizerAtBottom: true,
+      previousSize: null,
+      nextSize: { width: 800, height: 600 },
+    }),
+    true,
+  );
+});
+
+test("border-box sizing is preferred over contentRect", () => {
+  assert.deepEqual(
+    readObservedViewportSize({
+      borderBoxSize: [{ inlineSize: 800, blockSize: 600 }],
+      contentRect: { width: 1, height: 2 },
+    }),
+    { width: 800, height: 600 },
+  );
+  assert.deepEqual(
+    readObservedViewportSize({ contentRect: { width: 640, height: 480 } }),
+    { width: 640, height: 480 },
+  );
+  assert.equal(readObservedViewportSize({}), null);
+});
+
+// ── Observer wiring ──────────────────────────────────────────────────────────
+
+function harness({ atBottom = true } = {}) {
+  const frames = [];
+  const cancelled = [];
+  let settles = 0;
+  const handler = createVirtualizedViewportResizeHandler({
+    virtualizerAtBottomRef: { current: atBottom },
+    settleAtBottom: () => {
+      settles += 1;
+    },
+    requestFrame: (cb) => {
+      frames.push(cb);
+      return frames.length;
+    },
+    cancelFrame: (handle) => cancelled.push(handle),
+  });
+  return {
+    handler,
+    cancelled,
+    settles: () => settles,
+    pendingFrames: () => frames.length,
+    runFrames: () => {
+      const queued = frames.splice(0);
+      for (const cb of queued) cb();
+    },
+    deliver: (width, height) =>
+      handler.handleEntries([
+        { borderBoxSize: [{ inlineSize: width, blockSize: height }] },
+      ]),
+  };
+}
+
+test("the settle write is deferred out of the delivery pass", () => {
+  const h = harness();
+  h.deliver(800, 600);
+  // Nothing may run synchronously — a scroll write here resizes the observed
+  // element inside the pass that is delivering to us.
+  assert.equal(h.settles(), 0);
+  assert.equal(h.pendingFrames(), 1);
+  h.runFrames();
+  assert.equal(h.settles(), 1);
+});
+
+test("a re-entrant delivery does not queue a second frame", () => {
+  const h = harness();
+  h.deliver(800, 600);
+  h.deliver(800, 540);
+  assert.equal(h.pendingFrames(), 1);
+  h.runFrames();
+  assert.equal(h.settles(), 1);
+});
+
+test("a resize back to the same geometry settles nothing", () => {
+  const h = harness();
+  h.deliver(800, 600);
+  h.runFrames();
+  assert.equal(h.settles(), 1);
+
+  h.deliver(800, 600);
+  assert.equal(h.pendingFrames(), 0);
+  h.runFrames();
+  assert.equal(h.settles(), 1, "identical geometry must not re-settle");
+});
+
+test("geometry is tracked even while the virtualizer is not at bottom", () => {
+  const h = harness({ atBottom: false });
+  h.deliver(800, 600);
+  h.runFrames();
+  assert.equal(h.settles(), 0);
+});
+
+test("cancel releases a pending frame", () => {
+  const h = harness();
+  h.deliver(800, 600);
+  h.handler.cancel();
+  assert.deepEqual(h.cancelled, [1]);
+  // A second cancel is a no-op rather than a double free.
+  h.handler.cancel();
+  assert.deepEqual(h.cancelled, [1]);
 });

--- a/desktop/src/features/messages/ui/useVirtualizedViewportResize.ts
+++ b/desktop/src/features/messages/ui/useVirtualizedViewportResize.ts
@@ -1,11 +1,89 @@
 import * as React from "react";
 
+export type VirtualizedViewportSize = { width: number; height: number };
+
 export function shouldSettleVirtualizedViewportResize({
   virtualizerAtBottom,
+  previousSize,
+  nextSize,
 }: {
   virtualizerAtBottom: boolean;
+  /** Last size this observer acted on, or null before the first delivery. */
+  previousSize?: VirtualizedViewportSize | null;
+  nextSize?: VirtualizedViewportSize | null;
 }): boolean {
-  return virtualizerAtBottom;
+  if (!virtualizerAtBottom) return false;
+  // No baseline yet (or no readable box): the first delivery still settles, as
+  // it always has.
+  if (!previousSize || !nextSize) return true;
+  // A resize that round-trips to the same geometry has nothing to settle, and
+  // settling anyway is what keeps re-entering the observation pass.
+  return (
+    previousSize.width !== nextSize.width ||
+    previousSize.height !== nextSize.height
+  );
+}
+
+export function readObservedViewportSize(
+  entry: ResizeObserverEntry,
+): VirtualizedViewportSize | null {
+  const borderBox = entry.borderBoxSize?.[0];
+  if (borderBox) {
+    return { width: borderBox.inlineSize, height: borderBox.blockSize };
+  }
+  const rect = entry.contentRect;
+  if (!rect) return null;
+  return { width: rect.width, height: rect.height };
+}
+
+/**
+ * The ResizeObserver callback, lifted out of the hook so it can be driven
+ * without a DOM.
+ *
+ * `settleAtBottom` scrolls, which re-measures rows and can toggle the
+ * scrollbar — resizing the observed element at a deeper depth of the pass that
+ * is delivering to us. Running the write on the next frame keeps it out of that
+ * pass, so the browser stops reporting "ResizeObserver loop completed with
+ * undelivered notifications". This mirrors the rAF defer the sibling observer in
+ * `useVirtualizedBottomSettle` already uses.
+ */
+export function createVirtualizedViewportResizeHandler({
+  virtualizerAtBottomRef,
+  settleAtBottom,
+  requestFrame,
+  cancelFrame,
+}: {
+  virtualizerAtBottomRef: { current: boolean };
+  settleAtBottom: () => void;
+  requestFrame: (cb: () => void) => number;
+  cancelFrame: (handle: number) => void;
+}) {
+  let previousSize: VirtualizedViewportSize | null = null;
+  let frame: number | null = null;
+
+  return {
+    handleEntries(entries: readonly ResizeObserverEntry[]) {
+      const entry = entries.at(-1);
+      const nextSize = entry ? readObservedViewportSize(entry) : null;
+      const settle = shouldSettleVirtualizedViewportResize({
+        virtualizerAtBottom: virtualizerAtBottomRef.current,
+        previousSize,
+        nextSize,
+      });
+      if (nextSize) previousSize = nextSize;
+      if (!settle || frame !== null) return;
+      frame = requestFrame(() => {
+        frame = null;
+        settleAtBottom();
+      });
+    },
+    cancel() {
+      if (frame !== null) {
+        cancelFrame(frame);
+        frame = null;
+      }
+    },
+  };
 }
 
 /** Re-settles a bottom-pinned virtualized timeline after viewport reflow. */
@@ -24,16 +102,17 @@ export function useVirtualizedViewportResize(
       return;
     }
 
-    const observer = new ResizeObserver(() => {
-      if (
-        shouldSettleVirtualizedViewportResize({
-          virtualizerAtBottom: virtualizerAtBottomRef.current,
-        })
-      ) {
-        settleAtBottom();
-      }
+    const handler = createVirtualizedViewportResizeHandler({
+      virtualizerAtBottomRef,
+      settleAtBottom,
+      requestFrame: requestAnimationFrame,
+      cancelFrame: cancelAnimationFrame,
     });
+    const observer = new ResizeObserver(handler.handleEntries);
     observer.observe(container);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      handler.cancel();
+    };
   }, [scrollContainerRef, settleAtBottom, virtualizerAtBottomRef]);
 }


### PR DESCRIPTION
Refs #5717.

## What happens

`useVirtualizedViewportResize` runs its scroll write synchronously inside the
ResizeObserver callback:

```ts
const observer = new ResizeObserver(() => {
  if (shouldSettleVirtualizedViewportResize({ ... })) settleAtBottom();
});
```

`settleAtBottom` is `settle` in `useVirtualizedBottomSettle` (`:122-126`), which
calls `cancelFrame()` and then `pinToBottom()` directly — deliberately bypassing
the rAF-throttled `schedulePinToBottom` at `:50-56`. `pinToBottom` calls
`scrollToIndex(lastIndex, { align: "end" })`, which shifts Virtua's rendered
range; rows are re-measured, the inner sizing element's height changes and the
scrollbar can toggle. That resizes the observed element at a deeper depth of the
same delivery pass, and the browser reports:

```
ResizeObserver loop completed with undelivered notifications
```

Its only gate, `virtualizerAtBottomRef`, is `React.useRef(true)` at
`useAnchoredScroll.ts:174` — armed at rest, before Virtua has reported anything —
so this is live on a channel sitting idle at the bottom.

## Fix

Two things, both narrow:

1. **Defer the write to the next animation frame.** This is the same defer the
   sibling observer in `useVirtualizedBottomSettle:116-118` already uses, which
   is why that one throws no error. One frame is in flight at a time; the effect
   cleanup cancels a pending frame.
2. **Add a geometry guard.** The callback took no `entries`, so it could not
   compare sizes — a resize that round-tripped to the same layout still scrolled.
   It now reads the border box (falling back to `contentRect`) and skips
   deliveries where width and height are both unchanged. The first delivery has
   no baseline and still settles, so mount behaviour is unchanged.

The callback is lifted into `createVirtualizedViewportResizeHandler` so the frame
bookkeeping is drivable without a DOM.

## Deliberately not changed

`virtualizerAtBottomRef` is still read at delivery time rather than re-checked
inside the frame. Re-checking would be defensible — the reader can take scroll
ownership within that frame — but it changes when the pin retires, which is
beyond what this issue describes. Flagging it rather than folding it in.

## Evidence

`useVirtualizedViewportResize.test.mjs` goes from 1 test to 10. The wiring tests
drive the handler with fake entries and a fake frame queue, so they assert the
actual defect rather than a proxy for it:

- nothing runs synchronously on delivery; the settle is queued and only runs when
  the frame does
- a re-entrant delivery while a frame is pending does not queue a second one
- a delivery back to identical geometry settles nothing
- `cancel` releases a pending frame and is idempotent

Ran:

- `pnpm test` (desktop) — 4770/4770 pass, 69 suites
- `pnpm typecheck` — clean
- `pnpm exec biome check` on both changed files — clean

Not run locally: the Playwright E2E suite, and I have no Windows box to reproduce
the console message the issue reports firsthand — the wiring tests stand in for
that by asserting the re-entrancy directly. The Rust workspace is untouched.
