### PR TITLE
fix(desktop): let a declared owner remove their own stale agent seat

### DIFF
--- a/desktop/src/features/channels/lib/memberRemovalEligibility.test.mjs
+++ b/desktop/src/features/channels/lib/memberRemovalEligibility.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * Who the members sidebar offers a "Remove from channel" action for.
+ *
+ * The regression this pins: removal used to require key custody
+ * (`isLocallyManagedBot` — the agent is in this desktop's managed-agent
+ * registry). An agent the relay declares the viewer owns, but which has fallen
+ * out of that registry, showed as theirs in the profile panel while the member
+ * list offered no way to remove it — so stale bot memberships in a DM could not
+ * be cleared from the UI at all.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { canRemoveChannelMember } from "./memberUtils.ts";
+
+const ME = "a".repeat(64);
+const BOT = "b".repeat(64);
+
+function eligibility(overrides = {}) {
+  return canRemoveChannelMember({
+    memberPubkey: BOT,
+    memberRole: "bot",
+    selfRole: "member",
+    currentPubkey: ME,
+    isLocallyManagedBot: false,
+    viewerIsDeclaredOwner: false,
+    ...overrides,
+  });
+}
+
+describe("channel member removal eligibility", () => {
+  it("lets a declared owner remove an agent missing from the local registry", () => {
+    // The stale-bot case from the report: no key custody, relay says it's mine.
+    assert.equal(
+      eligibility({ isLocallyManagedBot: false, viewerIsDeclaredOwner: true }),
+      true,
+    );
+  });
+
+  it("still lets an owner remove a locally managed bot", () => {
+    assert.equal(
+      eligibility({ isLocallyManagedBot: true, viewerIsDeclaredOwner: false }),
+      true,
+    );
+  });
+
+  it("does not let an ordinary member remove someone else's agent", () => {
+    assert.equal(eligibility(), false);
+  });
+
+  it("requires channel membership before owner-declared removal applies", () => {
+    // A viewer who is not in the channel has no removal path, however the
+    // relay labels the agent.
+    assert.equal(
+      eligibility({ selfRole: undefined, viewerIsDeclaredOwner: true }),
+      false,
+    );
+  });
+
+  // ── Pre-existing rules, unchanged ────────────────────────────────────────
+
+  it("lets anyone remove themselves, even outside the channel roster", () => {
+    assert.equal(
+      eligibility({ memberPubkey: ME, selfRole: undefined }),
+      true,
+      "leaving is always yours to do",
+    );
+  });
+
+  it("lets an admin remove any other member", () => {
+    assert.equal(
+      eligibility({ selfRole: "admin", memberRole: "member" }),
+      true,
+    );
+    assert.equal(eligibility({ selfRole: "admin", memberRole: "owner" }), true);
+  });
+
+  it("lets an owner remove everyone except another owner", () => {
+    assert.equal(
+      eligibility({ selfRole: "owner", memberRole: "member" }),
+      true,
+    );
+    assert.equal(
+      eligibility({ selfRole: "owner", memberRole: "owner" }),
+      false,
+    );
+  });
+
+  it("an owner can still remove another owner's seat if it is their own agent", () => {
+    assert.equal(
+      eligibility({
+        selfRole: "owner",
+        memberRole: "owner",
+        viewerIsDeclaredOwner: true,
+      }),
+      true,
+    );
+  });
+
+  it("treats a missing current pubkey as no self-removal shortcut", () => {
+    assert.equal(
+      eligibility({ memberPubkey: BOT, currentPubkey: undefined }),
+      false,
+    );
+  });
+});

--- a/desktop/src/features/channels/lib/memberUtils.ts
+++ b/desktop/src/features/channels/lib/memberUtils.ts
@@ -37,3 +37,49 @@ export function compareMembersByRole(
   }
   return formatMemberName(left).localeCompare(formatMemberName(right));
 }
+
+/**
+ * Who may remove `member` from a channel.
+ *
+ * The two agent-ownership inputs are deliberately separate signals:
+ *
+ * - `isLocallyManagedBot` is **key custody** — this desktop holds the agent's
+ *   seckey and has it in the managed-agent registry.
+ * - `viewerIsDeclaredOwner` is **NIP-OA declared ownership** — the relay says
+ *   the viewer owns this agent. `UserProfilePanel` already keys off exactly
+ *   this (via `ownsAuthorAgent`) to decide whether to paint owner-scoped
+ *   actions.
+ *
+ * Gating removal on custody alone stranded memberships: an agent the relay
+ * declares the viewer owns, but which has fallen out of the local registry,
+ * showed as theirs in the profile panel while the member list offered no way
+ * to remove it. Membership removal is addressed by pubkey and enforced
+ * server-side, so declared ownership is the right authority here — the local
+ * registry is a cache, not the boundary.
+ */
+export function canRemoveChannelMember(input: {
+  memberPubkey: string;
+  memberRole: ChannelMember["role"];
+  selfRole: ChannelMember["role"] | undefined;
+  currentPubkey: string | undefined;
+  isLocallyManagedBot: boolean;
+  viewerIsDeclaredOwner: boolean;
+}): boolean {
+  const {
+    memberPubkey,
+    memberRole,
+    selfRole,
+    currentPubkey,
+    isLocallyManagedBot,
+    viewerIsDeclaredOwner,
+  } = input;
+
+  // Leaving is always yours to do, member or not.
+  if (memberPubkey === currentPubkey) return true;
+  // Every remaining path requires the viewer to be in the channel.
+  if (!selfRole) return false;
+
+  if (selfRole === "admin") return true;
+  if (selfRole === "owner" && memberRole !== "owner") return true;
+  return isLocallyManagedBot || viewerIsDeclaredOwner;
+}

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
+import { canRemoveChannelMember } from "@/features/channels/lib/memberUtils";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
 import { formatMemberName } from "@/features/channels/lib/memberUtils";
 import {
   canAddChannelMembers,
@@ -479,16 +481,22 @@ export function MembersSidebar({
       }),
     [bots, managedAgentByPubkey],
   );
+  const memberProfiles = memberProfilesQuery.data?.profiles;
   const canRemoveMember = React.useCallback(
     (member: ChannelMember) => {
-      return (
-        (selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
-        (selfMember?.role === "owner" && member.role !== "owner") ||
-        Boolean(selfMember && isMyBot(member)) ||
-        member.pubkey === currentPubkey
-      );
+      const profile = memberProfiles?.[normalizePubkey(member.pubkey)];
+      return canRemoveChannelMember({
+        memberPubkey: member.pubkey,
+        memberRole: member.role,
+        selfRole: selfMember?.role,
+        currentPubkey,
+        isLocallyManagedBot: isMyBot(member),
+        // Same signal UserProfilePanel uses to paint owner-scoped actions, so
+        // an agent whose profile says "managed by you" is also removable by you.
+        viewerIsDeclaredOwner: ownsAuthorAgent(profile, currentPubkey),
+      });
     },
-    [currentPubkey, isMyBot, selfMember],
+    [currentPubkey, isMyBot, memberProfiles, selfMember],
   );
   const removableManagedBots = React.useMemo(
     () =>


### PR DESCRIPTION
Refs #5754 — this addresses the **first** of the three defects listed there (`isMyBot` / removal affordance). See "Scope".

## What happens

`MembersSidebar.canRemoveMember` gates agent removal on `isMyBot`, and
`useClassifiedMembers.isMyBot` checks one thing:

```ts
const isMyBot = React.useCallback(
  (member: ChannelMember) => managedAgentPubkeys.has(normalizePubkey(member.pubkey)),
  [managedAgentPubkeys],
);
```

`managedAgentPubkeys` is this desktop's local managed-agent registry — i.e. **key
custody**. `UserProfilePanel` uses a different and broader signal for the same
question: NIP-OA **declared ownership**, via `ownsAuthorAgent(profile, currentPubkey)`,
with the comment that "the agent's seckey is never needed" for owner-scoped UI.

So an agent the relay declares the viewer owns, but which has fallen out of the
local registry, lands in the gap: the profile panel shows it as theirs and
offers `Archive agent`, while the member list and the profile's Channels tab
offer no `Remove from channel` at all. The reported consequence is a two-party
DM with stale bot memberships that the owner cannot clear from the UI —
permanently, since reopening the DM resolves back to the same channel.

## Fix

Key custody is the wrong authority here. Removal is addressed by pubkey
(`removeMemberMutation.mutateAsync(member.pubkey)`) and enforced server-side —
the local registry is a cache, not the boundary. `canRemoveMember` now also
accepts declared ownership, using the profiles `MembersSidebar` already fetches
(`memberProfilesQuery`, no new query), and reusing `ownsAuthorAgent` so the
member list and the profile panel agree on what "your agent" means.

The predicate itself moves into a pure `canRemoveChannelMember` in
`memberUtils.ts`, because the role rules had accumulated in an inline
four-way boolean and were untested.

`removableManagedBots` — the bulk "remove all managed bots" action — still
filters on the local registry. That action operates on locally managed agents by
definition, so widening it would be wrong.

## Behaviour preserved

The extraction is intentionally behaviour-preserving apart from the new clause.
The original read:

```ts
(selfMember?.role === "admin" && member.pubkey !== currentPubkey) ||
(selfMember?.role === "owner" && member.role !== "owner") ||
Boolean(selfMember && isMyBot(member)) ||
member.pubkey === currentPubkey
```

Self-removal is hoisted to the top, which subsumes the admin clause's
`!== currentPubkey` guard; `!selfRole` is equivalent to `!selfMember` because
`role` is required on `ChannelMember`. Tests pin each pre-existing rule
alongside the new one.

## Evidence

9 tests in a new `memberRemovalEligibility.test.mjs` — 4 for the change, 5
pinning the rules that must not move:

- a declared owner can remove an agent missing from the local registry (the
  reported case: no custody, relay says it's mine)
- a locally managed bot is still removable
- an ordinary member still cannot remove someone else's agent
- declared ownership still requires the viewer to be in the channel
- self-removal, admin, owner-vs-owner, and the missing-`currentPubkey` edge

Ran:

- `pnpm test` (desktop) — 4770/4770 pass, 70 suites
- `pnpm typecheck` — clean
- `pnpm exec biome check src/features/channels` — clean across all 149 files

Not run locally: the live DM repair. I cannot reproduce the reporter's tenant
state, so this is verified at the predicate, not end to end.

## Scope

The issue lists three defects; this is the first. The other two are deliberately
left out:

- `crates/buzz-db/src/dm.rs` — `open_dm` resolving by stored participant hash
  after membership expansion. Relay-side, separate concern, needs Postgres to
  test.
- `messageMentionPubkeys.ts` — outgoing DM recipient tags unioning
  `memberPubkeys` with `participantPubkeys`. I looked at making live membership
  authoritative there and backed off: #5765 ("return complete member rosters")
  is open against exactly the assumption that change would depend on. It should
  land after that one, not before it.

This PR restores the ability to *remove* the stale memberships; it does not by
itself stop them being re-tagged, which is the third defect above.
