### PR TITLE
perf(acp): avoid reply tool rediscovery

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -10,6 +10,8 @@ When a human references work "you" are doing in another channel, that work belon
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
 
+When the authenticated `mcp__buzz_dev_mcp__shell` interface is named in your system instructions, call it directly even if its schema is deferred or omitted from the initial tool list. Do not search the tool registry or try a generic local shell first. For an ordinary message send, get, or thread lookup, the inline contract here is sufficient; do not load the `buzz-cli` skill solely to repeat it.
+
 | Group | Key commands |
 |-------|-------------|
 | `buzz agents` | `draft-create`, `draft-update` |

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4275,6 +4275,14 @@ mod agent_draft_prompt_tests {
     }
 
     #[test]
+    fn shared_base_prompt_uses_authenticated_shell_without_discovery() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("call it directly even if its schema is deferred"));
+        assert!(prompt.contains("Do not search the tool registry"));
+        assert!(prompt.contains("do not load the `buzz-cli` skill solely to repeat it"));
+    }
+
+    #[test]
     fn shared_base_prompt_teaches_single_command_mentions_and_preflight() {
         let prompt = include_str!("base_prompt.md");
         assert!(prompt.contains("--mention <hex-or-npub>"));

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -50,7 +50,7 @@ const NEST_AGENTS_VERSION: u32 = 4;
 
 /// Template content version for SKILL.md.
 /// Bump this when changing `nest_skill.md` to trigger refresh on existing installs.
-const NEST_SKILL_VERSION: u32 = 5;
+const NEST_SKILL_VERSION: u32 = 6;
 
 const BEGIN_MARKER: &str = "<!-- BEGIN BUZZ MANAGED";
 const END_MARKER: &str = "<!-- END BUZZ MANAGED -->";

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -42,6 +42,13 @@ fn nest_skill_contains_safe_mention_workflow() {
 }
 
 #[test]
+fn nest_skill_does_not_claim_routine_message_replies() {
+    assert!(BUZZ_CLI_SKILL_MD.contains("Advanced Buzz CLI reference"));
+    assert!(BUZZ_CLI_SKILL_MD
+        .contains("Routine authenticated message replies use the inline Buzz base prompt"));
+}
+
+#[test]
 fn ensure_nest_creates_all_dirs_and_agents_md() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join(".buzz");

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -1,10 +1,11 @@
 ---
 name: buzz-cli
 description: >
-  Buzz CLI for relay operations: owner-reviewed agent drafts, messaging,
-  channels, DMs, users, workflows, feed, reactions, canvas, social, repos,
-  uploads, and agent memory.
-version: 1
+  Advanced Buzz CLI reference for owner-reviewed agent drafts, channel and DM
+  management, users, workflows, feed, reactions, canvas, social, repos,
+  uploads, agent memory, and non-routine messaging operations. Routine
+  authenticated message replies use the inline Buzz base prompt instead.
+version: 2
 ---
 
 # Buzz CLI Skill


### PR DESCRIPTION
## Summary

- teach managed agents to call the named authenticated Buzz shell directly, even when its schema is deferred
- keep routine message replies on the inline base-prompt contract instead of loading the full Buzz CLI skill
- refresh the installed skill metadata so existing nests stop claiming routine replies

## Evidence

A live first DM reply took 38.2s. The exact Codex timeline showed 18.2s to first token on a 31.6k-token cold prompt, followed by avoidable tool-registry discovery and a 175-line skill load before the 1.85s relay send. The ACP pool was already warm.

## Validation

- cargo fmt --all -- --check passed with Rust 1.95
- focused uzz-acp prompt-contract tests: 4 passed
- full uzz-acp: 741 passed; 31 existing shell-backed tests failed because Windows resolved a nonfunctional WSL ash.exe
- Desktop Rust suite could not compile udiopus_sys because the workstation Hermit cmake entry is a 16-byte placeholder

This removes the evidenced routing overhead. It does not claim to fix the separate cold-model first-token latency or the pre-turn gap.