### PR TITLE
Improve channel and thread load performance

### DIFF
--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -437,6 +437,9 @@ pub const KIND_THREAD_SUMMARY: u32 = 39005;
 /// content = `{has_more, next_cursor}`. The only authority on exhaustion —
 /// clients must not infer `has_more` from row counts.
 pub const KIND_WINDOW_BOUNDS: u32 = 39006;
+/// Thread page bounds overlay: `e` tag = root event id, content =
+/// `{has_more, next_cursor}`. Synthesized at query time and never stored.
+pub const KIND_THREAD_BOUNDS: u32 = 39007;
 
 /// Workflow definition (parameterized replaceable, d=workflow_uuid).
 pub const KIND_WORKFLOW_DEF: u32 = 30620;
@@ -692,6 +695,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_NIP29_GROUP_ROLES,
     KIND_THREAD_SUMMARY,
     KIND_WINDOW_BOUNDS,
+    KIND_THREAD_BOUNDS,
     KIND_PRESENCE_UPDATE,
     KIND_TYPING_INDICATOR,
     KIND_HUDDLE_REACTION,
@@ -836,6 +840,7 @@ pub const fn is_relay_only_kind(kind: u32) -> bool {
             | KIND_DM_VISIBILITY
             | KIND_THREAD_SUMMARY
             | KIND_WINDOW_BOUNDS
+            | KIND_THREAD_BOUNDS
     )
 }
 
@@ -864,6 +869,7 @@ const _: () = assert!(is_parameterized_replaceable(KIND_DM_VISIBILITY)); // 3062
 const _: () = assert!(is_parameterized_replaceable(KIND_PROJECT)); // 30621 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_THREAD_SUMMARY)); // 39005 ∈ 30000–39999
 const _: () = assert!(is_parameterized_replaceable(KIND_WINDOW_BOUNDS)); // 39006 ∈ 30000–39999
+const _: () = assert!(is_parameterized_replaceable(KIND_THREAD_BOUNDS)); // 39007 ∈ 30000–39999
 
 // Compile-time: NIP-34 parameterized replaceable kinds are in the correct range.
 const _: () = assert!(

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -2910,7 +2910,45 @@ impl Db {
         depth_limit: Option<u32>,
         limit: u32,
         cursor: Option<&[u8]>,
-    ) -> Result<Vec<thread::ThreadReply>> {
+    ) -> Result<thread::ThreadPage> {
+        self.get_thread_replies_ordered(
+            community_id,
+            root_event_id,
+            depth_limit,
+            limit,
+            cursor,
+            thread::ThreadOrder::Oldest,
+        )
+        .await
+    }
+
+    /// Fetch replies under a root event in the requested traversal order.
+    pub async fn get_thread_replies_ordered(
+        &self,
+        community_id: CommunityId,
+        root_event_id: &[u8],
+        depth_limit: Option<u32>,
+        limit: u32,
+        cursor: Option<&[u8]>,
+        order: thread::ThreadOrder,
+    ) -> Result<thread::ThreadPage> {
+        if order == thread::ThreadOrder::Newest {
+            // Descending pages can contain rows newer than their tail cursor;
+            // the ascending fence proof cannot establish that shape safely.
+            // Keep newest-first traversal writer-authoritative.
+            Self::record_route("thread_newest", "writer", "predicate");
+            return thread::get_thread_replies_ordered(
+                &self.pool,
+                community_id,
+                root_event_id,
+                depth_limit,
+                limit,
+                cursor,
+                order,
+            )
+            .await;
+        }
+
         let (path, predicate): (&'static str, RoutePredicate) = match cursor {
             Some(_) => (
                 "thread_cursor",
@@ -2923,29 +2961,34 @@ impl Db {
         if let RouteDecision::Replica(mut tx, entry, reason) =
             self.route_read(path, predicate).await
         {
-            match thread::get_thread_replies_on(
+            match thread::get_thread_replies_ordered_on(
                 &mut tx,
                 community_id,
                 root_event_id,
                 depth_limit,
                 limit,
                 cursor,
+                order,
             )
             .await
             {
-                Ok(replies) => {
+                Ok(page) => {
                     if cursor.is_none() {
                         // Predicate A: bounded-stale head page, served as proved.
                         Self::record_route(path, "replica", reason);
-                        return Ok(replies);
+                        return Ok(page);
                     }
-                    let full = replies.len() >= limit as usize;
-                    let below_fence = replies
-                        .last()
-                        .is_some_and(|tail| tail.created_at <= entry.fence_wall);
-                    if full && below_fence {
+                    // Only a non-terminal page whose raw scan cursor is at or
+                    // below the proved wall can be trusted from a replica. A
+                    // delivered-event tail is not authoritative: corrupt rows
+                    // may make it empty or older than the actual scan position.
+                    let below_fence = page
+                        .next_cursor
+                        .as_ref()
+                        .is_some_and(|(ts, _)| *ts <= entry.fence_wall);
+                    if page.has_more && below_fence {
                         Self::record_route(path, "replica", reason);
-                        return Ok(replies);
+                        return Ok(page);
                     }
                     // Candidate terminal page, or page reaching above the
                     // proved wall — verify against the writer. Recorded as
@@ -2965,13 +3008,14 @@ impl Db {
                 }
             }
         }
-        thread::get_thread_replies(
+        thread::get_thread_replies_ordered(
             &self.pool,
             community_id,
             root_event_id,
             depth_limit,
             limit,
             cursor,
+            order,
         )
         .await
     }

--- a/crates/buzz-db/src/thread.rs
+++ b/crates/buzz-db/src/thread.rs
@@ -15,6 +15,46 @@ use crate::{error::Result, event::row_to_stored_event};
 
 // -- Structs ------------------------------------------------------------------
 
+/// Traversal order for a thread page.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum ThreadOrder {
+    /// Preserve the historical oldest-to-newest traversal.
+    #[default]
+    Oldest,
+    /// Traverse newest-to-oldest so recent replies can be presented first.
+    Newest,
+}
+
+/// One authoritative page of thread replies.
+#[derive(Debug, Clone)]
+pub struct ThreadPage {
+    /// Reconstructable replies from the scanned raw rows.
+    pub replies: Vec<ThreadReply>,
+    /// Whether another raw row exists beyond this page.
+    pub has_more: bool,
+    /// Composite scan cursor `(created_at, event_id)` of the last raw row
+    /// retained for this page. Captured before reconstruction, so corrupt rows
+    /// cannot stall or prematurely terminate traversal. `Some` iff `has_more`.
+    pub next_cursor: Option<(DateTime<Utc>, Vec<u8>)>,
+}
+
+impl std::ops::Deref for ThreadPage {
+    type Target = [ThreadReply];
+
+    fn deref(&self) -> &Self::Target {
+        &self.replies
+    }
+}
+
+impl IntoIterator for ThreadPage {
+    type Item = ThreadReply;
+    type IntoIter = std::vec::IntoIter<ThreadReply>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.replies.into_iter()
+    }
+}
+
 /// A single reply within a thread, joined with event content.
 #[derive(Debug, Clone)]
 pub struct ThreadReply {
@@ -349,15 +389,38 @@ pub async fn get_thread_replies(
     depth_limit: Option<u32>,
     limit: u32,
     cursor: Option<&[u8]>,
-) -> Result<Vec<ThreadReply>> {
+) -> Result<ThreadPage> {
+    get_thread_replies_ordered(
+        pool,
+        community_id,
+        root_event_id,
+        depth_limit,
+        limit,
+        cursor,
+        ThreadOrder::Oldest,
+    )
+    .await
+}
+
+/// Fetch a thread page in the requested traversal order.
+pub async fn get_thread_replies_ordered(
+    pool: &PgPool,
+    community_id: CommunityId,
+    root_event_id: &[u8],
+    depth_limit: Option<u32>,
+    limit: u32,
+    cursor: Option<&[u8]>,
+    order: ThreadOrder,
+) -> Result<ThreadPage> {
     let mut conn = pool.acquire().await?;
-    get_thread_replies_on(
+    get_thread_replies_ordered_on(
         &mut conn,
         community_id,
         root_event_id,
         depth_limit,
         limit,
         cursor,
+        order,
     )
     .await
 }
@@ -366,14 +429,15 @@ pub async fn get_thread_replies(
 /// runs the page on the exact reader connection whose heartbeat observation
 /// proved coverage (the proof is connection-local; a different pooled
 /// session may sit at a different replay position).
-pub(crate) async fn get_thread_replies_on(
+pub(crate) async fn get_thread_replies_ordered_on(
     conn: &mut sqlx::PgConnection,
     community_id: CommunityId,
     root_event_id: &[u8],
     depth_limit: Option<u32>,
     limit: u32,
     cursor: Option<&[u8]>,
-) -> Result<Vec<ThreadReply>> {
+    order: ThreadOrder,
+) -> Result<ThreadPage> {
     // Decode cursor bytes -> keyset (timestamp, optional event_id) for the
     // WHERE condition. Layout: 8-byte BE i64 seconds, then the raw event_id.
     // An 8-byte-only cursor is legacy timestamp-only paging (no tiebreak).
@@ -430,25 +494,37 @@ pub(crate) async fn get_thread_replies_on(
     }
     match &cursor_key {
         Some((_, Some(_))) => {
-            // Composite keyset: strict row comparison with an event_id tiebreak
-            // so same-second replies paginate without gaps or duplicates.
+            // Composite keyset with an event_id tiebreak so same-second replies
+            // paginate without gaps or duplicates in either direction.
             let ts_idx = param_idx;
             let id_idx = param_idx + 1;
+            let op = match order {
+                ThreadOrder::Oldest => ">",
+                ThreadOrder::Newest => "<",
+            };
             sql.push_str(&format!(
-                " AND (tm.event_created_at, tm.event_id) > (${ts_idx}, ${id_idx})"
+                " AND (tm.event_created_at, tm.event_id) {op} (${ts_idx}, ${id_idx})"
             ));
             param_idx += 2;
         }
         Some((_, None)) => {
             // Legacy timestamp-only cursor (no tiebreak).
-            sql.push_str(&format!(" AND tm.event_created_at > ${param_idx}"));
+            let op = match order {
+                ThreadOrder::Oldest => ">",
+                ThreadOrder::Newest => "<",
+            };
+            sql.push_str(&format!(" AND tm.event_created_at {op} ${param_idx}"));
             param_idx += 1;
         }
         None => {}
     }
 
+    let direction = match order {
+        ThreadOrder::Oldest => "ASC",
+        ThreadOrder::Newest => "DESC",
+    };
     sql.push_str(&format!(
-        " ORDER BY tm.event_created_at ASC, tm.event_id ASC LIMIT ${param_idx}"
+        " ORDER BY tm.event_created_at {direction}, tm.event_id {direction} LIMIT ${param_idx}"
     ));
 
     let mut q = sqlx::query(sqlx::AssertSqlSafe(sql))
@@ -467,9 +543,23 @@ pub(crate) async fn get_thread_replies_on(
         }
         None => {}
     }
-    q = q.bind(limit as i32);
+    // One extra raw row is the server's authoritative evidence of continuation.
+    q = q.bind(limit as i64 + 1);
 
-    let rows = q.fetch_all(&mut *conn).await?;
+    let mut rows = q.fetch_all(&mut *conn).await?;
+    let has_more = rows.len() > limit as usize;
+    rows.truncate(limit as usize);
+    let next_cursor = if has_more {
+        match rows.last() {
+            Some(row) => Some((
+                row.try_get::<DateTime<Utc>, _>("event_created_at")?,
+                row.try_get::<Vec<u8>, _>("event_id")?,
+            )),
+            None => None,
+        }
+    } else {
+        None
+    };
 
     let mut replies = Vec::with_capacity(rows.len());
     for row in rows {
@@ -506,7 +596,11 @@ pub(crate) async fn get_thread_replies_on(
         });
     }
 
-    Ok(replies)
+    Ok(ThreadPage {
+        replies,
+        has_more,
+        next_cursor,
+    })
 }
 
 /// Fetch aggregated thread stats for a single event, plus up to 10 participant pubkeys.
@@ -1215,6 +1309,37 @@ mod tests {
         let mut expected_sorted = expected_ids.clone();
         expected_sorted.sort();
         assert_eq!(unique, expected_sorted, "paged set != inserted tied set");
+
+        // The optional reverse traversal must converge over the same tied set
+        // while issuing cursors from the last raw row of each descending page.
+        let mut newest_ids = Vec::new();
+        let mut newest_cursor: Option<Vec<u8>> = None;
+        loop {
+            let page = get_thread_replies_ordered(
+                &pool,
+                community,
+                root.id.as_bytes(),
+                Some(10),
+                page_limit,
+                newest_cursor.as_deref(),
+                ThreadOrder::Newest,
+            )
+            .await
+            .expect("fetch newest page");
+            newest_ids.extend(page.replies.iter().map(|reply| reply.event_id.clone()));
+            if !page.has_more {
+                assert!(page.next_cursor.is_none());
+                break;
+            }
+            let (ts, id) = page.next_cursor.expect("has_more implies cursor");
+            let mut next = ts.timestamp().to_be_bytes().to_vec();
+            next.extend_from_slice(&id);
+            newest_cursor = Some(next);
+        }
+        let mut newest_unique = newest_ids;
+        newest_unique.sort();
+        newest_unique.dedup();
+        assert_eq!(newest_unique, expected_sorted);
     }
 
     /// Nested replies (depth >= 2) must be reachable in a subtree read. Every
@@ -1417,7 +1542,15 @@ mod tests {
             .expect("insert root event");
 
         // Two replies under the same root: one stays valid, one we corrupt.
-        let good = make_stream_event(&author, "good");
+        // Pin ordering so the corrupt row is the entire first raw page and the
+        // valid row is beyond it. This exercises zero delivered events with
+        // `has_more = true`, not merely skip-and-continue within one page.
+        let bad_secs = root.created_at.as_secs() + 1;
+        let good_secs = bad_secs + 1;
+        let good = EventBuilder::new(Kind::Custom(9), "good")
+            .custom_created_at(nostr::Timestamp::from(good_secs))
+            .sign_with_keys(&author)
+            .expect("sign good reply");
         let good_id = good.id.to_hex();
         let good_created_at = event_created_at(&good);
         insert_event_with_thread_metadata(
@@ -1440,7 +1573,10 @@ mod tests {
         .await
         .expect("insert good reply");
 
-        let bad = make_stream_event(&author, "bad");
+        let bad = EventBuilder::new(Kind::Custom(9), "bad")
+            .custom_created_at(nostr::Timestamp::from(bad_secs))
+            .sign_with_keys(&author)
+            .expect("sign bad reply");
         let bad_created_at = event_created_at(&bad);
         insert_event_with_thread_metadata(
             &pool,
@@ -1474,15 +1610,40 @@ mod tests {
             .rows_affected();
         assert_eq!(rows_changed, 1, "expected to corrupt exactly one row");
 
-        let replies = get_thread_replies(&pool, community, root.id.as_bytes(), Some(10), 10, None)
+        let first = get_thread_replies(&pool, community, root.id.as_bytes(), Some(10), 1, None)
             .await
-            .expect("fetch thread replies must succeed despite a corrupt row");
+            .expect("fetch corrupt first page");
+        assert!(
+            first.replies.is_empty(),
+            "corrupt raw row must not be delivered"
+        );
+        assert!(
+            first.has_more,
+            "the valid row beyond the corrupt page remains"
+        );
+        let (cursor_ts, cursor_id) = first
+            .next_cursor
+            .expect("has_more page must expose its raw scan cursor");
+        assert_eq!(cursor_ts, bad_created_at);
+        assert_eq!(cursor_id, bad.id.as_bytes());
 
-        // The corrupt reply is skipped; the valid one survives. The whole
-        // query does NOT 500 on a single unreconstructable row.
-        assert_eq!(replies.len(), 1);
-        assert_eq!(replies[0].stored_event.event.id.to_hex(), good_id);
-        assert_eq!(replies[0].stored_event.event.content, "good");
+        let mut cursor = cursor_ts.timestamp().to_be_bytes().to_vec();
+        cursor.extend_from_slice(&cursor_id);
+        let second = get_thread_replies(
+            &pool,
+            community,
+            root.id.as_bytes(),
+            Some(10),
+            1,
+            Some(&cursor),
+        )
+        .await
+        .expect("fetch valid second page");
+        assert!(!second.has_more);
+        assert!(second.next_cursor.is_none());
+        assert_eq!(second.replies.len(), 1);
+        assert_eq!(second.replies[0].stored_event.event.id.to_hex(), good_id);
+        assert_eq!(second.replies[0].stored_event.event.content, "good");
     }
 
     /// Insert one top-level event (root metadata, broadcast) into a channel.

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -286,6 +286,19 @@ fn extract_depth_limit(raw: &Value) -> Option<u32> {
         .and_then(|n| u32::try_from(n).ok())
 }
 
+/// Optional thread traversal order. Unknown or absent values preserve the
+/// historical oldest-first behavior.
+fn extract_thread_order(raw: &Value) -> buzz_db::thread::ThreadOrder {
+    match raw
+        .get("thread_order")
+        .or_else(|| raw.get("threadOrder"))
+        .and_then(Value::as_str)
+    {
+        Some("newest") => buzz_db::thread::ThreadOrder::Newest,
+        _ => buzz_db::thread::ThreadOrder::Oldest,
+    }
+}
+
 /// Extract a thread pagination cursor from the raw filter JSON.
 ///
 /// The desktop pages `get_thread_replies` forward with a keyset cursor derived
@@ -1179,21 +1192,24 @@ async fn query_events_authed(
         let limit = filter
             .limit
             .unwrap_or(100)
-            .min(BRIDGE_THREAD_MAX_LIMIT as usize) as u32;
+            .min(BRIDGE_THREAD_MAX_LIMIT as usize)
+            .max(1) as u32;
         let thread_cursor = extract_thread_cursor(raw);
-        let thread_replies = state
+        let thread_order = extract_thread_order(raw);
+        let thread_page = state
             .db
-            .get_thread_replies(
+            .get_thread_replies_ordered(
                 tenant.community(),
                 &root_bytes,
                 Some(depth),
                 limit,
                 thread_cursor.as_deref(),
+                thread_order,
             )
             .await
             .map_err(|e| internal_error(&format!("thread query error: {e}")))?;
 
-        for reply in thread_replies {
+        for reply in thread_page.replies {
             let se = reply.stored_event;
             if !event_in_accessible_channel(&se, &accessible_channels) {
                 continue;
@@ -1208,6 +1224,45 @@ async fn query_events_authed(
                 events.push(v);
             }
         }
+
+        // Relay-signed, query-time pagination authority. The cursor describes
+        // the raw scan position, not the last event that happened to survive
+        // reconstruction or authorization filtering.
+        let next_cursor = thread_page.next_cursor.as_ref().map(|(ts, id)| {
+            serde_json::json!({
+                "created_at": ts.timestamp(),
+                "id": hex::encode(id),
+            })
+        });
+        let content = serde_json::json!({
+            "has_more": thread_page.has_more,
+            "next_cursor": next_cursor,
+        });
+        let order = match thread_order {
+            buzz_db::thread::ThreadOrder::Oldest => "oldest",
+            buzz_db::thread::ThreadOrder::Newest => "newest",
+        };
+        let request_cursor = thread_cursor
+            .as_deref()
+            .map(hex::encode)
+            .unwrap_or_else(|| "head".to_owned());
+        let tags = vec![
+            nostr::Tag::parse(["e", root_hex])
+                .map_err(|e| internal_error(&format!("thread bounds e tag: {e}")))?,
+            nostr::Tag::parse(["d", &format!("{root_hex}:{order}:{request_cursor}")])
+                .map_err(|e| internal_error(&format!("thread bounds d tag: {e}")))?,
+        ];
+        let overlay = nostr::EventBuilder::new(
+            nostr::Kind::Custom(buzz_core::kind::KIND_THREAD_BOUNDS as u16),
+            content.to_string(),
+        )
+        .tags(tags)
+        .sign_with_keys(&state.relay_keypair)
+        .map_err(|e| internal_error(&format!("thread bounds sign: {e}")))?;
+        events.push(
+            serde_json::to_value(&overlay)
+                .map_err(|e| internal_error(&format!("thread bounds serialize: {e}")))?,
+        );
         handled.insert(idx);
     }
 
@@ -3070,6 +3125,28 @@ mod tests {
     fn extract_depth_limit_valid() {
         let raw = serde_json::json!({ "depth_limit": 3 });
         assert_eq!(extract_depth_limit(&raw), Some(3));
+    }
+
+    #[test]
+    fn extract_thread_order_defaults_oldest_and_accepts_both_field_styles() {
+        use buzz_db::thread::ThreadOrder;
+
+        assert_eq!(
+            extract_thread_order(&serde_json::json!({})),
+            ThreadOrder::Oldest
+        );
+        assert_eq!(
+            extract_thread_order(&serde_json::json!({ "thread_order": "newest" })),
+            ThreadOrder::Newest
+        );
+        assert_eq!(
+            extract_thread_order(&serde_json::json!({ "threadOrder": "newest" })),
+            ThreadOrder::Newest
+        );
+        assert_eq!(
+            extract_thread_order(&serde_json::json!({ "thread_order": "future" })),
+            ThreadOrder::Oldest
+        );
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -1196,6 +1196,7 @@ async fn query_events_authed(
             .max(1) as u32;
         let thread_cursor = extract_thread_cursor(raw);
         let thread_order = extract_thread_order(raw);
+        let include_thread_bounds = extension_flag(raw, "thread_bounds");
         let thread_page = state
             .db
             .get_thread_replies_ordered(
@@ -1225,44 +1226,47 @@ async fn query_events_authed(
             }
         }
 
-        // Relay-signed, query-time pagination authority. The cursor describes
-        // the raw scan position, not the last event that happened to survive
-        // reconstruction or authorization filtering.
-        let next_cursor = thread_page.next_cursor.as_ref().map(|(ts, id)| {
-            serde_json::json!({
-                "created_at": ts.timestamp(),
-                "id": hex::encode(id),
-            })
-        });
-        let content = serde_json::json!({
-            "has_more": thread_page.has_more,
-            "next_cursor": next_cursor,
-        });
-        let order = match thread_order {
-            buzz_db::thread::ThreadOrder::Oldest => "oldest",
-            buzz_db::thread::ThreadOrder::Newest => "newest",
-        };
-        let request_cursor = thread_cursor
-            .as_deref()
-            .map(hex::encode)
-            .unwrap_or_else(|| "head".to_owned());
-        let tags = vec![
-            nostr::Tag::parse(["e", root_hex])
-                .map_err(|e| internal_error(&format!("thread bounds e tag: {e}")))?,
-            nostr::Tag::parse(["d", &format!("{root_hex}:{order}:{request_cursor}")])
-                .map_err(|e| internal_error(&format!("thread bounds d tag: {e}")))?,
-        ];
-        let overlay = nostr::EventBuilder::new(
-            nostr::Kind::Custom(buzz_core::kind::KIND_THREAD_BOUNDS as u16),
-            content.to_string(),
-        )
-        .tags(tags)
-        .sign_with_keys(&state.relay_keypair)
-        .map_err(|e| internal_error(&format!("thread bounds sign: {e}")))?;
-        events.push(
-            serde_json::to_value(&overlay)
-                .map_err(|e| internal_error(&format!("thread bounds serialize: {e}")))?,
-        );
+        // Relay-signed, query-time pagination authority, explicitly requested
+        // by clients that understand the overlay. Legacy clients page by the
+        // last returned reply, so appending a protocol event unconditionally
+        // would turn that overlay into their cursor and truncate large threads.
+        if include_thread_bounds {
+            let next_cursor = thread_page.next_cursor.as_ref().map(|(ts, id)| {
+                serde_json::json!({
+                    "created_at": ts.timestamp(),
+                    "id": hex::encode(id),
+                })
+            });
+            let content = serde_json::json!({
+                "has_more": thread_page.has_more,
+                "next_cursor": next_cursor,
+            });
+            let order = match thread_order {
+                buzz_db::thread::ThreadOrder::Oldest => "oldest",
+                buzz_db::thread::ThreadOrder::Newest => "newest",
+            };
+            let request_cursor = thread_cursor
+                .as_deref()
+                .map(hex::encode)
+                .unwrap_or_else(|| "head".to_owned());
+            let tags = vec![
+                nostr::Tag::parse(["e", root_hex])
+                    .map_err(|e| internal_error(&format!("thread bounds e tag: {e}")))?,
+                nostr::Tag::parse(["d", &format!("{root_hex}:{order}:{request_cursor}")])
+                    .map_err(|e| internal_error(&format!("thread bounds d tag: {e}")))?,
+            ];
+            let overlay = nostr::EventBuilder::new(
+                nostr::Kind::Custom(buzz_core::kind::KIND_THREAD_BOUNDS as u16),
+                content.to_string(),
+            )
+            .tags(tags)
+            .sign_with_keys(&state.relay_keypair)
+            .map_err(|e| internal_error(&format!("thread bounds sign: {e}")))?;
+            events.push(
+                serde_json::to_value(&overlay)
+                    .map_err(|e| internal_error(&format!("thread bounds serialize: {e}")))?,
+            );
+        }
         handled.insert(idx);
     }
 
@@ -3069,6 +3073,18 @@ mod tests {
         assert!(!extension_flag(
             &serde_json::json!({ "top_level": 1 }),
             "top_level"
+        ));
+        assert!(extension_flag(
+            &serde_json::json!({ "thread_bounds": true }),
+            "thread_bounds"
+        ));
+        assert!(!extension_flag(
+            &serde_json::json!({ "thread_bounds": false }),
+            "thread_bounds"
+        ));
+        assert!(!extension_flag(
+            &serde_json::json!({ "thread_bounds": "true" }),
+            "thread_bounds"
         ));
     }
 

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
         "**/add-community-screenshots.spec.ts",
         "**/hosted-communities-settings-screenshots.spec.ts",
         "**/invites-settings-screenshots.spec.ts",
+        "**/message-performance.spec.ts",
+        "**/thread-newest-ab.perf.ts",
         "**/messaging.spec.ts",
         "**/message-feedback-snapshots.spec.ts",
         "**/custom-emoji.spec.ts",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
         "**/hosted-communities-settings-screenshots.spec.ts",
         "**/invites-settings-screenshots.spec.ts",
         "**/message-performance.spec.ts",
-        "**/thread-newest-ab.perf.ts",
         "**/messaging.spec.ts",
         "**/message-feedback-snapshots.spec.ts",
         "**/custom-emoji.spec.ts",

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -264,10 +264,31 @@ pub async fn get_thread_replies(
         cap,
         thread_order.as_deref(),
         cursor.as_ref(),
+        true,
     );
 
     let events = query_relay(&state, &[serde_json::Value::Object(filter)]).await?;
-    thread_page::parse(events, &root_event_id)
+    match thread_page::parse(events, &root_event_id) {
+        Ok(page) => Ok(page),
+        Err(thread_page::ParseError::MissingBounds) => {
+            // Relays predating the bounds extension ignore the opt-in fields.
+            // Retry their historical oldest-first contract so Desktop releases
+            // remain safe during partial rollout and relay rollback.
+            let legacy_filter = build_thread_replies_filter(
+                &root_event_id,
+                channel_id.as_deref(),
+                depth_limit.unwrap_or(64),
+                cap,
+                None,
+                cursor.as_ref(),
+                false,
+            );
+            let legacy_events =
+                query_relay(&state, &[serde_json::Value::Object(legacy_filter)]).await?;
+            Ok(thread_page::parse_legacy(legacy_events, cap))
+        }
+        Err(error) => Err(error.to_string()),
+    }
 }
 
 /// Build the relay `/query` filter for the server-side thread-subtree read.
@@ -292,6 +313,7 @@ fn build_thread_replies_filter(
     cap: u32,
     thread_order: Option<&str>,
     cursor: Option<&crate::models::ThreadCursor>,
+    include_bounds: bool,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut filter = serde_json::Map::new();
     filter.insert("#e".to_string(), serde_json::json!([root_event_id]));
@@ -300,11 +322,13 @@ fn build_thread_replies_filter(
     // defaults it to a deep-but-bounded value so nested replies aren't dropped.
     filter.insert("depth_limit".to_string(), serde_json::json!(depth_limit));
     filter.insert("limit".to_string(), serde_json::json!(cap));
-    // Opt into the relay's authoritative raw-scan bounds overlay. Older clients
-    // do not understand protocol events in this response and must not receive it.
-    filter.insert("thread_bounds".to_string(), serde_json::json!(true));
-    if matches!(thread_order, Some("newest")) {
-        filter.insert("thread_order".to_string(), serde_json::json!("newest"));
+    // Opt into authoritative raw-scan bounds only on the modern attempt.
+    // Legacy retries omit both extensions to preserve the old relay contract.
+    if include_bounds {
+        filter.insert("thread_bounds".to_string(), serde_json::json!(true));
+        if matches!(thread_order, Some("newest")) {
+            filter.insert("thread_order".to_string(), serde_json::json!("newest"));
+        }
     }
     if let Some(cid) = channel_id {
         filter.insert("#h".to_string(), serde_json::json!([cid]));

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -2,6 +2,7 @@ use nostr::{Event, EventId, Keys, PublicKey};
 use tauri::{AppHandle, State};
 
 mod forum;
+mod thread_page;
 
 use forum::{
     apply_link_preview_suppression, fetch_agent_owner_pubkeys, link_preview_suppression_targets,
@@ -251,6 +252,7 @@ pub async fn get_thread_replies(
     channel_id: Option<String>,
     limit: Option<u32>,
     depth_limit: Option<u32>,
+    thread_order: Option<String>,
     cursor: Option<crate::models::ThreadCursor>,
     state: State<'_, AppState>,
 ) -> Result<ThreadRepliesResponse, String> {
@@ -260,32 +262,12 @@ pub async fn get_thread_replies(
         channel_id.as_deref(),
         depth_limit.unwrap_or(64),
         cap,
+        thread_order.as_deref(),
         cursor.as_ref(),
     );
 
     let events = query_relay(&state, &[serde_json::Value::Object(filter)]).await?;
-
-    // A full page implies there may be more; hand back the last event's
-    // composite key as the next cursor (the DB returns replies strictly after
-    // it, tiebroken by event_id so same-second replies are not skipped).
-    let next_cursor = if events.len() as u32 >= cap {
-        events.last().map(|ev| crate::models::ThreadCursor {
-            created_at: ev.created_at.as_secs() as i64,
-            event_id: ev.id.to_hex(),
-        })
-    } else {
-        None
-    };
-
-    let event_values: Vec<serde_json::Value> = events
-        .iter()
-        .filter_map(|ev| serde_json::to_value(ev).ok())
-        .collect();
-
-    Ok(ThreadRepliesResponse {
-        events: event_values,
-        next_cursor,
-    })
+    thread_page::parse(events, &root_event_id)
 }
 
 /// Build the relay `/query` filter for the server-side thread-subtree read.
@@ -308,6 +290,7 @@ fn build_thread_replies_filter(
     channel_id: Option<&str>,
     depth_limit: u32,
     cap: u32,
+    thread_order: Option<&str>,
     cursor: Option<&crate::models::ThreadCursor>,
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut filter = serde_json::Map::new();
@@ -317,6 +300,9 @@ fn build_thread_replies_filter(
     // defaults it to a deep-but-bounded value so nested replies aren't dropped.
     filter.insert("depth_limit".to_string(), serde_json::json!(depth_limit));
     filter.insert("limit".to_string(), serde_json::json!(cap));
+    if matches!(thread_order, Some("newest")) {
+        filter.insert("thread_order".to_string(), serde_json::json!("newest"));
+    }
     if let Some(cid) = channel_id {
         filter.insert("#h".to_string(), serde_json::json!([cid]));
     }

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -300,6 +300,9 @@ fn build_thread_replies_filter(
     // defaults it to a deep-but-bounded value so nested replies aren't dropped.
     filter.insert("depth_limit".to_string(), serde_json::json!(depth_limit));
     filter.insert("limit".to_string(), serde_json::json!(cap));
+    // Opt into the relay's authoritative raw-scan bounds overlay. Older clients
+    // do not understand protocol events in this response and must not receive it.
+    filter.insert("thread_bounds".to_string(), serde_json::json!(true));
     if matches!(thread_order, Some("newest")) {
         filter.insert("thread_order".to_string(), serde_json::json!("newest"));
     }

--- a/desktop/src-tauri/src/commands/messages/thread_page.rs
+++ b/desktop/src-tauri/src/commands/messages/thread_page.rs
@@ -1,7 +1,25 @@
 use nostr::Event;
 use serde::Deserialize;
+use std::fmt;
 
 use crate::models::{ThreadCursor, ThreadRepliesResponse};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ParseError {
+    MissingBounds,
+    InvalidBounds(String),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingBounds => {
+                formatter.write_str("Thread response omitted its bounds overlay")
+            }
+            Self::InvalidBounds(message) => formatter.write_str(message),
+        }
+    }
+}
 
 #[derive(Deserialize)]
 struct BoundsCursor {
@@ -18,13 +36,15 @@ struct BoundsPayload {
 pub(super) fn parse(
     events: Vec<Event>,
     root_event_id: &str,
-) -> Result<ThreadRepliesResponse, String> {
+) -> Result<ThreadRepliesResponse, ParseError> {
     let mut replies = Vec::new();
     let mut bounds = None;
     for event in events {
         if event.kind.as_u16() as u32 == buzz_core_pkg::kind::KIND_THREAD_BOUNDS {
             if bounds.is_some() {
-                return Err("Thread response contained multiple bounds overlays".to_string());
+                return Err(ParseError::InvalidBounds(
+                    "Thread response contained multiple bounds overlays".to_string(),
+                ));
             }
             let matches_root = event.tags.iter().any(|tag| {
                 let values = tag.as_slice();
@@ -32,27 +52,54 @@ pub(super) fn parse(
                     && values.get(1).map(String::as_str) == Some(root_event_id)
             });
             if !matches_root {
-                return Err("Thread bounds overlay does not match the requested root".to_string());
+                return Err(ParseError::InvalidBounds(
+                    "Thread bounds overlay does not match the requested root".to_string(),
+                ));
             }
             bounds = Some(
-                serde_json::from_str::<BoundsPayload>(&event.content)
-                    .map_err(|error| format!("Invalid thread bounds overlay: {error}"))?,
+                serde_json::from_str::<BoundsPayload>(&event.content).map_err(|error| {
+                    ParseError::InvalidBounds(format!("Invalid thread bounds overlay: {error}"))
+                })?,
             );
         } else if let Ok(value) = serde_json::to_value(&event) {
             replies.push(value);
         }
     }
-    let bounds = bounds.ok_or_else(|| "Thread response omitted its bounds overlay".to_string())?;
+    let bounds = bounds.ok_or(ParseError::MissingBounds)?;
     let next_cursor = bounds.next_cursor.map(|cursor| ThreadCursor {
         created_at: cursor.created_at,
         event_id: cursor.id,
     });
     if bounds.has_more != next_cursor.is_some() {
-        return Err("Thread bounds has_more and next_cursor disagree".to_string());
+        return Err(ParseError::InvalidBounds(
+            "Thread bounds has_more and next_cursor disagree".to_string(),
+        ));
     }
     Ok(ThreadRepliesResponse {
         events: replies,
         has_more: bounds.has_more,
         next_cursor,
     })
+}
+
+pub(super) fn parse_legacy(events: Vec<Event>, cap: u32) -> ThreadRepliesResponse {
+    let has_more = events.len() as u32 >= cap;
+    let next_cursor = if has_more {
+        events.last().map(|event| ThreadCursor {
+            created_at: event.created_at.as_secs() as i64,
+            event_id: event.id.to_hex(),
+        })
+    } else {
+        None
+    };
+    let events = events
+        .iter()
+        .filter_map(|event| serde_json::to_value(event).ok())
+        .collect();
+
+    ThreadRepliesResponse {
+        events,
+        has_more,
+        next_cursor,
+    }
 }

--- a/desktop/src-tauri/src/commands/messages/thread_page.rs
+++ b/desktop/src-tauri/src/commands/messages/thread_page.rs
@@ -1,0 +1,58 @@
+use nostr::Event;
+use serde::Deserialize;
+
+use crate::models::{ThreadCursor, ThreadRepliesResponse};
+
+#[derive(Deserialize)]
+struct BoundsCursor {
+    created_at: i64,
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct BoundsPayload {
+    has_more: bool,
+    next_cursor: Option<BoundsCursor>,
+}
+
+pub(super) fn parse(
+    events: Vec<Event>,
+    root_event_id: &str,
+) -> Result<ThreadRepliesResponse, String> {
+    let mut replies = Vec::new();
+    let mut bounds = None;
+    for event in events {
+        if event.kind.as_u16() as u32 == buzz_core_pkg::kind::KIND_THREAD_BOUNDS {
+            if bounds.is_some() {
+                return Err("Thread response contained multiple bounds overlays".to_string());
+            }
+            let matches_root = event.tags.iter().any(|tag| {
+                let values = tag.as_slice();
+                values.first().map(String::as_str) == Some("e")
+                    && values.get(1).map(String::as_str) == Some(root_event_id)
+            });
+            if !matches_root {
+                return Err("Thread bounds overlay does not match the requested root".to_string());
+            }
+            bounds = Some(
+                serde_json::from_str::<BoundsPayload>(&event.content)
+                    .map_err(|error| format!("Invalid thread bounds overlay: {error}"))?,
+            );
+        } else if let Ok(value) = serde_json::to_value(&event) {
+            replies.push(value);
+        }
+    }
+    let bounds = bounds.ok_or_else(|| "Thread response omitted its bounds overlay".to_string())?;
+    let next_cursor = bounds.next_cursor.map(|cursor| ThreadCursor {
+        created_at: cursor.created_at,
+        event_id: cursor.id,
+    });
+    if bounds.has_more != next_cursor.is_some() {
+        return Err("Thread bounds has_more and next_cursor disagree".to_string());
+    }
+    Ok(ThreadRepliesResponse {
+        events: replies,
+        has_more: bounds.has_more,
+        next_cursor,
+    })
+}

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -178,6 +178,7 @@ fn thread_replies_filter_carries_non_p_gated_kinds_to_clear_the_gate() {
     }
     assert_eq!(filter["#e"], serde_json::json!(["root-hex"]));
     assert_eq!(filter["depth_limit"], serde_json::json!(64));
+    assert_eq!(filter["thread_bounds"], serde_json::json!(true));
     assert_eq!(filter["#h"], serde_json::json!(["channel-1"]));
 }
 

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -1,4 +1,19 @@
 use super::*;
+use nostr::{EventBuilder, Kind, Tag};
+
+fn thread_page_event(kind: u32, content: &str, root: Option<&str>) -> Event {
+    let tags = root
+        .map(|root| vec![Tag::parse(["e", root]).expect("valid root tag")])
+        .unwrap_or_default();
+    EventBuilder::new(Kind::Custom(kind as u16), content)
+        .tags(tags)
+        .sign_with_keys(&Keys::generate())
+        .expect("test event should sign")
+}
+
+fn bounds_event(root: &str, content: &str) -> Event {
+    thread_page_event(buzz_core_pkg::kind::KIND_THREAD_BOUNDS, content, Some(root))
+}
 
 #[test]
 fn marker_author_scope_validates_scope_and_required_pubkey() {
@@ -184,6 +199,91 @@ fn thread_replies_filter_pages_with_composite_cursor() {
         !filter.contains_key("#h"),
         "no channel_id -> no #h scope in the filter"
     );
+}
+
+#[test]
+fn thread_page_parser_accepts_valid_empty_and_non_empty_pages() {
+    let empty = thread_page::parse(
+        vec![bounds_event(
+            "root",
+            r#"{"has_more":false,"next_cursor":null}"#,
+        )],
+        "root",
+    )
+    .expect("valid terminal page should parse");
+    assert!(empty.events.is_empty());
+    assert!(!empty.has_more);
+    assert!(empty.next_cursor.is_none());
+
+    let reply = thread_page_event(9, "reply", Some("root"));
+    let reply_id = reply.id.to_hex();
+    let page = thread_page::parse(
+        vec![
+            reply,
+            bounds_event(
+                "root",
+                r#"{"has_more":true,"next_cursor":{"created_at":1700000000,"id":"cursor-id"}}"#,
+            ),
+        ],
+        "root",
+    )
+    .expect("valid continuing page should parse");
+    assert_eq!(page.events.len(), 1);
+    assert_eq!(page.events[0]["id"], serde_json::json!(reply_id));
+    assert!(page.has_more);
+    let cursor = page.next_cursor.expect("continuing page needs a cursor");
+    assert_eq!(cursor.created_at, 1_700_000_000);
+    assert_eq!(cursor.event_id, "cursor-id");
+}
+
+#[test]
+fn thread_page_parser_rejects_missing_duplicate_and_wrong_root_bounds() {
+    let reply = thread_page_event(9, "reply", Some("root"));
+    assert!(thread_page::parse(vec![reply], "root")
+        .err()
+        .expect("missing bounds must fail closed")
+        .contains("omitted"));
+
+    let terminal = r#"{"has_more":false,"next_cursor":null}"#;
+    assert!(thread_page::parse(
+        vec![
+            bounds_event("root", terminal),
+            bounds_event("root", terminal)
+        ],
+        "root",
+    )
+    .err()
+    .expect("duplicate bounds must fail closed")
+    .contains("multiple"));
+
+    assert!(
+        thread_page::parse(vec![bounds_event("other-root", terminal)], "root")
+            .err()
+            .expect("mismatched root must fail closed")
+            .contains("does not match")
+    );
+}
+
+#[test]
+fn thread_page_parser_rejects_malformed_and_inconsistent_bounds() {
+    assert!(
+        thread_page::parse(vec![bounds_event("root", "not-json")], "root")
+            .err()
+            .expect("malformed bounds must fail closed")
+            .contains("Invalid thread bounds")
+    );
+
+    for content in [
+        r#"{"has_more":true,"next_cursor":null}"#,
+        r#"{"has_more":false,"next_cursor":{"created_at":1700000000,"id":"cursor-id"}}"#,
+    ] {
+        assert!(
+            thread_page::parse(vec![bounds_event("root", content)], "root")
+                .err()
+                .expect("cursor presence must agree with has_more")
+                .contains("disagree")
+        );
+    }
 }
 
 #[test]

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -1,14 +1,19 @@
 use super::*;
 use nostr::{EventBuilder, Kind, Tag};
 
-fn thread_page_event(kind: u32, content: &str, root: Option<&str>) -> Event {
+fn thread_page_event_at(kind: u32, content: &str, root: Option<&str>, created_at: u64) -> Event {
     let tags = root
         .map(|root| vec![Tag::parse(["e", root]).expect("valid root tag")])
         .unwrap_or_default();
     EventBuilder::new(Kind::Custom(kind as u16), content)
         .tags(tags)
+        .custom_created_at(nostr::Timestamp::from(created_at))
         .sign_with_keys(&Keys::generate())
         .expect("test event should sign")
+}
+
+fn thread_page_event(kind: u32, content: &str, root: Option<&str>) -> Event {
+    thread_page_event_at(kind, content, root, 1_700_000_000)
 }
 
 fn bounds_event(root: &str, content: &str) -> Event {
@@ -161,7 +166,8 @@ fn thread_replies_filter_carries_non_p_gated_kinds_to_clear_the_gate() {
     // and every kind MUST be non-p-gated (else the gate still fires). The
     // Playwright mock does not model p-gating, so this unit test is the
     // only guard against the client/relay auth contract drifting.
-    let filter = build_thread_replies_filter("root-hex", Some("channel-1"), 64, 200, None, None);
+    let filter =
+        build_thread_replies_filter("root-hex", Some("channel-1"), 64, 200, None, None, true);
 
     let kinds = filter
         .get("kinds")
@@ -191,8 +197,15 @@ fn thread_replies_filter_pages_with_composite_cursor() {
         created_at: 1_700_000_000,
         event_id: "abcd".to_string(),
     };
-    let filter =
-        build_thread_replies_filter("root-hex", None, 64, 200, Some("newest"), Some(&cursor));
+    let filter = build_thread_replies_filter(
+        "root-hex",
+        None,
+        64,
+        200,
+        Some("newest"),
+        Some(&cursor),
+        true,
+    );
     assert_eq!(filter["thread_order"], serde_json::json!("newest"));
     assert_eq!(filter["thread_cursor"], serde_json::json!(1_700_000_000));
     assert_eq!(filter["thread_cursor_id"], serde_json::json!("abcd"));
@@ -200,6 +213,120 @@ fn thread_replies_filter_pages_with_composite_cursor() {
         !filter.contains_key("#h"),
         "no channel_id -> no #h scope in the filter"
     );
+}
+
+#[test]
+fn legacy_thread_filter_omits_modern_extensions_but_keeps_composite_cursor() {
+    let cursor = crate::models::ThreadCursor {
+        created_at: 1_700_000_000,
+        event_id: "abcd".to_string(),
+    };
+    let filter = build_thread_replies_filter(
+        "root-hex",
+        Some("channel-1"),
+        64,
+        200,
+        None,
+        Some(&cursor),
+        false,
+    );
+
+    assert!(!filter.contains_key("thread_bounds"));
+    assert!(!filter.contains_key("thread_order"));
+    assert_eq!(filter["thread_cursor"], serde_json::json!(1_700_000_000));
+    assert_eq!(filter["thread_cursor_id"], serde_json::json!("abcd"));
+}
+
+#[test]
+fn legacy_thread_pages_converge_past_two_same_second_boundaries() {
+    let mut all_events: Vec<Event> = (0..401)
+        .map(|_| thread_page_event_at(9, "reply", Some("root"), 1_700_000_000))
+        .collect();
+    // Old relays order and keyset on (created_at ASC, event_id ASC).
+    all_events.sort_by_key(|event| (event.created_at.as_secs(), event.id.to_hex()));
+    let expected_ids: Vec<String> = all_events.iter().map(|event| event.id.to_hex()).collect();
+    let mut received_ids = Vec::new();
+    let mut cursor: Option<crate::models::ThreadCursor> = None;
+
+    loop {
+        let modern_filter = build_thread_replies_filter(
+            "root",
+            Some("channel-1"),
+            64,
+            200,
+            Some("newest"),
+            cursor.as_ref(),
+            true,
+        );
+        assert_eq!(modern_filter["thread_bounds"], serde_json::json!(true));
+        assert_eq!(modern_filter["thread_order"], serde_json::json!("newest"));
+
+        let select_old_relay_page = |request: &serde_json::Map<String, serde_json::Value>| {
+            let cursor_created_at = request
+                .get("thread_cursor")
+                .and_then(|value| value.as_i64());
+            let cursor_id = request
+                .get("thread_cursor_id")
+                .and_then(|value| value.as_str());
+            all_events
+                .iter()
+                .filter(|event| match (cursor_created_at, cursor_id) {
+                    (Some(created_at), Some(event_id)) => {
+                        (event.created_at.as_secs() as i64, event.id.to_hex())
+                            > (created_at, event_id.to_string())
+                    }
+                    _ => true,
+                })
+                .take(200)
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        // An old relay ignores the modern extensions and omits the overlay.
+        let modern_response = select_old_relay_page(&modern_filter);
+        assert!(matches!(
+            thread_page::parse(modern_response, "root"),
+            Err(thread_page::ParseError::MissingBounds)
+        ));
+
+        let legacy_filter = build_thread_replies_filter(
+            "root",
+            Some("channel-1"),
+            64,
+            200,
+            None,
+            cursor.as_ref(),
+            false,
+        );
+        assert!(!legacy_filter.contains_key("thread_bounds"));
+        assert!(!legacy_filter.contains_key("thread_order"));
+        if let Some(expected_cursor) = cursor.as_ref() {
+            assert_eq!(
+                legacy_filter["thread_cursor"],
+                serde_json::json!(expected_cursor.created_at)
+            );
+            assert_eq!(
+                legacy_filter["thread_cursor_id"],
+                serde_json::json!(expected_cursor.event_id)
+            );
+        }
+
+        let page = thread_page::parse_legacy(select_old_relay_page(&legacy_filter), 200);
+        received_ids.extend(
+            page.events
+                .iter()
+                .map(|event| event["id"].as_str().expect("event id").to_string()),
+        );
+        if !page.has_more {
+            assert!(page.next_cursor.is_none());
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    assert_eq!(received_ids, expected_ids);
+    let unique_ids: std::collections::HashSet<_> = received_ids.iter().collect();
+    assert_eq!(unique_ids.len(), 401);
 }
 
 #[test]
@@ -243,6 +370,7 @@ fn thread_page_parser_rejects_missing_duplicate_and_wrong_root_bounds() {
     assert!(thread_page::parse(vec![reply], "root")
         .err()
         .expect("missing bounds must fail closed")
+        .to_string()
         .contains("omitted"));
 
     let terminal = r#"{"has_more":false,"next_cursor":null}"#;
@@ -255,12 +383,14 @@ fn thread_page_parser_rejects_missing_duplicate_and_wrong_root_bounds() {
     )
     .err()
     .expect("duplicate bounds must fail closed")
+    .to_string()
     .contains("multiple"));
 
     assert!(
         thread_page::parse(vec![bounds_event("other-root", terminal)], "root")
             .err()
             .expect("mismatched root must fail closed")
+            .to_string()
             .contains("does not match")
     );
 }
@@ -271,6 +401,7 @@ fn thread_page_parser_rejects_malformed_and_inconsistent_bounds() {
         thread_page::parse(vec![bounds_event("root", "not-json")], "root")
             .err()
             .expect("malformed bounds must fail closed")
+            .to_string()
             .contains("Invalid thread bounds")
     );
 
@@ -282,6 +413,7 @@ fn thread_page_parser_rejects_malformed_and_inconsistent_bounds() {
             thread_page::parse(vec![bounds_event("root", content)], "root")
                 .err()
                 .expect("cursor presence must agree with has_more")
+                .to_string()
                 .contains("disagree")
         );
     }

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -146,7 +146,7 @@ fn thread_replies_filter_carries_non_p_gated_kinds_to_clear_the_gate() {
     // and every kind MUST be non-p-gated (else the gate still fires). The
     // Playwright mock does not model p-gating, so this unit test is the
     // only guard against the client/relay auth contract drifting.
-    let filter = build_thread_replies_filter("root-hex", Some("channel-1"), 64, 200, None);
+    let filter = build_thread_replies_filter("root-hex", Some("channel-1"), 64, 200, None, None);
 
     let kinds = filter
         .get("kinds")
@@ -175,7 +175,9 @@ fn thread_replies_filter_pages_with_composite_cursor() {
         created_at: 1_700_000_000,
         event_id: "abcd".to_string(),
     };
-    let filter = build_thread_replies_filter("root-hex", None, 64, 200, Some(&cursor));
+    let filter =
+        build_thread_replies_filter("root-hex", None, 64, 200, Some("newest"), Some(&cursor));
+    assert_eq!(filter["thread_order"], serde_json::json!("newest"));
     assert_eq!(filter["thread_cursor"], serde_json::json!(1_700_000_000));
     assert_eq!(filter["thread_cursor_id"], serde_json::json!("abcd"));
     assert!(

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -321,6 +321,7 @@ pub struct ThreadCursor {
 #[derive(Serialize, Deserialize)]
 pub struct ThreadRepliesResponse {
     pub events: Vec<serde_json::Value>,
+    pub has_more: bool,
     pub next_cursor: Option<ThreadCursor>,
 }
 

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -33,6 +33,7 @@ import {
 import { useUnreadChannels } from "@/features/channels/useUnreadChannels";
 import { useMembershipNotifications } from "@/features/channels/useMembershipNotifications";
 import { useFeedItemState } from "@/features/home/useFeedItemState";
+import { markChannelSelectionPerformance } from "@/features/messages/useMessagePerformance";
 import { useThreadFollows } from "@/features/messages/lib/useThreadFollows";
 import {
   useHomeFeedNotifications,
@@ -847,7 +848,13 @@ export function AppShell() {
                           await goChannel(directMessage.id);
                         }}
                         onSelectAgents={() => void goAgents()}
-                        onSelectChannel={handleSidebarChannelSelect}
+                        onSelectChannel={(channelId) => {
+                          markChannelSelectionPerformance(
+                            channelId,
+                            selectedChannelId,
+                          );
+                          handleSidebarChannelSelect(channelId);
+                        }}
                         onOpenSearchResult={handleOpenSearchResult}
                         searchChannels={channels}
                         searchFocusRequests={[

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useAppShell } from "@/app/AppShellContext";
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { useMeasuredOpenThread } from "@/features/messages/useMessagePerformance";
 import { useActiveChannelHeader } from "@/features/channels/useActiveChannelHeader";
 import { useChannelPaneHandlers } from "@/features/channels/useChannelPaneHandlers";
 import { useMessageEventProfilePubkeys } from "@/features/channels/useMessageEventProfilePubkeys";
@@ -595,6 +596,9 @@ export function ChannelScreen({
   const settledChannelIdRef = React.useRef<string | null>(null);
   const hasSettledThisChannel =
     activeChannelId !== null && settledChannelIdRef.current === activeChannelId;
+  const hasAuthoritativeTimelineCache = Boolean(
+    windowQuery.data && windowQuery.data.pages.length > 0,
+  );
   const timelineLoadingNow =
     activeChannel !== null &&
     activeChannel.channelType !== "forum" &&
@@ -606,6 +610,7 @@ export function ChannelScreen({
         dataLength: messagesQuery.data?.length ?? null,
       },
       hasSettledThisChannel,
+      hasAuthoritativeTimelineCache,
     );
   const { settledChannelId, isLoading: isTimelineLoading } =
     resolveTimelineLoadingLatch(
@@ -673,6 +678,10 @@ export function ChannelScreen({
       channelManagementOpen,
   );
   const displayedThreadHeadMessage = threadPanelData.threadHead;
+  const handleMeasuredOpenThread = useMeasuredOpenThread(
+    effectiveOpenThreadHeadId,
+    handleOpenThreadAndCloseAgentSession,
+  );
   const displayedThreadAllMessages = threadPanelData.messages;
   const displayedThreadMessages = threadPanelData.visibleReplies;
   const displayedThreadReplyTargetMessage = threadPanelData.replyTargetMessage;
@@ -914,7 +923,7 @@ export function ChannelScreen({
                   onOpenProfilePanel={handleOpenProfilePanel}
                   onResetThreadPanelWidth={handleThreadPanelWidthReset}
                   onCloseProfilePanel={handleCloseProfilePanel}
-                  onOpenThread={handleOpenThreadAndCloseAgentSession}
+                  onOpenThread={handleMeasuredOpenThread}
                   onSelectThreadReplyTarget={handleSelectThreadReplyTarget}
                   onSendMessage={handleSendMessage}
                   onSendToChannel={handleSendToChannel}

--- a/desktop/src/features/messages/lib/messagePerformance.ts
+++ b/desktop/src/features/messages/lib/messagePerformance.ts
@@ -44,8 +44,13 @@ export function recordPerformanceMark(
   name: string,
   detail?: Record<string, unknown>,
 ): void {
+  const current = listeners.get(name);
+  // Callback evidence exists only while a settle measurement is active. This
+  // keeps normal scrolling/resizing from filling the User Timing buffer or
+  // doing instrumentation work for the rest of the session.
+  if (!current?.size) return;
   performance.mark(name, detail ? { detail } : undefined);
-  for (const listener of listeners.get(name) ?? []) listener();
+  for (const listener of current) listener();
 }
 export function finishPerformanceMeasure(input: {
   startMark: string;

--- a/desktop/src/features/messages/lib/messagePerformance.ts
+++ b/desktop/src/features/messages/lib/messagePerformance.ts
@@ -1,0 +1,74 @@
+export const CHANNEL_SWITCH_START_MARK = "buzz:channel-switch:start";
+export const CHANNEL_ROWS_PAINTED_MARK = "buzz:channel-switch:rows-painted";
+export const CHANNEL_ROWS_PAINTED_MEASURE =
+  "buzz:channel-switch:rows-painted-duration";
+export const CHANNEL_VIEWPORT_SETTLED_MARK =
+  "buzz:channel-switch:viewport-settled";
+export const CHANNEL_VIEWPORT_SETTLED_MEASURE =
+  "buzz:channel-switch:viewport-settled-duration";
+export const CHANNEL_VIRTUALIZER_CALLBACK_MARK =
+  "buzz:channel-switch:virtualizer-callback";
+export const CHANNEL_RESIZE_OBSERVER_CALLBACK_MARK =
+  "buzz:channel-switch:resize-observer-callback";
+export const CHANNEL_SCROLL_WRITE_MARK = "buzz:channel-switch:scroll-write";
+export const THREAD_OPEN_START_MARK = "buzz:thread-open:start";
+export const THREAD_REPLIES_PAINTED_MARK = "buzz:thread-open:replies-painted";
+export const THREAD_REPLIES_PAINTED_MEASURE =
+  "buzz:thread-open:replies-painted-duration";
+export const THREAD_VIEWPORT_SETTLED_MARK = "buzz:thread-open:viewport-settled";
+export const THREAD_VIEWPORT_SETTLED_MEASURE =
+  "buzz:thread-open:viewport-settled-duration";
+
+const listeners = new Map<string, Set<() => void>>();
+export function subscribePerformanceMark(
+  names: readonly string[],
+  listener: () => void,
+): () => void {
+  for (const name of names) {
+    const current = listeners.get(name) ?? new Set();
+    current.add(listener);
+    listeners.set(name, current);
+  }
+  return () => {
+    for (const name of names) listeners.get(name)?.delete(listener);
+  };
+}
+export function startPerformanceMark(
+  name: string,
+  identity: string,
+  detail?: Record<string, unknown>,
+): void {
+  performance.mark(name, { detail: { ...detail, identity } });
+}
+export function recordPerformanceMark(
+  name: string,
+  detail?: Record<string, unknown>,
+): void {
+  performance.mark(name, detail ? { detail } : undefined);
+  for (const listener of listeners.get(name) ?? []) listener();
+}
+export function finishPerformanceMeasure(input: {
+  startMark: string;
+  endMark: string;
+  measure: string;
+  identity: string;
+  detail?: Record<string, unknown>;
+}): number | null {
+  const start = [...performance.getEntriesByName(input.startMark, "mark")]
+    .reverse()
+    .find(
+      (entry) => (entry as PerformanceMark).detail?.identity === input.identity,
+    );
+  if (!start) return null;
+  performance.mark(input.endMark, {
+    detail: { ...input.detail, identity: input.identity },
+  });
+  const end = performance.getEntriesByName(input.endMark, "mark").at(-1);
+  if (!end) return null;
+  performance.measure(input.measure, {
+    start: start.startTime,
+    end: end.startTime,
+    detail: { ...input.detail, identity: input.identity },
+  });
+  return start.startTime;
+}

--- a/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
+++ b/desktop/src/features/messages/lib/timelineLoadingState.test.mjs
@@ -85,6 +85,28 @@ test("initial load holds the skeleton while the cold-load top-up fetches", () =>
   );
 });
 
+test("pre-settle authoritative cached rows paint during revalidation", () => {
+  assert.equal(
+    selectTimelineLoadingState(
+      { ...settled, isFetching: true, dataLength: 8 },
+      false,
+      true,
+    ),
+    false,
+  );
+});
+
+test("pre-settle authoritative empty cache still holds the skeleton", () => {
+  assert.equal(
+    selectTimelineLoadingState(
+      { ...settled, isFetching: true, dataLength: 0 },
+      false,
+      true,
+    ),
+    true,
+  );
+});
+
 test("pre-settle placeholder rows paint immediately (snapshot revisit)", () => {
   // A revisit painting from the React-Query cache or a persisted snapshot:
   // placeholder rows are a previously-settled timeline, not a partial cold

--- a/desktop/src/features/messages/lib/timelineLoadingState.ts
+++ b/desktop/src/features/messages/lib/timelineLoadingState.ts
@@ -18,11 +18,17 @@ export type TimelineQueryStatus = {
 export function selectTimelineLoadingState(
   status: TimelineQueryStatus,
   hasSettled = true,
+  hasAuthoritativeCache = false,
 ): boolean {
   if (status.isPending) {
     return true;
   }
   if (!hasSettled) {
+    // A populated authoritative window proves these rows came from a previous
+    // settled load, not from the live subscription's partial pre-settle seed.
+    if (hasAuthoritativeCache && (status.dataLength ?? 0) > 0) {
+      return false;
+    }
     // Placeholder rows are a previously-settled timeline (React-Query cache on
     // revisit, or a persisted snapshot) — paint them stale-then-revalidate
     // instead of holding a skeleton over known content.

--- a/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
+++ b/desktop/src/features/messages/lib/timelineSnapshot.test.mjs
@@ -14,6 +14,7 @@ import {
   selectLatestMessageKey,
   selectTimelineBodySurface,
   selectTimelineIntroSurface,
+  selectTimelineRenderSource,
 } from "./timelineSnapshot.ts";
 
 // Local-midnight unix-second timestamps so isSameDay (local time) is stable
@@ -369,6 +370,39 @@ test("classifyTimelineMessageDelta: unchanged snapshots do not count as arrivals
 // painted (deferred) snapshot lags the live one for a frame. selectDeferredList
 // RenderState picks which of three states the reply region paints so we never
 // flash "No replies" over a list that's streaming in on the deferred commit.
+
+test("timeline-render-source: keeps a cold channel deferred until it commits", () => {
+  assert.equal(
+    selectTimelineRenderSource({
+      deferredChannelId: "old-channel",
+      liveChannelId: "cold-channel",
+      preferLiveSnapshot: false,
+    }),
+    null,
+  );
+});
+
+test("timeline-render-source: paints a settled channel cache during revisit", () => {
+  assert.equal(
+    selectTimelineRenderSource({
+      deferredChannelId: "other-channel",
+      liveChannelId: "cached-channel",
+      preferLiveSnapshot: true,
+    }),
+    "live",
+  );
+});
+
+test("timeline-render-source: uses the matching deferred snapshot", () => {
+  assert.equal(
+    selectTimelineRenderSource({
+      deferredChannelId: "channel-a",
+      liveChannelId: "channel-a",
+      preferLiveSnapshot: false,
+    }),
+    "deferred",
+  );
+});
 
 test("deferred-render: paints the list whenever the deferred snapshot has rows", () => {
   // deferred caught up — normal steady state.

--- a/desktop/src/features/messages/lib/timelineSnapshot.ts
+++ b/desktop/src/features/messages/lib/timelineSnapshot.ts
@@ -181,6 +181,22 @@ export function selectDeferredListRenderState(
   return "pending";
 }
 
+export type TimelineRenderSource = "live" | "deferred" | null;
+
+/** Keep cold loads deferred, but let an already-settled channel repaint cache. */
+export function selectTimelineRenderSource({
+  deferredChannelId,
+  liveChannelId,
+  preferLiveSnapshot,
+}: {
+  deferredChannelId: string | null;
+  liveChannelId: string | null;
+  preferLiveSnapshot: boolean;
+}): TimelineRenderSource {
+  if (deferredChannelId === liveChannelId) return "deferred";
+  return preferLiveSnapshot ? "live" : null;
+}
+
 export type TimelineBodySurface = "skeleton" | "empty" | "list";
 
 export function selectTimelineBodySurface({

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ArrowDown } from "lucide-react";
-
 import { useKnownAgentPubkeys } from "@/features/agents/useKnownAgentPubkeys";
 import { HuddleTranscriptIntro } from "@/features/huddle/components/HuddleTranscriptIntro";
 import { orderMentionPubkeysByText } from "@/features/messages/lib/orderMentionPubkeys";
@@ -52,7 +51,7 @@ import { useComposerHeightPadding } from "./useComposerHeightPadding";
 import { useStableSendToChannel } from "./useStableSendToChannel";
 import { useAnchoredScroll } from "./useAnchoredScroll";
 import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
-
+import { useThreadPerformance } from "@/features/messages/useMessagePerformance";
 type MessageThreadPanelProps = ThreadPanelLayoutProps & {
   channel: Channel | null;
   channelId: string | null;
@@ -343,9 +342,6 @@ export function MessageThreadPanel({
     }
   }, [collapsedThreadHeadId, scrollTargetIsVisibleReply, threadHeadId]);
 
-  // Which of the three states the reply region paints this frame. Delegated to
-  // a pure helper so the "don't flash empty over an incoming list" rule is
-  // covered in the lib test suite (see selectDeferredListRenderState).
   const repliesRenderState = selectDeferredListRenderState(
     deferredThreadReplies.length,
     threadReplies.length,
@@ -363,11 +359,6 @@ export function MessageThreadPanel({
   const visibleThreadHeadSummary = isThreadHeadRepliesCollapsed
     ? threadHeadSummary
     : null;
-  // Focus mode gives the thread a subject/body structure: the head is what the
-  // thread is about, the replies are the conversation about it. Only draw the
-  // rule when there is actually conversation under it — the "no replies yet"
-  // card and the streaming-in `pending` state would both leave a rule hanging
-  // over an empty region or a placeholder.
   const showThreadHeadDivider =
     !isHuddleTranscript &&
     isFocusMode &&
@@ -524,6 +515,15 @@ export function MessageThreadPanel({
     "padding",
     settleAtBottomAfterLayout,
   );
+  useThreadPerformance({
+    bodyRef: threadBodyRef,
+    ready:
+      repliesRenderState === "list" &&
+      !threadRepliesPending &&
+      !isRepliesPending,
+    replyCount: deferredThreadReplies.length,
+    threadHeadId,
+  });
   const knownAgentPubkeys = useKnownAgentPubkeys();
   const initialAgentPubkeys = React.useMemo(() => {
     if (
@@ -647,7 +647,9 @@ export function MessageThreadPanel({
           className={cn(THREAD_PANEL_MESSAGE_GUTTER_CLASS, "pb-3 pt-0")}
           data-testid="message-thread-replies"
         >
-          {threadRepliesPending && !isHuddleTranscript ? (
+          {threadRepliesPending &&
+          !isHuddleTranscript &&
+          deferredThreadReplies.length === 0 ? (
             <div
               className="space-y-2.5 pt-1"
               data-testid="message-thread-replies-loading"
@@ -655,7 +657,8 @@ export function MessageThreadPanel({
               <ThreadMessageSkeleton />
               <ThreadMessageSkeleton />
             </div>
-          ) : repliesRenderState === "list" ? (
+          ) : repliesRenderState === "list" ||
+            deferredThreadReplies.length > 0 ? (
             visibleThreadHeadSummary ? (
               <div
                 className="space-y-0"

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -5,9 +5,18 @@ import {
   isRenderedTimelineBehindHistoryPrepend,
   selectTimelineBodySurface,
   selectTimelineIntroSurface,
+  selectTimelineRenderSource,
 } from "@/features/messages/lib/timelineSnapshot";
 import { preloadTimelineImages } from "@/features/messages/lib/timelineImagePreload";
 import type { TimelineMessage } from "@/features/messages/types";
+import {
+  useChannelRowsPaintedPerformanceMeasure,
+  useChannelViewportSettledPerformanceMeasure,
+} from "@/features/messages/useMessagePerformance";
+import {
+  CHANNEL_VIRTUALIZER_CALLBACK_MARK,
+  recordPerformanceMark,
+} from "@/features/messages/lib/messagePerformance";
 import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { ChannelWindowThreadSummary } from "@/features/messages/lib/channelWindowStore";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -254,7 +263,45 @@ const MessageTimelineBase = React.forwardRef<
     liveSnapshot,
     EMPTY_TIMELINE_SNAPSHOT,
   );
-  const deferredMessages = deferredSnapshot.messages;
+  // Cold loads keep the deferred markdown gate. Once a channel has committed,
+  // a warm revisit can paint its cached snapshot immediately while refresh
+  // work continues behind it.
+  const requiresDeferredSettleRef = React.useRef(new Map<string, boolean>());
+  const snapshotChannelId = liveSnapshot.channelId;
+  if (snapshotChannelId) {
+    if (!requiresDeferredSettleRef.current.has(snapshotChannelId)) {
+      requiresDeferredSettleRef.current.set(snapshotChannelId, isLoading);
+    } else if (isLoading) {
+      requiresDeferredSettleRef.current.set(snapshotChannelId, true);
+    }
+    if (
+      !isLoading &&
+      deferredSnapshot.channelId === snapshotChannelId &&
+      messages.length > 0
+    ) {
+      requiresDeferredSettleRef.current.set(snapshotChannelId, false);
+    }
+  }
+  const renderSource = selectTimelineRenderSource({
+    deferredChannelId: deferredSnapshot.channelId,
+    liveChannelId: snapshotChannelId,
+    preferLiveSnapshot:
+      !isLoading &&
+      messages.length > 0 &&
+      (snapshotChannelId === null ||
+        requiresDeferredSettleRef.current.get(snapshotChannelId) === false),
+  });
+  const renderedSnapshot =
+    renderSource === "live"
+      ? liveSnapshot
+      : renderSource === "deferred"
+        ? deferredSnapshot
+        : EMPTY_TIMELINE_SNAPSHOT;
+  const deferredMessages = renderedSnapshot.messages;
+  useChannelRowsPaintedPerformanceMeasure(
+    channelId ?? null,
+    deferredMessages.length,
+  );
   const imagePreloadStateRef = React.useRef({
     activeImages: new Set<HTMLImageElement>(),
     requestedUrls: new Set<string>(),
@@ -262,11 +309,13 @@ const MessageTimelineBase = React.forwardRef<
   React.useEffect(() => {
     preloadTimelineImages(messages, imagePreloadStateRef.current);
   }, [messages]);
-  const isDeferredSnapshotStale = isDeferredTimelineSnapshotStale({
-    deferredSnapshot,
-    liveSnapshot,
-  });
-  const isRenderPending = deferredSnapshot !== liveSnapshot;
+  const isDeferredSnapshotStale =
+    renderSource === null &&
+    isDeferredTimelineSnapshotStale({
+      deferredSnapshot,
+      liveSnapshot,
+    });
+  const isRenderPending = renderedSnapshot !== liveSnapshot;
   const scrollRestorationId = targetMessageId
     ? `message-timeline:${channelId ?? "none"}:target:${targetMessageId}`
     : `message-timeline:${channelId ?? "none"}`;
@@ -339,7 +388,7 @@ const MessageTimelineBase = React.forwardRef<
   } = useSettleGatedPrependMessages({
     channelId,
     messages: bufferedTimeline.messages,
-    meta: deferredSnapshot.historyExhausted,
+    meta: renderedSnapshot.historyExhausted,
     scrollElementRef: activeScrollContainerRef,
   });
 
@@ -637,8 +686,20 @@ const MessageTimelineBase = React.forwardRef<
   );
 
   const handleVirtualizerRangeChanged = React.useCallback(() => {
+    recordPerformanceMark(CHANNEL_VIRTUALIZER_CALLBACK_MARK, {
+      channelId: channelId ?? null,
+    });
     bumpVirtualizerRenderVersion();
-  }, []);
+  }, [channelId]);
+  useChannelViewportSettledPerformanceMeasure({
+    channelId: channelId ?? null,
+    ready:
+      showMessageList &&
+      renderedMessages.length > 0 &&
+      !isRenderPending &&
+      !isHoldingPrepend,
+    settleVersion: virtualizerRenderVersion,
+  });
 
   const timelineList = showMessageList ? (
     <TimelineMessageList
@@ -792,7 +853,12 @@ const MessageTimelineBase = React.forwardRef<
                 )}
               >
                 {showTimelineSkeleton ? (
-                  <TimelineSkeleton rows={timelineSkeletonRows} />
+                  <div
+                    className="contents"
+                    data-testid="message-timeline-loading"
+                  >
+                    <TimelineSkeleton rows={timelineSkeletonRows} />
+                  </div>
                 ) : null}
                 {activeDirectMessageIntro ? (
                   <div

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -265,31 +265,48 @@ const MessageTimelineBase = React.forwardRef<
   );
   // Cold loads keep the deferred markdown gate. Once a channel has committed,
   // a warm revisit can paint its cached snapshot immediately while refresh
-  // work continues behind it.
-  const requiresDeferredSettleRef = React.useRef(new Map<string, boolean>());
+  // work continues behind it. Update this bounded session cache after commit,
+  // not during render: render-phase mutation made sibling timeline effects see
+  // a source that had never actually settled.
+  const [settledChannelIds, setSettledChannelIds] = React.useState<
+    ReadonlySet<string>
+  >(() => new Set());
   const snapshotChannelId = liveSnapshot.channelId;
-  if (snapshotChannelId) {
-    if (!requiresDeferredSettleRef.current.has(snapshotChannelId)) {
-      requiresDeferredSettleRef.current.set(snapshotChannelId, isLoading);
-    } else if (isLoading) {
-      requiresDeferredSettleRef.current.set(snapshotChannelId, true);
-    }
+  React.useEffect(() => {
     if (
-      !isLoading &&
-      deferredSnapshot.channelId === snapshotChannelId &&
-      messages.length > 0
+      !snapshotChannelId ||
+      isLoading ||
+      deferredSnapshot.channelId !== snapshotChannelId ||
+      messages.length === 0
     ) {
-      requiresDeferredSettleRef.current.set(snapshotChannelId, false);
+      return;
     }
-  }
+    setSettledChannelIds((current) => {
+      if (current.has(snapshotChannelId)) return current;
+      const next = new Set(current);
+      next.add(snapshotChannelId);
+      // Channel ids are only a warm-paint hint. Bound their session lifetime so
+      // traversing many channels cannot grow this component state forever.
+      while (next.size > 32) {
+        const oldest = next.values().next().value;
+        if (oldest === undefined) break;
+        next.delete(oldest);
+      }
+      return next;
+    });
+  }, [
+    deferredSnapshot.channelId,
+    isLoading,
+    messages.length,
+    snapshotChannelId,
+  ]);
   const renderSource = selectTimelineRenderSource({
     deferredChannelId: deferredSnapshot.channelId,
     liveChannelId: snapshotChannelId,
     preferLiveSnapshot:
       !isLoading &&
       messages.length > 0 &&
-      (snapshotChannelId === null ||
-        requiresDeferredSettleRef.current.get(snapshotChannelId) === false),
+      (snapshotChannelId === null || settledChannelIds.has(snapshotChannelId)),
   });
   const renderedSnapshot =
     renderSource === "live"

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -22,6 +22,10 @@ import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
 import type { ChannelWindowThreadSummary } from "@/features/messages/lib/channelWindowStore";
 import { buildVideoReviewContextsByMessageId } from "@/features/messages/lib/videoReviewContext";
 import type { TimelineMessage } from "@/features/messages/types";
+import {
+  CHANNEL_RESIZE_OBSERVER_CALLBACK_MARK,
+  recordPerformanceMark,
+} from "@/features/messages/lib/messagePerformance";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -695,7 +699,10 @@ function VirtualizedTimelineRows({
       setOffscreenBufferSize(host.clientHeight * 3);
     };
     updateBufferSize();
-    const resizeObserver = new ResizeObserver(updateBufferSize);
+    const resizeObserver = new ResizeObserver(() => {
+      recordPerformanceMark(CHANNEL_RESIZE_OBSERVER_CALLBACK_MARK);
+      updateBufferSize();
+    });
     resizeObserver.observe(host);
     return () => resizeObserver.disconnect();
   }, []);

--- a/desktop/src/features/messages/ui/useVirtualizedBottomSettle.ts
+++ b/desktop/src/features/messages/ui/useVirtualizedBottomSettle.ts
@@ -1,5 +1,9 @@
 import * as React from "react";
 import type { VListHandle } from "virtua";
+import {
+  CHANNEL_SCROLL_WRITE_MARK,
+  recordPerformanceMark,
+} from "@/features/messages/lib/messagePerformance";
 
 const SCROLL_INTENT_KEYS = new Set([
   "ArrowDown",
@@ -44,6 +48,7 @@ export function useVirtualizedBottomSettle(
     const scroller = hostRef.current?.firstElementChild;
     const lastIndex = itemsLengthRef.current - 1;
     if (!(scroller instanceof HTMLDivElement) || lastIndex < 0) return;
+    recordPerformanceMark(CHANNEL_SCROLL_WRITE_MARK, { lastIndex });
     listRef.current?.scrollToIndex(lastIndex, { align: "end" });
   }, [hostRef, itemsLengthRef, listRef]);
 

--- a/desktop/src/features/messages/useMessagePerformance.ts
+++ b/desktop/src/features/messages/useMessagePerformance.ts
@@ -1,0 +1,201 @@
+import * as React from "react";
+import {
+  CHANNEL_ROWS_PAINTED_MARK,
+  CHANNEL_ROWS_PAINTED_MEASURE,
+  CHANNEL_RESIZE_OBSERVER_CALLBACK_MARK,
+  CHANNEL_SCROLL_WRITE_MARK,
+  CHANNEL_SWITCH_START_MARK,
+  CHANNEL_VIRTUALIZER_CALLBACK_MARK,
+  CHANNEL_VIEWPORT_SETTLED_MARK,
+  CHANNEL_VIEWPORT_SETTLED_MEASURE,
+  THREAD_OPEN_START_MARK,
+  THREAD_REPLIES_PAINTED_MARK,
+  THREAD_REPLIES_PAINTED_MEASURE,
+  THREAD_VIEWPORT_SETTLED_MARK,
+  THREAD_VIEWPORT_SETTLED_MEASURE,
+  finishPerformanceMeasure,
+  startPerformanceMark,
+  subscribePerformanceMark,
+} from "@/features/messages/lib/messagePerformance";
+import type { TimelineMessage } from "@/features/messages/types";
+const CHANNEL_EVIDENCE = [
+  CHANNEL_VIRTUALIZER_CALLBACK_MARK,
+  CHANNEL_RESIZE_OBSERVER_CALLBACK_MARK,
+  CHANNEL_SCROLL_WRITE_MARK,
+] as const;
+export function markChannelSelectionPerformance(
+  channelId: string,
+  activeChannelId?: string | null,
+): void {
+  if (channelId !== activeChannelId)
+    startPerformanceMark(CHANNEL_SWITCH_START_MARK, channelId);
+}
+export function useMeasuredOpenThread(
+  openId: string | null,
+  onOpen: (message: TimelineMessage) => void,
+): (message: TimelineMessage) => void {
+  return React.useCallback(
+    (message) => {
+      if (message.id !== openId)
+        startPerformanceMark(THREAD_OPEN_START_MARK, message.id);
+      onOpen(message);
+    },
+    [onOpen, openId],
+  );
+}
+function usePaint(input: {
+  identity: string | null;
+  count: number;
+  start: string;
+  end: string;
+  measure: string;
+}): void {
+  const measured = React.useRef(-1);
+  React.useEffect(() => {
+    if (!input.identity || !input.count) return;
+    const frame = requestAnimationFrame(() => {
+      const value = finishPerformanceMeasure({
+        startMark: input.start,
+        endMark: input.end,
+        measure: input.measure,
+        identity: input.identity as string,
+        detail: { rowCount: input.count },
+      });
+      if (value !== null && value !== measured.current)
+        measured.current = value;
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [input.count, input.end, input.identity, input.measure, input.start]);
+}
+export function useChannelRowsPaintedPerformanceMeasure(
+  channelId: string | null,
+  count: number,
+): void {
+  usePaint({
+    identity: channelId,
+    count,
+    start: CHANNEL_SWITCH_START_MARK,
+    end: CHANNEL_ROWS_PAINTED_MARK,
+    measure: CHANNEL_ROWS_PAINTED_MEASURE,
+  });
+}
+export function useThreadRepliesPaintedPerformanceMeasure(
+  threadId: string | null,
+  count: number,
+): void {
+  usePaint({
+    identity: threadId,
+    count,
+    start: THREAD_OPEN_START_MARK,
+    end: THREAD_REPLIES_PAINTED_MARK,
+    measure: THREAD_REPLIES_PAINTED_MEASURE,
+  });
+}
+function useSettle(input: {
+  identity: string | null;
+  ready: boolean;
+  version: number;
+  evidence?: readonly string[];
+  start: string;
+  end: string;
+  measure: string;
+}): void {
+  const [evidenceVersion, bump] = React.useReducer((n: number) => n + 1, 0);
+  React.useEffect(
+    () =>
+      input.evidence?.length
+        ? subscribePerformanceMark(input.evidence, bump)
+        : undefined,
+    [input.evidence],
+  );
+  React.useEffect(() => {
+    void evidenceVersion;
+    void input.version;
+    if (!input.identity || !input.ready) return;
+    let second = 0;
+    const first = requestAnimationFrame(() => {
+      second = requestAnimationFrame(() =>
+        finishPerformanceMeasure({
+          startMark: input.start,
+          endMark: input.end,
+          measure: input.measure,
+          identity: input.identity as string,
+        }),
+      );
+    });
+    return () => {
+      cancelAnimationFrame(first);
+      if (second) cancelAnimationFrame(second);
+    };
+  }, [
+    evidenceVersion,
+    input.end,
+    input.identity,
+    input.measure,
+    input.ready,
+    input.start,
+    input.version,
+  ]);
+}
+export function useChannelViewportSettledPerformanceMeasure(input: {
+  channelId: string | null;
+  ready: boolean;
+  settleVersion: number;
+}): void {
+  useSettle({
+    identity: input.channelId,
+    ready: input.ready,
+    version: input.settleVersion,
+    evidence: CHANNEL_EVIDENCE,
+    start: CHANNEL_SWITCH_START_MARK,
+    end: CHANNEL_VIEWPORT_SETTLED_MARK,
+    measure: CHANNEL_VIEWPORT_SETTLED_MEASURE,
+  });
+}
+export function useThreadSettleVersion(
+  bodyRef: React.RefObject<HTMLElement | null>,
+): number {
+  const [version, bump] = React.useReducer((n: number) => n + 1, 0);
+  React.useEffect(() => {
+    const body = bodyRef.current;
+    if (!body) return;
+    const observer = new ResizeObserver(bump);
+    body.addEventListener("scroll", bump, { passive: true });
+    observer.observe(body);
+    return () => {
+      observer.disconnect();
+      body.removeEventListener("scroll", bump);
+    };
+  }, [bodyRef]);
+  return version;
+}
+export function useThreadViewportSettledPerformanceMeasure(input: {
+  ready: boolean;
+  settleVersion: number;
+  threadHeadId: string | null;
+}): void {
+  useSettle({
+    identity: input.threadHeadId,
+    ready: input.ready,
+    version: input.settleVersion,
+    start: THREAD_OPEN_START_MARK,
+    end: THREAD_VIEWPORT_SETTLED_MARK,
+    measure: THREAD_VIEWPORT_SETTLED_MEASURE,
+  });
+}
+export function useThreadPerformance(input: {
+  bodyRef: React.RefObject<HTMLElement | null>;
+  ready: boolean;
+  replyCount: number;
+  threadHeadId: string | null;
+}): void {
+  useThreadRepliesPaintedPerformanceMeasure(
+    input.threadHeadId,
+    input.replyCount,
+  );
+  useThreadViewportSettledPerformanceMeasure({
+    ready: input.ready,
+    settleVersion: useThreadSettleVersion(input.bodyRef),
+    threadHeadId: input.threadHeadId,
+  });
+}

--- a/desktop/src/features/messages/useThreadReplies.ts
+++ b/desktop/src/features/messages/useThreadReplies.ts
@@ -89,15 +89,22 @@ async function loadThreadReplies(
     const response = await getThreadReplies(rootId, channelId, {
       limit: THREAD_PAGE_LIMIT,
       cursor,
+      order: "newest",
     });
-    replies.push(...response.events);
-    if (!response.nextCursor) {
-      const fetched = await withThreadAux(channelId, rootId, replies);
+    const pageWithAux = await withThreadAux(channelId, rootId, response.events);
+    replies.push(...pageWithAux);
+    queryClient.setQueryData<RelayEvent[]>(queryKey, (current = []) =>
+      sortMessages([...current, ...pageWithAux]),
+    );
+    if (!response.hasMore) {
       const current = queryClient.getQueryData<RelayEvent[]>(queryKey) ?? [];
       const receivedInFlight = current.filter(
         (event) => !idsAtStart.has(event.id),
       );
-      return sortMessages([...fetched, ...receivedInFlight]);
+      return sortMessages([...replies, ...receivedInFlight]);
+    }
+    if (!response.nextCursor) {
+      throw new Error(`Thread ${rootId} returned hasMore without a cursor.`);
     }
     cursor = response.nextCursor;
   }

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -7,7 +7,10 @@ import {
   fromRawInstallRuntimeResult,
   type RawInstallRuntimeResult,
 } from "@/shared/api/installTypes";
-import type { RawSendChannelMessageResult } from "@/shared/api/tauriMessageTypes";
+import type {
+  RawSendChannelMessageResult,
+  RawThreadRepliesResponse,
+} from "@/shared/api/tauriMessageTypes";
 import type {
   AddChannelMembersInput,
   AddChannelMembersResult,
@@ -471,16 +474,6 @@ export async function getEventById(eventId: string): Promise<RelayEvent> {
   return JSON.parse(eventJson) as RelayEvent;
 }
 
-type RawThreadCursor = {
-  created_at: number;
-  event_id: string;
-};
-
-type RawThreadRepliesResponse = {
-  events: RelayEvent[];
-  next_cursor: RawThreadCursor | null;
-};
-
 /**
  * Fetch the full reply subtree under a thread root, server-side.
  *
@@ -504,6 +497,7 @@ export async function getThreadReplies(
     limit?: number;
     depthLimit?: number;
     cursor?: ThreadCursor | null;
+    order?: "oldest" | "newest";
   },
 ): Promise<ThreadRepliesResponse> {
   const response = await invokeTauri<RawThreadRepliesResponse>(
@@ -513,6 +507,7 @@ export async function getThreadReplies(
       channelId: channelId ?? null,
       limit: options?.limit ?? null,
       depthLimit: options?.depthLimit ?? null,
+      threadOrder: options?.order ?? null,
       cursor: options?.cursor
         ? {
             created_at: options.cursor.createdAt,
@@ -524,6 +519,7 @@ export async function getThreadReplies(
 
   return {
     events: response.events,
+    hasMore: response.has_more,
     nextCursor: response.next_cursor
       ? {
           createdAt: response.next_cursor.created_at,

--- a/desktop/src/shared/api/tauriMessageTypes.ts
+++ b/desktop/src/shared/api/tauriMessageTypes.ts
@@ -1,3 +1,11 @@
+import type { RelayEvent } from "@/shared/api/types";
+
+export type RawThreadRepliesResponse = {
+  events: RelayEvent[];
+  has_more: boolean;
+  next_cursor: { created_at: number; event_id: string } | null;
+};
+
 export type RawSendChannelMessageResult = {
   event_id: string;
   parent_event_id: string | null;

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -1,7 +1,6 @@
 export type ChannelType = "stream" | "forum" | "dm";
 export type ChannelVisibility = "open" | "private";
 export type ChannelRole = "owner" | "admin" | "member" | "guest" | "bot";
-
 export type Channel = {
   id: string;
   name: string;
@@ -20,7 +19,6 @@ export type Channel = {
   ttlSeconds: number | null;
   ttlDeadline: string | null;
 };
-
 export type ChannelDetail = Channel & {
   createdBy: string;
   createdAt: string;
@@ -965,9 +963,11 @@ export type ThreadCursor = {
 };
 
 export type ThreadRepliesResponse = {
-  /** The reply subtree (chronological, oldest first), depth >= 1. Excludes the root event (relay keys on `root_event_id`, which a root row lacks); the caller already holds the root. */
+  /** Page events; callers merge chronologically. */
   events: RelayEvent[];
-  /** Present only when a full page was returned — pass back to fetch the next page. */
+  /** Relay-authoritative; never infer from event count. */
+  hasMore: boolean;
+  /** Raw-scan continuation, present exactly with `hasMore`. */
   nextCursor: ThreadCursor | null;
 };
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -341,6 +341,8 @@ type E2eConfig = {
     threadRepliesDelayMs?: number;
     /** Hold the first continuation page until the E2E release seam is called. */
     holdThreadRepliesPage2?: boolean;
+    /** Hold the second continuation page until the E2E release seam is called. */
+    holdThreadRepliesPage3?: boolean;
     usersBatchDelayMs?: number;
     /** Delay (ms) applied only to initial channel-window requests. */
     initialChannelWindowDelayMs?: number;
@@ -1123,8 +1125,10 @@ declare global {
       requestId: number;
       startedAt: number;
     }>;
-    /** Release the held thread continuation page in the disposable A/B probe. */
+    /** Release the held first thread continuation page. */
     __BUZZ_E2E_RELEASE_THREAD_PAGE_2__?: () => void;
+    /** Release the held second thread continuation page. */
+    __BUZZ_E2E_RELEASE_THREAD_PAGE_3__?: () => void;
     /** Release a mock media proxy held at port 0 and return its ready port. */
     __BUZZ_E2E_RELEASE_MEDIA_PROXY__?: () => number;
     /** Release mock send events that were stored but withheld from live subscribers. */
@@ -4757,17 +4761,22 @@ async function handleGetThreadReplies(
           event_id: page[page.length - 1].id,
         }
       : null;
-  if (
-    config?.mock?.holdThreadRepliesPage2 &&
-    args.cursor &&
+  const requestNumber =
     window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__?.filter(
       (request) => request.command === "get_thread_replies",
-    ).length === 2 &&
-    window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__ === undefined
-  ) {
+    ).length ?? 0;
+  const holdReleaseKey =
+    config?.mock?.holdThreadRepliesPage2 && args.cursor && requestNumber === 2
+      ? "__BUZZ_E2E_RELEASE_THREAD_PAGE_2__"
+      : config?.mock?.holdThreadRepliesPage3 &&
+          args.cursor &&
+          requestNumber === 3
+        ? "__BUZZ_E2E_RELEASE_THREAD_PAGE_3__"
+        : null;
+  if (holdReleaseKey && window[holdReleaseKey] === undefined) {
     await new Promise<void>((resolve) => {
-      window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__ = () => {
-        delete window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__;
+      window[holdReleaseKey] = () => {
+        delete window[holdReleaseKey];
         resolve();
       };
     });

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -339,7 +339,11 @@ type E2eConfig = {
     /** Delay (ms) after snapshotting a thread-replies page so E2E tests can
      *  deliver live reply/aux events while an older response is in flight. */
     threadRepliesDelayMs?: number;
+    /** Hold the first continuation page until the E2E release seam is called. */
+    holdThreadRepliesPage2?: boolean;
     usersBatchDelayMs?: number;
+    /** Delay (ms) applied only to initial channel-window requests. */
+    initialChannelWindowDelayMs?: number;
     /** Delay (ms) applied to continuation channel-window requests so e2e
      *  tests can observe the in-flight prepend window. 0/undefined = instant. */
     channelWindowDelayMs?: number;
@@ -1111,6 +1115,16 @@ declare global {
       command: string;
       payload: unknown;
     }>;
+    /** Start/end timestamps for deterministic message-performance assertions. */
+    __BUZZ_E2E_MESSAGE_REQUEST_LOG__?: Array<{
+      command: "get_channel_window" | "get_thread_replies";
+      endedAt: number | null;
+      payload: unknown;
+      requestId: number;
+      startedAt: number;
+    }>;
+    /** Release the held thread continuation page in the disposable A/B probe. */
+    __BUZZ_E2E_RELEASE_THREAD_PAGE_2__?: () => void;
     /** Release a mock media proxy held at port 0 and return its ready port. */
     __BUZZ_E2E_RELEASE_MEDIA_PROXY__?: () => number;
     /** Release mock send events that were stored but withheld from live subscribers. */
@@ -4607,6 +4621,7 @@ type RawThreadCursor = {
 
 type RawThreadRepliesResponse = {
   events: RelayEvent[];
+  has_more: boolean;
   next_cursor: RawThreadCursor | null;
 };
 
@@ -4626,6 +4641,7 @@ async function handleGetThreadReplies(
     limit?: number | null;
     depthLimit?: number | null;
     cursor?: RawThreadCursor | null;
+    threadOrder?: "oldest" | "newest" | null;
   },
   config: E2eConfig | undefined,
 ): Promise<RawThreadRepliesResponse> {
@@ -4699,23 +4715,35 @@ async function handleGetThreadReplies(
             event_id: events[events.length - 1].id,
           }
         : null;
-    return { events, next_cursor: nextCursor };
+    return {
+      events,
+      has_more: nextCursor !== null,
+      next_cursor: nextCursor,
+    };
   }
 
   // Mock mode paging: sort by the composite key, then slice strictly after the
   // cursor so same-second ties can never be skipped across a page boundary.
-  subtree.sort(
-    (left, right) =>
-      left.created_at - right.created_at || left.id.localeCompare(right.id),
-  );
+  const order = args.threadOrder ?? "oldest";
+  subtree.sort((left, right) => {
+    const chronological =
+      left.created_at - right.created_at || left.id.localeCompare(right.id);
+    if (order === "oldest") return chronological;
+    return (
+      right.created_at - left.created_at || right.id.localeCompare(left.id)
+    );
+  });
   let start = 0;
   if (args.cursor) {
     const cursor = args.cursor;
-    start = subtree.findIndex(
-      (event) =>
-        event.created_at > cursor.created_at ||
-        (event.created_at === cursor.created_at &&
-          event.id.localeCompare(cursor.event_id) > 0),
+    start = subtree.findIndex((event) =>
+      order === "oldest"
+        ? event.created_at > cursor.created_at ||
+          (event.created_at === cursor.created_at &&
+            event.id.localeCompare(cursor.event_id) > 0)
+        : event.created_at < cursor.created_at ||
+          (event.created_at === cursor.created_at &&
+            event.id.localeCompare(cursor.event_id) < 0),
     );
     if (start < 0) {
       start = subtree.length;
@@ -4729,12 +4757,31 @@ async function handleGetThreadReplies(
           event_id: page[page.length - 1].id,
         }
       : null;
+  if (
+    config?.mock?.holdThreadRepliesPage2 &&
+    args.cursor &&
+    window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__?.filter(
+      (request) => request.command === "get_thread_replies",
+    ).length === 2 &&
+    window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__ === undefined
+  ) {
+    await new Promise<void>((resolve) => {
+      window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__ = () => {
+        delete window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__;
+        resolve();
+      };
+    });
+  }
   const delayMs = config?.mock?.threadRepliesDelayMs ?? 0;
   if (delayMs > 0) {
     await new Promise((resolve) => window.setTimeout(resolve, delayMs));
   }
 
-  return { events: page, next_cursor: nextCursor };
+  return {
+    events: page,
+    has_more: nextCursor !== null,
+    next_cursor: nextCursor,
+  };
 }
 
 const TIMELINE_KINDS = new Set([
@@ -5092,10 +5139,6 @@ async function handleGetChannelWindow(
     return relayQuery(config, [filter]);
   };
 
-  if (!args.cursor) {
-    return execute();
-  }
-
   const probe = window as unknown as {
     __CHANNEL_WINDOW_FETCH_COUNT__?: number;
     __CHANNEL_WINDOW_INFLIGHT__?: number;
@@ -5104,7 +5147,9 @@ async function handleGetChannelWindow(
   probe.__CHANNEL_WINDOW_FETCH_COUNT__ =
     (probe.__CHANNEL_WINDOW_FETCH_COUNT__ ?? 0) + 1;
 
-  const delayMs = getConfig()?.mock?.channelWindowDelayMs ?? 0;
+  const delayMs = args.cursor
+    ? (getConfig()?.mock?.channelWindowDelayMs ?? 0)
+    : (getConfig()?.mock?.initialChannelWindowDelayMs ?? 0);
   if (delayMs <= 0) {
     return execute();
   }
@@ -10166,6 +10211,7 @@ export function maybeInstallE2eTauriMocks() {
   window.__BUZZ_E2E_COMMANDS__ = [];
   window.__BUZZ_E2E_COMMAND_PAYLOADS__ = [];
   window.__BUZZ_E2E_COMMAND_LOG__ = [];
+  window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__ = [];
   mockMediaProxyPort = config.mock?.mediaProxyInitiallyUnavailable
     ? 0
     : MOCK_MEDIA_PROXY_PORT;
@@ -13166,11 +13212,37 @@ export function maybeInstallE2eTauriMocks() {
         throw new Error(`Unsupported mocked Tauri command: ${command}`);
     }
   };
+  const invokeMockCommand = async (
+    command: string,
+    payload: unknown,
+  ): Promise<unknown> => {
+    const messageCommand =
+      command === "get_channel_window" || command === "get_thread_replies"
+        ? command
+        : null;
+    if (!messageCommand) return handleMockCommand(command, payload);
+
+    const messageRequest: NonNullable<
+      typeof window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__
+    >[number] = {
+      command: messageCommand,
+      endedAt: null,
+      payload,
+      requestId: window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__?.length ?? 0,
+      startedAt: performance.now(),
+    };
+    window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__?.push(messageRequest);
+    try {
+      return await handleMockCommand(command, payload);
+    } finally {
+      messageRequest.endedAt = performance.now();
+    }
+  };
   window.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ = (command, payload) =>
-    handleMockCommand(command, payload ?? null);
+    invokeMockCommand(command, payload ?? null);
   window.__BUZZ_E2E_EMIT_TAURI_EVENT__ = (event, payload) =>
     emit(event, payload);
-  mockIPC(handleMockCommand, { shouldMockEvents: true });
+  mockIPC(invokeMockCommand, { shouldMockEvents: true });
   const tauriInternals = (
     window as typeof window & {
       __TAURI_INTERNALS__: {

--- a/desktop/tests/e2e/message-performance.spec.ts
+++ b/desktop/tests/e2e/message-performance.spec.ts
@@ -1,0 +1,483 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
+const DEEP_HISTORY_CHANNEL_ID = "feedf00d-0000-4000-8000-000000000007";
+
+type MessageRequest = {
+  command: "get_channel_window" | "get_thread_replies";
+  endedAt: number | null;
+  payload: unknown;
+  requestId: number;
+  startedAt: number;
+};
+
+async function clearMessageRequests(page: Page) {
+  await page.evaluate(() => {
+    window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__ = [];
+  });
+}
+
+async function readMessageRequests(
+  page: Page,
+  command: MessageRequest["command"],
+): Promise<MessageRequest[]> {
+  return page.evaluate(
+    (targetCommand) =>
+      (window.__BUZZ_E2E_MESSAGE_REQUEST_LOG__ ?? []).filter(
+        (entry) => entry.command === targetCommand,
+      ),
+    command,
+  );
+}
+
+async function openThread(root: Locator, page: Page) {
+  const timelineRoot = root.first();
+  await timelineRoot.hover();
+  await timelineRoot.getByRole("button", { name: "Reply" }).click();
+  const panel = page.getByTestId("message-thread-panel");
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+async function installChannelRevisitPaintTracking(page: Page) {
+  await page.evaluate(() => {
+    const tracking = {
+      cachedRowSeen: false,
+      cachedRowRemovedAfterPaint: false,
+      disconnect: () => {},
+    };
+    const inspect = () => {
+      const cachedRow = document.querySelector(
+        '[data-message-id^="mock-deep-history-"]',
+      );
+      if (cachedRow && !tracking.cachedRowSeen) {
+        tracking.cachedRowSeen = true;
+      }
+      if (tracking.cachedRowSeen && !cachedRow) {
+        tracking.cachedRowRemovedAfterPaint = true;
+      }
+    };
+    const observer = new MutationObserver(inspect);
+    observer.observe(document.body, { childList: true, subtree: true });
+    tracking.disconnect = () => observer.disconnect();
+    inspect();
+    (
+      window as typeof window & {
+        __MESSAGE_REVISIT_PAINT__?: typeof tracking;
+      }
+    ).__MESSAGE_REVISIT_PAINT__ = tracking;
+  });
+}
+
+async function readChannelRevisitPaintTracking(page: Page) {
+  return page.evaluate(() => {
+    const tracking = (
+      window as typeof window & {
+        __MESSAGE_REVISIT_PAINT__?: {
+          cachedRowSeen: boolean;
+          cachedRowRemovedAfterPaint: boolean;
+          disconnect: () => void;
+        };
+      }
+    ).__MESSAGE_REVISIT_PAINT__;
+    if (!tracking) throw new Error("revisit paint observer was not installed");
+    tracking.disconnect();
+    return tracking;
+  });
+}
+
+test("cold channel load keeps its skeleton; fresh and stale revisits keep cached rows painted", async ({
+  page,
+}) => {
+  await installMockBridge(page, { initialChannelWindowDelayMs: 700 });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await expect(
+    page.locator('[data-message-id="mock-general-welcome"]'),
+  ).toBeVisible();
+
+  await clearMessageRequests(page);
+  await page.getByTestId("channel-deep-history").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("deep-history");
+  // Negative guard: a genuinely cold query still holds the timeline skeleton.
+  await expect(page.getByTestId("message-timeline-loading")).toBeVisible();
+  await expect
+    .poll(() => readMessageRequests(page, "get_channel_window"))
+    .toHaveLength(1);
+  await expect(
+    page.locator('[data-message-id^="mock-deep-history-"]').first(),
+  ).toBeVisible();
+  await expect(page.getByTestId("message-timeline-loading")).toHaveCount(0);
+
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await clearMessageRequests(page);
+  await installChannelRevisitPaintTracking(page);
+
+  // A fresh warm revisit remains painted across the required
+  // post-subscription reconciliation.
+  await page.getByTestId("channel-deep-history").click();
+  await expect(
+    page.locator('[data-message-id^="mock-deep-history-"]').first(),
+  ).toBeVisible();
+  await expect
+    .poll(() => readMessageRequests(page, "get_channel_window"))
+    .toHaveLength(1);
+  await expect
+    .poll(async () =>
+      (await readMessageRequests(page, "get_channel_window")).every(
+        (request) => request.endedAt !== null,
+      ),
+    )
+    .toBe(true);
+  await expect(
+    page.locator('[data-message-id^="mock-deep-history-"]').first(),
+  ).toBeVisible();
+  const freshRevisit = await readChannelRevisitPaintTracking(page);
+  expect(freshRevisit.cachedRowSeen).toBe(true);
+  expect(freshRevisit.cachedRowRemovedAfterPaint).toBe(false);
+
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  // Make the now-inactive message cache older than its five-minute staleTime
+  // while retaining the authoritative channel-window proof.
+  await page.evaluate((channelId) => {
+    const queryClient = window.__BUZZ_E2E_QUERY_CLIENT__ as unknown as {
+      getQueryData: (key: readonly unknown[]) => unknown;
+      removeQueries: (filters: { queryKey: readonly unknown[] }) => void;
+      setQueryData: (
+        key: readonly unknown[],
+        data: unknown,
+        options?: { updatedAt?: number },
+      ) => void;
+    };
+    const key = ["channel-messages", channelId] as const;
+    const cachedMessages = queryClient.getQueryData(key);
+    queryClient.removeQueries({ queryKey: key });
+    queryClient.setQueryData(key, cachedMessages, {
+      updatedAt: Date.now() - 10 * 60 * 1_000,
+    });
+  }, DEEP_HISTORY_CHANNEL_ID);
+  await clearMessageRequests(page);
+  await installChannelRevisitPaintTracking(page);
+  const staleRevisitStartedAt = await page.evaluate(() => performance.now());
+
+  // A >5-minute stale revisit keeps cached rows painted while one delayed
+  // initial-window reconciliation runs behind it.
+  await page.getByTestId("channel-deep-history").click();
+  await expect(
+    page.locator('[data-message-id^="mock-deep-history-"]').first(),
+  ).toBeVisible();
+  const staleRevisit = await readChannelRevisitPaintTracking(page);
+  expect(staleRevisit.cachedRowSeen).toBe(true);
+  expect(staleRevisit.cachedRowRemovedAfterPaint).toBe(false);
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_channel_window");
+      return requests.some(
+        (request) =>
+          request.startedAt >= staleRevisitStartedAt &&
+          request.endedAt === null,
+      );
+    })
+    .toBe(true);
+  const staleRevalidation = (
+    await readMessageRequests(page, "get_channel_window")
+  ).find(
+    (request) =>
+      request.startedAt >= staleRevisitStartedAt && request.endedAt === null,
+  );
+  expect(staleRevalidation).toBeDefined();
+  expect(staleRevalidation?.endedAt).toBeNull();
+  await expect
+    .poll(
+      async () =>
+        (await readMessageRequests(page, "get_channel_window")).find(
+          (request) => request.requestId === staleRevalidation?.requestId,
+        )?.endedAt,
+    )
+    .not.toBeNull();
+});
+
+test("thread cache paints on fresh reopen and while a stale cache revalidates", async ({
+  page,
+}) => {
+  await installMockBridge(page, { threadRepliesDelayMs: 700 });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const root = page.locator('[data-message-id="mock-general-welcome"]');
+  await expect(root).toBeVisible();
+  const reply = await page.evaluate((parentEventId) => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) throw new Error("mock message emitter is unavailable");
+    return emit({
+      channelName: "general",
+      content: "Cached thread reply",
+      parentEventId,
+    });
+  }, "mock-general-welcome");
+
+  let panel = await openThread(root, page);
+  await expect(panel.locator(`[data-message-id="${reply.id}"]`)).toContainText(
+    "Cached thread reply",
+  );
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_thread_replies");
+      return requests.length === 1 && requests[0].endedAt !== null;
+    })
+    .toBe(true);
+  await panel.getByTestId("auxiliary-panel-close").click();
+  await expect(panel).toHaveCount(0);
+
+  // Every reopen paints the cache immediately and revalidates in background.
+  await clearMessageRequests(page);
+  panel = await openThread(root, page);
+  await expect(panel.locator(`[data-message-id="${reply.id}"]`)).toBeVisible();
+  await expect(panel.getByTestId("message-thread-replies-loading")).toHaveCount(
+    0,
+  );
+  await expect
+    .poll(() => readMessageRequests(page, "get_thread_replies"))
+    .toHaveLength(1);
+  const [freshRevalidation] = await readMessageRequests(
+    page,
+    "get_thread_replies",
+  );
+  expect(freshRevalidation.endedAt).toBeNull();
+  await expect
+    .poll(
+      async () =>
+        (await readMessageRequests(page, "get_thread_replies"))[0]?.endedAt,
+    )
+    .not.toBeNull();
+
+  // Negative guard: once genuinely stale, the same cached row remains painted
+  // while a delayed background reconciliation is in flight.
+  await panel.getByTestId("auxiliary-panel-close").click();
+  await expect(panel).toHaveCount(0);
+  await page.evaluate(
+    async ({ channelId, rootId }) => {
+      const queryClient = window.__BUZZ_E2E_QUERY_CLIENT__ as unknown as {
+        getQueryData: (key: readonly unknown[]) => unknown;
+        removeQueries: (filters: { queryKey: readonly unknown[] }) => void;
+        setQueryData: (
+          key: readonly unknown[],
+          data: unknown,
+          options?: { updatedAt?: number },
+        ) => void;
+      };
+      const key = ["thread-replies", channelId, rootId] as const;
+      const cachedReplies = queryClient.getQueryData(key);
+      queryClient.removeQueries({ queryKey: key });
+      queryClient.setQueryData(key, cachedReplies, {
+        updatedAt: Date.now() - 10 * 60 * 1_000,
+      });
+    },
+    { channelId: GENERAL_CHANNEL_ID, rootId: "mock-general-welcome" },
+  );
+  await clearMessageRequests(page);
+  await page.evaluate((replyId) => {
+    const tracking = {
+      cachedReplyFrameAt: null as number | null,
+      disconnect: () => {},
+    };
+    let framePending = false;
+    const inspect = () => {
+      if (tracking.cachedReplyFrameAt !== null || framePending) return;
+      if (!document.querySelector(`[data-message-id="${replyId}"]`)) return;
+      framePending = true;
+      requestAnimationFrame(() => {
+        tracking.cachedReplyFrameAt = performance.now();
+        framePending = false;
+      });
+    };
+    const observer = new MutationObserver(inspect);
+    observer.observe(document.body, { childList: true, subtree: true });
+    tracking.disconnect = () => observer.disconnect();
+    inspect();
+    (
+      window as typeof window & {
+        __THREAD_CACHE_PAINT__?: typeof tracking;
+      }
+    ).__THREAD_CACHE_PAINT__ = tracking;
+  }, reply.id);
+
+  panel = await openThread(root, page);
+  await expect(panel.locator(`[data-message-id="${reply.id}"]`)).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __THREAD_CACHE_PAINT__?: { cachedReplyFrameAt: number | null };
+            }
+          ).__THREAD_CACHE_PAINT__?.cachedReplyFrameAt ?? null,
+      ),
+    )
+    .not.toBeNull();
+  const cachedPaintedAt = await page.evaluate(() => {
+    const tracking = (
+      window as typeof window & {
+        __THREAD_CACHE_PAINT__?: {
+          cachedReplyFrameAt: number | null;
+          disconnect: () => void;
+        };
+      }
+    ).__THREAD_CACHE_PAINT__;
+    if (!tracking?.cachedReplyFrameAt) {
+      throw new Error("cached thread reply paint was not observed");
+    }
+    tracking.disconnect();
+    return tracking.cachedReplyFrameAt;
+  });
+  await expect(panel.getByTestId("message-thread-replies-loading")).toHaveCount(
+    0,
+  );
+  await expect
+    .poll(() => readMessageRequests(page, "get_thread_replies"))
+    .toHaveLength(1);
+  await expect
+    .poll(
+      async () =>
+        (await readMessageRequests(page, "get_thread_replies"))[0]?.endedAt,
+    )
+    .not.toBeNull();
+  const [revalidation] = await readMessageRequests(page, "get_thread_replies");
+  expect(revalidation.startedAt).toBeLessThanOrEqual(cachedPaintedAt);
+  expect(revalidation.endedAt ?? 0).toBeGreaterThanOrEqual(cachedPaintedAt);
+  await expect(panel.locator(`[data-message-id="${reply.id}"]`)).toBeVisible();
+});
+
+test("401-reply thread paints page 1, preserves a live arrival, and converges", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    holdThreadRepliesPage2: true,
+    threadRepliesDelayMs: 25,
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const seeded = await page.evaluate(() => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) throw new Error("mock message emitter is unavailable");
+    const root = emit({ channelName: "random", content: "Large thread root" });
+    const replyIds: string[] = [];
+    for (let index = 0; index < 401; index += 1) {
+      replyIds.push(
+        emit({
+          channelName: "random",
+          content: `Large thread reply ${index}`,
+          createdAt: 1_700_000_000 + index,
+          parentEventId: root.id,
+        }).id,
+      );
+    }
+    return { rootId: root.id, replyIds };
+  });
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  const root = page.locator(`[data-message-id="${seeded.rootId}"]`);
+  await expect(root).toBeVisible();
+  await clearMessageRequests(page);
+  const panel = await openThread(root, page);
+
+  // Page 2 is deliberately held. The newest page must already be useful; a
+  // skeleton or wait-for-convergence implementation cannot satisfy this.
+  await expect
+    .poll(() => readMessageRequests(page, "get_thread_replies"))
+    .toHaveLength(2);
+  const pageTwoPending = await readMessageRequests(page, "get_thread_replies");
+  expect(pageTwoPending[0].endedAt).not.toBeNull();
+  expect(pageTwoPending[1].endedAt).toBeNull();
+  expect((pageTwoPending[0].payload as { limit?: number }).limit).toBe(200);
+  expect(
+    (pageTwoPending[0].payload as { threadOrder?: string }).threadOrder,
+  ).toBe("newest");
+  await expect(panel).toContainText("Large thread reply 400");
+  await expect(panel).not.toContainText("Large thread reply 0");
+  await expect(panel.getByTestId("message-thread-replies-loading")).toHaveCount(
+    0,
+  );
+
+  const liveReply = await page.evaluate((parentEventId) => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) throw new Error("mock message emitter is unavailable");
+    return emit({
+      channelName: "random",
+      content: "Live reply during pagination",
+      createdAt: 1_700_000_500,
+      parentEventId,
+    });
+  }, seeded.rootId);
+  await expect(
+    panel.locator(`[data-message-id="${liveReply.id}"]`),
+  ).toBeVisible();
+
+  await page.evaluate(() => {
+    const release = window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__;
+    if (!release) throw new Error("thread page 2 was not held");
+    release();
+  });
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_thread_replies");
+      return (
+        requests.length === 3 &&
+        requests.every((request) => request.endedAt !== null)
+      );
+    })
+    .toBe(true);
+
+  const convergence = await page.evaluate(
+    ({ channelId, rootId, expectedIds, liveId }) => {
+      const queryClient = window.__BUZZ_E2E_QUERY_CLIENT__ as unknown as {
+        getQueryData: (key: readonly unknown[]) =>
+          | Array<{
+              created_at: number;
+              id: string;
+            }>
+          | undefined;
+      };
+      const replies =
+        queryClient.getQueryData(["thread-replies", channelId, rootId]) ?? [];
+      const ids = replies.map((reply) => reply.id);
+      return {
+        chronological: replies.every(
+          (reply, index) =>
+            index === 0 ||
+            replies[index - 1].created_at < reply.created_at ||
+            (replies[index - 1].created_at === reply.created_at &&
+              replies[index - 1].id.localeCompare(reply.id) <= 0),
+        ),
+        exactSeedSet: expectedIds.every((id) => ids.includes(id)),
+        liveCount: ids.filter((id) => id === liveId).length,
+        total: ids.length,
+        unique: new Set(ids).size,
+      };
+    },
+    {
+      channelId: RANDOM_CHANNEL_ID,
+      rootId: seeded.rootId,
+      expectedIds: seeded.replyIds,
+      liveId: liveReply.id,
+    },
+  );
+  expect(convergence).toEqual({
+    chronological: true,
+    exactSeedSet: true,
+    liveCount: 1,
+    total: 402,
+    unique: 402,
+  });
+});

--- a/desktop/tests/e2e/message-performance.spec.ts
+++ b/desktop/tests/e2e/message-performance.spec.ts
@@ -409,6 +409,15 @@ test("401-reply thread paints page 1, preserves a live arrival, and converges", 
   await expect(panel.getByTestId("message-thread-replies-loading")).toHaveCount(
     0,
   );
+  const threadBody = panel.getByTestId("message-thread-body");
+  await expect
+    .poll(() =>
+      threadBody.evaluate(
+        (element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    )
+    .toBeLessThanOrEqual(2);
 
   const liveReply = await page.evaluate((parentEventId) => {
     const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
@@ -480,4 +489,125 @@ test("401-reply thread paints page 1, preserves a live arrival, and converges", 
     total: 402,
     unique: 402,
   });
+  await expect
+    .poll(() =>
+      threadBody.evaluate(
+        (element) =>
+          element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    )
+    .toBeLessThanOrEqual(2);
+});
+
+test("later-page thread target settles and survives subsequent prepends", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    holdThreadRepliesPage2: true,
+    holdThreadRepliesPage3: true,
+    threadRepliesDelayMs: 25,
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const seeded = await page.evaluate(() => {
+    const emit = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+    if (!emit) throw new Error("mock message emitter is unavailable");
+    const root = emit({ channelName: "random", content: "Target thread root" });
+    const replies = Array.from({ length: 401 }, (_, index) =>
+      emit({
+        channelName: "random",
+        content: `Target thread reply ${index}`,
+        createdAt: 1_700_100_000 + index,
+        parentEventId: root.id,
+      }),
+    );
+    return { rootId: root.id, targetId: replies[150].id };
+  });
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  const root = page.locator(`[data-message-id="${seeded.rootId}"]`);
+  await expect(root).toBeVisible();
+  const panel = await openThread(root, page);
+  await expect
+    .poll(() => readMessageRequests(page, "get_thread_replies"))
+    .toHaveLength(2);
+  await expect(
+    panel.locator(`[data-message-id="${seeded.targetId}"]`),
+  ).toHaveCount(0);
+  await page.evaluate(() => window.__BUZZ_E2E_RELEASE_THREAD_PAGE_2__?.());
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_thread_replies");
+      return requests.length === 3 && requests[2]?.endedAt === null;
+    })
+    .toBe(true);
+
+  // Aim at the old reply only after page 2 makes it available. This exercises
+  // the same route target state used by deep links while page 3 is still held.
+  await page.evaluate(({ rootId, targetId }) => {
+    const hash = window.location.hash.replace(/^#/, "") || "/";
+    const [path, query = ""] = hash.split("?");
+    const params = new URLSearchParams(query);
+    params.set("messageId", targetId);
+    params.set("thread", rootId);
+    window.history.pushState(
+      {},
+      "",
+      `${window.location.pathname}#${path}?${params}`,
+    );
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, seeded);
+
+  const target = panel.locator(`[data-message-id="${seeded.targetId}"]`);
+  const body = panel.getByTestId("message-thread-body");
+  await expect
+    .poll(async () => {
+      if (!(await target.count())) return false;
+      return body.evaluate((element, targetId) => {
+        const row = element.querySelector(
+          `[data-message-id="${CSS.escape(targetId)}"]`,
+        );
+        if (!row) return false;
+        const bodyRect = element.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        return rowRect.top >= bodyRect.top && rowRect.bottom <= bodyRect.bottom;
+      }, seeded.targetId);
+    })
+    .toBe(true);
+
+  // Page 3 is now held after page 2 exposed and settled the target. Releasing
+  // it prepends more history; the target must remain the visible anchor.
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_thread_replies");
+      return requests.length === 3 && requests[2]?.endedAt === null;
+    })
+    .toBe(true);
+  await page.evaluate(() => window.__BUZZ_E2E_RELEASE_THREAD_PAGE_3__?.());
+  await expect
+    .poll(async () => {
+      const requests = await readMessageRequests(page, "get_thread_replies");
+      return (
+        requests.length === 3 &&
+        requests.every((request) => request.endedAt !== null)
+      );
+    })
+    .toBe(true);
+  await expect
+    .poll(() =>
+      body.evaluate((element, targetId) => {
+        const row = element.querySelector(
+          `[data-message-id="${CSS.escape(targetId)}"]`,
+        );
+        if (!row) return false;
+        const bodyRect = element.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        return rowRect.top >= bodyRect.top && rowRect.bottom <= bodyRect.bottom;
+      }, seeded.targetId),
+    )
+    .toBe(true);
 });

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -293,7 +293,11 @@ type MockBridgeOptions = {
   /** Delay (ms) after snapshotting a thread-replies page so E2E tests can
    * deliver live reply/aux events while an older response is in flight. */
   threadRepliesDelayMs?: number;
+  /** Hold page 2 until the E2E release seam is called. */
+  holdThreadRepliesPage2?: boolean;
   usersBatchDelayMs?: number;
+  /** Delay (ms) for initial channel-window requests. */
+  initialChannelWindowDelayMs?: number;
   /** Delay (ms) for older-history fetches; see e2eBridge mock config. */
   channelWindowDelayMs?: number;
   profileReadDelayMs?: number;

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -295,6 +295,8 @@ type MockBridgeOptions = {
   threadRepliesDelayMs?: number;
   /** Hold page 2 until the E2E release seam is called. */
   holdThreadRepliesPage2?: boolean;
+  /** Hold page 3 until the E2E release seam is called. */
+  holdThreadRepliesPage3?: boolean;
   usersBatchDelayMs?: number;
   /** Delay (ms) for initial channel-window requests. */
   initialChannelWindowDelayMs?: number;


### PR DESCRIPTION
## Summary

- add identity-correlated channel and thread loading instrumentation that distinguishes cold, fresh-cache, and stale-cache paint
- make thread paging corruption-safe with relay-authoritative `has_more` and composite cursors, while preserving oldest-first compatibility and adding writer-safe newest-first traversal
- paint the newest thread page immediately, merge subsequent pages without replacing cache or losing live arrivals, and fail closed on malformed bounds overlays
- add deterministic release smoke for real-reply paint, exact convergence, deduplication, live arrivals, bottom anchoring, and later-page target preservation

The controlled A/B harness moved median useful thread paint from 1554.9 ms to 593.2 ms (about 62% earlier) across seven runs per arm. The disposable benchmark fixture is not included in CI; the PR retains only deterministic production instrumentation and regression coverage. Target-aware virtualization remains separate because the fixed-window experiment made older targets unreachable.

### Related issue

N/A. No issue was provided for this investigation.

### Testing

Exact pushed head `b3a83e0334755a58721a684842d3601b0240dc75`:

- pre-push repository hooks passed, including Desktop check/typecheck/tests, Rust tests, and Desktop Tauri checks
- Desktop unit suite previously passed 4,766/4,766 on the integrated implementation
- `cargo test --lib thread_page_parser`: 3/3
- E2E production build: pass
- `message-performance.spec.ts --project=smoke --retries=0`: 4/4
- Biome on touched Desktop files, `cargo fmt --check`, file-size ratchet, and `git diff --check`: pass
- backend focused/package validation: `buzz-db` 104 passed (181 ignored), relay bridge 60 passed (6 ignored), `buzz-core` 249 passed; focused real-Postgres corrupt-boundary and same-second oldest/newest convergence tests passed

No visual styling changed, so screenshots are not applicable.
