### PR TITLE
fix(desktop): refresh avatars when media proxy starts

### DIFF
--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -6,6 +6,7 @@ import { parseAnimatedAvatarUrl } from "@/shared/lib/animatedAvatar";
 import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { useMediaProxyPort } from "@/shared/lib/useMediaProxyPort";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 import { Spinner } from "@/shared/ui/spinner";
 
@@ -30,6 +31,7 @@ export function ProfileAvatar({
   plain = false,
   testId,
 }: ProfileAvatarProps) {
+  useMediaProxyPort();
   const initials = getInitials(label);
   const presentation = useAvatarPresentation(avatarUrl);
   const presentedAvatarUrl = presentation?.displayUrl ?? avatarUrl;

--- a/desktop/src/features/profile/ui/ProfileAvatar.tsx
+++ b/desktop/src/features/profile/ui/ProfileAvatar.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { useMediaProxyPort } from "@/shared/lib/useMediaProxyPort";
+import { useRelayOrigin } from "@/shared/lib/useRelayOrigin";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 import { Spinner } from "@/shared/ui/spinner";
 
@@ -32,6 +33,7 @@ export function ProfileAvatar({
   testId,
 }: ProfileAvatarProps) {
   useMediaProxyPort();
+  useRelayOrigin();
   const initials = getInitials(label);
   const presentation = useAvatarPresentation(avatarUrl);
   const presentedAvatarUrl = presentation?.displayUrl ?? avatarUrl;

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -4,6 +4,7 @@ import { parseAnimatedAvatarUrl } from "@/shared/lib/animatedAvatar";
 import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { useMediaProxyPort } from "@/shared/lib/useMediaProxyPort";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 
 type UserAvatarSize = "xs" | "sm" | "md";
@@ -33,6 +34,7 @@ export function UserAvatar({
   fallbackDelayMs = 200,
   testId,
 }: UserAvatarProps) {
+  useMediaProxyPort();
   const initials = getInitials(displayName);
   // Animated avatars show their static poster frame until hovered, then play
   // the animation.

--- a/desktop/src/shared/ui/UserAvatar.tsx
+++ b/desktop/src/shared/ui/UserAvatar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
 import { useMediaProxyPort } from "@/shared/lib/useMediaProxyPort";
+import { useRelayOrigin } from "@/shared/lib/useRelayOrigin";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/ui/avatar";
 
 type UserAvatarSize = "xs" | "sm" | "md";
@@ -35,6 +36,7 @@ export function UserAvatar({
   testId,
 }: UserAvatarProps) {
   useMediaProxyPort();
+  useRelayOrigin();
   const initials = getInitials(displayName);
   // Animated avatars show their static poster frame until hovered, then play
   // the animation.

--- a/desktop/src/shared/ui/avatarMediaProxy.test.mjs
+++ b/desktop/src/shared/ui/avatarMediaProxy.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const HASH = "a".repeat(64);
+const RELAY_AVATAR_URL = `https://relay.example/media/${HASH}.png`;
+const PROXIED_AVATAR_URL = `http://127.0.0.1:54321/media/${HASH}.png`;
+const dom = new JSDOM(
+  '<!doctype html><html><body><div id="root"></div></body></html>',
+  { url: "http://localhost" },
+);
+
+let resolveProxyPort;
+const proxyPort = new Promise((resolve) => {
+  resolveProxyPort = resolve;
+});
+
+class LoadedImage extends dom.window.EventTarget {
+  complete = true;
+  naturalWidth = 1;
+  referrerPolicy = "";
+  #src = "";
+
+  get src() {
+    return this.#src;
+  }
+
+  set src(value) {
+    this.#src = value;
+  }
+}
+
+before(() => {
+  dom.window.Image = LoadedImage;
+  dom.window.__TAURI_INTERNALS__ = {
+    invoke(command) {
+      if (command === "get_media_proxy_port") return proxyPort;
+      if (command === "get_relay_http_url") {
+        return Promise.resolve("https://relay.example");
+      }
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    },
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Image: LoadedImage,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    MutationObserver: dom.window.MutationObserver,
+    window: dom.window,
+  });
+});
+
+after(() => dom.window.close());
+
+test("shared avatars switch to the authenticated media proxy when its port resolves", async () => {
+  const React = await import("react");
+  const { act } = React;
+  const { createRoot } = await import("react-dom/client");
+  const { ProfileAvatar } = await import("@/features/profile/ui/ProfileAvatar");
+  const { UserAvatar } = await import("./UserAvatar.tsx");
+  const root = createRoot(document.getElementById("root"));
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(UserAvatar, {
+          avatarUrl: RELAY_AVATAR_URL,
+          displayName: "Channel agent",
+          testId: "user-avatar",
+        }),
+        React.createElement(ProfileAvatar, {
+          avatarUrl: RELAY_AVATAR_URL,
+          label: "Running agent",
+          testId: "profile-avatar",
+        }),
+      ),
+    );
+  });
+
+  const userAvatar = document.querySelector(
+    '[data-testid="user-avatar-image"]',
+  );
+  const profileAvatar = document.querySelector(
+    '[data-testid="profile-avatar-image"]',
+  );
+  assert.equal(
+    userAvatar?.getAttribute("src"),
+    `buzz-media://localhost/media/${HASH}.png`,
+  );
+  assert.equal(
+    profileAvatar?.getAttribute("src"),
+    `buzz-media://localhost/media/${HASH}.png`,
+  );
+
+  await act(async () => {
+    resolveProxyPort(54321);
+    await proxyPort;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  assert.equal(userAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
+  assert.equal(profileAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
+
+  await act(async () => root.unmount());
+});

--- a/desktop/src/shared/ui/avatarMediaProxy.test.mjs
+++ b/desktop/src/shared/ui/avatarMediaProxy.test.mjs
@@ -5,8 +5,11 @@ import { JSDOM } from "jsdom";
 
 const HASH = "a".repeat(64);
 const RELAY_ORIGIN = "https://relay.example";
+const RELAY_AVATAR_URL = `${RELAY_ORIGIN}/media/${HASH}.png`;
 const EXTERNAL_AVATAR_URL = `https://blossom.example/media/${HASH}.png`;
-const MISROUTED_AVATAR_URL = `http://127.0.0.1:54321/media/${HASH}.png`;
+const FALLBACK_AVATAR_URL = `buzz-media://localhost/media/${HASH}.png`;
+const PROXIED_AVATAR_URL = `http://127.0.0.1:54321/media/${HASH}.png`;
+const MISROUTED_AVATAR_URL = PROXIED_AVATAR_URL;
 const dom = new JSDOM(
   '<!doctype html><html><body><div id="root"></div></body></html>',
   { url: "http://localhost" },
@@ -17,6 +20,14 @@ let resolveRelayOriginRetry;
 const relayOriginRetry = new Promise((resolve) => {
   resolveRelayOriginRetry = resolve;
 });
+let getMediaProxyPort = () => Promise.resolve(54321);
+let getRelayOrigin = () => {
+  relayOriginCalls += 1;
+  if (relayOriginCalls === 1) {
+    return Promise.reject(new Error("Relay origin is not ready"));
+  }
+  return relayOriginRetry;
+};
 
 class LoadedImage extends dom.window.EventTarget {
   complete = true;
@@ -37,14 +48,8 @@ before(() => {
   dom.window.Image = LoadedImage;
   dom.window.__TAURI_INTERNALS__ = {
     invoke(command) {
-      if (command === "get_media_proxy_port") return Promise.resolve(54321);
-      if (command === "get_relay_http_url") {
-        relayOriginCalls += 1;
-        if (relayOriginCalls === 1) {
-          return Promise.reject(new Error("Relay origin is not ready"));
-        }
-        return relayOriginRetry;
-      }
+      if (command === "get_media_proxy_port") return getMediaProxyPort();
+      if (command === "get_relay_http_url") return getRelayOrigin();
       return Promise.reject(new Error(`Unexpected command: ${command}`));
     },
   };
@@ -60,26 +65,23 @@ before(() => {
 
 after(() => dom.window.close());
 
-test("shared avatars recover external URLs when the relay origin resolves after the proxy port", async () => {
-  const React = await import("react");
-  const { act } = React;
-  const { createRoot } = await import("react-dom/client");
+async function renderSharedAvatars(React, createRoot, avatarUrl) {
   const { ProfileAvatar } = await import("@/features/profile/ui/ProfileAvatar");
   const { UserAvatar } = await import("./UserAvatar.tsx");
   const root = createRoot(document.getElementById("root"));
 
-  await act(async () => {
+  await React.act(async () => {
     root.render(
       React.createElement(
         React.Fragment,
         null,
         React.createElement(UserAvatar, {
-          avatarUrl: EXTERNAL_AVATAR_URL,
+          avatarUrl,
           displayName: "Channel agent",
           testId: "user-avatar",
         }),
         React.createElement(ProfileAvatar, {
-          avatarUrl: EXTERNAL_AVATAR_URL,
+          avatarUrl,
           label: "Running agent",
           testId: "profile-avatar",
         }),
@@ -87,22 +89,33 @@ test("shared avatars recover external URLs when the relay origin resolves after 
     );
   });
 
-  const userAvatar = document.querySelector(
-    '[data-testid="user-avatar-image"]',
-  );
-  const profileAvatar = document.querySelector(
-    '[data-testid="profile-avatar-image"]',
+  return {
+    profileAvatar: document.querySelector(
+      '[data-testid="profile-avatar-image"]',
+    ),
+    root,
+    userAvatar: document.querySelector('[data-testid="user-avatar-image"]'),
+  };
+}
+
+test("shared avatars recover external URLs when the relay origin resolves after the proxy port", async () => {
+  const React = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { profileAvatar, root, userAvatar } = await renderSharedAvatars(
+    React,
+    createRoot,
+    EXTERNAL_AVATAR_URL,
   );
   assert.equal(userAvatar?.getAttribute("src"), MISROUTED_AVATAR_URL);
   assert.equal(profileAvatar?.getAttribute("src"), MISROUTED_AVATAR_URL);
   assert.equal(relayOriginCalls, 1);
 
-  await act(async () => {
+  await React.act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
   assert.equal(relayOriginCalls, 2);
 
-  await act(async () => {
+  await React.act(async () => {
     resolveRelayOriginRetry(RELAY_ORIGIN);
     await relayOriginRetry;
   });
@@ -110,5 +123,36 @@ test("shared avatars recover external URLs when the relay origin resolves after 
   assert.equal(userAvatar?.getAttribute("src"), EXTERNAL_AVATAR_URL);
   assert.equal(profileAvatar?.getAttribute("src"), EXTERNAL_AVATAR_URL);
 
-  await act(async () => root.unmount());
+  await React.act(async () => root.unmount());
+});
+
+test("shared avatars switch to the authenticated media proxy when its port resolves", async () => {
+  const React = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { resetMediaCaches } = await import("@/shared/lib/mediaUrl");
+  let resolveProxyPort;
+  const proxyPort = new Promise((resolve) => {
+    resolveProxyPort = resolve;
+  });
+  getMediaProxyPort = () => proxyPort;
+  getRelayOrigin = () => Promise.resolve(RELAY_ORIGIN);
+  resetMediaCaches();
+
+  const { profileAvatar, root, userAvatar } = await renderSharedAvatars(
+    React,
+    createRoot,
+    RELAY_AVATAR_URL,
+  );
+  assert.equal(userAvatar?.getAttribute("src"), FALLBACK_AVATAR_URL);
+  assert.equal(profileAvatar?.getAttribute("src"), FALLBACK_AVATAR_URL);
+
+  await React.act(async () => {
+    resolveProxyPort(54321);
+    await proxyPort;
+  });
+
+  assert.equal(userAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
+  assert.equal(profileAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
+
+  await React.act(async () => root.unmount());
 });

--- a/desktop/src/shared/ui/avatarMediaProxy.test.mjs
+++ b/desktop/src/shared/ui/avatarMediaProxy.test.mjs
@@ -4,16 +4,18 @@ import { after, before, test } from "node:test";
 import { JSDOM } from "jsdom";
 
 const HASH = "a".repeat(64);
-const RELAY_AVATAR_URL = `https://relay.example/media/${HASH}.png`;
-const PROXIED_AVATAR_URL = `http://127.0.0.1:54321/media/${HASH}.png`;
+const RELAY_ORIGIN = "https://relay.example";
+const EXTERNAL_AVATAR_URL = `https://blossom.example/media/${HASH}.png`;
+const MISROUTED_AVATAR_URL = `http://127.0.0.1:54321/media/${HASH}.png`;
 const dom = new JSDOM(
   '<!doctype html><html><body><div id="root"></div></body></html>',
   { url: "http://localhost" },
 );
 
-let resolveProxyPort;
-const proxyPort = new Promise((resolve) => {
-  resolveProxyPort = resolve;
+let relayOriginCalls = 0;
+let resolveRelayOriginRetry;
+const relayOriginRetry = new Promise((resolve) => {
+  resolveRelayOriginRetry = resolve;
 });
 
 class LoadedImage extends dom.window.EventTarget {
@@ -35,9 +37,13 @@ before(() => {
   dom.window.Image = LoadedImage;
   dom.window.__TAURI_INTERNALS__ = {
     invoke(command) {
-      if (command === "get_media_proxy_port") return proxyPort;
+      if (command === "get_media_proxy_port") return Promise.resolve(54321);
       if (command === "get_relay_http_url") {
-        return Promise.resolve("https://relay.example");
+        relayOriginCalls += 1;
+        if (relayOriginCalls === 1) {
+          return Promise.reject(new Error("Relay origin is not ready"));
+        }
+        return relayOriginRetry;
       }
       return Promise.reject(new Error(`Unexpected command: ${command}`));
     },
@@ -54,7 +60,7 @@ before(() => {
 
 after(() => dom.window.close());
 
-test("shared avatars switch to the authenticated media proxy when its port resolves", async () => {
+test("shared avatars recover external URLs when the relay origin resolves after the proxy port", async () => {
   const React = await import("react");
   const { act } = React;
   const { createRoot } = await import("react-dom/client");
@@ -68,12 +74,12 @@ test("shared avatars switch to the authenticated media proxy when its port resol
         React.Fragment,
         null,
         React.createElement(UserAvatar, {
-          avatarUrl: RELAY_AVATAR_URL,
+          avatarUrl: EXTERNAL_AVATAR_URL,
           displayName: "Channel agent",
           testId: "user-avatar",
         }),
         React.createElement(ProfileAvatar, {
-          avatarUrl: RELAY_AVATAR_URL,
+          avatarUrl: EXTERNAL_AVATAR_URL,
           label: "Running agent",
           testId: "profile-avatar",
         }),
@@ -87,23 +93,22 @@ test("shared avatars switch to the authenticated media proxy when its port resol
   const profileAvatar = document.querySelector(
     '[data-testid="profile-avatar-image"]',
   );
-  assert.equal(
-    userAvatar?.getAttribute("src"),
-    `buzz-media://localhost/media/${HASH}.png`,
-  );
-  assert.equal(
-    profileAvatar?.getAttribute("src"),
-    `buzz-media://localhost/media/${HASH}.png`,
-  );
+  assert.equal(userAvatar?.getAttribute("src"), MISROUTED_AVATAR_URL);
+  assert.equal(profileAvatar?.getAttribute("src"), MISROUTED_AVATAR_URL);
+  assert.equal(relayOriginCalls, 1);
 
   await act(async () => {
-    resolveProxyPort(54321);
-    await proxyPort;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+  assert.equal(relayOriginCalls, 2);
+
+  await act(async () => {
+    resolveRelayOriginRetry(RELAY_ORIGIN);
+    await relayOriginRetry;
   });
 
-  assert.equal(userAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
-  assert.equal(profileAvatar?.getAttribute("src"), PROXIED_AVATAR_URL);
+  assert.equal(userAvatar?.getAttribute("src"), EXTERNAL_AVATAR_URL);
+  assert.equal(profileAvatar?.getAttribute("src"), EXTERNAL_AVATAR_URL);
 
   await act(async () => root.unmount());
 });


### PR DESCRIPTION
## What and why

Desktop could render an agent's avatar in Edit while showing a fallback in channels and My Agents when startup won a media-proxy readiness race. `UserAvatar` and `ProfileAvatar` now subscribe to the native media proxy port, which makes each component recompute the authenticated loopback URL when the port becomes available.

## Blast radius

These are shared Desktop avatar renderers, so the readiness update also applies to their callers across messages, channels, agent surfaces, projects, settings, huddles, search, and the sidebar. The change does not alter profile data, avatar selection precedence, media authentication, the proxy API, or relay behavior.

## How it was verified

At `f48ed5e9545e38aabc8c98a29a4893f5246ea89c`:

- The full Desktop test suite passed, 4,762/4,762, along with Desktop typecheck and changed-file Biome checks.
- Repository pre-push hooks passed `branch-skew`, `check-push-org`, `desktop-check`, `desktop-typecheck`, and `desktop-test`.
- Code Review Bot copied only the regression test to parent `45f4b91a` and observed both avatar sources remain stuck on `buzz-media://`, proving the test fails before the fix.
- No rebuilt Desktop app was installed for manual UI verification.

## Review guidance

Start with the intentionally unused `useMediaProxyPort()` calls in `UserAvatar` and `ProfileAvatar`. Their purpose is the subscription: when the port store publishes readiness, React re-renders and the existing `rewriteRelayUrl()` path switches both image sources from `buzz-media://localhost/...` to `http://127.0.0.1:<port>/media/...`. The test holds the native port promise pending, mounts both shared renderers, then resolves it and asserts that transition.

## Deploy and rollout notes

No migration, backfill, or rollout ordering is required. Merging does not update installed Desktop clients immediately; the behavior changes when this commit is included in a later Desktop build and release.

Originating Buzz thread: buzz://message?channel=72a712cf-e899-4f52-a19b-6ce7d3b867ab&id=fff5eaec911a957204867232ce1b0e0e57c8fa876c562d3b79ca5702b382b6ad
