### PR TITLE
fix(desktop): bound relay bridge reads with a dedicated client

### DIFF
--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -23,6 +23,11 @@ pub struct AppState {
     /// recovery flags are cleared so `get_identity` reports a consistent state.
     pub(crate) identity_storage: AtomicU8,
     pub http_client: reqwest::Client,
+    /// Client for the relay's JSON bridge (`POST /query`, `POST /events`,
+    /// `GET /info`). Separate from `http_client` because it is the only
+    /// consumer whose requests are uniformly small and short-lived, and so the
+    /// only one that can carry a read timeout. See [`build_relay_bridge_client`].
+    pub relay_bridge_client: reqwest::Client,
     /// A no-redirect client for authenticated relay media fetches (download,
     /// clipboard copy, snapshot, editor). Every caller pre-validates the URL
     /// origin, but the app-wide `http_client` follows redirects by default, so
@@ -157,26 +162,10 @@ fn identity_from_env() -> Option<Keys> {
     }
 }
 
-/// Build the no-redirect HTTP client used for authenticated relay media
-/// fetches (download / copy).
-///
-/// This client is a security boundary, not a convenience: it carries a minted
-/// media `Authorization` header, so it MUST NOT follow redirects. A relay 3xx
-/// to an off-origin or private host would otherwise forward that header across
-/// origins (a redirect-hop SSRF). `redirect::Policy::none()` returns the 3xx
-/// verbatim so the caller can reject it.
-///
-/// Returned as a `Result` so the fail-closed invariant is testable — callers
-/// must never substitute a redirect-following client on build failure. Shares
-/// the localhost `resolve`/pool config with the app-wide `http_client`.
-pub fn build_media_fetch_client() -> reqwest::Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .resolve("localhost", std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-        .pool_idle_timeout(std::time::Duration::from_secs(10))
-        .pool_max_idle_per_host(1)
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-}
+#[path = "app_state_http.rs"]
+mod http_clients;
+use http_clients::http_client_base;
+pub use http_clients::{build_media_fetch_client, build_relay_bridge_client};
 
 pub fn build_app_state() -> AppState {
     // Env var takes precedence (dev/CI). If absent, resolve_persisted_identity()
@@ -195,12 +184,14 @@ pub fn build_app_state() -> AppState {
     AppState {
         keys: Mutex::new(keys),
         identity_storage: AtomicU8::new(identity_storage as u8),
-        http_client: reqwest::Client::builder()
-            .resolve("localhost", std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-            .pool_idle_timeout(std::time::Duration::from_secs(10))
-            .pool_max_idle_per_host(1)
+        http_client: http_client_base()
             .build()
             .unwrap_or_else(|_| reqwest::Client::new()),
+        relay_bridge_client: build_relay_bridge_client().expect(
+            "relay_bridge_client must build with its read timeout; a fallback \
+             client would silently restore the unbounded wait that leaves the \
+             thread panel pending with no data and no error",
+        ),
         media_fetch_client: build_media_fetch_client().expect(
             "media_fetch_client must build with redirect::Policy::none(); a \
              redirect-following fallback would forward the minted media auth \

--- a/desktop/src-tauri/src/app_state_http.rs
+++ b/desktop/src-tauri/src/app_state_http.rs
@@ -1,0 +1,95 @@
+//! HTTP client construction for the desktop.
+//!
+//! Three clients exist for three different reasons, and the reason each is
+//! separate is the whole content of this module: `http_client` streams
+//! (uploads, media proxy, model downloads), `relay_bridge_client` carries
+//! small interactive JSON and so can afford a stall budget, and
+//! `media_fetch_client` is a no-redirect security boundary. Their shared
+//! configuration lives in [`http_client_base`] so the three cannot drift.
+
+/// Connect-phase budget shared by every desktop HTTP client.
+///
+/// Bounds only DNS + TCP + TLS. Safe on the streaming clients because it
+/// stops at the moment the connection is established — a 100 MB download or
+/// an hour-long video upload is never measured against it.
+pub const HTTP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Stall budget for the relay bridge.
+///
+/// `read_timeout` is two budgets in one: a hard deadline on time-to-response-
+/// headers, and — only after headers arrive — an idle timer between body
+/// frames. Both are correct for the bridge, whose requests carry small JSON
+/// bodies and are awaited by interactive UI. Both are wrong for uploads and
+/// model downloads, which is why this lives on a separate client.
+pub const RELAY_BRIDGE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Shared builder for every desktop HTTP client.
+///
+/// Three clients now exist for three different reasons — `http_client`
+/// (streaming: uploads, media proxy, model downloads), `relay_bridge_client`
+/// (small interactive JSON), and `media_fetch_client` (no-redirect security
+/// boundary). Only their *differences* belong at the call sites; the localhost
+/// `resolve`, pool sizing, and connect budget are common ground, and are here
+/// so the three cannot drift apart.
+pub(super) fn http_client_base() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .resolve("localhost", std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .pool_idle_timeout(std::time::Duration::from_secs(10))
+        .pool_max_idle_per_host(1)
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+}
+
+/// Build the client used for the relay's JSON bridge.
+///
+/// The bridge is the one HTTP surface where an unbounded wait is a bug rather
+/// than a feature: `get_thread_replies` and friends await these requests to
+/// paint the UI, so a half-dead pooled connection would leave the panel
+/// pending with no data, no error, and no spinner resolution.
+///
+/// This client is deliberately NOT the app-wide `http_client`. `read_timeout`
+/// is not reset by request-body progress, so any budget small enough to catch
+/// a dead thread read would also abort a healthy large upload
+/// (`commands::media::do_upload` mints a 1-hour auth window for video), the
+/// media proxy's streamed response bodies, and the ~100 MB STT model download.
+/// A per-request override is not available either: reqwest 0.13's
+/// `RequestBuilder` exposes only the total `.timeout()`, never read semantics.
+/// One number cannot serve both; two clients can. Covered by
+/// `read_timeout_would_break_streaming_clients` in `app_state_tests.rs`.
+pub fn build_relay_bridge_client() -> reqwest::Result<reqwest::Client> {
+    relay_bridge_client_with(RELAY_BRIDGE_READ_TIMEOUT)
+}
+
+/// [`build_relay_bridge_client`] with an explicit stall budget.
+///
+/// Exists so the tests can exercise the real construction path on a budget
+/// small enough to run in a second. They cannot simply pause tokio's clock:
+/// under `start_paused` the runtime auto-advances time whenever it is idle,
+/// and a pending real socket read counts as idle — so the *connect* timer
+/// fires instantly and the test proves nothing about the read timer.
+pub(super) fn relay_bridge_client_with(
+    read_timeout: std::time::Duration,
+) -> reqwest::Result<reqwest::Client> {
+    http_client_base().read_timeout(read_timeout).build()
+}
+
+/// Build the no-redirect HTTP client used for authenticated relay media
+/// fetches (download / copy).
+///
+/// This client is a security boundary, not a convenience: it carries a minted
+/// media `Authorization` header, so it MUST NOT follow redirects. A relay 3xx
+/// to an off-origin or private host would otherwise forward that header across
+/// origins (a redirect-hop SSRF). `redirect::Policy::none()` returns the 3xx
+/// verbatim so the caller can reject it.
+///
+/// Returned as a `Result` so the fail-closed invariant is testable — callers
+/// must never substitute a redirect-following client on build failure. Shares
+/// [`http_client_base`] with the other two clients.
+pub fn build_media_fetch_client() -> reqwest::Result<reqwest::Client> {
+    http_client_base()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+}
+
+#[cfg(test)]
+#[path = "app_state_http_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/app_state_http_tests.rs
+++ b/desktop/src-tauri/src/app_state_http_tests.rs
@@ -1,0 +1,234 @@
+//! Tests for the desktop's three HTTP clients.
+//!
+//! Lives beside `app_state_http.rs` rather than in `app_state_tests.rs` so the
+//! client construction and the tests that pin its invariants move together.
+
+use super::super::*;
+use super::*;
+
+// ── HTTP client timeout split ────────────────────────────────────────────────
+//
+// `relay_bridge_client` carries a read timeout; `http_client` deliberately does
+// not. These tests pin both halves, because each is only safe while the other
+// holds: a bridge without the timeout re-opens the silent stall that leaves a
+// thread panel pending forever, and a shared client with one silently truncates
+// video uploads, media streams, and the ~100 MB model download.
+//
+// These run on the real clock with a small `TEST_READ_TIMEOUT`, not under
+// `start_paused`. Paused time auto-advances whenever the runtime is idle, and a
+// pending socket read is idle — so the connect timer fires immediately and the
+// test passes while proving nothing. `paused_time_would_void_these_tests`
+// below is the control that documents that trap.
+
+/// Stall budget used by the tests in this section. Small enough to keep the
+/// suite fast, large enough not to race a loopback connect.
+const TEST_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(750);
+
+/// A loopback server that accepts, reads the request, and then never responds
+/// — the half-dead connection this whole change is about. Returns its base URL.
+///
+/// The listener moves into the thread and lives until the process exits, so a
+/// client that is *supposed* to hang keeps hanging rather than getting a
+/// spurious connection-reset that would look like a timeout.
+fn spawn_silent_server() -> String {
+    use std::io::Read as _;
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        while let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            // Hold the socket open and silent; never write a response.
+            held.push(stream);
+        }
+    });
+    format!("http://{addr}/")
+}
+
+/// A request body that takes `chunks` × `TEST_READ_TIMEOUT` to produce — a
+/// large upload on a slow uplink. Every chunk is forward progress; the client
+/// is never stalled, which is precisely why an idle-looking timer must not
+/// fire on it.
+fn slow_upload_body(chunks: u32) -> reqwest::Body {
+    let stream = futures_util::stream::unfold(0u32, move |i| async move {
+        if i >= chunks {
+            return None;
+        }
+        tokio::time::sleep(TEST_READ_TIMEOUT).await;
+        Some((
+            Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"payload")),
+            i + 1,
+        ))
+    });
+    reqwest::Body::wrap_stream(stream)
+}
+
+#[tokio::test]
+async fn relay_bridge_client_aborts_a_stalled_response() {
+    // The thread-panel failure mode: a connection that accepts the request and
+    // then goes silent. Without a read timeout this is indistinguishable from
+    // a slow relay and waits forever.
+    let url = spawn_silent_server();
+    let client = relay_bridge_client_with(TEST_READ_TIMEOUT).expect("bridge client must build");
+
+    let started = std::time::Instant::now();
+    // Outer bound so that losing the read timeout FAILS this test instead of
+    // hanging it — the regression is an unbounded wait, and a test that hangs
+    // wedges CI rather than reporting.
+    let outcome =
+        tokio::time::timeout(TEST_READ_TIMEOUT * 8, client.post(&url).body("[]").send()).await;
+    let elapsed = started.elapsed();
+
+    let result = outcome.expect(
+        "the bridge client hung: its read timeout is missing, which is exactly \
+         the silent stall that leaves the thread panel pending forever",
+    );
+    assert!(
+        result.is_err(),
+        "the bridge client must give up on a response that never arrives"
+    );
+    // Attribute the failure to the read timeout, not to connect or to a reset.
+    // A connect failure would land in microseconds on loopback.
+    assert!(
+        elapsed >= TEST_READ_TIMEOUT,
+        "must fail on the read budget, not before it (failed after {elapsed:?}: {result:?})"
+    );
+    assert!(
+        elapsed < HTTP_CONNECT_TIMEOUT,
+        "must fail on the read budget, not the connect budget (took {elapsed:?})"
+    );
+}
+
+#[tokio::test]
+async fn http_client_has_no_response_deadline() {
+    // Control for the test above: same silent server, the shared client. This
+    // is the pre-existing behaviour and it must stay — a deadline here would
+    // truncate media streams and the model download.
+    let url = spawn_silent_server();
+    let state = build_app_state();
+
+    let outcome = tokio::time::timeout(
+        TEST_READ_TIMEOUT * 4,
+        state.http_client.post(&url).body("[]").send(),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "the shared client must still be waiting; a response deadline here \
+         would abort long media streams and the ~100 MB model download \
+         (got {outcome:?})"
+    );
+}
+
+#[tokio::test]
+async fn read_timeout_would_break_streaming_clients() {
+    // Why the split exists. `read_timeout` is NOT reset by request-body
+    // progress — until response headers arrive it is a hard deadline. So the
+    // bridge's budget kills a healthy upload that merely takes longer than it,
+    // which is routine for video (`do_upload` mints a 1-hour auth window).
+    let url = spawn_silent_server();
+    let bridge = relay_bridge_client_with(TEST_READ_TIMEOUT).expect("bridge client must build");
+
+    let outcome = tokio::time::timeout(
+        TEST_READ_TIMEOUT * 8,
+        bridge.put(&url).body(slow_upload_body(4)).send(),
+    )
+    .await;
+
+    let result = outcome.expect("the bridge client's read timeout must bound this upload");
+    assert!(
+        result.is_err(),
+        "an upload longer than the read budget dies on the bridge client — \
+         this is why uploads keep the shared client"
+    );
+}
+
+#[tokio::test]
+async fn shared_client_survives_a_long_upload() {
+    // Positive half of the pair above: the same slow body on the shared client
+    // is still in flight rather than aborted.
+    let url = spawn_silent_server();
+    let state = build_app_state();
+
+    let outcome = tokio::time::timeout(
+        TEST_READ_TIMEOUT * 4,
+        state.http_client.put(&url).body(slow_upload_body(8)).send(),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "the shared client must not abort a slow upload; it should still be \
+         waiting on the (deliberately silent) server (got {outcome:?})"
+    );
+}
+
+#[tokio::test]
+async fn only_the_bridge_client_carries_a_response_timeout() {
+    // Structural counterpart to the behavioural tests above, and the one that
+    // catches the tempting "simplification": moving the read timeout onto the
+    // shared client. Behaviourally that regression only shows up on a request
+    // that outlives the production 30s budget — too slow for a unit test — so
+    // it is asserted on construction instead.
+    //
+    // `reqwest::Client`'s Debug prints `read_timeout` / `TotalTimeout` only
+    // when they are configured, which makes this a real assertion rather than
+    // a string-matching ritual. Verified against reqwest 0.13.4.
+    let state = build_app_state();
+
+    let bridge = format!("{:?}", state.relay_bridge_client);
+    assert!(
+        bridge.contains("read_timeout"),
+        "the bridge client must carry a read timeout, else a stalled relay \
+         connection leaves the thread panel pending forever: {bridge}"
+    );
+
+    for (name, client) in [
+        ("http_client", &state.http_client),
+        ("media_fetch_client", &state.media_fetch_client),
+    ] {
+        let rendered = format!("{client:?}");
+        assert!(
+            !rendered.contains("read_timeout") && !rendered.contains("TotalTimeout"),
+            "{name} must carry no response deadline — it streams video uploads, \
+             media bodies, and the ~100 MB model download, and any such budget \
+             truncates them: {rendered}"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn paused_time_would_void_these_tests() {
+    // Guard against a plausible "speed-up" of the tests above. Under paused
+    // time the runtime advances the clock whenever it is idle, and a pending
+    // socket read is idle — so both the connect and read budgets elapse in
+    // essentially zero real time. Every assertion above would still see an
+    // error and pass, while measuring nothing. Documented as a test so the
+    // trap is discoverable rather than rediscovered.
+    //
+    // Asserted on real elapsed time rather than the error kind: which of the
+    // two budgets wins the race depends on whether the loopback connect
+    // completes before the runtime next goes idle, so the kind is not stable
+    // under a loaded parallel run. That the failure is instant *is* stable,
+    // and it is the whole trap.
+    let url = spawn_silent_server();
+    let client = build_relay_bridge_client().expect("bridge client must build");
+
+    let started = std::time::Instant::now();
+    let result = client.post(&url).body("[]").send().await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        result.is_err(),
+        "paused time must produce an error from the production 30s budget \
+         without waiting 30s (got {result:?})"
+    );
+    assert!(
+        elapsed < RELAY_BRIDGE_READ_TIMEOUT / 10,
+        "the point of this control: paused time short-circuits the real budget \
+         ({elapsed:?} of {RELAY_BRIDGE_READ_TIMEOUT:?}), so a paused test \
+         cannot attribute a failure to the timeout it names"
+    );
+}

--- a/desktop/src-tauri/src/commands/relay_members.rs
+++ b/desktop/src-tauri/src/commands/relay_members.rs
@@ -27,7 +27,7 @@ pub async fn relay_requires_membership(
         .unwrap_or_else(|| relay_api_base_url_with_override(&state));
     let url = format!("{}/info", base_url.trim_end_matches('/'));
     let response = state
-        .http_client
+        .relay_bridge_client
         .get(url)
         .header("Accept", "application/nostr+json")
         .send()

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -913,7 +913,7 @@ pub(crate) async fn submit_engram_event(
     crate::relay_admission::wait_for_rate_limit().await;
     let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, url, event_json)?;
     let mut request = state
-        .http_client
+        .relay_bridge_client
         .post(url)
         .header("Authorization", auth)
         .header("Content-Type", "application/json");

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -631,7 +631,10 @@ pub(crate) fn spawn_transcription_task(
     // Capture the current generation at spawn time.
     let spawned_gen = session_generation.load(Ordering::Acquire);
 
-    let http_client = state.http_client.clone();
+    // STT posts kind:9 transcript events to the relay bridge's `POST /events`
+    // — small JSON bodies on the same surface as thread reads, so it takes the
+    // bridge client and its stall budget rather than the streaming client.
+    let http_client = state.relay_bridge_client.clone();
     let keys = match state.keys.lock() {
         Ok(k) => k.clone(),
         Err(_) => return,

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -324,7 +324,7 @@ pub async fn query_relay_at(
     let auth = build_nip98_auth_header(&Method::POST, &url, &body_bytes, state)?;
 
     let response = state
-        .http_client
+        .relay_bridge_client
         .post(&url)
         .header("Authorization", auth)
         .header("Content-Type", "application/json")
@@ -353,7 +353,7 @@ pub async fn query_relay_at_with_keys(
         serde_json::to_vec(filters).map_err(|e| format!("filter serialization failed: {e}"))?;
     let auth = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
     let mut request = state
-        .http_client
+        .relay_bridge_client
         .post(&url)
         .header("Authorization", auth)
         .header("Content-Type", "application/json");
@@ -456,7 +456,7 @@ pub async fn sync_managed_agent_profile(
     let auth = build_nip98_auth_header_for_keys(agent_keys, &Method::POST, &url, &body_bytes)?;
 
     let mut request = state
-        .http_client
+        .relay_bridge_client
         .post(&url)
         .header("Authorization", auth)
         .header("Content-Type", "application/json");
@@ -571,7 +571,7 @@ pub async fn submit_signed_event_with_keys(
     let auth_header = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
 
     let mut request = state
-        .http_client
+        .relay_bridge_client
         .post(&url)
         .header("Authorization", auth_header)
         .header("Content-Type", "application/json");

--- a/desktop/src-tauri/src/relay/submit.rs
+++ b/desktop/src-tauri/src/relay/submit.rs
@@ -29,7 +29,7 @@ pub async fn submit_signed_event_at_with_keys(
     let auth_header = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;
 
     let response = state
-        .http_client
+        .relay_bridge_client
         .post(&url)
         .header("Authorization", auth_header)
         .header("Content-Type", "application/json")


### PR DESCRIPTION
## Problem

Every relay read goes out on the app-wide `http_client`, which carries **no response deadline**. A connection that is open but dead — far end gone without a FIN, a proxy holding the socket, a NAT rebind — leaves the request awaiting response headers that never arrive.

`get_thread_replies` awaits exactly that. The thread panel then sits **pending with no data, no error, and no spinner resolution**, which is the reported symptom shape in the huddle thread-loading bug.

This is a robustness fix for that failure *mode*. It is not yet confirmed as the producer of Tyler's specific repro — the decisive live test is still outstanding — but an unbounded wait on the interactive read path is a bug on its own terms.

## Change

Give the relay bridge (`POST /query`, `POST /events`, `GET /info`) its own client with a **30s `read_timeout`**, and give all three clients a **15s `connect_timeout`**.

Client construction moves to `app_state_http.rs` with a shared `http_client_base()` so the three cannot drift apart.

| client | connect | response deadline | why |
|---|---|---|---|
| `relay_bridge_client` *(new)* | 15s | **30s read** | small interactive JSON; a stall is a bug |
| `http_client` | 15s | **none** | video uploads, media proxy, ~100 MB model download |
| `media_fetch_client` | 15s | **none** | no-redirect security boundary |

## Why not one client with one timeout

Probed against reqwest 0.13.4 with real sockets rather than assumed. 9/9 probes, independently re-run by @Eva:

| probe | result |
|---|---|
| `read_timeout` bounds time-to-response-headers | ✅ fires |
| after headers, acts as an idle timer between body frames | ✅ fires |
| spares a slow-but-progressing download (6s trickle, 2s budget) | ✅ survives |
| **reset by request-*body* progress** | ❌ **NOT reset — kills a healthy slow upload** |

That fourth row **contradicted my own earlier recommendation** in this thread, and it is the reason for the split: any budget tight enough to catch a dead thread read also aborts a legitimate large upload. `do_upload` mints a **1-hour** auth window for video.

A per-request override isn't available either — reqwest 0.13's `RequestBuilder` exposes only the total `.timeout()`, never read semantics (confirmed independently by @Eva). So the dedicated client is forced, not scope creep. It follows the existing `media_fetch_client` precedent.

`connect_timeout` is safe on all three because it stops at connection establishment and never measures a transfer.

## Tests

6 new, in `app_state_http_tests.rs`:

- `relay_bridge_client_aborts_a_stalled_response` — the actual failure mode, against a loopback server that accepts and goes silent. Asserts the failure lands **on the read budget**, not connect and not a reset.
- `http_client_has_no_response_deadline` / `shared_client_survives_a_long_upload` — the shared client must still be waiting.
- `read_timeout_would_break_streaming_clients` — pins *why* the split exists.
- `only_the_bridge_client_carries_a_response_timeout` — structural, via reqwest's `Debug` (which prints `read_timeout`/`TotalTimeout` only when configured — verified at `async_impl/client.rs:2988`).
- `paused_time_would_void_these_tests` — control for the trap below.

**Mutation-tested, and it changed the design:**

| mutation | first result | fix |
|---|---|---|
| drop the bridge `read_timeout` | **hung 10 min** instead of failing | `tokio::time::timeout` wrappers → regression is a fast failure, not wedged CI |
| move `read_timeout` onto the shared client *(worst regression)* | **survived** every behavioural test | added the structural `Debug` assertion |
| drop `connect_timeout` | caught | — |

**The trap that cost the most:** under `start_paused`, tokio auto-advances the clock whenever the runtime is idle, and a pending real socket read *counts as idle*. The 15s connect timer fired instantly and my bridge test passed **for the wrong reason**. All timeout tests now use the real clock with short budgets, and the trap is pinned as a test rather than left to be rediscovered.

## Validation

At `0172d41c2`, HEAD verified unchanged before and after each run:

- `cargo test` — **2432 passed, 0 failed, 14 ignored** (full package, not scoped)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- desktop file-size ratchet — clean (it caught real growth on `app_state.rs`; that's what prompted the module extraction)
- pre-push gates: branch-skew, desktop-check, desktop-typecheck, desktop-test, desktop-tauri-checks — all ✅

## Merge order

Overlaps #5763 (@Wren) on the same `relay.rs` sends. Measured rather than assumed: `git merge-tree` merges **clean**, and both sides' symbols survive in the merged tree. The changes are orthogonal by construction — his is the *argument* side of the send (which principal waits), mine is the *client* side (which `reqwest::Client` the `.post()` hangs off).

**#5763 should land first; I'll rebase.**
