### PR TITLE
Show date in thread panel timestamps for older messages

### DIFF
--- a/desktop/src/features/messages/lib/dateFormatters.test.mjs
+++ b/desktop/src/features/messages/lib/dateFormatters.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  formatDatedTime,
   formatDayHeading,
   formatShortMonthDayOrdinal,
   formatThreadSummaryLastReplyTime,
@@ -133,6 +134,34 @@ test("formatDayHeading includes the year for other years", () => {
     formatDayHeading(date.getTime() / 1_000),
     `${weekday(date)}, May 19th, ${year}`,
   );
+});
+
+test("formatDatedTime returns bare time for same-day timestamps", () => {
+  const now = new Date(2026, 4, 19, 18, 0).getTime() / 1_000;
+  const at = new Date(2026, 4, 19, 14, 34).getTime() / 1_000;
+
+  assert.equal(formatDatedTime(at, now), "2:34 PM");
+});
+
+test("formatDatedTime labels yesterday", () => {
+  const now = new Date(2026, 4, 19, 9, 0).getTime() / 1_000;
+  const at = new Date(2026, 4, 18, 14, 34).getTime() / 1_000;
+
+  assert.equal(formatDatedTime(at, now), "Yesterday at 2:34 PM");
+});
+
+test("formatDatedTime prefixes the date within the current year", () => {
+  const now = new Date(2026, 7, 20, 9, 0).getTime() / 1_000;
+  const at = new Date(2026, 4, 19, 14, 34).getTime() / 1_000;
+
+  assert.equal(formatDatedTime(at, now), "May 19th at 2:34 PM");
+});
+
+test("formatDatedTime includes the year for prior years", () => {
+  const now = new Date(2026, 4, 19, 9, 0).getTime() / 1_000;
+  const at = new Date(2025, 4, 19, 14, 34).getTime() / 1_000;
+
+  assert.equal(formatDatedTime(at, now), "May 19th, 2025 at 2:34 PM");
 });
 
 test("startOfLocalDaySeconds collapses a day's timestamps to one value", () => {

--- a/desktop/src/features/messages/lib/dateFormatters.ts
+++ b/desktop/src/features/messages/lib/dateFormatters.ts
@@ -106,6 +106,36 @@ export function formatShortMonthDayOrdinal(unixSeconds: number): string {
 }
 
 /**
+ * Clock time prefixed with the date when the timestamp is not from today,
+ * for timelines without day dividers (e.g. the thread panel).
+ * Returns "2:34 PM", "Yesterday at 2:34 PM", "May 19th at 2:34 PM",
+ * or "May 19th, 2025 at 2:34 PM" for prior years.
+ */
+export function formatDatedTime(
+  unixSeconds: number,
+  nowSeconds = Date.now() / 1_000,
+): string {
+  const time = formatTime(unixSeconds);
+  const date = new Date(unixSeconds * 1_000);
+  const now = new Date(nowSeconds * 1_000);
+
+  if (isSameDayDate(date, now)) {
+    return time;
+  }
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (isSameDayDate(date, yesterday)) {
+    return `Yesterday at ${time}`;
+  }
+
+  const dateLabel = formatMonthDayOrdinal(date, SHORT_MONTH_FORMATTER);
+  return date.getFullYear() === now.getFullYear()
+    ? `${dateLabel} at ${time}`
+    : `${dateLabel}, ${date.getFullYear()} at ${time}`;
+}
+
+/**
  * Relative thread-summary timestamp with expanded units, e.g. "3 hours ago",
  * falling back to "on May 19th" for older replies.
  */

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -627,7 +627,11 @@ export const MessageRow = React.memo(
 
     const inlineMetadataNode = (
       <div className="flex shrink-0 items-baseline gap-2 text-xs">
-        <MessageTimestamp createdAt={message.createdAt} time={message.time} />
+        <MessageTimestamp
+          createdAt={message.createdAt}
+          showDateForOlderDays={isThreadReplyLayout}
+          time={message.time}
+        />
         {statusMetadataNode}
       </div>
     );

--- a/desktop/src/features/messages/ui/MessageTimestamp.tsx
+++ b/desktop/src/features/messages/ui/MessageTimestamp.tsx
@@ -1,4 +1,5 @@
 import {
+  formatDatedTime,
   formatFullDateTime,
   formatTimeWithoutDayPeriod,
 } from "@/features/messages/lib/dateFormatters";
@@ -16,14 +17,21 @@ export function MessageTimestamp({
   className,
   createdAt,
   hideDayPeriod = false,
+  showDateForOlderDays = false,
   time,
 }: {
   className?: string;
   createdAt: number;
   hideDayPeriod?: boolean;
+  /** Prefix the date when the message is not from today ("May 19th at 2:34 PM"). */
+  showDateForOlderDays?: boolean;
   time: string;
 }) {
-  const displayTime = hideDayPeriod ? formatTimeWithoutDayPeriod(time) : time;
+  const displayTime = showDateForOlderDays
+    ? formatDatedTime(createdAt)
+    : hideDayPeriod
+      ? formatTimeWithoutDayPeriod(time)
+      : time;
 
   return (
     <TooltipProvider


### PR DESCRIPTION
The thread panel has no day dividers, so replies from previous days showed only a bare clock time, with no hint the conversation happened days or months ago. Timestamps there now include the date when the message wasn't sent today: "Yesterday at 2:34 PM", "May 19th at 2:34 PM", or "May 19th, 2025 at 2:34 PM" for prior years.

The main channel timeline is unchanged (it already has day dividers), as are the hover-only continuation timestamps and the full-date tooltip.

Generated with [Amp](https://ampcode.com)

<img width="383" height="376" alt="thread-dated-timestamps-panel" src="https://github.com/user-attachments/assets/70380585-afb0-42a8-b29f-f8f1caa9a3a3" />
