### PR TITLE
fix(desktop): route compact preview geometry fixture through media proxy

### DIFF
--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -1312,7 +1312,10 @@ test("compact link preview image geometry truncates long titles to one line", as
   page,
 }) => {
   const previewUrl = "https://github.com/block/buzz/pull/3246?geometry=1";
-  await page.route("http://localhost:3000/media/*.png", (route) =>
+  // Sent snapshot media is relay-hosted and rewritten through the
+  // authenticated media proxy (#5627), so serve the fixture from the mock
+  // proxy origin rather than the raw relay origin.
+  await page.route("http://127.0.0.1:54321/media/**", (route) =>
     route.fulfill({
       body: LINK_PREVIEW_IMAGE,
       contentType: "image/png",


### PR DESCRIPTION
**Category:** fix (CI)
**User Impact:** None — test-only change that unblocks `main` and every open PR.

**Problem:** `main` has been red since #5629 landed on `45f4b91a3`: `Desktop Smoke E2E (3)` fails `compact link preview image geometry truncates long titles to one line` on every build (main run 31727837133, and e.g. #5792, #5790). Two independently-green PRs raced: #5629 added the test stubbing its preview image at the raw relay origin (`http://localhost:3000/media/*.png`), while #5627 rewrites sent snapshot media through the authenticated local media proxy (`http://127.0.0.1:54321` in the E2E mock bridge). Merged together, the image request goes to the proxy origin, the stub never matches, and `naturalWidth` stays `0`.

**Solution:** Point the route stub at the mock proxy origin, matching the existing `sent link preview media uses the authenticated proxy in compact and rich cards` test in the same spec.

**Testing:** Reproduced the failure locally on `45f4b91a3`, then with this fix: targeted test passes, and the full `messaging.spec.ts` smoke suite passes 58/58.
