### PR TITLE
fix(desktop): intercept proxied link preview fixture

### DIFF
--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -1312,7 +1312,7 @@ test("compact link preview image geometry truncates long titles to one line", as
   page,
 }) => {
   const previewUrl = "https://github.com/block/buzz/pull/3246?geometry=1";
-  await page.route("http://localhost:3000/media/*.png", (route) =>
+  await page.route("http://127.0.0.1:54321/media/**", (route) =>
     route.fulfill({
       body: LINK_PREVIEW_IMAGE,
       contentType: "image/png",


### PR DESCRIPTION
**Category:** fix

**Problem:** The compact link-preview geometry E2E registered a route for the pre-upload `http://localhost:3000/media/*.png` URL. Once the preview snapshot is sent, the card renders the relay URL through the E2E media proxy at `http://127.0.0.1:54321/media/...`, so Chromium received `ERR_CONNECTION_REFUSED` and `naturalWidth` stayed `0`.

**Solution:** Intercept the same mock media-proxy endpoint used by the application and the existing proxy E2E. This keeps the decoded-image assertion intact and serves the committed PNG fixture on the URL the sent card actually loads.

**Verification:**
- `pnpm -C desktop check`
- `pnpm -C desktop test` (4,761 passed)
- `CI=1 pnpm -C desktop exec playwright test tests/e2e/messaging.spec.ts --project=smoke --grep 'compact link preview image geometry'`
