### PR TITLE
fix(desktop): align thread activity row with its composer

### DIFF
--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -927,7 +927,7 @@ export function MessageThreadPanel({
               className={THREAD_PANEL_COMPOSER_GUTTER_CLASS}
               visible={hasComposerBottomActivity}
             >
-              <div className="mx-auto flex w-full max-w-4xl items-center gap-2 overflow-visible pl-2">
+              <div className="flex w-full items-center gap-2 overflow-visible pl-2">
                 {activityAccessoryVisible && activityAccessoryContent ? (
                   <div className="flex min-w-0 flex-1 overflow-visible">
                     {activityAccessoryContent}


### PR DESCRIPTION
## Summary

The thread panel's composer activity row is wrapped in a centered 56rem frame, while the composer directly above it spans the full gutter:

```tsx
// desktop/src/features/messages/ui/MessageThreadPanel.tsx:930
<div className="mx-auto flex w-full max-w-4xl items-center gap-2 overflow-visible pl-2">
```

Below ~936px of panel width the cap never engages and the two happen to line up. Past it, `mx-auto` centers the row and it drifts away from the composer, leaving a gap that grows as `(panelWidth - 40 - 896) / 2` per side. The thread panel's upper bound is `max(720, viewport - 300)` (`shared/layout/auxiliaryPanelLayout.ts:15-20`), so the threshold is reachable on any viewport from roughly 1236px up.

The channel's equivalent wrapper (`ChannelComposerActivityAccessory.tsx:43`) has neither the cap nor the centering, so the two surfaces disagreed while rendering the same component (`BotActivityComposerAction`, `variant="inline"` in both).

`git log -L 930,930` traces the frame to #3151, where it was carried over from the toolbar row it replaced. It was the only `max-w-4xl` left in the conversation UI — the four remaining occurrences are Settings, two dialogs and onboarding.

Dropping it makes the wrapper byte-identical to the channel's:

```tsx
<div className="flex w-full items-center gap-2 overflow-visible pl-2">
```

Alternative considered: give the thread's `MessageComposer` the same `mx-auto max-w-4xl`. Rejected — that spreads an accidental constraint onto a surface that never had it and changes every thread's composer geometry, instead of restoring the two to one shared frame.

### Related issue

Fixes #5803. Searched open issues and PRs for duplicates: the agent-activity issues that come back are behavioral (indicator missing or stale, replies not rendered), none about layout. None found.

### Testing

Static, and I would rather be explicit about the limits than imply more:

- The resulting `className` is byte-identical to `ChannelComposerActivityAccessory.tsx:43`, which is the surface this row is meant to match.
- No test or snapshot references `activityAccessory`, `ComposerActivityAccessory`, or the `composer-activity` class strings.
- The class string is unchanged relative to the channel wrapper, so the Tailwind class sorter has nothing to reorder.
- The before state is in #5803, reported from a wide thread panel. I did not have a rendering environment to capture an after shot; reproducing takes seconds — widen the thread panel past ~936px with an agent working, and compare the row against the channel's.
