### PR TITLE
Fix Codex env-key authentication readiness

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_config_tests.rs
@@ -61,6 +61,7 @@ fn goose_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
     }
 }
 

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -11,8 +11,8 @@ use crate::{
     relay::query_relay,
 };
 
+mod auth_env;
 mod post_install_verification;
-
 fn active_installs() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
     use std::collections::HashSet;
     use std::sync::{Mutex, OnceLock};
@@ -22,7 +22,6 @@ fn active_installs() -> &'static std::sync::Mutex<std::collections::HashSet<Stri
 
 /// Returns the adapter install commands that `install_acp_runtime_blocking` would
 /// run for `runtime_id` given a resolved adapter binary at `adapter_path` (or `None` if not found).
-/// Returns `None` when no install is needed; `Some(cmds)` when adapter is missing or outdated.
 ///
 /// For the codex **outdated** case, returns a two-step reinstall: uninstall `@zed-industries/codex-acp`
 /// then install `@agentclientprotocol/codex-acp` (npm ≥7 refuses to overwrite a bin from another pkg).
@@ -69,7 +68,8 @@ pub async fn discover_acp_providers(
             .app_data_dir()
             .ok()
             .map(|d| d.join("custom_harnesses"));
-        crate::managed_agents::discover_acp_runtimes_from(custom_dir.as_deref())
+        let auth_envs = auth_env::load(&app);
+        crate::managed_agents::discover_acp_runtimes_from(custom_dir.as_deref(), &auth_envs)
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))

--- a/desktop/src-tauri/src/commands/agent_discovery/auth_env.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/auth_env.rs
@@ -104,10 +104,17 @@ mod tests {
 
         let envs = configured(std::slice::from_ref(&persona), &[agent], &global);
 
-        assert!(envs.iter().any(|env| env.get("GLOBAL_KEY") == Some(&"global".into())));
-        assert!(envs.iter().any(|env| env.get("PERSONA_KEY") == Some(&"persona".into())));
+        assert!(envs
+            .iter()
+            .any(|env| env.get("GLOBAL_KEY") == Some(&"global".into())));
+        assert!(envs
+            .iter()
+            .any(|env| env.get("PERSONA_KEY") == Some(&"persona".into())));
         let agent_env = envs.last().expect("agent environment");
-        assert_eq!(agent_env.get("AGENT_KEY").map(String::as_str), Some("agent"));
+        assert_eq!(
+            agent_env.get("AGENT_KEY").map(String::as_str),
+            Some("agent")
+        );
         assert_eq!(agent_env.get("SHARED_KEY").map(String::as_str), Some(""));
     }
 }

--- a/desktop/src-tauri/src/commands/agent_discovery/auth_env.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/auth_env.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+
+use tauri::AppHandle;
+
+use crate::managed_agents::{
+    baked_build_env, known_acp_runtime, load_global_agent_config, load_managed_agent_configs,
+    load_personas, merged_user_env, record_agent_command, resolve_effective_agent_env,
+    AgentDefinition, GlobalAgentConfig, ManagedAgentRecord,
+};
+
+/// Effective child environments that can supply pre-probe auth evidence.
+///
+/// Runtime discovery is global rather than agent-specific, so a runtime is
+/// authenticated when the desktop process or any configured child environment
+/// can authenticate it. Readiness still evaluates one exact child environment.
+pub(super) fn load(app: &AppHandle) -> Vec<BTreeMap<String, String>> {
+    let personas = load_personas(app).unwrap_or_else(|error| {
+        tracing::warn!(%error, "runtime auth discovery could not load personas");
+        vec![]
+    });
+    let records = load_managed_agent_configs(app).unwrap_or_else(|error| {
+        tracing::warn!(%error, "runtime auth discovery could not load agent configs");
+        vec![]
+    });
+    let global = load_global_agent_config(app).unwrap_or_else(|error| {
+        tracing::warn!(%error, "runtime auth discovery could not load global config");
+        GlobalAgentConfig::default()
+    });
+    configured(&personas, &records, &global)
+}
+
+fn configured(
+    personas: &[AgentDefinition],
+    records: &[ManagedAgentRecord],
+    global: &GlobalAgentConfig,
+) -> Vec<BTreeMap<String, String>> {
+    let mut base = baked_build_env();
+    base.extend(merged_user_env(&BTreeMap::new(), &global.env_vars));
+
+    let persona_envs = personas.iter().cloned().map(|persona| {
+        let record = persona.into_agent_record();
+        let command = record_agent_command(&record, &[]);
+        resolve_effective_agent_env(&record, &[], known_acp_runtime(&command), global).env
+    });
+    let agent_envs = records.iter().map(|record| {
+        let command = record_agent_command(record, personas);
+        resolve_effective_agent_env(record, personas, known_acp_runtime(&command), global).env
+    });
+
+    std::iter::once(base)
+        .chain(persona_envs)
+        .chain(agent_envs)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn persona(env_vars: BTreeMap<String, String>) -> AgentDefinition {
+        AgentDefinition {
+            id: "persona".into(),
+            display_name: "Persona".into(),
+            avatar_url: None,
+            system_prompt: "Help".into(),
+            runtime: Some("codex".into()),
+            model: None,
+            provider: None,
+            name_pool: vec![],
+            is_builtin: false,
+            is_active: true,
+            shared: false,
+            source_team: None,
+            source_team_persona_slug: None,
+            catalog_source: None,
+            env_vars,
+            respond_to: None,
+            respond_to_allowlist: vec![],
+            parallelism: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn collects_global_persona_and_agent_env_with_last_wins_precedence() {
+        let global = GlobalAgentConfig {
+            env_vars: BTreeMap::from([
+                ("GLOBAL_KEY".into(), "global".into()),
+                ("SHARED_KEY".into(), "global".into()),
+            ]),
+            ..Default::default()
+        };
+        let persona = persona(BTreeMap::from([
+            ("PERSONA_KEY".into(), "persona".into()),
+            ("SHARED_KEY".into(), "persona".into()),
+        ]));
+        let mut agent = persona.clone().into_agent_record();
+        agent.persona_id = Some(persona.id.clone());
+        agent.env_vars = BTreeMap::from([
+            ("AGENT_KEY".into(), "agent".into()),
+            ("SHARED_KEY".into(), String::new()),
+        ]);
+
+        let envs = configured(std::slice::from_ref(&persona), &[agent], &global);
+
+        assert!(envs.iter().any(|env| env.get("GLOBAL_KEY") == Some(&"global".into())));
+        assert!(envs.iter().any(|env| env.get("PERSONA_KEY") == Some(&"persona".into())));
+        let agent_env = envs.last().expect("agent environment");
+        assert_eq!(agent_env.get("AGENT_KEY").map(String::as_str), Some("agent"));
+        assert_eq!(agent_env.get("SHARED_KEY").map(String::as_str), Some(""));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
@@ -312,11 +312,7 @@ env_key = "CUSTOM_API_KEY=secret"
         let env = BTreeMap::from([("CODEX_HOME".to_string(), "/child/codex".to_string())]);
 
         assert_eq!(
-            codex_config_path_from(
-                &env,
-                Some("/desktop/codex".into()),
-                Some("/user".into())
-            ),
+            codex_config_path_from(&env, Some("/desktop/codex".into()), Some("/user".into())),
             Some(std::path::PathBuf::from("/child/codex/config.toml"))
         );
     }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
@@ -1,10 +1,56 @@
 use super::types::{ExtensionEntry, RuntimeFileConfig};
+use std::collections::BTreeMap;
 
 /// Read Codex config from `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`).
 pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
     let path = codex_config_path()?;
     let raw = std::fs::read_to_string(path).ok()?;
     parse_codex_config(&raw)
+}
+
+/// Return whether the active custom Codex provider has a usable env-backed
+/// credential. Codex accepts provider API keys through
+/// `[model_providers.<id>] env_key`, but `codex login status` only checks its
+/// persisted credential store. Buzz must account for both authentication
+/// paths before deciding that the runtime is logged out.
+pub(crate) fn env_key_auth_satisfied(effective_env: &BTreeMap<String, String>) -> bool {
+    let Some(env_key) = read_active_provider_env_key() else {
+        return false;
+    };
+
+    env_key_value_is_set(effective_env, &env_key)
+}
+
+fn env_key_value_is_set(effective_env: &BTreeMap<String, String>, env_key: &str) -> bool {
+    effective_env
+        .get(env_key)
+        .is_some_and(|value| !value.is_empty())
+        || std::env::var_os(env_key).is_some_and(|value| !value.is_empty())
+}
+
+fn read_active_provider_env_key() -> Option<String> {
+    let path = codex_config_path()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    parse_active_provider_env_key(&raw)
+}
+
+fn parse_active_provider_env_key(toml_str: &str) -> Option<String> {
+    let table: toml::Table = toml_str.parse().ok()?;
+    let provider = toml_string(&table, "model_provider")?;
+    let env_key = table
+        .get("model_providers")?
+        .as_table()?
+        .get(&provider)?
+        .as_table()?
+        .get("env_key")?
+        .as_str()?
+        .trim();
+
+    if crate::managed_agents::env_vars::is_well_formed_env_key(env_key) {
+        Some(env_key.to_string())
+    } else {
+        None
+    }
 }
 
 fn parse_codex_config(toml_str: &str) -> Option<RuntimeFileConfig> {
@@ -178,6 +224,59 @@ base_url = "http://localhost:8080"
         let cfg = parse_codex_config(toml).unwrap();
         assert_eq!(cfg.provider.as_deref(), Some("custom-provider"));
         assert!(cfg.extra.contains_key("model_providers.custom-provider"));
+    }
+
+    #[test]
+    fn parses_active_custom_provider_env_key() {
+        let toml = r#"
+model_provider = "custom-provider"
+
+[model_providers.custom-provider]
+env_key = "CUSTOM_API_KEY"
+"#;
+
+        assert_eq!(
+            parse_active_provider_env_key(toml).as_deref(),
+            Some("CUSTOM_API_KEY")
+        );
+    }
+
+    #[test]
+    fn ignores_env_key_for_inactive_provider() {
+        let toml = r#"
+model_provider = "active-provider"
+
+[model_providers.inactive-provider]
+env_key = "INACTIVE_API_KEY"
+"#;
+
+        assert_eq!(parse_active_provider_env_key(toml), None);
+    }
+
+    #[test]
+    fn rejects_malformed_provider_env_key() {
+        let toml = r#"
+model_provider = "custom-provider"
+
+[model_providers.custom-provider]
+env_key = "CUSTOM_API_KEY=secret"
+"#;
+
+        assert_eq!(parse_active_provider_env_key(toml), None);
+    }
+
+    #[test]
+    fn accepts_non_empty_effective_env_credential() {
+        let env = BTreeMap::from([("BUZZ_TEST_CODEX_API_KEY".to_string(), "secret".to_string())]);
+
+        assert!(env_key_value_is_set(&env, "BUZZ_TEST_CODEX_API_KEY"));
+    }
+
+    #[test]
+    fn rejects_empty_effective_env_credential() {
+        let env = BTreeMap::from([("BUZZ_TEST_CODEX_API_KEY".to_string(), String::new())]);
+
+        assert!(!env_key_value_is_set(&env, "BUZZ_TEST_CODEX_API_KEY"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/codex.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 /// Read Codex config from `~/.codex/config.toml` (or `$CODEX_HOME/config.toml`).
 pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
-    let path = codex_config_path()?;
+    let path = codex_config_path(&BTreeMap::new())?;
     let raw = std::fs::read_to_string(path).ok()?;
     parse_codex_config(&raw)
 }
@@ -14,7 +14,7 @@ pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
 /// persisted credential store. Buzz must account for both authentication
 /// paths before deciding that the runtime is logged out.
 pub(crate) fn env_key_auth_satisfied(effective_env: &BTreeMap<String, String>) -> bool {
-    let Some(env_key) = read_active_provider_env_key() else {
+    let Some(env_key) = read_active_provider_env_key(effective_env) else {
         return false;
     };
 
@@ -22,14 +22,22 @@ pub(crate) fn env_key_auth_satisfied(effective_env: &BTreeMap<String, String>) -
 }
 
 fn env_key_value_is_set(effective_env: &BTreeMap<String, String>, env_key: &str) -> bool {
-    effective_env
-        .get(env_key)
-        .is_some_and(|value| !value.is_empty())
-        || std::env::var_os(env_key).is_some_and(|value| !value.is_empty())
+    env_key_value_is_set_from(effective_env, env_key, std::env::var_os(env_key))
 }
 
-fn read_active_provider_env_key() -> Option<String> {
-    let path = codex_config_path()?;
+fn env_key_value_is_set_from(
+    effective_env: &BTreeMap<String, String>,
+    env_key: &str,
+    process_value: Option<std::ffi::OsString>,
+) -> bool {
+    match effective_env.get(env_key) {
+        Some(value) => !value.is_empty(),
+        None => process_value.is_some_and(|value| !value.is_empty()),
+    }
+}
+
+fn read_active_provider_env_key(effective_env: &BTreeMap<String, String>) -> Option<String> {
+    let path = codex_config_path(effective_env)?;
     let raw = std::fs::read_to_string(path).ok()?;
     parse_active_provider_env_key(&raw)
 }
@@ -168,12 +176,28 @@ fn toml_string(table: &toml::Table, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-pub(crate) fn codex_config_path() -> Option<std::path::PathBuf> {
-    if let Ok(home) = std::env::var("CODEX_HOME") {
-        return Some(std::path::PathBuf::from(home).join("config.toml"));
-    }
-    let home = dirs::home_dir()?;
-    Some(home.join(".codex").join("config.toml"))
+pub(crate) fn codex_config_path(
+    effective_env: &BTreeMap<String, String>,
+) -> Option<std::path::PathBuf> {
+    codex_config_path_from(
+        effective_env,
+        std::env::var_os("CODEX_HOME"),
+        dirs::home_dir(),
+    )
+}
+
+fn codex_config_path_from(
+    effective_env: &BTreeMap<String, String>,
+    process_codex_home: Option<std::ffi::OsString>,
+    default_home: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    let root = match effective_env.get("CODEX_HOME") {
+        Some(home) => std::path::PathBuf::from(home),
+        None => process_codex_home
+            .map(std::path::PathBuf::from)
+            .or_else(|| default_home.map(|home| home.join(".codex")))?,
+    };
+    Some(root.join("config.toml"))
 }
 
 #[cfg(test)]
@@ -276,7 +300,60 @@ env_key = "CUSTOM_API_KEY=secret"
     fn rejects_empty_effective_env_credential() {
         let env = BTreeMap::from([("BUZZ_TEST_CODEX_API_KEY".to_string(), String::new())]);
 
-        assert!(!env_key_value_is_set(&env, "BUZZ_TEST_CODEX_API_KEY"));
+        assert!(!env_key_value_is_set_from(
+            &env,
+            "BUZZ_TEST_CODEX_API_KEY",
+            Some("parent-secret".into())
+        ));
+    }
+
+    #[test]
+    fn effective_codex_home_wins_over_process_home() {
+        let env = BTreeMap::from([("CODEX_HOME".to_string(), "/child/codex".to_string())]);
+
+        assert_eq!(
+            codex_config_path_from(
+                &env,
+                Some("/desktop/codex".into()),
+                Some("/user".into())
+            ),
+            Some(std::path::PathBuf::from("/child/codex/config.toml"))
+        );
+    }
+
+    #[test]
+    fn process_codex_home_is_used_when_effective_env_omits_it() {
+        assert_eq!(
+            codex_config_path_from(
+                &BTreeMap::new(),
+                Some("/desktop/codex".into()),
+                Some("/user".into())
+            ),
+            Some(std::path::PathBuf::from("/desktop/codex/config.toml"))
+        );
+    }
+
+    #[test]
+    fn env_auth_reads_config_and_credential_from_effective_env() {
+        let codex_home = tempfile::tempdir().expect("temp CODEX_HOME");
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            r#"model_provider = "custom"
+
+[model_providers.custom]
+env_key = "CUSTOM_API_KEY"
+"#,
+        )
+        .expect("write config");
+        let env = BTreeMap::from([
+            (
+                "CODEX_HOME".to_string(),
+                codex_home.path().to_string_lossy().into_owned(),
+            ),
+            ("CUSTOM_API_KEY".to_string(), "secret".to_string()),
+        ]);
+
+        assert!(env_key_auth_satisfied(&env));
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/config_bridge/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/mod.rs
@@ -16,3 +16,11 @@ pub(crate) use types::*;
 pub(crate) fn read_goose_file_config() -> Option<RuntimeFileConfig> {
     goose::read_config_file()
 }
+
+/// Whether the active custom Codex provider is authenticated by the env key
+/// declared in its config.
+pub(crate) fn codex_env_key_auth_satisfied(
+    effective_env: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    codex::env_key_auth_satisfied(effective_env)
+}

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -199,7 +199,8 @@ fn mcp_config_file_path_for_runtime(runtime: &KnownAcpRuntime) -> Option<String>
         }
         "claude" => Some(resolve_tilde("~/.claude.json")),
         "codex" => {
-            super::codex::codex_config_path().map(|path| path.to_string_lossy().into_owned())
+            super::codex::codex_config_path(&Default::default())
+                .map(|path| path.to_string_lossy().into_owned())
         }
         _ => None,
     }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -198,10 +198,8 @@ fn mcp_config_file_path_for_runtime(runtime: &KnownAcpRuntime) -> Option<String>
             super::goose::goose_config_path().map(|path| path.to_string_lossy().into_owned())
         }
         "claude" => Some(resolve_tilde("~/.claude.json")),
-        "codex" => {
-            super::codex::codex_config_path(&Default::default())
-                .map(|path| path.to_string_lossy().into_owned())
-        }
+        "codex" => super::codex::codex_config_path(&Default::default())
+            .map(|path| path.to_string_lossy().into_owned()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -60,6 +60,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
     }
 }
 
@@ -649,6 +650,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -10,7 +10,7 @@ use crate::managed_agents::{
     HarnessSource,
 };
 mod presets;
-mod runtime_auth;
+pub(crate) mod runtime_auth;
 mod runtime_metadata;
 #[macro_use]
 mod windows_install;
@@ -19,7 +19,7 @@ pub(crate) use presets::{
     preset_harness_ids,
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
-pub(crate) use runtime_metadata::KnownAcpRuntime;
+pub(crate) use runtime_metadata::{AuthEvidenceStrategy, KnownAcpRuntime};
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
@@ -110,6 +110,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_evidence: AuthEvidenceStrategy::None,
     },
     KnownAcpRuntime {
         id: "claude",
@@ -143,6 +144,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run the Claude CLI to complete authentication."),
         auth_probe_args: Some(&["claude", "auth", "status"]),
+        auth_evidence: AuthEvidenceStrategy::StaticEnvKeys(&["CLAUDE_CODE_OAUTH_TOKEN"]),
     },
     KnownAcpRuntime {
         id: "codex",
@@ -175,8 +177,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_rounds_env_var: None,
         required_normalized_fields: &[],
         login_hint: Some("Run `codex login` to authenticate."),
-        // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+        auth_evidence: AuthEvidenceStrategy::CodexProviderEnvKey,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -210,6 +212,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_evidence: AuthEvidenceStrategy::None,
     },
 ];
 
@@ -1295,7 +1298,10 @@ struct PartialEntry {
     entry: AcpRuntimeCatalogEntry,
 }
 
-fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntry {
+fn discover_acp_runtime_phase1(
+    runtime: &'static KnownAcpRuntime,
+    auth_envs: &[std::collections::BTreeMap<String, String>],
+) -> PartialEntry {
     let adapter_result = runtime
         .commands
         .iter()
@@ -1399,8 +1405,7 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
             requires_external_cli: runtime.underlying_cli.is_some(),
             underlying_cli_path,
             node_required,
-            // Filled in here for env auth, or by the auth-probe phase below.
-            auth_status: runtime_auth::initial_status(runtime.id, &availability),
+            auth_status: runtime_auth::initial_status(runtime, &availability, auth_envs),
             login_hint: None,
             source: HarnessSource::Builtin,
             definition_env: Default::default(),
@@ -1415,34 +1420,29 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
 /// resolves, so it should not pay the cost of authenticating every catalog entry.
 pub(crate) fn discover_acp_runtime_availability(runtime_id: &str) -> Option<AcpAvailabilityStatus> {
     known_acp_runtime_exact(runtime_id)
-        .map(discover_acp_runtime_phase1)
+        .map(|runtime| discover_acp_runtime_phase1(runtime, &[]))
         .map(|partial| partial.entry.availability)
 }
 
-/// Discover all ACP runtimes, optionally merging user-defined custom harnesses
-/// from `custom_harnesses_dir`.
-///
-/// This is the primary entry point used by the Tauri command layer. It:
-/// 1. Builds entries for all compiled-in (`Builtin`) runtimes.
-/// 2. Runs auth probes in parallel.
-/// 3. Inserts static `Preset` entries (PATH-probed, `source: Preset`).
-/// 4. If `custom_harnesses_dir` is `Some`, loads `*.json` files from that
-///    directory and appends `Custom` entries — no auth probe, command resolved
-///    via PATH, availability is `Available` or `NotInstalled`.
+/// Discover all ACP runtimes, optionally merging custom harnesses from disk.
+/// This is the primary entry point used by the Tauri command layer. It builds
+/// builtin entries, settles auth evidence/probes, inserts static presets, then
+/// loads `*.json` files when `custom_harnesses_dir` is `Some` and
+/// appends `Custom` entries without auth probes.
 ///
 /// The custom dir is re-scanned on every call (goose `refresh_custom_providers`
 /// pattern) — no caching, no restart needed to pick up new files.
-///
 /// After building the catalog, updates the loaded-harness registry so spawn
 /// and readiness paths can resolve preset/custom harness commands without
 /// re-running discovery.
 pub fn discover_acp_runtimes_from(
     custom_harnesses_dir: Option<&Path>,
+    auth_envs: &[std::collections::BTreeMap<String, String>],
 ) -> Vec<AcpRuntimeCatalogEntry> {
     // Phase 1: build all builtin entries (fast — no probes yet).
     let mut partials: Vec<PartialEntry> = KNOWN_ACP_RUNTIMES
         .iter()
-        .map(discover_acp_runtime_phase1)
+        .map(|runtime| discover_acp_runtime_phase1(runtime, auth_envs))
         .collect();
 
     // Phase 2: run auth probes in parallel for entries that need them.

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -10,6 +10,7 @@ use crate::managed_agents::{
     HarnessSource,
 };
 mod presets;
+mod runtime_auth;
 mod runtime_metadata;
 #[macro_use]
 mod windows_install;
@@ -19,7 +20,6 @@ pub(crate) use presets::{
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
-
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
@@ -1382,7 +1382,7 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
             id: runtime.id.to_string(),
             label: runtime.label.to_string(),
             avatar_url: runtime.avatar_url.to_string(),
-            availability,
+            availability: availability.clone(),
             command,
             binary_path,
             default_args,
@@ -1399,8 +1399,8 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
             requires_external_cli: runtime.underlying_cli.is_some(),
             underlying_cli_path,
             node_required,
-            // Filled in by the auth-probe phase in full catalog discovery.
-            auth_status: AuthStatus::Unknown,
+            // Filled in here for env auth, or by the auth-probe phase below.
+            auth_status: runtime_auth::initial_status(runtime.id, &availability),
             login_hint: None,
             source: HarnessSource::Builtin,
             definition_env: Default::default(),
@@ -1451,7 +1451,7 @@ pub fn discover_acp_runtimes_from(
         .iter()
         .enumerate()
         .filter_map(|(idx, partial)| {
-            if partial.entry.availability != AcpAvailabilityStatus::Available {
+            if !runtime_auth::needs_probe(&partial.entry) {
                 return None;
             }
             let probe_args = partial.runtime.auth_probe_args?;

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -336,7 +336,7 @@ mod tests {
         let _path_guard = crate::managed_agents::lock_path_mutex();
         let _registry_guard = registry_test_lock();
 
-        let entry = super::super::discover_acp_runtimes_from(None)
+        let entry = super::super::discover_acp_runtimes_from(None, &[])
             .into_iter()
             .find(|entry| entry.id == "devin")
             .expect("Devin preset should appear in the runtime catalog");

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_auth.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_auth.rs
@@ -1,20 +1,61 @@
+use std::collections::BTreeMap;
+
 use crate::managed_agents::{
     config_bridge::codex_env_key_auth_satisfied, AcpAvailabilityStatus, AcpRuntimeCatalogEntry,
     AuthStatus,
 };
 
+use super::{AuthEvidenceStrategy, KnownAcpRuntime};
+
 /// Return the auth state that can be established without invoking a CLI.
-///
-/// `codex login status` only checks the persisted credential store. A custom
-/// provider can instead use the process env var named by its `env_key`.
-pub(super) fn initial_status(runtime_id: &str, availability: &AcpAvailabilityStatus) -> AuthStatus {
-    if runtime_id == "codex"
-        && *availability == AcpAvailabilityStatus::Available
-        && codex_env_key_auth_satisfied(&Default::default())
+pub(super) fn initial_status(
+    runtime: &KnownAcpRuntime,
+    availability: &AcpAvailabilityStatus,
+    effective_envs: &[BTreeMap<String, String>],
+) -> AuthStatus {
+    if *availability == AcpAvailabilityStatus::Available
+        && auth_evidence_satisfied(runtime.auth_evidence, effective_envs)
     {
         AuthStatus::LoggedIn
     } else {
         AuthStatus::Unknown
+    }
+}
+
+pub(crate) fn auth_evidence_satisfied(
+    strategy: AuthEvidenceStrategy,
+    effective_envs: &[BTreeMap<String, String>],
+) -> bool {
+    if effective_envs.is_empty() {
+        auth_evidence_satisfied_for_env(strategy, &BTreeMap::new())
+    } else {
+        effective_envs
+            .iter()
+            .any(|env| auth_evidence_satisfied_for_env(strategy, env))
+    }
+}
+
+fn auth_evidence_satisfied_for_env(
+    strategy: AuthEvidenceStrategy,
+    effective_env: &BTreeMap<String, String>,
+) -> bool {
+    match strategy {
+        AuthEvidenceStrategy::None => false,
+        AuthEvidenceStrategy::StaticEnvKeys(keys) => keys
+            .iter()
+            .any(|key| env_value_is_set_from(effective_env, key, std::env::var_os(key))),
+        AuthEvidenceStrategy::CodexProviderEnvKey => codex_env_key_auth_satisfied(effective_env),
+    }
+}
+
+fn env_value_is_set_from(
+    effective_env: &BTreeMap<String, String>,
+    key: &str,
+    process_value: Option<std::ffi::OsString>,
+) -> bool {
+    match effective_env.get(key) {
+        Some(value) => !value.trim().is_empty(),
+        None => process_value.is_some_and(|value| !value.to_string_lossy().trim().is_empty()),
     }
 }
 
@@ -44,5 +85,23 @@ mod tests {
             &AcpAvailabilityStatus::Available,
             &AuthStatus::LoggedIn
         ));
+    }
+
+    #[test]
+    fn static_env_key_uses_last_wins_semantics() {
+        let env = BTreeMap::from([("TOKEN".to_string(), String::new())]);
+
+        assert!(!env_value_is_set_from(
+            &env,
+            "TOKEN",
+            Some("parent-secret".into())
+        ));
+    }
+
+    #[test]
+    fn static_env_key_rejects_whitespace_only_values() {
+        let env = BTreeMap::from([("TOKEN".to_string(), " \t".to_string())]);
+
+        assert!(!env_value_is_set_from(&env, "TOKEN", None));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_auth.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_auth.rs
@@ -1,0 +1,48 @@
+use crate::managed_agents::{
+    config_bridge::codex_env_key_auth_satisfied, AcpAvailabilityStatus, AcpRuntimeCatalogEntry,
+    AuthStatus,
+};
+
+/// Return the auth state that can be established without invoking a CLI.
+///
+/// `codex login status` only checks the persisted credential store. A custom
+/// provider can instead use the process env var named by its `env_key`.
+pub(super) fn initial_status(runtime_id: &str, availability: &AcpAvailabilityStatus) -> AuthStatus {
+    if runtime_id == "codex"
+        && *availability == AcpAvailabilityStatus::Available
+        && codex_env_key_auth_satisfied(&Default::default())
+    {
+        AuthStatus::LoggedIn
+    } else {
+        AuthStatus::Unknown
+    }
+}
+
+pub(super) fn needs_probe(entry: &AcpRuntimeCatalogEntry) -> bool {
+    needs_probe_status(&entry.availability, &entry.auth_status)
+}
+
+fn needs_probe_status(availability: &AcpAvailabilityStatus, auth_status: &AuthStatus) -> bool {
+    *availability == AcpAvailabilityStatus::Available && *auth_status == AuthStatus::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_runtime_never_needs_auth_probe() {
+        assert!(!needs_probe_status(
+            &AcpAvailabilityStatus::NotInstalled,
+            &AuthStatus::Unknown
+        ));
+    }
+
+    #[test]
+    fn preauthenticated_runtime_does_not_need_auth_probe() {
+        assert!(!needs_probe_status(
+            &AcpAvailabilityStatus::Available,
+            &AuthStatus::LoggedIn
+        ));
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -1,3 +1,11 @@
+/// Authentication evidence that can settle a runtime before its CLI probe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AuthEvidenceStrategy {
+    None,
+    StaticEnvKeys(&'static [&'static str]),
+    CodexProviderEnvKey,
+}
+
 /// Static capabilities and installation metadata for a known ACP runtime.
 pub(crate) struct KnownAcpRuntime {
     pub id: &'static str,
@@ -64,6 +72,9 @@ pub(crate) struct KnownAcpRuntime {
     /// CLI args for probing authentication status. `args[0]` is the binary name;
     /// the remainder are the subcommand. `None` for runtimes with no login step.
     pub auth_probe_args: Option<&'static [&'static str]>,
+    /// Evidence read from the environment of the process Buzz will spawn.
+    /// When satisfied, it takes precedence over the sibling CLI probe.
+    pub auth_evidence: AuthEvidenceStrategy,
 }
 
 impl KnownAcpRuntime {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1686,7 +1686,7 @@ fn custom_catalog_entry_carries_definition_env_for_edit_roundtrip() {
     )
     .unwrap();
 
-    let entries = discover_acp_runtimes_from(Some(dir.path()));
+    let entries = discover_acp_runtimes_from(Some(dir.path()), &[]);
     let entry = entries
         .iter()
         .find(|e| e.id == "env-harness")
@@ -1716,7 +1716,7 @@ fn builtin_catalog_entry_has_empty_definition_env() {
     // publishes to the global registry.
     let _path_guard = crate::managed_agents::lock_path_mutex();
     let _lock = registry_test_lock();
-    let entries = discover_acp_runtimes_from(None);
+    let entries = discover_acp_runtimes_from(None, &[]);
     // Find any builtin entry (e.g. "goose" or "claude").
     let builtin = entries
         .iter()
@@ -1797,7 +1797,7 @@ fn discovery_publish_path_survives_mid_flight_save() {
         assert!(lookup_loaded_harness_by_id("mid-flight-save").is_some());
     }));
 
-    let _entries = discover_acp_runtimes_from(Some(dir.path()));
+    let _entries = discover_acp_runtimes_from(Some(dir.path()), &[]);
 
     assert!(
         lookup_loaded_harness_by_id("mid-flight-save").is_some(),
@@ -1830,7 +1830,7 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         assert!(lookup_loaded_harness_by_id("mid-flight-delete").is_none());
     }));
 
-    let _entries = discover_acp_runtimes_from(Some(dir.path()));
+    let _entries = discover_acp_runtimes_from(Some(dir.path()), &[]);
 
     assert!(
         lookup_loaded_harness_by_id("mid-flight-delete").is_none(),

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -435,12 +435,7 @@ fn collect_missing_requirements(
             let file_cfg = read_goose_file_config();
             goose_requirements(effective, file_cfg.as_ref())
         }
-        "claude" => cli_login::requirements(
-            &["claude", "auth", "status"],
-            "complete Claude Code authentication by running the Claude CLI",
-            rt,
-        ),
-        "codex" => cli_login::codex_requirements(rt, &effective.env),
+        "claude" | "codex" => cli_login::requirements_for_runtime(rt, &effective.env),
         _ => vec![],
     }
 }
@@ -1055,11 +1050,11 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
         }
     }
 
-    /// Returns the absolute path of the currently-running test binary as a `&'static str`.
-    /// Host-portable stand-in for a "present" binary: absolute path so `find_command` resolves
+    /// Host-portable absolute path that `find_command` resolves as present.
     /// it via `path.exists()`. Leaked allocation is intentional — process exits after tests.
     fn present_binary_str() -> &'static str {
         let path = std::env::current_exe().expect("current_exe must be available in tests");
@@ -1247,6 +1242,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -391,8 +391,8 @@ impl AgentReadiness {
 ///   - `databricks` / `databricks_v2` → `DATABRICKS_HOST` (token optional —
 ///     OAuth PKCE is the fallback)
 /// * **claude**: a successful `claude auth status` probe.
-/// * **codex**: a successful `codex login status` probe (checks the codex
-///   credential store — NOT `OPENAI_API_KEY`).
+/// * **codex**: either a successful `codex login status` probe or a non-empty
+///   credential named by the active custom provider's `env_key`.
 /// * **unknown / custom command**: always `Ready` (no requirements known).
 ///
 /// Databricks note: `DATABRICKS_TOKEN` is `.unwrap_or_default()` in
@@ -440,7 +440,7 @@ fn collect_missing_requirements(
             "complete Claude Code authentication by running the Claude CLI",
             rt,
         ),
-        "codex" => cli_login::requirements(&["codex", "login", "status"], "run `codex login`", rt),
+        "codex" => cli_login::codex_requirements(rt, &effective.env),
         _ => vec![],
     }
 }

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
@@ -206,7 +206,8 @@ mod tests {
     fn static_runtime_env_auth_bypasses_login_probe() {
         let exe = present_binary_str();
         let mut runtime = make_runtime(static_commands(vec![exe]), Some(exe));
-        runtime.auth_evidence = crate::managed_agents::AuthEvidenceStrategy::StaticEnvKeys(&["TOKEN"]);
+        runtime.auth_evidence =
+            crate::managed_agents::AuthEvidenceStrategy::StaticEnvKeys(&["TOKEN"]);
         let env = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
 
         let requirements = requirements_with_effective_env(

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::managed_agents::{
@@ -10,11 +11,34 @@ use crate::managed_agents::{
 
 use super::{cli_probe, Requirement};
 
+pub(super) fn codex_requirements(
+    runtime: &KnownAcpRuntime,
+    effective_env: &BTreeMap<String, String>,
+) -> Vec<Requirement> {
+    requirements_with_env_auth(
+        &["codex", "login", "status"],
+        "run `codex login`",
+        runtime,
+        crate::managed_agents::config_bridge::codex_env_key_auth_satisfied(effective_env),
+    )
+}
+
 /// Requirements for CLI-login runtimes (claude, codex).
 pub(super) fn requirements(
     probe_args: &[&str],
     setup_copy: &str,
     runtime: &KnownAcpRuntime,
+) -> Vec<Requirement> {
+    requirements_with_env_auth(probe_args, setup_copy, runtime, false)
+}
+
+/// Requirements for a CLI-login runtime that may also be authenticated by an
+/// environment credential outside the CLI's persisted login store.
+pub(super) fn requirements_with_env_auth(
+    probe_args: &[&str],
+    setup_copy: &str,
+    runtime: &KnownAcpRuntime,
+    env_auth_satisfied: bool,
 ) -> Vec<Requirement> {
     let adapter_result = runtime
         .commands
@@ -39,6 +63,9 @@ pub(super) fn requirements(
 
     match availability {
         AcpAvailabilityStatus::Available => {
+            if env_auth_satisfied {
+                return vec![];
+            }
             let Some(binary_path) = resolve_command(probe_args[0]) else {
                 return vec![missing_requirement(
                     probe_args,
@@ -76,5 +103,99 @@ fn missing_requirement(
         probe_args: probe_args.iter().map(|value| value.to_string()).collect(),
         setup_copy: setup_copy.to_string(),
         availability,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn present_binary_str() -> &'static str {
+        Box::leak(
+            std::env::current_exe()
+                .expect("test executable path")
+                .to_string_lossy()
+                .into_owned()
+                .into_boxed_str(),
+        )
+    }
+
+    fn static_commands(commands: Vec<&'static str>) -> &'static [&'static str] {
+        Box::leak(commands.into_boxed_slice())
+    }
+
+    fn make_runtime(
+        commands: &'static [&'static str],
+        underlying_cli: Option<&'static str>,
+    ) -> KnownAcpRuntime {
+        KnownAcpRuntime {
+            id: "test-cli-runtime",
+            label: "Test CLI",
+            commands,
+            aliases: &[],
+            avatar_url: "",
+            mcp_command: None,
+            mcp_hooks: false,
+            underlying_cli,
+            cli_install_commands: &[],
+            cli_install_commands_windows: &[],
+            adapter_install_commands: &[],
+            cli_install_instructions_url: "",
+            adapter_install_instructions_url: "",
+            cli_install_hint: "",
+            adapter_install_hint: "",
+            skill_dir: None,
+            supports_acp_model_switching: false,
+            model_env_var: None,
+            provider_env_var: None,
+            provider_locked: false,
+            default_env: &[],
+            config_file_path: None,
+            config_file_format: None,
+            supports_acp_native_config: false,
+            thinking_env_var: None,
+            max_tokens_env_var: None,
+            context_limit_env_var: None,
+            max_rounds_env_var: None,
+            required_normalized_fields: &[],
+            login_hint: None,
+            auth_probe_args: None,
+        }
+    }
+
+    #[test]
+    fn satisfied_env_auth_bypasses_login_probe() {
+        let exe = present_binary_str();
+        let runtime = make_runtime(static_commands(vec![exe]), Some(exe));
+        let requirements = requirements_with_env_auth(
+            &[exe, "--buzz-probe-must-not-run"],
+            "this should not show",
+            &runtime,
+            true,
+        );
+
+        assert!(requirements.is_empty());
+    }
+
+    #[test]
+    fn env_auth_does_not_hide_missing_tooling() {
+        let runtime = make_runtime(
+            &["__buzz_nonexistent_adapter_env_auth__"],
+            Some("__buzz_nonexistent_cli_env_auth__"),
+        );
+        let requirements = requirements_with_env_auth(
+            &["__buzz_nonexistent_cli_env_auth__", "status"],
+            "install the tool",
+            &runtime,
+            true,
+        );
+
+        assert!(matches!(
+            requirements.as_slice(),
+            [Requirement::CliLogin {
+                availability: AcpAvailabilityStatus::NotInstalled,
+                ..
+            }]
+        ));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
@@ -11,25 +11,49 @@ use crate::managed_agents::{
 
 use super::{cli_probe, Requirement};
 
-pub(super) fn codex_requirements(
-    runtime: &KnownAcpRuntime,
-    effective_env: &BTreeMap<String, String>,
-) -> Vec<Requirement> {
-    requirements_with_env_auth(
-        &["codex", "login", "status"],
-        "run `codex login`",
-        runtime,
-        crate::managed_agents::config_bridge::codex_env_key_auth_satisfied(effective_env),
-    )
-}
-
 /// Requirements for CLI-login runtimes (claude, codex).
+#[cfg(test)]
 pub(super) fn requirements(
     probe_args: &[&str],
     setup_copy: &str,
     runtime: &KnownAcpRuntime,
 ) -> Vec<Requirement> {
     requirements_with_env_auth(probe_args, setup_copy, runtime, false)
+}
+
+pub(super) fn requirements_with_effective_env(
+    probe_args: &[&str],
+    setup_copy: &str,
+    runtime: &KnownAcpRuntime,
+    effective_env: &BTreeMap<String, String>,
+) -> Vec<Requirement> {
+    let env_auth_satisfied =
+        crate::managed_agents::discovery::runtime_auth::auth_evidence_satisfied(
+            runtime.auth_evidence,
+            std::slice::from_ref(effective_env),
+        );
+    requirements_with_env_auth(probe_args, setup_copy, runtime, env_auth_satisfied)
+}
+
+pub(super) fn requirements_for_runtime(
+    runtime: &KnownAcpRuntime,
+    effective_env: &BTreeMap<String, String>,
+) -> Vec<Requirement> {
+    match runtime.id {
+        "claude" => requirements_with_effective_env(
+            &["claude", "auth", "status"],
+            "complete Claude Code authentication by running the Claude CLI",
+            runtime,
+            effective_env,
+        ),
+        "codex" => requirements_with_effective_env(
+            &["codex", "login", "status"],
+            "run `codex login`",
+            runtime,
+            effective_env,
+        ),
+        _ => vec![],
+    }
 }
 
 /// Requirements for a CLI-login runtime that may also be authenticated by an
@@ -160,6 +184,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_evidence: crate::managed_agents::AuthEvidenceStrategy::None,
         }
     }
 
@@ -172,6 +197,23 @@ mod tests {
             "this should not show",
             &runtime,
             true,
+        );
+
+        assert!(requirements.is_empty());
+    }
+
+    #[test]
+    fn static_runtime_env_auth_bypasses_login_probe() {
+        let exe = present_binary_str();
+        let mut runtime = make_runtime(static_commands(vec![exe]), Some(exe));
+        runtime.auth_evidence = crate::managed_agents::AuthEvidenceStrategy::StaticEnvKeys(&["TOKEN"]);
+        let env = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+
+        let requirements = requirements_with_effective_env(
+            &[exe, "--buzz-probe-must-not-run"],
+            "this should not show",
+            &runtime,
+            &env,
         );
 
         assert!(requirements.is_empty());

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -260,9 +260,17 @@ fn load_agent_store(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> 
 /// folded into the same store) are filtered out so every pre-fold call site
 /// keeps seeing exactly the records it always did.
 pub fn load_managed_agents(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> {
+    let mut records = load_managed_agent_configs(app)?;
+    hydrate_keys(&mut records);
+    Ok(records)
+}
+
+/// Load agent instance configuration without accessing private keys.
+pub(crate) fn load_managed_agent_configs(
+    app: &AppHandle,
+) -> Result<Vec<ManagedAgentRecord>, String> {
     let mut records = load_agent_store(app)?;
     records.retain(|record| !record.pubkey.is_empty());
-    hydrate_keys(&mut records);
     Ok(records)
 }
 


### PR DESCRIPTION
## Why
Codex supports custom providers authenticated through `[model_providers.<id>] env_key`, but Buzz relied only on `codex login status`. That false negative showed “Sign-in needed” and sent otherwise valid agents into setup mode.

## What
- Resolve `CODEX_HOME` and the active provider credential from the same effective environment used by the spawned child
- Preserve last-wins environment semantics, including an explicit empty child override masking an inherited desktop credential
- Feed global, persona, and agent environment candidates into catalog discovery so discovery and spawn readiness evaluate the same evidence
- Share a declarative pre-probe auth-evidence strategy between discovery and readiness: static keys for runtimes such as Claude and a dynamic active-provider resolver for Codex
- Preserve adapter and CLI availability checks, falling back to the existing login probe when environment evidence is absent
- Cover effective `CODEX_HOME`, empty override masking, environment layering, ready, fallback, and missing-tooling cases

## Risk Assessment
Low — environment evidence only bypasses the login-status probe when the child’s effective configuration supplies a non-empty credential. Missing, inactive, malformed, or explicitly empty values retain the existing fail-closed behavior, and executable/adapter checks remain required.

## Validation
- `bin/just desktop-check` at `5ad6e2b12c3676a35d9d86dfd75ef2db48a4f726`
- `bin/just desktop-tauri-fmt-check` at `5ad6e2b12c3676a35d9d86dfd75ef2db48a4f726`
- `bin/just desktop-tauri-clippy` at `5ad6e2b12c3676a35d9d86dfd75ef2db48a4f726`
- `bin/just desktop-tauri-test` at `5ad6e2b12c3676a35d9d86dfd75ef2db48a4f726` — 2,444 passed, 14 ignored

## References
- Closes #4755
- Incorporates and generalizes the declarative auth-evidence direction from #5822
- [Codex environment variables](https://learn.chatgpt.com/docs/config-file/environment-variables)
- [Codex configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference)

Generated with Codex
