### PR TITLE
fix(cli): reject empty message content in messages send

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -6,7 +6,7 @@ use crate::client::{normalize_events, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{
     infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
-    validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
+    validate_content_size, validate_hex64, validate_message_content, validate_uuid, MAX_DIFF_BYTES,
 };
 use buzz_sdk::mentions::{
     extract_at_mentions_with_known, extract_nostr_uris, strip_code_regions, MENTION_CAP,
@@ -580,6 +580,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
+    validate_message_content(&p.content, !p.files.is_empty())?;
     validate_content_size(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -72,6 +72,25 @@ pub fn validate_content_size(content: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Reject a message whose content is empty or whitespace-only, unless it
+/// attaches files (attachment-only messages are legitimate).
+///
+/// This closes a silent-failure mode for agent callers: `--content -` with a
+/// broken or missing stdin producer reads 0 bytes, the relay accepts the
+/// event, mentions still notify, and every layer reports success while the
+/// recipient sees a blank message.
+pub fn validate_message_content(content: &str, has_files: bool) -> Result<(), CliError> {
+    if content.trim().is_empty() && !has_files {
+        return Err(CliError::Usage(
+            "message content is empty; pass non-empty --content or attach --file \
+             (with `--content -`, an empty read usually means the stdin producer \
+             sent nothing)"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Percent-encode for URL path segments and query parameter values.
 /// Encodes all bytes except RFC 3986 unreserved: A-Z a-z 0-9 - _ . ~
 #[cfg(test)]
@@ -274,6 +293,30 @@ mod tests {
     #[test]
     fn validate_content_size_empty() {
         assert!(validate_content_size("").is_ok());
+    }
+
+    // --- validate_message_content ---
+
+    #[test]
+    fn validate_message_content_nonempty_ok() {
+        assert!(validate_message_content("hello", false).is_ok());
+    }
+
+    #[test]
+    fn validate_message_content_empty_rejected() {
+        let err = validate_message_content("", false).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn validate_message_content_whitespace_only_rejected() {
+        let err = validate_message_content(" \n\t ", false).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn validate_message_content_empty_with_files_ok() {
+        assert!(validate_message_content("", true).is_ok());
     }
 
     // --- percent_encode ---


### PR DESCRIPTION
## Problem

An agent running `buzz messages send --content -` with a broken or missing stdin producer reads 0 bytes and gets full success at every layer: the relay accepts the event, `--mention` still notifies recipients, and the caller receives a real `event_id`. The recipient sees a blank message. Nothing anywhere reports a failure.

This isn't hypothetical — auditing one agent fleet's session logs found 10 confirmed producerless `--content -` sends over two weeks (the model composes prose in a variable, passes only the command string to its exec tool, and never pipes the content in). A second fleet independently hit the same class. Blank notifications read as agent malfunctions and cost real debugging time.

## Fix

Add `validate_message_content` in `validate.rs` and call it in `cmd_send_message` immediately after `read_or_stdin`:

- Rejects empty or whitespace-only content with exit 1 (`user_error`) and a message that points at the likely cause (`--content -` with a producer that sent nothing).
- Attachment-only messages (`--file` with no caption) remain legitimate — the guard is gated on `files.is_empty()`.
- Deliberately **not** placed in `read_or_stdin`: that helper has ~11 call sites where empty passthrough is intentional (see the `read_or_stdin_passthrough_empty_string` test).

## Verification

- `cargo test -p buzz-cli`: 347 passed, 0 failed (4 new unit tests: nonempty ok, empty rejected, whitespace-only rejected, empty-with-files ok)
- `cargo clippy -p buzz-cli --all-targets`: clean
- `cargo fmt -p buzz-cli --check`: clean
- Behavioral check on the built binary — fails before any network call:

```
$ printf '' | buzz messages send --channel <uuid> --content -
{"error":"user_error","message":"message content is empty; pass non-empty --content or attach --file (with `--content -`, an empty read usually means the stdin producer sent nothing)","retryable":false}
(exit 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
