### PR TITLE
fix(acp): publish adapter replies through harness fallback

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -214,6 +214,10 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Text emitted in `agent_message_chunk` notifications for the current
+    /// `session/prompt` request. The harness uses this as a last-resort reply
+    /// body when an adapter cannot invoke the Buzz CLI itself.
+    turn_agent_message: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +567,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            turn_agent_message: String::new(),
         })
     }
 
@@ -781,6 +786,10 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        // A client can issue an initial-message prompt immediately before the
+        // user turn. Keep only the chunks emitted by this prompt so the
+        // harness fallback never republishes stale setup output.
+        self.turn_agent_message.clear();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -1755,6 +1764,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    self.turn_agent_message.push_str(text);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
@@ -1851,6 +1861,11 @@ impl AcpClient {
                 false
             }
         }
+    }
+
+    /// Take the text emitted by the most recent `session/prompt` turn.
+    pub(crate) fn take_turn_agent_message(&mut self) -> String {
+        std::mem::take(&mut self.turn_agent_message)
     }
 
     /// Record the standard ACP cumulative cost notification when emitted by
@@ -3073,6 +3088,39 @@ mod tests {
             matches!(result, Err(AcpError::IdleTimeout(_))),
             "expected IdleTimeout, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_agent_message_is_accumulated_and_reset_per_turn() {
+        let script = r#"
+            read -r _first_prompt
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"hello "}}}}'
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"world"}}}}'
+            echo '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'
+            read -r _second_prompt
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"next"}}}}'
+            echo '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+        "#;
+        let mut client = spawn_script(script).await;
+        let idle = std::time::Duration::from_secs(2);
+        let hard = std::time::Duration::from_secs(5);
+
+        assert!(matches!(
+            client
+                .session_prompt_with_idle_timeout("session", "first", idle, hard)
+                .await,
+            Ok(StopReason::EndTurn)
+        ));
+        assert_eq!(client.take_turn_agent_message(), "hello world");
+
+        assert!(matches!(
+            client
+                .session_prompt_with_idle_timeout("session", "second", idle, hard)
+                .await,
+            Ok(StopReason::EndTurn)
+        ));
+        assert_eq!(client.take_turn_agent_message(), "next");
+        client.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2317,6 +2317,7 @@ async fn tokio_main() -> Result<()> {
                         agent_name,
                         goose_system_prompt_supported: None,
                         protocol_version,
+                        reply_fallback: None,
                     };
                     pool.return_agent(agent);
                     tracing::info!(agent = rr.index, "respawn complete");
@@ -3847,6 +3848,35 @@ fn handle_prompt_result(
         result.agent.state.invalidate_channel(ch);
     }
 
+    // Some ACP adapters intentionally keep secret environment variables out
+    // of model-generated terminal commands. If the turn completed with text,
+    // let the authenticated harness publish it — but only after the relay-side
+    // duplicate check in `post_agent_reply_fallback` confirms the agent did not
+    // already send a message itself.
+    let fallback = if matches!(
+        &result.outcome,
+        PromptOutcome::Ok(acp::StopReason::EndTurn | acp::StopReason::Refusal)
+    ) {
+        let content = result.agent.acp.take_turn_agent_message();
+        result
+            .agent
+            .reply_fallback
+            .take()
+            .filter(|context| !removed_channels.contains(&context.channel_id))
+            .map(|context| (context, content))
+            .filter(|(_, content)| !content.trim().is_empty())
+    } else {
+        result.agent.reply_fallback = None;
+        let _ = result.agent.acp.take_turn_agent_message();
+        None
+    };
+    if let (Some(rest), Some((context, content))) = (rest_client, fallback) {
+        let rest = rest.clone();
+        tokio::spawn(async move {
+            pool::post_agent_reply_fallback(&rest, &context, &content).await;
+        });
+    }
+
     let outcome_label = match &result.outcome {
         PromptOutcome::Ok(_) => "ok",
         PromptOutcome::Error(_) => "error",
@@ -4488,6 +4518,7 @@ async fn initialize_agent_pool(
                             agent_name,
                             goose_system_prompt_supported: None,
                             protocol_version,
+                            reply_fallback: None,
                         }));
                     }
                     Ok(Err(e)) => {
@@ -6798,6 +6829,7 @@ mod error_outcome_emission_tests {
             // Error branches under test never read this; 1 is the legacy
             // non-systemPrompt path, the simplest valid value.
             protocol_version: 1,
+            reply_fallback: None,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -211,6 +211,18 @@ pub struct OwnedAgent {
     pub goose_system_prompt_supported: Option<bool>,
     /// Protocol version reported by the agent in its initialize response.
     pub protocol_version: u32,
+    /// Harness-side publish fallback metadata for the in-flight channel turn.
+    /// Cleared at dispatch and populated only after reply anchoring is resolved.
+    pub reply_fallback: Option<ReplyFallbackContext>,
+}
+
+/// Information needed to publish an ACP final response without exposing the
+/// agent's Nostr signing key to its terminal subprocess.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplyFallbackContext {
+    pub channel_id: Uuid,
+    pub reply_to: Option<String>,
+    pub turn_started_at_secs: u64,
 }
 
 /// Package name reported by `claude-agent-acp` in its `initialize` response.
@@ -1460,6 +1472,7 @@ pub async fn run_prompt_task(
     control_rx: Option<tokio::sync::oneshot::Receiver<ControlSignal>>,
     turn_id: String,
 ) {
+    agent.reply_fallback = None;
     // Is this a channel prompt or a heartbeat?
     let source = match &batch {
         Some(b) => PromptSource::Channel(b.channel_id),
@@ -1469,6 +1482,7 @@ pub async fn run_prompt_task(
         PromptSource::Channel(channel_id) => Some(*channel_id),
         PromptSource::Heartbeat => None,
     };
+    let turn_started_at_secs = nostr::Timestamp::now().as_secs();
     let turn_started_at = chrono::Utc::now().to_rfc3339();
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
@@ -2035,6 +2049,16 @@ pub async fn run_prompt_task(
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
+
+        agent.reply_fallback = Some(ReplyFallbackContext {
+            channel_id: b.channel_id,
+            reply_to: crate::queue::reply_anchor_for_batch(
+                b,
+                channel_info.as_ref(),
+                profile_lookup.as_ref(),
+            ),
+            turn_started_at_secs,
+        });
 
         let known_names: Vec<&str> = profile_lookup
             .iter()
@@ -4176,6 +4200,119 @@ pub(crate) async fn post_failure_notice(
     }
 }
 
+/// Publish the ACP turn's final text only when the agent did not already send
+/// a Buzz message during the turn.
+///
+/// The relay query is deliberately fail-closed: an unavailable or malformed
+/// response suppresses the fallback, because a missed reply is recoverable but
+/// a duplicate can notify people twice. The one-second Nostr timestamp
+/// granularity can also suppress a fallback when the agent authored another
+/// message in the same channel during the start second; that is the safer side
+/// of the same tradeoff.
+pub(crate) async fn post_agent_reply_fallback(
+    rest: &crate::relay::RestClient,
+    context: &ReplyFallbackContext,
+    content: &str,
+) {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let content = content.trim();
+    if content.is_empty() {
+        return;
+    }
+
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let channel = context.channel_id.to_string();
+    let filter = nostr::Filter::new()
+        .kinds([
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE_V2 as u16),
+        ])
+        .author(rest.keys.public_key())
+        .custom_tags(h_tag, [channel.as_str()])
+        .since(nostr::Timestamp::from(context.turn_started_at_secs))
+        .limit(1);
+
+    let existing = match tokio::time::timeout(
+        Duration::from_secs(5),
+        rest.query(std::slice::from_ref(&filter)),
+    )
+    .await
+    {
+        Ok(Ok(value)) => match value.as_array() {
+            Some(events) => !events.is_empty(),
+            None => {
+                tracing::warn!(
+                    channel = %context.channel_id,
+                    "reply fallback query returned malformed data — suppressing publish"
+                );
+                return;
+            }
+        },
+        Ok(Err(e)) => {
+            tracing::warn!(
+                channel = %context.channel_id,
+                "reply fallback query failed — suppressing publish: {e}"
+            );
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(
+                channel = %context.channel_id,
+                "reply fallback query timed out — suppressing publish"
+            );
+            return;
+        }
+    };
+    if existing {
+        tracing::debug!(
+            channel = %context.channel_id,
+            "agent already published during turn — suppressing reply fallback"
+        );
+        return;
+    }
+
+    let thread_ref = context.reply_to.as_deref().and_then(|reply_to| {
+        let event_id = nostr::EventId::from_hex(reply_to).ok()?;
+        Some(buzz_sdk::ThreadRef {
+            root_event_id: event_id,
+            parent_event_id: event_id,
+        })
+    });
+    let builder = match buzz_sdk::build_message(
+        context.channel_id,
+        content,
+        thread_ref.as_ref(),
+        &[],
+        false,
+        &[],
+    ) {
+        Ok(builder) => builder,
+        Err(e) => {
+            tracing::warn!(channel = %context.channel_id, "reply fallback build failed: {e}");
+            return;
+        }
+    };
+    let event = match builder.sign_with_keys(&rest.keys) {
+        Ok(event) => event,
+        Err(e) => {
+            tracing::warn!(channel = %context.channel_id, "reply fallback sign failed: {e}");
+            return;
+        }
+    };
+    match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
+        Ok(Ok(_)) => tracing::info!(
+            channel = %context.channel_id,
+            event_id = %event.id,
+            "published ACP final response via harness fallback"
+        ),
+        Ok(Err(e)) => {
+            tracing::warn!(channel = %context.channel_id, "reply fallback publish failed: {e}")
+        }
+        Err(_) => tracing::warn!(channel = %context.channel_id, "reply fallback publish timed out"),
+    }
+}
+
 /// Best-effort: remove a reaction via a signed kind:5 (NIP-09) deletion event.
 ///
 /// Queries kind:7 reactions by our pubkey targeting the event, finds the matching
@@ -5547,6 +5684,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            reply_fallback: None,
         };
         agent.state.heartbeat_session = Some("live-session".into());
 
@@ -5641,6 +5779,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            reply_fallback: None,
         };
         agent
             .state
@@ -5813,6 +5952,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            reply_fallback: None,
         };
         agent
             .state
@@ -5963,6 +6103,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            reply_fallback: None,
         };
         agent
             .state
@@ -6950,6 +7091,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            reply_fallback: None,
         };
 
         // Simulate dispatch: install a steer receiver (normally done by
@@ -7008,6 +7150,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            reply_fallback: None,
         };
 
         // Simulate a completed turn: `steer_rx` was consumed by the read loop
@@ -7977,5 +8120,144 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             "one fetch_channel_info sequence (initial attempt + single retry)"
         );
         server.abort();
+    }
+
+    async fn read_test_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+
+        let mut bytes = Vec::new();
+        let mut buf = [0_u8; 4096];
+        let header_end = loop {
+            let read = socket.read(&mut buf).await.expect("read test request");
+            assert!(read > 0, "connection closed before request headers");
+            bytes.extend_from_slice(&buf[..read]);
+            if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                break index + 4;
+            }
+        };
+        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("content length"))
+            })
+            .unwrap_or(0);
+        while bytes.len() < header_end + content_length {
+            let read = socket.read(&mut buf).await.expect("read test request body");
+            assert!(read > 0, "connection closed before request body");
+            bytes.extend_from_slice(&buf[..read]);
+        }
+        String::from_utf8(bytes[header_end..header_end + content_length].to_vec())
+            .expect("utf8 request body")
+    }
+
+    async fn write_test_http_json(socket: &mut tokio::net::TcpStream, body: &str) {
+        use tokio::io::AsyncWriteExt;
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write test response");
+    }
+
+    #[tokio::test]
+    async fn reply_fallback_publishes_threaded_message_when_turn_has_no_agent_post() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (submitted_tx, mut submitted_rx) = mpsc::unbounded_channel();
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.expect("accept query");
+            let _ = read_test_http_request(&mut query_socket).await;
+            write_test_http_json(&mut query_socket, "[]").await;
+
+            let (mut submit_socket, _) = listener.accept().await.expect("accept submit");
+            let body = read_test_http_request(&mut submit_socket).await;
+            submitted_tx.send(body).expect("capture submitted event");
+            write_test_http_json(&mut submit_socket, "{}").await;
+        });
+
+        let channel_id = Uuid::new_v4();
+        let reply_to = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        post_agent_reply_fallback(
+            &rest,
+            &ReplyFallbackContext {
+                channel_id,
+                reply_to: Some(reply_to.into()),
+                turn_started_at_secs: Timestamp::now().as_secs(),
+            },
+            "  fallback reply  ",
+        )
+        .await;
+        server.await.expect("test server");
+
+        let event: serde_json::Value =
+            serde_json::from_str(&submitted_rx.recv().await.expect("submitted event body"))
+                .expect("submitted event JSON");
+        assert_eq!(event["kind"], json!(9));
+        assert_eq!(event["content"], json!("fallback reply"));
+        let tags = event["tags"].as_array().expect("event tags");
+        assert!(tags.iter().any(|tag| tag == &json!(["h", channel_id])));
+        assert!(tags.iter().any(|tag| tag.as_array().is_some_and(|parts| {
+            parts.first() == Some(&json!("e")) && parts.get(1) == Some(&json!(reply_to))
+        })));
+    }
+
+    #[tokio::test]
+    async fn reply_fallback_suppresses_publish_when_agent_already_posted() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = Arc::clone(&requests);
+        let server = tokio::spawn(async move {
+            let (mut query_socket, _) = listener.accept().await.expect("accept query");
+            server_requests.fetch_add(1, Ordering::SeqCst);
+            let _ = read_test_http_request(&mut query_socket).await;
+            write_test_http_json(&mut query_socket, "[{}]").await;
+
+            if tokio::time::timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_ok()
+            {
+                server_requests.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: Keys::generate(),
+            auth_tag_json: None,
+        };
+        post_agent_reply_fallback(
+            &rest,
+            &ReplyFallbackContext {
+                channel_id: Uuid::new_v4(),
+                reply_to: None,
+                turn_started_at_secs: Timestamp::now().as_secs(),
+            },
+            "must not be submitted",
+        )
+        .await;
+        server.await.expect("test server");
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1266,6 +1266,36 @@ fn resolve_reply_anchor(
     )
 }
 
+/// Resolve the ordinary Buzz reply target for the newest event in a batch.
+///
+/// This is shared by prompt rendering and the harness-side publish fallback so
+/// both paths preserve the same human-facing thread shape.
+pub(crate) fn reply_anchor_for_batch(
+    batch: &FlushBatch,
+    channel_info: Option<&PromptChannelInfo>,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> Option<String> {
+    let last_event = batch.events.last()?;
+    let thread_tags = parse_thread_tags(&last_event.event);
+    let is_dm = channel_info
+        .map(|ci| ci.channel_type == "dm")
+        .unwrap_or(false);
+
+    if is_dm {
+        thread_tags
+            .root_event_id
+            .is_some()
+            .then(|| last_event.event.id.to_hex())
+    } else {
+        resolve_reply_anchor(
+            &last_event.event.pubkey.to_hex(),
+            &thread_tags,
+            &last_event.event.id.to_hex(),
+            profile_lookup,
+        )
+    }
+}
+
 /// Maximum length (in characters) of a channel description rendered into `[Context]`.
 ///
 /// Limits prompt bloat from unusually long descriptions; a raw embedded newline
@@ -1600,20 +1630,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
-    let sender_pubkey = last_event.event.pubkey.to_hex();
-    let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
-    } else {
-        resolve_reply_anchor(
-            &sender_pubkey,
-            &thread_tags,
-            &last_event.event.id.to_hex(),
-            args.profile_lookup,
-        )
-    };
+    let reply_anchor = reply_anchor_for_batch(batch, args.channel_info, args.profile_lookup);
     sections.push(format_context_hints(
         batch.channel_id,
         args.channel_info,


### PR DESCRIPTION
## Summary

- capture the current ACP turn's `agent_message_chunk` text in the authenticated harness
- publish that text as a signed Buzz message when the adapter completes without having authored a channel message during the turn
- preserve the existing human-facing reply anchor and fail closed when duplicate verification is unavailable
- keep `BUZZ_PRIVATE_KEY` out of model-generated terminal commands, so adapters such as Hermes can retain their secret-sandbox boundary

This fixes runtimes that can produce a valid ACP response but intentionally strip Buzz's signing key from their terminal subprocess. Runtimes that already call `buzz messages send` keep their existing behavior; the relay-side authored-message check suppresses the fallback.

### Related issue

N/A — no matching issue or PR found for `Hermes BUZZ_PRIVATE_KEY` or `ACP publish fallback`.

### Testing

- `cargo test -p buzz-acp` — 776 library tests and 9 lifecycle integration tests passed at `c20aa201c772a408af8d72bfb968c3cbee8cf58c`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Added regressions for per-turn ACP response reset/accumulation, threaded fallback publication, and duplicate suppression when the agent already posted.
