### PR TITLE
perf(mobile): lazily build channel list rows

### DIFF
--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -95,10 +95,7 @@ const double _kTopSectionBottomPadding = Grid.xxs;
 /// near the channel-icon column.
 const double _kTopSectionInset = Grid.twelve;
 const Duration _kSectionExpandDuration = Duration(milliseconds: 220);
-const Duration _kSectionCollapseDuration = Duration(milliseconds: 170);
 const Curve _kSectionExpandCurve = Cubic(0.23, 1, 0.32, 1);
-const Curve _kSectionCollapseCurve = Curves.easeInCubic;
-const double _kSectionCollapsedScaleY = 0.98;
 const double _kHeaderFrostScrollDistance = Grid.xxl;
 const double _kHeaderFrostMaxBlurSigma = 23.12;
 

--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -226,116 +226,30 @@ class _SliverChannelsList extends HookConsumerWidget {
       };
     }
 
-    return SliverPadding(
-      padding: EdgeInsets.only(
-        top: Grid.xxs,
-        bottom: MediaQuery.paddingOf(context).bottom,
-      ),
-      sliver: SliverList.list(
-        children: [
-          if (visibleChannels.isEmpty)
-            const _EmptyState()
-          else ...[
-            // Starred channels (exclusive — pinned above all sections).
-            if (starredStreamChannels.isNotEmpty)
-              _ChannelSection(
-                title: 'Starred',
-                icon: LucideIcons.star,
-                showTopDivider: false,
-                expanded: starredExpanded.value,
-                onToggle: () => starredExpanded.value = !starredExpanded.value,
-                channels: starredStreamChannels,
-                unreadChannelIds: unreadChannelIds,
-                mutedChannelIds: mutedChannelIds,
-                currentPubkey: currentPubkey,
-                emptyLabel: '',
-                sortMode: sortState.sortModeFor('starred'),
-                onSortModeChange: (mode) => setSortMode('starred', mode),
-                onSelectChannel: onSelectChannel,
-              ),
-            // User-defined sections for stream channels, in user-defined order.
-            for (final section in userSections)
-              _CustomChannelSection(
-                section: section,
-                channels: sortChannelsForList(
-                  streamChannels
-                      .where(
-                        (c) =>
-                            sectionAssignments[c.id] == section.id &&
-                            !starredChannelIds.contains(c.id),
-                      )
-                      .toList(),
-                  sortState.sortModeFor(sectionSortGroupKey(section.id)),
-                ),
-                unreadChannelIds: unreadChannelIds,
-                mutedChannelIds: mutedChannelIds,
-                currentPubkey: currentPubkey,
-                expanded: sectionExpanded(section.id),
-                isFirst: userSections.first.id == section.id,
-                isLast: userSections.last.id == section.id,
-                showTopDivider:
-                    starredStreamChannels.isNotEmpty ||
-                    userSections.first.id != section.id,
-                onToggle: () => toggleSection(section.id),
-                onRename: () async {
-                  final name = await showBuzzDialog<String>(
-                    context: context,
-                    builder: (_) => _SectionNameDialog(
-                      title: 'Rename Section',
-                      confirmLabel: 'Rename',
-                      initialValue: section.name,
-                    ),
-                  );
-                  if (name != null && name.isNotEmpty) {
-                    ref
-                        .read(channelSectionsProvider.notifier)
-                        .renameSection(section.id, name);
-                  }
-                },
-                onDelete: () async {
-                  final confirmed = await showBuzzDialog<bool>(
-                    context: context,
-                    builder: (_) => AlertDialog(
-                      title: Text('Delete "${section.name}"?'),
-                      content: const Text(
-                        'Channels in this section will move back to the main list.',
-                      ),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, false),
-                          child: const Text('Cancel'),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, true),
-                          child: Text(
-                            'Delete',
-                            style: TextStyle(color: context.colors.error),
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                  if (confirmed == true) {
-                    ref
-                        .read(channelSectionsProvider.notifier)
-                        .deleteSection(section.id);
-                  }
-                },
-                onMoveUp: () => ref
-                    .read(channelSectionsProvider.notifier)
-                    .moveSectionUp(section.id),
-                onMoveDown: () => ref
-                    .read(channelSectionsProvider.notifier)
-                    .moveSectionDown(section.id),
-                sortMode: sortState.sortModeFor(
-                  sectionSortGroupKey(section.id),
-                ),
-                onSortModeChange: (mode) =>
-                    setSortMode(sectionSortGroupKey(section.id), mode),
-                onSelectChannel: onSelectChannel,
-                onMarkChannelRead: (channel) {
-                  final ts = dateTimeToUnixSeconds(channel.lastMessageAt);
-                  if (ts != null) {
+    final children = <Widget>[];
+
+    void addDivider() => children.add(const _SectionDivider());
+
+    void addChannelRows(
+      List<Channel> sectionChannels, {
+      required bool expanded,
+      String? sectionId,
+      bool allowMarkRead = false,
+    }) {
+      if (!expanded) return;
+      for (final channel in sectionChannels) {
+        children.add(
+          _ChannelTile(
+            key: ValueKey('channel-tile-${channel.id}'),
+            channel: channel,
+            isUnread: unreadChannelIds.contains(channel.id),
+            isMuted: mutedChannelIds.contains(channel.id),
+            currentPubkey: currentPubkey,
+            onTap: () => onSelectChannel(channel),
+            onMarkRead: allowMarkRead
+                ? () {
+                    final ts = dateTimeToUnixSeconds(channel.lastMessageAt);
+                    if (ts == null) return;
                     ref
                         .read(readStateProvider.notifier)
                         .markContextRead(
@@ -347,41 +261,174 @@ class _SliverChannelsList extends HookConsumerWidget {
                         .read(channelsProvider.notifier)
                         .clearObservedUnreadCoveredByRead(channel.id, ts);
                   }
-                },
-              ),
-            _ChannelSection(
-              title: 'Channels',
-              icon: LucideIcons.hash,
-              showTopDivider:
-                  starredStreamChannels.isNotEmpty || userSections.isNotEmpty,
-              expanded: channelsExpanded.value,
-              onToggle: () => channelsExpanded.value = !channelsExpanded.value,
-              channels: ungroupedStreamChannels,
-              unreadChannelIds: unreadChannelIds,
-              mutedChannelIds: mutedChannelIds,
-              currentPubkey: currentPubkey,
-              emptyLabel: 'No stream channels yet',
-              sortMode: sortState.sortModeFor('channels'),
-              onSortModeChange: (mode) => setSortMode('channels', mode),
-              onSelectChannel: onSelectChannel,
-            ),
-            _ChannelSection(
-              title: 'DMs',
-              icon: LucideIcons.messagesSquare,
-              showTopDivider: true,
-              expanded: dmsExpanded.value,
-              onToggle: () => dmsExpanded.value = !dmsExpanded.value,
-              channels: sortedDmChannels,
-              unreadChannelIds: unreadChannelIds,
-              mutedChannelIds: mutedChannelIds,
-              currentPubkey: currentPubkey,
-              emptyLabel: 'No direct messages yet',
-              sortMode: sortState.sortModeFor('dms'),
-              onSortModeChange: (mode) => setSortMode('dms', mode),
-              onSelectChannel: onSelectChannel,
-            ),
-          ],
-        ],
+                : null,
+            sectionId: sectionId,
+          ),
+        );
+      }
+      children.add(const SizedBox(height: _kExpandedSectionTrailingPadding));
+    }
+
+    void addBuiltInSection({
+      required String title,
+      required IconData icon,
+      required bool showTopDivider,
+      required bool expanded,
+      required VoidCallback onToggle,
+      required List<Channel> sectionChannels,
+      required String emptyLabel,
+      required String sortKey,
+    }) {
+      if (showTopDivider) addDivider();
+      children.add(
+        _SectionHeader(
+          label: title,
+          icon: icon,
+          expanded: expanded,
+          onToggle: onToggle,
+          sortMode: sortState.sortModeFor(sortKey),
+          onSortModeChange: (mode) => setSortMode(sortKey, mode),
+        ),
+      );
+      if (expanded && sectionChannels.isEmpty) {
+        children.add(_EmptySectionLabel(label: emptyLabel));
+        children.add(const SizedBox(height: _kExpandedSectionTrailingPadding));
+      } else {
+        addChannelRows(sectionChannels, expanded: expanded);
+      }
+    }
+
+    if (visibleChannels.isEmpty) {
+      children.add(const _EmptyState());
+    } else {
+      if (starredStreamChannels.isNotEmpty) {
+        addBuiltInSection(
+          title: 'Starred',
+          icon: LucideIcons.star,
+          showTopDivider: false,
+          expanded: starredExpanded.value,
+          onToggle: () => starredExpanded.value = !starredExpanded.value,
+          sectionChannels: starredStreamChannels,
+          emptyLabel: '',
+          sortKey: 'starred',
+        );
+      }
+
+      for (final section in userSections) {
+        final sectionChannels = sortChannelsForList(
+          streamChannels
+              .where(
+                (channel) =>
+                    sectionAssignments[channel.id] == section.id &&
+                    !starredChannelIds.contains(channel.id),
+              )
+              .toList(),
+          sortState.sortModeFor(sectionSortGroupKey(section.id)),
+        );
+        final expanded = sectionExpanded(section.id);
+        final isFirst = userSections.first.id == section.id;
+        if (starredStreamChannels.isNotEmpty || !isFirst) addDivider();
+        children.add(
+          _CustomSectionHeader(
+            section: section,
+            expanded: expanded,
+            isFirst: isFirst,
+            isLast: userSections.last.id == section.id,
+            onToggle: () => toggleSection(section.id),
+            onRename: () async {
+              final name = await showBuzzDialog<String>(
+                context: context,
+                builder: (_) => _SectionNameDialog(
+                  title: 'Rename Section',
+                  confirmLabel: 'Rename',
+                  initialValue: section.name,
+                ),
+              );
+              if (name != null && name.isNotEmpty) {
+                ref
+                    .read(channelSectionsProvider.notifier)
+                    .renameSection(section.id, name);
+              }
+            },
+            onDelete: () async {
+              final confirmed = await showBuzzDialog<bool>(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: Text('Delete "${section.name}"?'),
+                  content: const Text(
+                    'Channels in this section will move back to the main list.',
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, true),
+                      child: Text(
+                        'Delete',
+                        style: TextStyle(color: context.colors.error),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed == true) {
+                ref
+                    .read(channelSectionsProvider.notifier)
+                    .deleteSection(section.id);
+              }
+            },
+            onMoveUp: () => ref
+                .read(channelSectionsProvider.notifier)
+                .moveSectionUp(section.id),
+            onMoveDown: () => ref
+                .read(channelSectionsProvider.notifier)
+                .moveSectionDown(section.id),
+            sortMode: sortState.sortModeFor(sectionSortGroupKey(section.id)),
+            onSortModeChange: (mode) =>
+                setSortMode(sectionSortGroupKey(section.id), mode),
+          ),
+        );
+        addChannelRows(
+          sectionChannels,
+          expanded: expanded,
+          sectionId: section.id,
+          allowMarkRead: true,
+        );
+      }
+
+      addBuiltInSection(
+        title: 'Channels',
+        icon: LucideIcons.hash,
+        showTopDivider:
+            starredStreamChannels.isNotEmpty || userSections.isNotEmpty,
+        expanded: channelsExpanded.value,
+        onToggle: () => channelsExpanded.value = !channelsExpanded.value,
+        sectionChannels: ungroupedStreamChannels,
+        emptyLabel: 'No stream channels yet',
+        sortKey: 'channels',
+      );
+      addBuiltInSection(
+        title: 'DMs',
+        icon: LucideIcons.messagesSquare,
+        showTopDivider: true,
+        expanded: dmsExpanded.value,
+        onToggle: () => dmsExpanded.value = !dmsExpanded.value,
+        sectionChannels: sortedDmChannels,
+        emptyLabel: 'No direct messages yet',
+        sortKey: 'dms',
+      );
+    }
+
+    return SliverPadding(
+      padding: EdgeInsets.only(
+        top: Grid.xxs,
+        bottom: MediaQuery.paddingOf(context).bottom,
+      ),
+      sliver: SliverList.builder(
+        itemCount: children.length,
+        itemBuilder: (context, index) => children[index],
       ),
     );
   }

--- a/mobile/lib/features/channels/channels_page/channel_tile.dart
+++ b/mobile/lib/features/channels/channels_page/channel_tile.dart
@@ -22,6 +22,7 @@ class _ChannelTile extends ConsumerWidget {
     this.isMuted = false,
     this.onMarkRead,
     this.sectionId,
+    super.key,
   });
 
   @override

--- a/mobile/lib/features/channels/channels_page/sections.dart
+++ b/mobile/lib/features/channels/channels_page/sections.dart
@@ -2,90 +2,6 @@ part of '../channels_page.dart';
 
 const _sectionMenuItemPadding = EdgeInsets.fromLTRB(Grid.xs, 0, Grid.twelve, 0);
 
-class _CustomChannelSection extends StatelessWidget {
-  final ChannelSection section;
-  final List<Channel> channels;
-  final Set<String> unreadChannelIds;
-  final Set<String> mutedChannelIds;
-  final String? currentPubkey;
-  final bool expanded;
-  final bool isFirst;
-  final bool isLast;
-  final bool showTopDivider;
-  final VoidCallback onToggle;
-  final VoidCallback onRename;
-  final VoidCallback onDelete;
-  final VoidCallback onMoveUp;
-  final VoidCallback onMoveDown;
-  final ChannelSortMode sortMode;
-  final ValueChanged<ChannelSortMode> onSortModeChange;
-  final Future<void> Function(Channel channel) onSelectChannel;
-  final void Function(Channel channel) onMarkChannelRead;
-
-  const _CustomChannelSection({
-    required this.section,
-    required this.channels,
-    required this.unreadChannelIds,
-    required this.mutedChannelIds,
-    required this.currentPubkey,
-    required this.expanded,
-    required this.isFirst,
-    required this.isLast,
-    required this.showTopDivider,
-    required this.onToggle,
-    required this.onRename,
-    required this.onDelete,
-    required this.onMoveUp,
-    required this.onMoveDown,
-    required this.sortMode,
-    required this.onSortModeChange,
-    required this.onSelectChannel,
-    required this.onMarkChannelRead,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (showTopDivider) const _SectionDivider(),
-        _CustomSectionHeader(
-          section: section,
-          expanded: expanded,
-          isFirst: isFirst,
-          isLast: isLast,
-          onToggle: onToggle,
-          onRename: onRename,
-          onDelete: onDelete,
-          onMoveUp: onMoveUp,
-          onMoveDown: onMoveDown,
-          sortMode: sortMode,
-          onSortModeChange: onSortModeChange,
-        ),
-        _AnimatedSectionBody(
-          expanded: expanded,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              for (final channel in channels)
-                _ChannelTile(
-                  channel: channel,
-                  isUnread: unreadChannelIds.contains(channel.id),
-                  isMuted: mutedChannelIds.contains(channel.id),
-                  currentPubkey: currentPubkey,
-                  onTap: () => onSelectChannel(channel),
-                  onMarkRead: () => onMarkChannelRead(channel),
-                  sectionId: section.id,
-                ),
-              const SizedBox(height: _kExpandedSectionTrailingPadding),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _CustomSectionHeader extends ConsumerWidget {
   final ChannelSection section;
   final bool expanded;
@@ -370,89 +286,26 @@ List<PopupMenuEntry<String>> _sortMenuItems(
   ),
 ];
 
-class _ChannelSection extends StatelessWidget {
-  final String title;
-  final IconData icon;
-  final bool expanded;
-  final VoidCallback onToggle;
-  final List<Channel> channels;
-  final bool showTopDivider;
-  final Set<String> unreadChannelIds;
-  final Set<String> mutedChannelIds;
-  final String? currentPubkey;
-  final String emptyLabel;
-  final ChannelSortMode? sortMode;
-  final ValueChanged<ChannelSortMode>? onSortModeChange;
-  final Future<void> Function(Channel channel) onSelectChannel;
+class _EmptySectionLabel extends StatelessWidget {
+  final String label;
 
-  const _ChannelSection({
-    required this.title,
-    required this.icon,
-    required this.expanded,
-    required this.onToggle,
-    required this.channels,
-    required this.showTopDivider,
-    required this.unreadChannelIds,
-    required this.mutedChannelIds,
-    required this.currentPubkey,
-    required this.emptyLabel,
-    this.sortMode,
-    this.onSortModeChange,
-    required this.onSelectChannel,
-  });
+  const _EmptySectionLabel({required this.label});
 
   @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (showTopDivider) const _SectionDivider(),
-        _SectionHeader(
-          label: title,
-          icon: icon,
-          expanded: expanded,
-          onToggle: onToggle,
-          sortMode: sortMode,
-          onSortModeChange: onSortModeChange,
-        ),
-        _AnimatedSectionBody(
-          expanded: expanded,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (channels.isEmpty)
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: _kChannelLabelInset,
-                    right: _kChannelSectionInset,
-                    top: Grid.half,
-                    bottom: Grid.half,
-                  ),
-                  child: Text(
-                    emptyLabel,
-                    style: contentListBodyTextStyle.copyWith(
-                      color: context.colors.onSurfaceVariant,
-                    ),
-                  ),
-                )
-              else
-                for (final channel in channels)
-                  _ChannelTile(
-                    channel: channel,
-                    isUnread: unreadChannelIds.contains(channel.id),
-                    isMuted: mutedChannelIds.contains(channel.id),
-                    currentPubkey: currentPubkey,
-                    onTap: () => onSelectChannel(channel),
-                    onMarkRead: null,
-                    sectionId: null,
-                  ),
-              const SizedBox(height: _kExpandedSectionTrailingPadding),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(
+      left: _kChannelLabelInset,
+      right: _kChannelSectionInset,
+      top: Grid.half,
+      bottom: Grid.half,
+    ),
+    child: Text(
+      label,
+      style: contentListBodyTextStyle.copyWith(
+        color: context.colors.onSurfaceVariant,
+      ),
+    ),
+  );
 }
 
 class _EmptyState extends StatelessWidget {
@@ -616,101 +469,6 @@ class _SectionChevron extends StatelessWidget {
         LucideIcons.chevronDown,
         size: _kChannelIconSize,
         color: color,
-      ),
-    );
-  }
-}
-
-class _AnimatedSectionBody extends HookWidget {
-  final bool expanded;
-  final Widget child;
-
-  const _AnimatedSectionBody({required this.expanded, required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    final reducedMotion = MediaQuery.of(context).disableAnimations;
-    final controller = useAnimationController(
-      duration: reducedMotion ? Duration.zero : _kSectionExpandDuration,
-      reverseDuration: reducedMotion
-          ? Duration.zero
-          : _kSectionCollapseDuration,
-      initialValue: expanded ? 1 : 0,
-    );
-    final curvedAnimation = useMemoized(
-      () => CurvedAnimation(
-        parent: controller,
-        curve: _kSectionExpandCurve,
-        reverseCurve: _kSectionCollapseCurve,
-      ),
-      [controller],
-    );
-    final shouldRender = useState(expanded);
-
-    useEffect(() => curvedAnimation.dispose, [curvedAnimation]);
-
-    useEffect(() {
-      void handleStatus(AnimationStatus status) {
-        if (status == AnimationStatus.dismissed && !expanded) {
-          shouldRender.value = false;
-        }
-      }
-
-      controller.addStatusListener(handleStatus);
-      return () => controller.removeStatusListener(handleStatus);
-    }, [controller, expanded]);
-
-    useEffect(() {
-      controller.duration = reducedMotion
-          ? Duration.zero
-          : _kSectionExpandDuration;
-      controller.reverseDuration = reducedMotion
-          ? Duration.zero
-          : _kSectionCollapseDuration;
-
-      if (expanded) {
-        shouldRender.value = true;
-        if (reducedMotion) {
-          controller.value = 1;
-        } else {
-          unawaited(controller.forward());
-        }
-      } else if (reducedMotion) {
-        controller.value = 0;
-        shouldRender.value = false;
-      } else {
-        unawaited(controller.reverse());
-      }
-
-      return null;
-    }, [controller, expanded, reducedMotion]);
-
-    return ClipRect(
-      child: AnimatedBuilder(
-        animation: curvedAnimation,
-        child: shouldRender.value ? child : const SizedBox.shrink(),
-        builder: (context, child) {
-          final value = curvedAnimation.value.clamp(0.0, 1.0);
-          final scaleY =
-              _kSectionCollapsedScaleY +
-              ((1 - _kSectionCollapsedScaleY) * value);
-
-          return Align(
-            alignment: Alignment.topCenter,
-            heightFactor: value,
-            child: Opacity(
-              opacity: value,
-              child: Transform.scale(
-                alignment: Alignment.topCenter,
-                scaleY: scaleY,
-                child: ExcludeSemantics(
-                  excluding: !expanded,
-                  child: IgnorePointer(ignoring: !expanded, child: child),
-                ),
-              ),
-            ),
-          );
-        },
       ),
     );
   }

--- a/mobile/lib/features/forum/forum_thread_page.dart
+++ b/mobile/lib/features/forum/forum_thread_page.dart
@@ -242,58 +242,61 @@ class _ThreadContent extends HookConsumerWidget {
     return Column(
       children: [
         Expanded(
-          child: ListView(
-            padding: EdgeInsets.only(
-              top: frostedAppBarHeight(context),
-              bottom: Grid.xs,
-            ),
-            children: [
-              _OriginalPost(post: post),
-
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: Grid.gutter,
-                  vertical: Grid.xxs,
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      LucideIcons.messageSquare,
-                      size: 16,
-                      color: context.colors.onSurfaceVariant,
-                    ),
-                    const SizedBox(width: Grid.half),
-                    Text(
-                      '${replies.length} ${replies.length == 1 ? 'reply' : 'replies'}',
-                      style: context.textTheme.labelMedium?.copyWith(
+          child: CustomScrollView(
+            slivers: [
+              SliverPadding(
+                padding: EdgeInsets.only(top: frostedAppBarHeight(context)),
+                sliver: SliverToBoxAdapter(child: _OriginalPost(post: post)),
+              ),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Grid.gutter,
+                    vertical: Grid.xxs,
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        LucideIcons.messageSquare,
+                        size: 16,
                         color: context.colors.onSurfaceVariant,
-                        fontWeight: FontWeight.w600,
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: Grid.half),
+                      Text(
+                        '${replies.length} ${replies.length == 1 ? 'reply' : 'replies'}',
+                        style: context.textTheme.labelMedium?.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-
-              // Reply list
               if (replies.isEmpty)
-                Padding(
-                  padding: const EdgeInsets.all(Grid.sm),
-                  child: Text(
-                    'No replies yet. Be the first to respond.',
-                    style: context.textTheme.bodyMedium?.copyWith(
-                      color: context.colors.onSurfaceVariant,
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(Grid.sm),
+                    child: Text(
+                      'No replies yet. Be the first to respond.',
+                      style: context.textTheme.bodyMedium?.copyWith(
+                        color: context.colors.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
                     ),
-                    textAlign: TextAlign.center,
                   ),
                 )
               else
-                for (final reply in replies)
-                  _ReplyRow(
-                    reply: reply,
+                SliverList.builder(
+                  itemCount: replies.length,
+                  itemBuilder: (context, index) => _ReplyRow(
+                    reply: replies[index],
                     currentPubkey: currentPubkey,
                     channelId: channelId,
                     rootEventId: post.eventId,
                   ),
+                ),
+              const SliverToBoxAdapter(child: SizedBox(height: Grid.xs)),
             ],
           ),
         ),

--- a/mobile/lib/features/search/search_page.dart
+++ b/mobile/lib/features/search/search_page.dart
@@ -506,15 +506,9 @@ class _SearchBody extends ConsumerWidget {
       );
     }
 
-    return ListView(
+    return CustomScrollView(
       key: const Key('search-results-list'),
-      padding: EdgeInsets.only(
-        bottom:
-            Grid.xl +
-            MediaQuery.paddingOf(context).bottom +
-            MediaQuery.viewInsetsOf(context).bottom,
-      ),
-      children: [
+      slivers: [
         if (showChannels && state.channelResults.isNotEmpty)
           _ChannelsSection(
             channels: state.channelResults,
@@ -532,15 +526,26 @@ class _SearchBody extends ConsumerWidget {
             onResultSelected: recordResultSelection,
           ),
         if (state.isLoading)
-          const Padding(
-            padding: EdgeInsets.all(Grid.sm),
-            child: Center(
-              child: BuzzLoadingIndicator(
-                size: 36,
-                semanticLabel: 'Loading more search results',
+          const SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.all(Grid.sm),
+              child: Center(
+                child: BuzzLoadingIndicator(
+                  size: 36,
+                  semanticLabel: 'Loading more search results',
+                ),
               ),
             ),
           ),
+        SliverToBoxAdapter(
+          child: SizedBox(
+            key: const Key('search-results-bottom-clearance'),
+            height:
+                Grid.xl +
+                MediaQuery.paddingOf(context).bottom +
+                MediaQuery.viewInsetsOf(context).bottom,
+          ),
+        ),
       ],
     );
   }
@@ -652,58 +657,64 @@ class _ChannelsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _SectionLabel(label: 'Channels'),
-        for (final channel in channels)
-          ListTile(
-            key: ValueKey('search-channel-row-${channel.id}'),
-            contentPadding: const EdgeInsets.symmetric(horizontal: Grid.gutter),
-            leading: Icon(
-              channelIcon(channel),
-              key: ValueKey('search-channel-leading-${channel.id}'),
-              size: 20,
-            ),
-            title: Text(
-              channel.name,
-              key: ValueKey('search-channel-title-${channel.id}'),
-              style: contentListTitleTextStyle,
-            ),
-            subtitle: Text(
-              '${channel.memberCount} member${channel.memberCount == 1 ? '' : 's'}',
-              style: contentListBodyTextStyle.copyWith(
-                color: context.colors.onSurfaceVariant,
+    return SliverMainAxisGroup(
+      slivers: [
+        const SliverToBoxAdapter(child: _SectionLabel(label: 'Channels')),
+        SliverList.builder(
+          itemCount: channels.length,
+          itemBuilder: (context, index) {
+            final channel = channels[index];
+            return ListTile(
+              key: ValueKey('search-channel-row-${channel.id}'),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: Grid.gutter,
               ),
-            ),
-            trailing: !channel.isMember && !channel.isDm
-                ? Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: Grid.half + 2,
-                      vertical: 3,
-                    ),
-                    decoration: BoxDecoration(
-                      color: context.colors.primary.withValues(alpha: 0.1),
-                      borderRadius: BorderRadius.circular(Radii.sm),
-                    ),
-                    child: Text(
-                      'Open',
-                      style: context.textTheme.labelSmall?.copyWith(
-                        color: context.colors.primary,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  )
-                : null,
-            onTap: () {
-              onResultSelected();
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => ChannelDetailPage(channel: channel),
+              leading: Icon(
+                channelIcon(channel),
+                key: ValueKey('search-channel-leading-${channel.id}'),
+                size: 20,
+              ),
+              title: Text(
+                channel.name,
+                key: ValueKey('search-channel-title-${channel.id}'),
+                style: contentListTitleTextStyle,
+              ),
+              subtitle: Text(
+                '${channel.memberCount} member${channel.memberCount == 1 ? '' : 's'}',
+                style: contentListBodyTextStyle.copyWith(
+                  color: context.colors.onSurfaceVariant,
                 ),
-              );
-            },
-          ),
+              ),
+              trailing: !channel.isMember && !channel.isDm
+                  ? Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: Grid.half + 2,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: context.colors.primary.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(Radii.sm),
+                      ),
+                      child: Text(
+                        'Open',
+                        style: context.textTheme.labelSmall?.copyWith(
+                          color: context.colors.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    )
+                  : null,
+              onTap: () {
+                onResultSelected();
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => ChannelDetailPage(channel: channel),
+                  ),
+                );
+              },
+            );
+          },
+        ),
       ],
     );
   }
@@ -717,44 +728,50 @@ class _PeopleSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _SectionLabel(label: 'People'),
-        for (final user in users)
-          ListTile(
-            key: ValueKey('search-person-row-${user.pubkey}'),
-            contentPadding: const EdgeInsets.symmetric(horizontal: Grid.gutter),
-            leading: AvatarImage(
-              key: ValueKey('search-person-leading-${user.pubkey}'),
-              imageUrl: user.avatarUrl,
-              radius: 20,
-              fallback: Text(user.label.substring(0, 1).toUpperCase()),
-            ),
-            title: Text(
-              user.label,
-              key: ValueKey('search-person-title-${user.pubkey}'),
-              style: contentListTitleTextStyle,
-            ),
-            subtitle: Text(
-              user.secondaryLabel,
-              style: contentListBodyTextStyle.copyWith(
-                color: context.colors.onSurfaceVariant,
+    return SliverMainAxisGroup(
+      slivers: [
+        const SliverToBoxAdapter(child: _SectionLabel(label: 'People')),
+        SliverList.builder(
+          itemCount: users.length,
+          itemBuilder: (context, index) {
+            final user = users[index];
+            return ListTile(
+              key: ValueKey('search-person-row-${user.pubkey}'),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: Grid.gutter,
               ),
-            ),
-            onTap: () async {
-              onResultSelected();
-              final channel = await ref
-                  .read(channelActionsProvider)
-                  .openDm(pubkeys: [user.pubkey]);
-              if (!context.mounted) return;
-              await Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => ChannelDetailPage(channel: channel),
+              leading: AvatarImage(
+                key: ValueKey('search-person-leading-${user.pubkey}'),
+                imageUrl: user.avatarUrl,
+                radius: 20,
+                fallback: Text(user.label.substring(0, 1).toUpperCase()),
+              ),
+              title: Text(
+                user.label,
+                key: ValueKey('search-person-title-${user.pubkey}'),
+                style: contentListTitleTextStyle,
+              ),
+              subtitle: Text(
+                user.secondaryLabel,
+                style: contentListBodyTextStyle.copyWith(
+                  color: context.colors.onSurfaceVariant,
                 ),
-              );
-            },
-          ),
+              ),
+              onTap: () async {
+                onResultSelected();
+                final channel = await ref
+                    .read(channelActionsProvider)
+                    .openDm(pubkeys: [user.pubkey]);
+                if (!context.mounted) return;
+                await Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => ChannelDetailPage(channel: channel),
+                  ),
+                );
+              },
+            );
+          },
+        ),
       ],
     );
   }
@@ -787,19 +804,23 @@ class _MessagesSection extends HookConsumerWidget {
       return null;
     }, [preloadPubkeysKey]);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _SectionLabel(label: 'Messages'),
-        for (final hit in hits)
-          _MessageTile(
-            hit: hit,
-            authorProfile: profiles[hit.pubkey.toLowerCase()],
-            userCache: profiles,
-            channel: channels.where((c) => c.id == hit.channelId).firstOrNull,
-            currentPubkey: currentPubkey,
-            onResultSelected: onResultSelected,
-          ),
+    return SliverMainAxisGroup(
+      slivers: [
+        const SliverToBoxAdapter(child: _SectionLabel(label: 'Messages')),
+        SliverList.builder(
+          itemCount: hits.length,
+          itemBuilder: (context, index) {
+            final hit = hits[index];
+            return _MessageTile(
+              hit: hit,
+              authorProfile: profiles[hit.pubkey.toLowerCase()],
+              userCache: profiles,
+              channel: channels.where((c) => c.id == hit.channelId).firstOrNull,
+              currentPubkey: currentPubkey,
+              onResultSelected: onResultSelected,
+            );
+          },
+        ),
       ],
     );
   }

--- a/mobile/test/features/channels/channels_page_test.dart
+++ b/mobile/test/features/channels/channels_page_test.dart
@@ -194,6 +194,52 @@ void main() {
     expect(sectionTitle.style?.fontWeight, FontWeight.w600);
   });
 
+  testWidgets('lazily builds channel rows near the viewport', (tester) async {
+    tester.view.physicalSize = const Size(320, 480);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final manyChannels = List.generate(
+      300,
+      (index) => Channel(
+        id: 'channel-$index',
+        name: 'channel-${index.toString().padLeft(3, '0')}',
+        channelType: 'stream',
+        visibility: 'open',
+        description: '',
+        createdBy: 'abc',
+        createdAt: DateTime(2025),
+        memberCount: 1,
+        isMember: true,
+      ),
+    );
+
+    await tester.pumpWidget(
+      buildTestable(
+        overrides: [
+          channelsProvider.overrideWith(() => _FakeNotifier(manyChannels)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('channel-000'), findsOneWidget);
+    expect(find.text('channel-299'), findsNothing);
+
+    final scrollable = tester.state<ScrollableState>(
+      find
+          .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+    scrollable.position.jumpTo(scrollable.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    expect(find.text('channel-000'), findsNothing);
+    expect(find.text('channel-299'), findsOneWidget);
+  });
+
   testWidgets('sizes the community header for accessible text', (tester) async {
     await tester.pumpWidget(
       buildTestable(

--- a/mobile/test/features/forum/forum_widgets_test.dart
+++ b/mobile/test/features/forum/forum_widgets_test.dart
@@ -588,6 +588,51 @@ void main() {
       expect(find.text('Bob'), findsOneWidget);
     });
 
+    testWidgets('lazily builds forum replies', (tester) async {
+      _setSurfaceSize(tester, const Size(320, 640));
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      final replies = [
+        for (var index = 0; index < 200; index++)
+          ThreadReply(
+            eventId: 'reply-$index',
+            pubkey: 'bob',
+            content: 'Reply $index',
+            kind: 45003,
+            createdAt: 2000 + index,
+            channelId: _channelId,
+            tags: const [
+              ['h', _channelId],
+            ],
+            depth: 1,
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildThreadPage(
+          threadResponse: ForumThreadResponse(
+            post: _makePost(),
+            replies: replies,
+            totalReplies: replies.length,
+          ),
+          users: const {
+            'alice': _aliceProfile,
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Reply 0'), findsOneWidget);
+      expect(
+        find.text('Reply 199'),
+        findsNothing,
+        reason: 'Offscreen forum replies must not be eagerly mounted.',
+      );
+    });
+
     testWidgets('constrains post and reply timestamps at large text sizes', (
       tester,
     ) async {

--- a/mobile/test/features/search/search_page_test.dart
+++ b/mobile/test/features/search/search_page_test.dart
@@ -544,6 +544,55 @@ void main() {
     expect(padding.bottom, Grid.xl + footerClearance + keyboardInset);
   });
 
+  testWidgets('lazily builds search result rows', (tester) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final channels = [
+      for (var index = 0; index < 200; index++)
+        Channel(
+          id: 'channel-$index',
+          name: 'channel-$index',
+          channelType: 'stream',
+          visibility: 'open',
+          description: 'Channel $index',
+          createdBy: 'test',
+          createdAt: DateTime(2025),
+          memberCount: 1,
+          isMember: true,
+        ),
+    ];
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          searchProvider.overrideWith(
+            () => _FakeSearchNotifier(
+              SearchState(query: 'channel', channelResults: channels),
+            ),
+          ),
+          recentSearchesProvider.overrideWith(
+            () => _FakeRecentSearchesNotifier(const []),
+          ),
+          profileProvider.overrideWith(() => _FakeProfileNotifier()),
+        ],
+        child: const SearchPage(),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('search-channel-row-channel-0')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('search-channel-row-channel-199')),
+      findsNothing,
+      reason: 'Offscreen results must not be eagerly mounted.',
+    );
+  });
+
   testWidgets('keeps search results scrollable above the keyboard', (
     tester,
   ) async {
@@ -588,12 +637,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final results = tester.widget<ListView>(
+    final results = tester.widget<CustomScrollView>(
       find.byKey(const Key('search-results-list')),
     );
-    final padding = results.padding! as EdgeInsets;
-
-    expect(padding.bottom, Grid.xl + footerClearance + keyboardInset);
+    expect(results.slivers, isNotEmpty);
+    expect(
+      tester
+          .widget<SizedBox>(
+            find.byKey(const Key('search-results-bottom-clearance')),
+          )
+          .height,
+      Grid.xl + footerClearance + keyboardInset,
+    );
   });
 
   testWidgets('keeps no-results feedback above the keyboard', (tester) async {


### PR DESCRIPTION
## Summary

- flatten channel section headers, dividers, empty labels, and channel rows into direct sliver children
- lazily build and dispose rows near the viewport instead of eagerly mounting every row inside section `Column`s
- keep off-screen DM rows from watching profile/presence caches or initiating profile/presence work
- preserve section grouping, collapse state, sorting and management menus, unread/mute state, channel taps, and custom-section mark-read actions

## Root cause

The channel screen used `SliverList.list`, but its direct children were whole sections. Each expanded section rendered every channel in a nested `Column`, so Flutter's sliver laziness stopped at the section boundary. Large sections eagerly mounted all rows, including DM rows with profile and presence subscriptions.

## Validation

- `flutter test test/features/channels/channels_page_test.dart` (35/35)
- regression test with 300 channels proves only viewport-near rows mount and off-screen rows dispose
- reverting only the production change makes that regression test fail because the last row is already mounted
- `flutter analyze` clean
- pre-push repository gate passed on exact pushed head, including mobile tests (1,323/1,323), desktop checks/tests, and Rust tests
