### PR TITLE
fix(desktop): preserve angle brackets in inline code

### DIFF
--- a/desktop/src/features/messages/lib/composerTextNode.ts
+++ b/desktop/src/features/messages/lib/composerTextNode.ts
@@ -1,0 +1,27 @@
+import { Node } from "@tiptap/core";
+
+/**
+ * Composer text node with Markdown serialization that leaves angle brackets
+ * untouched. tiptap-markdown's stock text serializer HTML-escapes them,
+ * which makes literal inline-code Markdown render `&lt;`/`&gt;` visibly.
+ */
+export const ComposerText = Node.create({
+  name: "text",
+  group: "inline",
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(
+          state: { text: (value: string) => void },
+          node: { text: string },
+        ) {
+          state.text(node.text);
+        },
+        parse: {
+          // handled by markdown-it
+        },
+      },
+    };
+  },
+});

--- a/desktop/src/features/messages/lib/markdownSerialization.test.mjs
+++ b/desktop/src/features/messages/lib/markdownSerialization.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown as TiptapMarkdown } from "tiptap-markdown";
+
+import { ComposerText } from "./composerTextNode.ts";
+
+function createEditor(content) {
+  return new Editor({
+    element: null,
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+        link: false,
+        text: false,
+        trailingNode: false,
+      }),
+      ComposerText,
+      TiptapMarkdown.configure({
+        html: false,
+        breaks: true,
+      }),
+    ],
+    content,
+  });
+}
+
+function serializeComposerMarkdown(editor) {
+  // Mirror getMarkdownFromEditor: the composer intentionally removes
+  // prosemirror-markdown's backslash escapes for user-authored Markdown.
+  let markdown = editor.storage.markdown.getMarkdown();
+  markdown = markdown.replace(/\\\n/g, "\n");
+  return markdown.replace(/\\([`*\\~[\]_])/g, "$1");
+}
+
+test("inline-code Markdown preserves angle brackets in Markdown serialization", () => {
+  const editor = createEditor({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "`<repo root>/website`",
+          },
+        ],
+      },
+    ],
+  });
+
+  try {
+    assert.equal(serializeComposerMarkdown(editor), "`<repo root>/website`");
+  } finally {
+    editor.destroy();
+  }
+});
+
+test("typed HTML entities remain literal text", () => {
+  const editor = createEditor({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "literal &lt;repo&gt;" }],
+      },
+    ],
+  });
+
+  try {
+    assert.equal(serializeComposerMarkdown(editor), "literal &lt;repo&gt;");
+  } finally {
+    editor.destroy();
+  }
+});
+
+test("Markdown punctuation and inline-code delimiters remain unchanged", () => {
+  const editor = createEditor({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "**bold** and `inline` [brackets] ~tilde~",
+          },
+        ],
+      },
+    ],
+  });
+
+  try {
+    assert.equal(
+      serializeComposerMarkdown(editor),
+      "**bold** and `inline` [brackets] ~tilde~",
+    );
+  } finally {
+    editor.destroy();
+  }
+});

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -41,6 +41,7 @@ import { SpoilerMark } from "./spoilerMark";
 import { createComposerLinkPasteHandler } from "./composerMessageLinkNode";
 import type { ComposerMessageLinkChannel } from "./useComposerMessageLinks";
 import { useComposerMessageLinks } from "./useComposerMessageLinks";
+import { ComposerText } from "./composerTextNode";
 
 function hardBreakLineBounds($from: ResolvedPos) {
   const parentStart = $from.start();
@@ -244,6 +245,7 @@ export function useRichTextEditor({
     {
       extensions: [
         StarterKit.configure({
+          text: false,
           // Use hard breaks (Shift+Enter) — Enter submits the message.
           hardBreak: {
             keepMarks: true,
@@ -270,6 +272,7 @@ export function useRichTextEditor({
           // below with custom options (autolink, openOnClick, etc.).
           link: false,
         }),
+        ComposerText,
         // macOS text fields traditionally support a small set of Emacs-style
         // Control shortcuts. Keep movement and kill-line scoped to the current
         // hard-break-delimited line rather than the whole ProseMirror block.


### PR DESCRIPTION
## Summary

- preserve literal angle brackets when the desktop composer serializes Markdown
- replace tiptap-markdown's HTML-escaping text node with a composer-specific serializer
- add regression coverage for inline code, literal HTML entities, and existing Markdown punctuation

The upstream text serializer HTML-escaped `<` and `>` before Markdown rendering. Inline code preserves those entity strings literally, so messages such as `<repo root>/website` displayed as `&lt;repo root&gt;/website`.

### Related issue

N/A — no matching open issue or pull request found.

### Testing

- `just ci`
- focused composer Markdown serialization tests (3 passed)
- full desktop unit suite (4,778 passed)
- desktop TypeScript typecheck
- changed-file Biome check

Manual regression case: type `` `<repo root>/website` `` in the desktop composer and send it. The rendered inline code should keep the angle brackets instead of showing HTML entities.

Before: the reported message displayed `&lt;repo root&gt;/website`.

After: the serializer regression test verifies the emitted Markdown remains `` `<repo root>/website` ``.

### Original Bug
<img width="578" height="193" alt="image" src="https://github.com/user-attachments/assets/6cd50d95-09ba-4084-a6d9-187cd9a66a4e" />
