### PR TITLE
fix(buzz-agent): promote reasoning_content to visible text when content is empty

### DIFF
--- a/crates/buzz-agent/src/agent.rs
+++ b/crates/buzz-agent/src/agent.rs
@@ -696,6 +696,12 @@ impl RunCtx<'_> {
                 // Only gate genuine end_turn — don't override max_tokens/refusal.
                 if stop == StopReason::EndTurn {
                     if stop_rejections >= self.cfg.stop_max_rejections {
+                        tracing::warn!(
+                            target: "buzz_agent",
+                            require_reply = self.cfg.require_reply,
+                            buzz_reply_call_seen,
+                            "end_turn: stop_max_rejections exhausted — allowing turn to end"
+                        );
                         return Ok(stop);
                     }
                     let mut objections = self
@@ -723,6 +729,14 @@ impl RunCtx<'_> {
                         push_hook_outputs_as_tool_results(self.history, "_Stop", &objections);
                         continue;
                     }
+                }
+                // Turn is ending with no objections. Log whether a publish was
+                // attempted — this is the last chance to catch silent drops.
+                if self.cfg.require_reply && !buzz_reply_call_seen {
+                    tracing::warn!(
+                        target: "buzz_agent",
+                        "end_turn: no publish attempt seen — turn ending silently"
+                    );
                 }
                 return Ok(stop);
             }

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -1101,6 +1101,18 @@ fn parse_responses(v: Value) -> Result<LlmResponse, AgentError> {
         Some("completed") => ProviderStop::EndTurn,
         _ => ProviderStop::Other,
     };
+    // DeepSeek reasoning models on the Responses API route may put the answer
+    // in `reasoning` items while leaving `output_text` empty. Promote reasoning
+    // to visible text so the model's answer is not silently lost.
+    if text.is_empty() && !reasoning.is_empty() {
+        tracing::warn!(
+            target: "buzz_agent::llm",
+            reasoning_bytes = reasoning.len(),
+            "Responses API: model returned empty output_text with non-empty \
+             reasoning — promoting reasoning to visible text"
+        );
+        std::mem::swap(&mut text, &mut reasoning);
+    }
     let input_tokens = sum_usage(&v, &["input_tokens"]).and_then(SumUsageResult::into_exact);
     let output_tokens = sum_usage(&v, &["output_tokens"]).and_then(SumUsageResult::into_exact);
     // The Responses API nests the cache split under `input_tokens_details`.
@@ -1286,6 +1298,13 @@ fn str_field(v: &Value, key: &str) -> String {
     v.get(key).and_then(Value::as_str).unwrap_or("").to_owned()
 }
 
+/// Prefix of a gateway placeholder injected when the model returns
+/// empty `content` (e.g. some OpenAI-compat gateways sanitise empty
+/// responses). Treat responses consisting only of this placeholder as
+/// empty content and promote `reasoning_content` to visible text instead.
+const GATEWAY_PLACEHOLDER_PREFIX: &str =
+    "[System: Empty message content sanitised to satisfy protocol";
+
 /// Append `part` to `buf` on its own line, ignoring empties.
 fn push_part(buf: &mut String, part: &str) {
     if part.is_empty() {
@@ -1309,7 +1328,14 @@ fn openai_content_parts(content: Option<&Value>) -> (String, String) {
     let mut text = String::new();
     let mut reasoning = String::new();
     match content {
-        Some(Value::String(s)) => text.push_str(s),
+        Some(Value::String(s))
+            // Some OpenAI-compat gateways inject a placeholder when the
+            // model returns empty content. Treat it as empty so
+            // reasoning_content (the actual answer) is promoted to text.
+            if !s.starts_with(GATEWAY_PLACEHOLDER_PREFIX) =>
+        {
+            text.push_str(s);
+        }
         Some(Value::Array(blocks)) => {
             for b in blocks {
                 match b.get("type").and_then(Value::as_str) {
@@ -1411,6 +1437,18 @@ fn parse_anthropic(v: Value) -> Result<LlmResponse, AgentError> {
     // Anthropic reports cache-creation tokens as `cache_creation_input_tokens`;
     // also a subset of `input_tokens` (already folded in above).
     let cache_write_tokens = usage_first(&v, &["cache_creation_input_tokens"], &[]);
+    // Anthropic extended thinking may leave the text block empty when the
+    // model exhausts its thinking budget. Promote thinking to visible text
+    // so the answer is not silently lost.
+    if text.is_empty() && !reasoning.is_empty() {
+        tracing::warn!(
+            target: "buzz_agent::llm",
+            reasoning_bytes = reasoning.len(),
+            "Anthropic: model returned empty text with non-empty thinking — \
+             promoting thinking to visible text"
+        );
+        std::mem::swap(&mut text, &mut reasoning);
+    }
     Ok(LlmResponse {
         text,
         tool_calls,
@@ -1473,13 +1511,13 @@ fn parse_openai(v: Value) -> Result<LlmResponse, AgentError> {
     let msg = choice
         .get("message")
         .ok_or_else(|| AgentError::Llm("missing message".into()))?;
-    let (text, block_reasoning) = openai_content_parts(msg.get("content"));
+    let (mut text, block_reasoning) = openai_content_parts(msg.get("content"));
     // DeepSeek and vLLM-style OpenAI-compat hosts expose reasoning tokens on the
     // message object. Prefer `reasoning_content` (DeepSeek's field name); fall
     // back to `reasoning` (some other providers), and last to reasoning blocks
     // found inside `content`. All three are absent for standard OpenAI
     // responses, which leaves this empty without any special-casing.
-    let reasoning = {
+    let mut reasoning = {
         let rc = str_field(msg, "reasoning_content");
         let rc = if rc.is_empty() {
             str_field(msg, "reasoning")
@@ -1492,6 +1530,21 @@ fn parse_openai(v: Value) -> Result<LlmResponse, AgentError> {
             rc
         }
     };
+    // DeepSeek reasoning models sometimes put the entire answer in
+    // `reasoning_content` while returning empty `content` (or a gateway
+    // placeholder like "[System: Empty message content sanitised to satisfy
+    // protocol...]"). When the visible text is empty but reasoning is non-empty,
+    // promote the reasoning to visible text so the model's answer is not
+    // silently lost.
+    if text.is_empty() && !reasoning.is_empty() {
+        tracing::warn!(
+            target: "buzz_agent::llm",
+            reasoning_bytes = reasoning.len(),
+            "model returned empty content with non-empty reasoning_content — \
+             promoting reasoning to visible text"
+        );
+        std::mem::swap(&mut text, &mut reasoning);
+    }
     let mut tool_calls = Vec::new();
     if stop != ProviderStop::MaxTokens {
         if let Some(arr) = msg.get("tool_calls").and_then(Value::as_array) {
@@ -5347,6 +5400,112 @@ mod tests {
     }
 
     #[test]
+    fn parse_openai_promotes_reasoning_content_to_text_when_content_empty() {
+        // DeepSeek reasoning model: answer in `reasoning_content`, empty
+        // `content`. The parser must promote reasoning to visible text.
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "The answer is 42 because..."
+                }
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 200}
+        });
+        let r = parse_openai(v).unwrap();
+        assert_eq!(r.text, "The answer is 42 because...");
+        assert_eq!(r.reasoning, "");
+        assert_eq!(r.stop, ProviderStop::EndTurn);
+    }
+
+    #[test]
+    fn parse_openai_promotes_reasoning_content_when_content_is_gateway_placeholder() {
+        // Gateway placeholder: "[System: Empty message content sanitised
+        // to satisfy protocol...". The parser must recognize this as empty
+        // and promote reasoning_content.
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "[System: Empty message content sanitised to satisfy protocol...]",
+                    "reasoning_content": "The answer is 42 because..."
+                }
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 200}
+        });
+        let r = parse_openai(v).unwrap();
+        assert_eq!(r.text, "The answer is 42 because...");
+        assert_eq!(r.reasoning, "");
+        assert_eq!(r.stop, ProviderStop::EndTurn);
+    }
+
+    #[test]
+    fn parse_openai_empty_end_turn_with_no_reasoning_is_warned() {
+        // Truly empty end_turn: no content, no reasoning, no tool calls.
+        // The parser must allow it (the model may choose silence) but the
+        // agent should warn about it at the turn level.
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": ""
+                }
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 0}
+        });
+        let r = parse_openai(v).unwrap();
+        assert_eq!(r.text, "");
+        assert_eq!(r.stop, ProviderStop::EndTurn);
+    }
+
+    #[test]
+    fn parse_openai_does_not_promote_reasoning_when_content_present() {
+        // Normal case: content present, reasoning present. Both survive.
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello world",
+                    "reasoning_content": "thinking step by step"
+                }
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50}
+        });
+        let r = parse_openai(v).unwrap();
+        assert_eq!(r.text, "Hello world");
+        assert_eq!(r.reasoning, "thinking step by step");
+        assert_eq!(r.stop, ProviderStop::EndTurn);
+    }
+
+    #[test]
+    fn parse_openai_does_not_reject_empty_end_turn_with_tool_calls() {
+        // Tool calls with empty text is a valid end_turn (e.g. model just
+        // calls tools without speaking). Must not be rejected.
+        let v = serde_json::json!({
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"}
+                    }]
+                }
+            }],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 10}
+        });
+        let r = parse_openai(v).unwrap();
+        assert!(r.tool_calls.len() == 1);
+    }
+
+    #[test]
     fn parse_responses_total_tokens_present_is_read() {
         // Responses API: `usage.total_tokens` is a genuine provider total.
         let v = serde_json::json!({
@@ -5370,6 +5529,36 @@ mod tests {
         });
         let r = parse_responses(v).unwrap();
         assert_eq!(r.total_tokens, None);
+    }
+
+    #[test]
+    fn parse_responses_promotes_reasoning_to_text_when_text_empty() {
+        // Responses API: reasoning items present but no output_text.
+        let v = serde_json::json!({
+            "output": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "The answer is 42"}]},
+                {"type": "message", "content": []}
+            ],
+            "status": "completed",
+            "usage": {"input_tokens": 80, "output_tokens": 20}
+        });
+        let r = parse_responses(v).unwrap();
+        assert_eq!(r.text, "The answer is 42");
+        assert_eq!(r.reasoning, "");
+    }
+
+    #[test]
+    fn parse_responses_empty_end_turn_with_no_reasoning_is_ok() {
+        // Responses API: empty output, no reasoning, status completed.
+        // The parser allows it (model may choose silence).
+        let v = serde_json::json!({
+            "output": [{"type": "message", "content": []}],
+            "status": "completed",
+            "usage": {"input_tokens": 80, "output_tokens": 0}
+        });
+        let r = parse_responses(v).unwrap();
+        assert_eq!(r.text, "");
+        assert_eq!(r.stop, ProviderStop::EndTurn);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When using OpenAI-compatible reasoning models (e.g. DeepSeek, etc.), the model often puts the entire answer in `reasoning_content` while leaving `content` empty (or with a gateway placeholder like `[System: Empty message content sanitised...]`). The `parse_openai` function extracted `text=""` and `reasoning="answer"`, but `agent_message_chunk` was never emitted (gated on `!text.is_empty()`), so the turn ended silently with `end_turn` — no error, no warning, just an empty reply.

The user sees the agent "turn" complete normally, but the channel gets no message.

## Root Cause

`parse_openai` in `crates/buzz-agent/src/llm.rs` did not check whether `reasoning_content` should be promoted to visible text when `content` is empty. The same gap existed in `parse_responses` (Responses API route) and `parse_anthropic` (Anthropic extended thinking).

## Fix

1. **`openai_content_parts()`**: Recognize a gateway placeholder prefix (`[System: Empty message content sanitised...]`) as empty content, so `reasoning_content` is promoted to visible text.
2. **`parse_openai()`**: After extracting `text`+`reasoning`, if `text` is empty and `reasoning` is non-empty, swap them so the model's answer reaches the agent's publish path.
3. **`parse_responses()`**: Same promotion logic for the Responses API route.
4. **`parse_anthropic()`**: Same promotion logic for Anthropic extended thinking blocks.
5. **`agent.rs`**: Added `warn!`-level logging when `end_turn` fires with no publish attempt and `require_reply` is enabled, giving operators a signal in the logs to detect silent drops.

## Tests

7 new tests covering:
- `parse_openai_promotes_reasoning_content_to_text_when_content_empty` — empty `content` with `reasoning_content` → text promoted
- `parse_openai_promotes_reasoning_content_when_content_is_gateway_placeholder` — gateway placeholder recognized as empty
- `parse_openai_empty_end_turn_with_no_reasoning_is_warned` — genuinely empty end_turn is allowed (model may choose silence)
- `parse_openai_does_not_promote_reasoning_when_content_present` — normal case: both survive
- `parse_openai_does_not_reject_empty_end_turn_with_tool_calls` — tool calls with empty text is valid
- `parse_responses_promotes_reasoning_to_text_when_text_empty` — Responses API reasoning promotion
- `parse_responses_empty_end_turn_with_no_reasoning_is_ok` — Responses API empty end_turn allowed

All 484 unit tests pass.

## Local Reproduction

```bash
# Set up a buzz-agent config with a reasoning model that returns
# content="" and reasoning_content="answer"
# Run a prompt; observe the agent turn completes with no channel message.
# With this fix, the reasoning content is promoted to visible text
# and published to the channel.
```
