### PR TITLE
fix(desktop): reject duplicate agent names

### DIFF
--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -725,16 +725,51 @@ pub async fn update_managed_agent(
             state.clear_agent_session_caches(pubkey);
         }
 
+        // Duplicate-name guard: run this BEFORE find_managed_agent_mut so the
+        // immutable &records borrow does not conflict with the mutable borrow
+        // below.
+        let maybe_rename = if let Some(name_update) = &input.name {
+            let candidate = name_update.trim().to_string();
+            let current_name = records
+                .iter()
+                .find(|r| r.pubkey == input.pubkey)
+                .map(|r| r.name.clone());
+            if !candidate.is_empty() {
+                let dup = crate::managed_agents::find_duplicate_keyed_name(
+                    &records,
+                    &candidate,
+                    Some(&input.pubkey),
+                );
+                if let Some(cur) = current_name {
+                    if candidate != cur && dup.is_none() {
+                        Some(candidate)
+                    } else if dup.is_some() {
+                        return Err(format!("agent with name '{candidate}' already exists"));
+                    } else {
+                        None
+                    }
+                } else {
+                    // No existing record found — should not happen after
+                    // find_managed_agent_mut succeeds below. Reject silently.
+                    if dup.is_some() {
+                        return Err(format!("agent with name '{candidate}' already exists"));
+                    }
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;
         let previous_record = record.clone();
 
         let mut name_changed = false;
-        if let Some(name_update) = input.name {
-            let trimmed = name_update.trim().to_string();
-            if !trimmed.is_empty() && trimmed != record.name {
-                record.name = trimmed;
-                name_changed = true;
-            }
+        if let Some(trimmed) = maybe_rename {
+            record.name = trimmed;
+            name_changed = true;
         }
         apply_model_provider_prompt_update(
             record,

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -634,6 +634,11 @@ pub async fn create_managed_agent(
         if records.iter().any(|record| record.pubkey == pubkey) {
             return Err(format!("agent {pubkey} already exists"));
         }
+        // Reject duplicate names among keyed managed instances (trimmed,
+        // case-insensitive).
+        if crate::managed_agents::find_duplicate_keyed_name(&records, &name, None).is_some() {
+            return Err(format!("agent with name '{name}' already exists"));
+        }
         let private_key_nsec = keys
             .secret_key()
             .to_bech32()
@@ -701,6 +706,11 @@ pub async fn create_managed_agent(
         // (extremely unlikely but safe to check).
         if records.iter().any(|record| record.pubkey == pubkey) {
             return Err(format!("agent {pubkey} already exists"));
+        }
+        // Re-check duplicate name under the final lock (race between Phase 1
+        // check and Phase 3 save is extremely unlikely but safe to close).
+        if crate::managed_agents::find_duplicate_keyed_name(&records, &name, None).is_some() {
+            return Err(format!("agent with name '{name}' already exists"));
         }
         // Provider config was already validated in Pre-Phase 2; cache the discovered binary path for deploy_to_provider.
         let provider_binary_path = if let BackendKind::Provider { ref id, .. } = input.backend {

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -40,6 +40,8 @@ pub(crate) mod storage;
 pub(crate) mod team_events;
 mod team_repair;
 mod teams;
+#[cfg(test)]
+mod tests;
 mod types;
 
 // Shared guard for tests that mutate or read process-global PATH.

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -351,6 +351,25 @@ pub fn find_managed_agent_mut<'a>(
         .ok_or_else(|| format!("agent {pubkey} not found"))
 }
 
+/// Return the first keyed managed instance whose trimmed name matches `candidate`
+/// (case-insensitive).
+///
+/// A keyed instance has a non-empty `pubkey`.  Keyless definition rows are
+/// excluded so that rename-collision logic never trips on persona /
+/// template definitions.
+pub fn find_duplicate_keyed_name<'a>(
+    records: &'a [ManagedAgentRecord],
+    candidate: &str,
+    exclude_pubkey: Option<&str>,
+) -> Option<&'a ManagedAgentRecord> {
+    let target = candidate.trim().to_lowercase();
+    records.iter().find(|r| {
+        !r.pubkey.is_empty()
+            && exclude_pubkey.map_or(true, |pk| r.pubkey != pk)
+            && r.name.trim().to_lowercase() == target
+    })
+}
+
 /// Pure decision function for the inbound author gate env vars.
 ///
 /// Returns the env vars to **set** and the env vars to **remove**. Removal is

--- a/desktop/src-tauri/src/managed_agents/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/tests.rs
@@ -1,0 +1,128 @@
+use super::runtime::find_duplicate_keyed_name;
+use super::{ManagedAgentRecord, RespondTo};
+
+fn keyed(name: &str, pubkey: &str) -> ManagedAgentRecord {
+    ManagedAgentRecord {
+        pubkey: pubkey.to_string(),
+        name: name.to_string(),
+        private_key_nsec: "nsec1fake".to_string(),
+        persona_id: None,
+        auth_tag: None,
+        relay_url: String::new(),
+        avatar_url: None,
+        acp_command: String::new(),
+        agent_command: String::new(),
+        agent_command_override: None,
+        agent_args: vec![],
+        mcp_command: String::new(),
+        turn_timeout_seconds: 0,
+        idle_timeout_seconds: None,
+        max_turn_duration_seconds: None,
+        parallelism: 1,
+        system_prompt: None,
+        model: None,
+        provider: None,
+        persona_source_version: None,
+        env_vars: std::collections::BTreeMap::new(),
+        start_on_app_launch: false,
+        runtime_pid: None,
+        backend: crate::managed_agents::BackendKind::Local,
+        backend_agent_id: None,
+        provider_binary_path: None,
+        team_id: None,
+        persona_team_dir: None,
+        persona_name_in_team: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+        last_started_at: None,
+        last_stopped_at: None,
+        last_exit_code: None,
+        last_error: None,
+        last_error_code: None,
+        respond_to: RespondTo::OwnerOnly,
+        respond_to_allowlist: vec![],
+        display_name: None,
+        slug: None,
+        runtime: None,
+        name_pool: vec![],
+        is_builtin: false,
+        is_active: true,
+        shared: false,
+        source_team: None,
+        source_team_persona_slug: None,
+        catalog_source: None,
+        relay_mesh: None,
+        auto_restart_on_config_change: false,
+        definition_respond_to: None,
+        definition_respond_to_allowlist: vec![],
+        definition_parallelism: None,
+    }
+}
+
+fn keyless(name: &str) -> ManagedAgentRecord {
+    let mut r = keyed(name, "keyless");
+    r.private_key_nsec = String::new();
+    r.pubkey = String::new();
+    r
+}
+
+#[test]
+fn exact_case_collision_detected() {
+    let records = vec![keyed("Duncan", "pk1")];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", None).is_some());
+}
+
+#[test]
+fn case_insensitive_collision_detected() {
+    let records = vec![keyed("Duncan", "pk1")];
+    assert!(find_duplicate_keyed_name(&records, "duncan", None).is_some());
+    assert!(find_duplicate_keyed_name(&records, "DUNCAN", None).is_some());
+}
+
+#[test]
+fn whitespace_normalized_before_comparison() {
+    let records = vec![keyed("  Duncan  ", "pk1")];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", None).is_some());
+}
+
+#[test]
+fn no_match_when_names_differ() {
+    let records = vec![keyed("Duncan", "pk1")];
+    assert!(find_duplicate_keyed_name(&records, "Paul", None).is_none());
+}
+
+#[test]
+fn keyless_records_excluded() {
+    let records = vec![keyless("Duncan")];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", None).is_none());
+}
+
+#[test]
+fn exclude_pubkey_skips_self() {
+    let records = vec![keyed("Duncan", "pk1")];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", Some("pk1")).is_none());
+}
+
+#[test]
+fn exclude_pubkey_still_catches_other_duplicate() {
+    let records = vec![keyed("Duncan", "pk1"), keyed("duncan", "pk2")];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", Some("pk1")).is_some());
+}
+
+#[test]
+fn multiple_keyed_records_first_match_returned() {
+    let records = vec![
+        keyed("Duncan", "pk1"),
+        keyed("duncan", "pk2"),
+        keyed("DUncAn", "pk3"),
+    ];
+    let found = find_duplicate_keyed_name(&records, "Duncan", None);
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().pubkey, "pk1");
+}
+
+#[test]
+fn empty_record_list_no_match() {
+    let records: Vec<ManagedAgentRecord> = vec![];
+    assert!(find_duplicate_keyed_name(&records, "Duncan", None).is_none());
+}


### PR DESCRIPTION
## Summary

This prevents duplicate managed-agent names from making mentions ambiguous.

Creating or renaming an agent now rejects a name that matches another managed instance after trimming whitespace and ignoring case. Keyless definition rows are intentionally excluded, and an agent can still keep its own name.

## Why

Each create operation minted a fresh keypair and only checked for a public-key collision. That allowed multiple active agents with the same display name, leaving name-based mention resolution ambiguous. Renames had the same gap.

## Validation

- `cargo fmt --check`
- `cargo test` from `desktop/src-tauri`

The added unit coverage exercises exact, case-insensitive, and whitespace-normalized collisions; self-exclusion during rename; and exclusion of keyless definition records.
