### PR TITLE
fix(mobile): bound startup channel relay load

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,7 +158,7 @@ Note: `KIND_AUTH` (22242) is `pub const KIND_AUTH: u32` in `buzz-core/src/kind.r
 | Relay → Client | `["NOTICE", "message"]` | Informational message |
 | Relay → Client | `["AUTH", <challenge>]` | Authentication challenge |
 
-Max frame size: 65,536 bytes. Max subscriptions per connection: 1024. Max historical results per filter: 500.
+Max frame size: 65,536 bytes. Max subscriptions per connection: 2048. Max historical results per filter: 500.
 
 ---
 
@@ -633,7 +633,7 @@ pub enum AuthState { Pending { challenge: String }, Authenticated(AuthContext), 
 | Constant | Value | Purpose |
 |----------|-------|---------|
 | `MAX_FRAME_BYTES` | 65,536 | Max WebSocket frame size |
-| `MAX_SUBSCRIPTIONS` | 1024 | Per-connection subscription limit |
+| `MAX_SUBSCRIPTIONS` | 2048 | Per-connection subscription limit |
 | `MAX_HISTORICAL_LIMIT` | 500 | Per-filter historical query cap |
 | `handler_semaphore` capacity | 1024 | Concurrent EVENT/REQ handlers |
 

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -22,7 +22,7 @@ use crate::connection::{AuthState, ConnectionState};
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
 
-const MAX_SUBSCRIPTIONS: usize = 1024;
+const MAX_SUBSCRIPTIONS: usize = 2048;
 
 /// Maximum `query_events` calls in flight per multi-filter REQ / bridge query.
 ///

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -1545,6 +1545,60 @@ mod tests {
     }
 
     #[test]
+    fn extracted_channel_scope_drives_live_fan_out() {
+        use crate::subscription::SubscriptionRegistry;
+        use buzz_core::StoredEvent;
+        use chrono::Utc;
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+
+        fn stored_channel_event(channel_id: uuid::Uuid) -> StoredEvent {
+            let event = EventBuilder::new(Kind::TextNote, "test")
+                .tags([Tag::parse(["h", &channel_id.to_string()]).expect("valid h tag")])
+                .sign_with_keys(&Keys::generate())
+                .expect("sign");
+            StoredEvent::with_received_at(event, Utc::now(), Some(channel_id), true)
+        }
+
+        let channel_a = uuid::Uuid::new_v4();
+        let channel_b = uuid::Uuid::new_v4();
+        let channel_a_filter = filter_with_channel(channel_a).kind(Kind::TextNote);
+        let registry = SubscriptionRegistry::new();
+        let conn_id = uuid::Uuid::new_v4();
+        registry.register(
+            conn_id,
+            "channel-a".into(),
+            vec![channel_a_filter.clone()],
+            extract_channel_id_from_filters(std::slice::from_ref(&channel_a_filter)),
+        );
+
+        assert_eq!(
+            registry.fan_out(&stored_channel_event(channel_a)),
+            vec![(conn_id, "channel-a".into())],
+        );
+        assert!(registry
+            .fan_out(&stored_channel_event(channel_b))
+            .is_empty());
+
+        let aggregate_filter = Filter::new().kind(Kind::TextNote).custom_tags(
+            SingleLetterTag::lowercase(Alphabet::H),
+            [channel_a.to_string(), channel_b.to_string()],
+        );
+        let aggregate_registry = SubscriptionRegistry::new();
+        aggregate_registry.register(
+            uuid::Uuid::new_v4(),
+            "aggregate".into(),
+            vec![aggregate_filter.clone()],
+            extract_channel_id_from_filters(&[aggregate_filter]),
+        );
+        assert!(aggregate_registry
+            .fan_out(&stored_channel_event(channel_a))
+            .is_empty(),);
+        assert!(aggregate_registry
+            .fan_out(&stored_channel_event(channel_b))
+            .is_empty(),);
+    }
+
+    #[test]
     fn test_extract_channel_id_single_channel() {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id)];

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -106,7 +106,7 @@ fn relay_limitation(max_message_length: usize) -> RelayLimitation {
 
     RelayLimitation {
         max_message_length: Some(max_message_length as u64),
-        max_subscriptions: Some(1024),
+        max_subscriptions: Some(2048),
         max_filters: Some(10),
         max_limit: Some(buzz_db::DEFAULT_MAX_PAGE_LIMIT as u32),
         max_subid_length: Some(256),

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -799,7 +799,7 @@ async fn test_auth_event_kind_rejected() {
 /// This is a protocol-cap test, not an admission-throughput test. Open one REQ
 /// at a time and wait out any shared fixed-window quota before retrying a REQ
 /// rejected specifically as `rate-limited`, so production admission remains
-/// enabled while the test deterministically reaches the independent 1024 cap.
+/// enabled while the test deterministically reaches the independent 2048 cap.
 #[tokio::test]
 #[ignore]
 async fn test_subscription_limit_enforced() {
@@ -807,7 +807,7 @@ async fn test_subscription_limit_enforced() {
     let keys = Keys::generate();
     let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
 
-    for i in 0..1024 {
+    for i in 0..2048 {
         let sid = format!("limit-sub-{i}");
         let filter = Filter::new().kind(Kind::Custom(49_999));
         subscribe_until_eose(&mut client, &sid, filter).await;
@@ -914,8 +914,8 @@ async fn test_nip11_relay_info() {
     let limitation = body.get("limitation").expect("Missing 'limitation' field");
     assert_eq!(
         limitation.get("max_subscriptions").and_then(|v| v.as_u64()),
-        Some(1024),
-        "limitation.max_subscriptions must be 1024"
+        Some(2048),
+        "limitation.max_subscriptions must be 2048"
     );
     // The REQ, EVENT, and COUNT handlers unconditionally require an
     // authenticated connection, so the NIP-11 doc must advertise that.

--- a/mobile/lib/features/channels/channel_sync.dart
+++ b/mobile/lib/features/channels/channel_sync.dart
@@ -11,6 +11,7 @@ import 'unread_badge/should_notify_for_event.dart';
 
 const lastMessageQueryBatchSize = 100;
 const lastMessageQueryTotalTimeout = Duration(seconds: 8);
+const liveSubscriptionReadyTimeout = Duration(seconds: 8);
 
 Future<List<NostrEvent>> fetchChannelHistoryBatch(
   RelaySessionNotifier session,
@@ -177,6 +178,31 @@ Map<String, int> resolveChannelLastMessages(
 
 typedef TaskDelay = Future<void> Function(Duration duration);
 typedef TaskErrorHandler = void Function(Object error);
+typedef CancellationTimer =
+    Timer Function(Duration duration, void Function() callback);
+typedef PendingSubscription =
+    Future<void Function()> Function(Future<void> cancelled);
+
+Future<void Function()> subscribeWhenReadyWithTimeout(
+  PendingSubscription subscribe,
+  Completer<void> cancellation, {
+  Duration timeout = liveSubscriptionReadyTimeout,
+  CancellationTimer timerFactory = Timer.new,
+}) async {
+  var timedOut = false;
+  final timer = timerFactory(timeout, () {
+    timedOut = true;
+    if (!cancellation.isCompleted) cancellation.complete();
+  });
+  try {
+    return await subscribe(cancellation.future);
+  } on RelaySubscriptionCancelledException {
+    if (timedOut) throw TimeoutException('Relay EOSE timed out after $timeout');
+    rethrow;
+  } finally {
+    timer.cancel();
+  }
+}
 
 Future<void> runPacedTasks(
   List<Future<void> Function()> tasks, {

--- a/mobile/lib/features/channels/channel_sync.dart
+++ b/mobile/lib/features/channels/channel_sync.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+
+import '../../shared/relay/relay.dart';
+import '../../shared/utils/string_utils.dart';
+import 'channel.dart';
+import 'unread_badge/should_notify_for_event.dart';
+
+const lastMessageQueryBatchSize = 100;
+const lastMessageQueryTotalTimeout = Duration(seconds: 8);
+
+Future<List<NostrEvent>> fetchChannelHistoryBatch(
+  RelaySessionNotifier session,
+  List<NostrFilter> filters, {
+  required String operation,
+  required bool Function() isCancelled,
+}) async {
+  if (filters.isEmpty || isCancelled()) return const [];
+
+  try {
+    return await session.queryRelay(filters);
+  } catch (error) {
+    debugPrint(
+      '[ChannelsNotifier] batched $operation failed; '
+      'using bounded websocket fallback: $error',
+    );
+  }
+
+  const fallbackConcurrency = 4;
+  final events = <NostrEvent>[];
+  for (var start = 0; start < filters.length; start += fallbackConcurrency) {
+    if (isCancelled()) break;
+    final end = min(start + fallbackConcurrency, filters.length);
+    final results = await Future.wait(
+      filters.sublist(start, end).map((filter) async {
+        try {
+          return await session.fetchHistory(filter);
+        } catch (_) {
+          return const <NostrEvent>[];
+        }
+      }),
+    );
+    if (isCancelled()) break;
+    for (final result in results) {
+      events.addAll(result);
+    }
+  }
+  return events;
+}
+
+Future<Set<String>> fetchHiddenDmIds(
+  RelaySessionNotifier session,
+  String myPk,
+) async {
+  try {
+    final events = await session.fetchHistory(NostrFilters.hiddenDms(myPk));
+    if (events.isEmpty) return const {};
+    NostrEvent latest = events.first;
+    for (final event in events.skip(1)) {
+      if (event.createdAt > latest.createdAt) {
+        latest = event;
+      }
+    }
+    return {
+      for (final tag in latest.tags)
+        if (tag.length >= 2 && tag[0] == 'h') tag[1],
+    };
+  } catch (_) {
+    return const {};
+  }
+}
+
+/// Build a [Channel] from a kind:39000 metadata event.
+///
+/// [displayNames] maps lowercase participant pubkey → resolved label and is
+/// used to populate [Channel.participants] for DMs so [Channel.displayLabel]
+/// can render real names instead of the relay-canonical "DM" name.
+Channel channelFromMeta(
+  NostrEvent event, {
+  required bool isMember,
+  Map<String, String> displayNames = const {},
+}) {
+  final data = ChannelData.fromEvent(event);
+  final participants = data.channelType == 'dm'
+      ? [
+          for (final pk in data.participantPubkeys)
+            displayNames[pk.toLowerCase()] ?? shortPubkey(pk),
+        ]
+      : const <String>[];
+  return Channel(
+    id: data.id,
+    name: data.name,
+    channelType: data.channelType,
+    visibility: data.visibility,
+    description: data.description,
+    topic: data.topic,
+    createdBy: event.pubkey,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(
+      event.createdAt * 1000,
+      isUtc: true,
+    ),
+    memberCount: 0,
+    lastMessageAt: null,
+    // `archivedAt` doubles as both the archived-state flag and the timestamp.
+    // The kind:39000 metadata only carries `["archived", "true"]`, not the
+    // moment of archival, so we stamp the event's `createdAt` — that's when
+    // the relay republished the metadata, which is the closest signal we have.
+    archivedAt: data.isArchived
+        ? DateTime.fromMillisecondsSinceEpoch(
+            event.createdAt * 1000,
+            isUtc: true,
+          )
+        : null,
+    participants: participants,
+    participantPubkeys: data.participantPubkeys,
+    isMember: isMember,
+    ttlSeconds: data.ttlSeconds,
+    ttlDeadline: data.ttlDeadline,
+  );
+}
+
+List<List<Channel>> chunkChannelsForLastMessageQuery(List<Channel> channels) =>
+    [
+      for (
+        var start = 0;
+        start < channels.length;
+        start += lastMessageQueryBatchSize
+      )
+        channels.sublist(
+          start,
+          min(start + lastMessageQueryBatchSize, channels.length),
+        ),
+    ];
+
+List<NostrFilter> buildChannelLastMessageFilters(List<Channel> channels) => [
+  for (final channel in channels)
+    NostrFilter(
+      kinds: EventKind.channelMessageEventKinds,
+      tags: {
+        '#h': [channel.id],
+      },
+      limit: channel.isDm ? 1 : 20,
+    ),
+];
+
+Map<String, int> resolveChannelLastMessages(
+  List<Channel> channels,
+  Iterable<NostrEvent> events, {
+  required String myPk,
+  Set<String> mutedChannelIds = const {},
+}) {
+  final channelsById = {for (final channel in channels) channel.id: channel};
+  final result = <String, int>{};
+  for (final event in events) {
+    final channelId = event.channelId;
+    final channel = channelId == null ? null : channelsById[channelId];
+    if (channel == null) continue;
+    if (!channel.isDm &&
+        !shouldNotifyForEvent(
+          event,
+          myPk,
+          mutedChannelIds: mutedChannelIds,
+          channelId: channelId,
+        )) {
+      continue;
+    }
+    final current = result[channel.id];
+    if (current == null || event.createdAt > current) {
+      result[channel.id] = event.createdAt;
+    }
+  }
+  return result;
+}
+
+typedef TaskDelay = Future<void> Function(Duration duration);
+typedef TaskErrorHandler = void Function(Object error);
+
+Future<void> runPacedTasks(
+  List<Future<void> Function()> tasks, {
+  required int maxConcurrent,
+  required Duration startInterval,
+  required bool Function() isCancelled,
+  TaskDelay delay = defaultTaskDelay,
+  TaskErrorHandler onError = _defaultTaskErrorHandler,
+}) async {
+  if (maxConcurrent < 1) throw ArgumentError.value(maxConcurrent);
+  var nextTask = 0;
+  var firstStart = true;
+  Future<void> startPermit = Future.value();
+
+  Future<bool> acquireStartPermit() async {
+    if (firstStart) {
+      firstStart = false;
+    } else {
+      startPermit = startPermit.then((_) => delay(startInterval));
+      await startPermit;
+    }
+    return !isCancelled();
+  }
+
+  Future<void> worker() async {
+    while (true) {
+      final index = nextTask++;
+      if (index >= tasks.length) return;
+      if (!await acquireStartPermit()) return;
+      try {
+        await tasks[index]();
+      } catch (error) {
+        onError(error);
+      }
+    }
+  }
+
+  await Future.wait([
+    for (var i = 0; i < min(maxConcurrent, tasks.length); i++) worker(),
+  ]);
+}
+
+Future<void> defaultTaskDelay(Duration duration) =>
+    Future<void>.delayed(duration);
+
+void _defaultTaskErrorHandler(Object error) {
+  debugPrint('[ChannelsNotifier] paced task failed: $error');
+}
+
+bool sameStringSet(Set<String> left, Set<String> right) =>
+    left.length == right.length && left.containsAll(right);
+
+String? observedUnreadRootId(NostrEvent event) =>
+    isBroadcastReply(event) ? null : event.threadReference.rootId;
+
+bool isBroadcastReply(NostrEvent event) => event.tags.any(
+  (tag) => tag.length >= 2 && tag[0] == 'broadcast' && tag[1] == '1',
+);
+
+Set<String> readRootIdSet(String? raw) {
+  if (raw == null || raw.isEmpty) return {};
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return {};
+    return {
+      for (final value in decoded)
+        if (value is String) value,
+    };
+  } catch (_) {
+    return {};
+  }
+}
+
+String encodeRootIdSet(Set<String> values) => jsonEncode(values.toList());

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'dart:math';
-
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme_provider.dart';
 import '../../shared/utils/string_utils.dart';
@@ -26,12 +24,9 @@ const _participatedRootIdsPrefix = 'buzz-thread-participation.v1';
 const _authoredRootIdsPrefix = 'buzz-thread-authored.v1';
 
 /// Loads the user's channel list from the relay over WebSocket.
-///
-/// Two-step query:
 ///   1. Fetch kind:39002 membership events tagged `#p:<my-pubkey>` to find
 ///      the channel ids I'm a member of.
 ///   2. Fetch the corresponding kind:39000 channel metadata events.
-///
 /// Live updates are layered on top via per-channel subscriptions on the
 /// `#h` tag for any of the visible channel event kinds — incoming events
 /// bump `lastMessageAt` for that channel.
@@ -566,26 +561,30 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
             final attempt = Object();
             var terminallyClosed = false;
             _pendingSubscriptionCancellations[channelId] = cancellation;
-            final unsubscribe = await session.subscribeWhenReady(
-              NostrFilter(
-                kinds: EventKind.channelEventKinds,
-                tags: {
-                  '#h': [channelId],
+            final unsubscribe = await subscribeWhenReadyWithTimeout(
+              (cancelled) => session.subscribeWhenReady(
+                NostrFilter(
+                  kinds: EventKind.channelEventKinds,
+                  tags: {
+                    '#h': [channelId],
+                  },
+                  limit: 0,
+                ),
+                _handleLiveEvent,
+                onClosed: (_) {
+                  terminallyClosed = true;
+                  final current = _liveSubscriptionsByChannel[channelId];
+                  if (current?.attempt != attempt) return;
+                  _liveSubscriptionsByChannel.remove(channelId);
+                  _terminallyClosedChannelIds.add(channelId);
+                  _unreadCatchUpChannelIds = Set.unmodifiable(
+                    _unreadCatchUpChannelIds.difference({channelId}),
+                  );
                 },
-                limit: 0,
+                cancelled: cancelled,
               ),
-              _handleLiveEvent,
-              onClosed: (_) {
-                terminallyClosed = true;
-                final current = _liveSubscriptionsByChannel[channelId];
-                if (current?.attempt != attempt) return;
-                _liveSubscriptionsByChannel.remove(channelId);
-                _terminallyClosedChannelIds.add(channelId);
-                _unreadCatchUpChannelIds = Set.unmodifiable(
-                  _unreadCatchUpChannelIds.difference({channelId}),
-                );
-              },
-              cancelled: cancellation.future,
+              cancellation,
+              timeout: ref.read(channelsLiveSubscriptionReadyTimeoutProvider),
             );
             _pendingSubscriptionCancellations.remove(channelId);
             if (terminallyClosed) {
@@ -613,8 +612,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
               attempt: attempt,
               unsubscribe: unsubscribe,
             );
-          } on RelaySubscriptionCancelledException {
-            // The desired channel set, relay, or provider lifetime changed.
+          } on TimeoutException catch (_) {
+          } on RelaySubscriptionCancelledException catch (_) {
           } catch (error) {
             debugPrint(
               '[ChannelsNotifier] live subscription failed for $channelId: $error',
@@ -994,6 +993,9 @@ final channelsProvider = AsyncNotifierProvider<ChannelsNotifier, List<Channel>>(
   ChannelsNotifier.new,
 );
 
+final channelsLiveSubscriptionReadyTimeoutProvider = Provider<Duration>(
+  (_) => liveSubscriptionReadyTimeout,
+);
 final channelsLiveSubscriptionDelayProvider = Provider<TaskDelay>(
   (_) => defaultTaskDelay,
 );

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
@@ -9,6 +8,7 @@ import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme_provider.dart';
 import '../../shared/utils/string_utils.dart';
 import 'channel.dart';
+import 'channel_sync.dart';
 import 'channel_management_provider.dart'
     show ChannelMember, channelDetailsProvider;
 import 'channel_mutes/channel_mutes_provider.dart';
@@ -20,8 +20,6 @@ import 'unread_badge/should_notify_for_event.dart';
 
 const _channelTypeOrder = {'stream': 0, 'forum': 1, 'dm': 2};
 const _unreadCatchUpLimit = 1000;
-const _lastMessageQueryBatchSize = 100;
-const _lastMessageQueryTotalTimeout = Duration(seconds: 8);
 const _unreadCatchUpConcurrency = 4;
 const _unreadCatchUpStartInterval = Duration(milliseconds: 125);
 const _participatedRootIdsPrefix = 'buzz-thread-participation.v1';
@@ -43,6 +41,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   final Map<String, ({Object attempt, void Function() unsubscribe})>
   _liveSubscriptionsByChannel = {};
   final Map<String, Completer<void>> _pendingSubscriptionCancellations = {};
+  final Set<String> _terminallyClosedChannelIds = {};
   Future<void> _liveSubscriptionQueue = Future.value();
   List<Channel> _desiredLiveChannels = const [];
   Set<String> _desiredLiveChannelIds = const {};
@@ -73,7 +72,6 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
   Map<String, int> get latestObservedByChannel =>
       Map.unmodifiable(_latestObservedByChannel);
-
   Map<String, Map<String, ObservedUnreadEvent>>
   get observedUnreadEventsByChannel =>
       Map<String, Map<String, ObservedUnreadEvent>>.unmodifiable({
@@ -112,6 +110,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
           !connected.isCompleted) {
         connected.complete();
       } else if (previous?.status != SessionStatus.connected) {
+        _terminallyClosedChannelIds.clear();
         unawaited(_backstopRefresh());
       }
     });
@@ -252,11 +251,11 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       }
     }
 
-    final hiddenDmIds = await _fetchHiddenDmIds(session, myPk);
+    final hiddenDmIds = await fetchHiddenDmIds(session, myPk);
 
     final channels = <Channel>[];
     for (final event in dedupedMetas) {
-      final channel = _channelFromMeta(
+      final channel = channelFromMeta(
         event,
         isMember: true,
         displayNames: displayNames,
@@ -338,8 +337,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       // so a slow relay cannot delay live subscription setup once per batch.
       final queryStopwatch = Stopwatch()..start();
       for (final batch in chunkChannelsForLastMessageQuery(activeChannels)) {
-        final remaining =
-            _lastMessageQueryTotalTimeout - queryStopwatch.elapsed;
+        final remaining = lastMessageQueryTotalTimeout - queryStopwatch.elapsed;
         if (remaining <= Duration.zero) {
           debugPrint('[ChannelsNotifier] last-message query budget exhausted');
           break;
@@ -430,11 +428,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         _applyLiveEventToChannels(channels, event, myPk);
       }
       _bootstrapLiveEvents.clear();
-      if (channels.length <= _lastMessageQueryBatchSize) {
-        await bootstrapLiveSync;
-      } else {
-        unawaited(bootstrapLiveSync!);
-      }
+      unawaited(bootstrapLiveSync!);
     }
     return channels;
   }
@@ -473,116 +467,6 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     _memberSnapshotsByChannelId = Map.unmodifiable(snapshots);
   }
 
-  Future<List<NostrEvent>> _fetchChannelHistoryBatch(
-    RelaySessionNotifier session,
-    List<NostrFilter> filters, {
-    required String operation,
-    required bool Function() isCancelled,
-  }) async {
-    if (filters.isEmpty || isCancelled()) return const [];
-
-    try {
-      return await session.queryRelay(filters);
-    } catch (error) {
-      debugPrint(
-        '[ChannelsNotifier] batched $operation failed; '
-        'using bounded websocket fallback: $error',
-      );
-    }
-
-    const fallbackConcurrency = 4;
-    final events = <NostrEvent>[];
-    for (var start = 0; start < filters.length; start += fallbackConcurrency) {
-      if (isCancelled()) break;
-      final end = min(start + fallbackConcurrency, filters.length);
-      final results = await Future.wait(
-        filters.sublist(start, end).map((filter) async {
-          try {
-            return await session.fetchHistory(filter);
-          } catch (_) {
-            return const <NostrEvent>[];
-          }
-        }),
-      );
-      if (isCancelled()) break;
-      for (final result in results) {
-        events.addAll(result);
-      }
-    }
-    return events;
-  }
-
-  Future<Set<String>> _fetchHiddenDmIds(
-    RelaySessionNotifier session,
-    String myPk,
-  ) async {
-    try {
-      final events = await session.fetchHistory(NostrFilters.hiddenDms(myPk));
-      if (events.isEmpty) return const {};
-      NostrEvent latest = events.first;
-      for (final event in events.skip(1)) {
-        if (event.createdAt > latest.createdAt) {
-          latest = event;
-        }
-      }
-      return {
-        for (final tag in latest.tags)
-          if (tag.length >= 2 && tag[0] == 'h') tag[1],
-      };
-    } catch (_) {
-      return const {};
-    }
-  }
-
-  /// Build a [Channel] from a kind:39000 metadata event.
-  ///
-  /// [displayNames] maps lowercase participant pubkey → resolved label and is
-  /// used to populate [Channel.participants] for DMs so [Channel.displayLabel]
-  /// can render real names instead of the relay-canonical "DM" name.
-  Channel _channelFromMeta(
-    NostrEvent event, {
-    required bool isMember,
-    Map<String, String> displayNames = const {},
-  }) {
-    final data = ChannelData.fromEvent(event);
-    final participants = data.channelType == 'dm'
-        ? [
-            for (final pk in data.participantPubkeys)
-              displayNames[pk.toLowerCase()] ?? shortPubkey(pk),
-          ]
-        : const <String>[];
-    return Channel(
-      id: data.id,
-      name: data.name,
-      channelType: data.channelType,
-      visibility: data.visibility,
-      description: data.description,
-      topic: data.topic,
-      createdBy: event.pubkey,
-      createdAt: DateTime.fromMillisecondsSinceEpoch(
-        event.createdAt * 1000,
-        isUtc: true,
-      ),
-      memberCount: 0,
-      lastMessageAt: null,
-      // `archivedAt` doubles as both the archived-state flag and the timestamp.
-      // The kind:39000 metadata only carries `["archived", "true"]`, not the
-      // moment of archival, so we stamp the event's `createdAt` — that's when
-      // the relay republished the metadata, which is the closest signal we have.
-      archivedAt: data.isArchived
-          ? DateTime.fromMillisecondsSinceEpoch(
-              event.createdAt * 1000,
-              isUtc: true,
-            )
-          : null,
-      participants: participants,
-      participantPubkeys: data.participantPubkeys,
-      isMember: isMember,
-      ttlSeconds: data.ttlSeconds,
-      ttlDeadline: data.ttlDeadline,
-    );
-  }
-
   /// Subscribe per-channel to live events (requires `#h` tag for relay
   /// channel-scoped fan-out). Also starts a 60s WS backstop poll to detect
   /// newly created channels we don't yet have subscriptions for.
@@ -592,7 +476,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         if (channel.isMember && !channel.isArchived) channel.id,
     };
     final relayBaseUrl = ref.read(relayConfigProvider).baseUrl;
-    if (!_sameStringSet(_unreadCatchUpChannelIds, channelIds)) {
+    if (!sameStringSet(_unreadCatchUpChannelIds, channelIds)) {
       // Stop admitting work from the old channel set while its replacement
       // live subscriptions are being established.
       _unreadCatchUpGeneration++;
@@ -601,6 +485,9 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       if (channelIds.contains(entry.key)) continue;
       _pendingSubscriptionCancellations.remove(entry.key);
       if (!entry.value.isCompleted) entry.value.complete();
+    }
+    if (!sameStringSet(_desiredLiveChannelIds, channelIds)) {
+      _terminallyClosedChannelIds.clear();
     }
     _desiredLiveChannels = channels;
     _desiredLiveChannelIds = channelIds;
@@ -662,7 +549,9 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
     final newChannelIds = [
       for (final channelId in channelIds)
-        if (!_liveSubscriptionsByChannel.containsKey(channelId)) channelId,
+        if (!_liveSubscriptionsByChannel.containsKey(channelId) &&
+            !_terminallyClosedChannelIds.contains(channelId))
+          channelId,
     ];
     final subscribeTasks = <Future<void> Function()>[
       for (final channelId in newChannelIds)
@@ -691,6 +580,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
                 final current = _liveSubscriptionsByChannel[channelId];
                 if (current?.attempt != attempt) return;
                 _liveSubscriptionsByChannel.remove(channelId);
+                _terminallyClosedChannelIds.add(channelId);
                 _unreadCatchUpChannelIds = Set.unmodifiable(
                   _unreadCatchUpChannelIds.difference({channelId}),
                 );
@@ -778,7 +668,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       for (final channel in channels)
         if (channel.isMember && !channel.isArchived) channel.id,
     };
-    if (_sameStringSet(_unreadCatchUpChannelIds, catchUpChannelIds)) return;
+    if (sameStringSet(_unreadCatchUpChannelIds, catchUpChannelIds)) return;
     _unreadCatchUpChannelIds = Set.unmodifiable(catchUpChannelIds);
     final catchUpGeneration = ++_unreadCatchUpGeneration;
     unawaited(_catchUpUnreadEvents(channels, catchUpGeneration));
@@ -830,7 +720,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     ];
 
     try {
-      final events = await _fetchChannelHistoryBatch(
+      final events = await fetchChannelHistoryBatch(
         session,
         filters,
         operation: 'unread catch-up',
@@ -963,10 +853,10 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     _threadInterestPubkey = normalizedPubkey;
     try {
       final prefs = ref.read(savedPrefsProvider);
-      _participatedRootIds = _readRootIdSet(
+      _participatedRootIds = readRootIdSet(
         prefs.getString('$_participatedRootIdsPrefix:$normalizedPubkey'),
       );
-      _authoredRootIds = _readRootIdSet(
+      _authoredRootIds = readRootIdSet(
         prefs.getString('$_authoredRootIdsPrefix:$normalizedPubkey'),
       );
     } catch (_) {
@@ -989,11 +879,11 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       final prefs = ref.read(savedPrefsProvider);
       prefs.setString(
         '$_participatedRootIdsPrefix:$normalizedPubkey',
-        _encodeRootIdSet(_participatedRootIds),
+        encodeRootIdSet(_participatedRootIds),
       );
       prefs.setString(
         '$_authoredRootIdsPrefix:$normalizedPubkey',
-        _encodeRootIdSet(_authoredRootIds),
+        encodeRootIdSet(_authoredRootIds),
       );
     } catch (_) {
       // Ignore storage failures; in-memory interest still works this session.
@@ -1002,7 +892,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
 
   void _recordUnreadEvent(Channel channel, NostrEvent event, String myPk) {
     final isThreadedReply =
-        event.threadReference.parentId != null && !_isBroadcastReply(event);
+        event.threadReference.parentId != null && !isBroadcastReply(event);
     final isHighPriority =
         channel.isDm || isHighPriorityEvent(event.tags, myPk);
     recordObservedUnreadEvent(
@@ -1011,7 +901,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       makeObservedUnreadEvent(
         id: event.id,
         createdAt: event.createdAt,
-        rootId: _observedUnreadRootId(event),
+        rootId: observedUnreadRootId(event),
         highPriority: isHighPriority,
         channelType: channel.channelType,
         isThreadedReply: isThreadedReply,
@@ -1071,6 +961,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     // cached channel list with [] or an error. Wait for `build()` to re-run
     // when the session transitions to connected.
     if (sessionState.status != SessionStatus.connected) return;
+    _terminallyClosedChannelIds.clear();
     state = await AsyncValue.guard(() => _fetch(subscribeLive: true));
   }
 
@@ -1090,6 +981,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       subscription.unsubscribe();
     }
     _liveSubscriptionsByChannel.clear();
+    _terminallyClosedChannelIds.clear();
     _subscriptionRelayBaseUrl = null;
     _backstopTimer?.cancel();
     _backstopTimer = null;
@@ -1103,135 +995,5 @@ final channelsProvider = AsyncNotifierProvider<ChannelsNotifier, List<Channel>>(
 );
 
 final channelsLiveSubscriptionDelayProvider = Provider<TaskDelay>(
-  (_) => _defaultTaskDelay,
+  (_) => defaultTaskDelay,
 );
-
-List<List<Channel>> chunkChannelsForLastMessageQuery(List<Channel> channels) =>
-    [
-      for (
-        var start = 0;
-        start < channels.length;
-        start += _lastMessageQueryBatchSize
-      )
-        channels.sublist(
-          start,
-          min(start + _lastMessageQueryBatchSize, channels.length),
-        ),
-    ];
-
-List<NostrFilter> buildChannelLastMessageFilters(List<Channel> channels) => [
-  for (final channel in channels)
-    NostrFilter(
-      kinds: EventKind.channelMessageEventKinds,
-      tags: {
-        '#h': [channel.id],
-      },
-      limit: channel.isDm ? 1 : 20,
-    ),
-];
-
-Map<String, int> resolveChannelLastMessages(
-  List<Channel> channels,
-  Iterable<NostrEvent> events, {
-  required String myPk,
-  Set<String> mutedChannelIds = const {},
-}) {
-  final channelsById = {for (final channel in channels) channel.id: channel};
-  final result = <String, int>{};
-  for (final event in events) {
-    final channelId = event.channelId;
-    final channel = channelId == null ? null : channelsById[channelId];
-    if (channel == null) continue;
-    if (!channel.isDm &&
-        !shouldNotifyForEvent(
-          event,
-          myPk,
-          mutedChannelIds: mutedChannelIds,
-          channelId: channelId,
-        )) {
-      continue;
-    }
-    final current = result[channel.id];
-    if (current == null || event.createdAt > current) {
-      result[channel.id] = event.createdAt;
-    }
-  }
-  return result;
-}
-
-typedef TaskDelay = Future<void> Function(Duration duration);
-typedef TaskErrorHandler = void Function(Object error);
-
-Future<void> runPacedTasks(
-  List<Future<void> Function()> tasks, {
-  required int maxConcurrent,
-  required Duration startInterval,
-  required bool Function() isCancelled,
-  TaskDelay delay = _defaultTaskDelay,
-  TaskErrorHandler onError = _defaultTaskErrorHandler,
-}) async {
-  if (maxConcurrent < 1) throw ArgumentError.value(maxConcurrent);
-  var nextTask = 0;
-  var firstStart = true;
-  Future<void> startPermit = Future.value();
-
-  Future<bool> acquireStartPermit() async {
-    if (firstStart) {
-      firstStart = false;
-    } else {
-      startPermit = startPermit.then((_) => delay(startInterval));
-      await startPermit;
-    }
-    return !isCancelled();
-  }
-
-  Future<void> worker() async {
-    while (true) {
-      final index = nextTask++;
-      if (index >= tasks.length) return;
-      if (!await acquireStartPermit()) return;
-      try {
-        await tasks[index]();
-      } catch (error) {
-        onError(error);
-      }
-    }
-  }
-
-  await Future.wait([
-    for (var i = 0; i < min(maxConcurrent, tasks.length); i++) worker(),
-  ]);
-}
-
-Future<void> _defaultTaskDelay(Duration duration) =>
-    Future<void>.delayed(duration);
-
-void _defaultTaskErrorHandler(Object error) {
-  debugPrint('[ChannelsNotifier] paced task failed: $error');
-}
-
-bool _sameStringSet(Set<String> left, Set<String> right) =>
-    left.length == right.length && left.containsAll(right);
-
-String? _observedUnreadRootId(NostrEvent event) =>
-    _isBroadcastReply(event) ? null : event.threadReference.rootId;
-
-bool _isBroadcastReply(NostrEvent event) => event.tags.any(
-  (tag) => tag.length >= 2 && tag[0] == 'broadcast' && tag[1] == '1',
-);
-
-Set<String> _readRootIdSet(String? raw) {
-  if (raw == null || raw.isEmpty) return {};
-  try {
-    final decoded = jsonDecode(raw);
-    if (decoded is! List) return {};
-    return {
-      for (final value in decoded)
-        if (value is String) value,
-    };
-  } catch (_) {
-    return {};
-  }
-}
-
-String _encodeRootIdSet(Set<String> values) => jsonEncode(values.toList());

--- a/mobile/lib/features/channels/channels_provider.dart
+++ b/mobile/lib/features/channels/channels_provider.dart
@@ -20,6 +20,10 @@ import 'unread_badge/should_notify_for_event.dart';
 
 const _channelTypeOrder = {'stream': 0, 'forum': 1, 'dm': 2};
 const _unreadCatchUpLimit = 1000;
+const _lastMessageQueryBatchSize = 100;
+const _lastMessageQueryTotalTimeout = Duration(seconds: 8);
+const _unreadCatchUpConcurrency = 4;
+const _unreadCatchUpStartInterval = Duration(milliseconds: 125);
 const _participatedRootIdsPrefix = 'buzz-thread-participation.v1';
 const _authoredRootIdsPrefix = 'buzz-thread-authored.v1';
 
@@ -36,13 +40,19 @@ const _authoredRootIdsPrefix = 'buzz-thread-authored.v1';
 class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
   static const _backstopInterval = Duration(seconds: 60);
 
-  final Map<String, void Function()> _unsubscribersByChannel = {};
+  final Map<String, ({Object attempt, void Function() unsubscribe})>
+  _liveSubscriptionsByChannel = {};
+  final Map<String, Completer<void>> _pendingSubscriptionCancellations = {};
   Future<void> _liveSubscriptionQueue = Future.value();
   List<Channel> _desiredLiveChannels = const [];
   Set<String> _desiredLiveChannelIds = const {};
   int _subscriptionVersion = 0;
   String? _subscriptionRelayBaseUrl;
   Timer? _backstopTimer;
+  int _unreadCatchUpGeneration = 0;
+  Set<String> _unreadCatchUpChannelIds = const {};
+  bool _bufferingBootstrapLiveEvents = false;
+  final List<NostrEvent> _bootstrapLiveEvents = [];
   final Map<String, int> _latestObservedByChannel = {};
   final Map<String, Map<String, ObservedUnreadEvent>>
   _observedUnreadEventsByChannel = {};
@@ -86,7 +96,17 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     final waitingForInitialConnection =
         sessionState.status != SessionStatus.connected;
     ref.listen(relaySessionProvider, (previous, next) {
-      if (next.status != SessionStatus.connected) return;
+      if (next.status != SessionStatus.connected) {
+        _cancelPendingLiveSubscriptions();
+        if (previous?.status == SessionStatus.connected) {
+          // In-flight history requests cannot always be aborted at the transport
+          // boundary. Invalidate their generation so late responses are ignored,
+          // and clear the completed-set marker so reconnect catch-up restarts.
+          _unreadCatchUpGeneration++;
+          _unreadCatchUpChannelIds = const {};
+        }
+        return;
+      }
       if (waitingForInitialConnection &&
           !_hasLoaded &&
           !connected.isCompleted) {
@@ -110,6 +130,10 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       _observedUnreadEventsByChannel.clear();
       _backstopTimer?.cancel();
       _backstopTimer = null;
+      _unreadCatchUpGeneration++;
+      _unreadCatchUpChannelIds = const {};
+      _bufferingBootstrapLiveEvents = false;
+      _bootstrapLiveEvents.clear();
     });
 
     if (sessionState.status != SessionStatus.connected) {
@@ -273,6 +297,26 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       }
     }
 
+    // Establish live callbacks before the bounded HTTP snapshot. During initial
+    // build there is no published channel list to mutate, so buffer callbacks
+    // and replay them onto the completed snapshot before returning it.
+    final bufferBootstrapLiveEvents = subscribeLive && !_hasLoaded;
+    if (bufferBootstrapLiveEvents) {
+      _bootstrapLiveEvents.clear();
+      _bufferingBootstrapLiveEvents = true;
+    }
+    Future<void>? bootstrapLiveSync;
+    if (subscribeLive) {
+      if (bufferBootstrapLiveEvents) {
+        // Subscription admission is deliberately paced and may take longer than
+        // the bounded snapshot. Run both concurrently; any not-yet-ready channel
+        // is covered by unread catch-up after the live pass completes.
+        bootstrapLiveSync = _subscribeLive(channels);
+      } else {
+        await _subscribeLive(channels);
+      }
+    }
+
     // Step 3: fetch the most recent message per channel to populate lastMessageAt.
     // kind:39000 metadata doesn't carry message timestamps, so channels load with
     // lastMessageAt: null. Without this, unread detection and badge computation
@@ -283,29 +327,38 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         for (final channel in channels)
           if (channel.isMember && !channel.isArchived) channel,
       ];
-      final channelById = {
-        for (final channel in activeChannels) channel.id: channel,
-      };
-      final events = await _fetchLastMessageEvents(session, activeChannels);
       final lastMessageMap = <String, int>{};
       final mutedChannelIds = _mutedChannelIds();
-      for (final event in events) {
-        final channelId = event.channelId;
-        if (channelId == null) continue;
-        final channel = channelById[channelId];
-        if (channel == null) continue;
-        if (!channel.isDm &&
-            !shouldNotifyForEvent(
-              event,
-              myPk,
-              mutedChannelIds: mutedChannelIds,
-              channelId: channelId,
-            )) {
-          continue;
+
+      // Keep the HTTP request bounded for very large accounts. Each batch still
+      // replaces hundreds of simultaneous WebSocket history subscriptions with
+      // one authenticated /query request, while a failed batch does not erase
+      // successful results from the others. The whole sequence shares the same
+      // eight-second startup budget as the former individual history requests,
+      // so a slow relay cannot delay live subscription setup once per batch.
+      final queryStopwatch = Stopwatch()..start();
+      for (final batch in chunkChannelsForLastMessageQuery(activeChannels)) {
+        final remaining =
+            _lastMessageQueryTotalTimeout - queryStopwatch.elapsed;
+        if (remaining <= Duration.zero) {
+          debugPrint('[ChannelsNotifier] last-message query budget exhausted');
+          break;
         }
-        final current = lastMessageMap[channelId];
-        if (current == null || event.createdAt > current) {
-          lastMessageMap[channelId] = event.createdAt;
+        try {
+          final events = await session.queryRelay(
+            buildChannelLastMessageFilters(batch),
+            timeout: remaining,
+          );
+          lastMessageMap.addAll(
+            resolveChannelLastMessages(
+              batch,
+              events,
+              myPk: myPk,
+              mutedChannelIds: mutedChannelIds,
+            ),
+          );
+        } catch (error) {
+          debugPrint('[ChannelsNotifier] last-message batch failed: $error');
         }
       }
 
@@ -319,6 +372,21 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
             ),
           );
         }
+      }
+    }
+
+    // Never let a refresh snapshot roll back a newer callback already applied
+    // to the published list while the bounded HTTP batches were in flight.
+    final publishedLastMessage = {
+      for (final channel in state.value ?? const <Channel>[])
+        if (channel.lastMessageAt != null) channel.id: channel.lastMessageAt!,
+    };
+    for (var i = 0; i < channels.length; i++) {
+      final published = publishedLastMessage[channels[i].id];
+      if (published != null &&
+          (channels[i].lastMessageAt == null ||
+              published.isAfter(channels[i].lastMessageAt!))) {
+        channels[i] = channels[i].copyWith(lastMessageAt: published);
       }
     }
 
@@ -351,8 +419,22 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
       }
     }
 
-    if (subscribeLive) {
-      await _subscribeLive(channels);
+    if (bufferBootstrapLiveEvents) {
+      // Publish immediately after the bounded snapshot. Events from live REQs
+      // already accepted are replayed now; later callbacks update published
+      // state normally. The paced live pass continues in the background and
+      // starts unread catch-up when complete, recovering the gap for channels
+      // whose REQ was not accepted before their snapshot batch completed.
+      _bufferingBootstrapLiveEvents = false;
+      for (final event in _bootstrapLiveEvents) {
+        _applyLiveEventToChannels(channels, event, myPk);
+      }
+      _bootstrapLiveEvents.clear();
+      if (channels.length <= _lastMessageQueryBatchSize) {
+        await bootstrapLiveSync;
+      } else {
+        unawaited(bootstrapLiveSync!);
+      }
     }
     return channels;
   }
@@ -391,40 +473,13 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     _memberSnapshotsByChannelId = Map.unmodifiable(snapshots);
   }
 
-  /// Fetches each channel's independent latest-message window in one HTTP
-  /// bridge request. The relay preserves NIP-01 per-filter limits while
-  /// executing the filters with bounded concurrency, avoiding an unbounded
-  /// burst of websocket REQs on communities with many channels.
-  Future<List<NostrEvent>> _fetchLastMessageEvents(
-    RelaySessionNotifier session,
-    List<Channel> channels,
-  ) async {
-    if (channels.isEmpty) return const [];
-
-    final filters = [
-      for (final channel in channels)
-        NostrFilter(
-          kinds: EventKind.channelMessageEventKinds,
-          tags: {
-            '#h': [channel.id],
-          },
-          limit: channel.isDm ? 1 : 20,
-        ),
-    ];
-
-    return _fetchChannelHistoryBatch(
-      session,
-      filters,
-      operation: 'latest-message query',
-    );
-  }
-
   Future<List<NostrEvent>> _fetchChannelHistoryBatch(
     RelaySessionNotifier session,
     List<NostrFilter> filters, {
     required String operation,
+    required bool Function() isCancelled,
   }) async {
-    if (filters.isEmpty) return const [];
+    if (filters.isEmpty || isCancelled()) return const [];
 
     try {
       return await session.queryRelay(filters);
@@ -438,6 +493,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     const fallbackConcurrency = 4;
     final events = <NostrEvent>[];
     for (var start = 0; start < filters.length; start += fallbackConcurrency) {
+      if (isCancelled()) break;
       final end = min(start + fallbackConcurrency, filters.length);
       final results = await Future.wait(
         filters.sublist(start, end).map((filter) async {
@@ -448,6 +504,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
           }
         }),
       );
+      if (isCancelled()) break;
       for (final result in results) {
         events.addAll(result);
       }
@@ -535,6 +592,16 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         if (channel.isMember && !channel.isArchived) channel.id,
     };
     final relayBaseUrl = ref.read(relayConfigProvider).baseUrl;
+    if (!_sameStringSet(_unreadCatchUpChannelIds, channelIds)) {
+      // Stop admitting work from the old channel set while its replacement
+      // live subscriptions are being established.
+      _unreadCatchUpGeneration++;
+    }
+    for (final entry in _pendingSubscriptionCancellations.entries.toList()) {
+      if (channelIds.contains(entry.key)) continue;
+      _pendingSubscriptionCancellations.remove(entry.key);
+      if (!entry.value.isCompleted) entry.value.complete();
+    }
     _desiredLiveChannels = channels;
     _desiredLiveChannelIds = channelIds;
     final subscriptionVersion = ++_subscriptionVersion;
@@ -556,7 +623,8 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     int subscriptionVersion,
     List<Channel> channels,
   ) async {
-    if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
+    if (!ref.mounted ||
+        ref.read(relaySessionProvider).status != SessionStatus.connected) {
       return;
     }
 
@@ -570,10 +638,14 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     }
 
     if (_subscriptionRelayBaseUrl != relayBaseUrl) {
-      for (final unsubscribe in _unsubscribersByChannel.values) {
-        unsubscribe();
+      for (final cancellation in _pendingSubscriptionCancellations.values) {
+        if (!cancellation.isCompleted) cancellation.complete();
       }
-      _unsubscribersByChannel.clear();
+      _pendingSubscriptionCancellations.clear();
+      for (final subscription in _liveSubscriptionsByChannel.values) {
+        subscription.unsubscribe();
+      }
+      _liveSubscriptionsByChannel.clear();
       _subscriptionRelayBaseUrl = relayBaseUrl;
     }
     if (ref.read(relayConfigProvider).baseUrl != relayBaseUrl) {
@@ -582,63 +654,117 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     final session = ref.read(relaySessionProvider.notifier);
     final channelIds = _desiredLiveChannelIds;
 
-    for (final entry in _unsubscribersByChannel.entries.toList()) {
+    for (final entry in _liveSubscriptionsByChannel.entries.toList()) {
       if (channelIds.contains(entry.key)) continue;
-      _unsubscribersByChannel.remove(entry.key);
-      entry.value();
+      _liveSubscriptionsByChannel.remove(entry.key);
+      entry.value.unsubscribe();
     }
 
-    for (final channelId in channelIds) {
-      if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
-        return;
-      }
-      if (_unsubscribersByChannel.containsKey(channelId)) continue;
-      try {
-        final unsubscribe = await session.subscribe(
-          NostrFilter(
-            kinds: EventKind.channelEventKinds,
-            tags: {
-              '#h': [channelId],
-            },
-            limit: 0,
-          ),
-          _handleLiveEvent,
-        );
-        if (ref.read(relaySessionProvider).status != SessionStatus.connected ||
-            !_desiredLiveChannelIds.contains(channelId) ||
-            ref.read(relayConfigProvider).baseUrl != relayBaseUrl ||
-            _subscriptionRelayBaseUrl != relayBaseUrl) {
-          unsubscribe();
-          return;
-        }
-        final replaced = _unsubscribersByChannel[channelId];
-        if (replaced != null) {
-          unsubscribe();
-          continue;
-        }
-        _unsubscribersByChannel[channelId] = unsubscribe;
-      } catch (error) {
-        debugPrint(
-          '[ChannelsNotifier] live subscription failed for $channelId: $error',
-        );
-      }
-    }
+    final newChannelIds = [
+      for (final channelId in channelIds)
+        if (!_liveSubscriptionsByChannel.containsKey(channelId)) channelId,
+    ];
+    final subscribeTasks = <Future<void> Function()>[
+      for (final channelId in newChannelIds)
+        () async {
+          if (!ref.mounted ||
+              ref.read(relaySessionProvider).status !=
+                  SessionStatus.connected) {
+            return;
+          }
+          try {
+            final cancellation = Completer<void>();
+            final attempt = Object();
+            var terminallyClosed = false;
+            _pendingSubscriptionCancellations[channelId] = cancellation;
+            final unsubscribe = await session.subscribeWhenReady(
+              NostrFilter(
+                kinds: EventKind.channelEventKinds,
+                tags: {
+                  '#h': [channelId],
+                },
+                limit: 0,
+              ),
+              _handleLiveEvent,
+              onClosed: (_) {
+                terminallyClosed = true;
+                final current = _liveSubscriptionsByChannel[channelId];
+                if (current?.attempt != attempt) return;
+                _liveSubscriptionsByChannel.remove(channelId);
+                _unreadCatchUpChannelIds = Set.unmodifiable(
+                  _unreadCatchUpChannelIds.difference({channelId}),
+                );
+              },
+              cancelled: cancellation.future,
+            );
+            _pendingSubscriptionCancellations.remove(channelId);
+            if (terminallyClosed) {
+              unsubscribe();
+              return;
+            }
+            if (!ref.mounted) {
+              unsubscribe();
+              return;
+            }
+            if (ref.read(relaySessionProvider).status !=
+                    SessionStatus.connected ||
+                !_desiredLiveChannelIds.contains(channelId) ||
+                ref.read(relayConfigProvider).baseUrl != relayBaseUrl ||
+                _subscriptionRelayBaseUrl != relayBaseUrl) {
+              unsubscribe();
+              return;
+            }
+            final replaced = _liveSubscriptionsByChannel[channelId];
+            if (replaced != null) {
+              unsubscribe();
+              return;
+            }
+            _liveSubscriptionsByChannel[channelId] = (
+              attempt: attempt,
+              unsubscribe: unsubscribe,
+            );
+          } on RelaySubscriptionCancelledException {
+            // The desired channel set, relay, or provider lifetime changed.
+          } catch (error) {
+            debugPrint(
+              '[ChannelsNotifier] live subscription failed for $channelId: $error',
+            );
+          } finally {
+            _pendingSubscriptionCancellations.remove(channelId);
+          }
+        },
+    ];
+    await runPacedTasks(
+      subscribeTasks,
+      maxConcurrent: _unreadCatchUpConcurrency,
+      startInterval: _unreadCatchUpStartInterval,
+      isCancelled: () =>
+          !ref.mounted ||
+          subscriptionVersion != _subscriptionVersion ||
+          ref.read(relaySessionProvider).status != SessionStatus.connected ||
+          ref.read(relayConfigProvider).baseUrl != relayBaseUrl,
+      delay: ref.read(channelsLiveSubscriptionDelayProvider),
+    );
 
-    if (ref.read(relaySessionProvider).status != SessionStatus.connected) {
+    if (!ref.mounted ||
+        ref.read(relaySessionProvider).status != SessionStatus.connected) {
       return;
     }
 
     if (subscriptionVersion != _subscriptionVersion) {
       final desiredChannelIds = _desiredLiveChannelIds;
-      for (final entry in _unsubscribersByChannel.entries.toList()) {
+      for (final entry in _liveSubscriptionsByChannel.entries.toList()) {
         if (desiredChannelIds.contains(entry.key)) continue;
-        _unsubscribersByChannel.remove(entry.key);
-        entry.value();
+        _liveSubscriptionsByChannel.remove(entry.key);
+        entry.value.unsubscribe();
       }
       return;
     }
 
-    unawaited(_catchUpUnreadEvents(channels));
+    _startUnreadCatchUpIfNeeded([
+      for (final channel in channels)
+        if (_liveSubscriptionsByChannel.containsKey(channel.id)) channel,
+    ]);
 
     _backstopTimer?.cancel();
     _backstopTimer = Timer.periodic(
@@ -647,11 +773,31 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     );
   }
 
-  Future<void> _catchUpUnreadEvents(List<Channel> channels) async {
+  void _startUnreadCatchUpIfNeeded(List<Channel> channels) {
+    final catchUpChannelIds = {
+      for (final channel in channels)
+        if (channel.isMember && !channel.isArchived) channel.id,
+    };
+    if (_sameStringSet(_unreadCatchUpChannelIds, catchUpChannelIds)) return;
+    _unreadCatchUpChannelIds = Set.unmodifiable(catchUpChannelIds);
+    final catchUpGeneration = ++_unreadCatchUpGeneration;
+    unawaited(_catchUpUnreadEvents(channels, catchUpGeneration));
+  }
+
+  Future<void> _catchUpUnreadEvents(
+    List<Channel> channels,
+    int catchUpGeneration,
+  ) async {
     final myPk = ref.read(myPubkeyProvider);
     if (myPk == null) return;
 
     final session = ref.read(relaySessionProvider.notifier);
+    final relayBaseUrl = ref.read(relayConfigProvider).baseUrl;
+    bool isCancelled() =>
+        !ref.mounted ||
+        catchUpGeneration != _unreadCatchUpGeneration ||
+        ref.read(relaySessionProvider).status != SessionStatus.connected ||
+        ref.read(relayConfigProvider).baseUrl != relayBaseUrl;
     final mutedChannelIds = _mutedChannelIds();
     final ReadStateState readState;
     try {
@@ -688,7 +834,11 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
         session,
         filters,
         operation: 'unread catch-up',
+        isCancelled: isCancelled,
       );
+      if (isCancelled()) {
+        return;
+      }
 
       for (final event in events) {
         if (event.pubkey.toLowerCase() == myPk.toLowerCase()) {
@@ -716,6 +866,7 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
           continue;
         }
         _recordUnreadEvent(channel, event, myPk);
+        _mergeLastMessageAt(channel.id, event.createdAt);
       }
     } catch (error) {
       debugPrint('[ChannelsNotifier] unread catch-up failed: $error');
@@ -724,49 +875,78 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     state = state.whenData((channels) => List<Channel>.of(channels));
   }
 
-  void _handleLiveEvent(NostrEvent event) {
-    final channelId = event.channelId;
-    if (channelId == null) return;
-
-    final myPk = ref.read(myPubkeyProvider);
-    final mutedChannelIds = _mutedChannelIds();
-
+  void _mergeLastMessageAt(String channelId, int createdAt) {
+    final eventTime = DateTime.fromMillisecondsSinceEpoch(
+      createdAt * 1000,
+      isUtc: true,
+    );
     state = state.whenData((channels) {
-      final idx = channels.indexWhere((c) => c.id == channelId);
-      if (idx == -1) {
-        refresh();
+      final index = channels.indexWhere((channel) => channel.id == channelId);
+      if (index == -1) return channels;
+      final channel = channels[index];
+      if (channel.lastMessageAt != null &&
+          !eventTime.isAfter(channel.lastMessageAt!)) {
         return channels;
       }
       final updated = List<Channel>.of(channels);
-      final channel = updated[idx];
-
-      if (myPk != null && event.pubkey.toLowerCase() == myPk.toLowerCase()) {
-        _recordSelfThreadInterest(event, myPk);
-      }
-
-      if (myPk != null &&
-          shouldNotifyForEvent(
-            event,
-            myPk,
-            participatedRootIds: _participatedRootIds,
-            followedRootIds: _followedRootIds(),
-            authoredRootIds: _authoredRootIds,
-            mutedChannelIds: mutedChannelIds,
-            channelId: channel.id,
-          )) {
-        _recordUnreadEvent(channel, event, myPk);
-        final eventTime = DateTime.fromMillisecondsSinceEpoch(
-          event.createdAt * 1000,
-          isUtc: true,
-        );
-        if (channel.lastMessageAt == null ||
-            eventTime.isAfter(channel.lastMessageAt!)) {
-          updated[idx] = channel.copyWith(lastMessageAt: eventTime);
-        }
-      }
-
+      updated[index] = channel.copyWith(lastMessageAt: eventTime);
       return updated;
     });
+  }
+
+  void _handleLiveEvent(NostrEvent event) {
+    if (_bufferingBootstrapLiveEvents) {
+      _bootstrapLiveEvents.add(event);
+      return;
+    }
+    final myPk = ref.read(myPubkeyProvider);
+
+    state = state.whenData((channels) {
+      final updated = List<Channel>.of(channels);
+      if (!_applyLiveEventToChannels(updated, event, myPk)) {
+        refresh();
+        return channels;
+      }
+      return updated;
+    });
+  }
+
+  bool _applyLiveEventToChannels(
+    List<Channel> channels,
+    NostrEvent event,
+    String? myPk,
+  ) {
+    final channelId = event.channelId;
+    if (channelId == null) return true;
+    final idx = channels.indexWhere((channel) => channel.id == channelId);
+    if (idx == -1) return false;
+    final channel = channels[idx];
+
+    if (myPk != null && event.pubkey.toLowerCase() == myPk.toLowerCase()) {
+      _recordSelfThreadInterest(event, myPk);
+    }
+
+    if (myPk != null &&
+        shouldNotifyForEvent(
+          event,
+          myPk,
+          participatedRootIds: _participatedRootIds,
+          followedRootIds: _followedRootIds(),
+          authoredRootIds: _authoredRootIds,
+          mutedChannelIds: _mutedChannelIds(),
+          channelId: channel.id,
+        )) {
+      _recordUnreadEvent(channel, event, myPk);
+      final eventTime = DateTime.fromMillisecondsSinceEpoch(
+        event.createdAt * 1000,
+        isUtc: true,
+      );
+      if (channel.lastMessageAt == null ||
+          eventTime.isAfter(channel.lastMessageAt!)) {
+        channels[idx] = channel.copyWith(lastMessageAt: eventTime);
+      }
+    }
+    return true;
   }
 
   Set<String> _mutedChannelIds() => {
@@ -894,23 +1074,144 @@ class ChannelsNotifier extends AsyncNotifier<List<Channel>> {
     state = await AsyncValue.guard(() => _fetch(subscribeLive: true));
   }
 
+  void _cancelPendingLiveSubscriptions() {
+    for (final cancellation in _pendingSubscriptionCancellations.values) {
+      if (!cancellation.isCompleted) cancellation.complete();
+    }
+    _pendingSubscriptionCancellations.clear();
+  }
+
   void _clearLiveSubscriptions() {
     _subscriptionVersion++;
     _desiredLiveChannels = const [];
     _desiredLiveChannelIds = const {};
-    for (final unsubscribe in _unsubscribersByChannel.values) {
-      unsubscribe();
+    _cancelPendingLiveSubscriptions();
+    for (final subscription in _liveSubscriptionsByChannel.values) {
+      subscription.unsubscribe();
     }
-    _unsubscribersByChannel.clear();
+    _liveSubscriptionsByChannel.clear();
     _subscriptionRelayBaseUrl = null;
     _backstopTimer?.cancel();
     _backstopTimer = null;
+    _unreadCatchUpGeneration++;
+    _unreadCatchUpChannelIds = const {};
   }
 }
 
 final channelsProvider = AsyncNotifierProvider<ChannelsNotifier, List<Channel>>(
   ChannelsNotifier.new,
 );
+
+final channelsLiveSubscriptionDelayProvider = Provider<TaskDelay>(
+  (_) => _defaultTaskDelay,
+);
+
+List<List<Channel>> chunkChannelsForLastMessageQuery(List<Channel> channels) =>
+    [
+      for (
+        var start = 0;
+        start < channels.length;
+        start += _lastMessageQueryBatchSize
+      )
+        channels.sublist(
+          start,
+          min(start + _lastMessageQueryBatchSize, channels.length),
+        ),
+    ];
+
+List<NostrFilter> buildChannelLastMessageFilters(List<Channel> channels) => [
+  for (final channel in channels)
+    NostrFilter(
+      kinds: EventKind.channelMessageEventKinds,
+      tags: {
+        '#h': [channel.id],
+      },
+      limit: channel.isDm ? 1 : 20,
+    ),
+];
+
+Map<String, int> resolveChannelLastMessages(
+  List<Channel> channels,
+  Iterable<NostrEvent> events, {
+  required String myPk,
+  Set<String> mutedChannelIds = const {},
+}) {
+  final channelsById = {for (final channel in channels) channel.id: channel};
+  final result = <String, int>{};
+  for (final event in events) {
+    final channelId = event.channelId;
+    final channel = channelId == null ? null : channelsById[channelId];
+    if (channel == null) continue;
+    if (!channel.isDm &&
+        !shouldNotifyForEvent(
+          event,
+          myPk,
+          mutedChannelIds: mutedChannelIds,
+          channelId: channelId,
+        )) {
+      continue;
+    }
+    final current = result[channel.id];
+    if (current == null || event.createdAt > current) {
+      result[channel.id] = event.createdAt;
+    }
+  }
+  return result;
+}
+
+typedef TaskDelay = Future<void> Function(Duration duration);
+typedef TaskErrorHandler = void Function(Object error);
+
+Future<void> runPacedTasks(
+  List<Future<void> Function()> tasks, {
+  required int maxConcurrent,
+  required Duration startInterval,
+  required bool Function() isCancelled,
+  TaskDelay delay = _defaultTaskDelay,
+  TaskErrorHandler onError = _defaultTaskErrorHandler,
+}) async {
+  if (maxConcurrent < 1) throw ArgumentError.value(maxConcurrent);
+  var nextTask = 0;
+  var firstStart = true;
+  Future<void> startPermit = Future.value();
+
+  Future<bool> acquireStartPermit() async {
+    if (firstStart) {
+      firstStart = false;
+    } else {
+      startPermit = startPermit.then((_) => delay(startInterval));
+      await startPermit;
+    }
+    return !isCancelled();
+  }
+
+  Future<void> worker() async {
+    while (true) {
+      final index = nextTask++;
+      if (index >= tasks.length) return;
+      if (!await acquireStartPermit()) return;
+      try {
+        await tasks[index]();
+      } catch (error) {
+        onError(error);
+      }
+    }
+  }
+
+  await Future.wait([
+    for (var i = 0; i < min(maxConcurrent, tasks.length); i++) worker(),
+  ]);
+}
+
+Future<void> _defaultTaskDelay(Duration duration) =>
+    Future<void>.delayed(duration);
+
+void _defaultTaskErrorHandler(Object error) {
+  debugPrint('[ChannelsNotifier] paced task failed: $error');
+}
+
+bool _sameStringSet(Set<String> left, Set<String> right) =>
+    left.length == right.length && left.containsAll(right);
 
 String? _observedUnreadRootId(NostrEvent event) =>
     _isBroadcastReply(event) ? null : event.threadReference.rootId;

--- a/mobile/lib/shared/relay/relay.dart
+++ b/mobile/lib/shared/relay/relay.dart
@@ -9,6 +9,8 @@ export 'relay_closed_policy.dart';
 export 'relay_client.dart';
 export 'relay_provider.dart';
 export 'relay_rate_limit_gate.dart';
+export 'relay_nip98_auth.dart';
 export 'relay_session.dart';
+export 'relay_session_state.dart';
 export 'relay_socket.dart';
 export 'signed_event_relay.dart';

--- a/mobile/lib/shared/relay/relay_closed_policy.dart
+++ b/mobile/lib/shared/relay/relay_closed_policy.dart
@@ -3,6 +3,9 @@ enum RelayClosedClass {
   /// A transient failure that may recover when the same REQ is retried.
   retryable,
 
+  /// Relay subscription capacity that may recover when another REQ closes.
+  capacity,
+
   /// Relay back-pressure that must also arm the shared request gate.
   rateLimited,
 
@@ -16,6 +19,9 @@ RelayClosedClass classifyRelayClosed(String message) {
   if (normalized.startsWith('rate-limited:')) {
     return RelayClosedClass.rateLimited;
   }
+  if (normalized.startsWith('error: too many subscriptions')) {
+    return RelayClosedClass.capacity;
+  }
   if (normalized.startsWith('restricted:') ||
       normalized.startsWith('auth-required:') ||
       normalized.startsWith('blocked:') ||
@@ -23,8 +29,7 @@ RelayClosedClass classifyRelayClosed(String message) {
       normalized.startsWith('pow:') ||
       normalized.startsWith('duplicate:') ||
       normalized.startsWith('unsupported:') ||
-      normalized.startsWith('error: mixed search') ||
-      normalized.startsWith('error: too many subscriptions')) {
+      normalized.startsWith('error: mixed search')) {
     return RelayClosedClass.terminal;
   }
   return RelayClosedClass.retryable;

--- a/mobile/lib/shared/relay/relay_nip98_auth.dart
+++ b/mobile/lib/shared/relay/relay_nip98_auth.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:pointycastle/digests/sha256.dart';
+import 'package:uuid/uuid.dart';
+
+String buildNip98AuthHeader({
+  required String method,
+  required String url,
+  required List<int> bodyBytes,
+  required String? nsec,
+}) {
+  if (nsec == null || nsec.isEmpty) {
+    throw Exception('Cannot query relay: no signing key available');
+  }
+  final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+  if (privkeyHex.isEmpty) {
+    throw Exception('Invalid nsec');
+  }
+  final payloadHash = SHA256Digest()
+      .process(Uint8List.fromList(bodyBytes))
+      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+      .join();
+  final event = nostr.Event.from(
+    kind: 27235,
+    content: '',
+    tags: [
+      ['u', url],
+      ['method', method.toUpperCase()],
+      ['payload', payloadHash],
+      ['nonce', const Uuid().v4()],
+    ],
+    secretKey: privkeyHex,
+    verify: false,
+  );
+  return 'Nostr ${base64.encode(utf8.encode(event.toJson()))}';
+}

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -3,9 +3,6 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:http/http.dart' as http;
-import 'package:nostr/nostr.dart' as nostr;
-import 'package:pointycastle/digests/sha256.dart';
-import 'package:uuid/uuid.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,19 +12,12 @@ import 'nostr_models.dart';
 import 'relay_client.dart';
 import 'relay_closed_policy.dart';
 import 'relay_http_query_client.dart';
+import 'relay_nip98_auth.dart';
+export 'relay_nip98_auth.dart';
+import 'relay_session_state.dart';
 import 'relay_provider.dart';
 import 'relay_rate_limit_gate.dart';
 import 'relay_socket.dart';
-
-enum SessionStatus { disconnected, connecting, connected, reconnecting }
-
-@immutable
-class SessionState {
-  final SessionStatus status;
-  final int reconnectAttempt;
-
-  const SessionState({required this.status, this.reconnectAttempt = 0});
-}
 
 class _HistorySubscription {
   final List<NostrEvent> events = [];
@@ -1004,35 +994,3 @@ final relaySessionProvider =
     NotifierProvider<RelaySessionNotifier, SessionState>(
       RelaySessionNotifier.new,
     );
-
-String buildNip98AuthHeader({
-  required String method,
-  required String url,
-  required List<int> bodyBytes,
-  required String? nsec,
-}) {
-  if (nsec == null || nsec.isEmpty) {
-    throw Exception('Cannot query relay: no signing key available');
-  }
-  final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
-  if (privkeyHex.isEmpty) {
-    throw Exception('Invalid nsec');
-  }
-  final payloadHash = SHA256Digest()
-      .process(Uint8List.fromList(bodyBytes))
-      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
-      .join();
-  final event = nostr.Event.from(
-    kind: 27235,
-    content: '',
-    tags: [
-      ['u', url],
-      ['method', method.toUpperCase()],
-      ['payload', payloadHash],
-      ['nonce', const Uuid().v4()],
-    ],
-    secretKey: privkeyHex,
-    verify: false,
-  );
-  return 'Nostr ${base64.encode(utf8.encode(event.toJson()))}';
-}

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -37,10 +37,18 @@ class _HistorySubscription {
   _HistorySubscription({required this.completer, required this.timeout});
 }
 
+class RelaySubscriptionCancelledException implements Exception {
+  const RelaySubscriptionCancelledException();
+
+  @override
+  String toString() => 'Relay subscription cancelled before ready';
+}
+
 class _LiveSubscription {
   final NostrFilter filter;
   final void Function(NostrEvent) onEvent;
   final void Function(String message)? onClosed;
+  final bool waitForRelayReady;
   Completer<void>? readyCompleter;
   int? lastSeenCreatedAt;
   int closedRetryAttempt = 0;
@@ -49,6 +57,7 @@ class _LiveSubscription {
   _LiveSubscription({
     required this.filter,
     required this.onEvent,
+    required this.waitForRelayReady,
     this.onClosed,
     this.readyCompleter,
   });
@@ -264,6 +273,30 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     NostrFilter filter,
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
+  }) =>
+      _subscribe(filter, onEvent, onClosed: onClosed, waitForRelayReady: false);
+
+  /// Subscribe and resolve only after the relay confirms the REQ with EOSE.
+  /// Retryable CLOSED responses keep this pending across the scheduled retry.
+  Future<void Function()> subscribeWhenReady(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+    Future<void>? cancelled,
+  }) => _subscribe(
+    filter,
+    onEvent,
+    onClosed: onClosed,
+    waitForRelayReady: true,
+    cancelled: cancelled,
+  );
+
+  Future<void Function()> _subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    required bool waitForRelayReady,
+    void Function(String message)? onClosed,
+    Future<void>? cancelled,
   }) async {
     if (_disposed) throw StateError('Relay session is disposed');
     final subId = _nextSubId('l');
@@ -272,26 +305,44 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _liveSubscriptions[subId] = _LiveSubscription(
       filter: filter,
       onEvent: onEvent,
+      waitForRelayReady: waitForRelayReady,
       onClosed: onClosed,
       readyCompleter: readyCompleter,
     );
 
     _sendReq(subId, filter);
 
-    // Wait for EOSE or a short fallback timeout.
-    try {
-      await readyCompleter.future.timeout(
-        const Duration(milliseconds: 500),
-        onTimeout: () {},
-      );
-    } catch (_) {
-      _liveSubscriptions.remove(subId);
-      _recentDeliveryKeys.removeWhere((key) => key.startsWith('$subId:'));
-      rethrow;
-    }
-    final liveSub = _liveSubscriptions[subId];
-    if (liveSub != null && liveSub.readyCompleter == readyCompleter) {
-      liveSub.readyCompleter = null;
+    if (waitForRelayReady) {
+      if (cancelled == null) {
+        await readyCompleter.future;
+      } else {
+        final cancelledBeforeReady = await Future.any([
+          readyCompleter.future.then((_) => false),
+          cancelled.then((_) => true),
+        ]);
+        if (cancelledBeforeReady) {
+          final liveSub = _liveSubscriptions[subId];
+          if (liveSub != null) _removeLiveSubscription(subId, liveSub);
+          _sendClose(subId);
+          throw const RelaySubscriptionCancelledException();
+        }
+      }
+    } else {
+      // Wait for EOSE or a short fallback timeout.
+      try {
+        await readyCompleter.future.timeout(
+          const Duration(milliseconds: 500),
+          onTimeout: () {},
+        );
+      } catch (_) {
+        _liveSubscriptions.remove(subId);
+        _recentDeliveryKeys.removeWhere((key) => key.startsWith('$subId:'));
+        rethrow;
+      }
+      final liveSub = _liveSubscriptions[subId];
+      if (liveSub != null && liveSub.readyCompleter == readyCompleter) {
+        liveSub.readyCompleter = null;
+      }
     }
 
     return () => _unsubscribe(subId);
@@ -694,7 +745,9 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       _removeLiveSubscription(subId, liveSub);
       return;
     }
-    if (readyCompleter != null && !readyCompleter.isCompleted) {
+    if (!liveSub.waitForRelayReady &&
+        readyCompleter != null &&
+        !readyCompleter.isCompleted) {
       readyCompleter.complete();
       liveSub.readyCompleter = null;
     }
@@ -931,6 +984,12 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     final subscriptions = _liveSubscriptions.values.toList();
     _liveSubscriptions.clear();
     for (final subscription in subscriptions) {
+      final readyCompleter = subscription.readyCompleter;
+      if (readyCompleter != null && !readyCompleter.isCompleted) {
+        readyCompleter.completeError(
+          const RelaySubscriptionCancelledException(),
+        );
+      }
       subscription.closedRetryTimer?.cancel();
       subscription.closedRetryTimer = null;
     }

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -762,6 +762,8 @@ class RelaySessionNotifier extends Notifier<SessionState> {
             ? fallbackMs
             : _rateLimitGate.remainingMs(),
       );
+    } else if (closedClass == RelayClosedClass.capacity) {
+      delayMs = max(backoffMs, RelayRateLimitGate.defaultRetrySeconds * 1000);
     }
 
     liveSub.closedRetryAttempt = attempt + 1;

--- a/mobile/lib/shared/relay/relay_session_state.dart
+++ b/mobile/lib/shared/relay/relay_session_state.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart';
+
+enum SessionStatus { disconnected, connecting, connected, reconnecting }
+
+@immutable
+class SessionState {
+  final SessionStatus status;
+  final int reconnectAttempt;
+
+  const SessionState({required this.status, this.reconnectAttempt = 0});
+}

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/channels_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
@@ -20,6 +22,304 @@ import 'package:buzz/shared/relay/relay.dart';
 /// events on demand.
 void main() {
   const myPk = 'me';
+
+  test('chunks 1,565 channels into sixteen bounded HTTP requests', () {
+    final chunks = chunkChannelsForLastMessageQuery([
+      for (var i = 0; i < 1565; i++) _channel(_generatedChannelId(i)),
+    ]);
+
+    expect(chunks, hasLength(16));
+    expect(chunks.take(15).every((chunk) => chunk.length == 100), isTrue);
+    expect(chunks.last, hasLength(65));
+  });
+
+  test('chunks aggregate last-message queries and isolates failures', () async {
+    final channelIds = List.generate(201, _generatedChannelId);
+    final session =
+        _FakeRelaySession(
+            memberships: [for (final id in channelIds) _membership(id, myPk)],
+            metadata: [for (final id in channelIds) _meta(id: id, name: id)],
+          )
+          ..queryFailureCalls.add(2)
+          ..queryEvents = [
+            _message(channelIds.first, createdAt: 10),
+            _message(channelIds[100], createdAt: 20),
+            _message(channelIds.last, createdAt: 30),
+          ];
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final channels = await container.read(channelsProvider.future);
+
+    expect(session.queryFilterBatches.map((batch) => batch.length), [
+      100,
+      100,
+      1,
+    ]);
+    expect(
+      session.queryTimeouts.every(
+        (timeout) => timeout <= const Duration(seconds: 8),
+      ),
+      isTrue,
+    );
+    expect(session.queryFilterBatches.expand((batch) => batch), hasLength(201));
+    expect(
+      channels
+          .firstWhere((channel) => channel.id == channelIds.first)
+          .lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(10000, isUtc: true),
+    );
+    expect(
+      channels
+          .firstWhere((channel) => channel.id == channelIds[100])
+          .lastMessageAt,
+      isNull,
+    );
+    expect(
+      channels
+          .firstWhere((channel) => channel.id == channelIds.last)
+          .lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(30000, isUtc: true),
+    );
+  });
+
+  test('catch-up recovers event missed before live REQ readiness', () async {
+    final channelIds = List.generate(101, _generatedChannelId);
+    final session = _FakeRelaySession(
+      memberships: [for (final id in channelIds) _membership(id, myPk)],
+      metadata: [for (final id in channelIds) _meta(id: id, name: id)],
+    );
+    session.pauseNextSubscribe();
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    final channels = await container.read(channelsProvider.future);
+    expect(
+      channels
+          .firstWhere((channel) => channel.id == channelIds.first)
+          .lastMessageAt,
+      isNull,
+    );
+    expect(session.activeSubscriptionCount, lessThan(101));
+
+    final missedEvent = _message(channelIds.first, createdAt: 50);
+    session.emit(missedEvent);
+    session.unreadEvents = [missedEvent];
+    session.resumePausedSubscribe();
+
+    await _waitUntil(() => session.unreadCatchUpQueryCount > 0);
+    await _waitUntil(
+      () =>
+          container
+              .read(channelsProvider.notifier)
+              .observedUnreadEventsByChannel[channelIds.first]
+              ?.containsKey(missedEvent.id) ==
+          true,
+      attempts: 30000,
+    );
+    expect(
+      container
+          .read(channelsProvider)
+          .value!
+          .firstWhere((channel) => channel.id == channelIds.first)
+          .lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(50000, isUtc: true),
+    );
+  });
+
+  test('loaded refresh preserves newer live timestamp', () async {
+    final channelIds = List.generate(101, _generatedChannelId);
+    final session = _FakeRelaySession(
+      memberships: [for (final id in channelIds) _membership(id, myPk)],
+      metadata: [for (final id in channelIds) _meta(id: id, name: id)],
+    )..queryEvents = [_message(channelIds.first, createdAt: 10)];
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    await container.read(channelsProvider.future);
+    session.pauseQueryCall(4);
+    final refresh = container.read(channelsProvider.notifier).refresh();
+    await session.nextPausedQueryStarted;
+    session.emit(_message(channelIds.first, createdAt: 50));
+    session.resumePausedQuery();
+    await refresh;
+
+    expect(
+      container
+          .read(channelsProvider)
+          .value!
+          .firstWhere((channel) => channel.id == channelIds.first)
+          .lastMessageAt,
+      DateTime.fromMillisecondsSinceEpoch(50000, isUtc: true),
+    );
+  });
+
+  test('stale unread fallback stops before its next wave', () async {
+    final channelIds = List.generate(9, _generatedChannelId);
+    final session = _FakeRelaySession(
+      memberships: [for (final id in channelIds) _membership(id, myPk)],
+      metadata: [for (final id in channelIds) _meta(id: id, name: id)],
+    )..queryFailureCalls.add(2);
+    session.pauseNextUnreadCatchUp();
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    await container.read(channelsProvider.future);
+    await session.nextUnreadCatchUpStarted;
+    expect(session.unreadFallbackFetchCount, 4);
+
+    session.setStatus(SessionStatus.disconnected);
+    session.resumePausedUnreadCatchUp();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(session.unreadFallbackFetchCount, 4);
+  });
+
+  test('unchanged refresh does not restart unread catch-up', () async {
+    final session = _FakeRelaySession(
+      memberships: [_membership(_channelA, myPk)],
+      metadata: [_meta(id: _channelA, name: 'general')],
+    );
+    final container = _buildContainer(session: session);
+    addTearDown(container.dispose);
+
+    await container.read(channelsProvider.future);
+    await _waitUntil(() => session.unreadCatchUpQueryCount == 1);
+    await container.read(channelsProvider.notifier).refresh();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(session.unreadCatchUpQueryCount, 1);
+  });
+
+  test(
+    'disconnect discards stale catch-up and reconnect restarts it',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, myPk)],
+        metadata: [_meta(id: _channelA, name: 'general')],
+      )..unreadEvents = [_message(_channelA, createdAt: 20)];
+      session.pauseNextUnreadCatchUp();
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await session.nextUnreadCatchUpStarted;
+
+      session.setStatus(SessionStatus.disconnected);
+      session.resumePausedUnreadCatchUp();
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container
+            .read(channelsProvider.notifier)
+            .observedUnreadEventsByChannel[_channelA],
+        isNull,
+      );
+
+      session.setStatus(SessionStatus.connected);
+      await _waitUntil(() => session.unreadCatchUpQueryCount == 2);
+      await _waitUntil(
+        () =>
+            container
+                .read(channelsProvider.notifier)
+                .observedUnreadEventsByChannel[_channelA]
+                ?.isNotEmpty ==
+            true,
+      );
+    },
+  );
+
+  test('builds one bounded last-message filter per channel type', () {
+    final filters = buildChannelLastMessageFilters([
+      _channel(_channelA),
+      _channel(_channelB, channelType: 'dm'),
+    ]);
+
+    expect(filters, hasLength(2));
+    expect(filters[0].tags['#h'], [_channelA]);
+    expect(filters[0].limit, 20);
+    expect(filters[1].tags['#h'], [_channelB]);
+    expect(filters[1].limit, 1);
+  });
+
+  test('maps newest qualifying last messages and preserves DM semantics', () {
+    final channels = [
+      _channel(_channelA),
+      _channel(_channelB, channelType: 'dm'),
+    ];
+    final result = resolveChannelLastMessages(channels, [
+      _message(_channelA, createdAt: 10, pubkey: myPk),
+      _message(_channelA, createdAt: 20),
+      _message(_channelA, createdAt: 15),
+      _message(_channelB, createdAt: 30, pubkey: myPk),
+      _message(_channelD, createdAt: 40),
+    ], myPk: myPk);
+
+    expect(result, {_channelA: 20, _channelB: 30});
+  });
+
+  test(
+    'paced tasks are lazy, bounded, failure-isolated, and cancellable',
+    () async {
+      var active = 0;
+      var maxActive = 0;
+      var created = 0;
+      var errors = 0;
+      var cancelled = false;
+      final permits = <Completer<void>>[];
+      final completions = List.generate(6, (_) => Completer<void>());
+      final tasks = [
+        for (var i = 0; i < completions.length; i++)
+          () async {
+            created++;
+            active++;
+            maxActive = max(maxActive, active);
+            if (i == 1) {
+              active--;
+              throw Exception('isolated');
+            }
+            await completions[i].future;
+            active--;
+          },
+      ];
+
+      final run = runPacedTasks(
+        tasks,
+        maxConcurrent: 4,
+        startInterval: const Duration(milliseconds: 125),
+        isCancelled: () => cancelled,
+        delay: (_) {
+          if (cancelled) return Future.value();
+          final permit = Completer<void>();
+          permits.add(permit);
+          return permit.future;
+        },
+        onError: (_) => errors++,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(created, 1);
+      expect(permits, hasLength(1));
+
+      for (var expectedCreated = 2; expectedCreated <= 4; expectedCreated++) {
+        permits.removeAt(0).complete();
+        await Future<void>.delayed(Duration.zero);
+        expect(created, expectedCreated);
+        if (expectedCreated < 4) expect(permits, hasLength(1));
+      }
+      expect(maxActive, 3);
+
+      cancelled = true;
+      for (final completion in completions) {
+        if (!completion.isCompleted) completion.complete();
+      }
+      for (final permit in permits) {
+        if (!permit.isCompleted) permit.complete();
+      }
+      await run;
+      expect(created, 4);
+      expect(errors, 1);
+    },
+  );
 
   test(
     'seeds members from the channel-list snapshot during reconnect',
@@ -133,6 +433,108 @@ void main() {
       expect(session.totalSubscribeCount, initialSubscribeCount);
       expect(session.unsubscribeCount, 0);
       expect(session.subscribeFilters, hasLength(2));
+    },
+  );
+
+  test(
+    'terminal live failure catches up only ready channels and retries gap',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [
+          _membership(_channelA, myPk),
+          _membership(_channelB, myPk),
+        ],
+        metadata: [
+          _meta(id: _channelA, name: 'general'),
+          _meta(id: _channelB, name: 'random'),
+        ],
+      )..subscribeFailuresByChannel[_channelA] = 1;
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(() => session.unreadCatchUpQueryCount == 1);
+      expect(session.activeChannels, {_channelB});
+      expect(
+        session.queryFilterBatches
+            .expand((filters) => filters)
+            .where((filter) => filter.since != null)
+            .map((filter) => filter.tags['#h']!.single),
+        [_channelB],
+      );
+
+      final missedEvent = _message(_channelA, createdAt: 50);
+      session.unreadEvents = [missedEvent];
+      await container.read(channelsProvider.notifier).refresh();
+
+      await _waitUntil(
+        () => session.queryFilterBatches
+            .expand((filters) => filters)
+            .any(
+              (filter) =>
+                  filter.since != null &&
+                  filter.tags['#h']?.single == _channelA,
+            ),
+        attempts: 30000,
+      );
+      expect(session.activeChannels, {_channelA, _channelB});
+      expect(
+        container
+            .read(channelsProvider.notifier)
+            .observedUnreadEventsByChannel[_channelA]
+            ?.containsKey(missedEvent.id),
+        isTrue,
+      );
+      expect(
+        container
+            .read(channelsProvider)
+            .value!
+            .firstWhere((channel) => channel.id == _channelA)
+            .lastMessageAt,
+        DateTime.fromMillisecondsSinceEpoch(50000, isUtc: true),
+      );
+    },
+  );
+
+  test(
+    'post-ready terminal close retries subscription and catches up gap',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, myPk)],
+        metadata: [_meta(id: _channelA, name: 'general')],
+      );
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(() => session.unreadCatchUpQueryCount == 1);
+      expect(session.activeChannels, {_channelA});
+
+      session.terminallyClose(_channelA);
+      expect(session.activeChannels, isEmpty);
+      final missedEvent = _message(_channelA, createdAt: 50);
+      session.unreadEvents = [missedEvent];
+
+      await container.read(channelsProvider.notifier).refresh();
+
+      await _waitUntil(
+        () =>
+            session.activeChannels.contains(_channelA) &&
+            container
+                    .read(channelsProvider.notifier)
+                    .observedUnreadEventsByChannel[_channelA]
+                    ?.containsKey(missedEvent.id) ==
+                true,
+        attempts: 30000,
+      );
+      expect(
+        container
+            .read(channelsProvider)
+            .value!
+            .firstWhere((channel) => channel.id == _channelA)
+            .lastMessageAt,
+        DateTime.fromMillisecondsSinceEpoch(50000, isUtc: true),
+      );
     },
   );
 
@@ -660,6 +1062,39 @@ const _channelA = '11111111-1111-4111-8111-111111111111';
 const _channelB = '22222222-2222-4222-8222-222222222222';
 const _channelD = '44444444-4444-4444-8444-444444444444';
 
+String _generatedChannelId(int index) {
+  final suffix = index.toRadixString(16).padLeft(12, '0');
+  return 'aaaaaaaa-aaaa-4aaa-8aaa-$suffix';
+}
+
+NostrEvent _message(
+  String channelId, {
+  required int createdAt,
+  String pubkey = 'alice',
+}) => NostrEvent(
+  id: 'message-$channelId-$createdAt',
+  pubkey: pubkey,
+  createdAt: createdAt,
+  kind: EventKind.streamMessageV2,
+  tags: [
+    ['h', channelId],
+  ],
+  content: 'message',
+  sig: 'sig',
+);
+
+Channel _channel(String id, {String channelType = 'stream'}) => Channel(
+  id: id,
+  name: id,
+  channelType: channelType,
+  visibility: 'open',
+  description: '',
+  createdBy: 'creator',
+  createdAt: DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true),
+  memberCount: 1,
+  isMember: true,
+);
+
 /// Build a kind:39002 membership event tagged with the channel id and member.
 NostrEvent _membership(
   String channelId,
@@ -725,13 +1160,16 @@ ProviderContainer _buildContainer({required _FakeRelaySession session}) {
     overrides: [
       appLifecycleProvider.overrideWith(() => _FakeAppLifecycleNotifier()),
       relaySessionProvider.overrideWith(() => session),
+      channelsLiveSubscriptionDelayProvider.overrideWithValue(
+        (_) => Future<void>.value(),
+      ),
       myPubkeyProvider.overrideWithValue('me'),
     ],
   );
 }
 
-Future<void> _waitUntil(bool Function() predicate) async {
-  for (var i = 0; i < 100; i++) {
+Future<void> _waitUntil(bool Function() predicate, {int attempts = 100}) async {
+  for (var i = 0; i < attempts; i++) {
     if (predicate()) return;
     await Future<void>.delayed(Duration.zero);
   }
@@ -757,16 +1195,53 @@ class _FakeRelaySession extends RelaySessionNotifier {
 
   final List<NostrFilter> historyFilters = [];
   final List<List<NostrFilter>> queryBatches = [];
+  final List<List<NostrFilter>> queryFilterBatches = [];
+  final List<Duration> queryTimeouts = [];
+  final Set<int> queryFailureCalls = {};
+  final Map<String, int> subscribeFailuresByChannel = {};
+  List<NostrEvent> queryEvents = [];
+  int? _pausedQueryCall;
+  Completer<void>? _pausedQuery;
+  Completer<void>? _pausedQueryStarted;
   final List<NostrFilter> subscribeFilters = [];
-  final Map<int, (NostrFilter, void Function(NostrEvent))> _subscriptions = {};
+  final Map<
+    int,
+    (NostrFilter, void Function(NostrEvent), void Function(String message)?)
+  >
+  _subscriptions = {};
   int _nextSubscriptionKey = 0;
   Completer<void>? _pausedSubscribe;
   Completer<void>? _subscribeStarted;
+  Completer<void>? _pausedUnreadCatchUp;
+  Completer<void>? _unreadCatchUpStarted;
+  List<NostrEvent> unreadEvents = [];
   int unsubscribeCount = 0;
   int totalSubscribeCount = 0;
 
+  int get unreadFallbackFetchCount => historyFilters
+      .where(
+        (filter) =>
+            filter.tags['#h']?.length == 1 &&
+            filter.since != null &&
+            filter.kinds.length == EventKind.channelMessageEventKinds.length &&
+            filter.kinds.every(EventKind.channelMessageEventKinds.contains),
+      )
+      .length;
+
+  int get unreadCatchUpQueryCount => queryFilterBatches
+      .expand((filters) => filters)
+      .where(
+        (filter) =>
+            filter.tags['#h']?.length == 1 &&
+            filter.since != null &&
+            filter.kinds.length == EventKind.channelMessageEventKinds.length &&
+            filter.kinds.every(EventKind.channelMessageEventKinds.contains),
+      )
+      .length;
+
   Set<String> get activeChannels => {
-    for (final (filter, _) in _subscriptions.values) ?filter.tags['#h']?.single,
+    for (final (filter, _, _) in _subscriptions.values)
+      ?filter.tags['#h']?.single,
   };
 
   int get activeSubscriptionCount => _subscriptions.length;
@@ -790,6 +1265,46 @@ class _FakeRelaySession extends RelaySessionNotifier {
   void resumePausedSubscribe() {
     final paused = _pausedSubscribe;
     if (paused == null) throw StateError('No subscription is paused');
+    paused.complete();
+  }
+
+  Future<void> get nextUnreadCatchUpStarted async {
+    final started = _unreadCatchUpStarted;
+    if (started == null) {
+      throw StateError('No paused unread catch-up is pending');
+    }
+    await started.future;
+  }
+
+  void pauseNextUnreadCatchUp() {
+    if (_pausedUnreadCatchUp != null) {
+      throw StateError('An unread catch-up is already paused');
+    }
+    _pausedUnreadCatchUp = Completer<void>();
+    _unreadCatchUpStarted = Completer<void>();
+  }
+
+  void resumePausedUnreadCatchUp() {
+    final paused = _pausedUnreadCatchUp;
+    if (paused == null) throw StateError('No unread catch-up is paused');
+    paused.complete();
+  }
+
+  Future<void> get nextPausedQueryStarted async {
+    final started = _pausedQueryStarted;
+    if (started == null) throw StateError('No query is paused');
+    await started.future;
+  }
+
+  void pauseQueryCall(int call) {
+    _pausedQueryCall = call;
+    _pausedQuery = Completer<void>();
+    _pausedQueryStarted = Completer<void>();
+  }
+
+  void resumePausedQuery() {
+    final paused = _pausedQuery;
+    if (paused == null) throw StateError('No query is paused');
     paused.complete();
   }
 
@@ -824,6 +1339,19 @@ class _FakeRelaySession extends RelaySessionNotifier {
       final ids = (filter.tags['#d'] ?? const <String>[]).toSet();
       return metadata.where((e) => ids.contains(e.getTagValue('d'))).toList();
     }
+    if (filter.since != null && filter.tags['#h']?.length == 1) {
+      final paused = _pausedUnreadCatchUp;
+      if (paused != null) {
+        _unreadCatchUpStarted!.complete();
+        await paused.future;
+        _pausedUnreadCatchUp = null;
+        _unreadCatchUpStarted = null;
+      }
+      final channelId = filter.tags['#h']!.single;
+      return unreadEvents
+          .where((event) => event.channelId == channelId)
+          .toList();
+    }
     return const [];
   }
 
@@ -832,10 +1360,39 @@ class _FakeRelaySession extends RelaySessionNotifier {
     List<NostrFilter> filters, {
     Duration timeout = const Duration(seconds: 8),
   }) async {
-    queryBatches.add(filters);
-    return recentMessages.where((event) {
+    queryBatches.add(List.of(filters));
+    queryFilterBatches.add(List.of(filters));
+    queryTimeouts.add(timeout);
+    if (_pausedQueryCall == queryFilterBatches.length) {
+      _pausedQueryStarted!.complete();
+      await _pausedQuery!.future;
+      _pausedQueryCall = null;
+      _pausedQuery = null;
+      _pausedQueryStarted = null;
+    }
+    if (queryFailureCalls.contains(queryFilterBatches.length)) {
+      throw Exception('query failed');
+    }
+    if (filters.any((filter) => filter.since != null)) {
+      final paused = _pausedUnreadCatchUp;
+      if (paused != null) {
+        _unreadCatchUpStarted!.complete();
+        await paused.future;
+        _pausedUnreadCatchUp = null;
+        _unreadCatchUpStarted = null;
+      }
+    }
+    final candidates = <NostrEvent>[
+      ...recentMessages,
+      ...queryEvents,
+      ...unreadEvents,
+    ];
+    return candidates.where((event) {
       return filters.any((filter) {
         if (!filter.kinds.contains(event.kind)) return false;
+        if (filter.since != null && event.createdAt < filter.since!) {
+          return false;
+        }
         for (final entry in filter.tags.entries) {
           final tagName = entry.key.startsWith('#')
               ? entry.key.substring(1)
@@ -855,22 +1412,44 @@ class _FakeRelaySession extends RelaySessionNotifier {
   }
 
   @override
+  Future<void Function()> subscribeWhenReady(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+    Future<void>? cancelled,
+  }) => _subscribeFake(filter, onEvent, onClosed: onClosed);
+
+  @override
   Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) => _subscribeFake(filter, onEvent, onClosed: onClosed);
+
+  Future<void Function()> _subscribeFake(
     NostrFilter filter,
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
   }) async {
     totalSubscribeCount++;
     subscribeFilters.add(filter);
+    final channelId = filter.tags['#h']?.single;
+    final remainingFailures = channelId == null
+        ? 0
+        : subscribeFailuresByChannel[channelId] ?? 0;
+    if (remainingFailures > 0) {
+      subscribeFailuresByChannel[channelId!] = remainingFailures - 1;
+      throw Exception('terminal subscription failure for $channelId');
+    }
     final paused = _pausedSubscribe;
-    if (paused != null) {
+    if (paused != null && !_subscribeStarted!.isCompleted) {
       _subscribeStarted!.complete();
       await paused.future;
       _pausedSubscribe = null;
       _subscribeStarted = null;
     }
     final subscriptionKey = ++_nextSubscriptionKey;
-    _subscriptions[subscriptionKey] = (filter, onEvent);
+    _subscriptions[subscriptionKey] = (filter, onEvent, onClosed);
     return () {
       final subscription = _subscriptions.remove(subscriptionKey);
       if (subscription == null) return;
@@ -883,9 +1462,18 @@ class _FakeRelaySession extends RelaySessionNotifier {
     state = SessionState(status: status);
   }
 
+  void terminallyClose(String channelId) {
+    final entry = _subscriptions.entries.singleWhere(
+      (entry) => entry.value.$1.tags['#h']?.single == channelId,
+    );
+    _subscriptions.remove(entry.key);
+    subscribeFilters.remove(entry.value.$1);
+    entry.value.$3?.call('restricted: access revoked');
+  }
+
   /// Emit a live event to all subscribers.
   void emit(NostrEvent event) {
-    for (final (_, listener) in List.of(_subscriptions.values)) {
+    for (final (_, listener, _) in List.of(_subscriptions.values)) {
       listener(event);
     }
   }

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/channel_sync.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 /// Tests for [ChannelsNotifier] in the pure-Nostr world.
@@ -126,6 +127,29 @@ void main() {
       DateTime.fromMillisecondsSinceEpoch(50000, isUtc: true),
     );
   });
+
+  test(
+    'small-account snapshot publishes without waiting for live EOSE',
+    () async {
+      final session = _FakeRelaySession(
+        memberships: [_membership(_channelA, myPk)],
+        metadata: [_meta(id: _channelA, name: 'general')],
+      );
+      session.pauseNextSubscribe();
+      final container = _buildContainer(session: session);
+      addTearDown(container.dispose);
+
+      final channelFuture = container.read(channelsProvider.future);
+      await session.nextSubscribeStarted;
+
+      final channels = await channelFuture.timeout(const Duration(seconds: 1));
+      expect(channels.single.id, _channelA);
+      expect(session.activeChannels, isEmpty);
+
+      session.resumePausedSubscribe();
+      await _waitUntil(() => session.activeChannels.contains(_channelA));
+    },
+  );
 
   test('loaded refresh preserves newer live timestamp', () async {
     final channelIds = List.generate(101, _generatedChannelId);
@@ -376,6 +400,7 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
 
       // One subscription per joined, non-archived channel.
       expect(session.subscribeFilters, hasLength(2));
@@ -426,6 +451,7 @@ void main() {
       addTearDown(container.dispose);
 
       await container.read(channelsProvider.future);
+      await _waitUntil(() => session.activeSubscriptionCount == 2);
       final initialSubscribeCount = session.totalSubscribeCount;
 
       await container.read(channelsProvider.notifier).refresh();
@@ -497,7 +523,7 @@ void main() {
   );
 
   test(
-    'post-ready terminal close retries subscription and catches up gap',
+    'post-ready terminal close stays quarantined until explicit refresh',
     () async {
       final session = _FakeRelaySession(
         memberships: [_membership(_channelA, myPk)],
@@ -512,8 +538,13 @@ void main() {
 
       session.terminallyClose(_channelA);
       expect(session.activeChannels, isEmpty);
+      final subscribeCountAfterClose = session.totalSubscribeCount;
       final missedEvent = _message(_channelA, createdAt: 50);
       session.unreadEvents = [missedEvent];
+
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(session.totalSubscribeCount, subscribeCountAfterClose);
+      expect(session.activeChannels, isEmpty);
 
       await container.read(channelsProvider.notifier).refresh();
 
@@ -958,6 +989,7 @@ void main() {
 
       final initial = await container.read(channelsProvider.future);
       expect(initial.single.name, 'general');
+      await _waitUntil(() => session.activeSubscriptionCount == 1);
       expect(session.subscribeFilters, hasLength(1));
 
       session.setStatus(SessionStatus.reconnecting);
@@ -1417,7 +1449,8 @@ class _FakeRelaySession extends RelaySessionNotifier {
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
     Future<void>? cancelled,
-  }) => _subscribeFake(filter, onEvent, onClosed: onClosed);
+  }) =>
+      _subscribeFake(filter, onEvent, onClosed: onClosed, cancelled: cancelled);
 
   @override
   Future<void Function()> subscribe(
@@ -1430,6 +1463,7 @@ class _FakeRelaySession extends RelaySessionNotifier {
     NostrFilter filter,
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
+    Future<void>? cancelled,
   }) async {
     totalSubscribeCount++;
     subscribeFilters.add(filter);
@@ -1444,7 +1478,18 @@ class _FakeRelaySession extends RelaySessionNotifier {
     final paused = _pausedSubscribe;
     if (paused != null && !_subscribeStarted!.isCompleted) {
       _subscribeStarted!.complete();
-      await paused.future;
+      if (cancelled == null) {
+        await paused.future;
+      } else {
+        final wasCancelled = await Future.any([
+          paused.future.then((_) => false),
+          cancelled.then((_) => true),
+        ]);
+        if (wasCancelled) {
+          subscribeFilters.remove(filter);
+          throw const RelaySubscriptionCancelledException();
+        }
+      }
       _pausedSubscribe = null;
       _subscribeStarted = null;
     }

--- a/mobile/test/features/channels/channels_provider_test.dart
+++ b/mobile/test/features/channels/channels_provider_test.dart
@@ -34,6 +34,14 @@ void main() {
     expect(chunks.last, hasLength(65));
   });
 
+  test('chunks exact multiples without an empty trailing batch', () {
+    final chunks = chunkChannelsForLastMessageQuery([
+      for (var i = 0; i < 200; i++) _channel(_generatedChannelId(i)),
+    ]);
+
+    expect(chunks.map((chunk) => chunk.length), [100, 100]);
+  });
+
   test('chunks aggregate last-message queries and isolates failures', () async {
     final channelIds = List.generate(201, _generatedChannelId);
     final session =
@@ -282,6 +290,72 @@ void main() {
     expect(result, {_channelA: 20, _channelB: 30});
   });
 
+  test('paced tasks enforce concurrency and requested start spacing', () async {
+    var active = 0;
+    var maxActive = 0;
+    var created = 0;
+    final delays = <Duration>[];
+    final completions = List.generate(12, (_) => Completer<void>());
+    final tasks = [
+      for (var i = 0; i < completions.length; i++)
+        () async {
+          created++;
+          active++;
+          maxActive = max(maxActive, active);
+          await completions[i].future;
+          active--;
+        },
+    ];
+
+    final run = runPacedTasks(
+      tasks,
+      maxConcurrent: 4,
+      startInterval: const Duration(milliseconds: 125),
+      isCancelled: () => false,
+      delay: (duration) async {
+        delays.add(duration);
+      },
+    );
+    await _waitUntil(() => created == 4);
+
+    expect(maxActive, 4);
+    expect(delays, everyElement(const Duration(milliseconds: 125)));
+    expect(delays, hasLength(3));
+
+    for (final completion in completions) {
+      completion.complete();
+    }
+    await run;
+    expect(maxActive, 4);
+    expect(created, 12);
+    expect(delays, hasLength(11));
+  });
+
+  test('readiness timeout cancels the pending subscription', () async {
+    final cancellation = Completer<void>();
+    Duration? armedFor;
+    void Function()? fire;
+    final timer = _TestTimer();
+    final subscription = subscribeWhenReadyWithTimeout(
+      (cancelled) async {
+        await cancelled;
+        throw const RelaySubscriptionCancelledException();
+      },
+      cancellation,
+      timerFactory: (duration, callback) {
+        armedFor = duration;
+        fire = callback;
+        return timer;
+      },
+    );
+
+    expect(armedFor, liveSubscriptionReadyTimeout);
+    expect(cancellation.isCompleted, isFalse);
+    fire!();
+    await expectLater(subscription, throwsA(isA<TimeoutException>()));
+    expect(timer.isActive, isFalse);
+  });
+
   test(
     'paced tasks are lazy, bounded, failure-isolated, and cancellable',
     () async {
@@ -459,6 +533,39 @@ void main() {
       expect(session.totalSubscribeCount, initialSubscribeCount);
       expect(session.unsubscribeCount, 0);
       expect(session.subscribeFilters, hasLength(2));
+    },
+  );
+
+  test(
+    'never-EOSE workers time out and later channels still catch up',
+    () async {
+      final channelIds = List.generate(6, _generatedChannelId);
+      final session = _FakeRelaySession(
+        memberships: [for (final id in channelIds) _membership(id, myPk)],
+        metadata: [for (final id in channelIds) _meta(id: id, name: id)],
+      )..neverReadyChannelIds.addAll(channelIds.take(4));
+      final missedEvent = _message(channelIds.last, createdAt: 50);
+      session.unreadEvents = [missedEvent];
+      final container = _buildContainer(
+        session: session,
+        liveReadyTimeout: Duration.zero,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(channelsProvider.future);
+      await _waitUntil(
+        () =>
+            session.activeChannels.containsAll(channelIds.skip(4)) &&
+            container
+                    .read(channelsProvider.notifier)
+                    .observedUnreadEventsByChannel[channelIds.last]
+                    ?.containsKey(missedEvent.id) ==
+                true,
+        attempts: 30000,
+      );
+
+      expect(session.activeChannels, containsAll(channelIds.skip(4)));
+      expect(session.totalSubscribeCount, channelIds.length);
     },
   );
 
@@ -1186,12 +1293,18 @@ NostrEvent _meta({
   sig: 'sig',
 );
 
-ProviderContainer _buildContainer({required _FakeRelaySession session}) {
+ProviderContainer _buildContainer({
+  required _FakeRelaySession session,
+  Duration liveReadyTimeout = liveSubscriptionReadyTimeout,
+}) {
   return ProviderContainer(
     retry: (_, _) => null,
     overrides: [
       appLifecycleProvider.overrideWith(() => _FakeAppLifecycleNotifier()),
       relaySessionProvider.overrideWith(() => session),
+      channelsLiveSubscriptionReadyTimeoutProvider.overrideWithValue(
+        liveReadyTimeout,
+      ),
       channelsLiveSubscriptionDelayProvider.overrideWithValue(
         (_) => Future<void>.value(),
       ),
@@ -1231,6 +1344,7 @@ class _FakeRelaySession extends RelaySessionNotifier {
   final List<Duration> queryTimeouts = [];
   final Set<int> queryFailureCalls = {};
   final Map<String, int> subscribeFailuresByChannel = {};
+  final Set<String> neverReadyChannelIds = {};
   List<NostrEvent> queryEvents = [];
   int? _pausedQueryCall;
   Completer<void>? _pausedQuery;
@@ -1468,6 +1582,11 @@ class _FakeRelaySession extends RelaySessionNotifier {
     totalSubscribeCount++;
     subscribeFilters.add(filter);
     final channelId = filter.tags['#h']?.single;
+    if (channelId != null && neverReadyChannelIds.contains(channelId)) {
+      if (cancelled == null) return Completer<void Function()>().future;
+      await cancelled;
+      throw const RelaySubscriptionCancelledException();
+    }
     final remainingFailures = channelId == null
         ? 0
         : subscribeFailuresByChannel[channelId] ?? 0;
@@ -1522,6 +1641,19 @@ class _FakeRelaySession extends RelaySessionNotifier {
       listener(event);
     }
   }
+}
+
+class _TestTimer implements Timer {
+  bool _isActive = true;
+
+  @override
+  bool get isActive => _isActive;
+
+  @override
+  int get tick => 0;
+
+  @override
+  void cancel() => _isActive = false;
 }
 
 class _FakeAppLifecycleNotifier extends AppLifecycleNotifier {

--- a/mobile/test/shared/relay/relay_closed_policy_test.dart
+++ b/mobile/test/shared/relay/relay_closed_policy_test.dart
@@ -15,7 +15,7 @@ void main() {
       'duplicate: subscription already exists': RelayClosedClass.terminal,
       'unsupported: filter extension': RelayClosedClass.terminal,
       'error: mixed search and channel filter': RelayClosedClass.terminal,
-      'error: too many subscriptions': RelayClosedClass.terminal,
+      'error: too many subscriptions': RelayClosedClass.capacity,
       'error: relay temporarily unavailable': RelayClosedClass.retryable,
       'subscription closed by relay': RelayClosedClass.retryable,
     };

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -749,6 +749,145 @@ void main() {
     },
   );
 
+  test(
+    'subscribeWhenReady stays pending across retryable CLOSED until retry EOSE',
+    () async {
+      final timers = <_ManualTimer>[];
+      final socket = _RecordingRelaySocket();
+      final session = RelaySessionNotifier(
+        retryTimerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          timers.add(timer);
+          return timer;
+        },
+      );
+      session.debugAttachSocketForTest(socket);
+      final events = <NostrEvent>[];
+      var ready = false;
+      final subscribe = session
+          .subscribeWhenReady(_channelFilter, events.add)
+          .whenComplete(() => ready = true);
+
+      session.debugHandleMessage(['CLOSED', 'l-1', 'error: relay overloaded']);
+      await Future<void>.delayed(Duration.zero);
+      expect(ready, isFalse);
+
+      timers.single.fire();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqs(socket).where((req) => req[1] == 'l-1'), hasLength(2));
+      expect(ready, isFalse);
+
+      final replayEvent = _event(createdAt: 30);
+      session.debugHandleMessage(['EVENT', 'l-1', replayEvent.toJson()]);
+      expect(events, isEmpty);
+      session.debugHandleMessage(['EOSE', 'l-1']);
+
+      final unsubscribe = await subscribe;
+      expect(events, [replayEvent]);
+      expect(ready, isTrue);
+      unsubscribe();
+    },
+  );
+
+  test(
+    'subscribeWhenReady stays pending across rate-limited CLOSED until retry EOSE',
+    () async {
+      final now = DateTime(2026);
+      final gateTimers = <_ManualTimer>[];
+      final retryTimers = <_ManualTimer>[];
+      final gate = RelayRateLimitGate(
+        now: () => now,
+        timerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          gateTimers.add(timer);
+          return timer;
+        },
+      );
+      final socket = _RecordingRelaySocket();
+      final session = RelaySessionNotifier(
+        rateLimitGate: gate,
+        retryTimerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          retryTimers.add(timer);
+          return timer;
+        },
+      );
+      session.debugAttachSocketForTest(socket);
+      var ready = false;
+      final subscribe = session
+          .subscribeWhenReady(_channelFilter, (_) {})
+          .whenComplete(() => ready = true);
+
+      session.debugHandleMessage([
+        'CLOSED',
+        'l-1',
+        'rate-limited: quota exceeded; retry in 4s',
+      ]);
+      await Future<void>.delayed(Duration.zero);
+      expect(ready, isFalse);
+
+      retryTimers.single.fire();
+      await Future<void>.delayed(Duration.zero);
+      expect(ready, isFalse);
+      gateTimers.single.fire();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqs(socket).where((req) => req[1] == 'l-1'), hasLength(2));
+      expect(ready, isFalse);
+
+      session.debugHandleMessage(['EOSE', 'l-1']);
+      final unsubscribe = await subscribe;
+      expect(ready, isTrue);
+      unsubscribe();
+    },
+  );
+
+  test(
+    'subscribeWhenReady cancellation removes the pending subscription',
+    () async {
+      final timers = <_ManualTimer>[];
+      final socket = _RecordingRelaySocket();
+      final session = RelaySessionNotifier(
+        retryTimerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          timers.add(timer);
+          return timer;
+        },
+      );
+      session.debugAttachSocketForTest(socket);
+      final cancelled = Completer<void>();
+      final subscribe = session.subscribeWhenReady(
+        _channelFilter,
+        (_) {},
+        cancelled: cancelled.future,
+      );
+      session.debugHandleMessage(['CLOSED', 'l-1', 'error: relay overloaded']);
+
+      cancelled.complete();
+      await expectLater(
+        subscribe,
+        throwsA(isA<RelaySubscriptionCancelledException>()),
+      );
+      expect(timers.single.isActive, isFalse);
+      expect(socket.messages, contains(equals(<dynamic>['CLOSE', 'l-1'])));
+
+      timers.single.fire();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqs(socket).where((req) => req[1] == 'l-1'), hasLength(1));
+    },
+  );
+
+  test('dispose fails a pending subscribeWhenReady', () async {
+    final session = RelaySessionNotifier();
+    final subscribe = session.subscribeWhenReady(_channelFilter, (_) {});
+
+    session.debugDispose();
+
+    await expectLater(
+      subscribe,
+      throwsA(isA<RelaySubscriptionCancelledException>()),
+    );
+  });
+
   test('CLOSED retries back off and reset after EOSE', () async {
     final timers = <_ManualTimer>[];
     final socket = _RecordingRelaySocket();

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -842,6 +842,44 @@ void main() {
   );
 
   test(
+    'subscribeWhenReady retries capacity CLOSED after a bounded cooldown',
+    () async {
+      final timers = <_ManualTimer>[];
+      final socket = _RecordingRelaySocket();
+      final session = RelaySessionNotifier(
+        retryTimerFactory: (duration, callback) {
+          final timer = _ManualTimer(duration, callback);
+          timers.add(timer);
+          return timer;
+        },
+      );
+      session.debugAttachSocketForTest(socket);
+      var ready = false;
+      final subscribe = session
+          .subscribeWhenReady(_channelFilter, (_) {})
+          .whenComplete(() => ready = true);
+
+      session.debugHandleMessage([
+        'CLOSED',
+        'l-1',
+        'error: too many subscriptions',
+      ]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ready, isFalse);
+      expect(timers.single.duration, const Duration(seconds: 10));
+      timers.single.fire();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqs(socket).where((req) => req[1] == 'l-1'), hasLength(2));
+
+      session.debugHandleMessage(['EOSE', 'l-1']);
+      final unsubscribe = await subscribe;
+      expect(ready, isTrue);
+      unsubscribe();
+    },
+  );
+
+  test(
     'subscribeWhenReady cancellation removes the pending subscription',
     () async {
       final timers = <_ManualTimer>[];


### PR DESCRIPTION
## Summary

- replace 1,565 per-channel startup last-message lookups with 16 bounded authenticated HTTP query batches sharing one eight-second budget
- admit required per-channel `#h` live subscriptions through four paced workers with 125 ms start spacing, while overlapping admission with the startup snapshot
- wait for relay EOSE before treating each live subscription as ready, including across retryable and rate-limited `CLOSED` responses
- preserve delivery across snapshot/live overlap, reconnect, cancellation, refresh, and terminal-close recovery with max-merged timestamps
- add relay fan-out, provider lifecycle, retry, cancellation, and gap-recovery regressions

## Problem

Large accounts launched one history request per channel during mobile startup. At 1,565 channels this caused a relay request storm and quota failures. The previous replacement in #5802 paced history requests, but still made startup wait minutes for all per-channel work and did not fully close snapshot/live delivery races.

This version keeps channel-scoped live REQs because relay fan-out requires `#h`, but paces their admission and moves snapshot discovery to bounded HTTP batches. Large startup can publish after the shared snapshot budget while live admission continues safely in the background.

## Correctness details

- `subscribeWhenReady` resolves only after EOSE; retryable/rate-limited `CLOSED` stays pending through replay
- replay events flush synchronously before readiness resolves
- pending admissions cancel on disconnect, channel removal, relay change, and provider disposal
- terminal `CLOSED` before or after readiness cannot leave stale provider state; attempt identity prevents an obsolete callback deleting a replacement
- catch-up runs only for successfully ready channels and reruns when a failed/closed channel is later admitted
- snapshot, live, refresh, and catch-up timestamp updates use max semantics so older results cannot roll back `lastMessageAt`

## Validation

Exact commit: `a9a786ddfabea27552a6633494c789ffd2ad9a80`

- focused channel-provider suite: 32/32 passed
- relay-session suite: 43/43 passed
- analyzer and formatting: clean
- mobile file-size ratchet: passed (`channels_provider.dart` 999 lines, `relay_session.dart` 996)
- pre-push hooks: passed on the exact pushed head, including all 1,371 mobile tests and branch-skew
- independent architecture review: keep the direction with snapshot/EOSE separation and terminal-close quarantine; both are implemented

## Follow-up device validation

Measure full live-subscription/unread convergence time and quota rejection counts on the 1,565-channel account. The channel snapshot itself remains bounded to eight seconds.
