### PR TITLE
fix(desktop): discover shared managed agents

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1039,23 +1039,59 @@ pub async fn discover_managed_agent_prereqs(
 
 #[tauri::command]
 pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAgentInfo>, String> {
-    // Query kind:10100 agent profile events from the relay.
-    let events = query_relay(
+    let managed_agent_events = query_relay(
         &state,
         &[serde_json::json!({
-            "kinds": [10100],
+            "kinds": [30177],
         })],
     )
     .await?;
 
-    // The convert helper returns `{"agents": [...]}`. Extract and re-deserialize
-    // into the strongly-typed `Vec<RelayAgentInfo>` the frontend expects.
-    let value = nostr_convert::agents_from_events(&events);
-    let agents = value
-        .get("agents")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!([]));
-    serde_json::from_value(agents).map_err(|e| format!("agent parse failed: {e}"))
+    let agent_pubkeys = nostr_convert::managed_agent_pubkeys_from_events(&managed_agent_events);
+    if agent_pubkeys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let profile_events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "authors": agent_pubkeys.iter().collect::<Vec<_>>(),
+            "kinds": [0],
+        })],
+    )
+    .await?;
+    let mut agents = nostr_convert::relay_agents_from_managed_agent_events(
+        &managed_agent_events,
+        &profile_events,
+    );
+    if agents.is_empty() {
+        return Ok(agents);
+    }
+
+    let verified_agent_pubkeys: std::collections::HashSet<String> =
+        agents.iter().map(|agent| agent.pubkey.clone()).collect();
+    let Some(relay_pubkey) = super::identity_archive::fetch_relay_self(&state).await? else {
+        return Ok(agents);
+    };
+    let membership_events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "kinds": [39002],
+            "authors": [relay_pubkey.clone()],
+            "#p": verified_agent_pubkeys.iter().collect::<Vec<_>>(),
+        })],
+    )
+    .await?;
+    let channel_ids = nostr_convert::agent_channel_ids_from_member_events(
+        &membership_events,
+        &verified_agent_pubkeys,
+        &relay_pubkey,
+    );
+    for agent in &mut agents {
+        agent.channel_ids = channel_ids.get(&agent.pubkey).cloned().unwrap_or_default();
+    }
+
+    Ok(agents)
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1037,30 +1037,72 @@ pub async fn discover_managed_agent_prereqs(
     .map_err(|e| format!("spawn_blocking failed: {e}"))
 }
 
+const RELAY_DIRECTORY_PAGE_SIZE: usize = 500;
+const PROFILE_AUTHOR_CHUNK_SIZE: usize = 250;
+
+fn advance_relay_cursor(filter: &mut serde_json::Value, page: &[nostr::Event]) {
+    let last = page
+        .last()
+        .expect("a full relay page always has a last event");
+    filter["until"] = serde_json::json!(last.created_at.as_secs());
+    filter["before_id"] = serde_json::json!(last.id.to_hex());
+}
+
+async fn query_all_relay_pages(
+    state: &AppState,
+    mut filter: serde_json::Value,
+) -> Result<Vec<nostr::Event>, String> {
+    filter["limit"] = serde_json::json!(RELAY_DIRECTORY_PAGE_SIZE);
+    let mut events = Vec::new();
+    loop {
+        let page = query_relay(state, &[filter.clone()]).await?;
+        let done = page.len() < RELAY_DIRECTORY_PAGE_SIZE;
+        if !done {
+            advance_relay_cursor(&mut filter, &page);
+        }
+        events.extend(page);
+        if done {
+            return Ok(events);
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAgentInfo>, String> {
-    let managed_agent_events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "kinds": [30177],
-        })],
-    )
-    .await?;
+    let directory_result =
+        query_all_relay_pages(&state, serde_json::json!({"kinds": [10100]})).await;
+    let managed_result = query_all_relay_pages(&state, serde_json::json!({"kinds": [30177]})).await;
+    let (directory_events, managed_agent_events) = match (directory_result, managed_result) {
+        (Ok(directory), Ok(managed)) => (directory, managed),
+        (_, Err(error)) => return Err(format!("relay agent managed-policy query failed: {error}")),
+        (Err(error), Ok(managed)) => {
+            tracing::warn!("relay agent runtime-directory query failed: {error}");
+            (Vec::new(), managed)
+        }
+    };
 
     let agent_pubkeys = nostr_convert::managed_agent_pubkeys_from_events(&managed_agent_events);
-    if agent_pubkeys.is_empty() {
-        return Ok(Vec::new());
+    let agent_pubkeys: Vec<_> = agent_pubkeys.into_iter().collect();
+    let mut profile_events = Vec::new();
+    for authors in agent_pubkeys.chunks(PROFILE_AUTHOR_CHUNK_SIZE) {
+        match query_relay(
+            &state,
+            &[serde_json::json!({
+                "authors": authors,
+                "kinds": [0],
+                "limit": PROFILE_AUTHOR_CHUNK_SIZE,
+            })],
+        )
+        .await
+        {
+            Ok(mut profiles) => profile_events.append(&mut profiles),
+            Err(error) => {
+                return Err(format!("relay agent owner-profile query failed: {error}"));
+            }
+        }
     }
-
-    let profile_events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "authors": agent_pubkeys.iter().collect::<Vec<_>>(),
-            "kinds": [0],
-        })],
-    )
-    .await?;
-    let mut agents = nostr_convert::relay_agents_from_managed_agent_events(
+    let mut agents = nostr_convert::relay_agents_from_directory_events(
+        &directory_events,
         &managed_agent_events,
         &profile_events,
     );
@@ -1070,18 +1112,29 @@ pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAg
 
     let verified_agent_pubkeys: std::collections::HashSet<String> =
         agents.iter().map(|agent| agent.pubkey.clone()).collect();
-    let Some(relay_pubkey) = super::identity_archive::fetch_relay_self(&state).await? else {
-        return Ok(agents);
+    let relay_pubkey = match super::identity_archive::fetch_relay_self(&state).await {
+        Ok(Some(pubkey)) => pubkey,
+        Ok(None) => return Ok(agents),
+        Err(error) => {
+            tracing::warn!("relay agent membership authority lookup failed: {error}");
+            return Ok(agents);
+        }
     };
-    let membership_events = query_relay(
+    let membership_events = match query_all_relay_pages(
         &state,
-        &[serde_json::json!({
+        serde_json::json!({
             "kinds": [39002],
             "authors": [relay_pubkey.clone()],
-            "#p": verified_agent_pubkeys.iter().collect::<Vec<_>>(),
-        })],
+        }),
     )
-    .await?;
+    .await
+    {
+        Ok(events) => events,
+        Err(error) => {
+            tracing::warn!("relay agent channel-membership enrichment failed: {error}");
+            return Ok(agents);
+        }
+    };
     let channel_ids = nostr_convert::agent_channel_ids_from_member_events(
         &membership_events,
         &verified_agent_pubkeys,
@@ -1097,6 +1150,22 @@ pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAg
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relay_directory_cursor_uses_timestamp_and_event_id() {
+        use nostr::{EventBuilder, Keys, Kind, Timestamp};
+
+        let event = EventBuilder::new(Kind::Custom(30177), "{}")
+            .custom_created_at(Timestamp::from(42))
+            .sign_with_keys(&Keys::generate())
+            .expect("sign cursor event");
+        let mut filter = serde_json::json!({"kinds": [30177]});
+
+        advance_relay_cursor(&mut filter, std::slice::from_ref(&event));
+
+        assert_eq!(filter["until"], 42);
+        assert_eq!(filter["before_id"], event.id.to_hex());
+    }
 
     // ── is_npm_global_install ─────────────────────────────────────────────────
 

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -512,6 +512,58 @@ pub fn managed_agent_pubkeys_from_events(events: &[Event]) -> std::collections::
         .collect()
 }
 
+fn event_is_newer(candidate: &Event, previous: &Event) -> bool {
+    candidate.created_at > previous.created_at
+        || (candidate.created_at == previous.created_at && candidate.id < previous.id)
+}
+
+fn relay_agents_from_legacy_events(events: &[Event]) -> Vec<RelayAgentInfo> {
+    let mut latest: HashMap<String, &Event> = HashMap::new();
+    for event in events {
+        let pubkey = event.pubkey.to_hex();
+        if latest
+            .get(&pubkey)
+            .is_none_or(|previous| event_is_newer(event, previous))
+        {
+            latest.insert(pubkey, event);
+        }
+    }
+
+    latest
+        .into_values()
+        .filter_map(|event| {
+            let value = agents_from_events(std::slice::from_ref(event));
+            let mut agent: RelayAgentInfo =
+                serde_json::from_value(value.get("agents")?.as_array()?.first()?.clone()).ok()?;
+            // Channel membership is authoritative only in relay-signed kind:39002.
+            agent.channel_ids.clear();
+            Some(agent)
+        })
+        .collect()
+}
+
+/// Merge self-authored kind:10100 runtime profiles with verified Desktop-managed
+/// policy records. Managed policy wins for the same agent; kind:10100-only
+/// headless agents remain discoverable.
+pub fn relay_agents_from_directory_events(
+    directory_events: &[Event],
+    managed_agent_events: &[Event],
+    profile_events: &[Event],
+) -> Vec<RelayAgentInfo> {
+    let mut agents: HashMap<String, RelayAgentInfo> =
+        relay_agents_from_legacy_events(directory_events)
+            .into_iter()
+            .map(|agent| (agent.pubkey.clone(), agent))
+            .collect();
+    for agent in relay_agents_from_managed_agent_events(managed_agent_events, profile_events) {
+        agents.insert(agent.pubkey.clone(), agent);
+    }
+
+    let mut agents: Vec<_> = agents.into_values().collect();
+    agents.sort_by(|left, right| left.name.cmp(&right.name));
+    agents
+}
+
 /// Build the relay agent directory from owner-authenticated managed-agent
 /// records. A kind:30177 event is accepted only when its author matches the
 /// owner cryptographically declared by the agent's own kind:0 NIP-OA tag.
@@ -524,7 +576,7 @@ pub fn relay_agents_from_managed_agent_events(
         let agent_pubkey = profile.pubkey.to_hex();
         let replace = latest_profiles
             .get(&agent_pubkey)
-            .is_none_or(|previous| profile.created_at > previous.created_at);
+            .is_none_or(|previous| event_is_newer(profile, previous));
         if replace {
             latest_profiles.insert(agent_pubkey, profile);
         }
@@ -563,7 +615,7 @@ pub fn relay_agents_from_managed_agent_events(
         };
         let replace = latest
             .get(agent_pubkey)
-            .is_none_or(|(previous, _)| event.created_at > previous.created_at);
+            .is_none_or(|(previous, _)| event_is_newer(event, previous));
         if replace {
             latest.insert(agent_pubkey.to_string(), (event, info));
         }
@@ -1226,6 +1278,161 @@ mod tests {
         let pubkeys = managed_agent_pubkeys_from_events(&[malformed, valid]);
 
         assert_eq!(pubkeys, [valid_pubkey].into_iter().collect());
+    }
+
+    #[test]
+    fn relay_agent_directory_preserves_headless_profiles_and_prefers_verified_managed_policy() {
+        let owner_keys = Keys::generate();
+        let managed_agent_keys = Keys::generate();
+        let managed_pubkey = managed_agent_keys.public_key().to_hex();
+        let headless_keys = Keys::generate();
+        let headless_pubkey = headless_keys.public_key().to_hex();
+        let viewer_pubkey = "a".repeat(64);
+
+        let headless_profile = EventBuilder::new(
+            Kind::Custom(10100),
+            serde_json::json!({
+                "name": "Headless",
+                "respond_to": "anyone",
+                "channel_ids": ["untrusted-channel"]
+            })
+            .to_string(),
+        )
+        .sign_with_keys(&headless_keys)
+        .expect("sign headless directory profile");
+        let stale_managed_profile = EventBuilder::new(
+            Kind::Custom(10100),
+            serde_json::json!({
+                "name": "Stale Codex",
+                "respond_to": "anyone"
+            })
+            .to_string(),
+        )
+        .sign_with_keys(&managed_agent_keys)
+        .expect("sign managed directory profile");
+
+        let auth_tag_json = buzz_sdk_pkg::nip_oa::compute_auth_tag(
+            &owner_keys,
+            &managed_agent_keys.public_key(),
+            "",
+        )
+        .expect("compute auth tag");
+        let auth_tag_values: Vec<String> =
+            serde_json::from_str(&auth_tag_json).expect("parse auth tag json");
+        let managed_identity = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Codex"}"#)
+            .tags([Tag::parse(auth_tag_values).expect("parse auth tag")])
+            .sign_with_keys(&managed_agent_keys)
+            .expect("sign managed profile");
+        let managed_policy = managed_agent_event(
+            &owner_keys,
+            &managed_pubkey,
+            "Codex",
+            "allowlist",
+            std::slice::from_ref(&viewer_pubkey),
+        );
+
+        let agents = relay_agents_from_directory_events(
+            &[headless_profile, stale_managed_profile],
+            std::slice::from_ref(&managed_policy),
+            std::slice::from_ref(&managed_identity),
+        );
+
+        assert_eq!(agents.len(), 2);
+        let headless = agents
+            .iter()
+            .find(|agent| agent.pubkey == headless_pubkey)
+            .expect("headless profile retained");
+        assert_eq!(
+            headless.respond_to,
+            Some(crate::managed_agents::RespondTo::Anyone)
+        );
+        assert!(
+            headless.channel_ids.is_empty(),
+            "claimed channel ids are not trusted"
+        );
+
+        let managed = agents
+            .iter()
+            .find(|agent| agent.pubkey == managed_pubkey)
+            .expect("managed profile retained");
+        assert_eq!(managed.name, "Codex");
+        assert_eq!(
+            managed.respond_to,
+            Some(crate::managed_agents::RespondTo::Allowlist)
+        );
+        assert_eq!(managed.respond_to_allowlist, vec![viewer_pubkey]);
+    }
+
+    #[test]
+    fn relay_agent_directory_resolves_equal_timestamp_heads_by_event_id() {
+        let keys = Keys::generate();
+        let timestamp = nostr::Timestamp::from(42);
+        let first = EventBuilder::new(
+            Kind::Custom(10100),
+            r#"{"name":"First","respond_to":"anyone"}"#,
+        )
+        .custom_created_at(timestamp)
+        .sign_with_keys(&keys)
+        .expect("sign first directory head");
+        let second = EventBuilder::new(
+            Kind::Custom(10100),
+            r#"{"name":"Second","respond_to":"anyone"}"#,
+        )
+        .custom_created_at(timestamp)
+        .sign_with_keys(&keys)
+        .expect("sign second directory head");
+        let expected_name = if first.id < second.id {
+            "First"
+        } else {
+            "Second"
+        };
+
+        let forward =
+            relay_agents_from_directory_events(&[first.clone(), second.clone()], &[], &[]);
+        let reverse = relay_agents_from_directory_events(&[second, first], &[], &[]);
+
+        assert_eq!(forward.len(), 1);
+        assert_eq!(reverse.len(), 1);
+        assert_eq!(forward[0].name, expected_name);
+        assert_eq!(reverse[0].name, expected_name);
+    }
+
+    #[test]
+    fn forged_managed_policy_cannot_suppress_a_headless_directory_agent() {
+        let attacker_keys = Keys::generate();
+        let targeted_agent_keys = Keys::generate();
+        let targeted_pubkey = targeted_agent_keys.public_key().to_hex();
+        let headless_keys = Keys::generate();
+        let headless_pubkey = headless_keys.public_key().to_hex();
+        let targeted_profile = EventBuilder::new(
+            Kind::Custom(10100),
+            r#"{"name":"Targeted","respond_to":"anyone"}"#,
+        )
+        .sign_with_keys(&targeted_agent_keys)
+        .expect("sign targeted profile");
+        let headless = EventBuilder::new(
+            Kind::Custom(10100),
+            r#"{"name":"Headless","respond_to":"anyone"}"#,
+        )
+        .sign_with_keys(&headless_keys)
+        .expect("sign headless profile");
+        let forged_policy = managed_agent_event(
+            &attacker_keys,
+            &targeted_pubkey,
+            "Codex",
+            "allowlist",
+            &["a".repeat(64)],
+        );
+
+        let agents = relay_agents_from_directory_events(
+            &[targeted_profile, headless],
+            std::slice::from_ref(&forged_policy),
+            &[],
+        );
+
+        assert_eq!(agents.len(), 2);
+        assert!(agents.iter().any(|agent| agent.pubkey == targeted_pubkey));
+        assert!(agents.iter().any(|agent| agent.pubkey == headless_pubkey));
     }
 
     #[test]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -12,7 +12,10 @@ use std::collections::{BTreeSet, HashMap};
 use nostr::{Event, ToBech32};
 use serde_json::{json, Value};
 
-use crate::models::*;
+use crate::{
+    managed_agents::{agent_events::managed_agent_content_from_event, RelayAgentInfo},
+    models::*,
+};
 
 mod user_search;
 pub use user_search::{
@@ -495,6 +498,115 @@ pub fn agents_from_events(events: &[Event]) -> Value {
     json!({ "agents": arr })
 }
 
+// ── kind:0 + kind:30177 managed-agent directory ────────────────────────────
+
+/// Collect valid agent pubkeys from kind:30177 `d` tags for follow-up relay
+/// queries. Malformed tags are ignored so one hostile event cannot invalidate
+/// the whole directory request.
+pub fn managed_agent_pubkeys_from_events(events: &[Event]) -> std::collections::HashSet<String> {
+    events
+        .iter()
+        .filter_map(|event| first_tag_value(event, "d"))
+        .filter_map(|pubkey| nostr::PublicKey::from_hex(pubkey).ok())
+        .map(|pubkey| pubkey.to_hex())
+        .collect()
+}
+
+/// Build the relay agent directory from owner-authenticated managed-agent
+/// records. A kind:30177 event is accepted only when its author matches the
+/// owner cryptographically declared by the agent's own kind:0 NIP-OA tag.
+pub fn relay_agents_from_managed_agent_events(
+    managed_agent_events: &[Event],
+    profile_events: &[Event],
+) -> Vec<RelayAgentInfo> {
+    let mut latest_profiles: HashMap<String, &Event> = HashMap::new();
+    for profile in profile_events {
+        let agent_pubkey = profile.pubkey.to_hex();
+        let replace = latest_profiles
+            .get(&agent_pubkey)
+            .is_none_or(|previous| profile.created_at > previous.created_at);
+        if replace {
+            latest_profiles.insert(agent_pubkey, profile);
+        }
+    }
+    let verified_owners: HashMap<String, String> = latest_profiles
+        .into_iter()
+        .filter_map(|(agent_pubkey, profile)| {
+            profile_valid_oa_owner_pubkey(profile).map(|owner| (agent_pubkey, owner))
+        })
+        .collect();
+
+    let mut latest: HashMap<String, (&Event, RelayAgentInfo)> = HashMap::new();
+    for event in managed_agent_events {
+        let Some(agent_pubkey) = first_tag_value(event, "d") else {
+            continue;
+        };
+        let Some(verified_owner) = verified_owners.get(agent_pubkey) else {
+            continue;
+        };
+        if event.pubkey.to_hex() != *verified_owner {
+            continue;
+        }
+        let Ok(content) = managed_agent_content_from_event(event) else {
+            continue;
+        };
+        let info = RelayAgentInfo {
+            pubkey: agent_pubkey.to_string(),
+            name: content.name,
+            agent_type: "agent".to_string(),
+            channels: Vec::new(),
+            channel_ids: Vec::new(),
+            capabilities: Vec::new(),
+            status: "offline".to_string(),
+            respond_to: Some(content.respond_to),
+            respond_to_allowlist: content.respond_to_allowlist,
+        };
+        let replace = latest
+            .get(agent_pubkey)
+            .is_none_or(|(previous, _)| event.created_at > previous.created_at);
+        if replace {
+            latest.insert(agent_pubkey.to_string(), (event, info));
+        }
+    }
+
+    let mut agents: Vec<_> = latest.into_values().map(|(_, info)| info).collect();
+    agents.sort_by(|left, right| left.name.cmp(&right.name));
+    agents
+}
+
+/// Build a pubkey-to-channel-id map from current kind:39002 membership heads.
+pub fn agent_channel_ids_from_member_events(
+    events: &[Event],
+    agent_pubkeys: &std::collections::HashSet<String>,
+    relay_pubkey: &str,
+) -> HashMap<String, Vec<String>> {
+    let mut channel_ids: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for event in events {
+        if !event.pubkey.to_hex().eq_ignore_ascii_case(relay_pubkey) {
+            continue;
+        }
+        let Some(channel_id) = first_tag_value(event, "d") else {
+            continue;
+        };
+        for tag in tags_named(event, "p") {
+            let Some(pubkey) = tag.get(1) else {
+                continue;
+            };
+            if agent_pubkeys.contains(pubkey) {
+                channel_ids
+                    .entry(pubkey.clone())
+                    .or_default()
+                    .insert(channel_id.to_string());
+            }
+        }
+    }
+
+    channel_ids
+        .into_iter()
+        .map(|(pubkey, ids)| (pubkey, ids.into_iter().collect()))
+        .collect()
+}
+
 // ── kind:13534 (relay membership list) ──────────────────────────────────────
 
 /// Convert a kind:13534 relay membership list to the relay members format.
@@ -610,6 +722,26 @@ mod tests {
             .sign_with_keys(&agent_keys)
             .expect("sign");
         (event, owner_keys.public_key().to_hex())
+    }
+
+    fn managed_agent_event(
+        owner_keys: &Keys,
+        agent_pubkey: &str,
+        name: &str,
+        respond_to: &str,
+        respond_to_allowlist: &[String],
+    ) -> Event {
+        let content = serde_json::json!({
+            "name": name,
+            "parallelism": 1,
+            "respond_to": respond_to,
+            "respond_to_allowlist": respond_to_allowlist,
+        })
+        .to_string();
+        EventBuilder::new(Kind::Custom(30177), content)
+            .tags([Tag::parse(["d", agent_pubkey]).expect("parse d tag")])
+            .sign_with_keys(owner_keys)
+            .expect("sign managed-agent event")
     }
 
     #[test]
@@ -961,6 +1093,139 @@ mod tests {
             Some(crate::managed_agents::RespondTo::Allowlist)
         );
         assert_eq!(parsed[0].respond_to_allowlist, vec!["a".repeat(64)]);
+    }
+
+    #[test]
+    fn managed_agent_directory_accepts_only_the_verified_owner_policy() {
+        let agent_keys = Keys::generate();
+        let owner_keys = Keys::generate();
+        let attacker_keys = Keys::generate();
+        let agent_pubkey = agent_keys.public_key().to_hex();
+        let viewer_pubkey = "a".repeat(64);
+
+        let auth_tag_json =
+            buzz_sdk_pkg::nip_oa::compute_auth_tag(&owner_keys, &agent_keys.public_key(), "")
+                .expect("compute auth tag");
+        let auth_tag_values: Vec<String> =
+            serde_json::from_str(&auth_tag_json).expect("parse auth tag json");
+        let profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Codex"}"#)
+            .tags([Tag::parse(auth_tag_values).expect("parse auth tag")])
+            .sign_with_keys(&agent_keys)
+            .expect("sign profile");
+        let authentic = managed_agent_event(
+            &owner_keys,
+            &agent_pubkey,
+            "Codex",
+            "allowlist",
+            std::slice::from_ref(&viewer_pubkey),
+        );
+        let forged =
+            managed_agent_event(&attacker_keys, &agent_pubkey, "Fake Codex", "anyone", &[]);
+
+        let agents = relay_agents_from_managed_agent_events(
+            &[forged, authentic],
+            std::slice::from_ref(&profile),
+        );
+
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].pubkey, agent_pubkey);
+        assert_eq!(agents[0].name, "Codex");
+        assert_eq!(
+            agents[0].respond_to,
+            Some(crate::managed_agents::RespondTo::Allowlist)
+        );
+        assert_eq!(agents[0].respond_to_allowlist, vec![viewer_pubkey]);
+    }
+
+    #[test]
+    fn managed_agent_directory_rejects_agents_without_verified_owner_profiles() {
+        let owner_keys = Keys::generate();
+        let unverified_agent_keys = Keys::generate();
+        let agent_pubkey = unverified_agent_keys.public_key().to_hex();
+        let profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Codex"}"#)
+            .sign_with_keys(&unverified_agent_keys)
+            .expect("sign profile");
+        let managed = managed_agent_event(&owner_keys, &agent_pubkey, "Codex", "anyone", &[]);
+
+        let agents = relay_agents_from_managed_agent_events(
+            std::slice::from_ref(&managed),
+            std::slice::from_ref(&profile),
+        );
+
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn managed_agent_directory_uses_the_latest_profile_head() {
+        let agent_keys = Keys::generate();
+        let owner_keys = Keys::generate();
+        let agent_pubkey = agent_keys.public_key().to_hex();
+        let auth_tag_json =
+            buzz_sdk_pkg::nip_oa::compute_auth_tag(&owner_keys, &agent_keys.public_key(), "")
+                .expect("compute auth tag");
+        let auth_tag_values: Vec<String> =
+            serde_json::from_str(&auth_tag_json).expect("parse auth tag json");
+        let verified_profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Codex"}"#)
+            .tags([Tag::parse(auth_tag_values).expect("parse auth tag")])
+            .custom_created_at(nostr::Timestamp::from(10))
+            .sign_with_keys(&agent_keys)
+            .expect("sign verified profile");
+        let revoked_profile = EventBuilder::new(Kind::Metadata, r#"{"display_name":"Codex"}"#)
+            .custom_created_at(nostr::Timestamp::from(20))
+            .sign_with_keys(&agent_keys)
+            .expect("sign revoked profile");
+        let managed = managed_agent_event(&owner_keys, &agent_pubkey, "Codex", "anyone", &[]);
+
+        let agents = relay_agents_from_managed_agent_events(
+            std::slice::from_ref(&managed),
+            &[verified_profile, revoked_profile],
+        );
+
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn managed_agent_channel_ids_use_current_membership_events() {
+        let relay_keys = Keys::generate();
+        let agent_pubkey = "a".repeat(64);
+        let stranger = "b".repeat(64);
+        let candidates = [agent_pubkey.clone()].into_iter().collect();
+        let general = EventBuilder::new(Kind::Custom(39002), "")
+            .tags([
+                Tag::parse(["d", "family"]).expect("parse d tag"),
+                Tag::parse(["p", &agent_pubkey, "", "bot"]).expect("parse agent tag"),
+                Tag::parse(["p", &stranger, "", "member"]).expect("parse member tag"),
+            ])
+            .sign_with_keys(&relay_keys)
+            .expect("sign membership");
+        let forged = ev(
+            39002,
+            "",
+            vec![vec!["d", "forged"], vec!["p", &agent_pubkey, "", "bot"]],
+        );
+
+        let channel_ids = agent_channel_ids_from_member_events(
+            &[forged, general],
+            &candidates,
+            &relay_keys.public_key().to_hex(),
+        );
+
+        assert_eq!(
+            channel_ids.get(&agent_pubkey),
+            Some(&vec!["family".to_string()])
+        );
+        assert!(!channel_ids.contains_key(&stranger));
+    }
+
+    #[test]
+    fn managed_agent_directory_query_pubkeys_reject_malformed_d_tags() {
+        let valid_pubkey = Keys::generate().public_key().to_hex();
+        let valid = ev(30177, "{}", vec![vec!["d", &valid_pubkey]]);
+        let malformed = ev(30177, "{}", vec![vec!["d", "not-a-pubkey"]]);
+
+        let pubkeys = managed_agent_pubkeys_from_events(&[malformed, valid]);
+
+        assert_eq!(pubkeys, [valid_pubkey].into_iter().collect());
     }
 
     #[test]

--- a/docs/handovers/2026-08-13-shared-agent-picker.md
+++ b/docs/handovers/2026-08-13-shared-agent-picker.md
@@ -4,8 +4,11 @@
 
 - Reproduced the live failure from Andrea's event: typed `@codex` had no `p` tag because Desktop's relay directory read kind `10100`, which managed agents do not publish.
 - `list_relay_agents` now joins kind `30177` access policy with the agent's NIP-OA-verified kind `0` owner and relay-signed kind `39002` channel membership.
+- The directory preserves self-authored kind `10100` headless agents, while verified kind `30177` policy wins on collisions for Desktop-managed agents.
+- Directory and membership reads use composite-cursor pagination, profile reads are bounded in 250-author chunks, and optional enrichment failures degrade to the remaining verified source.
 - Forged policy, forged membership, malformed agent IDs, missing owner proof, and revoked owner proof fail closed.
-- `just desktop-tauri-test`: 2,435 Rust tests, 0 failures, 15 ignored.
+- Equal-timestamp replaceable heads resolve deterministically by event ID.
+- `just desktop-tauri-test`: full Rust workspace suite green after the hardening pass.
 - `just desktop-tauri-fmt-check` and `just desktop-tauri-clippy`: green.
 
 ## Pending
@@ -13,6 +16,6 @@
 - Open the upstream PR and wait for a Buzz Desktop release.
 - Verify Andrea can select Codex, Opus, and Fable after installing that release.
 
-## Known limit
+## Related work
 
-- Relay queries still inherit the existing 1,000-event response cap. Large-community pagination is separate follow-up work.
+- Supersedes the incomplete tradeoffs in #4713, #4714, #4716, #5483, #5546, and #5691 by preserving both deployed directory shapes without trusting owner-claimed agent identities or agent-claimed channel membership.

--- a/docs/handovers/2026-08-13-shared-agent-picker.md
+++ b/docs/handovers/2026-08-13-shared-agent-picker.md
@@ -1,0 +1,18 @@
+# Shared agent picker fix
+
+## Verified
+
+- Reproduced the live failure from Andrea's event: typed `@codex` had no `p` tag because Desktop's relay directory read kind `10100`, which managed agents do not publish.
+- `list_relay_agents` now joins kind `30177` access policy with the agent's NIP-OA-verified kind `0` owner and relay-signed kind `39002` channel membership.
+- Forged policy, forged membership, malformed agent IDs, missing owner proof, and revoked owner proof fail closed.
+- `just desktop-tauri-test`: 2,435 Rust tests, 0 failures, 15 ignored.
+- `just desktop-tauri-fmt-check` and `just desktop-tauri-clippy`: green.
+
+## Pending
+
+- Open the upstream PR and wait for a Buzz Desktop release.
+- Verify Andrea can select Codex, Opus, and Fable after installing that release.
+
+## Known limit
+
+- Relay queries still inherit the existing 1,000-event response cap. Large-community pagination is separate follow-up work.


### PR DESCRIPTION
## What changed

Desktop now builds one shared-agent directory from both deployed agent shapes:

- self-authored kind `10100` runtime profiles for headless and legacy agents
- owner-authored kind `30177` policy for Desktop-managed agents
- agent-authored kind `0` NIP-OA proof that binds each managed agent to its owner
- relay-authored kind `39002` membership for channel IDs

Verified kind `30177` policy wins when the same agent also has a kind `10100` profile. A failed policy or owner-proof query cannot downgrade a managed agent to stale kind `10100` permissions.

The old Desktop path only read kind `10100`. Desktop-managed agents do not publish their policy there, so another allowed member could not select the agent. The outgoing message then had no agent `p` tag.

## Safety and scale

- malformed kind `30177` d-tags are skipped before author queries
- owner policy must match the NIP-OA owner named by the agents latest kind `0`
- forged policy cannot replace or suppress a headless kind `10100` agent
- channel membership must be signed by the relay NIP-11 self key
- agent-claimed channel IDs are discarded
- equal-timestamp replaceable heads use the relay canonical lower-event-ID winner
- directory and membership reads use the composite `until` plus `before_id` cursor
- kind `0` reads use bounded 250-author chunks
- kind `10100` failure can fall back to verified managed records, but managed-policy and owner-proof failures stop the read

This keeps compatibility with headless seats while closing the unverified d-tag issue discussed on #4716.

Closes #5240. Related reports: #5363, #3776, #3277, #2349, #2950. Related implementation work: #4713, #4714, #4716, #5483, #5546, #5691.

## Verification

Exact head: `2ae62afd1f3e6f2e8abd792aa66ec079c61ab73b`

- full Desktop Rust workspace suite: exit 0, 2,438 library tests
- `just desktop-tauri-fmt-check`: exit 0
- `just desktop-tauri-clippy`: exit 0
- focused red-green coverage for kind `10100` compatibility, managed-policy precedence, forged suppression, canonical head ordering, and composite cursor construction

No agent configuration rules changed. This patch only changes relay discovery.