### PR TITLE
test(desktop): gate debug-only storage migration tests

### DIFF
--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -504,6 +504,7 @@ fn newest_agent_log_breaks_mtime_ties_deterministically() {
 
 // ── keyring-dev-migration tests ────────────────────────────────────────
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_copies_keys_present_in_src_to_dst() {
     // Keys in src but not in dst must be copied in a single bulk write,
@@ -557,6 +558,7 @@ fn copy_agent_keys_copies_keys_present_in_src_to_dst() {
     );
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_skips_keys_already_in_dst() {
     // Idempotency: a key already present in dst must NOT be overwritten
@@ -587,6 +589,7 @@ fn copy_agent_keys_skips_keys_already_in_dst() {
     assert_eq!(*src.read_count.borrow(), 0);
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_skips_keys_absent_from_src() {
     // A pubkey with no entry in src (new agent that will mint a fresh key)
@@ -614,6 +617,7 @@ fn copy_agent_keys_skips_keys_absent_from_src() {
     );
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_skips_all_when_dst_unreachable() {
     // When dst keyring is unreachable the migration must be a no-op — never
@@ -634,6 +638,7 @@ fn copy_agent_keys_skips_all_when_dst_unreachable() {
     );
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_skips_entirely_when_marker_present() {
     // After the first migration, the marker is in dst. Subsequent calls
@@ -668,6 +673,7 @@ fn copy_agent_keys_skips_entirely_when_marker_present() {
     );
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn copy_agent_keys_writes_marker_even_with_empty_agent_list() {
     // An empty pubkey list (no agents yet) must still write the marker so


### PR DESCRIPTION
## Summary

`cargo test --release` configured out the development keyring migration helper and marker, but still compiled six tests that referenced them, causing 11 `E0425` errors. Gate those migration-only tests with `debug_assertions` to match the code they cover.

Debug builds still run all six tests, while release builds now compile and complete.

### Related issue

Fixes #5785.
Fixes #6150.

No duplicate PR was found in the open or historical search.

### Testing

- Before the change, `cargo test --release` failed with 11 `E0425` errors.
- `cargo test --release` (2,409 passed, 15 ignored)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml copy_agent_keys_ -- --nocapture` (6 passed)
- `just ci`
- Screenshots: N/A (test-only change)