### PR TITLE
feat(cli): add messages link for buzz://message URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,13 @@ or invoke with the full path.
 ### Deep Links
 
 `buzz://message?channel=<uuid>&id=<hex>` links reference a specific message
-thread. To read the linked thread:
+thread. To emit one:
+
+```bash
+buzz messages link --channel <uuid> --event <hex>
+```
+
+To read the linked thread:
 
 ```bash
 buzz messages thread --channel <uuid> --event <hex> --format compact

--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -34,6 +34,7 @@ buzz messages send --channel <uuid> --content "Reply" --reply-to <event-id> --br
 buzz messages send --channel <uuid> --content - < message.md   # read body from stdin
 buzz messages get --channel <uuid> --limit 20
 buzz messages thread --channel <uuid> --event <event-id>
+buzz messages link --channel <uuid> --event <event-id>
 buzz messages search --query "architecture"
 buzz messages search --author <pubkey|npub|name> --since <unix-ts>
 buzz messages edit --event <event-id> --content "Updated text"

--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -109,6 +109,7 @@ stored rules in `validation_error` so an owner can remove and repair them.
 | | `delete` | Delete a message |
 | | `get` | List messages in a channel |
 | | `thread` | Get a message thread |
+| | `link` | Build a `buzz://message` deep link (local) |
 | | `search` | Full-text search, filterable by author |
 | | `vote` | Vote on a forum post |
 | `channels` | `list` | List channels |

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -219,6 +219,9 @@ buzz messages get --channel "$CHANNEL_ID" --limit 5 | jq .
 # messages thread
 buzz messages thread --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
 
+# messages link (local, no relay)
+buzz messages link --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
+
 # messages search
 buzz messages search --query "Hello" | jq .
 buzz messages search --query "CLI test" --limit 5 | jq .
@@ -565,6 +568,7 @@ buzz channels delete --channel "$FORUM_ID" | jq .
 | 4 | `messages delete` | ☐ | |
 | 5 | `messages get` | ☐ | With limit |
 | 6 | `messages thread` | ☐ | |
+| 6b | `messages link` | ☐ | Local URL, no relay |
 | 7 | `messages search` | ☐ | With limit |
 | 8 | `messages vote` | ☐ | Up and down |
 | 9 | `channels list` | ☐ | With visibility, member |

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -219,8 +219,11 @@ buzz messages get --channel "$CHANNEL_ID" --limit 5 | jq .
 # messages thread
 buzz messages thread --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
 
-# messages link (local, no relay)
-buzz messages link --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
+# messages link (local, no relay or BUZZ_PRIVATE_KEY)
+buzz messages link --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq -r .link
+# Expected: buzz://message?channel=<uuid>&id=<hex>
+buzz messages link --channel "$CHANNEL_ID" --event "$EVENT_ID" --thread "$EVENT_ID" | jq -r .link
+# Expected: buzz://message?channel=<uuid>&id=<hex>&thread=<hex>
 
 # messages search
 buzz messages search --query "Hello" | jq .

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -835,6 +835,48 @@ pub async fn cmd_edit_message(
 }
 
 /// Vote on a forum post or comment.
+/// Emit a canonical `buzz://message` deep link. Local-only: no relay call.
+pub fn cmd_link_message(
+    channel_id: &str,
+    event_id: &str,
+    thread_root_id: Option<&str>,
+) -> Result<(), CliError> {
+    println!(
+        "{}",
+        message_link_payload(channel_id, event_id, thread_root_id)?
+    );
+    Ok(())
+}
+
+fn message_link_payload(
+    channel_id: &str,
+    event_id: &str,
+    thread_root_id: Option<&str>,
+) -> Result<serde_json::Value, CliError> {
+    validate_uuid(channel_id)?;
+    validate_hex64(event_id)?;
+    let thread = thread_root_id.map(str::trim).filter(|s| !s.is_empty());
+    if let Some(thread) = thread {
+        validate_hex64(thread)?;
+    }
+
+    let channel = parse_uuid(channel_id)?.to_string();
+    let event = event_id.to_ascii_lowercase();
+    let thread = thread.map(str::to_ascii_lowercase);
+    let link = crate::links::message_link(&channel, &event, thread.as_deref());
+
+    let mut body = serde_json::json!({
+        "link": link,
+        "channel": channel,
+        "id": event,
+    });
+    if let Some(thread) = thread {
+        body["thread"] = serde_json::Value::String(thread);
+    }
+    Ok(body)
+}
+
+/// Vote on a forum post or comment.
 pub async fn cmd_vote_on_post(
     client: &BuzzClient,
     event_id: &str,
@@ -984,6 +1026,11 @@ pub async fn dispatch(
             )
             .await
         }
+        MessagesCmd::Link {
+            channel,
+            event,
+            thread,
+        } => cmd_link_message(&channel, &event, thread.as_deref()),
         MessagesCmd::Vote { event, direction } => {
             cmd_vote_on_post(client, &event, &direction).await
         }
@@ -994,7 +1041,7 @@ pub async fn dispatch(
 mod tests {
     use super::{
         event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        message_link_payload, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
@@ -1011,6 +1058,37 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+    const CHANNEL: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    #[test]
+    fn message_link_payload_builds_canonical_url() {
+        let body = message_link_payload(CHANNEL, ID_A, None).unwrap();
+        let expected = format!("buzz://message?channel={CHANNEL}&id={ID_A}");
+        assert_eq!(body["link"].as_str(), Some(expected.as_str()));
+        assert_eq!(body["channel"].as_str(), Some(CHANNEL));
+        assert_eq!(body["id"].as_str(), Some(ID_A));
+        assert!(body.get("thread").is_none());
+    }
+
+    #[test]
+    fn message_link_payload_includes_thread_and_normalizes_hex() {
+        let mixed = ID_A.to_ascii_uppercase();
+        let body = message_link_payload(CHANNEL, &mixed, Some(&mixed)).unwrap();
+        let expected = format!("buzz://message?channel={CHANNEL}&id={ID_A}&thread={ID_A}");
+        assert_eq!(body["id"].as_str(), Some(ID_A));
+        assert_eq!(body["thread"].as_str(), Some(ID_A));
+        assert_eq!(body["link"].as_str(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn message_link_payload_rejects_bad_channel() {
+        assert!(message_link_payload("not-a-uuid", ID_A, None).is_err());
+    }
+
+    #[test]
+    fn message_link_payload_rejects_bad_event() {
+        assert!(message_link_payload(CHANNEL, "short", None).is_err());
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -834,7 +834,6 @@ pub async fn cmd_edit_message(
     Ok(())
 }
 
-/// Vote on a forum post or comment.
 /// Emit a canonical `buzz://message` deep link. Local-only: no relay call.
 pub fn cmd_link_message(
     channel_id: &str,
@@ -853,14 +852,15 @@ fn message_link_payload(
     event_id: &str,
     thread_root_id: Option<&str>,
 ) -> Result<serde_json::Value, CliError> {
-    validate_uuid(channel_id)?;
-    validate_hex64(event_id)?;
+    let channel_id = channel_id.trim();
+    let event_id = event_id.trim();
     let thread = thread_root_id.map(str::trim).filter(|s| !s.is_empty());
     if let Some(thread) = thread {
         validate_hex64(thread)?;
     }
 
     let channel = parse_uuid(channel_id)?.to_string();
+    validate_hex64(event_id)?;
     let event = event_id.to_ascii_lowercase();
     let thread = thread.map(str::to_ascii_lowercase);
     let link = crate::links::message_link(&channel, &event, thread.as_deref());
@@ -1044,6 +1044,7 @@ mod tests {
         message_link_payload, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
+    use crate::error::CliError;
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -1082,12 +1083,20 @@ mod tests {
 
     #[test]
     fn message_link_payload_rejects_bad_channel() {
-        assert!(message_link_payload("not-a-uuid", ID_A, None).is_err());
+        let err = message_link_payload("not-a-uuid", ID_A, None).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
     }
 
     #[test]
     fn message_link_payload_rejects_bad_event() {
-        assert!(message_link_payload(CHANNEL, "short", None).is_err());
+        let err = message_link_payload(CHANNEL, "short", None).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn message_link_payload_rejects_bad_thread() {
+        let err = message_link_payload(CHANNEL, ID_A, Some("nope")).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
     }
 
     #[test]

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -72,7 +72,8 @@ Configuration (flags override env vars):
   BUZZ_PRIVATE_KEY   Nostr private key (hex or nsec)  [required]
   BUZZ_AUTH_TAG      NIP-OA auth tag JSON  [optional]
 
-The 'pack' subcommand runs locally and does not require a relay connection.
+The 'pack' and 'messages link' subcommands run locally and do not require
+a relay connection or BUZZ_PRIVATE_KEY.
 
 Exit codes: 0=ok  1=bad input  2=relay/network error  3=auth error  4=other  5=write conflict
 Errors are JSON on stderr: {\"error\": \"<category>\", \"message\": \"<detail>\"}"
@@ -1966,12 +1967,20 @@ fn normalize_auth_tag_input(input: &str) -> String {
 async fn run(cli: Cli) -> Result<(), CliError> {
     let relay_url = client::normalize_relay_url(&cli.relay);
 
-    // Pack commands are local-only — no relay connection needed.
+    // Pack and messages link are local-only — no relay connection or key.
     if let Cmd::Pack(ref sub) = cli.command {
         return match sub {
             PackCmd::Validate { path } => commands::pack::cmd_validate(path),
             PackCmd::Inspect { path } => commands::pack::cmd_inspect(path),
         };
+    }
+    if let Cmd::Messages(MessagesCmd::Link {
+        channel,
+        event,
+        thread,
+    }) = cli.command
+    {
+        return commands::messages::cmd_link_message(&channel, &event, thread.as_deref());
     }
 
     // Auth: private key is required for all relay operations.

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -513,6 +513,21 @@ pub enum MessagesCmd {
         #[arg(long)]
         limit: Option<u32>,
     },
+    /// Build a `buzz://message` deep link for a channel event
+    #[command(
+        after_help = "Prints JSON `{link, channel, id}` (and `thread` when given). Does not hit the relay.\n\nExamples:\n  buzz messages link --channel <UUID> --event <HEX>\n  buzz messages link --channel <UUID> --event <HEX> --thread <HEX>"
+    )]
+    Link {
+        /// Channel UUID
+        #[arg(long)]
+        channel: String,
+        /// Message event ID (64-char hex)
+        #[arg(long)]
+        event: String,
+        /// Optional thread root event ID (64-char hex)
+        #[arg(long)]
+        thread: Option<String>,
+    },
     /// Upvote or downvote a forum post
     Vote {
         /// Event ID of the post to vote on (64-char hex)

--- a/crates/buzz-cli/src/links.rs
+++ b/crates/buzz-cli/src/links.rs
@@ -1,13 +1,14 @@
-//! Canonical `buzz://` deep links for Buzz-hosted git entities.
+//! Canonical `buzz://` deep links for Buzz-hosted entities.
 //!
-//! Buzz Desktop renders these links as rich preview cards in chat and
-//! navigates in-app when they are clicked. The desktop parser lives in
-//! `desktop/src/shared/lib/entityLink.ts` — the two implementations must
-//! stay format-compatible (see `golden_format_matches_desktop` below and
-//! the mirror test in `entityLink.test.mjs`).
+//! Desktop renders repo/PR/issue links as rich preview cards
+//! (`desktop/src/shared/lib/entityLink.ts`) and message links via
+//! `desktop/src/features/messages/lib/messageLink.ts`. Mobile builds the
+//! same message URL in `mobile/lib/shared/deeplink/deep_link.dart`. Keep
+//! these formats byte-compatible (see the golden tests below).
 //!
 //! Callers are expected to validate inputs first (`validate_hex64`,
-//! `validate_repo_id`); the identifier charsets need no URL encoding.
+//! `validate_uuid`, `validate_repo_id`); the identifier charsets need no
+//! URL encoding.
 
 /// Build a `buzz://repo` link for a repository announcement (kind 30617).
 pub fn repo_link(owner: &str, repo_id: &str) -> String {
@@ -22,6 +23,19 @@ pub fn pull_request_link(event_id: &str, owner: &str, repo_id: &str) -> String {
 /// Build a `buzz://issue` link for an issue event (kind 1621).
 pub fn issue_link(event_id: &str, owner: &str, repo_id: &str) -> String {
     format!("buzz://issue?id={event_id}&owner={owner}&d={repo_id}")
+}
+
+/// Build a `buzz://message` link for a channel message.
+///
+/// Format: `buzz://message?channel=<uuid>&id=<eventId>[&thread=<rootId>]`.
+/// An empty `thread_root_id` is treated as "no thread".
+pub fn message_link(channel_id: &str, event_id: &str, thread_root_id: Option<&str>) -> String {
+    match thread_root_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(thread) => {
+            format!("buzz://message?channel={channel_id}&id={event_id}&thread={thread}")
+        }
+        None => format!("buzz://message?channel={channel_id}&id={event_id}"),
+    }
 }
 
 #[cfg(test)]
@@ -46,6 +60,27 @@ mod tests {
         assert_eq!(
             repo_link(OWNER, "buzz-world"),
             format!("buzz://repo?owner={OWNER}&d=buzz-world")
+        );
+    }
+
+    #[test]
+    fn message_link_matches_desktop_and_mobile() {
+        let channel = "550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(
+            message_link(channel, EVENT_ID, None),
+            format!("buzz://message?channel={channel}&id={EVENT_ID}")
+        );
+        assert_eq!(
+            message_link(channel, EVENT_ID, Some(EVENT_ID)),
+            format!("buzz://message?channel={channel}&id={EVENT_ID}&thread={EVENT_ID}")
+        );
+        assert_eq!(
+            message_link(channel, EVENT_ID, Some("")),
+            format!("buzz://message?channel={channel}&id={EVENT_ID}")
+        );
+        assert_eq!(
+            message_link(channel, EVENT_ID, Some("   ")),
+            format!("buzz://message?channel={channel}&id={EVENT_ID}")
         );
     }
 }


### PR DESCRIPTION
## Summary

Agents can already *read* `buzz://message?channel=<uuid>&id=<hex>` links (`messages thread`), and desktop/mobile can *copy* them, but the CLI could not emit one. Repo/PR/issue creates already return `buzz://` links; messages did not.

Add `buzz messages link --channel <uuid> --event <hex> [--thread <hex>]`. It is local (no relay call) and prints JSON:

```json
{"link":"buzz://message?channel=<uuid>&id=<hex>","channel":"<uuid>","id":"<hex>"}
```

`--thread` adds the optional root id. Channel UUIDs are canonicalized; event ids are lowercased. Invalid UUID/hex is a usage error (exit 1).

### Related issue

None found. Closest existing work is desktop/mobile `buildMessageLink` / `messageLink.ts` (same URL format) and CLI `links.rs` for repo/PR/issue. No open PR adds `messages link`.

### Testing

- [x] `cargo test -p buzz-cli --lib message_link` — 5 passed (format, thread, hex normalize, bad channel, bad event)
- [x] `cargo clippy -p buzz-cli --all-targets -- -D warnings`
- [x] `cargo fmt -p buzz-cli`
- [ ] Live: `buzz messages link --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .` (runbook row added in TESTING.md)

Did not run full `just ci`.