### PR TITLE
fix(desktop): tag the parent author as a recipient on channel replies

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -2,11 +2,13 @@ use nostr::{Event, EventId, Keys, PublicKey};
 use tauri::{AppHandle, State};
 
 mod forum;
+mod reply_recipient;
 
 use forum::{
     apply_link_preview_suppression, fetch_agent_owner_pubkeys, link_preview_suppression_targets,
 };
 pub use forum::{get_forum_posts, get_forum_thread};
+use reply_recipient::{add_reply_recipient, mention_refs, ResolvedThreadRef};
 
 use crate::{
     app_state::AppState,
@@ -431,7 +433,7 @@ pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<S
 async fn resolve_thread_ref(
     parent_event_id: &str,
     state: &AppState,
-) -> Result<events::ThreadRef, String> {
+) -> Result<ResolvedThreadRef, String> {
     let parent_eid =
         EventId::from_hex(parent_event_id).map_err(|e| format!("invalid parent event ID: {e}"))?;
 
@@ -470,9 +472,12 @@ async fn resolve_thread_ref(
         _ => parent_eid,
     };
 
-    Ok(events::ThreadRef {
-        root_event_id: root_eid,
-        parent_event_id: parent_eid,
+    Ok(ResolvedThreadRef {
+        thread_ref: events::ThreadRef {
+            root_event_id: root_eid,
+            parent_event_id: parent_eid,
+        },
+        parent_pubkey: parent.pubkey.to_hex(),
     })
 }
 
@@ -493,8 +498,7 @@ pub async fn send_channel_message(
 ) -> Result<SendChannelMessageResponse, String> {
     let channel_uuid = uuid::Uuid::parse_str(&channel_id)
         .map_err(|_| format!("invalid channel UUID: {channel_id}"))?;
-    let mentions = mention_pubkeys.unwrap_or_default();
-    let mention_refs: Vec<&str> = mentions.iter().map(|s| s.as_str()).collect();
+    let mut mentions = mention_pubkeys.unwrap_or_default();
     let media = media_tags.unwrap_or_default();
     let emoji = emoji_tags.unwrap_or_default();
     let mention_refs_only = mention_tags.unwrap_or_default();
@@ -511,7 +515,7 @@ pub async fn send_channel_message(
         buzz_core_pkg::kind::KIND_FORUM_POST => events::build_forum_post(
             channel_uuid,
             content.trim(),
-            &mention_refs,
+            &mention_refs(&mentions),
             &media,
             &mention_refs_only,
         )?,
@@ -520,12 +524,12 @@ pub async fn send_channel_message(
                 .as_deref()
                 .ok_or("forum comment requires parent_event_id")?;
             let thread_ref = resolve_thread_ref(parent_id, &state).await?;
-            resolved_root = Some(thread_ref.root_event_id.to_hex());
+            resolved_root = Some(thread_ref.thread_ref.root_event_id.to_hex());
             events::build_forum_comment(
                 channel_uuid,
                 content.trim(),
-                &thread_ref,
-                &mention_refs,
+                &thread_ref.thread_ref,
+                &mention_refs(&mentions),
                 &media,
                 &mention_refs_only,
             )?
@@ -533,9 +537,14 @@ pub async fn send_channel_message(
         _ => {
             let thread_ref = match parent_event_id.as_deref() {
                 Some(pid) => {
-                    let tr = resolve_thread_ref(pid, &state).await?;
-                    resolved_root = Some(tr.root_event_id.to_hex());
-                    Some(tr)
+                    let resolved = resolve_thread_ref(pid, &state).await?;
+                    let sender_pubkey = {
+                        let keys = state.keys.lock().map_err(|e| e.to_string())?;
+                        keys.public_key().to_hex()
+                    };
+                    add_reply_recipient(&mut mentions, &resolved.parent_pubkey, &sender_pubkey);
+                    resolved_root = Some(resolved.thread_ref.root_event_id.to_hex());
+                    Some(resolved.thread_ref)
                 }
                 None => None,
             };
@@ -543,7 +552,7 @@ pub async fn send_channel_message(
                 channel_uuid,
                 content.trim(),
                 thread_ref.as_ref(),
-                &mention_refs,
+                &mention_refs(&mentions),
                 &media,
                 &emoji,
                 &mention_refs_only,
@@ -771,7 +780,7 @@ pub async fn send_managed_agent_channel_message(
     let submission_auth_tag =
         managed_agent_submission_auth_tag(&record, &state, &keys.public_key())?;
     let thread_ref = match parent_event_id.as_deref() {
-        Some(parent_id) => Some(resolve_thread_ref(parent_id, &state).await?),
+        Some(parent_id) => Some(resolve_thread_ref(parent_id, &state).await?.thread_ref),
         None => None,
     };
 

--- a/desktop/src-tauri/src/commands/messages/reply_recipient.rs
+++ b/desktop/src-tauri/src/commands/messages/reply_recipient.rs
@@ -1,0 +1,64 @@
+use crate::events;
+
+/// A resolved NIP-10 thread reference plus the parent event's author.
+///
+/// The author is carried alongside the thread ref because a reply addresses
+/// the person (or agent) being replied to: without their `p` tag the reply
+/// notifies nobody and never wakes an agent harness.
+pub(super) struct ResolvedThreadRef {
+    pub(super) thread_ref: events::ThreadRef,
+    pub(super) parent_pubkey: String,
+}
+
+/// Borrow the recipient list for the `events::build_*` tag builders, which
+/// take `&[&str]`.
+pub(super) fn mention_refs(mentions: &[String]) -> Vec<&str> {
+    mentions.iter().map(String::as_str).collect()
+}
+
+/// Add the parent event's author to a reply's recipient list.
+///
+/// No-op when the pubkey is empty, when it is the sender's own (nobody
+/// notifies themselves), or when an `@mention` already tagged them.
+pub(super) fn add_reply_recipient(
+    mentions: &mut Vec<String>,
+    parent_pubkey: &str,
+    sender_pubkey: &str,
+) {
+    let parent = parent_pubkey.trim().to_ascii_lowercase();
+    let sender = sender_pubkey.trim().to_ascii_lowercase();
+    if parent.is_empty()
+        || parent == sender
+        || mentions
+            .iter()
+            .any(|pubkey| pubkey.eq_ignore_ascii_case(&parent))
+    {
+        return;
+    }
+    mentions.push(parent);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::add_reply_recipient;
+
+    #[test]
+    fn adds_parent_once_and_skips_sender() {
+        let sender = "a".repeat(64);
+        let parent = "b".repeat(64);
+        let mut mentions = vec!["c".repeat(64)];
+
+        add_reply_recipient(&mut mentions, &parent.to_uppercase(), &sender);
+        add_reply_recipient(&mut mentions, &parent, &sender);
+        add_reply_recipient(&mut mentions, &sender, &sender);
+
+        assert_eq!(mentions, vec!["c".repeat(64), parent]);
+    }
+
+    #[test]
+    fn skips_blank_parent_pubkey() {
+        let mut mentions = Vec::new();
+        add_reply_recipient(&mut mentions, "   ", &"a".repeat(64));
+        assert!(mentions.is_empty());
+    }
+}

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -78,6 +78,7 @@ fn managed_agent_message_builder_rejects_invalid_mentions() {
     .expect_err("invalid mentions should fail");
     assert!(error.contains("pubkey must be a 64-character hex string"));
 }
+
 #[test]
 fn search_messages_filter_requests_prefix_mode_for_topbar_typeahead() {
     let filter = build_search_messages_filter("  pro  ", 12, Some("channel-1"), None, None, None);


### PR DESCRIPTION
## Summary

Replying to a message in a channel publishes no recipient `p` tag. The reply carries correct NIP-10 `e` tags but nothing naming the person or agent being replied to, so nobody is notified and no agent harness is woken.

The visible symptom is a remote agent: reply to its message and it never answers, while the identical content sent from `buzz-cli` with an explicit `--mention` gets an answer immediately.

`resolve_thread_ref` already fetches the parent event in order to resolve the thread root, and the parent's author is right there on the fetched event — it was just discarded. `send_channel_message` then built its recipient list from `mention_pubkeys` alone, which is empty unless the composer text happened to contain an `@mention`.

This PR returns the parent's pubkey alongside the thread ref and adds it to the recipient list for stream messages. `add_reply_recipient`:

- adds the parent author exactly once,
- never adds the sender to their own message,
- is case-insensitive against pubkeys an `@mention` already tagged.

Forum posts/comments and managed-agent sends are untouched.

The helpers live in a new `commands/messages/reply_recipient.rs`, alongside the existing `messages/forum.rs`. Keeping them inline pushed `messages.rs` from 988 to 1019 lines and tripped `desktop/scripts/check-file-sizes.mjs` (limit 1000); the split leaves it at 996.

### Related issue

None found. I searched open issues and PRs for reply/recipient/`p`-tag wording; the closest neighbours are #3971 and #3204, which are about the mention *picker* not offering remotely-hosted agents, and #2319, which is about NIP-27 references. None covers replies publishing no recipient tag. Happy to link one if a maintainer knows of a better match.

### Testing

`cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 2430 + 7 + 3 passed, 0 failed, 14 ignored, including the new `commands::messages::reply_recipient::tests`. `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

Verified end to end against a live relay, with a dev build of this branch and a remote agent running on a separate machine.

Before, from release 0.5.11 — Reply on the agent's own message:

```
8366abac  e root=7be61c3e  e reply=8e8b531d (author cf72c7aa…)   <- no p tag, agent silent
```

After, same UI action on the patched build:

```
334aad0c  e root=7be61c3e  e reply=18e23a1e  p=cf72c7aa…
9d4c60a8  remote agent's answer, 34s later
```

The reply body contained no `@mention` text — the exact case that was silent before.

No UI change, so no screenshots.
