### PR TITLE
fix(desktop): resolve NIP-21 nostr: profile URIs to recipient tags

### DIFF
--- a/desktop/src/features/messages/lib/extractMentionPubkeys.ts
+++ b/desktop/src/features/messages/lib/extractMentionPubkeys.ts
@@ -1,4 +1,5 @@
 import { getMentionOffsets } from "./hasMention";
+import { extractNostrUriPubkeys } from "./nostrUriMentions";
 
 export type MentionPubkeyCandidate = {
   displayName: string | null;
@@ -16,9 +17,10 @@ function normalizeDisplayName(name: string): string {
 }
 
 /**
- * Returns explicit selected mention pubkeys and manually typed channel-member
- * mentions. At each `@` offset, only the longest valid display name wins so a
- * member whose name prefixes another member is not spuriously tagged.
+ * Returns explicit selected mention pubkeys, manually typed channel-member
+ * mentions, and NIP-21 `nostr:` profile URIs. At each `@` offset, only the
+ * longest valid display name wins so a member whose name prefixes another
+ * member is not spuriously tagged.
  */
 export function extractMentionPubkeys({
   text,
@@ -87,5 +89,18 @@ export function extractMentionPubkeys({
       pubkeys.push(candidate.pubkey);
     }
   }
+
+  // A `nostr:npub…` URI addresses someone the same way `@Name` does, but it
+  // carries its own pubkey, so it resolves without a display-name match.
+  const taggedPubkeys = new Set(
+    pubkeys.map((pubkey) => pubkey.trim().toLowerCase()),
+  );
+  for (const pubkey of extractNostrUriPubkeys(text)) {
+    if (!taggedPubkeys.has(pubkey)) {
+      taggedPubkeys.add(pubkey);
+      pubkeys.push(pubkey);
+    }
+  }
+
   return pubkeys;
 }

--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -19,8 +19,11 @@ function maskRange(
 /**
  * Replace Markdown code with spaces while retaining offsets and line endings.
  * Handles fenced blocks, four-space/tab-indented lines, and backtick code spans.
+ *
+ * Exported so other mention extractors (NIP-27 `nostr:` URIs) apply the same
+ * rule: text inside code is never a mention.
  */
-function maskMarkdownCode(text: string): string {
+export function maskMarkdownCode(text: string): string {
   const chars = text.split("");
   const lines: Array<{ start: number; end: number; content: string }> = [];
 

--- a/desktop/src/features/messages/lib/nostrUriMentions.test.mjs
+++ b/desktop/src/features/messages/lib/nostrUriMentions.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nip19 } from "nostr-tools";
+
+import { extractNostrUriPubkeys } from "./nostrUriMentions.ts";
+
+const SAVJETNIK =
+  "cf72c7aaa9a829fa25371e86c9564acaaff1021595cad253158e4298bf3e828b";
+const PI314 =
+  "f3856e55ce82261142b9854e6450eabcee5e140617298ca51efb75ac9e14f0d9";
+
+const savjetnikNpub = nip19.npubEncode(SAVJETNIK);
+const pi314Npub = nip19.npubEncode(PI314);
+
+test("extracts the pubkey from a nostr:npub URI", () => {
+  assert.deepEqual(
+    extractNostrUriPubkeys(`nostr:${savjetnikNpub} koliki je promet danas?`),
+    [SAVJETNIK],
+  );
+});
+
+test("extracts the pubkey from a nostr:nprofile URI", () => {
+  const nprofile = nip19.nprofileEncode({
+    pubkey: SAVJETNIK,
+    relays: ["wss://relay.example"],
+  });
+  assert.deepEqual(extractNostrUriPubkeys(`hey nostr:${nprofile}`), [
+    SAVJETNIK,
+  ]);
+});
+
+test("returns each pubkey once, in first-appearance order", () => {
+  const text = `nostr:${pi314Npub} and nostr:${savjetnikNpub} and nostr:${pi314Npub}`;
+  assert.deepEqual(extractNostrUriPubkeys(text), [PI314, SAVJETNIK]);
+});
+
+test("stops at trailing punctuation", () => {
+  assert.deepEqual(
+    extractNostrUriPubkeys(`(nostr:${savjetnikNpub}), pitanje`),
+    [SAVJETNIK],
+  );
+});
+
+test("ignores URIs inside a code span", () => {
+  assert.deepEqual(
+    extractNostrUriPubkeys(`\`nostr:${savjetnikNpub} koliki je promet?\``),
+    [],
+  );
+});
+
+test("ignores URIs inside a fenced code block", () => {
+  const text = ["```", `nostr:${savjetnikNpub}`, "```"].join("\n");
+  assert.deepEqual(extractNostrUriPubkeys(text), []);
+});
+
+test("still reads a URI outside the code span in the same message", () => {
+  assert.deepEqual(
+    extractNostrUriPubkeys(
+      `\`nostr:${pi314Npub}\` but really nostr:${savjetnikNpub}`,
+    ),
+    [SAVJETNIK],
+  );
+});
+
+test("ignores event references, which name content and not a recipient", () => {
+  const nevent = nip19.neventEncode({ id: SAVJETNIK, author: PI314 });
+  const note = nip19.noteEncode(SAVJETNIK);
+  assert.deepEqual(extractNostrUriPubkeys(`nostr:${nevent} nostr:${note}`), []);
+});
+
+test("ignores a truncated or corrupted entity", () => {
+  assert.deepEqual(
+    extractNostrUriPubkeys(`nostr:${savjetnikNpub.slice(0, 30)}`),
+    [],
+  );
+});
+
+test("ignores a bare npub with no nostr: prefix", () => {
+  assert.deepEqual(extractNostrUriPubkeys(savjetnikNpub), []);
+});
+
+test("returns nothing for text with no URI", () => {
+  assert.deepEqual(extractNostrUriPubkeys("koliki je promet danas?"), []);
+});

--- a/desktop/src/features/messages/lib/nostrUriMentions.ts
+++ b/desktop/src/features/messages/lib/nostrUriMentions.ts
@@ -1,0 +1,69 @@
+import { nip19 } from "nostr-tools";
+
+import { maskMarkdownCode } from "./hasMention";
+
+/**
+ * NIP-21 `nostr:` URI naming a person: `npub` (bare pubkey) or `nprofile`
+ * (pubkey plus relay hints). Event references (`note`, `nevent`, `naddr`) name
+ * content rather than a recipient and are deliberately not matched.
+ *
+ * The data part uses the bech32 charset, which excludes `1`, `b`, `i`, and
+ * `o` — matching it exactly stops the match at surrounding punctuation.
+ */
+const NOSTR_PROFILE_URI_SOURCE =
+  "nostr:((?:npub|nprofile)1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)";
+
+function pubkeyFromEntity(entity: string): string | null {
+  let decoded: ReturnType<typeof nip19.decode>;
+  try {
+    decoded = nip19.decode(entity);
+  } catch {
+    // Truncated or corrupted bech32 — not a usable recipient.
+    return null;
+  }
+
+  const pubkey =
+    decoded.type === "npub"
+      ? decoded.data
+      : decoded.type === "nprofile"
+        ? decoded.data.pubkey
+        : null;
+
+  if (typeof pubkey !== "string") return null;
+  const normalized = pubkey.trim().toLowerCase();
+  return /^[0-9a-f]{64}$/.test(normalized) ? normalized : null;
+}
+
+/**
+ * Extract recipient pubkeys from NIP-21 `nostr:` URIs in composer text.
+ *
+ * A pasted `nostr:npub1…` addresses someone just as `@Name` does, so it must
+ * become a recipient `p` tag — without one the mention is decorative and no
+ * notification or agent wake-up happens.
+ *
+ * Code is masked first, so a URI inside backticks or a fenced block is left
+ * alone. That mirrors `getMentionOffsets`, which already refuses to read
+ * `@Name` out of code.
+ *
+ * Returns lowercase 64-char hex pubkeys in first-appearance order, deduped.
+ */
+export function extractNostrUriPubkeys(text: string): string[] {
+  if (!text.includes("nostr:")) return [];
+
+  const pattern = new RegExp(NOSTR_PROFILE_URI_SOURCE, "g");
+  const masked = maskMarkdownCode(text);
+  const pubkeys: string[] = [];
+  const seen = new Set<string>();
+
+  let match = pattern.exec(masked);
+  while (match !== null) {
+    const pubkey = pubkeyFromEntity(match[1]);
+    if (pubkey && !seen.has(pubkey)) {
+      seen.add(pubkey);
+      pubkeys.push(pubkey);
+    }
+    match = pattern.exec(masked);
+  }
+
+  return pubkeys;
+}


### PR DESCRIPTION
## Summary

Pasting a `nostr:npub1…` URI into the composer addresses nobody. The sent event carries no `p` tag, so there is no notification and no agent wake-up.

Today the only path from composer text to a recipient is `@Name`, and it needs a display-name match against a resolved channel member (`extractMentionPubkeys` → `useMentions` candidates). A NIP-21 URI carries the pubkey itself and matches no display name, so it falls through and goes out as inert text.

New `extractNostrUriPubkeys` decodes NIP-21 profile URIs — `npub` and `nprofile` — and `extractMentionPubkeys` appends the results, deduped against whatever `@mention` already resolved.

Deliberate boundaries:

- **Code is masked first.** A URI inside backticks or a fenced block is not a mention. This reuses `maskMarkdownCode`, which `getMentionOffsets` already applies to `@Name`, so both mention forms follow one rule.
- **Event references are not recipients.** `note`, `nevent`, and `naddr` name content rather than a person, and are not matched.
- **The `nostr:` scheme is required.** A bare `npub1…` in prose is left alone rather than silently notifying someone.
- Corrupted or truncated bech32 is skipped rather than throwing.

URIs naming a non-member flow into the existing non-member mention prompt, the same as a typed `@mention` of a non-member.

This is the send path only — it does not change how a received `nostr:` URI renders.

### Related issue

Partially addresses #2319 ("Mentions should use NIP-27"). That issue asks for mentions to be *written* as NIP-27 references; this is the reading half — a NIP-21 profile URI in composer text now resolves to a recipient tag. Rendering and outbound reference-writing are still open, so I would not close #2319 on this.

### Testing

`pnpm test` in `desktop/` — 4772 passed, 0 failed, including 11 new cases in `nostrUriMentions.test.mjs` covering npub, nprofile, dedupe and ordering, trailing punctuation, code spans, fenced blocks, event references, truncated entities, and bare npubs.

`pnpm typecheck` and `pnpm check` are clean.

No UI change, so no screenshots.
