### PR TITLE
fix(desktop): keep the number an ordered list starts from

### DIFF
--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1263,6 +1263,8 @@ export function createMarkdownComponents(
 ): Components {
   const listItemClassName = "[&_p]:inline";
   const listClassName = "space-y-1 pl-6 marker:text-muted-foreground/80";
+  const olClassName = cn("list-decimal", listClassName);
+  const ulClassName = cn("list-disc", listClassName);
 
   function MarkdownAnchor({
     children,
@@ -1543,9 +1545,7 @@ export function createMarkdownComponents(
     },
     input: MarkdownInput,
     li: ({ children }) => <li className={listItemClassName}>{children}</li>,
-    ol: ({ children }) => (
-      <ol className={cn("list-decimal", listClassName)}>{children}</ol>
-    ),
+    ol: (props) => <ol {...props} className={olClassName} />,
     p: function MarkdownParagraph({ children }) {
       // Detect media-only paragraphs (images + <br> from remarkBreaks).
       // Multi-image: render as a compact, count-aware mosaic. Two images split
@@ -1595,9 +1595,7 @@ export function createMarkdownComponents(
         {children}
       </th>
     ),
-    ul: ({ children }) => (
-      <ul className={cn("list-disc", listClassName)}>{children}</ul>
-    ),
+    ul: (props) => <ul {...props} className={ulClassName} />,
     mention: function MarkdownMention({
       children,
     }: {

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -516,6 +516,35 @@ test("markdown tables overflow wide content and fill the message when narrow", a
     .toBeLessThanOrEqual(1);
 });
 
+test("an ordered list keeps the number it starts from", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  // Emitting the event directly keeps the stored content exactly as written.
+  // Typing it would route through the composer's own list handling, which is
+  // not what this asserts.
+  await page.evaluate(() => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content: "42. ORDERED START ANSWER",
+      createdAt: Math.floor(Date.now() / 1000),
+    });
+  });
+
+  // CommonMark: the first item's number sets where the list starts. Dropping
+  // it renumbers the item to 1, which reads as a different answer than the
+  // one that was sent.
+  const orderedList = page
+    .getByTestId("message-row")
+    .filter({ hasText: "ORDERED START ANSWER" })
+    .locator("ol");
+  await expect(orderedList).toHaveAttribute("start", "42");
+});
+
 test("sent link preview media uses the authenticated proxy in compact and rich cards", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- forward the `start` prop in the `ol` renderer, so an ordered list keeps the number it starts from
- take both list class names from named constants and let `ol`/`ul` spread their props, the same shape `code` already uses in this file

Closes #5817.

## Why

`ol: ({ children }) => …` destructured only `children`, so `start` never reached the element and every ordered list restarted at 1.

CommonMark gives the first item's number to the list, so a message whose whole content is `42.` is a one-item list that starts at 42. The reporter hit this when an agent answered `42.` and the channel displayed `1.` — the stored event content was right, so the agent looked like it had given a different answer.

## Note on the file size ratchet

`markdown.tsx` is above the 1000-line cap, so `check:file-sizes` does not let it gain a line. Adding `start` makes `className` the second JSX attribute, and the formatter then breaks the element across three extra lines. Moving the two `cn(...)` calls into constants and spreading props keeps both renderers on one line each. The file ends up **two lines shorter** than before.

That is also why `ul` is touched: the two list renderers now read the same way, and the change pays for itself rather than sitting exactly on the cap.

## Validation

- RED to GREEN: with only `markdown.tsx` reverted, the new e2e fails with `unexpected value "null"` — the `start` attribute is absent. With the change it passes.
- the test emits the message through `window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__` rather than typing it, so the stored content stays exactly `42. …` and the assertion is about rendering, not about the composer's own list handling
- `pnpm --filter buzz exec tsc --noEmit`
- `pnpm --filter buzz check` — biome, file sizes, px-text, pubkey truncation
- `pnpm --filter buzz test` — 4,791 passed
- `messaging.spec.ts` in full — 57 passed, 2 failed; a control run of the same file on clean `main` also fails 2, one of them the same test and the other a different one, so the suite is flaky in my environment and this branch is not worse

One more thing worth stating plainly: `useDocumentVisible.test.mjs` → `visibility-gated hooks` failed in several full unit runs with `ReferenceError: window is not defined`, thrown by a jsdom timer that fires after the window is torn down. It passes in isolation and passed on a rerun of the full suite, and neither file in this PR is loaded by it.
