### PR TITLE
Publish tool-free ACP final responses to trusted DMs

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -1,6 +1,6 @@
 # buzz-acp
 
-ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and the agent replies using the Buzz CLI.
+ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and normally lets the agent reply using the Buzz CLI. A narrow opt-in bridge is also available for tool-free ACP chat agents whose final text would otherwise remain activity-only.
 
 ```
 Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
@@ -111,6 +111,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
+| `BUZZ_ACP_PUBLISH_FINAL_RESPONSE_TO_DM` | no | `false` | Publish the final ACP assistant text as one signed DM after a successful `end_turn`. See **Tool-free DM response bridge** below. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
@@ -118,6 +119,37 @@ All configuration is via environment variables (or CLI flags — every env var h
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+### Tool-free DM response bridge
+
+ACP `agent_message_chunk` notifications are activity/transcript output; by default they are not Buzz chat events. Agents with the normal base prompt publish deliberately through `buzz messages send`. For a chat-only Hermes adapter that intentionally has no Buzz tool, enable the trusted parent-side bridge:
+
+```bash
+export BUZZ_ACP_PUBLISH_FINAL_RESPONSE_TO_DM=true
+export BUZZ_ACP_NO_BASE_PROMPT=true
+export BUZZ_ACP_MCP_COMMAND=""
+export BUZZ_ACP_AGENTS=1
+export BUZZ_ACP_DEDUP=queue
+export BUZZ_ACP_MULTIPLE_EVENT_HANDLING=queue
+```
+
+The bridge is default-off and deliberately restricted:
+
+- the configured agent command must identify a Hermes adapter so configured MCP startup can be forcibly disabled;
+- only a relay-verified DM is eligible; unresolved routes fail closed;
+- only text captured from the matching ACP session and an actual `end_turn` is published;
+- the channel, thread ancestry, author key, and signature come from trusted harness state, never model output;
+- the exact signed event is retained across an ambiguous relay response and retried before another model prompt;
+- Buzz relay credentials are removed from the ACP child environment; Hermes also has configured MCP startup forced off;
+- `--no-base-prompt`, an empty MCP command, one agent, self-event filtering, `dedup=queue`, and `multiple-event-handling=queue` are required to prevent duplicate, recursive, or redirected sends.
+
+This mode is for one-answer DM adapters. It does not auto-publish heartbeats, channel/stream turns, partial output, refusals, cancellations, or token-limit stops.
+
+Operational limits:
+
+- Run only one `buzz-acp` publisher for a given agent key. Relay reconciliation is idempotent for one process, but two concurrent processes can race before either response exists.
+- Successfully published replies carry relay-backed correlation markers, preventing a replayed trigger from invoking Hermes again. The pending signed-event outbox itself is process-local; a crash after inference but before any event reaches the relay is recoverable only while the inbound trigger remains in the relay subscription replay window.
+- A Buzz DM can contain multiple members. Kind-9 message content is protected by channel access control but is not NIP-44 end-to-end encrypted from the relay/database.
 
 ### Parallel Agents & Heartbeat
 
@@ -254,7 +286,7 @@ Forum event kinds:
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
 3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
-5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
+5. **Agent response** — Normally the agent uses the Buzz CLI (`messages send`, `messages get`, etc.) to interact with Buzz. In the opt-in tool-free DM mode, the harness publishes the completed ACP assistant text itself.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
@@ -328,6 +360,8 @@ The harness works with any agent that implements the [ACP spec](https://agentcli
 - Accept `session/new` with `mcpServers` and return a `sessionId`
 - Accept `session/prompt` with a text message and stream `session/update` notifications
 - Return a `stopReason` (`end_turn`, `cancelled`, `max_tokens`, etc.)
+
+ACP assistant chunks alone appear in agent activity, not the Buzz chat timeline. An adapter must either use the normal Buzz send workflow or be launched with the restricted tool-free DM bridge described above.
 
 Set `BUZZ_ACP_AGENT_COMMAND` and `BUZZ_ACP_AGENT_ARGS` to point at your agent binary.
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -19,6 +19,25 @@ use crate::usage::{TurnUsage, UsageTracker};
 /// Maximum allowed size of a single NDJSON line from the agent's stdout.
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
+/// Maximum assistant text retained for an opt-in host-published chat response.
+/// Matches the Buzz kind-9 message content limit.
+const MAX_TURN_AGENT_MESSAGE_SIZE: usize = 64 * 1024;
+
+/// Append a UTF-8-safe prefix of `chunk` without exceeding `limit` bytes.
+/// Returns true only when the complete chunk fit.
+fn append_up_to_byte_limit(output: &mut String, chunk: &str, limit: usize) -> bool {
+    let remaining = limit.saturating_sub(output.len());
+    if remaining == 0 {
+        return chunk.is_empty();
+    }
+
+    let mut end = chunk.len().min(remaining);
+    while end > 0 && !chunk.is_char_boundary(end) {
+        end -= 1;
+    }
+    output.push_str(&chunk[..end]);
+    end == chunk.len()
+}
 
 /// An MCP server configuration passed to `session/new`.
 ///
@@ -103,6 +122,11 @@ pub enum AcpError {
 
     #[error("Protocol error: {0}")]
     Protocol(String),
+
+    /// The ACP turn completed, but its host-owned Buzz message has not yet
+    /// been confirmed by the relay. The agent stdio pipe remains healthy.
+    #[error("Final response publication error: {0}")]
+    Publication(String),
 
     #[error("Agent reported error (code {code}): {message}")]
     AgentError { code: i64, message: String },
@@ -211,6 +235,21 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Assistant message chunks observed during the current prompt. ACP text is
+    /// normally activity-only; the opt-in DM bridge consumes this after a clean
+    /// `end_turn` and publishes it with the harness-owned relay identity.
+    turn_agent_message: String,
+    /// Session whose in-flight prompt owns `turn_agent_message`. Updates for
+    /// any other session are ignored so a late notification cannot be routed
+    /// into the current DM response.
+    turn_agent_message_session_id: Option<String>,
+    /// True when assistant text exceeded the kind-9 content limit. A partial
+    /// answer must never be published as though the turn completed cleanly.
+    turn_agent_message_truncated: bool,
+    /// Actual stop reason parsed for the most recently completed prompt. The
+    /// control-signal completion race consumes this instead of synthesizing an
+    /// `end_turn` that could accidentally publish a refusal or partial answer.
+    completed_prompt_stop_reason: Option<StopReason>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -454,6 +493,27 @@ impl AcpClient {
         extra_env: &[(String, String)],
         has_generated_codex_config: bool,
     ) -> Result<Self, AcpError> {
+        Self::spawn_with_relay_credential_isolation(
+            command,
+            args,
+            extra_env,
+            has_generated_codex_config,
+            false,
+        )
+        .await
+    }
+
+    /// Spawn an ACP adapter, optionally removing every Buzz relay credential
+    /// from its inherited environment. The isolated mode is used by the
+    /// host-published DM bridge: the parent retains signing authority while the
+    /// adapter receives only ACP prompt/result traffic and provider settings.
+    pub async fn spawn_with_relay_credential_isolation(
+        command: &str,
+        args: &[String],
+        extra_env: &[(String, String)],
+        has_generated_codex_config: bool,
+        isolate_relay_credentials: bool,
+    ) -> Result<Self, AcpError> {
         use std::process::Stdio;
 
         let mut cmd = tokio::process::Command::new(command);
@@ -465,6 +525,38 @@ impl AcpClient {
             // Ensure the child is killed when the AcpClient is dropped (best-effort).
             // Callers MUST still call shutdown().await for guaranteed cleanup.
             .kill_on_drop(true);
+
+        const RELAY_CREDENTIAL_ENV: [&str; 7] = [
+            "BUZZ_PRIVATE_KEY",
+            "NOSTR_PRIVATE_KEY",
+            "BUZZ_AUTH_TAG",
+            "BUZZ_RELAY_URL",
+            "BUZZ_API_TOKEN",
+            "BUZZ_ACP_PRIVATE_KEY",
+            "BUZZ_ACP_API_TOKEN",
+        ];
+        if isolate_relay_credentials {
+            if let Some((key, _)) = extra_env
+                .iter()
+                .find(|(key, _)| RELAY_CREDENTIAL_ENV.contains(&key.as_str()))
+            {
+                return Err(AcpError::Protocol(format!(
+                    "isolated ACP adapter extra_env must not contain {key}"
+                )));
+            }
+            for key in RELAY_CREDENTIAL_ENV {
+                cmd.env_remove(key);
+            }
+
+            if let Some((_, value)) = extra_env
+                .iter()
+                .find(|(key, value)| key == "HERMES_ACP_SKIP_CONFIGURED_MCP" && *value != "1")
+            {
+                return Err(AcpError::Protocol(format!(
+                    "isolated Hermes ACP adapter requires HERMES_ACP_SKIP_CONFIGURED_MCP=1, got {value:?}"
+                )));
+            }
+        }
 
         // Per-persona env vars (e.g., GOOSE_PROVIDER, BUZZ_AGENT_PROVIDER).
         // For most keys, operator precedence wins: skip injection if already set
@@ -513,6 +605,17 @@ impl AcpClient {
             cmd.env("CODEX_CONFIG", merged);
         }
 
+        // The publication bridge keeps relay signing in this trusted parent.
+        // For Hermes, also force profile-configured MCP servers off even when
+        // the parent environment attempted to override the normal default.
+        if isolate_relay_credentials
+            && crate::config::default_agent_env(command)
+                .iter()
+                .any(|(key, _)| *key == "HERMES_ACP_SKIP_CONFIGURED_MCP")
+        {
+            cmd.env("HERMES_ACP_SKIP_CONFIGURED_MCP", "1");
+        }
+
         // Spawn the agent in its own process group so SIGKILL doesn't propagate
         // to the harness's own process group on Unix.
         // tokio::process::Command::process_group is a stable tokio API (no extra imports needed).
@@ -550,6 +653,10 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            turn_agent_message: String::new(),
+            turn_agent_message_session_id: None,
+            turn_agent_message_truncated: false,
+            completed_prompt_stop_reason: None,
         })
     }
 
@@ -768,6 +875,12 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        // A client may reuse one ACP session across many turns. Never let text
+        // from a cancelled, failed, or prior prompt leak into the next turn.
+        self.turn_agent_message.clear();
+        self.turn_agent_message_session_id = Some(session_id.to_owned());
+        self.turn_agent_message_truncated = false;
+        self.completed_prompt_stop_reason = None;
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -792,6 +905,7 @@ impl AcpClient {
         if let Err(e) = self.write_ndjson(&msg).await {
             self.last_prompt_id = None;
             self.current_hard_deadline = None;
+            self.turn_agent_message_session_id = None;
             return Err(e);
         }
 
@@ -811,6 +925,7 @@ impl AcpClient {
             Ok(_) => {
                 self.last_prompt_id = None;
                 self.current_hard_deadline = None;
+                self.turn_agent_message_session_id = None;
             }
             Err(AcpError::IdleTimeout(_) | AcpError::HardTimeout { .. }) => {
                 // Leave last_prompt_id and current_hard_deadline set —
@@ -819,9 +934,12 @@ impl AcpClient {
             Err(_) => {
                 self.last_prompt_id = None;
                 self.current_hard_deadline = None;
+                self.turn_agent_message_session_id = None;
             }
         }
-        self.parse_stop_reason(&result?)
+        let stop_reason = self.parse_stop_reason(&result?)?;
+        self.completed_prompt_stop_reason = Some(stop_reason.clone());
+        Ok(stop_reason)
     }
 
     /// Send a `session/cancel` **notification** (no `id` field, no response expected).
@@ -879,6 +997,24 @@ impl AcpClient {
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
         self.goose_usage.take()
+    }
+
+    /// Consume assistant text captured during the most recent prompt.
+    ///
+    /// The default Buzz behavior remains unchanged: ACP text is activity, not
+    /// a channel message. The private DM bridge is the sole production caller.
+    pub fn take_turn_agent_message(&mut self) -> Result<Option<String>, &'static str> {
+        let captured = std::mem::take(&mut self.turn_agent_message);
+        if std::mem::take(&mut self.turn_agent_message_truncated) {
+            return Err("ACP final assistant message exceeded the 64 KiB Buzz limit");
+        }
+        Ok((!captured.trim().is_empty()).then_some(captured))
+    }
+
+    /// Consume the exact stop reason recorded by the most recently completed
+    /// `session/prompt`, if any.
+    pub fn take_completed_prompt_stop_reason(&mut self) -> Option<StopReason> {
+        self.completed_prompt_stop_reason.take()
     }
 
     /// Notify the usage tracker that buzz-acp just spawned a new session.
@@ -1746,10 +1882,34 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    let session_id = msg["params"]["sessionId"].as_str();
+                    if self
+                        .turn_agent_message_session_id
+                        .as_deref()
+                        .is_some_and(|expected| session_id == Some(expected))
+                        && !append_up_to_byte_limit(
+                            &mut self.turn_agent_message,
+                            text,
+                            MAX_TURN_AGENT_MESSAGE_SIZE,
+                        )
+                    {
+                        self.turn_agent_message_truncated = true;
+                    }
                 }
                 false
             }
             "tool_call" => {
+                if self
+                    .turn_agent_message_session_id
+                    .as_deref()
+                    .is_some_and(|expected| msg["params"]["sessionId"].as_str() == Some(expected))
+                {
+                    // ACP adapters may stream a pre-tool status sentence as an
+                    // agent message. A visible reply must contain only the
+                    // terminal answer produced after the last tool call.
+                    self.turn_agent_message.clear();
+                    self.turn_agent_message_truncated = false;
+                }
                 let title = update
                     .get("title")
                     .and_then(|v| v.as_str())
@@ -2907,6 +3067,7 @@ mod tests {
         file_name: &str,
         var: &str,
         extra_env: &[(String, String)],
+        isolate_relay_credentials: bool,
     ) -> String {
         use std::os::unix::fs::PermissionsExt;
 
@@ -2922,11 +3083,12 @@ mod tests {
         permissions.set_mode(0o700);
         std::fs::set_permissions(&path, permissions).expect("chmod probe");
 
-        let mut client = AcpClient::spawn(
+        let mut client = AcpClient::spawn_with_relay_credential_isolation(
             path.to_str().expect("probe path is UTF-8"),
             &[],
             extra_env,
             false,
+            isolate_relay_credentials,
         )
         .await
         .expect("spawn env probe script");
@@ -2955,19 +3117,51 @@ mod tests {
         }
 
         assert_eq!(
-            spawn_named_and_read_child_env("hermes-acp", VAR, &[]).await,
+            spawn_named_and_read_child_env("hermes-acp", VAR, &[], false).await,
             "1",
             "Hermes spawns must default {VAR}=1"
         );
         assert_eq!(
-            spawn_named_and_read_child_env("hermes-acp", VAR, &[(VAR.into(), "0".into())]).await,
+            spawn_named_and_read_child_env("hermes-acp", VAR, &[(VAR.into(), "0".into())], false,)
+                .await,
             "0",
             "an explicit extra_env entry must override the runtime default"
         );
         assert_eq!(
-            spawn_named_and_read_child_env("other-agent", VAR, &[]).await,
+            spawn_named_and_read_child_env("other-agent", VAR, &[], false).await,
             "<unset>",
             "non-Hermes spawns must not receive Hermes defaults"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn isolated_hermes_spawn_forces_configured_mcp_off() {
+        const VAR: &str = "HERMES_ACP_SKIP_CONFIGURED_MCP";
+        const INNER_MARKER: &str = "BUZZ_ACP_HERMES_ISOLATION_INNER_TEST";
+        if std::env::var_os(INNER_MARKER).is_none() {
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("resolve current test executable"),
+            )
+            .arg("isolated_hermes_spawn_forces_configured_mcp_off")
+            .arg("--nocapture")
+            .env(INNER_MARKER, "1")
+            .env(VAR, "0")
+            .output()
+            .expect("run nested Hermes isolation test");
+            assert!(
+                output.status.success(),
+                "nested Hermes isolation test failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        assert_eq!(
+            spawn_named_and_read_child_env("run-buzz-hermes-venice.sh", VAR, &[], true,).await,
+            "1",
+            "isolated Hermes mode must override an inherited opt-out"
         );
     }
 
@@ -3566,6 +3760,307 @@ mod tests {
         AcpClient::spawn("cat", &[], &[], false)
             .await
             .expect("spawn cat as inert client")
+    }
+
+    fn agent_message_chunk_update(session_id: Option<&str>, text: &str) -> serde_json::Value {
+        let mut params = serde_json::json!({
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": { "text": text },
+            },
+        });
+        if let Some(session_id) = session_id {
+            params["sessionId"] = serde_json::json!(session_id);
+        }
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": params,
+        })
+    }
+
+    #[tokio::test]
+    async fn matching_hermes_and_goose_message_chunks_are_captured_with_whitespace() {
+        let mut client = spawn_inert_client().await;
+        client.turn_agent_message_session_id = Some("session-match".into());
+
+        // Hermes emits the minimal ACP shape: no messageId, content type, or
+        // adapter metadata is required for a text chunk.
+        let hermes = agent_message_chunk_update(Some("session-match"), "  Hermes\n");
+        assert!(!client.handle_session_update(&hermes));
+
+        // Goose adds message identity, a typed content block, and extension
+        // metadata. Those fields must not change capture semantics.
+        let goose = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-match",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "messageId": "message-goose-1",
+                    "content": { "type": "text", "text": "Goose  " },
+                    "_meta": { "goose": { "role": "assistant" } },
+                },
+            },
+        });
+        assert!(!client.handle_session_update(&goose));
+
+        assert_eq!(
+            client.take_turn_agent_message(),
+            Ok(Some("  Hermes\nGoose  ".into())),
+            "leading, embedded, and trailing whitespace must be preserved"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn message_chunks_for_wrong_or_missing_sessions_are_ignored() {
+        let mut client = spawn_inert_client().await;
+        client.turn_agent_message_session_id = Some("session-match".into());
+
+        let wrong = agent_message_chunk_update(Some("session-other"), "wrong");
+        let missing = agent_message_chunk_update(None, "missing");
+        client.handle_session_update(&wrong);
+        client.handle_session_update(&missing);
+
+        client.turn_agent_message_session_id = None;
+        let no_active_turn = agent_message_chunk_update(Some("session-match"), "inactive");
+        client.handle_session_update(&no_active_turn);
+
+        assert_eq!(client.take_turn_agent_message(), Ok(None));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn matching_tool_call_clears_pre_tool_text_and_truncation_state() {
+        let mut client = spawn_inert_client().await;
+        client.turn_agent_message_session_id = Some("session-match".into());
+
+        let oversized = "x".repeat(MAX_TURN_AGENT_MESSAGE_SIZE + 1);
+        client.handle_session_update(&agent_message_chunk_update(
+            Some("session-match"),
+            &oversized,
+        ));
+        assert!(!client.turn_agent_message.is_empty());
+        assert!(client.turn_agent_message_truncated);
+
+        let tool_call = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-match",
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "title": "read file",
+                    "kind": "read",
+                },
+            },
+        });
+        assert!(client.handle_session_update(&tool_call));
+        assert!(client.turn_agent_message.is_empty());
+        assert!(!client.turn_agent_message_truncated);
+
+        client.handle_session_update(&agent_message_chunk_update(
+            Some("session-match"),
+            "terminal answer",
+        ));
+        assert_eq!(
+            client.take_turn_agent_message(),
+            Ok(Some("terminal answer".into()))
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn utf8_overflow_at_64_kib_returns_explicit_capture_error() {
+        let mut client = spawn_inert_client().await;
+        client.turn_agent_message_session_id = Some("session-match".into());
+
+        // The byte limit lands between the two bytes of `é`. Capture must
+        // retain a valid UTF-8 prefix, mark truncation, and refuse publication.
+        let chunk = format!("{}é", "a".repeat(MAX_TURN_AGENT_MESSAGE_SIZE - 1));
+        client.handle_session_update(&agent_message_chunk_update(Some("session-match"), &chunk));
+        assert_eq!(
+            client.turn_agent_message.len(),
+            MAX_TURN_AGENT_MESSAGE_SIZE - 1
+        );
+        assert!(client
+            .turn_agent_message
+            .is_char_boundary(client.turn_agent_message.len()));
+        assert_eq!(
+            client.take_turn_agent_message(),
+            Err("ACP final assistant message exceeded the 64 KiB Buzz limit")
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn consecutive_prompt_turns_do_not_leak_captured_text() {
+        let script = r#"
+            read -r _first_prompt
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-reused","update":{"sessionUpdate":"agent_message_chunk","content":{"text":"first answer"}}}}'
+            echo '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'
+            read -r _second_prompt
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-reused","update":{"sessionUpdate":"agent_message_chunk","messageId":"m2","content":{"type":"text","text":"second answer"}}}}'
+            echo '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+            sleep 10
+        "#;
+        let mut client = spawn_script(script).await;
+        let idle = std::time::Duration::from_secs(2);
+        let max = std::time::Duration::from_secs(5);
+
+        assert_eq!(
+            client
+                .session_prompt_with_idle_timeout("session-reused", "first", idle, max)
+                .await
+                .expect("first prompt completes"),
+            StopReason::EndTurn
+        );
+        assert_eq!(client.turn_agent_message, "first answer");
+
+        // Deliberately do not consume the first answer. Starting the second
+        // prompt must clear it before any second-turn chunk arrives.
+        assert_eq!(
+            client
+                .session_prompt_with_idle_timeout("session-reused", "second", idle, max)
+                .await
+                .expect("second prompt completes"),
+            StopReason::EndTurn
+        );
+        assert_eq!(
+            client.take_turn_agent_message(),
+            Ok(Some("second answer".into()))
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn completed_stop_reason_is_retained_exactly_once_for_end_turn_and_refusal() {
+        let script = r#"
+            read -r _first_prompt
+            echo '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'
+            read -r _second_prompt
+            echo '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"refusal"}}'
+            sleep 10
+        "#;
+        let mut client = spawn_script(script).await;
+        let idle = std::time::Duration::from_secs(2);
+        let max = std::time::Duration::from_secs(5);
+
+        assert_eq!(
+            client
+                .session_prompt_with_idle_timeout("session", "first", idle, max)
+                .await
+                .expect("end-turn prompt completes"),
+            StopReason::EndTurn
+        );
+        assert_eq!(
+            client.take_completed_prompt_stop_reason(),
+            Some(StopReason::EndTurn)
+        );
+        assert_eq!(client.take_completed_prompt_stop_reason(), None);
+
+        assert_eq!(
+            client
+                .session_prompt_with_idle_timeout("session", "second", idle, max)
+                .await
+                .expect("refused prompt completes"),
+            StopReason::Refusal
+        );
+        assert_eq!(
+            client.take_completed_prompt_stop_reason(),
+            Some(StopReason::Refusal)
+        );
+        assert_eq!(client.take_completed_prompt_stop_reason(), None);
+        client.shutdown().await;
+    }
+
+    /// Run the isolation assertion in a nested copy of this test process. That
+    /// gives the spawned adapter real inherited credentials without racing the
+    /// primary test binary by mutating its process-global environment.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn isolated_child_omits_relay_credentials_but_keeps_provider_env() {
+        const INNER_MARKER: &str = "BUZZ_ACP_CREDENTIAL_ISOLATION_INNER_TEST";
+        if std::env::var_os(INNER_MARKER).is_none() {
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("resolve current test executable"),
+            )
+            .arg("isolated_child_omits_relay_credentials_but_keeps_provider_env")
+            .arg("--nocapture")
+            .env(INNER_MARKER, "1")
+            .env("BUZZ_PRIVATE_KEY", "inherited-private-key")
+            .env("NOSTR_PRIVATE_KEY", "inherited-nostr-private-key")
+            .env("BUZZ_AUTH_TAG", "inherited-auth-tag")
+            .env("BUZZ_RELAY_URL", "wss://inherited.invalid")
+            .env_remove("GOOSE_PROVIDER")
+            .output()
+            .expect("run nested credential-isolation test");
+            assert!(
+                output.status.success(),
+                "nested credential-isolation test failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        // `${VAR+x}` reveals presence only, so a regression never prints an
+        // inherited credential value into test output.
+        let script = r#"printf '%s|%s|%s|%s|%s\n' "${BUZZ_PRIVATE_KEY+x}" "${NOSTR_PRIVATE_KEY+x}" "${BUZZ_AUTH_TAG+x}" "${BUZZ_RELAY_URL+x}" "${GOOSE_PROVIDER-unset}"; sleep 10"#;
+        let extra_env = [("GOOSE_PROVIDER".into(), "anthropic".into())];
+        let mut client = AcpClient::spawn_with_relay_credential_isolation(
+            "bash",
+            &["-c".into(), script.into()],
+            &extra_env,
+            false,
+            true,
+        )
+        .await
+        .expect("spawn isolated environment probe");
+        let observed = client
+            .reader
+            .next()
+            .await
+            .expect("environment probe writes one line")
+            .expect("environment probe line is readable");
+        assert_eq!(observed, "||||anthropic");
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn isolated_spawn_rejects_sensitive_extra_env() {
+        for key in [
+            "BUZZ_PRIVATE_KEY",
+            "NOSTR_PRIVATE_KEY",
+            "BUZZ_AUTH_TAG",
+            "BUZZ_RELAY_URL",
+            "BUZZ_API_TOKEN",
+            "BUZZ_ACP_PRIVATE_KEY",
+            "BUZZ_ACP_API_TOKEN",
+        ] {
+            let extra_env = [(key.to_string(), "must-not-reach-child".into())];
+            match AcpClient::spawn_with_relay_credential_isolation(
+                "cat",
+                &[],
+                &extra_env,
+                false,
+                true,
+            )
+            .await
+            {
+                Err(AcpError::Protocol(message)) => assert!(
+                    message.contains(key),
+                    "rejection should identify forbidden key {key}: {message}"
+                ),
+                Err(other) => panic!("expected protocol rejection for {key}, got {other}"),
+                Ok(mut client) => {
+                    client.shutdown().await;
+                    panic!("isolated spawn accepted forbidden key {key}");
+                }
+            }
+        }
     }
 
     /// Build a `session/update` JSON-RPC notification carrying a

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -409,6 +409,20 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_NO_BASE_PROMPT")]
     pub no_base_prompt: bool,
 
+    /// Publish the completed ACP assistant message as a signed Buzz DM.
+    ///
+    /// This compatibility bridge is for a tool-free Hermes chat adapter whose
+    /// ACP text would otherwise remain activity-only. It is deliberately
+    /// DM-only and requires `--no-base-prompt` so the agent is not
+    /// simultaneously told to publish with `buzz messages send`.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_PUBLISH_FINAL_RESPONSE_TO_DM",
+        default_value_t = false,
+        requires = "no_base_prompt"
+    )]
+    pub publish_final_response_to_dm: bool,
+
     /// Path to a custom base prompt file. Overrides the compiled-in default.
     /// Mutually exclusive with --no-base-prompt.
     #[arg(
@@ -564,6 +578,9 @@ pub struct Config {
     pub agent_owner: Option<String>,
     /// Disable the [Base] platform-context section prepended to every prompt.
     pub no_base_prompt: bool,
+    /// Publish a captured final ACP assistant message for successful DM turns.
+    /// Default-off; intended only for tool-free compatibility harnesses.
+    pub publish_final_response_to_dm: bool,
     /// Resolved content from `--base-prompt-file`, read and validated in
     /// `from_cli()`. `None` when using the compiled-in default or when
     /// `--no-base-prompt` is set.
@@ -716,12 +733,15 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
 /// `session/new`, but Hermes otherwise starts every profile-configured MCP
 /// server before it responds to `initialize` — which can exhaust the host's
 /// startup budget (see block/buzz#3355). Skip that unrelated global startup
-/// by default; an operator or persona can still opt back in by setting the
-/// variable explicitly.
+/// by default; an operator or persona can still opt back in for ordinary
+/// Hermes launches. The isolated final-response bridge forcibly retains this
+/// setting because configured MCP is outside its content-only trust boundary.
 pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'static str)] {
-    match normalize_agent_command_identity(command).as_str() {
-        "hermes" | "hermes-agent" | "hermes-acp" => &[("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")],
-        _ => &[],
+    let identity = normalize_agent_command_identity(command);
+    if identity.split('-').any(|segment| segment == "hermes") {
+        &[("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")]
+    } else {
+        &[]
     }
 }
 
@@ -891,6 +911,55 @@ impl Config {
         } else {
             None
         };
+
+        if args.publish_final_response_to_dm && !args.no_base_prompt {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm requires no_base_prompt to prevent duplicate sends"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm && !args.mcp_command.trim().is_empty() {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm requires an empty mcp_command so no host-injected MCP tools can duplicate or redirect the reply"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm
+            && !default_agent_env(&args.agent_command)
+                .iter()
+                .any(|(key, value)| *key == "HERMES_ACP_SKIP_CONFIGURED_MCP" && *value == "1")
+        {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm currently requires a Hermes adapter command so configured MCP startup can be forcibly disabled"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm && args.no_ignore_self {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm requires ignore_self so published replies cannot recursively trigger the agent"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm && args.agents != 1 {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm currently requires agents=1 so an unconfirmed signed reply remains bound to its transport outbox"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm && !matches!(args.dedup, DedupMode::Queue) {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm requires dedup=queue so unconfirmed signed replies remain retryable"
+                    .into(),
+            ));
+        }
+        if args.publish_final_response_to_dm
+            && !matches!(args.multiple_event_handling, MultipleEventHandling::Queue)
+        {
+            return Err(ConfigError::ConfigFile(
+                "publish_final_response_to_dm requires multiple_event_handling=queue so trusted DM routing cannot change through native steering"
+                    .into(),
+            ));
+        }
 
         if matches!(args.subscribe, SubscribeMode::Config) {
             if args.kinds.is_some() {
@@ -1109,6 +1178,7 @@ impl Config {
             lazy_pool: args.lazy_pool,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
+            publish_final_response_to_dm: args.publish_final_response_to_dm,
             base_prompt_content,
         };
 
@@ -1131,7 +1201,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} publish_final_response_to_dm={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1150,6 +1220,7 @@ impl Config {
             self.presence_enabled,
             self.typing_enabled,
             self.memory_enabled,
+            self.publish_final_response_to_dm,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
             respond_to_detail,
@@ -1480,6 +1551,7 @@ mod tests {
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
+            publish_final_response_to_dm: false,
             base_prompt_content: None,
         }
     }
@@ -1649,6 +1721,7 @@ mod tests {
             "/opt/hermes/bin/hermes-acp",
             r"C:\Users\test\bin\HERMES_ACP.EXE",
             r"C:\Users\test\AppData\Roaming\npm\hermes-acp.cmd",
+            "/Users/test/.local/bin/run-buzz-hermes-venice.sh",
         ] {
             assert_eq!(
                 default_agent_env(command),
@@ -2741,6 +2814,101 @@ channels = "ALL"
     // A minimal valid private key for test use (secp256k1 scalar = 1).
     const TEST_PRIVATE_KEY: &str =
         "0000000000000000000000000000000000000000000000000000000000000001";
+
+    #[test]
+    fn final_response_dm_bridge_defaults_off() {
+        let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", TEST_PRIVATE_KEY])
+            .expect("default args should parse");
+        assert!(!args.publish_final_response_to_dm);
+    }
+
+    #[test]
+    fn final_response_dm_bridge_requires_explicit_safe_profile() {
+        let missing_no_base = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--publish-final-response-to-dm",
+        ]);
+        assert!(
+            missing_no_base.is_err(),
+            "clap must require --no-base-prompt"
+        );
+
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--agent-command",
+            "hermes",
+            "--publish-final-response-to-dm",
+            "--no-base-prompt",
+            "--multiple-event-handling",
+            "queue",
+        ])
+        .expect("safe bridge profile should parse");
+        let config = Config::from_args(args).expect("safe bridge profile should validate");
+        assert!(config.publish_final_response_to_dm);
+        assert!(config.ignore_self);
+        assert!(config.mcp_command.is_empty());
+        assert!(matches!(config.dedup_mode, DedupMode::Queue));
+        assert!(matches!(
+            config.multiple_event_handling,
+            MultipleEventHandling::Queue
+        ));
+    }
+
+    #[test]
+    fn final_response_dm_bridge_rejects_unsafe_delivery_modes() {
+        let unsafe_cases = [
+            vec!["--mcp-command", "buzz-dev-mcp"],
+            vec!["--no-ignore-self"],
+            vec!["--agents", "2"],
+            vec!["--dedup", "drop"],
+            vec!["--multiple-event-handling", "steer"],
+        ];
+        for unsafe_case in unsafe_cases {
+            let mut argv = vec![
+                "buzz-acp",
+                "--private-key",
+                TEST_PRIVATE_KEY,
+                "--agent-command",
+                "hermes",
+                "--publish-final-response-to-dm",
+                "--no-base-prompt",
+                "--multiple-event-handling",
+                "queue",
+            ];
+            argv.extend(unsafe_case.iter().copied());
+            let parsed = CliArgs::try_parse_from(argv);
+            let rejected = parsed.is_err()
+                || parsed
+                    .ok()
+                    .is_some_and(|args| Config::from_args(args).is_err());
+            assert!(
+                rejected,
+                "unsafe bridge args were accepted: {unsafe_case:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn final_response_dm_bridge_rejects_non_hermes_adapter() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--agent-command",
+            "goose",
+            "--publish-final-response-to-dm",
+            "--no-base-prompt",
+            "--multiple-event-handling",
+            "queue",
+        ])
+        .expect("CLI shape parses before runtime safety validation");
+        let error = Config::from_args(args).expect_err("Goose bridge must be rejected");
+        assert!(error.to_string().contains("requires a Hermes adapter"));
+    }
 
     #[test]
     fn allowed_respond_to_full_path_rejects_disallowed_mode() {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1843,6 +1843,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        publish_final_response_to_dm: config.publish_final_response_to_dm,
     });
 
     if !config.memory_enabled {
@@ -2059,10 +2060,20 @@ async fn tokio_main() -> Result<()> {
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
+                let isolate_relay_credentials = config.publish_final_response_to_dm;
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result = spawn_and_init(
+                        &cmd,
+                        &args,
+                        &env,
+                        has_codex,
+                        isolate_relay_credentials,
+                        idx,
+                        observer,
+                    )
+                    .await;
                     guard.send(result);
                 });
             }
@@ -2291,7 +2302,7 @@ async fn tokio_main() -> Result<()> {
                                     // the agent lost access).
                                     let drained_ids = queue.drain_channel(ch);
                                     let invalidated = if pool_ready {
-                                        pool.invalidate_channel_sessions(ch)
+                                        pool.forget_channel_on_removal(ch)
                                     } else {
                                         0
                                     };
@@ -3256,7 +3267,10 @@ fn dispatch_pending(
 ) -> Vec<(Uuid, ThreadTags)> {
     let mut dispatched_channels = Vec::new();
     loop {
-        let batch = match queue.flush_next() {
+        let reserved_channel = pool.reserved_final_response_channel();
+        let preferred_batch =
+            reserved_channel.and_then(|channel_id| queue.flush_channel(channel_id));
+        let batch = match preferred_batch.or_else(|| queue.flush_next()) {
             Some(b) => b,
             None => break,
         };
@@ -3513,6 +3527,22 @@ fn handle_prompt_result(
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
                 }
+            } else if matches!(
+                &result.outcome,
+                PromptOutcome::Error(acp::AcpError::Publication(_))
+            ) {
+                // Publication diagnostics may include relay response bodies or
+                // event IDs. Keep those in local logs/observer telemetry; never
+                // interpolate them into a group-DM-visible failure notice.
+                if let Some(dead) = queue.requeue_publication(batch) {
+                    result
+                        .agent
+                        .state
+                        .drop_pending_final_response(&dead.channel_id);
+                    let content = "⚠️ I generated a reply but couldn't deliver it to this chat after repeated attempts. Please re-send if it's still needed."
+                        .to_string();
+                    spawn_failure_notice(rest_client, &dead, content);
+                }
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
                 // Auth errors are non-retryable: the token won't self-repair
                 // between retries, so requeueing only wastes attempt slots and
@@ -3562,7 +3592,7 @@ fn handle_prompt_result(
     // agent was checked out. This covers the gap where invalidate_channel_sessions
     // only touches idle agents.
     for ch in removed_channels {
-        result.agent.state.invalidate_channel(ch);
+        result.agent.state.forget_channel(ch);
     }
 
     let outcome_label = match &result.outcome {
@@ -3873,12 +3903,22 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let isolate_relay_credentials = config.publish_final_response_to_dm;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            isolate_relay_credentials,
+            i,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 }
@@ -4068,6 +4108,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let isolate_relay_credentials = config.publish_final_response_to_dm;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -4079,7 +4120,16 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            isolate_relay_credentials,
+            index,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 
@@ -4123,6 +4173,7 @@ struct PoolStartup {
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
     has_generated_codex_config: bool,
+    isolate_relay_credentials: bool,
     model: Option<String>,
     observer: Option<observer::ObserverHandle>,
 }
@@ -4135,6 +4186,7 @@ impl PoolStartup {
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
             has_generated_codex_config: config.has_generated_codex_config,
+            isolate_relay_credentials: config.publish_final_response_to_dm,
             model: config.model.clone(),
             observer,
         }
@@ -4149,11 +4201,12 @@ async fn initialize_agent_pool(
     // Attempt each spawn under a 60-second timeout; a partial pool is valid.
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(startup.agents as usize);
     for i in 0..startup.agents as usize {
-        let spawn_result = AcpClient::spawn(
+        let spawn_result = AcpClient::spawn_with_relay_credential_isolation(
             &startup.command,
             &startup.args,
             &startup.extra_env,
             startup.has_generated_codex_config,
+            startup.isolate_relay_credentials,
         )
         .await;
         match spawn_result {
@@ -4254,12 +4307,19 @@ async fn spawn_and_init(
     args: &[String],
     extra_env: &[(String, String)],
     has_generated_codex_config: bool,
+    isolate_relay_credentials: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
+    let mut acp = AcpClient::spawn_with_relay_credential_isolation(
+        command,
+        args,
+        extra_env,
+        has_generated_codex_config,
+        isolate_relay_credentials,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
 
     match acp.initialize().await {
@@ -6251,6 +6311,7 @@ mod build_mcp_servers_tests {
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
+            publish_final_response_to_dm: false,
             base_prompt_content: None,
         }
     }
@@ -6473,6 +6534,7 @@ mod error_outcome_emission_tests {
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
+            publish_final_response_to_dm: false,
             base_prompt_content: None,
         }
     }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -100,6 +100,18 @@ pub struct ChannelDeliveryState {
     pub delivered_event_ids: HashSet<String>,
 }
 
+/// Signed DM response waiting for relay confirmation. Keeping the exact event
+/// in agent state lets queue retries resubmit the same event ID without
+/// invoking the model or re-signing a potentially different answer.
+#[derive(Clone)]
+struct PendingFinalResponse {
+    trigger_event_id: nostr::EventId,
+    event: nostr::Event,
+    standing_context_sent: bool,
+    batch_event_ids: HashSet<String>,
+    delivered_event_ids: HashSet<String>,
+}
+
 /// Per-channel session IDs, turn counters, and delivery state.
 ///
 /// Separated from `OwnedAgent` so the state machine is testable without
@@ -129,6 +141,10 @@ pub struct SessionState {
     /// Per-channel successful-delivery state. Created with the ACP session and
     /// cleared atomically with every invalidation path.
     pub deliveries: HashMap<Uuid, ChannelDeliveryState>,
+    /// Channel-scoped final responses whose signed relay event is not yet
+    /// confirmed. This is transport state, not ACP session state, so ordinary
+    /// session invalidation deliberately leaves it intact.
+    pending_final_responses: HashMap<Uuid, PendingFinalResponse>,
 }
 
 impl SessionState {
@@ -166,6 +182,22 @@ impl SessionState {
         self.core_sections.clear();
         self.canvas_sections.clear();
         self.deliveries.clear();
+    }
+
+    /// Forget all state that may cause work to resume for a channel after a
+    /// membership removal. Ordinary session rotation intentionally preserves
+    /// the transport outbox; membership removal must drop it.
+    pub(crate) fn forget_channel(&mut self, channel_id: &Uuid) -> bool {
+        let invalidated = self.invalidate_channel(channel_id);
+        self.drop_pending_final_response(channel_id);
+        invalidated
+    }
+
+    /// Discard an unconfirmed signed response when its retry budget or channel
+    /// membership is gone. This prevents later unrelated traffic from
+    /// publishing a stale reply after the original batch was dead-lettered.
+    pub(crate) fn drop_pending_final_response(&mut self, channel_id: &Uuid) -> bool {
+        self.pending_final_responses.remove(channel_id).is_some()
     }
 
     pub(crate) fn mark_channel_delivery_success(
@@ -605,6 +637,9 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Opt-in transport bridge for tool-free ACP chat agents. Successful DM
+    /// turns publish the captured final assistant text with trusted routing.
+    pub publish_final_response_to_dm: bool,
 }
 
 impl AgentPool {
@@ -627,16 +662,32 @@ impl AgentPool {
 
     /// Try to claim an idle agent for the given channel (or heartbeat if `None`).
     ///
-    /// Pass 1: prefer an agent that already has a session for `channel_id`.
-    /// Pass 2: any idle agent.
+    /// Pass 1: prefer the agent retaining an unconfirmed signed response for
+    /// `channel_id` so a queue retry cannot invoke a second model.
+    /// Pass 2: prefer an agent that already has a session for `channel_id`.
+    /// Pass 3: any idle agent that is not reserving an unconfirmed signed
+    /// response. A reserved agent may only be claimed by that response's
+    /// channel, so unrelated work cannot destroy or strand the outbox.
     ///
     /// Returns `None` if all agents are checked out.
     pub fn try_claim(&mut self, channel_id: Option<Uuid>) -> Option<OwnedAgent> {
-        // Pass 1: prefer agent with existing session for this channel.
+        // Pass 1: transport outbox affinity is stronger than session affinity.
         if let Some(cid) = channel_id {
+            let pending_idx = self.agents.iter().position(|slot| {
+                slot.as_ref()
+                    .is_some_and(|agent| agent.state.pending_final_responses.contains_key(&cid))
+            });
+            if let Some(i) = pending_idx {
+                return self.agents[i].take();
+            }
+
+            // Pass 2: prefer agent with existing session for this channel.
             let idx = self.agents.iter().position(|slot| {
                 slot.as_ref()
-                    .map(|a| a.state.sessions.contains_key(&cid))
+                    .map(|a| {
+                        a.state.pending_final_responses.is_empty()
+                            && a.state.sessions.contains_key(&cid)
+                    })
                     .unwrap_or(false)
             });
             if let Some(i) = idx {
@@ -644,8 +695,11 @@ impl AgentPool {
             }
         }
 
-        // Pass 2: first idle agent.
-        let idx = self.agents.iter().position(|slot| slot.is_some());
+        // Pass 3: first idle agent.
+        let idx = self.agents.iter().position(|slot| {
+            slot.as_ref()
+                .is_some_and(|agent| agent.state.pending_final_responses.is_empty())
+        });
         idx.map(|i| self.agents[i].take().unwrap())
     }
 
@@ -677,6 +731,16 @@ impl AgentPool {
             slot.as_ref()
                 .map(|a| a.state.sessions.contains_key(&channel_id))
                 .unwrap_or(false)
+        })
+    }
+
+    /// Channel whose idle agent is reserved by an unconfirmed signed reply.
+    /// The dispatcher prioritizes this channel over global FIFO so older
+    /// unrelated work cannot starve transport confirmation.
+    pub fn reserved_final_response_channel(&self) -> Option<Uuid> {
+        self.agents.iter().find_map(|slot| {
+            slot.as_ref()
+                .and_then(|agent| agent.state.pending_final_responses.keys().next().copied())
         })
     }
 
@@ -806,12 +870,12 @@ impl AgentPool {
         &mut self.agents
     }
 
-    /// Remove the session for `channel_id` from all idle agents.
+    /// Remove the ACP session for `channel_id` from all idle agents while
+    /// preserving any signed response awaiting relay confirmation.
     ///
-    /// Called when the agent is removed from a channel — stale sessions
-    /// should not be reused. Checked-out agents (in-flight) are not
-    /// modified; their sessions will fail naturally on the next prompt
-    /// if the relay rejects the request.
+    /// This is the ordinary rotation path. Membership removal must instead
+    /// call [`Self::forget_channel_on_removal`] so transport outbox state is
+    /// discarded as well.
     ///
     /// Returns the number of sessions invalidated.
     pub fn invalidate_channel_sessions(&mut self, channel_id: Uuid) -> usize {
@@ -819,6 +883,21 @@ impl AgentPool {
         for slot in &mut self.agents {
             if let Some(agent) = slot.as_mut() {
                 if agent.state.invalidate_channel(&channel_id) {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+
+    /// Forget both ACP session state and an unpublished signed response after
+    /// the agent loses channel membership. Checked-out agents are handled when
+    /// they return to the pool through the removed-channel set.
+    pub fn forget_channel_on_removal(&mut self, channel_id: Uuid) -> usize {
+        let mut count = 0;
+        for slot in &mut self.agents {
+            if let Some(agent) = slot.as_mut() {
+                if agent.state.forget_channel(&channel_id) {
                     count += 1;
                 }
             }
@@ -1438,6 +1517,443 @@ fn send_prompt_result(
     });
 }
 
+const FINAL_RESPONSE_RELAY_TIMEOUT: Duration = Duration::from_secs(15);
+const FINAL_RESPONSE_RECONCILE_DELAY: Duration = Duration::from_millis(250);
+
+/// Trusted destination for the opt-in ACP final-response bridge.
+///
+/// Every field comes from the accepted relay event and resolved channel
+/// metadata. Model output can supply only the message content.
+struct FinalResponseTarget {
+    channel_id: Uuid,
+    trigger_event_id: nostr::EventId,
+    root_event_id: Option<nostr::EventId>,
+}
+
+const FINAL_RESPONSE_MARKER_DOMAIN: &[u8] = b"buzz-acp-final/v1\0";
+const FINAL_RESPONSE_MARKER_LABEL: &str = "acp-trigger";
+
+/// Relay-queryable correlation for one inbound event covered by an automatic
+/// final response. The model cannot influence any input to this hash.
+fn final_response_marker(
+    author: nostr::PublicKey,
+    channel_id: Uuid,
+    inbound_event_id: nostr::EventId,
+) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut digest = Sha256::new();
+    digest.update(FINAL_RESPONSE_MARKER_DOMAIN);
+    digest.update(author.as_bytes());
+    digest.update(channel_id.as_bytes());
+    digest.update(inbound_event_id.as_bytes());
+    hex::encode(digest.finalize())
+}
+
+fn final_response_marker_tag(marker: &str) -> Result<nostr::Tag, AcpError> {
+    nostr::Tag::parse(["e", marker, "", FINAL_RESPONSE_MARKER_LABEL]).map_err(|error| {
+        AcpError::Publication(format!("response correlation tag build failed: {error}"))
+    })
+}
+
+fn final_response_target_for_dm(
+    batch: &FlushBatch,
+    channel_info: Option<&PromptChannelInfo>,
+) -> Result<Option<FinalResponseTarget>, AcpError> {
+    let channel_info = channel_info.ok_or_else(|| {
+        AcpError::Publication(format!(
+            "cannot verify channel {} is a DM",
+            batch.channel_id
+        ))
+    })?;
+    if channel_info.channel_type == "unknown" || channel_info.channel_type.trim().is_empty() {
+        return Err(AcpError::Publication(format!(
+            "channel {} has unresolved type metadata",
+            batch.channel_id
+        )));
+    }
+    if channel_info.channel_type != "dm" {
+        return Ok(None);
+    }
+
+    let trigger = batch
+        .events
+        .last()
+        .or_else(|| batch.cancelled_events.last())
+        .ok_or_else(|| AcpError::Publication("DM batch has no trusted triggering event".into()))?;
+    let thread_tags = crate::queue::parse_thread_tags(&trigger.event);
+    let root_event_id = match thread_tags.root_event_id {
+        Some(root) => match nostr::EventId::from_hex(&root) {
+            Ok(id) => Some(id),
+            Err(error) => {
+                tracing::warn!(
+                    channel = %batch.channel_id,
+                    trigger_event = %trigger.event.id,
+                    "final-response DM bridge rejected malformed thread root: {error}"
+                );
+                return Err(AcpError::Publication(format!(
+                    "DM trigger {} has malformed thread ancestry",
+                    trigger.event.id
+                )));
+            }
+        },
+        None => None,
+    };
+
+    Ok(Some(FinalResponseTarget {
+        channel_id: batch.channel_id,
+        trigger_event_id: trigger.event.id,
+        root_event_id,
+    }))
+}
+
+fn build_final_response_event(
+    rest: &RestClient,
+    target: &FinalResponseTarget,
+    covered_event_ids: &HashSet<String>,
+    content: &str,
+) -> Result<nostr::Event, AcpError> {
+    let thread_ref = target
+        .root_event_id
+        .map(|root_event_id| buzz_sdk::ThreadRef {
+            root_event_id,
+            parent_event_id: target.trigger_event_id,
+        });
+    let mut markers = covered_event_ids
+        .iter()
+        .map(|event_id| {
+            let event_id = nostr::EventId::from_hex(event_id).map_err(|error| {
+                AcpError::Publication(format!(
+                    "covered inbound event ID is invalid ({event_id:?}): {error}"
+                ))
+            })?;
+            Ok(final_response_marker(
+                rest.keys.public_key(),
+                target.channel_id,
+                event_id,
+            ))
+        })
+        .collect::<Result<Vec<_>, AcpError>>()?;
+    markers.sort_unstable();
+    markers.dedup();
+    let marker_tags = markers
+        .iter()
+        .map(|marker| final_response_marker_tag(marker))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let builder = buzz_sdk::build_message(
+        target.channel_id,
+        content,
+        thread_ref.as_ref(),
+        &[],
+        false,
+        &[],
+    )
+    .map_err(|error| AcpError::Publication(format!("message build failed: {error}")))?
+    .tags(marker_tags);
+    builder
+        .sign_with_keys(&rest.keys)
+        .map_err(|error| AcpError::Publication(format!("message signing failed: {error}")))
+}
+
+fn confirmed_final_response_event_ids(
+    response: &serde_json::Value,
+    author: nostr::PublicKey,
+    channel_id: Uuid,
+    marker_to_event_id: &HashMap<String, String>,
+) -> Result<HashSet<String>, AcpError> {
+    let values = response.as_array().ok_or_else(|| {
+        AcpError::Publication("relay correlation query returned a non-array response".into())
+    })?;
+    let channel = channel_id.to_string();
+    let mut confirmed = HashSet::new();
+
+    for value in values {
+        let Ok(event) = serde_json::from_value::<nostr::Event>(value.clone()) else {
+            tracing::warn!("ignoring malformed final-response correlation event");
+            continue;
+        };
+        if event.verify().is_err()
+            || event.pubkey != author
+            || event.kind != nostr::Kind::Custom(9)
+            || !event.tags.iter().any(|tag| {
+                let values = tag.as_slice();
+                values.first().map(String::as_str) == Some("h")
+                    && values.get(1).map(String::as_str) == Some(channel.as_str())
+            })
+        {
+            continue;
+        }
+        for tag in event.tags.iter() {
+            let values = tag.as_slice();
+            if values.first().map(String::as_str) != Some("e")
+                || values.get(3).map(String::as_str) != Some(FINAL_RESPONSE_MARKER_LABEL)
+            {
+                continue;
+            }
+            if let Some(event_id) = values
+                .get(1)
+                .and_then(|marker| marker_to_event_id.get(marker))
+            {
+                confirmed.insert(event_id.clone());
+            }
+        }
+    }
+    Ok(confirmed)
+}
+
+/// Reconcile relay-backed response markers before any ACP session work. This
+/// covers the harness restart replay window: already-answered inbound events
+/// are removed from the batch instead of invoking the model again.
+async fn remove_already_published_final_response_events(
+    rest: &RestClient,
+    batch: &mut FlushBatch,
+) -> Result<HashSet<String>, AcpError> {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let author = rest.keys.public_key();
+    let channel = batch.channel_id.to_string();
+    let mut marker_to_event_id = HashMap::new();
+    for event in batch.events.iter().chain(batch.cancelled_events.iter()) {
+        let event_id = event.event.id.to_hex();
+        marker_to_event_id.insert(
+            final_response_marker(author, batch.channel_id, event.event.id),
+            event_id,
+        );
+    }
+    if marker_to_event_id.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let e_tag = SingleLetterTag::lowercase(Alphabet::E);
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let filters = marker_to_event_id
+        .keys()
+        .map(|marker| {
+            nostr::Filter::new()
+                .kind(nostr::Kind::Custom(9))
+                .author(author)
+                .custom_tags(h_tag, [channel.as_str()])
+                .custom_tags(e_tag, [marker.as_str()])
+                .limit(1)
+        })
+        .collect::<Vec<_>>();
+    let response = timeout(FINAL_RESPONSE_RELAY_TIMEOUT, rest.query(filters.as_slice()))
+        .await
+        .map_err(|_| AcpError::Publication("response correlation query timed out".into()))?
+        .map_err(|error| {
+            AcpError::Publication(format!("response correlation query failed: {error}"))
+        })?;
+    let confirmed = confirmed_final_response_event_ids(
+        &response,
+        author,
+        batch.channel_id,
+        &marker_to_event_id,
+    )?;
+    if confirmed.is_empty() {
+        return Ok(confirmed);
+    }
+
+    batch
+        .events
+        .retain(|event| !confirmed.contains(&event.event.id.to_hex()));
+    batch
+        .cancelled_events
+        .retain(|event| !confirmed.contains(&event.event.id.to_hex()));
+    if batch.cancelled_events.is_empty() {
+        batch.cancel_reason = None;
+    }
+    Ok(confirmed)
+}
+
+async fn preflight_final_response_replay(
+    ctx: &PromptContext,
+    batch: &mut FlushBatch,
+) -> Result<(Option<PromptChannelInfo>, HashSet<String>), AcpError> {
+    let channel_info = ctx.channel_info.resolve(batch.channel_id).await;
+    if final_response_target_for_dm(batch, channel_info.as_ref())?.is_none() {
+        return Ok((channel_info, HashSet::new()));
+    }
+    let confirmed = remove_already_published_final_response_events(&ctx.rest_client, batch).await?;
+    Ok((channel_info, confirmed))
+}
+
+fn relay_response_contains_event(response: &serde_json::Value, event_id: nostr::EventId) -> bool {
+    let expected = event_id.to_hex();
+    response.as_array().is_some_and(|events| {
+        events
+            .iter()
+            .any(|event| event["id"].as_str() == Some(expected.as_str()))
+    })
+}
+
+fn relay_accepted_event(response: &serde_json::Value, event_id: nostr::EventId) -> bool {
+    let expected = event_id.to_hex();
+    response["accepted"].as_bool() == Some(true)
+        && response["event_id"].as_str() == Some(expected.as_str())
+}
+
+async fn final_response_event_exists(
+    rest: &RestClient,
+    event_id: nostr::EventId,
+) -> Result<bool, AcpError> {
+    let filter = nostr::Filter::new().id(event_id);
+    let response = timeout(
+        FINAL_RESPONSE_RELAY_TIMEOUT,
+        rest.query(std::slice::from_ref(&filter)),
+    )
+    .await
+    .map_err(|_| AcpError::Publication("relay reconciliation query timed out".into()))?
+    .map_err(|error| {
+        AcpError::Publication(format!("relay reconciliation query failed: {error}"))
+    })?;
+    Ok(relay_response_contains_event(&response, event_id))
+}
+
+/// Submit one already-signed event. A failed/ambiguous request is reconciled by
+/// exact event ID, then the same event bytes are retried once. The model is not
+/// called again and the answer is never re-signed inside this function.
+async fn submit_final_response_event(
+    rest: &RestClient,
+    event: &nostr::Event,
+) -> Result<(), AcpError> {
+    let first_error = match timeout(FINAL_RESPONSE_RELAY_TIMEOUT, rest.submit_event(event)).await {
+        Ok(Ok(response)) if relay_accepted_event(&response, event.id) => return Ok(()),
+        Ok(Ok(response)) => format!("relay returned an unconfirmed response: {response}"),
+        Ok(Err(error)) => format!("{error}"),
+        Err(_) => "publish timed out".to_string(),
+    };
+
+    tokio::time::sleep(FINAL_RESPONSE_RECONCILE_DELAY).await;
+    match final_response_event_exists(rest, event.id).await {
+        Ok(true) => return Ok(()),
+        Ok(false) => {}
+        Err(error) => tracing::warn!(
+            response_event = %event.id,
+            "final-response reconciliation after first failure was inconclusive: {error}"
+        ),
+    }
+
+    let second_error = match timeout(FINAL_RESPONSE_RELAY_TIMEOUT, rest.submit_event(event)).await {
+        Ok(Ok(response)) if relay_accepted_event(&response, event.id) => return Ok(()),
+        Ok(Ok(response)) => format!("relay returned an unconfirmed response: {response}"),
+        Ok(Err(error)) => format!("{error}"),
+        Err(_) => "retry timed out".to_string(),
+    };
+
+    tokio::time::sleep(FINAL_RESPONSE_RECONCILE_DELAY).await;
+    if final_response_event_exists(rest, event.id).await? {
+        return Ok(());
+    }
+
+    Err(AcpError::Publication(format!(
+        "relay did not confirm event {} (first: {first_error}; retry: {second_error})",
+        event.id
+    )))
+}
+
+async fn publish_captured_final_response(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    target: Option<&FinalResponseTarget>,
+    standing_context_sent: bool,
+    batch_event_ids: &HashSet<String>,
+    delivered_event_ids: &HashSet<String>,
+) -> Result<(), AcpError> {
+    if !ctx.publish_final_response_to_dm {
+        return Ok(());
+    }
+    let Some(target) = target else {
+        return Ok(());
+    };
+    let content = agent
+        .acp
+        .take_turn_agent_message()
+        .map_err(|error| AcpError::Publication(error.into()))?
+        .ok_or_else(|| {
+            AcpError::Publication("ACP ended the DM turn without a final assistant message".into())
+        })?;
+    let event = build_final_response_event(&ctx.rest_client, target, batch_event_ids, &content)?;
+    let response_event_id = event.id;
+
+    agent.state.pending_final_responses.insert(
+        target.channel_id,
+        PendingFinalResponse {
+            trigger_event_id: target.trigger_event_id,
+            event: event.clone(),
+            standing_context_sent,
+            batch_event_ids: batch_event_ids.clone(),
+            delivered_event_ids: delivered_event_ids.clone(),
+        },
+    );
+
+    submit_final_response_event(&ctx.rest_client, &event).await?;
+    agent
+        .state
+        .pending_final_responses
+        .remove(&target.channel_id);
+
+    tracing::info!(
+        channel = %target.channel_id,
+        trigger_event = %target.trigger_event_id,
+        response_event = %response_event_id,
+        "published ACP final response to DM"
+    );
+    Ok(())
+}
+
+/// Retry a previously signed response before invoking ACP again. Returns true
+/// when the pending event belongs to the current batch, which means successful
+/// relay confirmation fully completes this dispatch without another model
+/// call. A pending response from an older drop-mode batch is published first,
+/// then the current batch may continue normally.
+async fn retry_pending_final_response(
+    agent: &mut OwnedAgent,
+    ctx: &PromptContext,
+    batch: &mut FlushBatch,
+) -> Result<bool, AcpError> {
+    if !ctx.publish_final_response_to_dm {
+        return Ok(false);
+    }
+    let Some(pending) = agent
+        .state
+        .pending_final_responses
+        .get(&batch.channel_id)
+        .cloned()
+    else {
+        return Ok(false);
+    };
+
+    submit_final_response_event(&ctx.rest_client, &pending.event).await?;
+    agent
+        .state
+        .pending_final_responses
+        .remove(&batch.channel_id);
+    agent.state.mark_channel_delivery_success(
+        batch.channel_id,
+        pending.standing_context_sent,
+        pending.delivered_event_ids,
+    );
+    batch
+        .events
+        .retain(|event| !pending.batch_event_ids.contains(&event.event.id.to_hex()));
+    batch
+        .cancelled_events
+        .retain(|event| !pending.batch_event_ids.contains(&event.event.id.to_hex()));
+    if batch.cancelled_events.is_empty() {
+        batch.cancel_reason = None;
+    }
+    let completes_current_batch = batch.events.is_empty() && batch.cancelled_events.is_empty();
+    tracing::info!(
+        channel = %batch.channel_id,
+        trigger_event = %pending.trigger_event_id,
+        response_event = %pending.event.id,
+        completes_current_batch,
+        "confirmed pending ACP final response without invoking the model"
+    );
+    Ok(completes_current_batch)
+}
+
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
@@ -1452,7 +1968,7 @@ fn send_prompt_result(
 /// abort and the caller uses `task_map` to recover the agent index.
 pub async fn run_prompt_task(
     mut agent: OwnedAgent,
-    batch: Option<FlushBatch>,
+    mut batch: Option<FlushBatch>,
     prompt_text: Option<String>,
     ctx: Arc<PromptContext>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
@@ -1537,6 +2053,90 @@ pub async fn run_prompt_task(
         .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
+
+    // Publication retries are transport-only. If the preceding attempt
+    // completed ACP but could not confirm its signed DM event, retry that exact
+    // event before any session work so Venice is not billed for a second answer.
+    if let Some(queued_batch) = batch.as_mut() {
+        match retry_pending_final_response(&mut agent, &ctx, queued_batch).await {
+            Ok(true) => {
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Ok(StopReason::EndTurn),
+                    None,
+                );
+                return;
+            }
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(
+                    target: "pool::prompt",
+                    "pending final-response DM remains unconfirmed: {error}"
+                );
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Error(error),
+                    requeue_batch_if_queue(&ctx, batch),
+                );
+                return;
+            }
+        }
+    }
+
+    // Relay-backed replay reconciliation closes the normal restart overlap:
+    // each auto-published DM carries a deterministic marker for every inbound
+    // event it answered. Resolve the trusted DM route and remove confirmed
+    // events before session creation or any model-visible initial prompt.
+    let mut pre_resolved_channel_info: Option<PromptChannelInfo> = None;
+    let mut marker_confirmed_event_ids = HashSet::new();
+    if ctx.publish_final_response_to_dm {
+        if let Some(queued_batch) = batch.as_mut() {
+            match preflight_final_response_replay(&ctx, queued_batch).await {
+                Ok((channel_info, confirmed)) => {
+                    pre_resolved_channel_info = channel_info;
+                    marker_confirmed_event_ids = confirmed;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pool::prompt",
+                        "final-response replay preflight failed closed: {error}"
+                    );
+                    send_prompt_result(
+                        &result_tx,
+                        &turn_id,
+                        agent,
+                        source,
+                        PromptOutcome::Error(error),
+                        requeue_batch_if_queue(&ctx, batch),
+                    );
+                    return;
+                }
+            }
+
+            if queued_batch.events.is_empty() && queued_batch.cancelled_events.is_empty() {
+                tracing::info!(
+                    channel = %queued_batch.channel_id,
+                    confirmed_events = marker_confirmed_event_ids.len(),
+                    "skipping ACP because every replayed event already has a signed DM response"
+                );
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Ok(StopReason::EndTurn),
+                    None,
+                );
+                return;
+            }
+        }
+    }
 
     //
     // Core memory is delivered inside the system prompt the harness already
@@ -1768,6 +2368,16 @@ pub async fn run_prompt_task(
             }
         }
     };
+
+    if let PromptSource::Channel(channel_id) = &source {
+        if !marker_confirmed_event_ids.is_empty() {
+            agent.state.mark_channel_delivery_success(
+                *channel_id,
+                false,
+                marker_confirmed_event_ids.iter().cloned(),
+            );
+        }
+    }
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
         Some(session_id.clone()),
@@ -1950,9 +2560,16 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    // Trusted route for the opt-in final-response bridge. It is populated only
+    // after the relay confirms this batch belongs to a DM.
+    let mut final_response_target: Result<Option<FinalResponseTarget>, AcpError> = Ok(None);
     // Event IDs represented by this prompt. Commit only after ACP reports a
     // successful turn; failed/cancelled prompts must be retryable without loss.
     let mut pending_delivered_event_ids = HashSet::new();
+    // Trigger/cancelled event IDs only (conversation context excluded). Stored
+    // with a pending signed response so a merged queue retry can subtract the
+    // already-answered request before invoking ACP for newer events.
+    let mut prompt_batch_event_ids = HashSet::new();
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
@@ -1979,7 +2596,13 @@ pub async fn run_prompt_task(
     } else if let Some(ref b) = batch {
         // Build prompt from batch with context enrichment.
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
+        let channel_info = match pre_resolved_channel_info.as_ref() {
+            Some(info) => Some(info.clone()),
+            None => ctx.channel_info.resolve(b.channel_id).await,
+        };
+        if ctx.publish_final_response_to_dm {
+            final_response_target = final_response_target_for_dm(b, channel_info.as_ref());
+        }
 
         let conversation_context = if ctx.context_message_limit > 0 {
             fetch_conversation_context(b, &channel_info, &ctx).await
@@ -1992,6 +2615,7 @@ pub async fn run_prompt_task(
             .chain(b.cancelled_events.iter())
             .map(|event| event.event.id.to_hex())
             .collect();
+        prompt_batch_event_ids.extend(rendered_batch_ids.iter().cloned());
         let delivered_ids = agent
             .state
             .deliveries
@@ -2060,6 +2684,25 @@ pub async fn run_prompt_task(
             None,
         );
         return;
+    };
+
+    let final_response_target = match final_response_target {
+        Ok(target) => target,
+        Err(error) => {
+            tracing::warn!(
+                target: "pool::prompt",
+                "final-response DM routing could not be verified: {error}"
+            );
+            send_prompt_result(
+                &result_tx,
+                &turn_id,
+                agent,
+                source,
+                PromptOutcome::Error(error),
+                requeue_batch_if_queue(&ctx, batch),
+            );
+            return;
+        }
     };
 
     // 💬 — fire-and-forget so the prompt fires immediately.
@@ -2256,6 +2899,83 @@ pub async fn run_prompt_task(
                                 "control signal arrived but turn already completed — treating as success"
                             );
                         }
+                        let completed_stop_reason =
+                            agent.acp.take_completed_prompt_stop_reason();
+                        if completed_stop_reason.is_none()
+                            && ctx.publish_final_response_to_dm
+                            && final_response_target.is_some()
+                        {
+                            let error = AcpError::Publication(
+                                "ACP completion raced without a recorded terminal stop reason"
+                                    .into(),
+                            );
+                            tracing::warn!(
+                                target: "pool::prompt",
+                                "DM completion could not be proven as end_turn; requeueing"
+                            );
+                            let usage = agent.acp.take_turn_usage();
+                            publish_agent_turn_metric(
+                                &ctx,
+                                usage,
+                                observer_channel_id,
+                                &session_id,
+                                &turn_id,
+                                Some(buzz_core::agent_turn_metric::StopReason::Error),
+                            )
+                            .await;
+                            send_prompt_result(
+                                &result_tx,
+                                &turn_id,
+                                agent,
+                                source,
+                                PromptOutcome::Error(error),
+                                requeue_batch_if_queue(&ctx, batch),
+                            );
+                            return;
+                        }
+                        let is_confirmed_end_turn = matches!(
+                            completed_stop_reason.as_ref(),
+                            Some(StopReason::EndTurn)
+                        );
+                        let completed_stop_reason =
+                            completed_stop_reason.unwrap_or(StopReason::EndTurn);
+                        if is_confirmed_end_turn {
+                            let bridge_standing_sent = !agent.has_system_prompt_support();
+                            if let Err(error) = publish_captured_final_response(
+                                &mut agent,
+                                &ctx,
+                                final_response_target.as_ref(),
+                                bridge_standing_sent,
+                                &prompt_batch_event_ids,
+                                &pending_delivered_event_ids,
+                            )
+                            .await
+                            {
+                                tracing::error!(
+                                    target: "pool::prompt",
+                                    "completed DM turn could not publish its final response: {error}"
+                                );
+                                let usage = agent.acp.take_turn_usage();
+                                publish_agent_turn_metric(
+                                    &ctx,
+                                    usage,
+                                    observer_channel_id,
+                                    &session_id,
+                                    &turn_id,
+                                    Some(buzz_core::agent_turn_metric::StopReason::Error),
+                                )
+                                .await;
+                                send_prompt_result(
+                                    &result_tx,
+                                    &turn_id,
+                                    agent,
+                                    source,
+                                    PromptOutcome::Error(error),
+                                    requeue_batch_if_queue(&ctx, batch),
+                                );
+                                return;
+                            }
+                        }
                         if let PromptSource::Channel(cid) = &source {
                             let standing_sent = !agent.has_system_prompt_support();
                             agent.state.mark_channel_delivery_success(
@@ -2276,7 +2996,7 @@ pub async fn run_prompt_task(
                             observer_channel_id,
                             &session_id,
                             &turn_id,
-                            Some(buzz_core::agent_turn_metric::StopReason::EndTurn),
+                            Some(acp_stop_to_core(&completed_stop_reason)),
                         )
                         .await;
                         send_prompt_result(
@@ -2284,7 +3004,7 @@ pub async fn run_prompt_task(
                             &turn_id,
                             agent,
                             source,
-                            PromptOutcome::Ok(StopReason::EndTurn),
+                            PromptOutcome::Ok(completed_stop_reason),
                             None, // turn succeeded — batch was processed, no requeue
                         );
                         return;
@@ -2297,6 +3017,45 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+            let _ = agent.acp.take_completed_prompt_stop_reason();
+
+            if matches!(stop_reason, StopReason::EndTurn) {
+                let bridge_standing_sent = !agent.has_system_prompt_support();
+                if let Err(error) = publish_captured_final_response(
+                    &mut agent,
+                    &ctx,
+                    final_response_target.as_ref(),
+                    bridge_standing_sent,
+                    &prompt_batch_event_ids,
+                    &pending_delivered_event_ids,
+                )
+                .await
+                {
+                    tracing::error!(
+                        target: "pool::prompt",
+                        "completed DM turn could not publish its final response: {error}"
+                    );
+                    let usage = agent.acp.take_turn_usage();
+                    publish_agent_turn_metric(
+                        &ctx,
+                        usage,
+                        observer_channel_id,
+                        &session_id,
+                        &turn_id,
+                        Some(buzz_core::agent_turn_metric::StopReason::Error),
+                    )
+                    .await;
+                    send_prompt_result(
+                        &result_tx,
+                        &turn_id,
+                        agent,
+                        source,
+                        PromptOutcome::Error(error),
+                        requeue_batch_if_queue(&ctx, batch),
+                    );
+                    return;
+                }
+            }
 
             if let PromptSource::Channel(cid) = &source {
                 let standing_sent = !agent.has_system_prompt_support();
@@ -7409,6 +8168,497 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
         );
     }
 
+    #[test]
+    fn final_response_bridge_routes_only_verified_dms() {
+        let channel_id = Uuid::new_v4();
+        let batch = one_event_batch(channel_id);
+
+        let dm = PromptChannelInfo {
+            name: "private".into(),
+            channel_type: "dm".into(),
+        };
+        let target = final_response_target_for_dm(&batch, Some(&dm))
+            .expect("verified DM route")
+            .expect("DM target");
+        assert_eq!(target.channel_id, channel_id);
+        assert_eq!(target.trigger_event_id, batch.events[0].event.id);
+        assert!(target.root_event_id.is_none());
+
+        let stream = PromptChannelInfo {
+            name: "general".into(),
+            channel_type: "stream".into(),
+        };
+        assert!(final_response_target_for_dm(&batch, Some(&stream))
+            .expect("known non-DM")
+            .is_none());
+        assert!(final_response_target_for_dm(&batch, None).is_err());
+
+        let unknown = PromptChannelInfo {
+            name: "unresolved".into(),
+            channel_type: "unknown".into(),
+        };
+        assert!(final_response_target_for_dm(&batch, Some(&unknown)).is_err());
+    }
+
+    #[test]
+    fn final_response_bridge_rejects_malformed_thread_ancestry() {
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(9), "reply")
+            .tags([Tag::parse(["e", "not-an-event-id", "", "root"]).unwrap()])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let dm = PromptChannelInfo {
+            name: "private".into(),
+            channel_type: "dm".into(),
+        };
+        assert!(final_response_target_for_dm(&batch, Some(&dm)).is_err());
+    }
+
+    #[test]
+    fn final_response_event_is_signed_and_bound_to_trusted_thread() {
+        let channel_id = Uuid::new_v4();
+        let agent_keys = Keys::generate();
+        let root = EventBuilder::new(Kind::Custom(9), "root")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let trigger = EventBuilder::new(Kind::Custom(9), "trigger")
+            .tags([Tag::parse(["e", &root.id.to_hex(), "", "root"]).unwrap()])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let target = FinalResponseTarget {
+            channel_id,
+            trigger_event_id: trigger.id,
+            root_event_id: Some(root.id),
+        };
+        let rest = RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://127.0.0.1:0".into(),
+            keys: agent_keys.clone(),
+            auth_tag_json: None,
+        };
+
+        let covered = HashSet::from([trigger.id.to_hex(), root.id.to_hex()]);
+        let event = build_final_response_event(&rest, &target, &covered, "  exact markdown\n")
+            .expect("build signed response");
+        event.verify().expect("valid signature");
+        assert_eq!(event.pubkey, agent_keys.public_key());
+        assert_eq!(event.kind, Kind::Custom(9));
+        assert_eq!(event.content, "  exact markdown\n");
+        assert!(event.tags.iter().any(|tag| {
+            let values = tag.as_slice();
+            values.first().map(String::as_str) == Some("h")
+                && values.get(1).map(String::as_str) == Some(channel_id.to_string().as_str())
+        }));
+        let thread = crate::queue::parse_thread_tags(&event);
+        assert_eq!(
+            thread.root_event_id.as_deref(),
+            Some(root.id.to_hex().as_str())
+        );
+        assert_eq!(
+            thread.parent_event_id.as_deref(),
+            Some(trigger.id.to_hex().as_str())
+        );
+        let correlation_markers = event
+            .tags
+            .iter()
+            .filter(|tag| {
+                let values = tag.as_slice();
+                values.first().map(String::as_str) == Some("e")
+                    && values.get(3).map(String::as_str) == Some(FINAL_RESPONSE_MARKER_LABEL)
+            })
+            .count();
+        assert_eq!(correlation_markers, covered.len());
+
+        let marker_to_event_id = covered
+            .iter()
+            .map(|event_id| {
+                let parsed = nostr::EventId::from_hex(event_id).unwrap();
+                (
+                    final_response_marker(agent_keys.public_key(), channel_id, parsed),
+                    event_id.clone(),
+                )
+            })
+            .collect();
+        let confirmed = confirmed_final_response_event_ids(
+            &json!([event]),
+            agent_keys.public_key(),
+            channel_id,
+            &marker_to_event_id,
+        )
+        .expect("validate relay marker response");
+        assert_eq!(confirmed, covered);
+    }
+
+    #[test]
+    fn final_response_relay_ack_requires_matching_accepted_event() {
+        let event_id = EventBuilder::new(Kind::Custom(9), "answer")
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+            .id;
+        let other_id = EventBuilder::new(Kind::Custom(9), "other")
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+            .id;
+        assert!(relay_accepted_event(
+            &json!({"accepted": true, "event_id": event_id.to_hex()}),
+            event_id
+        ));
+        assert!(!relay_accepted_event(
+            &json!({"accepted": false, "event_id": event_id.to_hex()}),
+            event_id
+        ));
+        assert!(!relay_accepted_event(
+            &json!({"accepted": true, "event_id": other_id.to_hex()}),
+            event_id
+        ));
+        assert!(!relay_accepted_event(&serde_json::Value::Null, event_id));
+    }
+
+    #[test]
+    fn session_rotation_preserves_pending_response_but_membership_removal_drops_it() {
+        let channel_id = Uuid::new_v4();
+        let trigger = EventBuilder::new(Kind::Custom(9), "trigger")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let response = EventBuilder::new(Kind::Custom(9), "response")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let mut state = SessionState::default();
+        state.sessions.insert(channel_id, "session".into());
+        state.pending_final_responses.insert(
+            channel_id,
+            PendingFinalResponse {
+                trigger_event_id: trigger.id,
+                event: response,
+                standing_context_sent: false,
+                batch_event_ids: HashSet::from([trigger.id.to_hex()]),
+                delivered_event_ids: HashSet::from([trigger.id.to_hex()]),
+            },
+        );
+
+        assert!(state.invalidate_channel(&channel_id));
+        assert!(state.pending_final_responses.contains_key(&channel_id));
+        state.forget_channel(&channel_id);
+        assert!(!state.pending_final_responses.contains_key(&channel_id));
+    }
+
+    #[tokio::test]
+    async fn pending_response_reserves_its_agent_from_unrelated_work() {
+        let pending_channel = Uuid::new_v4();
+        let unrelated_channel = Uuid::new_v4();
+        let trigger = EventBuilder::new(Kind::Custom(9), "trigger")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let response = EventBuilder::new(Kind::Custom(9), "response")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let reserved_acp = AcpClient::spawn("cat", &[], &[], false)
+            .await
+            .expect("spawn reserved test agent");
+        let free_acp = AcpClient::spawn("cat", &[], &[], false)
+            .await
+            .expect("spawn free test agent");
+        let mut reserved = OwnedAgent {
+            index: 0,
+            acp: reserved_acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "hermes".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        reserved.state.pending_final_responses.insert(
+            pending_channel,
+            PendingFinalResponse {
+                trigger_event_id: trigger.id,
+                event: response,
+                standing_context_sent: false,
+                batch_event_ids: HashSet::from([trigger.id.to_hex()]),
+                delivered_event_ids: HashSet::from([trigger.id.to_hex()]),
+            },
+        );
+        let free = OwnedAgent {
+            index: 1,
+            acp: free_acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "hermes".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        let mut pool = AgentPool::from_slots(vec![Some(reserved), Some(free)]);
+        assert_eq!(
+            pool.reserved_final_response_channel(),
+            Some(pending_channel)
+        );
+
+        let unrelated = pool
+            .try_claim(Some(unrelated_channel))
+            .expect("free agent handles unrelated channel");
+        assert_eq!(unrelated.index, 1);
+        assert!(
+            pool.try_claim(None).is_none(),
+            "heartbeat must not consume the reserved outbox carrier"
+        );
+        pool.return_agent(unrelated);
+
+        let mut reserved = pool
+            .try_claim(Some(pending_channel))
+            .expect("pending channel reclaims its outbox carrier");
+        assert_eq!(reserved.index, 0);
+        let mut free = pool
+            .try_claim(Some(unrelated_channel))
+            .expect("free agent remains available");
+        assert_eq!(free.index, 1);
+        reserved.acp.shutdown().await;
+        free.acp.shutdown().await;
+    }
+
+    async fn read_test_http_request(socket: &mut tokio::net::TcpStream) -> (String, Vec<u8>) {
+        use tokio::io::AsyncReadExt;
+
+        let mut request = Vec::new();
+        let mut scratch = [0_u8; 8192];
+        let mut expected_len = None;
+        loop {
+            let read = socket.read(&mut scratch).await.expect("read test request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&scratch[..read]);
+            if expected_len.is_none() {
+                if let Some(header_end) = request.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_len = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    expected_len = Some(header_end + 4 + content_len);
+                }
+            }
+            if expected_len.is_some_and(|len| request.len() >= len) {
+                break;
+            }
+        }
+
+        let header_end = request
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("HTTP header terminator");
+        let request_line = String::from_utf8_lossy(&request[..header_end])
+            .lines()
+            .next()
+            .expect("request line")
+            .to_string();
+        (request_line, request[(header_end + 4)..].to_vec())
+    }
+
+    #[tokio::test]
+    async fn hermes_minimal_acp_end_turn_publishes_one_visible_dm() {
+        use tokio::io::AsyncWriteExt;
+
+        let channel_id = Uuid::new_v4();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind relay bridge");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (message_tx, mut message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let stored_messages = Arc::new(Mutex::new(Vec::<nostr::Event>::new()));
+        let server_messages = Arc::clone(&stored_messages);
+        let server = tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                let (request_line, body) = read_test_http_request(&mut socket).await;
+                let response_body = if request_line.contains(" /query ") {
+                    serde_json::to_string(&*server_messages.lock().unwrap())
+                        .expect("serialize stored messages")
+                } else if request_line.contains(" /events ") {
+                    let event: nostr::Event =
+                        serde_json::from_slice(&body).expect("submitted event JSON");
+                    if event.kind == Kind::Custom(9) {
+                        server_messages.lock().unwrap().push(event.clone());
+                        message_tx.send(event.clone()).expect("capture DM");
+                    }
+                    json!({"accepted": true, "event_id": event.id.to_hex()}).to_string()
+                } else {
+                    "{}".to_string()
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                socket
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write relay response");
+            }
+        });
+
+        let script = r#"IFS= read -r line
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"live-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello "}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"live-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"from Hermes"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'"#;
+        let acp = AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+            .await
+            .expect("spawn minimal Hermes ACP");
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "hermes".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        agent
+            .state
+            .sessions
+            .insert(channel_id, "live-session".into());
+        agent
+            .state
+            .deliveries
+            .insert(channel_id, ChannelDeliveryState::default());
+
+        let trigger = EventBuilder::new(Kind::Custom(9), "say hello")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let trigger_id = trigger.id.to_hex();
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event: trigger,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let replay_batch = batch.clone();
+
+        let mut ctx = make_prompt_context_no_owner();
+        ctx.publish_final_response_to_dm = true;
+        ctx.dedup_mode = DedupMode::Queue;
+        ctx.rest_client.base_url = base_url.clone();
+        ctx.channel_info = ChannelInfoResolver::new(
+            HashMap::from([(
+                channel_id,
+                crate::relay::ChannelInfo {
+                    name: "private".into(),
+                    channel_type: "dm".into(),
+                },
+            )]),
+            RestClient {
+                http: reqwest::Client::new(),
+                base_url,
+                keys: ctx.agent_keys.clone(),
+                auth_tag_json: None,
+            },
+        );
+        let expected_pubkey = ctx.agent_keys.public_key();
+        let ctx = Arc::new(ctx);
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            agent,
+            Some(batch),
+            None,
+            Arc::clone(&ctx),
+            result_tx,
+            None,
+            "hermes-visible-dm".into(),
+        )
+        .await;
+
+        let mut result = result_rx.recv().await.expect("prompt result");
+        assert!(matches!(
+            result.outcome,
+            PromptOutcome::Ok(StopReason::EndTurn)
+        ));
+        let message = tokio::time::timeout(Duration::from_secs(2), message_rx.recv())
+            .await
+            .expect("visible DM timeout")
+            .expect("visible DM event");
+        assert_eq!(message.content, "Hello from Hermes");
+        assert_eq!(message.pubkey, expected_pubkey);
+        message.verify().expect("signed visible DM");
+        assert!(message.tags.iter().any(|tag| {
+            let values = tag.as_slice();
+            values.first().map(String::as_str) == Some("h")
+                && values.get(1).map(String::as_str) == Some(channel_id.to_string().as_str())
+        }));
+        assert!(result.agent.state.pending_final_responses.is_empty());
+        assert!(result.agent.state.deliveries[&channel_id]
+            .delivered_event_ids
+            .contains(&trigger_id));
+
+        result.agent.acp.shutdown().await;
+
+        // Simulate a full harness restart: no session or in-memory outbox is
+        // retained. The relay marker must complete the replay without touching
+        // the ACP child and without producing another chat event.
+        let replay_acp = AcpClient::spawn(
+            "bash",
+            &["-c".into(), "IFS= read -r line; exit 99".into()],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn replay sentinel ACP");
+        let replay_agent = OwnedAgent {
+            index: 0,
+            acp: replay_acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "hermes".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+        };
+        let (replay_tx, mut replay_rx) = mpsc::unbounded_channel();
+        run_prompt_task(
+            replay_agent,
+            Some(replay_batch),
+            None,
+            ctx,
+            replay_tx,
+            None,
+            "hermes-restart-replay".into(),
+        )
+        .await;
+        let mut replay_result = replay_rx.recv().await.expect("replay result");
+        assert!(matches!(
+            replay_result.outcome,
+            PromptOutcome::Ok(StopReason::EndTurn)
+        ));
+        assert!(
+            message_rx.try_recv().is_err(),
+            "restart replay duplicated DM"
+        );
+        replay_result.agent.acp.shutdown().await;
+        server.abort();
+    }
+
     fn make_prompt_context_no_owner() -> PromptContext {
         let agent_keys = nostr::Keys::generate();
         make_prompt_context_impl(&agent_keys, None)
@@ -7462,6 +8712,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            publish_final_response_to_dm: false,
         }
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -258,6 +258,16 @@ impl EventQueue {
     /// across channels), drains ALL events for that channel into a single batch,
     /// inserts into `in_flight_channels`, and returns the batch.
     pub fn flush_next(&mut self) -> Option<FlushBatch> {
+        self.flush_next_for_channel(None)
+    }
+
+    /// Flush only `channel_id` when it is eligible. Used for an unconfirmed
+    /// signed response whose reserved agent must not be starved by global FIFO.
+    pub fn flush_channel(&mut self, channel_id: Uuid) -> Option<FlushBatch> {
+        self.flush_next_for_channel(Some(channel_id))
+    }
+
+    fn flush_next_for_channel(&mut self, only_channel: Option<Uuid>) -> Option<FlushBatch> {
         let now = Instant::now();
 
         // Auto-expire any stuck in-flight entries that missed mark_complete.
@@ -288,16 +298,24 @@ impl EventQueue {
 
         // Find the channel whose head event has the oldest received_at,
         // excluding in-flight channels and throttled channels.
-        let channel_id = self
-            .queues
-            .iter()
-            .filter(|(id, q)| {
-                !q.is_empty()
-                    && !self.in_flight_channels.contains(id)
-                    && self.retry_after.get(id).is_none_or(|&t| t <= now)
-            })
-            .min_by_key(|(_, q)| q.front().unwrap().received_at)
-            .map(|(id, _)| *id);
+        let is_ready = |id: &Uuid, q: &VecDeque<QueuedEvent>| {
+            !q.is_empty()
+                && !self.in_flight_channels.contains(id)
+                && self.retry_after.get(id).is_none_or(|&t| t <= now)
+        };
+        let channel_id = match only_channel {
+            Some(id) => self
+                .queues
+                .get(&id)
+                .filter(|queue| is_ready(&id, queue))
+                .map(|_| id),
+            None => self
+                .queues
+                .iter()
+                .filter(|(id, queue)| is_ready(id, queue))
+                .min_by_key(|(_, queue)| queue.front().unwrap().received_at)
+                .map(|(id, _)| *id),
+        };
 
         // Fallback: if no queued events are ready but a channel has cancelled
         // events waiting (e.g., explicit !cancel with no new @mention), flush
@@ -305,11 +323,21 @@ impl EventQueue {
         let channel_id = match channel_id {
             Some(id) => id,
             None => {
-                let cancelled_id = self
-                    .cancelled_batches
-                    .keys()
-                    .find(|id| !self.in_flight_channels.contains(id))
-                    .copied();
+                let cancelled_id = match only_channel {
+                    Some(id)
+                        if self.cancelled_batches.contains_key(&id)
+                            && !self.in_flight_channels.contains(&id)
+                            && self.retry_after.get(&id).is_none_or(|&t| t <= now) =>
+                    {
+                        Some(id)
+                    }
+                    Some(_) => None,
+                    None => self
+                        .cancelled_batches
+                        .keys()
+                        .find(|id| !self.in_flight_channels.contains(id))
+                        .copied(),
+                };
                 match cancelled_id {
                     Some(id) => {
                         // Move cancelled events into the regular events slot.
@@ -495,6 +523,20 @@ impl EventQueue {
         }
         self.retry_after.insert(channel_id, Instant::now() + delay);
         None
+    }
+
+    /// Requeue a batch whose model turn already completed and whose signed
+    /// response only needs transport confirmation. Cancelled events are moved
+    /// into the ordinary queue as scheduling tokens: the outbox retry removes
+    /// every covered ID before any subsequent model prompt.
+    pub fn requeue_publication(&mut self, mut batch: FlushBatch) -> Option<FlushBatch> {
+        if !batch.cancelled_events.is_empty() {
+            let mut covered = std::mem::take(&mut batch.cancelled_events);
+            covered.extend(batch.events);
+            batch.events = covered;
+            batch.cancel_reason = None;
+        }
+        self.requeue(batch)
     }
 
     /// Re-queue a batch preserving original `received_at` timestamps.
@@ -4960,5 +5002,62 @@ mod tests {
             after_second >= after_first,
             "second extend must not move deadline backward (monotonic)"
         );
+    }
+
+    #[test]
+    fn publication_requeue_preserves_cancelled_events_as_retry_tokens() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        let cancelled = BatchEvent {
+            event: make_event("cancelled"),
+            prompt_tag: "cancelled".into(),
+            received_at: Instant::now(),
+        };
+        let regular = BatchEvent {
+            event: make_event("regular"),
+            prompt_tag: "regular".into(),
+            received_at: Instant::now(),
+        };
+
+        assert!(q
+            .requeue_publication(FlushBatch {
+                channel_id,
+                events: vec![regular],
+                cancelled_events: vec![cancelled],
+                cancel_reason: Some(CancelReason::Steer),
+            })
+            .is_none());
+
+        let queued = q.queues.get(&channel_id).expect("publication retry queue");
+        assert_eq!(queued.len(), 2);
+        assert_eq!(queued[0].event.content, "cancelled");
+        assert_eq!(queued[1].event.content, "regular");
+        assert!(!q.cancelled_batches.contains_key(&channel_id));
+    }
+
+    #[test]
+    fn flush_channel_prioritizes_reserved_retry_over_older_fifo_work() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let older_channel = Uuid::new_v4();
+        let reserved_channel = Uuid::new_v4();
+        q.push(make_queued_at(
+            older_channel,
+            "older unrelated work",
+            Duration::from_secs(60),
+        ));
+        q.push(make_queued_at(
+            reserved_channel,
+            "signed-response retry token",
+            Duration::from_secs(1),
+        ));
+
+        let reserved = q
+            .flush_channel(reserved_channel)
+            .expect("reserved channel is eligible");
+        assert_eq!(reserved.channel_id, reserved_channel);
+        q.mark_complete(reserved_channel);
+
+        let older = q.flush_next().expect("older work remains queued");
+        assert_eq!(older.channel_id, older_channel);
     }
 }


### PR DESCRIPTION
## What

Adds a default-off parent-side publication bridge for tool-free Hermes ACP chat agents. Buzz currently records `agent_message_chunk` output as activity only; agents normally need `buzz messages send` to create a visible kind-9 chat event. A zero-tool private adapter cannot do that, so a successful turn is invisible.

## Safety boundary

- eligible only for a relay-verified DM and an actual `end_turn`
- route, thread ancestry, author, and signature come from trusted Buzz state; the model supplies content only
- requires Hermes, no base prompt, no host MCP, one agent, self-event filtering, queue dedup, and queued multi-event handling
- strips Buzz/Nostr signing credentials from the ACP child and forces configured Hermes MCP off
- keeps an exact signed-event outbox, reconciles ambiguous relay results, adds restart markers, prioritizes pending transport work, and fails closed on unresolved routes or truncated output
- remains off for Goose and every existing harness unless explicitly enabled

## Verification

- `cargo test -p buzz-acp --lib`: 758 passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- release build completed on macOS arm64
- independent blocker-only review bound to `9688a7303065896d37418c8fc168bd23db8589d4` found no remaining must-fix issue

## Operational limits

The pending outbox is process-local before any signed event reaches the relay; one publisher process per agent key is required. Buzz kind-9 DM content is channel-ACL-protected relay plaintext, not NIP-44 end-to-end encryption.