### PR TITLE
Standardize settings section layout

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -130,6 +130,7 @@ export default defineConfig({
         "**/profile-nsec-reveal.spec.ts",
         "**/profile-backup-settings.spec.ts",
         "**/signout-confirmation.spec.ts",
+        "**/settings-section-layout.spec.ts",
         "**/agent-provider-dropdowns.spec.ts",
         "**/agent-lifecycle-feedback.spec.ts",
         "**/agent-access-warning.spec.ts",

--- a/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
+++ b/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
@@ -12,6 +12,7 @@ import {
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
+import { SettingsOptionGroup } from "@/features/settings/ui/SettingsOptionGroup";
 import { SettingsSectionHeader } from "@/features/settings/ui/SettingsSectionHeader";
 import type {
   RelayMember,
@@ -314,17 +315,16 @@ export function CommunityMembersSettingsCard({
         description="Manage members and community access."
       />
 
-      <div className="overflow-hidden rounded-xl border border-border/70 bg-background/70 divide-y divide-border/55">
-        <div className="flex min-h-14 items-center px-4 py-3">
-          <h2 className="text-lg font-semibold tracking-tight">
+      <SettingsOptionGroup
+        title={
+          <>
             Members
             {members.length > 0 ? (
-              <span className="ml-1.5 text-sm font-normal text-muted-foreground">
-                {members.length}
-              </span>
+              <span className="ml-1.5 font-normal">{members.length}</span>
             ) : null}
-          </h2>
-        </div>
+          </>
+        }
+      >
         <div className="space-y-3 p-4 sm:p-5">
           <div className="relative">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -376,7 +376,7 @@ export function CommunityMembersSettingsCard({
             />
           )}
         </div>
-      </div>
+      </SettingsOptionGroup>
 
       <CommunityInviteDialog
         isOwner={currentRole === "owner"}

--- a/desktop/src/features/settings/UpdateChecker.tsx
+++ b/desktop/src/features/settings/UpdateChecker.tsx
@@ -20,7 +20,6 @@ export function UpdateChecker() {
         {status.state === "idle" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -37,7 +36,6 @@ export function UpdateChecker() {
         {status.state === "checking" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -51,7 +49,6 @@ export function UpdateChecker() {
         {status.state === "up-to-date" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -68,7 +65,6 @@ export function UpdateChecker() {
         {status.state === "unavailable" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -107,7 +103,6 @@ export function UpdateChecker() {
         {status.state === "available" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -121,7 +116,6 @@ export function UpdateChecker() {
         {status.state === "downloading" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -135,7 +129,6 @@ export function UpdateChecker() {
         {status.state === "installing" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -149,7 +142,6 @@ export function UpdateChecker() {
         {status.state === "ready" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p
                 className="text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
@@ -166,7 +158,6 @@ export function UpdateChecker() {
         {status.state === "error" && (
           <SettingsOptionRow>
             <div className="min-w-0">
-              <p className="text-sm font-medium">Update status</p>
               <p className="text-sm font-normal text-destructive">
                 Update failed: {status.message}
               </p>

--- a/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
+++ b/desktop/src/features/settings/ui/AgentsSettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { AgentDefaultsSettingsCard } from "./AgentDefaultsSettingsCard";
 import { HarnessesSettingsPanel } from "./HarnessesSettingsPanel";
 import { PreventSleepSettingsCard } from "./PreventSleepSettingsCard";
+import { SettingsOptionGroupList } from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 
 export function AgentsSettingsPanel() {
@@ -11,11 +12,11 @@ export function AgentsSettingsPanel() {
         description="Control how agents behave in conversations and run on this machine."
       />
 
-      <div className="flex flex-col gap-4">
+      <SettingsOptionGroupList>
         <PreventSleepSettingsCard />
         <HarnessesSettingsPanel />
         <AgentDefaultsSettingsCard />
-      </div>
+      </SettingsOptionGroupList>
     </section>
   );
 }

--- a/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
+++ b/desktop/src/features/settings/ui/KeyboardShortcutsCard.tsx
@@ -3,7 +3,11 @@ import {
   getPlatformKeys,
   type KeyboardShortcut,
 } from "@/shared/lib/keyboard-shortcuts";
-import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import {
+  SettingsOptionGroup,
+  SettingsOptionGroupList,
+  SettingsOptionRow,
+} from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 
 function KeyCombo({ shortcut }: { shortcut: KeyboardShortcut }) {
@@ -38,7 +42,7 @@ export function KeyboardShortcutsCard() {
         description="All available keyboard shortcuts. Shortcuts are read-only."
       />
 
-      <div className="space-y-4">
+      <SettingsOptionGroupList>
         {[...categories.entries()].map(([category, shortcuts]) => (
           <SettingsOptionGroup key={category} title={category}>
             {shortcuts.map((shortcut) => (
@@ -62,7 +66,7 @@ export function KeyboardShortcutsCard() {
             ))}
           </SettingsOptionGroup>
         ))}
-      </div>
+      </SettingsOptionGroupList>
     </section>
   );
 }

--- a/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/NotificationSettingsCard.tsx
@@ -17,7 +17,11 @@ import {
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Switch } from "@/shared/ui/switch";
-import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import {
+  SettingsOptionGroup,
+  SettingsOptionGroupList,
+  SettingsOptionRow,
+} from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 import { SoundPicker } from "./SoundPicker";
 
@@ -76,7 +80,7 @@ export function NotificationSettingsCard({
               : "Off"}
       </span>
 
-      <div className="flex flex-col gap-4">
+      <SettingsOptionGroupList>
         <SettingsOptionGroup title="Desktop">
           <SettingsOptionRow>
             <div className="min-w-0">
@@ -169,7 +173,7 @@ export function NotificationSettingsCard({
             </SettingsOptionGroup>
 
             {anyAlertsOn ? (
-              <>
+              <div className="space-y-4">
                 <SettingsOptionGroup title="Alert sounds">
                   {visibleSlots.map((slot) => {
                     const comingSoon = COMING_SOON_SLOTS.has(slot);
@@ -249,7 +253,7 @@ export function NotificationSettingsCard({
                     )}
                   </Button>
                 </div>
-              </>
+              </div>
             ) : null}
           </>
         ) : null}
@@ -281,7 +285,7 @@ export function NotificationSettingsCard({
             />
           </SettingsOptionRow>
         </SettingsOptionGroup>
-      </div>
+      </SettingsOptionGroupList>
 
       {permissionBlocked && (
         <p className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -23,6 +23,10 @@ import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
 import { Textarea } from "@/shared/ui/textarea";
 import { PrivateKeyBackupRow } from "./PrivateKeyBackupRow";
+import {
+  SettingsOptionGroup,
+  SettingsOptionGroupList,
+} from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 import { SignOutSection } from "./SignOutSection";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
@@ -668,15 +672,9 @@ export function ProfileSettingsCard({
                       data-testid="profile-readonly-content"
                       inert={isAvatarEditorOpen ? true : undefined}
                     >
-                      <div className="space-y-12">
-                        <div
-                          className="overflow-hidden rounded-xl border border-border/70 bg-background/70 shadow-xs divide-y divide-border/55"
-                          data-testid="profile-metadata-card"
-                        >
-                          <div className="flex min-h-14 items-center justify-between gap-4 px-4 py-3">
-                            <h2 className="text-lg font-semibold tracking-tight">
-                              Profile info
-                            </h2>
+                      <SettingsOptionGroupList>
+                        <SettingsOptionGroup
+                          headerAction={
                             <EditProfileMetadataButton
                               disabled={updateProfileMutation.isPending}
                               isEditing={isEditingProfileMetadata}
@@ -684,8 +682,10 @@ export function ProfileSettingsCard({
                               onClick={handleProfileMetadataEdit}
                               testId="profile-metadata-edit"
                             />
-                          </div>
-
+                          }
+                          data-testid="profile-metadata-card"
+                          title="Profile info"
+                        >
                           <div className="flex min-h-16 items-center gap-4 px-4 py-3">
                             <div className="min-w-0 flex-1 space-y-1">
                               <label
@@ -756,23 +756,23 @@ export function ProfileSettingsCard({
                               )}
                             </div>
                           </div>
-                        </div>
+                        </SettingsOptionGroup>
 
-                        <div>
+                        <SettingsOptionGroup title="Identity">
                           <details
-                            className="group overflow-hidden rounded-xl border border-border/70 bg-background/70 shadow-xs"
+                            className="group divide-y divide-border/55"
                             data-testid="profile-identity-card"
                           >
                             <summary
-                              className="group/identity flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 text-sm transition-colors duration-150 ease-out hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden"
+                              className="group/identity flex min-h-16 cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 transition-colors duration-150 ease-out hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden"
                               data-testid="profile-identity-toggle"
                             >
                               <div className="min-w-0">
-                                <h2 className="text-lg font-semibold tracking-tight">
-                                  Identity
-                                </h2>
+                                <p className="text-sm font-medium">
+                                  Identity details
+                                </p>
                                 <p
-                                  className="mt-1 text-sm font-normal text-muted-foreground/70"
+                                  className="text-sm font-normal text-muted-foreground/70"
                                   data-settings-subcopy
                                 >
                                   Your keypair and NIP-05 handle are fixed for
@@ -782,7 +782,7 @@ export function ProfileSettingsCard({
                               <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-[color,transform] duration-150 ease-out group-open:rotate-180 group-hover/identity:text-foreground group-focus-visible/identity:text-foreground" />
                             </summary>
                             <div
-                              className="border-t border-border/55 divide-y divide-border/55"
+                              className="divide-y divide-border/55"
                               data-testid="profile-identity-details"
                             >
                               <IdentityRow
@@ -802,8 +802,8 @@ export function ProfileSettingsCard({
                               <PrivateKeyBackupRow />
                             </div>
                           </details>
-                        </div>
-                      </div>
+                        </SettingsOptionGroup>
+                      </SettingsOptionGroupList>
                     </div>
 
                     {shouldRenderAvatarEditor ? (

--- a/desktop/src/features/settings/ui/SettingsOptionGroup.tsx
+++ b/desktop/src/features/settings/ui/SettingsOptionGroup.tsx
@@ -16,23 +16,24 @@ export function SettingsOptionGroup({
   surface?: "framed" | "soft";
   title?: React.ReactNode;
 }) {
+  const hasHeader = Boolean(title || description || headerAction);
+
   return (
-    <div
-      className={cn(
-        surface === "soft"
-          ? "overflow-hidden rounded-2xl bg-muted/20"
-          : "overflow-hidden rounded-xl border border-border/70 bg-background/70 divide-y divide-border/55",
-        className,
-      )}
-      {...props}
-    >
-      {title ? (
-        <div className="flex min-h-14 items-center justify-between gap-4 px-4 py-3">
-          <div className="min-w-0">
-            <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+    <div className={cn("space-y-2", className)} {...props}>
+      {hasHeader ? (
+        <div
+          className="flex min-h-7 items-end gap-3 px-4"
+          data-slot="settings-section-header"
+        >
+          <div className="min-w-0 flex-1">
+            {title ? (
+              <h2 className="text-sm font-semibold text-muted-foreground/70">
+                {title}
+              </h2>
+            ) : null}
             {description ? (
               <p
-                className="mt-1 text-sm font-normal text-muted-foreground/70"
+                className="mt-0.5 text-sm font-normal text-muted-foreground/70"
                 data-settings-subcopy
               >
                 {description}
@@ -42,8 +43,30 @@ export function SettingsOptionGroup({
           {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
         </div>
       ) : null}
-      {children}
+      <div
+        className={cn(
+          surface === "soft"
+            ? "overflow-hidden rounded-2xl bg-muted/20"
+            : "divide-y divide-border/55 overflow-hidden rounded-xl border border-border/70 bg-background/70",
+        )}
+        data-slot="settings-section-card"
+      >
+        {children}
+      </div>
     </div>
+  );
+}
+
+export function SettingsOptionGroupList({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("space-y-12", className)}
+      data-slot="settings-section-list"
+      {...props}
+    />
   );
 }
 

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -69,7 +69,11 @@ import { ModerationQueueCard } from "./ModerationQueueCard";
 import { NotificationSettingsCard } from "./NotificationSettingsCard";
 import { AgentsSettingsPanel } from "./AgentsSettingsPanel";
 import { HostedCommunitiesSettingsCard } from "./HostedCommunitiesSettingsCard";
-import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import {
+  SettingsOptionGroup,
+  SettingsOptionGroupList,
+  SettingsOptionRow,
+} from "./SettingsOptionGroup";
 import { ProfileSettingsCard } from "./ProfileSettingsCard";
 import { UpdateChecker } from "../UpdateChecker";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
@@ -635,7 +639,7 @@ function ThemeSettingsCard() {
         description="Choose how Buzz looks and feels."
       />
 
-      <div className="space-y-12">
+      <SettingsOptionGroupList>
         <SettingsOptionGroup
           data-testid="appearance-theme-card"
           headerAction={
@@ -807,7 +811,7 @@ function ThemeSettingsCard() {
           <LinkPreviewStyleSetting />
           <ThreadLayoutSetting />
         </SettingsOptionGroup>
-      </div>
+      </SettingsOptionGroupList>
     </section>
   );
 }

--- a/desktop/src/features/settings/ui/SignOutSection.tsx
+++ b/desktop/src/features/settings/ui/SignOutSection.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
-import { SettingsOptionGroup } from "./SettingsOptionGroup";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
 
 /**
  * The exact phrase the user must type before the destructive sign-out button
@@ -122,9 +122,18 @@ export function SignOutSection() {
 
   return (
     <div className="mt-12 pb-6" data-testid="settings-signout">
-      <SettingsOptionGroup
-        description="Removes your identity key and all local app data from this device. Before signing out, create and test a password-protected key backup above — this cannot be undone."
-        headerAction={
+      <SettingsOptionGroup title="Sign out">
+        <SettingsOptionRow>
+          <div className="min-w-0">
+            <p
+              className="text-sm font-normal text-muted-foreground/70"
+              data-settings-subcopy
+            >
+              Removes your identity key and all local app data from this device.
+              Before signing out, create and test a password-protected key
+              backup above — this cannot be undone.
+            </p>
+          </div>
           <Button
             data-testid="signout-open-dialog"
             disabled={isPending}
@@ -137,9 +146,8 @@ export function SignOutSection() {
             ) : null}
             {isPending ? "Signing out…" : "Delete my data"}
           </Button>
-        }
-        title="Sign out"
-      />
+        </SettingsOptionRow>
+      </SettingsOptionGroup>
       <AlertDialog
         onOpenChange={(open) => {
           if (!open && !isPending) {

--- a/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
@@ -22,7 +22,11 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { Switch } from "@/shared/ui/switch";
-import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+import {
+  SettingsOptionGroup,
+  SettingsOptionGroupList,
+  SettingsOptionRow,
+} from "./SettingsOptionGroup";
 import { SettingsSectionHeader } from "./SettingsSectionHeader";
 import {
   selectedVoiceForBackend,
@@ -187,7 +191,7 @@ export function VoiceSettingsCard() {
         description="Choose whether Buzz reads new agent responses aloud during an active huddle."
       />
 
-      <div className="flex flex-col gap-4">
+      <SettingsOptionGroupList>
         <SettingsOptionGroup title="Playback">
           <SettingsOptionRow>
             <div className="min-w-0">
@@ -329,17 +333,16 @@ export function VoiceSettingsCard() {
             </SettingsOptionRow>
           </SettingsOptionGroup>
         </div>
-
-        {error && (
-          <p
-            className="text-sm text-destructive"
-            data-testid="voice-settings-error"
-            role="alert"
-          >
-            {error}
-          </p>
-        )}
-      </div>
+      </SettingsOptionGroupList>
+      {error && (
+        <p
+          className="mt-4 text-sm text-destructive"
+          data-testid="voice-settings-error"
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
       <AlertDialog
         onOpenChange={(open) => {
           if (!open) setDeleteCandidate(null);

--- a/desktop/tests/e2e/doctor-states.spec.ts
+++ b/desktop/tests/e2e/doctor-states.spec.ts
@@ -185,7 +185,7 @@ test.describe("Doctor panel state screenshots", () => {
         .getByRole("heading", { name: "Agent runtimes", exact: true })
         .locator("..")
         .locator(".."),
-    ).toHaveCSS("align-items", "center");
+    ).toHaveCSS("align-items", "flex-end");
     for (const runtimeId of ["goose", "claude", "buzz-agent"]) {
       await expect(
         page.getByTestId(`doctor-runtime-menu-${runtimeId}`),

--- a/desktop/tests/e2e/mobile-pairing-qr.spec.ts
+++ b/desktop/tests/e2e/mobile-pairing-qr.spec.ts
@@ -46,7 +46,9 @@ test("mobile pairing starts on demand and reveals the QR code", async ({
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   const section = page.getByTestId("settings-mobile");
-  const card = page.getByTestId("mobile-pairing-card");
+  const card = page
+    .getByTestId("mobile-pairing-card")
+    .locator('[data-slot="settings-section-card"]');
   const layout = card.getByTestId("mobile-pairing-layout");
   const qrContainer = page.getByTestId("mobile-pairing-qr-container");
   const steps = card.getByTestId("mobile-pairing-steps");

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -2222,7 +2222,9 @@ test("shows agent runtimes in agent settings", async ({ page }) => {
     "settings-harnesses",
     "settings-global-agent-config",
   ]) {
-    const section = agentsPage.getByTestId(testId);
+    const section = agentsPage
+      .getByTestId(testId)
+      .locator('[data-slot="settings-section-card"]');
     await expect(section).toBeVisible();
     await expect(section).toHaveCSS("border-radius", "12px");
     await expect(section).toHaveCSS("border-top-width", "1px");

--- a/desktop/tests/e2e/settings-section-layout.spec.ts
+++ b/desktop/tests/e2e/settings-section-layout.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+import { openSettings } from "../helpers/settings";
+
+test("settings sections share the Appearance rhythm", async ({ page }) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await openSettings(page, "appearance");
+
+  const appearanceList = page
+    .getByTestId("settings-theme")
+    .locator('[data-slot="settings-section-list"]');
+  const [referenceGap] = await appearanceList
+    .locator(":scope > *")
+    .evaluateAll((elements) =>
+      elements.slice(1).map((element, index) => {
+        const previous = elements[index];
+        return (
+          element.getBoundingClientRect().top -
+          previous.getBoundingClientRect().bottom
+        );
+      }),
+    );
+
+  expect(referenceGap).toBeGreaterThan(0);
+
+  for (const section of [
+    "notifications",
+    "voice",
+    "agents",
+    "shortcuts",
+    "profile",
+  ] as const) {
+    await page.getByTestId(`settings-nav-${section}`).click();
+
+    const list = page
+      .getByTestId(`settings-${section}`)
+      .locator('[data-slot="settings-section-list"]');
+    await expect(list).toBeVisible();
+
+    const gaps = await list.locator(":scope > *").evaluateAll((elements) =>
+      elements.slice(1).map((element, index) => {
+        const previous = elements[index];
+        return (
+          element.getBoundingClientRect().top -
+          previous.getBoundingClientRect().bottom
+        );
+      }),
+    );
+    expect(gaps.length).toBeGreaterThan(0);
+    expect(gaps.every((gap) => Math.abs(gap - referenceGap) <= 1)).toBe(true);
+  }
+
+  await page.getByTestId("settings-nav-agents").click();
+  const headerToCardGap = async (testId: string) => {
+    const group = page.getByTestId(testId);
+    return group.evaluate((element) => {
+      const lastHeaderLine = element.querySelector(
+        '[data-slot="settings-section-header"] > div:first-child > :last-child',
+      );
+      const card = element.querySelector('[data-slot="settings-section-card"]');
+      if (
+        !(lastHeaderLine instanceof HTMLElement) ||
+        !(card instanceof HTMLElement)
+      ) {
+        throw new Error("Missing section header or card");
+      }
+      return (
+        card.getBoundingClientRect().top -
+        lastHeaderLine.getBoundingClientRect().bottom
+      );
+    });
+  };
+  const [titleOnlyGap, subtitleGap] = await Promise.all([
+    headerToCardGap("agents-preferences-card"),
+    headerToCardGap("settings-harnesses"),
+  ]);
+  expect(titleOnlyGap).toBeGreaterThan(0);
+  expect(Math.abs(titleOnlyGap - subtitleGap)).toBeLessThanOrEqual(1);
+});
+
+test("Profile sections keep visible cards and aligned actions", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await openSettings(page, "profile");
+
+  const identity = page.getByTestId("profile-identity-card");
+  const identityCard = identity.locator(
+    'xpath=ancestor::*[@data-slot="settings-section-card"][1]',
+  );
+  await expect(identityCard).toBeVisible();
+  await expect(
+    page.getByText("Identity details", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByTestId("profile-identity-details")).toBeHidden();
+
+  const signOut = page.getByTestId("settings-signout");
+  const signOutCard = signOut.locator('[data-slot="settings-section-card"]');
+  await expect(signOutCard).toBeVisible();
+  await expect(
+    signOutCard.getByRole("button", { name: "Delete my data" }),
+  ).toBeVisible();
+  await expect(signOut.getByText("Sign out", { exact: true })).toHaveCount(1);
+  await expect(
+    signOut.getByText("Sign out of Buzz", { exact: true }),
+  ).toHaveCount(0);
+
+  const profileInfo = page.getByTestId("profile-metadata-card");
+  await profileInfo.scrollIntoViewIfNeeded();
+  const [titleBottom, editBottom] = await Promise.all([
+    profileInfo
+      .getByRole("heading", { name: "Profile info" })
+      .evaluate((element) => element.getBoundingClientRect().bottom),
+    page
+      .getByTestId("profile-metadata-edit")
+      .evaluate((element) => element.getBoundingClientRect().bottom),
+  ]);
+  expect(Math.abs(titleBottom - editBottom)).toBeLessThanOrEqual(1);
+
+  await page.getByTestId("settings-nav-updates").click();
+  await expect(
+    page
+      .getByTestId("settings-updates")
+      .getByText("Update status", { exact: true }),
+  ).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary

- move Settings section labels outside their framed containers and centralize the spacing
- apply the shared hierarchy across Appearance, Notifications, Voice, Agents, Shortcuts, Members, and Profile
- give Identity and Sign out complete section treatments while removing redundant in-cell labels

## Testing

- desktop pre-push checks, including 4,791 tests
- focused Settings layout and sign-out Playwright coverage