### PR TITLE
feat(acp): auto-publish replies, @mention-tolerant owner commands, extra MCP servers, glm-5.3 effort table

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -214,6 +214,14 @@ pub struct AcpClient {
     standard_usage: StandardUsageTracker,
     /// Known adapter identity for prompt-response usage mapping.
     standard_adapter: Option<StandardAdapterKind>,
+    /// Assistant text streamed via `agent_message_chunk` notifications during
+    /// the current (or most recent) `session/prompt`. Concatenated verbatim —
+    /// chunks are already in order. Consumed once per turn by
+    /// [`take_turn_text`](Self::take_turn_text); a turn that produces no
+    /// assistant text (only tool calls) leaves this empty. Used by the
+    /// harness's auto-publish-reply fallback so an agent that streams an
+    /// answer without calling a publish tool still delivers it to the channel.
+    turn_text: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -563,6 +571,7 @@ impl AcpClient {
             goose_usage: UsageTracker::default(),
             standard_usage: StandardUsageTracker::default(),
             standard_adapter,
+            turn_text: String::new(),
         })
     }
 
@@ -790,6 +799,10 @@ impl AcpClient {
         // misattributed to this turn.
         self.goose_usage.begin_turn(session_id);
         self.standard_usage.begin_turn(session_id);
+        // Reset the assistant-text accumulator for the same reason: chunks
+        // arriving before the prompt response would otherwise leak from a
+        // previous turn into this one's auto-publish-reply fallback.
+        self.turn_text.clear();
 
         self.last_prompt_id = Some(self.next_id);
         let id = self.next_id;
@@ -899,6 +912,28 @@ impl AcpClient {
     pub(crate) fn notify_session_spawned(&mut self, session_id: &str) {
         self.goose_usage.seed_zero_baseline(session_id);
         self.standard_usage.seed_zero_baseline(session_id);
+    }
+
+    /// Consume and return the assistant text streamed during the most recent
+    /// `session/prompt` (concatenated `agent_message_chunk` content).
+    ///
+    /// Returns `None` when the agent emitted no assistant text this turn (e.g.
+    /// a pure tool-call turn). Subsequent calls return `None` until chunks
+    /// arrive for the next turn. Consumed by the harness's
+    /// auto-publish-reply fallback: an agent that streams an answer without
+    /// calling a publish tool still delivers it to the channel.
+    pub fn take_turn_text(&mut self) -> Option<String> {
+        let trimmed = self.turn_text.trim();
+        if trimmed.is_empty() {
+            // Keep the buffer cleared either way so a non-empty remnant can't
+            // leak into the next turn if begin_turn() is skipped (e.g. an error
+            // path that returns before session_prompt_* runs).
+            self.turn_text.clear();
+            None
+        } else {
+            let taken = std::mem::take(&mut self.turn_text);
+            Some(taken)
+        }
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1756,6 +1791,17 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    // Accumulate for the auto-publish-reply fallback. The turn
+                    // budget is reset in begin_turn(), so this never crosses a
+                    // turn boundary. Hard-cap at 32k chars to bound memory if a
+                    // runaway agent never stops streaming — the published reply
+                    // is best-effort and a 32k-char message is already far past
+                    // anything useful in chat.
+                    const TURN_TEXT_CAP: usize = 32_768;
+                    if self.turn_text.len() < TURN_TEXT_CAP {
+                        let remaining = TURN_TEXT_CAP - self.turn_text.len();
+                        self.turn_text.push_str(&text[..text.len().min(remaining)]);
+                    }
                 }
                 false
             }
@@ -3740,6 +3786,70 @@ mod tests {
             client.active_run_id(),
             Some("run-stable"),
             "non-string/non-null activeRunId must leave state untouched"
+        );
+    }
+
+    // ── take_turn_text (auto-publish-reply accumulator) ───────────────────
+
+    /// Build a `session/update` notification carrying an `agent_message_chunk`
+    /// with the given text. Mirrors the wire shape goose/buzz-agent emit.
+    fn agent_message_chunk_msg(text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess-test",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "type": "text", "text": text }
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn take_turn_text_concatenates_chunks_in_order() {
+        // Multiple chunks in one turn must concatenate verbatim, in arrival
+        // order — the auto-publish fallback posts this as the reply.
+        let mut client = spawn_inert_client().await;
+        let _ = client.handle_session_update(&agent_message_chunk_msg("2 + 27 "));
+        let _ = client.handle_session_update(&agent_message_chunk_msg("= 29."));
+        let text = client.take_turn_text().expect("accumulated text");
+        assert_eq!(text, "2 + 27 = 29.");
+        // Drained: a second take returns None.
+        assert!(client.take_turn_text().is_none());
+    }
+
+    #[tokio::test]
+    async fn take_turn_text_none_when_no_chunks() {
+        // A turn with only tool calls / thoughts (no agent_message_chunk)
+        // yields no text — the agent chose to act rather than narrate, and
+        // silence is a legitimate outcome.
+        let mut client = spawn_inert_client().await;
+        assert!(client.take_turn_text().is_none());
+    }
+
+    #[tokio::test]
+    async fn take_turn_text_none_when_only_whitespace() {
+        // Whitespace-only streams trim to empty: don't post a blank reply.
+        let mut client = spawn_inert_client().await;
+        let _ = client.handle_session_update(&agent_message_chunk_msg("   \n\t "));
+        assert!(client.take_turn_text().is_none());
+    }
+
+    #[tokio::test]
+    async fn take_turn_text_caps_at_32k_to_bound_memory() {
+        // A runaway agent that never stops streaming must not grow the buffer
+        // without limit. 32k chars is already far past any useful chat reply.
+        let mut client = spawn_inert_client().await;
+        let big = "x".repeat(40_000);
+        let _ = client.handle_session_update(&agent_message_chunk_msg(&big));
+        let text = client.take_turn_text().expect("capped text");
+        assert_eq!(
+            text.len(),
+            32_768,
+            "turn_text must be capped at 32768 chars, got {}",
+            text.len()
         );
     }
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -261,6 +261,22 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_MCP_COMMAND", default_value = "")]
     pub mcp_command: String,
 
+    /// Extra MCP servers to pass to the agent in addition to the primary
+    /// (`--mcp-command`) server. A JSON array string; each entry is an object
+    /// `{name, command, args, env}` mirroring the ACP `McpServerStdio` schema:
+    ///
+    /// ```json
+    /// [{"name":"browser","command":"npx","args":["@playwright/mcp@latest"],"env":[]}]
+    /// ```
+    ///
+    /// Extra servers receive **only** their declared `env` — no Buzz private
+    /// key or provider credentials are injected (least privilege; keeps
+    /// secrets out of e.g. a browser subprocess). The primary dev-mcp server
+    /// keeps its existing key injection unchanged. Empty (default) means no
+    /// extra servers.
+    #[arg(long, env = "BUZZ_ACP_EXTRA_MCP_SERVERS", default_value = "")]
+    pub extra_mcp_servers: String,
+
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
     #[arg(long, env = "BUZZ_ACP_IDLE_TIMEOUT")]
@@ -535,6 +551,7 @@ pub struct Config {
     pub agent_command: String,
     pub agent_args: Vec<String>,
     pub mcp_command: String,
+    pub extra_mcp_servers: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -1109,6 +1126,7 @@ impl Config {
             agent_command,
             agent_args,
             mcp_command: args.mcp_command,
+            extra_mcp_servers: args.extra_mcp_servers,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1176,12 +1194,20 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} auto_publish_reply={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} extra_mcp={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} auto_publish_reply={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
             self.agent_args.join(" "),
             self.mcp_command,
+            // Count only; validation happens in build_mcp_servers at startup.
+            if self.extra_mcp_servers.is_empty() {
+                0
+            } else {
+                serde_json::from_str::<Vec<serde_json::Value>>(&self.extra_mcp_servers)
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            },
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
             self.agents,
@@ -1491,6 +1517,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
+            extra_mcp_servers: String::new(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -409,6 +409,34 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_NO_BASE_PROMPT")]
     pub no_base_prompt: bool,
 
+    /// Auto-publish the agent's streamed assistant text as a channel reply when
+    /// a turn ends (`EndTurn`) without the agent itself calling
+    /// `buzz messages send` (or reacting).
+    ///
+    /// Some agent/model combinations reliably stream a text answer but never
+    /// invoke a publish tool — e.g. Goose on Gemini answering simple questions,
+    /// where the configured MCP server also failed to start (`buzz` has no
+    /// implicit MCP mode). Without this fallback the answer is silently
+    /// discarded: assistant text is never shown to channel members. When on,
+    /// the harness collects `agent_message_chunk` text during the turn and, if
+    /// nothing was published, posts it as a signed kind:45001 reply in the
+    /// triggering thread. Heartbeats are exempt. Default on.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_AUTO_PUBLISH_REPLY",
+        conflicts_with = "no_auto_publish_reply",
+        default_value_t = true
+    )]
+    pub auto_publish_reply: bool,
+
+    /// Disable auto-publishing the agent's streamed text as a fallback reply.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_NO_AUTO_PUBLISH_REPLY",
+        conflicts_with = "auto_publish_reply"
+    )]
+    pub no_auto_publish_reply: bool,
+
     /// Path to a custom base prompt file. Overrides the compiled-in default.
     /// Mutually exclusive with --no-base-prompt.
     #[arg(
@@ -579,6 +607,10 @@ pub struct Config {
     /// `from_cli()`. `None` when using the compiled-in default or when
     /// `--no-base-prompt` is set.
     pub base_prompt_content: Option<String>,
+    /// Whether auto-publishing the agent's streamed text as a fallback reply
+    /// is enabled. Resolved from the `--auto-publish-reply` /
+    /// `--no-auto-publish-reply` pair in `from_cli()`.
+    pub auto_publish_reply: bool,
 }
 
 /// Maximum length, in characters, of a session title sent to the adapter.
@@ -1122,6 +1154,7 @@ impl Config {
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
+            auto_publish_reply: args.auto_publish_reply && !args.no_auto_publish_reply,
         };
 
         Ok(config)
@@ -1143,7 +1176,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} auto_publish_reply={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1164,6 +1197,7 @@ impl Config {
             self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
+            self.auto_publish_reply,
             respond_to_detail,
             allowed_respond_to_detail,
         )
@@ -1494,6 +1528,7 @@ mod tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            auto_publish_reply: false,
         }
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2010,7 +2010,7 @@ async fn tokio_main() -> Result<()> {
 
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
-        mcp_servers: build_mcp_servers(&config),
+        mcp_servers: build_mcp_servers(&config)?,
         initial_message: config.initial_message.clone(),
         idle_timeout: Duration::from_secs(config.idle_timeout_secs),
         max_turn_duration: Duration::from_secs(config.max_turn_duration_secs),
@@ -4854,61 +4854,148 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
     Ok(())
 }
 
-fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
-    if config.mcp_command.is_empty() {
-        return vec![];
-    }
-    vec![McpServer {
-        name: std::path::Path::new(&config.mcp_command)
+/// Mirror of the ACP `McpServerStdio` schema used to deserialize
+/// `--extra-mcp-servers`. Kept separate from [`McpServer`] (which is
+/// serialize-only, as it is an ACP wire-output type) and from [`EnvVar`]
+/// for the same reason.
+#[derive(serde::Deserialize)]
+struct ExtraMcpServer {
+    name: String,
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: Vec<ExtraEnvVar>,
+}
+
+#[derive(serde::Deserialize)]
+struct ExtraEnvVar {
+    name: String,
+    value: String,
+}
+
+/// Safety valve mirroring `buzz_agent::mcp::MAX_MCP_SERVERS`: the agent
+/// refuses more than this many servers at `session/new`. We reject earlier,
+/// at harness startup, so a misconfiguration fails loud instead of per-turn.
+const MAX_MCP_SERVERS: usize = 16;
+
+fn build_mcp_servers(config: &Config) -> Result<Vec<McpServer>> {
+    let mut servers: Vec<McpServer> = Vec::new();
+    let mut used_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Primary dev-mcp server — the ONLY server that receives Buzz identity
+    // (relay URL + private key) so it can sign events on the agent's behalf.
+    if !config.mcp_command.is_empty() {
+        let name = std::path::Path::new(&config.mcp_command)
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("mcp")
-            .to_string(),
-        command: config.mcp_command.clone(),
-        args: vec![],
-        env: {
-            let mut env = vec![
-                EnvVar {
-                    name: "BUZZ_RELAY_URL".into(),
-                    value: config.relay_url.clone(),
-                },
-                EnvVar {
-                    name: "BUZZ_PRIVATE_KEY".into(),
-                    // bech32 encoding of a valid secret key is infallible.
-                    // Panic here is correct: injecting a bogus secret would cause
-                    // delayed, hard-to-diagnose agent failures downstream.
-                    value: config
-                        .keys
-                        .secret_key()
-                        .to_bech32()
-                        .expect("secret key bech32 encoding should never fail"),
-                },
-            ];
-            // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
-            // so the MCP server can attach it to every signed event.
-            if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
-                if !auth_tag.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_AUTH_TAG".into(),
-                        value: auth_tag,
-                    });
+            .to_string();
+        used_names.insert(name.clone());
+        servers.push(McpServer {
+            name,
+            command: config.mcp_command.clone(),
+            args: vec![],
+            env: {
+                let mut env = vec![
+                    EnvVar {
+                        name: "BUZZ_RELAY_URL".into(),
+                        value: config.relay_url.clone(),
+                    },
+                    EnvVar {
+                        name: "BUZZ_PRIVATE_KEY".into(),
+                        // bech32 encoding of a valid secret key is infallible.
+                        // Panic here is correct: injecting a bogus secret would cause
+                        // delayed, hard-to-diagnose agent failures downstream.
+                        value: config
+                            .keys
+                            .secret_key()
+                            .to_bech32()
+                            .expect("secret key bech32 encoding should never fail"),
+                    },
+                ];
+                // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
+                // so the MCP server can attach it to every signed event.
+                if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+                    if !auth_tag.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_AUTH_TAG".into(),
+                            value: auth_tag,
+                        });
+                    }
                 }
-            }
-            // Forward the agent's display name so dev-mcp can use it as the git
-            // author name instead of the raw npub. Read from the process env
-            // rather than Config: this is a pass-through of a contract owned
-            // upstream, and absent simply means dev-mcp falls back to the npub.
-            if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
-                if !display_name.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_ACP_DISPLAY_NAME".into(),
-                        value: display_name,
-                    });
+                // Forward the agent's display name so dev-mcp can use it as the git
+                // author name instead of the raw npub. Read from the process env
+                // rather than Config: this is a pass-through of a contract owned
+                // upstream, and absent simply means dev-mcp falls back to the npub.
+                if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
+                    if !display_name.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_ACP_DISPLAY_NAME".into(),
+                            value: display_name,
+                        });
+                    }
                 }
+                env
+            },
+        });
+    }
+
+    // Extra MCP servers (e.g. a headless browser via Playwright). These get
+    // ONLY their declared `env` — NO Buzz private key or provider credentials
+    // are injected — so a compromised or chatty subprocess (a browser, a
+    // network fetcher) cannot exfiltrate the agent's Nostr identity. dev-mcp,
+    // which needs the key to sign events, is unaffected.
+    if !config.extra_mcp_servers.is_empty() {
+        let extras: Vec<ExtraMcpServer> = serde_json::from_str(&config.extra_mcp_servers)
+            .map_err(|e| anyhow::anyhow!("invalid --extra-mcp-servers JSON: {e}"))?;
+        for spec in extras {
+            if spec.name.is_empty() {
+                return Err(anyhow::anyhow!("extra MCP server has an empty name"));
             }
-            env
-        },
-    }]
+            // The agent namespaces tools as `server__tool`; a `__` in the name
+            // would collide with that scheme (validated again in buzz-agent).
+            if spec.name.contains("__") {
+                return Err(anyhow::anyhow!(
+                    "extra MCP server name {:?} must not contain \"__\"",
+                    spec.name
+                ));
+            }
+            if spec.command.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "extra MCP server {:?} has an empty command",
+                    spec.name
+                ));
+            }
+            if !used_names.insert(spec.name.clone()) {
+                return Err(anyhow::anyhow!(
+                    "duplicate MCP server name {:?} (extra servers must not collide with the primary server or each other)",
+                    spec.name
+                ));
+            }
+            servers.push(McpServer {
+                name: spec.name,
+                command: spec.command,
+                args: spec.args,
+                env: spec
+                    .env
+                    .into_iter()
+                    .map(|e| EnvVar {
+                        name: e.name,
+                        value: e.value,
+                    })
+                    .collect(),
+            });
+        }
+        if servers.len() > MAX_MCP_SERVERS {
+            return Err(anyhow::anyhow!(
+                "too many MCP servers: {} > {MAX_MCP_SERVERS}",
+                servers.len()
+            ));
+        }
+    }
+
+    Ok(servers)
 }
 
 #[cfg(test)]
@@ -6583,6 +6670,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
+            extra_mcp_servers: String::new(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6627,7 +6715,7 @@ mod build_mcp_servers_tests {
     #[test]
     fn session_new_mcp_server_has_required_fields() {
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         assert_eq!(servers.len(), 1);
         let server = &servers[0];
         assert_eq!(server.name, "test-mcp-server");
@@ -6648,7 +6736,7 @@ mod build_mcp_servers_tests {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_AUTH_TAG", "test-attestation-tag");
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         std::env::remove_var("BUZZ_AUTH_TAG");
 
         let server = &servers[0];
@@ -6665,7 +6753,7 @@ mod build_mcp_servers_tests {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_AUTH_TAG", "");
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         std::env::remove_var("BUZZ_AUTH_TAG");
 
         let server = &servers[0];
@@ -6678,7 +6766,7 @@ mod build_mcp_servers_tests {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_ACP_DISPLAY_NAME", "Duncan");
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         std::env::remove_var("BUZZ_ACP_DISPLAY_NAME");
 
         let entry = servers[0]
@@ -6697,7 +6785,7 @@ mod build_mcp_servers_tests {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var("BUZZ_ACP_DISPLAY_NAME");
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
 
         // Absent, not empty-valued: dev-mcp distinguishes the two and only
         // falls back to the npub when the key is missing or blank.
@@ -6715,7 +6803,7 @@ mod build_mcp_servers_tests {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_ACP_DISPLAY_NAME", "");
         let config = test_config();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         std::env::remove_var("BUZZ_ACP_DISPLAY_NAME");
 
         assert!(
@@ -6731,7 +6819,7 @@ mod build_mcp_servers_tests {
     fn empty_mcp_command_returns_no_servers() {
         let mut config = test_config();
         config.mcp_command = "".into();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         assert!(
             servers.is_empty(),
             "empty mcp_command should produce no MCP servers"
@@ -6742,7 +6830,7 @@ mod build_mcp_servers_tests {
     fn absolute_path_mcp_command_uses_file_stem_as_name() {
         let mut config = test_config();
         config.mcp_command = "/opt/bin/my-mcp-server".into();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].name, "my-mcp-server");
     }
@@ -6763,11 +6851,148 @@ mod build_mcp_servers_tests {
 
         // Confirm a non-empty command with no stem (e.g. just a dot) also falls back.
         config.mcp_command = ".".into();
-        let servers = build_mcp_servers(&config);
+        let servers = build_mcp_servers(&config).unwrap();
         assert_eq!(servers.len(), 1);
         assert_eq!(
             servers[0].name, "mcp",
             "Path::new(\".\").file_stem() is None — should fall back to \"mcp\""
+        );
+    }
+
+    // --- extra MCP servers (--extra-mcp-servers / BUZZ_ACP_EXTRA_MCP_SERVERS) ---
+
+    fn config_with_extra(extra: &str) -> Config {
+        let mut config = test_config();
+        config.extra_mcp_servers = extra.into();
+        config
+    }
+
+    #[test]
+    fn extra_mcp_server_appended_after_primary_with_args_preserved() {
+        // Mirrors the Playwright config: command + args (npx @playwright/mcp).
+        let config = config_with_extra(
+            r#"[{"name":"browser","command":"npx","args":["@playwright/mcp@latest","--headless"],"env":[]}]"#,
+        );
+        let servers = build_mcp_servers(&config).unwrap();
+        assert_eq!(servers.len(), 2, "primary + one extra");
+        assert_eq!(servers[0].name, "test-mcp-server");
+        assert_eq!(servers[1].name, "browser");
+        assert_eq!(servers[1].command, "npx");
+        assert_eq!(
+            servers[1].args,
+            vec![
+                "@playwright/mcp@latest".to_string(),
+                "--headless".to_string()
+            ],
+            "args must be parsed and forwarded verbatim"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_receives_no_buzz_keys() {
+        // Security pin: only the primary dev-mcp server gets the Nostr identity.
+        // A browser/network subprocess must never see BUZZ_PRIVATE_KEY.
+        let config =
+            config_with_extra(r#"[{"name":"browser","command":"npx","args":[],"env":[]}]"#);
+        let servers = build_mcp_servers(&config).unwrap();
+        let extra_env: Vec<&str> = servers[1].env.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            !extra_env.contains(&"BUZZ_PRIVATE_KEY"),
+            "extra server must NOT receive BUZZ_PRIVATE_KEY; got {extra_env:?}"
+        );
+        assert!(
+            !extra_env.contains(&"BUZZ_RELAY_URL"),
+            "extra server must NOT receive BUZZ_RELAY_URL; got {extra_env:?}"
+        );
+        assert!(extra_env.is_empty(), "empty env should stay empty");
+    }
+
+    #[test]
+    fn extra_mcp_server_declared_env_passed_through() {
+        let config = config_with_extra(
+            r#"[{"name":"browser","command":"npx","args":[],"env":[{"name":"DISPLAY","value":":0"}]}]"#,
+        );
+        let servers = build_mcp_servers(&config).unwrap();
+        assert_eq!(servers[1].env.len(), 1);
+        assert_eq!(servers[1].env[0].name, "DISPLAY");
+        assert_eq!(servers[1].env[0].value, ":0");
+    }
+
+    #[test]
+    fn extra_mcp_server_works_without_primary() {
+        // mcp_command unset, only extras — extras stand alone.
+        let mut config = test_config();
+        config.mcp_command = String::new();
+        config.extra_mcp_servers =
+            r#"[{"name":"browser","command":"npx","args":[],"env":[]}]"#.into();
+        let servers = build_mcp_servers(&config).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "browser");
+    }
+
+    #[test]
+    fn extra_mcp_server_invalid_json_rejected() {
+        let config = config_with_extra(r#"not valid json"#);
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid --extra-mcp-servers JSON"),
+            "expected JSON parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_empty_name_rejected() {
+        let config = config_with_extra(r#"[{"name":"","command":"npx","args":[],"env":[]}]"#);
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("empty name"),
+            "expected empty-name error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_double_underscore_name_rejected() {
+        // The agent namespaces tools as server__tool; a "__" in the name collides.
+        let config =
+            config_with_extra(r#"[{"name":"bad__name","command":"npx","args":[],"env":[]}]"#);
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("__"),
+            "expected double-underscore rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_empty_command_rejected() {
+        let config = config_with_extra(r#"[{"name":"browser","command":"","args":[],"env":[]}]"#);
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("empty command"),
+            "expected empty-command error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_duplicate_of_primary_rejected() {
+        // Primary derives its name from "test-mcp-server" → "test-mcp-server".
+        let config =
+            config_with_extra(r#"[{"name":"test-mcp-server","command":"npx","args":[],"env":[]}]"#);
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate MCP server name"),
+            "expected duplicate-name error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_mcp_server_duplicate_within_extras_rejected() {
+        let config = config_with_extra(
+            r#"[{"name":"browser","command":"npx","args":[],"env":[]},{"name":"browser","command":"node","args":[],"env":[]}]"#,
+        );
+        let err = build_mcp_servers(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate MCP server name"),
+            "expected duplicate-name error, got: {err}"
         );
     }
 }
@@ -6807,6 +7032,7 @@ mod error_outcome_emission_tests {
             agent_command: "true".into(),
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
+            extra_mcp_servers: String::new(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3360,6 +3360,35 @@ fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
     })
 }
 
+/// Compare a message body to an owner control command, tolerating leading
+/// `@mention` labels.
+///
+/// Chat clients (and human habit) prefix commands with the agent's visible
+/// mention label — e.g. `@zai !cancel` — because typing the mention is also
+/// what produces the notifying `p` tag. A strict `content == "!cancel"` check
+/// would reject that, forcing owners onto the CLI. This strips every
+/// whitespace-separated token that starts with `@` before the exact comparison:
+///
+/// - `"!cancel"`          → `"!cancel"`     ✅
+/// - `"@zai !cancel"`     → `"!cancel"`     ✅
+/// - `"@zai   !cancel"`   → `"!cancel"`     ✅ (collapses whitespace)
+/// - `"hey @zai !cancel"` → `"hey !cancel"` ❌ (stray prose remains)
+///
+/// Safety is preserved by [`is_owner_control_command`]'s `p`-tag check: a
+/// command can only fire when the event actually mentions the agent, so a bare
+/// `!cancel` in an unrelated message never matches. Agent display names are
+/// expected to be single tokens (`zai`, `claude`); a multi-word name would
+/// leave its non-`@` words behind and fail to match, which is the safe
+/// direction (no false trigger).
+fn content_matches_command(content: &str, command: &str) -> bool {
+    let stripped: String = content
+        .split_whitespace()
+        .filter(|tok| !tok.starts_with('@'))
+        .collect::<Vec<_>>()
+        .join(" ");
+    stripped == command
+}
+
 fn is_owner_control_command(
     event: &nostr::Event,
     kind_u32: u32,
@@ -3367,7 +3396,7 @@ fn is_owner_control_command(
     agent_pubkey_hex: &str,
 ) -> bool {
     kind_u32 == KIND_STREAM_MESSAGE
-        && event.content.trim() == command
+        && content_matches_command(&event.content, command)
         && event_mentions_agent(event, agent_pubkey_hex)
 }
 
@@ -4965,6 +4994,58 @@ mod owner_control_command_tests {
             &no_mention,
             KIND_STREAM_MESSAGE,
             "!rotate",
+            &agent
+        ));
+    }
+
+    #[test]
+    fn owner_control_command_tolerates_leading_mention_label() {
+        let agent = "ab".repeat(32);
+
+        // Desktop-style "@zai !cancel" — the leading mention label is stripped
+        // before the exact comparison, so the command fires.
+        let with_label = make_event(KIND_STREAM_MESSAGE, "@zai !cancel", Some(&agent));
+        assert!(is_owner_control_command(
+            &with_label,
+            KIND_STREAM_MESSAGE,
+            "!cancel",
+            &agent
+        ));
+
+        // Bare command still matches (back-compat).
+        let bare = make_event(KIND_STREAM_MESSAGE, "!cancel", Some(&agent));
+        assert!(is_owner_control_command(
+            &bare,
+            KIND_STREAM_MESSAGE,
+            "!cancel",
+            &agent
+        ));
+
+        // Extra whitespace between the label and the command collapses.
+        let spaced = make_event(KIND_STREAM_MESSAGE, "@zai   !shutdown", Some(&agent));
+        assert!(is_owner_control_command(
+            &spaced,
+            KIND_STREAM_MESSAGE,
+            "!shutdown",
+            &agent
+        ));
+
+        // Surrounding prose is NOT stripped — "hey @zai !cancel that" stays
+        // "hey !cancel that" ≠ "!cancel", so it does not fire. Safe.
+        let prose = make_event(KIND_STREAM_MESSAGE, "hey @zai !cancel that", Some(&agent));
+        assert!(!is_owner_control_command(
+            &prose,
+            KIND_STREAM_MESSAGE,
+            "!cancel",
+            &agent
+        ));
+
+        // A trailing word also breaks the exact match.
+        let trailing = make_event(KIND_STREAM_MESSAGE, "@zai !cancel please", Some(&agent));
+        assert!(!is_owner_control_command(
+            &trailing,
+            KIND_STREAM_MESSAGE,
+            "!cancel",
             &agent
         ));
     }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2043,6 +2043,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        auto_publish_reply: config.auto_publish_reply,
     });
 
     if !config.memory_enabled {
@@ -3672,7 +3673,7 @@ fn spawn_failure_notice(
         let rest = rest.clone();
         let channel_id = batch.channel_id;
         tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
+            pool::post_channel_reply(&rest, channel_id, &thread_tags, &content).await;
         });
     }
 }
@@ -6538,6 +6539,7 @@ mod build_mcp_servers_tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            auto_publish_reply: false,
         }
     }
 
@@ -6761,6 +6763,7 @@ mod error_outcome_emission_tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+            auto_publish_reply: false,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -606,6 +606,11 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Whether the harness auto-publishes the agent's streamed assistant text
+    /// as a channel reply when a turn ends (`EndTurn`) without the agent
+    /// itself having published. Heartbeats are exempt. See
+    /// `Config::auto_publish_reply`.
+    pub auto_publish_reply: bool,
 }
 
 impl AgentPool {
@@ -2417,6 +2422,54 @@ pub async fn run_prompt_task(
                 Some(core_stop),
             )
             .await;
+
+            // Auto-publish-reply fallback: if the agent ended its turn without
+            // itself calling `buzz messages send` (or reacting) but did stream
+            // assistant text, post that text as a channel reply. Catches the
+            // common failure mode where a model reliably answers but never
+            // invokes a publish tool — without this the answer is silently
+            // discarded, since assistant text is never shown to channel
+            // members. Heartbeats are exempt (no triggering thread to reply
+            // to, and heartbeat output is internal). MaxTokens is also exempt:
+            // a truncated stream is not a complete answer, and re-prompting
+            // (or rotation, above) is the right response. Only `EndTurn`
+            // indicates the agent considered its answer finished.
+            if ctx.auto_publish_reply
+                && matches!(stop_reason, StopReason::EndTurn)
+                && matches!(source, PromptSource::Channel(_))
+            {
+                if let Some(text) = agent.acp.take_turn_text() {
+                    let rest = ctx.rest_client.clone();
+                    let channel_id = match &source {
+                        PromptSource::Channel(cid) => *cid,
+                        PromptSource::Heartbeat => unreachable!("guarded above"),
+                    };
+                    // Reply in the thread of the last triggering event — the
+                    // same root/parent the agent would have targeted with
+                    // `buzz messages send --reply-to`.
+                    let thread_tags = batch
+                        .as_ref()
+                        .and_then(|b| b.events.last())
+                        .map(|be| crate::queue::parse_thread_tags(&be.event))
+                        .unwrap_or_default();
+                    let turn_id_for_log = turn_id.clone();
+                    tokio::spawn(async move {
+                        post_channel_reply(&rest, channel_id, &thread_tags, &text).await;
+                        tracing::info!(
+                            target: "pool::autoreply",
+                            channel = %channel_id,
+                            turn = %turn_id_for_log,
+                            chars = text.len(),
+                            "auto-published agent reply (agent did not call buzz messages send)"
+                        );
+                    });
+                } else {
+                    // No streamed text AND no publish: the agent chose silence
+                    // (or only emitted tool calls / thoughts). That is a
+                    // legitimate outcome — the base prompt explicitly licenses
+                    // silence — so do nothing.
+                }
+            }
 
             send_prompt_result(
                 &result_tx,
@@ -4237,11 +4290,16 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
-pub(crate) async fn post_failure_notice(
+/// Best-effort post a signed channel reply (kind:45001) to the relay via
+/// `POST /events`.
+///
+/// Generalizes the original failure-notice path: the same build → sign → submit
+/// pipeline serves both error notices and the auto-publish-reply fallback for
+/// agents that stream an answer without calling `buzz messages send`. Content
+/// is posted as a threaded reply when `thread_tags` carries a root event id,
+/// otherwise as a top-level message. All failures are logged and swallowed —
+/// the caller (often a fire-and-forget spawned task) cannot act on them.
+pub(crate) async fn post_channel_reply(
     rest: &crate::relay::RestClient,
     channel_id: Uuid,
     thread_tags: &ThreadTags,
@@ -4263,21 +4321,21 @@ pub(crate) async fn post_failure_notice(
         match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
             Ok(b) => b,
             Err(e) => {
-                tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
+                tracing::warn!(channel = %channel_id, "channel reply: build failed: {e}");
                 return;
             }
         };
     let event = match builder.sign_with_keys(&rest.keys) {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
+            tracing::warn!(channel = %channel_id, "channel reply: sign failed: {e}");
             return;
         }
     };
     match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
-        Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
+        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "channel reply: submit failed: {e}"),
+        Err(_) => tracing::warn!(channel = %channel_id, "channel reply: submit timed out"),
     }
 }
 
@@ -7600,6 +7658,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            auto_publish_reply: false,
         }
     }
 

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -328,11 +328,16 @@ fn gpt5_base_matches(lower_model: &str, token: &str) -> bool {
 /// | gpt-5.4     | `none, low, medium, high, xhigh`          |
 /// | gpt-5.1     | `none, low, medium, high`                 |
 /// | gpt-5 (base)| `minimal, low, medium, high`              |
+/// | glm-5.3     | `low, high, max` (z.ai blog, Aug 2026)    |
 /// | unknown     | not doc-verified — `max` clamps to `xhigh` |
 ///
 /// Note the `none` vs `minimal` split: `gpt-5` (base) supports `minimal` but not `none`;
 /// `gpt-5.1`/`gpt-5.4`/`gpt-5.5`/`gpt-5.6` support `none` but not `minimal`. These are matched via
 /// nearest-supported fallback in `normalize_effort_for_openai_route`.
+///
+/// `glm-5.3` (z.ai, doc-verified against https://z.ai/blog/glm-5.3 and live API probes,
+/// Aug 2026) supports only `low|high|max`; thinking cannot be disabled, so `none`/`minimal`
+/// fall back to `low` and `medium`/`xhigh` to the nearest supported level.
 ///
 /// Match order: `-pro` variant checked before versioned strings to prevent `gpt-5-pro` from
 /// falling into the `gpt-5` base bucket (substring "gpt-5" is shared).
@@ -373,6 +378,13 @@ fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
         ThinkingEffort::Medium,
         ThinkingEffort::High,
     ];
+    // z.ai GLM-5.3: only low|high|max (thinking cannot be disabled).
+    // Doc-verified against https://z.ai/blog/glm-5.3 and live api.z.ai probes (Aug 2026).
+    const GLM_5_3: &[ThinkingEffort] = &[
+        ThinkingEffort::Low,
+        ThinkingEffort::High,
+        ThinkingEffort::Max,
+    ];
 
     let lower = model.to_ascii_lowercase();
     // Check gpt-5-pro before gpt-5.5 / gpt-5.4 etc. to avoid the `-pro` name
@@ -405,6 +417,12 @@ fn openai_efforts_for_model(model: &str) -> Option<&'static [ThinkingEffort]> {
     } else if gpt5_base_matches(&lower, "gpt-5") || gpt5_base_matches(&lower, "gpt5") {
         // Base gpt-5 (no version suffix matching any of the above).
         Some(GPT5_BASE)
+    } else if gpt5_token_matches(&lower, "glm-5.3")
+        || gpt5_token_matches(&lower, "glm5.3")
+        || gpt5_token_matches(&lower, "glm-5-3")
+        || gpt5_token_matches(&lower, "glm5-3")
+    {
+        Some(GLM_5_3)
     } else {
         // Unknown model — not doc-verified; server validates.
         None
@@ -2599,6 +2617,68 @@ mod tests {
         assert!(openai_efforts_for_model("llama-4").is_none());
         assert!(openai_efforts_for_model("claude-opus-4-8").is_none());
         assert!(openai_efforts_for_model("gpt-4o").is_none());
+    }
+
+    // ---- GLM-5.3 (z.ai): low|high|max only, thinking cannot be disabled ----
+
+    #[test]
+    fn openai_efforts_for_model_glm_5_3_is_low_high_max() {
+        let expected: &[ThinkingEffort] = &[
+            ThinkingEffort::Low,
+            ThinkingEffort::High,
+            ThinkingEffort::Max,
+        ];
+
+        for model in [
+            "glm-5.3",
+            "glm-5-3",
+            "glm5.3",
+            "zai-glm-5.3",
+            "glm-5.3-2026-08-14",
+        ] {
+            assert_eq!(
+                openai_efforts_for_model(model),
+                Some(expected),
+                "{model} must match the glm-5.3 effort table"
+            );
+        }
+    }
+
+    #[test]
+    fn openai_efforts_for_model_glm_5_3_rejects_neighbour_versions() {
+        // glm-5.2 and below are not doc-verified — must stay unknown (max clamps to xhigh).
+        assert!(openai_efforts_for_model("glm-5.2").is_none());
+        assert!(openai_efforts_for_model("glm-5.1").is_none());
+        // glm-5.30 must not false-match glm-5.3 (digit continuation is blocked).
+        assert!(openai_efforts_for_model("glm-5.30").is_none());
+    }
+
+    #[test]
+    fn normalize_effort_max_passes_through_for_glm_5_3() {
+        // The whole point of the table entry: max must NOT clamp to xhigh for glm-5.3.
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::Max, "glm-5.3"),
+            ThinkingEffort::Max
+        );
+    }
+
+    #[test]
+    fn normalize_effort_unsupported_levels_fall_back_for_glm_5_3() {
+        // medium → high (nearest supported, upward preference)
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::Medium, "glm-5.3"),
+            ThinkingEffort::High
+        );
+        // xhigh → max (nearest supported)
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::XHigh, "glm-5.3"),
+            ThinkingEffort::Max
+        );
+        // none → low (thinking cannot be disabled; peer minimal is unsupported)
+        assert_eq!(
+            normalize_effort_for_openai_route(ThinkingEffort::None, "glm-5.3"),
+            ThinkingEffort::Low
+        );
     }
 
     // ---- Boundary-safe matching: version digits must not false-match longer versions ----


### PR DESCRIPTION
## Summary

Four harness/agent improvements from operating the aumico relay deployment (4 persistent agents: GLM, Grok x2, Goose/Gemini).

### 1. Auto-publish streamed agent text as channel reply fallback (`581336418`)
When an agent answers an @mention by streaming assistant text without itself calling `buzz messages send` (e.g. Goose on Gemini), the response was silently discarded — assistant text is never shown to channel members. The harness now accumulates `agent_message_chunk` text during the turn and, if the turn ends with `EndTurn` without a publish, posts the text as a signed kind:45001 reply in the triggering thread. On by default (`--no-auto-publish-reply` to opt out); heartbeats and MaxTokens turns are exempt.

### 2. Tolerate leading @mention in owner control commands (`369276556`)
The desktop client inlines `@displayName` into message content (e.g. `@zai !cancel`), which broke the exact-content match for `!cancel`/`!shutdown`/`!rotate`. Leading `@`-prefixed tokens are now stripped before comparing, so owner control commands fire natively from the desktop client. The p-tag mention check still gates every command.

### 3. Extra MCP servers via `BUZZ_ACP_EXTRA_MCP_SERVERS` (`c6e2e0c6b`)
`build_mcp_servers` previously forwarded only the primary dev-mcp server, even though ACP and buzz-agent already accept a list (up to 16). Adds a JSON config for additional servers (e.g. a headless Playwright browser: `npx @playwright/mcp@latest --headless`), parsed and passed alongside dev-mcp on `session/new`.

**Security:** extra servers receive *only* their declared env — no `BUZZ_PRIVATE_KEY` or provider credentials are injected — keeping the agent's Nostr identity out of subprocesses such as a browser. Fail-fast at harness startup on invalid JSON, empty/duplicate names, or primary-name collisions; mirrors the agent's `MAX_MCP_SERVERS=16` cap.

### 4. Doc-verify glm-5.3 effort table (`f357ec5e3`)
z.ai's GLM-5.3 supports only `low|high|max` `reasoning_effort` values and thinking cannot be disabled (verified against the z.ai blog and live api.z.ai probes, Aug 2026). Adds the GLM_5_3 family to `openai_efforts_for_model` so `BUZZ_AGENT_THINKING_EFFORT=max` passes through unclamped; unsupported levels fall back to the nearest supported one (`medium→high`, `xhigh→max`, `none→low`).

## Testing

- `cargo test -p buzz-acp -p buzz-agent`: **1395 passed, 0 failed** (post-rebase)
- New unit tests: auto-publish accumulation (4), extra-MCP parsing/validation (10), glm-5.3 effort table + fallbacks (4)
- fmt + clippy clean for both crates
- Live-verified on a production relay deployment: Playwright browser MCP answering URL-read requests end-to-end; glm-5.3 with `reasoning_effort=max` (no clamp warning, correct model in LLM logs)
