### PR TITLE
fix(desktop): match fullwidth characters in mention autocomplete

### DIFF
--- a/desktop/src/features/messages/lib/mentionRanking.test.mjs
+++ b/desktop/src/features/messages/lib/mentionRanking.test.mjs
@@ -139,3 +139,24 @@ test("rankMentionCandidates: owned teams rank with runnable personas", () => {
     ["team", "identity"],
   );
 });
+
+test("rankMentionCandidates: fullwidth ｜ in display name matches halfwidth | query", () => {
+  const agent = candidate({
+    displayName: "Hermes｜居遊所總管",
+    isAgent: true,
+    isMember: true,
+  });
+
+  assert.deepEqual(rankedPubkeys([agent], "hermes|"), [OTHER_BRAIN_PUBKEY]);
+  assert.deepEqual(rankedPubkeys([agent], "hermes｜居"), [OTHER_BRAIN_PUBKEY]);
+});
+
+test("rankMentionCandidates: segment after ｜ matches as its own word", () => {
+  const agent = candidate({
+    displayName: "Hermes｜居遊所總管",
+    isAgent: true,
+    isMember: true,
+  });
+
+  assert.deepEqual(rankedPubkeys([agent], "居遊"), [OTHER_BRAIN_PUBKEY]);
+});

--- a/desktop/src/features/messages/lib/mentionRanking.ts
+++ b/desktop/src/features/messages/lib/mentionRanking.ts
@@ -36,15 +36,22 @@ function getMentionCandidateGroupRank(
   return 3;
 }
 
+// NFKC folds fullwidth punctuation/letters to their ASCII forms (｜ → |,
+// Ｈ → H), so typing a halfwidth pipe still matches names like
+// "Hermes｜居遊所總管".
+function foldForMatch(value: string): string {
+  return value.normalize("NFKC").toLowerCase();
+}
+
 function scoreMentionCandidateLabel(
   label: string,
   lowerQuery: string,
 ): number | null {
-  const lower = label.toLowerCase();
+  const lower = foldForMatch(label);
   if (lower === lowerQuery) return 0;
   if (lower.startsWith(lowerQuery)) return 1;
 
-  const words = lower.split(/[\s\-_]+/).filter(Boolean);
+  const words = lower.split(/[\s\-_|]+/).filter(Boolean);
   if (words.some((word) => word === lowerQuery)) return 2;
   if (words.some((word) => word.startsWith(lowerQuery))) return 3;
 
@@ -56,7 +63,7 @@ export function rankMentionCandidates<T extends MentionCandidateForRanking>(
   query: string,
   activePersonaIds: ReadonlySet<string> = new Set(),
 ): RankedMentionCandidate<T>[] {
-  const lowerQuery = query.toLowerCase();
+  const lowerQuery = foldForMatch(query);
 
   return candidates
     .map((candidate, order) => {


### PR DESCRIPTION
## Problem

Display names containing fullwidth punctuation — e.g. an agent named `Hermes｜居遊所總管` — are unreachable in the desktop mention autocomplete:

- Typing `@Hermes|` (halfwidth pipe) never matches the fullwidth `｜` (U+FF5C) in the name.
- The word splitter in `mentionRanking.ts` only breaks on whitespace/`-`/`_`, so the whole name is one "word" starting with `hermes` — typing `@居遊` (the CJK segment after the pipe) can never match either.

## Fix

- Fold both candidate labels and the query with NFKC normalization (fullwidth → ASCII forms) before lowercasing and comparing.
- Include `|` in the word-split pattern so segments around a pipe rank as standalone words.

## Testing

- Added ranking tests covering `hermes|`, `hermes｜居`, and `居遊` queries against `Hermes｜居遊所總管` — all match.
- Full desktop unit test suite, `tsc --noEmit`, and biome pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)