### PR TITLE
fix(desktop): authorize external channel-member mentions at send time

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -164,6 +164,42 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
+test("getMentionableAgentPubkeys: admits authorized roster agents despite stale directory channels", () => {
+  const authorizedMember = {
+    pubkey: PUB_B,
+    respondTo: "anyone",
+    respondToAllowlist: [],
+    channelIds: [],
+  };
+  const unauthorizedMember = {
+    pubkey: PUB_C,
+    respondTo: "allowlist",
+    respondToAllowlist: [OTHER_OWNER_PUBKEY],
+    channelIds: [],
+  };
+  const authorizedNonmember = {
+    pubkey: PUB_D,
+    respondTo: "anyone",
+    respondToAllowlist: [],
+    channelIds: [],
+  };
+
+  assert.deepEqual(
+    getMentionableAgentPubkeys({
+      eligibilityScope: {
+        type: "channel",
+        channelId: "general",
+        memberPubkeys: new Set([PUB_B, PUB_C]),
+      },
+      managedAgentPubkeys: [],
+      currentPubkey: CURRENT_PUBKEY,
+      relayAgents: [authorizedMember, unauthorizedMember, authorizedNonmember],
+      sharedChannelIds: new Set(["general"]),
+    }),
+    new Set([PUB_B]),
+  );
+});
+
 test("getMentionableAgentPubkeys: scopes channel composers and fails closed without context", () => {
   const relayAgents = [
     {

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -31,19 +31,35 @@ export function relayAgentIsSharedWithUser(
 }
 
 export function relayAgentCanRespondInChannel(
-  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
+  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist"> &
+    Partial<Pick<RelayAgent, "pubkey">>,
   channelId: string,
   currentPubkey?: string | null,
+  memberPubkeys: ReadonlySet<string> = new Set(),
 ) {
-  return (
-    agent.channelIds.includes(channelId) &&
-    relayAgentIsSharedWithUser(agent, new Set([channelId]), currentPubkey)
-  );
+  const hasChannelEvidence =
+    agent.channelIds.includes(channelId) ||
+    (agent.pubkey !== undefined &&
+      memberPubkeys.has(normalizePubkey(agent.pubkey)));
+  if (!hasChannelEvidence) return false;
+
+  if (agent.respondTo === "allowlist" && currentPubkey) {
+    const normalizedCurrentPubkey = normalizePubkey(currentPubkey);
+    return agent.respondToAllowlist
+      .map((pubkey) => normalizePubkey(pubkey))
+      .includes(normalizedCurrentPubkey);
+  }
+
+  return agent.respondTo === "anyone";
 }
 
 export type AgentEligibilityScope =
   | { type: "community" }
-  | { type: "channel"; channelId: string }
+  | {
+      type: "channel";
+      channelId: string;
+      memberPubkeys?: ReadonlySet<string>;
+    }
   | { type: "managed-only" };
 
 export function getMentionableAgentPubkeys({
@@ -73,6 +89,7 @@ export function getMentionableAgentPubkeys({
               agent,
               eligibilityScope.channelId,
               currentPubkey,
+              eligibilityScope.memberPubkeys,
             );
     if (isAllowed) {
       pubkeys.add(normalizePubkey(agent.pubkey));

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.test.mjs
@@ -8,12 +8,16 @@ const AGENT = "b".repeat(64);
 const HUMAN = "c".repeat(64);
 const OTHER_OWNER = "d".repeat(64);
 
-function options(refetchOwnerProfiles) {
+function options(refetchOwnerProfiles, overrides = {}) {
   return {
     pubkeys: [HUMAN, AGENT],
     agentPubkeys: new Set([AGENT]),
     currentPubkey: CURRENT,
-    eligibilityScope: { type: "channel", channelId: "general" },
+    eligibilityScope: {
+      type: "channel",
+      channelId: "general",
+      memberPubkeys: new Set([AGENT]),
+    },
     sharedChannelIds: new Set(["general"]),
     ownerOnly: true,
     ownerPolicyError: null,
@@ -29,7 +33,12 @@ function options(refetchOwnerProfiles) {
       ],
       error: null,
     }),
+    refetchChannelMembers: async () => ({
+      data: [{ pubkey: AGENT }],
+      error: null,
+    }),
     refetchOwnerProfiles,
+    ...overrides,
   };
 }
 
@@ -72,3 +81,89 @@ for (const [name, refetchOwnerProfiles] of [
     );
   });
 }
+
+test("channel revalidation drops an agent removed after selection", async () => {
+  const result = await revalidateAgentMentionPubkeys(
+    options(
+      async () => ({
+        profiles: { [AGENT]: { ownerPubkey: CURRENT } },
+        missing: [],
+      }),
+      { refetchChannelMembers: async () => ({ data: [], error: null }) },
+    ),
+  );
+
+  assert.deepEqual(result, [HUMAN]);
+});
+
+test("channel revalidation fails closed when the fresh roster fails", async () => {
+  const result = await revalidateAgentMentionPubkeys(
+    options(
+      async () => ({
+        profiles: { [AGENT]: { ownerPubkey: CURRENT } },
+        missing: [],
+      }),
+      {
+        refetchChannelMembers: async () => ({
+          data: [{ pubkey: AGENT }],
+          error: new Error("relay unavailable"),
+        }),
+      },
+    ),
+  );
+
+  assert.deepEqual(result, [HUMAN]);
+});
+
+test("invite preflight revalidates policy before requiring membership", async () => {
+  let rosterReads = 0;
+  const result = await revalidateAgentMentionPubkeys(
+    options(
+      async () => ({
+        profiles: { [AGENT]: { ownerPubkey: CURRENT } },
+        missing: [],
+      }),
+      {
+        eligibilityScope: {
+          type: "channel",
+          channelId: "general",
+          memberPubkeys: new Set(),
+        },
+        requireChannelMembership: false,
+        refetchChannelMembers: async () => {
+          rosterReads += 1;
+          return { data: [], error: null };
+        },
+      },
+    ),
+  );
+
+  assert.equal(rosterReads, 0);
+  assert.deepEqual(result, [HUMAN, AGENT]);
+});
+
+test("fresh roster admits an authorized agent with stale directory channels", async () => {
+  const result = await revalidateAgentMentionPubkeys(
+    options(
+      async () => ({
+        profiles: { [AGENT]: { ownerPubkey: CURRENT } },
+        missing: [],
+      }),
+      {
+        refetchRelayAgents: async () => ({
+          data: [
+            {
+              pubkey: AGENT,
+              respondTo: "anyone",
+              respondToAllowlist: [],
+              channelIds: [],
+            },
+          ],
+          error: null,
+        }),
+      },
+    ),
+  );
+
+  assert.deepEqual(result, [HUMAN, AGENT]);
+});

--- a/desktop/src/features/messages/lib/agentMentionRevalidation.ts
+++ b/desktop/src/features/messages/lib/agentMentionRevalidation.ts
@@ -7,6 +7,7 @@ import {
 import { evictUsersBatchEntries } from "@/features/profile/hooks";
 import { getUsersBatch } from "@/shared/api/tauriProfiles";
 import type {
+  ChannelMember,
   ManagedAgent,
   RelayAgent,
   UsersBatchResponse,
@@ -20,6 +21,10 @@ type DirectoryResult<T> = {
   error: Error | null;
 };
 
+type AgentMentionRevalidationOptions = {
+  requireChannelMembership?: boolean;
+};
+
 export async function revalidateAgentMentionPubkeys({
   pubkeys,
   agentPubkeys,
@@ -30,7 +35,9 @@ export async function revalidateAgentMentionPubkeys({
   ownerPolicyError,
   refetchManagedAgents,
   refetchRelayAgents,
+  refetchChannelMembers,
   refetchOwnerProfiles,
+  requireChannelMembership = true,
 }: {
   pubkeys: readonly string[];
   agentPubkeys: ReadonlySet<string>;
@@ -41,7 +48,9 @@ export async function revalidateAgentMentionPubkeys({
   ownerPolicyError: Error | null;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
   refetchRelayAgents: () => Promise<DirectoryResult<RelayAgent[]>>;
+  refetchChannelMembers?: () => Promise<DirectoryResult<ChannelMember[]>>;
   refetchOwnerProfiles: (pubkeys: string[]) => Promise<UsersBatchResponse>;
+  requireChannelMembership?: boolean;
 }) {
   const requestedAgentPubkeys = new Set(
     pubkeys.map(normalizePubkey).filter((pubkey) => agentPubkeys.has(pubkey)),
@@ -50,13 +59,19 @@ export async function revalidateAgentMentionPubkeys({
     return [...pubkeys];
   }
 
-  const [managedResult, relayResult, ownerProfiles] = await Promise.all([
-    refetchManagedAgents(),
-    refetchRelayAgents(),
-    ownerOnly
-      ? refetchOwnerProfiles([...requestedAgentPubkeys]).catch(() => null)
-      : Promise.resolve(null),
-  ]);
+  const [managedResult, relayResult, ownerProfiles, channelMembersResult] =
+    await Promise.all([
+      refetchManagedAgents(),
+      refetchRelayAgents(),
+      ownerOnly
+        ? refetchOwnerProfiles([...requestedAgentPubkeys]).catch(() => null)
+        : Promise.resolve(null),
+      eligibilityScope.type === "channel" &&
+      requireChannelMembership &&
+      refetchChannelMembers
+        ? refetchChannelMembers()
+        : Promise.resolve(null),
+    ]);
   if (
     managedResult.error !== null ||
     relayResult.error !== null ||
@@ -64,7 +79,12 @@ export async function revalidateAgentMentionPubkeys({
     relayResult.data === undefined ||
     ownerOnly === undefined ||
     ownerPolicyError !== null ||
-    (ownerOnly && ownerProfiles === null)
+    (ownerOnly && ownerProfiles === null) ||
+    (eligibilityScope.type === "channel" &&
+      requireChannelMembership &&
+      (channelMembersResult === null ||
+        channelMembersResult.error !== null ||
+        channelMembersResult.data === undefined))
   ) {
     return filterAdmittedMentionPubkeys(pubkeys, agentPubkeys, new Set());
   }
@@ -72,11 +92,34 @@ export async function revalidateAgentMentionPubkeys({
   const managedPubkeys = new Set(
     managedResult.data.map((agent) => normalizePubkey(agent.pubkey)),
   );
+  const freshMemberPubkeys = new Set(
+    (channelMembersResult?.data ?? []).map((member) =>
+      normalizePubkey(member.pubkey),
+    ),
+  );
+  const scopedManagedPubkeys =
+    eligibilityScope.type === "channel" && requireChannelMembership
+      ? new Set(
+          [...managedPubkeys].filter((pubkey) =>
+            freshMemberPubkeys.has(pubkey),
+          ),
+        )
+      : managedPubkeys;
+  const scopedRelayAgents =
+    eligibilityScope.type === "channel" && requireChannelMembership
+      ? relayResult.data.filter((agent) =>
+          freshMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+        )
+      : relayResult.data;
+  const freshEligibilityScope =
+    eligibilityScope.type === "channel" && requireChannelMembership
+      ? { ...eligibilityScope, memberPubkeys: freshMemberPubkeys }
+      : eligibilityScope;
   const mentionablePubkeys = getMentionableAgentPubkeys({
     currentPubkey,
-    eligibilityScope,
-    managedAgentPubkeys: managedPubkeys,
-    relayAgents: relayResult.data,
+    eligibilityScope: freshEligibilityScope,
+    managedAgentPubkeys: scopedManagedPubkeys,
+    relayAgents: scopedRelayAgents,
     sharedChannelIds,
   });
   const admittedPubkeys = new Set(
@@ -84,7 +127,7 @@ export async function revalidateAgentMentionPubkeys({
       (pubkey) =>
         getAgentMentionAdmission({
           isAgent: true,
-          isManagedAgent: managedPubkeys.has(pubkey),
+          isManagedAgent: scopedManagedPubkeys.has(pubkey),
           pubkey,
           ownerPubkey: ownerProfiles?.profiles[pubkey]?.ownerPubkey,
           currentPubkey,
@@ -107,6 +150,7 @@ export function useAgentMentionRevalidation({
   ownerPolicyError,
   refetchManagedAgents,
   refetchRelayAgents,
+  refetchChannelMembers,
 }: {
   agentPubkeys: ReadonlySet<string>;
   getSelectedAgentPubkeys: () => ReadonlySet<string>;
@@ -117,6 +161,7 @@ export function useAgentMentionRevalidation({
   ownerPolicyError: Error | null;
   refetchManagedAgents: () => Promise<DirectoryResult<ManagedAgent[]>>;
   refetchRelayAgents: () => Promise<DirectoryResult<RelayAgent[]>>;
+  refetchChannelMembers?: () => Promise<DirectoryResult<ChannelMember[]>>;
 }) {
   const queryClient = useQueryClient();
   const refetchOwnerProfiles = React.useCallback(
@@ -127,7 +172,10 @@ export function useAgentMentionRevalidation({
     [queryClient],
   );
   return React.useCallback(
-    (pubkeys: readonly string[]) =>
+    (
+      pubkeys: readonly string[],
+      options: AgentMentionRevalidationOptions = {},
+    ) =>
       revalidateAgentMentionPubkeys({
         pubkeys,
         agentPubkeys: new Set([...agentPubkeys, ...getSelectedAgentPubkeys()]),
@@ -138,7 +186,9 @@ export function useAgentMentionRevalidation({
         ownerPolicyError,
         refetchManagedAgents,
         refetchRelayAgents,
+        refetchChannelMembers,
         refetchOwnerProfiles,
+        requireChannelMembership: options.requireChannelMembership,
       }),
     [
       agentPubkeys,
@@ -148,6 +198,7 @@ export function useAgentMentionRevalidation({
       ownerOnly,
       ownerPolicyError,
       refetchManagedAgents,
+      refetchChannelMembers,
       refetchOwnerProfiles,
       refetchRelayAgents,
       sharedChannelIds,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -183,12 +183,29 @@ export function useMentions(
   const mentionChannelId = isAgentMentionChannelType(options?.channelType)
     ? channelId
     : null;
+  const channelRosterReady =
+    membersQuery.data !== undefined &&
+    membersQuery.error === null &&
+    !membersQuery.isFetching;
+  const memberPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (channelRosterReady ? (membersQuery.data ?? []) : []).map((member) =>
+          normalizePubkey(member.pubkey),
+        ),
+      ),
+    [channelRosterReady, membersQuery.data],
+  );
   const mentionableAgentPubkeys = React.useMemo(
     () =>
       getMentionableAgentPubkeys({
         currentPubkey,
         eligibilityScope: mentionChannelId
-          ? { type: "channel", channelId: mentionChannelId }
+          ? {
+              type: "channel",
+              channelId: mentionChannelId,
+              memberPubkeys,
+            }
           : { type: "managed-only" },
         managedAgentPubkeys,
         relayAgents: relayAgentsQuery.data,
@@ -197,6 +214,7 @@ export function useMentions(
     [
       currentPubkey,
       managedAgentPubkeys,
+      memberPubkeys,
       mentionChannelId,
       relayAgentsQuery.data,
       sharedChannelIds,
@@ -230,11 +248,6 @@ export function useMentions(
   const activePersonaIds = React.useMemo(
     () => new Set(activePersonas.map((persona) => persona.id)),
     [activePersonas],
-  );
-  const memberPubkeys = React.useMemo(
-    () =>
-      new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
-    [members],
   );
   const agentIdentityPubkeys = React.useMemo(
     () =>
@@ -821,13 +834,18 @@ export function useMentions(
     getSelectedAgentPubkeys,
     currentPubkey,
     eligibilityScope: mentionChannelId
-      ? { type: "channel", channelId: mentionChannelId }
+      ? {
+          type: "channel",
+          channelId: mentionChannelId,
+          memberPubkeys,
+        }
       : { type: "managed-only" },
     sharedChannelIds,
     ownerOnly: agentAccessOwnerOnlyQuery.data,
     ownerPolicyError: agentAccessOwnerOnlyQuery.error,
     refetchManagedAgents: managedAgentsQuery.refetch,
     refetchRelayAgents: relayAgentsQuery.refetch,
+    refetchChannelMembers: mentionChannelId ? membersQuery.refetch : undefined,
   });
 
   const extractMentionPersonas = React.useCallback(

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -399,7 +399,9 @@ export function useMentionSendFlow({
       let uploadStarted = false;
       try {
         const admittedMentionPubkeys = uniqueNormalizedPubkeys(
-          await mentions.revalidateMentionPubkeys(mentionPubkeys),
+          await mentions.revalidateMentionPubkeys(mentionPubkeys, {
+            requireChannelMembership: false,
+          }),
         );
         if (!isMountedRef.current) return persistPreflightDraft();
         const admittedMentionPubkeySet = new Set(admittedMentionPubkeys);
@@ -883,13 +885,16 @@ export function useMentionSendFlow({
     }
     setNonMemberPromptError(null);
     void (async () => {
-      const mentionPubkeys = uniqueNormalizedPubkeys(
-        await mentions.revalidateMentionPubkeys([
-          ...pendingNonMemberSend.mentionPubkeys,
-          ...pendingNonMemberSend.nonMemberPubkeys,
-        ]),
+      const preInviteMentionPubkeys = uniqueNormalizedPubkeys(
+        await mentions.revalidateMentionPubkeys(
+          [
+            ...pendingNonMemberSend.mentionPubkeys,
+            ...pendingNonMemberSend.nonMemberPubkeys,
+          ],
+          { requireChannelMembership: false },
+        ),
       );
-      const admittedMentionPubkeys = new Set(mentionPubkeys);
+      const admittedMentionPubkeys = new Set(preInviteMentionPubkeys);
       const originalNonMemberPubkeys = new Set(
         pendingNonMemberSend.nonMemberPubkeys.map(normalizePubkey),
       );
@@ -941,6 +946,9 @@ export function useMentionSendFlow({
         return;
       }
 
+      const mentionPubkeys = uniqueNormalizedPubkeys(
+        await mentions.revalidateMentionPubkeys(preInviteMentionPubkeys),
+      );
       await completeSend(
         {
           ...pendingNonMemberSend,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -233,6 +233,14 @@ async function waitForTimelineSettled(page: import("@playwright/test").Page) {
   await expect(page.locator("[data-render-pending]")).toHaveCount(0);
 }
 
+async function typeAfterSelectedMention(
+  input: import("@playwright/test").Locator,
+  text: string,
+) {
+  const current = ((await input.textContent()) ?? "").trimEnd();
+  await input.fill(`${current} ${text}`);
+}
+
 async function expectOwnedAgentProfileActions(
   profilePopover: import("@playwright/test").Locator,
   pubkey: string,
@@ -320,6 +328,95 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
 
+test("roster-authorized agents with stale directory channels emit the canonical p tag", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        name: "bob",
+        respondTo: "anyone",
+        channelIds: [],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Ask @bob");
+
+  const bobRow = autocomplete(page).locator("button", { hasText: "bob" });
+  await expect(bobRow).toBeVisible();
+  await bobRow.click();
+  await typeAfterSelectedMention(input, "please reply");
+
+  const content = "Ask @bob please reply";
+  await expect(input).toHaveText(content);
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toEqual([TEST_IDENTITIES.bob.pubkey]);
+});
+
+test("send-time roster refresh drops an agent removed after selection", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: TEST_IDENTITIES.bob.pubkey,
+        name: "bob",
+        respondTo: "anyone",
+        channelIds: [],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Ask @bob");
+  const bobRow = autocomplete(page).locator("button", { hasText: "bob" });
+  await expect(bobRow).toBeVisible();
+  await bobRow.click();
+  await typeAfterSelectedMention(input, "please reply");
+
+  await page.evaluate(
+    async ({ channelId, pubkey }) => {
+      const tauriWindow = window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload?: Record<string, unknown>,
+        ) => Promise<unknown>;
+        __TAURI_INTERNALS__?: {
+          invoke?: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<unknown>;
+        };
+      };
+      const invoke =
+        tauriWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__ ??
+        tauriWindow.__TAURI_INTERNALS__?.invoke;
+      if (!invoke) throw new Error("Mock invoke bridge is unavailable.");
+      await invoke("remove_channel_member", { channelId, pubkey });
+    },
+    { channelId: GENERAL_CHANNEL_ID, pubkey: TEST_IDENTITIES.bob.pubkey },
+  );
+
+  const content = "Ask @bob please reply";
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toEqual([]);
+});
+
 test("relay-only shared agents emit an outbound mention tag when selected", async ({
   page,
 }) => {
@@ -333,7 +430,7 @@ test("relay-only shared agents emit an outbound mention tag when selected", asyn
   const aliceRow = autocomplete(page).locator("button", { hasText: "alice" });
   await expect(aliceRow).toBeVisible();
   await aliceRow.click();
-  await page.keyboard.type("please reply");
+  await typeAfterSelectedMention(input, "please reply");
 
   const content = "Ask @alice please reply";
   await expect(input).toHaveText(content);
@@ -1037,7 +1134,7 @@ test("forum sends revalidate relay-agent authorization before signing", async ({
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
   await page.getByTestId("mention-autocomplete").getByText("quinn").click();
-  await page.keyboard.type("hello");
+  await typeAfterSelectedMention(input, "hello");
   await page.getByRole("button", { name: "Attach file" }).click();
   const removeAttachment = page.getByRole("button", {
     name: "Remove attachment",
@@ -1159,7 +1256,7 @@ test("relay-only allowlisted agents emit a p tag when sent", async ({
   const quinnRow = autocomplete(page).locator("button", { hasText: "quinn" });
   await expect(quinnRow).toBeVisible();
   await quinnRow.click();
-  await page.keyboard.type("hello");
+  await typeAfterSelectedMention(input, "hello");
   await expect(input).toHaveText("@quinn hello");
   await page.getByTestId("send-message").click();
   await page.getByRole("button", { name: "Invite", exact: true }).click();
@@ -1190,7 +1287,7 @@ test("selected relay agents revoked before send emit no p tag", async ({
   const quinnRow = autocomplete(page).locator("button", { hasText: "quinn" });
   await expect(quinnRow).toBeVisible();
   await quinnRow.click();
-  await page.keyboard.type("hello");
+  await typeAfterSelectedMention(input, "hello");
 
   await page.evaluate(async () => {
     window.__BUZZ_E2E__.mock ??= {};
@@ -1255,7 +1352,7 @@ test("selected relay agents revoked after the invite prompt cause no side effect
   const quinnRow = autocomplete(page).locator("button", { hasText: "quinn" });
   await expect(quinnRow).toBeVisible();
   await quinnRow.click();
-  await page.keyboard.type("hello");
+  await typeAfterSelectedMention(input, "hello");
   await page.getByTestId("send-message").click();
   const inviteButton = page.getByRole("button", {
     name: "Invite",
@@ -1312,7 +1409,7 @@ test("selected relay agents revoked during send emit no p tag", async ({
   const quinnRow = autocomplete(page).locator("button", { hasText: "quinn" });
   await expect(quinnRow).toBeVisible();
   await quinnRow.click();
-  await page.keyboard.type("hello");
+  await typeAfterSelectedMention(input, "hello");
 
   await page.evaluate(() => {
     window.__BUZZ_E2E__.mock ??= {};


### PR DESCRIPTION
## Summary

External Gateway agents can be authoritative members of a channel while their relay directory metadata still has stale or missing `channelIds`. In that state Buzz hides a legitimate member from mention autocomplete, creating a circular dependency: the agent cannot receive a canonical mention until its directory metadata is repaired manually.

This change lets an authoritative channel roster supplement directory channel metadata for autocomplete, without weakening the existing authorization boundary:

- the agent must still satisfy relay-directory identity, `respondTo`, allowlist, owner/build policy, and exact-pubkey checks;
- cached roster data is usable only when present, error-free, and not being refetched;
- send time always refetches directory policy and the authoritative channel roster, and fails closed on errors or membership removal;
- user-confirmed Invite uses two phases: fresh directory/owner-policy validation before adding the agent, then fresh roster validation after the mutation before emitting the `p` tag;
- ordinary nonmembers remain excluded.

The result is a canonical exact-pubkey `p` tag for an authorized external channel member, while stale caches and revoked membership cannot authorize a send.

### Related issue

Security/reliability follow-up to #5681.

The basic eligibility slice overlaps #5806, but that PR does not implement authoritative-roster readiness or fresh fail-closed send-time authorization. This contribution is intentionally separate and focused on that boundary.

### Testing

Verified on current `block/buzz` main `caa64b5e8f584a740e331887a5dd1cda32bcb958` at commit `7e126e0f88d5125062e85c98ae9570c31c267ae3`:

- `pnpm test`: **PASS**
- `pnpm typecheck`: **PASS**
- `pnpm build:e2e`: **PASS**
- Biome on all seven changed files: **PASS**
- `git diff --check`: **PASS**
- complete `mentions.spec.ts` Playwright coverage: **67/67 passed**
- focused security and managed-agent compatibility Playwright coverage: **7/7 passed**
  - roster-authorized agent with stale directory channels emits canonical `p` tag
  - membership removed after selection emits no agent `p` tag
  - invited relay-only allowlisted agent emits its `p` tag after authoritative membership is established
  - directory revocation during send emits no agent `p` tag
  - existing persona agent remains addable/startable without recreation
  - nonmember managed agent is added and started before send
  - nonmember provider-managed agent is deployed before send