### PR TITLE
fix(desktop): use literal keys in sidebar storage tests

### DIFF
--- a/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs
@@ -294,7 +294,7 @@ test("mergeStores: a fresh at-capacity unmute defeats an older remote mute", () 
       { muted: true, updatedAt: index + 1 },
     ]),
   );
-  channels["unmuted"] = { muted: false, updatedAt: 9999 };
+  channels.unmuted = { muted: false, updatedAt: 9999 };
   const bounded = boundMuteStore({ version: 1, channels });
 
   const result = mergeStores(bounded, {

--- a/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs
@@ -311,7 +311,7 @@ test("mergeStores: a fresh at-capacity unstar defeats an older remote star", () 
       { starred: true, updatedAt: index + 1 },
     ]),
   );
-  channels["unstarred"] = { starred: false, updatedAt: 9999 };
+  channels.unstarred = { starred: false, updatedAt: 9999 };
   const bounded = boundStarStore({ version: 1, channels });
 
   const result = mergeStores(bounded, {


### PR DESCRIPTION
## Summary

`pnpm exec biome check .` in `desktop/` flags `lint/complexity/useLiteralKeys` on two sidebar storage test files; depending on the biome version resolving locally, one reports at error level, making `just desktop-check` exit 1 on an untouched checkout. This applies biome's own fix — bracket-string access → dot access, no behavior change:

- `desktop/src/features/sidebar/lib/channelMutesStorage.test.mjs:297` — `channels["unmuted"]` → `channels.unmuted`
- `desktop/src/features/sidebar/lib/channelStarsStorage.test.mjs:314` — `channels["unstarred"]` → `channels.unstarred`

(Both fixes are classed "unsafe" by biome, so they required `--write --unsafe` scoped to these two files.)

## Verification

- `node --test` on both files: 52/52 pass
- `just desktop-check` exits 0 — the only remaining diagnostic is the pre-existing warning-level `noImportantStyles` in `terminal.css`, intentionally left alone
- Pre-push hooks: desktop-check, desktop-typecheck, branch-skew, desktop-test (4836 tests) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
