### PR TITLE
feat(desktop): read-only 'On this relay' agents directory section

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
         "**/huddle-transcription.spec.ts",
         "**/agent-numeric-tuning.spec.ts",
         "**/needs-restart-screenshots.spec.ts",
+        "**/relay-agents-section.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -18,6 +18,7 @@ import { TeamSnapshotImportDialog } from "./TeamSnapshotImportDialog";
 import { TeamShareDialog } from "./TeamShareDialog";
 import { TeamDeleteDialog } from "./TeamDeleteDialog";
 import { TeamDialog } from "./TeamDialog";
+import { RelayAgentsSection } from "./RelayAgentsSection";
 import { TeamsSection } from "./TeamsSection";
 import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
@@ -290,6 +291,13 @@ export function AgentsView() {
               }}
               personas={personas.libraryPersonas}
               teams={teamActions.teams}
+            />
+
+            <RelayAgentsSection
+              managedAgents={agents.managedAgents}
+              onOpenAgentProfile={(pubkey) => {
+                openProfilePanel?.(pubkey);
+              }}
             />
           </div>
         </div>

--- a/desktop/src/features/agents/ui/RelayAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/RelayAgentsSection.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import { BadgeCheck } from "lucide-react";
+
+import { useRelayAgentsQuery } from "@/features/agents/hooks";
+import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { ManagedAgent, RelayAgent } from "@/shared/api/types";
+import { Badge } from "@/shared/ui/badge";
+import { SectionHeader } from "@/shared/ui/PageHeader";
+import { AgentIdentityCard } from "./AgentIdentityCard";
+import { IDENTITY_CARD_GRID_CLASS } from "./UnifiedAgentsSection";
+
+type RelayAgentsSectionProps = {
+  /** Local managed agents; relay records for these pubkeys are shown above. */
+  managedAgents: ManagedAgent[];
+  onOpenAgentProfile: (pubkey: string) => void;
+};
+
+function audienceLabel(agent: RelayAgent): string {
+  switch (agent.respondTo) {
+    case "anyone":
+      return "anyone";
+    case "allowlist":
+      return "allowlist";
+    case "owner-only":
+      return "owner only";
+    default:
+      return "no audience set";
+  }
+}
+
+function channelsLabel(agent: RelayAgent): string {
+  const count = agent.channelIds.length;
+  if (count === 0) return "No channels";
+  return count === 1 ? "1 channel" : `${count} channels`;
+}
+
+/**
+ * Read-only directory of agents hosted outside this app (kind:10100 records
+ * published on the relay). These agents run elsewhere — there is deliberately
+ * no start/edit/delete here: recreating them locally would mint duplicate
+ * identities. Records whose pubkey matches a local managed agent are shown in
+ * the managed section instead; archived identities are hidden entirely.
+ */
+export function RelayAgentsSection({
+  managedAgents,
+  onOpenAgentProfile,
+}: RelayAgentsSectionProps) {
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const isArchived = useIsArchivedPredicate();
+  const identityQuery = useIdentityQuery();
+  const selfPubkey = identityQuery.data?.pubkey?.toLowerCase() ?? null;
+
+  const managedPubkeys = React.useMemo(
+    () => new Set(managedAgents.map((agent) => agent.pubkey.toLowerCase())),
+    [managedAgents],
+  );
+
+  const remoteAgents = React.useMemo(
+    () =>
+      (relayAgentsQuery.data ?? [])
+        .filter((agent) => !managedPubkeys.has(agent.pubkey.toLowerCase()))
+        .filter((agent) => !isArchived(agent.pubkey))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [relayAgentsQuery.data, managedPubkeys, isArchived],
+  );
+
+  const profilesQuery = useUsersBatchQuery(
+    remoteAgents.map((agent) => agent.pubkey),
+    { enabled: remoteAgents.length > 0 },
+  );
+
+  if (remoteAgents.length === 0) return null;
+
+  return (
+    <section className="relative space-y-4" data-testid="agents-on-this-relay">
+      <SectionHeader
+        description="Agents hosted elsewhere that operate in this community. Read-only — manage them where they run."
+        title="On this relay"
+      />
+      <div className={IDENTITY_CARD_GRID_CLASS}>
+        {remoteAgents.map((agent) => {
+          const summary =
+            profilesQuery.data?.profiles[agent.pubkey.toLowerCase()] ?? null;
+          const label = summary?.displayName?.trim() || agent.name;
+          const ownedByMe =
+            selfPubkey !== null &&
+            summary?.ownerPubkey?.toLowerCase() === selfPubkey;
+
+          return (
+            <AgentIdentityCard
+              ariaLabel={`Open ${label} profile`}
+              avatarUrl={summary?.avatarUrl}
+              dataTestId={`relay-agent-card-${agent.pubkey}`}
+              key={agent.pubkey}
+              label={label}
+              modelLabel={`${channelsLabel(agent)} · ${audienceLabel(agent)}`}
+              onClick={() => onOpenAgentProfile(agent.pubkey)}
+              statusBadge={
+                ownedByMe ? (
+                  <Badge className="gap-1" variant="success">
+                    <BadgeCheck className="h-3 w-3" />
+                    Owned by you
+                  </Badge>
+                ) : null
+              }
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/desktop/tests/e2e/relay-agents-section.spec.ts
+++ b/desktop/tests/e2e/relay-agents-section.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+const MOCK_IDENTITY_PUBKEY = "deadbeef".repeat(8);
+const OWNED_REMOTE_AGENT_PUBKEY = "a7".repeat(32);
+const DM_ONLY_REMOTE_AGENT_PUBKEY = "b7".repeat(32);
+
+test.beforeEach(async ({ page }) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: OWNED_REMOTE_AGENT_PUBKEY,
+        name: "AM Window",
+        channelNames: ["general", "random"],
+        respondTo: "anyone",
+      },
+      {
+        pubkey: DM_ONLY_REMOTE_AGENT_PUBKEY,
+        name: "Quinn",
+        respondTo: "owner-only",
+      },
+    ],
+    searchProfiles: [
+      {
+        pubkey: OWNED_REMOTE_AGENT_PUBKEY,
+        displayName: "AM Window",
+        ownerPubkey: MOCK_IDENTITY_PUBKEY,
+        isAgent: true,
+      },
+    ],
+  });
+});
+
+async function openAgentsView(page: import("@playwright/test").Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("open-agents-view")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByTestId("open-agents-view").click();
+  await expect(page.getByTestId("agents-page-content")).toBeVisible();
+}
+
+test("relay-hosted agents render in a read-only directory section", async ({
+  page,
+}) => {
+  await openAgentsView(page);
+
+  const section = page.getByTestId("agents-on-this-relay");
+  await section.scrollIntoViewIfNeeded();
+  await expect(section).toBeVisible();
+  await expect(section.getByText("On this relay")).toBeVisible();
+
+  // Channel-scoped agent: membership summary, audience, and the owner badge
+  // sourced from its kind:0 NIP-OA ownership (profile batch).
+  const ownedCard = section.getByTestId(
+    `relay-agent-card-${OWNED_REMOTE_AGENT_PUBKEY}`,
+  );
+  await expect(ownedCard).toBeVisible();
+  await expect(ownedCard).toContainText("AM Window");
+  await expect(ownedCard).toContainText("2 channels · anyone");
+  await expect(ownedCard).toContainText("Owned by you");
+
+  // DM-only agent: no channels in its directory record, no ownership proof
+  // seeded, so no badge.
+  const dmOnlyCard = section.getByTestId(
+    `relay-agent-card-${DM_ONLY_REMOTE_AGENT_PUBKEY}`,
+  );
+  await expect(dmOnlyCard).toBeVisible();
+  await expect(dmOnlyCard).toContainText("Quinn");
+  await expect(dmOnlyCard).toContainText("No channels · owner only");
+  await expect(dmOnlyCard).not.toContainText("Owned by you");
+
+  // The cards are read-only: no start button and no actions menu anywhere in
+  // the section.
+  await expect(section.getByRole("button", { name: /start/i })).toHaveCount(0);
+  await expect(section.getByRole("button", { name: /actions/i })).toHaveCount(
+    0,
+  );
+
+  await waitForAnimations(page);
+  await section.screenshot({
+    path: "test-results/relay-agents-section/section.png",
+  });
+});
+
+test("relay records mirroring local managed agents stay in the managed section", async ({
+  page,
+}) => {
+  await openAgentsView(page);
+
+  const section = page.getByTestId("agents-on-this-relay");
+  await section.scrollIntoViewIfNeeded();
+  await expect(section).toBeVisible();
+
+  // The mock bridge mirrors every managed agent into the relay directory
+  // (syncMockRelayAgentsFromManagedAgents). None of those pubkeys may render
+  // here — the managed section above already shows them.
+  const managedPubkeys = await page.evaluate(async () => {
+    const internals = (
+      window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (cmd: string) => Promise<{ pubkey: string }[]>;
+        };
+      }
+    ).__TAURI_INTERNALS__;
+    const agents = await internals.invoke("list_managed_agents");
+    return agents.map((agent) => agent.pubkey);
+  });
+  for (const pubkey of managedPubkeys) {
+    await expect(section.getByTestId(`relay-agent-card-${pubkey}`)).toHaveCount(
+      0,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Adds a read-only **"On this relay"** section to the Agents view, listing kind:10100 relay directory records — the inspection surface requested in #5870.

- Data comes from the existing `useRelayAgentsQuery` (no new IPC); each card shows the agent's name and avatar (resolved via the profile batch), channel count, respond-to audience, and an **"Owned by you"** badge when the record's kind:0 carries a NIP-OA auth tag resolving to the current user.
- Clicking a card opens the standard profile panel.
- **Deliberately read-only** — no start/edit/delete affordances: these agents run elsewhere, and recreating them locally mints duplicate identities (see #5868 for how that goes wrong).
- Records whose pubkey matches a local managed agent stay in the managed section above; archived identities (relay 13535 snapshot) are hidden.
- Reuses `AgentIdentityCard`, `SectionHeader`, and the shared card grid, so the section renders visually identical to the existing Agents/Teams sections.

Closes #5870. Related: #5869.

## Validation

- Two Playwright specs (registered in the smoke project): section content — names, channel/audience subtitles, ownership badge, and zero start/action buttons; and managed-agent mirrors excluded from the section.
- `tsc`, biome, `check:px-text`, `check-pubkey-truncation` all pass; desktop unit tests pass.
- Screenshots in the PR comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
