### PR TITLE
test(desktop): await channel E2E bridge readiness

### DIFF
--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2724,24 +2724,29 @@ test("channel settings only prompt editors to add an empty description", async (
   page,
 }) => {
   await page.goto("/");
+  await page.waitForFunction(
+    () =>
+      typeof window.__BUZZ_E2E_MUTATE_CHANNEL__ === "function" &&
+      typeof window.__BUZZ_E2E_INVALIDATE_CHANNELS__ === "function",
+  );
   await page.evaluate(
     async ({ generalChannelId, randomChannelId }) => {
       const bridge = window as Window & {
-        __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
-        __BUZZ_E2E_MUTATE_CHANNEL__?: (options: {
+        __BUZZ_E2E_INVALIDATE_CHANNELS__: () => Promise<void>;
+        __BUZZ_E2E_MUTATE_CHANNEL__: (options: {
           channelId: string;
           description?: string;
         }) => void;
       };
-      bridge.__BUZZ_E2E_MUTATE_CHANNEL__?.({
+      bridge.__BUZZ_E2E_MUTATE_CHANNEL__({
         channelId: generalChannelId,
         description: "",
       });
-      bridge.__BUZZ_E2E_MUTATE_CHANNEL__?.({
+      bridge.__BUZZ_E2E_MUTATE_CHANNEL__({
         channelId: randomChannelId,
         description: "",
       });
-      await bridge.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
+      await bridge.__BUZZ_E2E_INVALIDATE_CHANNELS__();
     },
     {
       generalChannelId: GENERAL_CHANNEL_ID,


### PR DESCRIPTION
## Summary

- wait for the channel mutation and cache invalidation E2E hooks before using them
- make those hooks required after readiness instead of silently skipping fixture setup
- keep the production channel settings behavior and assertion unchanged

## Why

On slower CI startup, `page.goto()` can resolve before the E2E bridge installs its globals. The test used optional calls, so all three fixture operations could silently do nothing and leave the seeded `General discussion for everyone` description in React Query. The assertion then failed deterministically, including both retries.

## Validation

At commit `5b4d5d290b316db5eef78c3596a17c7a270c8163`:

- `pnpm -C desktop build:e2e`
- focused Playwright test repeated 30 times: 30 passed
- `pnpm -C desktop exec biome check tests/e2e/channels.spec.ts`
- mandatory pre-push hooks passed on the exact pushed head: `branch-skew`, `desktop-check`, `desktop-typecheck`, `mobile-test`, `desktop-test`, `rust-tests`, and `desktop-tauri-checks`
- `git diff --check origin/main...HEAD`
