### PR TITLE
fix(mobile): increase chat message text size for readability

### DIFF
--- a/mobile/lib/features/search/search_page.dart
+++ b/mobile/lib/features/search/search_page.dart
@@ -32,7 +32,7 @@ enum _SearchFilter { all, messages, channels, people }
 
 const _searchFieldMinHeight = 36.0;
 const _searchIdleFieldHeight = 45.0;
-const _searchIdleTextSize = 15.0;
+const _searchIdleTextSize = 17.0;
 const _searchFieldVerticalPadding = Grid.xxs;
 const _searchFieldMoveDuration = Duration(milliseconds: 160);
 const _searchTitleReturnDuration = Duration(milliseconds: 80);
@@ -67,7 +67,7 @@ double _searchFieldHeight(BuildContext context) {
   const style = searchInputTextStyle;
   final scaledFontSize = MediaQuery.textScalerOf(
     context,
-  ).scale(style.fontSize ?? 15);
+  ).scale(style.fontSize ?? 17);
   final contentHeight =
       scaledFontSize * (style.height ?? 1) + _searchFieldVerticalPadding * 2;
   return contentHeight > _searchFieldMinHeight
@@ -80,7 +80,7 @@ double _idleSearchFieldHeight(BuildContext context) {
     context,
   ).scale(_searchIdleTextSize);
   final contentHeight =
-      scaledFontSize * (20 / _searchIdleTextSize) +
+      scaledFontSize * (22 / _searchIdleTextSize) +
       _searchFieldVerticalPadding * 2;
   return contentHeight > _searchIdleFieldHeight
       ? contentHeight
@@ -90,7 +90,7 @@ double _idleSearchFieldHeight(BuildContext context) {
 double _searchHeaderFiltersHeight(BuildContext context) {
   const style = filterChipTextStyle;
   final scaledLabelHeight =
-      MediaQuery.textScalerOf(context).scale(style.fontSize ?? 15) *
+      MediaQuery.textScalerOf(context).scale(style.fontSize ?? 17) *
       (style.height ?? 1);
   final chipHeight = scaledLabelHeight + _searchFilterChipVerticalPadding * 2;
   final contentHeight = chipHeight + _searchFilterBarVerticalPadding * 2;

--- a/mobile/lib/shared/theme/message_typography.dart
+++ b/mobile/lib/shared/theme/message_typography.dart
@@ -16,51 +16,51 @@ const compactMessageAvatarSize = messageAvatarSize;
 /// Horizontal space between a message avatar and its content.
 const messageAvatarContentGap = Grid.twelve;
 
-/// Primary message copy: 15sp regular on a 20sp line height.
+/// Primary message copy: 17sp regular on a 22sp line height.
 const messageBodyTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w400,
-  height: 20 / 15,
+  height: 22 / 17,
   letterSpacing: 0,
 );
 
-/// Message author names: 15sp semibold on a 17sp line height.
+/// Message author names: 17sp semibold on a 19sp line height.
 const messageUsernameTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w600,
-  height: 17 / 15,
+  height: 19 / 17,
   letterSpacing: 0,
 );
 
-/// Secondary author metadata: 15sp regular on a tight 17sp line height.
+/// Secondary author metadata: 17sp regular on a tight 19sp line height.
 const messageMetadataTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w400,
-  height: 17 / 15,
+  height: 19 / 17,
   letterSpacing: 0,
 );
 
 /// Message timestamps share the secondary author metadata style.
 const messageTimestampTextStyle = messageMetadataTextStyle;
 
-/// Compact reply previews: 13.1sp regular on a 17sp line height.
+/// Compact reply previews: 14sp regular on an 18sp line height.
 const replyPreviewTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 13.1,
+  fontSize: 14,
   fontWeight: FontWeight.w400,
-  height: 17 / 13.1,
+  height: 18 / 14,
   letterSpacing: 0,
 );
 
-/// Reaction counts: 13.1sp medium on a 17sp line height.
+/// Reaction counts: 14sp medium on an 18sp line height.
 const reactionCountTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 13.1,
+  fontSize: 14,
   fontWeight: FontWeight.w500,
-  height: 17 / 13.1,
+  height: 18 / 14,
   letterSpacing: 0,
 );
 
@@ -79,42 +79,42 @@ const contentListTitleTextStyle = messageUsernameTextStyle;
 /// Secondary copy in compact content lists.
 const contentListBodyTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 13.1,
+  fontSize: 14,
   fontWeight: FontWeight.w400,
-  height: 17 / 13.1,
+  height: 18 / 14,
   letterSpacing: 0,
 );
 
 /// Timestamps in compact content lists.
 const contentListTimestampTextStyle = messageMetadataTextStyle;
 
-/// Filter chip labels use a tighter 15sp Inter treatment.
+/// Filter chip labels use a tighter 17sp Inter treatment.
 const filterChipTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w400,
   height: 1,
   letterSpacing: 0,
 );
 
-/// Search fields use the primary 15sp body treatment.
+/// Search fields use the primary 17sp body treatment.
 const searchInputTextStyle = messageBodyTextStyle;
 
-/// System message actor names: 15sp semibold on a 17sp line height.
+/// System message actor names: 17sp semibold on a 19sp line height.
 const systemMessageHeadingTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w600,
-  height: 17 / 15,
+  height: 19 / 17,
   letterSpacing: 0,
 );
 
-/// System message copy: 15sp regular on a 20sp line height.
+/// System message copy: 17sp regular on a 22sp line height.
 const systemMessageBodyTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 15,
+  fontSize: 17,
   fontWeight: FontWeight.w400,
-  height: 20 / 15,
+  height: 22 / 17,
   letterSpacing: 0,
 );
 
@@ -124,12 +124,12 @@ const activityUsernameTextStyle = messageUsernameTextStyle;
 /// Activity timestamps share the secondary author metadata style.
 const activityTimestampTextStyle = messageMetadataTextStyle;
 
-/// Activity context labels: 13.1sp medium on a 17sp line height.
+/// Activity context labels: 14sp medium on an 18sp line height.
 const activityContextTextStyle = TextStyle(
   fontFamily: _fontFamily,
-  fontSize: 13.1,
+  fontSize: 14,
   fontWeight: FontWeight.w500,
-  height: 17 / 13.1,
+  height: 18 / 14,
   letterSpacing: 0,
 );
 

--- a/mobile/lib/shared/widgets/buzz_search_field.dart
+++ b/mobile/lib/shared/widgets/buzz_search_field.dart
@@ -120,7 +120,7 @@ class BuzzSearchField extends StatelessWidget {
                   hintStyle: searchInputTextStyle.copyWith(
                     color: placeholderColor,
                     fontSize: buzzSearchIdleTextSize,
-                    height: 20 / buzzSearchIdleTextSize,
+                    height: 22 / buzzSearchIdleTextSize,
                   ),
                   border: InputBorder.none,
                   enabledBorder: InputBorder.none,

--- a/mobile/test/features/search/search_page_test.dart
+++ b/mobile/test/features/search/search_page_test.dart
@@ -199,7 +199,7 @@ void main() {
         matching: find.byType(Text),
       ),
     );
-    expect(prompt.style?.fontSize, 15);
+    expect(prompt.style?.fontSize, 17);
     expect(prompt.maxLines, 1);
     expect(prompt.overflow, TextOverflow.ellipsis);
     expect(

--- a/mobile/test/shared/theme/message_typography_test.dart
+++ b/mobile/test/shared/theme/message_typography_test.dart
@@ -20,38 +20,38 @@ void main() {
   test('message typography matches the shared mobile scale', () {
     expectStyle(
       messageBodyTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 20,
+      lineHeight: 22,
       letterSpacing: 0,
     );
     expectStyle(
       messageUsernameTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w600,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       messageTimestampTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expect(messageTimestampTextStyle, messageMetadataTextStyle);
     expectStyle(
       replyPreviewTextStyle,
-      fontSize: 13.1,
+      fontSize: 14,
       fontWeight: FontWeight.w400,
-      lineHeight: 17,
+      lineHeight: 18,
       letterSpacing: 0,
     );
     expectStyle(
       reactionCountTextStyle,
-      fontSize: 13.1,
+      fontSize: 14,
       fontWeight: FontWeight.w500,
-      lineHeight: 17,
+      lineHeight: 18,
       letterSpacing: 0,
     );
     expectStyle(
@@ -63,16 +63,16 @@ void main() {
     );
     expectStyle(
       systemMessageHeadingTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w600,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       systemMessageBodyTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 20,
+      lineHeight: 22,
       letterSpacing: 0,
     );
   });
@@ -80,30 +80,30 @@ void main() {
   test('activity typography matches the conversation row scale', () {
     expectStyle(
       activityUsernameTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w600,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       activityTimestampTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       activityContextTextStyle,
-      fontSize: 13.1,
+      fontSize: 14,
       fontWeight: FontWeight.w500,
-      lineHeight: 17,
+      lineHeight: 18,
       letterSpacing: 0,
     );
     expectStyle(
       activityPreviewTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 20,
+      lineHeight: 22,
       letterSpacing: 0,
     );
   });
@@ -111,30 +111,30 @@ void main() {
   test('content list typography matches the compact list scale', () {
     expectStyle(
       contentListTitleTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w600,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       contentListBodyTextStyle,
-      fontSize: 13.1,
+      fontSize: 14,
       fontWeight: FontWeight.w400,
-      lineHeight: 17,
+      lineHeight: 18,
       letterSpacing: 0,
     );
     expectStyle(
       contentListTimestampTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 17,
+      lineHeight: 19,
       letterSpacing: 0,
     );
     expectStyle(
       filterChipTextStyle,
-      fontSize: 15,
+      fontSize: 17,
       fontWeight: FontWeight.w400,
-      lineHeight: 15,
+      lineHeight: 17,
       letterSpacing: 0,
     );
   });


### PR DESCRIPTION
## Summary
Gift from [avi-zloof/buzz#13](https://github.com/avi-zloof/buzz/pull/13), rebased onto `main`.

- Message body **15sp → 17sp** (22sp line height)
- Username/metadata and secondary tokens scaled with it
- Search idle hint follows the new body size (`buzz_search_field.dart` on current `main`)

## Test plan
- [ ] `flutter test test/shared/theme/message_typography_test.dart`
- [ ] `flutter test test/features/search/search_page_test.dart`


Made with [Cursor](https://cursor.com)