### PR TITLE
feat(desktop): mark the open thread's row in the main timeline

### DIFF
--- a/.release/desktop-candidate.json
+++ b/.release/desktop-candidate.json
@@ -1,10 +1,10 @@
 {
   "schema": 2,
-  "version": "0.5.10",
-  "base_sha": "f35930104bcbdb1332ff13735214ecb9fce1fc7b",
-  "previous_tag": "desktop-v0.5.9",
-  "previous_base_sha": "f8f2ef0440e7a074223ec04dc3b32d817b8b9d9b",
-  "previous_merge_sha": "538e5e113fc33571f939c87b925567fd4e277109",
-  "tag": "desktop-v0.5.10",
-  "commit_count": 18
+  "version": "0.5.11",
+  "base_sha": "4749bc7be3cdb78c2db4ce4864775ba7ab60b4cc",
+  "previous_tag": "desktop-v0.5.10",
+  "previous_base_sha": "f35930104bcbdb1332ff13735214ecb9fce1fc7b",
+  "previous_merge_sha": "4b3570671eb2786594267758af18784ac6e82972",
+  "tag": "desktop-v0.5.11",
+  "commit_count": 16
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.5.11
+
+### Desktop and shared changes
+
+- perf(desktop): persist channel snapshot hash ([#5684](https://github.com/block/buzz/pull/5684)) ([`c86443c5997c96c42829ce200e73e6e6efe52d96`](https://github.com/block/buzz/commit/c86443c5997c96c42829ce200e73e6e6efe52d96))
+- fix(agent): raise output limit and allow 3 recoveries ([#5475](https://github.com/block/buzz/pull/5475)) ([`72d56e7bd3a94fa3ee20b5a50bd1b868a9329d9c`](https://github.com/block/buzz/commit/72d56e7bd3a94fa3ee20b5a50bd1b868a9329d9c))
+- fix(desktop): defer foreground resume work ([#5696](https://github.com/block/buzz/pull/5696)) ([`59f613c404958d8ac99525b4aaaf26843257de31`](https://github.com/block/buzz/commit/59f613c404958d8ac99525b4aaaf26843257de31))
+- perf(desktop): coalesce thread-activity localStorage writes ([#5693](https://github.com/block/buzz/pull/5693)) ([`c6c6e7eca70d6b526c43af925e596e8616b19fb8`](https://github.com/block/buzz/commit/c6c6e7eca70d6b526c43af925e596e8616b19fb8))
+- Batch observer-store publications per relay envelope ([#5680](https://github.com/block/buzz/pull/5680)) ([`c3b0ccf383fe4ee936abbe6b9c9134b5728cc2b5`](https://github.com/block/buzz/commit/c3b0ccf383fe4ee936abbe6b9c9134b5728cc2b5))
+- feat(buzz-acp): idle re-sleep for woken lazy pools ([#5682](https://github.com/block/buzz/pull/5682)) ([`dc2dbfe0f570abb818d3f3da8a71ea235555ed27`](https://github.com/block/buzz/commit/dc2dbfe0f570abb818d3f3da8a71ea235555ed27))
+- fix(desktop): preserve agent mention separator after send ([#5623](https://github.com/block/buzz/pull/5623)) ([`a8e5c89e23b85ee93306f2c3c11d8fe6300cd360`](https://github.com/block/buzz/commit/a8e5c89e23b85ee93306f2c3c11d8fe6300cd360))
+- fix(link-previews): proxy sent preview media ([#5627](https://github.com/block/buzz/pull/5627)) ([`884ed8a5d35dfba3892fc40437f39e08856dec7d`](https://github.com/block/buzz/commit/884ed8a5d35dfba3892fc40437f39e08856dec7d))
+- feat(deletion): add durable whole-community deletion ([#4425](https://github.com/block/buzz/pull/4425)) ([`8a2c9af2dbe0cf315e77f43a4560d3572da5e554`](https://github.com/block/buzz/commit/8a2c9af2dbe0cf315e77f43a4560d3572da5e554))
+- fix(desktop): preserve live channel timelines ([#5662](https://github.com/block/buzz/pull/5662)) ([`63d14a0e95c8d5ae19f3f80123027729ec209bb2`](https://github.com/block/buzz/commit/63d14a0e95c8d5ae19f3f80123027729ec209bb2))
+- Refine channel settings and profile panels ([#5574](https://github.com/block/buzz/pull/5574)) ([`63f961c7e4818a1d29f1185002c123e486bd4a19`](https://github.com/block/buzz/commit/63f961c7e4818a1d29f1185002c123e486bd4a19))
+- fix(deps): bump webbrowser to 1.2.4 for RUSTSEC-2026-0257 ([#5659](https://github.com/block/buzz/pull/5659)) ([`c966b862fe8b9018c68c384b1680ca0173d0128c`](https://github.com/block/buzz/commit/c966b862fe8b9018c68c384b1680ca0173d0128c))
+- fix(desktop): launch Databricks OAuth from passive model discovery ([#5607](https://github.com/block/buzz/pull/5607)) ([`1ff98fa685fdb7133dbc18437d23dcdeeb42ce6e`](https://github.com/block/buzz/commit/1ff98fa685fdb7133dbc18437d23dcdeeb42ce6e))
+
+### Other repository changes
+
+- feat(acp): report standard adapter usage ([#4950](https://github.com/block/buzz/pull/4950)) ([`4749bc7be3cdb78c2db4ce4864775ba7ab60b4cc`](https://github.com/block/buzz/commit/4749bc7be3cdb78c2db4ce4864775ba7ab60b4cc))
+- fix(mobile): settle hydrated threads on latest reply ([#4702](https://github.com/block/buzz/pull/4702)) ([`7634fe74563ea7f3c86fb6017a0ad647a9934477`](https://github.com/block/buzz/commit/7634fe74563ea7f3c86fb6017a0ad647a9934477))
+- feat(acp): deliver channel description in prompt [Context] ([#4552](https://github.com/block/buzz/pull/4552)) ([`6e0631f6b5d2139e4e080bf94e27ecee8a3d4d74`](https://github.com/block/buzz/commit/6e0631f6b5d2139e4e080bf94e27ecee8a3d4d74))
+
+[Compare desktop-v0.5.10...desktop-v0.5.11](https://github.com/block/buzz/compare/desktop-v0.5.10...desktop-v0.5.11)
+
 ## v0.5.10
 
 ### Desktop and shared changes

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "buzz",
   "private": true,
-  "version": "0.5.10",
+  "version": "0.5.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       name: "smoke",
       testMatch: [
         "**/smoke.spec.ts",
+        "**/open-thread-highlight.spec.ts",
         "**/search-scope-screenshots.spec.ts",
         "**/onboarding-docked-cta-screenshots.spec.ts",
         "**/identity-key-help.spec.ts",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "buzz-desktop"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "arboard",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ members = ["crates/buzz-terminal"]
 
 [package]
 name = "buzz-desktop"
-version = "0.5.10"
+version = "0.5.11"
 description = "Buzz desktop app"
 authors = ["you"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Buzz",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "identifier": "xyz.block.buzz.app",
   "build": {
     "beforeDevCommand": {

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -622,6 +622,7 @@ export const ChannelPane = React.memo(function ChannelPane({
               !useFocusThreadDrawer &&
               Boolean(openThreadHeadId)
             }
+            openThreadHeadId={openThreadHeadId}
             threadUnreadCounts={threadUnreadCounts}
           />
           {isNonMemberView ? (

--- a/desktop/src/features/messages/ui/MessageTimeline.tsx
+++ b/desktop/src/features/messages/ui/MessageTimeline.tsx
@@ -117,6 +117,10 @@ type MessageTimelineProps = {
   targetMessageId?: string | null;
   onTargetReached?: (messageId: string) => void;
   splitThreadPanelOpen?: boolean;
+  /** Root id of the thread currently open in the thread panel, or null. The
+   *  matching main-timeline row is marked so the open thread stays
+   *  identifiable while the channel scrolls beside the panel. */
+  openThreadHeadId?: string | null;
   /** Event id of the oldest unread top-level message at channel open, or null. */
   firstUnreadMessageId?: string | null;
   /** Count of unread top-level messages at channel open. */
@@ -206,6 +210,7 @@ const MessageTimelineBase = React.forwardRef<
     targetMessageId = null,
     onTargetReached,
     splitThreadPanelOpen = false,
+    openThreadHeadId = null,
     firstUnreadMessageId = null,
     unreadCount = 0,
     threadUnreadCounts,
@@ -650,6 +655,7 @@ const MessageTimelineBase = React.forwardRef<
       firstUnreadMessageId={firstUnreadMessageId}
       followThreadById={followThreadById}
       highlightedMessageId={highlightedMessageId}
+      openThreadHeadId={openThreadHeadId}
       huddleMemberPubkeys={huddleMemberPubkeys}
       huddleMemberPubkeysPending={huddleMemberPubkeysPending}
       isFollowingThreadById={isFollowingThreadById}

--- a/desktop/src/features/messages/ui/TimelineMessageList.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageList.tsx
@@ -55,6 +55,8 @@ type TimelineMessageListProps = {
   firstUnreadMessageId?: string | null;
   followThreadById?: (rootId: string) => void;
   highlightedMessageId?: string | null;
+  /** Root id of the thread open in the thread panel; marks its timeline row. */
+  openThreadHeadId?: string | null;
   isFollowingThreadById?: (rootId: string) => boolean;
   isMessageUnreadById?: (messageId: string) => boolean;
   entranceMessageId?: string | null;
@@ -130,6 +132,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
   firstUnreadMessageId = null,
   followThreadById,
   highlightedMessageId = null,
+  openThreadHeadId = null,
   huddleMemberPubkeys,
   huddleMemberPubkeysPending = false,
   isFollowingThreadById,
@@ -249,6 +252,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
               followThreadById={followThreadById}
               footer={messageFooters?.[item.entry.message.id] ?? null}
               highlightedMessageId={highlightedMessageId}
+              openThreadHeadId={openThreadHeadId}
               huddleMemberPubkeys={huddleMemberPubkeys}
               huddleMemberPubkeysPending={huddleMemberPubkeysPending}
               hideAgentAccessBadges={hideAgentAccessBadges}
@@ -290,6 +294,7 @@ export const TimelineMessageList = React.memo(function TimelineMessageList({
       currentPubkey,
       followThreadById,
       highlightedMessageId,
+      openThreadHeadId,
       huddleMemberPubkeys,
       huddleMemberPubkeysPending,
       hideAgentAccessBadges,

--- a/desktop/src/features/messages/ui/TimelineMessageRow.tsx
+++ b/desktop/src/features/messages/ui/TimelineMessageRow.tsx
@@ -17,6 +17,15 @@ type ToggleReaction = (
   remove: boolean,
 ) => Promise<void>;
 
+/** Persistent marker for the main-timeline row whose thread is open in the
+ *  thread panel: a left accent rail plus a faint tint. Unlike the
+ *  search/route highlight it does not fade — it lasts as long as the panel
+ *  is open, which is the whole point of it. The rail is a pseudo-element so
+ *  the row keeps its exact layout (the timeline is virtualized and measures
+ *  row heights). */
+const OPEN_THREAD_HEAD_CLASSNAME =
+  "rounded-2xl bg-primary/10 after:pointer-events-none after:absolute after:inset-y-1 after:left-0 after:w-0.5 after:rounded-full after:bg-primary after:content-['']";
+
 type SystemRowProps = {
   currentPubkey?: string;
   entries?: MainTimelineEntry[];
@@ -73,6 +82,10 @@ type MessageRowItemProps = {
   isFollowedByContinuation?: boolean;
   isFollowingThreadById?: (rootId: string) => boolean;
   isUnread?: boolean;
+  /** Root id of the thread currently open in the thread panel, or null. Marks
+   *  its row in the main timeline so the open thread stays identifiable while
+   *  the channel keeps scrolling beside the panel. */
+  openThreadHeadId?: string | null;
   playEntrance?: boolean;
   onEntranceComplete?: (messageId: string) => void;
   onDelete?: (message: TimelineMessage) => void;
@@ -105,6 +118,7 @@ export function MessageRowItem({
   isFollowedByContinuation = false,
   isFollowingThreadById,
   isUnread,
+  openThreadHeadId,
   playEntrance = false,
   onEntranceComplete,
   onDelete,
@@ -130,6 +144,8 @@ export function MessageRowItem({
   );
   const canDelete = canManage && onDelete ? onDelete : undefined;
   const canEdit = canManage && onEdit ? onEdit : undefined;
+  const isOpenThreadHead =
+    Boolean(openThreadHeadId) && message.id === openThreadHeadId;
 
   if (summary && onOpenThread) {
     const isHighlighted = message.id === highlightedMessageId;
@@ -139,7 +155,9 @@ export function MessageRowItem({
           "group/message relative mx-1 mb-1 flex flex-col gap-0 rounded-2xl px-0 py-1 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
           isHighlighted &&
             "-mx-4 px-4 before:absolute before:-inset-y-1.5 before:inset-x-0 before:animate-[route-target-highlight-fade_2s_ease-out_forwards] before:bg-primary/10 before:content-[''] motion-reduce:before:animate-none sm:-mx-6 sm:px-6",
+          isOpenThreadHead && OPEN_THREAD_HEAD_CLASSNAME,
         )}
+        data-open-thread-head={isOpenThreadHead ? "true" : undefined}
       >
         <MessageRow
           channelId={channelId}
@@ -196,9 +214,11 @@ export function MessageRowItem({
   return (
     <div
       className={cn(
-        "flex flex-col gap-1",
+        "relative flex flex-col gap-1",
         isFollowedByContinuation ? "pb-0" : "pb-2.5",
+        isOpenThreadHead && OPEN_THREAD_HEAD_CLASSNAME,
       )}
+      data-open-thread-head={isOpenThreadHead ? "true" : undefined}
     >
       <MessageRow
         channelId={channelId}

--- a/desktop/tests/e2e/open-thread-highlight.spec.ts
+++ b/desktop/tests/e2e/open-thread-highlight.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+import { TEST_IDENTITIES, installMockBridge } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+  channelName: string,
+) {
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        ({ ch }) =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName: ch }) ??
+          false,
+        { ch: channelName },
+      ),
+    )
+    .toBe(true);
+}
+
+async function emitMockReply(
+  page: import("@playwright/test").Page,
+  channelName: string,
+  content: string,
+  parentEventId: string,
+) {
+  await page.evaluate(
+    ({ ch, msg, parent, pubkey }) =>
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            parentEventId?: string | null;
+            pubkey?: string;
+            createdAt?: number;
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: ch,
+        content: msg,
+        parentEventId: parent,
+        pubkey,
+        createdAt: Math.floor(Date.now() / 1000) - 10,
+      }),
+    {
+      ch: channelName,
+      msg: content,
+      parent: parentEventId,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+    },
+  );
+}
+
+test.describe("open thread marker in the main timeline", () => {
+  test("marks the thread head while the panel is open and clears on close", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await installMockBridge(page);
+
+    await page.goto("/");
+    await page.getByTestId("channel-general").click();
+    await expect(page.getByTestId("chat-title")).toHaveText("general");
+    await waitForMockLiveSubscription(page, "general");
+
+    await emitMockReply(
+      page,
+      "general",
+      "Reply to welcome",
+      "mock-general-welcome",
+    );
+
+    const markedRows = page.locator('[data-open-thread-head="true"]');
+    // Nothing is marked until a thread is actually open.
+    await expect(markedRows).toHaveCount(0);
+
+    const threadSummary = page.getByTestId("message-thread-summary").first();
+    await expect(threadSummary).toBeVisible();
+    await threadSummary.click();
+    await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+
+    // Exactly one main-timeline row carries the marker: the open thread head.
+    await expect(markedRows).toHaveCount(1);
+    await expect(markedRows.first()).toContainText("Welcome");
+
+    // Park the pointer away from the row so the capture shows the resting
+    // marker rather than the hover background.
+    await page.mouse.move(0, 0);
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: "test-results/open-thread-highlight.png",
+    });
+
+    // Escape is deliberately inert for the split panel (see `useEscapeKey` in
+    // MessageThreadPanelSkeleton) — close through the header action instead.
+    await page.getByTestId("auxiliary-panel-close").click();
+    await expect(page.getByTestId("message-thread-panel")).toHaveCount(0);
+    await expect(markedRows).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

Opening a thread leaves the channel timeline visible beside the panel, but nothing in that timeline says *which* message the panel belongs to. With a busy channel — or after scrolling while the panel stays open — you lose the anchor and have to re-open the thread to be sure you are replying in the right place.

## Change

The main-timeline row whose thread is open now carries a persistent marker: a left accent rail plus the `bg-primary/10` tint the route/search highlight already uses.

![open thread marker](https://raw.githubusercontent.com/razystylee/buzz/5753624947e596347bf92cefff2d93ace229f41d/pr-open-thread-marker.png)

Notes on the approach:

- **No new state.** `ChannelPane` already computes `openThreadHeadId` for `splitThreadPanelOpen`; this just threads it down to `MessageTimeline` → `TimelineMessageList` → `MessageRowItem`.
- **Persistent, not a flash.** The existing `highlightedMessageId` path animates out after 2s because it answers "where did I just land?". This answers "what is the panel showing?", so it lasts exactly as long as the panel is open.
- **Pseudo-element rail**, so row heights are unchanged — the timeline is virtualized and measures row heights, and a marker that adds layout would risk scroll shift.
- Both row variants are marked (with and without a thread summary), since a thread can be opened on a message that has no replies yet.
- `data-open-thread-head="true"` is exposed for tests.

## Testing

New `desktop/tests/e2e/open-thread-highlight.spec.ts` (registered in the `smoke` project) opens a real thread and asserts nothing is marked before opening, exactly one row is marked while the panel is open, and the marker clears on close.

```
✓ 1 [smoke] › open thread marker in the main timeline › marks the thread head while the panel is open and clears on close (2.0s)
```

`tsc --noEmit` and `biome check` are clean on the touched files.

Aside, noted while writing the spec: `Escape` is intentionally inert for the split thread panel (`useEscapeKey` in `MessageThreadPanelSkeleton` enables it only for overlay / single-panel / focus mode), so the spec closes via the header action. Not changed here.
