### PR TITLE
Virtualize long message threads

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         "**/community-rail.spec.ts",
         "**/boot-splash.spec.ts",
         "**/thread-reply-anchor-roleplay.spec.ts",
+        "**/thread-virtualization.spec.ts",
         "**/threadpane-ultrawide.spec.ts",
         "**/thread-focus-mode.spec.ts",
         "**/animated-avatar.spec.ts",

--- a/desktop/src/features/messages/lib/threadReplyVirtualization.test.mjs
+++ b/desktop/src/features/messages/lib/threadReplyVirtualization.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  shouldVirtualizeThreadReplies,
+  THREAD_REPLY_VIRTUALIZATION_THRESHOLD,
+} from "./threadReplyVirtualization.ts";
+
+test("small thread reply lists stay fully mounted", () => {
+  assert.equal(shouldVirtualizeThreadReplies(0), false);
+  assert.equal(
+    shouldVirtualizeThreadReplies(THREAD_REPLY_VIRTUALIZATION_THRESHOLD),
+    false,
+  );
+});
+
+test("large thread reply lists are virtualized", () => {
+  assert.equal(
+    shouldVirtualizeThreadReplies(THREAD_REPLY_VIRTUALIZATION_THRESHOLD + 1),
+    true,
+  );
+  assert.equal(shouldVirtualizeThreadReplies(2_418), true);
+});

--- a/desktop/src/features/messages/lib/threadReplyVirtualization.ts
+++ b/desktop/src/features/messages/lib/threadReplyVirtualization.ts
@@ -1,0 +1,12 @@
+/**
+ * Small threads stay fully mounted so their existing branch interactions keep
+ * the simplest possible DOM. Large threads are windowed before WebKit has to
+ * maintain hundreds of rich message rows in one scrolling tree.
+ */
+export const THREAD_REPLY_VIRTUALIZATION_THRESHOLD = 50;
+
+export const THREAD_REPLY_ESTIMATED_HEIGHT_PX = 88;
+
+export function shouldVirtualizeThreadReplies(replyCount: number): boolean {
+  return replyCount > THREAD_REPLY_VIRTUALIZATION_THRESHOLD;
+}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -46,12 +46,24 @@ import { MessageComposer } from "./MessageComposer";
 import { ThreadMessageSkeleton } from "./MessageThreadPanelSkeleton";
 import { MessageRow, type ThreadDepthGuideAction } from "./MessageRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
+import {
+  ThreadReplyRow,
+  type ThreadReplyRenderItem,
+  type ThreadReplyRowContext,
+} from "./ThreadReplyRow";
 import { TypingIndicatorRow } from "./TypingIndicatorRow";
-import { UnreadDivider } from "./UnreadDivider";
 import { useComposerHeightPadding } from "./useComposerHeightPadding";
 import { useStableSendToChannel } from "./useStableSendToChannel";
 import { useAnchoredScroll } from "./useAnchoredScroll";
 import { selectDeferredListRenderState } from "@/features/messages/lib/timelineSnapshot";
+import {
+  shouldVirtualizeThreadReplies,
+  THREAD_REPLY_ESTIMATED_HEIGHT_PX,
+} from "@/features/messages/lib/threadReplyVirtualization";
+import {
+  type ListVirtualizer,
+  VirtualizedList,
+} from "@/shared/ui/VirtualizedList";
 
 type MessageThreadPanelProps = ThreadPanelLayoutProps & {
   channel: Channel | null;
@@ -187,6 +199,10 @@ function getActiveContinuationDepths({
   return depths;
 }
 
+function getThreadReplyKey(item: ThreadReplyRenderItem): string {
+  return item.entry.message.renderKey ?? item.entry.message.id;
+}
+
 export function MessageThreadPanel({
   channel,
   channelId,
@@ -245,6 +261,9 @@ export function MessageThreadPanel({
   const threadBodyRef = React.useRef<HTMLDivElement>(null);
   const threadContentRef = React.useRef<HTMLDivElement>(null);
   const threadComposerWrapperRef = React.useRef<HTMLDivElement>(null);
+  const threadReplyVirtualizerRef = React.useRef<ListVirtualizer | null>(null);
+  const [virtualizerRenderVersion, bumpVirtualizerRenderVersion] =
+    React.useReducer((version: number) => version + 1, 0);
   const [hoveredCollapseBranchId, setHoveredCollapseBranchId] = React.useState<
     string | null
   >(null);
@@ -429,7 +448,7 @@ export function MessageThreadPanel({
     ];
     let previousGroupMessage: TimelineMessage | null = threadHead;
 
-    return deferredThreadReplies.map((entry, index) => {
+    return deferredThreadReplies.map<ThreadReplyRenderItem>((entry, index) => {
       while (
         ancestorStack.length > 0 &&
         ancestorStack[ancestorStack.length - 1].message.depth >=
@@ -499,11 +518,62 @@ export function MessageThreadPanel({
     isHuddleTranscript,
     threadHead,
   ]);
+  const virtualizeThreadReplies =
+    visibleThreadHeadSummary === null &&
+    shouldVirtualizeThreadReplies(threadReplyRenderItems.length);
+  const threadReplyIndexById = React.useMemo(
+    () =>
+      new Map(
+        threadReplyRenderItems.map((item, index) => [
+          item.entry.message.id,
+          index,
+        ]),
+      ),
+    [threadReplyRenderItems],
+  );
+  const registerThreadReplyVirtualizer = React.useCallback(
+    (virtualizer: ListVirtualizer) => {
+      threadReplyVirtualizerRef.current = virtualizer;
+    },
+    [],
+  );
+  const handleThreadReplyRangeChanged = React.useCallback(() => {
+    bumpVirtualizerRenderVersion();
+  }, []);
+  const virtualScrollToMessage = React.useCallback(
+    (messageId: string, options?: { behavior?: ScrollBehavior }): boolean => {
+      const index = threadReplyIndexById.get(messageId);
+      const virtualizer = threadReplyVirtualizerRef.current;
+      if (index === undefined || !virtualizer) {
+        return false;
+      }
+      virtualizer.scrollToIndex(index, {
+        align: "center",
+        behavior: options?.behavior ?? "auto",
+      });
+      return true;
+    },
+    [threadReplyIndexById],
+  );
+  const virtualScrollToBottom = React.useCallback(
+    (behavior: ScrollBehavior = "auto") => {
+      const virtualizer = threadReplyVirtualizerRef.current;
+      if (!virtualizer || threadReplyRenderItems.length === 0) {
+        return;
+      }
+      virtualizer.scrollToIndex(threadReplyRenderItems.length - 1, {
+        align: "end",
+        behavior,
+      });
+    },
+    [threadReplyRenderItems.length],
+  );
 
   const {
     isAtBottom,
     newMessageCount,
     onScroll,
+    onVirtualizerAtBottomStateChange,
     scrollToBottom,
     settleAtBottomAfterLayout,
   } = useAnchoredScroll({
@@ -517,7 +587,32 @@ export function MessageThreadPanel({
     pinTargetCentered: !scrollTargetHighlights,
     scrollContainerRef: threadBodyRef,
     targetMessageId: scrollTargetId,
+    virtualScrollToBottom: virtualizeThreadReplies
+      ? virtualScrollToBottom
+      : undefined,
+    virtualScrollToMessage: virtualizeThreadReplies
+      ? virtualScrollToMessage
+      : undefined,
+    virtualSettleAtBottom: virtualizeThreadReplies
+      ? virtualScrollToBottom
+      : undefined,
+    virtualizerOwnsPrependAnchoring: virtualizeThreadReplies,
+    virtualizerRenderVersion,
   });
+  const handleThreadScroll = React.useCallback(() => {
+    onScroll();
+    if (!virtualizeThreadReplies) {
+      return;
+    }
+    const container = threadBodyRef.current;
+    if (!container) {
+      return;
+    }
+    onVirtualizerAtBottomStateChange(
+      container.scrollHeight - container.clientHeight - container.scrollTop <=
+        32,
+    );
+  }, [onScroll, onVirtualizerAtBottomStateChange, virtualizeThreadReplies]);
   useComposerHeightPadding(
     threadBodyRef,
     threadComposerWrapperRef,
@@ -553,6 +648,32 @@ export function MessageThreadPanel({
     threadHead,
     onSendToChannel,
   );
+  const threadReplyRowContext: ThreadReplyRowContext = {
+    channelId,
+    currentPubkey,
+    firstUnreadReplyId,
+    highlightedBranch,
+    huddleMemberPubkeys,
+    huddleMemberPubkeysPending,
+    isMessageUnreadById,
+    onCollapseDepthGuide: handleCollapseDepthGuide,
+    onCollapseDepthGuideHoverChange: handleCollapseBranchHoverChange,
+    onDelete,
+    onEdit,
+    onExpandReplies,
+    onMarkRead,
+    onMarkUnread,
+    onSelectReplyTarget,
+    onSendToChannel: stableSendToChannel,
+    onToggleReaction,
+    profiles,
+    shouldShowThreadBranchGuides,
+    threadReplyUnreadCounts,
+    videoReviewPresentation,
+  };
+  const renderThreadReplyItem = (item: ThreadReplyRenderItem) => (
+    <ThreadReplyRow context={threadReplyRowContext} item={item} />
+  );
   if (!threadHead) {
     return null;
   }
@@ -562,7 +683,7 @@ export function MessageThreadPanel({
       data-buzz-conversation-scroll
       data-testid="message-thread-body"
       mode={isHuddleTranscript ? "panel" : undefined}
-      onScroll={onScroll}
+      onScroll={handleThreadScroll}
       tabIndex={-1}
       ref={threadBodyRef}
     >
@@ -646,6 +767,7 @@ export function MessageThreadPanel({
 
         <div
           className={cn(THREAD_PANEL_MESSAGE_GUTTER_CLASS, "pb-3 pt-0")}
+          data-virtualized={virtualizeThreadReplies ? "true" : undefined}
           data-testid="message-thread-replies"
         >
           {threadRepliesPending && !isHuddleTranscript ? (
@@ -678,152 +800,20 @@ export function MessageThreadPanel({
                 className="space-y-0"
                 data-render-pending={isRepliesPending ? "true" : undefined}
               >
-                {threadReplyRenderItems.map((item) => {
-                  const {
-                    collapseDepthGuideActions,
-                    connectsToVisibleChild,
-                    continuationDepths,
-                    entry,
-                    index,
-                    isContinuation,
-                  } = item;
-                  const showUnreadDivider =
-                    index > 0 && entry.message.id === firstUnreadReplyId;
-                  const isHighlightedBranchOwner =
-                    highlightedBranch?.id === entry.message.id;
-                  const isInsideHighlightedBranch =
-                    highlightedBranch != null &&
-                    index > highlightedBranch.startIndex &&
-                    index <= highlightedBranch.endIndex;
-                  const isDirectChildOfHighlightedBranch =
-                    isInsideHighlightedBranch &&
-                    highlightedBranch != null &&
-                    index > highlightedBranch.startIndex &&
-                    index <= highlightedBranch.endIndex &&
-                    entry.message.depth === highlightedBranch.depth + 1;
-                  const highlightedLineDepths =
-                    shouldShowThreadBranchGuides &&
-                    isInsideHighlightedBranch &&
-                    highlightedBranch
-                      ? [highlightedBranch.depth]
-                      : undefined;
-                  return (
-                    <div
-                      className={cn(
-                        "flex flex-col gap-0",
-                        entry.summary &&
-                          "group/message rounded-2xl px-0 py-0.5 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
-                      )}
-                      key={entry.message.renderKey ?? entry.message.id}
-                    >
-                      {showUnreadDivider ? <UnreadDivider /> : null}
-                      <MessageRow
-                        channelId={channelId}
-                        currentPubkey={currentPubkey}
-                        collapseDepthGuideActions={collapseDepthGuideActions}
-                        collapseDescendantsLabel="Collapse replies"
-                        connectDescendants={
-                          shouldShowThreadBranchGuides && connectsToVisibleChild
-                        }
-                        depthGuideDepths={
-                          shouldShowThreadBranchGuides
-                            ? continuationDepths
-                            : undefined
-                        }
-                        highlightDescendantRail={
-                          shouldShowThreadBranchGuides &&
-                          isHighlightedBranchOwner &&
-                          connectsToVisibleChild
-                        }
-                        highlightReplyConnector={
-                          shouldShowThreadBranchGuides &&
-                          isDirectChildOfHighlightedBranch
-                        }
-                        highlightThreadLineDepths={highlightedLineDepths}
-                        hoverBackground={!entry.summary}
-                        huddleMemberPubkeys={huddleMemberPubkeys}
-                        huddleMemberPubkeysPending={huddleMemberPubkeysPending}
-                        isContinuation={isContinuation}
-                        isUnread={isMessageUnreadById?.(entry.message.id)}
-                        layoutVariant="thread-reply"
-                        message={entry.message}
-                        onCollapseDepthGuide={handleCollapseDepthGuide}
-                        onCollapseDepthGuideHoverChange={
-                          handleCollapseBranchHoverChange
-                        }
-                        onCollapseDescendants={
-                          shouldShowThreadBranchGuides &&
-                          connectsToVisibleChild &&
-                          !entry.summary
-                            ? onExpandReplies
-                            : undefined
-                        }
-                        onCollapseDescendantsHoverChange={
-                          handleCollapseBranchHoverChange
-                        }
-                        onDelete={
-                          onDelete &&
-                          canManageMessageForCurrentUser(
-                            entry.message,
-                            currentPubkey,
-                            profiles,
-                          )
-                            ? onDelete
-                            : undefined
-                        }
-                        onEdit={
-                          onEdit &&
-                          canManageMessageForCurrentUser(
-                            entry.message,
-                            currentPubkey,
-                            profiles,
-                          )
-                            ? onEdit
-                            : undefined
-                        }
-                        onMarkUnread={onMarkUnread}
-                        onMarkRead={onMarkRead}
-                        onReply={onSelectReplyTarget}
-                        onSendToChannel={stableSendToChannel}
-                        onToggleReaction={onToggleReaction}
-                        profiles={profiles}
-                        showDepthGuides={shouldShowThreadBranchGuides}
-                        videoReviewCommentRootId={videoReviewPresentation?.commentRootIdsByMessageId.get(
-                          entry.message.id,
-                        )}
-                        videoReviewContext={videoReviewPresentation?.contextsByMessageId.get(
-                          entry.message.id,
-                        )}
-                      />
-                      {entry.summary ? (
-                        <MessageThreadSummaryRow
-                          collapseDepthGuideActions={collapseDepthGuideActions}
-                          depth={entry.message.depth}
-                          depthGuideDepths={
-                            shouldShowThreadBranchGuides
-                              ? continuationDepths
-                              : undefined
-                          }
-                          highlightThreadLineDepths={highlightedLineDepths}
-                          message={entry.message}
-                          onCollapseDepthGuide={handleCollapseDepthGuide}
-                          onCollapseDepthGuideHoverChange={
-                            handleCollapseBranchHoverChange
-                          }
-                          onOpenThread={onExpandReplies}
-                          summary={entry.summary}
-                          summaryIndentOffsetRem={
-                            THREAD_PANEL_SUMMARY_INDENT_OFFSET_REM
-                          }
-                          showDepthGuides={shouldShowThreadBranchGuides}
-                          unreadCount={threadReplyUnreadCounts?.get(
-                            entry.message.id,
-                          )}
-                        />
-                      ) : null}
-                    </div>
-                  );
-                })}
+                {virtualizeThreadReplies ? (
+                  <VirtualizedList
+                    estimateSize={THREAD_REPLY_ESTIMATED_HEIGHT_PX}
+                    getItemKey={getThreadReplyKey}
+                    items={threadReplyRenderItems}
+                    onRangeChanged={handleThreadReplyRangeChanged}
+                    onVirtualizer={registerThreadReplyVirtualizer}
+                    overscan={8}
+                    renderItem={renderThreadReplyItem}
+                    scrollRef={threadBodyRef}
+                  />
+                ) : (
+                  threadReplyRenderItems.map(renderThreadReplyItem)
+                )}
               </div>
             )
           ) : repliesRenderState === "empty" && !isHuddleTranscript ? (

--- a/desktop/src/features/messages/ui/ThreadReplyRow.tsx
+++ b/desktop/src/features/messages/ui/ThreadReplyRow.tsx
@@ -1,0 +1,208 @@
+import * as React from "react";
+
+import { canManageMessageForCurrentUser } from "@/features/messages/lib/canManageMessage";
+import type { MainTimelineEntry } from "@/features/messages/lib/threadPanel";
+import type { VideoReviewPresentation } from "@/features/messages/lib/videoReviewContext";
+import type { TimelineMessage } from "@/features/messages/types";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { cn } from "@/shared/lib/cn";
+import { MessageRow, type ThreadDepthGuideAction } from "./MessageRow";
+import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
+import { UnreadDivider } from "./UnreadDivider";
+
+const SUMMARY_INDENT_OFFSET_REM = 0;
+
+export type ThreadReplyRenderItem = {
+  collapseDepthGuideActions?: ThreadDepthGuideAction[];
+  connectsToVisibleChild: boolean;
+  continuationDepths: number[];
+  entry: MainTimelineEntry;
+  index: number;
+  isContinuation: boolean;
+};
+
+export type ThreadReplyRowContext = {
+  channelId: string | null;
+  currentPubkey?: string;
+  firstUnreadReplyId?: string | null;
+  highlightedBranch: {
+    depth: number;
+    endIndex: number;
+    id: string;
+    startIndex: number;
+  } | null;
+  huddleMemberPubkeys?: readonly string[];
+  huddleMemberPubkeysPending: boolean;
+  isMessageUnreadById?: (messageId: string) => boolean;
+  onCollapseDepthGuide: (message: TimelineMessage) => void;
+  onCollapseDepthGuideHoverChange: (
+    message: TimelineMessage,
+    hovered: boolean,
+  ) => void;
+  onDelete?: (message: TimelineMessage) => void;
+  onEdit?: (message: TimelineMessage) => void;
+  onExpandReplies: (message: TimelineMessage) => void;
+  onMarkRead?: (message: TimelineMessage) => void;
+  onMarkUnread?: (message: TimelineMessage) => void;
+  onSelectReplyTarget: (message: TimelineMessage) => void;
+  onSendToChannel?: (message: TimelineMessage) => Promise<void>;
+  onToggleReaction?: (
+    message: TimelineMessage,
+    emoji: string,
+    remove: boolean,
+  ) => Promise<void>;
+  profiles?: UserProfileLookup;
+  shouldShowThreadBranchGuides: boolean;
+  threadReplyUnreadCounts?: ReadonlyMap<string, number>;
+  videoReviewPresentation?: VideoReviewPresentation;
+};
+
+export const ThreadReplyRow = React.memo(function ThreadReplyRow({
+  context,
+  item,
+}: {
+  context: ThreadReplyRowContext;
+  item: ThreadReplyRenderItem;
+}) {
+  const {
+    collapseDepthGuideActions,
+    connectsToVisibleChild,
+    continuationDepths,
+    entry,
+    index,
+    isContinuation,
+  } = item;
+  const {
+    channelId,
+    currentPubkey,
+    firstUnreadReplyId,
+    highlightedBranch,
+    huddleMemberPubkeys,
+    huddleMemberPubkeysPending,
+    isMessageUnreadById,
+    onCollapseDepthGuide,
+    onCollapseDepthGuideHoverChange,
+    onDelete,
+    onEdit,
+    onExpandReplies,
+    onMarkRead,
+    onMarkUnread,
+    onSelectReplyTarget,
+    onSendToChannel,
+    onToggleReaction,
+    profiles,
+    shouldShowThreadBranchGuides,
+    threadReplyUnreadCounts,
+    videoReviewPresentation,
+  } = context;
+  const showUnreadDivider =
+    index > 0 && entry.message.id === firstUnreadReplyId;
+  const isHighlightedBranchOwner = highlightedBranch?.id === entry.message.id;
+  const isInsideHighlightedBranch =
+    highlightedBranch != null &&
+    index > highlightedBranch.startIndex &&
+    index <= highlightedBranch.endIndex;
+  const isDirectChildOfHighlightedBranch =
+    isInsideHighlightedBranch &&
+    highlightedBranch != null &&
+    entry.message.depth === highlightedBranch.depth + 1;
+  const highlightedLineDepths =
+    shouldShowThreadBranchGuides &&
+    isInsideHighlightedBranch &&
+    highlightedBranch
+      ? [highlightedBranch.depth]
+      : undefined;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-0",
+        entry.summary &&
+          "group/message rounded-2xl px-0 py-0.5 transition-colors hover:bg-muted/50 focus-within:bg-muted/50",
+      )}
+    >
+      {showUnreadDivider ? <UnreadDivider /> : null}
+      <MessageRow
+        channelId={channelId}
+        currentPubkey={currentPubkey}
+        collapseDepthGuideActions={collapseDepthGuideActions}
+        collapseDescendantsLabel="Collapse replies"
+        connectDescendants={
+          shouldShowThreadBranchGuides && connectsToVisibleChild
+        }
+        depthGuideDepths={
+          shouldShowThreadBranchGuides ? continuationDepths : undefined
+        }
+        highlightDescendantRail={
+          shouldShowThreadBranchGuides &&
+          isHighlightedBranchOwner &&
+          connectsToVisibleChild
+        }
+        highlightReplyConnector={
+          shouldShowThreadBranchGuides && isDirectChildOfHighlightedBranch
+        }
+        highlightThreadLineDepths={highlightedLineDepths}
+        hoverBackground={!entry.summary}
+        huddleMemberPubkeys={huddleMemberPubkeys}
+        huddleMemberPubkeysPending={huddleMemberPubkeysPending}
+        isContinuation={isContinuation}
+        isUnread={isMessageUnreadById?.(entry.message.id)}
+        layoutVariant="thread-reply"
+        message={entry.message}
+        onCollapseDepthGuide={onCollapseDepthGuide}
+        onCollapseDepthGuideHoverChange={onCollapseDepthGuideHoverChange}
+        onCollapseDescendants={
+          shouldShowThreadBranchGuides &&
+          connectsToVisibleChild &&
+          !entry.summary
+            ? onExpandReplies
+            : undefined
+        }
+        onCollapseDescendantsHoverChange={onCollapseDepthGuideHoverChange}
+        onDelete={
+          onDelete &&
+          canManageMessageForCurrentUser(entry.message, currentPubkey, profiles)
+            ? onDelete
+            : undefined
+        }
+        onEdit={
+          onEdit &&
+          canManageMessageForCurrentUser(entry.message, currentPubkey, profiles)
+            ? onEdit
+            : undefined
+        }
+        onMarkUnread={onMarkUnread}
+        onMarkRead={onMarkRead}
+        onReply={onSelectReplyTarget}
+        onSendToChannel={onSendToChannel}
+        onToggleReaction={onToggleReaction}
+        profiles={profiles}
+        showDepthGuides={shouldShowThreadBranchGuides}
+        videoReviewCommentRootId={videoReviewPresentation?.commentRootIdsByMessageId.get(
+          entry.message.id,
+        )}
+        videoReviewContext={videoReviewPresentation?.contextsByMessageId.get(
+          entry.message.id,
+        )}
+      />
+      {entry.summary ? (
+        <MessageThreadSummaryRow
+          collapseDepthGuideActions={collapseDepthGuideActions}
+          depth={entry.message.depth}
+          depthGuideDepths={
+            shouldShowThreadBranchGuides ? continuationDepths : undefined
+          }
+          highlightThreadLineDepths={highlightedLineDepths}
+          message={entry.message}
+          onCollapseDepthGuide={onCollapseDepthGuide}
+          onCollapseDepthGuideHoverChange={onCollapseDepthGuideHoverChange}
+          onOpenThread={onExpandReplies}
+          summary={entry.summary}
+          summaryIndentOffsetRem={SUMMARY_INDENT_OFFSET_REM}
+          showDepthGuides={shouldShowThreadBranchGuides}
+          unreadCount={threadReplyUnreadCounts?.get(entry.message.id)}
+        />
+      ) : null}
+    </div>
+  );
+});

--- a/desktop/src/shared/ui/VirtualizedList.tsx
+++ b/desktop/src/shared/ui/VirtualizedList.tsx
@@ -67,6 +67,8 @@ type VirtualizedListProps<T> = {
   overscan?: number;
   /** Receives the virtualizer instance (for `scrollToIndex`, etc). */
   onVirtualizer?: (virtualizer: ListVirtualizer) => void;
+  /** Fires when the rendered window changes (for pending target retries). */
+  onRangeChanged?: (firstIndex: number, lastIndex: number) => void;
 };
 
 export function VirtualizedList<T>({
@@ -81,6 +83,7 @@ export function VirtualizedList<T>({
   innerClassName,
   overscan = 5,
   onVirtualizer,
+  onRangeChanged,
 }: VirtualizedListProps<T>) {
   const internalScrollRef = React.useRef<HTMLDivElement>(null);
   const spacerRef = React.useRef<HTMLDivElement>(null);
@@ -131,6 +134,11 @@ export function VirtualizedList<T>({
   }, [onVirtualizer, virtualizer]);
 
   const virtualItems = virtualizer.getVirtualItems();
+  const firstVirtualIndex = virtualItems[0]?.index ?? -1;
+  const lastVirtualIndex = virtualItems[virtualItems.length - 1]?.index ?? -1;
+  React.useEffect(() => {
+    onRangeChanged?.(firstVirtualIndex, lastVirtualIndex);
+  }, [firstVirtualIndex, lastVirtualIndex, onRangeChanged]);
 
   // The header portals into `headerOverlayRef`, which the parent mounts before
   // this child — so it is populated on first commit. The dependency-free state

--- a/desktop/tests/e2e/thread-virtualization.spec.ts
+++ b/desktop/tests/e2e/thread-virtualization.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const CHANNEL = "general";
+const REPLY_COUNT = 2_419;
+
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+) {
+  await expect
+    .poll(async () => {
+      return page.evaluate(
+        ({ channelName }) =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName }) ?? false,
+        { channelName: CHANNEL },
+      );
+    })
+    .toBe(true);
+}
+
+test("a 2,419-reply thread keeps only the visible rows mounted and remains writable", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId(`channel-${CHANNEL}`).click();
+  await waitForMockLiveSubscription(page);
+
+  const rootId = await page.evaluate(
+    ({ channelName, replyCount }) => {
+      const emit = (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            parentEventId?: string;
+            createdAt?: number;
+          }) => { id: string };
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      if (!emit) {
+        return null;
+      }
+
+      const base = Math.floor(Date.now() / 1_000) - replyCount - 60;
+      const root = emit({
+        channelName,
+        content: "Long-running project thread",
+        createdAt: base,
+      });
+      for (let index = 0; index < replyCount; index += 1) {
+        emit({
+          channelName,
+          content: `Reply ${index + 1} of ${replyCount}`,
+          parentEventId: root.id,
+          createdAt: base + index + 1,
+        });
+      }
+      return root.id;
+    },
+    { channelName: CHANNEL, replyCount: REPLY_COUNT },
+  );
+  expect(rootId).not.toBeNull();
+
+  const summary = page.getByTestId("message-thread-summary").last();
+  await expect(summary).toBeVisible({ timeout: 30_000 });
+  await summary.click();
+
+  const threadPanel = page.getByTestId("message-thread-panel");
+  const replies = threadPanel.getByTestId("message-thread-replies");
+  await expect(threadPanel).toBeVisible();
+  await expect(replies).toHaveAttribute("data-virtualized", "true", {
+    timeout: 30_000,
+  });
+  await expect(
+    replies.getByText(`Reply ${REPLY_COUNT} of ${REPLY_COUNT}`, {
+      exact: true,
+    }),
+  ).toBeVisible();
+
+  const mountedReplyRows = replies.getByTestId("message-row");
+  await expect.poll(() => mountedReplyRows.count()).toBeGreaterThan(0);
+  expect(await mountedReplyRows.count()).toBeLessThan(80);
+
+  const editor = threadPanel
+    .getByTestId("message-composer")
+    .locator("[contenteditable='true']");
+  await editor.fill("Typing stays responsive in the long thread");
+  await expect(editor).toHaveText("Typing stays responsive in the long thread");
+
+  await threadPanel.getByRole("button", { name: "Close panel" }).click();
+  await expect(threadPanel).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed

- virtualize thread reply lists above 50 replies
- preserve anchored scrolling, deep-link targeting, and bottom pinning through the existing virtualizer integration
- keep small threads on the current fully mounted path
- add unit coverage for the threshold and a Playwright regression that seeds 2,419 replies

## Why

`MessageThreadPanel` mounted every rich reply row at once. Long-running threads therefore created thousands of React/WebKit nodes and could freeze the desktop composer and panel controls. The repository's existing performance coverage already identified 68 mounted replies as near-unusable in WKWebView; the reported production thread had 2,419 replies.

## User impact

Large threads now mount only the visible reply window plus overscan, while remaining writable, scrollable, deep-linkable, and closable. Small threads retain their existing behavior.

## Validation

- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test` (4,904 passing)
- `pnpm --dir desktop build:e2e`
- `pnpm --dir desktop exec playwright test tests/e2e/thread-virtualization.spec.ts --project=smoke` (2,419-reply browser path)

