### PR TITLE
fix(desktop-chrome): preserve collapsed sidebar gutters

### DIFF
--- a/desktop/src/app/AppShellChannelSurface.tsx
+++ b/desktop/src/app/AppShellChannelSurface.tsx
@@ -4,7 +4,7 @@ import { HuddleRoomHeader, HuddleStartingView } from "@/features/huddle";
 import { MainInsetProvider } from "@/shared/layout/MainInsetContext";
 import { chromeCssVarDefaults } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
-import { SidebarInset } from "@/shared/ui/sidebar";
+import { SidebarInset, useSidebar } from "@/shared/ui/sidebar";
 
 type AppShellChannelSurfaceProps = {
   children: React.ReactNode;
@@ -21,6 +21,8 @@ export function AppShellChannelSurface({
   mainInsetRef,
   terminal,
 }: AppShellChannelSurfaceProps) {
+  const { state: sidebarState } = useSidebar();
+
   return (
     <MainInsetProvider mainInsetRef={mainInsetRef}>
       <SidebarInset
@@ -36,7 +38,11 @@ export function AppShellChannelSurface({
         style={chromeCssVarDefaults as React.CSSProperties}
       >
         {isHuddleRoom && !isHuddleRoomStarting ? <HuddleRoomHeader /> : null}
-        <BuzzTheme.ContentSurface terminal={terminal} unframed={isHuddleRoom}>
+        <BuzzTheme.ContentSurface
+          insetLeft={sidebarState === "collapsed"}
+          terminal={terminal}
+          unframed={isHuddleRoom}
+        >
           {isHuddleRoomStarting ? <HuddleStartingView /> : children}
         </BuzzTheme.ContentSurface>
       </SidebarInset>

--- a/desktop/src/app/BuzzThemeSurfaces.tsx
+++ b/desktop/src/app/BuzzThemeSurfaces.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/cn";
 
 export function GradientLayer() {
   return (
@@ -22,21 +23,26 @@ export function GradientLayer() {
 
 export function ContentSurface({
   children,
+  insetLeft = false,
   unframed = false,
   terminal,
 }: {
   children: ReactNode;
+  /** Match the outer card gutter when no sidebar is visible to its left. */
+  insetLeft?: boolean;
   terminal?: ReactNode;
   /** Used by dedicated huddle windows, which should not resemble app cards. */
   unframed?: boolean;
 }) {
   return (
     <div
-      className={
+      className={cn(
+        "relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden bg-background",
         unframed
-          ? "relative z-10 flex min-h-0 flex-1 flex-col overflow-hidden bg-background"
-          : "relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
-      }
+          ? undefined
+          : "mb-2 mr-2 mt-px rounded-2xl shadow-content-edge motion-safe:transition-[margin] motion-safe:duration-200 motion-safe:ease-linear",
+        !unframed && (insetLeft ? "ml-2" : "ml-px"),
+      )}
       data-buzz-content-surface
       data-buzz-content-unframed={unframed ? true : undefined}
     >

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -374,7 +374,7 @@ export function CommunityRail({
   return (
     <nav
       aria-label="Communities"
-      className="relative z-0 flex w-14 shrink-0 flex-col items-center gap-2.5 overflow-y-auto bg-sidebar px-2.5 pb-5 pt-[calc(var(--buzz-top-chrome-height,40px)+7px)]"
+      className="relative z-20 flex w-14 shrink-0 flex-col items-center gap-2.5 overflow-y-auto bg-sidebar px-2.5 pb-5 pt-[calc(var(--buzz-top-chrome-height,40px)+7px)]"
       data-testid="community-rail"
     >
       <DndContext

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -64,7 +64,7 @@ test.describe("community rail", () => {
       "overflow",
       "visible",
     );
-    await expect(rail).toHaveCSS("z-index", "0");
+    await expect(rail).toHaveCSS("z-index", "20");
 
     const buttonA = page.getByTestId(`community-rail-button-${COMMUNITY_A.id}`);
     const buttonB = page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`);
@@ -1174,6 +1174,46 @@ test.describe("community rail", () => {
       page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`),
     ).toBeVisible();
     await expect(page.getByTestId("community-rail-add")).toBeVisible();
+  });
+
+  test("keeps the rail above the sidebar throughout the collapse animation", async ({
+    page,
+  }) => {
+    await installMockBridge(page, undefined, { skipCommunitySeed: true });
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_A.id);
+    await page.goto("/");
+
+    const rail = page.getByTestId("community-rail");
+    const communityButton = page.getByTestId(
+      `community-rail-button-${COMMUNITY_A.id}`,
+    );
+    await expect(rail).toBeVisible();
+    await expect(communityButton).toBeVisible();
+
+    // Slow only the moving sidebar surface so the assertion samples the
+    // transition rather than the steady expanded or collapsed endpoint.
+    await page.addStyleTag({
+      content:
+        '[data-testid="app-sidebar"] { transition-duration: 1000ms !important; }',
+    });
+    await page
+      .getByRole("button", { name: "Toggle Sidebar", exact: true })
+      .click();
+    await page.waitForTimeout(100);
+
+    const railOwnsCommunityButtonPoint = await communityButton.evaluate(
+      (button) => {
+        const bounds = button.getBoundingClientRect();
+        const topmost = document.elementFromPoint(
+          bounds.left + bounds.width / 2,
+          bounds.top + bounds.height / 2,
+        );
+        return (
+          topmost === button || (topmost !== null && button.contains(topmost))
+        );
+      },
+    );
+    expect(railOwnsCommunityButtonPoint).toBe(true);
   });
 
   test("clears the macOS traffic lights", async ({ page }) => {

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -541,6 +541,25 @@ test("sidebar rail resizes without toggling the sidebar", async ({ page }) => {
   await expect(rail).toBeHidden();
 });
 
+test("adds the outer-frame gutter when the sidebar is collapsed", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const contentSurface = page.locator("[data-buzz-content-surface]").first();
+  await expect(contentSurface).toHaveCSS("margin-left", "1px");
+
+  await page
+    .getByRole("button", { name: "Toggle Sidebar", exact: true })
+    .click();
+
+  await expect(page.getByTestId("app-sidebar").locator("..")).toHaveAttribute(
+    "data-state",
+    "collapsed",
+  );
+  await expect(contentSurface).toHaveCSS("margin-left", "8px");
+});
+
 test("resizes, persists, and snaps to the default sidebar width", async ({
   page,
 }) => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Collapsing the left sidebar now keeps the main content framed and community controls accessible throughout the animation.

**Problem:** The content card lost its left gutter when the sidebar collapsed, and the moving sidebar could paint over the community rail during the transition. **Solution:** Apply the intended 8px collapsed-state gutter and keep the community rail above the sidebar animation layer, preserving the layout approach and focused coverage from Anson's #5656 without including its unrelated shortcut changes.

<details>
<summary>File changes</summary>

**desktop/src/app/AppShellChannelSurface.tsx**
Passes the sidebar's expanded or collapsed state into the framed content surface.

**desktop/src/app/BuzzThemeSurfaces.tsx**
Adds the animated 8px left gutter for framed content when no sidebar is visible beside it.

**desktop/src/features/sidebar/ui/CommunityRail.tsx**
Raises the community rail above the moving sidebar so its controls remain reachable during collapse.

**desktop/tests/e2e/community-rail.spec.ts**
Covers the rail's stacking order at rest and during the collapse animation.

**desktop/tests/e2e/sidebar.spec.ts**
Covers the content surface changing from its 1px shared edge to the 8px outer-frame gutter.

</details>

## Reproduction steps

1. Launch Buzz Desktop with the sidebar expanded and confirm the content surface shares the sidebar edge.
2. Collapse the sidebar and confirm an 8px gutter appears on the content surface's left edge.
3. With communities configured, expand and collapse the sidebar and confirm the community rail remains visible and clickable throughout the animation.

## Screenshot

![Collapsed sidebar keeps its outer-frame gutter](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/5908/collapsed-sidebar-gutter.png)

Captured from the actual E2E build after collapsing the sidebar.

## Testing

- `cd desktop && pnpm check`
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm test` (4,954 passed)
- Focused Playwright smoke/integration coverage for both regressions (2 passed)
- Pre-push hooks: organization, branch skew, Desktop checks, typecheck, and tests passed

## Attribution

Layout approach and tests adapted from #5656 by Anson; commit includes `Co-authored-by: Anson <ansonox@gmail.com>`.
