### PR TITLE
fix(ci): read Playwright version without nested shell quoting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,7 +795,9 @@ jobs:
         run: just desktop-install-ci
       - name: Get Playwright version
         id: pw-version
-        run: echo "version=$(cd desktop && node -e \"console.log(require('@playwright/test/package.json').version)\")" >> "$GITHUB_OUTPUT"
+        run: |
+          PLAYWRIGHT_VERSION=$(cd desktop && node -p "require('@playwright/test/package.json').version")
+          echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
       - name: Restore Playwright browser cache
         id: playwright-cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5


### PR DESCRIPTION
## Summary

- replace the nested one-line shell quoting used to read the Playwright package version
- write the resolved version to `GITHUB_OUTPUT` from a multiline shell step

## Why

The `desktop-v0.5.12` release smoke job failed before executing tests because Bash received escaped quotes inside command substitution and parsed the Node expression as shell syntax.

## Validation

- `bash scripts/test-release-ref-contract.sh`
- isolated execution of the new shell fragment with a fixture `@playwright/test/package.json`, producing `version=1.58.2`
- `git diff --check`
