### PR TITLE
feat(agents): add explicit session wrap-up skill

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -43,20 +43,30 @@ pub(crate) const AGENTS_MD: &str = include_str!("nest_agents.md");
 /// Written to ~/.buzz/.agents/skills/buzz-cli/SKILL.md on first init.
 const BUZZ_CLI_SKILL_MD: &str = include_str!("nest_skill.md");
 
+/// Default SKILL.md content for the explicit session wrap-up skill.
+const WRAPUP_SKILL_MD: &str = include_str!("nest_wrapup_skill.md");
+
 /// Template content version for AGENTS.md static content (above managed markers).
 /// Bump this when changing `nest_agents.md` to trigger refresh on existing installs.
 /// Version 1 is implicitly "before this mechanism existed" (no version file).
-const NEST_AGENTS_VERSION: u32 = 4;
+const NEST_AGENTS_VERSION: u32 = 5;
 
 /// Template content version for SKILL.md.
 /// Bump this when changing `nest_skill.md` to trigger refresh on existing installs.
 const NEST_SKILL_VERSION: u32 = 5;
+
+/// Template content version for the wrap-up SKILL.md.
+const WRAPUP_SKILL_VERSION: u32 = 2;
 
 const BEGIN_MARKER: &str = "<!-- BEGIN BUZZ MANAGED";
 const END_MARKER: &str = "<!-- END BUZZ MANAGED -->";
 
 /// Canonical skill directory path relative to the nest root.
 const CANONICAL_SKILL_DIR: &str = ".agents/skills/buzz-cli";
+const CANONICAL_WRAPUP_SKILL_DIR: &str = ".agents/skills/buzz-wrapup";
+
+const BEGIN_SKILL_MARKER: &str = "<!-- BEGIN BUZZ MANAGED SKILL -->";
+const END_SKILL_MARKER: &str = "<!-- END BUZZ MANAGED SKILL -->";
 
 /// Nest directory name for production builds.
 const NEST_DIR_PROD: &str = ".buzz";
@@ -209,14 +219,32 @@ pub fn ensure_nest_at(root: &Path) -> Result<(), String> {
         }
     }
 
-    // Create harness-specific symlinks for all known providers.
-    // Migration of the old .claude/skills/buzz-cli real dir is handled in
-    // refresh_skill_md_if_stale; ensure_skill_symlinks skips paths that already exist.
-    ensure_skill_symlinks(root)?;
+    let wrapup_skill_dir = root.join(CANONICAL_WRAPUP_SKILL_DIR);
+    fs::create_dir_all(&wrapup_skill_dir)
+        .map_err(|e| format!("create {}: {e}", wrapup_skill_dir.display()))?;
+    let wrapup_skill_md = wrapup_skill_dir.join("SKILL.md");
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&wrapup_skill_md)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            file.write_all(WRAPUP_SKILL_MD.as_bytes())
+                .map_err(|e| format!("write {}: {e}", wrapup_skill_md.display()))?;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(format!("create {}: {e}", wrapup_skill_md.display())),
+    }
 
     // Refresh static content if the embedded template version is newer.
     refresh_agents_md_if_stale(root)?;
     refresh_skill_md_if_stale(root)?;
+    refresh_wrapup_skill_md_if_stale(root)?;
+
+    // Install provider-specific skill entries after refreshing canonical content.
+    // Unix uses links; platforms without symlink support receive managed copies.
+    ensure_skill_symlinks(root)?;
 
     // Set owner-only permissions on root and all subdirectories.
     // Skip any path that is a symlink — chmod would affect the target.
@@ -259,6 +287,13 @@ pub fn ensure_nest_at(root: &Path) -> Result<(), String> {
                 skill_perm_dirs.push(root.join(&accumulated));
             }
         }
+        {
+            let mut accumulated = std::path::PathBuf::new();
+            for component in std::path::Path::new(CANONICAL_WRAPUP_SKILL_DIR).components() {
+                accumulated.push(component);
+                skill_perm_dirs.push(root.join(&accumulated));
+            }
+        }
         for skill_dir in known_skill_dirs() {
             // Ensure every ancestor dir gets 700, not just the leaf.
             let mut accumulated = std::path::PathBuf::new();
@@ -290,21 +325,63 @@ fn ensure_skill_symlinks(root: &Path) -> Result<(), String> {
     for skill_dir in known_skill_dirs() {
         let parent = root.join(skill_dir);
         fs::create_dir_all(&parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
-        let link = parent.join("buzz-cli");
-        if link.symlink_metadata().is_ok() {
-            continue; // symlink or real path exists — skip
-        }
         let depth = std::path::Path::new(skill_dir).components().count();
         let prefix = "../".repeat(depth);
-        let target = format!("{prefix}{CANONICAL_SKILL_DIR}");
-        create_symlink(std::path::Path::new(&target), &link)
-            .map_err(|e| format!("symlink {} → {}: {e}", link.display(), target))?;
+        for (name, canonical) in [
+            ("buzz-cli", CANONICAL_SKILL_DIR),
+            ("buzz-wrapup", CANONICAL_WRAPUP_SKILL_DIR),
+        ] {
+            let link = parent.join(name);
+            if link.symlink_metadata().is_ok() {
+                continue;
+            }
+            let target = format!("{prefix}{canonical}");
+            create_symlink(std::path::Path::new(&target), &link)
+                .map_err(|e| format!("symlink {} → {}: {e}", link.display(), target))?;
+        }
     }
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn ensure_skill_symlinks(_root: &Path) -> Result<(), String> {
+fn ensure_skill_symlinks(root: &Path) -> Result<(), String> {
+    for skill_dir in known_skill_dirs() {
+        let destination = root.join(skill_dir).join("buzz-wrapup").join("SKILL.md");
+        install_managed_skill_copy(&destination, WRAPUP_SKILL_MD)?;
+    }
+    Ok(())
+}
+
+/// Create or refresh a managed skill copy without overwriting an owner-created
+/// file. Files containing our explicit markers retain everything after the end
+/// marker; unmarked existing files are left untouched.
+fn install_managed_skill_copy(path: &Path, template: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let content = match fs::read_to_string(path) {
+        Ok(existing) => match existing.find(END_SKILL_MARKER) {
+            Some(end) if existing[..end].contains(BEGIN_SKILL_MARKER) => {
+                let after_end = end + END_SKILL_MARKER.len();
+                format!("{}{}", template.trim_end(), &existing[after_end..])
+            }
+            _ => return Ok(()),
+        },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => template.to_string(),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| format!("tempfile in {}: {e}", parent.display()))?;
+    {
+        use std::io::Write;
+        tmp.write_all(content.as_bytes())
+            .map_err(|e| format!("write tempfile: {e}"))?;
+    }
+    tmp.persist(path)
+        .map_err(|e| format!("persist {}: {e}", path.display()))?;
     Ok(())
 }
 
@@ -516,6 +593,22 @@ fn refresh_skill_md_if_stale(root: &Path) -> Result<(), String> {
     fs::write(&version_path, format!("{NEST_SKILL_VERSION}\n"))
         .map_err(|e| format!("write {}: {e}", version_path.display()))?;
 
+    Ok(())
+}
+
+/// Refresh the managed wrap-up skill when its embedded template changes.
+fn refresh_wrapup_skill_md_if_stale(root: &Path) -> Result<(), String> {
+    let skill_dir = root.join(CANONICAL_WRAPUP_SKILL_DIR);
+    let version_path = skill_dir.join(".skill-version");
+    if read_version_file(&version_path) >= WRAPUP_SKILL_VERSION {
+        return Ok(());
+    }
+
+    fs::create_dir_all(&skill_dir).map_err(|e| format!("create {}: {e}", skill_dir.display()))?;
+    let skill_md = skill_dir.join("SKILL.md");
+    install_managed_skill_copy(&skill_md, WRAPUP_SKILL_MD)?;
+    fs::write(&version_path, format!("{WRAPUP_SKILL_VERSION}\n"))
+        .map_err(|e| format!("write {}: {e}", version_path.display()))?;
     Ok(())
 }
 

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -149,6 +149,51 @@ fn ensure_nest_creates_skill_file() {
 }
 
 #[test]
+fn ensure_nest_creates_wrapup_skill_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+
+    let skill = root.join(".agents/skills/buzz-wrapup/SKILL.md");
+    assert_eq!(fs::read_to_string(skill).unwrap(), WRAPUP_SKILL_MD);
+}
+
+#[test]
+fn wrapup_skill_has_explicit_triggers_and_safe_storage_contract() {
+    for trigger in ["`done`", "`wrap up`", "`end session`"] {
+        assert!(
+            WRAPUP_SKILL_MD.contains(trigger),
+            "missing trigger {trigger}"
+        );
+    }
+    assert!(WRAPUP_SKILL_MD.contains("Skip the wrap-up if the session was trivial"));
+    assert!(WRAPUP_SKILL_MD.contains("WORK_LOGS/"));
+    assert!(WRAPUP_SKILL_MD.contains("OUTBOX/session-digests/"));
+    assert!(WRAPUP_SKILL_MD.contains("never a runtime dependency"));
+    assert!(WRAPUP_SKILL_MD.contains("Ordinary agents must not write or sync the vault directly"));
+    assert!(AGENTS_MD.contains("run the bundled `buzz-wrapup` skill"));
+    assert!(!AGENTS_MD.contains("owner's `wrapup` skill"));
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_nest_creates_wrapup_skill_symlinks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+
+    for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
+        let link = root.join(dir).join("buzz-wrapup");
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(link.join("SKILL.md").exists());
+        assert_eq!(
+            fs::read_link(&link).unwrap().to_str().unwrap(),
+            format!("../../{CANONICAL_WRAPUP_SKILL_DIR}")
+        );
+    }
+}
+
+#[test]
 fn ensure_nest_does_not_overwrite_skill_file() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join(".buzz");
@@ -174,6 +219,7 @@ fn ensure_nest_skill_dir_has_700_permissions() {
         ".agents",
         ".agents/skills",
         ".agents/skills/buzz-cli",
+        ".agents/skills/buzz-wrapup",
         ".goose",
         ".goose/skills",
         ".claude",
@@ -846,6 +892,94 @@ fn refresh_skill_md_writes_version_file() {
     ensure_nest_at(&root).unwrap();
     let version = fs::read_to_string(root.join(".agents/skills/buzz-cli/.skill-version")).unwrap();
     assert_eq!(version.trim(), NEST_SKILL_VERSION.to_string());
+}
+
+#[test]
+fn refresh_wrapup_skill_writes_version_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    let version =
+        fs::read_to_string(root.join(".agents/skills/buzz-wrapup/.skill-version")).unwrap();
+    assert_eq!(version.trim(), WRAPUP_SKILL_VERSION.to_string());
+}
+
+#[test]
+fn refresh_wrapup_skill_preserves_user_content_at_current_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    let skill_md = root.join(".agents/skills/buzz-wrapup/SKILL.md");
+    fs::write(&skill_md, "owner customization").unwrap();
+
+    ensure_nest_at(&root).unwrap();
+
+    assert_eq!(fs::read_to_string(skill_md).unwrap(), "owner customization");
+}
+
+#[test]
+fn refresh_wrapup_skill_preserves_unmarked_owner_content_on_version_bump() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    let skill_md = root.join(".agents/skills/buzz-wrapup/SKILL.md");
+    fs::write(&skill_md, "stale wrapup skill").unwrap();
+    fs::remove_file(root.join(".agents/skills/buzz-wrapup/.skill-version")).unwrap();
+
+    ensure_nest_at(&root).unwrap();
+
+    assert_eq!(fs::read_to_string(skill_md).unwrap(), "stale wrapup skill");
+}
+
+#[test]
+fn refresh_wrapup_skill_updates_managed_content_and_preserves_owner_tail() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    ensure_nest_at(&root).unwrap();
+    let skill_md = root.join(".agents/skills/buzz-wrapup/SKILL.md");
+    fs::write(
+        &skill_md,
+        format!("{BEGIN_SKILL_MARKER}\nstale\n{END_SKILL_MARKER}\nowner notes\n"),
+    )
+    .unwrap();
+    fs::remove_file(root.join(".agents/skills/buzz-wrapup/.skill-version")).unwrap();
+
+    ensure_nest_at(&root).unwrap();
+
+    let content = fs::read_to_string(skill_md).unwrap();
+    assert!(content.starts_with(WRAPUP_SKILL_MD.trim_end()));
+    assert!(content.ends_with("\nowner notes\n"));
+    assert!(!content.contains("stale"));
+}
+
+#[test]
+fn managed_skill_copy_is_cross_platform_and_preserves_unmarked_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_md = tmp.path().join("provider/skills/buzz-wrapup/SKILL.md");
+
+    install_managed_skill_copy(&skill_md, WRAPUP_SKILL_MD).unwrap();
+    assert_eq!(fs::read_to_string(&skill_md).unwrap(), WRAPUP_SKILL_MD);
+
+    fs::write(&skill_md, "owner file without managed markers").unwrap();
+    install_managed_skill_copy(&skill_md, WRAPUP_SKILL_MD).unwrap();
+    assert_eq!(
+        fs::read_to_string(&skill_md).unwrap(),
+        "owner file without managed markers"
+    );
+}
+
+#[test]
+fn ensure_nest_does_not_collide_with_owner_wrapup_skill() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".buzz");
+    let owner_skill = root.join(".agents/skills/wrapup/SKILL.md");
+    fs::create_dir_all(owner_skill.parent().unwrap()).unwrap();
+    fs::write(&owner_skill, "owner wrapup").unwrap();
+
+    ensure_nest_at(&root).unwrap();
+
+    assert_eq!(fs::read_to_string(owner_skill).unwrap(), "owner wrapup");
+    assert!(root.join(".agents/skills/buzz-wrapup/SKILL.md").exists());
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/nest_agents.md
+++ b/desktop/src-tauri/src/managed_agents/nest_agents.md
@@ -18,6 +18,8 @@ Filenames: `ALL_CAPS_WITH_UNDERSCORES.md` (e.g., `OAUTH_FLOW_NOTES.md`).
 
 The bundled CLI is your primary tool interface — run its `--help` command for usage. The CLI skill file has the full reference.
 
+When the user explicitly says `done`, `wrap up`, or `end session`, run the bundled `buzz-wrapup` skill. It records only non-trivial sessions and queues any owner-authorized vault export without making the vault a runtime dependency.
+
 ## Knowledge File Conventions
 
 Files in `GUIDES/`, `PLANS/`, `RESEARCH/`, `WORK_LOGS/` should include YAML frontmatter:

--- a/desktop/src-tauri/src/managed_agents/nest_wrapup_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_wrapup_skill.md
@@ -1,0 +1,18 @@
+---
+name: buzz-wrapup
+description: Close a meaningful Buzz work session when the user explicitly says done, wrap up, or end session. Preserve a durable handover and queue a human-readable session digest without depending on Obsidian.
+---
+
+<!-- BEGIN BUZZ MANAGED SKILL -->
+# Wrap up a session
+
+Run only after an explicit `done`, `wrap up`, or `end session` request.
+
+1. Skip the wrap-up if the session was trivial: no work shipped, decision made, reusable finding produced, or open follow-up created.
+2. Create a uniquely named `WORK_LOGS/YYYY-MM-DD_SESSION_<SLUG>.md` handover. Include valid Buzz knowledge-file frontmatter, outcome, evidence, decisions, and open follow-ups. Never overwrite an existing file.
+3. Create a matching plain Markdown digest in `OUTBOX/session-digests/YYYY-MM-DD_SESSION_<SLUG>.md`. Treat it as pending export and never overwrite an existing file.
+4. If an owner-provided wrap-up or export integration is available and authorized, let that process export the digest one-way to the owner's vault. Ordinary agents must not write or sync the vault directly.
+5. If the vault or exporter is unavailable, leave the digest queued in `OUTBOX/session-digests/`. Wrap-up still succeeds.
+
+Buzz relay events, agent memory, and workspace files remain canonical. The vault is a human-readable archive, never a runtime dependency or bidirectional store.
+<!-- END BUZZ MANAGED SKILL -->

--- a/docs/handovers/2026-08-14-buzz-wrapup-skill.md
+++ b/docs/handovers/2026-08-14-buzz-wrapup-skill.md
@@ -1,0 +1,18 @@
+# Buzz Wrap-up Skill Handover
+
+## Verified
+
+- Managed nests install the bundled `buzz-wrapup` skill canonically and expose it in known provider skill directories.
+- Explicit `done`, `wrap up`, and `end session` requests trigger the bundled contract.
+- Non-trivial sessions create a `WORK_LOGS/` handover and queue an `OUTBOX/session-digests/` export without making Obsidian canonical or required.
+- Managed refreshes preserve owner content after the skill marker, and unmarked existing files are never overwritten.
+- Rust formatting, 47 focused nest tests, the full desktop Rust suite, skill validation, and an independent audit passed.
+
+## Pending
+
+- Push the branch and open a draft PR.
+- The owner-authorized vault exporter remains an external integration. Buzz queues digests but does not directly write a vault.
+
+## Blocked on Diego
+
+- None.


### PR DESCRIPTION
## What changed

- Bundle a managed `buzz-wrapup` skill for explicit `done`, `wrap up`, and `end session` requests.
- Save non-trivial handovers in `WORK_LOGS/` and queue one-way digest exports in `OUTBOX/session-digests/`.
- Keep Obsidian outside Buzz runtime state and direct agent writes.
- Install the skill across known provider directories while preserving owner customizations.

## Why

Buzz agents need durable, human-readable session continuity without making a personal vault a second writable source of truth or an availability dependency.

## Validation

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::nest::tests` (47 passed)
- `just desktop-tauri-test` (full desktop Rust workspace passed)
- Bundled skill validated with `quick_validate.py`
- Independent adversarial audit passed
