### PR TITLE
fix(desktop): align the thread activity row with its composer

### DIFF
--- a/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 import { CardMintComposerChip } from "@/features/agents/ui/CardMintComposerChip";
 import { useCardMintJobs } from "@/features/agents/cardMintStore";
 import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
+import { COMPOSER_ACTIVITY_ROW_CLASS } from "@/features/messages/lib/messageThreadPanelLayout";
 import { ComposerActivityAccessory } from "@/features/messages/ui/ComposerActivityAccessory";
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 
@@ -40,7 +41,7 @@ export function ChannelComposerActivityAccessory({
       testId="channel-composer-activity-row"
       visible={visible}
     >
-      <div className="flex w-full items-center gap-2 overflow-visible pl-2">
+      <div className={COMPOSER_ACTIVITY_ROW_CLASS}>
         {cardMintJobs.length > 0 ? <CardMintComposerChip /> : null}
         {workingBotPubkeys.length > 0 ? (
           <div className="flex min-w-0 flex-1 overflow-visible">

--- a/desktop/src/features/messages/lib/messageThreadPanelLayout.test.mjs
+++ b/desktop/src/features/messages/lib/messageThreadPanelLayout.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  COMPOSER_ACTIVITY_ROW_CLASS,
+  THREAD_PANEL_COMPOSER_GUTTER_CLASS,
+} from "./messageThreadPanelLayout.ts";
+
+const THREAD_PANEL = new URL("../ui/MessageThreadPanel.tsx", import.meta.url);
+const CHANNEL_ACCESSORY = new URL(
+  "../../channels/ui/ChannelComposerActivityAccessory.tsx",
+  import.meta.url,
+);
+
+test("composer activity row carries no max-width or centering of its own", () => {
+  // A cap here indents the row from its composer once the surface is wider
+  // than the cap, which is what made the thread panel's row drift right.
+  assert.ok(!COMPOSER_ACTIVITY_ROW_CLASS.includes("max-w-"));
+  assert.ok(!COMPOSER_ACTIVITY_ROW_CLASS.includes("mx-auto"));
+});
+
+test("composer activity row only inherits the composer gutter", () => {
+  assert.equal(THREAD_PANEL_COMPOSER_GUTTER_CLASS, "px-5");
+  assert.ok(!COMPOSER_ACTIVITY_ROW_CLASS.includes("px-"));
+});
+
+test("both composer activity rows use the shared frame", async () => {
+  for (const file of [THREAD_PANEL, CHANNEL_ACCESSORY]) {
+    const source = await readFile(file, "utf8");
+    assert.ok(
+      source.includes("className={COMPOSER_ACTIVITY_ROW_CLASS}"),
+      `${file.pathname} should frame its activity row with COMPOSER_ACTIVITY_ROW_CLASS`,
+    );
+  }
+});

--- a/desktop/src/features/messages/lib/messageThreadPanelLayout.ts
+++ b/desktop/src/features/messages/lib/messageThreadPanelLayout.ts
@@ -10,6 +10,17 @@ export const THREAD_PANEL_MESSAGE_GUTTER_CLASS = "px-2";
 export const THREAD_PANEL_COMPOSER_GUTTER_CLASS = "px-5";
 
 /**
+ * Inner frame of a composer activity row (the `<Agent>: <status>` indicator and
+ * the typing row). The row has to share its composer's frame, so it carries no
+ * max-width of its own: the composer above it is only ever inset by the gutter
+ * class, and a centered cap here indents the row once the surface is wider than
+ * the cap. Shared by the channel composer and the thread panel so the two
+ * cannot drift apart again.
+ */
+export const COMPOSER_ACTIVITY_ROW_CLASS =
+  "flex w-full items-center gap-2 overflow-visible pl-2";
+
+/**
  * Centers the reading column when a `columnMaxWidthPx` is supplied (focus-mode
  * drawer). `px-10` (40px) is the inline gutter between the column and the drawer
  * edges; the max-width itself is applied inline since it is a caller-provided

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -34,6 +34,7 @@ import {
   AuxiliaryPanelTitle,
 } from "@/shared/layout/AuxiliaryPanel";
 import {
+  COMPOSER_ACTIVITY_ROW_CLASS,
   THREAD_PANEL_COLUMN_CLASS,
   THREAD_PANEL_COMPOSER_GUTTER_CLASS,
   THREAD_PANEL_MESSAGE_GUTTER_CLASS,
@@ -928,7 +929,7 @@ export function MessageThreadPanel({
               className={THREAD_PANEL_COMPOSER_GUTTER_CLASS}
               visible={hasComposerBottomActivity}
             >
-              <div className="mx-auto flex w-full max-w-4xl items-center gap-2 overflow-visible pl-2">
+              <div className={COMPOSER_ACTIVITY_ROW_CLASS}>
                 {activityAccessoryVisible && activityAccessoryContent ? (
                   <div className="flex min-w-0 flex-1 overflow-visible">
                     {activityAccessoryContent}


### PR DESCRIPTION
Fixes #5803.

The thread panel frames its composer activity row with `mx-auto ... max-w-4xl` (`MessageThreadPanel.tsx:931`), but the thread composer directly above it is inset only by `THREAD_PANEL_COMPOSER_GUTTER_CLASS` (`px-5`). Once the panel is wider than ~936px the cap starts to bite and `mx-auto` centers the row, so the `<Agent>: <status>` indicator and the popover anchored to it sit indented while the composer stays flush left. It was the only `max-w-4xl` in the conversation UI — the other occurrences are settings, dialogs and onboarding.

The channel's equivalent wrapper (`ChannelComposerActivityAccessory.tsx:43`) already had the same class list without the cap, which is why the row is flush left there. This lifts that list into `messageThreadPanelLayout` as `COMPOSER_ACTIVITY_ROW_CLASS` and uses it from both places, so the two frames can't drift again.

Verified locally in `desktop/`: `pnpm typecheck`, `pnpm check`, and the new `messageThreadPanelLayout.test.mjs` (3/3). I did not run the app on a wide window — the reasoning about the threshold is the issue's, and the layout change is the removal of the cap and the centering.