### PR TITLE
fix(desktop): keep env var rows alive when the runtime catalog resolves

### DIFF
--- a/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
@@ -10,10 +10,19 @@
  *      — the guard fires when skipKeys changes, even if value is unchanged.
  *   4. inheritedRows: render/exclusion/override/no-serialize invariants.
  *   5. getBakedProviderInheritLabel: label helper correctness.
+ *   6. That reprojection happens in place: `reconcileRows` keeps the existing
+ *      row objects (and so their ids) instead of rebuilding from `value`.
  *
  * These are pure-logic tests — no React renderer needed. The transition tests
- * (Invariant 3) exercise the real exported `skipKeysEqual` guard that controls
- * whether the effect calls `setRows(toRows(value, skipKeys))`.
+ * (Invariant 3) exercise the real exported `skipKeysEqual` guard that decides
+ * whether the effect reprojects at all; Invariant 6 covers what it reprojects
+ * to. Note that a skipKeys change no longer means a full
+ * `setRows(toRows(value, skipKeys))` rebuild — that path is now reserved for a
+ * `value` the editor did not emit.
+ *
+ * Row identity here is object identity, which is necessary but not sufficient:
+ * `envVarsEditorCatalogRerender.test.mjs` mounts the component in jsdom and
+ * asserts the focused DOM input itself survives the update.
  */
 
 import { test } from "node:test";

--- a/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.test.mjs
@@ -24,6 +24,7 @@ import {
   toRecord,
   skipKeysEqual,
   isRequiredKeyMissing,
+  reconcileRows,
   buildRecord as buildRecordUtil,
 } from "./EnvVarsEditor.tsx";
 import { getBakedProviderInheritLabel } from "./bakedEnvHelpers.ts";
@@ -924,4 +925,72 @@ test("buildRecord_clearing_structured_field_allows_placeholder_to_return", () =>
     "Inherit (25)",
     "numeric input must show Inherit (<global value>) when a global override exists",
   );
+});
+
+// ── Invariant 6: a skip-key change re-projects without remounting rows ─────
+//
+// `toRows` mints a new id per row, and a new id remounts the input under the
+// user's cursor. The runtime catalog resolves seconds after a harness switch,
+// so that remount lands mid-typing and the rest of the keystrokes are lost.
+
+test("reconcileRows_keeps_row_identity_for_untouched_rows", () => {
+  const prev = [
+    { id: "row-1", key: "BUZZ_AC", value: "" },
+    { id: "row-2", key: "EDITOR", value: "vim" },
+  ];
+  const next = reconcileRows(prev, { EDITOR: "vim" }, new Set());
+  assert.deepEqual(next, prev);
+  // Same objects, so React reuses the same inputs and the caret survives.
+  assert.equal(next[0], prev[0]);
+  assert.equal(next[1], prev[1]);
+});
+
+test("reconcileRows_drops_a_row_whose_key_just_became_required", () => {
+  const prev = [
+    { id: "row-1", key: "ANTHROPIC_API_KEY", value: "sk-x" },
+    { id: "row-2", key: "EDITOR", value: "vim" },
+  ];
+  const next = reconcileRows(
+    prev,
+    { ANTHROPIC_API_KEY: "sk-x", EDITOR: "vim" },
+    new Set(["ANTHROPIC_API_KEY"]),
+  );
+  assert.deepEqual(
+    next.map((row) => row.key),
+    ["EDITOR"],
+  );
+});
+
+test("reconcileRows_restores_a_key_that_stopped_being_required", () => {
+  const prev = [{ id: "row-2", key: "EDITOR", value: "vim" }];
+  const next = reconcileRows(
+    prev,
+    { ANTHROPIC_API_KEY: "sk-x", EDITOR: "vim" },
+    new Set(),
+  );
+  assert.deepEqual(
+    next.map((row) => row.key),
+    ["EDITOR", "ANTHROPIC_API_KEY"],
+  );
+  assert.equal(next[0], prev[0]);
+});
+
+test("reconcileRows_keeps_a_half_typed_key_absent_from_value", () => {
+  // The row being typed into has no entry in `value` yet — `toRecord` skips
+  // empty keys and the parent has not seen the partial one either.
+  const prev = [
+    { id: "row-1", key: "", value: "" },
+    { id: "row-2", key: "BUZZ_AC", value: "" },
+  ];
+  const next = reconcileRows(prev, {}, new Set(["ANTHROPIC_API_KEY"]));
+  assert.deepEqual(next, prev);
+});
+
+test("reconcileRows_does_not_duplicate_a_key_already_present", () => {
+  const prev = [{ id: "row-1", key: "EDITOR", value: "nano" }];
+  const next = reconcileRows(prev, { EDITOR: "vim" }, new Set());
+  assert.deepEqual(next, prev);
+  // The row's own text wins while it is being edited; the parent record
+  // catches up on the next emit.
+  assert.equal(next[0].value, "nano");
 });

--- a/desktop/src/features/agents/ui/EnvVarsEditor.tsx
+++ b/desktop/src/features/agents/ui/EnvVarsEditor.tsx
@@ -58,6 +58,37 @@ export function toRecord(
   return out;
 }
 
+/**
+ * Re-project rows after a skip-key change **without** discarding in-progress
+ * edits.
+ *
+ * `toRows` mints a fresh `crypto.randomUUID()` for every row, so rebuilding
+ * from `value` remounts each input. When the runtime catalog resolves
+ * mid-typing — the request is in flight for seconds after a harness switch —
+ * that remount happens under the user's cursor: focus is lost and every
+ * further keystroke lands nowhere, so a key typed as
+ * `BUZZ_ACP_PERMISSION_MODE` is saved as `BUZZ_AC` with no warning.
+ *
+ * Keeping the existing row objects keeps their ids, so React reuses the same
+ * inputs and the caret stays put. The projection invariant is preserved the
+ * narrow way instead: rows whose key just became a skip key are dropped, and
+ * keys in `value` that just stopped being skipped are appended.
+ *
+ * Exported for unit tests.
+ */
+export function reconcileRows(
+  prevRows: readonly Row[],
+  value: EnvVarsValue,
+  skipKeys: ReadonlySet<string>,
+): Row[] {
+  const kept = prevRows.filter((row) => !skipKeys.has(row.key));
+  const present = new Set(kept.map((row) => row.key));
+  const restored = Object.entries(value)
+    .filter(([key]) => !skipKeys.has(key) && !present.has(key))
+    .map(([key, val]) => ({ id: crypto.randomUUID(), key, value: val }));
+  return restored.length > 0 ? [...kept, ...restored] : kept;
+}
+
 // Module-private empty set constant so skipKeys defaults are allocation-free.
 const EMPTY_SET: ReadonlySet<string> = new Set<string>();
 
@@ -258,9 +289,16 @@ export function EnvVarsEditor({
   React.useEffect(() => {
     const skipKeysChanged = !skipKeysEqual(prevSkipKeys.current, skipKeys);
     prevSkipKeys.current = skipKeys;
-    if (skipKeysChanged || !recordsEqual(lastEmitted.current, value)) {
+    if (!recordsEqual(lastEmitted.current, value)) {
+      // The parent supplied a value we did not emit (dialog reopened on a
+      // different agent) — a full rebuild is what we want.
       lastEmitted.current = value;
       setRows(toRows(value, skipKeys));
+    } else if (skipKeysChanged) {
+      // Only the skip-key sets moved, which happens when the async runtime
+      // catalog resolves. Re-project in place so a row being typed into keeps
+      // its identity, and with it the caret.
+      setRows((prev) => reconcileRows(prev, value, skipKeys));
     }
   }, [value, skipKeys]);
 

--- a/desktop/src/features/agents/ui/envVarsEditorCatalogRerender.test.mjs
+++ b/desktop/src/features/agents/ui/envVarsEditorCatalogRerender.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Mounted regression test for #5366: a row being typed into must survive the
+ * async runtime-catalog resolution.
+ *
+ * `reconcileRows` is unit-tested in `EnvVarsEditor.test.mjs`, but object
+ * identity in the helper does not prove that the component's effect picks the
+ * re-projection branch, nor that React preserves the focused DOM input across
+ * the update. That is the part users feel: the catalog request is in flight for
+ * seconds after a harness switch, and when it lands mid-typing the old code
+ * rebuilt every row with a fresh `crypto.randomUUID()`, remounting the input
+ * under the cursor so the rest of the keystrokes went nowhere.
+ *
+ * So this mounts the real component in jsdom, types a partial key, moves
+ * `hiddenKeys` the way the resolved catalog does, and asserts the very same
+ * input node is still focused and still accepts the rest of the key.
+ */
+
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+  dom.window.matchMedia = () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+test("a half-typed row keeps its focused input when the catalog resolves", async () => {
+  const { createElement, useState } = await import("react");
+  const { fireEvent, render, screen } = await import("@testing-library/react");
+  const { EnvVarsEditor } = await import("./EnvVarsEditor.tsx");
+
+  let latest = {};
+
+  function Host({ hiddenKeys }) {
+    const [value, setValue] = useState({});
+    return createElement(EnvVarsEditor, {
+      hiddenKeys,
+      onChange: (next) => {
+        latest = next;
+        setValue(next);
+      },
+      value,
+    });
+  }
+
+  // The catalog has not resolved yet, so nothing is hidden.
+  const { rerender } = render(createElement(Host, { hiddenKeys: [] }));
+
+  fireEvent.click(screen.getByTestId("env-vars-add"));
+  const keyInput = screen.getByTestId("env-vars-key");
+  keyInput.focus();
+  fireEvent.change(keyInput, { target: { value: "BUZZ_AC" } });
+
+  assert.ok(
+    dom.window.document.activeElement === keyInput,
+    "precondition: the row being typed into holds focus",
+  );
+
+  // The runtime catalog resolves and contributes a hidden key. `value` is
+  // unchanged from what the editor last emitted — only `skipKeys` moves.
+  rerender(createElement(Host, { hiddenKeys: ["BUZZ_RUNTIME_TOKEN"] }));
+
+  // Identity, not `assert.equal`: a failed deep-equal on two jsdom nodes
+  // spends ~45s building a diff nobody reads.
+  assert.ok(
+    screen.getByTestId("env-vars-key") === keyInput,
+    "the key input must be the same DOM node, not a remounted one",
+  );
+  assert.ok(
+    dom.window.document.activeElement === keyInput,
+    "focus must survive the catalog update",
+  );
+  assert.equal(keyInput.value, "BUZZ_AC", "the partial key must survive");
+
+  // Finish typing into that same input.
+  fireEvent.change(keyInput, {
+    target: { value: "BUZZ_ACP_PERMISSION_MODE" },
+  });
+  fireEvent.change(screen.getByTestId("env-vars-value"), {
+    target: { value: "acceptEdits" },
+  });
+
+  assert.equal(
+    latest.BUZZ_ACP_PERMISSION_MODE,
+    "acceptEdits",
+    "the whole key must reach the parent, not the truncated prefix",
+  );
+  assert.equal(
+    latest.BUZZ_AC,
+    undefined,
+    "the truncated prefix must not be saved",
+  );
+});

--- a/desktop/src/features/agents/ui/envVarsEditorFocus.test.mjs
+++ b/desktop/src/features/agents/ui/envVarsEditorFocus.test.mjs
@@ -18,11 +18,11 @@
  *      triggers a re-run).
  *
  * Why not a full component render test?
- * The project's test runner is plain Node `node:test` with no jsdom setup;
- * mounting a full React + Radix Dialog tree would require wiring up jsdom,
- * happy-dom, and React Testing Library — infrastructure that doesn't exist
- * in this repo. The logic under test is the focus-dispatch predicate and
- * one-shot guard, both of which are fully exercisable without a browser DOM.
+ * The logic under test is the focus-dispatch predicate and the one-shot guard,
+ * both fully exercisable without a browser DOM. (This file used to say the
+ * repo had no jsdom infrastructure. It does — `jsdom` and
+ * `@testing-library/react` are devDependencies and several suites mount
+ * components, including `envVarsEditorCatalogRerender.test.mjs` next door.)
  */
 
 import { test } from "node:test";


### PR DESCRIPTION
Fixes #5366.

`skipKeys` is derived from the async runtime-catalog query, so it changes seconds after a harness switch — routinely while someone is typing a key. The resync effect answered any skip-key change by rebuilding rows from `value`, and `toRows` mints a fresh `crypto.randomUUID()` per row, so every input remounted under the caret. Focus went with it: the characters typed before the catalog settled were kept and everything after landed nowhere, which is how `BUZZ_ACP_PERMISSION_MODE` gets saved as `BUZZ_AC` with no warning.

The effect had merged two cases that need different answers. A `value` the parent supplied that we did not emit (dialog reopened on another agent) still rebuilds. A skip-key-only change now re-projects in place through `reconcileRows`: existing row objects are kept, so React reuses the same inputs and the caret survives. The invariant the rebuild existed for is preserved directly instead — a row whose key just became required or hidden is dropped, and a key that just stopped being skipped is appended from `value`.

Verified in `desktop/`: `pnpm typecheck`, `pnpm check`, `pnpm build`, and `pnpm test` (4959 pass) — the five new cases in `EnvVarsEditor.test.mjs` assert row identity is preserved, not just the projection. Not run: the Playwright spec from the issue; these are pure-logic tests of the helper the effect now calls, so they cover the cause rather than the keystroke path.
