### PR TITLE
fix(acp): reconcile hosted agent directory profiles

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -137,6 +137,25 @@ Controls which authors' events the harness forwards to the agent. Events from di
 |------|---------|---------|-------------|
 | `--respond-to` | `BUZZ_ACP_RESPOND_TO` | `owner-only` | Author gate mode: `owner-only`, `allowlist`, `anyone`, `nobody`. |
 | `--respond-to-allowlist` | `BUZZ_ACP_RESPOND_TO_ALLOWLIST` | — | Comma-separated 64-char hex pubkeys (required when mode is `allowlist`). Owner is always implicitly included. |
+| `--channel-add-policy` | `BUZZ_ACP_CHANNEL_ADD_POLICY` | — | Current relay policy: `anyone`, `owner_only`, or `nobody`. Required only for the first kind `10100` directory reconciliation when no existing profile supplies it. |
+
+### Agent Directory Reconciliation
+
+After channel discovery and subscription, the harness reconciles its public,
+replaceable kind `10100` directory profile. It publishes the current channel
+IDs and names plus the effective `respond_to` mode and allowlist, while
+preserving unknown fields from the existing profile. Desktop clients use this
+directory event to admit remote/headless agents to mention autocomplete and to
+the final send boundary. The runtime owner is added to the public directory
+allowlist because `buzz-acp` admits that owner implicitly; `owner-only` is
+projected to the equivalent one-owner allowlist for clients that cannot resolve
+the harness's private owner configuration.
+
+The harness never guesses `channel_add_policy`. If no kind `10100` profile
+exists yet, set `BUZZ_ACP_CHANNEL_ADD_POLICY` to the identity's current relay
+policy for the first start. Later starts retain the published value when the
+setting is omitted. Reconciliation failures are logged and do not prevent the
+harness from receiving already-authorized traffic.
 
 **Modes:**
 

--- a/crates/buzz-acp/src/agent_profile.rs
+++ b/crates/buzz-acp/src/agent_profile.rs
@@ -1,0 +1,277 @@
+//! Reconcile the harness identity's public kind:10100 agent directory profile.
+//!
+//! Desktop mention admission uses this replaceable event as affirmative proof
+//! that a remote/headless agent is invocable. The harness owns the fields it
+//! can observe directly (memberships and inbound-author policy) and preserves
+//! every unknown field so future profile extensions are not erased.
+
+use std::collections::{HashMap, HashSet};
+
+use buzz_core::kind::KIND_AGENT_PROFILE;
+use nostr::{EventBuilder, Filter, Keys, Kind};
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use crate::config::{ChannelAddPolicy, RespondTo};
+use crate::relay::{ChannelInfo, RestClient};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReconcileOutcome {
+    Published(String),
+    Unchanged,
+    SkippedNoChannelAddPolicy,
+}
+
+fn event_content(event: &Value, kind: u32) -> Result<Map<String, Value>, String> {
+    let content = event
+        .get("content")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("kind:{kind} event has no string content"))?;
+    serde_json::from_str::<Value>(content)
+        .map_err(|error| format!("kind:{kind} content is invalid JSON: {error}"))?
+        .as_object()
+        .cloned()
+        .ok_or_else(|| format!("kind:{kind} content is not an object"))
+}
+
+fn first_event(events: &Value) -> Option<&Value> {
+    events.as_array().and_then(|items| items.first())
+}
+
+fn existing_policy(
+    existing: &Map<String, Value>,
+    configured: Option<ChannelAddPolicy>,
+) -> Result<Option<String>, String> {
+    if let Some(policy) = configured {
+        return Ok(Some(policy.to_string()));
+    }
+    let Some(value) = existing.get("channel_add_policy") else {
+        return Ok(None);
+    };
+    let Some(policy) = value.as_str() else {
+        return Err("kind:10100 channel_add_policy is not a string".into());
+    };
+    if !matches!(policy, "anyone" | "owner_only" | "nobody") {
+        return Err(format!(
+            "kind:10100 channel_add_policy has unsupported value {policy:?}"
+        ));
+    }
+    Ok(Some(policy.to_string()))
+}
+
+fn build_content(
+    mut existing: Map<String, Value>,
+    kind0: Option<&Map<String, Value>>,
+    channels: &HashMap<Uuid, ChannelInfo>,
+    respond_to: &RespondTo,
+    respond_to_allowlist: &HashSet<String>,
+    owner: Option<&str>,
+    channel_add_policy: &str,
+) -> Value {
+    if let Some(profile) = kind0 {
+        for field in ["name", "display_name", "picture"] {
+            if !existing.contains_key(field) {
+                if let Some(value) = profile.get(field) {
+                    existing.insert(field.to_string(), value.clone());
+                }
+            }
+        }
+        if !existing.contains_key("name") {
+            if let Some(value) = profile.get("display_name") {
+                existing.insert("name".into(), value.clone());
+            }
+        }
+    }
+
+    let mut memberships: Vec<(String, String)> = channels
+        .iter()
+        .map(|(id, info)| (id.to_string(), info.name.clone()))
+        .collect();
+    memberships.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let channel_ids: Vec<Value> = memberships
+        .iter()
+        .map(|(id, _)| Value::String(id.clone()))
+        .collect();
+    let channel_names: Vec<Value> = memberships
+        .into_iter()
+        .map(|(_, name)| Value::String(name))
+        .collect();
+    let (directory_respond_to, mut allowlist): (&str, Vec<String>) = match respond_to {
+        RespondTo::Anyone => ("anyone", Vec::new()),
+        RespondTo::Nobody => ("nobody", Vec::new()),
+        RespondTo::Allowlist => ("allowlist", respond_to_allowlist.iter().cloned().collect()),
+        // Desktop's relay-directory admission cannot resolve the implicit
+        // runtime owner from `owner-only`. Project it to an equivalent public
+        // allowlist so that owner-authored mentions remain selectable.
+        RespondTo::OwnerOnly if owner.is_some() => ("allowlist", Vec::new()),
+        RespondTo::OwnerOnly => ("owner-only", Vec::new()),
+    };
+    if matches!(respond_to, RespondTo::Allowlist | RespondTo::OwnerOnly) {
+        if let Some(owner) = owner {
+            allowlist.push(owner.to_string());
+        }
+    }
+    allowlist.sort();
+    allowlist.dedup();
+
+    existing.insert("agent_type".into(), json!("agent"));
+    existing.insert("channels".into(), Value::Array(channel_names));
+    existing.insert("channel_ids".into(), Value::Array(channel_ids));
+    existing.entry("capabilities").or_insert_with(|| json!([]));
+    existing.insert("respond_to".into(), json!(directory_respond_to));
+    existing.insert("respond_to_allowlist".into(), json!(allowlist));
+    existing.insert("channel_add_policy".into(), json!(channel_add_policy));
+    Value::Object(existing)
+}
+
+/// Publish the current complete directory profile when it differs from the
+/// relay head. A missing first-time channel-add policy is a safe skip: the
+/// harness must not guess and accidentally widen an operator's relay policy.
+pub async fn reconcile_agent_profile(
+    rest: &RestClient,
+    keys: &Keys,
+    channels: &HashMap<Uuid, ChannelInfo>,
+    respond_to: &RespondTo,
+    respond_to_allowlist: &HashSet<String>,
+    owner: Option<&str>,
+    configured_channel_add_policy: Option<ChannelAddPolicy>,
+) -> Result<ReconcileOutcome, String> {
+    let author = keys.public_key();
+    let profile_filter = Filter::new()
+        .kind(Kind::Custom(KIND_AGENT_PROFILE as u16))
+        .author(author)
+        .limit(1);
+    let profile_events = rest
+        .query(&[profile_filter])
+        .await
+        .map_err(|error| format!("kind:10100 query failed: {error}"))?;
+    let existing_event = first_event(&profile_events);
+    let existing = existing_event
+        .map(|event| event_content(event, KIND_AGENT_PROFILE))
+        .transpose()?
+        .unwrap_or_default();
+
+    let Some(channel_add_policy) = existing_policy(&existing, configured_channel_add_policy)?
+    else {
+        return Ok(ReconcileOutcome::SkippedNoChannelAddPolicy);
+    };
+
+    let kind0_filter = Filter::new().kind(Kind::Metadata).author(author).limit(1);
+    let kind0_events = rest
+        .query(&[kind0_filter])
+        .await
+        .map_err(|error| format!("kind:0 query failed: {error}"))?;
+    let kind0 = first_event(&kind0_events)
+        .map(|event| event_content(event, 0))
+        .transpose()?;
+
+    let content = build_content(
+        existing,
+        kind0.as_ref(),
+        channels,
+        respond_to,
+        respond_to_allowlist,
+        owner,
+        &channel_add_policy,
+    );
+    if existing_event
+        .and_then(|event| event.get("content"))
+        .and_then(Value::as_str)
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .as_ref()
+        == Some(&content)
+    {
+        return Ok(ReconcileOutcome::Unchanged);
+    }
+
+    let serialized = serde_json::to_string(&content)
+        .map_err(|error| format!("kind:10100 serialize failed: {error}"))?;
+    let event = EventBuilder::new(Kind::Custom(KIND_AGENT_PROFILE as u16), serialized)
+        .tags([])
+        .sign_with_keys(keys)
+        .map_err(|error| format!("kind:10100 sign failed: {error}"))?;
+    let event_id = event.id.to_hex();
+    rest.submit_event(&event)
+        .await
+        .map_err(|error| format!("kind:10100 publish failed: {error}"))?;
+    Ok(ReconcileOutcome::Published(event_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn channel(name: &str) -> ChannelInfo {
+        ChannelInfo {
+            name: name.into(),
+            channel_type: "stream".into(),
+            description: None,
+        }
+    }
+
+    #[test]
+    fn build_content_sorts_memberships_and_preserves_unknown_fields() {
+        let first = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let second = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let channels = HashMap::from([(second, channel("second")), (first, channel("first"))]);
+        let existing = Map::from_iter([("future_field".into(), json!({"kept": true}))]);
+        let kind0 = Map::from_iter([("display_name".into(), json!("Scout"))]);
+        let allowlist = HashSet::from(["b".repeat(64), "a".repeat(64)]);
+
+        let content = build_content(
+            existing,
+            Some(&kind0),
+            &channels,
+            &RespondTo::Allowlist,
+            &allowlist,
+            Some(&"c".repeat(64)),
+            "owner_only",
+        );
+
+        assert_eq!(content["name"], json!("Scout"));
+        assert_eq!(content["display_name"], json!("Scout"));
+        assert_eq!(content["future_field"], json!({"kept": true}));
+        assert_eq!(content["channels"], json!(["first", "second"]));
+        assert_eq!(
+            content["channel_ids"],
+            json!([first.to_string(), second.to_string()])
+        );
+        assert_eq!(
+            content["respond_to_allowlist"],
+            json!(["a".repeat(64), "b".repeat(64), "c".repeat(64)])
+        );
+    }
+
+    #[test]
+    fn owner_only_projects_to_owner_allowlist_for_directory_admission() {
+        let owner = "d".repeat(64);
+        let content = build_content(
+            Map::new(),
+            None,
+            &HashMap::new(),
+            &RespondTo::OwnerOnly,
+            &HashSet::new(),
+            Some(&owner),
+            "anyone",
+        );
+        assert_eq!(content["respond_to"], json!("allowlist"));
+        assert_eq!(content["respond_to_allowlist"], json!([owner]));
+    }
+
+    #[test]
+    fn configured_policy_wins_and_missing_policy_skips() {
+        let existing = Map::from_iter([("channel_add_policy".into(), json!("nobody"))]);
+        assert_eq!(
+            existing_policy(&existing, Some(ChannelAddPolicy::OwnerOnly)).unwrap(),
+            Some("owner_only".into())
+        );
+        assert_eq!(existing_policy(&Map::new(), None).unwrap(), None);
+    }
+
+    #[test]
+    fn invalid_existing_policy_fails_closed() {
+        let existing = Map::from_iter([("channel_add_policy".into(), json!("open"))]);
+        assert!(existing_policy(&existing, None).is_err());
+    }
+}

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -111,6 +111,30 @@ impl std::fmt::Display for RespondTo {
     }
 }
 
+/// Policy controlling who may add this agent identity to channels.
+///
+/// The value is published in the agent's kind:10100 directory profile. It is
+/// optional because an existing profile may already carry the authoritative
+/// policy; first-time headless profiles must configure it explicitly so the
+/// harness never widens a relay policy by guessing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ChannelAddPolicy {
+    Anyone,
+    #[value(name = "owner_only", alias = "owner-only")]
+    OwnerOnly,
+    Nobody,
+}
+
+impl std::fmt::Display for ChannelAddPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Anyone => f.write_str("anyone"),
+            Self::OwnerOnly => f.write_str("owner_only"),
+            Self::Nobody => f.write_str("nobody"),
+        }
+    }
+}
+
 /// Permission mode for agents that support `session/set_config_option` with
 /// `configId: "mode"` (e.g. `claude-agent-acp`).
 ///
@@ -458,6 +482,11 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_RESPOND_TO_ALLOWLIST", value_delimiter = ',')]
     pub respond_to_allowlist: Option<Vec<String>>,
 
+    /// Channel-add policy to publish in a first-time kind:10100 directory
+    /// profile. Existing profiles retain their published value when omitted.
+    #[arg(long, env = "BUZZ_ACP_CHANNEL_ADD_POLICY", value_enum)]
+    pub channel_add_policy: Option<ChannelAddPolicy>,
+
     /// Comma-separated list of allowed `--respond-to` modes.
     /// When set, the harness rejects startup if `--respond-to` is not in this list.
     /// Modes: owner-only, allowlist, anyone, nobody.
@@ -549,6 +578,9 @@ pub struct Config {
     pub respond_to: RespondTo,
     /// Validated allowlist of pubkey hex strings (used when respond_to == Allowlist).
     pub respond_to_allowlist: HashSet<String>,
+    /// Explicit channel-add policy for kind:10100 directory reconciliation.
+    /// `None` preserves an existing profile and skips first-time publication.
+    pub channel_add_policy: Option<ChannelAddPolicy>,
     /// Allowed `respond_to` modes. Empty = all modes allowed.
     pub allowed_respond_to: Vec<String>,
     /// Per-persona env vars to inject at agent spawn time (e.g., GOOSE_PROVIDER, GOOSE_MODEL, BUZZ_AGENT_MODEL).
@@ -1112,6 +1144,7 @@ impl Config {
             permission_mode: args.permission_mode,
             respond_to: args.respond_to,
             respond_to_allowlist,
+            channel_add_policy: args.channel_add_policy,
             allowed_respond_to,
             persona_env_vars,
             has_generated_codex_config,
@@ -1484,6 +1517,7 @@ mod tests {
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),
+            channel_add_policy: None,
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],
             has_generated_codex_config: false,
@@ -2483,6 +2517,27 @@ channels = "ALL"
         assert_eq!(
             RespondTo::from_str("nobody", true).unwrap(),
             RespondTo::Nobody
+        );
+    }
+
+    #[test]
+    fn test_channel_add_policy_value_enum_parsing() {
+        use clap::ValueEnum;
+        assert_eq!(
+            ChannelAddPolicy::from_str("anyone", true).unwrap(),
+            ChannelAddPolicy::Anyone
+        );
+        assert_eq!(
+            ChannelAddPolicy::from_str("owner_only", true).unwrap(),
+            ChannelAddPolicy::OwnerOnly
+        );
+        assert_eq!(
+            ChannelAddPolicy::from_str("owner-only", true).unwrap(),
+            ChannelAddPolicy::OwnerOnly
+        );
+        assert_eq!(
+            ChannelAddPolicy::from_str("nobody", true).unwrap(),
+            ChannelAddPolicy::Nobody
         );
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 
 mod acp;
+mod agent_profile;
 mod config;
 mod engram_fetch;
 mod filter;
@@ -2117,6 +2118,36 @@ async fn tokio_main() -> Result<()> {
         } else {
             subscribed_channel_ids.insert(*channel_id);
             tracing::info!("subscribed to channel {channel_id}");
+        }
+    }
+
+    let profile_rest = relay.rest_client();
+    match agent_profile::reconcile_agent_profile(
+        &profile_rest,
+        &config.keys,
+        &channel_info_map,
+        &config.respond_to,
+        &config.respond_to_allowlist,
+        startup_owner.as_deref(),
+        config.channel_add_policy,
+    )
+    .await
+    {
+        Ok(agent_profile::ReconcileOutcome::Published(event_id)) => {
+            tracing::info!(event_id, "reconciled kind:10100 agent directory profile");
+        }
+        Ok(agent_profile::ReconcileOutcome::Unchanged) => {
+            tracing::info!("kind:10100 agent directory profile is current");
+        }
+        Ok(agent_profile::ReconcileOutcome::SkippedNoChannelAddPolicy) => {
+            tracing::warn!(
+                "kind:10100 agent directory profile is missing and was not published: \
+                 set BUZZ_ACP_CHANNEL_ADD_POLICY to the agent's current relay policy \
+                 (anyone, owner_only, or nobody) for the first reconciliation"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(%error, "failed to reconcile kind:10100 agent directory profile");
         }
     }
 
@@ -6755,6 +6786,7 @@ mod build_mcp_servers_tests {
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: std::collections::HashSet::new(),
+            channel_add_policy: None,
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
             has_generated_codex_config: false,
@@ -6978,6 +7010,7 @@ mod error_outcome_emission_tests {
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),
+            channel_add_policy: None,
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
             has_generated_codex_config: false,


### PR DESCRIPTION
## Summary

- reconcile `buzz-acp` identities into the replaceable kind `10100` agent directory after startup channel discovery
- publish actual channel names/IDs and effective response authorization while preserving unknown profile fields
- project the implicit runtime owner into the public allowlist, including the equivalent owner allowlist for `owner-only` mode
- retain an existing `channel_add_policy`, or require an explicit first-time `BUZZ_ACP_CHANNEL_ADD_POLICY` so startup never guesses or widens policy
- skip unchanged profiles and keep reconciliation failures non-fatal

## Why

Desktop mention authorization now fails closed for remote agents missing current directory authorization. Legacy manually hosted agents can still be relay members and channel bots with valid kind `0` profiles, yet remain absent from autocomplete and receive no signed `p` tag. A live headless canary confirmed that a complete profile with the effective owner restores autocomplete, signed-recipient delivery, and harness wake without a Desktop restart.

Closes #5928.

## Validation

- live canary: Desktop 0.5.14 autocomplete -> signed `p` tag -> relay -> `buzz-acp` wake
- `cargo test -p buzz-acp` (783 passed)
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `just ci` (full workspace/desktop/web/mobile gate passed; mobile: 1,399 tests)
