### PR TITLE
feat(projects): render Markdown repository files

### DIFF
--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenText,
   Braces,
   ChevronRight,
   CodeXml,
@@ -32,7 +33,8 @@ import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { UserSearchResult } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-import { SyntaxHighlightedCode } from "@/shared/ui/markdown";
+import { Button } from "@/shared/ui/button";
+import { Markdown, SyntaxHighlightedCode } from "@/shared/ui/markdown";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   PROJECT_DETAIL_PANEL_CLASS,
@@ -548,7 +550,9 @@ function FileContentPanel({
   file: ProjectRepoFile;
   onOpenPath: (path: string) => void;
 }) {
+  const [showMarkdownSource, setShowMarkdownSource] = React.useState(false);
   const language = languageForPath(file.path);
+  const isMarkdown = /\.(?:md|markdown|mdx)$/i.test(file.path);
   const pathSegments = file.path.split("/").filter(Boolean);
   const fileName = pathSegments[pathSegments.length - 1] ?? file.path;
   const directorySegments = pathSegments.slice(0, -1);
@@ -575,6 +579,27 @@ function FileContentPanel({
         <span className="min-w-0 flex-1 truncate px-1.5 py-1 font-mono text-xs text-foreground">
           {fileName}
         </span>
+        {isMarkdown && file.previewContent ? (
+          <Button
+            aria-pressed={showMarkdownSource}
+            onClick={() => setShowMarkdownSource((current) => !current)}
+            size="xs"
+            type="button"
+            variant="ghost"
+          >
+            {showMarkdownSource ? (
+              <>
+                <BookOpenText />
+                View rendered
+              </>
+            ) : (
+              <>
+                <FileCode2 />
+                View source
+              </>
+            )}
+          </Button>
+        ) : null}
         <div className="hidden shrink-0 items-center gap-3 text-2xs text-muted-foreground sm:flex">
           <span>Last changed {formatLastChangedAt(file.lastChangedAt)}</span>
           <span>{formatFileSize(file.size)}</span>
@@ -586,7 +611,15 @@ function FileContentPanel({
       <div className="border-border/50 border-b bg-muted/10 px-4 py-2 text-2xs text-muted-foreground sm:hidden">
         Last changed {formatLastChangedAt(file.lastChangedAt)}
       </div>
-      {file.previewContent ? (
+      {file.previewContent && isMarkdown && !showMarkdownSource ? (
+        <div className="max-h-[36rem] overflow-auto bg-background/60 p-6">
+          <Markdown
+            className="text-sm"
+            content={file.previewContent}
+            interactive={false}
+          />
+        </div>
+      ) : file.previewContent ? (
         <pre className="max-h-[36rem] overflow-auto bg-background/60 p-4">
           {language ? (
             <SyntaxHighlightedCode

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11442,6 +11442,20 @@ export function maybeInstallE2eTauriMocks() {
           ],
           files: [
             {
+              path: "docs/TEAM_GUIDE.md",
+              kind: "blob",
+              size: 142,
+              preview_content: [
+                "# Team guide",
+                "",
+                "Use **Project Markdown** for durable team knowledge.",
+                "",
+                "```bash",
+                "buzz repos get --id team-wiki",
+                "```",
+              ].join("\n"),
+            },
+            {
               path: "desktop/src/features/projects/ui/ProjectDetailScreen.tsx",
               kind: "blob",
               size: 18420,

--- a/desktop/tests/e2e/project-pr-review.spec.ts
+++ b/desktop/tests/e2e/project-pr-review.spec.ts
@@ -1122,6 +1122,37 @@ test("project detail content areas do not paint background fills", async ({
   await expectVisiblePanelsToBeTransparent();
 });
 
+test("project Markdown files render by default and retain a source view", async ({
+  page,
+}) => {
+  await enableProjectsFeature(page);
+  await installMockBridge(page);
+  await openBuzzProject(page);
+
+  await page.getByRole("tab", { name: "Files", exact: true }).click();
+  await page.getByText("docs", { exact: true }).click();
+  await page.getByText("TEAM_GUIDE.md", { exact: true }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Team guide", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Project Markdown", { exact: true }),
+  ).toHaveJSProperty("tagName", "STRONG");
+  await expect(page.getByText("# Team guide", { exact: true })).toHaveCount(0);
+  await waitForAnimations(page);
+  await page.screenshot({
+    fullPage: false,
+    path: `${SHOTS}/markdown-file-rendered.png`,
+  });
+
+  await page.getByRole("button", { name: "View source" }).click();
+  await expect(page.getByText("# Team guide", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "View rendered" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
 test("project without a checkout offers fetch feedback and dropdown cloning", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- render `.md`, `.markdown`, and `.mdx` repository files in Project **Files** by default
- keep raw Markdown available through a **View source / View rendered** toggle
- cover the rendered and source states with a Project browser regression test

## Test plan

- `pnpm --dir desktop test` (4,715 passed)
- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop exec playwright test tests/e2e/project-pr-review.spec.ts --grep "project Markdown files render"`
- visually inspected the rendered Project file view

## Origin

Requested from the Buzz help thread: buzz://message?channel=ea2f81e9-5a02-43e2-b7ce-925aaa9364c5&id=7baab9bd05328cf1cae45885a3efb01dd1acb4155aaeb064fc82a9aff9313dcf
