### PR TITLE
fix(acp): dispatch mentioned forum events

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -222,7 +222,13 @@ Start with **N=2** for most deployments. Increase if queue depth grows under loa
 
 ## Forum Channels
 
-By default, the ACP harness subscribes to stream message kinds (9, 46010, 40007). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
+By default, the ACP harness subscribes to mentioned stream messages, workflow
+requests, reminders, forum posts, and forum comments (kinds 9, 46010, 40007,
+45001, and 45003). A forum post or comment wakes an agent only when it includes
+the agent's `p` tag.
+
+To receive all forum activity, including unmentioned posts, comments, and votes,
+opt in with `--kinds` and disable the mention filter:
 
 **CLI flags:**
 ```bash
@@ -246,13 +252,16 @@ Forum event kinds:
 - **45002** — Vote on a post or comment
 - **45003** — Comment reply on a forum post
 
-> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
+> **Note:** The default `subscribe=mentions` mode receives forum posts and
+> comments that explicitly mention the agent. Without `--no-mention-filter` (or
+> `require_mention = false`), unmentioned forum activity remains invisible.
 
 ## How It Works
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
+3. **Event loop** — Listens for supported events with the agent's pubkey in a
+   `#p` tag. Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -6,6 +6,10 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+use buzz_core::kind::{
+    KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
+};
 use clap::Parser;
 use clap::ValueEnum;
 use nostr::Keys;
@@ -29,6 +33,15 @@ pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 /// Default absolute wall-clock cap per agent turn (2 hours).
 /// Override via `--max-turn-duration` / `BUZZ_ACP_MAX_TURN_DURATION`.
 pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
+
+/// Event kinds delivered by the default mention-only subscription.
+pub(crate) const DEFAULT_MENTION_KINDS: &[u32] = &[
+    KIND_STREAM_MESSAGE,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_STREAM_REMINDER,
+    KIND_FORUM_POST,
+    KIND_FORUM_COMMENT,
+];
 
 /// Upper bound for `max_turn_duration` (7 days). Any higher is operationally
 /// meaningless and risks arithmetic overflow when deriving the in-flight
@@ -1255,10 +1268,6 @@ pub fn resolve_channel_filters(
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
         overrides
             .iter()
@@ -1273,13 +1282,10 @@ pub fn resolve_channel_filters(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => {
-            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            });
+            let kinds = config
+                .kinds_override
+                .clone()
+                .unwrap_or_else(|| DEFAULT_MENTION_KINDS.to_vec());
             let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
@@ -1357,10 +1363,6 @@ pub fn resolve_dynamic_channel_filter(
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     // In Mentions/All mode, if the operator explicitly constrained channels
     // with --channels, only allow dynamic subscription to channels in that
     // allowlist. Config mode ignores --channels (per CLI contract) and uses
@@ -1378,13 +1380,12 @@ pub fn resolve_dynamic_channel_filter(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => Some(ChannelFilter {
-            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            })),
+            kinds: Some(
+                config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_MENTION_KINDS.to_vec()),
+            ),
             require_mention: !config.no_mention_filter,
         }),
         SubscribeMode::All => Some(ChannelFilter {
@@ -1528,10 +1529,27 @@ mod tests {
             let f = result.get(ch).expect("channel should be present");
             assert!(f.require_mention, "mentions mode requires mention");
             let kinds = f.kinds.as_ref().expect("should have kinds");
-            assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
-            assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
-            assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
+            assert_eq!(kinds, DEFAULT_MENTION_KINDS);
+            assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_POST));
+            assert!(kinds.contains(&buzz_core::kind::KIND_FORUM_COMMENT));
+            assert!(!kinds.contains(&buzz_core::kind::KIND_FORUM_VOTE));
         }
+    }
+
+    #[test]
+    fn test_dynamic_mentions_mode_default_kinds() {
+        let config = test_config(SubscribeMode::Mentions);
+        let channel = Uuid::new_v4();
+        let filter = resolve_dynamic_channel_filter(&config, channel, &[])
+            .expect("channel should use the default mention filter");
+
+        assert!(filter.require_mention, "mentions mode requires mention");
+        assert_eq!(filter.kinds.as_deref(), Some(DEFAULT_MENTION_KINDS));
+        assert!(!filter
+            .kinds
+            .as_deref()
+            .expect("mentions mode should specify kinds")
+            .contains(&buzz_core::kind::KIND_FORUM_VOTE));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,7 +22,6 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -31,7 +30,7 @@ use buzz_core::observer::{
 use clap::Parser;
 use config::{
     AuthAgentArgs, AuthMethodsArgs, AuthenticateArgs, Config, DedupMode, ModelsArgs,
-    MultipleEventHandling, RespondTo, SubscribeMode,
+    MultipleEventHandling, RespondTo, SubscribeMode, DEFAULT_MENTION_KINDS,
 };
 use filter::SubscriptionRule;
 use futures_util::FutureExt;
@@ -1923,13 +1922,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_MENTION_KINDS.to_vec()),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -36,8 +36,8 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use nostr::EventId;
 use serde::{Deserialize, Serialize};
@@ -76,6 +76,17 @@ use crate::{
     event_mentions_agent, filter,
     relay::{HarnessRelay, RelayEventPublisher},
 };
+
+const DEFAULT_SETUP_MENTION_KINDS: &[u32] = &[
+    KIND_STREAM_MESSAGE,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_FORUM_POST,
+    KIND_FORUM_COMMENT,
+];
+
+fn is_setup_nudge_kind(kind: u32) -> bool {
+    DEFAULT_SETUP_MENTION_KINDS.contains(&kind)
+}
 
 // ── Payload ───────────────────────────────────────────────────────────────────
 
@@ -410,7 +421,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         }
 
         // Ignore non-message kinds (relay housekeeping, etc.).
-        if kind_u32 != KIND_STREAM_MESSAGE && kind_u32 != KIND_WORKFLOW_APPROVAL_REQUESTED {
+        if !is_setup_nudge_kind(kind_u32) {
             continue;
         }
 
@@ -524,7 +535,7 @@ fn build_setup_subscription_rules(config: &Config) -> Vec<filter::SubscriptionRu
     let kinds = config
         .kinds_override
         .clone()
-        .unwrap_or_else(|| vec![KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED]);
+        .unwrap_or_else(|| DEFAULT_SETUP_MENTION_KINDS.to_vec());
 
     match &config.subscribe_mode {
         // Config mode: load the actual rules, but they will be filtered by
@@ -650,6 +661,18 @@ async fn publish_setup_nudge(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn setup_default_kinds_include_mentioned_forum_events_not_votes() {
+        assert!(DEFAULT_SETUP_MENTION_KINDS.contains(&KIND_FORUM_POST));
+        assert!(DEFAULT_SETUP_MENTION_KINDS.contains(&KIND_FORUM_COMMENT));
+        assert!(!DEFAULT_SETUP_MENTION_KINDS.contains(&buzz_core::kind::KIND_FORUM_VOTE));
+
+        for kind in DEFAULT_SETUP_MENTION_KINDS {
+            assert!(is_setup_nudge_kind(*kind));
+        }
+        assert!(!is_setup_nudge_kind(buzz_core::kind::KIND_FORUM_VOTE));
+    }
 
     #[test]
     fn setup_payload_from_raw_returns_none_when_absent() {


### PR DESCRIPTION
## Summary

- include forum posts (`45001`) and forum comments (`45003`) in the ACP harness's default mention subscriptions
- keep mention gating enabled and continue excluding forum votes (`45002`)
- share the default kind list across static, dynamic, and main-loop subscription paths
- preserve setup mode's intentionally narrower defaults and update the forum documentation

## Root cause

The ACP harness subscribed to stream messages, workflow requests, and reminders by default, but omitted forum post and comment kinds. The relay's existing `p`-tag filter is kind-agnostic, so explicitly mentioned agents were never reached because those forum event kinds were not subscribed.

## Impact

Agents now wake for forum posts and comments that explicitly mention them. Unmentioned forum traffic and forum votes remain excluded unless an operator opts into broader kinds and disables mention filtering.

## Validation

- `cargo test -p buzz-acp --lib` — 777 passed
- `cargo test -p buzz-acp --test '*'` — 9 passed
- `cargo test -p buzz-sdk --lib` — 257 passed
- `cargo test --doc -p buzz-acp` — passed
- `cargo fmt --check -p buzz-acp` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `git diff --check` — passed
