### PR TITLE
fix(desktop): point Claude Code at the nest's AGENTS.md

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -133,6 +133,11 @@ pub fn ensure_nest() -> Result<(), String> {
 ///
 /// - Creates the root directory and all subdirectories.
 /// - Writes `AGENTS.md` only if it doesn't already exist.
+/// - Writes `CLAUDE.md` only if it doesn't already exist, containing the single
+///   line `@./AGENTS.md` — Claude Code auto-loads `CLAUDE.md`, so this is what
+///   makes the orientation file reach that runtime's context. If the write
+///   fails after the file is created, the partial file is removed so the next
+///   launch retries rather than seeing it as already provisioned.
 /// - Writes `.agents/skills/buzz-cli/SKILL.md` only if it doesn't already exist.
 /// - Creates harness-specific symlinks pointing to the canonical
 ///   `.agents/skills/buzz-cli` directory for each known provider.
@@ -209,8 +214,22 @@ pub fn ensure_nest_at(root: &Path) -> Result<(), String> {
     {
         Ok(mut file) => {
             use std::io::Write;
-            file.write_all(CLAUDE_MD.as_bytes())
-                .map_err(|e| format!("write {}: {e}", claude_md.display()))?;
+            if let Err(error) = file.write_all(CLAUDE_MD.as_bytes()) {
+                // `create_new` already made the path, so a failed write leaves
+                // an empty or partial pointer behind. Every later launch would
+                // then see AlreadyExists, treat provisioning as done, and never
+                // repair it — a permanently silent AGENTS.md. Remove it so the
+                // next launch retries; the file is one static line, so there is
+                // nothing of the user's to lose.
+                drop(file);
+                if let Err(cleanup) = fs::remove_file(&claude_md) {
+                    eprintln!(
+                        "buzz-desktop: could not remove the incomplete {}: {cleanup}",
+                        claude_md.display()
+                    );
+                }
+                return Err(format!("write {}: {error}", claude_md.display()));
+            }
         }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => {

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -39,6 +39,20 @@ const NEST_DIRS: &[&str] = &[
 /// Fully static — no runtime interpolation, no secrets, no user paths.
 pub(crate) const AGENTS_MD: &str = include_str!("nest_agents.md");
 
+/// Content of the nest's `CLAUDE.md`.
+///
+/// Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`, and buzz-acp only
+/// *names* AGENTS.md in the system prompt — `workspace_section()` never
+/// injects its contents. Everything the orientation file says is therefore
+/// inert for that runtime unless the agent decides to read the file, which
+/// includes the Git Commit Identity rules that name the human operator.
+///
+/// `@./AGENTS.md` is Claude Code's own include syntax: the file's contents
+/// reach the context window without a tool call. One line, so a user who
+/// wants to say more can edit it — the write below never clobbers an
+/// existing file.
+pub(crate) const CLAUDE_MD: &str = "@./AGENTS.md\n";
+
 /// Default SKILL.md content for the buzz-cli skill.
 /// Written to ~/.buzz/.agents/skills/buzz-cli/SKILL.md on first init.
 const BUZZ_CLI_SKILL_MD: &str = include_str!("nest_skill.md");
@@ -182,6 +196,25 @@ pub fn ensure_nest_at(root: &Path) -> Result<(), String> {
         }
         Err(e) => {
             return Err(format!("create {}: {e}", agents_md.display()));
+        }
+    }
+
+    // Point Claude Code at the orientation file. Same create_new posture as
+    // AGENTS.md above: written once, never clobbering a user's own file.
+    let claude_md = root.join("CLAUDE.md");
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&claude_md)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            file.write_all(CLAUDE_MD.as_bytes())
+                .map_err(|e| format!("write {}: {e}", claude_md.display()))?;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => {
+            return Err(format!("create {}: {e}", claude_md.display()));
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -934,8 +934,32 @@ fn nest_writes_a_claude_md_pointing_at_agents_md() {
     ensure_nest_at(&root).unwrap();
 
     let claude_md = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
-    assert_eq!(claude_md.trim(), "@./AGENTS.md");
+    // Exact bytes, not `trim()`: `@./AGENTS.md` is an include directive, and
+    // leading whitespace or a missing newline is the kind of drift that stops
+    // it resolving. It must be the whole file.
+    assert_eq!(claude_md, "@./AGENTS.md\n");
+    assert_eq!(claude_md, super::CLAUDE_MD);
     assert!(root.join("AGENTS.md").exists());
+}
+
+#[test]
+fn a_nest_with_no_claude_md_gets_the_pointer_back() {
+    // The state the write-failure cleanup restores: no file, so the next
+    // launch's `create_new` succeeds and writes the pointer. (The failing
+    // write itself needs an I/O fault to reproduce and is not simulated here;
+    // this covers the state it hands back.)
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("nest");
+    ensure_nest_at(&root).unwrap();
+    std::fs::remove_file(root.join("CLAUDE.md")).unwrap();
+
+    ensure_nest_at(&root).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(),
+        super::CLAUDE_MD,
+        "a nest missing its pointer must get it back on the next launch"
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -923,3 +923,33 @@ fn refresh_skill_overwrites_on_version_bump() {
         "SKILL.md must be refreshed on version bump"
     );
 }
+
+#[test]
+fn nest_writes_a_claude_md_pointing_at_agents_md() {
+    // Claude Code loads CLAUDE.md, not AGENTS.md, and buzz-acp only names the
+    // orientation file in the prompt — without this pointer everything in it
+    // (including the commit-identity rules) is inert for that runtime.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("nest");
+    ensure_nest_at(&root).unwrap();
+
+    let claude_md = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
+    assert_eq!(claude_md.trim(), "@./AGENTS.md");
+    assert!(root.join("AGENTS.md").exists());
+}
+
+#[test]
+fn nest_never_clobbers_an_existing_claude_md() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("nest");
+    ensure_nest_at(&root).unwrap();
+
+    std::fs::write(root.join("CLAUDE.md"), "@./AGENTS.md\n\nmine\n").unwrap();
+    ensure_nest_at(&root).unwrap();
+
+    let claude_md = std::fs::read_to_string(root.join("CLAUDE.md")).unwrap();
+    assert!(
+        claude_md.contains("mine"),
+        "user content must survive: {claude_md}"
+    );
+}


### PR DESCRIPTION
Fixes #5367.

The nest writes `AGENTS.md` as its orientation document, and `workspace_section()` in `crates/buzz-acp/src/pool.rs` tells the agent the file exists — but never injects its contents, and Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`. Grepping `crates/buzz-acp` for `AGENTS.md` returns that one prompt string.

So for the `claude-agent-acp` runtime everything in that file is inert unless the agent independently decides to `Read` it: the directory layout, the knowledge-file frontmatter conventions, "cite sources", and the **Git Commit Identity** section whose `Signed-off-by` / `Co-authored-by` trailers name the human operator. It is easy to miss because everything *looks* wired — the file exists, the prompt references it by name, and the agent will happily read it if asked.

This writes a one-line `CLAUDE.md` beside it containing Claude Code's own include syntax:

```
@./AGENTS.md
```

which is the reporter's own verified workaround. `create_new` keeps the existing posture used for `AGENTS.md` itself — written once on nest init, never clobbering a file the user has edited, which the second test asserts.

The alternative is injecting the file's contents into the ACP system prompt in `pool.rs`, which would cover every runtime rather than only Claude Code. That is a larger change to the prompt budget and belongs to whoever owns that path; this one is the small fix that makes the shipped template do what it says.

Verified locally with CI's own gates: `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` clean, `cargo fmt` clean, and `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — 2442 passed, including the two new nest tests. Not run: a real Claude Code session; the `@./AGENTS.md` behaviour is the issue's tested claim, not mine.
