### PR TITLE
fix(desktop): keep the Builderlab session across restarts

### DIFF
--- a/desktop/src-tauri/src/builderlab.rs
+++ b/desktop/src-tauri/src/builderlab.rs
@@ -139,6 +139,42 @@ const AUTH_COMPLETE_HTML: &str = r#"<!doctype html>
 </body>
 </html>"#;
 
+/// Keyring key holding the Builderlab session credential.
+///
+/// The credential used to live only in `BuilderlabSession`, i.e. in process
+/// memory, so quitting the app signed the Hosted communities page out while
+/// the Buzz identity itself — which *is* persisted — came back fine. Keep it
+/// beside that identity in the OS keyring instead.
+const SESSION_CREDENTIAL_KEY: &str = "builderlab.session";
+
+fn credential_store() -> &'static crate::secret_store::SecretStore {
+    crate::secret_store::SecretStore::shared(crate::app_state::keyring_service())
+}
+
+/// Persist the credential. Best-effort: a machine whose keyring is unreachable
+/// still gets a working session for this run, which is what it had before.
+fn persist_credential(credential: &str) {
+    if let Err(error) = credential_store().store(SESSION_CREDENTIAL_KEY, credential) {
+        tracing::warn!(%error, "builderlab: could not persist the session credential");
+    }
+}
+
+fn forget_credential() {
+    if let Err(error) = credential_store().delete(SESSION_CREDENTIAL_KEY) {
+        tracing::debug!(%error, "builderlab: could not delete the session credential");
+    }
+}
+
+fn stored_credential() -> Option<String> {
+    match credential_store().load(SESSION_CREDENTIAL_KEY) {
+        Ok(credential) => credential,
+        Err(error) => {
+            tracing::warn!(%error, "builderlab: could not read the session credential");
+            None
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct BuilderlabSession(Mutex<Option<StoredSession>>);
 
@@ -358,6 +394,7 @@ pub(crate) async fn start_builderlab_login(
         }
         *pending = None;
     }
+    persist_credential(&exchanged.session_credential);
     *session.0.lock().map_err(|error| error.to_string())? = Some(StoredSession {
         credential: exchanged.session_credential,
     });
@@ -369,14 +406,25 @@ pub(crate) async fn get_builderlab_auth(
     app_state: tauri::State<'_, crate::app_state::AppState>,
     session: tauri::State<'_, BuilderlabSession>,
 ) -> Result<Option<BuilderlabAuthInfo>, String> {
-    let stored = session
+    let in_memory = session
         .0
         .lock()
         .map_err(|error| error.to_string())?
         .as_ref()
         .map(|stored| stored.credential.clone());
-    let Some(credential) = stored else {
-        return Ok(None);
+    // A fresh process has nothing in memory; the credential from the last run
+    // is in the keyring. Hydrate before deciding the page is signed out.
+    let credential = match in_memory {
+        Some(credential) => credential,
+        None => {
+            let Some(credential) = stored_credential() else {
+                return Ok(None);
+            };
+            *session.0.lock().map_err(|error| error.to_string())? = Some(StoredSession {
+                credential: credential.clone(),
+            });
+            credential
+        }
     };
     match authenticated_user(&app_state.http_client, &credential).await {
         Ok(me) => Ok(Some(BuilderlabAuthInfo {
@@ -385,10 +433,14 @@ pub(crate) async fn get_builderlab_auth(
             name: me.name,
         })),
         Err(error) => {
+            // The credential is no longer good (expired, revoked, or the
+            // account changed). Drop it from both stores so the next launch
+            // asks for a sign-in instead of failing this call again.
             *session
                 .0
                 .lock()
                 .map_err(|lock_error| lock_error.to_string())? = None;
+            forget_credential();
             Err(error)
         }
     }
@@ -409,6 +461,7 @@ pub(crate) fn clear_builderlab_auth(
     session: tauri::State<'_, BuilderlabSession>,
 ) -> Result<(), String> {
     *session.0.lock().map_err(|error| error.to_string())? = None;
+    forget_credential();
     Ok(())
 }
 

--- a/desktop/src-tauri/src/builderlab.rs
+++ b/desktop/src-tauri/src/builderlab.rs
@@ -159,24 +159,104 @@ fn persist_credential(credential: &str) {
     }
 }
 
-fn forget_credential() {
-    if let Err(error) = credential_store().delete(SESSION_CREDENTIAL_KEY) {
-        tracing::debug!(%error, "builderlab: could not delete the session credential");
-    }
+/// Read the persisted credential.
+///
+/// A keyring that cannot be read is *not* "no credential": reporting the user
+/// as signed out when the store is merely unavailable invites them to sign in
+/// again over a session that is still perfectly good. The error is returned so
+/// the caller can say the storage failed.
+fn stored_credential() -> Result<Option<String>, String> {
+    credential_store()
+        .load(SESSION_CREDENTIAL_KEY)
+        .map_err(|error| format!("could not read the stored Builderlab session: {error}"))
 }
 
-fn stored_credential() -> Option<String> {
-    match credential_store().load(SESSION_CREDENTIAL_KEY) {
-        Ok(credential) => credential,
-        Err(error) => {
-            tracing::warn!(%error, "builderlab: could not read the session credential");
-            None
-        }
-    }
+/// The credential, plus the generation it was read at.
+///
+/// Session checks are `await`ed, so a login or a logout can land while one is
+/// in flight. Every mutation bumps `generation`, and a check applies its result
+/// only if the generation it started from is still current — otherwise an older
+/// rejected request deletes a credential that was just exchanged, or an older
+/// success reports auth for a session the user already signed out of.
+#[derive(Default)]
+struct SessionState {
+    stored: Option<StoredSession>,
+    generation: u64,
 }
 
 #[derive(Default)]
-pub(crate) struct BuilderlabSession(Mutex<Option<StoredSession>>);
+pub(crate) struct BuilderlabSession(Mutex<SessionState>);
+
+impl BuilderlabSession {
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, SessionState>, String> {
+        self.0.lock().map_err(|error| error.to_string())
+    }
+
+    /// The current credential and generation, without touching the keyring.
+    fn current(&self) -> Result<Option<(String, u64)>, String> {
+        let state = self.lock()?;
+        Ok(state
+            .stored
+            .as_ref()
+            .map(|stored| (stored.credential.clone(), state.generation)))
+    }
+
+    /// Install a freshly exchanged credential in memory and in the keyring.
+    ///
+    /// Both stores are written under the lock so a concurrent hydrate or clear
+    /// cannot interleave between them and leave the two disagreeing.
+    fn replace(&self, credential: String) -> Result<(), String> {
+        let mut state = self.lock()?;
+        persist_credential(&credential);
+        state.stored = Some(StoredSession { credential });
+        state.generation += 1;
+        Ok(())
+    }
+
+    /// Adopt the persisted credential into memory, if memory is still empty.
+    ///
+    /// Returns the credential now in effect. If a login landed while the
+    /// keyring was being read, that newer credential wins — hydration must
+    /// never resurrect an older session over it, nor over a logout.
+    fn hydrate(&self, credential: String) -> Result<(String, u64), String> {
+        let mut state = self.lock()?;
+        if let Some(stored) = state.stored.as_ref() {
+            return Ok((stored.credential.clone(), state.generation));
+        }
+        state.stored = Some(StoredSession {
+            credential: credential.clone(),
+        });
+        state.generation += 1;
+        Ok((credential, state.generation))
+    }
+
+    /// Drop the credential from memory and from the keyring.
+    ///
+    /// The keyring failure is returned rather than logged: reporting a
+    /// successful sign-out while the credential is still on disk means the next
+    /// launch hydrates it and silently signs the user back in.
+    fn clear(&self) -> Result<(), String> {
+        let mut state = self.lock()?;
+        state.stored = None;
+        state.generation += 1;
+        credential_store()
+            .delete(SESSION_CREDENTIAL_KEY)
+            .map_err(|error| format!("could not delete the stored Builderlab session: {error}"))
+    }
+
+    /// Drop the credential, but only if it is still the one that was checked.
+    fn clear_if_current(&self, generation: u64) -> Result<(), String> {
+        {
+            let state = self.lock()?;
+            if state.generation != generation {
+                // A login or logout landed while the check was in flight; its
+                // verdict is about a credential that is no longer in use.
+                return Ok(());
+            }
+        }
+        self.clear()
+    }
+}
 
 #[derive(Default)]
 pub(crate) struct BuilderlabLogin(Mutex<Option<PendingLogin>>);
@@ -394,10 +474,7 @@ pub(crate) async fn start_builderlab_login(
         }
         *pending = None;
     }
-    persist_credential(&exchanged.session_credential);
-    *session.0.lock().map_err(|error| error.to_string())? = Some(StoredSession {
-        credential: exchanged.session_credential,
-    });
+    session.replace(exchanged.session_credential)?;
     Ok(info)
 }
 
@@ -406,41 +483,36 @@ pub(crate) async fn get_builderlab_auth(
     app_state: tauri::State<'_, crate::app_state::AppState>,
     session: tauri::State<'_, BuilderlabSession>,
 ) -> Result<Option<BuilderlabAuthInfo>, String> {
-    let in_memory = session
-        .0
-        .lock()
-        .map_err(|error| error.to_string())?
-        .as_ref()
-        .map(|stored| stored.credential.clone());
     // A fresh process has nothing in memory; the credential from the last run
     // is in the keyring. Hydrate before deciding the page is signed out.
-    let credential = match in_memory {
-        Some(credential) => credential,
+    let (credential, generation) = match session.current()? {
+        Some(current) => current,
         None => {
-            let Some(credential) = stored_credential() else {
+            let Some(persisted) = stored_credential()? else {
                 return Ok(None);
             };
-            *session.0.lock().map_err(|error| error.to_string())? = Some(StoredSession {
-                credential: credential.clone(),
-            });
-            credential
+            session.hydrate(persisted)?
         }
     };
     match authenticated_user(&app_state.http_client, &credential).await {
-        Ok(me) => Ok(Some(BuilderlabAuthInfo {
-            expires_at: me.expires_at,
-            email: me.email,
-            name: me.name,
-        })),
+        Ok(me) => {
+            // Only report auth for the session still in effect. An older check
+            // completing after a logout would otherwise present the user as
+            // signed in to an account they just left.
+            if session.current()?.is_none_or(|(_, now)| now != generation) {
+                return Ok(None);
+            }
+            Ok(Some(BuilderlabAuthInfo {
+                expires_at: me.expires_at,
+                email: me.email,
+                name: me.name,
+            }))
+        }
         Err(error) => {
             // The credential is no longer good (expired, revoked, or the
             // account changed). Drop it from both stores so the next launch
             // asks for a sign-in instead of failing this call again.
-            *session
-                .0
-                .lock()
-                .map_err(|lock_error| lock_error.to_string())? = None;
-            forget_credential();
+            session.clear_if_current(generation)?;
             Err(error)
         }
     }
@@ -460,9 +532,7 @@ pub(crate) fn cancel_builderlab_login(
 pub(crate) fn clear_builderlab_auth(
     session: tauri::State<'_, BuilderlabSession>,
 ) -> Result<(), String> {
-    *session.0.lock().map_err(|error| error.to_string())? = None;
-    forget_credential();
-    Ok(())
+    session.clear()
 }
 
 #[derive(Debug, Deserialize)]
@@ -482,11 +552,8 @@ async fn authenticated_json(
     body: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let credential = session
-        .0
-        .lock()
-        .map_err(|error| error.to_string())?
-        .as_ref()
-        .map(|stored| stored.credential.clone())
+        .current()?
+        .map(|(credential, _generation)| credential)
         .ok_or_else(|| "Sign in to Builderlab first".to_owned())?;
     let response = client
         .request(method, api_url(path)?)
@@ -736,5 +803,57 @@ mod tests {
             Some("http://127.0.0.1:1234/callback/nonce")
         );
         assert!(!query.contains_key("screen_hint"));
+    }
+
+    #[test]
+    fn a_login_during_a_check_survives_that_check_s_rejection() {
+        // The race: a check reads generation N, the user signs in again while
+        // it is in flight, and the stale 401 comes back. It must not delete
+        // the credential that just replaced the one it checked.
+        let session = BuilderlabSession::default();
+        session.0.lock().unwrap().stored.replace(StoredSession {
+            credential: "old".into(),
+        });
+        let (credential, generation) = session.current().unwrap().expect("a session");
+        assert_eq!(credential, "old");
+
+        // A newer login lands, bumping the generation.
+        {
+            let mut state = session.0.lock().unwrap();
+            state.stored = Some(StoredSession {
+                credential: "new".into(),
+            });
+            state.generation += 1;
+        }
+
+        session
+            .clear_if_current(generation)
+            .expect("a stale verdict must be a no-op");
+
+        let (credential, _) = session.current().unwrap().expect("session must survive");
+        assert_eq!(
+            credential, "new",
+            "a stale rejection must not delete the credential that replaced it"
+        );
+    }
+
+    #[test]
+    fn hydration_never_overwrites_a_newer_credential() {
+        // The keyring read is not instant, so a login can land first. The
+        // credential from disk must not resurrect over it.
+        let session = BuilderlabSession::default();
+        {
+            let mut state = session.0.lock().unwrap();
+            state.stored = Some(StoredSession {
+                credential: "new".into(),
+            });
+            state.generation += 1;
+        }
+
+        let (credential, _) = session.hydrate("from-disk".into()).unwrap();
+        assert_eq!(
+            credential, "new",
+            "hydration must yield to the credential already in memory"
+        );
     }
 }

--- a/desktop/src-tauri/src/builderlab.rs
+++ b/desktop/src-tauri/src/builderlab.rs
@@ -171,6 +171,41 @@ fn stored_credential() -> Result<Option<String>, String> {
         .map_err(|error| format!("could not read the stored Builderlab session: {error}"))
 }
 
+/// Why a `/v1/auth/me` check did not return a user.
+///
+/// Only an explicit authentication rejection proves the credential is bad. A
+/// timeout, a DNS failure, a 5xx, a 429, or a body that does not parse says
+/// nothing about the credential — deleting it on those turns a blip in the
+/// service into a permanent sign-out, since the credential is gone from the
+/// keyring as well as from memory.
+#[derive(Debug)]
+enum SessionCheckError {
+    /// The service rejected the credential itself (HTTP 401 or 403).
+    Rejected(String),
+    /// Anything else. The credential is kept for the next attempt.
+    Transient(String),
+}
+
+impl SessionCheckError {
+    fn message(self) -> String {
+        match self {
+            SessionCheckError::Rejected(message) | SessionCheckError::Transient(message) => message,
+        }
+    }
+
+    fn invalidates_credential(&self) -> bool {
+        matches!(self, SessionCheckError::Rejected(_))
+    }
+}
+
+/// Whether an HTTP status is the service saying "this credential is not good".
+///
+/// 401 and 403 only. 429 in particular is *not* here: rate limiting says the
+/// caller asked too often, not that the session expired.
+fn status_rejects_credential(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN
+}
+
 /// The credential, plus the generation it was read at.
 ///
 /// Session checks are `await`ed, so a login or a logout can land while one is
@@ -343,24 +378,31 @@ fn login_url(return_to: &str) -> Result<Url, String> {
 async fn authenticated_user(
     client: &reqwest::Client,
     credential: &str,
-) -> Result<AuthMeResponse, String> {
+) -> Result<AuthMeResponse, SessionCheckError> {
+    let url = api_url("/v1/auth/me").map_err(SessionCheckError::Transient)?;
     let response = client
-        .get(api_url("/v1/auth/me")?)
+        .get(url)
         .header(BB_SESSION_CREDENTIAL_HEADER, credential)
         .timeout(Duration::from_secs(30))
         .send()
         .await
-        .map_err(|error| format!("Builderlab session check failed: {error}"))?;
-    if !response.status().is_success() {
-        return Err(format!(
-            "Builderlab session check failed with HTTP {}",
-            response.status()
-        ));
+        .map_err(|error| {
+            SessionCheckError::Transient(format!("Builderlab session check failed: {error}"))
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let message = format!("Builderlab session check failed with HTTP {status}");
+        return Err(if status_rejects_credential(status) {
+            SessionCheckError::Rejected(message)
+        } else {
+            SessionCheckError::Transient(message)
+        });
     }
-    response
-        .json()
-        .await
-        .map_err(|error| format!("invalid Builderlab session response: {error}"))
+    // A success status with a body we cannot read says nothing about the
+    // credential — a proxy or a deploy mid-flight can produce it.
+    response.json().await.map_err(|error| {
+        SessionCheckError::Transient(format!("invalid Builderlab session response: {error}"))
+    })
 }
 
 #[tauri::command]
@@ -455,7 +497,9 @@ pub(crate) async fn start_builderlab_login(
         return Err("Builderlab code exchange returned an empty credential".to_owned());
     }
 
-    let me = authenticated_user(&app_state.http_client, &exchanged.session_credential).await?;
+    let me = authenticated_user(&app_state.http_client, &exchanged.session_credential)
+        .await
+        .map_err(SessionCheckError::message)?;
     if exchanged.expires_at != me.expires_at {
         return Err("Builderlab session expiry did not match code exchange".to_owned());
     }
@@ -509,11 +553,13 @@ pub(crate) async fn get_builderlab_auth(
             }))
         }
         Err(error) => {
-            // The credential is no longer good (expired, revoked, or the
-            // account changed). Drop it from both stores so the next launch
-            // asks for a sign-in instead of failing this call again.
-            session.clear_if_current(generation)?;
-            Err(error)
+            // Only an explicit rejection means the credential is bad. On a
+            // timeout, a 5xx or a malformed body it is kept, so a blip in the
+            // service does not sign the user out of the next launch too.
+            if error.invalidates_credential() {
+                session.clear_if_current(generation)?;
+            }
+            Err(error.message())
         }
     }
 }
@@ -803,6 +849,50 @@ mod tests {
             Some("http://127.0.0.1:1234/callback/nonce")
         );
         assert!(!query.contains_key("screen_hint"));
+    }
+
+    #[test]
+    fn only_a_confirmed_authentication_rejection_invalidates_a_session() {
+        use reqwest::StatusCode;
+
+        // The service saying "not you".
+        for status in [StatusCode::UNAUTHORIZED, StatusCode::FORBIDDEN] {
+            assert!(
+                status_rejects_credential(status),
+                "HTTP {status} must invalidate the credential"
+            );
+        }
+
+        // Everything else is the service having a bad day. Deleting the
+        // credential on these turns a blip into a permanent sign-out, because
+        // it is removed from the keyring as well as from memory.
+        for status in [
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::NOT_FOUND,
+            StatusCode::BAD_REQUEST,
+        ] {
+            assert!(
+                !status_rejects_credential(status),
+                "HTTP {status} must preserve the credential for a retry"
+            );
+        }
+    }
+
+    #[test]
+    fn transient_failures_do_not_invalidate_but_rejections_do() {
+        assert!(SessionCheckError::Rejected("nope".into()).invalidates_credential());
+        // A transport failure, a timeout, or a body that would not parse.
+        assert!(!SessionCheckError::Transient("dns".into()).invalidates_credential());
+        assert_eq!(
+            SessionCheckError::Transient("dns".into()).message(),
+            "dns",
+            "the caller still reports what went wrong"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #5924.

The Builderlab session credential lives in the `BuilderlabSession` Tauri state and nowhere else, so it dies with the process. Settings → Hosted communities therefore comes back to "Sign in to manage hosted communities" on every launch, while the Buzz identity — which *is* persisted — reopens signed in. That asymmetry is what makes it read as a bug in that page rather than as a session policy, and it is why signing in works every time: nothing rejected the credential, there simply was not one.

(The issue's WebView2 observation points at session storage, but the credential never reaches the webview at all — `get_builderlab_auth` returns only `email` / `name` / `expires_at`. The session storage entries it saw belong to the UI's own per-run state.)

This keeps the credential beside the identity in the OS keyring, under `builderlab.session`:

- `exchange_builderlab_code` writes it after a successful exchange.
- `get_builderlab_auth` hydrates the in-memory state from it on the first read of a fresh process, then validates as before — so an expired or revoked credential still surfaces as an error rather than a fake signed-in state.
- that validation failure, and `clear_builderlab_auth` (Sign out), delete it from both places.

Persisting is best-effort: if the keyring write fails, the run behaves exactly as it does today (a session that lasts until quit) instead of failing the sign-in.

Verified locally with CI's own gates: `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` clean, `cargo fmt` clean, `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — 2440 passed. Not run: the sign-in flow end to end, which needs a Builderlab account and a hosted community; the store calls are the same `SecretStore` the identity path already uses.
