### PR TITLE
fix(desktop): say when an agent's key is gone, not that the keyring is down

### DIFF
--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -1,8 +1,9 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::{self, File, OpenOptions},
     io::{Read as _, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
 };
 
 use tauri::{AppHandle, Manager};
@@ -225,13 +226,66 @@ fn migrate_inline_key(store: &impl KeyStore, record: &ManagedAgentRecord) -> Key
 /// `BUZZ_PRIVATE_KEY`/`NOSTR_PRIVATE_KEY`, launching with no identity. Callers
 /// (the spawn path) must fail closed (Wes storage.rs:158).
 pub(crate) fn spawn_key_refusal(record: &ManagedAgentRecord) -> Option<String> {
-    record.private_key_nsec.is_empty().then(|| {
+    record
+        .private_key_nsec
+        .is_empty()
+        .then(|| key_refusal_message(&record.pubkey, key_known_missing(&record.pubkey)))
+}
+
+/// Agents whose key the keyring positively reported as absent this session.
+///
+/// Hydration is the only place that learns the difference between "the keyring
+/// has no key for this agent" and "the keyring could not be read", and the
+/// record it fills carries no room for it — `managed-agents.json` is the file
+/// format, and every construction site would have to grow a field. A session
+/// side table keeps the distinction where it is produced.
+fn keys_known_missing() -> &'static Mutex<HashSet<String>> {
+    static KEYS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    KEYS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+pub(crate) fn note_key_missing(pubkey: &str) {
+    if let Ok(mut keys) = keys_known_missing().lock() {
+        keys.insert(pubkey.to_string());
+    }
+}
+
+/// Clear the mark — the key was found, or the keyring could not be read and we
+/// no longer know. A stale mark would tell the user to recreate an agent whose
+/// key is sitting in a keyring that was merely locked a moment ago.
+pub(crate) fn forget_key_missing(pubkey: &str) {
+    if let Ok(mut keys) = keys_known_missing().lock() {
+        keys.remove(pubkey);
+    }
+}
+
+pub(crate) fn key_known_missing(pubkey: &str) -> bool {
+    keys_known_missing()
+        .lock()
+        .map(|keys| keys.contains(pubkey))
+        .unwrap_or(false)
+}
+
+/// Word the refusal for the condition that actually holds.
+///
+/// When the keyring answered and had nothing, "retry once the keyring is
+/// reachable" sends the user to inspect a keyring that is working fine while
+/// the key is gone for good: `managed-agents.json` never carries the secret,
+/// so there is nothing left to recover from. Pure, so both wordings are
+/// unit-tested.
+pub(crate) fn key_refusal_message(pubkey: &str, known_missing: bool) -> String {
+    if known_missing {
         format!(
-            "agent {} has no private key available — the OS keyring may be unreachable. \
-             Refusing to start without an identity; retry once the keyring is reachable.",
-            record.pubkey
+            "agent {pubkey} has no private key: none inline and none in the OS keyring. \
+             The key is not recoverable from managed-agents.json, which never holds it — \
+             recreate the agent to mint a new identity."
         )
-    })
+    } else {
+        format!(
+            "agent {pubkey} has no private key available — the OS keyring may be unreachable. \
+             Refusing to start without an identity; retry once the keyring is reachable."
+        )
+    }
 }
 
 /// Read the raw unified store — keyed instances AND key-less definitions —
@@ -326,12 +380,16 @@ fn hydrate_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRecord]) 
         }
         if record.private_key_nsec.is_empty() {
             match store.load(&agent_keyring_name(&record.pubkey)) {
-                Ok(Some(nsec)) => record.private_key_nsec = nsec,
+                Ok(Some(nsec)) => {
+                    record.private_key_nsec = nsec;
+                    forget_key_missing(&record.pubkey);
+                }
                 Ok(None) => {
                     eprintln!(
                         "buzz-desktop: agent {} has no key in JSON or keyring",
                         record.pubkey
                     );
+                    note_key_missing(&record.pubkey);
                 }
                 // Outage, NOT absence: the key may exist in the keyring but is
                 // unreadable this boot. Leave it empty so the spawn path
@@ -342,6 +400,8 @@ fn hydrate_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRecord]) 
                          agent will be refused until the keyring is reachable",
                         record.pubkey
                     );
+                    // Not "missing": the key may well be there, unread.
+                    forget_key_missing(&record.pubkey);
                 }
             }
         } else {

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -199,6 +199,14 @@ fn migrate_inline_key(store: &impl KeyStore, record: &ManagedAgentRecord) -> Key
     if record.private_key_nsec.is_empty() {
         return KeyMigration::Nothing;
     }
+    // Usable key material exists for this agent, whatever an earlier keyring
+    // read concluded. This is the single funnel every inline key passes
+    // through — hydration's fallback branch and the save-time persist
+    // chokepoint both land here — so it is where a stale "known missing" mark
+    // gets cleared. A restore from backup or an import shows up as an inline
+    // key without ever going through a successful keyring *read*, and without
+    // this the session would go on telling the user the identity is gone.
+    forget_key_missing(&record.pubkey);
     let name = agent_keyring_name(&record.pubkey);
     match store.probe(&name) {
         // Keyring down this boot: keep the key inline (file fallback), do NOT
@@ -269,16 +277,21 @@ pub(crate) fn key_known_missing(pubkey: &str) -> bool {
 /// Word the refusal for the condition that actually holds.
 ///
 /// When the keyring answered and had nothing, "retry once the keyring is
-/// reachable" sends the user to inspect a keyring that is working fine while
-/// the key is gone for good: `managed-agents.json` never carries the secret,
-/// so there is nothing left to recover from. Pure, so both wordings are
-/// unit-tested.
+/// reachable" sends the user to inspect a keyring that is working fine. What
+/// is true in that case is narrower than "the key is gone": the two places
+/// this session looked — the inline `private_key_nsec` in
+/// `managed-agents.json` (the deliberate `0600` fallback used when the keyring
+/// is unreachable) and the keyring itself — both came up empty. A copy of the
+/// nsec held anywhere else still restores the identity: `private_key_nsec` is
+/// a real field of the record and hydration reads it, so recreation is the
+/// last resort and not the only one. Pure, so both wordings are unit-tested.
 pub(crate) fn key_refusal_message(pubkey: &str, known_missing: bool) -> String {
     if known_missing {
         format!(
-            "agent {pubkey} has no private key: none inline and none in the OS keyring. \
-             The key is not recoverable from managed-agents.json, which never holds it — \
-             recreate the agent to mint a new identity."
+            "agent {pubkey} has no private key: none inline in managed-agents.json \
+             and none in the OS keyring. If you have this agent's nsec saved \
+             elsewhere, restore it to the record's private_key_nsec field; \
+             otherwise recreate the agent to mint a new identity."
         )
     } else {
         format!(

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -841,18 +841,116 @@ fn refusal_names_an_unreadable_keyring_when_the_key_may_still_exist() {
 }
 
 #[test]
-fn refusal_says_the_key_is_gone_when_the_keyring_answered_empty() {
+fn refusal_offers_nsec_restore_before_recreation_when_the_keyring_answered_empty() {
     // The failure #5837 reports: the keyring was fine and simply had no key,
     // but the message pointed the user at the keyring. It must not suggest a
-    // retry, and it must say where the key is not (managed-agents.json).
+    // retry. It must also not overstate what is known — an inline key in
+    // managed-agents.json is a supported fallback, so the claim is that this
+    // session found none there, not that the file never holds one, and a key
+    // backup restores the identity without minting a new one.
     let message = super::key_refusal_message("agentpubkey", true);
+    assert!(
+        message.contains("none inline in managed-agents.json"),
+        "{message}"
+    );
     assert!(message.contains("none in the OS keyring"), "{message}");
-    assert!(message.contains("managed-agents.json"), "{message}");
+    assert!(
+        message.contains("restore it to the record's private_key_nsec field"),
+        "{message}"
+    );
     assert!(message.contains("recreate the agent"), "{message}");
+    assert!(
+        !message.contains("never holds"),
+        "the 0600 inline fallback does hold the key when the keyring is down: {message}"
+    );
     assert!(
         !message.contains("retry once the keyring is reachable"),
         "a key the keyring says is absent does not come back on retry: {message}"
     );
+}
+
+#[test]
+fn an_absent_key_reaches_the_spawn_refusal_as_absent() {
+    // Hydrate to spawn, through the real boundary: a reachable keyring with no
+    // entry leaves the key empty, and the refusal the spawn path produces is
+    // the one about a key that is not there.
+    let pubkey = "e2e-absent-pubkey";
+    let store = FakeKeyStore::reachable();
+    let mut records = vec![record_with_pubkey_and_key(pubkey, "")];
+
+    hydrate_keys_with(&store, &mut records);
+
+    let refusal = super::spawn_key_refusal(&records[0]).expect("empty key must refuse");
+    assert!(
+        refusal.contains("restore it to the record's private_key_nsec field"),
+        "{refusal}"
+    );
+    assert!(
+        !refusal.contains("retry once the keyring is reachable"),
+        "{refusal}"
+    );
+}
+
+#[test]
+fn an_unreadable_keyring_reaches_the_spawn_refusal_as_an_outage() {
+    let pubkey = "e2e-outage-pubkey";
+    let store = FakeKeyStore::unreachable();
+    let mut records = vec![record_with_pubkey_and_key(pubkey, "")];
+
+    hydrate_keys_with(&store, &mut records);
+
+    let refusal = super::spawn_key_refusal(&records[0]).expect("empty key must refuse");
+    assert!(refusal.contains("keyring may be unreachable"), "{refusal}");
+}
+
+#[test]
+fn an_outage_after_a_known_absence_stops_claiming_the_key_is_gone() {
+    // Boot 1: keyring answers, has nothing. Boot 2: keyring cannot be read at
+    // all. What is known has weakened, so the message must weaken with it.
+    let pubkey = "e2e-absent-then-outage-pubkey";
+    let mut records = vec![record_with_pubkey_and_key(pubkey, "")];
+    hydrate_keys_with(&FakeKeyStore::reachable(), &mut records);
+    assert!(super::key_known_missing(pubkey));
+
+    hydrate_keys_with(&FakeKeyStore::unreachable(), &mut records);
+
+    assert!(!super::key_known_missing(pubkey));
+    let refusal = super::spawn_key_refusal(&records[0]).expect("empty key must refuse");
+    assert!(refusal.contains("keyring may be unreachable"), "{refusal}");
+}
+
+#[test]
+fn a_restored_inline_key_clears_an_earlier_absence() {
+    // The gap this closes: a restore or import puts the key back inline in
+    // managed-agents.json without any keyring read ever succeeding. Nothing
+    // traverses the `Ok(Some(..))` branch, so a mark left by an earlier boot
+    // would survive and keep insisting the identity is gone.
+    let pubkey = "e2e-restored-pubkey";
+    let mut absent = vec![record_with_pubkey_and_key(pubkey, "")];
+    hydrate_keys_with(&FakeKeyStore::reachable(), &mut absent);
+    assert!(super::key_known_missing(pubkey));
+
+    // Keyring still down, so the restored key stays inline (the 0600 fallback).
+    let mut restored = vec![record_with_pubkey_and_key(pubkey, "nsec1restored")];
+    hydrate_keys_with(&FakeKeyStore::unreachable(), &mut restored);
+
+    assert!(
+        !super::key_known_missing(pubkey),
+        "usable inline key material means the key is not missing"
+    );
+}
+
+#[test]
+fn persisting_a_key_clears_an_earlier_absence() {
+    // Same gap on the save side: the key arrives and is written to the keyring
+    // without any read having succeeded first.
+    let pubkey = "e2e-persisted-pubkey";
+    super::note_key_missing(pubkey);
+
+    let mut records = vec![record_with_pubkey_and_key(pubkey, "nsec1fresh")];
+    persist_agent_keys_with(&FakeKeyStore::reachable(), &mut records);
+
+    assert!(!super::key_known_missing(pubkey));
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -830,3 +830,39 @@ fn install_log_filename_accepts_ordinary_runtime_ids() {
         );
     }
 }
+
+#[test]
+fn refusal_names_an_unreadable_keyring_when_the_key_may_still_exist() {
+    // Default and outage case: the keyring did not answer, so the key may be
+    // sitting there behind a locked keychain. Retrying is the right advice.
+    let message = super::key_refusal_message("agentpubkey", false);
+    assert!(message.contains("keyring may be unreachable"), "{message}");
+    assert!(message.contains("retry"), "{message}");
+}
+
+#[test]
+fn refusal_says_the_key_is_gone_when_the_keyring_answered_empty() {
+    // The failure #5837 reports: the keyring was fine and simply had no key,
+    // but the message pointed the user at the keyring. It must not suggest a
+    // retry, and it must say where the key is not (managed-agents.json).
+    let message = super::key_refusal_message("agentpubkey", true);
+    assert!(message.contains("none in the OS keyring"), "{message}");
+    assert!(message.contains("managed-agents.json"), "{message}");
+    assert!(message.contains("recreate the agent"), "{message}");
+    assert!(
+        !message.contains("retry once the keyring is reachable"),
+        "a key the keyring says is absent does not come back on retry: {message}"
+    );
+}
+
+#[test]
+fn a_missing_key_mark_is_cleared_when_the_key_turns_up() {
+    let pubkey = "clearedagentpubkey";
+    super::note_key_missing(pubkey);
+    assert!(super::key_known_missing(pubkey));
+    super::forget_key_missing(pubkey);
+    assert!(
+        !super::key_known_missing(pubkey),
+        "a stale mark would tell the user to recreate an agent whose key is intact"
+    );
+}


### PR DESCRIPTION
Refs #5837 — the diagnosis half.

That issue is three problems in one (single keychain item, no export path, misleading error). This is the last of them, which is also the one that turned a recoverable situation into a wrong-turn: after the keychain item was deleted, every agent refused to start with

> the OS keyring may be unreachable. Refusing to start without an identity; retry once the keyring is reachable.

The keyring was demonstrably fine — the login keychain was unlocked and the app had just written to it during identity recovery. The message sends the user to inspect a working keyring and to retry, when the actual condition is that the key is gone: `managed-agents.json` never carries the secret, so there is nothing left to recover from.

The information exists — `hydrate_keys` sees `Ok(None)` (the keyring answered, no key) versus `Err` (it could not be read) and today throws that distinction away to stderr. Carrying it on `ManagedAgentRecord` would mean a new field on the on-disk format and a change at 27 construction sites, so this keeps a session side table of the pubkeys the keyring answered "no key" for, clears it when the key turns up or the keyring stops answering, and words the refusal from it. The wording function is pure, so both branches are unit-tested — including that the "gone" message does **not** suggest a retry.

Untouched here: the single-item storage layout and the export path the issue also asks for. Both are product decisions about key custody and belong with whoever owns that; this only stops the app from misdescribing what happened.

Verified locally with CI's own gates: `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` clean, `cargo fmt` clean, and the src-tauri lib suite green with the three new tests in `storage_tests.rs`. Not run: deleting a real keychain item to reproduce end to end.
