### PR TITLE
fix(acp): deliver forum mentions under the default subscription

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -222,22 +222,24 @@ Start with **N=2** for most deployments. Increase if queue depth grows under loa
 
 ## Forum Channels
 
-By default, the ACP harness subscribes to stream message kinds (9, 46010, 40007). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
+`subscribe=mentions` subscribes by default to kinds **9, 40002, 45001, 45003, 46010, 40007** — both canonical stream message kinds, forum posts and comments, approval requests and reminders. A forum post or comment that @mentions the agent is therefore delivered with no extra flags.
+
+What still needs opting in is *all* forum traffic — posts and comments that do not mention the agent, and votes (45002), which are never mentions. That means dropping the mention filter:
 
 **CLI flags:**
 ```bash
-buzz-acp --kinds 9,46010,40007,45001,45002,45003 --no-mention-filter
+buzz-acp --kinds 9,40002,46010,40007,45001,45002,45003 --no-mention-filter
 ```
 
 **Or with `--subscribe all`:**
 ```bash
-buzz-acp --subscribe all --kinds 9,46010,40007,45001,45002,45003
+buzz-acp --subscribe all --kinds 9,40002,46010,40007,45001,45002,45003
 ```
 
 **Per-channel config:**
 ```toml
 [channel.CHANNEL_UUID]
-kinds = [9, 46010, 40007, 45001, 45002, 45003]
+kinds = [9, 40002, 46010, 40007, 45001, 45002, 45003]
 require_mention = false
 ```
 
@@ -246,7 +248,9 @@ Forum event kinds:
 - **45002** — Vote on a post or comment
 - **45003** — Comment reply on a forum post
 
-> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
+> **Note:** `--kinds` **replaces** the default list rather than adding to it, so any list you pass must repeat the kinds you still want. Leaving 40002 out of one of these examples is enough to go deaf to direct mentions in v2 stream messages.
+>
+> Without `--no-mention-filter` (or `require_mention = false`), `subscribe=mentions` still filters out events that don't @mention the agent — forum posts addressed to nobody in particular remain invisible.
 
 ## How It Works
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -21,8 +21,9 @@ use std::time::Duration;
 use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -3515,9 +3516,17 @@ fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
 }
 
 /// Event kinds `--subscribe mentions` listens to by default.
+///
+/// A forum channel carries its conversation as kind:45001 posts and kind:45003
+/// comments, not kind:9 — so an agent left on the default subscription was
+/// deaf in exactly the channels built for threaded discussion: it joined, it
+/// showed online, and an `@mention` in a forum post produced no inbound event
+/// at all (#5268).
 fn default_mention_kinds() -> Vec<u32> {
     vec![
         KIND_STREAM_MESSAGE,
+        KIND_FORUM_POST,
+        KIND_FORUM_COMMENT,
         KIND_WORKFLOW_APPROVAL_REQUESTED,
         KIND_STREAM_REMINDER,
     ]
@@ -8685,8 +8694,18 @@ mod observer_payload_trim_tests {
 mod default_mention_kinds_tests {
     use super::default_mention_kinds;
     use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
+
+    #[test]
+    fn mentions_cover_forum_channels() {
+        // A forum channel's conversation is 45001/45003, so leaving them out
+        // makes the default subscription deaf there (#5268).
+        let kinds = default_mention_kinds();
+        assert!(kinds.contains(&KIND_FORUM_POST), "{kinds:?}");
+        assert!(kinds.contains(&KIND_FORUM_COMMENT), "{kinds:?}");
+    }
 
     #[test]
     fn mentions_still_cover_the_stream_kinds_they_always_did() {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2074,13 +2074,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(default_mention_kinds),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,
@@ -3515,6 +3512,15 @@ fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
         t.as_slice().first().map(|s| s.as_str()) == Some("p")
             && t.as_slice().get(1).map(|s| s.as_str()) == Some(agent_pubkey_hex)
     })
+}
+
+/// Event kinds `--subscribe mentions` listens to by default.
+fn default_mention_kinds() -> Vec<u32> {
+    vec![
+        KIND_STREAM_MESSAGE,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_REMINDER,
+    ]
 }
 
 fn is_owner_control_command(
@@ -8672,5 +8678,25 @@ mod observer_payload_trim_tests {
         assert!(leaf.starts_with('…'));
         assert!(leaf.ends_with('…'));
         assert!(leaf.contains("[elided"));
+    }
+}
+
+#[cfg(test)]
+mod default_mention_kinds_tests {
+    use super::default_mention_kinds;
+    use buzz_core::kind::{
+        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    };
+
+    #[test]
+    fn mentions_still_cover_the_stream_kinds_they_always_did() {
+        let kinds = default_mention_kinds();
+        for kind in [
+            KIND_STREAM_MESSAGE,
+            KIND_WORKFLOW_APPROVAL_REQUESTED,
+            KIND_STREAM_REMINDER,
+        ] {
+            assert!(kinds.contains(&kind), "{kind} missing from {kinds:?}");
+        }
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,8 +22,8 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_MEMBER_ADDED_NOTIFICATION,
-    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
-    KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_V2,
+    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -3522,9 +3522,15 @@ fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
 /// deaf in exactly the channels built for threaded discussion: it joined, it
 /// showed online, and an `@mention` in a forum post produced no inbound event
 /// at all (#5268).
+///
+/// The canonical message kinds are 9 *and* 40002; `buzz-db`'s mentions query
+/// (`feed.rs`) selects both alongside the two forum kinds, and this list has
+/// to match it or an agent stays deaf to direct mentions in v2 stream
+/// messages.
 fn default_mention_kinds() -> Vec<u32> {
     vec![
         KIND_STREAM_MESSAGE,
+        KIND_STREAM_MESSAGE_V2,
         KIND_FORUM_POST,
         KIND_FORUM_COMMENT,
         KIND_WORKFLOW_APPROVAL_REQUESTED,
@@ -8694,8 +8700,8 @@ mod observer_payload_trim_tests {
 mod default_mention_kinds_tests {
     use super::default_mention_kinds;
     use buzz_core::kind::{
-        KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
-        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_V2,
+        KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
 
     #[test]
@@ -8717,5 +8723,15 @@ mod default_mention_kinds_tests {
         ] {
             assert!(kinds.contains(&kind), "{kind} missing from {kinds:?}");
         }
+    }
+
+    #[test]
+    fn mentions_cover_both_canonical_message_kinds() {
+        // buzz-db's mentions query selects 9 and 40002 together; a default
+        // that carries only 9 leaves an agent deaf to direct mentions in v2
+        // stream messages.
+        let kinds = default_mention_kinds();
+        assert!(kinds.contains(&KIND_STREAM_MESSAGE), "{kinds:?}");
+        assert!(kinds.contains(&KIND_STREAM_MESSAGE_V2), "{kinds:?}");
     }
 }


### PR DESCRIPTION
Fixes #5268.

An agent started with the default `--subscribe mentions` subscribed to kind:9 stream messages, workflow approval requests and reminders. Forum channels don't use kind:9 — their conversation is kind:45001 posts and kind:45003 comments — so an agent invited to a forum channel joined, logged the subscription and showed online, and then never received an event for an `@mention` there. From the outside it looks like the agent is ignoring you; there's nothing in the log to suggest the mention was filtered out, because it was never delivered in the first place.

Both forum kinds are now in the default list.

- `--kinds` still overrides the default wholesale, so anyone who has narrowed it explicitly is unaffected.
- The three kinds the mode covered before are still covered, and a test asserts that, so a later edit can't quietly narrow it.
- The list moved out of an inline closure in `tokio_main` into `default_mention_kinds()` (first commit, no behaviour change) so it's testable and visible next to the other subscription helpers.

Verified locally on the pinned 1.95.0 toolchain:

- `cargo test -p buzz-acp --lib` — 780 passed (778 before, plus the two new)
- `cargo clippy -p buzz-acp --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Note: I'm an outside contributor, so the workflow runs on this PR will sit at `action_required` until a maintainer approves them; only the DCO check reports on its own.
