### PR TITLE
fix(relay): stop routing audio containers through the video validator

### DIFF
--- a/crates/buzz-media/src/lib.rs
+++ b/crates/buzz-media/src/lib.rs
@@ -27,4 +27,6 @@ pub use upload_record::{
     parse_port, parse_public_ip, upload_record_key, UploadAttribution, UploadNetworkInfo,
     UploadRecord, UPLOAD_RECORD_VERSION,
 };
-pub use validation::{looks_like_iso_bmff, serve_inline, validate_video_file, VideoMeta};
+pub use validation::{
+    looks_like_audio_iso_bmff, looks_like_iso_bmff, serve_inline, validate_video_file, VideoMeta,
+};

--- a/crates/buzz-media/src/lib.rs
+++ b/crates/buzz-media/src/lib.rs
@@ -27,6 +27,4 @@ pub use upload_record::{
     parse_port, parse_public_ip, upload_record_key, UploadAttribution, UploadNetworkInfo,
     UploadRecord, UPLOAD_RECORD_VERSION,
 };
-pub use validation::{
-    looks_like_audio_iso_bmff, looks_like_iso_bmff, serve_inline, validate_video_file, VideoMeta,
-};
+pub use validation::{looks_like_iso_bmff, serve_inline, validate_video_file, VideoMeta};

--- a/crates/buzz-media/src/validation.rs
+++ b/crates/buzz-media/src/validation.rs
@@ -19,6 +19,15 @@ const MP4_BRANDS: &[[u8; 4]] = &[
     *b"mp41", *b"mp42", *b"avc1", *b"dash", *b"M4V ",
 ];
 
+/// ISO-BMFF major brands that declare an audio-only container.
+///
+/// An Apple Voice Memo is `M4A ` with `isom`/`mp42` among its *compatible*
+/// brands, so the compatible-brand list cannot distinguish it from video —
+/// only the major brand can.
+const AUDIO_ONLY_BRANDS: &[[u8; 4]] = &[
+    *b"M4A ", *b"M4B ", *b"M4P ", *b"M4R ", *b"F4A ", *b"F4B ", *b"mp4a",
+];
+
 fn iso_bmff_ftyp_payload(bytes: &[u8]) -> Option<&[u8]> {
     if bytes.len() < 16 || &bytes[4..8] != b"ftyp" {
         return None;
@@ -47,6 +56,21 @@ fn iso_bmff_ftyp_payload(bytes: &[u8]) -> Option<&[u8]> {
 /// `ftyp` box, independent of the request MIME type or `infer`'s brand list.
 pub fn looks_like_iso_bmff(bytes: &[u8]) -> bool {
     iso_bmff_ftyp_payload(bytes).is_some()
+}
+
+/// Return whether the leading bytes are an ISO-BMFF container whose *major*
+/// brand declares audio-only content (`M4A `, `M4B `, …).
+///
+/// Such a file has no video track, so putting it through the video validator
+/// can only fail — and fails with a message about the moov atom that says
+/// nothing about the real problem.
+pub fn looks_like_audio_iso_bmff(bytes: &[u8]) -> bool {
+    let Some(payload) = iso_bmff_ftyp_payload(bytes) else {
+        return false;
+    };
+    payload[..4]
+        .try_into()
+        .is_ok_and(|brand: [u8; 4]| AUDIO_ONLY_BRANDS.contains(&brand))
 }
 
 pub(crate) fn looks_like_mp4_iso_bmff(bytes: &[u8]) -> bool {
@@ -1531,6 +1555,7 @@ mod tests {
         assert!(infer::get(proprietary_major).is_none());
         assert!(looks_like_iso_bmff(proprietary_major));
         assert!(looks_like_mp4_iso_bmff(proprietary_major));
+        assert!(!looks_like_audio_iso_bmff(proprietary_major));
         assert!(
             matches!(validate_file_content(proprietary_major, &config), Err(MediaError::DisallowedContentType(m)) if m == "application/iso-bmff")
         );
@@ -2682,5 +2707,62 @@ mod tests {
         assert!(!serve_inline("application/octet-stream"));
         assert!(!serve_inline("audio/mpeg"));
         assert!(!serve_inline("text/plain"));
+    }
+}
+
+#[cfg(test)]
+mod audio_iso_bmff_tests {
+    use super::{looks_like_audio_iso_bmff, looks_like_iso_bmff};
+
+    /// `ftyp` box: size, "ftyp", major brand, minor version, compatible brands.
+    fn ftyp(major: &[u8; 4], compatible: &[&[u8; 4]]) -> Vec<u8> {
+        let size = 16 + 4 * compatible.len();
+        let mut bytes = (size as u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(major);
+        bytes.extend_from_slice(&0u32.to_be_bytes());
+        for brand in compatible {
+            bytes.extend_from_slice(*brand);
+        }
+        bytes
+    }
+
+    #[test]
+    fn an_apple_voice_memo_is_recognised_as_audio() {
+        // A Voice Memo carries isom/mp42 as *compatible* brands, so only the
+        // major brand tells it apart from video.
+        let memo = ftyp(b"M4A ", &[b"M4A ", b"mp42", b"isom"]);
+        assert!(looks_like_iso_bmff(&memo));
+        assert!(looks_like_audio_iso_bmff(&memo));
+    }
+
+    #[test]
+    fn the_other_apple_audio_brands_are_recognised_too() {
+        for major in [b"M4B ", b"M4P ", b"M4R ", b"F4A ", b"F4B ", b"mp4a"] {
+            let bytes = ftyp(major, &[b"isom"]);
+            assert!(
+                looks_like_audio_iso_bmff(&bytes),
+                "{}",
+                String::from_utf8_lossy(major)
+            );
+        }
+    }
+
+    #[test]
+    fn an_mp4_video_is_not_audio() {
+        for major in [b"isom", b"mp42", b"avc1", b"M4V "] {
+            let bytes = ftyp(major, &[b"isom", b"mp42"]);
+            assert!(
+                !looks_like_audio_iso_bmff(&bytes),
+                "{}",
+                String::from_utf8_lossy(major)
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_iso_bmff_file_is_not_audio() {
+        assert!(!looks_like_audio_iso_bmff(b"\x89PNG\r\n\x1a\n"));
+        assert!(!looks_like_audio_iso_bmff(&[]));
     }
 }

--- a/crates/buzz-media/src/validation.rs
+++ b/crates/buzz-media/src/validation.rs
@@ -19,15 +19,6 @@ const MP4_BRANDS: &[[u8; 4]] = &[
     *b"mp41", *b"mp42", *b"avc1", *b"dash", *b"M4V ",
 ];
 
-/// ISO-BMFF major brands that declare an audio-only container.
-///
-/// An Apple Voice Memo is `M4A ` with `isom`/`mp42` among its *compatible*
-/// brands, so the compatible-brand list cannot distinguish it from video —
-/// only the major brand can.
-const AUDIO_ONLY_BRANDS: &[[u8; 4]] = &[
-    *b"M4A ", *b"M4B ", *b"M4P ", *b"M4R ", *b"F4A ", *b"F4B ", *b"mp4a",
-];
-
 fn iso_bmff_ftyp_payload(bytes: &[u8]) -> Option<&[u8]> {
     if bytes.len() < 16 || &bytes[4..8] != b"ftyp" {
         return None;
@@ -56,21 +47,6 @@ fn iso_bmff_ftyp_payload(bytes: &[u8]) -> Option<&[u8]> {
 /// `ftyp` box, independent of the request MIME type or `infer`'s brand list.
 pub fn looks_like_iso_bmff(bytes: &[u8]) -> bool {
     iso_bmff_ftyp_payload(bytes).is_some()
-}
-
-/// Return whether the leading bytes are an ISO-BMFF container whose *major*
-/// brand declares audio-only content (`M4A `, `M4B `, …).
-///
-/// Such a file has no video track, so putting it through the video validator
-/// can only fail — and fails with a message about the moov atom that says
-/// nothing about the real problem.
-pub fn looks_like_audio_iso_bmff(bytes: &[u8]) -> bool {
-    let Some(payload) = iso_bmff_ftyp_payload(bytes) else {
-        return false;
-    };
-    payload[..4]
-        .try_into()
-        .is_ok_and(|brand: [u8; 4]| AUDIO_ONLY_BRANDS.contains(&brand))
 }
 
 pub(crate) fn looks_like_mp4_iso_bmff(bytes: &[u8]) -> bool {
@@ -323,11 +299,6 @@ pub fn validate_content(bytes: &[u8], config: &MediaConfig) -> Result<String, Me
 ///
 /// Returns [`VideoMeta`] on success.
 pub fn validate_video_file(path: &Path, config: &MediaConfig) -> Result<VideoMeta, MediaError> {
-    // --- moov-before-mdat check (raw byte scan) ---
-    // We scan the top-level atom sequence before handing off to the mp4 crate,
-    // because the mp4 crate parses the whole file regardless of atom order.
-    check_moov_before_mdat(path)?;
-
     let file = std::fs::File::open(path).map_err(|e| MediaError::Io(e.to_string()))?;
     let size = file
         .metadata()
@@ -342,8 +313,6 @@ pub fn validate_video_file(path: &Path, config: &MediaConfig) -> Result<VideoMet
         });
     }
 
-    validate_mp4_metadata_free(path)?;
-
     let reader = BufReader::new(file);
     let mp4 = mp4::Mp4Reader::read_header(reader, size).map_err(|_| MediaError::InvalidVideo)?;
 
@@ -355,6 +324,41 @@ pub fn validate_video_file(path: &Path, config: &MediaConfig) -> Result<VideoMet
     if *brand == qt_brand {
         return Err(MediaError::UnsupportedContainer);
     }
+
+    // --- Classification ---
+    // What the container actually holds is decided from its parsed track
+    // types, never from the ftyp brand. `M4A `/`M4B ` are registered as iTunes
+    // MPEG-4 *audio* brands but are permitted to carry video, chapter and text
+    // tracks too, so the brand cannot answer this question — an `M4A `-branded
+    // file with a real video track is a video and is validated as one.
+    //
+    // This runs before the fast-start and metadata-free checks because both are
+    // video-only requirements. An audio-only container fails moov-before-mdat
+    // whenever it was not written fast-start — which a Voice Memo never is —
+    // and the resulting "moov atom not at front of file" says nothing about the
+    // real problem, which is that audio uploads are not supported at all.
+    let mut has_video = false;
+    let mut has_audio_track = false;
+    for track in mp4.tracks().values() {
+        match track.track_type().map_err(|_| MediaError::InvalidVideo)? {
+            mp4::TrackType::Video => has_video = true,
+            mp4::TrackType::Audio => has_audio_track = true,
+            _ => {}
+        }
+    }
+    if !has_video {
+        return Err(if has_audio_track {
+            MediaError::DisallowedContentType("audio/mp4".to_string())
+        } else {
+            MediaError::InvalidVideo
+        });
+    }
+
+    // --- Video-only requirements ---
+    // The moov scan reads the top-level atom sequence directly, because the mp4
+    // crate parses the whole file regardless of atom order.
+    check_moov_before_mdat(path)?;
+    validate_mp4_metadata_free(path)?;
 
     // --- Track inspection ---
     let mut video_meta: Option<VideoMeta> = None;
@@ -425,13 +429,9 @@ pub fn validate_video_file(path: &Path, config: &MediaConfig) -> Result<VideoMet
         }
     }
 
-    let mut meta = video_meta.ok_or_else(|| {
-        if has_audio {
-            MediaError::DisallowedContentType("audio/mp4".to_string())
-        } else {
-            MediaError::InvalidVideo
-        }
-    })?;
+    // Classification above already established there is a video track, so this
+    // is unreachable in practice; it stays as a total match rather than a panic.
+    let mut meta = video_meta.ok_or(MediaError::InvalidVideo)?;
     meta.has_audio = has_audio;
     Ok(meta)
 }
@@ -1555,7 +1555,6 @@ mod tests {
         assert!(infer::get(proprietary_major).is_none());
         assert!(looks_like_iso_bmff(proprietary_major));
         assert!(looks_like_mp4_iso_bmff(proprietary_major));
-        assert!(!looks_like_audio_iso_bmff(proprietary_major));
         assert!(
             matches!(validate_file_content(proprietary_major, &config), Err(MediaError::DisallowedContentType(m)) if m == "application/iso-bmff")
         );
@@ -1713,6 +1712,61 @@ mod tests {
     /// Build an MP4 with audio track.
     fn build_mp4_with_audio() -> Vec<u8> {
         build_mp4_bytes(true, b"avc1", 1_000, 320, 240, true)
+    }
+
+    /// Overwrite the ftyp major brand of an MP4 built by `build_mp4_bytes`.
+    fn with_major_brand(mut bytes: Vec<u8>, brand: &[u8; 4]) -> Vec<u8> {
+        bytes[8..12].copy_from_slice(brand);
+        bytes
+    }
+
+    /// Build an audio-only MP4: one AAC track, no video track.
+    ///
+    /// `fast_start == false` reproduces an Apple Voice Memo, which writes mdat
+    /// before moov.
+    fn build_audio_only_mp4(fast_start: bool) -> Vec<u8> {
+        let timescale: u32 = 1000;
+        let duration: u32 = 1_000;
+
+        let ftyp = {
+            let mut b = Vec::new();
+            b.extend_from_slice(&20u32.to_be_bytes());
+            b.extend_from_slice(b"ftyp");
+            b.extend_from_slice(b"M4A ");
+            b.extend_from_slice(&0u32.to_be_bytes());
+            b.extend_from_slice(b"isom");
+            b
+        };
+        let mdat = {
+            let mut b = Vec::new();
+            b.extend_from_slice(&8u32.to_be_bytes());
+            b.extend_from_slice(b"mdat");
+            b
+        };
+
+        // Same mvhd as build_moov, then an audio trak and nothing else.
+        let full = build_mp4_bytes(true, b"avc1", duration, 320, 240, false);
+        let mvhd = {
+            const FTYP_SIZE: usize = 20;
+            let moov_start = FTYP_SIZE + 8;
+            let mvhd_size =
+                u32::from_be_bytes(full[moov_start..moov_start + 4].try_into().unwrap()) as usize;
+            full[moov_start..moov_start + mvhd_size].to_vec()
+        };
+
+        let mut moov_payload = mvhd;
+        moov_payload.extend_from_slice(&build_audio_trak(1, duration, timescale));
+        let moov = box_wrap(b"moov", &moov_payload);
+
+        let mut out = ftyp;
+        if fast_start {
+            out.extend_from_slice(&moov);
+            out.extend_from_slice(&mdat);
+        } else {
+            out.extend_from_slice(&mdat);
+            out.extend_from_slice(&moov);
+        }
+        out
     }
 
     /// Insert a child box at the end of the top-level `moov` box.
@@ -2358,6 +2412,61 @@ mod tests {
     }
 
     #[test]
+    fn an_audio_only_container_is_reported_as_audio_not_as_a_moov_problem() {
+        // An Apple Voice Memo: one AAC track, no video, and mdat before moov
+        // because it was never written fast-start. The fast-start check used to
+        // run first and answered "moov atom not at front of file" — a detail
+        // about a requirement that does not apply to a file with no video in
+        // it. Classifying from the parsed tracks first gives the real answer.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), build_audio_only_mp4(false)).unwrap();
+        assert!(
+            matches!(
+                validate_video_file(tmp.path(), &test_config()),
+                Err(MediaError::DisallowedContentType(ref m)) if m == "audio/mp4"
+            ),
+            "got {:?}",
+            validate_video_file(tmp.path(), &test_config())
+        );
+    }
+
+    #[test]
+    fn a_fast_start_audio_only_container_is_also_reported_as_audio() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), build_audio_only_mp4(true)).unwrap();
+        assert!(matches!(
+            validate_video_file(tmp.path(), &test_config()),
+            Err(MediaError::DisallowedContentType(ref m)) if m == "audio/mp4"
+        ));
+    }
+
+    #[test]
+    fn an_audio_branded_file_that_holds_video_is_still_accepted() {
+        // MP4RA registers `M4A ` as an iTunes audio brand, but the brand is a
+        // compatibility declaration and does not forbid a video track. Rejecting
+        // on the brand would throw away a valid video.
+        let bytes = with_major_brand(build_minimal_mp4_moov_first(), b"M4A ");
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), bytes).unwrap();
+        let meta = validate_video_file(tmp.path(), &test_config())
+            .expect("an M4A-branded file with a video track is a video");
+        assert_eq!((meta.width, meta.height), (320, 240));
+    }
+
+    #[test]
+    fn an_audio_branded_file_that_holds_video_still_needs_fast_start() {
+        // The video-only requirements are not skipped for such a file — they
+        // are only deferred until the tracks say it is a video.
+        let bytes = with_major_brand(build_minimal_mp4_mdat_first(), b"M4A ");
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), bytes).unwrap();
+        assert!(matches!(
+            validate_video_file(tmp.path(), &test_config()),
+            Err(MediaError::MoovNotAtFront)
+        ));
+    }
+
+    #[test]
     fn test_accepts_exact_empty_ffmpeg_udta() {
         let empty_ffmpeg_udta = hex::decode(
             "000000356d657461000000000000002168646c7200000000000000006d6469726170706c00000000000000000000000008696c7374",
@@ -2707,62 +2816,5 @@ mod tests {
         assert!(!serve_inline("application/octet-stream"));
         assert!(!serve_inline("audio/mpeg"));
         assert!(!serve_inline("text/plain"));
-    }
-}
-
-#[cfg(test)]
-mod audio_iso_bmff_tests {
-    use super::{looks_like_audio_iso_bmff, looks_like_iso_bmff};
-
-    /// `ftyp` box: size, "ftyp", major brand, minor version, compatible brands.
-    fn ftyp(major: &[u8; 4], compatible: &[&[u8; 4]]) -> Vec<u8> {
-        let size = 16 + 4 * compatible.len();
-        let mut bytes = (size as u32).to_be_bytes().to_vec();
-        bytes.extend_from_slice(b"ftyp");
-        bytes.extend_from_slice(major);
-        bytes.extend_from_slice(&0u32.to_be_bytes());
-        for brand in compatible {
-            bytes.extend_from_slice(*brand);
-        }
-        bytes
-    }
-
-    #[test]
-    fn an_apple_voice_memo_is_recognised_as_audio() {
-        // A Voice Memo carries isom/mp42 as *compatible* brands, so only the
-        // major brand tells it apart from video.
-        let memo = ftyp(b"M4A ", &[b"M4A ", b"mp42", b"isom"]);
-        assert!(looks_like_iso_bmff(&memo));
-        assert!(looks_like_audio_iso_bmff(&memo));
-    }
-
-    #[test]
-    fn the_other_apple_audio_brands_are_recognised_too() {
-        for major in [b"M4B ", b"M4P ", b"M4R ", b"F4A ", b"F4B ", b"mp4a"] {
-            let bytes = ftyp(major, &[b"isom"]);
-            assert!(
-                looks_like_audio_iso_bmff(&bytes),
-                "{}",
-                String::from_utf8_lossy(major)
-            );
-        }
-    }
-
-    #[test]
-    fn an_mp4_video_is_not_audio() {
-        for major in [b"isom", b"mp42", b"avc1", b"M4V "] {
-            let bytes = ftyp(major, &[b"isom", b"mp42"]);
-            assert!(
-                !looks_like_audio_iso_bmff(&bytes),
-                "{}",
-                String::from_utf8_lossy(major)
-            );
-        }
-    }
-
-    #[test]
-    fn a_non_iso_bmff_file_is_not_audio() {
-        assert!(!looks_like_audio_iso_bmff(b"\x89PNG\r\n\x1a\n"));
-        assert!(!looks_like_audio_iso_bmff(&[]));
     }
 }

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -48,16 +48,14 @@ enum UploadRouteMode {
 
 /// Whether an upload should take the streaming video path.
 ///
-/// An audio-only container is excluded even though it is ISO-BMFF: it has no
-/// video track, so the video validator can only reject it — and it rejects a
-/// normal (non-fast-start) voice memo with "moov atom not at front of file",
-/// a 422 about a detail the user cannot act on. Sending it down the generic
-/// path instead produces the honest answer, `415 disallowed content type:
-/// audio/m4a`, which is what audio support actually being absent looks like.
+/// Every ISO-BMFF container does, including one whose major brand says audio.
+/// A brand is a compatibility declaration, not an inventory: MP4RA registers
+/// `M4A `/`M4B ` as iTunes audio brands that may still carry video, chapter
+/// and text tracks. Routing on the brand would send a genuine video down the
+/// generic path to be rejected as audio. The validator classifies from parsed
+/// track types instead, and answers `415 audio/mp4` for a container that turns
+/// out to hold no video.
 fn should_stream_as_video(sniff: &[u8]) -> bool {
-    if buzz_media::looks_like_audio_iso_bmff(sniff) {
-        return false;
-    }
     infer::get(sniff).is_some_and(|kind| kind.mime_type() == "video/mp4")
         || buzz_media::looks_like_iso_bmff(sniff)
 }
@@ -1004,12 +1002,14 @@ mod tests {
     }
 
     #[test]
-    fn audio_only_container_does_not_use_video_pipeline() {
-        // An Apple Voice Memo: major brand M4A, but isom/mp42 among its
-        // compatible brands, which is why it used to read as video.
+    fn an_audio_branded_container_stays_on_the_bounded_video_path() {
+        // An Apple Voice Memo is major brand `M4A `. It must still reach the
+        // validator: the brand does not rule out a video track, and only the
+        // parsed tracks can say. Routing it away here would reject a
+        // video-bearing `M4A ` file on its compatibility declaration alone.
         let memo = ftyp(b"M4A ", &[b"M4A ", b"mp42", b"isom"]);
         assert!(buzz_media::looks_like_iso_bmff(&memo));
-        assert!(!should_stream_as_video(&memo));
+        assert!(should_stream_as_video(&memo));
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -46,7 +46,18 @@ enum UploadRouteMode {
     LegacyMedia,
 }
 
+/// Whether an upload should take the streaming video path.
+///
+/// An audio-only container is excluded even though it is ISO-BMFF: it has no
+/// video track, so the video validator can only reject it — and it rejects a
+/// normal (non-fast-start) voice memo with "moov atom not at front of file",
+/// a 422 about a detail the user cannot act on. Sending it down the generic
+/// path instead produces the honest answer, `415 disallowed content type:
+/// audio/m4a`, which is what audio support actually being absent looks like.
 fn should_stream_as_video(sniff: &[u8]) -> bool {
+    if buzz_media::looks_like_audio_iso_bmff(sniff) {
+        return false;
+    }
     infer::get(sniff).is_some_and(|kind| kind.mime_type() == "video/mp4")
         || buzz_media::looks_like_iso_bmff(sniff)
 }
@@ -977,6 +988,34 @@ mod tests {
             upload_route_mode("/media"),
             Err(MediaError::NotFound)
         ));
+    }
+
+    /// `ftyp` box: size, "ftyp", major brand, minor version, compatible brands.
+    fn ftyp(major: &[u8; 4], compatible: &[&[u8; 4]]) -> Vec<u8> {
+        let size = 16 + 4 * compatible.len();
+        let mut bytes = (size as u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(b"ftyp");
+        bytes.extend_from_slice(major);
+        bytes.extend_from_slice(&0u32.to_be_bytes());
+        for brand in compatible {
+            bytes.extend_from_slice(*brand);
+        }
+        bytes
+    }
+
+    #[test]
+    fn audio_only_container_does_not_use_video_pipeline() {
+        // An Apple Voice Memo: major brand M4A, but isom/mp42 among its
+        // compatible brands, which is why it used to read as video.
+        let memo = ftyp(b"M4A ", &[b"M4A ", b"mp42", b"isom"]);
+        assert!(buzz_media::looks_like_iso_bmff(&memo));
+        assert!(!should_stream_as_video(&memo));
+    }
+
+    #[test]
+    fn mp4_video_still_uses_video_pipeline() {
+        let video = ftyp(b"isom", &[b"isom", b"mp42", b"avc1"]);
+        assert!(should_stream_as_video(&video));
     }
 
     #[test]


### PR DESCRIPTION
Addresses the first "minimum safe behavior" bullet of #5752 — the misleading error. It does not add audio support.

`should_stream_as_video` routed every ISO-BMFF container into the streaming video path. An M4A voice memo is ISO-BMFF, so an Apple Voice Memo reached `validate_video_file` and a normal (non-fast-start) recording died in `check_moov_before_mdat` with:

```
422 moov atom not at front of file (not fast-start)
```

That names an internal layout detail the user can do nothing about, and it isn't even the real obstacle — the same validator goes on to require a video track, which an audio-only file will never have. Rewriting the container to put `moov` first would move the failure, not fix it.

Audio-branded containers now take the generic file path, which already refuses audio explicitly, so the answer becomes:

```
415 disallowed content type: audio/m4a
```

That is what "Buzz has no audio pipeline yet" honestly looks like, and 415 is the correct status for it.

**Why a new predicate.** Nothing existing could tell the two apart. `looks_like_iso_bmff` is true for both, and `looks_like_mp4_iso_bmff` consults the *compatible* brand list — where an Apple Voice Memo carries `isom` and `mp42`, so it reads as MP4. Only the **major** brand declares what the container actually holds, which is what `looks_like_audio_iso_bmff` (first commit) reads.

Video routing is unchanged, including the proprietary-major-brand case the existing `proprietary_iso_bmff_brand_still_uses_video_pipeline` test pins.

Left for the follow-up the issue also asks for: the actual audio pipeline (remux/sanitize/strip metadata), and the mobile-side `PathNotFoundException` on retry, which is a Flutter change I can't run the suite for locally.

Verified locally on the pinned 1.95.0 toolchain:

- `cargo test -p buzz-media --lib` — **121 passed, 0 failed** (117 before, plus the 4 new)
- `cargo test -p buzz-relay --lib api::media` — 29 passed, plus the 2 new; the 6 failures there are pre-existing and identical on `main` (they need a database), and `buzz-relay` is not among the crates `just test-unit` runs
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Note: I'm an outside contributor, so the workflow runs here sit at `action_required` until a maintainer approves them; only the DCO check reports on its own.
