### PR TITLE
fix(desktop): tag and render a mention picked after a bracket

### DIFF
--- a/desktop/src/features/messages/lib/hasMention.test.mjs
+++ b/desktop/src/features/messages/lib/hasMention.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getMentionOffsets, hasMention } from "./hasMention.ts";
+
+test("a possessive still mentions the person", () => {
+  // The send path derives the event's p tags from these offsets, so a miss
+  // here means no notification — not merely an unstyled name.
+  assert.equal(hasMention("@Alice's PR is ready", "Alice"), true);
+  assert.equal(hasMention("ping @Alice's bot", "Alice"), true);
+});
+
+test("the curly apostrophe macOS substitutes counts too", () => {
+  assert.equal(hasMention("@Alice’s PR is ready", "Alice"), true);
+});
+
+test("a mention is found at the start, after whitespace, and after '('", () => {
+  assert.equal(hasMention("@Alice hi", "Alice"), true);
+  assert.equal(hasMention("hi @Alice", "Alice"), true);
+  assert.equal(hasMention("(@Alice)", "Alice"), true);
+});
+
+test("closing punctuation still ends a mention", () => {
+  for (const text of ["@Alice, ok", "@Alice.", "@Alice!", "@Alice?"]) {
+    assert.equal(hasMention(text, "Alice"), true, text);
+  }
+});
+
+test("bold and spoiler wrappers still mention", () => {
+  assert.equal(hasMention("**@Alice**", "Alice"), true);
+  assert.equal(hasMention("||@Alice||", "Alice"), true);
+});
+
+test("an email address is not a mention of its domain", () => {
+  assert.equal(hasMention("mail me at bob@Alice.dev", "Alice"), false);
+});
+
+test("a mention inside code is not a mention", () => {
+  assert.equal(hasMention("`@Alice`", "Alice"), false);
+  assert.equal(hasMention("```\n@Alice\n```", "Alice"), false);
+});
+
+test("matching is case-insensitive", () => {
+  assert.equal(hasMention("@alice hi", "Alice"), true);
+});
+
+test("every occurrence gets an offset, in order", () => {
+  assert.deepEqual(
+    getMentionOffsets("@Alice and @Alice's team", "Alice"),
+    [0, 11],
+  );
+});
+
+test("no mention yields no offsets", () => {
+  assert.deepEqual(getMentionOffsets("nothing here", "Alice"), []);
+});

--- a/desktop/src/features/messages/lib/hasMention.test.mjs
+++ b/desktop/src/features/messages/lib/hasMention.test.mjs
@@ -54,3 +54,16 @@ test("every occurrence gets an offset, in order", () => {
 test("no mention yields no offsets", () => {
   assert.deepEqual(getMentionOffsets("nothing here", "Alice"), []);
 });
+
+test("a bracket opens a mention, matching what autocomplete accepts", () => {
+  // `detectPrefixQuery` fires an autocomplete after `(`, `[` and `{`, so a
+  // name picked there has to be tagged — otherwise the pick silently
+  // produces no p tag.
+  for (const text of ["(@Alice", "[@Alice", "{@Alice"]) {
+    assert.equal(hasMention(text, "Alice"), true, text);
+  }
+});
+
+test("an ordinary character before the @ still opens nothing", () => {
+  assert.equal(hasMention("x@Alice", "Alice"), false);
+});

--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -138,12 +138,17 @@ function maskMarkdownCode(text: string): string {
  * chat area and TipTap's Bold extension wraps it in bold marks (font-weight >=
  * 500 -> bold), plus messages whose visible mention text is spoilered.
  *
+ * The mention must be followed by whitespace, closing punctuation, a spoiler
+ * delimiter, an apostrophe, or end-of-string. The apostrophe — straight and
+ * the curly U+2019 that macOS substitutes as you type — is what makes the
+ * possessive `@Alice's PR` a mention of Alice rather than of nobody.
+ *
  * Exported separately so it can be unit-tested without importing React.
  */
 export function getMentionOffsets(text: string, name: string): number[] {
   const escaped = escapeRegExp(name);
   const pattern = new RegExp(
-    `(^|\\s|\\(|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_]|$)`,
+    `(^|\\s|\\(|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_'\u2019]|$)`,
     "gi",
   );
   const maskedText = maskMarkdownCode(text);

--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -132,7 +132,8 @@ function maskMarkdownCode(text: string): string {
  * Check whether `text` contains an @mention of `name`.
  *
  * Matches `@Name` preceded by start-of-string, whitespace, an opening
- * parenthesis (for team expansions), markdown
+ * bracket of any kind — `(`, `[`, `{`, which is exactly what
+ * `detectPrefixQuery` lets open an autocomplete query — markdown
  * bold/italic markers (`*`, `**`, `***`, `_`, `__`, `___`), or spoiler
  * delimiters (`||`). This handles the case where a mention is pasted from the
  * chat area and TipTap's Bold extension wraps it in bold marks (font-weight >=
@@ -148,7 +149,7 @@ function maskMarkdownCode(text: string): string {
 export function getMentionOffsets(text: string, name: string): number[] {
   const escaped = escapeRegExp(name);
   const pattern = new RegExp(
-    `(^|\\s|\\(|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_'\u2019]|$)`,
+    `(^|\\s|[([{]|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_'\u2019]|$)`,
     "gi",
   );
   const maskedText = maskMarkdownCode(text);

--- a/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
+++ b/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
@@ -16,23 +16,38 @@ type NodeBuilderResult = Node | { node: Node; trailing?: string };
 type NodeBuilder = (matchText: string) => NodeBuilderResult;
 
 /**
+ * `leadGroup` names a capture group holding a leading boundary character that
+ * the pattern had to consume to assert one (WebKit before Safari 16.4 fails to
+ * *parse* lookbehind, blanking the whole app, so patterns capture instead).
+ * Its text is emitted back as plain text and is not part of the built node.
+ */
+type PrefixPluginOptions = { leadGroup?: number };
+
+/**
  * Create a remark plugin that walks the tree, finds regex matches in text
  * nodes, and replaces each match with a node produced by `buildNode`.
  */
 export function createRemarkPrefixPlugin(
   pattern: RegExp,
   buildNode: NodeBuilder,
+  options?: PrefixPluginOptions,
 ) {
+  const leadGroup = options?.leadGroup;
   return (
     // biome-ignore lint/suspicious/noExplicitAny: remark tree types are not available
     tree: any,
   ) => {
-    walkChildren(tree, pattern, buildNode);
+    walkChildren(tree, pattern, buildNode, leadGroup);
   };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: remark tree types are not available
-function walkChildren(node: any, pattern: RegExp, buildNode: NodeBuilder) {
+function walkChildren(
+  node: any,
+  pattern: RegExp,
+  buildNode: NodeBuilder,
+  leadGroup?: number,
+) {
   if (
     !node?.children ||
     !Array.isArray(node.children) ||
@@ -45,7 +60,7 @@ function walkChildren(node: any, pattern: RegExp, buildNode: NodeBuilder) {
     const child = node.children[i];
 
     if (child.type === "text") {
-      const parts = splitByPattern(child.value, pattern, buildNode);
+      const parts = splitByPattern(child.value, pattern, buildNode, leadGroup);
       if (
         parts.length > 1 ||
         (parts.length === 1 && parts[0].type !== "text")
@@ -53,7 +68,7 @@ function walkChildren(node: any, pattern: RegExp, buildNode: NodeBuilder) {
         node.children.splice(i, 1, ...parts);
       }
     } else {
-      walkChildren(child, pattern, buildNode);
+      walkChildren(child, pattern, buildNode, leadGroup);
     }
   }
 }
@@ -65,7 +80,12 @@ function shouldSkipNode(node: any): boolean {
   );
 }
 
-function splitByPattern(text: string, pattern: RegExp, buildNode: NodeBuilder) {
+function splitByPattern(
+  text: string,
+  pattern: RegExp,
+  buildNode: NodeBuilder,
+  leadGroup?: number,
+) {
   // Reset lastIndex — the pattern is reused across text nodes with the `g` flag
   pattern.lastIndex = 0;
   // biome-ignore lint/suspicious/noExplicitAny: building mdast-compatible nodes
@@ -79,11 +99,15 @@ function splitByPattern(text: string, pattern: RegExp, buildNode: NodeBuilder) {
       break;
     }
 
-    if (match.index > lastIndex) {
-      parts.push({ type: "text", value: text.slice(lastIndex, match.index) });
+    const lead = leadGroup === undefined ? "" : (match[leadGroup] ?? "");
+    const matchStart = match.index + lead.length;
+    if (matchStart > lastIndex) {
+      parts.push({ type: "text", value: text.slice(lastIndex, matchStart) });
     }
 
-    const result = normalizeBuildNodeResult(buildNode(match[0]));
+    const result = normalizeBuildNodeResult(
+      buildNode(match[0].slice(lead.length)),
+    );
     parts.push(result.node);
     if (result.trailing) {
       parts.push({ type: "text", value: result.trailing });

--- a/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
+++ b/desktop/src/shared/lib/createRemarkPrefixPlugin.ts
@@ -41,8 +41,8 @@ export function createRemarkPrefixPlugin(
   };
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: remark tree types are not available
 function walkChildren(
+  // biome-ignore lint/suspicious/noExplicitAny: remark tree types are not available
   node: any,
   pattern: RegExp,
   buildNode: NodeBuilder,

--- a/desktop/src/shared/lib/mentionPattern.test.mjs
+++ b/desktop/src/shared/lib/mentionPattern.test.mjs
@@ -78,3 +78,13 @@ test("the generic channel fallback also requires a leading boundary", () => {
   ]);
   assert.deepEqual(matches(pattern, "issue-42#general"), []);
 });
+
+test("a possessive apostrophe closes a mention, so it still renders", () => {
+  const pattern = buildMentionPattern(["alice"]);
+  assert.deepEqual(matches(pattern, "@alice's PR"), [
+    { text: "@alice", index: 0 },
+  ]);
+  assert.deepEqual(matches(pattern, "@alice’s PR"), [
+    { text: "@alice", index: 0 },
+  ]);
+});

--- a/desktop/src/shared/lib/mentionPattern.test.mjs
+++ b/desktop/src/shared/lib/mentionPattern.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildMentionPattern,
+  buildPrefixPattern,
+  PREFIX_LEAD_GROUP,
+} from "./mentionPattern.ts";
+
+/** All matches, with the leading boundary stripped the way the plugin does. */
+function matches(pattern, text) {
+  pattern.lastIndex = 0;
+  const found = [];
+  let match = pattern.exec(text);
+  while (match) {
+    const lead = match[PREFIX_LEAD_GROUP] ?? "";
+    found.push({
+      text: match[0].slice(lead.length),
+      index: match.index + lead.length,
+    });
+    match = pattern.exec(text);
+  }
+  return found;
+}
+
+test("a mention is matched at the start of the text", () => {
+  const pattern = buildMentionPattern(["alice"]);
+  assert.deepEqual(matches(pattern, "@alice hi"), [
+    { text: "@alice", index: 0 },
+  ]);
+});
+
+test("a mention is matched after whitespace and after an opening paren", () => {
+  const pattern = buildMentionPattern(["alice"]);
+  assert.deepEqual(matches(pattern, "hi @alice"), [
+    { text: "@alice", index: 3 },
+  ]);
+  assert.deepEqual(matches(pattern, "hi (@alice)"), [
+    { text: "@alice", index: 4 },
+  ]);
+});
+
+test("an email address is not a mention of its domain", () => {
+  // "@alice" here is part of bob@alice.dev — the composer's own highlighter
+  // draws the boundary in the same place, so the rendered message should too.
+  const pattern = buildMentionPattern(["alice"]);
+  assert.deepEqual(matches(pattern, "mail me at bob@alice.dev"), []);
+});
+
+test("the boundary does not eat the space between two adjacent mentions", () => {
+  const pattern = buildMentionPattern(["alice", "bob"]);
+  assert.deepEqual(matches(pattern, "@alice @bob"), [
+    { text: "@alice", index: 0 },
+    { text: "@bob", index: 7 },
+  ]);
+});
+
+test("longest known name still wins over a shorter prefix of it", () => {
+  const pattern = buildMentionPattern(["ali", "alice"]);
+  assert.deepEqual(matches(pattern, "hi @alice"), [
+    { text: "@alice", index: 3 },
+  ]);
+});
+
+test("unknown names are not matched", () => {
+  const pattern = buildMentionPattern(["alice"]);
+  assert.deepEqual(matches(pattern, "hi @carol"), []);
+});
+
+test("with no known names the mention pattern never matches", () => {
+  assert.deepEqual(matches(buildMentionPattern([]), "hi @alice"), []);
+});
+
+test("the generic channel fallback also requires a leading boundary", () => {
+  const pattern = buildPrefixPattern("#", [], { fallbackToGeneric: true });
+  assert.deepEqual(matches(pattern, "see #general"), [
+    { text: "#general", index: 4 },
+  ]);
+  assert.deepEqual(matches(pattern, "issue-42#general"), []);
+});

--- a/desktop/src/shared/lib/mentionPattern.test.mjs
+++ b/desktop/src/shared/lib/mentionPattern.test.mjs
@@ -88,3 +88,14 @@ test("a possessive apostrophe closes a mention, so it still renders", () => {
     { text: "@alice", index: 0 },
   ]);
 });
+
+test("a bracket opens a mention, matching what autocomplete accepts", () => {
+  const pattern = buildMentionPattern(["alice"]);
+  for (const [text, index] of [
+    ["(@alice)", 1],
+    ["[@alice]", 1],
+    ["{@alice}", 1],
+  ]) {
+    assert.deepEqual(matches(pattern, text), [{ text: "@alice", index }], text);
+  }
+});

--- a/desktop/src/shared/lib/mentionPattern.ts
+++ b/desktop/src/shared/lib/mentionPattern.ts
@@ -8,6 +8,26 @@ export function escapeRegExp(str: string): string {
 const NEVER_MATCH = /(?!)/gi;
 
 /**
+ * Capture index of the leading boundary character in a pattern built by
+ * {@link buildPrefixPattern} — pass it to `createRemarkPrefixPlugin` as
+ * `leadGroup` so the character is re-emitted as text rather than swallowed
+ * into the mention.
+ */
+export const PREFIX_LEAD_GROUP = 1;
+
+/**
+ * A prefix only opens a mention or channel link at the start of the text or
+ * after whitespace or an opening paren — `bob@alice.dev` is an address, not a
+ * mention of `@alice`, and the composer's own highlighter already draws the
+ * line in the same place.
+ *
+ * The boundary is a capture group rather than a lookbehind on purpose: WebKit
+ * before Safari 16.4 fails to parse lookbehind and blanks the whole app
+ * (#5547).
+ */
+const LEADING_BOUNDARY = "(^|[\\s(])";
+
+/**
  * Build a regex that matches a given prefix followed by known multi-word names
  * (longest-first to avoid partial matches). When known names are provided,
  * only those names are matched — no generic fallback.
@@ -33,14 +53,17 @@ export function buildPrefixPattern(
 
   if (sorted.length === 0) {
     if (options?.fallbackToGeneric) {
-      return new RegExp(`${escapedPrefix}\\S+`, "gi");
+      return new RegExp(`${LEADING_BOUNDARY}${escapedPrefix}\\S+`, "gi");
     }
     return NEVER_MATCH;
   }
 
   const nameAlternatives = sorted.map((name) => escapeRegExp(name)).join("|");
   const boundary = "(?=[\\s,;.!?:)\\]}]|$)";
-  return new RegExp(`${escapedPrefix}(?:${nameAlternatives})${boundary}`, "gi");
+  return new RegExp(
+    `${LEADING_BOUNDARY}${escapedPrefix}(?:${nameAlternatives})${boundary}`,
+    "gi",
+  );
 }
 
 /**

--- a/desktop/src/shared/lib/mentionPattern.ts
+++ b/desktop/src/shared/lib/mentionPattern.ts
@@ -17,15 +17,16 @@ export const PREFIX_LEAD_GROUP = 1;
 
 /**
  * A prefix only opens a mention or channel link at the start of the text or
- * after whitespace or an opening paren — `bob@alice.dev` is an address, not a
- * mention of `@alice`, and the composer's own highlighter already draws the
- * line in the same place.
+ * after whitespace or an opening bracket — `bob@alice.dev` is an address, not
+ * a mention of `@alice`. The bracket set matches `detectPrefixQuery`, which
+ * decides what opens an autocomplete query, so a name picked from the
+ * autocomplete always renders as the mention it was tagged as.
  *
  * The boundary is a capture group rather than a lookbehind on purpose: WebKit
  * before Safari 16.4 fails to parse lookbehind and blanks the whole app
  * (#5547).
  */
-const LEADING_BOUNDARY = "(^|[\\s(])";
+const LEADING_BOUNDARY = "(^|[\\s([{])";
 
 /**
  * Build a regex that matches a given prefix followed by known multi-word names

--- a/desktop/src/shared/lib/mentionPattern.ts
+++ b/desktop/src/shared/lib/mentionPattern.ts
@@ -59,7 +59,11 @@ export function buildPrefixPattern(
   }
 
   const nameAlternatives = sorted.map((name) => escapeRegExp(name)).join("|");
-  const boundary = "(?=[\\s,;.!?:)\\]}]|$)";
+  // A possessive still mentions the person, so the apostrophe closes a
+  // mention — both the straight one and the curly U+2019 that macOS
+  // substitutes while you type. `hasMention` (which decides the p-tag) uses
+  // the same set; the two must agree or a tagged mention renders unstyled.
+  const boundary = "(?=[\\s,;.!?:)\\]}'\u2019]|$)";
   return new RegExp(
     `${LEADING_BOUNDARY}${escapedPrefix}(?:${nameAlternatives})${boundary}`,
     "gi",

--- a/desktop/src/shared/lib/remarkChannelLinks.ts
+++ b/desktop/src/shared/lib/remarkChannelLinks.ts
@@ -8,7 +8,7 @@
  */
 
 import { createRemarkPrefixPlugin } from "./createRemarkPrefixPlugin";
-import { buildPrefixPattern } from "./mentionPattern";
+import { buildPrefixPattern, PREFIX_LEAD_GROUP } from "./mentionPattern";
 
 type RemarkChannelLinksOptions = {
   channelNames?: string[];
@@ -21,16 +21,20 @@ export default function remarkChannelLinks(
     fallbackToGeneric: true,
   });
 
-  return createRemarkPrefixPlugin(channelPattern, (matchText) => {
-    const channelName = matchText.slice(1);
-    return {
-      type: "channel-link",
-      value: matchText,
-      data: {
-        hName: "channel-link",
-        hChildren: [{ type: "text", value: matchText }],
-        channelName,
-      },
-    };
-  });
+  return createRemarkPrefixPlugin(
+    channelPattern,
+    (matchText) => {
+      const channelName = matchText.slice(1);
+      return {
+        type: "channel-link",
+        value: matchText,
+        data: {
+          hName: "channel-link",
+          hChildren: [{ type: "text", value: matchText }],
+          channelName,
+        },
+      };
+    },
+    { leadGroup: PREFIX_LEAD_GROUP },
+  );
 }

--- a/desktop/src/shared/lib/remarkMentions.ts
+++ b/desktop/src/shared/lib/remarkMentions.ts
@@ -8,7 +8,7 @@
  */
 
 import { createRemarkPrefixPlugin } from "./createRemarkPrefixPlugin";
-import { buildMentionPattern } from "./mentionPattern";
+import { buildMentionPattern, PREFIX_LEAD_GROUP } from "./mentionPattern";
 
 type RemarkMentionsOptions = {
   mentionNames?: string[];
@@ -17,12 +17,16 @@ type RemarkMentionsOptions = {
 export default function remarkMentions(options?: RemarkMentionsOptions) {
   const mentionPattern = buildMentionPattern(options?.mentionNames ?? []);
 
-  return createRemarkPrefixPlugin(mentionPattern, (matchText) => ({
-    type: "mention",
-    value: matchText,
-    data: {
-      hName: "mention",
-      hChildren: [{ type: "text", value: matchText }],
-    },
-  }));
+  return createRemarkPrefixPlugin(
+    mentionPattern,
+    (matchText) => ({
+      type: "mention",
+      value: matchText,
+      data: {
+        hName: "mention",
+        hChildren: [{ type: "text", value: matchText }],
+      },
+    }),
+    { leadGroup: PREFIX_LEAD_GROUP },
+  );
 }


### PR DESCRIPTION
Found by probing the three mention paths against each other; no issue filed.

`detectPrefixQuery` opens an autocomplete query after whitespace, `(`, `[` or `{`. The brackets are there on purpose — its comment says they were added because "a prefix glued to a `(` never fired". But the other two paths never learned about `[` and `{`:

| text typed | autocomplete offers Alice | event carries her `p` tag | renders as a mention |
|---|---|---|---|
| `@Alice` | yes | yes | yes |
| `(@Alice` | yes | yes | yes |
| `[@Alice` | **yes** | **no** | **no** |
| `{@Alice` | **yes** | **no** | **no** |

So the composer offers Alice, you pick her, and the message goes out mentioning nobody — no `p` tag, no notification, no agent wake-up, and the name rendered as plain text. Silent, and the composer actively led you into it.

Both paths now accept the same bracket set `detectPrefixQuery` does, in that order: tagging first, then rendering, so neither commit leaves the tree in a state where a tagged mention renders unstyled. `x@Alice` still opens nothing, and a test pins that.

**Stacked on #5949** (which is stacked on #5948) — the same two boundary definitions. This finishes the set: #5948 gave the render path a leading boundary at all, #5949 fixed the possessive on both sides, this one aligns the opener with what the autocomplete already accepts. Happy to squash the three or rebase them differently if you'd rather.

Verified locally at this head:

- `pnpm test` — **4976 passed, 0 failed** (4973 on the parent branch, plus the 3 new)
- `pnpm check` — clean; its 4 warnings and 2 infos are pre-existing and identical on `main`
- `pnpm build` — succeeded

Note: I'm an outside contributor, so the workflow runs here sit at `action_required` until a maintainer approves them; only the DCO check reports on its own.
