### PR TITLE
fix(cli): normalize the pubkey a moderation action is keyed on

### DIFF
--- a/crates/buzz-cli/src/commands/moderation.rs
+++ b/crates/buzz-cli/src/commands/moderation.rs
@@ -18,7 +18,7 @@ use nostr::Timestamp;
 
 use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
-use crate::validate::validate_hex64;
+use crate::validate::parse_hex64;
 use crate::{ModerationCmd, OutputFormat};
 
 /// Resolve `--expires-in <secs>` / `--expires-at <unix>` into an absolute
@@ -38,7 +38,7 @@ async fn cmd_ban(
     expires_at: Option<u64>,
     reason: Option<&str>,
 ) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = &parse_hex64(pubkey)?;
     let expiry = resolve_expiry(expires_in, expires_at);
     let builder = buzz_sdk::build_moderation_ban(pubkey, expiry, reason)
         .map_err(|e| CliError::Usage(format!("invalid ban: {e}")))?;
@@ -49,7 +49,7 @@ async fn cmd_ban(
 }
 
 async fn cmd_unban(client: &BuzzClient, pubkey: &str) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = &parse_hex64(pubkey)?;
     let builder = buzz_sdk::build_moderation_unban(pubkey)
         .map_err(|e| CliError::Usage(format!("invalid unban: {e}")))?;
     let event = client.sign_event(builder)?;
@@ -65,7 +65,7 @@ async fn cmd_timeout(
     expires_at: Option<u64>,
     reason: Option<&str>,
 ) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = &parse_hex64(pubkey)?;
     let expiry = resolve_expiry(expires_in, expires_at)
         .ok_or_else(|| CliError::Usage("timeout requires --expires-in or --expires-at".into()))?;
     let builder = buzz_sdk::build_moderation_timeout(pubkey, expiry, reason)
@@ -77,7 +77,7 @@ async fn cmd_timeout(
 }
 
 async fn cmd_untimeout(client: &BuzzClient, pubkey: &str) -> Result<(), CliError> {
-    validate_hex64(pubkey)?;
+    let pubkey = &parse_hex64(pubkey)?;
     let builder = buzz_sdk::build_moderation_untimeout(pubkey)
         .map_err(|e| CliError::Usage(format!("invalid untimeout: {e}")))?;
     let event = client.sign_event(builder)?;
@@ -93,7 +93,7 @@ async fn cmd_resolve(
     action: &str,
     reason: Option<&str>,
 ) -> Result<(), CliError> {
-    validate_hex64(report)?;
+    let report = &parse_hex64(report)?;
     let builder = buzz_sdk::build_moderation_resolve_report(report, status, action, reason)
         .map_err(|e| CliError::Usage(format!("invalid resolution: {e}")))?;
     let event = client.sign_event(builder)?;

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -25,7 +25,11 @@ pub fn validate_uuid(s: &str) -> Result<(), CliError> {
     Ok(())
 }
 
-/// Validate 64-character lowercase hex string (event_id, pubkey).
+/// Validate a 64-character hex string (event_id, pubkey).
+///
+/// Accepts either case — `is_ascii_hexdigit` does. Callers that put the value
+/// on the wire want [`parse_hex64`] instead: nostr matches tag values byte for
+/// byte, so an uppercase pubkey in a `p` tag is a different pubkey.
 pub fn validate_hex64(s: &str) -> Result<(), CliError> {
     if s.len() != 64 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(CliError::Usage(format!(
@@ -33,6 +37,17 @@ pub fn validate_hex64(s: &str) -> Result<(), CliError> {
         )));
     }
     Ok(())
+}
+
+/// Validate a 64-character hex string and return it lowercased.
+///
+/// Hex is case-insensitive to a human and byte-exact to a relay: a filter for
+/// `#p` `abc…` does not match a tag holding `ABC…`, so a value pasted in
+/// uppercase would be published as an identifier nothing else resolves to.
+/// Normalize once, at the boundary where the string enters the program.
+pub fn parse_hex64(s: &str) -> Result<String, CliError> {
+    validate_hex64(s)?;
+    Ok(s.to_ascii_lowercase())
 }
 
 /// Validate a git repo identifier: `[a-zA-Z0-9._-]{1,64}`, no leading dots, no `..`.
@@ -254,6 +269,28 @@ mod tests {
         hex.push('z'); // 'z' is not a hex digit
         let err = validate_hex64(&hex).unwrap_err();
         assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    // --- parse_hex64 ---
+
+    #[test]
+    fn parse_hex64_lowercases_an_uppercase_pubkey() {
+        let upper = "ABCDEF0123456789".repeat(4);
+        assert_eq!(super::parse_hex64(&upper).unwrap(), upper.to_lowercase());
+    }
+
+    #[test]
+    fn parse_hex64_leaves_a_lowercase_pubkey_alone() {
+        let lower = "abcdef0123456789".repeat(4);
+        assert_eq!(super::parse_hex64(&lower).unwrap(), lower);
+    }
+
+    #[test]
+    fn parse_hex64_rejects_what_validate_hex64_rejects() {
+        assert!(super::parse_hex64("").is_err());
+        assert!(super::parse_hex64(&"a".repeat(63)).is_err());
+        assert!(super::parse_hex64(&"a".repeat(65)).is_err());
+        assert!(super::parse_hex64(&format!("{}z", "a".repeat(63))).is_err());
     }
 
     // --- validate_content_size ---


### PR DESCRIPTION
Found by reading `validate_hex64` against its own doc comment; no issue filed.

`buzz moderation ban <pubkey>` validates the hex and then publishes it verbatim. Paste a pubkey in uppercase — from a block explorer, a log line, a colleague's message — and the ban goes out as `["p", "ABC…"]`.

Nothing resolves that to the person. Relays match tag values byte for byte (`filter_match_one` compares `event_val == filter_val`), and every other producer in the tree lowercases — `normalizeMentionPubkeys` in the desktop's `threading.ts`, `normalizePubkey` in `shared/lib/pubkey.ts`. So the ban is published, acknowledged, printed as success, and applies to nobody. `unban`, `timeout`, `untimeout` and report resolution all share the shape.

`validate_hex64`'s doc says it validates a "64-character **lowercase** hex string", but `is_ascii_hexdigit` accepts either case and no caller normalizes. The first commit adds `parse_hex64` — validate, then return the value lowercased — and corrects that doc to say what the function actually does. The second uses it in `moderation.rs`. A pubkey that was already lowercase is unaffected.

**Scope.** There are ~55 other `validate_hex64` call sites with the same latent gap, across issues, PRs, patches, reactions and social. They're separable, and each needs its own look at whether the value ends up in a tag, a URL path, or only a local comparison — I didn't want to sweep 14 files blind. Moderation is the one where the failure mode is worst: a command that reports success and silently does nothing.

Verified locally on the pinned 1.95.0 toolchain:

- `cargo test -p buzz-cli` — **352 passed, 0 failed** (349 before, plus the 3 new)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Note: I'm an outside contributor, so the workflow runs here sit at `action_required` until a maintainer approves them; only the DCO check reports on its own.
