### PR TITLE
fix(desktop): let the glass background show through the community rail

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     {
       name: "smoke",
       testMatch: [
+        "**/glass-rail.spec.ts",
         "**/smoke.spec.ts",
         "**/sidebar-offcanvas-rail.spec.ts",
         "**/search-scope-screenshots.spec.ts",

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -832,6 +832,7 @@
 :root[data-glass-background] .group\/sidebar-wrapper,
 :root[data-glass-background] [data-testid="app-sidebar"],
 :root[data-glass-background] [data-testid="settings-sidebar"],
+:root[data-glass-background] [data-testid="community-rail"].bg-sidebar,
 :root[data-glass-background] [data-buzz-glass-inset],
 :root[data-glass-background] [data-buzz-glass-footer-wrap],
 :root[data-glass-background]

--- a/desktop/tests/e2e/glass-rail.spec.ts
+++ b/desktop/tests/e2e/glass-rail.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+/**
+ * Glass background must clear the community rail's opaque `bg-sidebar` paint
+ * so the native vibrancy shows through the whole navigation column, not just
+ * the channel sidebar. Regression test for the rail being left out of the
+ * `:root[data-glass-background]` transparency list (theme.css).
+ */
+async function seedGlassOnMac(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("buzz-theme", "github-light");
+    window.localStorage.setItem("buzz-glass-background", "true");
+    (window as typeof window & { isTauri?: boolean }).isTauri = true;
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      get: () => "MacIntel",
+    });
+  });
+}
+
+/** Registered AFTER the bridge so it can append to the seeded community list. */
+async function appendSecondCommunity(page: Page) {
+  await page.addInitScript(() => {
+    const raw = window.localStorage.getItem("buzz-communities");
+    const list = raw ? (JSON.parse(raw) as Array<unknown>) : [];
+    list.push({
+      id: "ws-b",
+      name: "Bravo",
+      relayUrl: "ws://localhost:3001",
+      addedAt: "2026-01-02T00:00:00.000Z",
+    });
+    window.localStorage.setItem("buzz-communities", JSON.stringify(list));
+  });
+}
+
+test("glass background clears the community rail surface", async ({ page }) => {
+  await seedGlassOnMac(page);
+  await installMockBridge(page);
+  await appendSecondCommunity(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-glass-background",
+    "",
+  );
+
+  const rail = page.getByTestId("community-rail");
+  await expect(rail).toBeVisible();
+  await expect(rail).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+});


### PR DESCRIPTION
## Problem

With **Glass background** enabled, the community/relay rail stayed a solid opaque column while every other navigation surface frosted. Reported in buzz-bugs: the glass treatment "doesn't properly affect the relay column."

## Cause

The glass treatment (#5478) clears `background` on each nav surface via the `:root[data-glass-background]` transparency list in `theme.css` — app sidebar, settings sidebar, pinned header, footer — but the community rail's `bg-sidebar` selector was left out. The older Buzz-theme rule (`:root[data-buzz-sidebar]`) already lists `[data-testid="community-rail"].bg-sidebar`; the glass rule simply forgot it, so the rail kept its opaque paint.

## Fix

One selector added to the glass transparency list:

```css
:root[data-glass-background] [data-testid="community-rail"].bg-sidebar,
```

## Proof

Playwright regression spec (`glass-rail.spec.ts`, smoke project): glass enabled + two communities seeded → the rail's computed `background-color` must be `rgba(0, 0, 0, 0)`. Fails on the unpatched build (`rgb(246, 246, 246)`), passes with the fix. Before/after screenshots in the comment below.

## Verification

- `pnpm test` — 4954/4954 unit tests pass
- `pnpm lint` — clean on touched files
- `pnpm exec tsc` — clean
- New spec fails before / passes after
