### PR TITLE
fix(mobile): bound pairing connection lifecycle

### DIFF
--- a/mobile/lib/features/pairing/pairing_page.dart
+++ b/mobile/lib/features/pairing/pairing_page.dart
@@ -11,6 +11,7 @@ import '../../shared/widgets/buzz_loading_indicator.dart';
 import '../../shared/widgets/tappable_flapping_bee.dart';
 import 'pairing_provider.dart';
 import 'pairing_qr_scanner.dart';
+import 'pairing_socket.dart';
 
 part 'pairing_page/onboarding_background.dart';
 part 'pairing_page/pairing_welcome_view.dart';
@@ -148,6 +149,7 @@ class PairingPage extends HookConsumerWidget {
                   child: _PairingWelcomeView(
                     codeController: codeController,
                     isBusy: isBusy,
+                    progressMessage: pairingState.stage?.label,
                     pairingCodeExpanded: pairingCodeExpanded.value,
                     errorMessage: pairingState.status == PairingStatus.error
                         ? pairingState.errorMessage

--- a/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
+++ b/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
@@ -3,6 +3,7 @@ part of '../pairing_page.dart';
 class _PairingWelcomeView extends StatelessWidget {
   final TextEditingController codeController;
   final bool isBusy;
+  final String? progressMessage;
   final bool pairingCodeExpanded;
   final String? errorMessage;
   final VoidCallback onScan;
@@ -12,6 +13,7 @@ class _PairingWelcomeView extends StatelessWidget {
   const _PairingWelcomeView({
     required this.codeController,
     required this.isBusy,
+    required this.progressMessage,
     required this.pairingCodeExpanded,
     required this.errorMessage,
     required this.onScan,
@@ -189,6 +191,17 @@ class _PairingWelcomeView extends StatelessWidget {
                                   key: ValueKey('pairing-code-fields-hidden'),
                                 ),
                         ),
+                        if (isBusy && progressMessage != null) ...[
+                          const SizedBox(height: Grid.xxs),
+                          Text(
+                            progressMessage!,
+                            key: const Key('pairing-progress'),
+                            textAlign: TextAlign.center,
+                            style: context.textTheme.bodySmall?.copyWith(
+                              color: _onboardingMutedInk,
+                            ),
+                          ),
+                        ],
                         if (errorMessage != null) ...[
                           const SizedBox(height: Grid.twelve),
                           Container(

--- a/mobile/lib/features/pairing/pairing_provider.dart
+++ b/mobile/lib/features/pairing/pairing_provider.dart
@@ -33,6 +33,7 @@ enum PairingStatus {
 
 class PairingState {
   final PairingStatus status;
+  final PairingStage? stage;
   final String? errorMessage;
   final String? sasCode;
   final bool userConfirmedSas;
@@ -40,6 +41,7 @@ class PairingState {
 
   const PairingState({
     this.status = PairingStatus.idle,
+    this.stage,
     this.errorMessage,
     this.sasCode,
     this.userConfirmedSas = false,
@@ -48,12 +50,14 @@ class PairingState {
 
   PairingState copyWith({
     PairingStatus? status,
+    PairingStage? stage,
     String? errorMessage,
     String? sasCode,
     bool? userConfirmedSas,
     bool? sendsIdentityToDesktop,
   }) => PairingState(
     status: status ?? this.status,
+    stage: stage ?? this.stage,
     errorMessage: errorMessage ?? this.errorMessage,
     sasCode: sasCode ?? this.sasCode,
     userConfirmedSas: userConfirmedSas ?? this.userConfirmedSas,
@@ -68,12 +72,14 @@ typedef PairingSocketFactory =
       required String ephemeralPrivkey,
       required void Function(List<dynamic> message) onMessage,
       required void Function(Object? error) onDisconnected,
+      required void Function(PairingStage stage) onStage,
     });
 
 class PairingNotifier extends Notifier<PairingState> {
   final PairingSocketFactory _socketFactory;
   PairingSocket? _socket;
   Timer? _sessionTimeout;
+  int _attemptGeneration = 0;
 
   PairingNotifier({PairingSocketFactory? socketFactory})
     : _socketFactory = socketFactory ?? _createPairingSocket;
@@ -83,11 +89,13 @@ class PairingNotifier extends Notifier<PairingState> {
     required String ephemeralPrivkey,
     required void Function(List<dynamic> message) onMessage,
     required void Function(Object? error) onDisconnected,
+    required void Function(PairingStage stage) onStage,
   }) => PairingSocket(
     wsUrl: wsUrl,
     ephemeralPrivkey: ephemeralPrivkey,
     onMessage: onMessage,
     onDisconnected: onDisconnected,
+    onStage: onStage,
   );
 
   @override
@@ -137,7 +145,7 @@ class PairingNotifier extends Notifier<PairingState> {
   /// Deny the SAS code. Send abort and terminate.
   void denySas() {
     _sendAbort('sas_mismatch');
-    _cleanup();
+    _finishAttempt();
     state = PairingState(
       status: PairingStatus.error,
       errorMessage: 'SAS code mismatch — pairing cancelled for security.',
@@ -145,8 +153,13 @@ class PairingNotifier extends Notifier<PairingState> {
   }
 
   void reset() {
-    _cleanup();
+    _finishAttempt();
     state = const PairingState();
+  }
+
+  void _finishAttempt() {
+    _attemptGeneration++;
+    _cleanup();
   }
 
   void _cleanup() {
@@ -178,6 +191,7 @@ class PairingNotifier extends Notifier<PairingState> {
   final Set<String> _processedEventIds = {}; // NIP-AB §Duplicate Event Handling
 
   Future<void> _pairNipAb(String uri) async {
+    final attempt = ++_attemptGeneration;
     state = const PairingState(status: PairingStatus.connecting);
 
     try {
@@ -211,11 +225,25 @@ class PairingNotifier extends Notifier<PairingState> {
       final socket = _socketFactory(
         wsUrl: relayWsUrl,
         ephemeralPrivkey: _ephemeralPrivkey!,
-        onMessage: _handleRelayMessage,
-        onDisconnected: _handleDisconnected,
+        onMessage: (message) {
+          if (_isCurrentAttempt(attempt)) {
+            _handleRelayMessage(message);
+          }
+        },
+        onDisconnected: (error) {
+          if (_isCurrentAttempt(attempt)) {
+            _handleDisconnected(error);
+          }
+        },
+        onStage: (stage) {
+          if (_isCurrentAttempt(attempt)) {
+            _reportStage(stage, relayWsUrl);
+          }
+        },
       );
       _socket = socket;
       await socket.connect();
+      if (!_isCurrentAttempt(attempt)) return;
 
       if (!socket.isConnected) {
         throw StateError('Pairing socket did not reach the connected state');
@@ -223,10 +251,12 @@ class PairingNotifier extends Notifier<PairingState> {
 
       // 5. Subscribe for kind:24134 events tagged to our ephemeral pubkey.
       socket.subscribe('pair', 24134, _ephemeralPubkey!);
+      _reportStage(PairingStage.subscribed, relayWsUrl);
 
       // 6. Wait briefly for EOSE, then send offer.
       // (In practice, we send the offer immediately — the relay will buffer it.)
       await Future.delayed(const Duration(milliseconds: 500));
+      if (!_isCurrentAttempt(attempt)) return;
 
       // 7. Build and send the offer event.
       final offerContent = _encryptMessage({
@@ -242,6 +272,7 @@ class PairingNotifier extends Notifier<PairingState> {
           ['p', qr.sourcePubkey],
         ],
       );
+      _reportStage(PairingStage.offerPublished, relayWsUrl);
 
       // 8. Display SAS code and wait for sas-confirm from source.
       state = PairingState(
@@ -252,9 +283,10 @@ class PairingNotifier extends Notifier<PairingState> {
 
       // 9. Start 120s session timeout.
       _sessionTimeout = Timer(const Duration(seconds: 120), () {
+        if (!_isCurrentAttempt(attempt)) return;
         if (state.status != PairingStatus.success &&
             state.status != PairingStatus.error) {
-          _cleanup();
+          _finishAttempt();
           state = const PairingState(
             status: PairingStatus.error,
             errorMessage: 'Pairing session timed out.',
@@ -262,14 +294,19 @@ class PairingNotifier extends Notifier<PairingState> {
         }
       });
     } on FormatException catch (e) {
-      _cleanup();
+      if (!_isCurrentAttempt(attempt)) return;
+      _finishAttempt();
       state = PairingState(
         status: PairingStatus.error,
         errorMessage: 'Invalid pairing code: ${e.message}',
       );
     } catch (e) {
-      debugPrint('Pairing connection error: $e');
-      _cleanup();
+      if (!_isCurrentAttempt(attempt)) return;
+      debugPrint(
+        'Buzz pairing failed stage=${state.stage?.name ?? 'unknown'} '
+        'errorType=${e.runtimeType}',
+      );
+      _finishAttempt();
       state = PairingState(
         status: PairingStatus.error,
         errorMessage: _friendlyErrorMessage(e),
@@ -278,6 +315,10 @@ class PairingNotifier extends Notifier<PairingState> {
   }
 
   static String _friendlyErrorMessage(Object error) {
+    if (error is PairingConnectionException) {
+      return 'The pairing relay did not open within 15 seconds '
+          '(stage: ${error.stage.name}). Check Tailscale and try again.';
+    }
     final message = error.toString();
     if (message.contains('SocketException') ||
         message.contains('Connection refused') ||
@@ -306,6 +347,15 @@ class PairingNotifier extends Notifier<PairingState> {
     }
     return 'Connection failed. Please check your internet connection '
         'and try again.';
+  }
+
+  void _reportStage(PairingStage stage, String relayUrl) {
+    final uri = Uri.parse(relayUrl);
+    final endpoint = '${uri.host}${uri.hasPort ? ':${uri.port}' : ''}';
+    debugPrint('Buzz pairing stage=${stage.name} endpoint=$endpoint');
+    if (state.status == PairingStatus.connecting) {
+      state = state.copyWith(stage: stage);
+    }
   }
 
   void _handleRelayMessage(List<dynamic> data) {
@@ -401,7 +451,7 @@ class PairingNotifier extends Notifier<PairingState> {
     if (!constantTimeEquals(receivedBytes, expectedHash)) {
       // NIP-AB §Step 3: target MUST send abort with reason "sas_mismatch".
       _sendAbort('sas_mismatch');
-      _cleanup();
+      _finishAttempt();
       state = const PairingState(
         status: PairingStatus.error,
         errorMessage:
@@ -434,7 +484,7 @@ class PairingNotifier extends Notifier<PairingState> {
     final nsec = ref.read(relayConfigProvider).nsec;
     if (nsec == null || nsec.isEmpty) {
       _sendAbort('protocol_error');
-      _cleanup();
+      _finishAttempt();
       state = const PairingState(
         status: PairingStatus.error,
         errorMessage: 'No identity is available on this phone.',
@@ -472,6 +522,7 @@ class PairingNotifier extends Notifier<PairingState> {
     final payloadType = msg['payload_type'] as String?;
     final payload = msg['payload'] as String?;
     if (payload == null) {
+      _finishAttempt();
       state = const PairingState(
         status: PairingStatus.error,
         errorMessage: 'Received empty payload from source.',
@@ -479,7 +530,7 @@ class PairingNotifier extends Notifier<PairingState> {
       return;
     }
 
-    _processPayload(payloadType, payload);
+    unawaited(_processPayload(payloadType, payload));
   }
 
   void _handleComplete(Map<String, dynamic> msg) {
@@ -487,20 +538,20 @@ class PairingNotifier extends Notifier<PairingState> {
       return;
     }
     if (msg['success'] != true) {
-      _cleanup();
+      _finishAttempt();
       state = const PairingState(
         status: PairingStatus.error,
         errorMessage: 'Desktop could not store the identity.',
       );
       return;
     }
-    _cleanup();
+    _finishAttempt();
     state = const PairingState(status: PairingStatus.success);
   }
 
   void _handleAbort(Map<String, dynamic> msg) {
     final reason = msg['reason'] as String? ?? 'unknown';
-    _cleanup();
+    _finishAttempt();
     state = PairingState(
       status: PairingStatus.error,
       errorMessage: 'Source device aborted pairing: $reason',
@@ -613,12 +664,17 @@ class PairingNotifier extends Notifier<PairingState> {
         state.status == PairingStatus.error) {
       return;
     }
-    _cleanup();
+    final wasConnecting = state.status == PairingStatus.connecting;
+    _finishAttempt();
     state = PairingState(
       status: PairingStatus.error,
-      errorMessage: 'Lost connection to pairing relay.',
+      errorMessage: wasConnecting && error != null
+          ? _friendlyErrorMessage(error)
+          : 'Lost connection to pairing relay.',
     );
   }
+
+  bool _isCurrentAttempt(int attempt) => attempt == _attemptGeneration;
 
   // ── Legacy buzz:// flow ───────────────────────────────────────────────
 

--- a/mobile/lib/features/pairing/pairing_socket.dart
+++ b/mobile/lib/features/pairing/pairing_socket.dart
@@ -8,6 +8,47 @@ import '../../shared/relay/nostr_models.dart';
 
 const _desktopPairingAuthChallengeGrace = Duration(seconds: 3);
 const _pairingAuthOkTimeout = Duration(seconds: 8);
+const _pairingConnectionTimeout = Duration(seconds: 15);
+const _pairingDisconnectTimeout = Duration(seconds: 1);
+
+enum PairingStage {
+  openingWebSocket,
+  webSocketOpen,
+  waitingForAuth,
+  authenticating,
+  connected,
+  subscribed,
+  offerPublished,
+}
+
+extension PairingStageLabel on PairingStage {
+  String get label => switch (this) {
+    PairingStage.openingWebSocket => 'Opening secure connection...',
+    PairingStage.webSocketOpen => 'Secure connection opened...',
+    PairingStage.waitingForAuth => 'Checking pairing relay...',
+    PairingStage.authenticating => 'Authenticating pairing session...',
+    PairingStage.connected => 'Pairing relay connected...',
+    PairingStage.subscribed => 'Listening for the desktop...',
+    PairingStage.offerPublished => 'Waiting for the desktop code...',
+  };
+}
+
+class PairingConnectionException implements Exception {
+  final PairingStage stage;
+  final String message;
+
+  const PairingConnectionException({
+    required this.stage,
+    required this.message,
+  });
+
+  @override
+  String toString() => 'PairingConnectionException(${stage.name}): $message';
+}
+
+class PairingCanceledException implements Exception {
+  const PairingCanceledException();
+}
 
 /// Ephemeral WebSocket connection for NIP-AB pairing.
 ///
@@ -27,6 +68,8 @@ class PairingSocket {
   final String _ephemeralPrivkey;
   final void Function(List<dynamic> message) _onMessage;
   final void Function(Object? error) _onDisconnected;
+  final void Function(PairingStage stage) _onStage;
+  final Duration _connectionTimeout;
   final Duration _authChallengeTimeout;
   final Duration _authResponseTimeout;
   final WebSocketChannel Function(Uri uri) _channelFactory;
@@ -44,6 +87,8 @@ class PairingSocket {
     required String ephemeralPrivkey,
     required void Function(List<dynamic> message) onMessage,
     required void Function(Object? error) onDisconnected,
+    void Function(PairingStage stage)? onStage,
+    Duration connectionTimeout = _pairingConnectionTimeout,
     Duration authChallengeTimeout = _desktopPairingAuthChallengeGrace,
     Duration authResponseTimeout = _pairingAuthOkTimeout,
     WebSocketChannel Function(Uri uri) channelFactory =
@@ -52,6 +97,8 @@ class PairingSocket {
        _ephemeralPrivkey = ephemeralPrivkey,
        _onMessage = onMessage,
        _onDisconnected = onDisconnected,
+       _onStage = onStage ?? ((_) {}),
+       _connectionTimeout = connectionTimeout,
        _authChallengeTimeout = authChallengeTimeout,
        _authResponseTimeout = authResponseTimeout,
        _channelFactory = channelFactory;
@@ -60,31 +107,44 @@ class PairingSocket {
 
   /// Connect and answer a NIP-42 challenge when the relay requires one.
   Future<void> connect() async {
-    _channel = _channelFactory(Uri.parse(_wsUrl));
-    await _channel!.ready;
-
-    _authCompleter = Completer<void>();
-
-    _subscription = _channel!.stream.listen(
-      _handleRawMessage,
-      onError: _failAuth,
-      onDone: () => _failAuth(null),
-    );
-
-    // Dedicated pairing relays may be open and send no NIP-42 challenge.
-    _authChallengeTimer = Timer(_authChallengeTimeout, () {
-      if (_pendingAuthEventId == null &&
-          _authCompleter != null &&
-          !_authCompleter!.isCompleted) {
-        _authCompleter!.complete();
-      }
-    });
-
     try {
+      _onStage(PairingStage.openingWebSocket);
+      _channel = _channelFactory(Uri.parse(_wsUrl));
+      await _channel!.ready.timeout(
+        _connectionTimeout,
+        onTimeout: () => throw const PairingConnectionException(
+          stage: PairingStage.openingWebSocket,
+          message: 'Pairing WebSocket did not open before the deadline',
+        ),
+      );
+      _onStage(PairingStage.webSocketOpen);
+
+      _authCompleter = Completer<void>();
+      _subscription = _channel!.stream.listen(
+        _handleRawMessage,
+        onError: _failAuth,
+        onDone: () => _failAuth(null),
+      );
+
+      _onStage(PairingStage.waitingForAuth);
+      // Dedicated pairing relays may be open and send no NIP-42 challenge.
+      _authChallengeTimer = Timer(_authChallengeTimeout, () {
+        if (_pendingAuthEventId == null &&
+            _authCompleter != null &&
+            !_authCompleter!.isCompleted) {
+          _authCompleter!.complete();
+        }
+      });
+
       await _authCompleter!.future;
       _connected = true;
+      _onStage(PairingStage.connected);
     } catch (error) {
-      await disconnect();
+      try {
+        await disconnect().timeout(_pairingDisconnectTimeout);
+      } catch (_) {
+        // Connection failure reporting must not wait on a stuck close handshake.
+      }
       _onDisconnected(error);
       rethrow;
     } finally {
@@ -117,6 +177,7 @@ class PairingSocket {
 
   Future<void> disconnect() async {
     _connected = false;
+    _cancelAuthWait();
     _subscription?.cancel();
     _subscription = null;
     _authChallengeTimer?.cancel();
@@ -130,11 +191,18 @@ class PairingSocket {
 
   void dispose() {
     _connected = false;
+    _cancelAuthWait();
     _subscription?.cancel();
     _channel?.sink.close();
     _channel = null;
     _authChallengeTimer?.cancel();
     _authResponseTimer?.cancel();
+  }
+
+  void _cancelAuthWait() {
+    if (_authCompleter != null && !_authCompleter!.isCompleted) {
+      _authCompleter!.completeError(const PairingCanceledException());
+    }
   }
 
   void _failAuth(Object? error) {
@@ -176,6 +244,7 @@ class PairingSocket {
   void _handleAuthChallenge(List<dynamic> data) {
     if (data.length < 2) return;
     final challenge = data[1] as String;
+    _onStage(PairingStage.authenticating);
 
     _authChallengeTimer?.cancel();
     _authResponseTimer?.cancel();

--- a/mobile/test/features/pairing/pairing_page_test.dart
+++ b/mobile/test/features/pairing/pairing_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/pairing/pairing_page.dart';
 import 'package:buzz/features/pairing/pairing_provider.dart';
+import 'package:buzz/features/pairing/pairing_socket.dart';
 import 'package:buzz/shared/theme/theme.dart';
 import 'package:buzz/shared/widgets/buzz_loading_indicator.dart';
 import 'package:buzz/shared/widgets/tappable_flapping_bee.dart';
@@ -160,6 +161,25 @@ void main() {
       expect(find.text('Connect'), findsNothing);
     });
 
+    testWidgets('shows the current secret-free pairing stage', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testable(
+          overrides: [
+            pairingProvider.overrideWith(
+              () => _ConnectingPairingNotifier(
+                stage: PairingStage.openingWebSocket,
+              ),
+            ),
+          ],
+          child: const PairingPage(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Opening secure connection...'), findsOneWidget);
+      expect(find.byKey(const Key('pairing-progress')), findsOneWidget);
+    });
+
     testWidgets('pairing actions are disabled when connecting', (tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testable(
@@ -274,8 +294,13 @@ class _ErrorPairingNotifier extends Notifier<PairingState>
 
 class _ConnectingPairingNotifier extends Notifier<PairingState>
     implements PairingNotifier {
+  _ConnectingPairingNotifier({this.stage});
+
+  final PairingStage? stage;
+
   @override
-  PairingState build() => const PairingState(status: PairingStatus.connecting);
+  PairingState build() =>
+      PairingState(status: PairingStatus.connecting, stage: stage);
 
   @override
   Future<void> pair(String rawInput) async {}

--- a/mobile/test/features/pairing/pairing_provider_test.dart
+++ b/mobile/test/features/pairing/pairing_provider_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/pairing/pairing_crypto.dart';
@@ -59,6 +60,7 @@ void main() {
                 required ephemeralPrivkey,
                 required onMessage,
                 required void Function(Object? error) onDisconnected,
+                required onStage,
               }) => _DisconnectingSocket(disconnectCallback: onDisconnected),
         );
         container = ProviderContainer(
@@ -74,7 +76,7 @@ void main() {
         expect(container.read(pairingProvider).status, PairingStatus.error);
         expect(
           container.read(pairingProvider).errorMessage,
-          contains('internal error'),
+          contains('Connection failed'),
         );
       },
     );
@@ -208,11 +210,13 @@ void main() {
                 required ephemeralPrivkey,
                 required onMessage,
                 required onDisconnected,
+                required onStage,
               }) {
                 socket = _ControllableSocket(
                   ephemeralPrivkey: ephemeralPrivkey,
                   onMessage: onMessage,
                   onDisconnected: onDisconnected,
+                  onStage: onStage,
                 );
                 return socket;
               },
@@ -228,12 +232,75 @@ void main() {
       });
 
       test('recovery URI enables phone-to-desktop transfer', () async {
+        final stages = <PairingStage>[];
+        final subscription = container.listen(pairingProvider, (_, next) {
+          if (next.stage case final stage?) {
+            stages.add(stage);
+          }
+        });
+        addTearDown(subscription.close);
         await notifier.pair(recoveryCode);
 
         final state = container.read(pairingProvider);
         expect(state.status, PairingStatus.confirmingSas);
         expect(state.sendsIdentityToDesktop, isTrue);
         expect(state.sasCode, hasLength(6));
+        expect(socket.subscription, ('pair', 24134));
+        final messages = socket.decryptedPublishedMessages(sourceSecret);
+        expect(messages.any((message) => message['type'] == 'offer'), isTrue);
+        expect(stages, [
+          PairingStage.openingWebSocket,
+          PairingStage.webSocketOpen,
+          PairingStage.waitingForAuth,
+          PairingStage.connected,
+          PairingStage.subscribed,
+          PairingStage.offerPublished,
+        ]);
+      });
+
+      test('reset and retry ignore the previous socket callbacks', () async {
+        await notifier.pair(recoveryCode);
+        final previousSocket = socket;
+
+        notifier.reset();
+        await notifier.pair(recoveryCode);
+        previousSocket.emitDisconnected();
+
+        expect(
+          container.read(pairingProvider).status,
+          PairingStatus.confirmingSas,
+        );
+        expect(socket.isConnected, isTrue);
+      });
+
+      test('disconnect during offer delay remains terminal', () async {
+        final pairFuture = notifier.pair(recoveryCode);
+        await Future<void>.delayed(Duration.zero);
+
+        socket.emitDisconnected();
+        await pairFuture;
+
+        final state = container.read(pairingProvider);
+        expect(state.status, PairingStatus.error);
+        expect(state.errorMessage, contains('Connection failed'));
+      });
+
+      test('stage logs omit token-bearing relay paths', () async {
+        final messages = <String>[];
+        final previousDebugPrint = debugPrint;
+        debugPrint = (message, {wrapWidth}) {
+          if (message != null) messages.add(message);
+        };
+        addTearDown(() => debugPrint = previousDebugPrint);
+        final tokenCode = recoveryCode.replaceFirst(
+          'wss%3A%2F%2Fpairing.buzz.xyz',
+          'wss%3A%2F%2Fpairing.buzz.xyz%2Fpair%2Fsecret-token',
+        );
+
+        await notifier.pair(tokenCode);
+
+        expect(messages.join('\n'), contains('endpoint=pairing.buzz.xyz'));
+        expect(messages.join('\n'), isNot(contains('secret-token')));
       });
 
       test(
@@ -368,7 +435,10 @@ class _RecoveryRelayConfig extends RelayConfigNotifier {
 class _ControllableSocket extends PairingSocket {
   final String ephemeralPrivkey;
   final void Function(List<dynamic> message) relayMessageCallback;
+  final void Function(Object? error) disconnectCallback;
+  final void Function(PairingStage stage) stageCallback;
   final List<Map<String, dynamic>> published = [];
+  (String, int)? subscription;
   bool _connected = false;
   int _eventSequence = 0;
 
@@ -376,23 +446,40 @@ class _ControllableSocket extends PairingSocket {
     required this.ephemeralPrivkey,
     required super.onMessage,
     required super.onDisconnected,
+    required void Function(PairingStage stage) onStage,
   }) : relayMessageCallback = onMessage,
-       super(wsUrl: 'ws://unused', ephemeralPrivkey: ephemeralPrivkey);
+       disconnectCallback = onDisconnected,
+       stageCallback = onStage,
+       super(
+         wsUrl: 'ws://unused',
+         ephemeralPrivkey: ephemeralPrivkey,
+         onStage: onStage,
+       );
 
   @override
   bool get isConnected => _connected;
 
   @override
-  Future<void> connect() async => _connected = true;
+  Future<void> connect() async {
+    stageCallback(PairingStage.openingWebSocket);
+    stageCallback(PairingStage.webSocketOpen);
+    stageCallback(PairingStage.waitingForAuth);
+    _connected = true;
+    stageCallback(PairingStage.connected);
+  }
 
   @override
-  void subscribe(String subId, int kind, String pubkeyHex) {}
+  void subscribe(String subId, int kind, String pubkeyHex) {
+    subscription = (subId, kind);
+  }
 
   @override
   void publishEvent(Map<String, dynamic> event) => published.add(event);
 
   @override
   void dispose() => _connected = false;
+
+  void emitDisconnected() => disconnectCallback(Exception('stale socket'));
 
   List<Map<String, dynamic>> decryptedPublishedMessages(String sourceSecret) {
     final key = getConversationKey(

--- a/mobile/test/features/pairing/pairing_socket_test.dart
+++ b/mobile/test/features/pairing/pairing_socket_test.dart
@@ -25,8 +25,91 @@ void main() {
       expect(socket.isConnected, isTrue);
     });
 
+    test('reports the open-relay connection stages in order', () async {
+      final server = await _TestRelay.start((_) {});
+      addTearDown(server.close);
+      final stages = <PairingStage>[];
+      final socket = _socket(
+        server.url,
+        authChallengeTimeout: const Duration(milliseconds: 30),
+        onStage: stages.add,
+      );
+      addTearDown(socket.disconnect);
+
+      await socket.connect();
+
+      expect(stages, [
+        PairingStage.openingWebSocket,
+        PairingStage.webSocketOpen,
+        PairingStage.waitingForAuth,
+        PairingStage.connected,
+      ]);
+    });
+
+    test('fails closed when the WebSocket open deadline expires', () async {
+      final channel = _NeverReadyWebSocketChannel();
+      final stages = <PairingStage>[];
+      var disconnectCount = 0;
+      final socket = _socket(
+        'wss://pairing.example.test/pair',
+        connectionTimeout: const Duration(milliseconds: 20),
+        channelFactory: (_) => channel,
+        onDisconnected: (_) => disconnectCount++,
+        onStage: stages.add,
+      );
+
+      await expectLater(
+        socket.connect(),
+        throwsA(
+          isA<PairingConnectionException>().having(
+            (error) => error.stage,
+            'stage',
+            PairingStage.openingWebSocket,
+          ),
+        ),
+      );
+
+      expect(stages, [PairingStage.openingWebSocket]);
+      expect(disconnectCount, 1);
+      expect(channel.closed, isTrue);
+    });
+
+    test('reports timeout even when pre-ready close never completes', () async {
+      final channel = _NeverReadyWebSocketChannel(closeCompletes: false);
+      final socket = _socket(
+        'wss://pairing.example.test/pair',
+        connectionTimeout: const Duration(milliseconds: 20),
+        channelFactory: (_) => channel,
+      );
+
+      await expectLater(
+        socket.connect().timeout(const Duration(seconds: 2)),
+        throwsA(isA<PairingConnectionException>()),
+      );
+    });
+
+    test('dispose settles a pending authentication wait', () async {
+      final channel = _ControlledWebSocketChannel();
+      final socket = _socket(
+        'wss://pairing.example.test/pair',
+        authChallengeTimeout: const Duration(seconds: 30),
+        channelFactory: (_) => channel,
+      );
+
+      final connect = socket.connect();
+      final expectation = expectLater(
+        connect.timeout(const Duration(seconds: 1)),
+        throwsA(isA<PairingCanceledException>()),
+      );
+      await Future<void>.delayed(Duration.zero);
+      socket.dispose();
+
+      await expectation;
+    });
+
     test('answers an AUTH challenge and requires an accepted OK', () async {
       final authReceived = Completer<List<dynamic>>();
+      final stages = <PairingStage>[];
       final server = await _TestRelay.start((webSocket) async {
         webSocket.add(jsonEncode(['AUTH', 'challenge']));
         final auth =
@@ -36,13 +119,20 @@ void main() {
         webSocket.add(jsonEncode(['OK', event['id'], true, 'authenticated']));
       });
       addTearDown(server.close);
-      final socket = _socket(server.url);
+      final socket = _socket(server.url, onStage: stages.add);
       addTearDown(socket.disconnect);
 
       await socket.connect();
 
       expect(socket.isConnected, isTrue);
       expect((await authReceived.future).first, 'AUTH');
+      expect(stages, [
+        PairingStage.openingWebSocket,
+        PairingStage.webSocketOpen,
+        PairingStage.waitingForAuth,
+        PairingStage.authenticating,
+        PairingStage.connected,
+      ]);
     });
 
     test('fails when the pairing relay rejects AUTH', () async {
@@ -180,19 +270,70 @@ void main() {
 
 PairingSocket _socket(
   String url, {
+  Duration connectionTimeout = const Duration(seconds: 10),
   Duration authChallengeTimeout = const Duration(milliseconds: 500),
   Duration authResponseTimeout = const Duration(seconds: 10),
   void Function(Object? error)? onDisconnected,
+  void Function(PairingStage stage)? onStage,
   WebSocketChannel Function(Uri uri)? channelFactory,
 }) => PairingSocket(
   wsUrl: url,
   ephemeralPrivkey: _privateKey,
   onMessage: (_) {},
   onDisconnected: onDisconnected ?? (_) {},
+  onStage: onStage,
+  connectionTimeout: connectionTimeout,
   authChallengeTimeout: authChallengeTimeout,
   authResponseTimeout: authResponseTimeout,
   channelFactory: channelFactory ?? WebSocketChannel.connect,
 );
+
+class _NeverReadyWebSocketChannel implements WebSocketChannel {
+  _NeverReadyWebSocketChannel({bool closeCompletes = true})
+    : _sink = _TrackingWebSocketSink(closeCompletes: closeCompletes);
+
+  final Completer<void> _ready = Completer<void>();
+  final StreamController<dynamic> _streamController = StreamController();
+  final _TrackingWebSocketSink _sink;
+
+  bool get closed => _sink.closed;
+
+  @override
+  Future<void> get ready => _ready.future;
+
+  @override
+  Stream<dynamic> get stream => _streamController.stream;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TrackingWebSocketSink extends _ControlledWebSocketSink {
+  _TrackingWebSocketSink({required this.closeCompletes});
+
+  final bool closeCompletes;
+  bool closed = false;
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    closed = true;
+    if (!closeCompletes) {
+      await Completer<void>().future;
+    }
+  }
+}
 
 class _ControlledWebSocketChannel implements WebSocketChannel {
   final StreamController<dynamic> _streamController = StreamController();


### PR DESCRIPTION
## Summary

Bounds the mobile NIP-AB WebSocket connection and teardown lifecycle so pairing cannot remain on Connecting indefinitely. Adds typed, secret-free progress stages through WebSocket open, optional NIP-42 authentication, REQ subscription, and offer publication, while fencing canceled attempts from later retries.

### Related issue

Fixes #4476.

### Testing

- `flutter test test/features/pairing/pairing_socket_test.dart test/features/pairing/pairing_provider_test.dart test/features/pairing/pairing_page_test.dart` (43 passed)
- `flutter analyze` (full mobile tree, no issues)
- pre-push `flutter test` (1,425 passed)
- final autoreview clean, confidence 0.94

The regression coverage includes a never-ready WebSocket, a close handshake that never completes, reset during authentication, stale callbacks after retry, disconnect during the offer delay, NIP-42 stage order, REQ/offer emission, and relay-path token redaction.