### PR TITLE
fix(desktop): preserve Welcome team removals

### DIFF
--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -17,7 +17,7 @@ import {
 } from "@/features/onboarding/welcome";
 import { forceFreshOnboarding } from "@/features/onboarding/devFreshOnboarding";
 import { ensureWelcomeCanvas } from "@/features/onboarding/welcomeCanvas";
-import { ensureWelcomeTeam } from "@/features/onboarding/welcomeGuide";
+import { ensureWelcomeTeamForKickoff } from "@/features/onboarding/welcomeKickoff";
 import { useProfileQuery } from "@/features/profile/hooks";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -56,7 +56,7 @@ function seedWelcomeExperience(
 
   const promise = (async () => {
     try {
-      await ensureWelcomeTeam(channelId, communityScope);
+      await ensureWelcomeTeamForKickoff(channelId, communityScope);
       await ensureWelcomeCanvas(channelId);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),

--- a/desktop/src/features/onboarding/welcomeKickoff.test.mjs
+++ b/desktop/src/features/onboarding/welcomeKickoff.test.mjs
@@ -8,6 +8,7 @@ import {
   buildWelcomeKickoffOpenerSendInput,
   classifyWelcomeKickoffResolution,
   createWelcomeKickoffCoordinator,
+  ensureWelcomeTeamForKickoff,
   mergeKickoffEvents,
   resolveWelcomeAgentSet,
   selectWelcomeKickoffIntroTeammates,
@@ -32,6 +33,7 @@ function agent(name, personaId, pubkey) {
 const fizz = agent("Fizz", "builtin:fizz", "f".repeat(64));
 const honey = agent("Honey", "builtin:honey", "h".repeat(64));
 const bumble = agent("Bumble", "builtin:bumble", "b".repeat(64));
+const RELAY_A = "ws://localhost:3000";
 
 test("resolveWelcomeAgentSet orders agents by stable persona identity", () => {
   assert.deepEqual(resolveWelcomeAgentSet([bumble, fizz, honey]), {
@@ -146,6 +148,36 @@ test("kickoff coordinator preserves one task across rerenders and cancels on nav
   coordinator.cancel("welcome");
   assert.equal(first.signal.aborted, true);
   assert.ok(coordinator.begin("welcome"));
+});
+
+test("completed kickoff preserves intentional Welcome team removals", async () => {
+  let provisionCalls = 0;
+  const result = await ensureWelcomeTeamForKickoff("welcome", RELAY_A, {
+    hasCompleted: async () => true,
+    ensureTeam: async () => {
+      provisionCalls += 1;
+      return [fizz, honey, bumble];
+    },
+  });
+
+  assert.equal(result, null);
+  assert.equal(provisionCalls, 0);
+});
+
+test("incomplete kickoff still provisions the Welcome team", async () => {
+  let provisionCalls = 0;
+  const result = await ensureWelcomeTeamForKickoff("welcome", RELAY_A, {
+    hasCompleted: async () => false,
+    ensureTeam: async (channelId, relayUrl) => {
+      provisionCalls += 1;
+      assert.equal(channelId, "welcome");
+      assert.equal(relayUrl, RELAY_A);
+      return [fizz, honey, bumble];
+    },
+  });
+
+  assert.deepEqual(result, [fizz, honey, bumble]);
+  assert.equal(provisionCalls, 1);
 });
 
 test("closer degrades coherently for partial and total startup failure", () => {

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -357,6 +357,29 @@ async function markerExists(channelId: string, marker: string) {
   });
 }
 
+/**
+ * Provision the built-in team only while the channel's first-run kickoff is
+ * incomplete. The closer marker is durable relay state; once it exists, a
+ * missing team member can be an intentional owner removal and must not be
+ * "repaired" on a later visit or a new device.
+ */
+export async function ensureWelcomeTeamForKickoff(
+  channelId: string,
+  relayUrl?: string | null,
+  options: {
+    hasCompleted?: (channelId: string) => Promise<boolean>;
+    ensureTeam?: typeof ensureWelcomeTeam;
+  } = {},
+) {
+  const hasCompleted =
+    options.hasCompleted ??
+    ((targetChannelId: string) => markerExists(targetChannelId, closerMarker));
+  if (await hasCompleted(channelId)) {
+    return null;
+  }
+  return (options.ensureTeam ?? ensureWelcomeTeam)(channelId, relayUrl);
+}
+
 export function welcomeTeammateNeedsRestart(
   agent: ManagedAgent,
   leadPubkey: string,
@@ -575,10 +598,11 @@ export function useWelcomeKickoff(
       focusedWelcomeChannelRef.current !== channelId;
     void (async () => {
       try {
-        const welcomeTeam = await ensureWelcomeTeam(
+        const welcomeTeam = await ensureWelcomeTeamForKickoff(
           channelId,
           activeCommunity?.relayUrl,
         );
+        if (!welcomeTeam) return;
         await queryClient.invalidateQueries({
           queryKey: managedAgentsQueryKey,
         });
@@ -586,10 +610,6 @@ export function useWelcomeKickoff(
           lead: welcomeTeam[0],
           teammates: [welcomeTeam[1], welcomeTeam[2]],
         };
-
-        if (await markerExists(channelId, closerMarker)) {
-          return;
-        }
         if (!readiness.ready) {
           await sendManagedAgentChannelMessage({
             agentPubkey: resolvedAgentSet.lead.pubkey,


### PR DESCRIPTION
## Summary

- Stop completed Welcome kickoff flows from re-provisioning built-in teammates that an owner intentionally removed from the channel.
- Share the durable kickoff-closer guard across both onboarding seed paths.
- Add regression coverage for completed and incomplete kickoff states.

Desktop previously repaired "missing" Welcome teammates before checking whether the first-run kickoff had already finished. Because those repair events are signed by the owner's Desktop session, an intentional later removal looked like incomplete setup and Fizz, Honey, and Bumble reappeared. This change checks the durable closer marker before repairing membership.

### Related issue

Related to #5553. That issue covers deleting or hiding seeded persona/team definitions; this PR addresses the narrower channel-membership repair path after a completed kickoff. No exact duplicate issue or PR was found.

Originating live incident: [Buzz Welcome channel report](buzz://message?channel=3585ff50-2fb9-4af1-908f-ee7a22525bfa&id=cb7c88dcbbef2d9ae47ee0f41306a89eb4850aa81800e9669753600ce80a54ca)

### Testing

- Repository-required `just ci` at exact commit `28af2f429ae3052389a69bda4132941045ba596d`: root Rust clippy, Desktop static checks, Desktop Tauri format/clippy, and web checks passed. The first run stopped only while installing Flutter because the machine ran out of disk space; after removing reproducible build/cache outputs, `just mobile-check` passed separately at the same unchanged commit.
- Desktop unit suite: 71 suites, 4,956 tests, 0 failures.
- Desktop typecheck passed.
- Desktop static checks passed with four pre-existing findings in unrelated files.
- Mobile formatting checked 405 files with 0 changes; `flutter analyze` reported no issues; the mobile file-size check passed.
- Live workflow: renamed the reserved exact `Welcome` channel, removed Fizz, Honey, and Bumble, switched away and reopened it, then verified the relay and Desktop roster remained PB, Claude, and GPT.

No screenshots: this fixes background onboarding/membership behavior with no UI change.
