### PR TITLE
fix(acp): close the ACP session on rotation so the agent can reap its subprocess

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -853,6 +853,22 @@ impl AcpClient {
         self.send_notification("session/cancel", params).await
     }
 
+    /// Send a `session/close` **request** and wait for the agent to acknowledge.
+    ///
+    /// Tells the agent it may release everything tied to the session. Agents that
+    /// back each session with its own child process (the Claude adapter spawns one
+    /// `claude` per session) only reap that child here — dropping our session ID
+    /// without closing leaks the process for the lifetime of the agent subprocess.
+    ///
+    /// `session/close` is a baseline method for agents reporting protocol version
+    /// 2, so callers should gate on that; a version-1 agent answers method-not-found.
+    pub async fn session_close(&mut self, session_id: &str) -> Result<(), AcpError> {
+        let params = serde_json::json!({
+            "sessionId": session_id,
+        });
+        self.send_request("session/close", params).await.map(|_| ())
+    }
+
     /// Returns `true` if a `session/prompt` request is currently in flight.
     pub fn has_in_flight_prompt(&self) -> bool {
         self.last_prompt_id.is_some()

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1522,8 +1522,9 @@ fn any_respawn_in_flight(crash_history: &[SlotCircuit]) -> bool {
 /// Result of a background respawn task.
 struct RespawnResult {
     index: usize,
-    /// Tuple: (initialized client, protocol version, agent name).
-    result: Result<(AcpClient, u32, String)>,
+    /// Tuple: (initialized client, protocol version, agent name, whether the
+    /// agent accepts `session/close`).
+    result: Result<(AcpClient, u32, String, bool)>,
 }
 
 /// Outcome of a non-cancelling steer attempt, forwarded from a per-attempt
@@ -1567,7 +1568,7 @@ impl RespawnGuard {
     /// Send the result and disarm the guard. Uses `try_send` (sync) so there
     /// is no await boundary between marking `sent` and actually enqueueing —
     /// cancellation cannot slip between the two.
-    fn send(mut self, result: Result<(AcpClient, u32, String)>) {
+    fn send(mut self, result: Result<(AcpClient, u32, String, bool)>) {
         // Invariant: try_send succeeds because the channel capacity equals the
         // slot count, and respawn_in_flight guarantees at most one outstanding
         // result per slot. If this ever fails, the channel sizing or the
@@ -2457,7 +2458,7 @@ async fn tokio_main() -> Result<()> {
         while let Ok(rr) = respawn_rx.try_recv() {
             crash_history[rr.index].respawn_in_flight = false;
             match rr.result {
-                Ok((acp, protocol_version, agent_name)) => {
+                Ok((acp, protocol_version, agent_name, session_close_supported)) => {
                     let agent = OwnedAgent {
                         index: rr.index,
                         acp,
@@ -2468,6 +2469,7 @@ async fn tokio_main() -> Result<()> {
                         agent_name,
                         goose_system_prompt_supported: None,
                         protocol_version,
+                        session_close_supported,
                     };
                     pool.return_agent(agent);
                     tracing::info!(agent = rr.index, "respawn complete");
@@ -2681,7 +2683,7 @@ async fn tokio_main() -> Result<()> {
                                     // the agent lost access).
                                     let drained_ids = queue.drain_channel(ch);
                                     let invalidated = if pool_ready {
-                                        pool.invalidate_channel_sessions(ch)
+                                        pool.invalidate_channel_sessions(ch).await
                                     } else {
                                         0
                                     };
@@ -2811,7 +2813,7 @@ async fn tokio_main() -> Result<()> {
                                                 "!rotate received — cancelling in-flight turn and rotating session"
                                             );
                                         } else {
-                                            let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
+                                            let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id).await;
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
                                                 invalidated,
@@ -3467,7 +3469,7 @@ async fn tokio_main() -> Result<()> {
     // Drain any respawn results that completed before the abort. Explicitly
     // shut down returned agents instead of relying on AcpClient::Drop.
     while let Ok(rr) = respawn_rx.try_recv() {
-        if let Ok((mut acp, _, _)) = rr.result {
+        if let Ok((mut acp, _, _, _)) = rr.result {
             acp.shutdown().await;
             tracing::debug!(agent = rr.index, "reaped respawned agent on shutdown");
         }
@@ -4542,6 +4544,29 @@ fn spawn_respawn_task(
     true
 }
 
+/// Whether the agent will accept `session/close`.
+///
+/// The capability is authoritative, not the protocol version. The Claude adapter
+/// reports `protocolVersion: 1` while advertising
+/// `agentCapabilities.sessionCapabilities: {"close": {}, ...}` — gating on the
+/// version alone silently skips the close for exactly the agent that leaks a
+/// subprocess per session without it.
+///
+/// Per the ACP schema, supplying `sessionCapabilities` at all means the agent
+/// supports the baseline session methods, and `session/close` is one of them —
+/// so its presence is enough; an explicit `close` entry is merely the strongest
+/// form of the same signal. Agents that advertise nothing fall back to the
+/// version check.
+fn session_close_supported(init_result: &serde_json::Value, protocol_version: u32) -> bool {
+    let session_caps = init_result
+        .get("agentCapabilities")
+        .and_then(|c| c.get("sessionCapabilities"));
+    match session_caps {
+        Some(caps) if caps.is_object() => true,
+        _ => protocol_version >= 2,
+    }
+}
+
 fn normalized_agent_name(init_result: &serde_json::Value) -> String {
     init_result
         .get("agentInfo")
@@ -4652,6 +4677,8 @@ async fn initialize_agent_pool(
                             }),
                         );
                         let agent_name = normalized_agent_name(&init_result);
+                        let session_close_supported =
+                            session_close_supported(&init_result, protocol_version);
                         agent_slots.push(Some(OwnedAgent {
                             index: i,
                             acp,
@@ -4662,6 +4689,7 @@ async fn initialize_agent_pool(
                             agent_name,
                             goose_system_prompt_supported: None,
                             protocol_version,
+                            session_close_supported,
                         }));
                     }
                     Ok(Err(e)) => {
@@ -4712,7 +4740,7 @@ async fn spawn_and_init(
     has_generated_codex_config: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
-) -> Result<(AcpClient, u32, String)> {
+) -> Result<(AcpClient, u32, String, bool)> {
     let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
@@ -4730,7 +4758,8 @@ async fn spawn_and_init(
                 }),
             );
             let agent_name = normalized_agent_name(&init_result);
-            Ok((acp, protocol_version, agent_name))
+            let close_supported = session_close_supported(&init_result, protocol_version);
+            Ok((acp, protocol_version, agent_name, close_supported))
         }
         Err(e) => {
             // Explicitly shut down the spawned child to prevent zombie/leak.
@@ -7007,6 +7036,55 @@ mod error_outcome_emission_tests {
         );
     }
 
+    /// Regression: the Claude adapter reports `protocolVersion: 1` while
+    /// advertising `sessionCapabilities.close`. Gating the reap on the protocol
+    /// version skipped the close for exactly the agent that leaks a `claude`
+    /// subprocess per session without it.
+    ///
+    /// This is the adapter's real initialize response, trimmed to the fields the
+    /// gate reads (claude-agent-acp 0.66.0, captured from a live agent).
+    #[test]
+    fn session_close_supported_for_claude_adapter_despite_protocol_v1() {
+        let init = serde_json::json!({
+            "protocolVersion": 1,
+            "agentInfo": {"name": "@agentclientprotocol/claude-agent-acp", "version": "0.66.0"},
+            "agentCapabilities": {
+                "loadSession": true,
+                "sessionCapabilities": {
+                    "additionalDirectories": {}, "close": {}, "delete": {},
+                    "fork": {}, "list": {}, "resume": {}
+                }
+            }
+        });
+        assert!(
+            session_close_supported(&init, 1),
+            "must send session/close to an agent that advertises it, even at protocol v1"
+        );
+    }
+
+    #[test]
+    fn session_close_supported_falls_back_to_protocol_version() {
+        // Advertises nothing: trust the version.
+        let bare = serde_json::json!({"protocolVersion": 1, "agentCapabilities": {}});
+        assert!(!session_close_supported(&bare, 1));
+        assert!(session_close_supported(&bare, 2));
+
+        // No agentCapabilities at all (older agents).
+        let empty = serde_json::json!({"protocolVersion": 1});
+        assert!(!session_close_supported(&empty, 1));
+    }
+
+    #[test]
+    fn session_close_supported_from_bare_session_capabilities() {
+        // Per the schema, an empty `sessionCapabilities` object still means the
+        // baseline methods - which include session/close - are supported.
+        let init = serde_json::json!({
+            "protocolVersion": 1,
+            "agentCapabilities": {"sessionCapabilities": {}}
+        });
+        assert!(session_close_supported(&init, 1));
+    }
+
     /// Spawn a real but inert agent subprocess (`cat`) so the error paths have
     /// an `OwnedAgent` to move into respawn or return to the pool. The error
     /// branches never talk to the subprocess.
@@ -7022,6 +7100,7 @@ mod error_outcome_emission_tests {
             model_overridden: false,
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
+            session_close_supported: true,
             // Error branches under test never read this; 1 is the legacy
             // non-systemPrompt path, the simplest valid value.
             protocol_version: 1,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -211,6 +211,11 @@ pub struct OwnedAgent {
     pub goose_system_prompt_supported: Option<bool>,
     /// Protocol version reported by the agent in its initialize response.
     pub protocol_version: u32,
+    /// Whether the agent accepts `session/close`, from its advertised
+    /// `sessionCapabilities` (falling back to the protocol version when it
+    /// advertises none). Not the same as `protocol_version >= 2`: the Claude
+    /// adapter reports version 1 *and* advertises the capability.
+    pub session_close_supported: bool,
 }
 
 /// Package name reported by `claude-agent-acp` in its `initialize` response.
@@ -256,6 +261,57 @@ impl OwnedAgent {
             &self.agent_name,
             self.goose_system_prompt_supported,
         )
+    }
+
+    /// Close the session we are about to stop using, then drop our state for it.
+    ///
+    /// Invalidating alone only forgets the session ID on our side. Agents that
+    /// back each session with its own child process keep that child alive until
+    /// they are told the session is over, so a rotation that skips this leaks one
+    /// subprocess per rotation for the lifetime of the agent — the Claude adapter
+    /// leaks a ~190 MB `claude` per rotation this way.
+    ///
+    /// Gated on the agent's advertised `session/close` support rather than on the
+    /// protocol version: the Claude adapter reports `protocolVersion: 1` while
+    /// advertising `sessionCapabilities.close`, so a version gate would skip the
+    /// close for the very agent this fix exists for.
+    ///
+    /// Best-effort otherwise: a failure here must not stop the rotation. We log
+    /// and carry on, because a stale session on our side is worse than an
+    /// unreaped child.
+    pub(crate) async fn retire_session(&mut self, source: &PromptSource) {
+        let session_id = match source {
+            PromptSource::Channel(cid) => self.state.sessions.get(cid).cloned(),
+            PromptSource::Heartbeat => self.state.heartbeat_session.clone(),
+        };
+
+        if let Some(session_id) = session_id {
+            if self.session_close_supported {
+                match self.acp.session_close(&session_id).await {
+                    Ok(()) => tracing::debug!(
+                        target: "pool::session",
+                        "closed session {session_id} for {source:?} on agent {}",
+                        self.index
+                    ),
+                    Err(e) => tracing::warn!(
+                        target: "pool::session",
+                        "session/close failed for {session_id} on agent {} \
+                         (agent may leak the session's resources): {e}",
+                        self.index
+                    ),
+                }
+            } else {
+                tracing::debug!(
+                    target: "pool::session",
+                    "agent {} does not advertise session/close (protocol v{}); \
+                     skipping close for {session_id}",
+                    self.index,
+                    self.protocol_version
+                );
+            }
+        }
+
+        self.state.invalidate(source);
     }
 }
 
@@ -815,12 +871,22 @@ impl AgentPool {
     /// if the relay rejects the request.
     ///
     /// Returns the number of sessions invalidated.
-    pub fn invalidate_channel_sessions(&mut self, channel_id: Uuid) -> usize {
+    ///
+    /// Async because each live session is closed on the agent before it is
+    /// dropped — see [`OwnedAgent::retire_session`]. Skipping the close would
+    /// leak the session's subprocess on agents that spawn one per session.
+    pub async fn invalidate_channel_sessions(&mut self, channel_id: Uuid) -> usize {
         let mut count = 0;
         for slot in &mut self.agents {
             if let Some(agent) = slot.as_mut() {
-                if agent.state.invalidate_channel(&channel_id) {
+                if agent.state.sessions.contains_key(&channel_id) {
+                    agent
+                        .retire_session(&PromptSource::Channel(channel_id))
+                        .await;
                     count += 1;
+                } else {
+                    // No live session, but per-channel scratch state may linger.
+                    agent.state.invalidate_channel(&channel_id);
                 }
             }
         }
@@ -2403,7 +2469,7 @@ pub async fn run_prompt_task(
                     target: "pool::session",
                     "rotating session for {source:?} after {stop_reason:?}",
                 );
-                agent.state.invalidate(&source);
+                agent.retire_session(&source).await;
             }
 
             let core_stop = acp_stop_to_core(&stop_reason);
@@ -5654,6 +5720,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            session_close_supported: false,
         };
         agent.state.heartbeat_session = Some("live-session".into());
 
@@ -5748,6 +5815,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            session_close_supported: false,
         };
         agent
             .state
@@ -5920,6 +5988,7 @@ done"#
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            session_close_supported: false,
         };
         agent
             .state
@@ -6070,6 +6139,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "legacy-test-agent".into(),
             goose_system_prompt_supported: None,
             protocol_version: 1,
+            session_close_supported: false,
         };
         agent
             .state
@@ -7057,6 +7127,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            session_close_supported: true,
         };
 
         // Simulate dispatch: install a steer receiver (normally done by
@@ -7115,6 +7186,7 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            session_close_supported: true,
         };
 
         // Simulate a completed turn: `steer_rx` was consumed by the read loop
@@ -8137,5 +8209,161 @@ printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"
             "one fetch_channel_info sequence (initial attempt + single retry)"
         );
         server.abort();
+    }
+
+    /// Rotation must tell the agent to close the session it is retiring.
+    ///
+    /// Regression: `retire_session` previously only dropped the session ID from
+    /// our map. Agents that back each session with a child process (the Claude
+    /// adapter spawns one `claude` per session) never reaped that child, leaking
+    /// one subprocess — ~190 MB — per rotation.
+    #[tokio::test]
+    async fn test_retire_session_closes_the_session_on_the_agent() {
+        // The fake agent records the first request it receives so the test can
+        // assert on the actual wire message, not just on our own state.
+        let seen = std::env::temp_dir().join(format!("buzz-acp-close-{}", Uuid::new_v4()));
+        let script = format!(
+            r#"
+            read -t 5 req
+            printf '%s' "$req" > {path}
+            echo '{{"jsonrpc":"2.0","id":0,"result":{{}}}}'
+            sleep 5
+        "#,
+            path = seen.display()
+        );
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
+            .await
+            .expect("failed to spawn test agent");
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "unknown".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 2,
+            session_close_supported: true,
+        };
+        agent.state.heartbeat_session = Some("sess_hb_1".to_string());
+        agent.state.heartbeat_turn_count = 50;
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.retire_session(&PromptSource::Heartbeat),
+        )
+        .await
+        .expect("retire_session must not hang");
+
+        let sent = std::fs::read_to_string(&seen).expect("agent received no request at all");
+        let _ = std::fs::remove_file(&seen);
+        let sent: serde_json::Value =
+            serde_json::from_str(&sent).expect("request must be valid JSON-RPC");
+        assert_eq!(
+            sent["method"].as_str(),
+            Some("session/close"),
+            "rotation must send session/close, got {sent}"
+        );
+        assert_eq!(
+            sent["params"]["sessionId"].as_str(),
+            Some("sess_hb_1"),
+            "session/close must name the session being retired, got {sent}"
+        );
+        assert!(
+            sent.get("id").is_some(),
+            "session/close is a request, not a notification: {sent}"
+        );
+
+        assert!(
+            agent.state.heartbeat_session.is_none(),
+            "heartbeat session must be cleared after retirement"
+        );
+        assert_eq!(
+            agent.state.heartbeat_turn_count, 0,
+            "heartbeat turn counter must reset after retirement"
+        );
+    }
+
+    /// A close that the agent rejects must not block rotation: a stale session on
+    /// our side is worse than an unreaped child, so the state is cleared anyway.
+    #[tokio::test]
+    async fn test_retire_session_clears_state_when_close_fails() {
+        let script = r#"
+            read -t 5 _req
+            echo '{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"Method not found"}}'
+            sleep 5
+        "#;
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script.to_string()], &[], false)
+            .await
+            .expect("failed to spawn test agent");
+        let channel = Uuid::new_v4();
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "unknown".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 2,
+            session_close_supported: true,
+        };
+        agent
+            .state
+            .sessions
+            .insert(channel, "sess_ch_1".to_string());
+        agent.state.turn_counts.insert(channel, 50);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            agent.retire_session(&PromptSource::Channel(channel)),
+        )
+        .await
+        .expect("retire_session must not hang when the agent rejects the close");
+
+        assert!(
+            !agent.state.has_channel_state(&channel),
+            "channel state must be cleared even when session/close fails"
+        );
+    }
+
+    /// An agent that does not advertise `session/close` must not be sent one —
+    /// and we must not stall waiting for a reply that will never come.
+    #[tokio::test]
+    async fn test_retire_session_skips_close_when_unsupported() {
+        // This agent never answers. If retire_session sent a request it would
+        // block for REQUEST_TIMEOUT (60s) and blow the timeout below.
+        let acp = AcpClient::spawn(
+            "bash",
+            &["-c".to_string(), "sleep 30".to_string()],
+            &[],
+            false,
+        )
+        .await
+        .expect("failed to spawn test agent");
+        let mut agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "unknown".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 1,
+            session_close_supported: false,
+        };
+        agent.state.heartbeat_session = Some("sess_hb_v1".to_string());
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            agent.retire_session(&PromptSource::Heartbeat),
+        )
+        .await
+        .expect("an agent without the capability must skip the close, not wait on it");
+
+        assert!(agent.state.heartbeat_session.is_none());
     }
 }


### PR DESCRIPTION
## The bug

Session rotation drops the session ID from `SessionState` without telling the agent the session is over, so agents that back each session with its own child process never reap that child.

`crates/buzz-acp/src/pool.rs` (on `main` today):

```rust
tracing::info!(
    target: "pool::session",
    "rotating session for {source:?} after {stop_reason:?}",
);
agent.state.invalidate(&source);   // <- local HashMap mutation only, no RPC
```

`SessionState::invalidate` just sets `heartbeat_session = None` or removes the channel entry. Nothing is ever sent to the agent.

The Claude adapter (`@agentclientprotocol/claude-agent-acp`) is the clearest case. It spawns one `claude` per `session/new`, and only terminates it from `teardownSession()` -> `closeQueryStream()` -> `session.query.close()` — reachable over ACP as `session/close`. Since the harness never sends it, each rotated session leaves a `claude` alive in `Sl` state for the lifetime of the adapter process, holding ~190 MB.

It is not adapter-specific — an agent on the `buzz-agent` backend leaked the same way through orphaned `buzz-dev-mcp` children, just small enough (~2 MB each) that nobody noticed.

## Impact

A long-running headless deployment with `BUZZ_ACP_HEARTBEAT_INTERVAL=60` and `BUZZ_ACP_MAX_TURNS_PER_SESSION=50` rotates roughly every 50 minutes. Measured over 24h: 1,440 heartbeat turns, 28 rotations, **29 new processes**, none reaped.

Over 7 days that reached **205 orphaned processes and 36 GB**, taking the host to 89% memory with swap fully exhausted. Restarting the unit reclaimed all 36 GB at once, which is what made the leak obvious.

The spawn moment is visible in the logs — a rotation, then a new session, and the old process simply persists:

```
09:47:30  INFO pool::session: rotating session for Heartbeat after EndTurn
09:48:31  INFO acp::session: session created: f4ad89ad-1d25-4aa9-b133-1f500228ffad
09:48:31  INFO pool::session: created heartbeat session f4ad89ad-... for agent 0
```

## The fix

- Add `AcpClient::session_close`, sending `session/close` as a request.
- Add `OwnedAgent::retire_session`, which closes the live session before dropping the state, and use it at the rotation site.
- `AgentPool::invalidate_channel_sessions` becomes async so it can do the same; both callers were already in async contexts.

Two deliberate choices, both because a rotation must never be blocked by a cleanup step:

- **Gated on the advertised capability, not the protocol version.** The schema makes `session/close` a baseline v2 method, so a version gate looks correct — and that is what I wrote first. Checking against a live agent showed it would have been a no-op: `claude-agent-acp` 0.66.0 reports

  ```json
  "protocolVersion": 1,
  "agentCapabilities": { "sessionCapabilities": {
      "additionalDirectories":{}, "close":{}, "delete":{},
      "fork":{}, "list":{}, "resume":{} } }
  ```

  Version 1, capability explicitly advertised. A `protocol_version >= 2` gate would log "skipping session/close" on every rotation for precisely the agent that leaks without it. So the gate reads `agentCapabilities.sessionCapabilities` and falls back to the version check only when the agent advertises nothing. Per the schema, supplying `sessionCapabilities` at all implies the baseline methods, and `close` is one of them.

- **A failed close is logged at WARN and ignored.** A stale session on the harness side is worse than an unreaped child, so state is cleared either way.

## Tests

Six regression tests, all passing (`784 passed` in `buzz-acp`, clippy clean):

- `test_retire_session_closes_the_session_on_the_agent` — the fake agent records the request it receives to a file, and the test asserts the method is `session/close`, that it names the retired session, and that it is a request rather than a notification. It asserts on the wire frame, not on harness-side state, so it cannot pass vacuously. Verified by mutation: disabling the close makes this test fail.
- `test_retire_session_clears_state_when_close_fails` — agent returns `-32601`; state is still cleared.
- `test_retire_session_skips_close_when_unsupported` — a silent agent, wrapped in a 5s timeout, proving an agent without the capability is never made to answer.
- `session_close_supported_for_claude_adapter_despite_protocol_v1` — pins the adapter's real initialize response (version 1 + advertised `close`), so the mismatch has to be confronted rather than rediscovered in production.
- `session_close_supported_falls_back_to_protocol_version` and `..._from_bare_session_capabilities` — the fallback and the empty-object case from the schema.

## Notes

Found and diagnosed on a self-hosted deployment running the Claude adapter under `buzz-acp`. Happy to adjust the approach — in particular if you would rather the capability check be stricter (requiring an explicit `close` entry rather than treating any `sessionCapabilities` object as baseline), or want the same treatment extended to the `!rotate` control path.
