### PR TITLE
fix(cli): reject message content containing NUL bytes

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -6,7 +6,8 @@ use crate::client::{normalize_events, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{
     infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
-    validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
+    validate_content_no_nul, validate_hex64, validate_message_content, validate_uuid,
+    MAX_DIFF_BYTES,
 };
 use buzz_sdk::mentions::{
     extract_at_mentions_with_known, extract_nostr_uris, strip_code_regions, MENTION_CAP,
@@ -580,7 +581,7 @@ pub async fn cmd_send_message(
     // quoting — the source of countless self-inflicted command-substitution
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
-    validate_content_size(&p.content)?;
+    validate_message_content(&p.content)?;
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -726,6 +727,10 @@ pub async fn cmd_send_diff_message(client: &BuzzClient, p: SendDiffParams) -> Re
 
     // Read diff from stdin if "--diff -"
     let diff_content = read_or_stdin(&p.diff)?;
+    validate_content_no_nul(&diff_content)?;
+    if let Some(ref description) = p.description {
+        validate_content_no_nul(description)?;
+    }
 
     // Truncate at 60 KiB hunk boundary
     let (diff, truncated) = truncate_diff(&diff_content, MAX_DIFF_BYTES);
@@ -818,7 +823,7 @@ pub async fn cmd_edit_message(
     content: &str,
 ) -> Result<(), CliError> {
     validate_hex64(event_id)?;
-    validate_content_size(content)?;
+    validate_message_content(content)?;
 
     // Resolve channel_id from the event's h-tag
     let channel_uuid = resolve_channel_id(client, event_id).await?;

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -727,13 +727,15 @@ pub async fn cmd_send_diff_message(client: &BuzzClient, p: SendDiffParams) -> Re
 
     // Read diff from stdin if "--diff -"
     let diff_content = read_or_stdin(&p.diff)?;
-    validate_content_no_nul(&diff_content)?;
     if let Some(ref description) = p.description {
+        // Description is sent as-is (no size truncation path).
         validate_content_no_nul(description)?;
     }
 
-    // Truncate at 60 KiB hunk boundary
+    // Truncate at 60 KiB hunk boundary, then validate the **persisted** text.
+    // Checking pre-truncation would reject a NUL only in a discarded tail.
     let (diff, truncated) = truncate_diff(&diff_content, MAX_DIFF_BYTES);
+    validate_content_no_nul(&diff)?;
 
     // Language inference: explicit flag wins, then infer from file path
     let language = p

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -371,13 +371,16 @@ buzz agents archived"
 pub enum MessagesCmd {
     /// Send a message to a channel
     #[command(
-        after_help = "Examples:\n  buzz messages send --channel <UUID> --content \"hello\"\n  buzz messages send --channel <UUID> --content \"@alice check this\"\n  echo \"hello from stdin\" | buzz messages send --channel <UUID> --content -"
+        after_help = "Examples:\n  buzz messages send --channel <UUID> --content \"hello\"\n  buzz messages send --channel <UUID> --content \"@alice check this\"\n  echo \"hello from stdin\" | buzz messages send --channel <UUID> --content -\n\n\
+Content with embedded NUL (0x00) is rejected for Rust-visible bodies (stdin / resolved --content).\n\
+Windows argv can still truncate at NUL before buzz starts — that case is undetectable here.\n\
+Workaround: PowerShell literal here-string @'...'@, or pipe UTF-8 via --content - (avoid `0 escapes)."
     )]
     Send {
         /// Channel UUID (from 'buzz channels list')
         #[arg(long)]
         channel: String,
-        /// Message text — supports @mentions and markdown. Use '-' to read from stdin.
+        /// Message text — supports @mentions and markdown. Use '-' to read from stdin (preferred when the shell may inject NUL).
         #[arg(long)]
         content: String,
         /// Nostr event kind (default: channel default)

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -74,14 +74,20 @@ pub fn validate_content_size(content: &str) -> Result<(), CliError> {
 
 /// Reject content containing an embedded NUL byte (0x00).
 ///
-/// Interior NULs can be silently truncated at C-string boundaries on some
-/// paths; fail closed rather than publish `accepted:true` with truncated data.
+/// Contract: validates the **Rust-visible** string the CLI will persist/send.
+/// This catches stdin (`--content -`), edit bodies, and any path that still
+/// carries an interior NUL into process memory. It cannot detect Windows argv
+/// truncation (`CreateProcessW` / `CommandLineToArgvW`) that drops a NUL tail
+/// before `buzz.exe` starts — that loss never appears in the Clap `String`.
+/// Prefer PowerShell literal here-strings `@'...'@` or pipe UTF-8 via
+/// `--content -` without `` `0 `` escapes when the shell might inject NUL.
 pub fn validate_content_no_nul(content: &str) -> Result<(), CliError> {
     if content.contains('\0') {
         return Err(CliError::Usage(
-            "content contains a NUL byte (0x00); refusing to send truncated/binary content. \
-             If this came from PowerShell, use a literal here-string @'...'@ or pipe UTF-8 \
-             via --content - without `0 escapes."
+            "content contains a NUL byte (0x00); refusing to send binary/NUL-bearing text. \
+             Prefer a PowerShell literal here-string @'...'@ or pipe UTF-8 via --content - \
+             without `0 escapes. Note: Windows argv truncation before process start is not \
+             detectable here."
                 .into(),
         ));
     }
@@ -89,6 +95,9 @@ pub fn validate_content_no_nul(content: &str) -> Result<(), CliError> {
 }
 
 /// Validate message body content: size limit and no interior NUL bytes.
+///
+/// Applies to the resolved body after stdin expansion — the text that would
+/// actually be published — not pre-truncation intermediates on other paths.
 pub fn validate_message_content(content: &str) -> Result<(), CliError> {
     validate_content_size(content)?;
     validate_content_no_nul(content)?;

--- a/crates/buzz-cli/src/validate.rs
+++ b/crates/buzz-cli/src/validate.rs
@@ -72,6 +72,29 @@ pub fn validate_content_size(content: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Reject content containing an embedded NUL byte (0x00).
+///
+/// Interior NULs can be silently truncated at C-string boundaries on some
+/// paths; fail closed rather than publish `accepted:true` with truncated data.
+pub fn validate_content_no_nul(content: &str) -> Result<(), CliError> {
+    if content.contains('\0') {
+        return Err(CliError::Usage(
+            "content contains a NUL byte (0x00); refusing to send truncated/binary content. \
+             If this came from PowerShell, use a literal here-string @'...'@ or pipe UTF-8 \
+             via --content - without `0 escapes."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate message body content: size limit and no interior NUL bytes.
+pub fn validate_message_content(content: &str) -> Result<(), CliError> {
+    validate_content_size(content)?;
+    validate_content_no_nul(content)?;
+    Ok(())
+}
+
 /// Percent-encode for URL path segments and query parameter values.
 /// Encodes all bytes except RFC 3986 unreserved: A-Z a-z 0-9 - _ . ~
 #[cfg(test)]
@@ -256,7 +279,7 @@ mod tests {
         assert!(matches!(err, CliError::Usage(_)));
     }
 
-    // --- validate_content_size ---
+    // --- validate_content_size / validate_content_no_nul / validate_message_content ---
 
     #[test]
     fn validate_content_size_at_limit() {
@@ -274,6 +297,45 @@ mod tests {
     #[test]
     fn validate_content_size_empty() {
         assert!(validate_content_size("").is_ok());
+    }
+
+    #[test]
+    fn validate_content_no_nul_rejects_interior_nul() {
+        let err = validate_content_no_nul("hello\0world").unwrap_err();
+        assert!(matches!(err, CliError::Usage(msg) if msg.contains("NUL byte")));
+    }
+
+    #[test]
+    fn validate_content_no_nul_accepts_normal_content() {
+        assert!(validate_content_no_nul("hello world").is_ok());
+    }
+
+    #[test]
+    fn validate_content_no_nul_accepts_empty() {
+        assert!(validate_content_no_nul("").is_ok());
+    }
+
+    #[test]
+    fn validate_message_content_rejects_nul() {
+        let err = validate_message_content("before\0after").unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn validate_message_content_accepts_normal() {
+        assert!(validate_message_content("normal message").is_ok());
+    }
+
+    #[test]
+    fn validate_message_content_accepts_empty() {
+        assert!(validate_message_content("").is_ok());
+    }
+
+    #[test]
+    fn validate_message_content_size_limit_still_works() {
+        let content = "x".repeat(MAX_CONTENT_BYTES + 1);
+        let err = validate_message_content(&content).unwrap_err();
+        assert!(matches!(err, CliError::Usage(msg) if msg.contains("exceeds maximum size")));
     }
 
     // --- percent_encode ---


### PR DESCRIPTION
## Problem

`buzz messages send` can return `accepted: true` when the resolved Rust content still contains an embedded NUL (`0x00`) (notably stdin / paths that preserve interior nulls). Agents then believe binary/NUL-bearing text was delivered cleanly.

## Root cause

Message content was size-checked only. Nothing rejected interior NULs once content was a Rust `String`.

## Fix

- `validate_content_no_nul` / `validate_message_content` on send/edit bodies
- Diff path validates the **post-truncation** persisted text (not a discarded tail)
- CLI help documents PowerShell literal here-string / `--content -` workarounds

## Scope (honest)

This hardens **Rust-visible** stdin/content paths. It **cannot** detect Windows `CreateProcessW` / `CommandLineToArgvW` argv truncation that drops a NUL tail **before** `buzz.exe` starts — by then Clap only has a short `String` with no recoverable suffix. That full issue class remains open.

## Why it matters

Fail-closed on binary/NUL bodies the process can still see beats silent partial publishes with `accepted: true`.

## Test plan

```bash
. ./bin/activate-hermit
cargo test -p buzz-cli validate -- --nocapture
```

**64 passed** @ `2d1add610`

## Risk

Low. Only rejects NUL-bearing chat bodies. Does not claim to close Windows argv loss.

## Closest work

`none found` for open PRs on this CLI path.

Related to #5916 (non-closing — full argv class remains)
