### PR TITLE
Add Kimi Code's default install path to managed-agent binary discovery

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -47,6 +47,7 @@ fn common_binary_paths() -> &'static [PathBuf] {
                 home.join(".volta/bin"),
                 home.join(".asdf/shims"),
                 home.join(".bun/bin"),
+                home.join(".kimi-code/bin"),
             ]);
         }
         // Windows well-known dirs for npm global shims and standalone installer targets.


### PR DESCRIPTION
## Summary

Buzz Desktop fails to detect a freshly-installed Kimi Code CLI, even though `kimi --version` works fine in the terminal. Root cause is in binary discovery, not in Kimi's install.

## Problem

After running Kimi Code's installer, Buzz Desktop's harness list doesn't pick up the `kimi` binary — it stays undetected until the user manually sources their shell config.

## Repro

1. Install Kimi Code: `curl ... code.kimi.com/kimi-code/install.sh | bash` — installs to `~/.kimi-code/bin`, and the installer appends a PATH export only to `~/.zshrc`.
2. Open a fresh terminal or restart Buzz Desktop without `source ~/.zshrc`.
3. Buzz Desktop does not detect `kimi`, even though it's on disk and executable.

## Root cause

`find_via_login_shell()` in `desktop/src-tauri/src/managed_agents/discovery.rs` resolves binaries by spawning `zsh -l -c 'command -v <bin>'`. A login shell sources `~/.zprofile`/`~/.zshenv`, but zsh only sources `~/.zshrc` for *interactive* shells — so a PATH export that lives only in `~/.zshrc` (which is where Kimi's installer puts it) is invisible to this probe. `~/.kimi-code/bin` is also absent from the static fallback list in `common_binary_paths()`.

This is the same root-cause class already handled for `nvm` in this file (see the `find_nvm_default_bin` comment) — Kimi just doesn't have an equivalent fallback yet.

## Fix

Add `~/.kimi-code/bin` to the Unix branch of `common_binary_paths()`, alongside the existing `.volta/bin` / `.bun/bin` / `.asdf/shims` entries.

## Scope note

This PR only fixes detection (finding the binary). It does not address that Kimi shows a "Ready" badge regardless of login status — that's a separate, larger gap affecting all five preset harnesses (Kimi, OpenCode, Amp, Hermes, OpenClaw), tracked separately.

## Test plan

- [x] `just ci` passes
- [ ] Manual: fresh Kimi install per repro steps above, confirm Buzz Desktop shows it without sourcing `~/.zshrc`