### PR TITLE
test(desktop): stop splitting generated passphrases on a hyphen

### DIFF
--- a/desktop/src-tauri/src/key_backup_tests.rs
+++ b/desktop/src-tauri/src/key_backup_tests.rs
@@ -233,7 +233,11 @@ fn generated_passphrase_respects_word_count_and_separator() {
         WORDLIST.lines().filter(|l| !l.is_empty()).collect();
     assert_eq!(words.len(), 1296, "EFF short wordlist 2.0 has 1296 words");
 
-    for (count, separator) in [(3, "-"), (4, "-"), (6, " "), (5, "."), (10, "")] {
+    // "-" is deliberately absent: the wordlist contains "yo-yo", so splitting
+    // a phrase on "-" yields an extra part whenever that word is drawn (a
+    // ~0.5% flake per run). `generated_passphrase_clamps_word_count` below
+    // documents the same trap; the join logic itself is separator-agnostic.
+    for (count, separator) in [(3, "|"), (4, "|"), (6, " "), (5, "."), (10, "")] {
         let phrase = generate_passphrase(count, separator).unwrap();
         if separator.is_empty() {
             // No separator to split on; length gate below still applies.


### PR DESCRIPTION
## Summary
- `generated_passphrase_respects_word_count_and_separator` split generated phrases on `-`, but the EFF short wordlist 2.0 contains the word `yo-yo` — any draw containing it yields one extra part and fails the count assertion (~0.5% of runs).
- This bit Desktop Core on PR #5981's run ([31915536337](https://github.com/block/buzz/actions/runs/31915536337/job/95086711689): `left: 5, right: 4` at key_backup_tests.rs:242) despite that PR touching nothing near key backup.
- The sibling test `generated_passphrase_clamps_word_count` already documents this exact trap and uses `|`; this change applies the same separator (plus a comment) to the word-count loop. The join logic under test is separator-agnostic, so no coverage is lost.

### Testing
- [x] `cargo test --lib generated_passphrase` × 10 consecutive green at head c239b741
- [x] Full `just desktop-tauri-test` (src-tauri workspace) green at head c239b741

_Authored by Wintermute (agent); Thomas Petersen signed off._
