### PR TITLE
chore(nix): add optional development shells

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ typesense-data/
 
 # Hermit (toolchain manager cache)
 .hermit/
+
+# direnv (local Nix environment cache)
+.direnv/
+
 doc/
 /repos/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ scripts/              # Dev tooling
 
 ## Getting Started
 
+Use one toolchain environment at a time. Hermit is the portable default:
+
 ```bash
 . ./bin/activate-hermit   # activate hermit toolchain (Rust, Node, etc.)
 cp .env.example .env      # configure local environment
@@ -102,6 +104,20 @@ just setup                # install deps, run migrations
 just relay                # start relay at ws://localhost:3000
 just ci                   # run before any PR
 ```
+
+Nix is a supported alternative when it is already available on the host:
+
+```bash
+nix develop --command just setup
+nix develop .#mobile --command just ci
+```
+
+The default Nix shell covers Rust, relay, desktop, and web development. Use
+`nix develop .#mobile --command just <recipe>` for Flutter work and aggregate
+gates (`just check`, `just ci`, and pre-push), or `.#full` for the mobile
+toolchain plus occasional tools such as `gh` and `uv`. Do not activate Hermit
+inside a Nix shell. Agents must not assume that Nix or direnv is installed;
+follow the environment selected by the contributor.
 
 See CONTRIBUTING.md for full setup details and dependency requirements.
 
@@ -125,9 +141,15 @@ typechecking (`tsc --noEmit`), and fast unit tests in parallel (Rust, desktop
 JS, Tauri Rust, mobile Flutter) — no overlap with pre-commit. Builds are
 CI-only. Run `just fix-all` to auto-fix all formatting in one shot. Run
 `just ci` for the full local gate. Run `just hooks` to
-re-install hooks after env changes. Before agents run Git or hooks, activate the
-repo's Hermit environment (`. ./bin/activate-hermit`); do not rewrite hook
-commands to compensate for an unconfigured shell `PATH`.
+re-install hooks after env changes. Before agents run Git or hooks, ensure one
+of the repository toolchain environments is active. If `IN_NIX_SHELL` is set,
+use the current Nix environment directly. Otherwise activate Hermit with
+`. ./bin/activate-hermit`, unless the contributor explicitly selected Nix; for
+non-interactive Nix work, use `nix develop --command ...` for desktop/web/Rust
+recipes and `nix develop .#mobile --command ...` for mobile or aggregate gates.
+Because pre-push runs mobile tests, enter `.#mobile` before pushing from a Nix
+environment. Do not rewrite hook commands to compensate for an unconfigured
+shell `PATH`.
 
 **Commit with `git commit -s`.** The required **DCO Check** fails any PR with a commit missing a `Signed-off-by` trailer, and `just hooks` installs a `commit-msg` hook that adds it to commits you create locally (`git rebase` and `git cherry-pick` still need `--signoff`) — if you build commit commands programmatically, include `-s` every time. To repair a branch that already has unsigned commits: `git rebase --signoff main`, then force-push.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,9 +139,11 @@ Hermit pins Flutter 3.41.7 exactly. The mobile Nix shell currently uses Flutter
 3.41.9, the closest packaged release in the same stable line; `flake.lock` pins
 the package set used by the Nix path.
 
-Docker remains a host prerequisite for local services. Android SDK/Xcode are
-also host prerequisites when building for their respective mobile platforms;
-the mobile shell supplies Flutter and the tools used by repository checks.
+Docker remains a host prerequisite for local services. Xcode remains a host
+prerequisite for iOS builds. The `.#mobile` shell supplies Flutter and the tools
+used by repository checks but expects a host Android SDK for Android builds; on
+x86-64 Linux, `.#mobile-android` instead supplies the pinned Android SDK,
+emulator image, NDK, CMake, and JDK used by the emulator test workflow.
 
 #### Linux: Tauri system libraries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,14 @@ We review as capacity allows — focused PRs that follow this guide move fastest
 | `lefthook` | 2.1.3 (Hermit-pinned) | Auto-installed by `just hooks` — no manual install needed |
 | `sqlx` migrations | workspace crate | `just migrate` applies embedded migrations from `migrations/` |
 
-This repo uses [Hermit](https://cashapp.github.io/hermit/) for toolchain
-pinning. Activate it once per shell session:
+Buzz supports two development-environment paths. Hermit is the established,
+portable default and pins the repository's command-line tools. Nix is an
+optional alternative that also supplies native build and runtime libraries.
+Choose one path per shell rather than activating both.
+
+#### Hermit toolchain (default)
+
+Activate [Hermit](https://cashapp.github.io/hermit/) once per shell session:
 
 ```bash
 . ./bin/activate-hermit
@@ -98,12 +104,46 @@ Hermit pins Rust, `just`, Node, pnpm, and other tools to the versions in
 upfront. If you don't use Hermit, ensure your toolchain meets the minimum
 versions in the table above.
 
+#### Nix development shells (optional)
+
+If you already use [Nix](https://nixos.org/), the repository flake provides a
+complete development environment without requiring Hermit or system-wide Tauri
+libraries:
+
+```bash
+nix develop          # Rust, relay, desktop, and web development
+nix develop .#mobile # default environment plus Flutter
+nix develop .#full   # mobile environment plus occasional tools such as gh and uv
+```
+
+With [direnv](https://direnv.net/) installed, `direnv allow` loads the default
+desktop/web shell through the committed `.envrc`. Direnv is optional; agents
+and scripts should not assume it has loaded in a non-interactive shell. Use an
+explicit command in that case:
+
+```bash
+nix develop .#mobile --command just ci
+nix develop .#mobile --command just mobile-test
+```
+
+`just` runs inside the environment from which it was invoked, so it cannot
+select a larger Nix shell after a recipe starts. Enter `.#mobile` before running
+a mobile recipe. The aggregate `just check` and `just ci` recipes, and the
+pre-push hook, also include mobile checks and therefore require `.#mobile`. Do
+not activate Hermit inside a Nix shell; Buzz recipes detect `IN_NIX_SHELL` and
+use the Nix-provided tools instead of the Hermit shims.
+
+Hermit pins Flutter 3.41.7 exactly. The mobile Nix shell currently uses Flutter
+3.41.9, the closest packaged release in the same stable line; `flake.lock` pins
+the package set used by the Nix path.
+
 #### Linux: Tauri system libraries
 
-Hermit pins language toolchains, not system libraries. On Linux, the desktop
-app's Rust crates link against GTK and WebKitGTK, so `just ci` (and any
-`just desktop-tauri-*` recipe) needs these installed system-wide first. On
-Debian/Ubuntu:
+When using Hermit or a manually installed toolchain, Linux system libraries
+remain the contributor's responsibility. The desktop app's Rust crates link
+against GTK and WebKitGTK, so `just ci` (and any `just desktop-tauri-*` recipe)
+needs these installed system-wide first. The Nix shells already provide these
+libraries. On Debian/Ubuntu:
 
 ```bash
 sudo apt-get install -y --no-install-recommends \
@@ -146,11 +186,15 @@ just setup
 just hooks
 ```
 
+Nix users can replace step 2 by entering `nix develop`, then run the remaining
+commands normally. For non-interactive setup, use `nix develop --command just
+setup`.
+
 `just setup` runs `just bootstrap` first — it copies `.env.example` to `.env`
-if it doesn't already exist, and invokes `cargo`, `node`, and `pnpm` to trigger
-Hermit's lazy tool download (each tool is fetched once on first invocation and
-cached thereafter). You can also run `just bootstrap` independently at any time;
-it is safe to re-run.
+if it doesn't already exist and verifies `cargo`, `node`, and `pnpm`. Under
+Hermit, this triggers each tool's lazy download; inside Nix, it verifies the
+tools supplied by the selected shell. You can also run `just bootstrap`
+independently at any time; it is safe to re-run.
 
 `just setup` then starts Docker services (Postgres on `:5432`, Redis on `:6379`,
 Adminer on `:8082`, Keycloak on `:8180` for local OAuth/OIDC testing, MinIO on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,9 @@ versions in the table above.
 
 #### Nix development shells (optional)
 
-If you already use [Nix](https://nixos.org/), the repository flake provides a
-complete development environment without requiring Hermit or system-wide Tauri
-libraries:
+If you already use [Nix](https://nixos.org/) with flakes enabled, the repository
+flake provides the Buzz toolchain and native Tauri libraries without requiring
+Hermit or distro-specific library installation:
 
 ```bash
 nix develop          # Rust, relay, desktop, and web development
@@ -116,10 +116,12 @@ nix develop .#mobile # default environment plus Flutter
 nix develop .#full   # mobile environment plus occasional tools such as gh and uv
 ```
 
-With [direnv](https://direnv.net/) installed, `direnv allow` loads the default
-desktop/web shell through the committed `.envrc`. Direnv is optional; agents
-and scripts should not assume it has loaded in a non-interactive shell. Use an
-explicit command in that case:
+With a current [direnv](https://direnv.net/) release whose standard library
+provides `use flake`, `direnv allow` loads the default desktop/web shell through
+the committed `.envrc`. Older direnv installations may need
+[nix-direnv](https://github.com/nix-community/nix-direnv). Direnv is optional;
+agents and scripts should not assume it has loaded in a non-interactive shell.
+Use an explicit command in that case:
 
 ```bash
 nix develop .#mobile --command just ci
@@ -136,6 +138,10 @@ use the Nix-provided tools instead of the Hermit shims.
 Hermit pins Flutter 3.41.7 exactly. The mobile Nix shell currently uses Flutter
 3.41.9, the closest packaged release in the same stable line; `flake.lock` pins
 the package set used by the Nix path.
+
+Docker remains a host prerequisite for local services. Android SDK/Xcode are
+also host prerequisites when building for their respective mobile platforms;
+the mobile shell supplies Flutter and the tools used by repository checks.
 
 #### Linux: Tauri system libraries
 

--- a/Justfile
+++ b/Justfile
@@ -707,6 +707,14 @@ mobile-build-android:
     ./scripts/mobile-worktree-overrides.sh
     unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && flutter build apk --debug --no-pub
 
+# Manage the isolated Android emulator (run inside `nix develop .#mobile-android`)
+mobile-emulator *ARGS:
+    ./scripts/mobile-android-emulator.sh {{ARGS}}
+
+# Boot the emulator and run a selected on-device integration test
+mobile-emulator-test target:
+    ./scripts/mobile-android-emulator.sh test {{target}}
+
 # Run the mobile app on iOS simulator (worktree-aware debug identity)
 mobile-dev:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -689,8 +689,8 @@ mobile-fmt:
 mobile-fix:
     unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && dart format . && flutter analyze
 
-# Run mobile lint and format checks
-mobile-check:
+# Run mobile lint, format, file-size, and emulator-script safety checks
+mobile-check: mobile-emulator-script-test
     unset GIT_DIR GIT_WORK_TREE; cd {{mobile_dir}} && dart format --output=none --set-exit-if-changed . && flutter analyze && node ./scripts/check-file-sizes.mjs
 
 # Run mobile tests
@@ -710,6 +710,10 @@ mobile-build-android:
 # Manage the isolated Android emulator (run inside `nix develop .#mobile-android`)
 mobile-emulator *ARGS:
     ./scripts/mobile-android-emulator.sh {{ARGS}}
+
+# Verify Android emulator ownership and reset safety without starting a device
+mobile-emulator-script-test:
+    ./scripts/test-mobile-android-emulator.sh
 
 # Boot the emulator and run a selected on-device integration test
 mobile-emulator-test target:

--- a/Justfile
+++ b/Justfile
@@ -22,16 +22,16 @@ default:
 
 # ─── Dev Environment ─────────────────────────────────────────────────────────
 
-# Install required dev tools via Hermit and create .env (safe to re-run)
+# Prepare the selected development toolchain and create .env (safe to re-run)
 bootstrap:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ -z "${IN_NIX_SHELL:-}" ]]; then
         export PATH="{{justfile_directory()}}/bin:$PATH"
     fi
-    # Hermit's bin/ symlinks auto-download pinned tool versions on first use.
-    # Running each tool once triggers the download if not already cached.
-    echo "Ensuring toolchain via Hermit..."
+    # Outside Nix, Hermit's bin/ symlinks download pinned tools on first use.
+    # Inside Nix, these checks verify the tools supplied by the current shell.
+    echo "Ensuring project toolchain..."
     cargo --version &
     node --version &
     pnpm --version &

--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,9 @@ default:
 bootstrap:
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     # Hermit's bin/ symlinks auto-download pinned tool versions on first use.
     # Running each tool once triggers the download if not already cached.
     echo "Ensuring toolchain via Hermit..."
@@ -56,7 +58,9 @@ hooks:
     # Use the Hermit-pinned lefthook (bin/lefthook self-downloads on first use):
     # works with no pre-installed lefthook and guarantees the pinned version
     # rather than whatever happens to be on PATH.
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     # --path-format=absolute guarantees an absolute path from every invocation context:
     # without it, --git-common-dir returns ".git" from the main checkout and a
     # relative hooksPath would break linked-worktree dispatch just like .hooks did.
@@ -413,14 +417,18 @@ desktop-screenshot *ARGS:
 relay: bootstrap _ensure-migrations
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     cargo run -p buzz-relay
 
 # Start the relay with the built web UI served from it
 relay-web: bootstrap _ensure-migrations
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     [[ -d node_modules ]] || pnpm install
     pnpm -C web build
     BUZZ_WEB_DIR=./web/dist cargo run -p buzz-relay
@@ -429,7 +437,9 @@ relay-web: bootstrap _ensure-migrations
 admin: bootstrap _ensure-migrations
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     [[ -d node_modules ]] || pnpm install
     pnpm -C admin-web build
     export BUZZ_ADMIN_HOST="${BUZZ_ADMIN_HOST:-admin.localhost:3000}"
@@ -458,7 +468,9 @@ relay-release: _ensure-migrations
 dev *ARGS: bootstrap _ensure-sidecar-stubs _ensure-migrations
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     bind_addr="${BUZZ_BIND_ADDR:-0.0.0.0:3000}"
     relay_port="${bind_addr##*:}"; [[ -n "$relay_port" ]] || relay_port=3000
     health_port="${BUZZ_HEALTH_PORT:-8080}"
@@ -517,7 +529,9 @@ dev *ARGS: bootstrap _ensure-sidecar-stubs _ensure-migrations
 desktop-standalone *ARGS: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     cargo build -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
@@ -545,7 +559,9 @@ desktop-standalone *ARGS: _ensure-sidecar-stubs
 staging *ARGS: bootstrap _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     pnpm install  # unconditional: staging must always start with a clean dep tree
     cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     FEATURES=()
@@ -580,7 +596,9 @@ staging *ARGS: bootstrap _ensure-sidecar-stubs
 production *ARGS: bootstrap _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     pnpm install  # unconditional: production must always start with a clean dep tree
     cargo build --release -p buzz-acp -p buzz-agent -p buzz-backend-kubernetes -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     FEATURES=()
@@ -964,7 +982,9 @@ _release-pr lane version:
 goose relay="ws://localhost:3000" agents="1" heartbeat="0" prompt="" key="$BUZZ_PRIVATE_KEY":
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     source ./scripts/_goose-env.sh "{{relay}}" "{{key}}" "{{agents}}" "{{heartbeat}}" "{{prompt}}"
     exec env "${env_args[@]}" ./target/release/buzz-acp
 
@@ -972,7 +992,9 @@ goose relay="ws://localhost:3000" agents="1" heartbeat="0" prompt="" key="$BUZZ_
 goose-bg relay="ws://localhost:3000" agents="1" heartbeat="0" prompt="" key="$BUZZ_PRIVATE_KEY":
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     source ./scripts/_goose-env.sh "{{relay}}" "{{key}}" "{{agents}}" "{{heartbeat}}" "{{prompt}}"
     screen -dmS goose-agent-{{agents}} bash -c "$(printf '%q ' env "${env_args[@]}") ./target/release/buzz-acp"
     echo "Agent running in screen session 'goose-agent-{{agents}}'. Attach with: screen -r goose-agent-{{agents}}"
@@ -983,7 +1005,9 @@ goose-bg relay="ws://localhost:3000" agents="1" heartbeat="0" prompt="" key="$BU
 benchmark *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
-    export PATH="{{justfile_directory()}}/bin:$PATH"
+    if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+        export PATH="{{justfile_directory()}}/bin:$PATH"
+    fi
     uv run --project benchmarks/harbor-buzz-orchestra/testbed \
         benchmarks/harbor-buzz-orchestra/scripts/benchmark.py {{ARGS}}
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ git clone https://github.com/block/buzz.git && cd buzz
 just setup && just build
 ```
 
-**Alternatively, with Nix:**
+**Alternatively, with Nix (flakes enabled):**
 
 ```bash
 git clone https://github.com/block/buzz.git && cd buzz
@@ -180,6 +180,22 @@ largest tool set. If you use direnv, `direnv allow` loads the default shell.
 Hermit and Nix are alternative environments; do not activate both in the same
 shell. See [CONTRIBUTING.md](CONTRIBUTING.md#nix-development-shells-optional)
 for details.
+
+### Rationale: why a Nix development shell?
+
+Hermit reproducibly supplies Buzz's command-line tools, but native desktop
+libraries remain a host concern. On Linux, Tauri development otherwise requires
+distro-specific GTK, WebKitGTK, GStreamer, and media packages; on NixOS those
+libraries are not exposed through the conventional FHS paths expected by many
+build tools. The flake makes the language toolchain reproducible across Buzz's
+supported Linux and macOS architectures and pins the native library set needed
+on Linux.
+
+Nix remains an optional alternative to Hermit, not a replacement. The default
+shell covers relay, desktop, and web work; Flutter is isolated in `.#mobile`,
+while `.#full` adds infrequently used tools. This keeps contributors from
+paying for the largest closure unless their workflow needs it. Docker and any
+platform SDKs are still installed on the host.
 
 `just setup` runs `just bootstrap` automatically — it copies `.env.example` to
 `.env` if needed, prepares the selected toolchain, and starts Docker services +

--- a/README.md
+++ b/README.md
@@ -154,22 +154,45 @@ See **Quick start** below — this is the developer / self-host path.
 
 ## Quick start
 
-You'll need [Docker](https://docs.docker.com/get-docker/) and [Hermit](https://cashapp.github.io/hermit/) (or Rust 1.88+, Node 24+, pnpm 10+, `just`).
+You'll need [Docker](https://docs.docker.com/get-docker/). For the development
+toolchain, choose either [Hermit](https://cashapp.github.io/hermit/) (the
+portable default) or the optional Nix development shell. You can also provide
+Rust 1.88+, Node 24+, pnpm 10+, and `just` yourself.
 
-**Once:**
+**Once, with Hermit:**
 ```bash
 git clone https://github.com/block/buzz.git && cd buzz
 . ./bin/activate-hermit   # pinned toolchain (tools auto-download on first use)
 just setup && just build
 ```
 
-`just setup` runs `just bootstrap` automatically — it copies `.env.example` to `.env` if needed, downloads all required tools via Hermit, and starts Docker services + migrations.
+**Alternatively, with Nix:**
 
-**Every day:**
+```bash
+git clone https://github.com/block/buzz.git && cd buzz
+nix develop --command just setup
+nix develop --command just build
+```
+
+The default Nix shell covers Rust, relay, desktop, and web work. Use
+`nix develop .#mobile` for Flutter development or `nix develop .#full` for the
+largest tool set. If you use direnv, `direnv allow` loads the default shell.
+Hermit and Nix are alternative environments; do not activate both in the same
+shell. See [CONTRIBUTING.md](CONTRIBUTING.md#nix-development-shells-optional)
+for details.
+
+`just setup` runs `just bootstrap` automatically — it copies `.env.example` to
+`.env` if needed, prepares the selected toolchain, and starts Docker services +
+migrations.
+
+**Every day, with Hermit:**
 ```bash
 . ./bin/activate-hermit
 just dev   # starts the relay + desktop app together
 ```
+
+With Nix, enter `nix develop` (or let direnv load it) and then run the same
+`just` recipes.
 
 Relay on `ws://localhost:3000`. Desktop app pops up. You're in.
 

--- a/desktop/src-tauri/crates/buzz-terminal/src/path.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/path.rs
@@ -34,7 +34,31 @@ pub fn user_shell_path() -> String {
     // binaries only. `/usr/local/bin` is included because it is the
     // conventional prefix on both macOS and Linux for user-installed tools
     // that rc files expect to already be present.
-    "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string()
+    let mut paths = Vec::new();
+
+    // Nix and NixOS keep user/system commands outside the FHS locations below.
+    // Include only profiles that exist so other Unix hosts keep their historical
+    // PATH shape.
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_profile = std::path::PathBuf::from(home).join(".nix-profile/bin");
+        if user_profile.is_dir() {
+            paths.push(user_profile);
+        }
+    }
+    let nixos_system_profile = std::path::PathBuf::from("/run/current-system/sw/bin");
+    if nixos_system_profile.is_dir() {
+        paths.push(nixos_system_profile);
+    }
+
+    paths.extend(
+        ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+            .into_iter()
+            .map(std::path::PathBuf::from),
+    );
+    match std::env::join_paths(paths) {
+        Ok(path) => path.to_string_lossy().into_owned(),
+        Err(_) => "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string(),
+    }
 }
 
 #[cfg(windows)]

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -822,8 +822,9 @@ fn resolve_install_shell() -> Result<std::path::PathBuf, String> {
         if std::path::Path::new("/bin/bash").exists() {
             return Ok(std::path::PathBuf::from("/bin/bash"));
         }
-        crate::managed_agents::resolve_command("zsh")
-            .or_else(|| crate::managed_agents::resolve_command("bash"))
+        crate::managed_agents::login_shell_candidates()
+            .into_iter()
+            .next()
             .ok_or_else(|| "No zsh or bash executable was found".to_string())
     }
 

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -4,7 +4,12 @@ use crate::managed_agents::{
     DEFAULT_ACP_COMMAND,
 };
 
+mod install_shell;
 mod post_install_verification;
+
+#[cfg(windows)]
+pub(crate) use install_shell::install_shell_from;
+use install_shell::resolve_install_shell;
 
 fn active_installs() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
     use std::collections::HashSet;
@@ -804,43 +809,6 @@ fn install_shell_command(command: &str) -> Result<std::process::Command, String>
     apply_no_window(&mut cmd);
 
     Ok(cmd)
-}
-
-/// Resolve the shell binary for install commands.
-///
-/// Unix: zsh if available, else bash. The PATH fallback supports distributions
-/// such as NixOS that do not expose shells below `/bin`.
-/// Windows: Git Bash via `resolve_bash_path` — skips `BUZZ_SHELL` because install
-/// commands use bash-only `-l -c` syntax. A `BUZZ_SHELL=pwsh` user gets a green
-/// Doctor prereq (their agents work) but installs use the Git Bash fallback chain.
-fn resolve_install_shell() -> Result<std::path::PathBuf, String> {
-    #[cfg(not(windows))]
-    {
-        if std::path::Path::new("/bin/zsh").exists() {
-            return Ok(std::path::PathBuf::from("/bin/zsh"));
-        }
-        if std::path::Path::new("/bin/bash").exists() {
-            return Ok(std::path::PathBuf::from("/bin/bash"));
-        }
-        crate::managed_agents::login_shell_candidates()
-            .into_iter()
-            .next()
-            .ok_or_else(|| "No zsh or bash executable was found".to_string())
-    }
-
-    #[cfg(windows)]
-    {
-        install_shell_from(crate::managed_agents::git_bash::resolve_bash_path())
-    }
-}
-
-/// Pure mapping from a resolved bash path to the install-shell result.
-/// `None` → `Err(GIT_BASH_INSTALL_HINT)`, `Some(path)` → `Ok(path)`.
-#[cfg(windows)]
-pub(crate) fn install_shell_from(
-    resolved: Option<std::path::PathBuf>,
-) -> Result<std::path::PathBuf, String> {
-    resolved.ok_or_else(|| crate::managed_agents::git_bash::GIT_BASH_INSTALL_HINT.to_string())
 }
 
 /// Returns `true` when `command` is a Windows-native PowerShell invocation

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -808,7 +808,8 @@ fn install_shell_command(command: &str) -> Result<std::process::Command, String>
 
 /// Resolve the shell binary for install commands.
 ///
-/// Unix: `/bin/zsh` if present, else `/bin/bash`.
+/// Unix: zsh if available, else bash. The PATH fallback supports distributions
+/// such as NixOS that do not expose shells below `/bin`.
 /// Windows: Git Bash via `resolve_bash_path` — skips `BUZZ_SHELL` because install
 /// commands use bash-only `-l -c` syntax. A `BUZZ_SHELL=pwsh` user gets a green
 /// Doctor prereq (their agents work) but installs use the Git Bash fallback chain.
@@ -818,7 +819,12 @@ fn resolve_install_shell() -> Result<std::path::PathBuf, String> {
         if std::path::Path::new("/bin/zsh").exists() {
             return Ok(std::path::PathBuf::from("/bin/zsh"));
         }
-        Ok(std::path::PathBuf::from("/bin/bash"))
+        if std::path::Path::new("/bin/bash").exists() {
+            return Ok(std::path::PathBuf::from("/bin/bash"));
+        }
+        crate::managed_agents::resolve_command("zsh")
+            .or_else(|| crate::managed_agents::resolve_command("bash"))
+            .ok_or_else(|| "No zsh or bash executable was found".to_string())
     }
 
     #[cfg(windows)]
@@ -1368,16 +1374,19 @@ mod tests {
 
     // ── Phase A: install shell selection ─────────────────────────────────────
 
-    /// On Unix, resolve_install_shell always succeeds (returns zsh or bash).
+    /// On Unix, resolve_install_shell succeeds when zsh or bash is available.
     #[cfg(unix)]
     #[test]
     fn test_resolve_install_shell_succeeds_on_unix() {
         let result = super::resolve_install_shell();
-        assert!(result.is_ok(), "Unix must always resolve a shell");
+        assert!(result.is_ok(), "Unix must resolve an available shell");
         let shell = result.unwrap();
         assert!(
-            shell == std::path::Path::new("/bin/zsh") || shell == std::path::Path::new("/bin/bash"),
-            "expected /bin/zsh or /bin/bash, got {shell:?}"
+            matches!(
+                shell.file_name().and_then(std::ffi::OsStr::to_str),
+                Some("zsh" | "bash")
+            ),
+            "expected zsh or bash, got {shell:?}"
         );
     }
 
@@ -1452,19 +1461,21 @@ mod tests {
 
     /// Regression for the login-startup-file overwrite: `cmd.env("PATH", …)` is
     /// installed *before* `-l` sources the user's profile, so a profile that
-    /// assigns PATH silently discards the composed one. Uses `/bin/bash`
-    /// explicitly — the planted profile is bash-specific, so resolving the host
-    /// shell (which prefers zsh) would make this vacuous.
+    /// assigns PATH silently discards the composed one. Resolves bash explicitly
+    /// — the planted profile is bash-specific, so resolving the host shell
+    /// (which prefers zsh) would make this vacuous.
     #[cfg(unix)]
     #[test]
     fn test_composed_path_survives_a_profile_that_clears_it() {
+        let _guard = crate::managed_agents::lock_path_mutex();
         let home = tempfile::tempdir().expect("temp HOME");
         std::fs::write(home.path().join(".bash_profile"), "export PATH=\n")
             .expect("plant a hostile login profile");
         let composed = std::ffi::OsString::from("/buzz/sentinel/bin:/usr/bin:/bin");
 
         // `echo` is a shell builtin, so the child needs no PATH to report one.
-        let out = std::process::Command::new("/bin/bash")
+        let bash = crate::managed_agents::resolve_command("bash").expect("bash must resolve");
+        let out = std::process::Command::new(bash)
             .args(super::install_shell_args(
                 "echo \"$PATH\"",
                 Some(&composed),
@@ -1490,6 +1501,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_install_shell_pipeline_status_follows_left_side() {
+        let _guard = crate::managed_agents::lock_path_mutex();
         for (command, expect_success) in [("false | true", false), ("echo ok | cat", true)] {
             let status = super::install_shell_command(command)
                 .expect("Unix must always resolve an install shell")

--- a/desktop/src-tauri/src/commands/agent_discovery/install_shell.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/install_shell.rs
@@ -1,0 +1,32 @@
+/// Resolve the shell binary for install commands.
+///
+/// Unix prefers the historical `/bin` locations, then falls back to PATH for
+/// non-FHS distributions. Windows uses Git Bash because install commands use
+/// bash-only `-l -c` syntax.
+pub(super) fn resolve_install_shell() -> Result<std::path::PathBuf, String> {
+    #[cfg(not(windows))]
+    {
+        for shell in ["/bin/zsh", "/bin/bash"] {
+            if std::path::Path::new(shell).exists() {
+                return Ok(std::path::PathBuf::from(shell));
+            }
+        }
+        crate::managed_agents::login_shell_candidates()
+            .into_iter()
+            .next()
+            .ok_or_else(|| "No zsh or bash executable was found".to_string())
+    }
+
+    #[cfg(windows)]
+    {
+        install_shell_from(crate::managed_agents::git_bash::resolve_bash_path())
+    }
+}
+
+/// Map a resolved Git Bash path to the install-shell result.
+#[cfg(windows)]
+pub(crate) fn install_shell_from(
+    resolved: Option<std::path::PathBuf>,
+) -> Result<std::path::PathBuf, String> {
+    resolved.ok_or_else(|| crate::managed_agents::git_bash::GIT_BASH_INSTALL_HINT.to_string())
+}

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
@@ -280,6 +280,7 @@ fn test_resolve_adapter_path_returns_none_when_binary_absent() {
 #[test]
 fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
     use std::os::unix::fs::PermissionsExt;
+    let _path_guard = crate::managed_agents::lock_path_mutex();
     let tmp_dir = tempfile::TempDir::new().unwrap();
     let script = tmp_dir.path().join("probe.sh");
     let pgid_file = tmp_dir.path().join("pgid");
@@ -290,7 +291,7 @@ fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
     // Line 2: background the sleep and record its PID.
     // Line 3: emit the expected version and exit so the direct child exits promptly.
     let script_content = format!(
-        "#!/bin/sh\necho $$ > {pgid_file_path}\n/bin/sleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
+        "#!/bin/sh\necho $$ > {pgid_file_path}\nsleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
     );
     std::fs::write(&script, script_content.as_bytes()).unwrap();
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -361,9 +362,10 @@ fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
 #[test]
 fn test_probe_node_times_out_on_hung_binary() {
     use std::os::unix::fs::PermissionsExt;
+    let _path_guard = crate::managed_agents::lock_path_mutex();
     let tmp_dir = tempfile::TempDir::new().unwrap();
     let script = tmp_dir.path().join("hung.sh");
-    std::fs::write(&script, b"#!/bin/sh\n/bin/sleep 30\n").unwrap();
+    std::fs::write(&script, b"#!/bin/sh\nsleep 30\n").unwrap();
     std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let probe_timeout = std::time::Duration::from_secs(3);

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -763,7 +763,7 @@ fn path_candidates_from_env_raw(basename: &str) -> Vec<PathBuf> {
 /// on PATH. The latter supports non-FHS distributions such as NixOS.
 /// On Windows: Git Bash via `resolve_bash_path` — skips `BUZZ_SHELL` because
 /// login-shell callers use bash-only `-l -c` syntax.
-fn login_shell_candidates() -> Vec<PathBuf> {
+pub(crate) fn login_shell_candidates() -> Vec<PathBuf> {
     #[cfg(not(windows))]
     {
         let mut candidates = vec![PathBuf::from("/bin/zsh"), PathBuf::from("/bin/bash")];

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -759,13 +759,19 @@ fn path_candidates_from_env_raw(basename: &str) -> Vec<PathBuf> {
 
 /// Collect login shell candidates for the current platform.
 ///
-/// On Unix: `/bin/zsh`, `/bin/bash` (the historical defaults).
+/// On Unix: existing historical `/bin` locations followed by zsh/bash found
+/// on PATH. The latter supports non-FHS distributions such as NixOS.
 /// On Windows: Git Bash via `resolve_bash_path` — skips `BUZZ_SHELL` because
 /// login-shell callers use bash-only `-l -c` syntax.
 fn login_shell_candidates() -> Vec<PathBuf> {
     #[cfg(not(windows))]
     {
-        vec![PathBuf::from("/bin/zsh"), PathBuf::from("/bin/bash")]
+        let mut candidates = vec![PathBuf::from("/bin/zsh"), PathBuf::from("/bin/bash")];
+        candidates.extend(path_candidates_from_env("zsh"));
+        candidates.extend(path_candidates_from_env("bash"));
+        candidates.retain(|candidate| is_executable_file(candidate));
+        candidates.dedup();
+        candidates
     }
     #[cfg(windows)]
     {

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -11,6 +11,7 @@ use crate::managed_agents::{
 };
 mod presets;
 mod runtime_metadata;
+mod shell_candidates;
 #[macro_use]
 mod windows_install;
 pub(crate) use presets::{
@@ -19,6 +20,7 @@ pub(crate) use presets::{
 };
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
+pub(crate) use shell_candidates::login_shell_candidates;
 
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
@@ -755,28 +757,6 @@ fn path_candidates_from_env_raw(basename: &str) -> Vec<PathBuf> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()
-}
-
-/// Collect login shell candidates for the current platform.
-///
-/// On Unix: existing historical `/bin` locations followed by zsh/bash found
-/// on PATH. The latter supports non-FHS distributions such as NixOS.
-/// On Windows: Git Bash via `resolve_bash_path` — skips `BUZZ_SHELL` because
-/// login-shell callers use bash-only `-l -c` syntax.
-pub(crate) fn login_shell_candidates() -> Vec<PathBuf> {
-    #[cfg(not(windows))]
-    {
-        let mut candidates = vec![PathBuf::from("/bin/zsh"), PathBuf::from("/bin/bash")];
-        candidates.extend(path_candidates_from_env("zsh"));
-        candidates.extend(path_candidates_from_env("bash"));
-        candidates.retain(|candidate| is_executable_file(candidate));
-        candidates.dedup();
-        candidates
-    }
-    #[cfg(windows)]
-    {
-        super::git_bash::resolve_bash_path().into_iter().collect()
-    }
 }
 
 /// Run a command in a login shell (tries zsh then bash on Unix, Git Bash on Windows).

--- a/desktop/src-tauri/src/managed_agents/discovery/shell_candidates.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/shell_candidates.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+/// Collect executable login-shell candidates for the current platform.
+///
+/// Unix checks the historical `/bin` locations before PATH-backed non-FHS
+/// locations. Windows uses Git Bash for callers that require `-l -c`.
+pub(crate) fn login_shell_candidates() -> Vec<PathBuf> {
+    #[cfg(not(windows))]
+    {
+        let mut candidates = vec![PathBuf::from("/bin/zsh"), PathBuf::from("/bin/bash")];
+        candidates.extend(super::path_candidates_from_env("zsh"));
+        candidates.extend(super::path_candidates_from_env("bash"));
+        candidates.retain(|candidate| super::is_executable_file(candidate));
+        candidates.dedup();
+        candidates
+    }
+    #[cfg(windows)]
+    {
+        crate::managed_agents::git_bash::resolve_bash_path()
+            .into_iter()
+            .collect()
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1252,30 +1252,6 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     );
 }
 
-// ── Phase C: login_shell_candidates ─────────────────────────────────────────
-
-/// On Unix, login_shell_candidates returns at least one candidate.
-#[cfg(unix)]
-#[test]
-fn test_login_shell_candidates_non_empty_on_unix() {
-    let _guard = crate::managed_agents::lock_path_mutex();
-    let candidates = super::login_shell_candidates();
-    assert!(
-        !candidates.is_empty(),
-        "Unix must have at least one login shell candidate"
-    );
-    // The first candidate should resolve to zsh or bash, including on non-FHS
-    // distributions where the executable lives in a store path.
-    let first = &candidates[0];
-    assert!(
-        matches!(
-            first.file_name().and_then(std::ffi::OsStr::to_str),
-            Some("zsh" | "bash")
-        ),
-        "expected zsh or bash, got {first:?}"
-    );
-}
-
 // ── Regression: POSIX PATH must never reach native Windows consumers ───────
 
 /// `login_shell_path()` must return `None` on Windows so native-process

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1258,16 +1258,21 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
 #[cfg(unix)]
 #[test]
 fn test_login_shell_candidates_non_empty_on_unix() {
+    let _guard = crate::managed_agents::lock_path_mutex();
     let candidates = super::login_shell_candidates();
     assert!(
         !candidates.is_empty(),
         "Unix must have at least one login shell candidate"
     );
-    // The first candidate should be /bin/zsh or /bin/bash.
+    // The first candidate should resolve to zsh or bash, including on non-FHS
+    // distributions where the executable lives in a store path.
     let first = &candidates[0];
     assert!(
-        first == std::path::Path::new("/bin/zsh") || first == std::path::Path::new("/bin/bash"),
-        "expected /bin/zsh or /bin/bash, got {first:?}"
+        matches!(
+            first.file_name().and_then(std::ffi::OsStr::to_str),
+            Some("zsh" | "bash")
+        ),
+        "expected zsh or bash, got {first:?}"
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
@@ -1,4 +1,21 @@
-use crate::managed_agents::discovery::{clear_resolve_cache, resolve_command};
+use crate::managed_agents::discovery::{
+    clear_resolve_cache, login_shell_candidates, resolve_command,
+};
+
+#[cfg(unix)]
+#[test]
+fn login_shell_candidates_include_an_available_shell() {
+    let _guard = crate::managed_agents::lock_path_mutex();
+    let candidates = login_shell_candidates();
+    let first = candidates.first().expect("an available Unix login shell");
+    assert!(
+        matches!(
+            first.file_name().and_then(std::ffi::OsStr::to_str),
+            Some("zsh" | "bash")
+        ),
+        "expected zsh or bash, got {first:?}"
+    );
+}
 
 /// The legacy Goose Windows installer wrote `%USERPROFILE%\goose\goose.exe`,
 /// a directory on no standard PATH. `resolve_command_uncached` finds binaries

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -690,6 +690,7 @@ fn batch_shim_no_extension_is_not_rejected() {
 fn grandchild_inherits_pgid_of_process_group_leader() {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
+    let _path_guard = crate::managed_agents::lock_path_mutex();
 
     // Spawn a "harness" process in its own process group (mirrors
     // `command.process_group(0)` in the real spawn path). The harness
@@ -706,20 +707,13 @@ fn grandchild_inherits_pgid_of_process_group_leader() {
     // getpgid returned -1). The group is killed in cleanup, so the sleep
     // never runs to term.
     //
-    // Absolute `/bin/sh` and `/bin/sleep` rather than bare names: parallel
-    // tests holding `lock_path_mutex` legitimately swap PATH to a tempdir,
-    // and this test doesn't need the lock — but a PATH lookup during the
-    // swap window fails with NotFound, and a child spawned during it
-    // inherits the poisoned PATH for its lifetime, so the script's inner
-    // lookups must be absolute too (observed flake).
+    // Hold the PATH test mutex for the child lifetime so portable command names
+    // remain safe from tests that temporarily replace PATH.
     let mut harness = {
-        let mut cmd = Command::new("/bin/sh");
-        cmd.args([
-            "-c",
-            "/bin/sh -c '/bin/sleep 10 & echo $!' & wait $!; /bin/sleep 10",
-        ])
-        .stdout(std::process::Stdio::piped())
-        .process_group(0);
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sh -c 'sleep 10 & echo $!' & wait $!; sleep 10"])
+            .stdout(std::process::Stdio::piped())
+            .process_group(0);
         cmd.spawn().expect("spawn harness")
     };
 
@@ -799,19 +793,17 @@ fn grandchild_inherits_pgid_of_process_group_leader() {
 fn own_group_grandchild_detected_by_ancestor_walk() {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
+    let _path_guard = crate::managed_agents::lock_path_mutex();
 
     // The test process is the "harness". Spawn an intermediate with its own
     // process group (mirrors the node shim). It backgrounds a grandchild
     // (sleep 30) and prints the grandchild PID so we can inspect it.
     //
-    // Absolute `/bin/sh` and `/bin/sleep` — no PATH lookups anywhere in this
-    // tree. Parallel tests holding `lock_path_mutex` legitimately swap PATH to
-    // a tempdir; the outer spawn during that window fails with NotFound, and a
-    // child spawned during it inherits the poisoned PATH for its lifetime, so
-    // inner lookups must be absolute too (observed flake).
+    // Hold the PATH test mutex for the child lifetime so portable command names
+    // remain safe from tests that temporarily replace PATH.
     let mut intermediate = {
-        let mut cmd = Command::new("/bin/sh");
-        cmd.args(["-c", "/bin/sleep 30 & echo $!; wait"])
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30 & echo $!; wait"])
             .stdout(std::process::Stdio::piped())
             .process_group(0);
         cmd.spawn().expect("spawn intermediate")
@@ -1238,21 +1230,15 @@ fn minimal_record(pubkey: &str) -> crate::managed_agents::ManagedAgentRecord {
 fn make_pair_runtime_placeholder() -> crate::managed_agents::ManagedAgentPairRuntime {
     use std::process::{Command, Stdio};
     // Spawn a real child so ManagedAgentProcess's Child field is satisfied.
-    // `true` exits immediately with 0 — just a handle we need for type purposes.
-    // Absolute `/usr/bin/true` on unix (present on both macOS and Linux):
-    // parallel tests holding `lock_path_mutex` swap PATH to a tempdir, and a
-    // bare `true` lookup during that window fails with NotFound (observed
-    // flake). Windows keeps the PATH lookup — no test there swaps PATH.
-    #[cfg(unix)]
-    let program = "/usr/bin/true";
-    #[cfg(windows)]
-    let program = "true";
-    let child = Command::new(program)
+    // The absolute current-test path avoids both platform-specific system paths
+    // and races with tests that temporarily replace PATH.
+    let child = Command::new(std::env::current_exe().expect("current test executable"))
+        .arg("--help")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn true for placeholder");
+        .expect("spawn current test executable for placeholder");
     let process = crate::managed_agents::ManagedAgentProcess {
         child,
         log_path: Default::default(),

--- a/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_snapshot/diff/tests.rs
@@ -425,16 +425,16 @@ fn no_sentinel_reaches_snapshot_debug_output() {
 fn no_sentinel_reaches_the_owning_process_debug_output() {
     // `ManagedAgentProcess` derives `Debug` and delegates to the snapshot's
     // manual impl — this pins that the derive can never become the leak path.
-    #[cfg(unix)]
-    let program = "/usr/bin/true";
-    #[cfg(windows)]
-    let program = "true";
-    let child = std::process::Command::new(program)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .expect("spawn placeholder child");
+    // Use the absolute current-test path so the placeholder is portable and
+    // independent of concurrent tests that temporarily replace PATH.
+    let child =
+        std::process::Command::new(std::env::current_exe().expect("current test executable"))
+            .arg("--help")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn placeholder child");
     let process = crate::managed_agents::ManagedAgentProcess {
         child,
         log_path: std::path::PathBuf::new(),

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1786527240,
+        "narHash": "sha256-OLtJPnSXcRy79Rf7BhYaMeXAVF625FpLcd3+Svq641Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e0c84f9d0ad137f076dc957494f5b39885597d4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786762605,
+        "narHash": "sha256-iQpYIhInh8gRx+cSnPtX+Yp2Gg9kr2h+MehETCqRgDo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ad8ebb59d84bcf3780c46f107e1d99eb4ca2fe7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-flutter": {
+      "locked": {
+        "lastModified": 1778461020,
+        "narHash": "sha256-FM+OPMqbBG882JI1H5/kvN6/TXdhl5TAwMlTeq4eXQU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7fe56c8fe4e9cee3dbe797cae9e7b74def154567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7fe56c8fe4e9cee3dbe797cae9e7b74def154567",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1785031560,
@@ -70,6 +86,7 @@
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "nixpkgs-darwin": "nixpkgs-darwin",
+        "nixpkgs-flutter": "nixpkgs-flutter",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
             glib
             gtk3
             libayatana-appindicator
+            libopus
             librsvg
             openssl
             webkitgtk_4_1

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,10 @@
                 shellHook = ''
                   export PATH="$PWD/node_modules/.bin:$PATH"
 
+                  ${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+                    export XDG_DATA_DIRS="${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:''${XDG_DATA_DIRS:-}"
+                  ''}
+
                   echo "Buzz ${label} development shell"
                   echo "  Rust: $(rustc --version)"
                   echo "  Node: $(node --version)"

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
     # macOS builds. Keep that system on the supported 26.05 branch.
     nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
 
+    # Buzz pins Flutter 3.41.7 through Hermit. Nixpkgs skipped that patch
+    # release; 3.41.9 is the closest packaged release in the same stable line.
+    nixpkgs-flutter.url = "github:NixOS/nixpkgs/7fe56c8fe4e9cee3dbe797cae9e7b74def154567";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     rust-overlay = {
@@ -21,6 +25,7 @@
       flake-parts,
       nixpkgs,
       nixpkgs-darwin,
+      nixpkgs-flutter,
       rust-overlay,
       ...
     }:
@@ -42,18 +47,61 @@
             overlays = [ (import rust-overlay) ];
           };
 
+          flutterPkgs = import nixpkgs-flutter { inherit system; };
+
           toolchainChannel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
 
           rustToolchain = pkgs.rust-bin.stable.${toolchainChannel}.default;
+
+          biomeTarget =
+            {
+              aarch64-darwin = "darwin-arm64";
+              aarch64-linux = "linux-arm64";
+              x86_64-darwin = "darwin-x64";
+              x86_64-linux = "linux-x64";
+            }
+            .${system};
+
+          biomeHash =
+            {
+              aarch64-darwin = "sha256-5K3KJbVulY/AuXtfU5tH060gzexeJxZglFAi9X2WbyM=";
+              aarch64-linux = "sha256-rTXsRcUV7i5UyLvO2dWv6rJuEE9O01gTM3YatbF5iGs=";
+              x86_64-darwin = "sha256-UlLAWG/6l5mOoErfMbSg/iK63sHoCXsWMmUWHZJ5Mzg=";
+              x86_64-linux = "sha256-7HYAu+gNJXqs1uvJ1+jnspwMWHccZ9z+njWDHATSwSw=";
+            }
+            .${system};
+
+          biomeTool = pkgs.stdenv.mkDerivation {
+            pname = "biome";
+            version = "2.4.16";
+            src = pkgs.fetchurl {
+              url = "https://registry.npmjs.org/@biomejs/cli-${biomeTarget}/-/cli-${biomeTarget}-2.4.16.tgz";
+              hash = biomeHash;
+            };
+            sourceRoot = "package";
+            nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+              pkgs.autoPatchelfHook
+            ];
+            buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+              pkgs.stdenv.cc.cc
+            ];
+            installPhase = ''
+              runHook preInstall
+              install -Dm755 biome "$out/bin/biome"
+              runHook postInstall
+            '';
+          };
 
           commonPackages = with pkgs; [
             cargo-deny
             cargo-nextest
             cmake
             curl
+            ffmpeg
             file
             git
             just
+            jq
             lefthook
             ninja
             nodejs_24
@@ -65,6 +113,13 @@
             rust-analyzer
             rustToolchain
             wget
+          ];
+
+          mobilePackages = [ flutterPkgs.flutter ];
+
+          occasionalPackages = with pkgs; [
+            gh
+            uv
           ];
 
           linuxLibraries = with pkgs; [
@@ -99,30 +154,60 @@
             ]
             ++ linuxLibraries
             ++ gstreamerPlugins;
+
+          # Just runs inside the caller's current environment; it cannot switch
+          # Nix shells per recipe. Keep the direnv/default shell focused on
+          # desktop, web, and Rust work, and opt into the larger closures with
+          # `nix develop .#mobile` or `nix develop .#full`.
+          mkBuzzShell =
+            {
+              label,
+              extraPackages ? [ ],
+            }:
+            pkgs.mkShell {
+              packages =
+                commonPackages
+                ++ extraPackages
+                ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
+
+              CMAKE_POLICY_VERSION_MINIMUM = "3.5";
+              LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+                pkgs.lib.makeLibraryPath linuxLibraries
+              );
+
+              GST_PLUGIN_SYSTEM_PATH_1_0 = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+                pkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerPlugins
+              );
+
+              # The npm launcher honors this variable. Point it at Nix's patched
+              # executable so Biome works on NixOS without a global nix-ld setup.
+              BIOME_BINARY = "${biomeTool}/bin/biome";
+
+              FLUTTER_SUPPRESS_ANALYTICS = "true";
+
+              shellHook = ''
+                export PATH="$PWD/node_modules/.bin:$PATH"
+
+                echo "Buzz ${label} development shell"
+                echo "  Rust: $(rustc --version)"
+                echo "  Node: $(node --version)"
+                echo "  pnpm: $(pnpm --version)"
+              '';
+            };
         in
         {
           formatter = pkgs.nixfmt;
 
-          devShells.default = pkgs.mkShell {
-            packages = commonPackages ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
-
-            CMAKE_POLICY_VERSION_MINIMUM = "3.5";
-            LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
-              pkgs.lib.makeLibraryPath linuxLibraries
-            );
-
-            GST_PLUGIN_SYSTEM_PATH_1_0 = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
-              pkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerPlugins
-            );
-
-            shellHook = ''
-              export PATH="$PWD/node_modules/.bin:$PATH"
-
-              echo "Buzz development shell"
-              echo "  Rust: $(rustc --version)"
-              echo "  Node: $(node --version)"
-              echo "  pnpm: $(pnpm --version)"
-            '';
+          devShells = {
+            default = mkBuzzShell { label = "desktop/web"; };
+            mobile = mkBuzzShell {
+              label = "mobile";
+              extraPackages = mobilePackages;
+            };
+            full = mkBuzzShell {
+              label = "full";
+              extraPackages = mobilePackages ++ occasionalPackages;
+            };
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,53 @@
             overlays = [ (import rust-overlay) ];
           };
 
+          androidEmulatorSupported = system == "x86_64-linux";
+          androidPkgs = import nixpkgsForSystem {
+            inherit system;
+            config = {
+              allowUnfree = true;
+              android_sdk.accept_license = true;
+            };
+          };
+
+          androidBuildComposition =
+            if androidEmulatorSupported then
+              androidPkgs.androidenv.composeAndroidPackages {
+                platformVersions = [
+                  "34"
+                  "35"
+                  "36"
+                ];
+                buildToolsVersions = [
+                  "35.0.0"
+                  "36.0.0"
+                ];
+                includeNDK = true;
+                ndkVersions = [ "28.2.13676358" ];
+                includeCmake = true;
+                cmakeVersions = [ "3.22.1" ];
+              }
+            else
+              null;
+
+          androidEmulatorComposition =
+            if androidEmulatorSupported then
+              androidPkgs.androidenv.composeAndroidPackages {
+                platformVersions = [ "36" ];
+                includeEmulator = true;
+                includeSystemImages = true;
+                systemImageTypes = [ "default" ];
+                abiVersions = [ "x86_64" ];
+                includeNDK = false;
+                includeCmake = false;
+              }
+            else
+              null;
+
+          androidBuildSdk = if androidEmulatorSupported then androidBuildComposition.androidsdk else null;
+          androidEmulatorSdk =
+            if androidEmulatorSupported then androidEmulatorComposition.androidsdk else null;
+
           flutterPkgs = import nixpkgs-flutter { inherit system; };
 
           toolchainChannel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
@@ -156,12 +203,19 @@
               label,
               extraPackages ? [ ],
               withFlutter ? false,
+              withAndroid ? false,
             }:
+            assert !withAndroid || androidEmulatorSupported;
             pkgs.mkShell (
               {
                 packages =
                   commonPackages
                   ++ pkgs.lib.optionals withFlutter [ flutterPkgs.flutter ]
+                  ++ pkgs.lib.optionals withAndroid [
+                    androidBuildSdk
+                    androidEmulatorSdk
+                    pkgs.jdk17
+                  ]
                   ++ extraPackages
                   ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
 
@@ -193,6 +247,17 @@
               }
               // pkgs.lib.optionalAttrs withFlutter {
                 FLUTTER_SUPPRESS_ANALYTICS = "true";
+              }
+              // pkgs.lib.optionalAttrs withAndroid {
+                ANDROID_HOME = "${androidBuildSdk}/libexec/android-sdk";
+                ANDROID_SDK_ROOT = "${androidBuildSdk}/libexec/android-sdk";
+                ANDROID_NDK_ROOT = "${androidBuildSdk}/libexec/android-sdk/ndk/28.2.13676358";
+                JAVA_HOME = pkgs.jdk17.home;
+                GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidBuildSdk}/libexec/android-sdk/build-tools/35.0.0/aapt2";
+                BUZZ_ANDROID_EMULATOR_SDK = "${androidEmulatorSdk}/libexec/android-sdk";
+                BUZZ_ANDROID_EMULATOR_API = "36";
+                BUZZ_ANDROID_EMULATOR_ABI = "x86_64";
+                BUZZ_ANDROID_EMULATOR_SERIAL = "emulator-5556";
               }
             );
         in
@@ -227,6 +292,13 @@
               label = "full";
               extraPackages = occasionalPackages;
               withFlutter = true;
+            };
+          }
+          // pkgs.lib.optionalAttrs androidEmulatorSupported {
+            mobile-android = mkBuzzShell {
+              label = "mobile Android emulator";
+              withFlutter = true;
+              withAndroid = true;
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,115 @@
+{
+  description = "Buzz desktop development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Nixpkgs 26.11 dropped x86_64-darwin while Buzz still ships Intel
+    # macOS builds. Keep that system on the supported 26.05 branch.
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      nixpkgs,
+      nixpkgs-darwin,
+      rust-overlay,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      perSystem =
+        { system, ... }:
+        let
+          nixpkgsForSystem = if system == "x86_64-darwin" then nixpkgs-darwin else nixpkgs;
+
+          pkgs = import nixpkgsForSystem {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+
+          toolchainChannel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+
+          rustToolchain = pkgs.rust-bin.stable.${toolchainChannel}.default;
+
+          commonPackages = with pkgs; [
+            cargo-deny
+            cargo-nextest
+            cmake
+            curl
+            file
+            git
+            just
+            lefthook
+            ninja
+            nodejs_24
+            openssl
+            perl
+            pkg-config
+            pnpm_11
+            python3
+            rust-analyzer
+            rustToolchain
+            wget
+          ];
+
+          linuxLibraries = with pkgs; [
+            alsa-lib
+            atk
+            cairo
+            gdk-pixbuf
+            glib
+            gtk3
+            libayatana-appindicator
+            librsvg
+            openssl
+            webkitgtk_4_1
+            xdotool
+          ];
+
+          linuxPackages =
+            with pkgs;
+            [
+              gcc
+              mold
+              patchelf
+            ]
+            ++ linuxLibraries;
+        in
+        {
+          formatter = pkgs.nixfmt;
+
+          devShells.default = pkgs.mkShell {
+            packages = commonPackages ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
+
+            CMAKE_POLICY_VERSION_MINIMUM = "3.5";
+            LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+              pkgs.lib.makeLibraryPath linuxLibraries
+            );
+
+            shellHook = ''
+              export PATH="$PWD/node_modules/.bin:$PATH"
+
+              echo "Buzz development shell"
+              echo "  Rust: $(rustc --version)"
+              echo "  Node: $(node --version)"
+              echo "  pnpm: $(pnpm --version)"
+            '';
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,6 @@
             cargo-nextest
             cmake
             curl
-            ffmpeg
             file
             git
             just
@@ -108,6 +107,8 @@
             openssl
             perl
             pkg-config
+            # pnpm honors package.json's packageManager field and dispatches to
+            # the workspace-pinned release when commands run in the repo.
             pnpm_11
             python3
             rust-analyzer
@@ -115,9 +116,8 @@
             wget
           ];
 
-          mobilePackages = [ flutterPkgs.flutter ];
-
           occasionalPackages = with pkgs; [
+            ffmpeg
             gh
             uv
           ];
@@ -145,15 +145,7 @@
             gstreamer
           ];
 
-          linuxPackages =
-            with pkgs;
-            [
-              gcc
-              mold
-              patchelf
-            ]
-            ++ linuxLibraries
-            ++ gstreamerPlugins;
+          linuxPackages = with pkgs; [ patchelf ] ++ linuxLibraries ++ gstreamerPlugins;
 
           # Just runs inside the caller's current environment; it cannot switch
           # Nix shells per recipe. Keep the direnv/default shell focused on
@@ -163,50 +155,74 @@
             {
               label,
               extraPackages ? [ ],
+              withFlutter ? false,
             }:
-            pkgs.mkShell {
-              packages =
-                commonPackages
-                ++ extraPackages
-                ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
+            pkgs.mkShell (
+              {
+                packages =
+                  commonPackages
+                  ++ pkgs.lib.optionals withFlutter [ flutterPkgs.flutter ]
+                  ++ extraPackages
+                  ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxPackages;
 
-              CMAKE_POLICY_VERSION_MINIMUM = "3.5";
-              LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
-                pkgs.lib.makeLibraryPath linuxLibraries
-              );
+                CMAKE_POLICY_VERSION_MINIMUM = "3.5";
+                LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+                  pkgs.lib.makeLibraryPath linuxLibraries
+                );
 
-              GST_PLUGIN_SYSTEM_PATH_1_0 = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
-                pkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerPlugins
-              );
+                GST_PLUGIN_SYSTEM_PATH_1_0 = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+                  pkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerPlugins
+                );
 
-              # The npm launcher honors this variable. Point it at Nix's patched
-              # executable so Biome works on NixOS without a global nix-ld setup.
-              BIOME_BINARY = "${biomeTool}/bin/biome";
+                # The npm launcher honors this variable. Point it at Nix's patched
+                # executable so Biome works on NixOS without a global nix-ld setup.
+                BIOME_BINARY = "${biomeTool}/bin/biome";
 
-              FLUTTER_SUPPRESS_ANALYTICS = "true";
+                shellHook = ''
+                  export PATH="$PWD/node_modules/.bin:$PATH"
 
-              shellHook = ''
-                export PATH="$PWD/node_modules/.bin:$PATH"
-
-                echo "Buzz ${label} development shell"
-                echo "  Rust: $(rustc --version)"
-                echo "  Node: $(node --version)"
-                echo "  pnpm: $(pnpm --version)"
-              '';
-            };
+                  echo "Buzz ${label} development shell"
+                  echo "  Rust: $(rustc --version)"
+                  echo "  Node: $(node --version)"
+                  echo "  pnpm: $(pnpm --version)"
+                '';
+              }
+              // pkgs.lib.optionalAttrs withFlutter {
+                FLUTTER_SUPPRESS_ANALYTICS = "true";
+              }
+            );
         in
         {
           formatter = pkgs.nixfmt;
+
+          checks.toolchain =
+            pkgs.runCommand "buzz-development-toolchain-check"
+              {
+                nativeBuildInputs = [
+                  biomeTool
+                  pkgs.nodejs_24
+                  pkgs.pnpm_11
+                  rustToolchain
+                ];
+              }
+              ''
+                rustc --version | grep -F "rustc ${toolchainChannel} "
+                node --version
+                pnpm --version
+                biome --version
+                touch "$out"
+              '';
 
           devShells = {
             default = mkBuzzShell { label = "desktop/web"; };
             mobile = mkBuzzShell {
               label = "mobile";
-              extraPackages = mobilePackages;
+              withFlutter = true;
             };
             full = mkBuzzShell {
               label = "full";
-              extraPackages = mobilePackages ++ occasionalPackages;
+              extraPackages = occasionalPackages;
+              withFlutter = true;
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
           ];
 
           gstreamerPlugins = with pkgs.gst_all_1; [
+            gst-libav
+            gst-plugins-bad
             gst-plugins-base
             gst-plugins-good
             gstreamer

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
             xdotool
           ];
 
+          gstreamerPlugins = with pkgs.gst_all_1; [
+            gst-plugins-base
+            gst-plugins-good
+            gstreamer
+          ];
+
           linuxPackages =
             with pkgs;
             [
@@ -89,7 +95,8 @@
               mold
               patchelf
             ]
-            ++ linuxLibraries;
+            ++ linuxLibraries
+            ++ gstreamerPlugins;
         in
         {
           formatter = pkgs.nixfmt;
@@ -100,6 +107,10 @@
             CMAKE_POLICY_VERSION_MINIMUM = "3.5";
             LD_LIBRARY_PATH = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
               pkgs.lib.makeLibraryPath linuxLibraries
+            );
+
+            GST_PLUGIN_SYSTEM_PATH_1_0 = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux (
+              pkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerPlugins
             );
 
             shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
             cargo-nextest
             cmake
             curl
+            ffmpeg
             file
             git
             just
@@ -117,7 +118,6 @@
           ];
 
           occasionalPackages = with pkgs; [
-            ffmpeg
             gh
             uv
           ];

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -19,6 +19,17 @@ just mobile-dev
 cd mobile && flutter run
 ```
 
+On x86-64 Linux, the repository also provides a pinned Android SDK, emulator,
+system image, NDK, CMake, and Java environment:
+
+```bash
+nix develop .#mobile-android
+just mobile-emulator start --window
+```
+
+See [TESTING.md](TESTING.md) for lifecycle, reset, screenshots, and running
+integration-test targets.
+
 ### Worktree-aware debug identity
 
 Debug builds produced from a git worktree get a unique app identifier keyed

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -28,7 +28,8 @@ just mobile-emulator start --window
 ```
 
 See [TESTING.md](TESTING.md) for lifecycle, reset, screenshots, and running
-integration-test targets.
+integration-test targets. The helper refuses to reuse or stop a device on its
+configured serial unless it is the Buzz-owned AVD.
 
 ### Worktree-aware debug identity
 

--- a/mobile/TESTING.md
+++ b/mobile/TESTING.md
@@ -17,6 +17,15 @@ mutable data is isolated under
 `${XDG_STATE_HOME:-$HOME/.local/state}/buzz/android-emulator`, never mixed with
 Android Studio's default AVDs. Override that location with
 `BUZZ_ANDROID_EMULATOR_HOME` when parallel checkouts need independent state.
+Use a dedicated path that does not already contain unrelated data: the helper
+creates a versioned ownership marker and refuses to adopt or reset any
+pre-existing unowned directory.
+
+The default serial is `emulator-5556`. If another AVD already owns that serial,
+the helper fails closed rather than reusing or stopping it. With a separate
+state root, override `BUZZ_ANDROID_EMULATOR_SERIAL` for parallel devices; each
+configured serial is verified against the expected Buzz AVD name before
+lifecycle commands run.
 
 The emulator runs headless by default. Use `just mobile-emulator start
 --window` for interactive work. Hardware acceleration uses `/dev/kvm` when it

--- a/mobile/TESTING.md
+++ b/mobile/TESTING.md
@@ -1,0 +1,43 @@
+# Mobile Testing
+
+## Reproducible Android emulator
+
+On x86-64 Linux, use the repository's dedicated Nix shell. It pins the Android
+36 SDK and default x86-64 system image together with the build-tools, emulator,
+NDK, CMake, Java, and Flutter versions used by the project:
+
+```bash
+nix develop .#mobile-android
+just mobile-emulator start
+just mobile-emulator status
+```
+
+The AVD is named and configured by `scripts/mobile-android-emulator.sh`. Its
+mutable data is isolated under
+`${XDG_STATE_HOME:-$HOME/.local/state}/buzz/android-emulator`, never mixed with
+Android Studio's default AVDs. Override that location with
+`BUZZ_ANDROID_EMULATOR_HOME` when parallel checkouts need independent state.
+
+The emulator runs headless by default. Use `just mobile-emulator start
+--window` for interactive work. Hardware acceleration uses `/dev/kvm` when it
+is available and falls back to slower software emulation otherwise.
+
+Useful lifecycle commands:
+
+```bash
+just mobile-emulator screenshot test-results/mobile-emulator/manual.png
+just mobile-emulator stop
+just mobile-emulator reset  # deletes only Buzz's isolated AVD state
+```
+
+The emulator lifecycle is independent of any specific test. To run an
+on-device integration target, pass its path explicitly:
+
+```bash
+just mobile-emulator-test integration_test/example_test.dart
+```
+
+Add focused specs under `mobile/integration_test/` when a feature needs real
+Android rendering. Keep providers and data deterministic; use a paired debug
+installation and a relay only for workflows whose integration boundary is
+itself under test.

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -446,6 +446,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -568,6 +573,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -712,6 +722,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1080,6 +1095,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: transitive
     description:
@@ -1325,6 +1348,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1557,6 +1588,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   crypto: ^3.0.7
   custom_lint: ^0.8.0

--- a/mobile/test_driver/integration_test.dart
+++ b/mobile/test_driver/integration_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+Future<void> main() async {
+  final outputDirectory = Directory(
+    Platform.environment['BUZZ_MOBILE_SCREENSHOT_DIR'] ??
+        'test-results/mobile-emulator',
+  );
+  outputDirectory.createSync(recursive: true);
+
+  await integrationDriver(
+    onScreenshot: (name, bytes, [args]) async {
+      File('${outputDirectory.path}/$name.png').writeAsBytesSync(bytes);
+      return true;
+    },
+    writeResponseOnFailure: true,
+  );
+}

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -86,7 +86,8 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         GENERATE_DEV_ICON="$WORKTREE_ROOT/scripts/generate-dev-icon.swift"
         BASE_ICON="$WORKTREE_ROOT/desktop/src-tauri/icons/icon.icns"
 
-        if swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
+        if command -v swift >/dev/null 2>&1 &&
+            swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${BUZZ_WORKTREE_LABEL}"
             export VITE_DEV_BRANCH="$BUZZ_WORKTREE_LABEL"
             BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev.${BUZZ_INSTANCE_SLUG}\",\"productName\":\"Buzz Dev (${BUZZ_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"

--- a/scripts/mobile-android-emulator.sh
+++ b/scripts/mobile-android-emulator.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Reproducible Android emulator lifecycle for Buzz mobile UI tests.
+# Toolchain and system image come from `nix develop .#mobile-android`;
+# mutable AVD data stays isolated under XDG_STATE_HOME and can be reset safely.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+state_root="${BUZZ_ANDROID_EMULATOR_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/buzz/android-emulator}"
+state_marker="$state_root/.buzz-android-emulator-state"
+android_user_home="$state_root/user"
+android_avd_home="$state_root/avd"
+avd_name="buzz_pixel_api_${BUZZ_ANDROID_EMULATOR_API:-36}"
+api="${BUZZ_ANDROID_EMULATOR_API:-36}"
+abi="${BUZZ_ANDROID_EMULATOR_ABI:-x86_64}"
+serial="${BUZZ_ANDROID_EMULATOR_SERIAL:-emulator-5556}"
+port="${serial#emulator-}"
+system_image="system-images;android-${api};default;${abi}"
+log_file="$state_root/emulator.log"
+emulator_sdk="${BUZZ_ANDROID_EMULATOR_SDK:-${ANDROID_HOME:-}}"
+emulator_sdk_package="${emulator_sdk%/libexec/android-sdk}"
+avdmanager_bin="$emulator_sdk_package/bin/avdmanager"
+emulator_bin="$emulator_sdk_package/bin/emulator"
+
+export ANDROID_USER_HOME="$android_user_home"
+export ANDROID_AVD_HOME="$android_avd_home"
+export ANDROID_SERIAL="$serial"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mobile-android-emulator.sh <command> [args]
+
+Commands:
+  start [--window]        Create and boot the isolated emulator
+  stop                    Stop the Buzz emulator
+  status                  Print emulator and AVD status
+  reset                   Stop and delete only the isolated Buzz AVD state
+  screenshot [path]       Save a PNG (default: test-results/mobile-emulator/device.png)
+  test <target>           Run the selected Flutter integration test
+
+Run inside: nix develop .#mobile-android
+EOF
+}
+
+require_toolchain() {
+  : "${ANDROID_HOME:?Enter nix develop .#mobile-android first}"
+  : "${emulator_sdk:?The mobile-android shell did not provide an emulator SDK}"
+  for tool in adb flutter; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "missing $tool; enter nix develop .#mobile-android" >&2
+      exit 1
+    fi
+  done
+  for tool in "$avdmanager_bin" "$emulator_bin"; do
+    if [[ ! -x "$tool" ]]; then
+      echo "missing $tool; enter nix develop .#mobile-android" >&2
+      exit 1
+    fi
+  done
+}
+
+device_ready() {
+  adb -s "$serial" get-state >/dev/null 2>&1 &&
+    [[ "$(adb -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]
+}
+
+create_avd() {
+  mkdir -p "$android_user_home" "$android_avd_home"
+  touch "$state_marker"
+  if ANDROID_HOME="$emulator_sdk" ANDROID_SDK_ROOT="$emulator_sdk" \
+    "$avdmanager_bin" list avd | grep -Fq "Name: $avd_name"; then
+    return
+  fi
+
+  echo "Creating $avd_name from $system_image"
+  printf 'no\n' | ANDROID_HOME="$emulator_sdk" ANDROID_SDK_ROOT="$emulator_sdk" \
+    "$avdmanager_bin" create avd \
+    --force \
+    --name "$avd_name" \
+    --package "$system_image"
+
+  cat >>"$android_avd_home/$avd_name.avd/config.ini" <<'EOF'
+hw.keyboard = yes
+hw.lcd.width = 1008
+hw.lcd.height = 2244
+hw.lcd.density = 360
+showDeviceFrame = no
+skin.dynamic = yes
+EOF
+}
+
+start_emulator() {
+  local window_mode="${1:-}"
+  if device_ready; then
+    echo "$serial is already ready"
+    return
+  fi
+
+  if adb devices | awk 'NR > 1 {print $1}' | grep -Fxq "$serial"; then
+    echo "$serial exists but is not ready; stop or reset it before retrying" >&2
+    exit 1
+  fi
+
+  create_avd
+  mkdir -p "$state_root"
+
+  local -a flags=(
+    -avd "$avd_name"
+    -port "$port"
+    -no-audio
+    -no-boot-anim
+    -no-snapshot
+    -gpu swiftshader_indirect
+  )
+  if [[ "$window_mode" != "--window" ]]; then
+    flags+=(-no-window)
+  fi
+  if [[ ! -r /dev/kvm ]]; then
+    echo "KVM is unavailable; using slower software emulation"
+    flags+=(-accel off)
+  fi
+
+  echo "Starting $avd_name as $serial"
+  ANDROID_HOME="$emulator_sdk" ANDROID_SDK_ROOT="$emulator_sdk" \
+    nohup "$emulator_bin" "${flags[@]}" </dev/null >"$log_file" 2>&1 &
+
+  local deadline=$((SECONDS + 600))
+  until device_ready; do
+    if ((SECONDS >= deadline)); then
+      echo "emulator did not become ready; see $log_file" >&2
+      exit 1
+    fi
+    sleep 5
+  done
+
+  adb -s "$serial" shell settings put global window_animation_scale 0
+  adb -s "$serial" shell settings put global transition_animation_scale 0
+  adb -s "$serial" shell settings put global animator_duration_scale 0
+  adb -s "$serial" shell settings put system pointer_location 0
+  adb -s "$serial" shell settings put system show_touches 0
+  adb -s "$serial" shell input keyevent 82
+  echo "$serial is ready"
+}
+
+stop_emulator() {
+  if adb -s "$serial" get-state >/dev/null 2>&1; then
+    adb -s "$serial" emu kill >/dev/null
+    echo "stopped $serial"
+  else
+    echo "$serial is not running"
+  fi
+}
+
+reset_emulator() {
+  stop_emulator
+  if [[ ! -e "$state_root" ]]; then
+    echo "isolated emulator state is already absent: $state_root"
+    return
+  fi
+  case "$state_root" in
+    "" | / | "$HOME")
+      echo "refusing unsafe emulator state path: $state_root" >&2
+      exit 1
+      ;;
+  esac
+  if [[ ! -f "$state_marker" ]]; then
+    echo "refusing unrecognized emulator state path: $state_root" >&2
+    exit 1
+  fi
+  rm -rf -- "$state_root"
+  echo "removed isolated emulator state: $state_root"
+}
+
+take_screenshot() {
+  local output="${1:-$repo_root/test-results/mobile-emulator/device.png}"
+  if ! device_ready; then
+    echo "$serial is not ready" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$output")"
+  adb -s "$serial" exec-out screencap -p >"$output"
+  echo "$output"
+}
+
+run_test() {
+  local target="${1:?test requires an integration-test target}"
+  start_emulator
+  "$repo_root/scripts/mobile-worktree-overrides.sh"
+  mkdir -p "$repo_root/test-results/mobile-emulator"
+  (
+    cd "$repo_root/mobile"
+    BUZZ_MOBILE_SCREENSHOT_DIR="$repo_root/test-results/mobile-emulator" \
+      flutter drive \
+      --driver=test_driver/integration_test.dart \
+      --target="$target" \
+      --device-id="$serial"
+  )
+}
+
+require_toolchain
+case "${1:-}" in
+  start)
+    start_emulator "${2:-}"
+    ;;
+  stop)
+    stop_emulator
+    ;;
+  status)
+    echo "state: $state_root"
+    echo "avd: $avd_name ($system_image)"
+    adb devices -l | grep -E "^List|^${serial}[[:space:]]" || true
+    ;;
+  reset)
+    reset_emulator
+    ;;
+  screenshot)
+    take_screenshot "${2:-}"
+    ;;
+  test)
+    run_test "${2:-}"
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/mobile-android-emulator.sh
+++ b/scripts/mobile-android-emulator.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 state_root="${BUZZ_ANDROID_EMULATOR_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/buzz/android-emulator}"
 state_marker="$state_root/.buzz-android-emulator-state"
+state_marker_value="buzz-android-emulator-state-v1"
 android_user_home="$state_root/user"
 android_avd_home="$state_root/avd"
 avd_name="buzz_pixel_api_${BUZZ_ANDROID_EMULATOR_API:-36}"
@@ -63,9 +64,40 @@ device_ready() {
     [[ "$(adb -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]
 }
 
-create_avd() {
+device_present() {
+  adb devices | awk 'NR > 1 {print $1}' | grep -Fxq "$serial"
+}
+
+device_avd_name() {
+  adb -s "$serial" emu avd name 2>/dev/null |
+    tr -d '\r' |
+    awk 'NF && $0 != "OK" { print; exit }'
+}
+
+device_is_owned() {
+  state_is_owned && [[ "$(device_avd_name)" == "$avd_name" ]]
+}
+
+state_is_owned() {
+  [[ -d "$state_root" && -f "$state_marker" ]] || return 1
+  [[ "$(<"$state_marker")" == "$state_marker_value" ]]
+}
+
+claim_state_root() {
+  if [[ -e "$state_root" ]]; then
+    if ! state_is_owned; then
+      echo "refusing pre-existing unowned emulator state path: $state_root" >&2
+      return 1
+    fi
+  else
+    mkdir -p "$state_root"
+    printf '%s\n' "$state_marker_value" >"$state_marker"
+  fi
   mkdir -p "$android_user_home" "$android_avd_home"
-  touch "$state_marker"
+}
+
+create_avd() {
+  claim_state_root || return 1
   if ANDROID_HOME="$emulator_sdk" ANDROID_SDK_ROOT="$emulator_sdk" \
     "$avdmanager_bin" list avd | grep -Fq "Name: $avd_name"; then
     return
@@ -90,14 +122,17 @@ EOF
 
 start_emulator() {
   local window_mode="${1:-}"
-  if device_ready; then
-    echo "$serial is already ready"
-    return
-  fi
-
-  if adb devices | awk 'NR > 1 {print $1}' | grep -Fxq "$serial"; then
-    echo "$serial exists but is not ready; stop or reset it before retrying" >&2
-    exit 1
+  if device_present; then
+    if ! device_is_owned; then
+      echo "refusing device $serial: it is not the Buzz-owned AVD $avd_name" >&2
+      return 1
+    fi
+    if device_ready; then
+      echo "$serial is already ready"
+      return
+    fi
+    echo "$serial is the Buzz-owned AVD but is not ready; stop or reset it before retrying" >&2
+    return 1
   fi
 
   create_avd
@@ -142,16 +177,19 @@ start_emulator() {
 }
 
 stop_emulator() {
-  if adb -s "$serial" get-state >/dev/null 2>&1; then
-    adb -s "$serial" emu kill >/dev/null
-    echo "stopped $serial"
-  else
+  if ! device_present; then
     echo "$serial is not running"
+    return
   fi
+  if ! device_is_owned; then
+    echo "refusing to stop $serial: it is not the Buzz-owned AVD $avd_name" >&2
+    return 1
+  fi
+  adb -s "$serial" emu kill >/dev/null
+  echo "stopped $serial"
 }
 
 reset_emulator() {
-  stop_emulator
   if [[ ! -e "$state_root" ]]; then
     echo "isolated emulator state is already absent: $state_root"
     return
@@ -162,10 +200,11 @@ reset_emulator() {
       exit 1
       ;;
   esac
-  if [[ ! -f "$state_marker" ]]; then
+  if ! state_is_owned; then
     echo "refusing unrecognized emulator state path: $state_root" >&2
-    exit 1
+    return 1
   fi
+  stop_emulator || return 1
   rm -rf -- "$state_root"
   echo "removed isolated emulator state: $state_root"
 }
@@ -183,7 +222,7 @@ take_screenshot() {
 
 run_test() {
   local target="${1:?test requires an integration-test target}"
-  start_emulator
+  start_emulator || return 1
   "$repo_root/scripts/mobile-worktree-overrides.sh"
   mkdir -p "$repo_root/test-results/mobile-emulator"
   (
@@ -196,30 +235,36 @@ run_test() {
   )
 }
 
-require_toolchain
-case "${1:-}" in
-  start)
-    start_emulator "${2:-}"
-    ;;
-  stop)
-    stop_emulator
-    ;;
-  status)
-    echo "state: $state_root"
-    echo "avd: $avd_name ($system_image)"
-    adb devices -l | grep -E "^List|^${serial}[[:space:]]" || true
-    ;;
-  reset)
-    reset_emulator
-    ;;
-  screenshot)
-    take_screenshot "${2:-}"
-    ;;
-  test)
-    run_test "${2:-}"
-    ;;
-  *)
-    usage >&2
-    exit 2
-    ;;
-esac
+main() {
+  require_toolchain
+  case "${1:-}" in
+    start)
+      start_emulator "${2:-}"
+      ;;
+    stop)
+      stop_emulator
+      ;;
+    status)
+      echo "state: $state_root"
+      echo "avd: $avd_name ($system_image)"
+      adb devices -l | grep -E "^List|^${serial}[[:space:]]" || true
+      ;;
+    reset)
+      reset_emulator
+      ;;
+    screenshot)
+      take_screenshot "${2:-}"
+      ;;
+    test)
+      run_test "${2:-}"
+      ;;
+    *)
+      usage >&2
+      return 2
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/test-mobile-android-emulator.sh
+++ b/scripts/test-mobile-android-emulator.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Safety contract tests for scripts/mobile-android-emulator.sh.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+export BUZZ_ANDROID_EMULATOR_HOME="$test_root/initial"
+# shellcheck source=mobile-android-emulator.sh
+source "$repo_root/scripts/mobile-android-emulator.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok: %s\n' "$1"
+}
+
+set_state_root() {
+  state_root="$1"
+  state_marker="$state_root/.buzz-android-emulator-state"
+  android_user_home="$state_root/user"
+  android_avd_home="$state_root/avd"
+  log_file="$state_root/emulator.log"
+}
+
+set_state_root "$test_root/pre-existing"
+mkdir -p "$state_root"
+printf 'keep\n' >"$state_root/unrelated-data"
+if claim_state_root 2>/dev/null; then
+  fail "a pre-existing unowned state root must be rejected"
+fi
+[[ -f "$state_root/unrelated-data" && ! -e "$state_marker" ]] ||
+  fail "rejecting an unowned root must preserve its contents"
+pass "pre-existing unowned state roots are preserved"
+
+set_state_root "$test_root/fresh"
+claim_state_root
+[[ "$(<"$state_marker")" == "$state_marker_value" ]] ||
+  fail "a fresh state root must carry the versioned ownership marker"
+pass "fresh state roots receive a versioned ownership marker"
+
+set_state_root "$test_root/legacy-marker"
+mkdir -p "$state_root"
+: >"$state_marker"
+printf 'keep\n' >"$state_root/unrelated-data"
+if reset_emulator 2>/dev/null; then
+  fail "an empty legacy marker must not authorize deletion"
+fi
+[[ -f "$state_root/unrelated-data" ]] || fail "legacy-marker rejection must preserve data"
+pass "legacy or forged empty markers cannot authorize reset"
+
+fake_avd_name="$avd_name"
+fake_device_present=1
+kill_log="$test_root/killed"
+adb() {
+  if [[ "$*" == "devices" || "$*" == "devices -l" ]]; then
+    printf 'List of devices attached\n'
+    [[ "$fake_device_present" == "1" ]] && printf '%s\tdevice\n' "$serial"
+  elif [[ "$*" == *"emu avd name"* ]]; then
+    printf '%s\nOK\n' "$fake_avd_name"
+  elif [[ "$*" == *"emu kill"* ]]; then
+    printf 'killed\n' >"$kill_log"
+  elif [[ "$*" == *"get-state"* ]]; then
+    printf 'device\n'
+  elif [[ "$*" == *"shell getprop sys.boot_completed"* ]]; then
+    printf '1\n'
+  fi
+}
+
+fake_avd_name="someone-elses-avd"
+set_state_root "$test_root/start-foreign"
+if start_emulator 2>/dev/null; then
+  fail "start must reject a foreign AVD on the configured serial"
+fi
+[[ ! -e "$state_root" ]] || fail "foreign-device rejection must not create state"
+pass "foreign AVDs are never adopted"
+
+if stop_emulator 2>/dev/null; then
+  fail "stop must reject a foreign AVD on the configured serial"
+fi
+[[ ! -e "$kill_log" ]] || fail "a foreign AVD must never receive emu kill"
+pass "foreign AVDs are never stopped"
+
+fake_avd_name="$avd_name"
+set_state_root "$test_root/same-name-unowned"
+if start_emulator 2>/dev/null; then
+  fail "start must not adopt a same-named AVD without owned state"
+fi
+if stop_emulator 2>/dev/null; then
+  fail "stop must not kill a same-named AVD without owned state"
+fi
+[[ ! -e "$state_root" && ! -e "$kill_log" ]] ||
+  fail "same-name rejection must not create state or kill the device"
+pass "same-named AVDs require Buzz-owned state"
+
+fake_avd_name="someone-elses-avd"
+set_state_root "$test_root/owned"
+mkdir -p "$state_root"
+printf '%s\n' "$state_marker_value" >"$state_marker"
+printf 'keep\n' >"$state_root/owned-data"
+if reset_emulator 2>/dev/null; then
+  fail "reset must reject a foreign AVD before deleting owned state"
+fi
+[[ -f "$state_root/owned-data" && ! -e "$kill_log" ]] ||
+  fail "foreign-device rejection must preserve the owned state root"
+pass "reset preserves state when the configured serial belongs to another AVD"
+
+fake_avd_name="$avd_name"
+stop_emulator >/dev/null
+[[ -f "$kill_log" ]] || fail "the expected Buzz AVD must be stoppable"
+pass "the expected Buzz AVD can be stopped"
+
+fake_device_present=0
+rm -f "$kill_log"
+set_state_root "$test_root/reset-stopped"
+mkdir -p "$state_root"
+printf '%s\n' "$state_marker_value" >"$state_marker"
+reset_emulator >/dev/null
+[[ ! -e "$state_root" && ! -e "$kill_log" ]] ||
+  fail "reset of a stopped Buzz AVD must remove only its owned state"
+pass "owned state resets cleanly when no emulator is running"


### PR DESCRIPTION
## Summary

Add an optional, reproducible Nix development environment for Buzz without replacing the existing Hermit workflow.

Buzz Desktop on Linux depends on a distro-specific set of native Tauri, WebKitGTK, GStreamer, and media libraries. This is especially difficult on non-FHS distributions such as NixOS. The new shells pin those dependencies while preserving the repository's existing `just` commands and Hermit-first contributor path.

## What changed

- Add pinned `default`, `mobile`, `mobile-android`, and `full` Nix development shells plus optional direnv support.
- Supply the Linux native libraries and GStreamer plugins required by Tauri/WebKit media workflows.
- Make shell, process, terminal, and install-command discovery work on non-FHS systems.
- Add a reproducible x86-64 Linux Android emulator workflow with the pinned SDK, system image, NDK, CMake, JDK, and Flutter toolchain.
- Add an explicit Flutter integration-test driver and `just` recipes for emulator lifecycle and selected on-device tests.
- Keep the Android emulator's mutable state isolated and fail closed before adopting, stopping, or resetting an unowned or unexpected AVD, including a same-named AVD without Buzz ownership state.
- Document when the host SDK is expected and when `.#mobile-android` supplies the complete Android toolchain.
- Keep Flutter and infrequently used tools opt-in; Hermit remains the portable default.

### Related issue

Related to #2516.

This remains intentionally narrower than #3434 and #3734: it provides development environments only. It does not package Buzz, add deployment outputs, or introduce a NixOS module.

## Regression hardening

The final adversarial review added ownership tests around emulator state deletion and serial reuse, and split existing Rust discovery helpers into focused modules so the desktop file-size ratchet remains green. These changes preserve the existing discovery behavior while covering non-FHS shell lookup explicitly.

## Testing

- `nix flake check --no-build --all-systems`
- `nix develop --command just desktop-tauri-test` — full Tauri workspace suite passed
- `nix develop .#mobile --command just mobile-check`
- `nix develop --command pnpm -C desktop check:file-sizes`
- `nix develop --command cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `scripts/test-mobile-android-emulator.sh` — 9 ownership/reset safety scenarios
- `git diff --check`

Screenshots: N/A — no user interface changed.
