### PR TITLE
fix(cli): scope root event lookup to --channel in cmd_get_thread

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -417,6 +417,7 @@ pub async fn cmd_get_thread(
     }
     let root_filter = serde_json::json!({
         "ids": [event_id],
+        "#h": [channel_id],
         "limit": 1
     });
     let resp = client.query_multi(&[reply_filter, root_filter]).await?;


### PR DESCRIPTION
## Problem

`cmd_get_thread` validates `--channel` and then never applies it to one of the two filters it sends. The `reply_filter` correctly scopes to the channel via `"#h": [channel_id]`, but `root_filter` (the lookup for the root event by ID) omits the tag entirely. This means the root event is fetched globally rather than scoped to the specified channel — `--channel` is silently ignored for the root event half of the query.

Fixes #6006

## Triage / Root cause

`crates/buzz-cli/src/commands/messages.rs` line 418: `root_filter` only has `"ids": [event_id]` and `"limit": 1`, missing `"#h": [channel_id]` that `reply_filter` already has.

## Fix

Add `"#h": [channel_id]` to `root_filter` so both halves of the `query_multi` are scoped to the specified channel.

## Verification

```bash
cargo check -p buzz-cli   # clean
cargo clippy -p buzz-cli  # clean (no warnings)
```

## Notes / Risks

- Minimal one-line addition matching the existing pattern already used in `reply_filter`.
- No behavioral change for the `reply_filter` path; only the root-event lookup becomes channel-scoped.
- Requires a running relay to functionally verify (per `crates/buzz-cli/TESTING.md`), which is outside CI; the fix is structurally identical to the existing `reply_filter` scoping.

Signed-off-by: Santhi Prakash <b.santhiprakash@gmail.com>