### PR TITLE
Add group DM mention-resolution test coverage (#6027)

### DIFF
--- a/desktop/src/features/messages/lib/messageMentionPubkeys.test.mjs
+++ b/desktop/src/features/messages/lib/messageMentionPubkeys.test.mjs
@@ -46,3 +46,53 @@ test("stream messages preserve explicit-mention semantics", () => {
     [],
   );
 });
+
+test("group DM (3+ members) plain messages p-tag every other participant", () => {
+  const groupDm = channel({
+    memberCount: 4,
+    memberPubkeys: ["owner", "fizz", "honey", "bumble"],
+    participantPubkeys: ["owner", "fizz", "honey", "bumble"],
+  });
+  assert.deepEqual(
+    messageMentionPubkeys(groupDm, "owner").sort(),
+    ["bumble", "fizz", "honey"].sort(),
+  );
+});
+
+test("group DM still notifies everyone when memberPubkeys is stale/empty but participantPubkeys holds", () => {
+  // Regresses a real gap: `memberPubkeys` comes from a separate, best-effort
+  // relay query (desktop/src-tauri/src/commands/channels.rs) that silently
+  // defaults to empty on failure/timeout, with no retry or surfaced error.
+  // `participantPubkeys` is parsed synchronously from the channel's own
+  // metadata event tags, so it should keep this working even when the
+  // member-count query comes back empty.
+  const groupDm = channel({
+    memberCount: 4,
+    memberPubkeys: [],
+    participantPubkeys: ["owner", "fizz", "honey", "bumble"],
+  });
+  assert.deepEqual(
+    messageMentionPubkeys(groupDm, "owner").sort(),
+    ["bumble", "fizz", "honey"].sort(),
+  );
+});
+
+test("KNOWN GAP: group DM silently drops every recipient when both pubkey sources are empty", () => {
+  // Documents the actual failure mode behind the incident where a message in
+  // a 4-person group DM went out with zero `p` tags and nobody was notified.
+  // `participantPubkeys` is parsed once from the channel's metadata event at
+  // creation time (nostr_convert.rs) and is never refreshed — if a member is
+  // added to the DM after creation and the separate `memberPubkeys` relay
+  // query (channels.rs) hasn't caught up yet (or fails), both sources can be
+  // incomplete/empty at send time, and this function has no fallback.
+  // This test intentionally asserts the current (broken) behavior so it goes
+  // red the moment a real fix (e.g. refreshing participantPubkeys, or
+  // retrying/erroring instead of silently defaulting memberPubkeys to empty)
+  // lands — flip the assertion to the non-empty recipient list at that point.
+  const groupDm = channel({
+    memberCount: 4,
+    memberPubkeys: [],
+    participantPubkeys: [],
+  });
+  assert.deepEqual(messageMentionPubkeys(groupDm, "owner"), []);
+});


### PR DESCRIPTION
Fixes/covers #6027

## Summary

Adds regression coverage for `messageMentionPubkeys()` on 3+ member group DMs, following a live incident where a group DM message went out with zero `p` tags and nobody was notified.

## What's added

`desktop/src/features/messages/lib/messageMentionPubkeys.test.mjs`:
- Group DM (4 members), plain message — p-tags every other participant.
- Resilience case — `memberPubkeys` empty but `participantPubkeys` intact still notifies everyone (proves the union's existing fallback works as designed).
- **Known-gap case** — both sources empty → zero recipients, reproducing the incident. This test intentionally asserts the *current broken* behavior; a comment flags it for whoever lands the fix to flip the assertion.

## What's NOT in this PR

The actual fix. Root cause has two independent, equally-plausible failure paths (see #6027 for full analysis) — a best-effort `member_pubkeys` relay query that silently defaults to empty on failure, and a `participant_pubkeys` list that's parsed once from channel metadata and never refreshed on membership changes. Picking a fix without confirming which path failed in the live incident risks fixing the wrong one, so that's left open in the issue pending a live repro or added instrumentation.

## Test plan

- [x] `just ci` passes
- [x] `node --import ./test-loader.mjs --experimental-strip-types --test src/features/messages/lib/messageMentionPubkeys.test.mjs` — 6/6 green