### PR TITLE
fix(desktop): actually hold a sleep block on Windows

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -210,7 +210,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1111,6 +1111,7 @@ dependencies = [
  "image",
  "infer",
  "iroh",
+ "keepawake",
  "keyring",
  "libc",
  "mesh-llm-client",
@@ -1624,7 +1625,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2291,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2469,7 +2470,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2750,7 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3268,7 +3269,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -4709,6 +4710,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepawake"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5521b450ec179362595d5cbda7c3abd5da3af3dff58456434ad3ca33c95226b7"
+dependencies = [
+ "cfg-if 1.0.4",
+ "derive_builder",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "zbus 5.17.0",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,7 +5742,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5885,7 +5901,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6398,7 +6414,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6722,7 +6738,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "dispatch2",
  "libc",
+ "objc2",
  "objc2-core-foundation",
 ]
 
@@ -7102,7 +7122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8128,7 +8148,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8859,7 +8879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8929,7 +8949,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9196,7 +9216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9815,7 +9835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10829,10 +10849,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10854,7 +10874,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11596,7 +11616,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11697,7 +11717,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12548,7 +12568,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -51,6 +51,11 @@ notify-rust = "4"
 webkit2gtk = { version = "=2.0.2", features = ["v2_22"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# Safe wrapper over the platform idle-sleep APIs (IOKit here, Win32 power
+# requests on Windows). Target-gated to the two platforms that have a
+# mechanism: Linux stays a documented no-op, so pulling keepawake's zbus path
+# in there would add a runtime D-Bus requirement for behaviour we do not want.
+keepawake = "0.6"
 block2 = { version = "0.6", default-features = false, features = ["std"] }
 objc2 = { version = "0.6.4", default-features = false }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSEvent", "NSHapticFeedback", "NSMenu", "NSMenuItem", "NSStatusItem", "block2"] }
@@ -63,7 +68,8 @@ user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Power", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+keepawake = "0.6"
+windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native", "vendored"], optional = true }
 user-idle = { version = "0.6", default-features = false }
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Power", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native", "vendored"], optional = true }
 user-idle = { version = "0.6", default-features = false }
 

--- a/desktop/src-tauri/src/prevent_sleep.rs
+++ b/desktop/src-tauri/src/prevent_sleep.rs
@@ -1,27 +1,22 @@
 //! Keeps the machine awake while local managed agents are running.
 //!
-//! Two platforms have a real mechanism:
+//! macOS and Windows have a real mechanism, reached through the `keepawake`
+//! crate rather than local FFI — `AGENTS.md` forbids `unsafe` code, and a safe
+//! wrapper also retires the IOKit `extern "C"` block this module used to carry.
 //!
-//! * **macOS** — an IOKit `PreventUserIdleSystemSleep` power assertion.
-//! * **Windows** — a Win32 *power request* (`PowerCreateRequest` +
-//!   `PowerSetRequest(PowerRequestSystemRequired)`).
+//! The guard is owned by a **dedicated thread** for the lifetime of the block.
+//! Windows' underlying request is thread-local — its effect dies with the
+//! thread that set it — while [`acquire`] and [`release`] are reached from
+//! Tauri command handlers on a worker pool and from the shutdown hook,
+//! potentially three different threads. Binding the request to any of those
+//! would either evaporate (the acquiring worker retires while an agent is
+//! still running) or leak (release lands on a thread that never set it). The
+//! thread costs a wake-up channel and buys a lifetime that matches the block.
 //!
-//! The Windows side deliberately does **not** use `SetThreadExecutionState`.
-//! That API is per-thread and its effect dies with the calling thread, but
-//! [`acquire`] and [`release`] are reached from Tauri command handlers running
-//! on a worker pool and from the shutdown hook — potentially three different
-//! threads. A `SetThreadExecutionState` pair would therefore either evaporate
-//! (the acquiring worker thread retires while an agent is still running) or
-//! leak (release lands on a thread that never set the flag). A power request is
-//! a kernel object owned by the *process*: any thread may create, set, clear,
-//! and close it, and the handle can be stored in shared state. The alternative
-//! — an owned dedicated thread parked for the lifetime of the block — costs a
-//! thread plus a wake-up channel to achieve the same thing, so the power
-//! request wins.
-//!
-//! Linux is a deliberate, documented no-op: there is no portable
-//! inhibit mechanism (logind vs. elogind vs. none), so [`acquire`] succeeds
-//! without holding anything and no cap timer is armed.
+//! Linux is a deliberate, documented no-op. keepawake can inhibit there, but
+//! only through a live D-Bus session; the crate is target-gated to macOS and
+//! Windows so a Linux build gains no runtime D-Bus requirement. [`acquire`]
+//! succeeds without holding anything and no cap timer is armed.
 //!
 //! Whatever a platform hands back is stored as a [`SleepBlock`], whose `Drop`
 //! performs the matching release. Every teardown path — explicit
@@ -45,14 +40,16 @@ pub struct PreventSleepState {
 /// A live OS-level "do not idle-sleep" request. Dropping it releases the
 /// request; there is no other release path.
 enum SleepBlock {
-    /// macOS `IOPMAssertionID` for a `PreventUserIdleSystemSleep` assertion.
-    #[cfg(target_os = "macos")]
-    IoKitAssertion(u32),
-    /// Windows power-request `HANDLE`, held as an integer so the state stays
-    /// `Send` without an `unsafe impl` (the raw pointer is reconstituted only
-    /// at the call site).
-    #[cfg(windows)]
-    PowerRequest(isize),
+    /// A dedicated thread owning the `keepawake` guard for the whole lifetime
+    /// of the block. See [`platform_begin`] for why the guard cannot simply
+    /// live in this struct.
+    #[cfg(any(target_os = "macos", windows))]
+    Worker {
+        /// Dropping this disconnects the channel the worker is parked on,
+        /// which is the signal to release.
+        stop: Option<std::sync::mpsc::Sender<()>>,
+        thread: Option<std::thread::JoinHandle<()>>,
+    },
     /// Test-only inert block. Dropping it bumps the counter, which lets the
     /// platform-independent bookkeeping be asserted on every OS.
     #[cfg(test)]
@@ -68,27 +65,15 @@ impl Drop for SleepBlock {
     // irrefutable — which is correct, not a mistake.
     #[allow(irrefutable_let_patterns)]
     fn drop(&mut self) {
-        #[cfg(target_os = "macos")]
-        if let Self::IoKitAssertion(id) = self {
-            unsafe {
-                macos::IOPMAssertionRelease(*id);
-            }
-        }
-
-        #[cfg(windows)]
-        if let Self::PowerRequest(handle) = self {
-            use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
-            use windows_sys::Win32::System::Power::{
-                PowerClearRequest, PowerRequestSystemRequired,
-            };
-
-            let handle = *handle as HANDLE;
-            unsafe {
-                // Clear before close: closing an un-cleared request also drops
-                // it, but clearing first keeps `powercfg /requests` accurate if
-                // the close ever fails.
-                PowerClearRequest(handle, PowerRequestSystemRequired);
-                CloseHandle(handle);
+        #[cfg(any(target_os = "macos", windows))]
+        if let Self::Worker { stop, thread } = self {
+            // Dropping the sender disconnects the channel the worker is parked
+            // on. Joining afterwards is what makes this synchronous: it
+            // guarantees the guard has actually been dropped, on the thread
+            // that created it, before this `drop` returns.
+            drop(stop.take());
+            if let Some(thread) = thread.take() {
+                let _ = thread.join();
             }
         }
 
@@ -99,149 +84,79 @@ impl Drop for SleepBlock {
     }
 }
 
-// ── macOS implementation ────────────────────────────────────────────────────
-
-#[cfg(target_os = "macos")]
-mod macos {
-    #[link(name = "IOKit", kind = "framework")]
-    extern "C" {
-        pub fn IOPMAssertionCreateWithName(
-            assertion_type: *const std::ffi::c_void, // CFStringRef
-            level: u32,                              // IOPMAssertionLevel
-            name: *const std::ffi::c_void,           // CFStringRef
-            assertion_id: *mut u32,                  // IOPMAssertionID
-        ) -> i32; // IOReturn
-
-        pub fn IOPMAssertionRelease(assertion_id: u32) -> i32;
-    }
-
-    #[link(name = "CoreFoundation", kind = "framework")]
-    extern "C" {
-        pub fn CFStringCreateWithCString(
-            alloc: *const std::ffi::c_void,
-            c_str: *const std::ffi::c_char,
-            encoding: u32,
-        ) -> *const std::ffi::c_void;
-        pub fn CFRelease(cf: *const std::ffi::c_void);
-    }
-}
-
-#[cfg(target_os = "macos")]
-const K_IOPM_ASSERTION_LEVEL_ON: u32 = 255;
-
-#[cfg(target_os = "macos")]
-const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
-
-/// Ask the OS for a sleep block. `Ok(None)` means this platform has no
-/// mechanism (see the module docs) — that is success, not failure.
-#[cfg(target_os = "macos")]
-fn platform_begin() -> Result<Option<SleepBlock>, String> {
-    let assertion_type = c"PreventUserIdleSystemSleep".as_ptr();
-    let reason = c"Buzz \u{2014} agents are active".as_ptr();
-
-    unsafe {
-        let cf_type = macos::CFStringCreateWithCString(
-            std::ptr::null(),
-            assertion_type,
-            K_CF_STRING_ENCODING_UTF8,
-        );
-        let cf_reason =
-            macos::CFStringCreateWithCString(std::ptr::null(), reason, K_CF_STRING_ENCODING_UTF8);
-
-        if cf_type.is_null() || cf_reason.is_null() {
-            if !cf_type.is_null() {
-                macos::CFRelease(cf_type);
-            }
-            if !cf_reason.is_null() {
-                macos::CFRelease(cf_reason);
-            }
-            return Err("Failed to create CFString for IOKit assertion".into());
-        }
-
-        let mut assertion_id: u32 = 0;
-        let ret = macos::IOPMAssertionCreateWithName(
-            cf_type,
-            K_IOPM_ASSERTION_LEVEL_ON,
-            cf_reason,
-            &mut assertion_id,
-        );
-
-        macos::CFRelease(cf_type);
-        macos::CFRelease(cf_reason);
-
-        if ret != 0 {
-            return Err(format!(
-                "IOPMAssertionCreateWithName failed with IOReturn {ret}"
-            ));
-        }
-
-        Ok(Some(SleepBlock::IoKitAssertion(assertion_id)))
-    }
-}
-
-// ── Windows implementation ──────────────────────────────────────────────────
-
-/// `POWER_REQUEST_CONTEXT_VERSION` from `winnt.h`. Not re-exported by
-/// `windows-sys`, so it is spelled out here.
-#[cfg(windows)]
-const POWER_REQUEST_CONTEXT_VERSION: u32 = 0;
+// ── Platform implementation ─────────────────────────────────────────────────
 
 /// Ask the OS for a sleep block. `Ok(None)` means this platform has no
 /// mechanism (see the module docs) — that is success, not failure.
 ///
-/// `PowerRequestSystemRequired` is the direct analogue of the macOS
-/// `PreventUserIdleSystemSleep` assertion: it blocks *idle* sleep only. It
-/// deliberately does not block a user-initiated sleep, a lid close, or the
-/// low-power transition on a Modern Standby machine, and it does not keep the
-/// display awake (that would need `PowerRequestDisplayRequired`).
-#[cfg(windows)]
+/// The guard is created on, and dropped by, a thread this function owns.
+/// Windows' underlying request is thread-local: its effect dies with the
+/// thread that set it. [`acquire`] and [`release`] are reached from Tauri
+/// command handlers on a worker pool and from the shutdown hook — potentially
+/// three different threads — so binding the request to any of those would
+/// either evaporate (the acquiring worker retires while agents still run) or
+/// leak (release lands on a thread that never set it). One dedicated thread,
+/// parked for the block's whole lifetime, is what makes the lifetime correct.
+#[cfg(any(target_os = "macos", windows))]
 fn platform_begin() -> Result<Option<SleepBlock>, String> {
-    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::System::Power::{
-        PowerCreateRequest, PowerRequestSystemRequired, PowerSetRequest,
-    };
-    use windows_sys::Win32::System::Threading::{
-        POWER_REQUEST_CONTEXT_SIMPLE_STRING, REASON_CONTEXT, REASON_CONTEXT_0,
-    };
+    use std::sync::mpsc;
 
-    // `PowerCreateRequest` copies the reason string, so a stack-local buffer
-    // that lives across the call is enough.
-    let mut reason: Vec<u16> = "Buzz \u{2014} agents are active"
-        .encode_utf16()
-        .chain(std::iter::once(0))
-        .collect();
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+    let (stop_tx, stop_rx) = mpsc::channel::<()>();
 
-    let context = REASON_CONTEXT {
-        Version: POWER_REQUEST_CONTEXT_VERSION,
-        Flags: POWER_REQUEST_CONTEXT_SIMPLE_STRING,
-        Reason: REASON_CONTEXT_0 {
-            SimpleReasonString: reason.as_mut_ptr(),
-        },
-    };
+    let thread = std::thread::Builder::new()
+        .name("buzz-prevent-sleep".to_string())
+        .spawn(move || {
+            // `idle(true)` is the direct analogue of the previous macOS
+            // `PreventUserIdleSystemSleep` assertion: block *idle* sleep only.
+            // `display(false)` keeps the screen free to blank, and
+            // `sleep(false)` leaves a user-initiated sleep or lid close alone.
+            let awake = keepawake::Builder::default()
+                .display(false)
+                .idle(true)
+                .sleep(false)
+                .reason("Agents are active")
+                .app_name("Buzz")
+                .app_reverse_domain("xyz.block.buzz.app")
+                .create();
 
-    let request: HANDLE = unsafe { PowerCreateRequest(&context) };
-    if request.is_null() || request == INVALID_HANDLE_VALUE {
-        let code = unsafe { GetLastError() };
-        return Err(format!(
-            "PowerCreateRequest failed with GetLastError {code}"
-        ));
-    }
+            match awake {
+                Ok(awake) => {
+                    if ready_tx.send(Ok(())).is_err() {
+                        // Nobody is waiting any more; drop the guard and go.
+                        return;
+                    }
+                    // Blocks until the sender is dropped by `SleepBlock::drop`.
+                    // The guard is dropped here, on the thread that made it.
+                    let _ = stop_rx.recv();
+                    drop(awake);
+                }
+                Err(error) => {
+                    let _ = ready_tx.send(Err(format!("keepawake failed: {error}")));
+                }
+            }
+        })
+        .map_err(|error| format!("failed to spawn the sleep-block thread: {error}"))?;
 
-    if unsafe { PowerSetRequest(request, PowerRequestSystemRequired) } == 0 {
-        let code = unsafe { GetLastError() };
-        unsafe {
-            CloseHandle(request);
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(Some(SleepBlock::Worker {
+            stop: Some(stop_tx),
+            thread: Some(thread),
+        })),
+        Ok(Err(error)) => {
+            let _ = thread.join();
+            Err(error)
         }
-        return Err(format!("PowerSetRequest failed with GetLastError {code}"));
+        Err(_) => {
+            let _ = thread.join();
+            Err("the sleep-block thread exited before reporting readiness".to_string())
+        }
     }
-
-    Ok(Some(SleepBlock::PowerRequest(request as isize)))
 }
 
-// ── Platforms with no mechanism ─────────────────────────────────────────────
-
 /// Ask the OS for a sleep block. Linux and friends have no portable inhibit
-/// mechanism, so this is a documented no-op that reports success without
+/// mechanism we want to depend on — keepawake's Linux path needs a live D-Bus
+/// session — so this stays a documented no-op that reports success without
 /// holding anything (and therefore without arming the cap timer).
 #[cfg(not(any(target_os = "macos", windows)))]
 fn platform_begin() -> Result<Option<SleepBlock>, String> {
@@ -426,14 +341,17 @@ mod tests {
         // Dropping the guard releases the real OS request.
     }
 
+    /// Identity of the held block — the owning worker's thread id. A second
+    /// `ensure_block` must reuse it rather than spawn a second thread and
+    /// strand the first one holding a request nothing will ever release.
     #[cfg(any(target_os = "macos", windows))]
-    fn block_identity(guard: &PreventSleepState) -> Option<isize> {
+    fn block_identity(guard: &PreventSleepState) -> Option<String> {
         guard.block.as_ref().map(|block| match block {
-            #[cfg(target_os = "macos")]
-            SleepBlock::IoKitAssertion(id) => *id as isize,
-            #[cfg(windows)]
-            SleepBlock::PowerRequest(handle) => *handle,
-            SleepBlock::Inert(_) => 0,
+            SleepBlock::Worker { thread, .. } => thread
+                .as_ref()
+                .map(|thread| format!("{:?}", thread.thread().id()))
+                .unwrap_or_else(|| "detached".to_string()),
+            SleepBlock::Inert(_) => "inert".to_string(),
         })
     }
 

--- a/desktop/src-tauri/src/prevent_sleep.rs
+++ b/desktop/src-tauri/src/prevent_sleep.rs
@@ -1,14 +1,102 @@
+//! Keeps the machine awake while local managed agents are running.
+//!
+//! Two platforms have a real mechanism:
+//!
+//! * **macOS** — an IOKit `PreventUserIdleSystemSleep` power assertion.
+//! * **Windows** — a Win32 *power request* (`PowerCreateRequest` +
+//!   `PowerSetRequest(PowerRequestSystemRequired)`).
+//!
+//! The Windows side deliberately does **not** use `SetThreadExecutionState`.
+//! That API is per-thread and its effect dies with the calling thread, but
+//! [`acquire`] and [`release`] are reached from Tauri command handlers running
+//! on a worker pool and from the shutdown hook — potentially three different
+//! threads. A `SetThreadExecutionState` pair would therefore either evaporate
+//! (the acquiring worker thread retires while an agent is still running) or
+//! leak (release lands on a thread that never set the flag). A power request is
+//! a kernel object owned by the *process*: any thread may create, set, clear,
+//! and close it, and the handle can be stored in shared state. The alternative
+//! — an owned dedicated thread parked for the lifetime of the block — costs a
+//! thread plus a wake-up channel to achieve the same thing, so the power
+//! request wins.
+//!
+//! Linux is a deliberate, documented no-op: there is no portable
+//! inhibit mechanism (logind vs. elogind vs. none), so [`acquire`] succeeds
+//! without holding anything and no cap timer is armed.
+//!
+//! Whatever a platform hands back is stored as a [`SleepBlock`], whose `Drop`
+//! performs the matching release. Every teardown path — explicit
+//! [`release`], the [`INACTIVITY_CAP_SECONDS`] safety valve, and process exit —
+//! goes through that single `Drop`, so no path can clear the bookkeeping while
+//! leaving the OS-level request outstanding.
+
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter};
 
-/// Tracks the macOS IOKit power assertion that prevents idle sleep
-/// while local managed agents are running.
+/// Tracks the OS-level power request that prevents idle sleep while local
+/// managed agents are running.
 #[derive(Default)]
 pub struct PreventSleepState {
-    assertion_id: Option<u32>,
+    block: Option<SleepBlock>,
     timer_handle: Option<tauri::async_runtime::JoinHandle<()>>,
     timer_generation: u64,
+}
+
+/// A live OS-level "do not idle-sleep" request. Dropping it releases the
+/// request; there is no other release path.
+enum SleepBlock {
+    /// macOS `IOPMAssertionID` for a `PreventUserIdleSystemSleep` assertion.
+    #[cfg(target_os = "macos")]
+    IoKitAssertion(u32),
+    /// Windows power-request `HANDLE`, held as an integer so the state stays
+    /// `Send` without an `unsafe impl` (the raw pointer is reconstituted only
+    /// at the call site).
+    #[cfg(windows)]
+    PowerRequest(isize),
+    /// Test-only inert block. Dropping it bumps the counter, which lets the
+    /// platform-independent bookkeeping be asserted on every OS.
+    #[cfg(test)]
+    Inert(Arc<std::sync::atomic::AtomicUsize>),
+}
+
+impl Drop for SleepBlock {
+    // One `if let` per platform rather than a `match`: on platforms with no
+    // mechanism the enum has no variants at all, and an arm-less `match` over
+    // `&mut Self` does not compile there (`min_exhaustive_patterns` does not
+    // see through the reference). The flip side is that in a non-test build
+    // each platform leaves exactly one variant, making its `if let`
+    // irrefutable — which is correct, not a mistake.
+    #[allow(irrefutable_let_patterns)]
+    fn drop(&mut self) {
+        #[cfg(target_os = "macos")]
+        if let Self::IoKitAssertion(id) = self {
+            unsafe {
+                macos::IOPMAssertionRelease(*id);
+            }
+        }
+
+        #[cfg(windows)]
+        if let Self::PowerRequest(handle) = self {
+            use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+            use windows_sys::Win32::System::Power::{
+                PowerClearRequest, PowerRequestSystemRequired,
+            };
+
+            let handle = *handle as HANDLE;
+            unsafe {
+                // Clear before close: closing an un-cleared request also drops
+                // it, but clearing first keeps `powercfg /requests` accurate if
+                // the close ever fails.
+                PowerClearRequest(handle, PowerRequestSystemRequired);
+                CloseHandle(handle);
+            }
+        }
+
+        #[cfg(test)]
+        if let Self::Inert(released) = self {
+            released.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
 }
 
 // ── macOS implementation ────────────────────────────────────────────────────
@@ -43,6 +131,124 @@ const K_IOPM_ASSERTION_LEVEL_ON: u32 = 255;
 
 #[cfg(target_os = "macos")]
 const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+/// Ask the OS for a sleep block. `Ok(None)` means this platform has no
+/// mechanism (see the module docs) — that is success, not failure.
+#[cfg(target_os = "macos")]
+fn platform_begin() -> Result<Option<SleepBlock>, String> {
+    let assertion_type = c"PreventUserIdleSystemSleep".as_ptr();
+    let reason = c"Buzz \u{2014} agents are active".as_ptr();
+
+    unsafe {
+        let cf_type = macos::CFStringCreateWithCString(
+            std::ptr::null(),
+            assertion_type,
+            K_CF_STRING_ENCODING_UTF8,
+        );
+        let cf_reason =
+            macos::CFStringCreateWithCString(std::ptr::null(), reason, K_CF_STRING_ENCODING_UTF8);
+
+        if cf_type.is_null() || cf_reason.is_null() {
+            if !cf_type.is_null() {
+                macos::CFRelease(cf_type);
+            }
+            if !cf_reason.is_null() {
+                macos::CFRelease(cf_reason);
+            }
+            return Err("Failed to create CFString for IOKit assertion".into());
+        }
+
+        let mut assertion_id: u32 = 0;
+        let ret = macos::IOPMAssertionCreateWithName(
+            cf_type,
+            K_IOPM_ASSERTION_LEVEL_ON,
+            cf_reason,
+            &mut assertion_id,
+        );
+
+        macos::CFRelease(cf_type);
+        macos::CFRelease(cf_reason);
+
+        if ret != 0 {
+            return Err(format!(
+                "IOPMAssertionCreateWithName failed with IOReturn {ret}"
+            ));
+        }
+
+        Ok(Some(SleepBlock::IoKitAssertion(assertion_id)))
+    }
+}
+
+// ── Windows implementation ──────────────────────────────────────────────────
+
+/// `POWER_REQUEST_CONTEXT_VERSION` from `winnt.h`. Not re-exported by
+/// `windows-sys`, so it is spelled out here.
+#[cfg(windows)]
+const POWER_REQUEST_CONTEXT_VERSION: u32 = 0;
+
+/// Ask the OS for a sleep block. `Ok(None)` means this platform has no
+/// mechanism (see the module docs) — that is success, not failure.
+///
+/// `PowerRequestSystemRequired` is the direct analogue of the macOS
+/// `PreventUserIdleSystemSleep` assertion: it blocks *idle* sleep only. It
+/// deliberately does not block a user-initiated sleep, a lid close, or the
+/// low-power transition on a Modern Standby machine, and it does not keep the
+/// display awake (that would need `PowerRequestDisplayRequired`).
+#[cfg(windows)]
+fn platform_begin() -> Result<Option<SleepBlock>, String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Power::{
+        PowerCreateRequest, PowerRequestSystemRequired, PowerSetRequest,
+    };
+    use windows_sys::Win32::System::Threading::{
+        POWER_REQUEST_CONTEXT_SIMPLE_STRING, REASON_CONTEXT, REASON_CONTEXT_0,
+    };
+
+    // `PowerCreateRequest` copies the reason string, so a stack-local buffer
+    // that lives across the call is enough.
+    let mut reason: Vec<u16> = "Buzz \u{2014} agents are active"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let context = REASON_CONTEXT {
+        Version: POWER_REQUEST_CONTEXT_VERSION,
+        Flags: POWER_REQUEST_CONTEXT_SIMPLE_STRING,
+        Reason: REASON_CONTEXT_0 {
+            SimpleReasonString: reason.as_mut_ptr(),
+        },
+    };
+
+    let request: HANDLE = unsafe { PowerCreateRequest(&context) };
+    if request.is_null() || request == INVALID_HANDLE_VALUE {
+        let code = unsafe { GetLastError() };
+        return Err(format!(
+            "PowerCreateRequest failed with GetLastError {code}"
+        ));
+    }
+
+    if unsafe { PowerSetRequest(request, PowerRequestSystemRequired) } == 0 {
+        let code = unsafe { GetLastError() };
+        unsafe {
+            CloseHandle(request);
+        }
+        return Err(format!("PowerSetRequest failed with GetLastError {code}"));
+    }
+
+    Ok(Some(SleepBlock::PowerRequest(request as isize)))
+}
+
+// ── Platforms with no mechanism ─────────────────────────────────────────────
+
+/// Ask the OS for a sleep block. Linux and friends have no portable inhibit
+/// mechanism, so this is a documented no-op that reports success without
+/// holding anything (and therefore without arming the cap timer).
+#[cfg(not(any(target_os = "macos", windows)))]
+fn platform_begin() -> Result<Option<SleepBlock>, String> {
+    Ok(None)
+}
+
+// ── Shared bookkeeping ──────────────────────────────────────────────────────
 
 /// One hour covers a silent long-running tool call while bounding idle keep-awake time.
 const INACTIVITY_CAP_SECONDS: u64 = 60 * 60;
@@ -80,92 +286,42 @@ fn expire_if_current(state: &Arc<Mutex<PreventSleepState>>, generation: u64) -> 
     }
 
     guard.timer_handle = None;
-
-    #[cfg(target_os = "macos")]
-    if let Some(id) = guard.assertion_id.take() {
-        unsafe {
-            macos::IOPMAssertionRelease(id);
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        guard.assertion_id = None;
-    }
+    // Dropping the block is the release, on every platform.
+    guard.block = None;
 
     true
 }
 
-/// Create a `PreventUserIdleSystemSleep` assertion if not already held.
-/// Refreshes the inactivity cap when the assertion is already held.
+/// Ensure a sleep block is held, creating one if necessary.
+///
+/// Returns whether a block is now held — i.e. whether the caller should arm the
+/// inactivity cap timer. `false` means the platform has no mechanism, so there
+/// is nothing to cap.
+fn ensure_block(guard: &mut PreventSleepState) -> Result<bool, String> {
+    if guard.block.is_none() {
+        guard.block = platform_begin()?;
+    }
+    Ok(guard.block.is_some())
+}
+
+/// Acquire an OS sleep block if not already held.
+/// Refreshes the inactivity cap whenever a block is held.
 pub fn acquire(
     state: &Arc<Mutex<PreventSleepState>>,
     app_handle: &AppHandle,
 ) -> Result<(), String> {
     let mut guard = state.lock().map_err(|e| e.to_string())?;
 
-    if guard.assertion_id.is_some() {
-        arm_cap_timer(&mut guard, state, app_handle);
-        return Ok(());
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        let assertion_type = c"PreventUserIdleSystemSleep".as_ptr();
-        let reason = c"Buzz \u{2014} agents are active".as_ptr();
-
-        unsafe {
-            let cf_type = macos::CFStringCreateWithCString(
-                std::ptr::null(),
-                assertion_type,
-                K_CF_STRING_ENCODING_UTF8,
-            );
-            let cf_reason = macos::CFStringCreateWithCString(
-                std::ptr::null(),
-                reason,
-                K_CF_STRING_ENCODING_UTF8,
-            );
-
-            if cf_type.is_null() || cf_reason.is_null() {
-                if !cf_type.is_null() {
-                    macos::CFRelease(cf_type);
-                }
-                if !cf_reason.is_null() {
-                    macos::CFRelease(cf_reason);
-                }
-                return Err("Failed to create CFString for IOKit assertion".into());
-            }
-
-            let mut assertion_id: u32 = 0;
-            let ret = macos::IOPMAssertionCreateWithName(
-                cf_type,
-                K_IOPM_ASSERTION_LEVEL_ON,
-                cf_reason,
-                &mut assertion_id,
-            );
-
-            macos::CFRelease(cf_type);
-            macos::CFRelease(cf_reason);
-
-            if ret != 0 {
-                return Err(format!(
-                    "IOPMAssertionCreateWithName failed with IOReturn {ret}"
-                ));
-            }
-
-            guard.assertion_id = Some(assertion_id);
-        }
-    }
-
-    // Start the inactivity cap timer only if an assertion was actually created.
-    if guard.assertion_id.is_some() {
+    // Start (or refresh) the inactivity cap timer only if a block is actually
+    // held — on a platform with no mechanism there is nothing to cap.
+    if ensure_block(&mut guard)? {
         arm_cap_timer(&mut guard, state, app_handle);
     }
 
     Ok(())
 }
 
-/// Release the power assertion if held. Cancel the cap timer.
+/// Release the sleep block if held. Cancel the cap timer.
 pub fn release(state: &Arc<Mutex<PreventSleepState>>) {
     let mut guard = match state.lock() {
         Ok(g) => g,
@@ -177,24 +333,117 @@ pub fn release(state: &Arc<Mutex<PreventSleepState>>) {
     }
     guard.timer_generation = guard.timer_generation.wrapping_add(1);
 
-    #[cfg(target_os = "macos")]
-    if let Some(id) = guard.assertion_id.take() {
-        unsafe {
-            macos::IOPMAssertionRelease(id);
-        }
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        guard.assertion_id = None;
-    }
+    // Dropping the block is the release, on every platform.
+    guard.block = None;
 }
 
-/// Returns `true` if a power assertion is currently held.
+/// Returns `true` if a sleep block is currently held.
 #[allow(dead_code)]
 pub fn is_held(state: &Arc<Mutex<PreventSleepState>>) -> bool {
-    state
-        .lock()
-        .map(|g| g.assertion_id.is_some())
-        .unwrap_or(false)
+    state.lock().map(|g| g.block.is_some()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Build a state holding an inert block, plus the counter its `Drop` bumps.
+    fn state_with_inert_block() -> (Arc<Mutex<PreventSleepState>>, Arc<AtomicUsize>) {
+        let released = Arc::new(AtomicUsize::new(0));
+        let state = Arc::new(Mutex::new(PreventSleepState {
+            block: Some(SleepBlock::Inert(Arc::clone(&released))),
+            timer_handle: None,
+            timer_generation: 7,
+        }));
+        (state, released)
+    }
+
+    #[test]
+    fn release_drops_the_block_and_invalidates_the_timer() {
+        let (state, released) = state_with_inert_block();
+        assert!(is_held(&state));
+
+        release(&state);
+
+        assert_eq!(
+            released.load(Ordering::SeqCst),
+            1,
+            "block released exactly once"
+        );
+        assert!(!is_held(&state));
+        // The in-flight timer's generation must no longer match, so a late
+        // expiry cannot fire an event for a block that is already gone.
+        assert!(!expire_if_current(&state, 7));
+    }
+
+    #[test]
+    fn expire_ignores_a_stale_generation_and_keeps_the_block() {
+        let (state, released) = state_with_inert_block();
+
+        assert!(!expire_if_current(&state, 6));
+
+        assert_eq!(released.load(Ordering::SeqCst), 0);
+        assert!(is_held(&state), "a stale timer must not release the block");
+    }
+
+    #[test]
+    fn expire_releases_the_block_once_for_the_current_generation() {
+        let (state, released) = state_with_inert_block();
+
+        assert!(expire_if_current(&state, 7));
+        assert_eq!(released.load(Ordering::SeqCst), 1);
+        assert!(!is_held(&state));
+
+        // A duplicate expiry for the same generation must not double-release.
+        assert!(expire_if_current(&state, 7));
+        assert_eq!(released.load(Ordering::SeqCst), 1);
+    }
+
+    /// The bug this module was fixed for: on Windows `acquire` used to leave
+    /// the state empty, so nothing was held and the inactivity cap was never
+    /// armed. `ensure_block` must report `true` — that return value is exactly
+    /// what gates `arm_cap_timer` in [`acquire`].
+    #[cfg(any(target_os = "macos", windows))]
+    #[test]
+    fn ensure_block_holds_a_real_os_block_and_is_idempotent() {
+        let mut guard = PreventSleepState::default();
+
+        assert!(
+            ensure_block(&mut guard).expect("platform_begin should succeed"),
+            "a supported platform must report a held block so the cap timer arms"
+        );
+        assert!(guard.block.is_some());
+
+        let before = block_identity(&guard);
+        assert!(ensure_block(&mut guard).expect("second call should succeed"));
+        assert_eq!(
+            before,
+            block_identity(&guard),
+            "an already-held block must be reused, not replaced and leaked"
+        );
+
+        // Dropping the guard releases the real OS request.
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    fn block_identity(guard: &PreventSleepState) -> Option<isize> {
+        guard.block.as_ref().map(|block| match block {
+            #[cfg(target_os = "macos")]
+            SleepBlock::IoKitAssertion(id) => *id as isize,
+            #[cfg(windows)]
+            SleepBlock::PowerRequest(handle) => *handle,
+            SleepBlock::Inert(_) => 0,
+        })
+    }
+
+    /// Platforms with no mechanism report "not held" so no cap timer is armed,
+    /// but they must not surface an error to the caller.
+    #[cfg(not(any(target_os = "macos", windows)))]
+    #[test]
+    fn unsupported_platforms_are_a_silent_success() {
+        let mut guard = PreventSleepState::default();
+        assert!(!ensure_block(&mut guard).expect("no-op platform must not error"));
+        assert!(guard.block.is_none());
+    }
 }


### PR DESCRIPTION
## The bug

Sleep prevention has never worked on Windows, and the UI says it does.

On `main`, the entire assertion-creation block in `desktop/src-tauri/src/prevent_sleep.rs` sits under `#[cfg(target_os = "macos")]` (`prevent_sleep.rs:112-158`). On Windows, `acquire()` falls straight through to the `if guard.assertion_id.is_some()` check at `prevent_sleep.rs:161`, which is `false`, so `arm_cap_timer` never runs and the function returns `Ok(())`. `set_prevent_sleep_active` (`desktop/src-tauri/src/commands/prevent_sleep.rs:9-15`) propagates that `Ok`, so the Settings toggle reports success while nothing is held — the machine sleeps mid agent-turn.

## The fix

Reach the platform mechanism through the `keepawake` crate rather than local FFI. `AGENTS.md:135` says "No `unsafe` code" and `CONTRIBUTING.md:276` says all crates enforce `#![deny(unsafe_code)]`, so a safe wrapper is the policy-compliant route — and it also retires the IOKit `extern "C"` block and CoreFoundation string plumbing this module already carried on `main`. **The file goes from 3 `unsafe {}` blocks and 2 `extern "C"` blocks to zero.**

### Thread lifetime is solved structurally, not by choice of API

keepawake's Windows backend is `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)`, which is per-thread: its effect dies with the thread that set it. `acquire()` and `release()` are reached from Tauri command workers and from the shutdown hook — potentially three different threads — so binding the request to any of them would either evaporate (the acquiring worker retires while an agent still runs) or leak (release lands on a thread that never set it).

So the guard is owned by a dedicated `buzz-prevent-sleep` thread for the block's whole lifetime: it creates the guard, parks on an mpsc channel, and drops the guard when the channel disconnects. `SleepBlock::drop` drops the sender and then **joins** that thread, so release is synchronous — when `drop` returns, the OS request is provably gone, released on the same thread that took it.

### One release path

`assertion_id: Option<u32>` becomes `block: Option<SleepBlock>`, whose `Drop` performs the platform release. That **removes** both `#[cfg(not(target_os = "macos"))] { guard.assertion_id = None; }` blocks rather than re-gating them (`main` lines 91-94 and 187-190): `guard.block = None` now *is* the release on every platform, so explicit `release()`, cap expiry and process exit share one path, and none can clear the bookkeeping while leaving an OS request outstanding.

### Platform behaviour

- **Windows** — new. `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)`, held for the block's lifetime by the dedicated thread.
- **macOS** — equivalent, not byte-identical. With `display(false).idle(true).sleep(false)`, keepawake creates exactly one `PreventUserIdleSystemSleep` assertion at `kIOPMAssertionLevelOn` — the same assertion type and level `main` created by hand. Two visible differences worth knowing: the reason string shown by `pmset -g assertions` changes from `Buzz — agents are active` to `Agents are active`, and the failure message changes from `IOPMAssertionCreateWithName failed with IOReturn {ret}` to `keepawake failed: {error}`.
- **Linux** — unchanged no-op, now documented. keepawake is target-gated to macOS and Windows, because its Linux inhibit path needs a live D-Bus session; a Linux build therefore gains no new runtime requirement and no new dependency.

`INACTIVITY_CAP_SECONDS` is reused unchanged, so Windows gets the same one-hour safety valve macOS has.

## Dependency cost, measured

`desktop/src-tauri/Cargo.lock` grows by exactly one package — 1,228 → 1,229 `[[package]]` entries: `keepawake 0.6.0`, MIT. Every transitive dependency it names (`windows 0.62.2`, `zbus 5.17.0`, `objc2-core-foundation`, `objc2-io-kit`, `derive_builder`, `thiserror`, `cfg-if`) was already locked. No package besides keepawake is added, removed, upgraded or downgraded.

The lock diff is larger than that implies, and the extra churn is benign: re-resolution collapsed ~19 dependency **edges** onto versions already present in the tree (`windows-sys` → 0.61.2 for `rustix`, `tempfile`, `errno`, `socket2`, `anstream` and friends; `tempfile` → `getrandom 0.4.3`; `data-encoding-macro-internal` → `syn 2`). Those crates declare wide ranges — `tempfile` asks for `windows-sys ">=0.52, <0.62"` and `getrandom ">=0.3.0, <0.5"`; `data-encoding-macro-internal` asks for `syn ">= 1, < 3"` — so cargo is free to unify them, and did. No pin moved.

`cargo-deny` is unaffected: the root workspace excludes `desktop/src-tauri` (`Cargo.toml:34`) and CI's `rust` path filter excludes it too, so the `Security` job never sees this crate.

## Known limitation, stated plainly

On Modern Standby (S0 low-power idle) systems **on battery**, Windows terminates system-required requests some minutes after the sleep timeout expires. No single Win32 mechanism closes that gap — the same rule applies to `PowerSetRequest`, which is why the choice of API is not what would fix it. On that machine class this is strictly better than the previous no-op but does not fully achieve "stays awake for a long agent turn." On S3 systems (`powercfg /a`) the request is honoured for the full block.

## Behaviour change worth knowing for QA

`acquire()` now arms the inactivity cap on Windows for the first time, so `prevent-sleep-expired` can fire there and `PreventSleepSettingsCard` will render the *"Sleep prevention expired after 1 hour without agent activity"* banner (`desktop/src/features/settings/ui/PreventSleepSettingsCard.tsx:81-84`). That is intended macOS parity, but it is a state Windows users have never seen.

## Testing

Four tests compile per platform in `prevent_sleep::tests`:

1. `ensure_block_holds_a_real_os_block_and_is_idempotent` — macOS/Windows only. Takes a real OS block through keepawake, asserts a block is held (that return value is exactly what gates `arm_cap_timer`), and asserts a second `ensure_block` reuses the same worker thread rather than stranding one holding a request nothing will ever release.
2. `release_drops_the_block_and_invalidates_the_timer`
3. `expire_ignores_a_stale_generation_and_keeps_the_block`
4. `expire_releases_the_block_once_for_the_current_generation`

2–4 are platform-independent, using a `#[cfg(test)]`-only `SleepBlock::Inert(Arc<AtomicUsize>)` whose `Drop` bumps a counter — that is how release-exactly-once is asserted without an OS call. On Linux, `unsupported_platforms_are_a_silent_success` takes the fourth slot and asserts the no-op reports "not held" without erroring.

**Honest note on coverage:** only test 1 covers the bug, and it exercises `ensure_block()`, which does not exist on `main` — so it cannot be run red against `main` directly. The red was produced by cfg-ing out the new `platform_begin` in the fixed file. The real regression guard is the Windows CI leg: `cargo test --manifest-path desktop/src-tauri/Cargo.toml --target x86_64-pc-windows-msvc` in the `Windows Rust (x86_64-pc-windows-msvc)` job (`.github/workflows/ci.yml:1060`), which this diff triggers through the `desktop-rust` path filter.

**Run locally** (dev box; `just _ensure-sidecar-stubs` first, otherwise the Tauri crate will not compile):

- `cargo check` and `cargo fmt --check` on the desktop Tauri manifest: clean
- `prevent_sleep` tests: 4 passed / 0 failed
- Full desktop-tauri suite: 2,319 passed / 1 failed — `managed_agents::runtime::tests::claude_spawn_uses_the_probed_cli_executable`, which mutates process-global `PATH` and races other tests in the same process. It passes in isolation and this branch does not touch that module.

**Not verified here:** repository CI has not built this branch (workflow runs sit at `action_required` pending maintainer approval), so no Windows or Linux CI leg has compiled it. Separately, `clippy -D warnings` on Windows fails in `desktop/src-tauri/crates/buzz-terminal` (unused `std::io` / `Instant` / `portable_pty::Child` imports used only behind `#[cfg(unix)]`) — pre-existing on `main`, that crate is not in this diff, and the Windows CI job runs `cargo check`, not clippy, over the Tauri workspace.

## Out of scope

- No change to the Settings UI, the `set_prevent_sleep_active` command, the one-hour cap duration, or Linux behaviour.
- No attempt to work around Modern Standby on battery.
- No change to `buzz-terminal`'s pre-existing Windows clippy warnings.