### PR TITLE
fix(acp): shell-split space-separated BUZZ_ACP_AGENT_ARGS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "shlex",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -64,6 +64,7 @@ anyhow = { workspace = true }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
+shlex = "1"
 
 # Config file
 toml = "1.0"

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -109,13 +109,13 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_PRIVATE_KEY` | **yes** | — | Agent's Nostr private key (`nsec1...`). Used for relay auth and agent identity. |
 | `BUZZ_RELAY_URL` | no | `ws://localhost:3000` | Relay WebSocket URL. |
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
-| `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
+| `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated, or one shell-quoted string). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 
-**Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
+**Note:** `BUZZ_ACP_AGENT_ARGS` accepts either comma-separated tokens (`-m,my-model,--flag`) or a single shell-quoted string (`-m my-model --flag "value with spaces"`). Comma form is preferred for simple flags; shell form matches how most users set env vars. Malformed quoting is logged and left unchanged.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -790,9 +790,30 @@ pub fn codex_network_env(agent_command: &str, relay_url: &str) -> Option<(String
 }
 
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
-    let normalized = agent_args
+    // clap splits BUZZ_ACP_AGENT_ARGS on commas (value_delimiter = ',').
+    // A space-separated value (the form every shell user reaches for first)
+    // arrives as a single element containing spaces, e.g.
+    //   BUZZ_ACP_AGENT_ARGS="-m my-model --reasoning low acp"
+    // becomes vec!["-m my-model --reasoning low acp"].
+    // Detect this: when clap produced exactly one element that contains spaces,
+    // shell-split it so the agent receives individual arguments.
+    // Comma-separated input is already correctly split by clap and is left alone.
+    let pre_split = if agent_args.len() == 1 {
+        let arg = &agent_args[0];
+        if arg.contains(' ') {
+            shlex::split(arg).unwrap_or_else(|| vec![arg.trim().to_string()])
+        } else {
+            vec![arg.trim().to_string()]
+        }
+    } else {
+        agent_args
+            .into_iter()
+            .map(|arg| arg.trim().to_string())
+            .collect::<Vec<_>>()
+    };
+
+    let normalized = pre_split
         .into_iter()
-        .map(|arg| arg.trim().to_string())
         .filter(|arg| !arg.is_empty())
         .collect::<Vec<_>>();
 
@@ -1147,7 +1168,7 @@ impl Config {
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
-            self.agent_args.join(" "),
+            format_args!("[{}]", self.agent_args.iter().map(|a| format!("\"{}\"", a)).collect::<Vec<_>>().join(", ")),
             self.mcp_command,
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
@@ -1599,6 +1620,61 @@ mod tests {
         assert_eq!(
             normalize_agent_args("custom-agent", vec!["".into(), "serve".into()]),
             vec!["serve"]
+        );
+    }
+
+    #[test]
+    fn shell_splits_single_space_separated_agent_args() {
+        // clap produces a single element when the env var has no commas.
+        // normalize_agent_args should shell-split it into individual arguments.
+        assert_eq!(
+            normalize_agent_args(
+                "custom-agent",
+                vec!["-m my-model --reasoning low acp".into()]
+            ),
+            vec!["-m", "my-model", "--reasoning", "low", "acp"]
+        );
+    }
+
+    #[test]
+    fn shell_splits_single_arg_with_quoted_values() {
+        assert_eq!(
+            normalize_agent_args(
+                "custom-agent",
+                vec!["--model \"gpt-5\" --flag value".into()]
+            ),
+            vec!["--model", "gpt-5", "--flag", "value"]
+        );
+    }
+
+    #[test]
+    fn does_not_re_split_comma_separated_args() {
+        // Comma-separated input is already correctly split by clap.
+        // normalize_agent_args must leave multi-element results alone.
+        assert_eq!(
+            normalize_agent_args(
+                "custom-agent",
+                vec!["-m".into(), "my-model".into(), "--flag".into()]
+            ),
+            vec!["-m", "my-model", "--flag"]
+        );
+    }
+
+    #[test]
+    fn shell_split_preserves_default_single_token() {
+        // Default value "acp" is a single element with no spaces.
+        // Must remain as-is, not trigger shell-splitting.
+        assert_eq!(
+            normalize_agent_args("goose", vec!["acp".into()]),
+            vec!["acp"]
+        );
+    }
+
+    #[test]
+    fn shell_split_empty_args_stays_empty() {
+        assert_eq!(
+            normalize_agent_args("custom-agent", vec!["".into()]),
+            Vec::<String>::new()
         );
     }
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -191,7 +191,8 @@ pub struct AuthAgentArgs {
     #[arg(long, env = "BUZZ_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
-    /// Arguments passed to the agent binary.
+    /// Arguments passed to the agent binary (comma-separated, or a single
+    /// shell-quoted string when the value contains whitespace).
     #[arg(
         long,
         env = "BUZZ_ACP_AGENT_ARGS",
@@ -789,19 +790,38 @@ pub fn codex_network_env(agent_command: &str, relay_url: &str) -> Option<(String
     ))
 }
 
+fn shell_split_single_agent_arg(arg: &str) -> Vec<String> {
+    let trimmed = arg.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    match shlex::split(trimmed) {
+        Some(parts) => parts,
+        None => {
+            tracing::warn!(
+                agent_args = %trimmed,
+                "BUZZ_ACP_AGENT_ARGS shell split failed — preserving the original value; \
+                 fix quoting or switch to comma-separated args"
+            );
+            vec![trimmed.to_string()]
+        }
+    }
+}
+
 pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
     // clap splits BUZZ_ACP_AGENT_ARGS on commas (value_delimiter = ',').
-    // A space-separated value (the form every shell user reaches for first)
-    // arrives as a single element containing spaces, e.g.
+    // A shell-style value (the form every shell user reaches for first) arrives
+    // as a single element containing whitespace, e.g.
     //   BUZZ_ACP_AGENT_ARGS="-m my-model --reasoning low acp"
     // becomes vec!["-m my-model --reasoning low acp"].
-    // Detect this: when clap produced exactly one element that contains spaces,
-    // shell-split it so the agent receives individual arguments.
+    // Detect this: when clap produced exactly one element that contains
+    // whitespace, shell-split it so the agent receives individual arguments.
     // Comma-separated input is already correctly split by clap and is left alone.
     let pre_split = if agent_args.len() == 1 {
         let arg = &agent_args[0];
-        if arg.contains(' ') {
-            shlex::split(arg).unwrap_or_else(|| vec![arg.trim().to_string()])
+        if arg.chars().any(char::is_whitespace) {
+            shell_split_single_agent_arg(arg)
         } else {
             vec![arg.trim().to_string()]
         }
@@ -1164,11 +1184,11 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} agent_args={:?} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
-            format_args!("[{}]", self.agent_args.iter().map(|a| format!("\"{}\"", a)).collect::<Vec<_>>().join(", ")),
+            self.agent_args,
             self.mcp_command,
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
@@ -1644,6 +1664,22 @@ mod tests {
                 vec!["--model \"gpt-5\" --flag value".into()]
             ),
             vec!["--model", "gpt-5", "--flag", "value"]
+        );
+    }
+
+    #[test]
+    fn shell_splits_tab_separated_agent_args() {
+        assert_eq!(
+            normalize_agent_args("custom-agent", vec!["-m\tmy-model\tacp".into()]),
+            vec!["-m", "my-model", "acp"]
+        );
+    }
+
+    #[test]
+    fn shell_split_malformed_quoting_preserves_original() {
+        assert_eq!(
+            normalize_agent_args("custom-agent", vec!["-m \"unclosed".into()]),
+            vec!["-m \"unclosed"]
         );
     }
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -800,7 +800,7 @@ fn shell_split_single_agent_arg(arg: &str) -> Vec<String> {
         Some(parts) => parts,
         None => {
             tracing::warn!(
-                agent_args = %trimmed,
+                agent_args = ?trimmed,
                 "BUZZ_ACP_AGENT_ARGS shell split failed — preserving the original value; \
                  fix quoting or switch to comma-separated args"
             );
@@ -818,24 +818,34 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
     // Detect this: when clap produced exactly one element that contains
     // whitespace, shell-split it so the agent receives individual arguments.
     // Comma-separated input is already correctly split by clap and is left alone.
-    let pre_split = if agent_args.len() == 1 {
+    // Empty tokens from a successful shell split are real argv values
+    // (`--flag "" tail` → ["--flag", "", "tail"]) and must be kept. Empty
+    // raw/comma-separated entries are still dropped as unset config.
+    let (pre_split, keep_empty_tokens) = if agent_args.len() == 1 {
         let arg = &agent_args[0];
         if arg.chars().any(char::is_whitespace) {
-            shell_split_single_agent_arg(arg)
+            (shell_split_single_agent_arg(arg), true)
         } else {
-            vec![arg.trim().to_string()]
+            (vec![arg.trim().to_string()], false)
         }
     } else {
-        agent_args
-            .into_iter()
-            .map(|arg| arg.trim().to_string())
-            .collect::<Vec<_>>()
+        (
+            agent_args
+                .into_iter()
+                .map(|arg| arg.trim().to_string())
+                .collect::<Vec<_>>(),
+            false,
+        )
     };
 
-    let normalized = pre_split
-        .into_iter()
-        .filter(|arg| !arg.is_empty())
-        .collect::<Vec<_>>();
+    let normalized = if keep_empty_tokens {
+        pre_split
+    } else {
+        pre_split
+            .into_iter()
+            .filter(|arg| !arg.is_empty())
+            .collect::<Vec<_>>()
+    };
 
     let Some(default_args) = default_agent_args(command) else {
         return normalized;
@@ -1664,6 +1674,18 @@ mod tests {
                 vec!["--model \"gpt-5\" --flag value".into()]
             ),
             vec!["--model", "gpt-5", "--flag", "value"]
+        );
+    }
+
+    #[test]
+    fn shell_split_preserves_quoted_empty_argument() {
+        assert_eq!(
+            normalize_agent_args("custom-agent", vec!["--flag \"\" tail".into()]),
+            vec!["--flag", "", "tail"]
+        );
+        assert_eq!(
+            normalize_agent_args("custom-agent", vec!["--flag '' tail".into()]),
+            vec!["--flag", "", "tail"]
         );
     }
 


### PR DESCRIPTION
## Problem

`BUZZ_ACP_AGENT_ARGS` uses clap `value_delimiter=','` so space-separated values (the form every shell user reaches for first) arrive as a **single** argv entry. The agent fails to parse it, times out at 60s, and the startup log hides the problem.

## Fix

Shell-split single space-containing elements in `normalize_agent_args()`. Comma-separated input is untouched (backward compatible). Also log `agent_args` as a quoted list so a misconfigured single-element value is visible.

## Linked issue

Fixes #6017

## Test plan

- `cargo test -p buzz-acp` — 666 passed
- `cargo fmt --check -p buzz-acp` — passed
- `cargo clippy -p buzz-acp --lib -- -D warnings` — passed
- New tests: space-split, quoted values, comma passthrough, default token, empty