### PR TITLE
fix(acp): make accepted work durable and controllable

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -100,7 +100,7 @@ treats both Claude ACP command names as the same zero-arg runtime.
 
 ## Configuration
 
-All configuration is via environment variables (or CLI flags — every env var has a matching flag).
+Configuration is via environment variables and CLI flags. Runtime queue-journal overrides are environment-only because they are operational recovery controls, not normal launch policy.
 
 ### Core
 
@@ -113,6 +113,8 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
+| `BUZZ_ACP_PENDING_STORE` | no | `$HOME/.local/state/buzz-acp/pending-<agent-pubkey>.json` | Override the per-agent durable pending/dead-letter journal path. |
+| `BUZZ_ACP_REPLAY_DEAD_LETTERS` | no | `false` | Move all retained dead letters back to pending work at startup. Enable for a deliberate replay, then unset it. |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
@@ -152,10 +154,11 @@ The gate applies to **all** inbound events — @mentions, DMs, thread replies, a
 | Command | Effect |
 |---------|--------|
 | `!shutdown` | Gracefully exits the harness. |
-| `!cancel` | Cancels the current in-flight turn for that channel, if any. |
+| `!status`, `status`, or `status?` | Reports whether a turn is active and how many follow-ups are queued without disturbing the active turn. A single leading display mention is accepted. |
+| `!cancel`, `!stop`, or `stop` | Cancels the current in-flight turn for that channel, if any. A single leading display mention is accepted. |
 | `!rotate` | Rotates the ACP session for that channel. If a turn is in-flight, it is cancelled and the channel session is invalidated when the task returns; otherwise the cached idle session is invalidated immediately. The next queued/received event starts a fresh session. |
 
-Use `!cancel` to stop only the current turn; it is a no-op when the channel is idle. Use `!rotate` when you want the next turn in the channel to start from a fresh ACP session, even if the channel is currently idle.
+Use `!cancel` or `!stop` to stop only the current turn; it is a no-op when the channel is idle. Use `!rotate` when you want the next turn in the channel to start from a fresh ACP session, even if the channel is currently idle.
 
 Owner control commands must be kind:9 stream messages from the owner, must mention this agent with a `p` tag, and are consumed by the harness instead of being forwarded to the agent.
 
@@ -255,11 +258,11 @@ Forum event kinds:
 3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
-6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
+6. **Recovery** — Accepted events are atomically journaled before the harness acknowledges them. A process restart restores unfinished work from that journal. Terminal failures remain in durable dead-letter storage for audit or deliberate replay. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events that were not yet accepted.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
 
-> **Note:** On startup, the harness replays all unprocessed @mentions since the last run. Expect a burst of activity if there are stale events in the channel.
+> **Note:** On startup, the harness replays unfinished accepted work from its per-agent journal. Set `BUZZ_ACP_REPLAY_DEAD_LETTERS=1` only for a deliberate dead-letter replay, then unset it to avoid replaying future failures after every restart.
 
 ## Bring Your Own Harness (BYOH)
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -113,7 +113,7 @@ Configuration is via environment variables and CLI flags. Runtime queue-journal 
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
-| `BUZZ_ACP_PENDING_STORE` | no | `$HOME/.local/state/buzz-acp/pending-<agent-pubkey>.json` | Override the per-agent durable pending/dead-letter journal path. |
+| `BUZZ_ACP_PENDING_STORE` | no | Unix: `$HOME/.local/state/buzz-acp/pending-<agent-pubkey>.json`; Windows: `%LOCALAPPDATA%\buzz-acp\pending-<agent-pubkey>.json` | Override the per-agent durable pending/dead-letter journal path. Windows falls back to `%APPDATA%`, then `%USERPROFILE%\AppData\Local`. |
 | `BUZZ_ACP_REPLAY_DEAD_LETTERS` | no | `false` | Move all retained dead letters back to pending work at startup. Enable for a deliberate replay, then unset it. |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4375,12 +4375,16 @@ fn recover_panicked_agent(
     if let Some(batch) = meta.recoverable_batch {
         if let Some(ch) = meta.channel_id {
             if !removed_channels.contains(&ch) {
-                // Dead-letter on exhaustion is logged inside requeue(); a
-                // panic path has no outcome to report, so no notice here.
                 if let Some(dead) = queue.requeue(batch) {
-                    queue.finish_batch(&dead);
+                    queue.dead_letter_batch(&dead, "retry budget exhausted after agent panic");
+                    tracing::error!(
+                        agent = i,
+                        channel_id = %ch,
+                        "dead-lettered panicked batch after retry budget exhaustion"
+                    );
+                } else {
+                    tracing::warn!("requeued batch for panicked agent {i}");
                 }
-                tracing::warn!("requeued batch for panicked agent {i}");
             } else {
                 tracing::debug!(
                     channel_id = %ch,
@@ -7575,6 +7579,86 @@ mod error_outcome_emission_tests {
             Some(channel_id.to_string().as_str())
         );
         assert_eq!(panic.turn_id.as_deref(), Some("panic-turn-id"));
+    }
+
+    #[tokio::test]
+    async fn panic_retry_exhaustion_retains_accepted_work_as_dead_letter() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-panic-dead-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let journal_path = dir.join("pending.json");
+        let store = crate::pending_store::PendingStore::open_path(journal_path.clone())
+            .expect("open pending store");
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(9), "survive panic exhaustion")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event");
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Queue).with_pending_store(store);
+        assert!(queue.push(crate::queue::QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        let batch = queue.flush_next().expect("flush accepted event");
+        queue.set_retry_count_for_test(channel_id, crate::queue::MAX_RETRIES);
+
+        let mut pool = AgentPool::from_slots(vec![]);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let abort_handle = pool.join_set.spawn(async move {
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        let task_id = abort_handle.id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "panic-dead-letter-turn".to_string(),
+                recoverable_batch: Some(batch),
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+        started_rx.await.expect("task started");
+        abort_handle.abort();
+        let join_error = pool.join_set.join_next().await.unwrap().unwrap_err();
+
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = HashSet::new();
+        let mut typing_channels = HashMap::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        recover_panicked_agent(
+            &mut pool,
+            &mut queue,
+            &config,
+            join_error,
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut typing_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+        );
+
+        let journal: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&journal_path).expect("read pending journal"))
+                .expect("parse pending journal");
+        assert!(journal["pending"].as_object().unwrap().is_empty());
+        assert!(journal["dead_letters"].get(&event_id).is_some());
+
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2757,6 +2757,55 @@ async fn tokio_main() -> Result<()> {
                                 // contain "!shutdown" from a non-owner.
                             }
 
+                            // Owner-only, mode-independent status lane. Exact
+                            // commands are answered by the harness so checking
+                            // progress never cancels, steers, or queues behind
+                            // the active model turn.
+                            let is_status = ["!status", "status", "status?"]
+                                .iter()
+                                .any(|command| {
+                                    is_owner_control_phrase(
+                                        &buzz_event.event,
+                                        kind_u32,
+                                        command,
+                                        &pubkey_hex,
+                                    )
+                                });
+                            if is_status {
+                                if let Some(owner) = owner_cache.get() {
+                                    if buzz_event.event.pubkey.to_hex() == *owner {
+                                        let active = queue
+                                            .is_channel_in_flight(buzz_event.channel_id);
+                                        let queued =
+                                            queue.queued_event_count(&buzz_event.channel_id);
+                                        let content = if active {
+                                            format!(
+                                                "Status: the current task is still running; {queued} follow-up request(s) are durably queued. Send !stop to stop the active task."
+                                            )
+                                        } else {
+                                            format!(
+                                                "Status: no task is currently running; {queued} request(s) are durably queued."
+                                            )
+                                        };
+                                        let thread_tags =
+                                            queue::parse_thread_tags(&buzz_event.event);
+                                        let rest = ctx.rest_client.clone();
+                                        let channel_id = buzz_event.channel_id;
+                                        tokio::spawn(async move {
+                                            pool::post_failure_notice(
+                                                &rest,
+                                                channel_id,
+                                                &thread_tags,
+                                                &content,
+                                            )
+                                            .await;
+                                        });
+                                        continue;
+                                    }
+                                }
+                                // Not from owner — fall through to normal prompt handling.
+                            }
+
                             // Mirrors !shutdown: kind:9, content "!cancel", from
                             // owner, mentions THIS agent. Must be BEFORE
                             // queue.push() — the event content is moved by push.
@@ -2764,12 +2813,16 @@ async fn tokio_main() -> Result<()> {
                             // Mode-independent: !cancel fires regardless of
                             // --multiple-event-handling. It is explicit user
                             // intent, not an automatic policy decision.
-                            let is_cancel = is_owner_control_command(
-                                &buzz_event.event,
-                                kind_u32,
-                                "!cancel",
-                                &pubkey_hex,
-                            );
+                            let is_cancel = ["!cancel", "!stop", "stop"]
+                                .iter()
+                                .any(|command| {
+                                    is_owner_control_phrase(
+                                        &buzz_event.event,
+                                        kind_u32,
+                                        command,
+                                        &pubkey_hex,
+                                    )
+                                });
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
@@ -2781,7 +2834,7 @@ async fn tokio_main() -> Result<()> {
                                         if !fired {
                                             tracing::warn!(
                                                 channel_id = %buzz_event.channel_id,
-                                                "!cancel received but no in-flight task — no-op"
+                                                "stop command received but no in-flight task — no-op"
                                             );
                                         }
                                         continue; // consume event — do NOT push to queue
@@ -3558,6 +3611,27 @@ fn is_owner_control_command(
         && event_mentions_agent(event, agent_pubkey_hex)
 }
 
+fn is_owner_control_phrase(
+    event: &nostr::Event,
+    kind_u32: u32,
+    command: &str,
+    agent_pubkey_hex: &str,
+) -> bool {
+    if kind_u32 != KIND_STREAM_MESSAGE || !event_mentions_agent(event, agent_pubkey_hex) {
+        return false;
+    }
+    let content = event.content.trim();
+    if content.eq_ignore_ascii_case(command) {
+        return true;
+    }
+    let mut words = content.split_whitespace();
+    matches!(
+        (words.next(), words.next(), words.next()),
+        (Some(mention), Some(candidate), None)
+            if mention.starts_with('@') && candidate.eq_ignore_ascii_case(command)
+    )
+}
+
 // ── signal_in_flight_task ─────────────────────────────────────────────────────
 
 /// Decide which [`ControlSignal`] (if any) to send to an in-flight turn when a
@@ -3959,7 +4033,7 @@ fn handle_prompt_result(
                 tracing::error!(
                     channel_id = %batch.channel_id,
                     events = batch.events.len(),
-                    "dead-lettering batch after hard-cap timeout (no recent activity) — discarding {} events",
+                    "dead-lettering batch after hard-cap timeout (no recent activity) — retaining {} events in durable dead-letter storage",
                     batch.events.len(),
                 );
                 let content = format!(
@@ -3967,7 +4041,7 @@ fn handle_prompt_result(
                     config.max_turn_duration_secs
                 );
                 spawn_failure_notice(rest_client, &batch, content);
-                queue.finish_batch(&batch);
+                queue.dead_letter_batch(&batch, "hard-cap timeout without recent activity");
                 hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
             } else if matches!(
                 result.outcome,
@@ -3986,7 +4060,7 @@ fn handle_prompt_result(
                         config.max_turn_duration_secs
                     );
                     spawn_failure_notice(rest_client, &dead, content);
-                    queue.finish_batch(&dead);
+                    queue.dead_letter_batch(&dead, "retry budget exhausted after hard-cap timeout");
                     hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
@@ -4006,7 +4080,7 @@ fn handle_prompt_result(
                     and then re-send."
                     .to_string();
                 spawn_failure_notice(rest_client, &batch, content);
-                queue.finish_batch(&batch);
+                queue.dead_letter_batch(&batch, "non-retryable authentication error");
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
                     PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
@@ -4021,7 +4095,7 @@ fn handle_prompt_result(
                     "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
                 );
                 spawn_failure_notice(rest_client, &dead, content);
-                queue.finish_batch(&dead);
+                queue.dead_letter_batch(&dead, "retry budget exhausted");
             }
         } else {
             tracing::debug!(
@@ -5326,6 +5400,26 @@ mod owner_control_command_tests {
             &keys,
         );
         assert!(unaddressed.is_err());
+    }
+
+    #[test]
+    fn owner_control_phrase_accepts_a_single_display_mention_prefix() {
+        let agent = "ab".repeat(32);
+        let prefixed = make_event(KIND_STREAM_MESSAGE, "@Jarvis status?", Some(&agent));
+        assert!(is_owner_control_phrase(
+            &prefixed,
+            KIND_STREAM_MESSAGE,
+            "status?",
+            &agent
+        ));
+
+        let conversational = make_event(KIND_STREAM_MESSAGE, "@Jarvis please stop", Some(&agent));
+        assert!(!is_owner_control_phrase(
+            &conversational,
+            KIND_STREAM_MESSAGE,
+            "stop",
+            &agent
+        ));
     }
 }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3823,10 +3823,11 @@ fn dispatch_pending(
         };
         tracing::debug!(agent = agent.index, channel = %channel_id, affinity_hit, "agent_claimed");
 
-        let recoverable_batch = match ctx.dedup_mode {
-            DedupMode::Queue => Some(batch.clone()),
-            DedupMode::Drop => None,
-        };
+        // Retain a disposition copy in both dedup modes. PromptResult::batch
+        // remains responsible for retry policy (None in Drop mode), while this
+        // copy ensures every accepted event can be removed or dead-lettered in
+        // the durable journal after success, terminal failure, or panic.
+        let recoverable_batch = Some(batch.clone());
 
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
@@ -4108,6 +4109,24 @@ fn handle_prompt_result(
         }
     }
 
+    // Drop mode deliberately returns no PromptResult::batch, so it never
+    // retries. The TaskMeta disposition copy must still reach a terminal
+    // durable state or the accepted event would replay after every restart.
+    if matches!(config.dedup_mode, DedupMode::Drop)
+        && !matches!(
+            result.outcome,
+            PromptOutcome::Ok(_) | PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
+        )
+    {
+        if let Some(batch) = recoverable_batch.as_ref() {
+            if removed_channels.contains(&batch.channel_id) {
+                queue.finish_batch(batch);
+            } else {
+                queue.dead_letter_batch(batch, "terminal prompt failure in drop mode");
+            }
+        }
+    }
+
     if matches!(result.outcome, PromptOutcome::Ok(_))
         || (matches!(
             result.outcome,
@@ -4375,21 +4394,37 @@ fn recover_panicked_agent(
     if let Some(batch) = meta.recoverable_batch {
         if let Some(ch) = meta.channel_id {
             if !removed_channels.contains(&ch) {
-                if let Some(dead) = queue.requeue(batch) {
-                    queue.dead_letter_batch(&dead, "retry budget exhausted after agent panic");
-                    tracing::error!(
-                        agent = i,
-                        channel_id = %ch,
-                        "dead-lettered panicked batch after retry budget exhaustion"
-                    );
-                } else {
-                    tracing::warn!("requeued batch for panicked agent {i}");
+                match config.dedup_mode {
+                    DedupMode::Queue => {
+                        if let Some(dead) = queue.requeue(batch) {
+                            queue.dead_letter_batch(
+                                &dead,
+                                "retry budget exhausted after agent panic",
+                            );
+                            tracing::error!(
+                                agent = i,
+                                channel_id = %ch,
+                                "dead-lettered panicked batch after retry budget exhaustion"
+                            );
+                        } else {
+                            tracing::warn!("requeued batch for panicked agent {i}");
+                        }
+                    }
+                    DedupMode::Drop => {
+                        queue.dead_letter_batch(&batch, "agent panic in drop mode");
+                        tracing::error!(
+                            agent = i,
+                            channel_id = %ch,
+                            "dead-lettered panicked batch in drop mode"
+                        );
+                    }
                 }
             } else {
                 tracing::debug!(
                     channel_id = %ch,
-                    "dropping panicked batch for removed channel"
+                    "finalizing panicked batch for removed channel"
                 );
+                queue.finish_batch(&batch);
             }
         }
     }
@@ -7581,6 +7616,61 @@ mod error_outcome_emission_tests {
         assert_eq!(panic.turn_id.as_deref(), Some("panic-turn-id"));
     }
 
+    async fn recover_test_batch_after_panic(
+        queue: &mut EventQueue,
+        batch: FlushBatch,
+        config: &Config,
+        removed_channels: &HashSet<Uuid>,
+    ) {
+        let channel_id = batch.channel_id;
+        let mut pool = AgentPool::from_slots(vec![]);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let abort_handle = pool.join_set.spawn(async move {
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        let task_id = abort_handle.id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "panic-durable-turn".to_string(),
+                recoverable_batch: Some(batch),
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+        started_rx.await.expect("task started");
+        abort_handle.abort();
+        let join_error = pool.join_set.join_next().await.unwrap().unwrap_err();
+
+        let mut heartbeat_in_flight = false;
+        let mut typing_channels = HashMap::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        recover_panicked_agent(
+            &mut pool,
+            queue,
+            config,
+            join_error,
+            &mut heartbeat_in_flight,
+            removed_channels,
+            &mut typing_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+        );
+    }
+
     #[tokio::test]
     async fn panic_retry_exhaustion_retains_accepted_work_as_dead_letter() {
         let dir = std::env::temp_dir().join(format!("buzz-acp-panic-dead-{}", Uuid::new_v4()));
@@ -7603,54 +7693,9 @@ mod error_outcome_emission_tests {
         let batch = queue.flush_next().expect("flush accepted event");
         queue.set_retry_count_for_test(channel_id, crate::queue::MAX_RETRIES);
 
-        let mut pool = AgentPool::from_slots(vec![]);
-        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-        let abort_handle = pool.join_set.spawn(async move {
-            let _ = started_tx.send(());
-            std::future::pending::<()>().await;
-        });
-        let task_id = abort_handle.id();
-        pool.task_map_mut().insert(
-            task_id,
-            crate::pool::TaskMeta {
-                agent_index: 0,
-                channel_id: Some(channel_id),
-                turn_id: "panic-dead-letter-turn".to_string(),
-                recoverable_batch: Some(batch),
-                control_tx: None,
-                steer_tx: None,
-                successful_steer_deliveries: HashSet::new(),
-            },
-        );
-        started_rx.await.expect("task started");
-        abort_handle.abort();
-        let join_error = pool.join_set.join_next().await.unwrap().unwrap_err();
-
         let config = test_config();
-        let mut heartbeat_in_flight = false;
         let removed_channels = HashSet::new();
-        let mut typing_channels = HashMap::new();
-        let mut crash_history = vec![SlotCircuit {
-            crash_times: Vec::new(),
-            open_until: None,
-            respawn_in_flight: false,
-        }];
-        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
-        let mut respawn_tasks = tokio::task::JoinSet::new();
-
-        recover_panicked_agent(
-            &mut pool,
-            &mut queue,
-            &config,
-            join_error,
-            &mut heartbeat_in_flight,
-            &removed_channels,
-            &mut typing_channels,
-            &mut crash_history,
-            &respawn_tx,
-            &mut respawn_tasks,
-            None,
-        );
+        recover_test_batch_after_panic(&mut queue, batch, &config, &removed_channels).await;
 
         let journal: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&journal_path).expect("read pending journal"))
@@ -7658,6 +7703,149 @@ mod error_outcome_emission_tests {
         assert!(journal["pending"].as_object().unwrap().is_empty());
         assert!(journal["dead_letters"].get(&event_id).is_some());
 
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
+    }
+
+    #[tokio::test]
+    async fn panic_in_drop_mode_dead_letters_without_retrying() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-panic-drop-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let journal_path = dir.join("pending.json");
+        let store = crate::pending_store::PendingStore::open_path(journal_path.clone())
+            .expect("open pending store");
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(9), "drop panic")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event");
+        let event_id = event.id.to_hex();
+        let mut queue = EventQueue::new(config::DedupMode::Drop).with_pending_store(store);
+        assert!(queue.push(crate::queue::QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        let batch = queue.flush_next().expect("flush accepted event");
+        let mut config = test_config();
+        config.dedup_mode = config::DedupMode::Drop;
+        recover_test_batch_after_panic(&mut queue, batch, &config, &HashSet::new()).await;
+
+        let journal: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&journal_path).expect("read pending journal"))
+                .expect("parse pending journal");
+        assert!(journal["pending"].as_object().unwrap().is_empty());
+        assert!(journal["dead_letters"].get(&event_id).is_some());
+        assert_eq!(queue.queued_event_count(&channel_id), 0);
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
+    }
+
+    #[tokio::test]
+    async fn panic_for_removed_channel_finalizes_durable_work() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-panic-removed-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let journal_path = dir.join("pending.json");
+        let store = crate::pending_store::PendingStore::open_path(journal_path.clone())
+            .expect("open pending store");
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(9), "removed channel panic")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event");
+        let mut queue = EventQueue::new(config::DedupMode::Queue).with_pending_store(store);
+        assert!(queue.push(crate::queue::QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        let batch = queue.flush_next().expect("flush accepted event");
+        recover_test_batch_after_panic(
+            &mut queue,
+            batch,
+            &test_config(),
+            &HashSet::from([channel_id]),
+        )
+        .await;
+
+        let journal: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&journal_path).expect("read pending journal"))
+                .expect("parse pending journal");
+        assert!(journal["pending"].as_object().unwrap().is_empty());
+        assert!(journal["dead_letters"].as_object().unwrap().is_empty());
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
+    }
+
+    #[tokio::test]
+    async fn drop_mode_success_finalizes_durable_work_without_retry_batch() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-drop-success-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let journal_path = dir.join("pending.json");
+        let store = crate::pending_store::PendingStore::open_path(journal_path.clone())
+            .expect("open pending store");
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(9), "drop success")
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event");
+        let mut queue = EventQueue::new(config::DedupMode::Drop).with_pending_store(store);
+        assert!(queue.push(crate::queue::QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now(),
+            prompt_tag: "test".into(),
+        }));
+        let disposition_batch = queue.flush_next().expect("flush accepted event");
+
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "drop-success-turn".to_string(),
+                recoverable_batch: Some(disposition_batch),
+                control_tx: None,
+                steer_tx: None,
+                successful_steer_deliveries: HashSet::new(),
+            },
+        );
+        let mut config = test_config();
+        config.dedup_mode = config::DedupMode::Drop;
+        let mut heartbeat_in_flight = false;
+        let removed_channels = HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+        let result = PromptResult {
+            agent,
+            source: PromptSource::Channel(channel_id),
+            turn_id: "drop-success-turn".to_string(),
+            outcome: PromptOutcome::Ok(crate::acp::StopReason::EndTurn),
+            batch: None,
+        };
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            result,
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        );
+
+        let journal: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&journal_path).expect("read pending journal"))
+                .expect("parse pending journal");
+        assert!(journal["pending"].as_object().unwrap().is_empty());
+        assert!(journal["dead_letters"].as_object().unwrap().is_empty());
         std::fs::remove_dir_all(dir).expect("remove tempdir");
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod engram_fetch;
 mod filter;
 mod observer;
+mod pending_store;
 mod pool;
 mod pool_lifecycle;
 mod queue;
@@ -2135,8 +2136,18 @@ async fn tokio_main() -> Result<()> {
 
     let runtime_start_nonce = std::env::var("BUZZ_MANAGED_AGENT_START_NONCE").unwrap_or_default();
     let dedup_mode = config.dedup_mode;
-    let mut queue =
-        EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
+    let pending_store = pending_store::PendingStore::open(&pubkey_hex)
+        .map_err(|error| anyhow::anyhow!("open durable pending-work journal: {error}"))?;
+    let mut queue = EventQueue::new(dedup_mode)
+        .with_in_flight_deadline(config.max_turn_duration_secs)
+        .with_pending_store(pending_store);
+    let restored_event_ids = queue.pending_event_ids();
+    if !restored_event_ids.is_empty() {
+        let rest = relay.rest_client();
+        for event_id in &restored_event_ids {
+            pool::reaction_add(&rest, event_id, "👀").await;
+        }
+    }
 
     // Online means the harness can receive work, not merely that its socket is
     // connected. Publishing after channel subscriptions gives desktop callers
@@ -3413,6 +3424,15 @@ async fn tokio_main() -> Result<()> {
     // explicitly shut them down here to reap child processes. If the grace
     // period expires, remaining tasks are aborted and fall back to
     // AcpClient::Drop (start_kill + try_wait — best-effort, not guaranteed).
+    let shutdown_batches: HashMap<usize, FlushBatch> = pool
+        .task_map()
+        .values()
+        .filter_map(|meta| {
+            meta.recoverable_batch
+                .clone()
+                .map(|batch| (meta.agent_index, batch))
+        })
+        .collect();
     let (rx_ref, js_ref) = pool.rx_and_join_set();
     let shutdown_result = tokio::time::timeout(grace, async {
         loop {
@@ -3427,6 +3447,11 @@ async fn tokio_main() -> Result<()> {
                 maybe_result = rx_ref.recv() => {
                     if let Some(mut pr) = maybe_result {
                         let idx = pr.agent.index;
+                        if matches!(pr.outcome, PromptOutcome::Ok(_)) {
+                            if let Some(batch) = shutdown_batches.get(&idx) {
+                                queue.finish_batch(batch);
+                            }
+                        }
                         pr.agent.acp.shutdown().await;
                         tracing::debug!(agent = idx, "reaped checked-out agent on shutdown");
                     }
@@ -3444,6 +3469,11 @@ async fn tokio_main() -> Result<()> {
     // before tasks were aborted.
     while let Ok(mut pr) = pool.result_rx_try_recv() {
         let idx = pr.agent.index;
+        if matches!(pr.outcome, PromptOutcome::Ok(_)) {
+            if let Some(batch) = shutdown_batches.get(&idx) {
+                queue.finish_batch(batch);
+            }
+        }
         pr.agent.acp.shutdown().await;
         tracing::debug!(agent = idx, "reaped late-arriving agent on shutdown");
     }
@@ -3849,6 +3879,12 @@ fn handle_prompt_result(
     observer: Option<observer::ObserverHandle>,
     rest_client: Option<&relay::RestClient>,
 ) -> LoopAction {
+    let had_retry_batch = result.batch.is_some();
+    let recoverable_batch = pool
+        .task_map()
+        .values()
+        .find(|meta| meta.agent_index == result.agent.index)
+        .and_then(|meta| meta.recoverable_batch.clone());
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
     let successful_steer_deliveries = pool
@@ -3931,6 +3967,7 @@ fn handle_prompt_result(
                     config.max_turn_duration_secs
                 );
                 spawn_failure_notice(rest_client, &batch, content);
+                queue.finish_batch(&batch);
                 hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
             } else if matches!(
                 result.outcome,
@@ -3949,6 +3986,7 @@ fn handle_prompt_result(
                         config.max_turn_duration_secs
                     );
                     spawn_failure_notice(rest_client, &dead, content);
+                    queue.finish_batch(&dead);
                     hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
@@ -3968,6 +4006,7 @@ fn handle_prompt_result(
                     and then re-send."
                     .to_string();
                 spawn_failure_notice(rest_client, &batch, content);
+                queue.finish_batch(&batch);
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
                     PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
@@ -3982,6 +4021,7 @@ fn handle_prompt_result(
                     "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
                 );
                 spawn_failure_notice(rest_client, &dead, content);
+                queue.finish_batch(&dead);
             }
         } else {
             tracing::debug!(
@@ -3990,6 +4030,18 @@ fn handle_prompt_result(
                 "dropping failed batch for removed channel"
             );
             hard_timeout_fate_suffix = Some(" — batch dropped (channel removed)");
+            queue.finish_batch(&batch);
+        }
+    }
+
+    if matches!(result.outcome, PromptOutcome::Ok(_))
+        || (matches!(
+            result.outcome,
+            PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
+        ) && !had_retry_batch)
+    {
+        if let Some(batch) = recoverable_batch.as_ref() {
+            queue.finish_batch(batch);
         }
     }
 
@@ -4251,7 +4303,9 @@ fn recover_panicked_agent(
             if !removed_channels.contains(&ch) {
                 // Dead-letter on exhaustion is logged inside requeue(); a
                 // panic path has no outcome to report, so no notice here.
-                let _ = queue.requeue(batch);
+                if let Some(dead) = queue.requeue(batch) {
+                    queue.finish_batch(&dead);
+                }
                 tracing::warn!("requeued batch for panicked agent {i}");
             } else {
                 tracing::debug!(

--- a/crates/buzz-acp/src/pending_store.rs
+++ b/crates/buzz-acp/src/pending_store.rs
@@ -13,7 +13,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-const STORE_VERSION: u32 = 1;
+const STORE_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct StoredPendingEvent {
@@ -26,12 +26,23 @@ pub(crate) struct StoredPendingEvent {
 #[derive(Debug, Serialize, Deserialize)]
 struct StoreFile {
     version: u32,
-    events: BTreeMap<String, StoredPendingEvent>,
+    #[serde(default, alias = "events")]
+    pending: BTreeMap<String, StoredPendingEvent>,
+    #[serde(default)]
+    dead_letters: BTreeMap<String, StoredDeadLetter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredDeadLetter {
+    pending: StoredPendingEvent,
+    reason: String,
+    dead_lettered_at_nanos: u64,
 }
 
 pub(crate) struct PendingStore {
     path: PathBuf,
-    events: BTreeMap<String, StoredPendingEvent>,
+    pending: BTreeMap<String, StoredPendingEvent>,
+    dead_letters: BTreeMap<String, StoredDeadLetter>,
 }
 
 impl PendingStore {
@@ -41,7 +52,7 @@ impl PendingStore {
     }
 
     pub(crate) fn open_path(path: PathBuf) -> io::Result<Self> {
-        let events = match std::fs::read(&path) {
+        let (pending, dead_letters) = match std::fs::read(&path) {
             Ok(bytes) => {
                 let stored: StoreFile = serde_json::from_slice(&bytes).map_err(|error| {
                     io::Error::new(
@@ -49,7 +60,7 @@ impl PendingStore {
                         format!("invalid pending-work journal {}: {error}", path.display()),
                     )
                 })?;
-                if stored.version != STORE_VERSION {
+                if !matches!(stored.version, 1 | STORE_VERSION) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
@@ -59,30 +70,58 @@ impl PendingStore {
                         ),
                     ));
                 }
-                stored.events
+                let pending = stored
+                    .pending
+                    .into_iter()
+                    .map(|(id, event)| validate_stored_event(&path, id, event))
+                    .collect::<io::Result<BTreeMap<_, _>>>()?;
+                let dead_letters = stored
+                    .dead_letters
+                    .into_iter()
+                    .map(|(id, mut dead_letter)| {
+                        let (id, pending) = validate_stored_event(&path, id, dead_letter.pending)?;
+                        dead_letter.pending = pending;
+                        Ok((id, dead_letter))
+                    })
+                    .collect::<io::Result<BTreeMap<_, _>>>()?;
+                (pending, dead_letters)
             }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                (BTreeMap::new(), BTreeMap::new())
+            }
             Err(error) => return Err(error),
         };
-        Ok(Self { path, events })
+        let mut store = Self {
+            path,
+            pending,
+            dead_letters,
+        };
+        if replay_dead_letters_requested() && !store.dead_letters.is_empty() {
+            let replayed = store.replay_all_dead_letters()?;
+            tracing::warn!(
+                replayed,
+                "replayed durable dead letters because BUZZ_ACP_REPLAY_DEAD_LETTERS is enabled"
+            );
+        }
+        Ok(store)
     }
 
     pub(crate) fn restored(&self) -> Vec<StoredPendingEvent> {
-        let mut events = self.events.values().cloned().collect::<Vec<_>>();
+        let mut events = self.pending.values().cloned().collect::<Vec<_>>();
         events.sort_by_key(|event| event.accepted_at_nanos);
         events
     }
 
     pub(crate) fn record(&mut self, event: StoredPendingEvent) -> io::Result<()> {
         let id = event.event.id.to_hex();
-        let previous = self.events.insert(id.clone(), event);
+        let previous = self.pending.insert(id.clone(), event);
         if let Err(error) = self.persist() {
             match previous {
                 Some(previous) => {
-                    self.events.insert(id, previous);
+                    self.pending.insert(id, previous);
                 }
                 None => {
-                    self.events.remove(&id);
+                    self.pending.remove(&id);
                 }
             }
             return Err(error);
@@ -93,16 +132,63 @@ impl PendingStore {
     pub(crate) fn remove<'a>(&mut self, ids: impl IntoIterator<Item = &'a str>) -> io::Result<()> {
         let removed: Vec<(String, StoredPendingEvent)> = ids
             .into_iter()
-            .filter_map(|id| self.events.remove_entry(id))
+            .filter_map(|id| self.pending.remove_entry(id))
             .collect();
         if removed.is_empty() {
             return Ok(());
         }
         if let Err(error) = self.persist() {
-            self.events.extend(removed);
+            self.pending.extend(removed);
             return Err(error);
         }
         Ok(())
+    }
+
+    pub(crate) fn dead_letter<'a>(
+        &mut self,
+        ids: impl IntoIterator<Item = &'a str>,
+        reason: &str,
+    ) -> io::Result<usize> {
+        let old_pending = self.pending.clone();
+        let old_dead_letters = self.dead_letters.clone();
+        let now = unix_time_nanos();
+        let mut moved = 0;
+        for id in ids {
+            if let Some(pending) = self.pending.remove(id) {
+                self.dead_letters.insert(
+                    id.to_string(),
+                    StoredDeadLetter {
+                        pending,
+                        reason: reason.to_string(),
+                        dead_lettered_at_nanos: now,
+                    },
+                );
+                moved += 1;
+            }
+        }
+        if moved > 0 {
+            if let Err(error) = self.persist() {
+                self.pending = old_pending;
+                self.dead_letters = old_dead_letters;
+                return Err(error);
+            }
+        }
+        Ok(moved)
+    }
+
+    fn replay_all_dead_letters(&mut self) -> io::Result<usize> {
+        let old_pending = self.pending.clone();
+        let old_dead_letters = self.dead_letters.clone();
+        let replayed = self.dead_letters.len();
+        for (id, dead_letter) in std::mem::take(&mut self.dead_letters) {
+            self.pending.entry(id).or_insert(dead_letter.pending);
+        }
+        if let Err(error) = self.persist() {
+            self.pending = old_pending;
+            self.dead_letters = old_dead_letters;
+            return Err(error);
+        }
+        Ok(replayed)
     }
 
     fn persist(&self) -> io::Result<()> {
@@ -117,7 +203,8 @@ impl PendingStore {
         }
         let bytes = serde_json::to_vec(&StoreFile {
             version: STORE_VERSION,
-            events: self.events.clone(),
+            pending: self.pending.clone(),
+            dead_letters: self.dead_letters.clone(),
         })
         .map_err(io::Error::other)?;
         let temp = self.path.with_extension("json.tmp");
@@ -131,8 +218,54 @@ impl PendingStore {
         let mut file = options.open(&temp)?;
         std::io::Write::write_all(&mut file, &bytes)?;
         file.sync_all()?;
-        std::fs::rename(temp, &self.path)
+        std::fs::rename(temp, &self.path)?;
+        #[cfg(unix)]
+        std::fs::File::open(parent)?.sync_all()?;
+        Ok(())
     }
+}
+
+fn validate_stored_event(
+    path: &Path,
+    id: String,
+    event: StoredPendingEvent,
+) -> io::Result<(String, StoredPendingEvent)> {
+    if id != event.event.id.to_hex() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "pending-work journal {} contains mismatched event id",
+                path.display()
+            ),
+        ));
+    }
+    event.event.verify().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "pending-work journal {} contains an invalid signed event: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    Ok((id, event))
+}
+
+fn unix_time_nanos() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .min(u64::MAX as u128) as u64
+}
+
+fn replay_dead_letters_requested() -> bool {
+    std::env::var("BUZZ_ACP_REPLAY_DEAD_LETTERS").is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes"
+        )
+    })
 }
 
 fn pending_store_path(agent_pubkey: &str) -> io::Result<PathBuf> {
@@ -189,6 +322,48 @@ mod tests {
                 .restored()
                 .len(),
             0
+        );
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
+    }
+
+    #[test]
+    fn dead_letters_are_retained_and_replayable() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-dead-letters-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let path = dir.join("pending.json");
+        let mut store = PendingStore::open_path(path.clone()).expect("open");
+        let event = event("retry me later");
+        let id = event.id.to_hex();
+        store
+            .record(StoredPendingEvent {
+                channel_id: Uuid::new_v4(),
+                event,
+                prompt_tag: "@mention".into(),
+                accepted_at_nanos: 1,
+            })
+            .expect("record");
+
+        assert_eq!(
+            store
+                .dead_letter([id.as_str()], "retry budget exhausted")
+                .expect("dead letter"),
+            1
+        );
+        assert!(store.restored().is_empty());
+        drop(store);
+
+        let mut reopened = PendingStore::open_path(path.clone()).expect("reopen");
+        assert!(reopened.restored().is_empty());
+        assert_eq!(reopened.replay_all_dead_letters().expect("replay"), 1);
+        assert_eq!(reopened.restored().len(), 1);
+        drop(reopened);
+
+        assert_eq!(
+            PendingStore::open_path(path)
+                .expect("final reopen")
+                .restored()
+                .len(),
+            1
         );
         std::fs::remove_dir_all(dir).expect("remove tempdir");
     }

--- a/crates/buzz-acp/src/pending_store.rs
+++ b/crates/buzz-acp/src/pending_store.rs
@@ -272,15 +272,45 @@ fn pending_store_path(agent_pubkey: &str) -> io::Result<PathBuf> {
     if let Some(path) = std::env::var_os("BUZZ_ACP_PENDING_STORE") {
         return Ok(PathBuf::from(path));
     }
-    let home = std::env::var_os("HOME").ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            "HOME is unset and BUZZ_ACP_PENDING_STORE was not provided",
-        )
-    })?;
-    Ok(Path::new(&home)
+    default_pending_store_path(
+        agent_pubkey,
+        cfg!(windows),
+        std::env::var_os("HOME").map(PathBuf::from),
+        std::env::var_os("LOCALAPPDATA").map(PathBuf::from),
+        std::env::var_os("APPDATA").map(PathBuf::from),
+        std::env::var_os("USERPROFILE").map(PathBuf::from),
+    )
+}
+
+fn default_pending_store_path(
+    agent_pubkey: &str,
+    windows: bool,
+    home: Option<PathBuf>,
+    local_app_data: Option<PathBuf>,
+    app_data: Option<PathBuf>,
+    user_profile: Option<PathBuf>,
+) -> io::Result<PathBuf> {
+    let state_dir = if windows {
+        local_app_data
+            .or(app_data)
+            .or_else(|| user_profile.map(|profile| profile.join("AppData").join("Local")))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "LOCALAPPDATA, APPDATA, and USERPROFILE are unset and BUZZ_ACP_PENDING_STORE was not provided",
+                )
+            })?
+            .join("buzz-acp")
+    } else {
+        home.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "HOME is unset and BUZZ_ACP_PENDING_STORE was not provided",
+            )
+        })?
         .join(".local/state/buzz-acp")
-        .join(format!("pending-{agent_pubkey}.json")))
+    };
+    Ok(state_dir.join(format!("pending-{agent_pubkey}.json")))
 }
 
 #[cfg(test)]
@@ -292,6 +322,79 @@ mod tests {
         EventBuilder::text_note(content)
             .sign_with_keys(&Keys::generate())
             .expect("sign event")
+    }
+
+    #[test]
+    fn default_path_uses_unix_home() {
+        let path = default_pending_store_path(
+            "agent",
+            false,
+            Some(PathBuf::from("/home/tester")),
+            None,
+            None,
+            None,
+        )
+        .expect("Unix path");
+        assert_eq!(
+            path,
+            PathBuf::from("/home/tester/.local/state/buzz-acp/pending-agent.json")
+        );
+    }
+
+    #[test]
+    fn default_windows_path_prefers_local_app_data() {
+        let path = default_pending_store_path(
+            "agent",
+            true,
+            None,
+            Some(PathBuf::from(r"C:\Users\tester\AppData\Local")),
+            Some(PathBuf::from(r"C:\Users\tester\AppData\Roaming")),
+            Some(PathBuf::from(r"C:\Users\tester")),
+        )
+        .expect("Windows local app data path");
+        assert_eq!(
+            path,
+            PathBuf::from(r"C:\Users\tester\AppData\Local")
+                .join("buzz-acp")
+                .join("pending-agent.json")
+        );
+    }
+
+    #[test]
+    fn default_windows_path_falls_back_to_app_data_then_profile() {
+        let app_data = default_pending_store_path(
+            "agent",
+            true,
+            None,
+            None,
+            Some(PathBuf::from(r"C:\Users\tester\AppData\Roaming")),
+            Some(PathBuf::from(r"C:\Users\tester")),
+        )
+        .expect("Windows app data path");
+        assert_eq!(
+            app_data,
+            PathBuf::from(r"C:\Users\tester\AppData\Roaming")
+                .join("buzz-acp")
+                .join("pending-agent.json")
+        );
+
+        let profile = default_pending_store_path(
+            "agent",
+            true,
+            None,
+            None,
+            None,
+            Some(PathBuf::from(r"C:\Users\tester")),
+        )
+        .expect("Windows profile fallback");
+        assert_eq!(
+            profile,
+            PathBuf::from(r"C:\Users\tester")
+                .join("AppData")
+                .join("Local")
+                .join("buzz-acp")
+                .join("pending-agent.json")
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/pending_store.rs
+++ b/crates/buzz-acp/src/pending_store.rs
@@ -1,0 +1,195 @@
+//! Durable journal for channel events accepted by the ACP queue.
+//!
+//! The relay subscription watermark intentionally starts at process startup, so
+//! an event accepted immediately before a service restart is not replayed by
+//! the relay. This journal closes that gap: an event is written atomically
+//! before the harness publishes its "seen" reaction and is removed only after
+//! the turn succeeds or the user receives a terminal failure.
+
+use nostr::Event;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+const STORE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StoredPendingEvent {
+    pub channel_id: Uuid,
+    pub event: Event,
+    pub prompt_tag: String,
+    pub accepted_at_nanos: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoreFile {
+    version: u32,
+    events: BTreeMap<String, StoredPendingEvent>,
+}
+
+pub(crate) struct PendingStore {
+    path: PathBuf,
+    events: BTreeMap<String, StoredPendingEvent>,
+}
+
+impl PendingStore {
+    pub(crate) fn open(agent_pubkey: &str) -> io::Result<Self> {
+        let path = pending_store_path(agent_pubkey)?;
+        Self::open_path(path)
+    }
+
+    pub(crate) fn open_path(path: PathBuf) -> io::Result<Self> {
+        let events = match std::fs::read(&path) {
+            Ok(bytes) => {
+                let stored: StoreFile = serde_json::from_slice(&bytes).map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid pending-work journal {}: {error}", path.display()),
+                    )
+                })?;
+                if stored.version != STORE_VERSION {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "unsupported pending-work journal version {} in {}",
+                            stored.version,
+                            path.display()
+                        ),
+                    ));
+                }
+                stored.events
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => BTreeMap::new(),
+            Err(error) => return Err(error),
+        };
+        Ok(Self { path, events })
+    }
+
+    pub(crate) fn restored(&self) -> Vec<StoredPendingEvent> {
+        let mut events = self.events.values().cloned().collect::<Vec<_>>();
+        events.sort_by_key(|event| event.accepted_at_nanos);
+        events
+    }
+
+    pub(crate) fn record(&mut self, event: StoredPendingEvent) -> io::Result<()> {
+        let id = event.event.id.to_hex();
+        let previous = self.events.insert(id.clone(), event);
+        if let Err(error) = self.persist() {
+            match previous {
+                Some(previous) => {
+                    self.events.insert(id, previous);
+                }
+                None => {
+                    self.events.remove(&id);
+                }
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn remove<'a>(&mut self, ids: impl IntoIterator<Item = &'a str>) -> io::Result<()> {
+        let removed: Vec<(String, StoredPendingEvent)> = ids
+            .into_iter()
+            .filter_map(|id| self.events.remove_entry(id))
+            .collect();
+        if removed.is_empty() {
+            return Ok(());
+        }
+        if let Err(error) = self.persist() {
+            self.events.extend(removed);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn persist(&self) -> io::Result<()> {
+        let parent = self.path.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "pending journal has no parent")
+        })?;
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+        }
+        let bytes = serde_json::to_vec(&StoreFile {
+            version: STORE_VERSION,
+            events: self.events.clone(),
+        })
+        .map_err(io::Error::other)?;
+        let temp = self.path.with_extension("json.tmp");
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temp)?;
+        std::io::Write::write_all(&mut file, &bytes)?;
+        file.sync_all()?;
+        std::fs::rename(temp, &self.path)
+    }
+}
+
+fn pending_store_path(agent_pubkey: &str) -> io::Result<PathBuf> {
+    if let Some(path) = std::env::var_os("BUZZ_ACP_PENDING_STORE") {
+        return Ok(PathBuf::from(path));
+    }
+    let home = std::env::var_os("HOME").ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "HOME is unset and BUZZ_ACP_PENDING_STORE was not provided",
+        )
+    })?;
+    Ok(Path::new(&home)
+        .join(".local/state/buzz-acp")
+        .join(format!("pending-{agent_pubkey}.json")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys};
+
+    fn event(content: &str) -> Event {
+        EventBuilder::text_note(content)
+            .sign_with_keys(&Keys::generate())
+            .expect("sign event")
+    }
+
+    #[test]
+    fn journal_round_trips_and_removes_atomically() {
+        let dir = std::env::temp_dir().join(format!("buzz-acp-pending-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("create tempdir");
+        let path = dir.join("pending.json");
+        let mut store = PendingStore::open_path(path.clone()).expect("open");
+        let event = event("survive restart");
+        let id = event.id.to_hex();
+        store
+            .record(StoredPendingEvent {
+                channel_id: Uuid::new_v4(),
+                event,
+                prompt_tag: "@mention".into(),
+                accepted_at_nanos: 1,
+            })
+            .expect("record");
+        drop(store);
+
+        let mut restored = PendingStore::open_path(path.clone()).expect("reopen");
+        assert_eq!(restored.restored().len(), 1);
+        restored.remove([id.as_str()]).expect("remove");
+        drop(restored);
+        assert_eq!(
+            PendingStore::open_path(path)
+                .expect("final reopen")
+                .restored()
+                .len(),
+            0
+        );
+        std::fs::remove_dir_all(dir).expect("remove tempdir");
+    }
+}

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -46,8 +46,10 @@ use crate::relay::{ChannelInfo, RestClient};
 /// the turn as "recently active" (eligible for requeue instead of dead-letter).
 const RECENT_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
 
-// FlushBatch and BatchEvent derive Clone (added in queue.rs) so we can store
-// a recoverable copy in TaskMeta for panic recovery in Queue mode.
+// FlushBatch and BatchEvent derive Clone (added in queue.rs) so TaskMeta can
+// retain a durable-journal disposition copy for every channel task. Queue mode
+// may requeue that copy after a panic; Drop mode only finishes or dead-letters
+// it and never retries.
 
 /// Metadata stored per in-flight task for panic recovery.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -61,7 +63,8 @@ pub struct TaskMeta {
     pub channel_id: Option<Uuid>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
-    /// Clone of batch for Queue mode panic recovery.
+    /// Clone of the accepted batch for durable-journal disposition and panic recovery.
+    /// In Drop mode this is never requeued.
     pub recoverable_batch: Option<FlushBatch>,
     /// Control signal for the in-flight prompt task.
     /// `None` for heartbeat tasks (not controllable) and after signal is consumed.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use crate::config::DedupMode;
+use crate::pending_store::{PendingStore, StoredPendingEvent};
 
 /// Maximum events queued per channel before oldest events are dropped.
 const MAX_PENDING_PER_CHANNEL: usize = 500;
@@ -168,6 +169,7 @@ pub struct EventQueue {
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
     in_flight_deadline: Duration,
+    pending_store: Option<PendingStore>,
 }
 
 impl EventQueue {
@@ -189,7 +191,32 @@ impl EventQueue {
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
+            pending_store: None,
         }
+    }
+
+    /// Attach durable pending-work storage and restore unfinished events.
+    pub(crate) fn with_pending_store(mut self, store: PendingStore) -> Self {
+        for stored in store.restored() {
+            self.queues
+                .entry(stored.channel_id)
+                .or_default()
+                .push_back(QueuedEvent {
+                    channel_id: stored.channel_id,
+                    event: stored.event,
+                    received_at: Instant::now(),
+                    prompt_tag: stored.prompt_tag,
+                });
+        }
+        if !self.queues.is_empty() {
+            tracing::warn!(
+                events = self.queues.values().map(VecDeque::len).sum::<usize>(),
+                channels = self.queues.len(),
+                "restored unfinished work from durable pending journal"
+            );
+        }
+        self.pending_store = Some(store);
+        self
     }
 
     /// Set the in-flight backstop deadline from the configured max turn
@@ -237,18 +264,64 @@ impl EventQueue {
             );
             return false;
         }
+        if let Some(store) = self.pending_store.as_mut() {
+            if let Err(error) = store.record(StoredPendingEvent {
+                channel_id: event.channel_id,
+                event: event.event.clone(),
+                prompt_tag: event.prompt_tag.clone(),
+                accepted_at_nanos: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+                    .min(u64::MAX as u128) as u64,
+            }) {
+                tracing::error!(
+                    channel_id = %event.channel_id,
+                    event_id = %event.event.id,
+                    %error,
+                    "refusing to acknowledge event because durable queue write failed"
+                );
+                return false;
+            }
+        }
         let queue = self.queues.entry(event.channel_id).or_default();
         // Enforce per-channel depth cap: drop oldest to make room.
-        if queue.len() >= MAX_PENDING_PER_CHANNEL {
-            queue.pop_front();
+        let dropped_id = if queue.len() >= MAX_PENDING_PER_CHANNEL {
+            let dropped = queue.pop_front().map(|event| event.event.id.to_hex());
             tracing::warn!(
                 channel_id = %event.channel_id,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "queue depth cap reached — dropped oldest event"
             );
-        }
+            dropped
+        } else {
+            None
+        };
         queue.push_back(event);
+        if let Some(dropped_id) = dropped_id {
+            self.remove_pending_ids([dropped_id]);
+        }
         true
+    }
+
+    /// Permanently finish every event represented by a completed/dead batch.
+    pub fn finish_batch(&mut self, batch: &FlushBatch) {
+        let ids = batch
+            .events
+            .iter()
+            .chain(batch.cancelled_events.iter())
+            .map(|event| event.event.id.to_hex())
+            .collect::<Vec<_>>();
+        self.remove_pending_ids(ids);
+    }
+
+    fn remove_pending_ids(&mut self, ids: impl IntoIterator<Item = String>) {
+        let ids = ids.into_iter().collect::<Vec<_>>();
+        if let Some(store) = self.pending_store.as_mut() {
+            if let Err(error) = store.remove(ids.iter().map(String::as_str)) {
+                tracing::error!(%error, "failed to remove completed events from durable pending journal");
+            }
+        }
     }
 
     /// Try to flush the next batch.
@@ -472,27 +545,30 @@ impl EventQueue {
             "requeueing failed batch with backoff"
         );
 
-        let queue = self.queues.entry(channel_id).or_default();
-        // Push to front in reverse order so original order is preserved.
-        for be in batch.events.into_iter().rev() {
-            queue.push_front(QueuedEvent {
-                channel_id,
-                event: be.event,
-                prompt_tag: be.prompt_tag,
-                received_at: be.received_at, // preserve original timestamp (#46)
-            });
+        let mut dropped_ids = Vec::new();
+        {
+            let queue = self.queues.entry(channel_id).or_default();
+            // Push to front in reverse order so original order is preserved.
+            for be in batch.events.into_iter().rev() {
+                queue.push_front(QueuedEvent {
+                    channel_id,
+                    event: be.event,
+                    prompt_tag: be.prompt_tag,
+                    received_at: be.received_at, // preserve original timestamp (#46)
+                });
+            }
+            while queue.len() > MAX_PENDING_PER_CHANNEL {
+                if let Some(dropped) = queue.pop_back() {
+                    dropped_ids.push(dropped.event.id.to_hex());
+                }
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "requeue overflow — dropped oldest event to enforce cap"
+                );
+            }
         }
-        // Enforce per-channel cap: trim oldest (back) events if requeue pushed
-        // the queue over the limit. Without this, repeated requeue+push cycles
-        // can grow the queue unboundedly.
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "requeue overflow — dropped oldest event to enforce cap"
-            );
-        }
+        self.remove_pending_ids(dropped_ids);
         self.retry_after.insert(channel_id, Instant::now() + delay);
         None
     }
@@ -507,25 +583,30 @@ impl EventQueue {
     /// caller must call `mark_complete` separately.
     pub fn requeue_preserve_timestamps(&mut self, batch: FlushBatch) {
         let channel_id = batch.channel_id;
-        let queue = self.queues.entry(channel_id).or_default();
-        // Push to front in reverse order so original order is preserved.
-        for be in batch.events.into_iter().rev() {
-            queue.push_front(QueuedEvent {
-                channel_id,
-                event: be.event,
-                prompt_tag: be.prompt_tag,
-                received_at: be.received_at,
-            });
+        let mut dropped_ids = Vec::new();
+        {
+            let queue = self.queues.entry(channel_id).or_default();
+            // Push to front in reverse order so original order is preserved.
+            for be in batch.events.into_iter().rev() {
+                queue.push_front(QueuedEvent {
+                    channel_id,
+                    event: be.event,
+                    prompt_tag: be.prompt_tag,
+                    received_at: be.received_at,
+                });
+            }
+            while queue.len() > MAX_PENDING_PER_CHANNEL {
+                if let Some(dropped) = queue.pop_back() {
+                    dropped_ids.push(dropped.event.id.to_hex());
+                }
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "requeue_preserve overflow — dropped newest event to enforce cap"
+                );
+            }
         }
-        // Enforce per-channel cap: trim newest (back) events if over limit.
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "requeue_preserve overflow — dropped newest event to enforce cap"
-            );
-        }
+        self.remove_pending_ids(dropped_ids);
     }
 
     /// Requeue a cancelled batch so its events appear as `cancelled_events`
@@ -628,6 +709,15 @@ impl EventQueue {
         self.queues.len()
     }
 
+    /// Event IDs restored at startup, used to restore the visible seen marker.
+    pub(crate) fn pending_event_ids(&self) -> Vec<String> {
+        self.queues
+            .values()
+            .flatten()
+            .map(|event| event.event.id.to_hex())
+            .collect()
+    }
+
     /// Number of queued events for a specific channel. Test-only.
     #[cfg(test)]
     pub fn queued_event_count(&self, channel_id: &Uuid) -> usize {
@@ -656,16 +746,21 @@ impl EventQueue {
     /// Returns the event IDs of dropped events so the caller can clean up
     /// any reactions (👀) that were added at queue-push time.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
-        let ids = self
+        let mut ids: Vec<String> = self
             .queues
             .remove(&channel_id)
             .map(|q| q.into_iter().map(|e| e.event.id.to_hex()).collect())
             .unwrap_or_default();
         self.retry_after.remove(&channel_id);
         self.retry_counts.remove(&channel_id);
-        self.cancelled_batches.remove(&channel_id);
+        if let Some(cancelled) = self.cancelled_batches.remove(&channel_id) {
+            ids.extend(cancelled.into_iter().map(|event| event.event.id.to_hex()));
+        }
         self.cancel_reasons.remove(&channel_id);
-        self.withheld_native_steer.remove(&channel_id);
+        if let Some(withheld) = self.withheld_native_steer.remove(&channel_id) {
+            ids.extend(withheld.into_iter().map(|event| event.event.id.to_hex()));
+        }
+        self.remove_pending_ids(ids.iter().cloned());
         // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
         // task will eventually complete (calling mark_complete) or the deadline
         // will expire (auto-cleaning the channel). Removing deadlines without
@@ -755,16 +850,22 @@ impl EventQueue {
         // Push to FRONT so original `received_at` keeps the event at the head
         // of the channel's queue. Per-channel cap is enforced below in case
         // a flood of events arrived during the ack window.
-        let queue = self.queues.entry(channel_id).or_default();
-        queue.push_front(qe);
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "release_native_steer overflow — dropped newest event to enforce cap"
-            );
+        let mut dropped_ids = Vec::new();
+        {
+            let queue = self.queues.entry(channel_id).or_default();
+            queue.push_front(qe);
+            while queue.len() > MAX_PENDING_PER_CHANNEL {
+                if let Some(dropped) = queue.pop_back() {
+                    dropped_ids.push(dropped.event.id.to_hex());
+                }
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "release_native_steer overflow — dropped newest event to enforce cap"
+                );
+            }
         }
+        self.remove_pending_ids(dropped_ids);
     }
 
     /// Drop a specific event by id from both the side table and the main
@@ -780,6 +881,7 @@ impl EventQueue {
                 self.withheld_native_steer.remove(&channel_id);
             }
         }
+        self.remove_pending_ids([event_id.to_string()]);
         if let Some(q) = self.queues.get_mut(&channel_id) {
             q.retain(|qe| qe.event.id.to_hex() != event_id);
             if q.is_empty() {
@@ -806,18 +908,24 @@ impl EventQueue {
             return;
         };
         let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
-        for qe in entries.into_iter().rev() {
-            queue.push_front(qe);
+        let mut dropped_ids = Vec::new();
+        {
+            let queue = self.queues.entry(channel_id).or_default();
+            for qe in entries.into_iter().rev() {
+                queue.push_front(qe);
+            }
+            while queue.len() > MAX_PENDING_PER_CHANNEL {
+                if let Some(dropped) = queue.pop_back() {
+                    dropped_ids.push(dropped.event.id.to_hex());
+                }
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "withheld-steer recovery overflow — dropped newest event to enforce cap"
+                );
+            }
         }
-        while queue.len() > MAX_PENDING_PER_CHANNEL {
-            queue.pop_back();
-            tracing::warn!(
-                channel_id = %channel_id,
-                limit = MAX_PENDING_PER_CHANNEL,
-                "withheld-steer recovery overflow — dropped newest event to enforce cap"
-            );
-        }
+        self.remove_pending_ids(dropped_ids);
         tracing::warn!(
             channel_id = %channel_id,
             recovered = n,
@@ -5391,4 +5499,41 @@ mod tests {
             "unresolved metadata must not render a Description field; got: {prompt}"
         );
     }
+}
+#[test]
+fn accepted_event_survives_queue_recreation_until_finished() {
+    let dir = std::env::temp_dir().join(format!("buzz-acp-queue-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    let path = dir.join("pending.json");
+    let channel_id = Uuid::new_v4();
+    let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "survive restart")
+        .sign_with_keys(&nostr::Keys::generate())
+        .expect("sign event");
+    let queued = QueuedEvent {
+        channel_id,
+        event,
+        received_at: Instant::now(),
+        prompt_tag: "test".into(),
+    };
+    let event_id = queued.event.id.to_hex();
+
+    let store = PendingStore::open_path(path.clone()).expect("open store");
+    let mut before = EventQueue::new(DedupMode::Queue).with_pending_store(store);
+    assert!(before.push(queued));
+    let in_flight = before.flush_next().expect("dispatch before restart");
+    assert_eq!(in_flight.events[0].event.id.to_hex(), event_id);
+    drop(before);
+
+    let store = PendingStore::open_path(path.clone()).expect("reopen store");
+    let mut after = EventQueue::new(DedupMode::Queue).with_pending_store(store);
+    let recovered = after.flush_next().expect("restore after restart");
+    assert_eq!(recovered.events[0].event.id.to_hex(), event_id);
+    after.finish_batch(&recovered);
+    drop(after);
+
+    let store = PendingStore::open_path(path).expect("final reopen");
+    let mut final_queue = EventQueue::new(DedupMode::Queue).with_pending_store(store);
+    assert!(final_queue.flush_next().is_none());
+    drop(final_queue);
+    std::fs::remove_dir_all(dir).expect("remove tempdir");
 }

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -315,6 +315,35 @@ impl EventQueue {
         self.remove_pending_ids(ids);
     }
 
+    /// Move every event in a terminally failed batch to durable dead-letter
+    /// storage. Dead letters are retained for audit and can be replayed on a
+    /// later startup with `BUZZ_ACP_REPLAY_DEAD_LETTERS=1`.
+    pub fn dead_letter_batch(&mut self, batch: &FlushBatch, reason: &str) {
+        let ids = batch
+            .events
+            .iter()
+            .chain(batch.cancelled_events.iter())
+            .map(|event| event.event.id.to_hex())
+            .collect::<Vec<_>>();
+        if let Some(store) = self.pending_store.as_mut() {
+            match store.dead_letter(ids.iter().map(String::as_str), reason) {
+                Ok(moved) => tracing::error!(
+                    channel_id = %batch.channel_id,
+                    events = moved,
+                    reason,
+                    "moved terminally failed events to durable dead-letter storage"
+                ),
+                Err(error) => tracing::error!(
+                    channel_id = %batch.channel_id,
+                    events = ids.len(),
+                    reason,
+                    %error,
+                    "failed to move terminally failed events to durable dead-letter storage; keeping them pending for restart recovery"
+                ),
+            }
+        }
+    }
+
     fn remove_pending_ids(&mut self, ids: impl IntoIterator<Item = String>) {
         let ids = ids.into_iter().collect::<Vec<_>>();
         if let Some(store) = self.pending_store.as_mut() {
@@ -512,7 +541,7 @@ impl EventQueue {
                 channel_id = %channel_id,
                 attempt,
                 events = batch.events.len(),
-                "dead-lettering batch after {} retries — discarding {} events",
+                "retry budget exhausted after {} retries — returning {} events for durable dead-letter handling",
                 MAX_RETRIES,
                 batch.events.len(),
             );
@@ -718,10 +747,15 @@ impl EventQueue {
             .collect()
     }
 
-    /// Number of queued events for a specific channel. Test-only.
-    #[cfg(test)]
+    /// Number of undispatched events for a specific channel across every
+    /// queue side table. Used by the owner `!status` control command and tests.
     pub fn queued_event_count(&self, channel_id: &Uuid) -> usize {
         self.queues.get(channel_id).map_or(0, |q| q.len())
+            + self.cancelled_batches.get(channel_id).map_or(0, Vec::len)
+            + self
+                .withheld_native_steer
+                .get(channel_id)
+                .map_or(0, Vec::len)
     }
 
     /// Force a channel's retry-attempt counter to `count`, simulating `count`


### PR DESCRIPTION
## What changed

- Atomically persist accepted ACP events before acknowledging them and restore unfinished work after process restarts.
- Retain terminal failures in a durable dead-letter journal with deliberate startup replay via `BUZZ_ACP_REPLAY_DEAD_LETTERS=1`.
- Validate restored Nostr event IDs and signatures and fsync the journal directory after atomic rename.
- Add an owner-only, non-disruptive status lane (`!status`, `status`, `status?`) and explicit stop aliases (`!stop`, `stop`) while preserving `!cancel`.
- Document journal configuration, recovery, status, stop, and replay behavior.

## Why

The relay subscription starts at process startup, so an event accepted immediately before a harness restart could previously disappear from the in-memory queue. In addition, `steer` handling can perturb a long-running turn when the owner only wants a status check. This change makes accepted work crash-recoverable and separates status/stop control from ordinary queued follow-ups.

## Validation

- `cargo clippy -p buzz-acp --all-targets -- -D warnings` — pass.
- Focused pending-store tests — 2 passed.
- Focused restart-recovery test — pass.
- Focused owner-control tests — 6 passed.
- Full `cargo test -p buzz-acp --no-fail-fast` — 781 passed, 1 failed. The lone failure is the timing-sensitive `acp::tests::keepalive_resets_idle_past_deadline`; it reproduces unchanged at base SHA `d8281b9`, so it predates and is unrelated to this branch.

## Operational impact

The durable journal is enabled by default at a per-agent path. Existing version-1 journals migrate in place. Dead-letter replay is opt-in and should be unset after a deliberate replay.