### PR TITLE
fix(relay): fan out live events to multi-channel subscriptions

### DIFF
--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -24,7 +24,6 @@ use crate::state::{
     run_registered_community_connection, AppState, CommunityConnectionControl,
     CommunityDisconnectReason,
 };
-use buzz_pubsub::EventTopic;
 
 /// Maximum time a new socket may hold a connection slot without completing NIP-42 auth.
 const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
@@ -287,10 +286,9 @@ async fn handle_active_connection(
     let _ = auth_timeout_task.await;
 
     for removed in state.sub_registry.remove_connection(conn.conn_id) {
-        state
-            .pubsub
-            .release_topic(&conn.tenant, topic_for_subscription(removed.channel_id))
-            .await;
+        for topic in crate::subscription::topics_for_subscription(removed.channel_ids.as_deref()) {
+            state.pubsub.release_topic(&conn.tenant, topic).await;
+        }
     }
     state.conn_manager.deregister(conn.conn_id);
     if let AuthState::Authenticated(ref auth_ctx) = *conn.auth_state.read().await {
@@ -726,13 +724,6 @@ fn send_admission_result(
             ));
             false
         }
-    }
-}
-
-fn topic_for_subscription(channel_id: Option<Uuid>) -> EventTopic {
-    match channel_id {
-        Some(channel_id) => EventTopic::Channel(channel_id),
-        None => EventTopic::Global,
     }
 }
 

--- a/crates/buzz-relay/src/handlers/close.rs
+++ b/crates/buzz-relay/src/handlers/close.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 use crate::connection::ConnectionState;
 use crate::protocol::RelayMessage;
 use crate::state::AppState;
-use buzz_pubsub::EventTopic;
+use crate::subscription::topics_for_subscription;
 
 /// Handle a CLOSE command — remove the subscription and send CLOSED acknowledgement.
 pub async fn handle_close(sub_id: String, conn: Arc<ConnectionState>, state: Arc<AppState>) {
@@ -16,20 +16,12 @@ pub async fn handle_close(sub_id: String, conn: Arc<ConnectionState>, state: Arc
     // Deregister from the fan-out index before sending CLOSED so no new
     // messages are routed to this sub after the client's CLOSE is acknowledged.
     if let Some(removed) = state.sub_registry.remove_subscription(conn_id, &sub_id) {
-        state
-            .pubsub
-            .release_topic(&conn.tenant, topic_for_subscription(removed.channel_id))
-            .await;
+        for topic in topics_for_subscription(removed.channel_ids.as_deref()) {
+            state.pubsub.release_topic(&conn.tenant, topic).await;
+        }
     }
 
     conn.send(RelayMessage::closed(&sub_id, ""));
 
     debug!(conn_id = %conn_id, sub_id = %sub_id, "Subscription closed");
-}
-
-fn topic_for_subscription(channel_id: Option<uuid::Uuid>) -> EventTopic {
-    match channel_id {
-        Some(channel_id) => EventTopic::Channel(channel_id),
-        None => EventTopic::Global,
-    }
 }

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use tracing::{debug, warn};
 
+use crate::subscription::topics_for_subscription;
 use buzz_core::filter::filters_match;
 use buzz_core::kind::{
     is_unshared_gated_event, AUTHOR_ONLY_KINDS, KIND_AGENT_ENGRAM, KIND_AGENT_TURN_METRIC,
@@ -12,7 +13,6 @@ use buzz_core::kind::{
 };
 use buzz_core::tenant::TenantContext;
 use buzz_db::EventQuery;
-use buzz_pubsub::EventTopic;
 use hex;
 use nostr::Filter;
 
@@ -106,7 +106,7 @@ pub async fn handle_req(
         accessible_channels.retain(|channel_id| allowed.contains(channel_id));
     }
 
-    let channel_id = extract_channel_id_from_filters(&filters);
+    let channel_ids = extract_channel_ids_from_filters(&filters);
 
     // Build the conformance `AbstractState` once at request entry. The
     // `Option` only goes `None` on malformed pubkey bytes (already a
@@ -126,7 +126,7 @@ pub async fn handle_req(
     // `resolve_request_local_access`). Running this ahead of the search branch
     // is what fixes the search false-miss: a `#h=<just-added>` search would
     // otherwise be scoped against the stale vector and return empty.
-    if let Some(ch_id) = channel_id {
+    for &ch_id in channel_ids.as_deref().unwrap_or_default() {
         let token_allows = token_channel_ids
             .as_deref()
             .is_none_or(|allowed| allowed.contains(&ch_id));
@@ -175,10 +175,10 @@ pub async fn handle_req(
     // kinds) to harvest indexed-but-globally-stored sensitive events. Search
     // hits are looked up by event id and returned without the per-filter
     // post-check the historical-delivery branch applies, so the gate must run
-    // here, up front. Only applies to GLOBAL subscriptions (channel_id = None):
+    // here, up front. Only applies to GLOBAL subscriptions (channel_ids = None):
     // channel-scoped subs can never receive globally-stored events because of
     // the fan_out() invariant in subscription.rs.
-    if channel_id.is_none() {
+    if channel_ids.is_none() {
         let authed_pubkey_hex = hex::encode(&pubkey_bytes);
         if !p_gated_filters_authorized(&filters, &authed_pubkey_hex) {
             conn.send(RelayMessage::closed(
@@ -241,18 +241,16 @@ pub async fn handle_req(
         conn_id,
         sub_id.clone(),
         filters.clone(),
-        channel_id,
+        channel_ids.clone(),
     );
     if let Some(replaced) = replaced {
-        state
-            .pubsub
-            .release_topic(&conn.tenant, topic_for_subscription(replaced.channel_id))
-            .await;
+        for topic in topics_for_subscription(replaced.channel_ids.as_deref()) {
+            state.pubsub.release_topic(&conn.tenant, topic).await;
+        }
     }
-    state
-        .pubsub
-        .retain_topic(&conn.tenant, topic_for_subscription(channel_id))
-        .await;
+    for topic in topics_for_subscription(channel_ids.as_deref()) {
+        state.pubsub.retain_topic(&conn.tenant, topic).await;
+    }
 
     debug!(conn_id = %conn_id, sub_id = %sub_id, "Subscription registered");
 
@@ -262,6 +260,14 @@ pub async fn handle_req(
     // per-filter limits or non-overlapping time windows.
     let mut seen_ids: HashSet<nostr::EventId> = HashSet::new();
     let mut total_sent: usize = 0;
+
+    // A single-channel subscription still provides the historical fallback
+    // scope. Filters of a multi-channel subscription are each channel
+    // constrained by construction, so they resolve per filter or fall back to
+    // the access-scoped query exactly as global subscriptions always have.
+    let sub_single_channel = channel_ids
+        .as_ref()
+        .and_then(|ids| (ids.len() == 1).then(|| ids[0]));
 
     // Phase 1 — pure query construction, in filter order.
     let filter_queries: Vec<(usize, Option<uuid::Uuid>, EventQuery)> = filters
@@ -284,7 +290,7 @@ pub async fn handle_req(
                             None
                         }
                     })
-                    .or(channel_id)
+                    .or(sub_single_channel)
             };
             let mut params =
                 filter_to_query_params(filter, per_filter_channel, conn.tenant.community());
@@ -1026,8 +1032,17 @@ pub(crate) fn apply_access_scope_to_query(
 /// - Multiple distinct channel UUIDs appear across filters (can't index under one channel).
 ///
 /// Callers that receive `None` treat the subscription as global (slow-path fan-out).
-fn extract_channel_id_from_filters(filters: &[Filter]) -> Option<uuid::Uuid> {
-    let mut found_id: Option<uuid::Uuid> = None;
+/// Resolve the channel scope of a subscription from its filters.
+///
+/// Returns `Some(ids)` (the deduplicated union of every `#h` channel named
+/// across the filters) when EVERY filter names at least one channel, and
+/// `None` — a community-global subscription — when any filter carries no
+/// channel constraint. Multiple distinct channels used to collapse to `None`
+/// here, which silently parked a member's multi-channel subscription on the
+/// global topic, where channel events never arrive (the fan_out() invariant);
+/// now each named channel is membership-checked and subscribed individually.
+fn extract_channel_ids_from_filters(filters: &[Filter]) -> Option<Vec<uuid::Uuid>> {
+    let mut found: Vec<uuid::Uuid> = Vec::new();
     for f in filters {
         let mut filter_has_channel = false;
         for (tag_key, tag_values) in f.generic_tags.iter() {
@@ -1036,12 +1051,8 @@ fn extract_channel_id_from_filters(filters: &[Filter]) -> Option<uuid::Uuid> {
                 for val in tag_values {
                     if let Ok(id) = val.parse::<uuid::Uuid>() {
                         filter_has_channel = true;
-                        match found_id {
-                            Some(existing) if existing != id => {
-                                // Multiple distinct channel IDs — fall back to global.
-                                return None;
-                            }
-                            _ => found_id = Some(id),
+                        if !found.contains(&id) {
+                            found.push(id);
                         }
                     }
                 }
@@ -1052,7 +1063,11 @@ fn extract_channel_id_from_filters(filters: &[Filter]) -> Option<uuid::Uuid> {
             return None;
         }
     }
-    found_id
+    if found.is_empty() {
+        None
+    } else {
+        Some(found)
+    }
 }
 
 pub(crate) fn p_gated_filters_authorized(filters: &[Filter], authed_pubkey_hex: &str) -> bool {
@@ -1287,13 +1302,6 @@ pub(crate) fn author_only_filters_authorized(filters: &[Filter], authed_pubkey_h
                     .all(|a| a.to_hex().eq_ignore_ascii_case(authed_pubkey_hex))
         })
     })
-}
-
-fn topic_for_subscription(channel_id: Option<uuid::Uuid>) -> EventTopic {
-    match channel_id {
-        Some(channel_id) => EventTopic::Channel(channel_id),
-        None => EventTopic::Global,
-    }
 }
 
 #[cfg(test)]
@@ -1545,45 +1553,68 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_channel_id_single_channel() {
+    fn test_extract_channel_ids_single_channel() {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id)];
-        assert_eq!(extract_channel_id_from_filters(&filters), Some(channel_id));
+        assert_eq!(
+            extract_channel_ids_from_filters(&filters),
+            Some(vec![channel_id])
+        );
     }
 
     #[test]
-    fn test_extract_channel_id_mixed_channels_returns_none() {
+    fn test_extract_channel_ids_mixed_channels_returns_all() {
+        // Distinct channels across filters used to collapse the subscription
+        // to global; now each is a first-class scope.
         let channel_a = uuid::Uuid::new_v4();
         let channel_b = uuid::Uuid::new_v4();
         let filters = vec![
             filter_with_channel(channel_a),
             filter_with_channel(channel_b),
         ];
-        assert_eq!(extract_channel_id_from_filters(&filters), None);
+        assert_eq!(
+            extract_channel_ids_from_filters(&filters),
+            Some(vec![channel_a, channel_b])
+        );
     }
 
     #[test]
-    fn test_extract_channel_id_no_channel_tag_returns_none() {
+    fn test_extract_channel_ids_multiple_channels_one_filter() {
+        let channel_a = uuid::Uuid::new_v4();
+        let channel_b = uuid::Uuid::new_v4();
+        let h = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
+        let filters =
+            vec![Filter::new().custom_tags(h, [channel_a.to_string(), channel_b.to_string()])];
+        let got = extract_channel_ids_from_filters(&filters).expect("channel scoped");
+        assert_eq!(got.len(), 2);
+        assert!(got.contains(&channel_a) && got.contains(&channel_b));
+    }
+
+    #[test]
+    fn test_extract_channel_ids_no_channel_tag_returns_none() {
         let filters = vec![Filter::new()];
-        assert_eq!(extract_channel_id_from_filters(&filters), None);
+        assert_eq!(extract_channel_ids_from_filters(&filters), None);
     }
 
     #[test]
-    fn test_extract_channel_id_one_filter_missing_channel_returns_none() {
+    fn test_extract_channel_ids_one_filter_missing_channel_returns_none() {
         // Even if one filter has a channel, a second filter without one makes it global.
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id), Filter::new()];
-        assert_eq!(extract_channel_id_from_filters(&filters), None);
+        assert_eq!(extract_channel_ids_from_filters(&filters), None);
     }
 
     #[test]
-    fn test_extract_channel_id_same_channel_multiple_filters() {
+    fn test_extract_channel_ids_same_channel_multiple_filters_dedupes() {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![
             filter_with_channel(channel_id),
             filter_with_channel(channel_id),
         ];
-        assert_eq!(extract_channel_id_from_filters(&filters), Some(channel_id));
+        assert_eq!(
+            extract_channel_ids_from_filters(&filters),
+            Some(vec![channel_id])
+        );
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -122,10 +122,11 @@ async fn evict_conn_channel_subscriptions(
     }
 
     for (sub_id, removed_scope) in removed {
-        state
-            .pubsub
-            .release_topic(tenant, topic_for_subscription(removed_scope.channel_id))
-            .await;
+        for topic in
+            crate::subscription::topics_for_subscription(removed_scope.channel_ids.as_deref())
+        {
+            state.pubsub.release_topic(tenant, topic).await;
+        }
         let _ = state.conn_manager.send_to(
             conn_id,
             RelayMessage::closed(&sub_id, "restricted: channel access revoked"),
@@ -3365,13 +3366,6 @@ pub async fn publish_nipia_unarchived(
         None,
     )
     .await
-}
-
-fn topic_for_subscription(channel_id: Option<Uuid>) -> EventTopic {
-    match channel_id {
-        Some(channel_id) => EventTopic::Channel(channel_id),
-        None => EventTopic::Global,
-    }
 }
 
 #[cfg(test)]

--- a/crates/buzz-relay/src/subscription.rs
+++ b/crates/buzz-relay/src/subscription.rs
@@ -13,7 +13,9 @@ pub type ConnId = Uuid;
 /// Subscription identifier — the client-supplied string from a REQ message.
 pub type SubId = String;
 /// Stored subscription entry: filters paired with server-resolved community and optional channel scope.
-pub type SubEntry = (Vec<Filter>, CommunityId, Option<Uuid>);
+/// `Some(ids)` scopes the subscription to those channels (every filter named at
+/// least one channel); `None` is a community-global subscription.
+pub type SubEntry = (Vec<Filter>, CommunityId, Option<Vec<Uuid>>);
 
 /// Index key combining a channel and event kind for O(1) fan-out lookups.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -32,12 +34,25 @@ struct GlobalPKindIndexKey {
 }
 
 /// A removed subscription's server-resolved routing scope.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RemovedSubscription {
     /// Server-resolved community this subscription belonged to.
     pub community_id: CommunityId,
     /// Tenant-local channel scope; `None` means the community-global topic.
-    pub channel_id: Option<Uuid>,
+    pub channel_ids: Option<Vec<Uuid>>,
+}
+
+/// The Redis topics a subscription with the given channel scope rides: one
+/// per scoped channel, or the community-global topic for an unscoped one.
+pub fn topics_for_subscription(channel_ids: Option<&[Uuid]>) -> Vec<buzz_pubsub::EventTopic> {
+    match channel_ids {
+        Some(ids) => ids
+            .iter()
+            .copied()
+            .map(buzz_pubsub::EventTopic::Channel)
+            .collect(),
+        None => vec![buzz_pubsub::EventTopic::Global],
+    }
 }
 
 /// Thread-safe registry of active subscriptions with targeted in-memory fan-out indexes.
@@ -72,25 +87,27 @@ impl SubscriptionRegistry {
         conn_id: ConnId,
         sub_id: SubId,
         filters: Vec<Filter>,
-        channel_id: Option<Uuid>,
+        channel_ids: Option<Vec<Uuid>>,
     ) -> Option<RemovedSubscription> {
         let removed = self.remove_subscription(conn_id, &sub_id);
 
-        self.subs
-            .entry(conn_id)
-            .or_default()
-            .insert(sub_id.clone(), (filters.clone(), community_id, channel_id));
+        self.subs.entry(conn_id).or_default().insert(
+            sub_id.clone(),
+            (filters.clone(), community_id, channel_ids.clone()),
+        );
         metrics::gauge!("buzz_subscriptions_active").increment(1.0);
 
-        if let Some(ch_id) = channel_id {
+        if let Some(ref ch_ids) = channel_ids {
             match extract_kinds_from_filters(&filters) {
                 None => {
                     // At least one filter has no `kinds` constraint — wildcard,
-                    // this sub wants all kinds in this channel.
-                    self.channel_wildcard_index
-                        .entry((community_id, ch_id))
-                        .or_default()
-                        .push((conn_id, sub_id.clone()));
+                    // this sub wants all kinds in each scoped channel.
+                    for &ch_id in ch_ids {
+                        self.channel_wildcard_index
+                            .entry((community_id, ch_id))
+                            .or_default()
+                            .push((conn_id, sub_id.clone()));
+                    }
                 }
                 Some(kinds) if kinds.is_empty() => {
                     // All filters had explicit empty kinds lists (`kinds: []`).
@@ -99,15 +116,17 @@ impl SubscriptionRegistry {
                     // anywhere; `filters_match` will reject all events at fan-out.
                 }
                 Some(kinds) => {
-                    for kind in kinds {
-                        let key = IndexKey {
-                            channel_id: ch_id,
-                            kind,
-                        };
-                        self.channel_kind_index
-                            .entry((community_id, key))
-                            .or_default()
-                            .push((conn_id, sub_id.clone()));
+                    for &ch_id in ch_ids {
+                        for kind in &kinds {
+                            let key = IndexKey {
+                                channel_id: ch_id,
+                                kind: *kind,
+                            };
+                            self.channel_kind_index
+                                .entry((community_id, key))
+                                .or_default()
+                                .push((conn_id, sub_id.clone()));
+                        }
                     }
                 }
             }
@@ -155,7 +174,13 @@ impl SubscriptionRegistry {
         filters: Vec<Filter>,
         channel_id: Option<Uuid>,
     ) {
-        self.register_scoped(test_community(), conn_id, sub_id, filters, channel_id);
+        self.register_scoped(
+            test_community(),
+            conn_id,
+            sub_id,
+            filters,
+            channel_id.map(|id| vec![id]),
+        );
     }
 
     /// Remove a single subscription and clean up its index entries.
@@ -177,16 +202,22 @@ impl SubscriptionRegistry {
         F: FnOnce(),
     {
         let mut conn_subs = self.subs.get_mut(&conn_id)?;
-        let (filters, community_id, channel_id) = conn_subs.remove(sub_id)?;
+        let (filters, community_id, channel_ids) = conn_subs.remove(sub_id)?;
 
         after_remove();
-        self.remove_from_index(conn_id, sub_id, &filters, community_id, channel_id);
+        self.remove_from_index(
+            conn_id,
+            sub_id,
+            &filters,
+            community_id,
+            channel_ids.as_deref(),
+        );
         drop(conn_subs);
 
         metrics::gauge!("buzz_subscriptions_active").decrement(1.0);
         Some(RemovedSubscription {
             community_id,
-            channel_id,
+            channel_ids,
         })
     }
 
@@ -195,11 +226,17 @@ impl SubscriptionRegistry {
         let mut removed = Vec::new();
         if let Some((_, conn_subs)) = self.subs.remove(&conn_id) {
             let count = conn_subs.len();
-            for (sub_id, (filters, community_id, channel_id)) in &conn_subs {
-                self.remove_from_index(conn_id, sub_id, filters, *community_id, *channel_id);
+            for (sub_id, (filters, community_id, channel_ids)) in &conn_subs {
+                self.remove_from_index(
+                    conn_id,
+                    sub_id,
+                    filters,
+                    *community_id,
+                    channel_ids.as_deref(),
+                );
                 removed.push(RemovedSubscription {
                     community_id: *community_id,
-                    channel_id: *channel_id,
+                    channel_ids: channel_ids.clone(),
                 });
             }
             metrics::gauge!("buzz_subscriptions_active").decrement(count as f64);
@@ -220,9 +257,12 @@ impl SubscriptionRegistry {
             .map(|conn_subs| {
                 conn_subs
                     .iter()
-                    .filter_map(|(sub_id, (_, sub_community_id, sub_channel_id))| {
-                        (*sub_community_id == community_id && *sub_channel_id == Some(channel_id))
-                            .then_some(sub_id.clone())
+                    .filter_map(|(sub_id, (_, sub_community_id, sub_channel_ids))| {
+                        (*sub_community_id == community_id
+                            && sub_channel_ids
+                                .as_ref()
+                                .is_some_and(|ids| ids.contains(&channel_id)))
+                        .then_some(sub_id.clone())
                     })
                     .collect()
             })
@@ -441,12 +481,17 @@ impl SubscriptionRegistry {
         seen: &mut HashSet<(ConnId, SubId)>,
     ) {
         if let Some(conn_subs) = self.subs.get(&conn_id) {
-            if let Some((filters, sub_community_id, sub_channel_id)) = conn_subs.get(sub_id) {
+            if let Some((filters, sub_community_id, sub_channel_ids)) = conn_subs.get(sub_id) {
                 // Candidate snapshots can become stale while a same-ID replacement
                 // moves the subscription. Re-check its authoritative scope before
                 // matching so an old index entry cannot deliver across scopes.
+                let scope_matches = match (sub_channel_ids, event.channel_id) {
+                    (Some(ids), Some(event_channel)) => ids.contains(&event_channel),
+                    (None, None) => true,
+                    _ => false,
+                };
                 if *sub_community_id == community_id
-                    && *sub_channel_id == event.channel_id
+                    && scope_matches
                     && filters_match(filters, event)
                 {
                     let entry = (conn_id, sub_id.to_string());
@@ -466,20 +511,22 @@ impl SubscriptionRegistry {
         sub_id: &str,
         filters: &[Filter],
         community_id: CommunityId,
-        channel_id: Option<Uuid>,
+        channel_ids: Option<&[Uuid]>,
     ) {
-        if let Some(ch_id) = channel_id {
+        if let Some(ch_ids) = channel_ids {
             match extract_kinds_from_filters(filters) {
                 // None = wildcard (at least one filter had no kinds constraint).
                 None => {
-                    // Was in wildcard index.
-                    if let Some(mut entries) =
-                        self.channel_wildcard_index.get_mut(&(community_id, ch_id))
-                    {
-                        entries.retain(|(cid, sid)| !(*cid == conn_id && sid == sub_id));
-                        if entries.is_empty() {
-                            drop(entries);
-                            self.channel_wildcard_index.remove(&(community_id, ch_id));
+                    // Was in the wildcard index, once per scoped channel.
+                    for &ch_id in ch_ids {
+                        if let Some(mut entries) =
+                            self.channel_wildcard_index.get_mut(&(community_id, ch_id))
+                        {
+                            entries.retain(|(cid, sid)| !(*cid == conn_id && sid == sub_id));
+                            if entries.is_empty() {
+                                drop(entries);
+                                self.channel_wildcard_index.remove(&(community_id, ch_id));
+                            }
                         }
                     }
                 }
@@ -488,20 +535,22 @@ impl SubscriptionRegistry {
                     // so there is nothing to remove here.
                 }
                 Some(kinds) => {
-                    // Was in kind-specific index.
-                    for kind in kinds {
-                        let key = IndexKey {
-                            channel_id: ch_id,
-                            kind,
-                        };
-                        if let Some(mut entries) = self
-                            .channel_kind_index
-                            .get_mut(&(community_id, key.clone()))
-                        {
-                            entries.retain(|(cid, sid)| !(*cid == conn_id && sid == sub_id));
-                            if entries.is_empty() {
-                                drop(entries);
-                                self.channel_kind_index.remove(&(community_id, key));
+                    // Was in the kind-specific index, once per (channel, kind).
+                    for &ch_id in ch_ids {
+                        for kind in &kinds {
+                            let key = IndexKey {
+                                channel_id: ch_id,
+                                kind: *kind,
+                            };
+                            if let Some(mut entries) = self
+                                .channel_kind_index
+                                .get_mut(&(community_id, key.clone()))
+                            {
+                                entries.retain(|(cid, sid)| !(*cid == conn_id && sid == sub_id));
+                                if entries.is_empty() {
+                                    drop(entries);
+                                    self.channel_kind_index.remove(&(community_id, key));
+                                }
                             }
                         }
                     }
@@ -684,6 +733,106 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, conn_id);
         assert_eq!(matches[0].1, sub_id);
+    }
+
+    #[test]
+    fn test_multi_channel_subscription_receives_live_events_in_every_channel() {
+        // The regression this guards: a REQ naming several channels used to
+        // collapse to a global scope and never receive channel events at all.
+        let registry = SubscriptionRegistry::new();
+        let conn_id = Uuid::new_v4();
+        let channel_a = Uuid::new_v4();
+        let channel_b = Uuid::new_v4();
+        let sub_id = "multi".to_string();
+
+        let filters = vec![Filter::new().kind(Kind::TextNote)];
+        registry.register_scoped(
+            test_community(),
+            conn_id,
+            sub_id.clone(),
+            filters,
+            Some(vec![channel_a, channel_b]),
+        );
+
+        for ch in [channel_a, channel_b] {
+            let event = make_stored_event(Kind::TextNote, Some(ch));
+            let matches = registry.fan_out(&event);
+            assert_eq!(matches.len(), 1, "channel {ch} must deliver");
+            assert_eq!(matches[0], (conn_id, sub_id.clone()));
+        }
+
+        // Other channels and global events stay out of scope.
+        let other = make_stored_event(Kind::TextNote, Some(Uuid::new_v4()));
+        assert!(registry.fan_out(&other).is_empty());
+        let global = make_stored_event(Kind::TextNote, None);
+        assert!(registry.fan_out(&global).is_empty());
+    }
+
+    #[test]
+    fn test_multi_channel_subscription_removal_cleans_every_index() {
+        let registry = SubscriptionRegistry::new();
+        let conn_id = Uuid::new_v4();
+        let channel_a = Uuid::new_v4();
+        let channel_b = Uuid::new_v4();
+        let sub_id = "multi".to_string();
+
+        let filters = vec![Filter::new().kind(Kind::TextNote)];
+        registry.register_scoped(
+            test_community(),
+            conn_id,
+            sub_id.clone(),
+            filters,
+            Some(vec![channel_a, channel_b]),
+        );
+        let removed = registry
+            .remove_subscription(conn_id, &sub_id)
+            .expect("was registered");
+        assert_eq!(removed.channel_ids, Some(vec![channel_a, channel_b]));
+
+        for ch in [channel_a, channel_b] {
+            let event = make_stored_event(Kind::TextNote, Some(ch));
+            assert!(registry.fan_out(&event).is_empty());
+        }
+    }
+
+    #[test]
+    fn test_channel_eviction_removes_multi_channel_subscription() {
+        // A kick from ANY scoped channel evicts the whole subscription; the
+        // client re-subscribes with the channels it still belongs to.
+        let registry = SubscriptionRegistry::new();
+        let conn_id = Uuid::new_v4();
+        let channel_a = Uuid::new_v4();
+        let channel_b = Uuid::new_v4();
+        let sub_id = "multi".to_string();
+
+        let filters = vec![Filter::new().kind(Kind::TextNote)];
+        registry.register_scoped(
+            test_community(),
+            conn_id,
+            sub_id.clone(),
+            filters,
+            Some(vec![channel_a, channel_b]),
+        );
+
+        let removed =
+            registry.remove_channel_subscriptions_scoped(test_community(), conn_id, channel_b);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, sub_id);
+
+        let event = make_stored_event(Kind::TextNote, Some(channel_a));
+        assert!(registry.fan_out(&event).is_empty());
+    }
+
+    #[test]
+    fn test_topics_for_subscription_scopes() {
+        use buzz_pubsub::EventTopic;
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        assert_eq!(
+            topics_for_subscription(Some(&[a, b])),
+            vec![EventTopic::Channel(a), EventTopic::Channel(b)]
+        );
+        assert_eq!(topics_for_subscription(None), vec![EventTopic::Global]);
     }
 
     #[test]
@@ -1598,14 +1747,14 @@ mod tests {
             conn_a,
             "a".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel_id),
+            Some(vec![channel_id]),
         );
         registry.register_scoped(
             community_b,
             conn_b,
             "b".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel_id),
+            Some(vec![channel_id]),
         );
 
         let event = make_stored_event(Kind::TextNote, Some(channel_id));
@@ -1667,14 +1816,14 @@ mod tests {
             conn_a,
             "a".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel_id),
+            Some(vec![channel_id]),
         );
         registry.register_scoped(
             community_b,
             conn_b,
             "b".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel_id),
+            Some(vec![channel_id]),
         );
 
         let removed = registry.remove_channel_subscriptions_scoped(community_a, conn_a, channel_id);
@@ -1705,7 +1854,7 @@ mod tests {
             conn_a,
             "a1".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel),
+            Some(vec![channel]),
         );
         registry.register_scoped(
             community_a,
@@ -1719,7 +1868,7 @@ mod tests {
             conn_b,
             "b1".to_string(),
             vec![Filter::new().kind(Kind::TextNote)],
-            Some(channel),
+            Some(vec![channel]),
         );
 
         let snap = registry.per_community_subscriptions();

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -535,6 +535,59 @@ async fn test_subscription_filters_by_kind() {
 
 #[tokio::test]
 #[ignore]
+async fn test_multi_channel_subscription_receives_live_events_in_every_channel() {
+    // Regression: a REQ whose filters name several `#h` channels used to be
+    // routed as a community-global subscription, and channel events are never
+    // fanned out globally — so the subscription got history, EOSE, then
+    // silence. Each named channel is now a first-class scope.
+    let url = relay_url();
+    let kind: u16 = 9;
+
+    let keys = Keys::generate();
+    let channel_a = create_test_channel(&keys).await;
+    let channel_b = create_test_channel(&keys).await;
+    let mut client = BuzzTestClient::connect(&url, &keys).await.expect("connect");
+
+    let sid = sub_id("multi-h-live");
+    let filter = Filter::new().kind(Kind::Custom(kind)).custom_tags(
+        SingleLetterTag::lowercase(Alphabet::H),
+        [channel_a.as_str(), channel_b.as_str()],
+    );
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe");
+    client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("EOSE");
+
+    let mut sender = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect sender");
+    for (channel, text) in [(&channel_a, "live in a"), (&channel_b, "live in b")] {
+        let ok = sender
+            .send_text_message(&keys, channel, text, kind)
+            .await
+            .expect("send");
+        assert!(ok.accepted, "event rejected: {}", ok.message);
+
+        let msg = client
+            .recv_event(Duration::from_secs(5))
+            .await
+            .unwrap_or_else(|e| panic!("no live delivery for {text:?}: {e}"));
+        match msg {
+            RelayMessage::Event { event, .. } => assert_eq!(event.content, text),
+            other => panic!("Expected Event, got {other:?}"),
+        }
+    }
+
+    sender.disconnect().await.expect("disconnect sender");
+    client.disconnect().await.expect("disconnect");
+}
+
+#[tokio::test]
+#[ignore]
 async fn test_close_subscription_stops_delivery() {
     let url = relay_url();
     let kind: u16 = 9;


### PR DESCRIPTION
## Problem

A REQ whose filters name several `#h` channels never receives live events. `extract_channel_id_from_filters` collapses multiple distinct channel ids to `None`, the subscription is registered as community-global and rides the Global Redis topic, and channel events are only ever published on their channel topic (the `fan_out` scoping invariant). The subscriber gets stored events and EOSE, then silence, with no error.

Reproduced against a production relay with raw frames, same connection, same posted message:

```
["REQ","single",{"kinds":[9],"#h":["<a>"],"limit":0}]        -> EOSE, then live EVENT arrives
["REQ","multi",{"kinds":[9],"#h":["<a>","<b>", ...],"limit":0}] -> EOSE, then silence forever
```

Any standard Nostr client that subscribes to several channels in one REQ, and any bot or bridge using a multi-`#h` filter, silently misses all live traffic even when the subscriber is a member of every named channel.

## Fix

Subscriptions now carry a set of channel scopes instead of at most one:

- `extract_channel_ids_from_filters` returns every channel named across the filters. It still returns `None` (global) if any filter carries no channel constraint, so the global gates (`p_gated_filters_authorized` and friends) keep applying exactly where they did before.
- Channel membership is verified for each named channel before the subscription is accepted, including the existing stale-cache repair path, so the access model is unchanged.
- The registry indexes the subscription under each `(channel, kind)` key. `fan_out_scoped` is untouched; the `push_match` staleness re-check now compares the event's channel against the authoritative scope set, so a stale index entry still cannot deliver across scopes.
- One Redis topic is retained per scoped channel, and every topic is released on close, disconnect, same-id replacement, and channel eviction.
- Eviction on kick removes any subscription whose scope set contains the channel (the client re-subscribes with the channels it still belongs to).

The isolation invariant is unchanged in both directions: global subscriptions never receive channel events, channel subscriptions never receive global events.

## Testing

- New registry unit tests: multi-channel registration delivers in every scoped channel and nothing else, removal cleans every index, kick eviction matches set membership, topic mapping.
- New end-to-end regression test (`test_multi_channel_subscription_receives_live_events_in_every_channel`): one REQ naming two channels, live delivery asserted in both.
- Full `e2e_relay` suite against a locally running patched relay: 44/45 pass; the one failure (`test_unarchive_emits_member_added_notification`) fails identically on unpatched `main` in the same environment.
- `cargo fmt`, `cargo clippy --all-targets`, `cargo test -p buzz-relay --lib` clean (pre-existing environment-dependent failures in `api::media`/`api::admin`/`telemetry` reproduce on unpatched `main`).
- Deployed on our production community relay (chat.creatorhive.ai); the raw-frame reproduction above now shows live delivery on both subscription shapes, and existing single-channel clients are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
