### PR TITLE
fix(desktop): show owned relay agents in channel picker

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -204,6 +204,8 @@ pub struct RelayAgentInfo {
     pub capabilities: Vec<String>,
     pub status: String,
     #[serde(default)]
+    pub channel_add_policy: Option<String>,
+    #[serde(default)]
     pub respond_to: Option<RespondTo>,
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -925,6 +925,7 @@ mod tests {
         assert_eq!(parsed[0].channels, Vec::<String>::new());
         assert_eq!(parsed[0].capabilities, Vec::<String>::new());
         assert_eq!(parsed[0].status, "offline");
+        assert_eq!(parsed[0].channel_add_policy.as_deref(), Some("owner-only"));
         assert_eq!(parsed[0].respond_to, None);
     }
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -255,6 +255,13 @@ test("isAgentIdentityInAllowedList: keeps people and only explicitly allowed age
     ),
     false,
   );
+  assert.equal(
+    isAgentIdentityInAllowedList(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      allowedAgentPubkeys,
+    ),
+    true,
+  );
 });
 
 test("shouldHideAgentFromMentions: never hides non-agents", () => {
@@ -299,7 +306,7 @@ test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () =>
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+test("shouldHideAgentFromMentions: room membership overrides stale directory exclusion", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       ownerOnly: false,
@@ -309,11 +316,11 @@ test("shouldHideAgentFromMentions: hides member agents with an explicit not-invo
       mentionableAgentPubkeys: new Set(),
       directoryAgentPubkeys: new Set([PUB_A]),
     }),
-    true,
+    false,
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents without an affirmative directory grant", () => {
+test("shouldHideAgentFromMentions: room membership is sufficient without a directory grant", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       ownerOnly: false,
@@ -323,11 +330,11 @@ test("shouldHideAgentFromMentions: hides member agents without an affirmative di
       mentionableAgentPubkeys: new Set(),
       directoryAgentPubkeys: new Set(),
     }),
-    true,
+    false,
   );
 });
 
-test("shouldHideAgentFromMentions: hides unknown member agents while directories load", () => {
+test("shouldHideAgentFromMentions: room members remain available while directories load", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       ownerOnly: false,
@@ -338,11 +345,11 @@ test("shouldHideAgentFromMentions: hides unknown member agents while directories
       directoryAgentPubkeys: new Set(),
       directoryReady: false,
     }),
-    true,
+    false,
   );
 });
 
-test("shouldHideAgentFromMentions: hides mentionable member agents while directories load", () => {
+test("shouldHideAgentFromMentions: mentionable room members remain available while directories load", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       ownerOnly: false,
@@ -353,7 +360,7 @@ test("shouldHideAgentFromMentions: hides mentionable member agents while directo
       directoryAgentPubkeys: new Set(),
       directoryReady: false,
     }),
-    true,
+    false,
   );
 });
 
@@ -372,7 +379,7 @@ test("shouldHideAgentFromMentions: shows non-agent members while directories loa
   );
 });
 
-test("shouldHideAgentFromMentions: hides unknown member agents after empty directories settle", () => {
+test("shouldHideAgentFromMentions: room members remain available after empty directories settle", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       ownerOnly: false,
@@ -383,7 +390,7 @@ test("shouldHideAgentFromMentions: hides unknown member agents after empty direc
       directoryAgentPubkeys: new Set(),
       directoryReady: true,
     }),
-    true,
+    false,
   );
 });
 
@@ -408,12 +415,12 @@ test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
     shouldHideAgentFromMentions({
       ownerOnly: false,
       isAgent: true,
-      isMember: true,
+      isMember: false,
       pubkey: mixedCase,
-      mentionableAgentPubkeys: new Set(),
+      mentionableAgentPubkeys: new Set([normalized]),
       directoryAgentPubkeys: new Set([normalized]),
     }),
-    true,
+    false,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -83,11 +83,12 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInAllowedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   allowedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
+    candidate.isMember === true ||
     allowedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
@@ -96,6 +97,7 @@ export type AgentMentionAdmission = "allow" | "deny" | "unknown";
 
 export function getAgentMentionAdmission({
   isAgent,
+  isMember,
   isManagedAgent,
   pubkey,
   ownerPubkey,
@@ -105,6 +107,7 @@ export function getAgentMentionAdmission({
   ownerOnly,
 }: {
   isAgent: boolean;
+  isMember?: boolean;
   isManagedAgent: boolean;
   pubkey: string;
   ownerPubkey?: string | null;
@@ -114,6 +117,9 @@ export function getAgentMentionAdmission({
   ownerOnly: boolean | undefined;
 }): AgentMentionAdmission {
   if (!isAgent) return "allow";
+  // Authoritative room membership is the invitation boundary. Once an agent
+  // has been added here it remains addressable while directory metadata catches up.
+  if (isMember === true) return "allow";
   if (!directoryReady || ownerOnly === undefined) return "unknown";
 
   const normalized = normalizePubkey(pubkey);
@@ -128,6 +134,7 @@ export function getAgentMentionAdmission({
 
 export function shouldHideAgentFromMentions({
   isAgent,
+  isMember = false,
   isManagedAgent = false,
   pubkey,
   ownerPubkey,
@@ -137,6 +144,7 @@ export function shouldHideAgentFromMentions({
   ownerOnly,
 }: {
   isAgent: boolean;
+  isMember?: boolean;
   isManagedAgent?: boolean;
   pubkey: string;
   ownerPubkey?: string | null;
@@ -148,6 +156,7 @@ export function shouldHideAgentFromMentions({
   return (
     getAgentMentionAdmission({
       isAgent,
+      isMember,
       isManagedAgent,
       pubkey,
       ownerPubkey,

--- a/desktop/src/features/agents/lib/relayAgentPickerEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/relayAgentPickerEligibility.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getRelayAgentPickerCandidates } from "./relayAgentPickerEligibility.ts";
+
+const OWNER = "a".repeat(64);
+const OTHER_OWNER = "b".repeat(64);
+const OWNED = "1".repeat(64);
+const FOREIGN = "2".repeat(64);
+const MANAGED = "3".repeat(64);
+const MEMBER = "4".repeat(64);
+
+function agent(pubkey, name) {
+  return {
+    pubkey,
+    name,
+    agentType: "hermes",
+    channels: [],
+    channelIds: [],
+    capabilities: ["messages", "channels", "tools"],
+    status: "online",
+    respondTo: "anyone",
+    respondToAllowlist: [],
+  };
+}
+
+function profile(ownerPubkey, displayName = null, avatarUrl = null) {
+  return {
+    displayName,
+    avatarUrl,
+    nip05Handle: null,
+    ownerPubkey,
+    isAgent: true,
+  };
+}
+
+test("includes owned relay-native agents with canonical profile metadata", () => {
+  const result = getRelayAgentPickerCandidates({
+    currentPubkey: OWNER,
+    managedAgentPubkeys: [],
+    memberPubkeys: [],
+    profiles: {
+      [OWNED]: profile(OWNER, "Sigma", "https://relay.example/sigma.png"),
+    },
+    relayAgents: [agent(OWNED, "fallback")],
+  });
+
+  assert.deepEqual(result, [
+    {
+      agent: agent(OWNED, "fallback"),
+      avatarUrl: "https://relay.example/sigma.png",
+      displayName: "Sigma",
+      pubkey: OWNED,
+    },
+  ]);
+});
+
+test("excludes foreign, locally managed, and existing channel agents", () => {
+  const result = getRelayAgentPickerCandidates({
+    currentPubkey: OWNER,
+    managedAgentPubkeys: [MANAGED.toUpperCase()],
+    memberPubkeys: [MEMBER.toUpperCase()],
+    profiles: {
+      [FOREIGN]: profile(OTHER_OWNER),
+      [MANAGED]: profile(OWNER),
+      [MEMBER]: profile(OWNER),
+    },
+    relayAgents: [
+      agent(FOREIGN, "foreign"),
+      agent(MANAGED, "managed"),
+      agent(MEMBER, "member"),
+    ],
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test("normalizes and deduplicates pubkeys and falls back to directory name", () => {
+  const result = getRelayAgentPickerCandidates({
+    currentPubkey: OWNER.toUpperCase(),
+    managedAgentPubkeys: [],
+    memberPubkeys: [],
+    profiles: {
+      [OWNED]: profile(OWNER.toUpperCase(), "   ", null),
+    },
+    relayAgents: [
+      agent(OWNED.toUpperCase(), "Winston"),
+      agent(OWNED, "duplicate"),
+    ],
+  });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].displayName, "Winston");
+  assert.equal(result[0].pubkey, OWNED);
+});
+
+test("returns no candidates until identity and ownership profiles resolve", () => {
+  assert.deepEqual(
+    getRelayAgentPickerCandidates({
+      currentPubkey: null,
+      managedAgentPubkeys: [],
+      memberPubkeys: [],
+      profiles: {},
+      relayAgents: [agent(OWNED, "Sigma")],
+    }),
+    [],
+  );
+  assert.deepEqual(
+    getRelayAgentPickerCandidates({
+      currentPubkey: OWNER,
+      managedAgentPubkeys: [],
+      memberPubkeys: [],
+      profiles: {},
+      relayAgents: [agent(OWNED, "Sigma")],
+    }),
+    [],
+  );
+});

--- a/desktop/src/features/agents/lib/relayAgentPickerEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/relayAgentPickerEligibility.test.mjs
@@ -19,6 +19,7 @@ function agent(pubkey, name) {
     channelIds: [],
     capabilities: ["messages", "channels", "tools"],
     status: "online",
+    channelAddPolicy: null,
     respondTo: "anyone",
     respondToAllowlist: [],
   };
@@ -112,6 +113,22 @@ test("returns no candidates until identity and ownership profiles resolve", () =
       memberPubkeys: [],
       profiles: {},
       relayAgents: [agent(OWNED, "Sigma")],
+    }),
+    [],
+  );
+});
+
+test("excludes agents whose channel-add policy is nobody", () => {
+  const blocked = agent(OWNED, "Sigma");
+  blocked.channelAddPolicy = "nobody";
+
+  assert.deepEqual(
+    getRelayAgentPickerCandidates({
+      currentPubkey: OWNER,
+      managedAgentPubkeys: [],
+      memberPubkeys: [],
+      profiles: { [OWNED]: profile(OWNER, "Sigma") },
+      relayAgents: [blocked],
     }),
     [],
   );

--- a/desktop/src/features/agents/lib/relayAgentPickerEligibility.ts
+++ b/desktop/src/features/agents/lib/relayAgentPickerEligibility.ts
@@ -1,7 +1,4 @@
-import type {
-  RelayAgent,
-  UserProfileSummary,
-} from "@/shared/api/types";
+import type { RelayAgent, UserProfileSummary } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export type RelayAgentPickerCandidate = {
@@ -55,6 +52,7 @@ export function getRelayAgentPickerCandidates({
       seen.has(pubkey) ||
       managed.has(pubkey) ||
       members.has(pubkey) ||
+      agent.channelAddPolicy?.replaceAll("-", "_").toLowerCase() === "nobody" ||
       ownerPubkey !== normalizedCurrentPubkey
     ) {
       continue;
@@ -69,5 +67,9 @@ export function getRelayAgentPickerCandidates({
     });
   }
 
-  return candidates;
+  return candidates.sort((left, right) =>
+    left.displayName.localeCompare(right.displayName, undefined, {
+      sensitivity: "base",
+    }),
+  );
 }

--- a/desktop/src/features/agents/lib/relayAgentPickerEligibility.ts
+++ b/desktop/src/features/agents/lib/relayAgentPickerEligibility.ts
@@ -1,0 +1,73 @@
+import type {
+  RelayAgent,
+  UserProfileSummary,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export type RelayAgentPickerCandidate = {
+  agent: RelayAgent;
+  avatarUrl: string | null;
+  displayName: string;
+  pubkey: string;
+};
+
+type RelayAgentPickerEligibilityInput = {
+  currentPubkey: string | null | undefined;
+  managedAgentPubkeys: Iterable<string>;
+  memberPubkeys: Iterable<string>;
+  profiles: Record<string, UserProfileSummary>;
+  relayAgents: readonly RelayAgent[];
+};
+
+/**
+ * Returns relay-native agents owned by the current identity that can be added
+ * directly to the channel without creating a duplicate local managed runtime.
+ */
+export function getRelayAgentPickerCandidates({
+  currentPubkey,
+  managedAgentPubkeys,
+  memberPubkeys,
+  profiles,
+  relayAgents,
+}: RelayAgentPickerEligibilityInput): RelayAgentPickerCandidate[] {
+  const normalizedCurrentPubkey = currentPubkey
+    ? normalizePubkey(currentPubkey)
+    : null;
+  if (!normalizedCurrentPubkey) return [];
+
+  const managed = new Set(
+    [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
+  );
+  const members = new Set(
+    [...memberPubkeys].map((pubkey) => normalizePubkey(pubkey)),
+  );
+  const seen = new Set<string>();
+  const candidates: RelayAgentPickerCandidate[] = [];
+
+  for (const agent of relayAgents) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    const profile = profiles[pubkey];
+    const ownerPubkey = profile?.ownerPubkey
+      ? normalizePubkey(profile.ownerPubkey)
+      : null;
+
+    if (
+      seen.has(pubkey) ||
+      managed.has(pubkey) ||
+      members.has(pubkey) ||
+      ownerPubkey !== normalizedCurrentPubkey
+    ) {
+      continue;
+    }
+
+    seen.add(pubkey);
+    candidates.push({
+      agent,
+      avatarUrl: profile.avatarUrl,
+      displayName: profile.displayName?.trim() || agent.name,
+      pubkey,
+    });
+  }
+
+  return candidates;
+}

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -3,17 +3,25 @@ import * as React from "react";
 
 import {
   useCreateChannelManagedAgentsMutation,
+  useManagedAgentsQuery,
   usePersonasQuery,
+  useRelayAgentsQuery,
   useTeamsQuery,
   type CreateChannelManagedAgentResult,
 } from "@/features/agents/hooks";
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
+import { getRelayAgentPickerCandidates } from "@/features/agents/lib/relayAgentPickerEligibility";
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
 import { AddChannelBotPersonasSection } from "@/features/channels/ui/AddChannelBotPersonasSection";
+import { AddChannelBotRelayAgentsSection } from "@/features/channels/ui/AddChannelBotRelayAgentsSection";
 import { AddChannelBotTeamsSection } from "@/features/channels/ui/AddChannelBotTeamsSection";
+import { useAddChannelMembersMutation, useChannelMembersQuery } from "@/features/channels/hooks";
 import { useInChannelPersonaIds } from "@/features/channels/ui/useInChannelPersonaIds";
-import type { AcpRuntime } from "@/shared/api/types";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type { AcpRuntime, RelayAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
@@ -63,12 +71,17 @@ export function AddChannelBotDialog({
   onOpenChange,
 }: AddChannelBotDialogProps) {
   const personasQuery = usePersonasQuery();
+  const identityQuery = useIdentityQuery();
+  const managedAgentsQuery = useManagedAgentsQuery({ enabled: open });
+  const relayAgentsQuery = useRelayAgentsQuery({ enabled: open });
   const teamsQuery = useTeamsQuery();
+  const channelMembersQuery = useChannelMembersQuery(channelId, open);
   const inChannelPersonaIds = useInChannelPersonaIds(
     channelId,
     open && channelId !== null,
   );
   const createBotsMutation = useCreateChannelManagedAgentsMutation(channelId);
+  const addMembersMutation = useAddChannelMembersMutation(channelId);
   const personas = React.useMemo(
     () => getActivePersonas(personasQuery.data ?? []),
     [personasQuery.data],
@@ -80,6 +93,8 @@ export function AddChannelBotDialog({
   const [selectedPersonaIds, setSelectedPersonaIds] = React.useState<string[]>(
     [],
   );
+  const [selectedRelayAgentPubkeys, setSelectedRelayAgentPubkeys] =
+    React.useState<string[]>([]);
   const [submissionNotice, setSubmissionNotice] = React.useState<string | null>(
     null,
   );
@@ -90,6 +105,52 @@ export function AddChannelBotDialog({
   const selectedPersonas = React.useMemo(
     () => personas.filter((persona) => selectedPersonaIds.includes(persona.id)),
     [personas, selectedPersonaIds],
+  );
+  const localManagedAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (managedAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+      ),
+    [managedAgentsQuery.data],
+  );
+  const relayAgentProfilesQuery = useUsersBatchQuery(
+    (relayAgentsQuery.data ?? []).map((agent) => agent.pubkey),
+    { enabled: open && (relayAgentsQuery.data?.length ?? 0) > 0 },
+  );
+  const relayAgents = React.useMemo(
+    () =>
+      getRelayAgentPickerCandidates({
+        currentPubkey: identityQuery.data?.pubkey,
+        managedAgentPubkeys: localManagedAgentPubkeys,
+        memberPubkeys: [],
+        profiles: relayAgentProfilesQuery.data?.profiles ?? {},
+        relayAgents: relayAgentsQuery.data ?? [],
+      }).map((candidate) => candidate.agent),
+    [
+      identityQuery.data?.pubkey,
+      localManagedAgentPubkeys,
+      relayAgentProfilesQuery.data,
+      relayAgentsQuery.data,
+    ],
+  );
+  const inChannelPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (channelMembersQuery.data ?? []).map((member) =>
+          normalizePubkey(member.pubkey),
+        ),
+      ),
+    [channelMembersQuery.data],
+  );
+
+  const selectedRelayAgents = React.useMemo(
+    () =>
+      relayAgents.filter((agent) =>
+        selectedRelayAgentPubkeys.includes(normalizePubkey(agent.pubkey)),
+      ),
+    [relayAgents, selectedRelayAgentPubkeys],
   );
 
   React.useEffect(() => {
@@ -102,11 +163,24 @@ export function AddChannelBotDialog({
     );
   }, [inChannelPersonaIds, personas]);
 
+  React.useEffect(() => {
+    const eligiblePubkeys = new Set(
+      relayAgents.map((agent) => normalizePubkey(agent.pubkey)),
+    );
+    setSelectedRelayAgentPubkeys((current) =>
+      current.filter(
+        (pubkey) => eligiblePubkeys.has(pubkey) && !inChannelPubkeys.has(pubkey),
+      ),
+    );
+  }, [inChannelPubkeys, relayAgents]);
+
   function reset() {
     setSelectedPersonaIds([]);
+    setSelectedRelayAgentPubkeys([]);
     setSubmissionNotice(null);
     setSubmissionError(null);
     createBotsMutation.reset();
+    addMembersMutation.reset();
   }
 
   function handleOpenChange(next: boolean) {
@@ -135,7 +209,8 @@ export function AddChannelBotDialog({
   }
 
   async function handleSubmit() {
-    if (providers.length === 0 || selectedPersonas.length === 0) return;
+    if (selectedPersonas.length === 0 && selectedRelayAgents.length === 0) return;
+    if (selectedPersonas.length > 0 && providers.length === 0) return;
 
     const inputs = selectedPersonas.map((persona) => {
       const resolved = resolvePersonaRuntime(
@@ -161,8 +236,26 @@ export function AddChannelBotDialog({
     setSubmissionError(null);
 
     try {
-      const result = await createBotsMutation.mutateAsync(inputs);
-      if (result.failures.length === 0) {
+      const relayResult =
+        selectedRelayAgents.length > 0
+          ? await addMembersMutation.mutateAsync({
+              pubkeys: selectedRelayAgents.map((agent) => agent.pubkey),
+              role: "bot",
+            })
+          : { added: [], errors: [] };
+      const result =
+        inputs.length > 0
+          ? await createBotsMutation.mutateAsync(inputs)
+          : { successes: [], failures: [] };
+      const relayAgentsByPubkey = new Map<string, RelayAgent>(
+        selectedRelayAgents.map((agent) => [normalizePubkey(agent.pubkey), agent]),
+      );
+      const relayFailures = relayResult.errors.map(({ pubkey, error }) => ({
+        name: relayAgentsByPubkey.get(normalizePubkey(pubkey))?.name ?? pubkey,
+        error,
+      }));
+      const failures = [...result.failures, ...relayFailures];
+      if (failures.length === 0) {
         if (result.successes[0]) onAdded?.(result.successes[0]);
         handleOpenChange(false);
         return;
@@ -176,30 +269,38 @@ export function AddChannelBotDialog({
       setSelectedPersonaIds((current) =>
         current.filter((personaId) => failedPersonaIds.has(personaId)),
       );
-      if (result.successes.length > 0) {
+      const failedRelayPubkeys = new Set(
+        relayResult.errors.map(({ pubkey }) => normalizePubkey(pubkey)),
+      );
+      setSelectedRelayAgentPubkeys((current) =>
+        current.filter((pubkey) => failedRelayPubkeys.has(pubkey)),
+      );
+      const successCount = result.successes.length + relayResult.added.length;
+      if (successCount > 0) {
         setSubmissionNotice(
-          `Added ${result.successes.length} ${formatAgentCountLabel(
-            result.successes.length,
-          )}.`,
+          `Added ${successCount} ${formatAgentCountLabel(successCount)}.`,
         );
       }
-      setSubmissionError(formatBatchFailureSummary(result.failures));
+      setSubmissionError(formatBatchFailureSummary(failures));
     } catch {
       // The mutation error is rendered inline.
     }
   }
 
   const canSubmit =
-    providers.length > 0 &&
-    selectedPersonas.length > 0 &&
+    (selectedPersonas.length > 0 || selectedRelayAgents.length > 0) &&
+    (selectedPersonas.length === 0 || providers.length > 0) &&
     !providersLoading &&
-    !createBotsMutation.isPending;
-  const addButtonLabel = createBotsMutation.isPending
-    ? selectedPersonas.length > 1
-      ? `Adding ${selectedPersonas.length}…`
+    !createBotsMutation.isPending &&
+    !addMembersMutation.isPending;
+  const selectionCount = selectedPersonas.length + selectedRelayAgents.length;
+  const isSubmitting = createBotsMutation.isPending || addMembersMutation.isPending;
+  const addButtonLabel = isSubmitting
+    ? selectionCount > 1
+      ? `Adding ${selectionCount}…`
       : "Adding…"
-    : selectedPersonas.length > 1
-      ? `Add ${selectedPersonas.length} agents`
+    : selectionCount > 1
+      ? `Add ${selectionCount} agents`
       : "Add agent";
 
   return (
@@ -236,7 +337,7 @@ export function AddChannelBotDialog({
         title="Add agents"
       >
         <AddChannelBotPersonasSection
-          canToggleSelections={!createBotsMutation.isPending}
+          canToggleSelections={!isSubmitting}
           inChannelPersonaIds={inChannelPersonaIds}
           isLoading={personasQuery.isLoading}
           onCreateAgent={handleCreateAgent}
@@ -247,6 +348,24 @@ export function AddChannelBotDialog({
           }}
           personas={personas}
           selectedPersonaIds={selectedPersonaIds}
+        />
+
+        <AddChannelBotRelayAgentsSection
+          canToggleSelections={!isSubmitting}
+          inChannelPubkeys={inChannelPubkeys}
+          isLoading={
+            relayAgentsQuery.isLoading ||
+            relayAgentProfilesQuery.isLoading ||
+            channelMembersQuery.isLoading
+          }
+          onToggleAgent={(pubkey) => {
+            setSelectedRelayAgentPubkeys((current) => toggleValue(current, pubkey));
+            setSubmissionNotice(null);
+            setSubmissionError(null);
+          }}
+          profiles={relayAgentProfilesQuery.data?.profiles ?? {}}
+          relayAgents={relayAgents}
+          selectedPubkeys={selectedRelayAgentPubkeys}
         />
 
         {teams.length > 0 ? (
@@ -261,7 +380,7 @@ export function AddChannelBotDialog({
           />
         ) : null}
 
-        {providers.length === 0 && !providersLoading ? (
+        {providers.length === 0 && selectedPersonas.length > 0 && !providersLoading ? (
           <div className="flex gap-3 rounded-lg border border-warning/30 bg-warning-bg px-4 py-3">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
             <p className="text-sm text-warning">
@@ -293,6 +412,11 @@ export function AddChannelBotDialog({
         {createBotsMutation.error instanceof Error ? (
           <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {createBotsMutation.error.message}
+          </p>
+        ) : null}
+        {addMembersMutation.error instanceof Error ? (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {addMembersMutation.error.message}
           </p>
         ) : null}
       </ChooserDialogContent>

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -16,7 +16,10 @@ import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
 import { AddChannelBotPersonasSection } from "@/features/channels/ui/AddChannelBotPersonasSection";
 import { AddChannelBotRelayAgentsSection } from "@/features/channels/ui/AddChannelBotRelayAgentsSection";
 import { AddChannelBotTeamsSection } from "@/features/channels/ui/AddChannelBotTeamsSection";
-import { useAddChannelMembersMutation, useChannelMembersQuery } from "@/features/channels/hooks";
+import {
+  useAddChannelMembersMutation,
+  useChannelMembersQuery,
+} from "@/features/channels/hooks";
 import { useInChannelPersonaIds } from "@/features/channels/ui/useInChannelPersonaIds";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -119,20 +122,40 @@ export function AddChannelBotDialog({
     (relayAgentsQuery.data ?? []).map((agent) => agent.pubkey),
     { enabled: open && (relayAgentsQuery.data?.length ?? 0) > 0 },
   );
+  const relaySourceError =
+    identityQuery.error ??
+    managedAgentsQuery.error ??
+    relayAgentsQuery.error ??
+    relayAgentProfilesQuery.error ??
+    channelMembersQuery.error;
+  const relaySourcesReady =
+    relaySourceError === null &&
+    identityQuery.data !== undefined &&
+    managedAgentsQuery.data !== undefined &&
+    relayAgentsQuery.data !== undefined &&
+    ((relayAgentsQuery.data?.length ?? 0) === 0 ||
+      relayAgentProfilesQuery.data !== undefined) &&
+    channelMembersQuery.data !== undefined;
   const relayAgents = React.useMemo(
     () =>
-      getRelayAgentPickerCandidates({
-        currentPubkey: identityQuery.data?.pubkey,
-        managedAgentPubkeys: localManagedAgentPubkeys,
-        memberPubkeys: [],
-        profiles: relayAgentProfilesQuery.data?.profiles ?? {},
-        relayAgents: relayAgentsQuery.data ?? [],
-      }).map((candidate) => candidate.agent),
+      !relaySourcesReady
+        ? []
+        : getRelayAgentPickerCandidates({
+            currentPubkey: identityQuery.data?.pubkey,
+            managedAgentPubkeys: localManagedAgentPubkeys,
+            memberPubkeys: (channelMembersQuery.data ?? []).map(
+              (member) => member.pubkey,
+            ),
+            profiles: relayAgentProfilesQuery.data?.profiles ?? {},
+            relayAgents: relayAgentsQuery.data ?? [],
+          }).map((candidate) => candidate.agent),
     [
+      channelMembersQuery.data,
       identityQuery.data?.pubkey,
       localManagedAgentPubkeys,
       relayAgentProfilesQuery.data,
       relayAgentsQuery.data,
+      relaySourcesReady,
     ],
   );
   const inChannelPubkeys = React.useMemo(
@@ -169,7 +192,8 @@ export function AddChannelBotDialog({
     );
     setSelectedRelayAgentPubkeys((current) =>
       current.filter(
-        (pubkey) => eligiblePubkeys.has(pubkey) && !inChannelPubkeys.has(pubkey),
+        (pubkey) =>
+          eligiblePubkeys.has(pubkey) && !inChannelPubkeys.has(pubkey),
       ),
     );
   }, [inChannelPubkeys, relayAgents]);
@@ -209,7 +233,8 @@ export function AddChannelBotDialog({
   }
 
   async function handleSubmit() {
-    if (selectedPersonas.length === 0 && selectedRelayAgents.length === 0) return;
+    if (selectedPersonas.length === 0 && selectedRelayAgents.length === 0)
+      return;
     if (selectedPersonas.length > 0 && providers.length === 0) return;
 
     const inputs = selectedPersonas.map((persona) => {
@@ -235,56 +260,93 @@ export function AddChannelBotDialog({
     setSubmissionNotice(null);
     setSubmissionError(null);
 
-    try {
-      const relayResult =
-        selectedRelayAgents.length > 0
-          ? await addMembersMutation.mutateAsync({
-              pubkeys: selectedRelayAgents.map((agent) => agent.pubkey),
-              role: "bot",
-            })
-          : { added: [], errors: [] };
-      const result =
-        inputs.length > 0
-          ? await createBotsMutation.mutateAsync(inputs)
-          : { successes: [], failures: [] };
-      const relayAgentsByPubkey = new Map<string, RelayAgent>(
-        selectedRelayAgents.map((agent) => [normalizePubkey(agent.pubkey), agent]),
-      );
-      const relayFailures = relayResult.errors.map(({ pubkey, error }) => ({
-        name: relayAgentsByPubkey.get(normalizePubkey(pubkey))?.name ?? pubkey,
-        error,
-      }));
-      const failures = [...result.failures, ...relayFailures];
-      if (failures.length === 0) {
-        if (result.successes[0]) onAdded?.(result.successes[0]);
-        handleOpenChange(false);
-        return;
-      }
+    let relayResult: {
+      added: string[];
+      errors: { pubkey: string; error: string }[];
+    } = { added: [], errors: [] };
+    let result: Awaited<ReturnType<typeof createBotsMutation.mutateAsync>> = {
+      successes: [],
+      failures: [],
+    };
+    let relayTransportError: string | null = null;
+    let managedTransportError: string | null = null;
 
-      const failedPersonaIds = new Set(
-        result.failures
-          .map((failure) => failure.personaId)
-          .filter((personaId): personaId is string => Boolean(personaId)),
-      );
-      setSelectedPersonaIds((current) =>
-        current.filter((personaId) => failedPersonaIds.has(personaId)),
-      );
-      const failedRelayPubkeys = new Set(
-        relayResult.errors.map(({ pubkey }) => normalizePubkey(pubkey)),
-      );
-      setSelectedRelayAgentPubkeys((current) =>
-        current.filter((pubkey) => failedRelayPubkeys.has(pubkey)),
-      );
-      const successCount = result.successes.length + relayResult.added.length;
-      if (successCount > 0) {
-        setSubmissionNotice(
-          `Added ${successCount} ${formatAgentCountLabel(successCount)}.`,
-        );
+    if (selectedRelayAgents.length > 0) {
+      try {
+        relayResult = await addMembersMutation.mutateAsync({
+          pubkeys: selectedRelayAgents.map((agent) => agent.pubkey),
+          role: "bot",
+        });
+      } catch (error) {
+        relayTransportError =
+          error instanceof Error ? error.message : "Failed to add relay agents";
       }
-      setSubmissionError(formatBatchFailureSummary(failures));
-    } catch {
-      // The mutation error is rendered inline.
     }
+    if (inputs.length > 0) {
+      try {
+        result = await createBotsMutation.mutateAsync(inputs);
+      } catch (error) {
+        managedTransportError =
+          error instanceof Error
+            ? error.message
+            : "Failed to add managed agents";
+      }
+    }
+
+    const relayAgentsByPubkey = new Map<string, RelayAgent>(
+      selectedRelayAgents.map((agent) => [
+        normalizePubkey(agent.pubkey),
+        agent,
+      ]),
+    );
+    const relayFailures = relayResult.errors.map(({ pubkey, error }) => ({
+      name: relayAgentsByPubkey.get(normalizePubkey(pubkey))?.name ?? pubkey,
+      error,
+    }));
+    const failures = [...result.failures, ...relayFailures];
+    if (
+      failures.length === 0 &&
+      relayTransportError === null &&
+      managedTransportError === null
+    ) {
+      if (result.successes[0]) onAdded?.(result.successes[0]);
+      handleOpenChange(false);
+      return;
+    }
+
+    const failedPersonaIds = new Set(
+      managedTransportError
+        ? selectedPersonaIds
+        : result.failures
+            .map((failure) => failure.personaId)
+            .filter((personaId): personaId is string => Boolean(personaId)),
+    );
+    setSelectedPersonaIds((current) =>
+      current.filter((personaId) => failedPersonaIds.has(personaId)),
+    );
+    const failedRelayPubkeys = new Set(
+      relayTransportError
+        ? selectedRelayAgentPubkeys
+        : relayResult.errors.map(({ pubkey }) => normalizePubkey(pubkey)),
+    );
+    setSelectedRelayAgentPubkeys((current) =>
+      current.filter((pubkey) => failedRelayPubkeys.has(pubkey)),
+    );
+    const successCount = result.successes.length + relayResult.added.length;
+    if (successCount > 0) {
+      setSubmissionNotice(
+        `Added ${successCount} ${formatAgentCountLabel(successCount)}.`,
+      );
+    }
+    setSubmissionError(
+      [
+        failures.length > 0 ? formatBatchFailureSummary(failures) : null,
+        relayTransportError,
+        managedTransportError,
+      ]
+        .filter((message): message is string => Boolean(message))
+        .join("; "),
+    );
   }
 
   const canSubmit =
@@ -294,7 +356,8 @@ export function AddChannelBotDialog({
     !createBotsMutation.isPending &&
     !addMembersMutation.isPending;
   const selectionCount = selectedPersonas.length + selectedRelayAgents.length;
-  const isSubmitting = createBotsMutation.isPending || addMembersMutation.isPending;
+  const isSubmitting =
+    createBotsMutation.isPending || addMembersMutation.isPending;
   const addButtonLabel = isSubmitting
     ? selectionCount > 1
       ? `Adding ${selectionCount}…`
@@ -353,13 +416,11 @@ export function AddChannelBotDialog({
         <AddChannelBotRelayAgentsSection
           canToggleSelections={!isSubmitting}
           inChannelPubkeys={inChannelPubkeys}
-          isLoading={
-            relayAgentsQuery.isLoading ||
-            relayAgentProfilesQuery.isLoading ||
-            channelMembersQuery.isLoading
-          }
+          isLoading={!relaySourcesReady && relaySourceError === null}
           onToggleAgent={(pubkey) => {
-            setSelectedRelayAgentPubkeys((current) => toggleValue(current, pubkey));
+            setSelectedRelayAgentPubkeys((current) =>
+              toggleValue(current, pubkey),
+            );
             setSubmissionNotice(null);
             setSubmissionError(null);
           }}
@@ -370,7 +431,7 @@ export function AddChannelBotDialog({
 
         {teams.length > 0 ? (
           <AddChannelBotTeamsSection
-            canToggleSelections={!createBotsMutation.isPending}
+            canToggleSelections={!isSubmitting}
             inChannelPersonaIds={inChannelPersonaIds}
             isLoading={teamsQuery.isLoading}
             onToggleTeam={handleToggleTeam}
@@ -380,7 +441,9 @@ export function AddChannelBotDialog({
           />
         ) : null}
 
-        {providers.length === 0 && selectedPersonas.length > 0 && !providersLoading ? (
+        {providers.length === 0 &&
+        selectedPersonas.length > 0 &&
+        !providersLoading ? (
           <div className="flex gap-3 rounded-lg border border-warning/30 bg-warning-bg px-4 py-3">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
             <p className="text-sm text-warning">
@@ -399,6 +462,11 @@ export function AddChannelBotDialog({
             {personasQuery.error.message}
           </p>
         ) : null}
+        {relaySourceError instanceof Error ? (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            Relay agents are unavailable: {relaySourceError.message}
+          </p>
+        ) : null}
         {submissionNotice ? (
           <p className="rounded-lg bg-muted px-4 py-3 text-sm text-foreground">
             {submissionNotice}
@@ -408,13 +476,11 @@ export function AddChannelBotDialog({
           <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {submissionError}
           </p>
-        ) : null}
-        {createBotsMutation.error instanceof Error ? (
+        ) : createBotsMutation.error instanceof Error ? (
           <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {createBotsMutation.error.message}
           </p>
-        ) : null}
-        {addMembersMutation.error instanceof Error ? (
+        ) : addMembersMutation.error instanceof Error ? (
           <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {addMembersMutation.error.message}
           </p>

--- a/desktop/src/features/channels/ui/AddChannelBotRelayAgentsSection.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotRelayAgentsSection.tsx
@@ -1,0 +1,92 @@
+import { Check } from "lucide-react";
+
+import type {
+  RelayAgent,
+  UserProfileSummary,
+} from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
+
+type AddChannelBotRelayAgentsSectionProps = {
+  canToggleSelections: boolean;
+  inChannelPubkeys: ReadonlySet<string>;
+  isLoading: boolean;
+  onToggleAgent: (pubkey: string) => void;
+  profiles: Record<string, UserProfileSummary>;
+  relayAgents: RelayAgent[];
+  selectedPubkeys: readonly string[];
+};
+
+export function AddChannelBotRelayAgentsSection({
+  canToggleSelections,
+  inChannelPubkeys,
+  isLoading,
+  onToggleAgent,
+  profiles,
+  relayAgents,
+  selectedPubkeys,
+}: AddChannelBotRelayAgentsSectionProps) {
+  const available = relayAgents
+    .filter((agent) => !inChannelPubkeys.has(normalizePubkey(agent.pubkey)))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  if (!isLoading && available.length === 0) return null;
+
+  return (
+    <div className="space-y-1 border-t border-border pt-3">
+      <div className="px-3 pb-1 text-xs font-medium text-muted-foreground">
+        Available agents
+      </div>
+      {isLoading ? (
+        <p className="px-3 text-sm text-muted-foreground">
+          Loading available agents…
+        </p>
+      ) : null}
+      {available.map((agent) => {
+        const pubkey = normalizePubkey(agent.pubkey);
+        const selected = selectedPubkeys.includes(pubkey);
+        const profile = profiles[pubkey];
+        const label = profile?.displayName?.trim() || agent.name;
+        return (
+          <button
+            aria-pressed={selected}
+            className={cn(
+              "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "bg-accent text-accent-foreground"
+                : "hover:bg-accent/60",
+              !canToggleSelections && "cursor-not-allowed opacity-50",
+            )}
+            data-testid={`add-channel-relay-agent-${pubkey}`}
+            disabled={!canToggleSelections}
+            key={pubkey}
+            onClick={() => onToggleAgent(pubkey)}
+            type="button"
+          >
+            <ProfileAvatar
+              avatarUrl={profile?.avatarUrl ?? null}
+              className="h-9 w-9 shrink-0 text-xs"
+              iconClassName="h-5 w-5"
+              label={label}
+            />
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {label}
+            </span>
+            <span
+              aria-hidden
+              className={cn(
+                "flex h-5 w-5 shrink-0 items-center justify-center rounded border",
+                selected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background",
+              )}
+            >
+              {selected ? <Check className="h-3.5 w-3.5" /> : null}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -256,6 +256,7 @@ export function useMentions(
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,
+          isMember: candidate.isMember === true,
           isManagedAgent: candidate.isManagedAgent === true,
           pubkey,
           ownerPubkey: candidate.ownerPubkey,

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -111,6 +111,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
             agent.status === "running" || agent.status === "deployed"
               ? "online"
               : "offline",
+          channelAddPolicy: null,
           respondTo: agent.respondTo,
           respondToAllowlist: agent.respondToAllowlist,
         });

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -106,6 +106,7 @@ type RawRelayAgent = {
   channel_ids: string[];
   capabilities: string[];
   status: RelayAgent["status"];
+  channel_add_policy?: string;
   respond_to?: RelayAgent["respondTo"];
   respond_to_allowlist?: string[];
 };
@@ -662,6 +663,7 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
     channelIds: agent.channel_ids ?? [],
     capabilities: agent.capabilities,
     status: agent.status,
+    channelAddPolicy: agent.channel_add_policy ?? null,
     respondTo: agent.respond_to ?? null,
     respondToAllowlist: agent.respond_to_allowlist ?? [],
   };

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -275,6 +275,7 @@ export type RelayAgent = {
   channelIds: string[];
   capabilities: string[];
   status: "online" | "away" | "offline";
+  channelAddPolicy: string | null;
   respondTo: RespondToMode | null;
   respondToAllowlist: string[];
 };


### PR DESCRIPTION
## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
