### PR TITLE
Add channel community discovery endpoint

### DIFF
--- a/crates/buzz-relay/src/api/community_identity.rs
+++ b/crates/buzz-relay/src/api/community_identity.rs
@@ -1,0 +1,90 @@
+//! Host-scoped discovery of a channel's parent community identity.
+//!
+//! The endpoint is intentionally narrow: the request host binds the tenant
+//! before the requested channel is checked, and the response contains only the
+//! two UUIDs needed to pin an external launch contract. It exposes neither
+//! channel metadata nor membership data.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+/// Response returned by [`channel_community`].
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ChannelCommunityResponse {
+    schema: &'static str,
+    channel_id: Uuid,
+    community_id: Uuid,
+}
+
+/// Return the parent community UUID for one active channel on this request host.
+///
+/// `GET /.well-known/buzz/channels/{channel_id}/community` is a deployment
+/// bootstrap read. The request is bound to its host-derived tenant first, so a
+/// channel UUID from another community cannot resolve here. Unknown hosts and
+/// unknown or deleted channels both return the same generic 404 response.
+pub async fn channel_community(
+    State(state): State<Arc<AppState>>,
+    Path(channel_id): Path<Uuid>,
+    headers: HeaderMap,
+) -> Response {
+    let raw_host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    let tenant = match crate::tenant::bind_community(&state.db, raw_host).await {
+        Ok(tenant) => tenant,
+        Err(_) => return not_found(),
+    };
+
+    if state
+        .db
+        .get_channel(tenant.community(), channel_id)
+        .await
+        .is_err()
+    {
+        return not_found();
+    }
+
+    Json(ChannelCommunityResponse {
+        schema: "buzz.channel-community/v1",
+        channel_id,
+        community_id: *tenant.community().as_uuid(),
+    })
+    .into_response()
+}
+
+fn not_found() -> Response {
+    (StatusCode::NOT_FOUND, "relay: channel is not available on this host").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_contains_only_the_versioned_channel_community_binding() {
+        let response = ChannelCommunityResponse {
+            schema: "buzz.channel-community/v1",
+            channel_id: Uuid::from_u128(1),
+            community_id: Uuid::from_u128(2),
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).expect("response should serialize"),
+            serde_json::json!({
+                "schema": "buzz.channel-community/v1",
+                "channel_id": "00000000-0000-0000-0000-000000000001",
+                "community_id": "00000000-0000-0000-0000-000000000002"
+            })
+        );
+    }
+}

--- a/crates/buzz-relay/src/api/mod.rs
+++ b/crates/buzz-relay/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod bridge;
+pub mod community_identity;
 pub mod events;
 pub mod git;
 pub mod invites;

--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -64,6 +64,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/", get(nip11_or_ws_handler))
         .route("/info", get(relay_info_handler))
         .route("/.well-known/nostr.json", get(api::nip05::nostr_nip05))
+        .route(
+            "/.well-known/buzz/channels/{channel_id}/community",
+            get(api::community_identity::channel_community),
+        )
         // Health endpoints
         .route("/health", get(health_handler))
         .route("/_liveness", get(liveness_handler))


### PR DESCRIPTION
## What changed

- Add a host-bound, well-known relay endpoint that maps a live channel UUID to its community UUID.
- Return only the two UUIDs and a versioned response schema.
- Refuse an unknown host or channel with the existing non-enumerating not-found response.

## Why

The StokeOS source-read pilot needs the relay's authoritative community UUID for its explicit launch policy. The desktop client's cached connection record is not that server identity.

## Validation

- Windows Git commit hook passed: gitleaks scanned the staged commit with no leaks.
- `git diff --check` passed.
- Not run: Rust formatter and focused test. The repository Hermit bootstrap fails before Cargo starts because `HERMIT_STATE_DIR_RAW` is unbound, and no host Cargo is installed.