### PR TITLE
feat(desktop): full-panel thread view mode + brand identity variant layer

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
         "**/thread-reply-anchor-roleplay.spec.ts",
         "**/threadpane-ultrawide.spec.ts",
         "**/thread-focus-mode.spec.ts",
+        "**/full-thread-shot.spec.ts",
         "**/animated-avatar.spec.ts",
         "**/reminders.spec.ts",
         "**/reminder-click-repro.spec.ts",

--- a/desktop/src/features/channels/lib/threadViewModePreference.test.mjs
+++ b/desktop/src/features/channels/lib/threadViewModePreference.test.mjs
@@ -25,12 +25,12 @@ async function withStorage(storage, run) {
   }
 }
 
-test("missing, malformed, and unreadable preferences default to split", async () => {
+test("missing, malformed, and unreadable preferences default to full", async () => {
   for (const stored of [null, "side-by-side", "{bad-json"]) {
     await withStorage(
       { getItem: (key) => (key === KEY ? stored : null), setItem() {} },
       ({ getThreadViewMode }) => {
-        assert.equal(getThreadViewMode(), "split");
+        assert.equal(getThreadViewMode(), "full");
       },
     );
   }
@@ -43,7 +43,7 @@ test("missing, malformed, and unreadable preferences default to split", async ()
       setItem() {},
     },
     ({ getThreadViewMode }) => {
-      assert.equal(getThreadViewMode(), "split");
+      assert.equal(getThreadViewMode(), "full");
     },
   );
 });

--- a/desktop/src/features/channels/lib/threadViewModePreference.ts
+++ b/desktop/src/features/channels/lib/threadViewModePreference.ts
@@ -7,25 +7,29 @@ import * as React from "react";
  *   leaving a narrow scrim-dimmed sliver of the channel visible as an
  *   orientation cue and a click-target back to the channel.
  * - `split` — the thread opens in a resizable side panel next to the channel.
+ * - `full` — the thread replaces the channel timeline in the main column
+ *   (the channel sidebar lives outside the pane, so it always stays visible).
+ *   The timeline stays mounted but hidden, so its scroll and composer state
+ *   survive closing the thread.
  *
  * Persisted in localStorage. This is a device-level UI preference, not
  * community-scoped data, so it is intentionally not reset on community switch.
  * Only applies at viewport widths wide enough for a two-pane channel view;
  * narrow viewports keep their single-panel/floating-overlay behavior.
  */
-export type ThreadViewMode = "focus" | "split";
+export type ThreadViewMode = "focus" | "split" | "full";
 
 const STORAGE_KEY = "buzz.channels.threadViewMode";
 
 /** Layout used when nothing is stored, or the stored value is unrecognized. */
-const DEFAULT_THREAD_VIEW_MODE: ThreadViewMode = "split";
+const DEFAULT_THREAD_VIEW_MODE: ThreadViewMode = "full";
 
 const listeners = new Set<() => void>();
 
 let threadViewMode = readStoredThreadViewMode();
 
 function parseThreadViewMode(value: string | null | undefined): ThreadViewMode {
-  return value === "focus" || value === "split"
+  return value === "focus" || value === "split" || value === "full"
     ? value
     : DEFAULT_THREAD_VIEW_MODE;
 }
@@ -73,7 +77,7 @@ export function setThreadViewMode(mode: ThreadViewMode): void {
   }
 }
 
-/** How threads should open in a channel: as a focus drawer or a split pane. */
+/** How threads should open in a channel: focus drawer, split pane, or full panel. */
 export function useThreadViewMode(): ThreadViewMode {
   return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -214,10 +214,22 @@ export const ChannelPane = React.memo(function ChannelPane({
     agentPubkeysPending && hasOtherDmParticipant(activeChannel, currentPubkey);
   const isActiveWelcomeChannel =
     activeChannel !== null && isWelcomeExperience(activeChannel);
+  const isOverlay = useIsThreadPanelOverlay();
+  const threadViewMode = useThreadViewMode();
+  // "full" thread mode: the open thread replaces the channel timeline in the
+  // main column (the channel sidebar lives outside ChannelPane, so it always
+  // stays visible). The timeline stays mounted but hidden, so its scroll and
+  // composer state survive closing the thread. Narrow viewports keep their
+  // overlay behavior regardless of this preference.
+  const threadFullPanel =
+    threadViewMode === "full" &&
+    !isOverlay &&
+    (threadHeadMessage != null || shouldShowThreadSkeleton);
+  const singlePanelLayout = isSinglePanelView || threadFullPanel;
   useComposerHeightPadding(
     timelineScrollRef,
     composerWrapperRef,
-    `${activeChannelId}:${isSinglePanelView}:${hasMainComposerOverlay}`,
+    `${activeChannelId}:${singlePanelLayout}:${hasMainComposerOverlay}`,
     "css-variable",
     () => messageTimelineRef.current?.settleAtBottom() ?? false,
   );
@@ -396,7 +408,7 @@ export const ChannelPane = React.memo(function ChannelPane({
     hasMainComposerOverlay &&
     !isComposerDisabled &&
     !isMainDeferredEditPending &&
-    !isSinglePanelView;
+    !singlePanelLayout;
   const hasTypingActivity = typingPubkeys.length > 0;
   // Unified working set for the composer bar: observer-derived turns primary,
   // bot typing fallback (both folded together by agentWorkingSignal). This is
@@ -496,9 +508,7 @@ export const ChannelPane = React.memo(function ChannelPane({
     threadHeadMessage,
   ]);
 
-  const isOverlay = useIsThreadPanelOverlay();
-  const useSplitAuxiliaryPane = !isSinglePanelView && !isOverlay;
-  const threadViewMode = useThreadViewMode();
+  const useSplitAuxiliaryPane = !singlePanelLayout && !isOverlay;
   const useFocusThreadDrawer =
     threadViewMode === "focus" &&
     useSplitAuxiliaryPane &&
@@ -562,13 +572,14 @@ export const ChannelPane = React.memo(function ChannelPane({
     ) : (
       wrapAux(panel, "message-thread-panel", { key: THREAD_SURFACE_KEY })
     );
-  const threadHeaderLeading = useSplitAuxiliaryPane ? (
-    <ThreadViewModeToggle onChange={changeThreadViewMode} />
-  ) : undefined;
+  const threadHeaderLeading =
+    useSplitAuxiliaryPane || (threadFullPanel && !isSinglePanelView) ? (
+      <ThreadViewModeToggle onChange={changeThreadViewMode} />
+    ) : undefined;
   const threadLayoutProps = getThreadPanelLayout({
     headerLeading: threadHeaderLeading,
     isFocusDrawer: useFocusThreadDrawer,
-    isSinglePanelView,
+    isSinglePanelView: singlePanelLayout,
     useSplitAuxiliaryPane,
   });
   const timelineReplyHandler =
@@ -584,15 +595,21 @@ export const ChannelPane = React.memo(function ChannelPane({
           className={cn(
             "pointer-events-none absolute inset-x-0 top-0 z-30 bg-background/80 backdrop-blur-md supports-backdrop-filter:bg-background/70 dark:bg-background/70 dark:backdrop-blur-xl dark:supports-backdrop-filter:bg-background/55",
             channelChrome.headerHeight,
+            threadFullPanel && "hidden",
           )}
           data-testid="channel-shared-header-backdrop"
         />
       ) : null}
 
+      {/* In "full" thread mode the timeline stays mounted (hidden) so its
+          scroll position and composer state survive closing the thread. */}
       {!isSinglePanelView ? (
         <section
           aria-label="Channel messages and composer"
-          className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+          className={cn(
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+            threadFullPanel && "hidden",
+          )}
           inert={channelIsCovered ? true : undefined}
           data-testid="channel-drop-zone"
           onDragEnter={
@@ -955,7 +972,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 }
                 channelId={effectiveAgentSessionChannelId}
                 isSinglePanelView={
-                  useSplitAuxiliaryPane ? false : isSinglePanelView
+                  useSplitAuxiliaryPane ? false : singlePanelLayout
                 }
                 layout={useSplitAuxiliaryPane ? "split" : "standalone"}
                 transparentChrome={useSplitAuxiliaryPane}
@@ -974,7 +991,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                 currentPubkey={currentPubkey}
                 callerChannelId={activeChannelId}
                 isSinglePanelView={
-                  useSplitAuxiliaryPane ? false : isSinglePanelView
+                  useSplitAuxiliaryPane ? false : singlePanelLayout
                 }
                 layout={useSplitAuxiliaryPane ? "split" : "standalone"}
                 transparentChrome={useSplitAuxiliaryPane}

--- a/desktop/src/features/channels/ui/ThreadViewModeToggle.tsx
+++ b/desktop/src/features/channels/ui/ThreadViewModeToggle.tsx
@@ -1,4 +1,4 @@
-import { Columns2, PanelRightOpen } from "lucide-react";
+import { Columns2, PanelRightOpen, Square } from "lucide-react";
 
 import {
   type ThreadViewMode,
@@ -16,20 +16,27 @@ export function shouldRestoreThreadToggleFocus(clickDetail: number): boolean {
  * Both glyphs depict the layout the button switches *to*, never the current one.
  *
  * They also come from one family — each is a picture of a destination, not a verb
- * — because the user watches these two alternate in the same 28px slot. A diagram
+ * — because the user watches the cycle advance in the same 28px slot. A diagram
  * flipping to an action icon reads as two different controls sharing a position.
  *
- * `columns-2` depicts the split destination, while `panel-right-open` depicts
- * the thread expanding from its right-hand pane into the larger focus surface.
- * The latter preserves the thread's spatial origin without implying browser
- * fullscreen or a separate app window.
+ * `panel-right-open` depicts the thread expanding from its right-hand pane into
+ * the larger focus surface, `square` depicts the thread filling the whole main
+ * panel, and `columns-2` depicts the split destination. The first two preserve
+ * the thread's spatial origin without implying browser fullscreen or a separate
+ * app window.
  */
 const THREAD_VIEW_MODE_TOGGLE = {
-  focus: {
-    // Viewing the drawer → offer the pane.
+  full: {
+    // Viewing the full panel → offer the pane.
     icon: Columns2,
     label: "Show thread beside channel",
     target: "split",
+  },
+  focus: {
+    // Viewing the drawer → offer the full panel.
+    icon: Square,
+    label: "Fill the panel with the thread",
+    target: "full",
   },
   split: {
     // Viewing the pane → offer the drawer.

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -812,6 +812,12 @@ export const MessageRow = React.memo(
           )}
           data-message-id={message.id}
           data-testid="message-row"
+          data-author-kind={
+            message.isAgent ||
+            (message.pubkey && isKnownAgentPubkey(message.pubkey))
+              ? "agent"
+              : "human"
+          }
           onAnimationEnd={handleEntranceAnimationEnd}
         >
           {isThreadReplyLayout ? (

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -666,6 +666,11 @@ const THREAD_VIEW_MODE_OPTIONS: {
   description: string;
 }[] = [
   {
+    value: "full",
+    label: "Full panel",
+    description: "Threads fill the whole panel; channels stay on the left",
+  },
+  {
     value: "focus",
     label: "Focus",
     description: "Threads open over the channel, full width",

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -850,3 +850,38 @@
   position: absolute;
   z-index: 0;
 }
+
+/* ── Identity variants (brand exploration) ───────────────────────────────
+ * Active only when a variant stamps `data-identity` on <html> (see
+ * shared/theme/identity-variants.ts). `--agent-accent` is an HSL channel
+ * triplet set inline by the variant; per-variant rules below shape how
+ * agent-authored rows read against human ones. */
+
+/* Shared agent-row treatment: tinted surface + signature edge + the author
+ * name in the agent hue. */
+[data-identity] [data-author-kind="agent"] {
+  background: hsl(var(--agent-accent) / 0.07);
+  box-shadow: inset 2px 0 0 hsl(var(--agent-accent) / 0.75);
+}
+[data-identity] [data-author-kind="agent"] [data-testid="message-author"] {
+  color: hsl(var(--agent-accent));
+}
+
+/* dual — the "read a channel at a glance" direction: strongest tint. */
+[data-identity="dual"] [data-author-kind="agent"] {
+  background: hsl(var(--agent-accent) / 0.11);
+}
+
+/* mono — dev-tool identity: JetBrains Mono on names + channel labels, and a
+ * plain-text AGENT marker instead of a badge. */
+[data-identity="mono"] [data-testid="message-author"],
+[data-identity="mono"] [data-testid^="channel-"] {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+}
+[data-identity="mono"]
+  [data-author-kind="agent"]
+  [data-testid="message-author"]::after {
+  content: " · agent";
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}

--- a/desktop/src/shared/theme/ThemeProvider.tsx
+++ b/desktop/src/shared/theme/ThemeProvider.tsx
@@ -12,6 +12,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invokeTauri } from "@/shared/api/tauri";
 import { isMacPlatform } from "@/shared/lib/platform";
 import { createThemeVars, hexToHsl } from "./adaptive-theme";
+import { applyIdentityVariant, readIdentityVariant } from "./identity-variants";
 import {
   SYNTAX_THEMES,
   type SyntaxThemeName,
@@ -193,6 +194,9 @@ function applyAccentColor(value: string) {
     root.style.setProperty("--sidebar-primary-foreground", background);
     root.style.setProperty("--sidebar-active", foreground);
     root.style.setProperty("--sidebar-active-foreground", background);
+    // Identity variants re-assert their signature vars after every accent
+    // application so they always win over the theme/accent layer.
+    applyIdentityVariant(readIdentityVariant());
     return;
   }
 
@@ -211,6 +215,8 @@ function applyAccentColor(value: string) {
   root.style.setProperty("--sidebar-primary-foreground", fgHsl);
   root.style.setProperty("--sidebar-active", accentHsl);
   root.style.setProperty("--sidebar-active-foreground", fgHsl);
+  // See the neutral branch above.
+  applyIdentityVariant(readIdentityVariant());
 }
 
 /**

--- a/desktop/src/shared/theme/identity-variants.ts
+++ b/desktop/src/shared/theme/identity-variants.ts
@@ -1,0 +1,138 @@
+/**
+ * Brand-identity variants (exploration branch — "give Buzz its own face").
+ *
+ * A variant is a thin layer ON TOP of the theme engine: `applyTheme` /
+ * `applyAccentColor` run first, then `applyIdentityVariant` re-asserts the
+ * variant's signature vars as inline overrides on `:root` and stamps
+ * `data-identity` on `<html>` so the companion CSS (theme.css, "Identity
+ * variants" section) can restyle agent rows, type, and geometry.
+ *
+ * Hooked at the exit points of `applyAccentColor` (ThemeProvider) — every
+ * theme or accent application funnels through there, so variant vars always
+ * win and never go stale across light/dark flips.
+ *
+ * Directions:
+ *   stock — untouched app (default; no attribute, no overrides)
+ *   honey — brand-forward: signature amber accent (the "buzz"/bee identity),
+ *           teal agent signature
+ *   dual  — human/agent duality: indigo for humans, strong cyan treatment
+ *           for agents so a channel reads at a glance
+ *   mono  — dev-tool identity: green accent, violet agents, sharp corners,
+ *           JetBrains Mono on names/labels
+ *
+ * Known limitation (fine for exploration): variants are seeded per page load
+ * (screenshot harness / localStorage); switching variant mid-session without
+ * reload leaves the previous variant's --radius/--primary overrides in place.
+ */
+
+export const IDENTITY_STORAGE_KEY = "buzz-identity-variant";
+
+export const IDENTITY_VARIANTS = ["stock", "honey", "dual", "mono"] as const;
+export type IdentityVariant = (typeof IDENTITY_VARIANTS)[number];
+
+/** HSL channel triplets (shadcn token format), except --radius (length). */
+type VariantVars = {
+  light: Record<string, string>;
+  dark: Record<string, string>;
+};
+
+const VARIANT_VARS: Record<Exclude<IdentityVariant, "stock">, VariantVars> = {
+  honey: {
+    light: {
+      "--primary": "38 92% 44%",
+      "--primary-foreground": "0 0% 100%",
+      "--sidebar-primary": "38 92% 44%",
+      "--sidebar-primary-foreground": "0 0% 100%",
+      "--sidebar-active": "38 92% 44%",
+      "--sidebar-active-foreground": "0 0% 100%",
+      "--buzz-selected-accent": "38 92% 44%",
+      "--agent-accent": "174 84% 32%",
+    },
+    dark: {
+      "--primary": "43 96% 56%",
+      "--primary-foreground": "24 10% 10%",
+      "--sidebar-primary": "43 96% 56%",
+      "--sidebar-primary-foreground": "24 10% 10%",
+      "--sidebar-active": "43 96% 56%",
+      "--sidebar-active-foreground": "24 10% 10%",
+      "--buzz-selected-accent": "43 96% 56%",
+      "--agent-accent": "174 72% 45%",
+    },
+  },
+  dual: {
+    light: {
+      "--primary": "239 84% 60%",
+      "--primary-foreground": "0 0% 100%",
+      "--sidebar-primary": "239 84% 60%",
+      "--sidebar-primary-foreground": "0 0% 100%",
+      "--sidebar-active": "239 84% 60%",
+      "--sidebar-active-foreground": "0 0% 100%",
+      "--buzz-selected-accent": "239 84% 60%",
+      "--agent-accent": "192 91% 36%",
+    },
+    dark: {
+      "--primary": "239 84% 67%",
+      "--primary-foreground": "0 0% 100%",
+      "--sidebar-primary": "239 84% 67%",
+      "--sidebar-primary-foreground": "0 0% 100%",
+      "--sidebar-active": "239 84% 67%",
+      "--sidebar-active-foreground": "0 0% 100%",
+      "--buzz-selected-accent": "239 84% 67%",
+      "--agent-accent": "187 85% 53%",
+    },
+  },
+  mono: {
+    light: {
+      "--primary": "142 76% 36%",
+      "--primary-foreground": "0 0% 100%",
+      "--sidebar-primary": "142 76% 36%",
+      "--sidebar-primary-foreground": "0 0% 100%",
+      "--sidebar-active": "142 76% 36%",
+      "--sidebar-active-foreground": "0 0% 100%",
+      "--buzz-selected-accent": "142 76% 36%",
+      "--agent-accent": "262 83% 58%",
+      "--radius": "0.125rem",
+    },
+    dark: {
+      "--primary": "142 69% 45%",
+      "--primary-foreground": "24 10% 10%",
+      "--sidebar-primary": "142 69% 45%",
+      "--sidebar-primary-foreground": "24 10% 10%",
+      "--sidebar-active": "142 69% 45%",
+      "--sidebar-active-foreground": "24 10% 10%",
+      "--buzz-selected-accent": "142 69% 45%",
+      "--agent-accent": "262 83% 70%",
+      "--radius": "0.125rem",
+    },
+  },
+};
+
+/** Vars only ever set by variants — safe to remove when stock is active. */
+const VARIANT_ONLY_VARS = ["--agent-accent"];
+
+export function readIdentityVariant(): IdentityVariant {
+  try {
+    const stored = window.localStorage.getItem(IDENTITY_STORAGE_KEY);
+    if (stored && (IDENTITY_VARIANTS as readonly string[]).includes(stored)) {
+      return stored as IdentityVariant;
+    }
+  } catch {
+    // Storage unavailable — fall through to stock.
+  }
+  return "stock";
+}
+
+export function applyIdentityVariant(variant: IdentityVariant): void {
+  const root = document.documentElement;
+  if (variant === "stock") {
+    root.removeAttribute("data-identity");
+    for (const key of VARIANT_ONLY_VARS) root.style.removeProperty(key);
+    return;
+  }
+  root.setAttribute("data-identity", variant);
+  const isDark = root.classList.contains("dark");
+  const vars = VARIANT_VARS[variant][isDark ? "dark" : "light"];
+  for (const [key, value] of Object.entries(vars)) {
+    root.style.setProperty(key, value);
+  }
+}

--- a/desktop/tests/e2e/full-thread-shot.spec.ts
+++ b/desktop/tests/e2e/full-thread-shot.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+// Screenshot spec for the "full" thread view mode (thread fills the main
+// panel, channel sidebar stays on the left), rendered with the Honey identity.
+test("full thread mode screenshot", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.addInitScript(() => {
+    localStorage.setItem("buzz.channels.threadViewMode", "full");
+    localStorage.setItem("buzz-identity-variant", "honey");
+  });
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey:
+          "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
+        name: "alice",
+        status: "stopped",
+      },
+    ],
+  });
+  await page.goto("/");
+
+  const rootId = await page.evaluate(() => {
+    const root = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content:
+        "Can we get the supplier reconciliation report ready for Thursday's ops review?",
+      createdAt: 1_700_900_000,
+    });
+    if (!root) throw new Error("Failed to seed thread root");
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content:
+        "Yes — I will pull the deltas from last week and flag anything over 5%.",
+      parentEventId: root.id,
+      createdAt: 1_700_900_060,
+    });
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content:
+        "Draft is up: three suppliers account for 80% of the variance. I annotated the outliers so you can skim it in five minutes.",
+      parentEventId: root.id,
+      createdAt: 1_700_900_120,
+      pubkey:
+        "953d3363262e86b770419834c53d2446409db6d918a57f8f339d495d54ab001f",
+    });
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "general",
+      content: "Perfect, that is exactly the shape I needed. Thanks both.",
+      parentEventId: root.id,
+      createdAt: 1_700_900_180,
+    });
+    return root.id;
+  });
+
+  await page.getByTestId("channel-general").click();
+  const summary = page.locator(
+    `[data-testid="message-thread-summary"][data-thread-head-id="${rootId}"]`,
+  );
+  await expect(summary).toBeVisible();
+  await summary.click();
+
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: "test-results/screenshots/thread-full-panel.png",
+  });
+});

--- a/desktop/tests/e2e/thread-focus-mode.spec.ts
+++ b/desktop/tests/e2e/thread-focus-mode.spec.ts
@@ -187,25 +187,50 @@ test("focus and split preserve reading context and interaction ownership", async
   });
   const anchorId = await topVisibleMessageId(body);
 
+  // The toggle cycles split → focus → full → split. From the focus drawer it
+  // offers the full panel first.
   const focusModeToggle = page.getByRole("button", {
-    name: "Show thread beside channel",
+    name: "Fill the panel with the thread",
   });
   await focusModeToggle.hover();
   await expect(
-    page.getByRole("tooltip", { name: "Show thread beside channel" }),
+    page.getByRole("tooltip", { name: "Fill the panel with the thread" }),
   ).toBeVisible();
   await focusModeToggle.click();
+
+  // Full mode: the drawer is gone, the channel timeline stays mounted but
+  // hidden, and the thread panel fills the main column.
   await expect(drawer).toHaveCount(0);
+  await expect(channel).toBeHidden();
+  await expect(channel).not.toHaveAttribute("inert", "");
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+  await expect(page.getByRole("tooltip")).toHaveCount(0);
+  await expect(
+    body.locator(`[data-message-id="${anchorId}"]`),
+  ).toBeInViewport();
+
+  // The per-switch contract is "the reply being read stays visible": each
+  // switch preserves the top-visible row and centers it, so the reading
+  // anchor walks up a few rows per hop. Re-capture the top-visible row in
+  // the full panel — that is the row the split pane must preserve.
+  const fullAnchorId = await topVisibleMessageId(body);
+
+  // From the full panel the toggle offers the split pane.
+  const fullModeToggle = page.getByRole("button", {
+    name: "Show thread beside channel",
+  });
+  await fullModeToggle.click();
+  await expect(channel).toBeVisible();
   await expect(channel).not.toHaveAttribute("inert", "");
   await expectChannelHeaderUnobscured(page);
   await expect(page.getByRole("tooltip")).toHaveCount(0);
   await expect(page.getByTestId("message-thread-body")).toBeFocused();
   await expect(summary).not.toBeFocused();
   await expect(
-    body.locator(`[data-message-id="${anchorId}"]`),
+    body.locator(`[data-message-id="${fullAnchorId}"]`),
   ).toBeInViewport();
   await expect(
-    body.locator(`[data-message-id="${anchorId}"]`),
+    body.locator(`[data-message-id="${fullAnchorId}"]`),
   ).not.toHaveAttribute("data-highlighted", "true");
 
   // Sidebar background dismissal belongs to the overlay presentation only.
@@ -214,6 +239,7 @@ test("focus and split preserve reading context and interaction ownership", async
     .evaluate((element) => (element as HTMLElement).click());
   await expect(page.getByTestId("message-thread-panel")).toBeVisible();
 
+  const splitAnchorId = await topVisibleMessageId(body);
   const splitModeToggle = page.getByRole("button", { name: "Expand thread" });
   await splitModeToggle.focus();
   await splitModeToggle.press("Enter");
@@ -221,7 +247,7 @@ test("focus and split preserve reading context and interaction ownership", async
   await expect(channel).toHaveAttribute("inert", "");
   await expect(page.getByTestId("thread-view-mode-toggle")).toBeFocused();
   await expect(
-    body.locator(`[data-message-id="${anchorId}"]`),
+    body.locator(`[data-message-id="${splitAnchorId}"]`),
   ).toBeInViewport();
 
   // Focus mode owns Escape even while the rich-text composer and one of its


### PR DESCRIPTION
## What

Two related changes from the app-identity thread (buzz://message?channel=19dd4184-366f-48a2-8c60-444f755f598a&id=279c1f84355d5c1cc1019ba9ca4119448eeec72f58b3496f48e07580713bb545):

1. **Full-panel thread view mode** — a third thread view mode where the open thread replaces the channel timeline in the main column while the channel sidebar stays visible on the left. The timeline stays mounted (hidden), so scroll position and composer state survive closing the thread.
   - Full is the **new default**; the thread-header toggle cycles full → split → focus, and Settings offers the same three-way choice.
   - The layout toggle is only offered when a two-pane layout is actually available; narrow viewports keep single-panel behavior.
   - Reading position is preserved across mode switches via the existing top-visible-row anchor.

2. **Brand identity variant layer** — a variant layer on top of the theme engine: `applyIdentityVariant` re-asserts a variant's signature vars after every theme/accent application and stamps `data-identity` on `<html>`; `MessageRow` articles carry `data-author-kind` (agent/human) for the agent visual signature. Variants: `stock` (default, untouched), `honey`, `dual`, `mono`.
   - **Ships inert**: stock stays the default; the variant is selected via `localStorage["buzz-identity-variant"]` until a settings appearance panel lands.

## How to verify

- `node --import ./test-loader.mjs --experimental-strip-types --test "src/features/channels/**/*.test.mjs"` — 9/9 view-mode unit tests pass.
- `pnpm build:e2e && pnpm exec playwright test --project=smoke tests/e2e/thread-focus-mode.spec.ts tests/e2e/full-thread-shot.spec.ts` — 3/3 pass (mode cycle, cross-mode scroll anchoring, narrow-viewport toggle gating, full-mode screenshot).
- `pnpm exec biome check` on touched files — clean.

## Not in this PR

- Identity settings panel, brand moments (login/empty states/switcher), and mobile variants — follow-up build-out.
- Mid-session variant switching needs a reload (documented in `identity-variants.ts`).
