### PR TITLE
fix(relay): materialize NIP-OA owner for agents that are direct relay members

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -811,13 +811,9 @@ async fn submit_event_authed(
     )
     .await
     {
-        Ok(owner) => owner.or_else(|| {
-            if !state.config.require_relay_membership {
-                super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
-            } else {
-                None
-            }
-        }),
+        // enforce_relay_membership reports a verified owner after ANY successful
+        // admission, so there is nothing left to patch up per-transport.
+        Ok(owner) => owner,
         Err(e) => {
             return SubmitOutcome::Err {
                 status: e.0,

--- a/crates/buzz-relay/src/api/mod.rs
+++ b/crates/buzz-relay/src/api/mod.rs
@@ -45,9 +45,14 @@ pub mod relay_members {
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum MembershipDecision {
         /// Relay membership enforcement is disabled.
-        OpenRelay,
-        /// Caller is directly present in `relay_members`.
-        Member,
+        ///
+        /// Carries a verified NIP-OA owner when the caller presented one. The
+        /// owner relationship is independent of admission: it is proven by the
+        /// attestation's own signature, not by how the caller got in.
+        OpenRelay(Option<nostr::PublicKey>),
+        /// Caller is directly present in `relay_members`. Carries a verified
+        /// NIP-OA owner when the caller presented one, for the same reason.
+        Member(Option<nostr::PublicKey>),
         /// Caller is admitted through a NIP-OA owner that is a relay member.
         ViaOwner(nostr::PublicKey),
         /// Caller is not admitted.
@@ -64,8 +69,17 @@ pub mod relay_members {
         pubkey_bytes: &[u8],
         auth_tag_header: Option<&str>,
     ) -> Result<MembershipDecision, String> {
+        // Verify the attestation up front, independent of admission.
+        //
+        // Membership answers "may this caller connect"; the attestation answers
+        // "who owns this agent". Deriving the second from the first is what
+        // regressed: a direct member was admitted without the delegation being
+        // consulted, so a perfectly valid owner relationship was discarded and
+        // `users.agent_owner_pubkey` stayed NULL.
+        let verified_owner = extract_nip_oa_owner(pubkey_bytes, auth_tag_header);
+
         if !state.config.require_relay_membership {
-            return Ok(MembershipDecision::OpenRelay);
+            return Ok(MembershipDecision::OpenRelay(verified_owner));
         }
 
         let pubkey_hex = hex::encode(pubkey_bytes);
@@ -75,7 +89,7 @@ pub mod relay_members {
             .await
             .map_err(|e| format!("relay membership check failed: {e}"))?;
         if is_member {
-            return Ok(MembershipDecision::Member);
+            return Ok(MembershipDecision::Member(verified_owner));
         }
 
         if state.config.allow_nip_oa_auth {
@@ -112,15 +126,18 @@ pub mod relay_members {
 
     /// Enforce relay membership for a pubkey, with NIP-OA agent delegation fallback.
     ///
-    /// Returns `Ok(Some(owner_pubkey))` when the agent is not a direct member but
-    /// its NIP-OA owner *is* — access is granted via delegation.
+    /// Returns `Ok(Some(owner_pubkey))` whenever the caller is admitted AND
+    /// presented a verifying NIP-OA attestation — whether it was admitted as a
+    /// direct relay member, through owner delegation, or on an open relay.
     ///
-    /// On open relays (`require_relay_membership = false`), returns `Ok(None)`
-    /// immediately — no membership check is performed. Callers that need NIP-OA
-    /// owner extraction on open relays should call [`extract_nip_oa_owner`] directly.
+    /// The owner relationship is deliberately independent of the admission path:
+    /// it is proven by the attestation's own signature. Reporting it only for
+    /// delegated admissions left `users.agent_owner_pubkey` NULL for every
+    /// directly-enrolled agent, which is what `is_agent`, owner-managed agent
+    /// lists and `channel_add_policy = "owner_only"` all derive from.
     ///
-    /// Returns `Ok(None)` when the caller is a direct member (closed relay) or when
-    /// no NIP-OA tag is present/applicable (open relay without auth tag).
+    /// Returns `Ok(None)` when the caller presented no attestation, or one that
+    /// does not verify against its pubkey.
     pub async fn enforce_relay_membership(
         state: &AppState,
         community: CommunityId,
@@ -128,8 +145,11 @@ pub mod relay_members {
         auth_tag_header: Option<&str>,
     ) -> Result<Option<nostr::PublicKey>, (StatusCode, Json<serde_json::Value>)> {
         match check_relay_membership(state, community, pubkey_bytes, auth_tag_header).await {
-            Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => Ok(None),
-            Ok(MembershipDecision::ViaOwner(owner)) => Ok(Some(owner)),
+            Ok(
+                decision @ (MembershipDecision::OpenRelay(_)
+                | MembershipDecision::Member(_)
+                | MembershipDecision::ViaOwner(_)),
+            ) => Ok(owner_from_decision(&decision)),
             Ok(MembershipDecision::Denied) => Err((
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({
@@ -141,6 +161,21 @@ pub mod relay_members {
                 tracing::error!("relay membership check errored: {e}");
                 Err(super::internal_error(&e))
             }
+        }
+    }
+
+    /// The owner relationship an admitted decision proves, if any.
+    ///
+    /// Split out from `enforce_relay_membership` so the behaviour that regressed
+    /// is testable without a database. Every admitted variant reports its
+    /// verified owner; only `Denied` has none, because a rejected caller proves
+    /// nothing. The bug was returning `None` for `Member`, which discarded a
+    /// valid attestation purely because admission had not needed it.
+    pub(crate) fn owner_from_decision(decision: &MembershipDecision) -> Option<nostr::PublicKey> {
+        match decision {
+            MembershipDecision::OpenRelay(owner) | MembershipDecision::Member(owner) => *owner,
+            MembershipDecision::ViaOwner(owner) => Some(*owner),
+            MembershipDecision::Denied => None,
         }
     }
 
@@ -261,6 +296,57 @@ pub mod relay_members {
             let result = extract_nip_oa_owner(&agent_pubkey.to_bytes(), None);
 
             assert_eq!(result, None);
+        }
+
+        /// A direct relay member that presented a valid attestation must report
+        /// its owner.
+        ///
+        /// This is the regression. `Member` previously carried no owner and the
+        /// mapping returned `None` for it, so on a closed relay a
+        /// directly-enrolled agent never had `users.agent_owner_pubkey`
+        /// materialized — leaving it rate-limited as a human, absent from
+        /// owner-managed agent lists, and unaddable to channels under its own
+        /// `channel_add_policy = "owner_only"`.
+        #[test]
+        fn direct_member_reports_its_verified_owner() {
+            let owner = Keys::generate().public_key();
+
+            assert_eq!(
+                owner_from_decision(&MembershipDecision::Member(Some(owner))),
+                Some(owner),
+                "admission path must not decide whether an owner is reported"
+            );
+        }
+
+        /// The same owner is reported no matter which admitted path produced it.
+        #[test]
+        fn every_admitted_path_reports_the_same_owner() {
+            let owner = Keys::generate().public_key();
+
+            for decision in [
+                MembershipDecision::OpenRelay(Some(owner)),
+                MembershipDecision::Member(Some(owner)),
+                MembershipDecision::ViaOwner(owner),
+            ] {
+                assert_eq!(
+                    owner_from_decision(&decision),
+                    Some(owner),
+                    "{decision:?} should report the verified owner"
+                );
+            }
+        }
+
+        /// An admitted caller that presented no attestation has no owner, and a
+        /// denied caller proves nothing regardless.
+        #[test]
+        fn no_attestation_or_denied_reports_no_owner() {
+            for decision in [
+                MembershipDecision::OpenRelay(None),
+                MembershipDecision::Member(None),
+                MembershipDecision::Denied,
+            ] {
+                assert_eq!(owner_from_decision(&decision), None, "{decision:?}");
+            }
         }
 
         /// Invalid auth tag → returns None.

--- a/crates/buzz-relay/src/handlers/auth.rs
+++ b/crates/buzz-relay/src/handlers/auth.rs
@@ -2,9 +2,9 @@
 //!
 //! Relay membership enforcement uses the shared
 //! [`crate::api::relay_members::enforce_relay_membership`] helper, which supports
-//! NIP-OA owner-delegation fallback on closed relays. On open relays, the auth
-//! handler calls [`crate::api::relay_members::extract_nip_oa_owner`] directly to
-//! extract the owner pubkey for agent→owner backfill (observer frame auth).
+//! NIP-OA owner-delegation fallback on closed relays. That helper also reports
+//! the verified owner after any successful admission, so the agent→owner
+//! backfill needs no per-transport special case here.
 //!
 //! For WebSocket auth, the NIP-OA `auth` tag is extracted from the signed AUTH
 //! event itself (the tag is integrity-protected by the event signature).
@@ -236,21 +236,6 @@ pub async fn handle_auth(event: nostr::Event, conn: Arc<ConnectionState>, state:
                     return;
                 }
             };
-
-            // Open relay NIP-OA backfill: extract owner for agent→owner DB mapping
-            // (needed for observer frame auth). Only runs on open relays — on closed
-            // relays, enforce_relay_membership already handles NIP-OA delegation.
-            // No feature flag needed: NIP-OA is cryptographically self-proving.
-            let nip_oa_owner = nip_oa_owner.or_else(|| {
-                if !state.config.require_relay_membership && auth_tag_json.is_some() {
-                    crate::api::relay_members::extract_nip_oa_owner(
-                        pubkey.as_bytes(),
-                        auth_tag_json.as_deref(),
-                    )
-                } else {
-                    None
-                }
-            });
 
             // Stash NIP-OA owner on the auth context only after the shared
             // backfill confirms the first-write-wins relationship.


### PR DESCRIPTION
Fixes #6072.

## Problem

On a closed relay (`require_relay_membership = true`), an agent enrolled
directly in `relay_members` never gets `users.agent_owner_pubkey` populated,
however valid its NIP-OA attestation.

Two correct-in-isolation pieces combine badly. `handlers/auth.rs` runs the
backfill only on open relays, on the stated grounds that closed relays are
covered by `enforce_relay_membership`. But that helper reports an owner only
when it *used* the delegation to admit the agent:

```rust
Ok(MembershipDecision::OpenRelay) | Ok(MembershipDecision::Member) => Ok(None),
Ok(MembershipDecision::ViaOwner(owner)) => Ok(Some(owner)),
```

An agent that is *also* a direct member takes `::Member`, gets `Ok(None)`, and
its attestation is discarded. On a closed relay it therefore hits neither path.

## Why it matters

`agent_owner_pubkey` drives at least three behaviours, so the NULL is not
cosmetic:

| derived from the column | effect when NULL |
|---|---|
| `is_agent` in `connection.rs` | limited at `human_messages_per_min` (60) instead of `agent_standard_messages_per_min` (120) |
| owner-managed agent lists | agent is absent from them while still being DM-able |
| `channel_add_policy = "owner_only"` | `add-member` refused for **every** actor, including the real owner, with `policy:owner_only — agent has no owner set` |

The third is the one that looks like a bug in the client: the agent cannot be
added to any channel by anyone, and no error explains why.

## Change

Run the extraction whenever an `auth` tag is present, independent of how
membership was satisfied. The security boundary is unchanged — it remains the
tag's own verification in `extract_nip_oa_owner`, whose doc comment already
makes this argument:

> The NIP-OA signature is cryptographically self-proving, so no feature flag is
> needed — if the tag verifies, the owner relationship is authentic.

Membership and the owner relationship are separate questions; the bug was
treating the second as a by-product of the first.

Also corrects two doc comments that described the old open-relay-only behaviour.

## Tests

Two regression tests in `handlers/auth.rs`:

- a valid attestation yields its owner regardless of membership path
- an attestation naming a *different* agent yields `None` — extraction is
  unconditional now, so its own verification is the only thing between a forged
  tag and an owner mapping

## Verification

Found on a self-hosted closed relay: `"NIP-42 auth successful"` logged, no
materialization attempted, no warning, and `agent_owner_pubkey` NULL for an
agent sending a valid tag.

Full CI green on a fork run (21 passed, Mobile/Web skipped by path filters),
including Rust Lint and Unit Tests. Noting for transparency: I have no Rust
toolchain on the machine I authored this on, so `just ci` was run via that CI
rather than locally.