### PR TITLE
test(desktop): stabilize community validation route check

### DIFF
--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -858,7 +858,14 @@ test.describe("community rail", () => {
       ),
     ).toBe(1);
     await page.getByTestId(`community-rail-button-${COMMUNITY_B.id}`).click();
-    await expect(page).not.toHaveURL(/#\/channels\/general$/);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("buzz-active-community-id"),
+        ),
+      )
+      .toBe(COMMUNITY_B.id);
+    await expect(page).toHaveURL(/#\/channels\/general$/);
     await expect
       .poll(() =>
         page.evaluate((communityId) => {


### PR DESCRIPTION
## Summary

The community-switch test asserted that the remembered channel was absent from the URL immediately after clicking community B. The switch intentionally writes that channel route before recording B as active, so the negative assertion races the async switch: it can pass against the transient Home route or time out after the switch completes.

Wait for community B's active-community marker, then assert the remembered route. The later assertions still verify that failed live validation preserves the remembered destination and a successful authoritative read repairs it to Home.

### Related issue

Addresses the separate `:716` failure signature in #6007. #4652 covers only the keyboard-reorder failure from the same issue. No existing pull request covers this route-validation failure.

### Testing

- With the completed-switch wait and the existing negative URL assertion, 5/5 runs failed at that assertion.
- With the corrected positive assertion, 60/60 runs passed with retries disabled:
  `PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-results.json CI=1 pnpm --dir desktop exec playwright test tests/e2e/community-rail.spec.ts --project=smoke --grep 'does not repair a remembered channel until live validation succeeds' --repeat-each=60 --workers=1 --retries=0 --max-failures=0 --reporter=json`
- `pnpm --dir desktop exec biome check tests/e2e/community-rail.spec.ts`
- `pnpm --dir desktop typecheck`
- `CHECK_FILE_SIZES_BASE=upstream/main just ci`
- Screenshots: N/A (test-only change)
