### PR TITLE
buzz-acp: accept owner control commands with rendered mention text

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -157,7 +157,7 @@ The gate applies to **all** inbound events — @mentions, DMs, thread replies, a
 
 Use `!cancel` to stop only the current turn; it is a no-op when the channel is idle. Use `!rotate` when you want the next turn in the channel to start from a fresh ACP session, even if the channel is currently idle.
 
-Owner control commands must be kind:9 stream messages from the owner, must mention this agent with a `p` tag, and are consumed by the harness instead of being forwarded to the agent.
+Owner control commands must be kind:9 stream messages from the owner, must mention this agent with a `p` tag, and are consumed by the harness instead of being forwarded to the agent. Send them the way you would any mention — `@Fountain Maintainer !rotate` — the harness ignores the mention text the client renders into the body (`@Name …` or `nostr:npub…`, before or after the command) and matches on the command alone. Content that does not begin with the mention, or that continues past the command ("please !rotate", "!rotate now"), is an ordinary message and is forwarded to the agent.
 
 > **Note:** The default mode is `owner-only`. Agents without a registered `agent_owner_pubkey` will not respond to any events until the owner is resolved. Set `--respond-to anyone` to disable the gate entirely.
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3638,6 +3638,46 @@ fn workflow_attributed_author(event: &nostr::Event, relay_self: Option<&str>) ->
     Some(owner.to_hex())
 }
 
+/// Does `content` carry exactly one owner control `command`, allowing for the
+/// mention text a client renders into the message body?
+///
+/// Clients that mention an agent (desktop, mobile) insert the mention into the
+/// content as literal text — `@Fountain Maintainer !rotate` — alongside the
+/// `p` tag. The `p` tag is what proves the mention; the text is decoration. So
+/// a command matches when the trimmed content is:
+///
+/// - the bare command (`!rotate`), or
+/// - mention text followed by whitespace and the command
+///   (`@Fountain Maintainer !rotate`, `nostr:npub1… !rotate`), or
+/// - the command followed by whitespace and mention text
+///   (`!rotate @Fountain Maintainer`).
+///
+/// Mention text must start with `@` or `nostr:` and may contain spaces (display
+/// names are multi-word, and the harness does not know its own rendered name,
+/// so `@Fountain Maintainer please !rotate` also matches). Content that does
+/// not start with a mention, or that continues past the command — "please
+/// !rotate", "!rotate now" — is a normal message and is forwarded to the agent.
+fn control_command_content_matches(content: &str, command: &str) -> bool {
+    let content = content.trim();
+    if content == command {
+        return true;
+    }
+    let is_mention_text = |s: &str| s.starts_with('@') || s.starts_with("nostr:");
+    if let Some(prefix) = content.strip_suffix(command) {
+        let trimmed = prefix.trim_end();
+        if trimmed.len() < prefix.len() && is_mention_text(trimmed) {
+            return true;
+        }
+    }
+    if let Some(suffix) = content.strip_prefix(command) {
+        let trimmed = suffix.trim_start();
+        if trimmed.len() < suffix.len() && is_mention_text(trimmed) {
+            return true;
+        }
+    }
+    false
+}
+
 fn is_owner_control_command(
     event: &nostr::Event,
     kind_u32: u32,
@@ -3645,7 +3685,7 @@ fn is_owner_control_command(
     agent_pubkey_hex: &str,
 ) -> bool {
     kind_u32 == KIND_STREAM_MESSAGE
-        && event.content.trim() == command
+        && control_command_content_matches(&event.content, command)
         && event_mentions_agent(event, agent_pubkey_hex)
 }
 
@@ -5261,6 +5301,43 @@ mod owner_control_command_tests {
             "!rotate",
             &agent
         ));
+    }
+
+    #[test]
+    fn owner_control_command_tolerates_rendered_mention_text() {
+        // Desktop/mobile insert the mention as literal text next to the p tag.
+        for content in [
+            "@Fountain Maintainer !rotate",
+            "@Fountain Maintainer  !rotate ",
+            "!rotate @Fountain Maintainer",
+            "nostr:npub1abc !rotate",
+            "@fm !rotate",
+            // Display names are multi-word and unknown to the harness, so
+            // words between the mention and the command are treated as part
+            // of the mention text.
+            "@Fountain Maintainer please !rotate",
+        ] {
+            assert!(
+                control_command_content_matches(content, "!rotate"),
+                "{content:?} should match"
+            );
+        }
+        // Anything that is not just mention text around the command is a
+        // normal message for the agent.
+        for content in [
+            "please !rotate",
+            "!rotate now",
+            "@Fountain Maintainer!rotate",
+            "@Fountain Maintainer !rotate now",
+            "!rotate !cancel",
+            "@Fountain Maintainer !rotates",
+            "",
+        ] {
+            assert!(
+                !control_command_content_matches(content, "!rotate"),
+                "{content:?} should not match"
+            );
+        }
     }
 
     #[test]

--- a/docs/welcome-kickoff-silent-failures.md
+++ b/docs/welcome-kickoff-silent-failures.md
@@ -406,7 +406,8 @@ That splits the problem in half in one run:
 ## 5. Backlog
 
 **`!cancel` / `!shutdown` / `!rotate` are unreachable from every product
-surface.** `is_owner_control_command` (`lib.rs:2476`) requires *all* of: kind:9,
+surface.** *(Fixed: `is_owner_control_command` now tolerates the rendered
+`@Name` / `nostr:` mention text around the command.)* `is_owner_control_command` (`lib.rs:2476`) requires *all* of: kind:9,
 `content.trim() == "!cancel"` (**exact**), and a `p` tag naming the agent. But
 every surface derives the `p` tag *from `@Name` text in the content* (Desktop:
 `hasMention.ts:143`; CLI: `resolve_content_mentions`, `messages.rs:128` —


### PR DESCRIPTION
Fixes #6014, fixes #6051.

## Summary

`!shutdown` / `!cancel` / `!rotate` were unreachable from the desktop (and mobile) UI. `is_owner_control_command` required all of: kind:9, `content.trim() == "!rotate"` **exactly**, and a `p` tag mentioning the agent. But clients render a mention as literal text in the body alongside the `p` tag, so:

- `@Fountain Maintainer !rotate` → has the `p` tag, but content ≠ `"!rotate"` → forwarded to the agent as a prompt (agent replies "not sure what `!rotate` should do here")
- bare `!rotate` → content matches, but no `p` tag → dropped

This was already called out in `docs/welcome-kickoff-silent-failures.md` §5 as mutually exclusive on every real surface.

## Fix

New `control_command_content_matches`: a command matches when the trimmed content is the bare command, or the command is the last/first token with only mention text (`@…` / `nostr:…`, spaces allowed since display names are multi-word) on the other side. Content that does not begin with a mention, or that continues past the command (`please !rotate`, `!rotate now`), is still forwarded as an ordinary message. Owner + `p`-mention + kind:9 checks are unchanged.

Since the harness doesn't know its own rendered display name, `@Fountain Maintainer please !rotate` also matches — documented in the fn doc and README.

## Related work

- #6014 (@sfasching) and #6051 (@jeff-theta) — both report exactly this: the exact-content and `p`-tag requirements are jointly unsatisfiable from the Desktop composer. This PR is the harness-side fix for both.
- #5866 (@johnnyclawson26-aumico) — item 2 of that four-part PR also relaxes the matcher, by dropping every whitespace token that starts with `@` before comparing. That handles single-word names (`@zai !cancel`) but, as its own doc comment notes, a multi-word display name (`@Fountain Maintainer !rotate` → `Maintainer !rotate`) still fails to match. This PR instead treats everything from the leading `@`/`nostr:` up to the trailing command as mention text, so multi-word names work, and it's scoped to just this fix so it can land independently. Happy to defer to #5866 if that lands first — the two would conflict on `is_owner_control_command`.
- #3711 / #3877 / #3916 — command *feedback* (acknowledging consumed commands in the channel). Orthogonal: they assume the command fires; this makes it fire from a real client. #6014 points out the silent-prompt failure here is probably the substrate of the "commands feel invisible" experience.
- #932 — the original `!rotate` PR.

## Test plan

- [x] `cargo test -p buzz-acp --lib owner_control_command` — new `owner_control_command_tolerates_rendered_mention_text` covers the accepted and rejected shapes
- [x] `cargo clippy -p buzz-acp --all-targets`, `cargo fmt`
- [ ] Manual: send `@<agent> !rotate` from desktop as owner; harness logs the rotate and does not reply conversationally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
