### PR TITLE
fix(agent): surface retries and honor Retry-After

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3968,20 +3968,33 @@ fn handle_prompt_result(
                     and then re-send."
                     .to_string();
                 spawn_failure_notice(rest_client, &batch, content);
-            } else if let Some(dead) = queue.requeue(batch) {
-                let reason = match &result.outcome {
-                    PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
-                    PromptOutcome::Timeout(TimeoutKind::Hard { .. }) => {
-                        "the turn exceeded the maximum duration".to_string()
-                    }
-                    PromptOutcome::AgentExited => "the agent process exited".to_string(),
-                    PromptOutcome::Error(e) => format!("{e}"),
-                    _ => "repeated failures".to_string(),
-                };
-                let content = format!(
-                    "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
-                );
-                spawn_failure_notice(rest_client, &dead, content);
+            } else {
+                let first_failure = queue.retry_count(&batch.channel_id) == 0;
+                if first_failure {
+                    spawn_failure_notice(
+                        rest_client,
+                        &batch,
+                        "⚠️ I couldn't complete that request. I'm retrying automatically; no action is needed yet."
+                            .to_string(),
+                    );
+                }
+                if let Some(dead) = queue.requeue(batch) {
+                    let reason = match &result.outcome {
+                        PromptOutcome::Timeout(TimeoutKind::Idle) => {
+                            "the turn timed out".to_string()
+                        }
+                        PromptOutcome::Timeout(TimeoutKind::Hard { .. }) => {
+                            "the turn exceeded the maximum duration".to_string()
+                        }
+                        PromptOutcome::AgentExited => "the agent process exited".to_string(),
+                        PromptOutcome::Error(e) => format!("{e}"),
+                        _ => "repeated failures".to_string(),
+                    };
+                    let content = format!(
+                        "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
+                    );
+                    spawn_failure_notice(rest_client, &dead, content);
+                }
             }
         } else {
             tracing::debug!(

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -409,6 +409,14 @@ impl EventQueue {
         }
     }
 
+    /// Number of failed processing attempts already recorded for a channel.
+    ///
+    /// Used by the harness to emit one immediate user-visible retry notice,
+    /// without repeating that notice on every exponential-backoff attempt.
+    pub(crate) fn retry_count(&self, channel_id: &Uuid) -> u32 {
+        self.retry_counts.get(channel_id).copied().unwrap_or(0)
+    }
+
     /// Re-queue a batch of events that failed to process.
     ///
     /// Events are pushed back to the **front** of the channel's queue so they
@@ -3131,6 +3139,25 @@ mod tests {
         // Retry state is cleared so fresh traffic isn't throttled.
         assert!(!q.retry_counts.contains_key(&ch));
         assert!(!q.retry_after.contains_key(&ch));
+    }
+
+    #[test]
+    fn test_retry_count_tracks_first_failure_and_resets_after_success() {
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        q.push(make_queued(ch, "retry-visible"));
+        let batch = q.flush_next().expect("flush");
+
+        assert_eq!(q.retry_count(&ch), 0);
+        assert!(q.requeue(batch).is_none());
+        assert_eq!(q.retry_count(&ch), 1);
+        q.mark_complete(ch);
+
+        q.retry_after
+            .insert(ch, Instant::now() - Duration::from_secs(1));
+        let _batch = q.flush_next().expect("retry flush");
+        q.mark_complete(ch);
+        assert_eq!(q.retry_count(&ch), 0);
     }
 
     #[test]

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -1902,15 +1902,23 @@ where
             )));
         }
         if status.is_server_error() || status == 429 || status.as_u16() == 499 {
+            let retry_after = (status == 429)
+                .then(|| parse_retry_after_header(resp.headers()))
+                .flatten();
             let body = read_error_body(resp).await;
             if attempt + 1 < MAX_RETRIES {
                 tracing::warn!(
                     attempt = attempt + 1,
                     max_attempts = MAX_RETRIES,
                     %status,
+                    retry_after_ms = retry_after.map(|delay| delay.as_millis() as u64),
                     "llm: retryable status, retrying"
                 );
-                backoff_with_jitter(attempt).await;
+                if let Some(delay) = retry_after {
+                    tokio::time::sleep(delay).await;
+                } else {
+                    backoff_with_jitter(attempt).await;
+                }
                 continue;
             }
             return Err(PostError::Agent(terminal_llm_error(
@@ -7486,6 +7494,39 @@ mod tests {
         .await
         .expect("second attempt succeeds");
         assert_eq!(out["choices"][0]["message"]["content"], "ok");
+        assert!(
+            before.elapsed() >= Duration::from_secs(1),
+            "must sleep at least the Retry-After hint"
+        );
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    /// The generic OpenAI-compatible transport honors Retry-After too. Azure
+    /// Foundry uses this path, so ignoring the header would immediately spend
+    /// all three attempts inside the same throttling window.
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_429_honors_retry_after_header() {
+        let (url, _captured, attempts) = spawn_openrouter_stub(vec![
+            CannedResponse::new(429, r#"{"error":{"message":"rate limited"}}"#)
+                .with_header("Retry-After", "1"),
+            CannedResponse::new(200, r#"{"ok":true}"#),
+        ])
+        .await;
+        let http = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap();
+        let before = std::time::Instant::now();
+        let out = post(
+            &http,
+            &format!("{url}/x"),
+            &json!({}),
+            Duration::from_secs(5),
+            |request| request,
+        )
+        .await
+        .expect("second attempt succeeds");
+        assert_eq!(out["ok"], true);
         assert!(
             before.elapsed() >= Duration::from_secs(1),
             "must sleep at least the Retry-After hint"


### PR DESCRIPTION
## Summary

When a provider turn fails transiently, the harness currently stays silent until the full retry budget is exhausted. For Azure Foundry that can leave a healthy, online agent visibly unresponsive for about 25 minutes. The generic OpenAI-compatible transport also ignores the provider's `Retry-After` hint on HTTP 429, so its three attempts can land inside the same throttle window.

This change:

- posts one immediate user-visible notice on the first generic retry, while preserving the existing final dead-letter notice
- suppresses repeated notices on later exponential-backoff attempts
- honors bounded `Retry-After` hints on the generic OpenAI-compatible transport used by Azure Foundry, falling back to existing jittered backoff
- logs only the retry delay metadata, not response content

### Related issue

Closest existing issue: #5196. Related: #5557 and #5918 / #5975.

This is complementary rather than duplicate work: #5557 is the relay HTTP publish path; this PR changes the `buzz-agent` provider transport. #5975 parks recognized multi-hour subscription-limit errors; this PR gives immediate feedback for the generic retry path and does not change retry/dead-letter policy.

### Testing

- regression test proves the generic OpenAI-compatible transport waits for `Retry-After` before its successful retry
- queue regression test proves the first-failure counter increments and resets after completion
- `cargo test -p buzz-agent -p buzz-acp`
- `cargo clippy -p buzz-agent -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- full `just ci` (workspace lint/tests, desktop, web, Tauri, and 1,465 mobile tests)

No desktop or mobile UI changes.

### Follow-up

After merge and an upstream image release, downstream deployments can pin the released digest; no deployment-specific fork is required.