### PR TITLE
feat(agent): default the reply guard on

### DIFF
--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -164,24 +164,24 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `BUZZ_AGENT_MAX_LINE_BYTES` | `4194304` | 4 MiB. Hard cap on inbound JSON-RPC frames. |
 | `BUZZ_AGENT_MAX_HISTORY_BYTES` | `1048576` | 1 MiB. Old turns are evicted past this. |
 | `BUZZ_AGENT_MAX_TOOL_RESULT_TEXT_BYTES` | `51200` | 50 KiB. Per-result cap on tool-output text; oversize is middle-elided (head + tail kept) with an inline marker. Images are exempt. |
-| `BUZZ_AGENT_REQUIRE_REPLY` | `0` (`1` on mesh) | `1` enables the [reply guard](#reply-guard) — remind the model to publish when a turn is about to end with nothing posted to Buzz. Desktop defaults it to `1` for Buzz shared-compute agents. |
+| `BUZZ_AGENT_REQUIRE_REPLY` | `1` | `0` disables the [reply guard](#reply-guard) — remind the model to publish when a turn is about to end with nothing posted to Buzz. |
 
 
 ## Reply Guard
 
-Off by default, except on Buzz shared-compute (mesh) agents, where Buzz Desktop
-sets `BUZZ_AGENT_REQUIRE_REPLY=1` automatically. With it enabled, a turn that is
-about to end without any recognized attempt to post to Buzz gets a reminder that
-its assistant text is invisible to humans, and is rerolled.
+On by default. A turn that is about to end without any recognized attempt to
+post to Buzz gets a reminder that its assistant text is invisible to humans,
+and is rerolled.
 
 This exists because a Buzz agent's reasoning and tool output are not shown to
 anyone. A turn that does real work and never posts is a silent failure — the
 requester waits on a result that was produced and thrown away.
 
-Mesh agents get it by default because they run on small local models, which are
-the ones most likely to do the work and then end the turn without publishing it.
-Setting `BUZZ_AGENT_REQUIRE_REPLY=0` on the agent, persona, or global env opts a
-mesh agent back out; the default never overrides an explicit value.
+Setting `BUZZ_AGENT_REQUIRE_REPLY=0` on the agent, persona, or global env opts
+out. Buzz shared-compute (mesh) agents also always get it via Desktop's
+`insert_default_if_unset`, which never overrides an explicit value — so an
+agent, persona, or global `BUZZ_AGENT_REQUIRE_REPLY=0` still opts a mesh agent
+out even though the binary's own default now agrees with it.
 
 **Advisory, never a trap.** At most two reminders, then the turn ends whether or
 not anything was published. The guard catches accidental omission; it does not

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -818,8 +818,8 @@ pub struct Config {
     /// disable `_Stop` hooks entirely (agent always honors end_turn).
     pub stop_max_rejections: u32,
     /// Remind the model to publish when a turn is about to end without any
-    /// recognized attempt to post to Buzz. Default off; opt in per agent with
-    /// `BUZZ_AGENT_REQUIRE_REPLY=1`.
+    /// recognized attempt to post to Buzz. Default on; opt out per agent with
+    /// `BUZZ_AGENT_REQUIRE_REPLY=0`.
     ///
     /// Advisory only: at most `MAX_REPLY_NAGS` reminders (see `agent.rs`),
     /// then the turn ends regardless. Bounded by the same
@@ -958,7 +958,7 @@ impl Config {
             max_parallel_tools: parse_env("BUZZ_AGENT_MAX_PARALLEL_TOOLS", 8usize)?,
             hook_timeout: Duration::from_millis(parse_env("BUZZ_AGENT_HOOK_TIMEOUT_MS", 2500u64)?),
             stop_max_rejections: parse_env("BUZZ_AGENT_STOP_MAX_REJECTIONS", 3u32)?,
-            require_reply: parse_env("BUZZ_AGENT_REQUIRE_REPLY", 0u8)? != 0,
+            require_reply: parse_env("BUZZ_AGENT_REQUIRE_REPLY", 1u8)? != 0,
             hook_servers: parse_hook_servers_env("MCP_HOOK_SERVERS"),
             hints_enabled: parse_env("BUZZ_AGENT_NO_HINTS", 0u8)? == 0,
             thinking_effort: parse_thinking_effort(env("BUZZ_AGENT_THINKING_EFFORT").as_deref())?,

--- a/crates/buzz-agent/tests/databricks_oauth.rs
+++ b/crates/buzz-agent/tests/databricks_oauth.rs
@@ -23,6 +23,14 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
+/// A `cwd` value that `Path::is_absolute()` accepts on every platform this
+/// suite runs on. `/tmp` is absolute on Unix but not on Windows (it lacks a
+/// drive prefix), so `session/new` rejects it there with "cwd must be an
+/// absolute path" before the test ever reaches the behavior under test.
+fn test_cwd() -> String {
+    std::env::temp_dir().to_string_lossy().into_owned()
+}
+
 #[derive(Deserialize)]
 struct TokenForm {
     grant_type: String,
@@ -518,6 +526,9 @@ impl AgentHarness {
             .env("BUZZ_AGENT_MAX_ROUNDS", "2")
             .env("BUZZ_AGENT_MAX_SESSIONS", max_sessions.to_string())
             .env("BUZZ_AGENT_MCP_INIT_TIMEOUT_SECS", "2")
+            // This suite predates the reply guard and doesn't exercise it;
+            // pinned off so a nag can't perturb its ACP envelope assertions.
+            .env("BUZZ_AGENT_REQUIRE_REPLY", "0")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -584,8 +595,11 @@ async fn run_single_prompt(provider: &str, base: &str, model: &str) {
     )
     .await;
     h.recv_for(1).await;
-    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
-        .await;
+    h.send(
+        "session/new",
+        json!({ "cwd": test_cwd(), "mcpServers": [] }),
+    )
+    .await;
     let r = h.recv_for(2).await;
     let sid = r["result"]["sessionId"].as_str().unwrap().to_string();
     h.send(
@@ -782,8 +796,11 @@ async fn run_with_set_model(
     )
     .await;
     h.recv_for(1).await;
-    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
-        .await;
+    h.send(
+        "session/new",
+        json!({ "cwd": test_cwd(), "mcpServers": [] }),
+    )
+    .await;
     let r = h.recv_for(2).await;
     let sid = r["result"]["sessionId"].as_str().unwrap().to_string();
 
@@ -932,8 +949,11 @@ async fn session_set_model_unknown_session_returns_error() {
     )
     .await;
     h.recv_for(1).await;
-    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
-        .await;
+    h.send(
+        "session/new",
+        json!({ "cwd": test_cwd(), "mcpServers": [] }),
+    )
+    .await;
     h.recv_for(2).await;
 
     // Call set_model with a bogus session ID.
@@ -969,8 +989,11 @@ async fn session_set_model_empty_model_id_returns_error() {
     )
     .await;
     h.recv_for(1).await;
-    h.send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
-        .await;
+    h.send(
+        "session/new",
+        json!({ "cwd": test_cwd(), "mcpServers": [] }),
+    )
+    .await;
     let r = h.recv_for(2).await;
     let sid = r["result"]["sessionId"].as_str().unwrap().to_string();
 
@@ -1111,7 +1134,10 @@ async fn oauth_missing_token_uses_configured_model_then_retries_discovery() {
     assert!(h.recv_for(initialize).await.get("result").is_some());
 
     let first = h
-        .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .send(
+            "session/new",
+            json!({ "cwd": test_cwd(), "mcpServers": [] }),
+        )
         .await;
     let first_response = h.recv_for(first).await;
     assert!(
@@ -1127,7 +1153,10 @@ async fn oauth_missing_token_uses_configured_model_then_retries_discovery() {
     write_cached_oauth_token(h.oauth_home(), &host, "cached-bearer");
 
     let second = h
-        .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .send(
+            "session/new",
+            json!({ "cwd": test_cwd(), "mcpServers": [] }),
+        )
         .await;
     let second_response = h.recv_for(second).await;
     assert!(
@@ -1182,7 +1211,10 @@ async fn non_auth_discovery_failure_uses_configured_model_without_caching_fallba
 
     for expected_attempts in 1..=2 {
         let request = h
-            .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+            .send(
+                "session/new",
+                json!({ "cwd": test_cwd(), "mcpServers": [] }),
+            )
             .await;
         let response = h.recv_for(request).await;
         assert!(
@@ -1250,7 +1282,7 @@ async fn rejected_static_token_does_not_consume_capacity_or_spawn_mcp() {
     let failed = h
         .send(
             "session/new",
-            json!({ "cwd": "/tmp", "mcpServers": mcp_servers }),
+            json!({ "cwd": test_cwd(), "mcpServers": mcp_servers }),
         )
         .await;
     let failed_response = h.recv_for(failed).await;
@@ -1269,7 +1301,10 @@ async fn rejected_static_token_does_not_consume_capacity_or_spawn_mcp() {
     );
 
     let retry = h
-        .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .send(
+            "session/new",
+            json!({ "cwd": test_cwd(), "mcpServers": [] }),
+        )
         .await;
     let retry_response = h.recv_for(retry).await;
     assert!(

--- a/crates/buzz-agent/tests/fake_llm.rs
+++ b/crates/buzz-agent/tests/fake_llm.rs
@@ -16,6 +16,14 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 
+/// A `cwd` value that `Path::is_absolute()` accepts on every platform this
+/// suite runs on. `/tmp` is absolute on Unix but not on Windows (it lacks a
+/// drive prefix), so `session/new` rejects it there with "cwd must be an
+/// absolute path" before the test ever reaches the behavior under test.
+fn test_cwd() -> String {
+    std::env::temp_dir().to_string_lossy().into_owned()
+}
+
 async fn spawn_fake_llm(responses: Vec<Value>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let url = format!("http://{}", listener.local_addr().unwrap());
@@ -182,6 +190,10 @@ impl Harness {
             .env("BUZZ_AGENT_LLM_TIMEOUT_SECS", "5")
             .env("BUZZ_AGENT_TOOL_TIMEOUT_SECS", "5")
             .env("BUZZ_AGENT_MAX_ROUNDS", "4")
+            // This suite predates the reply guard and asserts exact LLM-call
+            // counts / response shapes that a nag would perturb; none of it
+            // exercises the guard itself, so it's pinned off.
+            .env("BUZZ_AGENT_REQUIRE_REPLY", "0")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -276,7 +288,7 @@ async fn init_session(h: &mut Harness) -> String {
     let r = h.recv().await;
     assert_eq!(r["result"]["protocolVersion"], 2);
     assert_eq!(r["result"]["agentInfo"]["name"], "buzz-agent");
-    h.send("session/new", json!({"cwd":"/tmp","mcpServers":[]}))
+    h.send("session/new", json!({"cwd": test_cwd(),"mcpServers":[]}))
         .await;
     let r = h.recv().await;
     let sid = r["result"]["sessionId"].as_str().unwrap().to_owned();
@@ -371,7 +383,7 @@ async fn unsupported_image_response_recovers_without_replaying_image() {
         .send(
             "session/new",
             json!({
-                "cwd": "/tmp",
+                "cwd": test_cwd(),
                 "mcpServers": [{
                     "name": "fake",
                     "command": env!("CARGO_BIN_EXE_fake-mcp"),
@@ -465,7 +477,10 @@ async fn unsupported_image_without_image_in_history_fails_instead_of_looping() {
     .await;
     let _ = h.recv().await;
     let session_id = h
-        .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .send(
+            "session/new",
+            json!({ "cwd": test_cwd(), "mcpServers": [] }),
+        )
         .await;
     let session = h.recv_until(|v| v["id"] == json!(session_id)).await;
     let sid = session["result"]["sessionId"].as_str().unwrap();
@@ -611,7 +626,7 @@ async fn session_new_rejects_oversized_system_prompt() {
     let id = h
         .send(
             "session/new",
-            json!({"cwd":"/tmp","mcpServers":[],"systemPrompt": big_prompt}),
+            json!({"cwd": test_cwd(),"mcpServers":[],"systemPrompt": big_prompt}),
         )
         .await;
     let r = h.recv_until(|v| v["id"] == json!(id)).await;
@@ -648,7 +663,7 @@ async fn system_prompt_reaches_llm_system_role() {
     let sn_id = h
         .send(
             "session/new",
-            json!({"cwd":"/tmp","mcpServers":[],"systemPrompt": canary}),
+            json!({"cwd": test_cwd(),"mcpServers":[],"systemPrompt": canary}),
         )
         .await;
     let r = h.recv_until(|v| v["id"] == json!(sn_id)).await;
@@ -716,7 +731,7 @@ async fn system_prompt_absent_no_canary() {
 
     // session/new WITHOUT systemPrompt field.
     let sn_id = h
-        .send("session/new", json!({"cwd":"/tmp","mcpServers":[]}))
+        .send("session/new", json!({"cwd": test_cwd(),"mcpServers":[]}))
         .await;
     let r = h.recv_until(|v| v["id"] == json!(sn_id)).await;
     let sid = r["result"]["sessionId"].as_str().unwrap().to_owned();

--- a/crates/buzz-agent/tests/golden_transcripts.rs
+++ b/crates/buzz-agent/tests/golden_transcripts.rs
@@ -8,6 +8,14 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 
+/// A `cwd` value that `Path::is_absolute()` accepts on every platform this
+/// suite runs on. `/tmp` is absolute on Unix but not on Windows (it lacks a
+/// drive prefix), so `session/new` rejects it there with "cwd must be an
+/// absolute path" before the test ever reaches the behavior under test.
+fn test_cwd() -> String {
+    std::env::temp_dir().to_string_lossy().into_owned()
+}
+
 struct Harness {
     child: tokio::process::Child,
     stdin: tokio::process::ChildStdin,
@@ -25,6 +33,11 @@ impl Harness {
             .env("BUZZ_AGENT_LLM_TIMEOUT_SECS", "5")
             .env("BUZZ_AGENT_TOOL_TIMEOUT_SECS", "5")
             .env("BUZZ_AGENT_MAX_ROUNDS", "4")
+            // This suite predates the reply guard and asserts exact
+            // transcripts a nag would perturb; none of it exercises the
+            // guard itself, so it's pinned off (an explicit override in
+            // `extra` still wins, since that loop runs after this).
+            .env("BUZZ_AGENT_REQUIRE_REPLY", "0")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -193,7 +206,10 @@ async fn handshake(h: &mut Harness) -> String {
     );
 
     let new_id = h
-        .send("session/new", json!({ "cwd": "/tmp", "mcpServers": [] }))
+        .send(
+            "session/new",
+            json!({ "cwd": test_cwd(), "mcpServers": [] }),
+        )
         .await;
     let new = h.recv_for_id(new_id).await;
     let sid = new["result"]["sessionId"].as_str().unwrap().to_owned();

--- a/crates/buzz-agent/tests/regressions.rs
+++ b/crates/buzz-agent/tests/regressions.rs
@@ -1918,12 +1918,17 @@ async fn prompt_to_completion(h: &mut Harness, sid: &str) -> Value {
     }
 }
 
-/// Default off: a silent turn ends on the first end_turn with no extra round.
-/// This is the invariant that keeps the feature free for everyone who hasn't
-/// opted in.
+/// Default ON: a turn that ends without publishing is reminded once before it
+/// is allowed to end. This is the inverse of the invariant this test asserted
+/// while the guard was opt-in, and it is the contract that makes the guard
+/// reach runs Desktop's mesh launcher never touches — manual runs, dev runs,
+/// and non-Desktop harnesses.
+///
+/// The reminder is bounded (`MAX_REPLY_NAGS`) and explicitly licenses silence,
+/// so this costs a silent turn one extra round, not a forced reply.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn reply_guard_off_by_default() {
-    let llm = spawn_capturing_llm(vec![openai_text("done"), openai_text("unexpected")]).await;
+async fn reply_guard_on_by_default() {
+    let llm = spawn_capturing_llm(vec![openai_text("done"), openai_text("still done")]).await;
     let mut h = Harness::spawn(&llm.url).await;
     let sid = init_session(&mut h, json!([])).await;
 
@@ -1931,10 +1936,9 @@ async fn reply_guard_off_by_default() {
     assert_eq!(r["result"]["stopReason"], "end_turn");
 
     let captured = llm.captured.lock().await;
-    assert_eq!(
-        captured.len(),
-        1,
-        "guard must be inert when unset, got {} LLM calls",
+    assert!(
+        captured.len() > 1,
+        "guard must nag an unpublished turn when unset, got {} LLM call(s)",
         captured.len()
     );
     h.shutdown().await;

--- a/crates/buzz-agent/tests/regressions.rs
+++ b/crates/buzz-agent/tests/regressions.rs
@@ -15,6 +15,14 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 
+/// A `cwd` value that `Path::is_absolute()` accepts on every platform this
+/// suite runs on. `/tmp` is absolute on Unix but not on Windows (it lacks a
+/// drive prefix), so `session/new` rejects it there with "cwd must be an
+/// absolute path" before the test ever reaches the behavior under test.
+fn test_cwd() -> String {
+    std::env::temp_dir().to_string_lossy().into_owned()
+}
+
 struct CapturingLlm {
     url: String,
     captured: Arc<Mutex<Vec<Value>>>,
@@ -105,7 +113,29 @@ struct Harness {
 }
 
 impl Harness {
+    /// Pins the reply guard off by default. Most of this suite predates the
+    /// guard and asserts exact LLM-call counts that a nag would inflate; an
+    /// explicit `BUZZ_AGENT_REQUIRE_REPLY` in `extra` still overrides this,
+    /// since `extra` is applied after. The one test that needs the real
+    /// unset default (`reply_guard_on_by_default`) uses
+    /// `spawn_with_true_env_defaults` instead.
     async fn spawn_with_env(base_url: &str, extra: &[(&str, &str)]) -> Self {
+        Self::spawn_with_env_inner(base_url, extra, true).await
+    }
+
+    /// Like `spawn_with_env`, but sends no reply-guard override at all — not
+    /// even the off-by-default pin — so the guard's actual compiled-in
+    /// default reaches the process. Only `reply_guard_on_by_default` should
+    /// call this; every other test wants `spawn_with_env` or `spawn`.
+    async fn spawn_with_true_env_defaults(base_url: &str, extra: &[(&str, &str)]) -> Self {
+        Self::spawn_with_env_inner(base_url, extra, false).await
+    }
+
+    async fn spawn_with_env_inner(
+        base_url: &str,
+        extra: &[(&str, &str)],
+        pin_reply_guard_off: bool,
+    ) -> Self {
         let bin = env!("CARGO_BIN_EXE_buzz-agent");
         let mut cmd = tokio::process::Command::new(bin);
         cmd.env("BUZZ_AGENT_PROVIDER", "openai")
@@ -116,6 +146,9 @@ impl Harness {
             .env("BUZZ_AGENT_TOOL_TIMEOUT_SECS", "5")
             .env("BUZZ_AGENT_MAX_ROUNDS", "8")
             .env("BUZZ_AGENT_MCP_INIT_TIMEOUT_SECS", "2");
+        if pin_reply_guard_off {
+            cmd.env("BUZZ_AGENT_REQUIRE_REPLY", "0");
+        }
         for (k, v) in extra {
             cmd.env(k, v);
         }
@@ -279,7 +312,7 @@ async fn init_session(h: &mut Harness, mcp_servers: Value) -> String {
     let _ = h.recv().await;
     h.send(
         "session/new",
-        json!({"cwd":"/tmp","mcpServers": mcp_servers}),
+        json!({"cwd": test_cwd(), "mcpServers": mcp_servers}),
     )
     .await;
     let r = h
@@ -352,7 +385,7 @@ async fn mcp_init_timeout_kills_child() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "stuck",
                 "command": fake_mcp,
@@ -397,7 +430,7 @@ async fn tool_metadata_caps_enforced() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "many",
                 "command": fake_mcp,
@@ -470,8 +503,11 @@ async fn mcp_server_count_cap() {
             })
         })
         .collect();
-    h.send("session/new", json!({"cwd":"/tmp","mcpServers": servers}))
-        .await;
+    h.send(
+        "session/new",
+        json!({"cwd": test_cwd(), "mcpServers": servers}),
+    )
+    .await;
     let r = h
         .recv_until(|v| v.get("result").is_some() || v.get("error").is_some())
         .await;
@@ -649,7 +685,7 @@ async fn per_turn_tool_call_cap_enforced() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "many",
                 "command": fake_mcp,
@@ -724,7 +760,7 @@ async fn description_clamping_enforced() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "big",
                 "command": fake_mcp,
@@ -790,7 +826,7 @@ async fn init_session_with_fake_mcp(h: &mut Harness, extra_mcp_env: &[(&str, &st
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "fake",
                 "command": fake_mcp,
@@ -1928,8 +1964,15 @@ async fn prompt_to_completion(h: &mut Harness, sid: &str) -> Value {
 /// so this costs a silent turn one extra round, not a forced reply.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn reply_guard_on_by_default() {
-    let llm = spawn_capturing_llm(vec![openai_text("done"), openai_text("still done")]).await;
-    let mut h = Harness::spawn(&llm.url).await;
+    let llm = spawn_capturing_llm(vec![
+        openai_text("done"),
+        openai_text("still done"),
+        openai_text("truly done"),
+    ])
+    .await;
+    // Not `spawn`/`spawn_with_env` — both pin the guard off for the rest of
+    // this suite. This test exists to prove the *unset* compiled-in default.
+    let mut h = Harness::spawn_with_true_env_defaults(&llm.url, &[]).await;
     let sid = init_session(&mut h, json!([])).await;
 
     let r = prompt_to_completion(&mut h, &sid).await;
@@ -3567,7 +3610,7 @@ async fn handoff_cap_binds_within_a_single_turn() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "cap_test",
                 "command": fake_mcp,
@@ -3763,7 +3806,7 @@ async fn failed_summarize_burns_handoff_attempt_budget() {
     h.send(
         "session/new",
         json!({
-            "cwd": "/tmp",
+            "cwd": test_cwd(),
             "mcpServers": [{
                 "name": "budget_test",
                 "command": fake_mcp,

--- a/desktop/src-tauri/src/managed_agents/relay_mesh.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_mesh.rs
@@ -59,9 +59,12 @@ pub fn apply_relay_mesh_env(
     // may deliberately choose a smaller cap or a different effort. This function
     // runs after those layers during readiness, so never clobber their values.
     insert_default_if_unset(env, "BUZZ_AGENT_MAX_OUTPUT_TOKENS", "4096");
-    // Mesh agents run on small local models, which are the ones most likely to
-    // do the work and then end the turn without publishing it — the failure the
-    // reply guard exists to catch. Everywhere else it stays opt-in and unset.
+    // Redundant with the buzz-agent binary's own default, which is now on, and
+    // kept deliberately. Mesh agents run on small local models — the ones most
+    // likely to do the work and then end the turn without publishing it, which
+    // is the failure the reply guard exists to catch — so this line states the
+    // requirement at the layer that knows about it, rather than inheriting it
+    // from a default another crate could reasonably revisit.
     // A default, not policy: an explicit `0` from the agent/persona/global env
     // survives (see `insert_default_if_unset`, and the copy-forward list in
     // `relay_mesh_process_env` that preserves it through the spawn path).

--- a/docs/MCP_DRIVEN_HOOKS.md
+++ b/docs/MCP_DRIVEN_HOOKS.md
@@ -68,9 +68,9 @@ Hooks are **off by default**. The operator must explicitly opt in via
 ### Not a hook: the reply guard
 
 `buzz-agent` has one in-process objection at the `_Stop` gate that is **not** an
-MCP hook and exposes no hook tool: the reply guard
-(`BUZZ_AGENT_REQUIRE_REPLY=1`), which reminds the model to publish when a turn is
-about to end with nothing posted to Buzz. There is no `_ReplyGuard` tool to
+MCP hook and exposes no hook tool: the reply guard, which reminds the model to
+publish when a turn is about to end with nothing posted to Buzz. It is on by
+default; `BUZZ_AGENT_REQUIRE_REPLY=0` opts out. There is no `_ReplyGuard` tool to
 implement and no server to allowlist — the env var and the recognition contract
 are documented in
 [crates/buzz-agent/README.md](../crates/buzz-agent/README.md#reply-guard).


### PR DESCRIPTION
Split out of #5888, where it was a stray commit that the PR description argued *against*. It is a product-default change to the `buzz-agent` binary and deserves to be reviewed as one.

## What changes

`BUZZ_AGENT_REQUIRE_REPLY` defaults to on. `BUZZ_AGENT_REQUIRE_REPLY=0` on the agent, persona, or global env still opts out.

## Why

The guard reminds a model that is about to end a turn without having published anything. The failure it catches is an agent doing real work and then ending the turn silently — the work then exists nowhere.

Desktop already forces it on for mesh agents (`relay_mesh.rs`, `insert_default_if_unset`). The binary's `false` default therefore only governed the paths Desktop never touches: manual runs, dev runs, and non-Desktop harnesses. Those silently missed the guard.

## The argument against, stated fairly

The existing comment at `relay_mesh.rs:62-64` said *"Everywhere else it stays opt-in and unset"*, and that was a deliberate choice, not an oversight: the guard is calibrated for **small local models**, which are the ones that exhibit this failure. Frontier models mostly do not. Turning it on globally taxes every silent turn to catch a failure that is rare on the models most agents run — and the base prompt tells agents that "silence is usually correct."

Three things make that cost smaller than it first appears:

- **It is bounded.** `MAX_REPLY_NAGS = 2`, and the reminders share the `BUZZ_AGENT_STOP_MAX_REJECTIONS` budget, which can cut it lower. Setting that budget to `0` disables the guard entirely.
- **It does not compel speech.** The reminder text explicitly ends *"if silence is genuinely correct for this turn, ignore this and end your turn"*, and the code comment on `MAX_REPLY_NAGS` says the guard "exists to catch accidental omission, not to compel speech."
- **The recurring-cost case is narrower than it sounds.** `BUZZ_ACP_HEARTBEAT_INTERVAL` defaults to `0` (disabled), so absent an explicit heartbeat configuration a silent turn only happens when an agent was genuinely woken and chose not to publish — which is the case worth catching.

Weighed against invisible work loss, that trade looks right. Reviewers who disagree should say so here rather than in a circuit-breaker PR, which is the point of the split.

## Completing the flip

The default change alone is not self-consistent, and this is most of the diff:

- **`reply_guard_off_by_default` asserted the opposite contract.** It spawned with no env override and asserted exactly one LLM call, documented as *"the invariant that keeps the feature free for everyone who hasn't opted in."* That is precisely what this reverses, so it is renamed to `reply_guard_on_by_default` and inverted. Shipping the flip without this leaves `cargo test -p buzz-agent` red.
- **The `=0` opt-out test is untouched** and is now the more important of the pair: it is the only thing standing between a user who opted out and a guard that ignores them.
- **`relay_mesh.rs`** no longer claims the guard is opt-in elsewhere. The mesh line is kept rather than deleted as newly redundant — it states the requirement at the layer that knows *why* small local models need it, instead of inheriting a default another crate could reasonably revisit.
- **`docs/MCP_DRIVEN_HOOKS.md`** described the guard as `(BUZZ_AGENT_REQUIRE_REPLY=1)`, which read as the opt-in switch; it now states the default and the opt-out.

## Verification (updated)

The original version of this PR could not run `buzz-agent`'s integration test suite at all on this machine — every test failed during `session/new` setup with `"cwd must be an absolute path"`, a pre-existing Windows bug in the test harnesses (they hardcoded `cwd: "/tmp"`, which isn't absolute on Windows). That's now fixed, which made it possible to actually exercise this PR's own claims locally instead of deferring everything to CI — and doing so surfaced two real bugs the "unexecuted" tests were hiding:

1. **The default flip broke ~21 pre-existing regression tests** in `regressions.rs` that assert exact LLM-call counts or transcripts and predate the guard. None of them anticipated a reply-guard nag turn. Fixed by pinning `BUZZ_AGENT_REQUIRE_REPLY=0` as the base spawn env in each of the four independent test harnesses this crate's test suite uses (`regressions.rs`, `fake_llm.rs`, `golden_transcripts.rs`, `databricks_oauth.rs` — there's no shared test module, each `tests/*.rs` file is its own binary), so tests that don't care about the guard keep their pre-flip behavior. An explicit override in a test's own env list still wins over the pin.
2. **`reply_guard_on_by_default` itself was wrong.** It supplied only 2 canned LLM responses, but this harness registers no publish-capable tool, so every text-only reply reads as "silent" to the guard — it nags twice (`MAX_REPLY_NAGS`) before giving up, which is 3 LLM calls, not 2. The 3rd call hit the fake server's empty response queue and produced a JSON-RPC error instead of `end_turn`. Fixed by adding a 3rd canned response.

Both are now fixed in a follow-up commit, and everything is actually green locally, not just compiled:

- `regressions.rs`: 52/52
- `fake_llm.rs`: 20/20
- `golden_transcripts.rs`: 16/16
- `databricks_oauth.rs`: 17/18 — the one remaining failure (`oauth_missing_token_uses_configured_model_then_retries_discovery`) reproduces identically on unmodified `main` with no other changes; confirmed unrelated to this PR.
- `cargo test -p buzz-agent --lib`: 450/451 — the one failure (`hints::tests::discover_skills_dedup_by_name`) is also pre-existing and unrelated (a Windows path-separator assumption in a file this PR never touches).
- `cargo fmt` and `cargo clippy -p buzz-agent --tests -- -D warnings` clean.

