### PR TITLE
fix(desktop): support Turkish huddle transcription

### DIFF
--- a/desktop/src-tauri/src/huddle/OPENAI_WHISPER_LICENSE.txt
+++ b/desktop/src-tauri/src/huddle/OPENAI_WHISPER_LICENSE.txt
@@ -1,0 +1,30 @@
+OpenAI Whisper Base multilingual
+Copyright (c) 2022 OpenAI
+
+Licensed under the MIT License:
+https://github.com/openai/whisper/blob/main/LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Original model: https://github.com/openai/whisper
+Converted to ONNX with int8 quantization by the sherpa-onnx project
+(https://github.com/k2-fsa/sherpa-onnx); Buzz ships this conversion unmodified.
+
+Provided "AS IS", without warranty of any kind, express or implied. See the
+license text for full warranty disclaimer.

--- a/desktop/src-tauri/src/huddle/latency_bench.rs
+++ b/desktop/src-tauri/src/huddle/latency_bench.rs
@@ -152,7 +152,7 @@ fn baseline_stt_fake_llm_tts_first_audio() {
     );
 
     let t = Instant::now();
-    let (stt, mut text_rx) = SttPipeline::new(stt_dir, None, None).expect("stt pipeline");
+    let (stt, mut text_rx) = SttPipeline::new(stt_dir, None, None, None).expect("stt pipeline");
     // Recognizer loads inside the worker thread; give it time, then verify
     // liveness via a first throwaway feed below.
     std::thread::sleep(Duration::from_secs(2));

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -41,6 +41,7 @@ pub mod relay_api;
 pub mod state;
 pub mod stt;
 pub mod transcription;
+pub mod transcription_settings;
 pub mod tts;
 pub mod tts_settings;
 mod tts_voice_import;
@@ -768,7 +769,7 @@ pub fn push_audio_pcm(
     }
 }
 
-/// Trigger a background download of voice models (Parakeet STT + Pocket TTS).
+/// Trigger a background download of voice models (Whisper STT + Pocket TTS).
 ///
 /// Returns immediately — downloads run in tokio background tasks.
 /// Poll `get_model_status` to track progress.

--- a/desktop/src-tauri/src/huddle/models.rs
+++ b/desktop/src-tauri/src/huddle/models.rs
@@ -1,7 +1,7 @@
-//! Model download manager for STT (Parakeet TDT-CTC 110M) and TTS (Pocket TTS) models.
+//! Model download manager for STT (Whisper Base multilingual) and TTS (Pocket TTS) models.
 //!
 //! Mental model:
-//!   app launch → start_stt_download (background) → ~/.buzz/models/parakeet-tdt-ctc-110m-en/
+//!   app launch → start_stt_download (background) → ~/.buzz/models/whisper-base-multilingual/
 //!   app launch → start_tts_download (background) → ~/.buzz/models/pocket-tts/
 //!   STT pipeline → is_stt_ready() → stt_model_dir() → run inference
 //!   TTS pipeline → is_tts_ready() → tts_model_dir() → run synthesis
@@ -10,12 +10,11 @@
 //! is written alongside model files — if the on-disk version doesn't match the
 //! compiled-in version, the model is re-downloaded.
 //!
-//! Upgrade note: an older Moonshine STT model directory at
-//! `~/.buzz/models/moonshine-tiny/` is removed best-effort once the new STT
-//! model finishes installing successfully. Cleanup is gated on the new model
-//! being Ready, so a failed download never removes the previous on-disk model
-//! during migration. If removal fails (permissions, etc.) the leftover is
-//! harmless and can be removed by hand.
+//! Upgrade note: older Moonshine and English-only Parakeet STT model directories
+//! are removed best-effort once the new STT model finishes installing successfully.
+//! Cleanup is gated on the new model being Ready, so a failed download never
+//! removes the previous on-disk model during migration. If removal fails
+//! (permissions, etc.) the leftover is harmless and can be removed by hand.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -42,9 +41,9 @@ mod voice_upgrade;
 // update the corresponding constant.
 
 /// SHA-256 hash of the STT archive
-/// (sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2).
+/// (sherpa-onnx-whisper-base.tar.bz2).
 /// Computed from a known-good download. Update when upgrading model versions.
-const STT_ARCHIVE_SHA256: &str = "17f945007b52ccd8b7200ffc7c5652e9e8e961dfdf479cefcabd06cf5703630b";
+const STT_ARCHIVE_SHA256: &str = "911b2083efd7c0dca2ac3b358b75222660dc09fb716d64fbfc417ba6c99ff3de";
 
 fn pocket_artifact_url(filename: &str) -> String {
     format!(
@@ -89,11 +88,9 @@ const TTS_REFERENCE_ARTIFACT: PocketModelArtifact = PocketModelArtifact {
 // considered stale and re-downloaded. Increment when upgrading model files.
 
 /// Model manifest version for the STT model. Increment when upgrading model files.
-/// Bumped from "1" → "2" alongside the migration from Moonshine Tiny to
-/// Parakeet TDT-CTC 110M — the model directory name also changed, so this
-/// is technically belt-and-suspenders, but it keeps the manifest semantics
-/// honest (each version tag identifies one specific set of model bytes).
-const STT_MODEL_VERSION: &str = "2";
+/// Bumped from "2" → "3" alongside the migration from English-only Parakeet
+/// to multilingual Whisper Base.
+const STT_MODEL_VERSION: &str = "3";
 
 /// Identifies the April INT8 asset set plus the official VCTK presets.
 const TTS_MODEL_VERSION: &str = "5";
@@ -103,58 +100,38 @@ const MANIFEST_FILENAME: &str = ".buzz-model-manifest";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-/// Maximum expected STT archive size (200 MB — actual is ~100 MB).
+/// Maximum expected STT archive size (200 MiB — actual is ~198 MiB).
 const MAX_STT_DOWNLOAD_BYTES: u64 = 200 * 1024 * 1024;
 
 /// Maximum expected Pocket TTS file size. The largest pinned INT8 artifact is
 /// `flow_lm_main_int8.onnx` at 76,341,079 bytes.
 const MAX_TTS_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
-/// NVIDIA Parakeet TDT-CTC 110M (English, int8) — packaged for sherpa-onnx by
-/// k2-fsa. Single ONNX file (CTC head) + tokens.txt. Avg WER ~7.5% across
-/// the OpenASR-style benchmarks; ~half the WER of Moonshine Tiny at ~2× the
-/// disk footprint. CTC blank-token decoding eliminates the silence/cut-audio
-/// hallucination class that hurts encoder-decoder models on noisy huddle audio.
-/// License: CC-BY-4.0 (attribution required — see About dialog).
+/// OpenAI Whisper Base multilingual (int8) packaged for sherpa-onnx by k2-fsa.
+/// The multilingual checkpoint supports Turkish and automatically detects the
+/// spoken language when no language hint is supplied.
 const STT_DOWNLOAD_URL: &str =
     "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/\
-     sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8.tar.bz2";
+     sherpa-onnx-whisper-base.tar.bz2";
 
 /// Subdirectory name produced by `tar xjf` on the archive.
-const STT_ARCHIVE_SUBDIR: &str = "sherpa-onnx-nemo-parakeet_tdt_ctc_110m-en-36000-int8";
+const STT_ARCHIVE_SUBDIR: &str = "sherpa-onnx-whisper-base";
 
 /// Final directory name under `~/.buzz/models/`.
-const STT_MODEL_DIR_NAME: &str = "parakeet-tdt-ctc-110m-en";
+const STT_MODEL_DIR_NAME: &str = "whisper-base-multilingual";
 
 /// All files that must be present for the model to be considered ready.
 ///
-/// Includes the attribution sidecar written by Buzz during install. The
-/// upstream archive does not ship a license file, so readiness should require
-/// the local CC-BY-4.0 attribution to travel with the cached model bytes.
-const STT_EXPECTED_FILES: &[&str] = &["model.int8.onnx", "tokens.txt", STT_LICENSE_FILE_NAME];
+const STT_EXPECTED_FILES: &[&str] = &[
+    "base-encoder.int8.onnx",
+    "base-decoder.int8.onnx",
+    "base-tokens.txt",
+    STT_LICENSE_FILE_NAME,
+];
 
-/// CC-BY-4.0 §3(a)(1) attribution block written next to the STT model files
-/// after install. Travels with the bytes — if a user copies the model
-/// directory, the attribution comes with it. Mirrored in About/Credits.
-///
-/// Covers all five §3(a)(1) bullets: creator, copyright notice, license
-/// notice, warranty disclaimer reference, and URI to the source material.
+/// MIT attribution written next to the STT model files after install.
 const STT_LICENSE_FILE_NAME: &str = "MODEL_LICENSE.txt";
-const STT_LICENSE_TEXT: &str = "\
-NVIDIA Parakeet TDT-CTC 110M (English)
-© NVIDIA Corporation.
-
-Licensed under the Creative Commons Attribution 4.0 International License
-(CC-BY-4.0). License text: https://creativecommons.org/licenses/by/4.0/
-
-Original model: https://huggingface.co/nvidia/parakeet-tdt_ctc-110m
-Converted to ONNX with int8 quantization by the sherpa-onnx project
-(https://github.com/k2-fsa/sherpa-onnx); Buzz ships this conversion
-unmodified.
-
-Provided \"AS IS\", without warranty of any kind, express or implied. See the
-license text for full warranty disclaimer.
-";
+const STT_LICENSE_TEXT: &str = include_str!("OPENAI_WHISPER_LICENSE.txt");
 
 // ── Pocket TTS model ──────────────────────────────────────────────────────────
 
@@ -204,9 +181,9 @@ pub enum ModelStatus {
 
 /// Combined status for all voice models (returned to the frontend).
 ///
-/// `stt` is the speech-to-text model status (currently Parakeet TDT-CTC 110M;
-/// historically Moonshine Tiny). The field name describes the role, not the
-/// specific model, so future model swaps don't ripple into the API surface.
+/// `stt` is the speech-to-text model status (currently Whisper Base multilingual;
+/// historically Parakeet and Moonshine Tiny). The field name describes the role,
+/// not the specific model, so future model swaps don't ripple into the API surface.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoiceModelStatus {
     pub stt: ModelStatus,
@@ -657,14 +634,14 @@ impl ModelManager {
 
     /// Start a background STT model download. No-op if already ready or downloading.
     ///
-    /// Also schedules a best-effort cleanup of the legacy Moonshine model
-    /// directory — but **only when the new STT model is already on disk and
+    /// Also schedules best-effort cleanup of legacy STT model directories —
+    /// but **only when the new STT model is already on disk and
     /// Ready**. This covers the "fast-path" upgrade scenario (new model
     /// installed by a previous build, `download_stt_model` short-circuits, the
     /// post-install cleanup never runs). For users mid-migration (old model
     /// present, new model still downloading) we keep the old files until the
-    /// Parakeet install finishes, avoiding unnecessary data loss if the
-    /// ~100 MB download fails. The post-install path inside
+    /// Whisper install finishes, avoiding unnecessary data loss if the
+    /// download fails. The post-install path inside
     /// `download_stt_model` handles cleanup once the new install reaches Ready.
     pub fn start_stt_download(&self, http_client: reqwest::Client) {
         let manager = self.clone();
@@ -677,10 +654,10 @@ impl ModelManager {
         if self.stt.is_ready(&self.models_dir) {
             // Detached cleanup task — must not block startup. Gated above on
             // the new model being Ready, so a mid-migration user keeps their
-            // existing moonshine-tiny files until Parakeet install completes.
+            // existing STT files until the Whisper install completes.
             let models_dir = self.models_dir.clone();
             tauri::async_runtime::spawn(async move {
-                cleanup_legacy_moonshine_dir(&models_dir).await;
+                cleanup_legacy_stt_dirs(&models_dir).await;
             });
         }
     }
@@ -764,10 +741,14 @@ impl ModelManager {
             ));
         }
 
-        // Write the CC-BY-4.0 attribution sidecar before the atomic install,
+        for unused_model in ["base-encoder.onnx", "base-decoder.onnx"] {
+            let _ = tokio::fs::remove_file(extracted_subdir.join(unused_model)).await;
+        }
+
+        // Write the MIT attribution sidecar before the atomic install,
         // so it lands in the final model dir as part of the same rename. The
-        // upstream tarball ships no LICENSE/NOTICE, so we provide it ourselves
-        // per §3(a)(1) (license must travel with Shared material).
+        // upstream tarball ships no LICENSE/NOTICE, so the required copyright
+        // and permission notice travels with the installed model bytes.
         let license_path = extracted_subdir.join(STT_LICENSE_FILE_NAME);
         if let Err(e) = tokio::fs::write(&license_path, STT_LICENSE_TEXT).await {
             let _ = tokio::fs::remove_dir_all(&temp_dir).await;
@@ -792,7 +773,7 @@ impl ModelManager {
         // failed download never removes the previous on-disk model during
         // migration. The same cleanup also runs from `start_stt_download` to
         // cover users who already have the new model installed.
-        cleanup_legacy_moonshine_dir(&self.models_dir).await;
+        cleanup_legacy_stt_dirs(&self.models_dir).await;
 
         eprintln!(
             "buzz-desktop: STT model ready at {}",
@@ -948,9 +929,9 @@ pub fn is_stt_ready() -> bool {
         .unwrap_or(false)
 }
 
-/// Best-effort cleanup of the legacy Moonshine STT model directory.
+/// Best-effort cleanup of legacy STT model directories.
 ///
-/// Removes `~/.buzz/models/moonshine-tiny/` if present (~70 MB on disk).
+/// Removes the old Moonshine and English-only Parakeet directories if present.
 /// Idempotent — no-op if the directory is absent. Errors are logged and
 /// swallowed; the leftover is harmless and the user can remove it manually.
 ///
@@ -958,21 +939,23 @@ pub fn is_stt_ready() -> bool {
 /// dependency on `ModelManager` state, runs from both pre- and post-install
 /// code paths, and the call site is meant to be easy to delete in a future
 /// release once we're confident no users are still on the old model dir.
-async fn cleanup_legacy_moonshine_dir(models_dir: &Path) {
-    let legacy = models_dir.join("moonshine-tiny");
-    if !legacy.exists() {
-        return;
-    }
-    match tokio::fs::remove_dir_all(&legacy).await {
-        Ok(()) => eprintln!(
-            "buzz-desktop: removed legacy STT model dir {}",
-            legacy.display()
-        ),
-        Err(e) => eprintln!(
-            "buzz-desktop: could not remove legacy STT model dir {}: {e} \
-             (harmless — remove manually to reclaim disk space)",
-            legacy.display()
-        ),
+async fn cleanup_legacy_stt_dirs(models_dir: &Path) {
+    for directory in ["moonshine-tiny", "parakeet-tdt-ctc-110m-en"] {
+        let legacy = models_dir.join(directory);
+        if !legacy.exists() {
+            continue;
+        }
+        match tokio::fs::remove_dir_all(&legacy).await {
+            Ok(()) => eprintln!(
+                "buzz-desktop: removed legacy STT model dir {}",
+                legacy.display()
+            ),
+            Err(e) => eprintln!(
+                "buzz-desktop: could not remove legacy STT model dir {}: {e} \
+                 (harmless — remove manually to reclaim disk space)",
+                legacy.display()
+            ),
+        }
     }
 }
 

--- a/desktop/src-tauri/src/huddle/models_tests.rs
+++ b/desktop/src-tauri/src/huddle/models_tests.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+#[test]
+fn stt_contract_uses_multilingual_whisper_artifacts() {
+    assert_eq!(STT_MODEL_DIR_NAME, "whisper-base-multilingual");
+    assert_eq!(
+        STT_EXPECTED_FILES,
+        &[
+            "base-encoder.int8.onnx",
+            "base-decoder.int8.onnx",
+            "base-tokens.txt",
+            STT_LICENSE_FILE_NAME,
+        ]
+    );
+    assert!(!STT_DOWNLOAD_URL.contains("-en"));
+}
+
 fn create_ready_model_dir(root: &Path) -> PathBuf {
     let model_dir = root.join(TTS_MODEL_DIR_NAME);
     std::fs::create_dir_all(&model_dir).expect("create model dir");

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -296,6 +296,13 @@ pub(crate) async fn maybe_start_stt_pipeline(
         return Ok(false); // Models not downloaded yet — voice-only mode.
     }
     let model_dir = models::stt_model_dir().ok_or("STT model directory not found")?;
+    let transcription_language = state
+        .huddle_audio
+        .tts
+        .lock()
+        .map_err(|error| format!("text-to-speech settings lock poisoned: {error}"))?
+        .transcription_language
+        .clone();
 
     let channel_uuid = parse_channel_uuid(ephemeral_channel_id)?;
 
@@ -353,7 +360,12 @@ pub(crate) async fn maybe_start_stt_pipeline(
     drop(old_stt);
 
     let constructed = tokio::task::spawn_blocking(move || {
-        stt::SttPipeline::new(model_dir, ptt_active_for_stt, manual_mic_unmuted_for_stt)
+        stt::SttPipeline::new(
+            model_dir,
+            transcription_language,
+            ptt_active_for_stt,
+            manual_mic_unmuted_for_stt,
+        )
     })
     .await;
     let (pipeline, text_rx) = match constructed {

--- a/desktop/src-tauri/src/huddle/stt.rs
+++ b/desktop/src-tauri/src/huddle/stt.rs
@@ -9,7 +9,7 @@
 //!   → stt_worker thread
 //!       rubato: 48 kHz → 16 kHz mono
 //!       earshot VAD: accumulate speech frames
-//!       sherpa-onnx Parakeet TDT-CTC 110M: transcribe on silence
+//!       sherpa-onnx Whisper Base multilingual: transcribe on silence
 //!   → text_rx  [mpsc channel]
 //!   → tokio task (start_stt_pipeline)
 //!       builds kind:9 event → relay
@@ -19,7 +19,7 @@
 //! sherpa-onnx is CPU-bound and not Send-safe across await points.
 
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::{self, Receiver, SyncSender},
@@ -82,6 +82,7 @@ impl SttPipeline {
     /// thread on every `recv_timeout` call).
     pub fn new(
         model_dir: PathBuf,
+        transcription_language: Option<String>,
         ptt_active: Option<Arc<AtomicBool>>,
         manual_mic_unmuted: Option<Arc<AtomicBool>>,
     ) -> Result<(Self, tokio_mpsc::Receiver<String>), String> {
@@ -95,14 +96,15 @@ impl SttPipeline {
         let handle = thread::Builder::new()
             .name("stt-worker".into())
             .spawn(move || {
-                stt_worker(
+                stt_worker(SttWorkerConfig {
                     model_dir,
+                    transcription_language,
                     audio_rx,
                     text_tx,
-                    shutdown_worker,
-                    ptt_active_worker,
-                    manual_mic_unmuted_worker,
-                )
+                    shutdown: shutdown_worker,
+                    ptt_active: ptt_active_worker,
+                    manual_mic_unmuted: manual_mic_unmuted_worker,
+                })
             })
             .map_err(|e| format!("failed to spawn stt-worker thread: {e}"))?;
 
@@ -175,7 +177,7 @@ const VAD_THRESHOLD: f32 = 0.5;
 
 /// Minimum voiced audio needed before an utterance may be decoded.
 /// One earshot false-positive frame is only 16 ms; requiring 192 ms prevents
-/// silence/room-noise blips from reaching Parakeet and becoming hallucinated
+/// silence/room-noise blips from reaching Whisper and becoming hallucinated
 /// transcript text while still preserving short replies such as "yes".
 const MIN_VOICED_FRAMES: usize = 12;
 
@@ -185,7 +187,7 @@ const RECV_TIMEOUT: Duration = Duration::from_millis(50);
 /// Number of ONNX Runtime intra-op threads used by the offline recognizer.
 ///
 /// Held at 1 (conservative) until we have a local A/B on real huddle audio.
-/// Sherpa-onnx's Parakeet example uses 2 and most published RTF numbers are
+/// Sherpa-onnx's Whisper examples use 2 and most published RTF numbers are
 /// at 2 threads on x86_64 server class hardware, but the encoder runs only
 /// on VAD chunk boundaries on a dedicated thread, so the threading knob
 /// trades worker latency against potential oversubscription with the audio
@@ -203,7 +205,7 @@ fn stt_num_threads() -> i32 {
         .unwrap_or(STT_NUM_THREADS)
 }
 
-/// EXPERIMENTAL (latency bench): `BUZZ_STT_SPECULATIVE=1` starts the Parakeet
+/// EXPERIMENTAL (latency bench): `BUZZ_STT_SPECULATIVE=1` starts the Whisper
 /// decode at the FIRST silent VAD frame instead of after the full flush
 /// window, overlapping the ~150-250 ms decode with the silence wait. If
 /// speech resumes, the speculative result is discarded. When silence holds
@@ -213,14 +215,26 @@ fn stt_speculative_decode() -> bool {
     std::env::var("BUZZ_STT_SPECULATIVE").is_ok_and(|v| v == "1")
 }
 
-fn stt_worker(
+struct SttWorkerConfig {
     model_dir: PathBuf,
+    transcription_language: Option<String>,
     audio_rx: Receiver<Vec<u8>>,
     text_tx: tokio_mpsc::Sender<String>,
     shutdown: Arc<AtomicBool>,
     ptt_active: Option<Arc<AtomicBool>>,
     manual_mic_unmuted: Option<Arc<AtomicBool>>,
-) {
+}
+
+fn stt_worker(config: SttWorkerConfig) {
+    let SttWorkerConfig {
+        model_dir,
+        transcription_language,
+        audio_rx,
+        text_tx,
+        shutdown,
+        ptt_active,
+        manual_mic_unmuted,
+    } = config;
     // ── 1. Initialise rubato resampler (48 kHz → 16 kHz, mono) ───────────────
     use rubato::{Fft, FixedSync, Resampler};
 
@@ -239,16 +253,19 @@ fn stt_worker(
 
     // ── 3. Initialise sherpa-onnx recognizer ─────────────────────────────────
     //
-    // Parakeet TDT-CTC 110M ships as a single `model.int8.onnx` (CTC head) plus
-    // `tokens.txt`. sherpa-onnx infers the model family from which inner config
-    // has a `model` path set, so we don't need to set `model_type` explicitly.
-    // (See rust-api-examples/parakeet_tdt_ctc_simulate_streaming_microphone.rs
-    // in k2-fsa/sherpa-onnx.)
-    use sherpa_onnx::{OfflineRecognizer, OfflineRecognizerConfig};
+    use sherpa_onnx::OfflineRecognizer;
 
-    let tokens_path = model_dir.join("tokens.txt");
-    let model_path = model_dir.join("model.int8.onnx");
-    if !tokens_path.exists() || !model_path.exists() {
+    let config = recognizer_config(&model_dir, transcription_language.as_deref());
+    let whisper = &config.model_config.whisper;
+    let files_ready = [
+        whisper.encoder.as_deref(),
+        whisper.decoder.as_deref(),
+        config.model_config.tokens.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .all(|path| Path::new(path).exists());
+    if !files_ready {
         eprintln!(
             "buzz-desktop: STT model not found at {} — STT disabled",
             model_dir.display()
@@ -257,15 +274,7 @@ fn stt_worker(
         return;
     }
 
-    let mut cfg = OfflineRecognizerConfig::default();
-    cfg.model_config.nemo_ctc.model = Some(model_path.to_string_lossy().into_owned());
-    cfg.model_config.tokens = Some(tokens_path.to_string_lossy().into_owned());
-    cfg.model_config.num_threads = stt_num_threads();
-    // Explicit — defaults are not part of the API contract, and noisy debug
-    // logging in release builds would be expensive on every VAD chunk.
-    cfg.model_config.debug = false;
-
-    let recognizer = match OfflineRecognizer::create(&cfg) {
+    let recognizer = match OfflineRecognizer::create(&config) {
         Some(r) => r,
         None => {
             eprintln!("buzz-desktop: OfflineRecognizer::create returned None — STT disabled");
@@ -369,6 +378,36 @@ fn stt_worker(
     // No final flush — leave_huddle/end_huddle emit lifecycle events before
     // the STT worker exits, so a final flush would post a kind:9 message AFTER
     // the user has "left." Losing the last partial utterance is acceptable.
+}
+
+fn recognizer_config(
+    model_dir: &Path,
+    transcription_language: Option<&str>,
+) -> sherpa_onnx::OfflineRecognizerConfig {
+    let mut config = sherpa_onnx::OfflineRecognizerConfig::default();
+    config.model_config.whisper.encoder = Some(
+        model_dir
+            .join("base-encoder.int8.onnx")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    config.model_config.whisper.decoder = Some(
+        model_dir
+            .join("base-decoder.int8.onnx")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    config.model_config.whisper.task = Some("transcribe".to_string());
+    config.model_config.whisper.language = transcription_language.map(str::to_string);
+    config.model_config.tokens = Some(
+        model_dir
+            .join("base-tokens.txt")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    config.model_config.num_threads = stt_num_threads();
+    config.model_config.debug = false;
+    config
 }
 
 /// Resample a mono 48 kHz chunk to 16 kHz using rubato.
@@ -570,7 +609,40 @@ use super::drain_until_shutdown;
 
 #[cfg(test)]
 mod tests {
-    use super::{has_enough_voiced_audio, vad_flush_allowed, MIN_VOICED_FRAMES};
+    use super::{has_enough_voiced_audio, recognizer_config, vad_flush_allowed, MIN_VOICED_FRAMES};
+
+    #[test]
+    fn recognizer_uses_multilingual_whisper_with_language_auto_detection() {
+        let model_dir = std::path::Path::new("/models/whisper-base-multilingual");
+        let config = recognizer_config(model_dir, None);
+
+        assert_eq!(
+            config.model_config.whisper.encoder.as_deref(),
+            Some("/models/whisper-base-multilingual/base-encoder.int8.onnx")
+        );
+        assert_eq!(
+            config.model_config.whisper.decoder.as_deref(),
+            Some("/models/whisper-base-multilingual/base-decoder.int8.onnx")
+        );
+        assert_eq!(config.model_config.whisper.language, None);
+        assert_eq!(
+            config.model_config.whisper.task.as_deref(),
+            Some("transcribe")
+        );
+        assert!(config.model_config.nemo_ctc.model.is_none());
+    }
+
+    #[test]
+    fn recognizer_can_force_turkish_for_short_utterances() {
+        let model_dir = std::path::Path::new("/models/whisper-base-multilingual");
+        let config = recognizer_config(model_dir, Some("tr"));
+
+        assert_eq!(config.model_config.whisper.language.as_deref(), Some("tr"));
+        assert_eq!(
+            config.model_config.whisper.task.as_deref(),
+            Some("transcribe")
+        );
+    }
 
     #[test]
     fn short_vad_blips_do_not_reach_the_recognizer() {

--- a/desktop/src-tauri/src/huddle/transcription_settings.rs
+++ b/desktop/src-tauri/src/huddle/transcription_settings.rs
@@ -1,0 +1,82 @@
+use tauri::{AppHandle, State};
+
+use crate::app_state::AppState;
+
+use super::tts_settings::{
+    current_settings, ensure_settings_writable, save_to_path, settings_path, TtsSettings,
+};
+
+pub(crate) fn normalize_transcription_language(
+    language: Option<&str>,
+) -> Result<Option<String>, String> {
+    let language = language.unwrap_or_default().trim().to_ascii_lowercase();
+    if language.is_empty() || language == "auto" {
+        return Ok(None);
+    }
+    if language.len() == 2 && language.bytes().all(|byte| byte.is_ascii_lowercase()) {
+        return Ok(Some(language));
+    }
+    Err("Transcription language must be Auto or a two-letter language code".to_string())
+}
+
+#[tauri::command]
+pub async fn set_transcription_language(
+    language: Option<String>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<TtsSettings, String> {
+    let transition = state.huddle_audio.tts_transition.lock().await;
+    ensure_settings_writable(&state)?;
+    let mut settings = current_settings(&state)?;
+    settings.transcription_language = normalize_transcription_language(language.as_deref())?;
+    save_to_path(&settings_path(&app)?, &settings)?;
+    *state
+        .huddle_audio
+        .tts
+        .lock()
+        .map_err(|error| format!("text-to-speech settings lock poisoned: {error}"))? =
+        settings.clone();
+    drop(transition);
+    Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::huddle::tts_settings::load_from_path;
+
+    #[test]
+    fn accepts_auto_and_iso_639_1_codes() {
+        assert_eq!(normalize_transcription_language(None).unwrap(), None);
+        assert_eq!(normalize_transcription_language(Some("")).unwrap(), None);
+        assert_eq!(
+            normalize_transcription_language(Some("AUTO")).unwrap(),
+            None
+        );
+        assert_eq!(
+            normalize_transcription_language(Some("TR")).unwrap(),
+            Some("tr".to_string())
+        );
+        assert!(normalize_transcription_language(Some("tur"))
+            .expect_err("three-letter language code should fail")
+            .contains("two-letter"));
+    }
+
+    #[test]
+    fn existing_settings_without_language_load_as_auto() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("tts-settings.json");
+        std::fs::write(
+            &path,
+            r#"{"version":1,"agentTextToSpeech":true,"voicePreferences":["pocket:mary"]}"#,
+        )
+        .expect("fixture write");
+
+        assert_eq!(
+            load_from_path(&path)
+                .expect("legacy settings")
+                .transcription_language,
+            None
+        );
+    }
+}

--- a/desktop/src-tauri/src/huddle/tts_settings.rs
+++ b/desktop/src-tauri/src/huddle/tts_settings.rs
@@ -20,6 +20,7 @@ use crate::{app_state::AppState, managed_agents::storage::atomic_write_json_rest
 use super::{
     models,
     pocket::DEFAULT_VOICE,
+    transcription_settings::normalize_transcription_language,
     tts_voice_registry::{source_url, MARY_VOICE_KEY, POCKET_VOICES},
     HuddlePhase, HuddleState,
 };
@@ -136,6 +137,8 @@ pub fn voice_registry(app: &AppHandle) -> Vec<VoiceRegistryEntry> {
 pub struct TtsSettings {
     pub version: u32,
     pub agent_text_to_speech: bool,
+    #[serde(default)]
+    pub transcription_language: Option<String>,
     pub voice_preferences: VoicePreferences,
 }
 
@@ -144,6 +147,7 @@ impl Default for TtsSettings {
         Self {
             version: CURRENT_VERSION,
             agent_text_to_speech: true,
+            transcription_language: None,
             voice_preferences: vec![MARY_VOICE_KEY.to_string()],
         }
     }
@@ -271,6 +275,7 @@ pub(crate) fn load_from_path(path: &Path) -> Result<TtsSettings, String> {
                 .get("agentTextToSpeech")
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
+            transcription_language: None,
             voice_preferences: vec![voice_key],
         });
     }
@@ -286,10 +291,13 @@ pub(crate) fn load_from_path(path: &Path) -> Result<TtsSettings, String> {
     {
         settings.voice_preferences = TtsSettings::default().voice_preferences;
     }
+    settings.transcription_language =
+        normalize_transcription_language(settings.transcription_language.as_deref())?;
     Ok(settings)
 }
 
 pub(crate) fn save_to_path(path: &Path, settings: &TtsSettings) -> Result<(), String> {
+    normalize_transcription_language(settings.transcription_language.as_deref())?;
     if settings.voice_preferences.is_empty() {
         return Err("At least one voice preference is required".to_string());
     }
@@ -345,7 +353,7 @@ pub fn list_voice_registry(app: AppHandle) -> Vec<VoiceRegistryEntry> {
     voice_registry(&app)
 }
 
-fn ensure_settings_writable(state: &AppState) -> Result<(), String> {
+pub(crate) fn ensure_settings_writable(state: &AppState) -> Result<(), String> {
     if let Some(error) = state
         .huddle_audio
         .tts_load_error
@@ -463,7 +471,7 @@ async fn apply_tts_settings(
     Ok(voice_change_wait)
 }
 
-fn current_settings(state: &AppState) -> Result<TtsSettings, String> {
+pub(crate) fn current_settings(state: &AppState) -> Result<TtsSettings, String> {
     state
         .huddle_audio
         .tts
@@ -738,6 +746,7 @@ mod tests {
             TtsSettings {
                 version: 1,
                 agent_text_to_speech: true,
+                transcription_language: None,
                 voice_preferences: vec!["pocket:mary".to_string()],
             }
         );
@@ -864,6 +873,7 @@ mod tests {
             TtsSettings {
                 version: 1,
                 agent_text_to_speech: false,
+                transcription_language: None,
                 voice_preferences: vec![EVE_VOICE_KEY.to_string()],
             }
         );

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -861,6 +861,7 @@ pub fn run() {
             set_tts_enabled,
             huddle::tts_settings::get_tts_settings,
             huddle::tts_settings::list_voice_registry,
+            huddle::transcription_settings::set_transcription_language,
             huddle::tts_settings::set_pocket_voice,
             huddle::tts_settings::preview_pocket_voice,
             huddle::tts_settings::import_pocket_voice,
@@ -978,7 +979,6 @@ pub fn run() {
         RunEvent::Exit => {
             shut_down_app(app_handle, &run_shutdown_done);
             app_handle.state::<ClipboardState>().release();
-
             #[cfg(all(feature = "mesh-llm", target_os = "macos"))]
             if restart_requested.load(Ordering::SeqCst) {
                 relaunch_after_mesh_shutdown(app_handle);

--- a/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
@@ -38,8 +38,15 @@ import {
 export type TtsSettings = {
   version: number;
   agentTextToSpeech: boolean;
+  transcriptionLanguage: string | null;
   voicePreferences: string[];
 };
+
+const TRANSCRIPTION_LANGUAGES = [
+  { value: "auto", label: "Auto" },
+  { value: "tr", label: "Turkish" },
+  { value: "en", label: "English" },
+] as const;
 
 type TtsVoiceMutation = {
   settings: TtsSettings;
@@ -132,6 +139,29 @@ export function VoiceSettingsCard() {
     }
   }, []);
 
+  const saveTranscriptionLanguage = React.useCallback(
+    async (language: string) => {
+      setBusy(true);
+      setError(null);
+      try {
+        const saved = await invokeTauri<TtsSettings>(
+          "set_transcription_language",
+          { language: language === "auto" ? null : language },
+        );
+        setSettings(saved);
+      } catch (saveError) {
+        setError(
+          saveError instanceof Error
+            ? saveError.message
+            : "Transcription language could not be saved.",
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
   const importPocketVoice = React.useCallback(async () => {
     setBusy(true);
     setError(null);
@@ -192,6 +222,50 @@ export function VoiceSettingsCard() {
       />
 
       <SettingsOptionGroupList>
+        <SettingsOptionGroup title="Transcription">
+          <SettingsOptionRow>
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Spoken language</p>
+              <p
+                className="text-sm text-muted-foreground/70"
+                data-settings-subcopy
+              >
+                Used for new huddles. Choose Turkish for reliable short replies.
+              </p>
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  aria-label="Huddle transcription language"
+                  className="min-w-32 justify-between"
+                  data-testid="transcription-language-selector"
+                  disabled={!settings || busy}
+                  variant="outline"
+                >
+                  {TRANSCRIPTION_LANGUAGES.find(
+                    ({ value }) =>
+                      value === (settings?.transcriptionLanguage ?? "auto"),
+                  )?.label ?? "Auto"}
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuRadioGroup
+                  onValueChange={(language) => {
+                    if (settings) void saveTranscriptionLanguage(language);
+                  }}
+                  value={settings?.transcriptionLanguage ?? "auto"}
+                >
+                  {TRANSCRIPTION_LANGUAGES.map(({ value, label }) => (
+                    <DropdownMenuRadioItem key={value} value={value}>
+                      {label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SettingsOptionRow>
+        </SettingsOptionGroup>
         <SettingsOptionGroup title="Playback">
           <SettingsOptionRow>
             <div className="min-w-0">

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -182,6 +182,7 @@ type E2eConfig = {
     ttsSettings?: {
       version: number;
       agentTextToSpeech: boolean;
+      transcriptionLanguage: string | null;
       voicePreferences: string[];
     };
     /** Native picker boundary result for Pocket voice import tests. */
@@ -10929,6 +10930,7 @@ export function maybeInstallE2eTauriMocks() {
           activeConfig?.mock?.ttsSettings ?? {
             version: 1,
             agentTextToSpeech: true,
+            transcriptionLanguage: null,
             voicePreferences: ["pocket:mary"],
           }
         );
@@ -11045,8 +11047,35 @@ export function maybeInstallE2eTauriMocks() {
         const settings = {
           version: 1,
           agentTextToSpeech: enabled,
+          transcriptionLanguage:
+            activeConfig?.mock?.ttsSettings?.transcriptionLanguage ?? null,
           voicePreferences: activeConfig?.mock?.ttsSettings
             ?.voicePreferences ?? ["pocket:mary"],
+        };
+        if (activeConfig) {
+          activeConfig.mock ??= {};
+          activeConfig.mock.ttsSettings = settings;
+        }
+        return settings;
+      }
+      case "set_transcription_language": {
+        const language = (payload as { language?: string | null })?.language;
+        if (
+          language !== undefined &&
+          language !== null &&
+          !/^[a-z]{2}$/.test(language)
+        ) {
+          throw new Error("Invalid transcription language");
+        }
+        const current = activeConfig?.mock?.ttsSettings ?? {
+          version: 1,
+          agentTextToSpeech: true,
+          transcriptionLanguage: null,
+          voicePreferences: ["pocket:mary"],
+        };
+        const settings = {
+          ...current,
+          transcriptionLanguage: language ?? null,
         };
         if (activeConfig) {
           activeConfig.mock ??= {};
@@ -11062,6 +11091,7 @@ export function maybeInstallE2eTauriMocks() {
         const current = activeConfig?.mock?.ttsSettings ?? {
           version: 1,
           agentTextToSpeech: true,
+          transcriptionLanguage: null,
           voicePreferences: ["pocket:mary"],
         };
         const firstPocketIndex = current.voicePreferences.findIndex((key) =>
@@ -11111,6 +11141,7 @@ export function maybeInstallE2eTauriMocks() {
         const current = activeConfig?.mock?.ttsSettings ?? {
           version: 1,
           agentTextToSpeech: true,
+          transcriptionLanguage: null,
           voicePreferences: ["pocket:mary"],
         };
         const settings = {
@@ -11136,6 +11167,7 @@ export function maybeInstallE2eTauriMocks() {
         const current = activeConfig?.mock?.ttsSettings ?? {
           version: 1,
           agentTextToSpeech: true,
+          transcriptionLanguage: null,
           voicePreferences: ["pocket:mary"],
         };
         const settings = {

--- a/desktop/tests/e2e/huddle-transcription.spec.ts
+++ b/desktop/tests/e2e/huddle-transcription.spec.ts
@@ -764,6 +764,7 @@ test("assigns distinct agent voices and exposes compact per-agent controls", asy
     ttsSettings: {
       version: 1,
       agentTextToSpeech: true,
+      transcriptionLanguage: null,
       voicePreferences: ["pocket:vera"],
     },
     huddle: {

--- a/desktop/tests/e2e/voice-settings.spec.ts
+++ b/desktop/tests/e2e/voice-settings.spec.ts
@@ -9,6 +9,30 @@ const SCREENSHOT_PATH = "test-results/voice-settings/pocket-voices.png";
 test.describe("Pocket voice settings", () => {
   test.use({ viewport: { width: 1100, height: 760 } });
 
+  test("sets Turkish for reliable short huddle transcripts", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await openSettings(page, "voice");
+
+    await expect(
+      page.getByTestId("transcription-language-selector"),
+    ).toContainText("Auto");
+    await page.getByTestId("transcription-language-selector").click();
+    await page.getByRole("menuitemradio", { name: "Turkish" }).click();
+    await expect(
+      page.getByTestId("transcription-language-selector"),
+    ).toContainText("Turkish");
+
+    const mutation = await page.evaluate(() =>
+      (window.__BUZZ_E2E_COMMAND_LOG__ ?? []).findLast(
+        (entry) => entry.command === "set_transcription_language",
+      ),
+    );
+    expect(mutation?.payload).toEqual({ language: "tr" });
+  });
+
   test("selects and retains a bundled voice while text to speech is off", async ({
     page,
   }) => {
@@ -74,6 +98,7 @@ test.describe("Pocket voice settings", () => {
       ttsSettings: {
         version: 1,
         agentTextToSpeech: true,
+        transcriptionLanguage: "tr",
         voicePreferences: ["pocket:eve"],
       },
     });

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -150,6 +150,7 @@ type MockBridgeOptions = {
   ttsSettings?: {
     version: number;
     agentTextToSpeech: boolean;
+    transcriptionLanguage: string | null;
     voicePreferences: string[];
   };
   /** Native picker boundary result for Pocket voice import tests. */


### PR DESCRIPTION
## Summary
- replace the English-only huddle recognizer with Whisper Base multilingual
- add Auto, Turkish, and English transcription language settings
- persist the choice for new huddles and retain legacy settings compatibility
- preserve the current 0.5.14 huddle latency and push-to-talk behavior

### Related issue
None found.

### Testing
- reproduced the defect with real Turkish audio: the old English-only model produced phonetic gibberish
- verified the new model with real Turkish audio: Evet and Merhaba, bugün hangi fırsatlar ilgimi bekliyor.
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (2445 passed, 15 ignored in the main desktop library; auxiliary suites passed)
- pnpm check
- pnpm typecheck
- pnpm build:e2e
- pnpm exec playwright test tests/e2e/voice-settings.spec.ts --project=smoke (6 passed)

The installed signed Buzz application was not replaced; this remains source-level verification pending review and a signed release.