### PR TITLE
fix(inbox): clear thread activity when the thread is read

### DIFF
--- a/desktop/src/app/useChannelActivityProjection.test.mjs
+++ b/desktop/src/app/useChannelActivityProjection.test.mjs
@@ -1,7 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveChannelActivityFeedItemReadAt } from "./useChannelActivityProjection.ts";
+import {
+  resolveChannelActivityFeedItemReadAt,
+  resolveThreadActivityItemReadAt,
+} from "./useChannelActivityProjection.ts";
+
+/** A thread reply tagged with its root, in NIP-10 shape. */
+function threadReply(id, channelId, rootId) {
+  return {
+    id,
+    channelId,
+    tags: [
+      ["e", rootId, "", "root"],
+      ["e", rootId, "", "reply"],
+    ],
+  };
+}
 
 test("channel activity read state folds the item's own message and channel markers", () => {
   const markers = new Map([
@@ -26,5 +41,54 @@ test("channel activity read state honors a channel marker without a message mark
       (contextId) => (contextId === "general" ? 300 : null),
     ),
     300,
+  );
+});
+
+test("reading the thread clears its replies even with no message marker", () => {
+  // The regression this guards: only the thread marker moved, and the channel
+  // and per-message markers never did. Before folding the thread frontier in,
+  // this returned null and every reply stayed unread forever.
+  assert.equal(
+    resolveThreadActivityItemReadAt(
+      threadReply("reply-1", "general", "root-1"),
+      () => null,
+      (rootId) => (rootId === "root-1" ? 400 : null),
+    ),
+    400,
+  );
+});
+
+test("a reply's own message marker still wins when it is ahead of the thread", () => {
+  assert.equal(
+    resolveThreadActivityItemReadAt(
+      threadReply("reply-1", "general", "root-1"),
+      (contextId) => (contextId === "msg:reply-1" ? 900 : null),
+      () => 400,
+    ),
+    900,
+  );
+});
+
+test("a different thread's marker does not clear this reply", () => {
+  assert.equal(
+    resolveThreadActivityItemReadAt(
+      threadReply("reply-1", "general", "root-1"),
+      () => null,
+      (rootId) => (rootId === "other-root" ? 400 : null),
+    ),
+    null,
+  );
+});
+
+test("a reply with no resolvable root falls back to the channel-level read state", () => {
+  // Malformed or root-less tags must not throw, and must not silently report
+  // the item as read.
+  assert.equal(
+    resolveThreadActivityItemReadAt(
+      { id: "reply-1", channelId: "general", tags: [] },
+      (contextId) => (contextId === "general" ? 250 : null),
+      () => 999,
+    ),
+    250,
   );
 });

--- a/desktop/src/app/useChannelActivityProjection.ts
+++ b/desktop/src/app/useChannelActivityProjection.ts
@@ -6,7 +6,10 @@ import {
   msgContextKey,
 } from "@/features/channels/readState/readStateFormat";
 import type { ThreadActivityItem } from "@/features/channels/useUnreadChannels";
-import { isThreadReply } from "@/features/messages/lib/threading";
+import {
+  getThreadReference,
+  isThreadReply,
+} from "@/features/messages/lib/threading";
 import type { Channel, FeedItem, HomeFeed } from "@/shared/api/types";
 
 type ReadTimestamp = (contextKey: string) => number | null;
@@ -35,6 +38,29 @@ export function resolveChannelActivityFeedItemReadAt(
   return maxReadAt(
     getOwnReadAt(msgContextKey(item.id)),
     item.channelId ? getOwnReadAt(item.channelId) : null,
+  );
+}
+
+/**
+ * Read frontier for a thread reply, folding in the thread's own marker.
+ *
+ * `resolveChannelActivityFeedItemReadAt` knows only the per-message and
+ * channel markers. Reading a thread advances `thread:<rootId>`, a key it never
+ * looks at — so without this, marking a thread read leaves all of its replies
+ * looking unread indefinitely, since nothing else advances a marker that
+ * function can see. `getThreadReadAt` already folds the channel marker in
+ * itself; taking the max here is belt-and-braces for a reply whose own message
+ * marker is ahead of both.
+ */
+export function resolveThreadActivityItemReadAt(
+  item: Pick<FeedItem, "channelId" | "id" | "tags">,
+  getOwnReadAt: ReadTimestamp,
+  getThreadReadAt: (rootId: string, channelId?: string | null) => number | null,
+): number | null {
+  const rootId = getThreadReference(item.tags).rootId;
+  return maxReadAt(
+    resolveChannelActivityFeedItemReadAt(item, getOwnReadAt),
+    rootId ? getThreadReadAt(rootId, item.channelId) : null,
   );
 }
 
@@ -112,10 +138,16 @@ export function useChannelActivityProjection({
       (item) =>
         isThreadReply(item.tags) &&
         (unreadFeedItemIds.has(item.id) ||
-          item.createdAt > (getChannelActivityItemReadAt(item) ?? 0)),
+          item.createdAt >
+            (resolveThreadActivityItemReadAt(
+              item,
+              getOwnReadAt,
+              getThreadReadAt,
+            ) ?? 0)),
     );
   }, [
-    getChannelActivityItemReadAt,
+    getOwnReadAt,
+    getThreadReadAt,
     locallyUnreadFeedItems,
     readStateVersion,
     threadActivityFeedItems,


### PR DESCRIPTION
Reading a thread leaves every one of its replies looking unread indefinitely. The thread stays in the Inbox no matter how many times you open it — the only thing that clears it is marking each reply read individually.

`resolveChannelActivityFeedItemReadAt` consults the per-message marker (`msg:<id>`) and the channel marker, but not `thread:<rootId>` — which is the one marker that reading a thread actually advances. So the read frontier moves and nothing that consumes it can see the change.

`getThreadReadAt`, fifty lines above in the same file, already computes theright value; it just wasn't used on this path. This adds
`resolveThreadActivityItemReadAt` to fold the thread frontier in alongside the existing markers, and uses it in the `unreadThreadFeedItems` filter.

Tests cover the regression directly: a reply where only the thread marker moved, which resolved to `null` before this change. Also covered — a reply's own message marker still wins when it is ahead, a different thread's marker doesn't clear this one, and a reply with no resolvable root falls back to channel-level read state rather than throwing.