### PR TITLE
fix(mobile): keep #-prefixed markdown link labels visible

### DIFF
--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -282,6 +282,10 @@ class MessageContent extends HookConsumerWidget {
         textAlign: textAlign,
         maxLines: maxLines,
         inlineComponents: [
+          // Own ATag first so link *labels* never re-enter mention/channel/
+          // emoji components (those would turn `[#2959](url)` into an empty
+          // nested WidgetSpan on device). Drop the stock ATagMd below.
+          _AuthoredMarkdownLinkMd(),
           _MentionMd(
             mentionNames: resolvedMentionNames,
             agentMentionPubkeys: resolvedAgentMentionPubkeys,
@@ -292,7 +296,9 @@ class MessageContent extends HookConsumerWidget {
             channelNames: resolvedChannelNames,
             onChannelTap: resolvedChannelTap,
           ),
-          ...MarkdownComponent.inlineComponents,
+          ...MarkdownComponent.inlineComponents.where(
+            (component) => component is! ATagMd,
+          ),
         ],
       ),
     );

--- a/mobile/lib/features/channels/message_content/token_pill.dart
+++ b/mobile/lib/features/channels/message_content/token_pill.dart
@@ -10,10 +10,13 @@ String? _channelNameForId(Map<String, String> channels, String channelId) {
 class _ChannelLinkMd extends InlineMd {
   final Map<String, String> channelNames;
   final void Function(String channelId)? onChannelTap;
+  // Require at least one letter/underscore so digits-only tokens like
+  // `#2959` (common GitHub issue labels) are never claimed as channels.
   late final RegExp _exp = _buildPrefixPattern(
     prefix: '#',
     knownNames: channelNames.keys,
-    genericTokenPattern: r'[A-Za-z0-9_][A-Za-z0-9_-]*',
+    genericTokenPattern:
+        r'(?=[A-Za-z0-9_-]*[A-Za-z_])[A-Za-z0-9_][A-Za-z0-9_-]*',
   );
 
   _ChannelLinkMd({required this.channelNames, this.onChannelTap});
@@ -101,6 +104,118 @@ class _TokenPill extends StatelessWidget {
       button: interactive,
       child: ExcludeSemantics(child: pill),
     );
+  }
+}
+
+/// Markdown `[label](url)` that keeps custom mention/channel/emoji components
+/// out of the *label*. gpt_markdown's default [ATagMd] re-runs the full
+/// `inlineComponents` list on the label, so `_ChannelLinkMd` used to swallow
+/// labels like `#2959` into a token pill and leave the link blank on device.
+class _AuthoredMarkdownLinkMd extends InlineMd {
+  @override
+  RegExp get exp => RegExp(r'(?<!\!)\[.*\]\([^\s]*\)');
+
+  @override
+  InlineSpan span(
+    BuildContext context,
+    String text,
+    final GptMarkdownConfig config,
+  ) {
+    var bracketCount = 0;
+    const start = 1;
+    var end = 0;
+    for (var i = 0; i < text.length; i++) {
+      if (text[i] == '[') {
+        bracketCount++;
+      } else if (text[i] == ']') {
+        bracketCount--;
+        if (bracketCount == 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    if (end + 1 >= text.length || text[end + 1] != '(') {
+      return const TextSpan();
+    }
+
+    final linkText = text.substring(start, end);
+    final urlStart = end + 2;
+
+    var parenCount = 0;
+    var urlEnd = urlStart;
+    for (var i = urlStart; i < text.length; i++) {
+      final char = text[i];
+      if (char == '(') {
+        parenCount++;
+      } else if (char == ')') {
+        if (parenCount == 0) {
+          urlEnd = i;
+          break;
+        }
+        parenCount--;
+      }
+    }
+
+    if (urlEnd == urlStart) {
+      return const TextSpan();
+    }
+
+    final url = text.substring(urlStart, urlEnd).trim();
+    final builder = config.linkBuilder;
+    final ending = text.substring(urlEnd + 1);
+    final endingSpans = MarkdownComponent.generate(
+      context,
+      ending,
+      config,
+      false,
+    );
+    final theme = GptMarkdownTheme.of(context);
+
+    // Formatting (bold/italic/…) stays; mention/channel/emoji pills do not.
+    final labelConfig = config.copyWith(
+      inlineComponents: MarkdownComponent.inlineComponents
+          .where((component) => component is! ATagMd)
+          .toList(growable: false),
+    );
+    final linkTextSpan = TextSpan(
+      children: MarkdownComponent.generate(
+        context,
+        linkText,
+        labelConfig,
+        false,
+      ),
+      style: config.style?.copyWith(
+        color: theme.linkColor,
+        decorationColor: theme.linkColor,
+      ),
+    );
+
+    WidgetSpan? child;
+    if (builder != null) {
+      child = WidgetSpan(
+        baseline: TextBaseline.alphabetic,
+        alignment: PlaceholderAlignment.baseline,
+        child: GestureDetector(
+          onTap: () => config.onLinkTap?.call(url, linkText),
+          child: builder(
+            context,
+            linkTextSpan,
+            url,
+            config.style ?? const TextStyle(),
+          ),
+        ),
+      );
+    }
+
+    child ??= WidgetSpan(
+      alignment: PlaceholderAlignment.baseline,
+      baseline: TextBaseline.alphabetic,
+      child: config.getRich(linkTextSpan),
+    );
+
+    return TextSpan(children: [child, ...endingSpans]);
   }
 }
 

--- a/mobile/test/features/channels/message_content_test.dart
+++ b/mobile/test/features/channels/message_content_test.dart
@@ -2072,6 +2072,63 @@ Photos
         expect(_allRichText(tester), contains('https://example.com/docs#frag'));
         expect(find.text('#frag'), findsNothing);
       });
+
+      testWidgets('digits-only bare #token is not a channel pill', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _testable(
+            const MessageContent(
+              content: 'Issue #2959 is open',
+              channelNames: {},
+            ),
+          ),
+        );
+
+        expect(find.byIcon(LucideIcons.hash), findsNothing);
+        expect(_allRichText(tester), contains('#2959'));
+      });
+    });
+
+    group('authored markdown links with # labels', () {
+      testWidgets('keeps #-prefixed link labels visible (not channel pills)', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _testable(
+            const MessageContent(
+              content:
+                  'See [#2959](https://github.com/block/buzz/issues/2959) for details.',
+              channelNames: {},
+            ),
+          ),
+        );
+
+        expect(find.byIcon(LucideIcons.hash), findsNothing);
+        expect(find.textContaining('#2959'), findsOneWidget);
+        expect(_allRichText(tester), contains('#2959'));
+        // Surrounding prose must still be there — the old bug left only
+        // punctuation: "See  for details."
+        expect(_allRichText(tester), contains('See'));
+        expect(_allRichText(tester), contains('for details'));
+      });
+
+      testWidgets('known channel name inside a link label stays plain text', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _testable(
+            const MessageContent(
+              content: 'Docs: [#general](https://example.com/general)',
+              channelNames: {'general': 'ch-id-1'},
+            ),
+          ),
+        );
+
+        // Must not promote the label into a channel pill (hash icon).
+        expect(find.byIcon(LucideIcons.hash), findsNothing);
+        expect(find.textContaining('#general'), findsOneWidget);
+      });
     });
 
     group('mixed content', () {


### PR DESCRIPTION
## Problem

On iOS, Markdown links whose **label starts with `#`** render as nothing. A body like:

```markdown
See [#2959](https://github.com/block/buzz/issues/2959) for details.
```

shows `See  for details.` — no label, no underline, no tap target. Desktop renders the same message correctly.

## Root cause

1. `MessageContent` registers `_ChannelLinkMd` (and mentions/emoji) ahead of gpt_markdown defaults.
2. Default `ATagMd` builds the link **label** by re-running the full `inlineComponents` list on the label text.
3. `_ChannelLinkMd` matches digits-only tokens (`#2959`) and replaces them with a `_TokenPill` `WidgetSpan`.
4. `_buildLink` only collects plain `TextSpan.text`, so the label becomes empty nested placeholders and draws blank on device.

Paths: `mobile/lib/features/channels/message_content.dart`, `message_content/token_pill.dart`.

## Fix

- **`_AuthoredMarkdownLinkMd`**: own the `[label](url)` path; generate labels with stock formatting components only (no mention/channel/emoji). Drop stock `ATagMd` from the list to avoid double handling.
- **Channel generic token**: require at least one letter/underscore so bare digits-only `#2959` is never a channel pill (defense in depth for non-link text too).

## Why it matters

GitHub-style issue/PR links in chat are common. Invisible links on mobile lose the destination and break reading flow; desktop already works.

## Test plan

```bash
cd mobile
flutter test test/features/channels/message_content_test.dart
# 76 passed @ fa17ab2ed
```

Named regressions:

- `digits-only bare #token is not a channel pill`
- `keeps #-prefixed link labels visible (not channel pills)`
- `known channel name inside a link label stays plain text`
- existing `#channel links` group still green

## Manual verify

1. Post `See [#2959](https://github.com/block/buzz/issues/2959) for details.` from Desktop.
2. Open the message on iOS — label `#2959` visible, tappable, opens the URL.
3. Bare `#general` for a real channel still pills and navigates.

## Risk / blast radius

- Link labels no longer turn into channel/mention pills (authored `[label](url)` keeps plain label text). Bare `#channel` / `@mention` outside links unchanged.
- Digits-only bare `#N` no longer becomes a non-interactive channel pill (never a valid channel name).

## Closest work

none found (issue #6124 unlinked; related area #4572 is tappable-links, different symptom)

Fixes #6124

## Acceptance retest (2026-08-18b)

- Rebased onto current `main`
- Head: `b8d66159908f9cb5b5420c20a740cee85275a981`
- Mini: `cd mobile && flutter test test/features/channels/message_content_test.dart` (see nest)
