### PR TITLE
fix(mobile): OS notifications for inbox items and agent-done

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -51,6 +51,8 @@
 	<string>Buzz needs photo library access so you can attach images to messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Buzz needs permission to save images to your photo library.</string>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>Buzz notifies you about inbox mentions, approvals, direct messages, and agent job results.</string>
 	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'features/activity/activity_provider.dart';
+import 'features/activity/inbox_notification_listener.dart';
 import 'features/activity/inbox_local_state_provider.dart';
 import 'features/activity/inbox_read_state.dart';
 import 'features/channels/unread_badge/unread_badge_provider.dart';
@@ -87,6 +88,7 @@ class App extends HookConsumerWidget {
       ref.watch(observerRelayProvider);
       ref.watch(appLifecycleProvider);
       ref.watch(userStatusCacheProvider);
+      ref.watch(inboxNotificationListenerProvider);
       hasUnreadInbox = ref.watch(_unreadInboxItemCountProvider) > 0;
     }
 

--- a/mobile/lib/features/activity/inbox_notification_eligibility.dart
+++ b/mobile/lib/features/activity/inbox_notification_eligibility.dart
@@ -1,0 +1,274 @@
+import 'dart:convert';
+
+import '../../shared/deeplink/deep_link.dart';
+import 'feed_item.dart';
+import 'inbox_item.dart';
+
+const inboxNotificationBodyMaxLength = 140;
+
+/// Items that should surface as an OS inbox notification.
+enum InboxNotificationKind { mention, needsAction, dm, agentActivity }
+
+/// Whether [item] belongs in the Activity inbox notification surface.
+InboxNotificationKind? inboxNotificationKindFor(
+  FeedItem item, {
+  required Set<String> dmChannelIds,
+}) {
+  if (item.category == 'needs_action') {
+    return InboxNotificationKind.needsAction;
+  }
+  if (item.category == 'mention') {
+    return InboxNotificationKind.mention;
+  }
+  if (item.category == 'agent_activity') {
+    return InboxNotificationKind.agentActivity;
+  }
+  if (item.category == 'activity') {
+    final channelId = item.channelId;
+    if (channelId != null && dmChannelIds.contains(channelId)) {
+      return InboxNotificationKind.dm;
+    }
+  }
+  return null;
+}
+
+/// Collect inbox-eligible feed items sorted oldest-first for delivery order.
+List<FeedItem> eligibleInboxNotificationItems(
+  HomeFeedResponse feed, {
+  required Set<String> dmChannelIds,
+}) {
+  final items = <FeedItem>[
+    ...feed.mentions,
+    ...feed.needsAction,
+    ...feed.agentActivity,
+    for (final item in feed.activity)
+      if (inboxNotificationKindFor(item, dmChannelIds: dmChannelIds) ==
+          InboxNotificationKind.dm)
+        item,
+  ];
+  items.sort((left, right) => left.createdAt.compareTo(right.createdAt));
+  return items;
+}
+
+/// All inbox-eligible ids currently present in [feed] (for first-snapshot seeding).
+List<String> collectInboxNotificationItemIds(
+  HomeFeedResponse feed, {
+  required Set<String> dmChannelIds,
+}) {
+  return eligibleInboxNotificationItems(
+    feed,
+    dmChannelIds: dmChannelIds,
+  ).map((item) => item.id).toList();
+}
+
+bool isOwnFeedItem(FeedItem item, String myPubkey) {
+  return item.pubkey.toLowerCase() == myPubkey.toLowerCase();
+}
+
+bool isMutedChannelForInboxNotification(
+  FeedItem item,
+  Set<String> mutedChannelIds,
+) {
+  final channelId = item.channelId;
+  if (channelId == null) return false;
+  if (!mutedChannelIds.contains(channelId)) return false;
+  // Mentions still notify on muted channels (matches desktop feed toasts).
+  return inboxNotificationKindFor(item, dmChannelIds: const {}) !=
+      InboxNotificationKind.mention;
+}
+
+bool isMutedThreadForInboxNotification(
+  FeedItem item,
+  Set<String> mutedRootIds,
+) {
+  if (mutedRootIds.isEmpty) return false;
+  final thread = threadReferenceOf(item.tags);
+  final rootId = isBroadcastReply(item.tags)
+      ? null
+      : (thread.rootId ?? thread.parentId);
+  return rootId != null && mutedRootIds.contains(rootId);
+}
+
+/// Whether a new inbox item should post an OS notification.
+bool shouldNotifyForInboxItem(
+  FeedItem item, {
+  required String myPubkey,
+  required Set<String> dmChannelIds,
+  required Set<String> mutedChannelIds,
+  required Set<String> mutedRootIds,
+}) {
+  if (isOwnFeedItem(item, myPubkey)) return false;
+  if (inboxNotificationKindFor(item, dmChannelIds: dmChannelIds) == null) {
+    return false;
+  }
+  if (isMutedChannelForInboxNotification(item, mutedChannelIds)) {
+    return false;
+  }
+  if (isMutedThreadForInboxNotification(item, mutedRootIds)) {
+    return false;
+  }
+  return true;
+}
+
+String? notificationChannelLabel({
+  required String? channelId,
+  required String channelName,
+  required bool isDm,
+}) {
+  if (isDm) return null;
+  final trimmed = channelName.trim();
+  if (trimmed.isEmpty) return null;
+  return '#$trimmed';
+}
+
+String formatNotificationTitle({
+  required String prefix,
+  required String? channelLabel,
+}) {
+  if (channelLabel != null && channelLabel.isNotEmpty) {
+    return '$prefix in $channelLabel';
+  }
+  return prefix;
+}
+
+String truncateNotificationBody(String content, String fallback) {
+  final trimmed = content.trim();
+  if (trimmed.isEmpty) return fallback;
+  if (trimmed.length <= inboxNotificationBodyMaxLength) return trimmed;
+  return '${trimmed.substring(0, inboxNotificationBodyMaxLength - 3).trimRight()}...';
+}
+
+String inboxNotificationTitle(
+  FeedItem item, {
+  required bool isDm,
+  required String? channelLabel,
+  String? senderName,
+}) {
+  if (isDm) {
+    return senderName?.trim().isNotEmpty == true
+        ? senderName!.trim()
+        : 'Direct message';
+  }
+
+  final kind = inboxNotificationKindFor(item, dmChannelIds: const {});
+  switch (kind) {
+    case InboxNotificationKind.mention:
+      return formatNotificationTitle(
+        prefix: senderName?.trim().isNotEmpty == true
+            ? '$senderName mentioned you'
+            : '@Mention',
+        channelLabel: channelLabel,
+      );
+    case InboxNotificationKind.needsAction:
+      if (item.kind == 46010) {
+        return formatNotificationTitle(
+          prefix: senderName?.trim().isNotEmpty == true
+              ? '$senderName requested approval'
+              : 'Approval Requested',
+          channelLabel: channelLabel,
+        );
+      }
+      return formatNotificationTitle(
+        prefix: senderName?.trim().isNotEmpty == true
+            ? senderName!.trim()
+            : 'Needs Action',
+        channelLabel: channelLabel,
+      );
+    case InboxNotificationKind.agentActivity:
+      if (item.kind == 43004) {
+        return formatNotificationTitle(
+          prefix: senderName?.trim().isNotEmpty == true
+              ? '$senderName finished a job'
+              : 'Agent finished a job',
+          channelLabel: channelLabel,
+        );
+      }
+      return formatNotificationTitle(
+        prefix: senderName?.trim().isNotEmpty == true
+            ? senderName!.trim()
+            : item.headline,
+        channelLabel: channelLabel,
+      );
+    case InboxNotificationKind.dm:
+      return senderName?.trim().isNotEmpty == true
+          ? senderName!.trim()
+          : 'Direct message';
+    case null:
+      return 'Buzz';
+  }
+}
+
+String inboxNotificationBody(FeedItem item) {
+  final fallback = switch (item.kind) {
+    46010 => 'A workflow is waiting for your approval.',
+    43004 => 'An agent finished a job.',
+    _ => 'Something in Buzz needs your attention.',
+  };
+  return truncateNotificationBody(item.content, fallback);
+}
+
+/// Deep-link payload stored on the OS notification for tap handling.
+String inboxNotificationPayload(FeedItem item) {
+  final channelId = item.channelId;
+  if (channelId == null || channelId.isEmpty) {
+    throw ArgumentError('inboxNotificationPayload: channelId is required');
+  }
+  final thread = threadReferenceOf(item.tags);
+  final threadRootId = isBroadcastReply(item.tags) ? null : thread.parentId;
+  return buildMessageLink(
+    channelId: channelId,
+    messageId: item.id,
+    threadRootId: threadRootId,
+  );
+}
+
+bool shouldSkipInboxNotificationBecauseVisible({
+  required FeedItem item,
+  required VisibleConversationSnapshot? visible,
+  required bool appIsResumed,
+}) {
+  if (!appIsResumed || visible == null) return false;
+  if (visible.channelId != item.channelId) return false;
+
+  final thread = threadReferenceOf(item.tags);
+  final itemThreadRoot = isBroadcastReply(item.tags)
+      ? null
+      : (thread.rootId ?? thread.parentId);
+
+  if (itemThreadRoot != null) {
+    return visible.threadRootId == itemThreadRoot;
+  }
+  return visible.threadRootId == null;
+}
+
+/// Minimal projection of [VisibleConversation] for pure eligibility tests.
+class VisibleConversationSnapshot {
+  final String channelId;
+  final String? messageId;
+  final String? threadRootId;
+
+  const VisibleConversationSnapshot({
+    required this.channelId,
+    this.messageId,
+    this.threadRootId,
+  });
+}
+
+Set<String> readMutedThreadRootIds(String? rawJson) {
+  if (rawJson == null || rawJson.isEmpty) return {};
+  try {
+    final decoded = jsonDecode(rawJson);
+    if (decoded is! List) return {};
+    return {
+      for (final value in decoded)
+        if (value is String) value,
+    };
+  } catch (_) {
+    return {};
+  }
+}
+
+const mutedThreadRootIdsStoragePrefix = 'buzz-thread-muted.v1';
+
+String mutedThreadRootIdsPrefsKey(String pubkey) =>
+    '$mutedThreadRootIdsStoragePrefix:${pubkey.toLowerCase()}';

--- a/mobile/lib/features/activity/inbox_notification_listener.dart
+++ b/mobile/lib/features/activity/inbox_notification_listener.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/widgets.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../shared/notifications/inbox_notification_seen.dart';
+import '../../shared/notifications/local_notifications_service.dart';
+import '../../shared/notifications/visible_conversation.dart';
+import '../../shared/relay/relay.dart';
+import '../../shared/theme/theme_provider.dart';
+import '../channels/channel.dart';
+import '../channels/channel_mutes/channel_mutes_provider.dart';
+import '../channels/channels_provider.dart';
+import '../profile/user_cache_provider.dart';
+import 'activity_provider.dart';
+import 'feed_item.dart';
+import 'inbox_notification_eligibility.dart';
+
+/// Wires Activity feed changes to OS inbox notifications.
+final inboxNotificationListenerProvider = Provider<void>((ref) {
+  final myPk = ref.watch(myPubkeyProvider)?.trim().toLowerCase();
+  if (myPk == null || myPk.isEmpty) return;
+
+  final coordinator = ref.watch(_inboxNotificationCoordinatorProvider(myPk));
+
+  ref.listen<AsyncValue<HomeFeedResponse>>(activityProvider, (_, next) {
+    final feed = next.value;
+    if (feed == null) return;
+
+    final channels =
+        ref.read(channelsProvider).asData?.value ?? const <Channel>[];
+    final dmChannelIds = {
+      for (final channel in channels)
+        if (channel.isDm) channel.id,
+    };
+    final channelById = {for (final channel in channels) channel.id: channel};
+    final mutedChannelIds = {
+      for (final entry in ref.read(channelMutesProvider).store.channels.entries)
+        if (entry.value.muted) entry.key,
+    };
+    final prefs = ref.read(savedPrefsProvider);
+    final mutedRootIds = readMutedThreadRootIds(
+      prefs.getString(mutedThreadRootIdsPrefsKey(myPk)),
+    );
+    final lifecycle = ref.read(appLifecycleProvider);
+    final visible = currentVisibleConversation;
+    final profiles = ref.read(userCacheProvider);
+
+    coordinator.processFeed(
+      feed: feed,
+      myPubkey: myPk,
+      dmChannelIds: dmChannelIds,
+      mutedChannelIds: mutedChannelIds,
+      mutedRootIds: mutedRootIds,
+      channelById: channelById,
+      appIsResumed: lifecycle == AppLifecycleState.resumed,
+      visible: visible == null
+          ? null
+          : VisibleConversationSnapshot(
+              channelId: visible.channelId,
+              messageId: visible.messageId,
+              threadRootId: visible.threadRootId,
+            ),
+      resolveSenderName: (pubkey) {
+        final profile = profiles[pubkey.toLowerCase()];
+        final display = profile?.displayName?.trim();
+        if (display != null && display.isNotEmpty) return display;
+        return null;
+      },
+    );
+  }, fireImmediately: true);
+});
+
+final _inboxNotificationCoordinatorProvider =
+    Provider.family<_InboxNotificationCoordinator, String>((ref, pubkey) {
+      final prefs = ref.watch(savedPrefsProvider);
+      return _InboxNotificationCoordinator(prefs: prefs, pubkey: pubkey);
+    });
+
+class _InboxNotificationCoordinator {
+  _InboxNotificationCoordinator({required this.prefs, required this.pubkey})
+    : _seenIds = readStoredInboxNotificationSeenIds(prefs, pubkey).toSet();
+
+  final SharedPreferences prefs;
+  final String pubkey;
+
+  Set<String> _seenIds;
+  bool _hasInitializedFeed = false;
+  bool _requestedPermission = false;
+
+  Future<void> processFeed({
+    required HomeFeedResponse feed,
+    required String myPubkey,
+    required Set<String> dmChannelIds,
+    required Set<String> mutedChannelIds,
+    required Set<String> mutedRootIds,
+    required Map<String, Channel> channelById,
+    required bool appIsResumed,
+    required VisibleConversationSnapshot? visible,
+    required String? Function(String pubkey) resolveSenderName,
+  }) async {
+    final allEligible = collectInboxNotificationItemIds(
+      feed,
+      dmChannelIds: dmChannelIds,
+    );
+
+    if (!_hasInitializedFeed) {
+      _hasInitializedFeed = true;
+      if (allEligible.isNotEmpty) {
+        _seenIds = allEligible.toSet();
+        await writeStoredInboxNotificationSeenIds(prefs, pubkey, _seenIds);
+      }
+      return;
+    }
+
+    final newItems =
+        eligibleInboxNotificationItems(feed, dmChannelIds: dmChannelIds).where((
+          item,
+        ) {
+          if (_seenIds.contains(item.id)) return false;
+          if (!shouldNotifyForInboxItem(
+            item,
+            myPubkey: myPubkey,
+            dmChannelIds: dmChannelIds,
+            mutedChannelIds: mutedChannelIds,
+            mutedRootIds: mutedRootIds,
+          )) {
+            return false;
+          }
+          return !shouldSkipInboxNotificationBecauseVisible(
+            item: item,
+            visible: visible,
+            appIsResumed: appIsResumed,
+          );
+        }).toList();
+
+    final nextSeen = {..._seenIds, ...allEligible};
+    _seenIds = capSeenInboxNotificationIds(nextSeen);
+    await writeStoredInboxNotificationSeenIds(prefs, pubkey, _seenIds);
+
+    if (newItems.isEmpty) return;
+
+    if (!_requestedPermission) {
+      _requestedPermission = true;
+      await LocalNotificationsService.instance.requestPermissionsIfNeeded();
+    }
+
+    for (final item in newItems) {
+      final channelId = item.channelId;
+      if (channelId == null) continue;
+      final channel = channelById[channelId];
+      final isDm = channel?.isDm ?? dmChannelIds.contains(channelId);
+      final senderName = resolveSenderName(item.pubkey);
+      final title = inboxNotificationTitle(
+        item,
+        isDm: isDm,
+        channelLabel: notificationChannelLabel(
+          channelId: channelId,
+          channelName: channel?.name ?? item.channelName,
+          isDm: isDm,
+        ),
+        senderName: senderName,
+      );
+      final body = inboxNotificationBody(item);
+      final payload = inboxNotificationPayload(item);
+      await LocalNotificationsService.instance.showInboxNotification(
+        notificationId: stableInboxNotificationId(item.id),
+        title: title,
+        body: body,
+        payload: payload,
+      );
+    }
+  }
+}

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -50,6 +50,7 @@ import 'members_sheet.dart';
 import 'message_actions.dart';
 import 'message_long_press_region.dart';
 import 'message_content.dart';
+import '../../shared/notifications/visible_conversation.dart';
 import '../../shared/read_state/deferred_read_state_update.dart';
 import '../../shared/read_state/read_state_format.dart';
 import '../../shared/read_state/read_state_provider.dart';
@@ -255,6 +256,18 @@ class ChannelDetailPage extends HookConsumerWidget {
       final session = ref.read(relaySessionProvider.notifier);
       return session.registerVisibleChannel(channel.id);
     }, [channel.id]);
+
+    useEffect(() {
+      final owner = Object();
+      return registerVisibleConversation(
+        owner,
+        VisibleConversation(
+          channelId: channel.id,
+          messageId: initialMessageId,
+          threadRootId: initialThreadRootId,
+        ),
+      );
+    }, [channel.id, initialMessageId, initialThreadRootId]);
 
     // Preload channel member profiles so @mentions resolve correctly.
     useEffect(() {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,18 +3,25 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
+import 'shared/deeplink/pending_deep_link_provider.dart';
+import 'shared/notifications/local_notifications_service.dart';
 import 'shared/theme/theme_provider.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Pre-load preferences so the first frame uses the saved theme/accent.
   final prefs = await SharedPreferences.getInstance();
 
-  runApp(
-    ProviderScope(
-      overrides: [savedPrefsProvider.overrideWithValue(prefs)],
-      child: const App(),
-    ),
+  final container = ProviderContainer(
+    overrides: [savedPrefsProvider.overrideWithValue(prefs)],
   );
+
+  await LocalNotificationsService.instance.initialize(
+    onTap: (link) {
+      container.read(pendingDeepLinkProvider.notifier).parkLink(link);
+    },
+  );
+
+  runApp(UncontrolledProviderScope(container: container, child: const App()));
 }

--- a/mobile/lib/shared/deeplink/pending_deep_link_provider.dart
+++ b/mobile/lib/shared/deeplink/pending_deep_link_provider.dart
@@ -42,6 +42,11 @@ class PendingDeepLinkNotifier extends Notifier<BuzzDeepLink?> {
       debugPrint('deep-link: ignoring unsupported link: $uri');
       return;
     }
+    parkLink(link);
+  }
+
+  /// Park a parsed deep link for later dispatch (e.g. notification taps).
+  void parkLink(BuzzDeepLink link) {
     if (state == null) {
       state = link;
     } else {

--- a/mobile/lib/shared/notifications/inbox_notification_seen.dart
+++ b/mobile/lib/shared/notifications/inbox_notification_seen.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+const inboxNotificationSeenStorageKey = 'buzz-home-feed-seen.v1';
+const inboxNotificationSeenMaxItems = 500;
+
+String inboxNotificationSeenPrefsKey(String pubkey) {
+  return '$inboxNotificationSeenStorageKey:${pubkey.toLowerCase()}';
+}
+
+List<String> readStoredInboxNotificationSeenIds(
+  SharedPreferences prefs,
+  String pubkey,
+) {
+  final normalized = pubkey.trim().toLowerCase();
+  if (normalized.isEmpty) return const [];
+
+  final raw = prefs.getString(inboxNotificationSeenPrefsKey(normalized));
+  if (raw == null || raw.isEmpty) return const [];
+
+  try {
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return const [];
+    return [
+      for (final value in decoded)
+        if (value is String) value,
+    ].take(inboxNotificationSeenMaxItems).toList();
+  } catch (_) {
+    return const [];
+  }
+}
+
+Future<void> writeStoredInboxNotificationSeenIds(
+  SharedPreferences prefs,
+  String pubkey,
+  Iterable<String> ids,
+) async {
+  final normalized = pubkey.trim().toLowerCase();
+  if (normalized.isEmpty) return;
+
+  final capped = ids.toList();
+  if (capped.length > inboxNotificationSeenMaxItems) {
+    capped.removeRange(0, capped.length - inboxNotificationSeenMaxItems);
+  }
+  await prefs.setString(
+    inboxNotificationSeenPrefsKey(normalized),
+    jsonEncode(capped),
+  );
+}
+
+Set<String> capSeenInboxNotificationIds(Set<String> ids) {
+  if (ids.length <= inboxNotificationSeenMaxItems) return ids;
+  final list = ids.toList();
+  return list.sublist(list.length - inboxNotificationSeenMaxItems).toSet();
+}

--- a/mobile/lib/shared/notifications/local_notifications_service.dart
+++ b/mobile/lib/shared/notifications/local_notifications_service.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../deeplink/deep_link.dart';
+
+typedef InboxNotificationTapHandler = void Function(MessageDeepLink link);
+
+const _androidChannelId = 'buzz_inbox';
+const _androidChannelName = 'Inbox';
+
+/// Thin wrapper around [FlutterLocalNotificationsPlugin] for inbox alerts.
+class LocalNotificationsService {
+  LocalNotificationsService._();
+
+  static final LocalNotificationsService instance =
+      LocalNotificationsService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+  InboxNotificationTapHandler? _onTap;
+  bool _initialized = false;
+
+  @visibleForTesting
+  FlutterLocalNotificationsPlugin get plugin => _plugin;
+
+  Future<void> initialize({required InboxNotificationTapHandler onTap}) async {
+    if (_initialized) return;
+    _onTap = onTap;
+
+    const androidSettings = AndroidInitializationSettings(
+      '@mipmap/ic_launcher',
+    );
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+    const settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _plugin.initialize(
+      settings: settings,
+      onDidReceiveNotificationResponse: _handleNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse: _backgroundTapHandler,
+    );
+
+    final androidPlugin = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    await androidPlugin?.createNotificationChannel(
+      const AndroidNotificationChannel(
+        _androidChannelId,
+        _androidChannelName,
+        description: 'Mentions, inbox items, and agent job results',
+        importance: Importance.high,
+      ),
+    );
+
+    _initialized = true;
+    await _dispatchLaunchNotification();
+  }
+
+  Future<void> requestPermissionsIfNeeded() async {
+    final iosPlugin = _plugin
+        .resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin
+        >();
+    await iosPlugin?.requestPermissions(alert: true, badge: true, sound: true);
+
+    final androidPlugin = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    await androidPlugin?.requestNotificationsPermission();
+  }
+
+  Future<bool> showInboxNotification({
+    required int notificationId,
+    required String title,
+    required String body,
+    required String payload,
+  }) async {
+    if (!_initialized) return false;
+
+    final details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        _androidChannelId,
+        _androidChannelName,
+        channelDescription: 'Mentions, inbox items, and agent job results',
+        importance: Importance.high,
+        priority: Priority.high,
+      ),
+      iOS: const DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
+      ),
+    );
+
+    await _plugin.show(
+      id: notificationId,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: payload,
+    );
+    return true;
+  }
+
+  Future<void> _dispatchLaunchNotification() async {
+    final launchDetails = await _plugin.getNotificationAppLaunchDetails();
+    if (launchDetails?.didNotificationLaunchApp != true) return;
+    final payload = launchDetails?.notificationResponse?.payload;
+    _dispatchPayload(payload);
+  }
+
+  void _handleNotificationResponse(NotificationResponse response) {
+    _dispatchPayload(response.payload);
+  }
+
+  void _dispatchPayload(String? payload) {
+    if (payload == null || payload.isEmpty) return;
+    final uri = Uri.tryParse(payload);
+    if (uri == null) return;
+    final link = parseMessageDeepLink(uri);
+    if (link == null) return;
+    _onTap?.call(link);
+  }
+
+  @pragma('vm:entry-point')
+  static void _backgroundTapHandler(NotificationResponse response) {
+    // Foreground/background taps are handled by onDidReceiveNotificationResponse.
+  }
+}
+
+int stableInboxNotificationId(String eventId) {
+  return eventId.hashCode & 0x7fffffff;
+}
+
+String encodeInboxNotificationPayloadForTest({
+  required String channelId,
+  required String messageId,
+  String? threadRootId,
+}) {
+  return buildMessageLink(
+    channelId: channelId,
+    messageId: messageId,
+    threadRootId: threadRootId,
+  );
+}
+
+MessageDeepLink? decodeInboxNotificationPayload(String payload) {
+  final uri = Uri.tryParse(payload);
+  if (uri == null) return null;
+  return parseMessageDeepLink(uri);
+}

--- a/mobile/lib/shared/notifications/visible_conversation.dart
+++ b/mobile/lib/shared/notifications/visible_conversation.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+/// The inbox/channel destination currently visible to the user.
+@immutable
+class VisibleConversation {
+  final String channelId;
+  final String? messageId;
+  final String? threadRootId;
+
+  const VisibleConversation({
+    required this.channelId,
+    this.messageId,
+    this.threadRootId,
+  });
+}
+
+final Map<Object, VisibleConversation> _visibleConversationOwners = {};
+
+/// The conversation currently on screen, if any.
+VisibleConversation? get currentVisibleConversation {
+  if (_visibleConversationOwners.isEmpty) return null;
+  return _visibleConversationOwners.values.last;
+}
+
+/// Register [conversation] for [owner] until the returned callback runs.
+void Function() registerVisibleConversation(
+  Object owner,
+  VisibleConversation conversation,
+) {
+  _visibleConversationOwners[owner] = conversation;
+  return () {
+    _visibleConversationOwners.remove(owner);
+  };
+}
+
+/// Clears all visible-conversation registrations (community remount).
+void resetVisibleConversationRegistry() {
+  _visibleConversationOwners.clear();
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -462,6 +462,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "22.3.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.2.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_math_fork:
     dependency: transitive
     description:
@@ -1357,6 +1397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   tuple:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   path_provider: ^2.1.6
   share_plus: ^13.3.0
   local_auth: ^3.0.2
+  flutter_local_notifications: ^22.3.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/features/activity/inbox_notification_eligibility_test.dart
+++ b/mobile/test/features/activity/inbox_notification_eligibility_test.dart
@@ -1,0 +1,295 @@
+import 'package:buzz/features/activity/feed_item.dart';
+import 'package:buzz/features/activity/inbox_notification_eligibility.dart';
+import 'package:buzz/features/activity/inbox_item.dart';
+import 'package:buzz/shared/deeplink/deep_link.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _testChannelId = '580ca78b-9dae-46f3-8854-bd671853ba32';
+const _testEventId =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _testRootId =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _testParentId =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+FeedItem feedItem({
+  required String id,
+  String category = 'mention',
+  String pubkey = 'sender-pk',
+  String? channelId = 'channel-1',
+  int kind = 9,
+  String content = 'hello there',
+  int createdAt = 100,
+  List<List<String>> tags = const [],
+}) {
+  return FeedItem(
+    id: id,
+    kind: kind,
+    pubkey: pubkey,
+    content: content,
+    createdAt: createdAt,
+    channelId: channelId,
+    channelName: 'general',
+    tags: tags,
+    category: category,
+  );
+}
+
+HomeFeedResponse feed({
+  List<FeedItem> mentions = const [],
+  List<FeedItem> needsAction = const [],
+  List<FeedItem> activity = const [],
+  List<FeedItem> agentActivity = const [],
+}) {
+  return HomeFeedResponse(
+    mentions: mentions,
+    needsAction: needsAction,
+    activity: activity,
+    agentActivity: agentActivity,
+  );
+}
+
+List<List<String>> replyTags(String rootId, String parentId) => [
+  ['e', rootId, '', 'root'],
+  ['e', parentId, '', 'reply'],
+];
+
+void main() {
+  const myPk = 'my-pk';
+  const dmChannelIds = {'dm-1'};
+
+  group('inboxNotificationKindFor', () {
+    test('maps mention, needs-action, dm, and agent activity', () {
+      expect(
+        inboxNotificationKindFor(
+          feedItem(id: 'm', category: 'mention'),
+          dmChannelIds: dmChannelIds,
+        ),
+        InboxNotificationKind.mention,
+      );
+      expect(
+        inboxNotificationKindFor(
+          feedItem(id: 'n', category: 'needs_action', kind: 46010),
+          dmChannelIds: dmChannelIds,
+        ),
+        InboxNotificationKind.needsAction,
+      );
+      expect(
+        inboxNotificationKindFor(
+          feedItem(id: 'd', category: 'activity', channelId: 'dm-1'),
+          dmChannelIds: dmChannelIds,
+        ),
+        InboxNotificationKind.dm,
+      );
+      expect(
+        inboxNotificationKindFor(
+          feedItem(id: 'a', category: 'agent_activity', kind: 43004),
+          dmChannelIds: dmChannelIds,
+        ),
+        InboxNotificationKind.agentActivity,
+      );
+    });
+
+    test('ignores non-dm activity', () {
+      expect(
+        inboxNotificationKindFor(
+          feedItem(id: 'x', category: 'activity', channelId: 'stream-1'),
+          dmChannelIds: dmChannelIds,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('shouldNotifyForInboxItem', () {
+    test('allows mention, needs-action, dm, and job_result 43004', () {
+      for (final item in [
+        feedItem(id: 'm', category: 'mention'),
+        feedItem(id: 'n', category: 'needs_action', kind: 46010),
+        feedItem(id: 'd', category: 'activity', channelId: 'dm-1'),
+        feedItem(id: 'j', category: 'agent_activity', kind: 43004),
+      ]) {
+        expect(
+          shouldNotifyForInboxItem(
+            item,
+            myPubkey: myPk,
+            dmChannelIds: dmChannelIds,
+            mutedChannelIds: const {},
+            mutedRootIds: const {},
+          ),
+          isTrue,
+          reason: item.id,
+        );
+      }
+    });
+
+    test('blocks own pubkey, muted channel, and muted thread', () {
+      expect(
+        shouldNotifyForInboxItem(
+          feedItem(id: 'own', pubkey: myPk),
+          myPubkey: myPk,
+          dmChannelIds: dmChannelIds,
+          mutedChannelIds: const {},
+          mutedRootIds: const {},
+        ),
+        isFalse,
+      );
+      expect(
+        shouldNotifyForInboxItem(
+          feedItem(
+            id: 'muted',
+            category: 'needs_action',
+            channelId: 'muted-ch',
+          ),
+          myPubkey: myPk,
+          dmChannelIds: dmChannelIds,
+          mutedChannelIds: const {'muted-ch'},
+          mutedRootIds: const {},
+        ),
+        isFalse,
+      );
+      expect(
+        shouldNotifyForInboxItem(
+          feedItem(
+            id: 'thread',
+            category: 'mention',
+            tags: replyTags('root-1', 'parent-1'),
+          ),
+          myPubkey: myPk,
+          dmChannelIds: dmChannelIds,
+          mutedChannelIds: const {},
+          mutedRootIds: const {'root-1'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('mention still notifies on muted channel', () {
+      expect(
+        shouldNotifyForInboxItem(
+          feedItem(
+            id: 'mention-muted',
+            category: 'mention',
+            channelId: 'muted-ch',
+          ),
+          myPubkey: myPk,
+          dmChannelIds: dmChannelIds,
+          mutedChannelIds: const {'muted-ch'},
+          mutedRootIds: const {},
+        ),
+        isTrue,
+      );
+    });
+
+    test('agent job_result notifies without mention tag', () {
+      expect(
+        shouldNotifyForInboxItem(
+          feedItem(
+            id: 'job',
+            category: 'agent_activity',
+            kind: 43004,
+            tags: const [],
+          ),
+          myPubkey: myPk,
+          dmChannelIds: dmChannelIds,
+          mutedChannelIds: const {},
+          mutedRootIds: const {},
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('seen snapshot behavior', () {
+    test('first snapshot ids are collected without implying delivery', () {
+      final response = feed(
+        mentions: [
+          feedItem(id: 'old-1'),
+          feedItem(id: 'old-2'),
+        ],
+        agentActivity: [
+          feedItem(id: 'old-agent', category: 'agent_activity', kind: 43004),
+        ],
+      );
+      final ids = collectInboxNotificationItemIds(
+        response,
+        dmChannelIds: dmChannelIds,
+      );
+      expect(ids, ['old-1', 'old-2', 'old-agent']);
+
+      final seen = ids.toSet();
+      final later = feed(
+        mentions: [
+          ...response.mentions,
+          feedItem(id: 'new-1', createdAt: 200),
+        ],
+      );
+      final fresh = eligibleInboxNotificationItems(
+        later,
+        dmChannelIds: dmChannelIds,
+      ).where((item) => !seen.contains(item.id)).toList();
+      expect(fresh.map((item) => item.id), ['new-1']);
+    });
+  });
+
+  group('payload + title/body', () {
+    test('payload includes channel and event id for tap', () {
+      final item = feedItem(id: _testEventId, channelId: _testChannelId);
+      final payload = inboxNotificationPayload(item);
+      final link = parseMessageDeepLink(Uri.parse(payload));
+      expect(link?.channelId, _testChannelId);
+      expect(link?.messageId, _testEventId);
+    });
+
+    test('thread payload includes thread root when reply-tagged', () {
+      final item = feedItem(
+        id: _testEventId,
+        channelId: _testChannelId,
+        tags: replyTags(_testRootId, _testParentId),
+      );
+      final payload = inboxNotificationPayload(item);
+      final link = parseMessageDeepLink(Uri.parse(payload));
+      expect(link?.threadRootId, _testParentId);
+    });
+
+    test('job_result title/body are agent-specific', () {
+      final item = feedItem(
+        id: 'job',
+        category: 'agent_activity',
+        kind: 43004,
+        content: 'Done: shipped the fix',
+      );
+      expect(
+        inboxNotificationTitle(
+          item,
+          isDm: false,
+          channelLabel: '#agents',
+          senderName: 'Sprig',
+        ),
+        'Sprig finished a job in #agents',
+      );
+      expect(inboxNotificationBody(item), 'Done: shipped the fix');
+    });
+  });
+
+  group('shouldSkipInboxNotificationBecauseVisible', () {
+    test('skips when resumed and same channel is visible', () {
+      expect(
+        shouldSkipInboxNotificationBecauseVisible(
+          item: feedItem(id: 'x', channelId: 'ch-1'),
+          visible: const VisibleConversationSnapshot(channelId: 'ch-1'),
+          appIsResumed: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldSkipInboxNotificationBecauseVisible(
+          item: feedItem(id: 'x', channelId: 'ch-1'),
+          visible: const VisibleConversationSnapshot(channelId: 'ch-1'),
+          appIsResumed: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/mobile/test/features/notifications/inbox_notification_seen_test.dart
+++ b/mobile/test/features/notifications/inbox_notification_seen_test.dart
@@ -1,0 +1,32 @@
+import 'package:buzz/shared/notifications/inbox_notification_seen.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('inbox notification seen storage', () {
+    test('read/write round-trips per pubkey', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      expect(readStoredInboxNotificationSeenIds(prefs, 'AbC'), isEmpty);
+
+      await writeStoredInboxNotificationSeenIds(prefs, 'AbC', ['a', 'b']);
+      expect(readStoredInboxNotificationSeenIds(prefs, 'abc'), ['a', 'b']);
+    });
+
+    test('capSeenInboxNotificationIds keeps newest entries', () {
+      final ids = {
+        for (var i = 0; i < inboxNotificationSeenMaxItems + 5; i++) 'id-$i',
+      };
+      final capped = capSeenInboxNotificationIds(ids);
+      expect(capped.length, inboxNotificationSeenMaxItems);
+      expect(
+        capped.contains('id-${inboxNotificationSeenMaxItems + 4}'),
+        isTrue,
+      );
+      expect(capped.contains('id-0'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Gift-back from Eitan Medical (generic Buzz — no branding/SSO).

Adds local OS notifications on mobile when new inbox-eligible Activity items arrive while the app process is alive: mentions, needs-action, DMs, and agent job results. Mirrors desktop feed alerts with seen-id dedupe, mute respect, visible-conversation suppression, and `buzz://` tap navigation.

Cherry-pick conflict resolution: merged notification `parkLink` with upstream deep-link FIFO queue; kept both `local_auth` and `flutter_local_notifications` deps.

## Test plan

- [x] `dart format --set-exit-if-changed`
- [x] `flutter test test/features/activity/inbox_notification_eligibility_test.dart test/features/notifications/inbox_notification_seen_test.dart`
- [ ] Manual: receive mention/DM/agent-done while app backgrounded; tap notification opens thread


Made with [Cursor](https://cursor.com)