### PR TITLE
fix(mobile): p-tag participating agents on thread reply

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/mentions/agent_identity_provider.dart';
 import '../../shared/relay/relay.dart';
 import '../channels/channel_management_provider.dart';
 import '../profile/user_cache_provider.dart';
@@ -7,6 +8,7 @@ import '../profile/user_profile.dart';
 import 'channel.dart';
 import 'channel_messages_provider.dart';
 import 'message_mention_pubkeys.dart';
+import 'threading.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
@@ -18,6 +20,7 @@ class SendMessage {
   final void Function(String channelId, String eventId) _completeLocalMessage;
   final void Function(String channelId, String eventId) _removeLocalMessage;
   final bool Function()? _isDeliveryValid;
+  final bool Function(String channelId, String pubkey)? _isAgentPubkey;
 
   SendMessage({
     required SignedEventRelay signedEventRelay,
@@ -29,13 +32,15 @@ class SendMessage {
     completeLocalMessage,
     required void Function(String channelId, String eventId) removeLocalMessage,
     bool Function()? isDeliveryValid,
+    bool Function(String channelId, String pubkey)? isAgentPubkey,
   }) : _signedEventRelay = signedEventRelay,
        _fetchMembers = fetchMembers,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
        _completeLocalMessage = completeLocalMessage,
        _removeLocalMessage = removeLocalMessage,
-       _isDeliveryValid = isDeliveryValid;
+       _isDeliveryValid = isDeliveryValid,
+       _isAgentPubkey = isAgentPubkey;
 
   /// Send a text message to a channel.
   ///
@@ -51,6 +56,7 @@ class SendMessage {
     String? rootEventId,
     List<String>? mentionPubkeys,
     Channel? channel,
+    List<NostrEvent>? threadEvents,
     List<List<String>> mediaTags = const [],
   }) async {
     _ensureDeliveryValid();
@@ -74,9 +80,21 @@ class SendMessage {
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
     // the desktop's normalizeMentionPubkeys).
     final selfLower = authorPubkey?.toLowerCase();
+    var mentionList = resolvedMentions;
+    final isAgentPubkey = _isAgentPubkey;
+    if (parentEventId != null && isAgentPubkey != null) {
+      final events = threadEvents ?? const <NostrEvent>[];
+      final root = rootEventId ?? resolveReplyRootId(parentEventId, events);
+      mentionList = mentionPubkeysWithThreadAgents(
+        mentionList,
+        events,
+        root,
+        (pubkey) => isAgentPubkey(channelId, pubkey),
+      );
+    }
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
+      for (final pk in mentionList)
         if (seenMentions.add(pk.toLowerCase())) pk,
     ];
 
@@ -236,6 +254,9 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
     removeLocalMessage: (channelId, eventId) => ref
         .read(channelMessagesProvider(channelId).notifier)
         .removeLocalMessage(eventId),
+    isAgentPubkey: (channelId, pubkey) => ref
+        .read(agentMentionPubkeysProvider(channelId))
+        .contains(pubkey.toLowerCase()),
     isDeliveryValid: () {
       final currentConfig = ref.read(relayConfigProvider);
       return currentConfig.baseUrl == config.baseUrl &&

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -425,6 +425,9 @@ class ThreadDetailPage extends HookConsumerWidget {
     // The root of the entire thread chain. If the current thread head is
     // itself a root message its rootId is null, so fall back to its own id.
     final effectiveRootId = threadHead.rootId ?? threadHead.id;
+    final threadEventsForSend = repliesState.whenData((events) {
+      return mergeThreadEvents(events, liveChannelEvents);
+    }).value;
 
     // Composer size changes and keyboard metrics changes are independent:
     // the dock grows first, then the Scaffold's viewport shrinks once the
@@ -766,6 +769,7 @@ class ThreadDetailPage extends HookConsumerWidget {
                               channel: channel,
                               parentEventId: threadHead.id,
                               rootEventId: effectiveRootId,
+                              threadEvents: threadEventsForSend,
                               mediaTags: mediaTags,
                             ),
                       ),

--- a/mobile/lib/features/channels/threading.dart
+++ b/mobile/lib/features/channels/threading.dart
@@ -1,0 +1,85 @@
+import '../../shared/relay/relay.dart';
+
+/// Whether [event] belongs to the thread rooted at [rootEventId].
+bool eventBelongsToThread(NostrEvent event, String rootEventId) {
+  if (event.id == rootEventId) {
+    return true;
+  }
+  final ref = event.threadReference;
+  return ref.rootId == rootEventId || ref.parentId == rootEventId;
+}
+
+/// Resolve the outermost thread root for a reply to [parentEventId].
+String resolveReplyRootId(String parentEventId, List<NostrEvent> events) {
+  for (final event in events) {
+    if (event.id == parentEventId) {
+      return event.threadReference.rootId ?? event.id;
+    }
+  }
+  return parentEventId;
+}
+
+/// Agent pubkeys that already participate in a thread — authors of thread
+/// messages who are agents, and agent pubkeys already p-tagged in that thread.
+///
+/// Used so a reply without a visible `@` still p-tags those agents and wakes
+/// mention-filtered subscriptions (ACP). Does not include humans.
+List<String> collectParticipatingAgentPubkeys(
+  List<NostrEvent> events,
+  String rootEventId,
+  bool Function(String pubkey) isAgentPubkey,
+) {
+  if (rootEventId.isEmpty) {
+    return const [];
+  }
+
+  final seen = <String>{};
+  final result = <String>[];
+
+  void addIfAgent(String? pubkey) {
+    if (pubkey == null) {
+      return;
+    }
+    final normalized = pubkey.trim().toLowerCase();
+    if (normalized.isEmpty || seen.contains(normalized)) {
+      return;
+    }
+    if (!isAgentPubkey(normalized) && !isAgentPubkey(pubkey)) {
+      return;
+    }
+    seen.add(normalized);
+    result.add(normalized);
+  }
+
+  for (final event in events) {
+    if (!eventBelongsToThread(event, rootEventId)) {
+      continue;
+    }
+    addIfAgent(event.pubkey);
+    for (final tag in event.tags) {
+      if (tag.isNotEmpty && tag[0] == 'p' && tag.length > 1) {
+        addIfAgent(tag[1]);
+      }
+    }
+  }
+
+  return result;
+}
+
+/// Merge explicit mention pubkeys with participating thread agents.
+List<String> mentionPubkeysWithThreadAgents(
+  List<String>? mentionPubkeys,
+  List<NostrEvent> events,
+  String rootEventId,
+  bool Function(String pubkey) isAgentPubkey,
+) {
+  final participating = collectParticipatingAgentPubkeys(
+    events,
+    rootEventId,
+    isAgentPubkey,
+  );
+  if (participating.isEmpty) {
+    return mentionPubkeys ?? const [];
+  }
+  return [...?mentionPubkeys, ...participating];
+}

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -8,6 +8,12 @@ import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
+const _human =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _agent =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _channelId = '11111111-1111-4111-8111-111111111111';
+
 void main() {
   test(
     'adds the signed message locally before relay acknowledgement',
@@ -236,9 +242,66 @@ void main() {
       ),
     );
   });
-}
 
-const _channelId = '11111111-1111-4111-8111-111111111111';
+  test('thread reply p-tags participating agents without explicit @', () async {
+    final session = _PendingPublishRelaySession();
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(
+        session: session,
+        nsec: nostr.Keys.generate().nsec,
+      ),
+      fetchMembers: (_) async => const [],
+      readUserCache: () => const {},
+      addLocalMessage: (_, event) {},
+      completeLocalMessage: (_, eventId) {},
+      removeLocalMessage: (_, eventId) {},
+      isAgentPubkey: (_, pubkey) =>
+          pubkey.toLowerCase() == _agent.toLowerCase(),
+    );
+
+    final root = NostrEvent(
+      id: 'root1',
+      pubkey: _human,
+      createdAt: 1_700_000_000,
+      kind: EventKind.streamMessage,
+      tags: [
+        ['h', _channelId],
+        ['p', _agent],
+      ],
+      content: 'thread head',
+      sig: 'sig',
+    );
+    final agentReply = NostrEvent(
+      id: 'reply-agent',
+      pubkey: _agent,
+      createdAt: 1_700_000_001,
+      kind: EventKind.streamMessage,
+      tags: [
+        ['h', _channelId],
+        ['e', 'root1', '', 'reply'],
+      ],
+      content: 'agent reply',
+      sig: 'sig',
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'human reply without @',
+      parentEventId: 'reply-agent',
+      rootEventId: 'root1',
+      threadEvents: [root, agentReply],
+    );
+    await session.published;
+    session.accept();
+    await result;
+
+    final pTags = session.event.tags
+        .where((tag) => tag.isNotEmpty && tag[0] == 'p')
+        .map((tag) => tag[1])
+        .toList();
+    expect(pTags, contains(_agent));
+  });
+}
 
 Channel _dmChannel(List<String> participantPubkeys) => Channel(
   id: _channelId,

--- a/mobile/test/features/channels/threading_test.dart
+++ b/mobile/test/features/channels/threading_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/threading.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+const _human =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _otherHuman =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+const _agent =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _otherAgent =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+bool _isAgentPubkey(String pubkey) {
+  final normalized = pubkey.trim().toLowerCase();
+  return normalized == _agent || normalized == _otherAgent;
+}
+
+NostrEvent _event(
+  String id,
+  String pubkey, {
+  List<List<String>> tags = const [],
+}) {
+  return NostrEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 1_700_000_000,
+    kind: EventKind.streamMessage,
+    tags: tags,
+    content: '',
+    sig: 'sig',
+  );
+}
+
+void main() {
+  test(
+    'reply to a human in an agent thread still includes the agent p-tag',
+    () {
+      final root = _event(
+        'root1',
+        _human,
+        tags: [
+          ['h', 'ch'],
+          ['p', _agent],
+        ],
+      );
+      final agentReply = _event(
+        'reply-agent',
+        _agent,
+        tags: [
+          ['h', 'ch'],
+          ['e', 'root1', '', 'reply'],
+        ],
+      );
+      final humanReply = _event(
+        'reply-human',
+        _otherHuman,
+        tags: [
+          ['h', 'ch'],
+          ['e', 'root1', '', 'root'],
+          ['e', 'reply-agent', '', 'reply'],
+          ['p', _otherHuman],
+        ],
+      );
+
+      final participating = collectParticipatingAgentPubkeys(
+        [root, agentReply, humanReply],
+        resolveReplyRootId(humanReply.id, [root, agentReply, humanReply]),
+        _isAgentPubkey,
+      );
+
+      expect(participating, [_agent]);
+    },
+  );
+
+  test('top-level send does not auto-tag channel agents', () {
+    final topLevel = _event(
+      'top1',
+      _human,
+      tags: [
+        ['h', 'ch'],
+      ],
+    );
+    final unrelatedAgent = _event(
+      'other-agent-msg',
+      _otherAgent,
+      tags: [
+        ['h', 'ch'],
+      ],
+    );
+    final otherThreadRoot = _event(
+      'other-root',
+      _human,
+      tags: [
+        ['h', 'ch'],
+        ['p', _agent],
+      ],
+    );
+
+    final participating = collectParticipatingAgentPubkeys(
+      [topLevel, unrelatedAgent, otherThreadRoot],
+      topLevel.id,
+      _isAgentPubkey,
+    );
+
+    expect(participating, isEmpty);
+  });
+
+  test('humans in a thread are not auto-tagged', () {
+    final root = _event(
+      'root1',
+      _human,
+      tags: [
+        ['h', 'ch'],
+        ['p', _agent],
+        ['p', _otherHuman],
+      ],
+    );
+    final humanReply = _event(
+      'reply-human',
+      _otherHuman,
+      tags: [
+        ['h', 'ch'],
+        ['e', 'root1', '', 'reply'],
+        ['p', _human],
+      ],
+    );
+
+    final participating = collectParticipatingAgentPubkeys(
+      [root, humanReply],
+      'root1',
+      _isAgentPubkey,
+    );
+
+    expect(participating, [_agent]);
+    expect(participating, isNot(contains(_human)));
+    expect(participating, isNot(contains(_otherHuman)));
+  });
+}


### PR DESCRIPTION
## Summary

Gift-back from Eitan Medical (generic Buzz — no branding/SSO).

Ports desktop `collectParticipatingAgentPubkeys` so thread replies without `@` still wake ACP mention-filtered agents, matching INT-1328 desktop behavior.

Cherry-pick conflict resolution: kept upstream `AndroidImeLift`, DM `channel` param, and typing UI while adding `threadEvents` for agent p-tags.

## Test plan

- [x] `dart format --set-exit-if-changed`
- [x] `flutter test test/features/channels/send_message_provider_test.dart test/features/channels/threading_test.dart`
- [ ] Manual: reply in agent thread without @mention; agent still receives turn


Made with [Cursor](https://cursor.com)