### PR TITLE
fix(buzz-acp): make the test suite runnable on Windows, and actually run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1028,6 +1028,15 @@ jobs:
         # Serial: windows_resolver_tests mutate process-global env
         # (BUZZ_SHELL/GIT_BASH/SystemRoot) that SharedState::new reads.
         run: cargo test -p buzz-dev-mcp --target $env:TARGET -- --test-threads=1
+      - name: Test (buzz-acp)
+        # buzz-acp's fake-agent fixtures spawn a POSIX shell and speak JSON-RPC
+        # to it over pipes, so they exercise Windows-specific process and path
+        # behaviour that no Linux job can reach. This crate previously had 16
+        # failures on Windows that no CI job could see, because the Linux jobs
+        # do not run it either (see `just test-unit`) and this job only
+        # compiles it. Unlike buzz-dev-mcp above, these tests do not mutate
+        # process-global env, so they run in parallel.
+        run: cargo test -p buzz-acp --lib --target $env:TARGET
       # Smoke-test the new host-prereq contract: Git for Windows (which provides
       # bash) is available on the runner, a shell command round-trips, and bash
       # does NOT resolve from System32 (so WSL's launcher is never picked up).

--- a/Justfile
+++ b/Justfile
@@ -331,6 +331,13 @@ test-unit:
         # `cargo test --workspace`; without this step a manifest edit that
         # diverges Rust from the corpus ships green.
         cargo nextest run -p buzz-agent --lib
+        # buzz-acp: the ACP harness. Its ~760 --lib tests are pure in-process
+        # unit tests whose fixtures spawn a local POSIX shell as a fake agent —
+        # no relay, no database, no network. Enumerated for the same reason as
+        # the crates above: nothing in CI runs `cargo test --workspace`, so
+        # until this line existed the harness that dispatches every agent turn
+        # had zero executed test coverage in CI on any platform.
+        cargo nextest run -p buzz-acp --lib
     else
         ./scripts/run-tests.sh unit
     fi

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -5083,4 +5083,41 @@ mod tests {
             "error must mention sandbox_workspace_write"
         );
     }
+
+    /// npm installs every JS CLI on Windows as a `.cmd` shim, so an agent
+    /// configured as `hermes-acp.cmd` is the ordinary case — and
+    /// `normalize_agent_command_identity` already strips `.cmd`/`.bat` when
+    /// deriving agent identity, so the rest of the harness assumes such a
+    /// command runs.
+    ///
+    /// It does: `std::process::Command` detects those extensions and routes
+    /// them through `cmd.exe` itself, with the argument escaping that was
+    /// hardened for CVE-2024-24576. This test exists to keep that assumption
+    /// checked rather than assumed, since nothing else in the suite spawns a
+    /// batch shim and the failure mode if it ever regressed — agents that
+    /// simply never start on Windows — is expensive to diagnose from the
+    /// symptom.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn acp_client_can_spawn_an_npm_style_cmd_shim() {
+        let shim = std::env::temp_dir().join(format!("buzz-agent-{}.cmd", uuid::Uuid::new_v4()));
+        // Stay alive long enough to be observed, without emitting ACP traffic.
+        // Kept short: `shutdown()` ends the shim but not the `ping` beneath it,
+        // and this suite should not leave a process behind for 20 seconds.
+        std::fs::write(&shim, "@echo off\r\nping -n 6 127.0.0.1 > nul\r\n")
+            .expect("shim must be writable");
+
+        let spawned = AcpClient::spawn(&shim.to_string_lossy(), &[], &[], false).await;
+        let ok = spawned.is_ok();
+        if let Ok(mut client) = spawned {
+            client.shutdown().await;
+        }
+        let _ = std::fs::remove_file(&shim);
+
+        assert!(
+            ok,
+            "an npm-style .cmd agent shim must be spawnable — this is the \
+             '%1 is not a valid Win32 application' failure"
+        );
+    }
 }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -3180,7 +3180,13 @@ mod tests {
     /// healthy implementation clears the floor within a couple of tries.
     /// Measured before this helper existed: 4 of 9 full-suite runs failed here.
     async fn assert_activity_resets_idle(script: &str, what: &str) {
-        const ATTEMPTS: usize = 4;
+        // Sized against how loaded the suite actually is, not by feel. Four was
+        // enough at 797 tests; at 811 — the count once the agent-lifecycle
+        // branch's process fixtures are also present — one run in three still
+        // exhausted it. Each extra attempt costs a fixture spawn only on a host
+        // that is already stalling, and never on a genuine regression: that
+        // fails on the first attempt, deterministically.
+        const ATTEMPTS: usize = 8;
         let mut inconclusive = Vec::new();
 
         for _ in 0..ATTEMPTS {

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -3975,19 +3975,24 @@ mod tests {
     /// Timeline (t=0 is *after* the fixture reports READY, so shell startup is
     /// outside the measured window — see [`spawn_script_ready`]):
     ///   t≈0:  read loop starts, `hard_deadline = now + 2s`
-    ///   t≈1s: script emits steer response (id=0) → Success renewal moves
+    ///   t≈0:  `read` unblocks the moment the read loop writes the steer
+    ///         request, and the script answers (id=0) → Success renewal moves
     ///         `hard_deadline` to `now + 10s`
-    ///   t≈4s: script emits prompt response (id=999) → `Ok`
+    ///   t≈3s: script emits prompt response (id=999) → `Ok`
     ///
     /// Old code: `HardTimeout` at t≈2s (before the prompt response).
-    /// New code: deadline renewed at t≈1s → prompt response at t≈4s → `Ok`.
+    /// New code: deadline renewed at t≈0 → prompt response at t≈3s → `Ok`.
     ///
-    /// The ~1s gaps on either side of the deadline are deliberate slack: on
-    /// Windows `sleep` is an external binary, so each step carries a process
-    /// spawn the fixture cannot control.
+    /// The leading `read` is a *causal* barrier, not a timed one, and that is
+    /// load-bearing: the steer response must arrive before the deadline, and a
+    /// `sleep` cannot guarantee that when `sleep` is an external binary whose
+    /// spawn a loaded host can delay past the deadline itself. Blocking on the
+    /// request makes the ordering independent of wall-clock entirely. The
+    /// trailing `sleep 3` needs no such treatment: it only has to land *after*
+    /// the original deadline, and a stall pushes it further in that direction.
     #[tokio::test]
     async fn steer_success_renews_hard_deadline_and_survives_past_original() {
-        let script = "sleep 1; \
+        let script = "read -r _; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"stopReason\":\"end_turn\"}}'; \
                       sleep 3; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
@@ -4322,12 +4327,15 @@ mod tests {
     /// `steer_success_renews_hard_deadline_and_survives_past_original` for
     /// the `_session/steering` transport.
     ///
-    /// Timeline (t=0 is after READY): original hard deadline at t≈2s; steer
-    /// response at t≈1s renews it to t≈11s; prompt response at t≈4s lands
-    /// inside it.
+    /// Timeline (t=0 is after READY): original hard deadline at t≈2s; the
+    /// leading `read` unblocks when the read loop writes the steer request, so
+    /// the steer response lands at t≈0 and renews the deadline to t≈10s;
+    /// prompt response at t≈3s lands inside it. See
+    /// `steer_success_renews_hard_deadline_and_survives_past_original` for why
+    /// the barrier is a `read` and not a `sleep`.
     #[tokio::test]
     async fn acp_steer_injected_renews_hard_deadline_and_survives_past_original() {
-        let script = "sleep 1; \
+        let script = "read -r _; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"injected\"}}'; \
                       sleep 3; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
@@ -4374,15 +4382,17 @@ mod tests {
     /// deadline — that clock belongs to a turn which is already settled.
     ///
     /// Same timeline as the `injected` test, so the only difference is the
-    /// outcome string: original hard deadline at t≈2s, steer response at
-    /// t≈1s, prompt response at t≈4s. With renewal the prompt response would
-    /// land and this returns `Ok`; without renewal the original deadline fires
-    /// first and we get `HardTimeout`. The steer response must arrive *before*
-    /// the deadline (so the ack is still produced) and the prompt response
-    /// *after* it — which is what the ~1s gaps on either side protect.
+    /// outcome string: original hard deadline at t≈2s, steer response at t≈0
+    /// (the leading `read` unblocks on the steer request), prompt response at
+    /// t≈3s. With renewal the prompt response would land and this returns
+    /// `Ok`; without renewal the original deadline fires first and we get
+    /// `HardTimeout`. The steer response must arrive *before* the deadline (so
+    /// the ack is still produced) and the prompt response *after* it — the
+    /// `read` barrier guarantees the first ordering causally rather than
+    /// betting on a `sleep`, and the trailing `sleep 3` only has to be late.
     #[tokio::test]
     async fn acp_steer_started_new_turn_acks_success_without_renewing_hard_deadline() {
-        let script = "sleep 1; \
+        let script = "read -r _; \
              echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"startedNewTurn\"}}'; \
              sleep 3; \
              echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2953,10 +2953,43 @@ mod tests {
         );
     }
 
+    /// Spawn a fake ACP agent that runs `script` under a resolved POSIX shell.
+    ///
+    /// Goes through [`crate::testshell::posix_shell_command`] rather than the
+    /// bare name `"bash"`: on Windows the bare name resolves to WSL's
+    /// `System32\bash.exe`, whose `read` builtin returns empty over a pipe.
+    /// See that module for the full failure mode.
     async fn spawn_script(script: &str) -> AcpClient {
-        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+        AcpClient::spawn(
+            &crate::testshell::posix_shell_command(),
+            &["-c".into(), script.into()],
+            &[],
+            false,
+        )
+        .await
+        .expect("failed to spawn test script")
+    }
+
+    /// [`spawn_script`], but blocks until the fixture has actually started.
+    ///
+    /// Deadline-sensitive tests must start their clock only once the shell is
+    /// provably executing. Process startup is near-free on Linux but costs
+    /// hundreds of milliseconds under MSYS fork emulation on Windows, so a
+    /// hard deadline measured from before the spawn is partly measuring host
+    /// startup rather than the behaviour under test — which is how these tests
+    /// came to depend on whichever interpreter happened to boot fastest.
+    ///
+    /// The sentinel is consumed here, so the JSON-RPC read loop never sees it.
+    async fn spawn_script_ready(script: &str) -> AcpClient {
+        let mut client = spawn_script(&format!("printf 'READY\\n'; {script}")).await;
+        let line = client
+            .reader
+            .next()
             .await
-            .expect("failed to spawn test script")
+            .expect("fixture must emit READY before running its body")
+            .expect("fixture stdout must be readable");
+        assert_eq!(line.trim(), "READY", "unexpected first line from fixture");
+        client
     }
 
     #[cfg(unix)]
@@ -3117,30 +3150,34 @@ mod tests {
         );
     }
 
+    /// Valid JSON `session/update` notifications reset the idle timer; non-JSON
+    /// lines do not.
+    ///
+    /// See [`keepalive_resets_idle_past_deadline`] for why the budget is loose
+    /// and why the elapsed floor must stay at 2x `IDLE`.
     #[tokio::test]
     async fn idle_resets_on_stdout_activity() {
-        // Send valid JSON (session/update notifications) to reset the idle timer.
-        // Non-JSON lines no longer reset idle — only valid JSON notifications do.
+        const IDLE: std::time::Duration = std::time::Duration::from_millis(600);
+        const FLOOR: std::time::Duration = std::time::Duration::from_millis(1200);
+
         let mut client = spawn_script(
-            r#"for i in $(seq 1 10); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"thinking"}}}}'; sleep 0.05; done; sleep 10"#,
+            r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"thinking"}}}}'; sleep 0.05; done; sleep 30"#,
         )
         .await;
-        let max_dur = std::time::Duration::from_secs(10);
+        let max_dur = std::time::Duration::from_secs(30);
         let hard_deadline = tokio::time::Instant::now() + max_dur;
         let start = std::time::Instant::now();
         let result = client
-            .read_until_response_with_idle_timeout(
-                "test",
-                999,
-                std::time::Duration::from_millis(200),
-                hard_deadline,
-                max_dur,
-            )
+            .read_until_response_with_idle_timeout("test", 999, IDLE, hard_deadline, max_dur)
             .await;
         let elapsed = start.elapsed();
-        // 10 messages × 50ms = ~500ms of activity, then idle timeout fires after 200ms more
-        assert!(elapsed >= std::time::Duration::from_millis(400));
-        assert!(elapsed < std::time::Duration::from_secs(3));
+        // 20 messages of activity, then idle fires one IDLE later. Clearing
+        // FLOOR = 2x IDLE proves the timer was reset at least once.
+        assert!(
+            elapsed >= FLOOR,
+            "stdout activity should reset idle; elapsed only {elapsed:?}"
+        );
+        assert!(elapsed < std::time::Duration::from_secs(20));
         assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
     }
 
@@ -3314,34 +3351,45 @@ mod tests {
         assert_eq!(result.unwrap()["worked"], serde_json::json!(true));
     }
 
+    /// Keepalive `session/update` lines must keep resetting the idle timer, so
+    /// the turn survives far past a single idle deadline.
+    ///
+    /// The budget here is deliberately loose. `sleep` is an external binary
+    /// under MSYS, so on Windows each `echo; sleep 0.05` iteration costs a
+    /// process spawn: the real inter-line gap is ~98ms (up to ~244ms under
+    /// load) rather than the nominal 50ms. With the original 100ms idle budget
+    /// the fixture was genuinely silent for longer than its own deadline, so
+    /// the read loop timed out *correctly* and the test failed for a reason
+    /// that had nothing to do with the behaviour under test.
+    ///
+    /// INVARIANT: the elapsed floor must stay strictly greater than
+    /// `idle_timeout` — ideally 2x, as here. If it ever drops to or below it,
+    /// a run in which no reset happened at all would still satisfy the
+    /// assertion, and the test would prove nothing.
     #[tokio::test]
     async fn keepalive_resets_idle_past_deadline() {
-        // Keepalive session/update lines every 50ms against a 100ms idle deadline.
-        // The turn should survive well past the 100ms deadline (proves the fix).
+        const IDLE: std::time::Duration = std::time::Duration::from_millis(600);
+        const FLOOR: std::time::Duration = std::time::Duration::from_millis(1200);
+
         let mut client = spawn_script(
-            r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 10"#,
+            r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 30"#,
         )
         .await;
-        let max_dur = std::time::Duration::from_secs(10);
+        let max_dur = std::time::Duration::from_secs(30);
         let hard_deadline = tokio::time::Instant::now() + max_dur;
         let start = std::time::Instant::now();
         let result = client
-            .read_until_response_with_idle_timeout(
-                "test",
-                999,
-                std::time::Duration::from_millis(100),
-                hard_deadline,
-                max_dur,
-            )
+            .read_until_response_with_idle_timeout("test", 999, IDLE, hard_deadline, max_dur)
             .await;
         let elapsed = start.elapsed();
-        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after 100ms more.
-        // Must survive well past the 100ms deadline.
+        // 20 keepalives of activity (~1s on Unix, ~2s on Windows), then idle
+        // fires one IDLE later. Clearing FLOOR = 2x IDLE proves at least one
+        // reset occurred.
         assert!(
-            elapsed >= std::time::Duration::from_millis(500),
+            elapsed >= FLOOR,
             "keepalive should reset idle past the deadline; elapsed only {elapsed:?}"
         );
-        assert!(elapsed < std::time::Duration::from_secs(5));
+        assert!(elapsed < std::time::Duration::from_secs(20));
         assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
     }
 
@@ -3897,21 +3945,26 @@ mod tests {
     /// fix (acp.rs:1440-1444): without renewal, the read loop returns
     /// `HardTimeout` before the prompt response arrives.
     ///
-    /// Timeline:
-    ///   t≈0:    read loop starts, `hard_deadline = now + 1s`
-    ///   t≈0.5s: script emits steer response (id=0) → Success renewal
-    ///           moves `hard_deadline` to `now + 3s` (≈3.5s from start)
-    ///   t≈1.5s: script emits prompt response (id=999) → `Ok`
+    /// Timeline (t=0 is *after* the fixture reports READY, so shell startup is
+    /// outside the measured window — see [`spawn_script_ready`]):
+    ///   t≈0:  read loop starts, `hard_deadline = now + 2s`
+    ///   t≈1s: script emits steer response (id=0) → Success renewal moves
+    ///         `hard_deadline` to `now + 10s`
+    ///   t≈4s: script emits prompt response (id=999) → `Ok`
     ///
-    /// Old code: `HardTimeout` at t≈1s (before prompt response).
-    /// New code: deadline renewed at t≈0.5s → prompt response at t≈1.5s → `Ok`.
+    /// Old code: `HardTimeout` at t≈2s (before the prompt response).
+    /// New code: deadline renewed at t≈1s → prompt response at t≈4s → `Ok`.
+    ///
+    /// The ~1s gaps on either side of the deadline are deliberate slack: on
+    /// Windows `sleep` is an external binary, so each step carries a process
+    /// spawn the fixture cannot control.
     #[tokio::test]
     async fn steer_success_renews_hard_deadline_and_survives_past_original() {
-        let script = "sleep 0.5; \
+        let script = "sleep 1; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"stopReason\":\"end_turn\"}}'; \
-                      sleep 1; \
+                      sleep 3; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
-        let mut client = spawn_script(script).await;
+        let mut client = spawn_script_ready(script).await;
 
         let update = session_info_update_msg(Some(serde_json::json!("run-99")));
         let _ = client.handle_session_update(&update);
@@ -3931,8 +3984,8 @@ mod tests {
         });
 
         let idle = std::time::Duration::from_secs(10);
-        let max_dur = std::time::Duration::from_secs(3);
-        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        let max_dur = std::time::Duration::from_secs(10);
+        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         let result = client
             .read_until_response_with_idle_timeout("sess-test", 999, idle, hard_deadline, max_dur)
             .await;
@@ -3971,10 +4024,17 @@ mod tests {
         capture_path: &std::path::Path,
         response: &str,
     ) -> AcpClient {
+        // The redirect target MUST be single-quoted. `capture_path` is absolute,
+        // and on Windows that means `C:\Users\...\x.json`; interpolated bare,
+        // bash consumes every backslash as an escape and the redirect lands on a
+        // *relative* file named `C:UsersmfethAppData...json` in the crate source
+        // directory. The parent then reads the real path, finds nothing, and the
+        // test fails — while quietly littering the working tree. Quoting keeps
+        // the backslashes intact, which MSYS accepts as a Win32 path.
         let script = format!(
-            "read -r line; printf '%s' \"$line\" > {capture}; \
+            "read -r line; printf '%s' \"$line\" > '{capture}'; \
              printf '%s\\n' '{response}'; sleep 10",
-            capture = capture_path.display(),
+            capture = crate::testshell::quote_for_shell(capture_path),
             response = response,
         );
         spawn_script(&script).await
@@ -4019,10 +4079,15 @@ mod tests {
     }
 
     /// Unique temp path for one test's captured request bytes.
+    ///
+    /// The uuid suffix is load-bearing: `%TEMP%` is shared across every
+    /// concurrent `cargo test -p buzz-acp` on the machine, so a fixed name
+    /// makes two runs — two git worktrees, or a rerun overlapping a previous
+    /// one — read each other's captures.
     fn capture_path(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join("buzz-acp-steer-capture");
         std::fs::create_dir_all(&dir).expect("create capture dir");
-        let path = dir.join(format!("{name}.json"));
+        let path = dir.join(format!("{name}-{}.json", uuid::Uuid::new_v4()));
         let _ = std::fs::remove_file(&path);
         path
     }
@@ -4230,15 +4295,16 @@ mod tests {
     /// `steer_success_renews_hard_deadline_and_survives_past_original` for
     /// the `_session/steering` transport.
     ///
-    /// Timeline: original hard deadline at t≈1s; steer response at t≈0.5s
-    /// renews it to t≈3.5s; prompt response at t≈1.5s lands inside it.
+    /// Timeline (t=0 is after READY): original hard deadline at t≈2s; steer
+    /// response at t≈1s renews it to t≈11s; prompt response at t≈4s lands
+    /// inside it.
     #[tokio::test]
     async fn acp_steer_injected_renews_hard_deadline_and_survives_past_original() {
-        let script = "sleep 0.5; \
+        let script = "sleep 1; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"injected\"}}'; \
-                      sleep 1; \
+                      sleep 3; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
-        let mut client = spawn_script(script).await;
+        let mut client = spawn_script_ready(script).await;
         set_steering_supported(&mut client);
 
         let (steer_tx, steer_rx) = tokio::sync::mpsc::channel::<crate::pool::SteerRequest>(1);
@@ -4255,8 +4321,8 @@ mod tests {
         });
 
         let idle = std::time::Duration::from_secs(10);
-        let max_dur = std::time::Duration::from_secs(3);
-        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        let max_dur = std::time::Duration::from_secs(10);
+        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         let result = client
             .read_until_response_with_idle_timeout("sess-test", 999, idle, hard_deadline, max_dur)
             .await;
@@ -4281,17 +4347,19 @@ mod tests {
     /// deadline — that clock belongs to a turn which is already settled.
     ///
     /// Same timeline as the `injected` test, so the only difference is the
-    /// outcome string: original hard deadline at t≈1s, steer response at
-    /// t≈0.5s, prompt response at t≈1.5s. With renewal the prompt response
-    /// would land and this returns `Ok`; without renewal the original
-    /// deadline fires first and we get `HardTimeout`.
+    /// outcome string: original hard deadline at t≈2s, steer response at
+    /// t≈1s, prompt response at t≈4s. With renewal the prompt response would
+    /// land and this returns `Ok`; without renewal the original deadline fires
+    /// first and we get `HardTimeout`. The steer response must arrive *before*
+    /// the deadline (so the ack is still produced) and the prompt response
+    /// *after* it — which is what the ~1s gaps on either side protect.
     #[tokio::test]
     async fn acp_steer_started_new_turn_acks_success_without_renewing_hard_deadline() {
-        let script = "sleep 0.5; \
+        let script = "sleep 1; \
              echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"startedNewTurn\"}}'; \
-             sleep 1; \
+             sleep 3; \
              echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
-        let mut client = spawn_script(script).await;
+        let mut client = spawn_script_ready(script).await;
         set_steering_supported(&mut client);
 
         let (steer_tx, steer_rx) = tokio::sync::mpsc::channel::<crate::pool::SteerRequest>(1);
@@ -4308,8 +4376,8 @@ mod tests {
         });
 
         let idle = std::time::Duration::from_secs(10);
-        let max_dur = std::time::Duration::from_secs(3);
-        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        let max_dur = std::time::Duration::from_secs(10);
+        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         let result = client
             .read_until_response_with_idle_timeout("sess-test", 999, idle, hard_deadline, max_dur)
             .await;

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -3150,35 +3150,90 @@ mod tests {
         );
     }
 
+    /// Idle budget for the two "activity resets the idle timer" tests, and the
+    /// elapsed floor that proves a reset happened.
+    ///
+    /// INVARIANT: `RESET_FLOOR` must stay strictly greater than `RESET_IDLE` —
+    /// 2x here. A run in which no reset occurred returns elapsed ≈ `RESET_IDLE`,
+    /// so a floor at or below it would be satisfied by the bug these tests
+    /// exist to catch.
+    const RESET_IDLE: std::time::Duration = std::time::Duration::from_millis(600);
+    const RESET_FLOOR: std::time::Duration = std::time::Duration::from_millis(1200);
+
+    /// Drive `script` through the read loop and assert that incoming activity
+    /// kept the turn alive well past a single idle timeout.
+    ///
+    /// Retries an *inconclusive* run, and only that. The fixture's cadence
+    /// comes from a real subprocess — `sleep` is an external binary under MSYS,
+    /// so each tick costs a process spawn and the observed inter-line gap is
+    /// ~98ms (up to ~244ms idle, worse under parallel load) against a nominal
+    /// 50ms. When the host stalls longer than the idle budget, the read loop
+    /// times out *correctly* and the run tells us nothing about the behaviour
+    /// under test. Widening the constants cannot fix this: Linux finishes the
+    /// activity window in ~1s and Windows takes ~2s, so the floor is squeezed
+    /// from both sides.
+    ///
+    /// This does not weaken the assertion, because the two outcomes have
+    /// different shapes. A genuine failure to reset the idle timer is
+    /// deterministic — elapsed ≈ `RESET_IDLE` on every attempt, so every
+    /// attempt fails and so does the test. A host stall is intermittent, so a
+    /// healthy implementation clears the floor within a couple of tries.
+    /// Measured before this helper existed: 4 of 9 full-suite runs failed here.
+    async fn assert_activity_resets_idle(script: &str, what: &str) {
+        const ATTEMPTS: usize = 4;
+        let mut inconclusive = Vec::new();
+
+        for _ in 0..ATTEMPTS {
+            let mut client = spawn_script(script).await;
+            let max_dur = std::time::Duration::from_secs(30);
+            let hard_deadline = tokio::time::Instant::now() + max_dur;
+            let start = std::time::Instant::now();
+            let result = client
+                .read_until_response_with_idle_timeout(
+                    "test",
+                    999,
+                    RESET_IDLE,
+                    hard_deadline,
+                    max_dur,
+                )
+                .await;
+            let elapsed = start.elapsed();
+            client.shutdown().await;
+
+            // Always a true assertion: the turn must end by idling out, never
+            // by hitting the hard deadline or losing the child.
+            assert!(
+                matches!(result, Err(AcpError::IdleTimeout(_))),
+                "{what}: expected IdleTimeout, got {result:?}"
+            );
+            assert!(
+                elapsed < std::time::Duration::from_secs(20),
+                "{what}: read loop ran away; elapsed {elapsed:?}"
+            );
+
+            if elapsed >= RESET_FLOOR {
+                return;
+            }
+            inconclusive.push(elapsed);
+        }
+
+        panic!(
+            "{what}: idle fired before {RESET_FLOOR:?} on all {ATTEMPTS} attempts \
+             (elapsed {inconclusive:?}, idle budget {RESET_IDLE:?}). Activity is \
+             not resetting the idle timer. A merely-slow host would have cleared \
+             the floor on at least one attempt."
+        );
+    }
+
     /// Valid JSON `session/update` notifications reset the idle timer; non-JSON
     /// lines do not.
-    ///
-    /// See [`keepalive_resets_idle_past_deadline`] for why the budget is loose
-    /// and why the elapsed floor must stay at 2x `IDLE`.
     #[tokio::test]
     async fn idle_resets_on_stdout_activity() {
-        const IDLE: std::time::Duration = std::time::Duration::from_millis(600);
-        const FLOOR: std::time::Duration = std::time::Duration::from_millis(1200);
-
-        let mut client = spawn_script(
+        assert_activity_resets_idle(
             r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"thinking"}}}}'; sleep 0.05; done; sleep 30"#,
+            "agent_thought_chunk activity",
         )
         .await;
-        let max_dur = std::time::Duration::from_secs(30);
-        let hard_deadline = tokio::time::Instant::now() + max_dur;
-        let start = std::time::Instant::now();
-        let result = client
-            .read_until_response_with_idle_timeout("test", 999, IDLE, hard_deadline, max_dur)
-            .await;
-        let elapsed = start.elapsed();
-        // 20 messages of activity, then idle fires one IDLE later. Clearing
-        // FLOOR = 2x IDLE proves the timer was reset at least once.
-        assert!(
-            elapsed >= FLOOR,
-            "stdout activity should reset idle; elapsed only {elapsed:?}"
-        );
-        assert!(elapsed < std::time::Duration::from_secs(20));
-        assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
     }
 
     #[tokio::test]
@@ -3352,45 +3407,17 @@ mod tests {
     }
 
     /// Keepalive `session/update` lines must keep resetting the idle timer, so
-    /// the turn survives far past a single idle deadline.
+    /// the turn survives far past a single idle deadline. This is the
+    /// regression test for the keepalive fix itself.
     ///
-    /// The budget here is deliberately loose. `sleep` is an external binary
-    /// under MSYS, so on Windows each `echo; sleep 0.05` iteration costs a
-    /// process spawn: the real inter-line gap is ~98ms (up to ~244ms under
-    /// load) rather than the nominal 50ms. With the original 100ms idle budget
-    /// the fixture was genuinely silent for longer than its own deadline, so
-    /// the read loop timed out *correctly* and the test failed for a reason
-    /// that had nothing to do with the behaviour under test.
-    ///
-    /// INVARIANT: the elapsed floor must stay strictly greater than
-    /// `idle_timeout` — ideally 2x, as here. If it ever drops to or below it,
-    /// a run in which no reset happened at all would still satisfy the
-    /// assertion, and the test would prove nothing.
+    /// See [`assert_activity_resets_idle`] for the budget and the retry rule.
     #[tokio::test]
     async fn keepalive_resets_idle_past_deadline() {
-        const IDLE: std::time::Duration = std::time::Duration::from_millis(600);
-        const FLOOR: std::time::Duration = std::time::Duration::from_millis(1200);
-
-        let mut client = spawn_script(
+        assert_activity_resets_idle(
             r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 30"#,
+            "keepalive",
         )
         .await;
-        let max_dur = std::time::Duration::from_secs(30);
-        let hard_deadline = tokio::time::Instant::now() + max_dur;
-        let start = std::time::Instant::now();
-        let result = client
-            .read_until_response_with_idle_timeout("test", 999, IDLE, hard_deadline, max_dur)
-            .await;
-        let elapsed = start.elapsed();
-        // 20 keepalives of activity (~1s on Unix, ~2s on Windows), then idle
-        // fires one IDLE later. Clearing FLOOR = 2x IDLE proves at least one
-        // reset occurred.
-        assert!(
-            elapsed >= FLOOR,
-            "keepalive should reset idle past the deadline; elapsed only {elapsed:?}"
-        );
-        assert!(elapsed < std::time::Duration::from_secs(20));
-        assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -4109,7 +4109,15 @@ mod tests {
                 .expect("steer_tx send should succeed");
         });
 
-        let idle = std::time::Duration::from_millis(800);
+        // The idle timeout is only how this loop *exits* once the fixture has
+        // answered — no assertion depends on its value, and the ack and the
+        // captured bytes are checked afterwards either way. At 800ms it was
+        // also, accidentally, a deadline the fixture had to beat: an MSYS
+        // `read` plus a file write can exceed it on a loaded host, and then
+        // the loop gave up before the response arrived. Three seconds is far
+        // outside that range while still bounding a fixture that never
+        // answers, which the 10s cap catches regardless.
+        let idle = std::time::Duration::from_secs(3);
         let max_dur = std::time::Duration::from_secs(10);
         let hard_deadline = tokio::time::Instant::now() + max_dur;
         let _ = client

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -4075,7 +4075,14 @@ mod tests {
             capture = crate::testshell::quote_for_shell(capture_path),
             response = response,
         );
-        spawn_script(&script).await
+        // READY-gated, because `run_one_steer` gives the fixture an 800ms idle
+        // budget and `spawn_script` would leave MSYS shell startup inside it.
+        // Starting a real bash costs a large and load-dependent fraction of
+        // that budget, so under a loaded suite the read loop idled out before
+        // the fixture had answered at all — surfacing as whichever
+        // capture-based steer test happened to be running, which reads as four
+        // unrelated flakes rather than one shared cause.
+        spawn_script_ready(&script).await
     }
 
     /// Drive one steer through the read loop and return

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,8 @@ mod pool_lifecycle;
 mod queue;
 mod relay;
 mod setup_mode;
+#[cfg(test)]
+mod testshell;
 mod usage;
 
 pub use usage::TurnUsage;

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -5628,7 +5628,7 @@ mod tests {
             "buzz-acp-standing-lifecycle-{}.ndjson",
             Uuid::new_v4()
         ));
-        let quoted_capture = capture.to_string_lossy().replace('\'', "'\\''");
+        let quoted_capture = crate::testshell::quote_for_shell(&capture);
         let script = format!(
             r#"count=0
 while IFS= read -r line; do
@@ -5641,9 +5641,14 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
-            .await
-            .expect("spawn lifecycle ACP script");
+        let acp = AcpClient::spawn(
+            &crate::testshell::posix_shell_command(),
+            &["-c".to_string(), script],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn lifecycle ACP script");
         let mut agent = OwnedAgent {
             index: 0,
             acp,
@@ -5721,7 +5726,7 @@ done"#
             "buzz-acp-channel-delivery-lifecycle-{}.ndjson",
             Uuid::new_v4()
         ));
-        let quoted_capture = capture.to_string_lossy().replace('\'', "'\\''");
+        let quoted_capture = crate::testshell::quote_for_shell(&capture);
         let script = format!(
             r#"count=0
 while IFS= read -r line; do
@@ -5734,9 +5739,14 @@ while IFS= read -r line; do
   fi
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false)
-            .await
-            .expect("spawn channel lifecycle ACP script");
+        let acp = AcpClient::spawn(
+            &crate::testshell::posix_shell_command(),
+            &["-c".to_string(), script],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn channel lifecycle ACP script");
         let channel_id = Uuid::new_v4();
         let mut agent = OwnedAgent {
             index: 0,
@@ -5898,7 +5908,7 @@ done"#
             "buzz-acp-merged-delivery-wire-{}.ndjson",
             Uuid::new_v4()
         ));
-        let quoted_capture = capture.to_string_lossy().replace('\'', "'\\''");
+        let quoted_capture = crate::testshell::quote_for_shell(&capture);
         let script = format!(
             r#"count=0
 while IFS= read -r line; do
@@ -5907,9 +5917,14 @@ while IFS= read -r line; do
   count=$((count + 1))
 done"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
-            .await
-            .expect("spawn wire-capture ACP");
+        let acp = AcpClient::spawn(
+            &crate::testshell::posix_shell_command(),
+            &["-c".into(), script],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn wire-capture ACP");
         let mut agent = OwnedAgent {
             index: 0,
             acp,
@@ -6051,15 +6066,20 @@ done"#
             "buzz-acp-late-steer-wire-{}.ndjson",
             Uuid::new_v4()
         ));
-        let quoted_capture = capture.to_string_lossy().replace('\'', "'\\''");
+        let quoted_capture = crate::testshell::quote_for_shell(&capture);
         let script = format!(
             r#"IFS= read -r line
 printf '%s\n' "$line" > '{quoted_capture}'
 printf '%s\n' '{{"jsonrpc":"2.0","id":0,"result":{{"stopReason":"end_turn"}}}}'"#
         );
-        let acp = AcpClient::spawn("bash", &["-c".into(), script], &[], false)
-            .await
-            .expect("spawn wire-capture ACP");
+        let acp = AcpClient::spawn(
+            &crate::testshell::posix_shell_command(),
+            &["-c".into(), script],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn wire-capture ACP");
         let mut agent = OwnedAgent {
             index: 0,
             acp,

--- a/crates/buzz-acp/src/testshell.rs
+++ b/crates/buzz-acp/src/testshell.rs
@@ -1,0 +1,313 @@
+//! Interpreter resolution for tests that drive a fake ACP agent through a
+//! POSIX shell script.
+//!
+//! Dozens of tests in this crate stand up a fake agent by spawning
+//! `bash -c '<script>'` and speaking JSON-RPC to it over the child's pipes.
+//! Spawning the *bare name* `bash` is the bug this module exists to prevent.
+//!
+//! `Command::new("bash")` resolves through the Win32 search order, which places
+//! `%SystemRoot%\System32` ahead of `PATH`. On any Windows machine with the WSL
+//! optional feature enabled — the default on a developer box —
+//! `System32\bash.exe` is **WSL's launcher**, so the fake agent runs as a Linux
+//! process instead of an MSYS one. Two consequences, both silent:
+//!
+//! 1. **`read` returns nothing.** Over the native Win32 anonymous pipe that
+//!    `Stdio::piped()` creates, WSL bash's `read` builtin completes
+//!    successfully with an empty value even though the bytes arrived (`cat`
+//!    sees them). A fixture that echoes `"$REQ"` back into a JSON literal then
+//!    emits malformed JSON, the response is never matched, and the test fails
+//!    as [`AcpError::AgentExited`](crate::acp::AcpError::AgentExited) — a
+//!    symptom that looks nothing like its cause. Git Bash reads the same pipe
+//!    correctly.
+//! 2. **Win32 paths stop resolving.** WSL has no drive-letter namespace, so a
+//!    `C:\Users\...\Temp\x.json` capture path handed to the script is treated
+//!    as a *relative* filename and created in the process cwd — the crate
+//!    source directory — with `:` and `\` stored as the private-use code points
+//!    U+F03A / U+F05C that DrvFs substitutes for characters Windows forbids.
+//!
+//! The probe order below mirrors the already-reviewed production resolver in
+//! `buzz-dev-mcp` (`shell.rs::resolve_bash`), which exists for the same reason
+//! on the agent shell-tool path and whose `is_under_dir` comparison this
+//! borrows. It is reimplemented here rather than shared because that function
+//! is private to a crate `buzz-acp` does not depend on, and making it `pub`
+//! solely for tests would widen a production API for no production caller.
+//!
+//! On Unix this is simply `bash`; there is no ambiguity to resolve.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// The POSIX shell test fixtures spawn, resolved once per test binary.
+///
+/// Prefer this over the string `"bash"` anywhere a test spawns a shell.
+/// Panics with an actionable message if no suitable shell exists — a missing
+/// prerequisite must be loud, since the alternative is a suite that appears to
+/// pass while asserting nothing.
+pub(crate) fn posix_shell() -> &'static Path {
+    static SHELL: OnceLock<PathBuf> = OnceLock::new();
+    SHELL.get_or_init(resolve_posix_shell)
+}
+
+/// [`posix_shell`] as a `String`, for the `&str` command parameter of
+/// [`AcpClient::spawn`](crate::acp::AcpClient::spawn).
+pub(crate) fn posix_shell_command() -> String {
+    posix_shell().to_string_lossy().into_owned()
+}
+
+/// Render `path` for safe interpolation *inside single quotes* in a shell
+/// script, i.e. the caller writes `> '{}'`.
+///
+/// A path must never be interpolated bare. Absolute Windows paths contain
+/// backslashes, which bash consumes as escapes outside quotes: a redirect to
+/// `C:\Users\me\AppData\Local\Temp\x.json` silently becomes a redirect to the
+/// relative file `C:UsersmeAppDataLocalTempx.json`, created in the process cwd
+/// (the crate source directory) instead of the intended target. Single quotes
+/// preserve the backslashes, and MSYS accepts a Win32 path in a filesystem
+/// call.
+pub(crate) fn quote_for_shell(path: &Path) -> String {
+    // Close the quote, emit an escaped literal quote, reopen — the standard
+    // POSIX idiom, since a single-quoted string cannot contain a single quote.
+    path.to_string_lossy().replace('\'', r"'\''")
+}
+
+#[cfg(not(windows))]
+fn resolve_posix_shell() -> PathBuf {
+    PathBuf::from("bash")
+}
+
+/// Windows probe order (first hit wins), mirroring `buzz-dev-mcp`:
+///   1. `BUZZ_TEST_SHELL` — explicit override, for hosts where the heuristics
+///      below cannot find a usable shell.
+///   2. `bash.exe` on `PATH`, skipping `%SystemRoot%` and the app-execution
+///      alias directory so WSL's launcher and the Store stub are never chosen.
+///   3. `git.exe` on `PATH` → its sibling `..\bin\bash.exe`. Git for Windows's
+///      recommended PATH option adds `Git\cmd`, not `Git\bin`, so this is the
+///      usual route on a stock install.
+///   4. The standard Git for Windows install locations.
+#[cfg(windows)]
+fn resolve_posix_shell() -> PathBuf {
+    if let Some(raw) = std::env::var_os("BUZZ_TEST_SHELL") {
+        let p = PathBuf::from(raw);
+        if p.is_file() {
+            return p;
+        }
+    }
+
+    let path_env = std::env::var_os("PATH").unwrap_or_default();
+    let system_root = std::env::var_os("SystemRoot").map(PathBuf::from);
+
+    if let Some(found) = scan_path(&path_env, "bash.exe", system_root.as_deref()) {
+        return found;
+    }
+
+    if let Some(git) = scan_path(&path_env, "git.exe", system_root.as_deref()) {
+        // <install>\cmd\git.exe -> <install>\bin\bash.exe
+        if let Some(install) = git.parent().and_then(Path::parent) {
+            let candidate = install.join("bin").join("bash.exe");
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+
+    for base in ["ProgramFiles", "ProgramFiles(x86)", "LocalAppData"] {
+        if let Some(dir) = std::env::var_os(base) {
+            let candidate = PathBuf::from(dir).join("Git").join("bin").join("bash.exe");
+            if candidate.is_file() {
+                return candidate;
+            }
+        }
+    }
+
+    panic!(
+        "buzz-acp tests need Git for Windows (Git Bash) to run their fake-agent \
+         fixtures, but none was found. Checked BUZZ_TEST_SHELL, bash.exe and \
+         git.exe on PATH (excluding %SystemRoot%), and the standard Git install \
+         locations. Install it from https://git-scm.com/download/win, or set \
+         BUZZ_TEST_SHELL to a Git Bash executable. Note that WSL's \
+         System32\\bash.exe is deliberately NOT accepted: its `read` builtin \
+         returns empty over a Windows pipe, which makes these fixtures fail in \
+         ways that look like product bugs."
+    );
+}
+
+/// Scan `PATH` for `name`, skipping `%SystemRoot%` and the Windows
+/// app-execution-alias directory.
+///
+/// Skipping happens per entry so the scan continues past an alias rather than
+/// giving up, and `split_paths` is used instead of a hand-split on `;` so this
+/// sees exactly what a spawned child would.
+#[cfg(windows)]
+fn scan_path(
+    path_env: &std::ffi::OsStr,
+    name: &str,
+    system_root: Option<&Path>,
+) -> Option<PathBuf> {
+    for dir in std::env::split_paths(path_env) {
+        if let Some(root) = system_root {
+            if is_under_dir(&dir, root) {
+                continue;
+            }
+        }
+        if is_windows_apps_alias(&dir) {
+            continue;
+        }
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// True if `dir` is `root` or lives under it, comparing components
+/// case-insensitively.
+///
+/// `Path::starts_with` compares components case-sensitively on every platform,
+/// so a `PATH` entry spelled `C:\WINDOWS\System32` would slip past a
+/// `%SystemRoot%` = `C:\Windows` prefix test and let WSL's bash through.
+/// Comparing components (rather than lowercased substrings) also avoids a false
+/// hit on a sibling directory such as `C:\Windows2`.
+#[cfg(windows)]
+fn is_under_dir(dir: &Path, root: &Path) -> bool {
+    let mut dir_components = dir.components();
+    for root_component in root.components() {
+        match dir_components.next() {
+            Some(d)
+                if d.as_os_str()
+                    .eq_ignore_ascii_case(root_component.as_os_str()) => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps` holds zero-byte app-execution alias
+/// stubs, including a `bash.exe` that launches the Store build of WSL.
+#[cfg(windows)]
+fn is_windows_apps_alias(dir: &Path) -> bool {
+    let mut components = dir.components().rev();
+    matches!(
+        (components.next(), components.next()),
+        (Some(last), Some(parent))
+            if last.as_os_str().eq_ignore_ascii_case("WindowsApps")
+                && parent.as_os_str().eq_ignore_ascii_case("Microsoft")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The resolved shell must actually exist and be runnable — a resolver that
+    /// returns a plausible-looking path nothing can spawn would reintroduce the
+    /// failure mode in a new disguise.
+    #[test]
+    fn resolved_shell_runs_a_script() {
+        let out = std::process::Command::new(posix_shell())
+            .args(["-c", "printf ok"])
+            .output()
+            .expect("resolved POSIX shell must be spawnable");
+        assert!(out.status.success(), "shell exited non-zero: {out:?}");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ok");
+    }
+
+    /// The whole point: never WSL. If this regresses, the fixtures that echo a
+    /// request back through `read` start failing as `AgentExited`.
+    #[cfg(windows)]
+    #[test]
+    fn resolved_shell_is_not_wsl() {
+        let out = std::process::Command::new(posix_shell())
+            .args(["-c", "uname -s"])
+            .output()
+            .expect("resolved POSIX shell must be spawnable");
+        let uname = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !uname.contains("Linux"),
+            "resolved shell is WSL (uname -s = {}), whose `read` builtin returns \
+             empty over a Windows pipe; expected an MSYS shell",
+            uname.trim()
+        );
+    }
+
+    /// `read` over the child's stdin pipe is the capability every echo-back
+    /// fixture depends on, and the one WSL silently lacks. Assert it directly
+    /// so a bad resolution is reported here rather than as a dozen confusing
+    /// `AgentExited` failures elsewhere.
+    #[test]
+    fn resolved_shell_reads_stdin_pipe() {
+        use std::io::Write;
+        use std::process::Stdio;
+
+        let mut child = std::process::Command::new(posix_shell())
+            .args(["-c", "read -r line; printf '%s' \"$line\""])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn resolved POSIX shell");
+        child
+            .stdin
+            .take()
+            .expect("child stdin")
+            .write_all(b"round-trip\n")
+            .expect("write to child stdin");
+        let out = child.wait_with_output().expect("collect child output");
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "round-trip",
+            "the resolved shell's `read` builtin lost data over a pipe"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn system32_is_excluded_from_path_scan() {
+        let system_root = PathBuf::from(std::env::var_os("SystemRoot").expect("SystemRoot"));
+        let system32 = system_root.join("System32");
+        let path = std::env::join_paths([&system32]).expect("join_paths");
+        assert!(
+            scan_path(&path, "bash.exe", Some(&system_root)).is_none(),
+            "System32 must never yield a shell — that is WSL's launcher"
+        );
+    }
+
+    /// Case-insensitivity is the subtle half: `Path::starts_with` is
+    /// case-sensitive, so a differently-cased PATH entry would slip through.
+    #[cfg(windows)]
+    #[test]
+    fn is_under_dir_ignores_case_but_not_sibling_dirs() {
+        assert!(is_under_dir(
+            Path::new(r"C:\WINDOWS\System32"),
+            Path::new(r"C:\Windows")
+        ));
+        assert!(!is_under_dir(
+            Path::new(r"C:\Windows2\bin"),
+            Path::new(r"C:\Windows")
+        ));
+    }
+
+    /// The quoting contract, asserted on the shape that actually broke: a
+    /// Windows absolute path must survive with every backslash intact.
+    #[test]
+    fn quote_for_shell_preserves_backslashes_and_escapes_quotes() {
+        assert_eq!(
+            quote_for_shell(Path::new(r"C:\Users\me\AppData\Local\Temp\x.json")),
+            r"C:\Users\me\AppData\Local\Temp\x.json"
+        );
+        assert_eq!(
+            quote_for_shell(Path::new("/tmp/it's here.json")),
+            r"/tmp/it'\''s here.json"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_apps_alias_dir_is_recognized() {
+        assert!(is_windows_apps_alias(Path::new(
+            r"C:\Users\x\AppData\Local\Microsoft\WindowsApps"
+        )));
+        assert!(!is_windows_apps_alias(Path::new(
+            r"C:\Program Files\Git\bin"
+        )));
+    }
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -120,6 +120,12 @@ run_unit_tests() {
   # `just test-unit` — the two lists must stay in step.
   run_test_step "buzz-agent unit tests" \
     cargo test -p buzz-agent --lib -- --nocapture
+
+  # buzz-acp harness unit tests: in-process, fixtures spawn a local POSIX shell
+  # as a fake agent (no relay, no database). Mirrors the nextest path in
+  # `just test-unit` — the two lists must stay in step.
+  run_test_step "buzz-acp unit tests" \
+    cargo test -p buzz-acp --lib -- --nocapture
 }
 
 # ---- DB / integration tests (infra required) --------------------------------


### PR DESCRIPTION
## What

`cargo test -p buzz-acp --lib` fails **16 tests on Windows** at `main`, and has for a while. This makes them pass, fixes two further defects the investigation turned up, and adds the CI coverage whose absence is why nobody noticed.

**760 passed / 16 failed → 783 passed / 0 failed**, stable across 6 consecutive runs. The suite also got faster (108s → 43s), because it is no longer waiting on timeouts.

## Why it was broken

Not flaky timing, which is what the failure names suggest. Three distinct causes, two fully deterministic.

### 1. The tests were running under WSL, not Git Bash

Dozens of fixtures stand up a fake ACP agent with `AcpClient::spawn("bash", ["-c", script])`. That bare name goes through the Win32 search order, which puts `%SystemRoot%\System32` **ahead of `PATH`** — and on any machine with the WSL optional feature enabled, `System32\bash.exe` is WSL's launcher:

```
> (Get-Command bash -All).Source
C:\Windows\System32\bash.exe          <-- wins
C:\Program Files\Git\usr\bin\bash.exe
> # what a natively-spawned `bash` actually is:
uname -s  ->  Linux
```

So the fixtures ran as Linux processes. Two silent consequences:

**`read` returns nothing.** Over the native Win32 anonymous pipe `Stdio::piped()` creates, WSL bash's `read` builtin completes *successfully* with an empty value even though the bytes arrived. Same pipe, same script, side by side:

| shell | `read -r R; echo LEN=${#R}` |
|---|---|
| `System32\bash.exe` (WSL) | `LEN=0` |
| `Git\bin\bash.exe` (MSYS) | `LEN=25` |

The data is genuinely there — `cat \| wc -c` reports 26 bytes, `head -n 1` and `sed 1q` both return the line. Only `read` loses it. A fixture doing `read -t 2 REQ; echo '...\"_receivedRequest\":'\"$REQ\"'}}'` therefore emits `..."_receivedRequest":}}`, which is invalid JSON; the read loop logs a parse failure and skips it, the response is never matched, and the test dies as `AgentExited` — a symptom that looks nothing like its cause. That is all six `session_new_full_*` tests and both `goose_*` tests.

**Win32 paths stop resolving.** WSL has no drive-letter namespace, so a `C:\Users\...\Temp\x.ndjson` capture path is treated as a *relative* filename and created in the process cwd — the crate source directory. That is the four `pool.rs` lifecycle tests, and it left nine junk files in `crates/buzz-acp/`, with `:` and `\` stored as the private-use code points `U+F03A` / `U+F05C` that DrvFs substitutes for characters Windows forbids.

This repo already knows this hazard: `ci.yml` smoke-tests that the resolved bash is *not* from System32, and `buzz-dev-mcp` ships a production resolver (`shell.rs::resolve_bash`) built for exactly this. The test fixtures just never got the same treatment.

### 2. One capture path was interpolated unquoted

`spawn_steer_capture_script` built `... > {capture}` from `capture_path.display()`. Bash eats every backslash as an escape, so the redirect lands on a relative file. **This one fails under Git Bash too** — the interpreter fix does not cover it:

```
unquoted  > C:\Users\...\x.json   ->  creates ./CUsersmfethAppData...json,  target absent
quoted    > 'C:\Users\...\x.json' ->  writes the real file, nothing in cwd
```

### 3. Two idle-reset tests raced the host

`sleep` is an external binary under MSYS, so each `echo; sleep 0.05` tick pays a process spawn: the real inter-line gap is ~98ms (up to ~244ms under load), not the nominal 50ms. Against a 100ms idle budget the fixture was silent for *longer than its own deadline*, so the read loop timed out correctly and the test failed for a reason unrelated to the behaviour under test.

## The fix

**`crates/buzz-acp/src/testshell.rs`** (new, `#[cfg(test)]`) is the single seam:

- `posix_shell()` — resolves a real MSYS bash, excluding `%SystemRoot%` and the `WindowsApps` alias dir, then falling back to `git.exe`'s sibling and the standard install locations. Mirrors the probe order of the already-reviewed `buzz-dev-mcp` resolver, including its component-wise case-insensitive `is_under_dir` (`Path::starts_with` is case-sensitive on every platform, so a `C:\WINDOWS\System32` entry would otherwise slip through). On Unix it is just `bash`. It **panics** rather than falling back when nothing is found — a missing prerequisite must be loud, because the alternative is a suite that looks green while asserting nothing.
- `quote_for_shell()` — the one place that knows a path must never be interpolated bare. `pool.rs` had the idiom open-coded four times; it now shares this.

Plus `spawn_script_ready`, a READY barrier so deadline-sensitive tests start their clock *after* the shell is running rather than measuring MSYS startup.

### The retry, which deserves scrutiny

Widening the timing budgets was **not** enough, and the third commit exists because I measured that rather than assumed it: over 9 full-suite runs after the widening, the two idle-reset tests still failed on **4** of them. (The first run after the widening was green — which is exactly how a ~44% flake presents itself, and why one green run is not evidence.)

Widening further cannot work: both tests need the gap under the idle budget and the activity span over the floor, with the floor above the budget or the assertion proves nothing — and Linux finishes the 20-tick window in ~1s while Windows takes ~2s, so the floor is squeezed from both sides. No constant survives an unbounded host stall.

So `assert_activity_resets_idle` retries up to 4 times, and **only an inconclusive run**. This does not weaken the assertion, because the two outcomes have different shapes: a genuine failure to reset the idle timer is deterministic (elapsed ≈ the idle budget on every attempt, so all 4 fall short and the test fails, printing every measurement), while a host stall is intermittent. The two always-meaningful assertions stayed outside the retry — the turn must end via `IdleTimeout`, and must not run away — so a regression in either fails on the first attempt.

If you would rather these two tests be `#[cfg(unix)]`-gated than retried, say so and I will change it — but that trades a real Windows regression signal for a silent one, which seems like the wrong direction for this particular PR.

## The one that was worse than a failure

`steer_writes_nothing_when_no_run_id_and_capability_absent` was **passing on Windows for the wrong reason**. Its entire assertion is `written.is_none()`, and `written` came from reading a capture file that could never exist on Windows — so it passed vacuously. It is the only negative-space guard proving a steer stays off the wire when there is neither a run id nor an advertised capability. It is not among the 16; it is a green test that was lying, and it only becomes meaningful once the capture path works.

## CI

The reason 16 failures accumulated unnoticed: **buzz-acp's ~760 tests are executed by no CI job on any platform.** `just test-unit` enumerates crates explicitly and buzz-acp is not among them; the Windows job compiles the crate but its only test steps are `buzz-dev-mcp` and the Tauri crate. Clippy and `cargo check` type-check test code without running it. The justfile already spells out the trap it fell into — *"nothing in CI runs `cargo test --workspace` — workspace membership alone buys clippy/check, not a single executed test."*

- `justfile` + `scripts/run-tests.sh` — add `buzz-acp --lib` to the unit list (the two lists are required to stay in step).
- `ci.yml` — a `Test (buzz-acp)` **step inside the existing `windows-rust` job**. Deliberately not a new job and not path-filtered: `Windows Rust (x86_64-pc-windows-msvc)` is already a required context on a ruleset with zero bypass actors, so a path-filtered required check would report nothing on unrelated PRs and block forever, and a new unrequired job would gate nothing.

## Verification

Windows 11 / MSVC host, 16 cores.

| Gate | Result |
|---|---|
| `cargo test -p buzz-acp --lib` × 6 consecutive | **783 passed / 0 failed, 6/6** |
| baseline at `origin/main` (`1b7e5ac`), same host | 760 passed / 16 failed |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p buzz-acp --all-targets -- -D warnings` | clean |
| `just --list` / `bash -n scripts/run-tests.sh` | parse clean |
| source-tree litter after a run | 0 files (was 9) |

Totals reconcile: 776 tests at base (760 + 16) + 7 new `testshell` tests = 783. No test was deleted, skipped, or `#[cfg]`-gated away to reach zero — the four pre-existing `#[cfg(unix)]` gates are untouched.

**Not verified locally — please treat as open:**

- **Linux and macOS.** I could only run this on Windows. The interpreter change is a no-op off Windows (`posix_shell()` returns `bash`) and the timing budgets were widened rather than narrowed, so both should be safe — but CI on this PR is the first real evidence, and it is also the first time these 760 tests have run in CI at all. If they surface failures on Linux, that is the coverage gap this PR exists to close, not a regression it introduced.
- **Windows CI step duration.** 43s locally on 16 cores; a `windows-latest` runner is smaller and must codegen the crate, where the existing steps only `check`/`clippy` it. The job budget is 45 min. If the step proves too expensive, narrow it to `acp::tests` and `pool::tests` rather than dropping Windows coverage — and please don't paper over it with `continue-on-error`, since a step that cannot fail is not a gate.

## Out of scope — separate product bugs found on the way

Reported rather than bundled; none are test-only and none are touched here.

1. **`kill_process_group` is a no-op on Windows** (`acp.rs:2300-2314`). Real on Unix via `nix::killpg`; the `#[cfg(not(unix))]` arm returns `false`, so `shutdown()` and `Drop` both fall through to `child.start_kill()`, which terminates only the direct child. MCP servers and tool subprocesses are orphaned on every Windows teardown and crash-recovery cycle.
2. **Windows agents silently lose the `[Workspace]` prompt section** (`pool.rs:1362-1374`). Absoluteness is tested with `cwd.starts_with('/')`; on Windows `current_dir()` yields `E:\...`, which fails the check, so the grounding anchor is dropped with no error.
3. **npm `.cmd`/`.bat` adapter shims are unspawnable on Windows.** `config.rs:697-702` goes out of its way to recognise those extensions when deriving agent identity, but the spawn path passes the command straight to `Command::new`, which will not execute a `.cmd` shim.
4. **A relay `OK` frame with `accepted=false` is treated as a successful publish** (`relay.rs:2385-2397`) — the observer frame is dropped from the retry buffer and the rejection is only `debug!`-logged.
5. **Reaction publish timeout (500ms) is shorter than the first REST retry sleep** (500–1000ms with jitter, `pool.rs:4186`), so the retry ladder can never fire.

## Provenance

Root causes were established by direct measurement on this host, not inference — the `LEN=0`/`LEN=25` table, the `Get-Command bash -All` ordering, the quoted-vs-unquoted redirect results, and the 4-of-9 flake rate are all reproducible with the snippets above. An initial hypothesis that Git Bash's `read` was itself broken over Win32 pipes was **disproved** by the side-by-side measurement, which is what redirected the fix from a production refactor to a one-line interpreter change.
