### PR TITLE
Remove GitHub security advisory commitment

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,6 +121,4 @@ We use `cargo audit` in CI to scan for known vulnerabilities in dependencies.
 ## Disclosure Policy
 
 We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
-Once a fix is ready and released, we will publish a security advisory on
-GitHub describing the vulnerability, its impact, and the fix. Reporters will
-be credited unless they request anonymity.
+Reporters will be credited unless they request anonymity.


### PR DESCRIPTION
Removes the promise in `SECURITY.md` to publish a GitHub Security Advisory after every security fix is released.

The disclosure policy continues to state that Buzz follows coordinated disclosure and credits reporters unless they request anonymity.

Checked with `git diff --check`.