### PR TITLE
fix(desktop): scope Inbox context lookups to channel

### DIFF
--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -411,18 +411,26 @@ pub async fn get_channel_messages_before(
     })
 }
 
-#[tauri::command]
-pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<String, String> {
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "ids": [event_id],
-            "kinds": [0, 1, 3, 5, 7, 9, 30078, 40002, 40003, 40008, 40099, 40100, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
-            "limit": 1
-        })],
-    )
-    .await?;
+fn event_by_id_filter(event_id: &str, channel_id: Option<&str>) -> serde_json::Value {
+    let mut filter = serde_json::json!({
+        "ids": [event_id],
+        "kinds": [0, 1, 3, 5, 7, 9, 30078, 40002, 40003, 40008, 40099, 40100, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
+        "limit": 1
+    });
+    if let Some(channel_id) = channel_id.filter(|id| !id.trim().is_empty()) {
+        filter["#h"] = serde_json::json!([channel_id]);
+    }
+    filter
+}
 
+#[tauri::command]
+pub async fn get_event(
+    event_id: String,
+    channel_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let filter = event_by_id_filter(&event_id, channel_id.as_deref());
+    let events = query_relay(&state, &[filter]).await?;
     let ev = events
         .first()
         .ok_or_else(|| "event not found".to_string())?;

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn event_by_id_filter_scopes_group_lookup_when_channel_is_known() {
+    let filter = event_by_id_filter("event-id", Some("channel-id"));
+
+    assert_eq!(filter["ids"], serde_json::json!(["event-id"]));
+    assert_eq!(filter["#h"], serde_json::json!(["channel-id"]));
+    assert_eq!(filter["limit"], 1);
+}
+
+#[test]
+fn event_by_id_filter_keeps_unscoped_lookup_for_channel_less_events() {
+    let filter = event_by_id_filter("event-id", None);
+
+    assert!(filter.get("#h").is_none());
+}
+
+#[test]
 fn search_messages_limit_allows_discussion_discovery_page() {
     assert_eq!(search_messages_limit(None), 20);
     assert_eq!(search_messages_limit(Some(500)), 500);

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -698,7 +698,28 @@ function InboxMessageDetailPane({
                 data-testid="home-inbox-context-error"
               >
                 <AlertCircle className="h-4 w-4 shrink-0" />
-                <span>Some message context could not be loaded.</span>
+                <span className="min-w-0 flex-1">
+                  Some message context could not be loaded.
+                </span>
+                {canOpenChannel && contextChannelId ? (
+                  <Button
+                    className="h-7 shrink-0 gap-1 px-2 text-destructive hover:text-destructive"
+                    data-testid="home-inbox-context-error-open"
+                    onClick={() =>
+                      onOpenContext(
+                        contextChannelId,
+                        sourceEventId,
+                        contextThreadRootId,
+                      )
+                    }
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Open channel
+                  </Button>
+                ) : null}
               </div>
             ) : null}
             {displayMessages.map((message, index) => {

--- a/desktop/src/features/home/useInboxThreadContext.ts
+++ b/desktop/src/features/home/useInboxThreadContext.ts
@@ -112,7 +112,10 @@ export function useInboxThreadContext(
             }
 
             try {
-              const event = await getEventById(eventId);
+              const event = await getEventById(
+                eventId,
+                selectedChannelId ?? undefined,
+              );
               eventsById.set(event.id, event);
               return event;
             } catch {

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -317,9 +317,7 @@ export function fromRawFeedItem(item: RawFeedItem) {
     createdAt: item.created_at,
     channelId: item.channel_id,
     channelName: item.channel_name,
-    // Canonicalize the wire `null` to undefined so FeedItem's optional
-    // channelType contract holds at runtime (enrichment and the DM
-    // notification filter both key off `=== undefined`).
+    // FeedItem and DM filters require absent channelType to be undefined.
     channelType: item.channel_type ?? undefined,
     tags: item.tags,
     category: item.category,
@@ -407,9 +405,7 @@ export async function getCanvas(channelId: string): Promise<CanvasResponse> {
   });
   return {
     content: response.content,
-    // Normalize absent keys to null: ensureWelcomeCanvas treats null as
-    // "no canvas yet", and `undefined !== null` would make every fresh
-    // channel look already-seeded.
+    // ensureWelcomeCanvas uses null for "no canvas yet".
     updatedAt: response.updated_at ?? null,
     author: response.author ?? null,
   };
@@ -466,8 +462,14 @@ export async function searchMessages(
   };
 }
 
-export async function getEventById(eventId: string): Promise<RelayEvent> {
-  const eventJson = await invokeTauri<string>("get_event", { eventId });
+export async function getEventById(
+  eventId: string,
+  channelId?: string,
+): Promise<RelayEvent> {
+  const eventJson = await invokeTauri<string>("get_event", {
+    eventId,
+    channelId,
+  });
   return JSON.parse(eventJson) as RelayEvent;
 }
 
@@ -779,9 +781,7 @@ export async function getMyRelayMembership(): Promise<RelayMember | null> {
     const raw = await invokeTauri<RawRelayMember>("get_my_relay_membership");
     return fromRawRelayMember(raw);
   } catch (error) {
-    // "relay returned 404 Not Found" = not a relay member — return null so
-    // the UI hides the Members tab. Re-throw real errors (network, auth, 500)
-    // so React Query surfaces them.
+    // Hide Members for 404; surface network, auth, and server failures.
     if (
       error instanceof Error &&
       error.message.startsWith("relay returned 404")
@@ -1134,8 +1134,7 @@ export async function applyCommunity(
   });
 }
 
-// Validate a candidate repos dir without mutating the filesystem. Rejects
-// with a human-readable reason; resolves for a valid or empty path.
+// Validate a repos dir without mutation; reject with a human-readable reason.
 export async function validateReposDir(dir: string): Promise<void> {
   await invokeTauri("validate_repos_dir", { dir });
 }


### PR DESCRIPTION
## Summary
- include the known `#h` channel scope when Inbox hydrates parent/root events by ID
- preserve unscoped `get_event` behavior for callers that do not know a channel
- add an explicit **Open channel** action to the partial-context error banner

## Problem
For private/group-scoped stream messages, Inbox asked `get_event` for ancestors using only the event ID. The relay can require the channel `#h` context for those events, so an existing root was reported as missing and Inbox showed `Some message context could not be loaded.`

## Validation
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml event_by_id_filter --lib` — 2 passed
- `corepack pnpm --dir desktop exec tsc --noEmit` — passed
- `corepack pnpm --dir desktop lint` — passed with pre-existing warnings in unrelated files
- `corepack pnpm --dir desktop exec tauri build --bundles app --no-sign --ci` — passed
- `git diff --check` — passed

## Live reproduction evidence
The affected private-channel root and selected reply both exist and the channel-scoped thread query returns them. The failure was limited to Desktop's unscoped ancestor lookup.
