### PR TITLE
feat(invites): join configured default channels atomically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,3 +250,7 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # BUZZ_TERMS_OF_SERVICE_MARKDOWN="# Terms of Service\n\nFull terms here."
 # BUZZ_PRIVACY_POLICY_MARKDOWN="# Privacy Policy\n\nFull policy here."
 # BUZZ_AGE_ATTESTATION_REQUIRED=true
+
+# Optional comma-separated open channels joined atomically with community
+# invite admission. Every name must resolve or the claim fails closed.
+# BUZZ_INVITE_DEFAULT_CHANNELS=general,welcome-everyone,bugs

--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -366,6 +366,93 @@ async fn acquire_channel_membership_lock(
     Ok(())
 }
 
+/// Add one invite claimant to every configured default channel in the same
+/// transaction as relay admission.
+///
+/// Every configured channel must exist, be active, and be open. A deployment
+/// typo therefore fails the invite claim instead of admitting somebody to an
+/// empty community. Existing active roles are preserved; a previously removed
+/// membership is revived as an ordinary member.
+pub(crate) async fn add_invite_default_channel_memberships_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    community_id: CommunityId,
+    pubkey_hex: &str,
+    channel_names: &[String],
+) -> Result<Vec<Uuid>> {
+    if channel_names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let pubkey = hex::decode(pubkey_hex)
+        .map_err(|_| DbError::InvalidData("invite claimant pubkey must be hex".to_string()))?;
+    if pubkey.len() != 32 {
+        return Err(DbError::InvalidData(format!(
+            "invite claimant pubkey must be 32 bytes, got {}",
+            pubkey.len()
+        )));
+    }
+
+    let rows = sqlx::query(
+        r#"
+        SELECT id, name
+        FROM channels
+        WHERE community_id = $1
+          AND name = ANY($2)
+          AND visibility = 'open'
+          AND archived_at IS NULL
+          AND deleted_at IS NULL
+        ORDER BY id
+        FOR SHARE
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(channel_names)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let found_names = rows
+        .iter()
+        .map(|row| row.try_get::<String, _>("name"))
+        .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+    let missing = channel_names
+        .iter()
+        .filter(|name| !found_names.contains(name.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        return Err(DbError::InvalidData(format!(
+            "invite default channels must exist and be open: {}",
+            missing.join(", ")
+        )));
+    }
+
+    let mut channel_ids = Vec::with_capacity(rows.len());
+    for row in rows {
+        let channel_id: Uuid = row.try_get("id")?;
+        sqlx::query(
+            r#"
+            INSERT INTO channel_members (community_id, channel_id, pubkey, role, invited_by)
+            VALUES ($1, $2, $3, 'member', NULL)
+            ON CONFLICT (community_id, channel_id, pubkey) DO UPDATE SET
+                removed_at = NULL,
+                removed_by = NULL,
+                role = CASE
+                    WHEN channel_members.removed_at IS NULL THEN channel_members.role
+                    ELSE 'member'::member_role
+                END
+            "#,
+        )
+        .bind(community_id.as_uuid())
+        .bind(channel_id)
+        .bind(&pubkey)
+        .execute(&mut **tx)
+        .await?;
+        channel_ids.push(channel_id);
+    }
+
+    Ok(channel_ids)
+}
+
 /// Add a member to a channel.
 ///
 /// Role enforcement:

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -4388,6 +4388,26 @@ impl Db {
             .await
     }
 
+    /// Claim relay membership and configured default channels atomically.
+    pub async fn claim_relay_membership_with_channels(
+        &self,
+        community: CommunityId,
+        pubkey: &str,
+        role: &str,
+        policy_version: Option<&str>,
+        default_channel_names: &[String],
+    ) -> Result<relay_members::RelayMembershipClaim> {
+        relay_members::claim_relay_membership_with_channels(
+            &self.pool,
+            community,
+            pubkey,
+            role,
+            policy_version,
+            default_channel_names,
+        )
+        .await
+    }
+
     /// Returns whether a member has persisted acceptance evidence for a policy version.
     #[datastore_span(name = "has_join_policy_acceptance", system = "postgresql")]
     pub async fn has_join_policy_acceptance(
@@ -4521,6 +4541,26 @@ impl Db {
             token_hash,
             claimer_pubkey,
             policy_version,
+        )
+        .await
+    }
+
+    /// Claim a v2 relay invite and configured default channels atomically.
+    pub async fn claim_relay_invite_with_channels(
+        &self,
+        community: CommunityId,
+        token_hash: &[u8; 32],
+        claimer_pubkey: &str,
+        policy_version: Option<&str>,
+        default_channel_names: &[String],
+    ) -> Result<relay_invite::ClaimOutcome> {
+        relay_invite::claim_relay_invite_with_channels(
+            &self.pool,
+            community,
+            token_hash,
+            claimer_pubkey,
+            policy_version,
+            default_channel_names,
         )
         .await
     }

--- a/crates/buzz-db/src/relay_invite.rs
+++ b/crates/buzz-db/src/relay_invite.rs
@@ -39,6 +39,8 @@ pub enum ClaimOutcome {
         use_count: i32,
         /// Remaining slots, or `None` when the invite is unlimited.
         uses_remaining: Option<i32>,
+        /// Every configured default channel refreshed by the transaction.
+        channel_ids: Vec<uuid::Uuid>,
     },
     /// The claimer was already a member. `use_count` was NOT incremented.
     AlreadyMember {
@@ -46,6 +48,8 @@ pub enum ClaimOutcome {
         use_count: i32,
         /// Remaining slots, or `None` when the invite is unlimited.
         uses_remaining: Option<i32>,
+        /// Every configured default channel refreshed by the transaction.
+        channel_ids: Vec<uuid::Uuid>,
     },
     /// The invite's `expires_at` has passed.
     Expired,
@@ -215,6 +219,26 @@ pub async fn claim_relay_invite(
     claimer_pubkey: &str,
     policy_version: Option<&str>,
 ) -> Result<ClaimOutcome> {
+    claim_relay_invite_with_channels(
+        pool,
+        community,
+        token_hash,
+        claimer_pubkey,
+        policy_version,
+        &[],
+    )
+    .await
+}
+
+/// Atomically claim a v2 relay invite and join configured default channels.
+pub async fn claim_relay_invite_with_channels(
+    pool: &PgPool,
+    community: CommunityId,
+    token_hash: &[u8; 32],
+    claimer_pubkey: &str,
+    policy_version: Option<&str>,
+    default_channel_names: &[String],
+) -> Result<ClaimOutcome> {
     let mut tx = pool.begin().await?;
 
     // 2. SELECT FOR UPDATE — lock the invite row for the duration of this txn.
@@ -279,6 +303,13 @@ pub async fn claim_relay_invite(
             .execute(&mut *tx)
             .await?;
         }
+        let channel_ids = crate::channel::add_invite_default_channel_memberships_tx(
+            &mut tx,
+            community,
+            claimer_pubkey,
+            default_channel_names,
+        )
+        .await?;
         tx.commit().await?;
         log_claim_outcome(
             community,
@@ -290,6 +321,7 @@ pub async fn claim_relay_invite(
         return Ok(ClaimOutcome::AlreadyMember {
             use_count,
             uses_remaining: uses_remaining(),
+            channel_ids,
         });
     }
 
@@ -338,6 +370,13 @@ pub async fn claim_relay_invite(
     }
 
     if !inserted {
+        let channel_ids = crate::channel::add_invite_default_channel_memberships_tx(
+            &mut tx,
+            community,
+            claimer_pubkey,
+            default_channel_names,
+        )
+        .await?;
         tx.commit().await?;
         log_claim_outcome(
             community,
@@ -349,8 +388,17 @@ pub async fn claim_relay_invite(
         return Ok(ClaimOutcome::AlreadyMember {
             use_count,
             uses_remaining: uses_remaining(),
+            channel_ids,
         });
     }
+
+    let channel_ids = crate::channel::add_invite_default_channel_memberships_tx(
+        &mut tx,
+        community,
+        claimer_pubkey,
+        default_channel_names,
+    )
+    .await?;
 
     // 10. Increment use_count (for every new member, even unlimited).
     let new_use_count = use_count + 1;
@@ -377,6 +425,7 @@ pub async fn claim_relay_invite(
     Ok(ClaimOutcome::Joined {
         use_count: new_use_count,
         uses_remaining: new_uses_remaining,
+        channel_ids,
     })
 }
 
@@ -454,6 +503,16 @@ mod tests {
             .execute(&mut *tx)
             .await
             .expect("delete test members");
+        sqlx::query("DELETE FROM channel_members WHERE community_id = $1")
+            .bind(community.as_uuid())
+            .execute(&mut *tx)
+            .await
+            .expect("delete test channel members");
+        sqlx::query("DELETE FROM channels WHERE community_id = $1")
+            .bind(community.as_uuid())
+            .execute(&mut *tx)
+            .await
+            .expect("delete test channels");
         sqlx::query("DELETE FROM communities WHERE id = $1")
             .bind(community.as_uuid())
             .execute(&mut *tx)
@@ -599,6 +658,7 @@ mod tests {
             ClaimOutcome::Joined {
                 use_count: 1,
                 uses_remaining: Some(0),
+                channel_ids: Vec::new(),
             }
         );
         assert_eq!(
@@ -608,6 +668,7 @@ mod tests {
             ClaimOutcome::AlreadyMember {
                 use_count: 1,
                 uses_remaining: Some(0),
+                channel_ids: Vec::new(),
             }
         );
         assert_eq!(
@@ -832,6 +893,7 @@ mod tests {
                 ClaimOutcome::Joined {
                     use_count: expected_count,
                     uses_remaining: None,
+                    channel_ids: Vec::new(),
                 }
             );
         }
@@ -865,6 +927,92 @@ mod tests {
                 .expect("claim after rollback"),
             ClaimOutcome::Joined { use_count: 1, .. }
         ));
+        delete_test_community(&pool, community).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn default_channel_admission_is_atomic_with_invite_claim() {
+        let pool = setup_pool().await;
+        let community = make_test_community(&pool).await;
+        let pubkey = test_pubkey();
+        let creator = vec![1_u8; 32];
+        let mut channel_ids = Vec::new();
+        for name in ["general", "welcome-everyone", "bugs"] {
+            let channel_id = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO channels \
+                 (id, community_id, name, channel_type, visibility, created_by) \
+                 VALUES ($1, $2, $3, 'stream', 'open', $4)",
+            )
+            .bind(channel_id)
+            .bind(community.as_uuid())
+            .bind(name)
+            .bind(&creator)
+            .execute(&pool)
+            .await
+            .expect("insert default channel");
+            channel_ids.push(channel_id);
+        }
+
+        let invite = mint_relay_invite(&pool, community, "owner", 3600, Some(1))
+            .await
+            .expect("mint invite");
+        let hash = hash_v2_code(&invite.code);
+
+        let invalid = claim_relay_invite_with_channels(
+            &pool,
+            community,
+            &hash,
+            &pubkey,
+            None,
+            &["general".to_string(), "missing".to_string()],
+        )
+        .await
+        .expect_err("missing default channel must reject claim");
+        assert!(matches!(invalid, crate::DbError::InvalidData(_)));
+        assert!(!is_relay_member(&pool, community, &pubkey)
+            .await
+            .expect("membership after rejected defaults"));
+        assert_eq!(use_count(&pool, community, invite.invite_id).await, 0);
+
+        let names = vec![
+            "general".to_string(),
+            "welcome-everyone".to_string(),
+            "bugs".to_string(),
+        ];
+        let outcome =
+            claim_relay_invite_with_channels(&pool, community, &hash, &pubkey, None, &names)
+                .await
+                .expect("claim with default channels");
+        let mut admitted_ids = match outcome {
+            ClaimOutcome::Joined {
+                use_count: 1,
+                uses_remaining: Some(0),
+                channel_ids,
+            } => channel_ids,
+            other => panic!("unexpected claim outcome: {other:?}"),
+        };
+        admitted_ids.sort_unstable();
+        channel_ids.sort_unstable();
+        assert_eq!(admitted_ids, channel_ids);
+
+        let channel_memberships: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM channel_members \
+             WHERE community_id = $1 AND pubkey = decode($2, 'hex') \
+             AND removed_at IS NULL AND role = 'member'",
+        )
+        .bind(community.as_uuid())
+        .bind(&pubkey)
+        .fetch_one(&pool)
+        .await
+        .expect("count default channel memberships");
+        assert_eq!(channel_memberships, 3);
+        assert!(is_relay_member(&pool, community, &pubkey)
+            .await
+            .expect("relay membership after claim"));
+        assert_eq!(use_count(&pool, community, invite.invite_id).await, 1);
+
         delete_test_community(&pool, community).await;
     }
 }

--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -153,6 +153,31 @@ pub async fn claim_relay_membership(
     role: &str,
     policy_version: Option<&str>,
 ) -> Result<bool> {
+    Ok(
+        claim_relay_membership_with_channels(pool, community, pubkey, role, policy_version, &[])
+            .await?
+            .inserted,
+    )
+}
+
+/// Result of an invite-backed relay membership claim with default channels.
+#[derive(Debug, PartialEq)]
+pub struct RelayMembershipClaim {
+    /// Whether relay membership was newly inserted.
+    pub inserted: bool,
+    /// Every configured default channel refreshed by the transaction.
+    pub channel_ids: Vec<uuid::Uuid>,
+}
+
+/// Claim relay membership and default channel memberships atomically.
+pub async fn claim_relay_membership_with_channels(
+    pool: &PgPool,
+    community: CommunityId,
+    pubkey: &str,
+    role: &str,
+    policy_version: Option<&str>,
+    default_channel_names: &[String],
+) -> Result<RelayMembershipClaim> {
     let mut tx = pool.begin().await?;
     let inserted = sqlx::query(
         "INSERT INTO relay_members (community_id, pubkey, role, added_by) \
@@ -179,8 +204,19 @@ pub async fn claim_relay_membership(
         .await?;
     }
 
+    let channel_ids = crate::channel::add_invite_default_channel_memberships_tx(
+        &mut tx,
+        community,
+        pubkey,
+        default_channel_names,
+    )
+    .await?;
+
     tx.commit().await?;
-    Ok(inserted)
+    Ok(RelayMembershipClaim {
+        inserted,
+        channel_ids,
+    })
 }
 
 /// Returns whether a member has persisted acceptance evidence for a policy version.

--- a/crates/buzz-relay/src/api/invites.rs
+++ b/crates/buzz-relay/src/api/invites.rs
@@ -24,7 +24,9 @@ use axum::{
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::handlers::side_effects::{publish_nip43_member_added, publish_nip43_membership_list};
+use crate::handlers::side_effects::{
+    emit_group_discovery_events, publish_nip43_member_added, publish_nip43_membership_list,
+};
 use buzz_core::invite::{
     hash_v2_code, validate_v2_code, DEFAULT_INVITE_TTL_SECS, MAX_INVITE_TTL_SECS, MAX_INVITE_USES,
     MIN_INVITE_TTL_SECS, V2_PREFIX,
@@ -396,7 +398,7 @@ pub async fn claim_invite(
         let token_hash = hash_v2_code(&request.code);
         let outcome = state
             .db
-            .claim_relay_invite(
+            .claim_relay_invite_with_channels(
                 tenant.community(),
                 &token_hash,
                 &claimer_hex,
@@ -405,12 +407,13 @@ pub async fn claim_invite(
                     .join_policy
                     .as_ref()
                     .map(|policy| policy.version.as_str()),
+                &state.config.invite_default_channels,
             )
             .await
             .map_err(|e| internal_error(&format!("v2 invite claim: {e}")))?;
 
         return match outcome {
-            buzz_db::relay_invite::ClaimOutcome::Joined { .. } => {
+            buzz_db::relay_invite::ClaimOutcome::Joined { channel_ids, .. } => {
                 tracing::info!(
                     community = %tenant.community(),
                     member = %claimer_hex,
@@ -425,6 +428,7 @@ pub async fn claim_invite(
                 if let Err(e) = publish_nip43_membership_list(&tenant, &state).await {
                     tracing::warn!("failed to publish NIP-43 membership list after v2 claim: {e}");
                 }
+                publish_invite_channel_snapshots(&tenant, &state, &pubkey, &channel_ids).await;
                 Ok(Json(serde_json::json!({
                     "status": "joined",
                     "community_id": tenant.community().to_string(),
@@ -432,7 +436,8 @@ pub async fn claim_invite(
                     "role": "member",
                 })))
             }
-            buzz_db::relay_invite::ClaimOutcome::AlreadyMember { .. } => {
+            buzz_db::relay_invite::ClaimOutcome::AlreadyMember { channel_ids, .. } => {
+                publish_invite_channel_snapshots(&tenant, &state, &pubkey, &channel_ids).await;
                 Ok(Json(serde_json::json!({
                     "status": "already_member",
                     "community_id": tenant.community().to_string(),
@@ -473,9 +478,9 @@ pub async fn claim_invite(
             .map_err(|_| api_error(StatusCode::FORBIDDEN, "join_policy_required"))?;
     }
 
-    let was_inserted = state
+    let claim = state
         .db
-        .claim_relay_membership(
+        .claim_relay_membership_with_channels(
             tenant.community(),
             &claimer_hex,
             &payload.r,
@@ -484,11 +489,12 @@ pub async fn claim_invite(
                 .join_policy
                 .as_ref()
                 .map(|policy| policy.version.as_str()),
+            &state.config.invite_default_channels,
         )
         .await
         .map_err(|e| internal_error(&format!("invite claim insert: {e}")))?;
 
-    if was_inserted {
+    if claim.inserted {
         tracing::info!(
             community = %tenant.community(),
             member = %claimer_hex,
@@ -501,13 +507,34 @@ pub async fn claim_invite(
             tracing::warn!("failed to publish NIP-43 membership list after claim: {e}");
         }
     }
+    publish_invite_channel_snapshots(&tenant, &state, &pubkey, &claim.channel_ids).await;
 
     Ok(Json(serde_json::json!({
-        "status": if was_inserted { "joined" } else { "already_member" },
+        "status": if claim.inserted { "joined" } else { "already_member" },
         "community_id": tenant.community().to_string(),
         "host": tenant.host(),
         "role": payload.r,
     })))
+}
+
+async fn publish_invite_channel_snapshots(
+    tenant: &buzz_core::TenantContext,
+    state: &Arc<AppState>,
+    pubkey: &nostr::PublicKey,
+    channel_ids: &[uuid::Uuid],
+) {
+    let pubkey_bytes = pubkey.to_bytes();
+    for &channel_id in channel_ids {
+        state.invalidate_membership(tenant, channel_id, &pubkey_bytes);
+        if let Err(error) = emit_group_discovery_events(tenant, state, channel_id).await {
+            tracing::warn!(
+                channel = %channel_id,
+                member = %pubkey.to_hex(),
+                %error,
+                "failed to publish channel membership snapshot after invite claim"
+            );
+        }
+    }
 }
 
 /// Fixed-window rate limit on claim attempts, keyed by community and claimer

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -281,6 +281,10 @@ pub struct Config {
     /// documents or age attestation are configured.
     pub join_policy: Option<JoinPolicyConfig>,
 
+    /// Open channels joined atomically with a successful community invite.
+    /// Configured by `BUZZ_INVITE_DEFAULT_CHANNELS` as comma-separated names.
+    pub invite_default_channels: Vec<String>,
+
     /// Deployment-admin API and SPA configuration. Absent means the surface is disabled.
     pub admin: Option<AdminConfig>,
 
@@ -409,6 +413,39 @@ fn parse_bool(name: &str, default: bool) -> Result<bool, ConfigError> {
 
 fn parse_optional_bool(name: &str) -> Result<bool, ConfigError> {
     parse_bool(name, false)
+}
+
+fn parse_invite_default_channels(raw: Option<String>) -> Result<Vec<String>, ConfigError> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    if raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut names = Vec::new();
+    for part in raw.split(',') {
+        let name = part.trim();
+        if name.is_empty() {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_INVITE_DEFAULT_CHANNELS contains an empty channel name".to_string(),
+            ));
+        }
+        if name.len() > 128 {
+            return Err(ConfigError::InvalidValue(
+                "BUZZ_INVITE_DEFAULT_CHANNELS channel names must be at most 128 bytes".to_string(),
+            ));
+        }
+        if !names.iter().any(|existing| existing == name) {
+            names.push(name.to_string());
+        }
+    }
+    if names.len() > 32 {
+        return Err(ConfigError::InvalidValue(
+            "BUZZ_INVITE_DEFAULT_CHANNELS supports at most 32 channels".to_string(),
+        ));
+    }
+    Ok(names)
 }
 
 fn ensure_git_repo_path(
@@ -908,6 +945,8 @@ impl Config {
         let privacy_markdown = read_policy_markdown("BUZZ_PRIVACY_POLICY_MARKDOWN")?;
         let age_attestation_required = parse_optional_bool("BUZZ_AGE_ATTESTATION_REQUIRED")?;
         let audit_enabled = parse_bool("BUZZ_AUDIT_ENABLED", true)?;
+        let invite_default_channels =
+            parse_invite_default_channels(std::env::var("BUZZ_INVITE_DEFAULT_CHANNELS").ok())?;
         let join_policy = if terms_markdown.is_none()
             && privacy_markdown.is_none()
             && !age_attestation_required
@@ -1038,6 +1077,7 @@ impl Config {
             push_gateway_delivery_url,
             push_gateway_timeout,
             join_policy,
+            invite_default_channels,
             admin,
             web_dir,
             serve_git_web_gui,
@@ -1048,6 +1088,22 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invite_default_channels_are_trimmed_and_deduplicated() {
+        assert_eq!(
+            parse_invite_default_channels(Some(
+                "general, welcome-everyone,bugs,general".to_string()
+            ))
+            .expect("valid default channels"),
+            vec!["general", "welcome-everyone", "bugs"]
+        );
+    }
+
+    #[test]
+    fn invite_default_channels_reject_empty_entries() {
+        assert!(parse_invite_default_channels(Some("general,,bugs".to_string())).is_err());
+    }
 
     // Mutex to serialize tests that mutate environment variables.
     // Parallel env-var mutation causes `defaults_are_valid` to see the invalid

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -576,6 +576,45 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // A deployment with invite-default channels treats the database channel
+    // roster as onboarding-critical state. Refresh every signed NIP-29
+    // discovery snapshot before opening the listener so direct operational
+    // repairs (membership or visibility) are reflected on the next rollout.
+    if !state.config.invite_default_channels.is_empty() {
+        match buzz_relay::tenant::bind_deployment_community(&state.db, &state.config.relay_url)
+            .await
+        {
+            Ok(tenant) => match state.db.list_channels(tenant.community(), None).await {
+                Ok(channels) => {
+                    let mut refreshed = 0usize;
+                    for channel in channels {
+                        match buzz_relay::handlers::side_effects::emit_group_discovery_events(
+                            &tenant, &state, channel.id,
+                        )
+                        .await
+                        {
+                            Ok(()) => refreshed += 1,
+                            Err(error) => tracing::warn!(
+                                channel = %channel.id,
+                                %error,
+                                "invite-default channel snapshot refresh failed"
+                            ),
+                        }
+                    }
+                    info!(refreshed, "invite-default channel snapshots refreshed");
+                }
+                Err(error) => tracing::warn!(
+                    %error,
+                    "invite-default channel snapshot refresh could not list channels"
+                ),
+            },
+            Err(error) => tracing::warn!(
+                ?error,
+                "invite-default channel snapshot refresh could not bind community"
+            ),
+        }
+    }
+
     // Emit kind:39000/39002 discovery events for channels that exist in the DB
     // but don't have corresponding events (e.g. seeded via direct SQL inserts).
     // Only runs when BUZZ_RECONCILE_CHANNELS=true (dev/CI environments).


### PR DESCRIPTION
## Summary

- admit relay invite claims to configured default channels in the same database transaction
- fail closed if any configured channel is missing, private, archived, or deleted
- refresh signed NIP-29 discovery snapshots after invite claims and on configured relay startup
- preserve existing channel roles and revive removed memberships as members

## Configuration

`BUZZ_INVITE_DEFAULT_CHANNELS=general,welcome-everyone,bugs`

The comma-separated channel names are trimmed, deduplicated, length-limited, and capped at 32 entries.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p buzz-db -p buzz-relay`
- `cargo test -p buzz-db relay_invite::tests::default_channel_admission_is_atomic_with_invite_claim`
- `cargo test -p buzz-db migration::tests::run_migrations_applies_consolidated_initial_schema_on_fresh_database`
- relay configuration unit tests
