### PR TITLE
Remove Startup Recovery section in base prompt

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -87,12 +87,10 @@ All replies and delegations — including task assignments to other agents — g
 - Use top-level channel-visible posts for milestones teammates must act on: picked up, blocked + need input, PR up, done.
 - Praise in public; correct in the work, not the person.
 
-## Startup Recovery
+## Turn Contracts
 
-1. `buzz feed get` — surface pending mentions and action items. Filter by type: `mentions`, `needs_action`, `activity`, `agent_activity`.
-2. `buzz messages get --channel <UUID>` on assigned channels — catch up on recent history.
-3. Check `AGENTS.md` in your working directory for team context.
-4. Check `RESEARCH/`, `GUIDES/`, `PLANS/` before searching externally. Use `buzz messages search --query "..."` for cross-channel keyword lookups.
+- **Channel turn:** The current `[Context]` and triggering Buzz event define your work and reply destination. Stay in that channel unless the user explicitly asks otherwise. Use the context's `buzz messages` hint only when you need more history; do not scan the feed for unrelated work.
+- **Heartbeat turn:** A `[System: Heartbeat]` prompt has no incoming event or channel context. Follow that prompt to check the feed for actionable work, and end the turn silently when there is none.
 
 ## Workspace Layout
 

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -87,11 +87,6 @@ All replies and delegations — including task assignments to other agents — g
 - Use top-level channel-visible posts for milestones teammates must act on: picked up, blocked + need input, PR up, done.
 - Praise in public; correct in the work, not the person.
 
-## Turn Contracts
-
-- **Channel turn:** The current `[Context]` and triggering Buzz event define your work and reply destination. Stay in that channel unless the user explicitly asks otherwise. Use the context's `buzz messages` hint only when you need more history; do not scan the feed for unrelated work.
-- **Heartbeat turn:** A `[System: Heartbeat]` prompt has no incoming event or channel context. Follow that prompt to check the feed for actionable work, and end the turn silently when there is none.
-
 ## Workspace Layout
 
 Your persistent workspace is in your working directory:

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4584,6 +4584,17 @@ mod agent_draft_prompt_tests {
             .contains("add them explicitly with `buzz channels add-member` only when authorized"));
         assert!(prompt.contains("never changes membership automatically"));
     }
+
+    #[test]
+    fn shared_base_prompt_distinguishes_channel_and_heartbeat_turns() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("## Turn Contracts"));
+        assert!(prompt.contains("**Channel turn:**"));
+        assert!(prompt.contains("**Heartbeat turn:**"));
+        assert!(prompt.contains("`[Context]` and triggering Buzz event"));
+        assert!(prompt.contains("`[System: Heartbeat]` prompt has no incoming event"));
+        assert!(!prompt.contains("## Startup Recovery"));
+    }
 }
 
 fn default_heartbeat_prompt() -> String {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4584,17 +4584,6 @@ mod agent_draft_prompt_tests {
             .contains("add them explicitly with `buzz channels add-member` only when authorized"));
         assert!(prompt.contains("never changes membership automatically"));
     }
-
-    #[test]
-    fn shared_base_prompt_distinguishes_channel_and_heartbeat_turns() {
-        let prompt = include_str!("base_prompt.md");
-        assert!(prompt.contains("## Turn Contracts"));
-        assert!(prompt.contains("**Channel turn:**"));
-        assert!(prompt.contains("**Heartbeat turn:**"));
-        assert!(prompt.contains("`[Context]` and triggering Buzz event"));
-        assert!(prompt.contains("`[System: Heartbeat]` prompt has no incoming event"));
-        assert!(!prompt.contains("## Startup Recovery"));
-    }
 }
 
 fn default_heartbeat_prompt() -> String {


### PR DESCRIPTION
## Why

Managed channel sessions already receive authoritative per-turn context. The old startup recovery checklist told every new session to scan the global feed,

## What

- Remove `Startup Recovery` with concise channel and heartbeat turn contracts.

## Risk Assessment

Low. This changes prompt guidance and its test only; routing and runtime behavior are unchanged.

Generated with Codex
