### PR TITLE
fix: require profiles for mobile invite joins

### DIFF
--- a/desktop/src/features/messages/lib/mentionRanking.test.mjs
+++ b/desktop/src/features/messages/lib/mentionRanking.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { rankMentionCandidates } from "./mentionRanking.ts";
+import {
+  mentionCandidatesForQuery,
+  rankMentionCandidates,
+} from "./mentionRanking.ts";
 
 const CHANNEL_BRAIN_PUBKEY = "1".repeat(64);
 const OTHER_BRAIN_PUBKEY = "2".repeat(64);
@@ -137,5 +140,31 @@ test("rankMentionCandidates: owned teams rank with runnable personas", () => {
       (item) => item.candidate.kind,
     ),
     ["team", "identity"],
+  );
+});
+
+test("mentionCandidatesForQuery: empty @ menu contains channel members only", () => {
+  const member = candidate({
+    displayName: "Ariel",
+    isMember: true,
+    pubkey: CHANNEL_BRAIN_PUBKEY,
+  });
+  const remoteAgent = candidate({
+    displayName: "Fizz",
+    isAgent: true,
+    pubkey: OTHER_BRAIN_PUBKEY,
+  });
+
+  assert.deepEqual(
+    mentionCandidatesForQuery([member, remoteAgent], "").map(
+      (item) => item.pubkey,
+    ),
+    [CHANNEL_BRAIN_PUBKEY],
+  );
+  assert.deepEqual(
+    mentionCandidatesForQuery([member, remoteAgent], "fizz").map(
+      (item) => item.pubkey,
+    ),
+    [CHANNEL_BRAIN_PUBKEY, OTHER_BRAIN_PUBKEY],
   );
 });

--- a/desktop/src/features/messages/lib/mentionRanking.ts
+++ b/desktop/src/features/messages/lib/mentionRanking.ts
@@ -100,3 +100,18 @@ export function rankMentionCandidates<T extends MentionCandidateForRanking>(
         a.groupRank - b.groupRank || a.score - b.score || a.order - b.order,
     );
 }
+
+/** Keep an empty @ menu local to the current conversation.
+ *
+ * Non-member people, personas, teams, and agents remain searchable once the
+ * author types a query, but do not leak directory status rows into the default
+ * picker.
+ */
+export function mentionCandidatesForQuery<T extends MentionCandidateForRanking>(
+  candidates: readonly T[],
+  query: string,
+): readonly T[] {
+  return query.trim().length === 0
+    ? candidates.filter((candidate) => candidate.isMember)
+    : candidates;
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -46,7 +46,10 @@ import { useAgentMentionRevalidation } from "./agentMentionRevalidation";
 import { hasMention } from "./hasMention";
 import { extractMentionPubkeys } from "./extractMentionPubkeys";
 import { useDraftMentionRouting } from "./useDraftMentionRouting";
-import { rankMentionCandidates } from "./mentionRanking";
+import {
+  mentionCandidatesForQuery,
+  rankMentionCandidates,
+} from "./mentionRanking";
 import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
 import {
   appendUniqueName,
@@ -529,7 +532,7 @@ export function useMentions(
     }
 
     return rankMentionCandidates(
-      mentionCandidatesWithTeams,
+      mentionCandidatesForQuery(mentionCandidatesWithTeams, mentionQuery),
       mentionQuery,
       activePersonaIds,
     )

--- a/mobile/lib/features/invites/invite_join_provider.dart
+++ b/mobile/lib/features/invites/invite_join_provider.dart
@@ -8,6 +8,7 @@ import '../../shared/auth/auth.dart';
 import '../../shared/deeplink/deep_link.dart';
 import '../../shared/relay/relay_session.dart';
 import '../../shared/relay/relay_validation.dart';
+import '../profile/profile_provider.dart';
 
 final inviteJoinHttpClientProvider = Provider<http.Client>((ref) {
   final client = http.Client();
@@ -25,6 +26,7 @@ enum InviteJoinStatus {
   idle,
   confirming,
   claiming,
+  profileError,
   success,
   switchedExisting,
   error,
@@ -65,6 +67,8 @@ class InviteJoinState {
 }
 
 class InviteJoinNotifier extends Notifier<InviteJoinState> {
+  Community? _joinedCommunity;
+
   @override
   InviteJoinState build() => const InviteJoinState();
 
@@ -93,12 +97,20 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
     );
   }
 
-  Future<void> confirmJoin() async {
+  Future<void> confirmJoin({required String displayName}) async {
     final invite = state.invite;
+    final normalizedName = displayName.trim();
     if (invite == null ||
+        normalizedName.isEmpty ||
         state.requiresFreshInvite ||
         (state.status != InviteJoinStatus.confirming &&
-            state.status != InviteJoinStatus.error)) {
+            state.status != InviteJoinStatus.error &&
+            state.status != InviteJoinStatus.profileError)) {
+      return;
+    }
+
+    if (state.status == InviteJoinStatus.profileError) {
+      await _retryProfile(normalizedName);
       return;
     }
 
@@ -164,6 +176,24 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
       await ref
           .read(authProvider.notifier)
           .authenticateWithCommunity(community);
+      _joinedCommunity = community;
+      try {
+        await publishProfileOverHttp(
+          client: ref.read(inviteJoinHttpClientProvider),
+          relayUrl: invite.relayUrl,
+          nsec: keys.nsec,
+          displayName: normalizedName,
+        );
+        ref.invalidate(profileProvider);
+      } catch (_) {
+        state = state.copyWith(
+          status: InviteJoinStatus.profileError,
+          errorMessage:
+              'You joined, but Buzz could not save your name. Try again.',
+          requiresFreshInvite: false,
+        );
+        return;
+      }
       state = state.copyWith(
         status: InviteJoinStatus.success,
         communityName: community.name,
@@ -179,7 +209,33 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
   }
 
   void reset() {
+    _joinedCommunity = null;
     state = const InviteJoinState();
+  }
+
+  Future<void> _retryProfile(String displayName) async {
+    final community = _joinedCommunity;
+    if (community?.nsec == null) return;
+    state = state.copyWith(status: InviteJoinStatus.claiming, errorMessage: '');
+    try {
+      await publishProfileOverHttp(
+        client: ref.read(inviteJoinHttpClientProvider),
+        relayUrl: community!.relayUrl,
+        nsec: community.nsec!,
+        displayName: displayName,
+      );
+      ref.invalidate(profileProvider);
+      state = state.copyWith(
+        status: InviteJoinStatus.success,
+        communityName: community.name,
+        errorMessage: '',
+      );
+    } catch (_) {
+      state = state.copyWith(
+        status: InviteJoinStatus.profileError,
+        errorMessage: 'Buzz still could not save your name. Try again.',
+      );
+    }
   }
 }
 

--- a/mobile/lib/features/invites/invite_join_sheet.dart
+++ b/mobile/lib/features/invites/invite_join_sheet.dart
@@ -17,11 +17,24 @@ Future<void> showInviteJoinSheet(BuildContext context, WidgetRef ref) {
   );
 }
 
-class InviteJoinSheet extends ConsumerWidget {
+class InviteJoinSheet extends ConsumerStatefulWidget {
   const InviteJoinSheet({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<InviteJoinSheet> createState() => _InviteJoinSheetState();
+}
+
+class _InviteJoinSheetState extends ConsumerState<InviteJoinSheet> {
+  final _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(inviteJoinProvider);
     final isClaiming = state.status == InviteJoinStatus.claiming;
     final host = state.host ?? 'unknown host';
@@ -79,13 +92,26 @@ class InviteJoinSheet extends ConsumerWidget {
               ),
             ],
             const SizedBox(height: Grid.sm),
+            TextField(
+              controller: _nameController,
+              enabled: !isClaiming,
+              textCapitalization: TextCapitalization.words,
+              autofillHints: const [AutofillHints.name],
+              decoration: const InputDecoration(
+                labelText: 'Your name',
+                hintText: 'How people will see you',
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: Grid.sm),
             Text(
               'This phone is the only copy of this identity. If you lose it before pairing or backing up, you’ll lose access as this member.',
               style: context.textTheme.bodyMedium?.copyWith(
                 color: context.colors.onSurfaceVariant,
               ),
             ),
-            if (state.status == InviteJoinStatus.error &&
+            if ((state.status == InviteJoinStatus.error ||
+                    state.status == InviteJoinStatus.profileError) &&
                 state.errorMessage != null) ...[
               const SizedBox(height: Grid.sm),
               Text(
@@ -109,11 +135,14 @@ class InviteJoinSheet extends ConsumerWidget {
                 const SizedBox(width: Grid.sm),
                 Expanded(
                   child: FilledButton.icon(
-                    onPressed: isClaiming || state.requiresFreshInvite
+                    onPressed:
+                        isClaiming ||
+                            state.requiresFreshInvite ||
+                            _nameController.text.trim().isEmpty
                         ? null
                         : () => ref
                               .read(inviteJoinProvider.notifier)
-                              .confirmJoin(),
+                              .confirmJoin(displayName: _nameController.text),
                     icon: isClaiming
                         ? SizedBox(
                             width: 16,
@@ -124,7 +153,13 @@ class InviteJoinSheet extends ConsumerWidget {
                             ),
                           )
                         : const Icon(LucideIcons.check),
-                    label: Text(isClaiming ? 'Joining…' : 'Join'),
+                    label: Text(
+                      isClaiming
+                          ? 'Saving…'
+                          : state.status == InviteJoinStatus.profileError
+                          ? 'Save name'
+                          : 'Join',
+                    ),
                   ),
                 ),
               ],

--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../shared/theme/theme.dart';
+import '../../shared/widgets/modal_presentation.dart';
+import 'profile_provider.dart';
+
+Future<void> showEditProfileSheet(
+  BuildContext context, {
+  required String initialName,
+}) {
+  return showBuzzModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => _EditProfileSheet(initialName: initialName),
+  );
+}
+
+class _EditProfileSheet extends ConsumerStatefulWidget {
+  const _EditProfileSheet({required this.initialName});
+
+  final String initialName;
+
+  @override
+  ConsumerState<_EditProfileSheet> createState() => _EditProfileSheetState();
+}
+
+class _EditProfileSheetState extends ConsumerState<_EditProfileSheet> {
+  late final TextEditingController _controller;
+  bool _isSaving = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final name = _controller.text.trim();
+    if (name.isEmpty || _isSaving) return;
+    setState(() {
+      _isSaving = true;
+      _error = null;
+    });
+    try {
+      await ref.read(profileProvider.notifier).saveDisplayName(name);
+      if (mounted) Navigator.of(context).pop();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _isSaving = false;
+        _error = 'Buzz could not save your name. Try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          Grid.sm,
+          0,
+          Grid.sm,
+          MediaQuery.viewInsetsOf(context).bottom + Grid.sm,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Edit profile', style: context.textTheme.titleLarge),
+            const SizedBox(height: Grid.sm),
+            TextField(
+              key: const ValueKey('edit-profile-name'),
+              controller: _controller,
+              enabled: !_isSaving,
+              autofocus: true,
+              textCapitalization: TextCapitalization.words,
+              autofillHints: const [AutofillHints.name],
+              decoration: const InputDecoration(labelText: 'Your name'),
+              onChanged: (_) => setState(() {}),
+              onSubmitted: (_) => _save(),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: Grid.xs),
+              Text(
+                _error!,
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colors.error,
+                ),
+              ),
+            ],
+            const SizedBox(height: Grid.sm),
+            FilledButton(
+              onPressed: _isSaving || _controller.text.trim().isEmpty
+                  ? null
+                  : _save,
+              child: Text(_isSaving ? 'Saving…' : 'Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:nostr/nostr.dart' as nostr;
 
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';
@@ -38,11 +41,132 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
   Future<void> refresh() async {
     state = await AsyncValue.guard(_fetch);
   }
+
+  Future<void> saveDisplayName(String displayName) async {
+    final normalized = displayName.trim();
+    if (normalized.isEmpty) {
+      throw ArgumentError.value(
+        displayName,
+        'displayName',
+        'must not be empty',
+      );
+    }
+
+    final config = ref.read(relayConfigProvider);
+    final nsec = config.nsec;
+    if (nsec == null || nsec.isEmpty) {
+      throw StateError('Cannot save profile without a signing key');
+    }
+
+    final previous = state.asData?.value;
+    final client = http.Client();
+    try {
+      await publishProfileOverHttp(
+        client: client,
+        relayUrl: config.baseUrl,
+        nsec: nsec,
+        displayName: normalized,
+        existing: previous,
+      );
+    } finally {
+      client.close();
+    }
+
+    final pubkey = pubkeyFromNsec(nsec);
+    if (pubkey == null) {
+      throw StateError('Cannot derive profile public key');
+    }
+    state = AsyncData(
+      UserProfile(
+        pubkey: pubkey,
+        displayName: normalized,
+        avatarUrl: previous?.avatarUrl,
+        about: previous?.about,
+        nip05Handle: previous?.nip05Handle,
+        ownerPubkey: previous?.ownerPubkey,
+      ),
+    );
+  }
 }
 
 final profileProvider = AsyncNotifierProvider<ProfileNotifier, UserProfile?>(
   ProfileNotifier.new,
 );
+
+/// Publish a signed kind:0 profile through the relay's authenticated HTTP
+/// bridge. Invite onboarding uses this before the WebSocket reconnect settles;
+/// Settings uses the same path so an unnamed mobile identity can recover.
+Future<void> publishProfileOverHttp({
+  required http.Client client,
+  required String relayUrl,
+  required String nsec,
+  required String displayName,
+  UserProfile? existing,
+}) async {
+  final normalized = displayName.trim();
+  if (normalized.isEmpty) {
+    throw ArgumentError.value(displayName, 'displayName', 'must not be empty');
+  }
+
+  final privateKey = nostr.Nip19.decode(payload: nsec).data;
+  if (privateKey.isEmpty) throw StateError('Invalid signing key');
+
+  final content = <String, dynamic>{
+    'name': normalized,
+    'display_name': normalized,
+    'picture': ?existing?.avatarUrl,
+    'about': ?existing?.about,
+    'nip05': ?existing?.nip05Handle,
+  };
+  final event = nostr.Event.from(
+    kind: EventKind.metadata,
+    content: jsonEncode(content),
+    tags: const [],
+    secretKey: privateKey,
+    verify: false,
+  );
+  final bodyBytes = utf8.encode(jsonEncode(event.toMap()));
+  final url = _eventsUrlFromRelay(relayUrl);
+  final request = http.Request('POST', Uri.parse(url))
+    ..followRedirects = false
+    ..headers.addAll({
+      'Authorization': buildNip98AuthHeader(
+        method: 'POST',
+        url: url,
+        bodyBytes: bodyBytes,
+        nsec: nsec,
+      ),
+      'Content-Type': 'application/json',
+    })
+    ..bodyBytes = bodyBytes;
+  final response = await http.Response.fromStream(await client.send(request));
+  final decoded = jsonDecode(response.body.isEmpty ? '{}' : response.body);
+  final accepted =
+      response.statusCode >= 200 &&
+      response.statusCode < 300 &&
+      decoded is Map &&
+      decoded['accepted'] == true;
+  if (!accepted) {
+    throw StateError('Relay rejected profile update');
+  }
+}
+
+String _eventsUrlFromRelay(String relayUrl) {
+  final uri = Uri.parse(relayUrl);
+  final scheme = switch (uri.scheme) {
+    'wss' => 'https',
+    'ws' => 'http',
+    'https' => 'https',
+    'http' => 'http',
+    _ => throw FormatException('Invalid relay URL scheme: ${uri.scheme}'),
+  };
+  return Uri(
+    scheme: scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: '/events',
+  ).toString();
+}
 
 /// Presence status for the current user.
 ///

--- a/mobile/lib/features/profile/settings_profile_header.dart
+++ b/mobile/lib/features/profile/settings_profile_header.dart
@@ -13,6 +13,7 @@ import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/anchored_popover_menu.dart';
 import '../../shared/widgets/masked_avatar_badge.dart';
 import '../../shared/widgets/progressive_animated_avatar.dart';
+import 'edit_profile_sheet.dart';
 import 'profile_provider.dart';
 import 'set_status_sheet.dart';
 import 'user_status_provider.dart';
@@ -83,10 +84,21 @@ class SettingsProfileHeader extends HookConsumerWidget {
             ),
           ),
           const SizedBox(height: Grid.twelve),
-          Text(
-            profile?.label ?? 'Your profile',
-            style: context.textTheme.titleMedium,
-            textAlign: TextAlign.center,
+          TextButton.icon(
+            key: const ValueKey('settings-edit-profile'),
+            onPressed: () => showEditProfileSheet(
+              context,
+              initialName: profile?.displayName ?? '',
+            ),
+            iconAlignment: IconAlignment.end,
+            icon: const Icon(LucideIcons.pencil, size: 16),
+            label: Text(
+              profile?.displayName?.trim().isNotEmpty == true
+                  ? profile!.displayName!.trim()
+                  : 'Add your name',
+              style: context.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
           ),
           // Keep the status text visible even when no emoji is set. NIP-38
           // permits text-only statuses, which the avatar badge cannot represent.

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// Keep in sync with `desktop/src/shared/constants/kinds.ts`.
 abstract final class EventKind {
+  static const metadata = 0;
   static const note = 1;
   static const contactList = 3;
   static const deletion = 5;

--- a/mobile/test/features/invites/invite_join_provider_test.dart
+++ b/mobile/test/features/invites/invite_join_provider_test.dart
@@ -80,7 +80,7 @@ void main() {
     'claim posts with freshly-generated key and stores joined community',
     () async {
       final keys = nostr.Keys.generate();
-      http.Request? capturedRequest;
+      final capturedRequests = <http.Request>[];
       final storage = CommunityStorage(secure: FakeSecureStorage());
       final auth = _RecordingAuthNotifier();
       final container = ProviderContainer(
@@ -90,7 +90,13 @@ void main() {
           inviteKeyGeneratorProvider.overrideWithValue(() => keys),
           inviteJoinHttpClientProvider.overrideWithValue(
             http_testing.MockClient((request) async {
-              capturedRequest = request;
+              capturedRequests.add(request);
+              if (request.url.path == '/events') {
+                return http.Response(
+                  jsonEncode({'accepted': true, 'message': 'saved'}),
+                  200,
+                );
+              }
               return http.Response(
                 jsonEncode({
                   'status': 'joined',
@@ -119,19 +125,22 @@ void main() {
         InviteJoinStatus.confirming,
       );
 
-      await container.read(inviteJoinProvider.notifier).confirmJoin();
+      await container
+          .read(inviteJoinProvider.notifier)
+          .confirmJoin(displayName: 'Matt Example');
 
       final state = container.read(inviteJoinProvider);
       expect(state.status, InviteJoinStatus.success);
-      expect(capturedRequest, isNotNull);
+      expect(capturedRequests, hasLength(2));
+      final capturedRequest = capturedRequests.first;
       expect(
-        capturedRequest!.url.toString(),
+        capturedRequest.url.toString(),
         'https://relay.example.com/api/invites/claim',
       );
-      expect(capturedRequest!.body, jsonEncode({'code': 'code'}));
-      final authHeader = capturedRequest!.headers['Authorization'];
+      expect(capturedRequest.body, jsonEncode({'code': 'code'}));
+      final authHeader = capturedRequest.headers['Authorization'];
       expect(authHeader, startsWith('Nostr '));
-      expect(capturedRequest!.followRedirects, isFalse);
+      expect(capturedRequest.followRedirects, isFalse);
       final encoded = authHeader!.substring('Nostr '.length);
       final authEvent =
           jsonDecode(
@@ -142,11 +151,11 @@ void main() {
           .map((tag) => (tag as List<dynamic>).cast<String>())
           .toList();
       final payloadHash = SHA256Digest()
-          .process(capturedRequest!.bodyBytes)
+          .process(capturedRequest.bodyBytes)
           .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
           .join();
       expect(authEvent['kind'], 27235);
-      expect(tags, contains(equals(['u', capturedRequest!.url.toString()])));
+      expect(tags, contains(equals(['u', capturedRequest.url.toString()])));
       expect(tags, contains(equals(['method', 'POST'])));
       expect(tags, contains(equals(['payload', payloadHash])));
       expect(auth.authenticatedCommunities, hasLength(1));
@@ -156,6 +165,16 @@ void main() {
       );
       expect(auth.authenticatedCommunities.single.pubkey, keys.public);
       expect(auth.authenticatedCommunities.single.nsec, keys.nsec);
+      final profileRequest = capturedRequests.last;
+      expect(profileRequest.url.toString(), 'https://relay.example.com/events');
+      final profileEvent =
+          jsonDecode(profileRequest.body) as Map<String, dynamic>;
+      expect(profileEvent['kind'], 0);
+      expect(profileEvent['pubkey'], keys.public);
+      final profileContent =
+          jsonDecode(profileEvent['content'] as String) as Map<String, dynamic>;
+      expect(profileContent['display_name'], 'Matt Example');
+      expect(profileContent['name'], 'Matt Example');
       expect(
         auth.authenticatedCommunities.single.sensitiveActionPolicy,
         SensitiveActionPolicy.disabledByUser,
@@ -208,7 +227,9 @@ void main() {
             policyReceipt: 'expired.receipt',
           ),
         );
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
 
     final state = container.read(inviteJoinProvider);
     expect(state.status, InviteJoinStatus.error);
@@ -218,7 +239,9 @@ void main() {
       'This invite approval has expired. Re-open the invite link to try again.',
     );
 
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
     expect(attempts, 1);
   });
 
@@ -251,7 +274,9 @@ void main() {
             code: 'v2.exhausted-secret',
           ),
         );
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
 
     final state = container.read(inviteJoinProvider);
     expect(state.status, InviteJoinStatus.error);
@@ -261,7 +286,9 @@ void main() {
       'This invite has reached its use limit. Ask for a new invite.',
     );
 
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
     expect(attempts, 1);
   });
 
@@ -278,6 +305,12 @@ void main() {
         inviteKeyGeneratorProvider.overrideWithValue(() => keys),
         inviteJoinHttpClientProvider.overrideWithValue(
           http_testing.MockClient((request) async {
+            if (request.url.path == '/events') {
+              return http.Response(
+                jsonEncode({'accepted': true, 'message': 'saved'}),
+                200,
+              );
+            }
             attempts++;
             bodies.add(request.body);
             if (attempts == 1) {
@@ -306,10 +339,14 @@ void main() {
             policyReceipt: 'receipt.value',
           ),
         );
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
     expect(container.read(inviteJoinProvider).status, InviteJoinStatus.error);
 
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
 
     expect(container.read(inviteJoinProvider).status, InviteJoinStatus.success);
     expect(attempts, 2);
@@ -320,6 +357,65 @@ void main() {
       ),
     );
     expect(auth.authenticatedCommunities, hasLength(1));
+  });
+
+  test('profile failure retries without claiming the invite twice', () async {
+    final keys = nostr.Keys.generate();
+    var claimAttempts = 0;
+    var profileAttempts = 0;
+    final storage = CommunityStorage(secure: FakeSecureStorage());
+    final container = ProviderContainer(
+      overrides: [
+        communityStorageProvider.overrideWithValue(storage),
+        authProvider.overrideWith(_RecordingAuthNotifier.new),
+        inviteKeyGeneratorProvider.overrideWithValue(() => keys),
+        inviteJoinHttpClientProvider.overrideWithValue(
+          http_testing.MockClient((request) async {
+            if (request.url.path == '/events') {
+              profileAttempts++;
+              return http.Response(
+                jsonEncode({'accepted': profileAttempts > 1}),
+                200,
+              );
+            }
+            claimAttempts++;
+            return http.Response(
+              jsonEncode({
+                'status': 'joined',
+                'host': 'relay.example.com',
+                'role': 'member',
+              }),
+              200,
+            );
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(inviteJoinProvider.notifier)
+        .prepare(
+          const InviteDeepLink(
+            relayUrl: 'wss://relay.example.com',
+            code: 'code',
+          ),
+        );
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
+    expect(
+      container.read(inviteJoinProvider).status,
+      InviteJoinStatus.profileError,
+    );
+
+    await container
+        .read(inviteJoinProvider.notifier)
+        .confirmJoin(displayName: 'Matt');
+
+    expect(container.read(inviteJoinProvider).status, InviteJoinStatus.success);
+    expect(claimAttempts, 1);
+    expect(profileAttempts, 2);
   });
 }
 

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:buzz/features/profile/profile_provider.dart';
 import 'package:buzz/features/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
@@ -5,9 +7,54 @@ import 'package:buzz/shared/theme/theme.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:nostr/nostr.dart' as nostr;
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  test(
+    'publishes a signed kind:0 profile and preserves existing fields',
+    () async {
+      final keys = nostr.Keys.generate();
+      http.Request? captured;
+      final client = http_testing.MockClient((request) async {
+        captured = request;
+        return http.Response(jsonEncode({'accepted': true}), 200);
+      });
+      addTearDown(client.close);
+
+      await publishProfileOverHttp(
+        client: client,
+        relayUrl: 'wss://relay.example.com/tenant-path?ignored=true',
+        nsec: keys.nsec,
+        displayName: '  Matt Example  ',
+        existing: const UserProfile(
+          pubkey: 'old',
+          avatarUrl: 'https://cdn.example/avatar.png',
+          about: 'Builder',
+          nip05Handle: 'matt@example.com',
+        ),
+      );
+
+      expect(captured?.url.toString(), 'https://relay.example.com/events');
+      expect(captured?.headers['Authorization'], startsWith('Nostr '));
+      expect(captured?.followRedirects, isFalse);
+      final event = jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(event['kind'], 0);
+      expect(event['pubkey'], keys.public);
+      final content =
+          jsonDecode(event['content'] as String) as Map<String, dynamic>;
+      expect(content, {
+        'name': 'Matt Example',
+        'display_name': 'Matt Example',
+        'picture': 'https://cdn.example/avatar.png',
+        'about': 'Builder',
+        'nip05': 'matt@example.com',
+      });
+    },
+  );
+
   test(
     'manual presence persists until Online restores automatic mode',
     () async {

--- a/mobile/test/features/profile/settings_profile_header_test.dart
+++ b/mobile/test/features/profile/settings_profile_header_test.dart
@@ -20,6 +20,33 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../helpers/widget_helpers.dart';
 
 void main() {
+  testWidgets('opens name recovery from the profile header', (tester) async {
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(_FakeProfileNotifier.new),
+          presenceProvider.overrideWith(() => _FakePresenceNotifier('online')),
+          userStatusProvider.overrideWith(() => _FakeUserStatusNotifier(null)),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings-edit-profile')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit profile'), findsOneWidget);
+    expect(
+      tester
+          .widget<TextField>(find.byKey(const ValueKey('edit-profile-name')))
+          .controller
+          ?.text,
+      'Test',
+    );
+  });
+
   testWidgets('shows the poster until the animated avatar is ready', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- require a display name before a mobile invite join can finish
- sign and publish the joiner's Nostr kind:0 profile, with retry-safe recovery when publication fails
- let existing unnamed mobile users add or edit their name from Settings
- keep the desktop bare `@` picker scoped to current channel members while retaining typed search for nonmember agents and people

## Why

Mobile invite joins currently create an identity without ever publishing profile metadata. Other clients therefore have no name to hydrate and can only display a shortened public key. The default desktop mention picker also surfaces global agent-directory rows with `not in channel` status before the author has typed a query.

## Verification

- `flutter analyze` on the changed mobile files
- focused Flutter tests: 14 passed
- focused desktop mention-ranking tests: 6 passed
- complete desktop unit suite: 4,985 passed
- desktop TypeScript check passed

The existing full desktop Biome check still reports unrelated pre-existing warnings in sidebar storage tests, terminal CSS, and an E2E fixture; the changed mention files are formatted and pass their focused checks.
